### PR TITLE
Update copy for home domain upsell banner

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/domain-upsell/index.jsx
@@ -5,7 +5,7 @@ import {
 	domainProductSlugs,
 } from '@automattic/calypso-products';
 import { useDomainSuggestions } from '@automattic/domain-picker/src';
-import { useLocale } from '@automattic/i18n-utils';
+import { useHasEnTranslation, useLocale } from '@automattic/i18n-utils';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { useMemo } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
@@ -144,6 +144,38 @@ export function RenderDomainUpsell( { isFreePlan, isMonthlyPlan, searchTerm, sit
 			? translate( 'That perfect domain is waiting' )
 			: translate( 'Own a domain. Build a site.' );
 
+	const updatedCopy = translate(
+		"{{strong}}%(domainSuggestion)s{{/strong}} is the perfect site address. It's available and easy to find and follow. And .com, .net, and .org domains start at just %(domainPrice)s—Get it now and claim a corner of the web.",
+		{
+			components: {
+				strong: <strong />,
+			},
+			args: {
+				domainSuggestion: domainSuggestionName,
+				domainPrice: domainProductCost,
+			},
+		}
+	);
+
+	const oldCopy = translate(
+		"{{strong}}%(domainSuggestion)s{{/strong}} is a perfect site address. It's available and easy to find and follow. Get it now and claim a corner of the web.",
+		{
+			components: {
+				strong: <strong />,
+			},
+			args: {
+				domainSuggestion: domainSuggestionName,
+				domainPrice: domainProductCost,
+			},
+		}
+	);
+
+	const hasTranslationForNewCopy = useHasEnTranslation()(
+		"{{strong}}%(domainSuggestion)s{{/strong}} is the perfect site address. It's available and easy to find and follow. And .com, .net, and .org domains start at just %(domainPrice)s—Get it now and claim a corner of the web."
+	);
+
+	const cardSubtitleFreePlansCopy = hasTranslationForNewCopy ? updatedCopy : oldCopy;
+
 	const cardSubtitle =
 		! isFreePlan && ! isMonthlyPlan
 			? translate(
@@ -157,18 +189,7 @@ export function RenderDomainUpsell( { isFreePlan, isMonthlyPlan, searchTerm, sit
 						},
 					}
 			  )
-			: translate(
-					"{{strong}}%(domainSuggestion)s{{/strong}} is the perfect site address. It's available and easy to find and follow. And .com, .net, and .org domains start at just %(domainPrice)s—Get it now and claim a corner of the web.",
-					{
-						components: {
-							strong: <strong />,
-						},
-						args: {
-							domainSuggestion: domainSuggestionName,
-							domainPrice: domainProductCost,
-						},
-					}
-			  );
+			: cardSubtitleFreePlansCopy;
 
 	const domainNameSVG = (
 		<svg viewBox="0 0 40 18" id="map">

--- a/client/my-sites/customer-home/cards/tasks/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/domain-upsell/index.jsx
@@ -1,4 +1,9 @@
-import { getPlan, isFreePlanProduct, getIntervalTypeForTerm } from '@automattic/calypso-products';
+import {
+	getPlan,
+	isFreePlanProduct,
+	getIntervalTypeForTerm,
+	domainProductSlugs,
+} from '@automattic/calypso-products';
 import { useDomainSuggestions } from '@automattic/domain-picker/src';
 import { useLocale } from '@automattic/i18n-utils';
 import { useShoppingCart } from '@automattic/shopping-cart';
@@ -8,6 +13,7 @@ import page from 'page';
 import { useState } from 'react';
 import { useSelector } from 'react-redux';
 import domainUpsellMobileIllustration from 'calypso/assets/images/customer-home/illustration--task-domain-upsell-mobile.svg';
+import { useQueryProductsList } from 'calypso/components/data/query-products-list';
 import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
 import { preventWidows } from 'calypso/lib/formatting';
 import { addQueryArgs } from 'calypso/lib/url';
@@ -17,6 +23,7 @@ import { TASK_DOMAIN_UPSELL } from 'calypso/my-sites/customer-home/cards/constan
 import Task from 'calypso/my-sites/customer-home/cards/tasks/task';
 import { isStagingSite } from 'calypso/sites-dashboard/utils';
 import { isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
+import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import { getDomainsBySite } from 'calypso/state/sites/domains/selectors';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSelectedSite, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -88,6 +95,13 @@ export function RenderDomainUpsell( { isFreePlan, isMonthlyPlan, searchTerm, sit
 
 	const domainSuggestionProductSlug = domainSuggestion?.product_slug;
 
+	useQueryProductsList();
+
+	const domainRegistrationProduct = useSelector( ( state ) =>
+		getProductBySlug( state, domainProductSlugs.DOTCOM_DOMAIN_REGISTRATION )
+	);
+	const domainProductCost = domainRegistrationProduct?.combined_cost_display;
+
 	const searchLink = addQueryArgs(
 		{
 			domainAndPlanPackage: true,
@@ -144,13 +158,14 @@ export function RenderDomainUpsell( { isFreePlan, isMonthlyPlan, searchTerm, sit
 					}
 			  )
 			: translate(
-					"{{strong}}%(domainSuggestion)s{{/strong}} is a perfect site address. It's available and easy to find and follow. Get it now and claim a corner of the web.",
+					"{{strong}}%(domainSuggestion)s{{/strong}} is the perfect site address. It's available and easy to find and follow. And .com, .net, and .org domains start at just %(domainPrice)s—Get it now and claim a corner of the web.",
 					{
 						components: {
 							strong: <strong />,
 						},
 						args: {
 							domainSuggestion: domainSuggestionName,
+							domainPrice: domainProductCost,
 						},
 					}
 			  );

--- a/client/my-sites/customer-home/cards/tasks/domain-upsell/test/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/domain-upsell/test/index.jsx
@@ -8,6 +8,7 @@ import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
 import DomainUpsell from '../';
 
 const initialState = {
@@ -54,6 +55,9 @@ const initialState = {
 			primary_blog: 1,
 		},
 	},
+	productsList: {
+		isFetching: false,
+	},
 };
 
 jest.mock( '@automattic/domain-picker/src', () => {
@@ -82,7 +86,7 @@ const searchForDomainCta = 'Find other domains';
 describe( 'index', () => {
 	test( 'Should show H3 content for the Home domain upsell and test search domain button link', async () => {
 		const queryClient = new QueryClient();
-		const mockStore = configureStore();
+		const mockStore = configureStore( [ thunk ] );
 		const store = mockStore( initialState );
 
 		render(
@@ -114,7 +118,7 @@ describe( 'index', () => {
 			.reply( 200 );
 
 		const queryClient = new QueryClient();
-		const mockStore = configureStore();
+		const mockStore = configureStore( [ thunk ] );
 		const store = mockStore( initialState );
 
 		render(
@@ -162,7 +166,7 @@ describe( 'index', () => {
 		};
 
 		const queryClient = new QueryClient();
-		const mockStore = configureStore();
+		const mockStore = configureStore( [ thunk ] );
 		const store = mockStore( newInitialState );
 
 		render(
@@ -202,7 +206,7 @@ describe( 'index', () => {
 		};
 
 		const queryClient = new QueryClient();
-		const mockStore = configureStore();
+		const mockStore = configureStore( [ thunk ] );
 		const store = mockStore( newInitialState );
 
 		render(
@@ -260,7 +264,7 @@ describe( 'index', () => {
 		};
 
 		const queryClient = new QueryClient();
-		const mockStore = configureStore();
+		const mockStore = configureStore( [ thunk ] );
 		const store = mockStore( newInitialState );
 
 		render(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/4027

## Proposed Changes

| Before  | After |
| :-------------: | :-------------: |
| <img src="https://github.com/Automattic/wp-calypso/assets/6586048/37d32b77-4ad9-4a36-b68a-3e72832bc8ef">  | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/13a6287e-f0e5-42ed-a337-8cc69f6eb641">|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Have a launched free site and go to /home
* Check the copy

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?