### PR TITLE
state: refactor away from `_.flowRight`

### DIFF
--- a/client/state/analytics/test/actions.js
+++ b/client/state/analytics/test/actions.js
@@ -1,4 +1,3 @@
-import { flowRight } from 'lodash';
 import { ANALYTICS_MULTI_TRACK, ANALYTICS_STAT_BUMP } from 'calypso/state/action-types';
 import {
 	composeAnalytics,
@@ -64,11 +63,10 @@ describe( 'middleware', () => {
 		} );
 
 		test( 'should compose multiple analytics calls with normal actions', () => {
-			const composite = flowRight(
-				withAnalytics( bumpStat( 'spline_types', 'ocean' ) ),
-				withAnalytics( bumpStat( 'spline_types', 'river' ) ),
-				() => ( { type: 'RETICULATE_SPLINES' } )
-			)();
+			const action = { type: 'RETICULATE_SPLINES' };
+			const composite = withAnalytics( bumpStat( 'spline_types', 'ocean' ) )(
+				withAnalytics( bumpStat( 'spline_types', 'river' ) )( action )
+			);
 
 			expect( composite.meta.analytics ).toHaveLength( 2 );
 		} );

--- a/client/state/automated-transfer/selectors/get-automated-transfer-status.ts
+++ b/client/state/automated-transfer/selectors/get-automated-transfer-status.ts
@@ -1,4 +1,3 @@
-import { get, flowRight as compose } from 'lodash';
 import { getAutomatedTransfer } from 'calypso/state/automated-transfer/selectors/get-automated-transfer';
 import type { AppState } from 'calypso/types';
 
@@ -10,7 +9,7 @@ import 'calypso/state/automated-transfer/init';
  * @param {Object} state automated transfer state sub-tree for a site
  * @returns {string} status of transfer
  */
-export const getStatusData = ( state: AppState ): string | null => get( state, 'status', null );
+export const getStatusData = ( state: AppState ): string | null => state?.status ?? null;
 
 /**
  * Returns status info for transfer
@@ -19,4 +18,5 @@ export const getStatusData = ( state: AppState ): string | null => get( state, '
  * @param {number} siteId requested site for transfer info
  * @returns {string|null} status if available else `null`
  */
-export const getAutomatedTransferStatus = compose( getStatusData, getAutomatedTransfer );
+export const getAutomatedTransferStatus = ( state: AppState, siteId: number | null ) =>
+	getStatusData( getAutomatedTransfer( state, siteId ) );

--- a/client/state/automated-transfer/selectors/index.ts
+++ b/client/state/automated-transfer/selectors/index.ts
@@ -1,4 +1,4 @@
-import { flowRight as compose, get } from 'lodash';
+import { get } from 'lodash';
 import { getAutomatedTransfer } from 'calypso/state/automated-transfer/selectors/get-automated-transfer';
 import type { AppState } from 'calypso/types';
 
@@ -48,7 +48,8 @@ export const getEligibilityData = ( state: AppState ): EligibilityData =>
  * @param siteId requested site for transfer info
  * @returns eligibility data if available else empty info
  */
-export const getEligibility = compose( getEligibilityData, getAutomatedTransfer );
+export const getEligibility = ( state: AppState, siteId: number | null ) =>
+	getEligibilityData( getAutomatedTransfer( state, siteId ) );
 
 /**
  * Helper to infer eligibility status from local transfer state sub-tree
@@ -66,4 +67,5 @@ export const getEligibilityStatus = ( state: AppState ): boolean =>
  * @param {number} siteId requested site for transfer info
  * @returns {boolean} True if current site is eligible for transfer, otherwise false
  */
-export const isEligibleForAutomatedTransfer = compose( getEligibilityStatus, getEligibility );
+export const isEligibleForAutomatedTransfer = ( state: AppState, siteId: number | null ) =>
+	getEligibilityStatus( getEligibility( state, siteId ) );

--- a/client/state/automated-transfer/selectors/is-automated-transfer-active.js
+++ b/client/state/automated-transfer/selectors/is-automated-transfer-active.js
@@ -1,4 +1,3 @@
-import { flowRight as compose } from 'lodash';
 import { transferStates } from 'calypso/state/automated-transfer/constants';
 import { getAutomatedTransferStatus } from 'calypso/state/automated-transfer/selectors/get-automated-transfer-status';
 
@@ -17,6 +16,7 @@ export const isActive = ( status ) => ( status ? status === transferStates.START
  * @param {number} siteId site of interest
  * @returns {?boolean} whether or not transfer is active, or null if not known
  */
-export const isAutomatedTransferActive = compose( isActive, getAutomatedTransferStatus );
+export const isAutomatedTransferActive = ( state, siteId ) =>
+	isActive( getAutomatedTransferStatus( state, siteId ) );
 
 export default isAutomatedTransferActive;

--- a/client/state/automated-transfer/selectors/is-automated-transfer-failed.js
+++ b/client/state/automated-transfer/selectors/is-automated-transfer-failed.js
@@ -1,4 +1,3 @@
-import { flowRight as compose } from 'lodash';
 import { transferStates } from 'calypso/state/automated-transfer/constants';
 import { getAutomatedTransferStatus } from 'calypso/state/automated-transfer/selectors/get-automated-transfer-status';
 
@@ -18,6 +17,7 @@ export const isFailed = ( status ) =>
  * @param {number} siteId site of interest
  * @returns {?boolean} whether or not transfer is failed, or null if not known
  */
-export const isAutomatedTransferFailed = compose( isFailed, getAutomatedTransferStatus );
+export const isAutomatedTransferFailed = ( state, siteId ) =>
+	isFailed( getAutomatedTransferStatus( state, siteId ) );
 
 export default isAutomatedTransferFailed;


### PR DESCRIPTION
## Proposed Changes

PR refactors away from `_.flowRight` in `client/state`. 

## Testing Instructions

* Changes are partly covered by unit tests, verify they still pass
* As with a lot of lodash methods it's good practice to ensure we don't accidentally miss guards for whether we operate on the expected data structure.
