### PR TITLE
Site Profiler: Handle site profiler special cases

### DIFF
--- a/client/site-profiler/components/heading-information/index.tsx
+++ b/client/site-profiler/components/heading-information/index.tsx
@@ -6,6 +6,7 @@ import { HostingProvider } from 'calypso/data/site-profiler/types';
 import StatusCtaInfo from '../heading-information/status-cta-info';
 import StatusInfo from '../heading-information/status-info';
 import type { CONVERSION_ACTION } from '../../hooks/use-define-conversion-action';
+import type { SPECIAL_DOMAIN_CASES } from '../../utils/get-special-domain-mapping';
 import './styles.scss';
 
 interface Props {
@@ -14,10 +15,19 @@ interface Props {
 	hostingProvider?: HostingProvider;
 	urlData?: UrlData;
 	onCheckAnotherSite?: () => void;
+	specialDomainMapping?: SPECIAL_DOMAIN_CASES;
 }
 
 export default function HeadingInformation( props: Props ) {
-	const { domain, conversionAction, hostingProvider, urlData, onCheckAnotherSite } = props;
+	const {
+		domain,
+		conversionAction,
+		hostingProvider,
+		urlData,
+		onCheckAnotherSite,
+		specialDomainMapping,
+	} = props;
+	const finalStatus = specialDomainMapping ?? conversionAction;
 
 	const onRegisterDomain = () => {
 		page( `/start/domain/domain-only?new=${ domain }&search=yes` );
@@ -35,6 +45,30 @@ export default function HeadingInformation( props: Props ) {
 		page( `/setup/google-transfer/intro?new=${ domain }` );
 	};
 
+	const onLearnMoreHosting = () => {
+		window.open( 'https://wordpress.com/hosting', '_blank' );
+	};
+
+	const onGetWordPress = () => {
+		window.open( 'https://wordpress.org/download', '_blank' );
+	};
+
+	const onLearnMoreAutomattic = () => {
+		window.open( 'https://automattic.com', '_blank' );
+	};
+
+	const onJoinTumblr = () => {
+		window.open( 'https://tumblr.com/', '_blank' );
+	};
+
+	const onLearnMoreGravatar = () => {
+		window.open( 'https://gravatar.com/', '_blank' );
+	};
+
+	const onGetAkismet = () => {
+		window.open( 'https://akismet.com/', '_blank' );
+	};
+
 	return (
 		<div className="heading-information">
 			<summary>
@@ -44,32 +78,68 @@ export default function HeadingInformation( props: Props ) {
 					conversionAction={ conversionAction }
 					hostingProvider={ hostingProvider }
 					urlData={ urlData }
+					specialDomainMapping={ specialDomainMapping }
 				/>
 			</summary>
 			<footer>
-				<StatusCtaInfo conversionAction={ conversionAction } />
+				<StatusCtaInfo
+					conversionAction={ conversionAction }
+					specialDomainMapping={ specialDomainMapping }
+				/>
 				<div className="cta-wrapper">
-					{ conversionAction === 'register-domain' && (
+					{ ( finalStatus === 'wordpress-com' ||
+						finalStatus === 'local-development' ||
+						finalStatus === 'wpcom-sp' ||
+						finalStatus === 'genaral-a8c-properties' ) && (
+						<Button className="button-action" onClick={ onLearnMoreHosting }>
+							{ translate( 'Learn more' ) }
+						</Button>
+					) }
+					{ finalStatus === 'wordpress-org' && (
+						<Button className="button-action" onClick={ onGetWordPress }>
+							{ translate( 'Get WordPress' ) }
+						</Button>
+					) }
+					{ finalStatus === 'automattic-com' && (
+						<Button className="button-action" onClick={ onLearnMoreAutomattic }>
+							{ translate( 'Learn more' ) }
+						</Button>
+					) }
+					{ finalStatus === 'tumblr-com' && (
+						<Button className="button-action" onClick={ onJoinTumblr }>
+							{ translate( 'Join Tumblr' ) }
+						</Button>
+					) }
+					{ finalStatus === 'gravatar-com' && (
+						<Button className="button-action" onClick={ onLearnMoreGravatar }>
+							{ translate( 'Learn more' ) }
+						</Button>
+					) }
+					{ finalStatus === 'akismet-com' && (
+						<Button className="button-action" onClick={ onGetAkismet }>
+							{ translate( 'Get started with Akismet' ) }
+						</Button>
+					) }
+					{ finalStatus === 'register-domain' && (
 						<Button className="button-action" onClick={ onRegisterDomain }>
 							{ translate( 'Register domain' ) }
 						</Button>
 					) }
-					{ ( conversionAction === 'transfer-domain' ||
-						conversionAction === 'transfer-domain-hosting' ) && (
+					{ ( finalStatus === 'transfer-domain' || finalStatus === 'transfer-domain-hosting' ) && (
 						<Button className="button-action" onClick={ onTransferDomain }>
 							{ translate( 'Transfer domain' ) }
 						</Button>
 					) }
-					{ ( conversionAction === 'transfer-google-domain' ||
-						conversionAction === 'transfer-google-domain-hosting' ) && (
+					{ ( finalStatus === 'transfer-google-domain' ||
+						finalStatus === 'transfer-google-domain-hosting' ) && (
 						<Button className="button-action" onClick={ onTransferDomainFree }>
 							{ translate( 'Transfer domain for free' ) }
 						</Button>
 					) }
-					{ ( conversionAction === 'transfer-hosting' ||
-						conversionAction === 'transfer-hosting-wp' ||
-						conversionAction === 'transfer-domain-hosting-wp' ||
-						conversionAction === 'transfer-google-domain-hosting-wp' ) && (
+					{ ( finalStatus === 'transfer-hosting' ||
+						finalStatus === 'transfer-hosting-wp' ||
+						finalStatus === 'transfer-domain-hosting-wp' ||
+						finalStatus === 'transfer-google-domain-hosting-wp' ) && (
 						<Button className="button-action" onClick={ onMigrateSite }>
 							{ translate( 'Migrate site' ) }
 						</Button>

--- a/client/site-profiler/components/heading-information/status-cta-info.tsx
+++ b/client/site-profiler/components/heading-information/status-cta-info.tsx
@@ -1,13 +1,73 @@
 import { translate } from 'i18n-calypso';
 import { CONVERSION_ACTION } from '../../hooks/use-define-conversion-action';
+import type { SPECIAL_DOMAIN_CASES } from '../../utils/get-special-domain-mapping';
 
 interface Props {
 	conversionAction?: CONVERSION_ACTION;
+	specialDomainMapping?: SPECIAL_DOMAIN_CASES;
 }
 export default function StatusCtaInfo( props: Props ) {
-	const { conversionAction } = props;
+	const { conversionAction, specialDomainMapping } = props;
+	// if there's a speical domain mapping, use that instead of the conversion action
+	const finalStatus = specialDomainMapping ?? conversionAction;
 
-	switch ( conversionAction ) {
+	switch ( finalStatus ) {
+		case 'wordpress-com':
+			return (
+				<p>
+					{ translate(
+						'Host your site with {{strong}}WordPress.com{{/strong}} ' +
+							'and benefit from one of the best platforms in the world.',
+						{
+							components: { strong: <strong /> },
+						}
+					) }
+				</p>
+			);
+		case 'wordpress-org':
+			return (
+				<p>
+					{ translate(
+						'Create a place for your business, your interests, ' +
+							'or anything else—with the open source platform that powers the web.'
+					) }
+				</p>
+			);
+		case 'automattic-com':
+			return (
+				<p>
+					{ translate(
+						'At {{strong}}Automattic{{/strong}}, we’re passionate about making the web a better place',
+						{
+							components: { strong: <strong /> },
+						}
+					) }
+				</p>
+			);
+		case 'tumblr-com':
+			return (
+				<p>
+					{ translate(
+						'It’s time to try {{strong}}Tumblr{{/strong}}. You’ll never be bored again.',
+						{
+							components: { strong: <strong /> },
+						}
+					) }
+				</p>
+			);
+		case 'gravatar-com':
+			return (
+				<p>{ translate( 'Global avatar —“Gravatar” get it? One pic for all your profiles.' ) }</p>
+			);
+		case 'akismet-com':
+			return (
+				<p>
+					{ translate(
+						'Akismet’s advanced AI filters out comment, form, and text spam with 99.99% accuracy, ' +
+							'so you never have to worry about it again.'
+					) }
+				</p>
+			);
 		case 'register-domain':
 			return (
 				<p>
@@ -49,13 +109,22 @@ export default function StatusCtaInfo( props: Props ) {
 			);
 		case 'transfer-hosting':
 		case 'transfer-hosting-wp':
+		case 'local-development':
+		case 'wpcom-sp':
+		case 'genaral-a8c-properties':
 			return (
 				<p>
 					{ translate(
-						'If you own this site, consider hosting it with {{strong}}WordPress.com{{/strong}} and ' +
+						'If you own %(article)s site, consider hosting it with {{strong}}WordPress.com{{/strong}} and ' +
 							'benefiting from one of the best platforms in the world.',
 						{
 							components: { strong: <strong /> },
+							args: {
+								article:
+									finalStatus === 'transfer-hosting-wp' || finalStatus === 'transfer-hosting'
+										? 'this'
+										: 'a',
+							},
 						}
 					) }
 				</p>

--- a/client/site-profiler/components/heading-information/status-cta-info.tsx
+++ b/client/site-profiler/components/heading-information/status-cta-info.tsx
@@ -37,7 +37,7 @@ export default function StatusCtaInfo( props: Props ) {
 			return (
 				<p>
 					{ translate(
-						'At {{strong}}Automattic{{/strong}}, we’re passionate about making the web a better place',
+						'At {{strong}}Automattic{{/strong}}, we’re passionate about making the web a better place.',
 						{
 							components: { strong: <strong /> },
 						}
@@ -109,22 +109,27 @@ export default function StatusCtaInfo( props: Props ) {
 			);
 		case 'transfer-hosting':
 		case 'transfer-hosting-wp':
+			return (
+				<p>
+					{ translate(
+						'If you own this site, consider hosting it with {{strong}}WordPress.com{{/strong}} and ' +
+							'benefiting from one of the best platforms in the world.',
+						{
+							components: { strong: <strong /> },
+						}
+					) }
+				</p>
+			);
 		case 'local-development':
 		case 'wpcom-sp':
 		case 'genaral-a8c-properties':
 			return (
 				<p>
 					{ translate(
-						'If you own %(article)s site, consider hosting it with {{strong}}WordPress.com{{/strong}} and ' +
+						'If you own a site, consider hosting it with {{strong}}WordPress.com{{/strong}} and ' +
 							'benefiting from one of the best platforms in the world.',
 						{
 							components: { strong: <strong /> },
-							args: {
-								article:
-									finalStatus === 'transfer-hosting-wp' || finalStatus === 'transfer-hosting'
-										? 'this'
-										: 'a',
-							},
 						}
 					) }
 				</p>

--- a/client/site-profiler/components/heading-information/status-info.tsx
+++ b/client/site-profiler/components/heading-information/status-info.tsx
@@ -3,17 +3,54 @@ import { UrlData } from 'calypso/blocks/import/types';
 import { HostingProvider } from 'calypso/data/site-profiler/types';
 import useHostingProviderName from 'calypso/site-profiler/hooks/use-hosting-provider-name';
 import { CONVERSION_ACTION } from '../../hooks/use-define-conversion-action';
+import type { SPECIAL_DOMAIN_CASES } from '../../utils/get-special-domain-mapping';
 
 interface Props {
 	conversionAction?: CONVERSION_ACTION;
 	hostingProvider?: HostingProvider;
 	urlData?: UrlData;
+	specialDomainMapping?: SPECIAL_DOMAIN_CASES;
 }
 export default function StatusInfo( props: Props ) {
-	const { conversionAction, hostingProvider, urlData } = props;
+	const { conversionAction, hostingProvider, urlData, specialDomainMapping } = props;
 	const hostingProviderName = useHostingProviderName( hostingProvider, urlData );
-
-	switch ( conversionAction ) {
+	// if there's a speical domain mapping, use that instead of the conversion action
+	const finalStatus = specialDomainMapping ?? conversionAction;
+	switch ( finalStatus ) {
+		case 'wordpress-com':
+			return <p>{ translate( 'Well yes, WordPress.com runs on WordPress.com!' ) }</p>;
+		case 'wordpress-org':
+			return (
+				<p>
+					{ translate( 'This amazing community have great taste–this site runs on WordPress!' ) }
+				</p>
+			);
+		case 'automattic-com':
+			return <p>{ translate( 'It’s WordPress.com all the way down!' ) }</p>;
+		case 'local-development':
+			return (
+				<p>
+					{ translate(
+						'Home is where localhost is, right? Just so you know, we have no idea where that is.'
+					) }
+				</p>
+			);
+		case 'wpcom-sp':
+			return (
+				<p>
+					{ translate(
+						'Profiling the profiler? Nice try! Believe it or not, it’s hosted on WordPress.com.'
+					) }
+				</p>
+			);
+		case 'tumblr-com':
+			return (
+				<p>{ translate( 'A WordPress.com? On my Tumblr? What? PS: It may contain crabs.' ) }</p>
+			);
+		case 'gravatar-com':
+		case 'akismet-com':
+		case 'genaral-a8c-properties':
+			return <p>{ translate( 'This site is proudly hosted on WordPress.com.' ) }</p>;
 		case 'register-domain':
 			return (
 				<p>

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -93,15 +93,13 @@ export default function SiteProfiler() {
 						) }
 						{ siteProfilerData && ! siteProfilerData.is_domain_available && (
 							<>
-								{ siteProfilerData && (
-									<LayoutBlockSection>
-										<HostingInformation
-											dns={ siteProfilerData.dns }
-											urlData={ urlData }
-											hostingProvider={ hostingProviderData?.hosting_provider }
-										/>
-									</LayoutBlockSection>
-								) }
+								<LayoutBlockSection>
+									<HostingInformation
+										dns={ siteProfilerData.dns }
+										urlData={ urlData }
+										hostingProvider={ hostingProviderData?.hosting_provider }
+									/>
+								</LayoutBlockSection>
 								<LayoutBlockSection>
 									<DomainInformation
 										domain={ domain }

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -52,8 +52,8 @@ export default function SiteProfiler() {
 
 		navigate( location.pathname + '?' + queryParams.toString() );
 	};
-
-	const showResultScreen = siteProfilerData || ( specialDomainMapping && ! isDomainValid );
+	const noNeedToFetchApi = specialDomainMapping && isDomainSpecialInput;
+	const showResultScreen = siteProfilerData || noNeedToFetchApi;
 
 	return (
 		<>
@@ -119,7 +119,7 @@ export default function SiteProfiler() {
 			<LayoutBlock
 				className="hosting-intro-block globe-bg"
 				isMonoBg={
-					!! showResultScreen && conversionAction !== 'register-domain' && ! isDomainSpecialInput
+					!! showResultScreen && conversionAction !== 'register-domain' && ! noNeedToFetchApi
 				}
 			>
 				<HostingIntro />

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -20,7 +20,12 @@ export default function SiteProfiler() {
 	const location = useLocation();
 	const navigate = useNavigate();
 	const queryParams = useQuery();
-	const { domain, isValid: isDomainValid } = useDomainQueryParam();
+	const {
+		domain,
+		isValid: isDomainValid,
+		specialDomainMapping,
+		isDomainSpecialInput,
+	} = useDomainQueryParam();
 
 	const {
 		data: siteProfilerData,
@@ -48,9 +53,11 @@ export default function SiteProfiler() {
 		navigate( location.pathname + '?' + queryParams.toString() );
 	};
 
+	const showResultScreen = siteProfilerData || ( specialDomainMapping && ! isDomainValid );
+
 	return (
 		<>
-			{ ! siteProfilerData && (
+			{ ! showResultScreen && (
 				<LayoutBlock className="domain-analyzer-block" width="medium">
 					<DocumentHead title={ translate( 'Site Profiler' ) } />
 					<DomainAnalyzer
@@ -64,50 +71,56 @@ export default function SiteProfiler() {
 				</LayoutBlock>
 			) }
 
-			{ siteProfilerData && (
-				<LayoutBlock className="domain-result-block">
-					{
-						// Translators: %s is the domain name searched
-						<DocumentHead title={ translate( '%s ‹ Site Profiler', { args: [ domain ] } ) } />
-					}
-					{ siteProfilerData && (
-						<LayoutBlockSection>
-							<HeadingInformation
-								domain={ domain }
-								conversionAction={ conversionAction }
-								onCheckAnotherSite={ () => updateDomainQueryParam( '' ) }
-								hostingProvider={ hostingProviderData?.hosting_provider }
-								urlData={ urlData }
-							/>
-						</LayoutBlockSection>
-					) }
-					{ ! siteProfilerData.is_domain_available && (
-						<>
-							{ siteProfilerData && (
-								<LayoutBlockSection>
-									<HostingInformation
-										dns={ siteProfilerData.dns }
-										urlData={ urlData }
-										hostingProvider={ hostingProviderData?.hosting_provider }
-									/>
-								</LayoutBlockSection>
-							) }
+			{
+				// For speical vaild domain mapping, we need to wait until the result comes back
+				showResultScreen && (
+					<LayoutBlock className="domain-result-block">
+						{
+							// Translators: %s is the domain name searched
+							<DocumentHead title={ translate( '%s ‹ Site Profiler', { args: [ domain ] } ) } />
+						}
+						{ ( siteProfilerData || specialDomainMapping ) && (
 							<LayoutBlockSection>
-								<DomainInformation
+								<HeadingInformation
 									domain={ domain }
-									whois={ siteProfilerData.whois }
+									conversionAction={ conversionAction }
+									onCheckAnotherSite={ () => updateDomainQueryParam( '' ) }
 									hostingProvider={ hostingProviderData?.hosting_provider }
 									urlData={ urlData }
+									specialDomainMapping={ specialDomainMapping }
 								/>
 							</LayoutBlockSection>
-						</>
-					) }
-				</LayoutBlock>
-			) }
+						) }
+						{ siteProfilerData && ! siteProfilerData.is_domain_available && (
+							<>
+								{ siteProfilerData && (
+									<LayoutBlockSection>
+										<HostingInformation
+											dns={ siteProfilerData.dns }
+											urlData={ urlData }
+											hostingProvider={ hostingProviderData?.hosting_provider }
+										/>
+									</LayoutBlockSection>
+								) }
+								<LayoutBlockSection>
+									<DomainInformation
+										domain={ domain }
+										whois={ siteProfilerData.whois }
+										hostingProvider={ hostingProviderData?.hosting_provider }
+										urlData={ urlData }
+									/>
+								</LayoutBlockSection>
+							</>
+						) }
+					</LayoutBlock>
+				)
+			}
 
 			<LayoutBlock
 				className="hosting-intro-block globe-bg"
-				isMonoBg={ !! siteProfilerData && conversionAction !== 'register-domain' }
+				isMonoBg={
+					!! showResultScreen && conversionAction !== 'register-domain' && ! isDomainSpecialInput
+				}
 			>
 				<HostingIntro />
 			</LayoutBlock>

--- a/client/site-profiler/hooks/use-domain-query-param.ts
+++ b/client/site-profiler/hooks/use-domain-query-param.ts
@@ -1,19 +1,42 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { extractDomainFromInput, getFixedDomainSearch } from 'calypso/lib/domains';
+import {
+	isSpecialInput,
+	SPECIAL_DOMAIN_CASES,
+	getSpecialDomainMapping,
+} from 'calypso/site-profiler/utils/get-special-domain-mapping';
 
 export default function useDomainQueryParam( sanitize = true ) {
 	const [ domain, setDomain ] = useState( '' );
 	const [ isValid, setIsValid ] = useState< undefined | boolean >();
+	const [ specialDomainMapping, setSpecialDomainMapping ] = useState< SPECIAL_DOMAIN_CASES >();
 	const queryParams = useQuery();
+	const _domain = ( queryParams.get( 'domain' ) || '' ).trim();
+	const isDomainSpecialInput = isSpecialInput( _domain );
+
+	const getFinalizedDomain = useCallback(
+		( _domain: string ) => {
+			const domain_lc = _domain.toLowerCase();
+			if ( isDomainSpecialInput ) {
+				if ( domain_lc.includes( 'wordpress.com/site-profiler' ) ) {
+					return 'wordpress.com/site-profiler';
+				} else if ( domain_lc.includes( 'localhost' ) ) {
+					return 'localhost';
+				} else if ( domain_lc.includes( '127.0.0.1' ) ) {
+					return '127.0.0.1';
+				}
+			}
+			return sanitize ? getFixedDomainSearch( extractDomainFromInput( domain_lc ) ) : domain_lc;
+		},
+		[ isDomainSpecialInput, sanitize ]
+	);
 
 	useEffect( () => {
-		const _domain = ( queryParams.get( 'domain' ) || '' ).trim();
-
 		try {
 			if ( _domain ) {
 				// Only allow domains with a dot in them (not localhost, for example).
-				if ( ! _domain.includes( '.' ) ) {
+				if ( ! _domain.includes( '.' ) || isDomainSpecialInput ) {
 					throw new Error( 'Invalid domain' );
 				}
 
@@ -35,9 +58,11 @@ export default function useDomainQueryParam( sanitize = true ) {
 		} catch ( e ) {
 			setIsValid( false );
 		}
+		const finalizedDomain = getFinalizedDomain( _domain );
+		const specialDomains = getSpecialDomainMapping( finalizedDomain );
+		setSpecialDomainMapping( specialDomains );
+		setDomain( finalizedDomain );
+	}, [ _domain, getFinalizedDomain, isDomainSpecialInput ] );
 
-		setDomain( sanitize ? getFixedDomainSearch( extractDomainFromInput( _domain ) ) : _domain );
-	}, [ queryParams ] );
-
-	return { domain, isValid };
+	return { domain, isValid, specialDomainMapping, isDomainSpecialInput };
 }

--- a/client/site-profiler/utils/get-special-domain-mapping.ts
+++ b/client/site-profiler/utils/get-special-domain-mapping.ts
@@ -1,0 +1,65 @@
+export type SPECIAL_DOMAIN_CASES =
+	| 'wordpress-com'
+	| 'wordpress-org'
+	| 'automattic-com'
+	| 'tumblr-com'
+	| 'gravatar-com'
+	| 'akismet-com'
+	| 'genaral-a8c-properties'
+	| 'wpcom-sp'
+	| 'local-development';
+
+const SPECIAL_CASES = [ /wordpress\.com\/site-profiler/, /localhost/, /127\.0\.0\.1/ ];
+
+export function getSpecialDomainMapping( domain: string ): SPECIAL_DOMAIN_CASES | undefined {
+	const domain_lc = domain.toLowerCase();
+	let specialDomainCase: SPECIAL_DOMAIN_CASES | undefined;
+
+	switch ( domain_lc ) {
+		case 'wordpress.com':
+			specialDomainCase = 'wordpress-com';
+			break;
+		case 'wordpress.org':
+			specialDomainCase = 'wordpress-org';
+			break;
+		case 'automattic.com':
+			specialDomainCase = 'automattic-com';
+			break;
+		case 'tumblr.com':
+			specialDomainCase = 'tumblr-com';
+			break;
+		case 'gravatar.com':
+			specialDomainCase = 'gravatar-com';
+			break;
+		case 'akismet.com':
+			specialDomainCase = 'akismet-com';
+			break;
+		case 'wordpress.com/site-profiler':
+			specialDomainCase = 'wpcom-sp';
+			break;
+		case 'localhost':
+		case '127.0.0.1':
+			specialDomainCase = 'local-development';
+			break;
+		case 'wpvip.com':
+		case 'longreads.com':
+		case 'happy.tools':
+		case 'simplenote.com':
+		case 'jetpack.com':
+		case 'woocommerce.com':
+		case 'dayoneapp.com':
+			specialDomainCase = 'genaral-a8c-properties';
+			break;
+		default:
+			specialDomainCase = undefined;
+			break;
+	}
+
+	return specialDomainCase;
+}
+
+export function isSpecialInput( domain: string ): boolean {
+	const domain_lc = domain.toLowerCase();
+
+	return SPECIAL_CASES.some( ( pattern ) => pattern.test( domain_lc ) );
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #82535

## Proposed Changes

* In this PR, we handle more special domain cases and output different status info for those domains. Please checkout the issue linked above.

WordPress.com

![Screen Shot 2023-10-04 at 7 22 45 PM](https://github.com/Automattic/wp-calypso/assets/4074459/a2ec158e-aa68-4021-a3d6-897b0a0296c8)

WordPress.org

![Screen Shot 2023-10-04 at 7 23 21 PM](https://github.com/Automattic/wp-calypso/assets/4074459/ec019b2d-53e5-4d99-93f0-4a9054374959)

Automattic.com

![Screen Shot 2023-10-04 at 7 24 47 PM](https://github.com/Automattic/wp-calypso/assets/4074459/228562f9-c746-4f1c-8b8f-4a9cc830b6a7)

127.0.0.1 / localhost

![Screen Shot 2023-10-04 at 7 25 31 PM](https://github.com/Automattic/wp-calypso/assets/4074459/bbd5658a-2f4f-470b-b6b7-4567b3c68be0)

wordpress.com/site-profiler

![Screen Shot 2023-10-04 at 7 25 58 PM](https://github.com/Automattic/wp-calypso/assets/4074459/6c53c15e-8add-4519-bbbf-f743f45530f7)

tumblr.com

![Screen Shot 2023-10-04 at 7 26 28 PM](https://github.com/Automattic/wp-calypso/assets/4074459/921a5b6a-a2f3-45fd-8f85-2ccc977f9d06)

gravatar.com

![Screen Shot 2023-10-04 at 7 26 44 PM](https://github.com/Automattic/wp-calypso/assets/4074459/4d4d16b2-ee29-4963-a909-387058dab5ad)

akismet.com

![Screen Shot 2023-10-04 at 7 53 57 PM](https://github.com/Automattic/wp-calypso/assets/4074459/5438f5f3-ea77-43e1-b682-06336f855bab)

Other Automattic properties

![Screen Shot 2023-10-04 at 7 54 35 PM](https://github.com/Automattic/wp-calypso/assets/4074459/9e4fe792-6cd4-4209-9d35-0d736925f187)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*. Check out the issue ticket above and go through all the domains on the list and compare the description, action, and CTA with the data from the table. 
* Do more test with regular domains and make sure nothing is broken.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?