### PR TITLE
Launchpad: Add the Navigator package structure

### DIFF
--- a/packages/launchpad-navigator/CHANGELOG.md
+++ b/packages/launchpad-navigator/CHANGELOG.md
@@ -1,0 +1,6 @@
+
+# Changelog
+
+## 0.1.0
+
+- Initial release

--- a/packages/launchpad-navigator/README.md
+++ b/packages/launchpad-navigator/README.md
@@ -1,0 +1,34 @@
+# Launchpad Navigator
+
+This package provides the components for attaching the Navigator of the 
+Launchpads to the master bar.
+
+## Usage
+
+First you need to import the components:
+
+```js
+import {
+    LaunchpadNavigator,
+    LaunchpadNavigatorIcon,
+} from '@automattic/launchpad-navigator';
+```
+
+This simple example shows how to render the navigator icon and the 
+floating navigator component:
+
+```js
+function renderApp() {
+    const [ showNavigator, setShowNavigator ] = useState( false );
+    return (
+        <>
+            <Button onClick={ setShowNavigator( ! showNavigator ) }>
+                <LaunchpadNavigatorIcon siteSlug={ siteSlug } />
+            </Button>
+            { showNavigator && (
+                <FloatingNavigator siteSlug={ siteSlug } />
+            ) } 
+        </>
+    );
+}
+```

--- a/packages/launchpad-navigator/README.md
+++ b/packages/launchpad-navigator/README.md
@@ -1,7 +1,7 @@
 # Launchpad Navigator
 
-This package provides the components for attaching the Navigator of the 
-Launchpads to the master bar.
+This package provides the components for showing and interacting with
+one or more Launchpad task lists for a given site.
 
 ## Usage
 

--- a/packages/launchpad-navigator/README.md
+++ b/packages/launchpad-navigator/README.md
@@ -9,7 +9,7 @@ First you need to import the components:
 
 ```js
 import {
-    LaunchpadNavigator,
+    FloatingNavigator,
     LaunchpadNavigatorIcon,
 } from '@automattic/launchpad-navigator';
 ```

--- a/packages/launchpad-navigator/package.json
+++ b/packages/launchpad-navigator/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/launchpad-navigator",
-	"version": "1.0.0",
+	"version": "0.1.0",
 	"description": "Launchpad navigator components",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/launchpad-navigator/package.json
+++ b/packages/launchpad-navigator/package.json
@@ -55,6 +55,5 @@
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
 		"redux": "^4.2.1"
-	},
-	"private": true
+	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* This PR adds the basic structure for publishing the Launchpad Navigator package. As part of our project, we need to publish this package so we can easily use it on jetpack-mu-wpcom.
* This will be made possible by Dale's PR: https://github.com/Automattic/jetpack/pull/33045

More info:
https://github.com/Automattic/wp-calypso/blob/40811b2929612ebb529ee4bff7ce51bdc61c51e7/docs/monorepo.md#publishing

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visual inspection of the changed files

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?