### PR TITLE
Social Signup: Add notice

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -1183,6 +1183,7 @@ class SignupForm extends Component {
 					isReskinned={ this.props.isReskinned }
 					redirectToAfterLoginUrl={ this.props.redirectToAfterLoginUrl }
 					queryArgs={ this.props.queryArgs }
+					notice={ this.getNotice() }
 				/>
 			);
 		}

--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -25,6 +25,7 @@ interface SignupFormSocialFirst {
 	handleSocialResponse: () => void;
 	isReskinned: boolean;
 	queryArgs: object;
+	notice: JSX.Element | false;
 }
 
 const SignupFormSocialFirst = ( {
@@ -39,6 +40,7 @@ const SignupFormSocialFirst = ( {
 	handleSocialResponse,
 	isReskinned,
 	queryArgs,
+	notice,
 }: SignupFormSocialFirst ) => {
 	const [ currentStep, setCurrentStep ] = useState( 'initial' );
 	const { __, hasTranslation } = useI18n();
@@ -63,23 +65,26 @@ const SignupFormSocialFirst = ( {
 					: __( 'Email' );
 
 			return (
-				<SocialSignupForm
-					handleResponse={ handleSocialResponse }
-					socialService={ socialService }
-					socialServiceResponse={ socialServiceResponse }
-					isReskinned={ isReskinned }
-					redirectToAfterLoginUrl={ redirectToAfterLoginUrl }
-					disableTosText={ true }
-					compact={ true }
-				>
-					<Button
-						className="social-buttons__button button"
-						onClick={ () => setCurrentStep( 'email' ) }
+				<>
+					{ notice }
+					<SocialSignupForm
+						handleResponse={ handleSocialResponse }
+						socialService={ socialService }
+						socialServiceResponse={ socialServiceResponse }
+						isReskinned={ isReskinned }
+						redirectToAfterLoginUrl={ redirectToAfterLoginUrl }
+						disableTosText={ true }
+						compact={ true }
 					>
-						<MailIcon width="20" height="20" />
-						<span className="social-buttons__service-name">{ buttonEmailText }</span>
-					</Button>
-				</SocialSignupForm>
+						<Button
+							className="social-buttons__button button"
+							onClick={ () => setCurrentStep( 'email' ) }
+						>
+							<MailIcon width="20" height="20" />
+							<span className="social-buttons__service-name">{ buttonEmailText }</span>
+						</Button>
+					</SocialSignupForm>
+				</>
 			);
 		} else if ( currentStep === 'email' ) {
 			const gravatarProps = isGravatar

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -520,7 +520,7 @@ export class UserStep extends Component {
 					socialService={ socialService }
 					socialServiceResponse={ socialServiceResponse }
 					recaptchaClientId={ this.state.recaptchaClientId }
-					horizontal={ isReskinned }
+					horizontal={ false }
 					isReskinned={ isReskinned }
 					shouldDisplayUserExistsError={ ! isWooOAuth2Client( oauth2Client ) }
 				/>


### PR DESCRIPTION
Social signup was lacking the notice we show to the user when they social signup with an already existing account. This PR adds it back.

<img width="609" alt="image" src="https://github.com/Automattic/wp-calypso/assets/52076348/c880199c-38d8-4863-8a68-77c23df86c63">

## Testing

Testing social logins is quite difficult, an easy way would be to
1. Checkout branch and `yarn start`
2.
Make this change to [this line](https://github.com/Automattic/wp-calypso/blob/update/social-first-notice/client/blocks/signup-form/index.jsx#L874)
```
// const userExistsError = this.getUserExistsError( this.props );
		const userExistsError = {
			email: 'test-email@gmail.com',
		};
```
3. Visit `/start/user` while in Incognito