### PR TITLE
Site profiler: Add record tracks events

### DIFF
--- a/client/site-profiler/components/domain-information/index.tsx
+++ b/client/site-profiler/components/domain-information/index.tsx
@@ -1,7 +1,8 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button } from '@wordpress/components';
 import { createElement, createInterpolateElement } from '@wordpress/element';
 import { TranslateOptions, translate } from 'i18n-calypso';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { UrlData } from 'calypso/blocks/import/types';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { useDomainAnalyzerWhoisRawDataQuery } from 'calypso/data/site-profiler/use-domain-whois-raw-data-query';
@@ -33,6 +34,11 @@ export default function DomainInformation( props: Props ) {
 
 	const whoisDataAvailability = whois && Object.keys( whois ).length > 0;
 	const { fieldsRedacted, filteredWhois } = useFilteredWhoisData( whois );
+
+	useEffect( () => {
+		fetchWhoisRawData &&
+			recordTracksEvent( 'calypso_site_profiler_domain_whois_raw_data_fetch', { domain } );
+	}, [ fetchWhoisRawData ] );
 
 	const contactArgs = ( args?: string | string[] ): TranslateOptions => {
 		return {

--- a/client/site-profiler/components/heading-information/index.tsx
+++ b/client/site-profiler/components/heading-information/index.tsx
@@ -59,26 +59,32 @@ export default function HeadingInformation( props: Props ) {
 	};
 
 	const onLearnMoreHosting = () => {
+		recordCtaEvent( 'learnMoreHosting' );
 		window.open( 'https://wordpress.com/hosting', '_blank' );
 	};
 
 	const onGetWordPress = () => {
+		recordCtaEvent( 'getWordpress' );
 		window.open( 'https://wordpress.org/download', '_blank' );
 	};
 
 	const onLearnMoreAutomattic = () => {
+		recordCtaEvent( 'learnMoreAutomattic' );
 		window.open( 'https://automattic.com', '_blank' );
 	};
 
 	const onJoinTumblr = () => {
+		recordCtaEvent( 'joinTumblr' );
 		window.open( 'https://tumblr.com/', '_blank' );
 	};
 
 	const onLearnMoreGravatar = () => {
+		recordCtaEvent( 'learnMoreGravatar' );
 		window.open( 'https://gravatar.com/', '_blank' );
 	};
 
 	const onGetAkismet = () => {
+		recordCtaEvent( 'getAkismet' );
 		window.open( 'https://akismet.com/', '_blank' );
 	};
 

--- a/client/site-profiler/components/heading-information/index.tsx
+++ b/client/site-profiler/components/heading-information/index.tsx
@@ -35,6 +35,7 @@ export default function HeadingInformation( props: Props ) {
 			domain,
 			cta_name: ctaName,
 			conversion_action: conversionAction,
+			special_domain_mapping: specialDomainMapping,
 		} );
 	};
 

--- a/client/site-profiler/components/heading-information/index.tsx
+++ b/client/site-profiler/components/heading-information/index.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button } from '@wordpress/components';
 import { translate } from 'i18n-calypso';
 import page from 'page';
@@ -29,20 +30,32 @@ export default function HeadingInformation( props: Props ) {
 	} = props;
 	const finalStatus = specialDomainMapping ?? conversionAction;
 
+	const recordCtaEvent = ( ctaName: string ) => {
+		recordTracksEvent( 'calypso_site_profiler_cta', {
+			domain,
+			cta_name: ctaName,
+			conversion_action: conversionAction,
+		} );
+	};
+
 	const onRegisterDomain = () => {
+		recordCtaEvent( 'registerDomain' );
 		page( `/start/domain/domain-only?new=${ domain }&search=yes` );
 	};
 
 	const onTransferDomain = () => {
+		recordCtaEvent( 'transferDomain' );
 		page( `/setup/domain-transfer/intro?new=${ domain }&search=yes` );
 	};
 
-	const onMigrateSite = () => {
-		page( `/setup/import-hosted-site?from=${ domain }` );
+	const onTransferDomainFree = () => {
+		recordCtaEvent( 'transferDomainGoogle' );
+		page( `/setup/google-transfer/intro?new=${ domain }` );
 	};
 
-	const onTransferDomainFree = () => {
-		page( `/setup/google-transfer/intro?new=${ domain }` );
+	const onMigrateSite = () => {
+		recordCtaEvent( 'migrateSite' );
+		page( `/setup/import-hosted-site?from=${ domain }` );
 	};
 
 	const onLearnMoreHosting = () => {

--- a/client/site-profiler/components/heading-information/status-cta-info.tsx
+++ b/client/site-profiler/components/heading-information/status-cta-info.tsx
@@ -8,7 +8,7 @@ interface Props {
 }
 export default function StatusCtaInfo( props: Props ) {
 	const { conversionAction, specialDomainMapping } = props;
-	// if there's a speical domain mapping, use that instead of the conversion action
+	// if there's a special domain mapping, use that instead of the conversion action
 	const finalStatus = specialDomainMapping ?? conversionAction;
 
 	switch ( finalStatus ) {

--- a/client/site-profiler/components/hosting-information/index.tsx
+++ b/client/site-profiler/components/hosting-information/index.tsx
@@ -20,6 +20,7 @@ export default function HostingInformation( props: Props ) {
 
 	useEffect( () => {
 		hostingProvider &&
+			urlData &&
 			recordTracksEvent( 'calypso_site_profiler_hosting_information', {
 				domain_url: urlData?.url,
 				is_cdn: hostingProvider?.is_cdn,
@@ -31,7 +32,7 @@ export default function HostingInformation( props: Props ) {
 				platform_is_wpengine: urlData?.platform_data?.is_wpengine,
 				platform_is_pressable: urlData?.platform_data?.is_pressable,
 			} );
-	}, [ hostingProvider ] );
+	}, [ hostingProvider, urlData ] );
 
 	return (
 		<div className="hosting-information">

--- a/client/site-profiler/components/hosting-information/index.tsx
+++ b/client/site-profiler/components/hosting-information/index.tsx
@@ -1,4 +1,6 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { translate } from 'i18n-calypso';
+import { useEffect } from 'react';
 import { UrlData } from 'calypso/blocks/import/types';
 import useHostingProviderURL from 'calypso/site-profiler/hooks/use-hosting-provider-url';
 import HostingProviderName from './hosting-provider-name';
@@ -15,6 +17,21 @@ export default function HostingInformation( props: Props ) {
 	const { dns = [], urlData, hostingProvider } = props;
 	const aRecordIps = dns.filter( ( x ) => x.type === 'A' && x.ip );
 	const supportUrl = useHostingProviderURL( 'support', hostingProvider, urlData );
+
+	useEffect( () => {
+		hostingProvider &&
+			recordTracksEvent( 'calypso_site_profiler_hosting_information', {
+				domain_url: urlData?.url,
+				is_cdn: hostingProvider?.is_cdn,
+				provider_slug: hostingProvider?.slug,
+				provider_name: hostingProvider?.name,
+				platform: urlData?.platform,
+				platform_slug: urlData?.platform_data?.slug,
+				platform_is_wpcom: urlData?.platform_data?.is_wpcom,
+				platform_is_wpengine: urlData?.platform_data?.is_wpengine,
+				platform_is_pressable: urlData?.platform_data?.is_pressable,
+			} );
+	}, [ hostingProvider ] );
 
 	return (
 		<div className="hosting-information">

--- a/client/site-profiler/components/hosting-information/index.tsx
+++ b/client/site-profiler/components/hosting-information/index.tsx
@@ -20,19 +20,24 @@ export default function HostingInformation( props: Props ) {
 
 	useEffect( () => {
 		hostingProvider &&
-			urlData &&
 			recordTracksEvent( 'calypso_site_profiler_hosting_information', {
-				domain_url: urlData?.url,
 				is_cdn: hostingProvider?.is_cdn,
 				provider_slug: hostingProvider?.slug,
 				provider_name: hostingProvider?.name,
+			} );
+	}, [ hostingProvider ] );
+
+	useEffect( () => {
+		urlData &&
+			recordTracksEvent( 'calypso_site_profiler_hosting_information', {
+				domain_url: urlData?.url,
 				platform: urlData?.platform,
 				platform_slug: urlData?.platform_data?.slug,
 				platform_is_wpcom: urlData?.platform_data?.is_wpcom,
 				platform_is_wpengine: urlData?.platform_data?.is_wpengine,
 				platform_is_pressable: urlData?.platform_data?.is_pressable,
 			} );
-	}, [ hostingProvider, urlData ] );
+	}, [ urlData ] );
 
 	return (
 		<div className="hosting-information">

--- a/client/site-profiler/components/hosting-information/index.tsx
+++ b/client/site-profiler/components/hosting-information/index.tsx
@@ -1,9 +1,7 @@
-import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { translate } from 'i18n-calypso';
-import { useEffect } from 'react';
-import { UrlData } from 'calypso/blocks/import/types';
 import useHostingProviderURL from 'calypso/site-profiler/hooks/use-hosting-provider-url';
 import HostingProviderName from './hosting-provider-name';
+import type { UrlData } from 'calypso/blocks/import/types';
 import type { DNS, HostingProvider } from 'calypso/data/site-profiler/types';
 import './style.scss';
 
@@ -17,27 +15,6 @@ export default function HostingInformation( props: Props ) {
 	const { dns = [], urlData, hostingProvider } = props;
 	const aRecordIps = dns.filter( ( x ) => x.type === 'A' && x.ip );
 	const supportUrl = useHostingProviderURL( 'support', hostingProvider, urlData );
-
-	useEffect( () => {
-		hostingProvider &&
-			recordTracksEvent( 'calypso_site_profiler_hosting_information', {
-				is_cdn: hostingProvider?.is_cdn,
-				provider_slug: hostingProvider?.slug,
-				provider_name: hostingProvider?.name,
-			} );
-	}, [ hostingProvider ] );
-
-	useEffect( () => {
-		urlData &&
-			recordTracksEvent( 'calypso_site_profiler_hosting_information', {
-				domain_url: urlData?.url,
-				platform: urlData?.platform,
-				platform_slug: urlData?.platform_data?.slug,
-				platform_is_wpcom: urlData?.platform_data?.is_wpcom,
-				platform_is_wpengine: urlData?.platform_data?.is_wpengine,
-				platform_is_pressable: urlData?.platform_data?.is_pressable,
-			} );
-	}, [ urlData ] );
 
 	return (
 		<div className="hosting-information">

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -30,14 +30,14 @@ export default function SiteProfiler() {
 		error: errorSP,
 		isFetching: isFetchingSP,
 	} = useDomainAnalyzerQuery( domain, isDomainValid );
-	const { data: urlData } = useAnalyzeUrlQuery( domain, isDomainValid );
+	const { data: urlData, isError: isErrorUrlData } = useAnalyzeUrlQuery( domain, isDomainValid );
 	const { data: hostingProviderData } = useHostingProviderQuery( domain, isDomainValid );
 	const isBusyForWhile = useLongFetchingDetection( domain, isFetchingSP );
 	const conversionAction = useDefineConversionAction(
 		domain,
 		siteProfilerData,
 		hostingProviderData,
-		urlData
+		isErrorUrlData ? null : urlData
 	);
 
 	useSiteProfilerRecordAnalytics(

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -33,15 +33,13 @@ export default function SiteProfiler() {
 	const { data: urlData } = useAnalyzeUrlQuery( domain, isDomainValid );
 	const { data: hostingProviderData } = useHostingProviderQuery( domain, isDomainValid );
 	const isBusyForWhile = useLongFetchingDetection( domain, isFetchingSP );
-	const isWordPressPlatForm = urlData?.platform === 'wordpress';
 	const conversionAction = useDefineConversionAction(
 		domain,
-		siteProfilerData?.whois,
-		siteProfilerData?.is_domain_available,
-		siteProfilerData?.eligible_google_transfer,
-		hostingProviderData?.hosting_provider,
-		isWordPressPlatForm
+		siteProfilerData,
+		hostingProviderData,
+		urlData
 	);
+
 	useSiteProfilerRecordAnalytics(
 		domain,
 		isDomainValid,

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -73,7 +73,7 @@ export default function SiteProfiler() {
 			) }
 
 			{
-				// For speical vaild domain mapping, we need to wait until the result comes back
+				// For special valid domain mapping, we need to wait until the result comes back
 				showResultScreen && (
 					<LayoutBlock className="domain-result-block">
 						{

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -42,7 +42,14 @@ export default function SiteProfiler() {
 		hostingProviderData?.hosting_provider,
 		isWordPressPlatForm
 	);
-	useSiteProfilerRecordAnalytics( domain, isDomainValid, conversionAction, specialDomainMapping );
+	useSiteProfilerRecordAnalytics(
+		domain,
+		isDomainValid,
+		conversionAction,
+		specialDomainMapping,
+		hostingProviderData?.hosting_provider,
+		urlData
+	);
 
 	const updateDomainQueryParam = ( value: string ) => {
 		// Update the domain query param;

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -42,7 +42,7 @@ export default function SiteProfiler() {
 		hostingProviderData?.hosting_provider,
 		isWordPressPlatForm
 	);
-	useSiteProfilerRecordAnalytics( domain, isDomainValid, conversionAction );
+	useSiteProfilerRecordAnalytics( domain, isDomainValid, conversionAction, specialDomainMapping );
 
 	const updateDomainQueryParam = ( value: string ) => {
 		// Update the domain query param;

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -8,6 +8,7 @@ import { LayoutBlock, LayoutBlockSection } from 'calypso/site-profiler/component
 import useDefineConversionAction from 'calypso/site-profiler/hooks/use-define-conversion-action';
 import useDomainQueryParam from 'calypso/site-profiler/hooks/use-domain-query-param';
 import useLongFetchingDetection from '../hooks/use-long-fetching-detection';
+import useSiteProfilerRecordAnalytics from '../hooks/use-site-profiler-record-analytics';
 import DomainAnalyzer from './domain-analyzer';
 import DomainInformation from './domain-information';
 import HeadingInformation from './heading-information';
@@ -41,6 +42,7 @@ export default function SiteProfiler() {
 		hostingProviderData?.hosting_provider,
 		isWordPressPlatForm
 	);
+	useSiteProfilerRecordAnalytics( domain, isDomainValid, conversionAction );
 
 	const updateDomainQueryParam = ( value: string ) => {
 		// Update the domain query param;

--- a/client/site-profiler/hooks/use-define-conversion-action.ts
+++ b/client/site-profiler/hooks/use-define-conversion-action.ts
@@ -1,5 +1,10 @@
+import { useState, useEffect } from 'react';
 import { normalizeWhoisField } from '../utils/normalize-whois-entry';
-import type { HostingProvider, WhoIs } from 'calypso/data/site-profiler/types';
+import type { UrlData } from 'calypso/blocks/import/types';
+import type {
+	DomainAnalyzerQueryResponse,
+	HostingProviderQueryResponse,
+} from 'calypso/data/site-profiler/types';
 
 export type CONVERSION_ACTION =
 	| 'register-domain'
@@ -15,41 +20,60 @@ export type CONVERSION_ACTION =
 
 export default function useDefineConversionAction(
 	domain: string,
-	whois?: WhoIs,
-	isDomainAvailable?: boolean,
-	isEligibleGoogleTransfer?: boolean,
-	hostingProvider?: HostingProvider,
-	isWordPressPlatform?: boolean
+	siteProfilerData?: DomainAnalyzerQueryResponse,
+	hostingProviderData?: HostingProviderQueryResponse,
+	urlData?: UrlData
 ): CONVERSION_ACTION | undefined {
+	const [ conversionAction, setConversionAction ] = useState< CONVERSION_ACTION | undefined >();
+
+	const isDomainAvailable = siteProfilerData?.is_domain_available;
+	const isEligibleGoogleTransfer = siteProfilerData?.eligible_google_transfer;
+
 	const isWpDomain = domain.toLowerCase().includes( 'wordpress.com' );
 	const isWpAtomicDomain = domain.toLowerCase().includes( 'wpcomstaging.com' );
-	const isA8cRegistrar = normalizeWhoisField( whois?.registrar )
+	const isWpPlatform = urlData?.platform === 'wordpress';
+
+	const isA8cRegistrar = normalizeWhoisField( siteProfilerData?.whois?.registrar )
 		.toLowerCase()
 		.includes( 'automattic' );
 	const isA8cDomain = isA8cRegistrar || isWpDomain || isWpAtomicDomain;
-	const isA8cHosting = hostingProvider?.slug === 'automattic';
+	const isA8cHosting = hostingProviderData?.hosting_provider?.slug === 'automattic';
 
-	if ( isDomainAvailable ) {
-		return 'register-domain';
-	} else if ( isA8cDomain && ! isA8cHosting ) {
-		if ( isWordPressPlatform ) {
-			return 'transfer-hosting-wp';
+	useEffect( () => {
+		! domain && setConversionAction( undefined );
+	}, [ domain ] );
+
+	useEffect( () => {
+		if (
+			siteProfilerData !== undefined ||
+			hostingProviderData !== undefined ||
+			urlData !== undefined
+		) {
+			return;
 		}
-		return 'transfer-hosting';
-	} else if ( ! isA8cDomain && isEligibleGoogleTransfer && isA8cHosting ) {
-		return 'transfer-google-domain';
-	} else if ( ! isA8cDomain && isEligibleGoogleTransfer && ! isA8cHosting ) {
-		if ( isWordPressPlatform ) {
-			return 'transfer-google-domain-hosting-wp';
+
+		if ( isDomainAvailable ) {
+			setConversionAction( 'register-domain' );
+		} else if ( isA8cDomain && ! isA8cHosting ) {
+			isWpPlatform
+				? setConversionAction( 'transfer-hosting-wp' )
+				: setConversionAction( 'transfer-hosting' );
+		} else if ( ! isA8cDomain && isEligibleGoogleTransfer && isA8cHosting ) {
+			setConversionAction( 'transfer-google-domain' );
+		} else if ( ! isA8cDomain && isEligibleGoogleTransfer && ! isA8cHosting ) {
+			isWpPlatform
+				? setConversionAction( 'transfer-google-domain-hosting-wp' )
+				: setConversionAction( 'transfer-google-domain-hosting' );
+		} else if ( ! isA8cDomain && isA8cHosting ) {
+			setConversionAction( 'transfer-domain' );
+		} else if ( ! isA8cDomain && ! isA8cHosting ) {
+			isWpPlatform
+				? setConversionAction( 'transfer-domain-hosting-wp' )
+				: setConversionAction( 'transfer-domain-hosting' );
+		} else {
+			setConversionAction( 'idle' );
 		}
-		return 'transfer-google-domain-hosting';
-	} else if ( ! isA8cDomain && isA8cHosting ) {
-		return 'transfer-domain';
-	} else if ( ! isA8cDomain && ! isA8cHosting ) {
-		if ( isWordPressPlatform ) {
-			return 'transfer-domain-hosting-wp';
-		}
-		return 'transfer-domain-hosting';
-	}
-	return 'idle';
+	}, [ siteProfilerData, hostingProviderData, urlData ] );
+
+	return conversionAction;
 }

--- a/client/site-profiler/hooks/use-define-conversion-action.ts
+++ b/client/site-profiler/hooks/use-define-conversion-action.ts
@@ -22,7 +22,7 @@ export default function useDefineConversionAction(
 	domain: string,
 	siteProfilerData?: DomainAnalyzerQueryResponse,
 	hostingProviderData?: HostingProviderQueryResponse,
-	urlData?: UrlData
+	urlData?: UrlData | null
 ): CONVERSION_ACTION | undefined {
 	const [ conversionAction, setConversionAction ] = useState< CONVERSION_ACTION | undefined >();
 

--- a/client/site-profiler/hooks/use-define-conversion-action.ts
+++ b/client/site-profiler/hooks/use-define-conversion-action.ts
@@ -45,9 +45,9 @@ export default function useDefineConversionAction(
 
 	useEffect( () => {
 		if (
-			siteProfilerData !== undefined ||
-			hostingProviderData !== undefined ||
-			urlData !== undefined
+			siteProfilerData === undefined ||
+			hostingProviderData === undefined ||
+			urlData === undefined
 		) {
 			return;
 		}

--- a/client/site-profiler/hooks/use-site-profiler-record-analytics.ts
+++ b/client/site-profiler/hooks/use-site-profiler-record-analytics.ts
@@ -23,13 +23,14 @@ export default function useSiteProfilerRecordAnalytics(
 
 	useEffect( () => {
 		domain &&
+			conversionAction &&
 			recordTracksEvent( 'calypso_site_profiler_domain_analyze', {
 				domain,
 				is_domain_valid: isDomainValid,
 				conversion_action: conversionAction,
 				special_domain_mapping: specialDomainMapping,
 			} );
-	}, [ domain, isDomainValid ] );
+	}, [ domain, isDomainValid, conversionAction ] );
 
 	useEffect( () => {
 		hostingProvider &&

--- a/client/site-profiler/hooks/use-site-profiler-record-analytics.ts
+++ b/client/site-profiler/hooks/use-site-profiler-record-analytics.ts
@@ -22,15 +22,17 @@ export default function useSiteProfilerRecordAnalytics(
 	}, [] );
 
 	useEffect( () => {
+		const noNeedToFetchApi = specialDomainMapping && ! isDomainValid;
+
 		domain &&
-			( conversionAction || specialDomainMapping ) &&
+			( conversionAction || noNeedToFetchApi ) &&
 			recordTracksEvent( 'calypso_site_profiler_domain_analyze', {
 				domain,
 				is_domain_valid: isDomainValid,
 				conversion_action: conversionAction,
 				special_domain_mapping: specialDomainMapping,
 			} );
-	}, [ domain, isDomainValid, conversionAction, specialDomainMapping ] );
+	}, [ domain, isDomainValid, conversionAction ] );
 
 	useEffect( () => {
 		hostingProvider &&

--- a/client/site-profiler/hooks/use-site-profiler-record-analytics.ts
+++ b/client/site-profiler/hooks/use-site-profiler-record-analytics.ts
@@ -1,0 +1,26 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { useEffect } from 'react';
+import type { CONVERSION_ACTION } from 'calypso/site-profiler/hooks/use-define-conversion-action';
+
+/**
+ * Record analytics events for site-profiler.tsx root element only
+ * The idea is to move all root element analytics events to this hook
+ */
+export default function useSiteProfilerRecordAnalytics(
+	domain: string,
+	isDomainValid?: boolean,
+	conversionAction?: CONVERSION_ACTION
+) {
+	useEffect( () => {
+		recordTracksEvent( 'calypso_site_profiler_page_view' );
+	}, [] );
+
+	useEffect( () => {
+		domain &&
+			isDomainValid &&
+			recordTracksEvent( 'calypso_site_profiler_domain_analyze', {
+				domain,
+				conversion_action: conversionAction,
+			} );
+	}, [ domain, isDomainValid ] );
+}

--- a/client/site-profiler/hooks/use-site-profiler-record-analytics.ts
+++ b/client/site-profiler/hooks/use-site-profiler-record-analytics.ts
@@ -1,6 +1,8 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useEffect } from 'react';
 import { SPECIAL_DOMAIN_CASES } from 'calypso/site-profiler/utils/get-special-domain-mapping';
+import type { UrlData } from 'calypso/blocks/import/types';
+import type { HostingProvider } from 'calypso/data/site-profiler/types';
 import type { CONVERSION_ACTION } from 'calypso/site-profiler/hooks/use-define-conversion-action';
 
 /**
@@ -11,7 +13,9 @@ export default function useSiteProfilerRecordAnalytics(
 	domain: string,
 	isDomainValid?: boolean,
 	conversionAction?: CONVERSION_ACTION,
-	specialDomainMapping?: SPECIAL_DOMAIN_CASES
+	specialDomainMapping?: SPECIAL_DOMAIN_CASES,
+	hostingProvider?: HostingProvider,
+	urlData?: UrlData
 ) {
 	useEffect( () => {
 		recordTracksEvent( 'calypso_site_profiler_page_view' );
@@ -26,4 +30,26 @@ export default function useSiteProfilerRecordAnalytics(
 				special_domain_mapping: specialDomainMapping,
 			} );
 	}, [ domain, isDomainValid ] );
+
+	useEffect( () => {
+		hostingProvider &&
+			recordTracksEvent( 'calypso_site_profiler_hosting_information_provider', {
+				domain: domain,
+				is_cdn: hostingProvider?.is_cdn,
+				provider_slug: hostingProvider?.slug,
+				provider_name: hostingProvider?.name,
+			} );
+	}, [ hostingProvider ] );
+
+	useEffect( () => {
+		urlData &&
+			recordTracksEvent( 'calypso_site_profiler_hosting_information_url_data', {
+				domain: domain,
+				platform: urlData?.platform,
+				platform_slug: urlData?.platform_data?.slug,
+				platform_is_wpcom: urlData?.platform_data?.is_wpcom,
+				platform_is_wpengine: urlData?.platform_data?.is_wpengine,
+				platform_is_pressable: urlData?.platform_data?.is_pressable,
+			} );
+	}, [ urlData ] );
 }

--- a/client/site-profiler/hooks/use-site-profiler-record-analytics.ts
+++ b/client/site-profiler/hooks/use-site-profiler-record-analytics.ts
@@ -1,5 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useEffect } from 'react';
+import { SPECIAL_DOMAIN_CASES } from 'calypso/site-profiler/utils/get-special-domain-mapping';
 import type { CONVERSION_ACTION } from 'calypso/site-profiler/hooks/use-define-conversion-action';
 
 /**
@@ -9,7 +10,8 @@ import type { CONVERSION_ACTION } from 'calypso/site-profiler/hooks/use-define-c
 export default function useSiteProfilerRecordAnalytics(
 	domain: string,
 	isDomainValid?: boolean,
-	conversionAction?: CONVERSION_ACTION
+	conversionAction?: CONVERSION_ACTION,
+	specialDomainMapping?: SPECIAL_DOMAIN_CASES
 ) {
 	useEffect( () => {
 		recordTracksEvent( 'calypso_site_profiler_page_view' );
@@ -17,10 +19,11 @@ export default function useSiteProfilerRecordAnalytics(
 
 	useEffect( () => {
 		domain &&
-			isDomainValid &&
 			recordTracksEvent( 'calypso_site_profiler_domain_analyze', {
 				domain,
+				is_domain_valid: isDomainValid,
 				conversion_action: conversionAction,
+				special_domain_mapping: specialDomainMapping,
 			} );
 	}, [ domain, isDomainValid ] );
 }

--- a/client/site-profiler/hooks/use-site-profiler-record-analytics.ts
+++ b/client/site-profiler/hooks/use-site-profiler-record-analytics.ts
@@ -23,14 +23,14 @@ export default function useSiteProfilerRecordAnalytics(
 
 	useEffect( () => {
 		domain &&
-			conversionAction &&
+			( conversionAction || specialDomainMapping ) &&
 			recordTracksEvent( 'calypso_site_profiler_domain_analyze', {
 				domain,
 				is_domain_valid: isDomainValid,
 				conversion_action: conversionAction,
 				special_domain_mapping: specialDomainMapping,
 			} );
-	}, [ domain, isDomainValid, conversionAction ] );
+	}, [ domain, isDomainValid, conversionAction, specialDomainMapping ] );
 
 	useEffect( () => {
 		hostingProvider &&


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/82000

## Proposed Changes

* Added record tracks events

Events:
- `calypso_site_profiler_page_view`
- `calypso_site_profiler_domain_analyze` with props: domain, conversion_action
- `calypso_site_profiler_hosting_information` with props: is_cdn, provider_name, etc.
- `calypso_site_profiler_cta` with props: cta_name, etc.
- `calypso_site_profiler_domain_whois_raw_data_fetch` with prop: domain
- `calypso_site_profiler_hosting_information_provider` with props
- `calypso_site_profiler_hosting_information_url_data ` with props

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/site-profiler`
* Open developer tool
* Turn on analytics log
* Check if there are events properly triggered

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?