### PR TITLE
First post: change selected tab title

### DIFF
--- a/client/reader/discover/controller.js
+++ b/client/reader/discover/controller.js
@@ -34,7 +34,7 @@ const exported = {
 		context.primary = (
 			<>
 				<DocumentHead
-					title={ translate( 'Browse %s Blogs & Read Articles ‹ Reader', {
+					title={ translate( 'Browse %s blogs & read articles ‹ Reader', {
 						args: [ tabTitle ],
 						comment: '%s is the type of blog being explored e.g. food, art, technology etc.',
 					} ) }

--- a/client/reader/discover/controller.js
+++ b/client/reader/discover/controller.js
@@ -1,5 +1,4 @@
 import { translate } from 'i18n-calypso';
-import titlecase from 'to-title-case';
 import AsyncLoad from 'calypso/components/async-load';
 import DocumentHead from 'calypso/components/data/document-head';
 import { sectionify } from 'calypso/lib/route';
@@ -29,7 +28,7 @@ const exported = {
 			context.renderHeaderSection = renderHeaderSection;
 		}
 		const selectedTab = context.query.selectedTab || DEFAULT_TAB;
-		const tabTitle = titlecase( getSelectedTabTitle( selectedTab ) || '' );
+		const tabTitle = getSelectedTabTitle( selectedTab ) || '';
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		context.primary = (
 			<>

--- a/client/reader/discover/helper.js
+++ b/client/reader/discover/helper.js
@@ -30,7 +30,7 @@ export function getSelectedTabTitle( selectedTab ) {
 		return 'new';
 	}
 	if ( selectedTab === FIRST_POSTS_TAB ) {
-		return 'firstposts';
+		return 'fresh';
 	}
 	return selectedTab;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

Currently when you browse to the First posts tab the title on the tab is "Browse Firstposts Blogs & read articles < Reader". This PR replaces Firstposts by Fresh, which is what we are using in the tagline, it also fixes the uppercase issues.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR or go to Calypso.live.
* Go to http://calypso.localhost:3000/discover?selectedTab=firstposts
* Verify the tab title reads "Browse fresh blogs & read articles < Reader"
* Go to other tabs and verify the casing is OK.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?