### PR TITLE
Add whois fields normalization

### DIFF
--- a/client/data/site-profiler/types.ts
+++ b/client/data/site-profiler/types.ts
@@ -36,7 +36,7 @@ export interface WhoIs {
 	registrant_postal_code?: string;
 	registrant_state?: string;
 	registrant_street?: string | string[];
-	registrar?: string;
+	registrar?: string | string[];
 	registrar_iana_id?: string;
 	registrar_url?: string;
 	registrar_whois_server?: string;

--- a/client/site-profiler/components/domain-information/index.tsx
+++ b/client/site-profiler/components/domain-information/index.tsx
@@ -6,6 +6,7 @@ import { UrlData } from 'calypso/blocks/import/types';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { useDomainAnalyzerWhoisRawDataQuery } from 'calypso/data/site-profiler/use-domain-whois-raw-data-query';
 import { useFilteredWhoisData } from 'calypso/site-profiler/hooks/use-filtered-whois-data';
+import { normalizeWhoisField } from 'calypso/site-profiler/utils/normalize-whois-entry';
 import VerifiedProvider from './verified-provider';
 import type { HostingProvider, WhoIs } from 'calypso/data/site-profiler/types';
 import './styles.scss';
@@ -54,13 +55,13 @@ export default function DomainInformation( props: Props ) {
 	};
 
 	const formatDateTime = ( date?: string | string[] ) => {
-		if ( Array.isArray( date ) && date.length > 0 ) {
-			date = date[ 0 ];
-		}
-
-		const res = moment.utc( date );
+		const res = moment.utc( normalizeWhoisField( date ) );
 
 		return res.isValid() ? res.format( momentFormat ) : '';
+	};
+
+	const formatRegistrar = ( registrar?: string | string[] ) => {
+		return normalizeWhoisField( registrar );
 	};
 
 	return (
@@ -87,7 +88,7 @@ export default function DomainInformation( props: Props ) {
 										{ whois.registrar }
 									</a>
 								) }
-							{ ! whois.registrar_url && <span>{ whois.registrar }</span> }
+							{ ! whois.registrar_url && <span>{ formatRegistrar( whois.registrar ) }</span> }
 						</div>
 					</li>
 				) }

--- a/client/site-profiler/components/domain-information/index.tsx
+++ b/client/site-profiler/components/domain-information/index.tsx
@@ -60,10 +60,6 @@ export default function DomainInformation( props: Props ) {
 		return res.isValid() ? res.format( momentFormat ) : '';
 	};
 
-	const formatRegistrar = ( registrar?: string | string[] ) => {
-		return normalizeWhoisField( registrar );
-	};
-
 	return (
 		<div className="domain-information">
 			<h3>{ translate( 'Domain information' ) }</h3>
@@ -88,7 +84,7 @@ export default function DomainInformation( props: Props ) {
 										{ whois.registrar }
 									</a>
 								) }
-							{ ! whois.registrar_url && <span>{ formatRegistrar( whois.registrar ) }</span> }
+							{ ! whois.registrar_url && <span>{ normalizeWhoisField( whois.registrar ) }</span> }
 						</div>
 					</li>
 				) }

--- a/client/site-profiler/hooks/use-define-conversion-action.ts
+++ b/client/site-profiler/hooks/use-define-conversion-action.ts
@@ -1,3 +1,4 @@
+import { normalizeWhoisField } from '../utils/normalize-whois-entry';
 import type { HostingProvider, WhoIs } from 'calypso/data/site-profiler/types';
 
 export type CONVERSION_ACTION =
@@ -22,8 +23,9 @@ export default function useDefineConversionAction(
 ): CONVERSION_ACTION | undefined {
 	const isWpDomain = domain.toLowerCase().includes( 'wordpress.com' );
 	const isWpAtomicDomain = domain.toLowerCase().includes( 'wpcomstaging.com' );
-	const isA8cRegistrar = whois?.registrar?.toLowerCase().includes( 'automattic' );
-
+	const isA8cRegistrar = normalizeWhoisField( whois?.registrar )
+		.toLowerCase()
+		.includes( 'automattic' );
 	const isA8cDomain = isA8cRegistrar || isWpDomain || isWpAtomicDomain;
 	const isA8cHosting = hostingProvider?.slug === 'automattic';
 

--- a/client/site-profiler/hooks/use-filtered-whois-data.ts
+++ b/client/site-profiler/hooks/use-filtered-whois-data.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { WhoIs } from 'calypso/data/site-profiler/types';
+import { normalizeWhoisField } from '../utils/normalize-whois-entry';
 
 interface FilteredWhois {
 	[ name: string ]: boolean;
@@ -18,11 +19,7 @@ export const useFilteredWhoisData = ( whois: WhoIs ): FilteredWhoisData => {
 
 		// Check if there are redacted whois fields
 		for ( const key in whois ) {
-			let value = whois[ key as keyof WhoIs ] ?? '';
-
-			if ( Array.isArray( value ) ) {
-				value = value.length > 0 ? value[ 0 ] : '';
-			}
+			let value = normalizeWhoisField( whois[ key as keyof WhoIs ] );
 
 			value = value?.toLowerCase().replace( /[ .]/g, '' );
 			const isRedacted = redactedFields.includes( value );

--- a/client/site-profiler/utils/normalize-whois-entry.ts
+++ b/client/site-profiler/utils/normalize-whois-entry.ts
@@ -1,0 +1,8 @@
+// Normalize a whois entry field to a string
+export function normalizeWhoisField( field: string | string[] | undefined ): string {
+	if ( Array.isArray( field ) ) {
+		return field.length > 0 ? field[ 0 ] : '';
+	}
+
+	return field ?? '';
+}


### PR DESCRIPTION
Context: p1696422548035839-slack-C01A60HCGUA
Fixes https://github.com/Automattic/wp-calypso/issues/82587

## Proposed Changes

* Normalize whois arrays of strings to a string before using that as a string

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* http://calypso.localhost:3000/site-profiler?domain=jeroenpf.nl should not create a JS error and show a single "NAMECHEAP, INC." as registrar (not an entire array)
* http://calypso.localhost:3000/site-profiler?domain=google.nl should not create a JS error and show "MarkMonitor Inc." as registrar

Following domains must work as before.
* http://calypso.localhost:3000/site-profiler?domain=paulocoelhoblog.com
* http://calypso.localhost:3000/site-profiler?domain=karmico-indugio-0q.wixsite.com
* http://calypso.localhost:3000/site-profiler?domain=wordpress.com
* http://calypso.localhost:3000/site-profiler?domain=adomainnotregistered.com

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?