### PR TITLE
Launchpad: Add the structure for publishing the package on NPM

### DIFF
--- a/packages/launchpad/CHANGELOG.md
+++ b/packages/launchpad/CHANGELOG.md
@@ -1,0 +1,6 @@
+
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/packages/launchpad/README.md
+++ b/packages/launchpad/README.md
@@ -30,4 +30,6 @@ The site slug of the site to display the checklist for.
 
 ### checklistSlug
 
-Optional slug of the checklist to display. If not provided, we use the site intent to determine which checklist to display.
+Optional slug of the checklist to display. This is ID of the checklist defined on Jetpack's side. See https://github.com/Automattic/jetpack/blob/2d37c444fe42eb852f34f1df6c285e94c37e9376/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php.
+
+We use the `@automattic/data-stores` package to fetch the checklist data and cache it, through the `useLaunchpad` query.

--- a/packages/launchpad/README.md
+++ b/packages/launchpad/README.md
@@ -30,6 +30,6 @@ The site slug of the site to display the checklist for.
 
 ### checklistSlug
 
-Optional slug of the checklist to display. This is ID of the checklist defined on Jetpack's side. See https://github.com/Automattic/jetpack/blob/2d37c444fe42eb852f34f1df6c285e94c37e9376/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php.
+Optional slug of the checklist to display. This is ID of the checklist defined on Jetpack's side. See [Jetpack checklist definitions](https://github.com/Automattic/jetpack/blob/2d37c444fe42eb852f34f1df6c285e94c37e9376/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php).
 
 We use the `@automattic/data-stores` package to fetch the checklist data and cache it, through the `useLaunchpad` query.

--- a/packages/launchpad/README.md
+++ b/packages/launchpad/README.md
@@ -1,0 +1,33 @@
+# Launchpad
+
+Launchpad is the base component for displaying a checklist in the WordPress.com dashboard. It handles fetching the checklist data and displaying the checklist.
+
+## Usage
+
+First, import the Launchpad component:
+
+```js
+import { Launchpad } from '@automattic/launchpad'
+```
+
+Then, use it in your code:
+
+```js
+function App( { siteSlug, checklistSlug } ) {
+    return (
+        <Launchpad
+            siteSlug={ siteSlug }
+            checklistSlug={ checklistSlug } />
+    );
+}
+```
+
+## Props
+
+### siteSlug
+
+The site slug of the site to display the checklist for.
+
+### checklistSlug
+
+Optional slug of the checklist to display. If not provided, we use the site intent to determine which checklist to display.

--- a/packages/launchpad/package.json
+++ b/packages/launchpad/package.json
@@ -55,6 +55,5 @@
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
 		"redux": "^4.2.1"
-	},
-	"private": true
+	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
* https://github.com/Automattic/wp-calypso/pull/82580
* https://github.com/Automattic/jetpack/pull/33045

## Proposed Changes

* We need the Launchpad package to be published on NPM so we can use it on the Launchpad Navigator package. Both packages will be used on jetpack-mu-wpcom, so we can display the Launchpad progress on a modal.

More info:
https://github.com/Automattic/wp-calypso/blob/40811b2929612ebb529ee4bff7ce51bdc61c51e7/docs/monorepo.md#publishing

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visual inspection of the changes

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?