### PR TITLE
Add anon_id to user Signup and Login

### DIFF
--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -1,3 +1,4 @@
+import { getTracksAnonymousUserId } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import emailValidator from 'email-validator';
@@ -90,6 +91,7 @@ class PasswordlessSignupForm extends Component {
 					oauth2_client_id,
 					oauth2_redirect: oauth2_redirect && `0@${ oauth2_redirect }`,
 				} ),
+				anon_id: getTracksAnonymousUserId(),
 			} );
 			this.createAccountCallback( null, response );
 		} catch ( err ) {

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -1,3 +1,4 @@
+import { getTracksAnonymousUserId } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import {
 	WPCOM_DIFM_LITE,
@@ -894,6 +895,7 @@ export function createAccount(
 				client_secret: config( 'wpcom_signup_key' ),
 				...userData,
 				tos: getToSAcceptancePayload(),
+				anon_id: getTracksAnonymousUserId(),
 			},
 			responseHandler( SIGNUP_TYPE_SOCIAL )
 		);
@@ -912,6 +914,7 @@ export function createAccount(
 					client_id: config( 'wpcom_signup_id' ),
 					client_secret: config( 'wpcom_signup_key' ),
 					tos: getToSAcceptancePayload(),
+					anon_id: getTracksAnonymousUserId(),
 				},
 				oauth2Signup
 					? {

--- a/client/state/login/actions/login-social-user.js
+++ b/client/state/login/actions/login-social-user.js
@@ -1,3 +1,4 @@
+import { getTracksAnonymousUserId } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { get } from 'lodash';
 import getToSAcceptancePayload from 'calypso/lib/tos-acceptance-tracking';
@@ -34,6 +35,7 @@ export const loginSocialUser = ( socialInfo, redirectTo ) => ( dispatch ) => {
 		client_id: config( 'wpcom_signup_id' ),
 		client_secret: config( 'wpcom_signup_key' ),
 		tos: JSON.stringify( getToSAcceptancePayload() ),
+		anon_id: getTracksAnonymousUserId(),
 	} )
 		.then( ( response ) => {
 			if ( get( response, 'body.data.two_step_notification_sent' ) === 'sms' ) {

--- a/client/state/login/actions/login-user.js
+++ b/client/state/login/actions/login-user.js
@@ -1,3 +1,4 @@
+import { getTracksAnonymousUserId } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { get } from 'lodash';
 import getToSAcceptancePayload from 'calypso/lib/tos-acceptance-tracking';
@@ -13,7 +14,6 @@ import {
 	getSMSMessageFromResponse,
 	postLoginRequest,
 } from 'calypso/state/login/utils';
-
 import 'calypso/state/login/init';
 
 /**
@@ -38,6 +38,7 @@ export const loginUser = ( usernameOrEmail, password, redirectTo, domain ) => ( 
 		client_secret: config( 'wpcom_signup_key' ),
 		domain: domain,
 		tos: JSON.stringify( getToSAcceptancePayload() ),
+		anon_id: getTracksAnonymousUserId(),
 	} )
 		.then( ( response ) => {
 			if ( get( response, 'body.data.two_step_notification_sent' ) === 'sms' ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

More info: p4qSXL-6N9-p2#comment-20652

This adds the `anon_id` to the Signup and Login flows. This is needed by D124183-code to ensure the ExPlat assignment is maintained across login barrier.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow instructions in D124183-code

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
