### PR TITLE
Update advertising e2e to match new DOM structure in BlazePress

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/blaze-campaign-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/blaze-campaign-page.ts
@@ -56,7 +56,7 @@ export class BlazeCampaignPage {
 	 * @param {string} param0.snippet Expected snippet.
 	 */
 	async validatePreview( { title, snippet }: { title: string; snippet: string } ) {
-		await this.page.locator( '.grid-widget-summary' ).getByText( title ).waitFor();
-		await this.page.locator( '.grid-widget-summary' ).getByText( snippet ).waitFor();
+		await this.page.locator( '.ad-preview-section' ).getByText( title ).waitFor();
+		await this.page.locator( '.ad-preview-section' ).getByText( snippet ).waitFor();
 	}
 }

--- a/test/e2e/specs/tools/advertising__promote.ts
+++ b/test/e2e/specs/tools/advertising__promote.ts
@@ -105,7 +105,7 @@ skipDescribeIf( envVariables.ATOMIC_VARIATION === 'private' )(
 
 		it( 'Enter title and snippet', async function () {
 			await blazeCampaignPage.enterText( 'Page title', pageTitle );
-			await blazeCampaignPage.enterText( 'Article Snippet', snippet );
+			await blazeCampaignPage.enterText( 'Ad text', snippet );
 		} );
 
 		it( 'Validate preview', async function () {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

The actual BlazePress DOM content is version controlled outside of Calypso and rendered via a widget.

There were some updates that were causing our E2E tests to permafail. This makes those updates!

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

PR tests pass

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?