### PR TITLE
Explore adding some basic context to the launchpad navigator

### DIFF
--- a/client/layout/masterbar/masterbar-launchpad-navigator.tsx
+++ b/client/layout/masterbar/masterbar-launchpad-navigator.tsx
@@ -28,7 +28,10 @@ const MasterbarLaunchpadNavigator = () => {
 			/>
 			{ launchpadIsVisible && (
 				<div className="masterbar__launchpad-navigator">
-					<FloatingNavigator siteSlug={ siteSlug } />
+					<FloatingNavigator
+						siteSlug={ siteSlug }
+						toggleLaunchpadIsVisible={ setLaunchpadIsVisible }
+					/>
 				</div>
 			) }
 		</>

--- a/client/layout/masterbar/masterbar-launchpad-navigator.tsx
+++ b/client/layout/masterbar/masterbar-launchpad-navigator.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 import { useSelector } from 'react-redux';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import Item from './item';
+import type { ToggleLaunchpadIsVisible } from '@automattic/launchpad-navigator';
 
 const MasterbarLaunchpadNavigator = () => {
 	const [ launchpadIsVisible, setLaunchpadIsVisible ] = useState( false );
@@ -30,7 +31,7 @@ const MasterbarLaunchpadNavigator = () => {
 				<div className="masterbar__launchpad-navigator">
 					<FloatingNavigator
 						siteSlug={ siteSlug }
-						toggleLaunchpadIsVisible={ setLaunchpadIsVisible }
+						toggleLaunchpadIsVisible={ setLaunchpadIsVisible as ToggleLaunchpadIsVisible }
 					/>
 				</div>
 			) }

--- a/client/layout/masterbar/masterbar-launchpad-navigator.tsx
+++ b/client/layout/masterbar/masterbar-launchpad-navigator.tsx
@@ -5,7 +5,6 @@ import { useState } from 'react';
 import { useSelector } from 'react-redux';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import Item from './item';
-import type { ToggleLaunchpadIsVisible } from '@automattic/launchpad-navigator';
 
 const MasterbarLaunchpadNavigator = () => {
 	const [ launchpadIsVisible, setLaunchpadIsVisible ] = useState( false );
@@ -31,7 +30,7 @@ const MasterbarLaunchpadNavigator = () => {
 				<div className="masterbar__launchpad-navigator">
 					<FloatingNavigator
 						siteSlug={ siteSlug }
-						toggleLaunchpadIsVisible={ setLaunchpadIsVisible as ToggleLaunchpadIsVisible }
+						toggleLaunchpadIsVisible={ setLaunchpadIsVisible }
 					/>
 				</div>
 			) }

--- a/packages/launchpad-navigator/package.json
+++ b/packages/launchpad-navigator/package.json
@@ -34,6 +34,7 @@
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/launchpad": "workspace:^",
 		"classnames": "^2.3.1",
+		"i18n-calypso": "workspace:^",
 		"tslib": "^2.3.0",
 		"wpcom-proxy-request": "workspace:^"
 	},

--- a/packages/launchpad-navigator/src/floating-navigator/index.tsx
+++ b/packages/launchpad-navigator/src/floating-navigator/index.tsx
@@ -1,4 +1,4 @@
-import { Card, Button } from '@automattic/components';
+import { Card, Button, Gridicon } from '@automattic/components';
 import { LaunchpadNavigator } from '@automattic/data-stores';
 import { DefaultWiredLaunchpad } from '@automattic/launchpad';
 import { select } from '@wordpress/data';
@@ -6,11 +6,14 @@ import { useTranslate } from 'i18n-calypso';
 
 import './style.scss';
 
+type ToggleLaunchpadIsVisible = ( shouldBeVisible: boolean ) => void;
+
 export type FloatingNavigatorProps = {
 	siteSlug: string | null;
+	toggleLaunchpadIsVisible?: ToggleLaunchpadIsVisible;
 };
 
-const FloatingNavigator = ( { siteSlug }: FloatingNavigatorProps ) => {
+const FloatingNavigator = ( { siteSlug, toggleLaunchpadIsVisible }: FloatingNavigatorProps ) => {
 	const launchpadContext = 'launchpad-navigator';
 	const translate = useTranslate();
 	const checklistSlug = select( LaunchpadNavigator.store ).getActiveChecklistSlug() || null;
@@ -19,9 +22,21 @@ const FloatingNavigator = ( { siteSlug }: FloatingNavigatorProps ) => {
 		return null;
 	}
 
+	const setLaunchpadIsVisible = toggleLaunchpadIsVisible || ( () => {} );
+
 	return (
 		<Card className="launchpad-navigator__floating-navigator">
-			<h2>{ translate( 'Next steps for your site' ) }</h2>
+			<div className="launchpad-navigator__floating-navigator-header">
+				<h2>{ translate( 'Next steps for your site' ) }</h2>
+				<Button
+					aria-label={ translate( 'Close task list modal' ) }
+					borderless
+					className="launchpad-navigator__floating-navigator-close-button"
+					onClick={ () => setLaunchpadIsVisible( false ) }
+				>
+					<Gridicon icon="cross" size={ 18 } />
+				</Button>
+			</div>
 			<DefaultWiredLaunchpad
 				siteSlug={ siteSlug }
 				checklistSlug={ checklistSlug }

--- a/packages/launchpad-navigator/src/floating-navigator/index.tsx
+++ b/packages/launchpad-navigator/src/floating-navigator/index.tsx
@@ -1,7 +1,8 @@
-import { Card } from '@automattic/components';
+import { Card, Button } from '@automattic/components';
 import { LaunchpadNavigator } from '@automattic/data-stores';
 import { DefaultWiredLaunchpad } from '@automattic/launchpad';
 import { select } from '@wordpress/data';
+import { useTranslate } from 'i18n-calypso';
 
 import './style.scss';
 
@@ -11,6 +12,7 @@ export type FloatingNavigatorProps = {
 
 const FloatingNavigator = ( { siteSlug }: FloatingNavigatorProps ) => {
 	const launchpadContext = 'launchpad-navigator';
+	const translate = useTranslate();
 	const checklistSlug = select( LaunchpadNavigator.store ).getActiveChecklistSlug() || null;
 
 	if ( ! checklistSlug ) {
@@ -19,11 +21,15 @@ const FloatingNavigator = ( { siteSlug }: FloatingNavigatorProps ) => {
 
 	return (
 		<Card className="launchpad-navigator__floating-navigator">
+			<h2>{ translate( 'Next steps for your site' ) }</h2>
 			<DefaultWiredLaunchpad
 				siteSlug={ siteSlug }
 				checklistSlug={ checklistSlug }
 				launchpadContext={ launchpadContext }
 			/>
+			<div className="launchpad-navigator__floating-navigator-actions">
+				<Button disabled>{ translate( 'Older tasks' ) }</Button>
+			</div>
 		</Card>
 	);
 };

--- a/packages/launchpad-navigator/src/floating-navigator/index.tsx
+++ b/packages/launchpad-navigator/src/floating-navigator/index.tsx
@@ -6,7 +6,7 @@ import { useTranslate } from 'i18n-calypso';
 
 import './style.scss';
 
-type ToggleLaunchpadIsVisible = ( shouldBeVisible: boolean ) => void;
+export type ToggleLaunchpadIsVisible = ( shouldBeVisible: boolean ) => void;
 
 export type FloatingNavigatorProps = {
 	siteSlug: string | null;

--- a/packages/launchpad-navigator/src/floating-navigator/index.tsx
+++ b/packages/launchpad-navigator/src/floating-navigator/index.tsx
@@ -6,7 +6,7 @@ import { useTranslate } from 'i18n-calypso';
 
 import './style.scss';
 
-export type ToggleLaunchpadIsVisible = ( shouldBeVisible: boolean ) => void;
+type ToggleLaunchpadIsVisible = ( shouldBeVisible: boolean ) => void;
 
 export type FloatingNavigatorProps = {
 	siteSlug: string | null;

--- a/packages/launchpad-navigator/src/floating-navigator/style.scss
+++ b/packages/launchpad-navigator/src/floating-navigator/style.scss
@@ -11,11 +11,23 @@
 	transition: max-height 0.5s;
 	min-width: 25em;
 
-	h2 {
-		font-family: $font-sf-pro-display;
-		font-size: $font-title-small;
-		font-weight: 500;
-		line-height: 50px;
+	.launchpad-navigator__floating-navigator-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+
+		h2 {
+			font-family: $font-sf-pro-display;
+			font-size: $font-title-small;
+			font-weight: 500;
+			line-height: 50px;
+		}
+
+		.button.is-borderless .gridicon {
+			height: 18px;
+			top: 4px;
+			width: 18px;
+		}
 	}
 
 	.launchpad-navigator__floating-navigator-actions {

--- a/packages/launchpad-navigator/src/floating-navigator/style.scss
+++ b/packages/launchpad-navigator/src/floating-navigator/style.scss
@@ -1,3 +1,5 @@
+@import "@automattic/components/src/styles/typography";
+
 .launchpad-navigator__floating-navigator {
 	position: fixed;
 	top: calc(var(--masterbar-height) + 2px);
@@ -7,4 +9,17 @@
 	z-index: 9999;
 	cursor: default;
 	transition: max-height 0.5s;
+	min-width: 25em;
+
+	h2 {
+		font-family: $font-sf-pro-display;
+		font-size: $font-title-small;
+		font-weight: 500;
+		line-height: 50px;
+	}
+
+	.launchpad-navigator__floating-navigator-actions {
+		display: flex;
+		margin-top: 1em;
+	}
 }

--- a/packages/launchpad-navigator/src/index.ts
+++ b/packages/launchpad-navigator/src/index.ts
@@ -1,3 +1,3 @@
 export { default as FloatingNavigator } from './floating-navigator';
 export { default as LaunchpadNavigatorIcon } from './icon';
-export type { FloatingNavigatorProps } from './floating-navigator';
+export type { FloatingNavigatorProps, ToggleLaunchpadIsVisible } from './floating-navigator';

--- a/packages/launchpad-navigator/src/index.ts
+++ b/packages/launchpad-navigator/src/index.ts
@@ -1,3 +1,3 @@
 export { default as FloatingNavigator } from './floating-navigator';
 export { default as LaunchpadNavigatorIcon } from './icon';
-export type { FloatingNavigatorProps, ToggleLaunchpadIsVisible } from './floating-navigator';
+export type { FloatingNavigatorProps } from './floating-navigator';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1078,6 +1078,7 @@ __metadata:
     "@automattic/i18n-utils": "workspace:^"
     "@automattic/launchpad": "workspace:^"
     classnames: ^2.3.1
+    i18n-calypso: "workspace:^"
     postcss: ^8.4.5
     react: ^18.2.0
     react-dom: ^18.2.0


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* This PR explores adding some basic context and to the `FloatingNavigator` component, as well as improving the styles slightly to align better with the launchpad styles in Customer Home. The specific changes are:
   - Add a (hard-coded) "Next steps for your site" title, with styles to match the list in Customer Home
     * The replicated styles suggests that we should move more of the styles into the core components
   - Add a minimum width to the modal
   - Add an inactive/disabled `Older tasks` button -- this is a placeholder for the "show me older task lists" interaction I've been thinking of
   - Add an X button/icon to allow closing the modal explicitly

Furthermore, I want to call out changes _not_ included in this PR, which should be tackled in follow-ups:
 - The launchpad remains visible when doing client-side routing, which may or may not be what we want, but that should be handled in its own PR
 - The display and hiding of the card isn't smooth, or aligned with the Help Center or Notifications items
 - We are not treating or handling the card as a modal, e.g. when clicking on a task that navigates to a new page, or when clicking outside the card area
 - The Help Center, Notifications bar, and Launchpad Navigator can be stacked on each other, which needs to be untangled and sorted out
 - There seems to be a weird race condition where the tasks for the Customer Home and navigator task lists get re-sorted for some reason. Not sure what's going on for this yet.
 - This PR doesn't fix click handling for tasks that depend on injected functions, e.g. Share Site, where we need a function to show a modal

### Screenshot

<img width="1370" alt="Screenshot 2023-10-10 at 17 03 12" src="https://github.com/Automattic/wp-calypso/assets/3376401/3ca48917-baff-4a1d-bbd6-233538b618a3">

## Testing Instructions

* Run this branch locally or via Calypso.live
* Navigate to Customer Home for a site that is currently showing a task list
* Add `?flags=launchpad/navigator` to the URL
* Click on the launchpad navigator icon in the masterbar to open the modal
* Verify that you see the modal open up at a sufficiently wide starting point, and we show the "Next steps for your site header" while we're loading the checklist content
* Also verify that the modal has an X icon that is correctly clickable with the right cursor display
* Verify that clicking on the X icon closes the Launchpad Navigator
* Click on some of the tasks and verify that you're taken to the correct screens
  - If you're going to another Calypso screen (excluding Stepper screens), the launchpad navigator should remain visible across the transition (at least for now)
  - If you're leaving Calypso, the launchpad navigator should end up being hidden because we're losing both our client-side config state (i.e. the feature flag) _and_ possibly the context

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
