### PR TITLE
Logins: Initial fix for social login via email invite

### DIFF
--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -2,6 +2,53 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
+body {
+	background: #fdfdfd;
+	.invite-logged-out-header {
+		position: absolute;
+		top: 28px;
+		height: 60px;
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+		left: 0;
+		padding: 0 24px;
+		right: 0;
+
+		.wordpress-logo {
+			fill: var(--color-text);
+			margin: 0;
+		}
+
+		a.components-button {
+			color: #1d2327 !important;
+			font-family: "SF Pro Text", sans-serif;
+			font-size: 0.875rem;
+			font-style: normal;
+			font-weight: 500;
+			line-height: 20px;
+			text-underline-offset: 5px;
+			height: 22px;
+		}
+	}
+	.invite-logged-out-title {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		margin: 48px 0 24px;
+
+		.formatted-header__title {
+			margin: 0;
+			font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
+			font-weight: 400;
+			color: #101517;
+			letter-spacing: 0.2px;
+			font-size: 2rem;
+			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+			line-height: 3.25rem;
+		}
+	}
+}
 .signup-form .signup-form__input.form-text-input {
 	margin-bottom: 20px;
 	transition: none;
@@ -49,17 +96,6 @@
 		&:last-child {
 			margin: 10px 0 0;
 		}
-	}
-}
-
-.signup-form__social-buttons {
-	button {
-		display: block;
-		margin: 0 auto 15px;
-		box-shadow:
-			0 1px 1px 0 rgba(0, 0, 0, 0.14),
-			0 2px 1px -1px rgba(0, 0, 0, 0.12),
-			0 1px 3px 0 rgba(0, 0, 0, 0.2);
 	}
 }
 
@@ -137,93 +173,151 @@
 	}
 }
 
+body.is-section-accept-invite,
 body.is-section-signup {
+	.signup-form__social-buttons {
+		display: flex;
+		flex-direction: column;
+		height: 100%;
+		justify-content: center;
+		gap: 16px;
+	}
 
-	.signup__step.is-user {
+	.social-buttons__button {
+		display: flex;
+		height: 48px;
+		padding: 4px 16px !important;
+		justify-content: center;
+		align-items: center;
+		align-self: stretch;
+		border-radius: 4px;
+		border: 1px solid var(--studio-gray-50, #646970) !important;
+		background: var(--black-white-white, #fff);
+		margin-bottom: 0;
 
-		.signup-form-social-first {
-			width: 327px;
-			margin: 0 auto;
+		text-align: start;
+		padding-left: 0;
+		padding-bottom: 0;
+		box-shadow: none;
+		background-color: transparent;
 
-			.signup-form__social {
-				padding: 0 !important;
-			}
+		&:hover {
+			background: var(--studio-gray-0, #f6f7f7);
+		}
 
-			.signup-form-social-first__tos-link {
+		&:focus {
+			background: var(--studio-gray-0, #f6f7f7);
+			outline: 2px solid var(--studio-gray-90, #1d2327);
+			outline-offset: 1px;
+		}
+
+		@include break-small {
+			text-align: center;
+		}
+
+		@include break-medium {
+			text-align: start;
+		}
+
+		>svg {
+			margin-right: auto;
+		}
+
+		span {
+			color: var(--studio-gray-80, #2c3338);
+			font-feature-settings: "clig" off, "liga" off;
+			font-family: "SF Pro Text", sans-serif;
+			font-size: 0.875rem;
+			font-style: normal;
+			font-weight: 500;
+			line-height: normal;
+			letter-spacing: 0.32px;
+			margin-right: auto;
+			margin-left: -20px;
+		}
+	}
+	.signup-form-social-first {
+		width: 327px;
+		margin: 0 auto;
+
+		.signup-form__social {
+			padding: 0 !important;
+		}
+
+		.signup-form-social-first__tos-link {
+			color: var(--studio-gray-50, #646970);
+			text-align: center;
+			font-family: "SF Pro Text", sans-serif;
+			font-size: 0.75rem;
+			font-style: normal;
+			font-weight: 400;
+			line-height: 18px;
+			margin-top: 32px;
+
+			a {
 				color: var(--studio-gray-50, #646970);
-				text-align: center;
-				font-family: "SF Pro Text", sans-serif;
-				font-size: 0.75rem;
-				font-style: normal;
-				font-weight: 400;
-				line-height: 18px;
-				margin-top: 32px;
+				text-decoration-line: underline;
+			}
+		}
+	}
 
-				a {
-					color: var(--studio-gray-50, #646970);
-					text-decoration-line: underline;
-				}
+	.signup-form-social-first-email {
+		.card {
+			box-shadow: none;
+			padding-left: 0;
+			padding-right: 0;
+
+			button {
+				display: block;
+				max-width: 327px;
+				margin: 0 auto;
 			}
 		}
 
-		.signup-form-social-first-email {
-			.card {
+		.form-label {
+			color: var(--studio-gray-60, #50575e);
+			font-family: "SF Pro Text", sans-serif;
+			font-size: 0.875rem;
+			font-style: normal;
+			font-weight: 500;
+			line-height: 20px;
+		}
+
+		.logged-out-form__footer {
+			margin-top: 16px;
+		}
+
+		button.back-button {
+			color: #1d2327;
+			text-align: center;
+			font-family: "SF Pro Text", sans-serif;
+			font-size: 0.875rem;
+			font-style: normal;
+			font-weight: 500;
+			line-height: 20px;
+			display: block;
+			margin: 0 auto;
+			text-underline-offset: 5px;
+
+			&:hover {
+				color: var(--studio-blue-50, #0675c4);
+			}
+
+			&:focus {
+				outline: 1px dashed var(--studio-blue-50, #0675c4);
+				outline-offset: 3px;
 				box-shadow: none;
-				padding-left: 0;
-				padding-right: 0;
-
-				button {
-					display: block;
-					max-width: 327px;
-					margin: 0 auto;
-				}
+				border-radius: 0;
 			}
+		}
 
-			.form-label {
-				color: var(--studio-gray-60, #50575e);
-				font-family: "SF Pro Text", sans-serif;
-				font-size: 0.875rem;
-				font-style: normal;
-				font-weight: 500;
-				line-height: 20px;
-			}
+		button.button {
+			border-radius: 4px;
 
-			.logged-out-form__footer {
-				margin-top: 16px;
-			}
-
-			button.back-button {
-				color: #1d2327;
-				text-align: center;
-				font-family: "SF Pro Text", sans-serif;
-				font-size: 0.875rem;
-				font-style: normal;
-				font-weight: 500;
-				line-height: 20px;
-				display: block;
-				margin: 0 auto;
-				text-underline-offset: 5px;
-
-				&:hover {
-					color: var(--studio-blue-50, #0675c4);
-				}
-
-				&:focus {
-					outline: 1px dashed var(--studio-blue-50, #0675c4);
-					outline-offset: 3px;
-					box-shadow: none;
-					border-radius: 0;
-				}
-			}
-
-			button.button {
-				border-radius: 4px;
-
-				&:focus {
-					box-shadow: none;
-					outline: 2px solid var(--studio-blue-60, #055d9c);
-					outline-offset: 1px;
-				}
+			&:focus {
+				box-shadow: none;
+				outline: 2px solid var(--studio-blue-60, #055d9c);
+				outline-offset: 1px;
 			}
 		}
 	}

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -2,53 +2,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-body {
-	background: #fdfdfd;
-	.invite-logged-out-header {
-		position: absolute;
-		top: 28px;
-		height: 60px;
-		display: flex;
-		flex-direction: row;
-		justify-content: space-between;
-		left: 0;
-		padding: 0 24px;
-		right: 0;
-
-		.wordpress-logo {
-			fill: var(--color-text);
-			margin: 0;
-		}
-
-		a.components-button {
-			color: #1d2327 !important;
-			font-family: "SF Pro Text", sans-serif;
-			font-size: 0.875rem;
-			font-style: normal;
-			font-weight: 500;
-			line-height: 20px;
-			text-underline-offset: 5px;
-			height: 22px;
-		}
-	}
-	.invite-logged-out-title {
-		display: flex;
-		justify-content: center;
-		align-items: center;
-		margin: 48px 0 24px;
-
-		.formatted-header__title {
-			margin: 0;
-			font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
-			font-weight: 400;
-			color: #101517;
-			letter-spacing: 0.2px;
-			font-size: 2rem;
-			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-			line-height: 3.25rem;
-		}
-	}
-}
 .signup-form .signup-form__input.form-text-input {
 	margin-bottom: 20px;
 	transition: none;

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -280,7 +280,7 @@ export default withCurrentRoute(
 		const isPopup = '1' === currentQuery?.is_popup;
 		const noMasterbarForSection =
 			! isWooOAuth2Client( oauth2Client ) &&
-			[ 'signup', 'jetpack-connect' ].includes( sectionName );
+			[ 'accept-invite', 'signup', 'jetpack-connect' ].includes( sectionName );
 		const isJetpackWooCommerceFlow = 'woocommerce-onboarding' === currentQuery?.from;
 		const isWooCoreProfilerFlow = isWooCommerceCoreProfilerFlow( state );
 		const wccomFrom = currentQuery?.[ 'wccom-from' ];

--- a/client/my-sites/invites/invite-accept-logged-out/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-out/index.jsx
@@ -156,6 +156,31 @@ class InviteAcceptLoggedOut extends Component {
 		);
 	};
 
+	renderFormTitle = () => {
+		return (
+			<>
+				{ this.renderPageLogin() }
+				<div className="invite-logged-out-title">
+					<h1 className="formatted-header__title">
+						{ this.props.translate( 'Create your account' ) }
+					</h1>
+				</div>
+			</>
+		);
+	};
+
+	renderPageLogin = () => {
+		return (
+			<div className="invite-logged-out-header">
+				<WordPressLogo size={ 24 } />
+
+				<Button href={ '/log-in?redirect_to=' + window.location.href } variant="link">
+					<span>{ this.props.translate( 'Log in' ) }</span>
+				</Button>
+			</div>
+		);
+	};
+
 	render() {
 		if ( this.props.forceMatchingEmail && this.props.invite.knownUser ) {
 			return this.renderSignInLinkOnly();
@@ -175,18 +200,7 @@ class InviteAcceptLoggedOut extends Component {
 
 		return (
 			<div>
-				<div className="invite-logged-out-header">
-					<WordPressLogo size={ 24 } />
-
-					<Button href="" variant="link">
-						<span>{ this.props.translate( 'Log in' ) }</span>
-					</Button>
-				</div>
-				<div className="invite-logged-out-title">
-					<h1 className="formatted-header__title">
-						{ this.props.translate( 'Create your account' ) }
-					</h1>
-				</div>
+				{ this.renderFormTitle() }
 				<SignupForm
 					redirectToAfterLoginUrl={ window.location.href }
 					disabled={ this.state.submitting }

--- a/client/my-sites/invites/invite-accept-logged-out/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-out/index.jsx
@@ -158,14 +158,11 @@ class InviteAcceptLoggedOut extends Component {
 
 	renderFormTitle = () => {
 		return (
-			<>
-				{ this.renderPageLogin() }
-				<div className="invite-logged-out-title">
-					<h1 className="formatted-header__title">
-						{ this.props.translate( 'Create your account' ) }
-					</h1>
-				</div>
-			</>
+			<div className="invite-logged-out-title">
+				<h1 className="formatted-header__title">
+					{ this.props.translate( 'Create your account' ) }
+				</h1>
+			</div>
 		);
 	};
 
@@ -200,6 +197,7 @@ class InviteAcceptLoggedOut extends Component {
 
 		return (
 			<div>
+				{ this.renderPageLogin() }
 				{ this.renderFormTitle() }
 				<SignupForm
 					redirectToAfterLoginUrl={ window.location.href }

--- a/client/my-sites/invites/invite-accept-logged-out/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-out/index.jsx
@@ -1,4 +1,5 @@
 import { Card } from '@automattic/components';
+import { Button } from '@wordpress/components';
 import debugModule from 'debug';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
@@ -9,6 +10,7 @@ import SignupForm from 'calypso/blocks/signup-form';
 import FormButton from 'calypso/components/forms/form-button';
 import LoggedOutFormLinkItem from 'calypso/components/logged-out-form/link-item';
 import LoggedOutFormLinks from 'calypso/components/logged-out-form/links';
+import WordPressLogo from 'calypso/components/wordpress-logo';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { login } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/route';
@@ -173,6 +175,18 @@ class InviteAcceptLoggedOut extends Component {
 
 		return (
 			<div>
+				<div className="invite-logged-out-header">
+					<WordPressLogo size={ 24 } />
+
+					<Button href="" variant="link">
+						<span>{ this.props.translate( 'Log in' ) }</span>
+					</Button>
+				</div>
+				<div className="invite-logged-out-title">
+					<h1 className="formatted-header__title">
+						{ this.props.translate( 'Create your account' ) }
+					</h1>
+				</div>
 				<SignupForm
 					redirectToAfterLoginUrl={ window.location.href }
 					disabled={ this.state.submitting }

--- a/client/my-sites/invites/invite-accept/style.scss
+++ b/client/my-sites/invites/invite-accept/style.scss
@@ -1,3 +1,52 @@
+
+body {
+	background: #fdfdfd;
+	.invite-logged-out-header {
+		position: absolute;
+		top: 28px;
+		height: 60px;
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+		left: 0;
+		padding: 0 24px;
+		right: 0;
+
+		.wordpress-logo {
+			fill: var(--color-text);
+			margin: 0;
+		}
+
+		a.components-button {
+			color: var(--studio-gray-90, #1d2327) !important;
+			font-family: "SF Pro Text", sans-serif;
+			font-size: 0.875rem;
+			font-style: normal;
+			font-weight: 500;
+			line-height: 20px;
+			text-underline-offset: 5px;
+			height: 22px;
+		}
+	}
+	.invite-logged-out-title {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		margin: 48px 0 24px;
+
+		.formatted-header__title {
+			margin: 0;
+			font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
+			font-weight: 400;
+			color: #101517;
+			letter-spacing: 0.2px;
+			font-size: 2rem;
+			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+			line-height: 3.25rem;
+		}
+
+	}
+}
 .invite-accept .locale-suggestions {
 	margin-top: 0;
 }

--- a/client/my-sites/invites/invite-accept/style.scss
+++ b/client/my-sites/invites/invite-accept/style.scss
@@ -46,6 +46,17 @@ body {
 		}
 
 	}
+	.logged-out-form__footer {
+		button.is-primary {
+			background-color: #117ac9;
+			border-color: transparent !important;
+			&:hover,
+			&:focus {
+				background-color: var(--studio-blue-60);
+			}
+		}
+	}
+
 }
 .invite-accept .locale-suggestions {
 	margin-top: 0;

--- a/client/my-sites/invites/invite-accept/style.scss
+++ b/client/my-sites/invites/invite-accept/style.scss
@@ -5,6 +5,7 @@
 .invite-accept__form {
 	margin: 0 auto;
 	max-width: 400px;
+	margin-top: 25vh;
 
 	&.is-error {
 		max-width: none;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/82560

## Proposed Changes

The new social login broke the login via email invite, this PR fixes it by making this type of login also part of https://github.com/Automattic/wp-calypso/pull/82121.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


- Create or open a site and invite another user
- This user should receive an email with a link to join the site
- Replace the `wordpress.com` for the live link generated by calypso and navigate to it
- It should look and behave like the newly created https://github.com/Automattic/wp-calypso/pull/82121

Please also test other flows to make sure they all look and work fine.

Example:
Link in Bio
Newsletter
Domain-transfer

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?