### PR TITLE
Fix: verified provider component shows the hosting provider

### DIFF
--- a/client/site-profiler/components/domain-information/index.tsx
+++ b/client/site-profiler/components/domain-information/index.tsx
@@ -79,7 +79,7 @@ export default function DomainInformation( props: Props ) {
 								<VerifiedProvider
 									hostingProvider={ hostingProvider }
 									urlData={ urlData }
-									showHosting={ true }
+									showHostingProvider={ false }
 								/>
 							) }
 							{ whois.registrar_url &&

--- a/client/site-profiler/components/domain-information/index.tsx
+++ b/client/site-profiler/components/domain-information/index.tsx
@@ -76,7 +76,11 @@ export default function DomainInformation( props: Props ) {
 						<div className="name">{ translate( 'Registrar' ) }</div>
 						<div>
 							{ whois.registrar_url?.toLowerCase().includes( 'automattic' ) && (
-								<VerifiedProvider hostingProvider={ hostingProvider } urlData={ urlData } />
+								<VerifiedProvider
+									hostingProvider={ hostingProvider }
+									urlData={ urlData }
+									showHosting={ true }
+								/>
 							) }
 							{ whois.registrar_url &&
 								! whois.registrar_url?.toLowerCase().includes( 'automattic' ) && (

--- a/client/site-profiler/components/domain-information/verified-provider.tsx
+++ b/client/site-profiler/components/domain-information/verified-provider.tsx
@@ -8,11 +8,11 @@ import useHostingProviderURL from 'calypso/site-profiler/hooks/use-hosting-provi
 interface Props {
 	hostingProvider?: HostingProvider;
 	urlData?: UrlData;
-	showHosting: boolean;
+	showHostingProvider: boolean;
 }
 
 export default function VerifiedProvider( props: Props ) {
-	const { hostingProvider, urlData, showHosting } = props;
+	const { hostingProvider, urlData, showHostingProvider } = props;
 	const hostingProviderName = useHostingProviderName( hostingProvider, urlData );
 	const hostingProviderHomepage = useHostingProviderURL( 'homepage', hostingProvider, urlData );
 	const hostingProviderLogin = useHostingProviderURL( 'login', hostingProvider, urlData );
@@ -23,15 +23,13 @@ export default function VerifiedProvider( props: Props ) {
 				{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
 				<Gridicon icon="checkmark" size={ 10 } />
 			</span>
-			<a href={ showHosting ? 'https://wordpress.com' : hostingProviderHomepage }>
-				{ showHosting ? translate( 'WordPress.com' ) : hostingProviderName }
+			<a href={ showHostingProvider ? hostingProviderHomepage : 'https://wordpress.com' }>
+				{ showHostingProvider ? hostingProviderName : translate( 'WordPress.com' ) }
 			</a>
-			{ ! showHosting && (
-				<>
-					&nbsp;&nbsp;
-					<a href={ hostingProviderLogin }>({ translate( 'login' ) })</a>
-				</>
-			) }
+			&nbsp;&nbsp;
+			<a href={ showHostingProvider ? hostingProviderLogin : 'https://wordpress.com/login' }>
+				({ translate( 'login' ) })
+			</a>
 		</>
 	);
 }

--- a/client/site-profiler/components/domain-information/verified-provider.tsx
+++ b/client/site-profiler/components/domain-information/verified-provider.tsx
@@ -8,10 +8,11 @@ import useHostingProviderURL from 'calypso/site-profiler/hooks/use-hosting-provi
 interface Props {
 	hostingProvider?: HostingProvider;
 	urlData?: UrlData;
+	showHosting: boolean;
 }
 
 export default function VerifiedProvider( props: Props ) {
-	const { hostingProvider, urlData } = props;
+	const { hostingProvider, urlData, showHosting } = props;
 	const hostingProviderName = useHostingProviderName( hostingProvider, urlData );
 	const hostingProviderHomepage = useHostingProviderURL( 'homepage', hostingProvider, urlData );
 	const hostingProviderLogin = useHostingProviderURL( 'login', hostingProvider, urlData );
@@ -22,9 +23,15 @@ export default function VerifiedProvider( props: Props ) {
 				{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
 				<Gridicon icon="checkmark" size={ 10 } />
 			</span>
-			<a href={ hostingProviderHomepage }>{ hostingProviderName }</a>
-			&nbsp;&nbsp;
-			<a href={ hostingProviderLogin }>({ translate( 'login' ) })</a>
+			<a href={ showHosting ? 'https://wordpress.com' : hostingProviderHomepage }>
+				{ showHosting ? translate( 'WordPress.com' ) : hostingProviderName }
+			</a>
+			{ ! showHosting && (
+				<>
+					&nbsp;&nbsp;
+					<a href={ hostingProviderLogin }>({ translate( 'login' ) })</a>
+				</>
+			) }
 		</>
 	);
 }

--- a/client/site-profiler/components/hosting-information/hosting-provider-name.tsx
+++ b/client/site-profiler/components/hosting-information/hosting-provider-name.tsx
@@ -52,7 +52,11 @@ export default function HostingProviderName( props: Props ) {
 		<div className="hosting-provider-name__container">
 			{ hostingProvider?.slug !== 'automattic' && <NonA8cHostingName /> }
 			{ hostingProvider?.slug === 'automattic' && (
-				<VerifiedProvider hostingProvider={ hostingProvider } urlData={ urlData } />
+				<VerifiedProvider
+					hostingProvider={ hostingProvider }
+					urlData={ urlData }
+					showHosting={ false }
+				/>
 			) }
 		</div>
 	);

--- a/client/site-profiler/components/hosting-information/hosting-provider-name.tsx
+++ b/client/site-profiler/components/hosting-information/hosting-provider-name.tsx
@@ -55,7 +55,7 @@ export default function HostingProviderName( props: Props ) {
 				<VerifiedProvider
 					hostingProvider={ hostingProvider }
 					urlData={ urlData }
-					showHosting={ false }
+					showHostingProvider={ true }
 				/>
 			) }
 		</div>


### PR DESCRIPTION
Context: p1696422641343489-slack-C01A60HCGUA
Fixes: https://github.com/Automattic/wp-calypso/issues/82598

## Proposed Changes

* Fix the verified provider output

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* http://calypso.localhost:3000/site-profiler?domain=wecanwang.com should be "Pressable" and "WordPress.com"
* http://calypso.localhost:3000/site-profiler?domain=cagrimmett.com should be "Pressable" and "Tucows"
* http://calypso.localhost:3000/site-profiler?domain=home.blog should be "WordPress.com" and "Knock knock"
* Other domains must work as well.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?