### PR TITLE
Gardening action: enable new board automation task

### DIFF
--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -44,4 +44,6 @@ jobs:
          slack_team_channel: ${{ secrets.SLACK_TEAM_CHANNEL }}
          slack_he_triage_channel: ${{ secrets.SLACK_HE_TRIAGE_CHANNEL }}
          slack_quality_channel: ${{ secrets.SLACK_QUALITY_CHANNEL }}
-         tasks: 'assignIssues,cleanLabels,notifyDesign,notifyEditorial,flagOss,triageIssues,gatherSupportReferences,replyToCustomersReminder'
+         triage_projects_token: ${{ secrets.PROJECT_AUTOMATION_TOKEN }}
+         project_board_url: ${{ secrets.PROJECT_BOARD_URL }}
+         tasks: 'assignIssues,cleanLabels,notifyDesign,notifyEditorial,flagOss,triageIssues,gatherSupportReferences,replyToCustomersReminder,updateBoard'


### PR DESCRIPTION
Replaces #80931

> **Warning**
> This is on hold until https://github.com/Automattic/jetpack/pull/33469 gets merged

## Proposed Changes

This task was created in https://github.com/Automattic/jetpack/pull/33469

By enabling it, we'll be able to automate some of the column updates in "The One Board" when labels are updated in issues in this repo.

> **Note**
> The necessary secrets have already been added to this repo.

Related discussion: pciE2j-2u3-p2#comment-2359

## Testing Instructions

This cannot be tested before merge. We'll need to have it merge and then make changes to the Priority label in an issue that's already on the board to see it work.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
