### PR TITLE
Refactor cleanup domain suggestions and log

### DIFF
--- a/client/my-sites/plans-features-main/hooks/use-suggested-free-domain-from-paid-domain.ts
+++ b/client/my-sites/plans-features-main/hooks/use-suggested-free-domain-from-paid-domain.ts
@@ -3,7 +3,7 @@ import { DomainSuggestions } from '@automattic/data-stores';
 import { logToLogstash } from 'calypso/lib/logstash';
 import type { DataResponse } from 'calypso/my-sites/plans-grid/types';
 
-export function useGetFreeSubdomainSuggestion( query: string ): {
+export function useGetFreeSubdomainSuggestion( query: string | null ): {
 	wpcomFreeDomainSuggestion: DataResponse< DomainSuggestions.DomainSuggestion >;
 	invalidateDomainSuggestionCache: () => void;
 } {
@@ -16,7 +16,7 @@ export function useGetFreeSubdomainSuggestion( query: string ): {
 
 	const result = ( ! isError && wordPressSubdomainSuggestions?.[ 0 ] ) || undefined;
 
-	if ( ! isLoading && ! result ) {
+	if ( query && ! isLoading && ! result ) {
 		logToLogstash( {
 			feature: 'calypso_client',
 			message: `Sub domain suggestion wasn't available for query: ${ query }`,

--- a/packages/data-stores/src/domain-suggestions/queries.ts
+++ b/packages/data-stores/src/domain-suggestions/queries.ts
@@ -51,7 +51,8 @@ export function useGetDomainSuggestions(
 
 	return {
 		...result,
-		invalidateCache: () => queryClient.invalidateQueries( queryKey ),
+		invalidateCache: () =>
+			queryClient.invalidateQueries( [ 'domain-suggestions', search, searchOptions ] ),
 	};
 }
 

--- a/packages/data-stores/src/domain-suggestions/queries.ts
+++ b/packages/data-stores/src/domain-suggestions/queries.ts
@@ -6,27 +6,20 @@ import type { DomainSuggestion, DomainSuggestionSelectorOptions } from './types'
 
 const STALE_TIME = 1000 * 60 * 5; // 5 minutes
 
-function getDomainSuggestionsQueryKey(
-	search: string,
-	options: DomainSuggestionSelectorOptions = {}
-) {
-	return [ 'domain-suggestions', search, options ];
-}
-
 export function useGetDomainSuggestions(
-	search: string,
+	search?: string | null,
 	searchOptions: DomainSuggestionSelectorOptions = {},
 	queryOptions = {}
 ) {
-	const queryKey = getDomainSuggestionsQueryKey( search, searchOptions );
 	const queryClient = useQueryClient();
 	const result = useQuery( {
-		queryKey,
+		queryKey: [ 'domain-suggestions', search, searchOptions ],
 		queryFn: async () => {
-			const queryObject = normalizeDomainSuggestionQuery( search, searchOptions );
-			if ( ! queryObject.query ) {
-				throw new Error( 'Empty query' );
+			if ( ! search ) {
+				return [];
 			}
+			const queryObject = normalizeDomainSuggestionQuery( search, searchOptions );
+
 			const suggestions: DomainSuggestion[] = await wpcomProxyRequest( {
 				apiVersion: '1.1',
 				path: '/domains/suggestions',
@@ -65,7 +58,7 @@ export function useGetDomainSuggestions(
 /**
  * Returns the expected *.wordpress.com for a given domain name
  */
-export function useGetWordPressSubdomain( paidDomainName: string ) {
+export function useGetWordPressSubdomain( paidDomainName?: string | null ) {
 	return useGetDomainSuggestions( paidDomainName, {
 		quantity: 1,
 		include_wordpressdotcom: true,
@@ -78,7 +71,7 @@ export function useGetWordPressSubdomain( paidDomainName: string ) {
 /**
  * Returns a custom .com domain suggestion for a given query
  */
-export function useGetSingleCustomDotComDomainSuggestion( query: string, locale?: string ) {
+export function useGetSingleCustomDotComDomainSuggestion( query?: string | null, locale?: string ) {
 	return useGetDomainSuggestions( query, {
 		quantity: 1,
 		include_wordpressdotcom: false,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes
* Prevents a log if the domain is empty
* Refactors domain suggestion hook to accept empty values so that it can be used in contexts where a domain query is not guaranteed.
* The issue relates to a situation where the hook was being used in a non typescript context where the domain query could be null.

https://github.com/Automattic/wp-calypso/blob/2017f6e1154ab51ae85ce393435ed9e6fb1c9c54/client/my-sites/plans-features-main/index.tsx#L282-L285

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through the `/start` flow
* Make sure the Free domain is selected
* Make sure a Free plan is selected
* Make sure a domain suggestion is shown
<img width="1716" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3422709/f0697eca-0e36-41ad-bc1e-66d89df37e23">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?