### PR TITLE
Discover tag_popular feed - remove age based decay

### DIFF
--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -30,6 +30,7 @@ const noop = () => {};
  * `following`
  * `site:1234`
  * `search:a:value` ( prefix is `search`, suffix is `a:value` )
+ *
  * @param  {string} streamKey The stream ID to break apart
  * @returns {string}          The stream ID suffix
  */
@@ -312,7 +313,6 @@ const streamApis = {
 				tags: streamKeySuffix( streamKey ),
 				tag_recs_per_card: 5,
 				site_recs_per_card: 5,
-				age_based_decay: 0.5,
 			} ),
 	},
 	list: {
@@ -326,6 +326,7 @@ const streamApis = {
 
 /**
  * Request a page for the given stream
+ *
  * @param  {Object}   action   Action being handled
  * @returns {Object | undefined} http action for data-layer to dispatch
  */


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* removes the age_based_decay property from the tag_popular stream. (note, we will continue to use this for the discover sections tags tabs).

#### Notes and History:

We recently updated both tags tabs in the Discover section as well as the 'Popular' section of individual tags feeds with this new `age_based_decay` param. The idea was that without this param, feeds felt too stagnant day to day by having the same top result(s) for a few days at a time.

Recently I was talking with @davemart-in about how the "Popular" tab in the tags pages can feel odd, as with many less commonly used tags the age decay causes the results to quickly be not super popular or highly engaged posts. His suggestion was to keep the decay in place for the discover tags tabs, but to remove it from the "Popular" section of tags pages and allow them to showcase a longer list of popular results not as highly constrained by date. 

<img width="836" alt="Screenshot 2023-10-04 at 12 54 18 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/9d114e74-e56b-4e87-9d2d-514a2c014ffb">

Here we remove this decay from the tags popular feeds (reverting to default behavior and age decay that is present within the stream), but we continue to use this functionality for the discover tags tabs.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso build
* Go to an individual tags page, on the "popular" tab.
* Verify there are more engaging posts (higher comments/likes) towards the top of the feed compared to production. Its ok if these posts are a few days old.
* You can try this with a more commonly used tag (like `photography`), as well as the extreme of less commonly used tags (like `yarn`). In either case, there should be more popular results.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
