### PR TITLE
Vdimitrakis/selfserve 775/add ad preview modal in campaign details

### DIFF
--- a/client/my-sites/promote-post-i2/components/ad-preview/index.tsx
+++ b/client/my-sites/promote-post-i2/components/ad-preview/index.tsx
@@ -1,14 +1,18 @@
 import './style.scss';
 import classNames from 'classnames';
 import { useEffect } from 'react';
+import { BannerWidth } from 'calypso/my-sites/promote-post-i2/components/campaign-item-details/AdPreviewModal';
 
 interface Props {
 	htmlCode: string;
 	templateFormat: string;
 	isLoading?: boolean;
+	width?: BannerWidth;
 }
 
-export default function AdPreview( { htmlCode, isLoading, templateFormat }: Props ) {
+export default function AdPreview( { htmlCode, isLoading, templateFormat, width }: Props ) {
+	const adWidth = width ? `${ width }px` : '300px';
+
 	useEffect( () => {
 		if ( ! isLoading && templateFormat === 'html5_v2' ) {
 			// we only need this listener to resize the iframe for html5_v2 templates
@@ -49,7 +53,7 @@ export default function AdPreview( { htmlCode, isLoading, templateFormat }: Prop
 	} );
 
 	return (
-		<div className={ classes }>
+		<div className={ classes } style={ { width: adWidth } }>
 			<iframe srcDoc={ htmlCode } title="adPreview" />
 		</div>
 	);

--- a/client/my-sites/promote-post-i2/components/ad-preview/index.tsx
+++ b/client/my-sites/promote-post-i2/components/ad-preview/index.tsx
@@ -11,7 +11,7 @@ interface Props {
 }
 
 export default function AdPreview( { htmlCode, isLoading, templateFormat, width }: Props ) {
-	const adWidth = width ? `${ width }px` : '300px';
+	const adWidth = width ? `${ width }` : '300px';
 
 	useEffect( () => {
 		if ( ! isLoading && templateFormat === 'html5_v2' ) {

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/AdPreviewModal.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/AdPreviewModal.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import AdPreview from 'calypso/my-sites/promote-post-i2/components/ad-preview';
 
 type Device = 'mobile' | 'tablet' | 'desktop';
-export type BannerWidth = 300 | 500 | 650;
+export type BannerWidth = '300px' | '500px' | '650px' | '100%';
 
 type Props = {
 	templateFormat?: string | undefined;
@@ -97,11 +97,11 @@ const AdPreviewModal: React.FC< Props > = ( { templateFormat, htmlCode, isLoadin
 	function getPreviewWidth( device: Device ): BannerWidth {
 		switch ( device ) {
 			case 'mobile':
-				return 300;
+				return '300px';
 			case 'tablet':
-				return 500;
+				return '500px';
 			case 'desktop':
-				return 650;
+				return '650px';
 		}
 	}
 

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/AdPreviewModal.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/AdPreviewModal.tsx
@@ -1,0 +1,189 @@
+import { Modal } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import classNames from 'classnames';
+import AdPreview from 'calypso/my-sites/promote-post-i2/components/ad-preview';
+
+type Device = 'mobile' | 'tablet' | 'desktop';
+export type BannerWidth = 300 | 500 | 650;
+
+type Props = {
+	templateFormat?: string | undefined;
+	isLoading?: boolean;
+	htmlCode?: string | undefined;
+};
+
+const AdPreviewModal: React.FC< Props > = ( { templateFormat, htmlCode, isLoading } ) => {
+	const [ isOpen, setOpen ] = useState( false );
+	const openModal = () => setOpen( true );
+	const closeModal = () => setOpen( false );
+
+	const [ previewSelected, setPreviewSelected ] = useState< Device >( 'mobile' );
+
+	const MobileIcon = () => {
+		const color = previewSelected === 'mobile' ? 'var( --studio-gray-80 )' : 'var( --color-link )';
+		return (
+			<svg
+				width="18px"
+				height="18px"
+				viewBox="0 0 18 18"
+				fill="none"
+				xmlns="http://www.w3.org/2000/svg"
+			>
+				<path d="M9.8,12.3H8.2v1.2h1.7V12.3z" fill={ color } />
+				<path
+					fillRule="evenodd"
+					clipRule="evenodd"
+					d="M4.8,4c0-0.9,0.7-1.7,1.7-1.7h5c0.9,0,1.7,0.7,1.7,1.7v10c0,0.9-0.7,1.7-1.7,1.7h-5c-0.9,0-1.7-0.7-1.7-1.7V4z M6.5,3.6h5c0.2,0,0.4,0.2,0.4,0.4v10c0,0.2-0.2,0.4-0.4,0.4h-5c-0.2,0-0.4-0.2-0.4-0.4V4C6.1,3.8,6.3,3.6,6.5,3.6z"
+					fill={ color }
+				/>
+			</svg>
+		);
+	};
+
+	const TabletIcon = () => {
+		const color = previewSelected === 'tablet' ? 'var( --studio-gray-80 )' : 'var( --color-link )';
+		return (
+			<svg
+				width="18px"
+				height="18px"
+				viewBox="0 0 18 18"
+				fill="none"
+				xmlns="http://www.w3.org/2000/svg"
+			>
+				<path d="M10.7,12.3H7.3v1.2h3.3V12.3z" fill={ color } />
+				<path
+					fillRule="evenodd"
+					clipRule="evenodd"
+					d="M3.2,4c0-0.9,0.7-1.7,1.7-1.7h8.3c0.9,0,1.7,0.7,1.7,1.7v10c0,0.9-0.7,1.7-1.7,1.7H4.8c-0.9,0-1.7-0.7-1.7-1.7 V4z M4.8,3.6h8.3c0.2,0,0.4,0.2,0.4,0.4v10c0,0.2-0.2,0.4-0.4,0.4H4.8c-0.2,0-0.4-0.2-0.4-0.4V4C4.4,3.8,4.6,3.6,4.8,3.6z"
+					fill={ color }
+				/>
+			</svg>
+		);
+	};
+
+	const DesktopIcon = () => {
+		const color = previewSelected === 'desktop' ? 'var( --studio-gray-80 )' : 'var( --color-link )';
+		return (
+			<svg
+				width="18px"
+				height="18px"
+				viewBox="0 0 18 18"
+				fill="none"
+				xmlns="http://www.w3.org/2000/svg"
+			>
+				<path
+					fillRule="evenodd"
+					clipRule="evenodd"
+					d="M2.5,5.9c0-0.9,0.7-1.7,1.7-1.7h9.6c0.9,0,1.7,0.7,1.7,1.7v6.7h0.6c0.7,0,1.2,0.6,1.2,1.2H0.7	c0-0.7,0.6-1.2,1.2-1.2h0.6V5.9z M4.2,5.5h9.6c0.2,0,0.4,0.2,0.4,0.4v6.3H3.8V5.9C3.8,5.6,4,5.5,4.2,5.5z"
+					fill={ color }
+				/>
+			</svg>
+		);
+	};
+
+	function showMobilePreview() {
+		setPreviewSelected( 'mobile' );
+	}
+
+	function showTabletPreview() {
+		setPreviewSelected( 'tablet' );
+	}
+
+	function showDesktopPreview() {
+		setPreviewSelected( 'desktop' );
+	}
+
+	function getPreviewWidth( device: Device ): BannerWidth {
+		switch ( device ) {
+			case 'mobile':
+				return 300;
+			case 'tablet':
+				return 500;
+			case 'desktop':
+				return 650;
+		}
+	}
+
+	const PreviewIcon = () => {
+		return (
+			<svg
+				width="20"
+				height="20"
+				viewBox="0 0 20 20"
+				fill="none"
+				xmlns="http://www.w3.org/2000/svg"
+				className="ad-preview-icon"
+			>
+				<path
+					fillRule="evenodd"
+					clipRule="evenodd"
+					d="M3.33301 16.666L3.33301 3.33268L4.58301 3.33268L4.58301 16.666L3.33301 16.666ZM7.91634 4.99935L7.91634 14.9993C7.91634 15.2295 8.10289 15.416 8.33301 15.416L11.6663 15.416C11.8965 15.416 12.083 15.2295 12.083 14.9993L12.083 4.99935C12.083 4.76923 11.8965 4.58268 11.6663 4.58268L8.33301 4.58268C8.10289 4.58268 7.91634 4.76923 7.91634 4.99935ZM6.66634 14.9993L6.66634 4.99935C6.66634 4.07887 7.41253 3.33268 8.33301 3.33268L11.6663 3.33268C12.5868 3.33268 13.333 4.07887 13.333 4.99935L13.333 14.9993C13.333 15.9198 12.5868 16.666 11.6663 16.666L8.33301 16.666C7.41253 16.666 6.66634 15.9198 6.66634 14.9993ZM15.4163 3.33268L15.4163 16.666L16.6663 16.666L16.6663 3.33268L15.4163 3.33268Z"
+				/>
+			</svg>
+		);
+	};
+
+	return (
+		<>
+			<button onClick={ openModal }>
+				<PreviewIcon />
+				<span>{ __( 'Preview' ) }</span>
+			</button>
+			{ isOpen && (
+				<Modal className="ad-preview-modal" title="Ad Preview" onRequestClose={ closeModal }>
+					<div className="ad-preview-modal__creatives">
+						<AdPreview
+							isLoading={ isLoading }
+							htmlCode={ htmlCode || '' }
+							templateFormat={ templateFormat || '' }
+							width={ getPreviewWidth( previewSelected ) }
+						/>
+					</div>
+					<div className="ad-preview-modal__links">
+						<button
+							onClick={ showMobilePreview }
+							color="inherit"
+							rel="noreferrer"
+							className={ classNames(
+								'link-preview',
+								previewSelected === 'mobile' ? 'active' : ''
+							) }
+						>
+							<MobileIcon />
+							<span>{ __( 'Mobile' ) }</span>
+						</button>
+
+						<button
+							onClick={ showTabletPreview }
+							color="inherit"
+							rel="noreferrer"
+							className={ classNames(
+								'link-preview',
+								previewSelected === 'tablet' ? 'active' : ''
+							) }
+						>
+							<TabletIcon />
+							<span>{ __( 'Tablet' ) }</span>
+						</button>
+
+						<button
+							onClick={ showDesktopPreview }
+							color="inherit"
+							rel="noreferrer"
+							className={ classNames(
+								'link-preview',
+								previewSelected === 'desktop' ? 'active' : ''
+							) }
+						>
+							<DesktopIcon />
+							<span>{ __( 'Desktop' ) }</span>
+						</button>
+					</div>
+				</Modal>
+			) }
+		</>
+	);
+};
+
+export default AdPreviewModal;

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -631,6 +631,7 @@ export default function CampaignItemDetails( props: Props ) {
 								isLoading={ isLoading }
 								htmlCode={ creative_html || '' }
 								templateFormat={ format || '' }
+								width={ format === 'html5_v2' ? '100%' : '300px' }
 							/>
 							<p className="campaign-item-details__preview-disclosure">
 								{ translate(

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -20,6 +20,7 @@ import Notice from 'calypso/components/notice';
 import { CampaignResponse } from 'calypso/data/promote-post/use-promote-post-campaigns-query';
 import useCancelCampaignMutation from 'calypso/data/promote-post/use-promote-post-cancel-campaign-mutation';
 import AdPreview from 'calypso/my-sites/promote-post-i2/components/ad-preview';
+import AdPreviewModal from 'calypso/my-sites/promote-post-i2/components/campaign-item-details/AdPreviewModal';
 import useOpenPromoteWidget from 'calypso/my-sites/promote-post-i2/hooks/use-open-promote-widget';
 import {
 	canCancelCampaign,
@@ -161,25 +162,6 @@ export default function CampaignItemDetails( props: Props ) {
 		},
 	];
 
-	const PreviewIcon = () => {
-		return (
-			<svg
-				width="20"
-				height="20"
-				viewBox="0 0 20 20"
-				fill="none"
-				xmlns="http://www.w3.org/2000/svg"
-				className="ad-preview-icon"
-			>
-				<path
-					fillRule="evenodd"
-					clipRule="evenodd"
-					d="M3.33301 16.666L3.33301 3.33268L4.58301 3.33268L4.58301 16.666L3.33301 16.666ZM7.91634 4.99935L7.91634 14.9993C7.91634 15.2295 8.10289 15.416 8.33301 15.416L11.6663 15.416C11.8965 15.416 12.083 15.2295 12.083 14.9993L12.083 4.99935C12.083 4.76923 11.8965 4.58268 11.6663 4.58268L8.33301 4.58268C8.10289 4.58268 7.91634 4.76923 7.91634 4.99935ZM6.66634 14.9993L6.66634 4.99935C6.66634 4.07887 7.41253 3.33268 8.33301 3.33268L11.6663 3.33268C12.5868 3.33268 13.333 4.07887 13.333 4.99935L13.333 14.9993C13.333 15.9198 12.5868 16.666 11.6663 16.666L8.33301 16.666C7.41253 16.666 6.66634 15.9198 6.66634 14.9993ZM15.4163 3.33268L15.4163 16.666L16.6663 16.666L16.6663 3.33268L15.4163 3.33268Z"
-				/>
-			</svg>
-		);
-	};
-
 	const adPreviewLabel =
 		// maybe we will need to edit this condition when we add more templates
 		format !== 'html5_v2' ? (
@@ -188,10 +170,7 @@ export default function CampaignItemDetails( props: Props ) {
 			</div>
 		) : (
 			<div className="campaign-item-details__preview-header-preview-button">
-				<button>
-					<PreviewIcon />
-					<span>{ __( 'Preview' ) }</span>
-				</button>
+				<AdPreviewModal templateFormat={ format || '' } htmlCode={ creative_html || '' } />
 			</div>
 		);
 

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -161,6 +161,40 @@ export default function CampaignItemDetails( props: Props ) {
 		},
 	];
 
+	const PreviewIcon = () => {
+		return (
+			<svg
+				width="20"
+				height="20"
+				viewBox="0 0 20 20"
+				fill="none"
+				xmlns="http://www.w3.org/2000/svg"
+				className="ad-preview-icon"
+			>
+				<path
+					fillRule="evenodd"
+					clipRule="evenodd"
+					d="M3.33301 16.666L3.33301 3.33268L4.58301 3.33268L4.58301 16.666L3.33301 16.666ZM7.91634 4.99935L7.91634 14.9993C7.91634 15.2295 8.10289 15.416 8.33301 15.416L11.6663 15.416C11.8965 15.416 12.083 15.2295 12.083 14.9993L12.083 4.99935C12.083 4.76923 11.8965 4.58268 11.6663 4.58268L8.33301 4.58268C8.10289 4.58268 7.91634 4.76923 7.91634 4.99935ZM6.66634 14.9993L6.66634 4.99935C6.66634 4.07887 7.41253 3.33268 8.33301 3.33268L11.6663 3.33268C12.5868 3.33268 13.333 4.07887 13.333 4.99935L13.333 14.9993C13.333 15.9198 12.5868 16.666 11.6663 16.666L8.33301 16.666C7.41253 16.666 6.66634 15.9198 6.66634 14.9993ZM15.4163 3.33268L15.4163 16.666L16.6663 16.666L16.6663 3.33268L15.4163 3.33268Z"
+				/>
+			</svg>
+		);
+	};
+
+	const adPreviewLabel =
+		// maybe we will need to edit this condition when we add more templates
+		format !== 'html5_v2' ? (
+			<div className="campaign-item-details__preview-header-dimensions">
+				<span>{ `${ width }x${ height }` }</span>
+			</div>
+		) : (
+			<div className="campaign-item-details__preview-header-preview-button">
+				<button>
+					<PreviewIcon />
+					<span>{ __( 'Preview' ) }</span>
+				</button>
+			</div>
+		);
+
 	const icon = (
 		<span className="campaign-item-details__support-buttons-icon">
 			<svg
@@ -609,14 +643,8 @@ export default function CampaignItemDetails( props: Props ) {
 								<div className="campaign-item-details__preview-header-title">
 									{ translate( 'Ad preview' ) }
 								</div>
-								<div className="campaign-item-details__preview-header-dimensions">
-									{ ! isLoading && format !== 'html5_v2' ? (
-										<>
-											<span>{ `${ width }x${ height }` }</span>
-										</>
-									) : (
-										<FlexibleSkeleton />
-									) }
+								<div className="campaign-item-details__preview-header-label">
+									{ ! isLoading ? <>{ adPreviewLabel }</> : <FlexibleSkeleton /> }
 								</div>
 							</div>
 							{ isSmallScreen && <hr className="campaign-item-ad-header-line" /> }

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
@@ -639,3 +639,56 @@ $break-huge-collapsed-menu: $break-huge - 222px;
 		@include blazepress-huge;
 	}
 }
+
+.ad-preview-modal {
+	border-radius: 4px;
+	padding: 48px 48px 0 48px;
+	width: 748px;
+
+	.components-modal__content {
+		align-items: center;
+		display: flex;
+		justify-content: center;
+		margin: 0;
+		padding: 0;
+	}
+
+	.ad-preview-modal__creatives {
+		align-items: center;
+		display: flex;
+		margin-top: 10px;
+		max-width: 820px;
+		min-height: 540px;
+
+		iframe {
+			width: 100%;
+		}
+	}
+
+	.ad-preview-modal__links {
+		display: flex;
+		justify-content: center;
+		margin-bottom: 48px;
+		padding-top: 22px;
+
+		.active {
+			background-color: $studio-gray-0;
+			color: $studio-gray-80;
+			cursor: default;
+		}
+
+		button {
+			align-items: center;
+			border-radius: 4px;
+			color: var(--color-link);
+			cursor: pointer;
+			display: inline-flex;
+			padding: 8px 12px 8px 8px;
+			text-decoration: none;
+
+			svg {
+				margin-right: 5px;
+			}
+		}
+	}
+}

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
@@ -250,6 +250,10 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 		.campaign-item-details__preview-header-preview-button {
 			min-width: 76px;
 
+			@media (max-width: $break-large) {
+				display: none;
+			}
+
 			svg {
 				margin-right: 6px;
 

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
@@ -107,14 +107,13 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 		}
 
 		.campaign-item-details__wrapper {
+
 			.campaign-item-details__label,
 			.campaign-item-details__text {
 				color: var(--studio-gray-100);
-			}
-			.campaign-item-details__text
-			.campaign-item-details__text {
 				line-height: 1.25;
 			}
+
 		}
 	}
 
@@ -158,7 +157,6 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 			margin-bottom: 24px;
 
 			@media (max-width: 660px) {
-				border: 0;
 				border: 1px solid #ddd;
 				border-radius: 0;
 				margin-bottom: 0;
@@ -180,7 +178,7 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 				&:last-child {
 					.horizontal-bar-list-item-bar {
 						&::before {
-							background-color: #f6f7f7;
+							background-color: $studio-gray-0;
 						}
 					}
 				}
@@ -239,11 +237,35 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 			}
 		}
 
-		.campaign-item-details__preview-header-dimensions {
-			align-items: center;
+		.campaign-item-details__preview-header-label {
+			align-items: end;
 			display: flex;
+			min-width: 60px;
 		}
 
+		.campaign-item-details__preview-header-dimensions {
+			min-width: 60px;
+		}
+
+		.campaign-item-details__preview-header-preview-button {
+			min-width: 76px;
+
+			svg {
+				margin-right: 6px;
+
+				path {
+					fill: var(--color-link);
+				}
+			}
+
+			> button {
+				align-items: center;
+				display: flex;
+				text-decoration: none;
+				cursor: pointer;
+				color: var(--color-link);
+			}
+		}
 
 		.campaign-item-details__secondary-stats-row,
 		.campaign-item-details__secondary-payment-row {
@@ -325,7 +347,7 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 		}
 
 		.campaign-item-details__ad-destination-url-container a {
-			background-color: #f6f7f7;
+			background-color: $studio-gray-0;
 			border: none;
 		}
 
@@ -397,8 +419,8 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 	}
 
 	.campaign-item-details__preview-container {
-		border-radius: 2px;
-		background-color: #f6f7f7;
+		background-color: $studio-gray-0;
+		border-radius: 4px;
 		margin-bottom: 24px;
 		padding: 24px;
 
@@ -410,10 +432,10 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 
 	.campaign-item-details__preview-header {
 		display: flex;
-		justify-content: space-between;
-		margin-bottom: 24px;
 		font-size: 0.875rem;
 		font-weight: 400;
+		justify-content: space-between;
+		margin-bottom: 24px;
 	}
 
 	.campaign-item-details__preview-content {
@@ -438,8 +460,9 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 	}
 
 	.campaign-item-details__preview-disclosure {
-		margin: 12px auto 0 auto;
+		margin: 20px auto 0 auto;
 		max-width: 300px;
+		text-align: center;
 	}
 
 	.campaign-item-details__preview-header-title {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
SELFSERVE*775

Adds a new modal for previewing the new ad format (for the new responsive ad)

- we added a new modal in the campaign details page (for Blaze ads)

now ads (with the new format) have a button to preview formats above the ad preview

 
![Screenshot 2023-10-04 at 20 20 43](https://github.com/Automattic/wp-calypso/assets/1416426/ce9f7d42-3643-4016-926c-13861dd538ed)

when clicked a modal will open (with the following 3 states)


![Screenshot 2023-10-04 at 20 20 26](https://github.com/Automattic/wp-calypso/assets/1416426/e65d8c44-99f5-483d-9434-ad547a52bd9f)
![Screenshot 2023-10-04 at 20 20 36](https://github.com/Automattic/wp-calypso/assets/1416426/302b293a-2c7d-4910-a1ba-ce96d82cca3b)
![Screenshot 2023-10-04 at 20 20 40](https://github.com/Automattic/wp-calypso/assets/1416426/ff3d154c-aa2c-4526-befc-985d7aa54e90)

Please test that the old format ads dont have this button but instead have the old dimensions text (as below)

![Screenshot 2023-10-04 at 20 20 58](https://github.com/Automattic/wp-calypso/assets/1416426/3bf6f9b9-7f60-414b-b69f-133671eb1d80)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
