### PR TITLE
Fix label for email clicks stats card

### DIFF
--- a/client/my-sites/stats/stats-email-module/index.jsx
+++ b/client/my-sites/stats/stats-email-module/index.jsx
@@ -1,4 +1,4 @@
-import { localize } from 'i18n-calypso';
+import { localize, translate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -39,6 +39,7 @@ class StatsEmailModule extends Component {
 		const moduleStrings = statsStrings()[ path ];
 		// TODO: Support error state in redux store
 		const hasError = false;
+		const metricLabel = path === 'links' ? translate( 'Clicks' ) : null;
 
 		return (
 			<>
@@ -49,6 +50,7 @@ class StatsEmailModule extends Component {
 					emptyMessage={ moduleStrings.empty }
 					error={ hasError && <ErrorPanel /> }
 					loader={ isLoading && <StatsModulePlaceholder isLoading={ isLoading } /> }
+					metricLabel={ metricLabel }
 					heroElement={
 						path === 'countries' && (
 							<Geochart kind="email" statType={ statType } postId={ postId } query={ query } />

--- a/client/my-sites/stats/stats-email-module/index.jsx
+++ b/client/my-sites/stats/stats-email-module/index.jsx
@@ -39,7 +39,7 @@ class StatsEmailModule extends Component {
 		const moduleStrings = statsStrings()[ path ];
 		// TODO: Support error state in redux store
 		const hasError = false;
-		const metricLabel = path === 'links' ? translate( 'Clicks' ) : null;
+		const metricLabel = statType === 'clicks' ? translate( 'Clicks' ) : null;
 
 		return (
 			<>


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/82584

## Proposed Changes

If you go to Stats -> Email Click, the card with the links clicked had Views in the label for the number of clicks per link, but now it says Clicks.

Before:
![image](https://github.com/Automattic/wp-calypso/assets/3832570/26445939-7d8c-48b8-9a59-b6f9d6bb5e3c)

Now:
<img width="608" alt="Screenshot 2023-10-04 at 19 57 51" src="https://github.com/Automattic/wp-calypso/assets/3832570/9241a3f1-04c0-4f98-96f9-c2aef38f2063">

## Testing Instructions

1. Apply this PR and start the application.
2. Go to `http://calypso.localhost:3000/stats/day/[domain]`. Use the domain of a site that already has some email stats on it.
3. Click on an email in the `Emails` card that has some clicks on it.
4. Click the `Email Clicks` tab.
5. The `Links` card should have `Clicks` as the label in the right instead of `Views` like in the rest of the cards.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?