### PR TITLE
Jetpack Cloud: Add the skeleton for a new sidebar navigation component

### DIFF
--- a/client/jetpack-cloud/components/sidebar/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/index.tsx
@@ -1,0 +1,31 @@
+import classNames from 'classnames';
+import './style.scss';
+
+// This is meant to be the "base" sidebar component. All context-specific sidebars
+// (Sites Management, Plugin Management, Purchases, non-Manage functionality)
+// would use it to construct the right experience for that context.
+
+type Props = {
+	className?: string;
+};
+const Sidebar = ( { className }: Props ) => (
+	<nav className={ classNames( 'jetpack-cloud-sidebar', className ) }>
+		<header className="jetpack-cloud-sidebar__header">Header</header>
+		<div className="jetpack-cloud-sidebar__main">
+			<ul role="menu" className="jetpack-cloud-sidebar__navigation-list">
+				<li
+					className={ classNames(
+						'jetpack-cloud-sidebar__navigation-item',
+						'jetpack-cloud-sidebar__navigation-item--highlighted'
+					) }
+				>
+					Navigation items
+				</li>
+				<li className="jetpack-cloud-sidebar__navigation-item">Will go here</li>
+			</ul>
+		</div>
+		<div className="jetpack-cloud-sidebar__footer">Footer</div>
+	</nav>
+);
+
+export default Sidebar;

--- a/client/jetpack-cloud/components/sidebar/style.scss
+++ b/client/jetpack-cloud/components/sidebar/style.scss
@@ -1,0 +1,2 @@
+// This file is meant to house style rules that all implementations of the base
+// sidebar will implement by default.

--- a/client/jetpack-cloud/sections/agency-dashboard/controller.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/controller.tsx
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import page from 'page';
+import NewJetpackManageSidebar from 'calypso/jetpack-cloud/sections/sidebar-navigation/jetpack-manage';
 import { isAgencyUser } from 'calypso/state/partner-portal/partner/selectors';
 import DashboardOverview from './dashboard-overview';
 import Header from './header';
@@ -24,7 +25,13 @@ export function agencyDashboardContext( context: PageJS.Context, next: VoidFunct
 
 	const currentPage = parseInt( contextPage ) || 1;
 	context.header = <Header />;
-	context.secondary = <DashboardSidebar path={ context.path } />;
+
+	if ( config.isEnabled( 'jetpack/new-navigation' ) ) {
+		context.secondary = <NewJetpackManageSidebar />;
+	} else {
+		context.secondary = <DashboardSidebar path={ context.path } />;
+	}
+
 	context.primary = (
 		<DashboardOverview
 			search={ search }

--- a/client/jetpack-cloud/sections/partner-portal/controller.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/controller.tsx
@@ -25,7 +25,7 @@ import {
 	LicenseSortDirection,
 	LicenseSortField,
 } from 'calypso/jetpack-cloud/sections/partner-portal/types';
-import NewJetpackManageSidebar from 'calypso/jetpack-cloud/sections/sidebar-navigation/jetpack-manage';
+import NewPurchasesSidebar from 'calypso/jetpack-cloud/sections/sidebar-navigation/purchases';
 import { addQueryArgs } from 'calypso/lib/route';
 import {
 	getCurrentPartner,
@@ -40,7 +40,7 @@ import type PageJS from 'page';
 
 const setSidebar = ( context: PageJS.Context ): void => {
 	if ( isEnabled( 'jetpack/new-navigation' ) ) {
-		context.secondary = <NewJetpackManageSidebar />;
+		context.secondary = <NewPurchasesSidebar />;
 	} else {
 		context.secondary = <PartnerPortalSidebar path={ context.path } />;
 	}

--- a/client/jetpack-cloud/sections/partner-portal/controller.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/controller.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import page from 'page';
 import {
 	publicToInternalLicenseFilter,
@@ -24,6 +25,7 @@ import {
 	LicenseSortDirection,
 	LicenseSortField,
 } from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import NewJetpackManageSidebar from 'calypso/jetpack-cloud/sections/sidebar-navigation/jetpack-manage';
 import { addQueryArgs } from 'calypso/lib/route';
 import {
 	getCurrentPartner,
@@ -35,6 +37,14 @@ import getSites from 'calypso/state/selectors/get-sites';
 import Header from './header';
 import WPCOMAtomicHosting from './primary/wpcom-atomic-hosting';
 import type PageJS from 'page';
+
+const setSidebar = ( context: PageJS.Context ): void => {
+	if ( isEnabled( 'jetpack/new-navigation' ) ) {
+		context.secondary = <NewJetpackManageSidebar />;
+	} else {
+		context.secondary = <PartnerPortalSidebar path={ context.path } />;
+	}
+};
 
 export function partnerContext( context: PageJS.Context, next: () => void ): void {
 	context.header = <Header />;
@@ -56,7 +66,7 @@ export function partnerKeyContext( context: PageJS.Context, next: () => void ): 
 
 export function billingDashboardContext( context: PageJS.Context, next: () => void ): void {
 	context.header = <Header />;
-	context.secondary = <PartnerPortalSidebar path={ context.path } />;
+	setSidebar( context );
 	context.primary = <BillingDashboard />;
 	next();
 }
@@ -73,7 +83,7 @@ export function licensesContext( context: PageJS.Context, next: () => void ): vo
 	);
 
 	context.header = <Header />;
-	context.secondary = <PartnerPortalSidebar path={ context.path } />;
+	setSidebar( context );
 	context.primary = (
 		<Licenses
 			filter={ filter }
@@ -92,7 +102,7 @@ export function issueLicenseContext( context: PageJS.Context, next: () => void )
 	const sites = getSites( state );
 	const selectedSite = siteId ? sites.find( ( site ) => site?.ID === parseInt( siteId ) ) : null;
 	context.header = <Header />;
-	context.secondary = <PartnerPortalSidebar path={ context.path } />;
+	setSidebar( context );
 	context.primary = (
 		<IssueLicense selectedSite={ selectedSite } suggestedProduct={ suggestedProduct } />
 	);
@@ -101,7 +111,7 @@ export function issueLicenseContext( context: PageJS.Context, next: () => void )
 
 export function downloadProductsContext( context: PageJS.Context, next: () => void ): void {
 	context.header = <Header />;
-	context.secondary = <PartnerPortalSidebar path={ context.path } />;
+	setSidebar( context );
 	context.primary = <DownloadProducts />;
 	next();
 }
@@ -113,7 +123,7 @@ export function assignLicenseContext( context: PageJS.Context, next: () => void 
 	const currentPage = parseInt( page ) || 1;
 
 	context.header = <Header />;
-	context.secondary = <PartnerPortalSidebar path={ context.path } />;
+	setSidebar( context );
 	context.primary = (
 		<AssignLicense sites={ sites } currentPage={ currentPage } search={ search || '' } />
 	);
@@ -122,14 +132,15 @@ export function assignLicenseContext( context: PageJS.Context, next: () => void 
 
 export function paymentMethodListContext( context: PageJS.Context, next: () => void ): void {
 	context.header = <Header />;
-	context.secondary = <PartnerPortalSidebar path={ context.path } />;
+	setSidebar( context );
 	context.primary = <PaymentMethodList />;
 	next();
 }
 
 export function paymentMethodAddContext( context: PageJS.Context, next: () => void ): void {
 	context.header = <Header />;
-	context.secondary = <PartnerPortalSidebar path={ context.path } />;
+	setSidebar( context );
+
 	const { site_id: siteId } = context.query;
 	const state = context.store.getState();
 	const sites = getSites( state );
@@ -140,21 +151,21 @@ export function paymentMethodAddContext( context: PageJS.Context, next: () => vo
 
 export function invoicesDashboardContext( context: PageJS.Context, next: () => void ): void {
 	context.header = <Header />;
-	context.secondary = <PartnerPortalSidebar path={ context.path } />;
+	setSidebar( context );
 	context.primary = <InvoicesDashboard />;
 	next();
 }
 
 export function companyDetailsDashboardContext( context: PageJS.Context, next: () => void ): void {
 	context.header = <Header />;
-	context.secondary = <PartnerPortalSidebar path={ context.path } />;
+	setSidebar( context );
 	context.primary = <CompanyDetailsDashboard />;
 	next();
 }
 
 export function pricesContext( context: PageJS.Context, next: () => void ): void {
 	context.header = <Header />;
-	context.secondary = <PartnerPortalSidebar path={ context.path } />;
+	setSidebar( context );
 	context.primary = <Prices />;
 	next();
 }
@@ -166,14 +177,13 @@ export function landingPageContext() {
 
 export function wpcomAtomicHostingContext( context: PageJS.Context, next: () => void ): void {
 	context.header = <Header />;
-	context.secondary = <PartnerPortalSidebar path={ context.path } />;
+	setSidebar( context );
 	context.primary = <WPCOMAtomicHosting />;
 	next();
 }
 
 /**
  * Require the user to have a partner with at least 1 active partner key.
- *
  * @param {PageJS.Context} context PageJS context.
  * @param {() => void} next Next context callback.
  */
@@ -199,7 +209,6 @@ export function requireAccessContext( context: PageJS.Context, next: () => void 
 
 /**
  * Require the user to have consented to the terms of service.
- *
  * @param {PageJS.Context} context PageJS context.
  * @param {() => void} next Next context callback.
  */
@@ -230,7 +239,6 @@ export function requireTermsOfServiceConsentContext(
 
 /**
  * Require the user to have selected a partner key to use.
- *
  * @param {PageJS.Context} context PageJS context.
  * @param {() => void} next Next context callback.
  */
@@ -261,7 +269,6 @@ export function requireSelectedPartnerKeyContext(
 
 /**
  * Require the user to have a valid payment method registered.
- *
  * @param {PageJS.Context} context PageJS context.
  * @param {() => void} next Next context callback.
  */

--- a/client/jetpack-cloud/sections/sidebar-navigation/jetpack-manage.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/jetpack-manage.tsx
@@ -1,0 +1,9 @@
+import NewSidebar from 'calypso/jetpack-cloud/components/sidebar';
+
+// This sidebar is what Jetpack Manage customers will see by default as they
+// navigate around Jetpack Cloud with no specific site selected.
+// It'll display menu options like Sites Management, Plugin Management,
+// and Purchases.
+const JetpackManageSidebar = () => <NewSidebar />;
+
+export default JetpackManageSidebar;

--- a/client/jetpack-cloud/sections/sidebar-navigation/jetpack-manage.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/jetpack-manage.tsx
@@ -4,6 +4,11 @@ import NewSidebar from 'calypso/jetpack-cloud/components/sidebar';
 // navigate around Jetpack Cloud with no specific site selected.
 // It'll display menu options like Sites Management, Plugin Management,
 // and Purchases.
-const JetpackManageSidebar = () => <NewSidebar />;
+const JetpackManageSidebar = () => (
+	<>
+		-- Jetpack Manage sidebar --
+		<NewSidebar />
+	</>
+);
 
 export default JetpackManageSidebar;

--- a/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
@@ -2,6 +2,11 @@ import NewSidebar from 'calypso/jetpack-cloud/components/sidebar';
 
 // This sidebar is what people will see when they pick a site from the site
 // selector. It'll display menu options like Activity Log, Backup, Social, etc.
-const ManageSelectedSiteSidebar = () => <NewSidebar />;
+const ManageSelectedSiteSidebar = () => (
+	<>
+		-- Manage selected site sidebar --
+		<NewSidebar />
+	</>
+);
 
 export default ManageSelectedSiteSidebar;

--- a/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
@@ -1,0 +1,7 @@
+import NewSidebar from 'calypso/jetpack-cloud/components/sidebar';
+
+// This sidebar is what people will see when they pick a site from the site
+// selector. It'll display menu options like Activity Log, Backup, Social, etc.
+const ManageSelectedSiteSidebar = () => <NewSidebar />;
+
+export default ManageSelectedSiteSidebar;

--- a/client/jetpack-cloud/sections/sidebar-navigation/purchases.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/purchases.tsx
@@ -1,0 +1,8 @@
+import NewSidebar from 'calypso/jetpack-cloud/components/sidebar';
+
+// This sidebar is what Jetpack Manage customers will see when they select the
+// Purchases item from the top-level navigation sidebar. It'll display options
+// like Licenses, Invoices, Billing, etc.
+const PurchasesSidebar = () => <NewSidebar />;
+
+export default PurchasesSidebar;

--- a/client/jetpack-cloud/sections/sidebar-navigation/purchases.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/purchases.tsx
@@ -3,6 +3,11 @@ import NewSidebar from 'calypso/jetpack-cloud/components/sidebar';
 // This sidebar is what Jetpack Manage customers will see when they select the
 // Purchases item from the top-level navigation sidebar. It'll display options
 // like Licenses, Invoices, Billing, etc.
-const PurchasesSidebar = () => <NewSidebar />;
+const PurchasesSidebar = () => (
+	<>
+		-- Purchases sidebar --
+		<NewSidebar />
+	</>
+);
 
 export default PurchasesSidebar;

--- a/client/my-sites/navigation/index.jsx
+++ b/client/my-sites/navigation/index.jsx
@@ -22,7 +22,16 @@ class MySitesNavigation extends Component {
 		let sitePickerProps = {};
 
 		if ( config.isEnabled( 'jetpack-cloud' ) ) {
-			asyncSidebar = <AsyncLoad require="calypso/components/jetpack/sidebar" { ...asyncProps } />;
+			if ( config.isEnabled( 'jetpack/new-navigation' ) ) {
+				asyncSidebar = (
+					<AsyncLoad
+						require="calypso/jetpack-cloud/sections/sidebar-navigation/manage-selected-site"
+						{ ...asyncProps }
+					/>
+				);
+			} else {
+				asyncSidebar = <AsyncLoad require="calypso/components/jetpack/sidebar" { ...asyncProps } />;
+			}
 
 			sitePickerProps = {
 				showManageSitesButton: false,


### PR DESCRIPTION
### ⚠️ Please read the notes under "Known issues." ⚠️ 

This pull request creates some minimal scaffolding to start the development process toward new navigation sidebars in Jetpack Cloud. All new behavior remains gated behind the feature flag `jetpack/new-navigation`, disabled by default.

Resolves https://github.com/Automattic/jetpack-genesis/issues/34.

## Proposed Changes

* Create a new "base" component `sidebar` inside the new `client/jetpack-cloud/components` directory, to be used in the creation of new navigation sidebars in whichever contexts they're needed.
* Create three new sidebar components for use in Jetpack Cloud:
  * Jetpack Manage (contains Sites Management, Plugin Management, and Purchases)
  * Purchases (sub-menu of Jetpack Manage; contains Licenses, Billing, Invoices, etc.)
  * Manage single site (contains Activity Log, Backup, Social, etc.)
* Add conditionals inside Jetpack Cloud, such that enabling the `jetpack/new-navigation` flag displays the appropriate new sidebar component.

## Known issues

* **IMPORTANT:** This PR does *not* explicitly create separate components for header, main, and footer components in the sidebar. I made this decision purposely, because after looking at designs, it appears that these sections all hold different content depending on the context. I made a tentative decision to organize these sidebars first by their context, assuming that later we'll be able to make a more informed decision about whether/how to divide them up into headers, footers, etc.
* As this PR only seeks to introduce scaffolding for future development, the new sidebar components have little to no functionality. They exist only to give us a place to put new code as it's made ready.

## Testing Instructions

* In your testing environment, visit Jetpack Cloud.
* Without changing any configuration or flags, verify sidebars continue to function correctly  on all pages (specifically Dashboard, Licensing, and Manage Sites).
* Re-visit each of the aforementioned pages/sections, adding `?flags=jetpack/new-navigation` to your browser's query string arguments.
* Verify you see a new sidebar with text appropriate to the section you're in: Jetpack Manage, Purchases, or Manage selected site, respectively.

### Reference screenshots

<img height="250" alt="image" src="https://github.com/Automattic/wp-calypso/assets/670067/4aa66054-36e2-4332-a7ad-c33f3b0fceff">
<img height="250" alt="image" src="https://github.com/Automattic/wp-calypso/assets/670067/93fced38-e9cf-48f7-be27-f3170bd5664b">
<img height="250" alt="image" src="https://github.com/Automattic/wp-calypso/assets/670067/63f4348b-2dfe-4390-9216-e6f239d714ba">
