### PR TITLE
Domains: Remove references to the deprecated `domainManagementContactsPrivacy` path

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -19,7 +19,6 @@ import { onboardingUrl } from 'calypso/lib/paths';
 import { addQueryArgs, getSiteFragment, sectionify, trailingslashit } from 'calypso/lib/route';
 import { withoutHttp } from 'calypso/lib/url';
 import {
-	domainManagementContactsPrivacy,
 	domainManagementDns,
 	domainManagementEdit,
 	domainManagementEditContactInfo,
@@ -178,7 +177,6 @@ function renderSelectedSiteIsDIFMLiteInProgress( reactContext, selectedSite ) {
 
 function isPathAllowedForDomainOnlySite( path, slug, primaryDomain, contextParams ) {
 	const allPaths = [
-		domainManagementContactsPrivacy,
 		domainManagementDns,
 		domainManagementDnsAddRecord,
 		domainManagementDnsEditRecord,

--- a/client/my-sites/domains/domain-management/README.md
+++ b/client/my-sites/domains/domain-management/README.md
@@ -6,7 +6,6 @@ Supported routes:
 
 - `/domains/manage` - entry point for domains management
 - `/domains/manage/:site` - lists domains for a site
-- `/domains/manage/:domain/contacts-privacy/:site` - displays contacts and privacy information for a domain
 - `/domains/manage/:domain/dns/:site` - manages DNS records for a domain
 - `/domains/manage/:domain/add-dns-record/:site` - add new DNS record for a domain
 - `/domains/manage/:domain/edit-dns-record/:site` - update DNS record for a domain

--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -6,7 +6,6 @@ import { decodeURIComponentIfValid } from 'calypso/lib/url';
 import {
 	domainManagementAllEditSelectedContactInfo,
 	domainManagementEditSelectedContactInfo,
-	domainManagementContactsPrivacy,
 	domainManagementDns,
 	domainManagementDnsAddRecord,
 	domainManagementDnsEditRecord,
@@ -132,20 +131,6 @@ export default {
 				needsPlans
 				needsProductsList
 				selectedDomainName={ decodeURIComponentIfValid( pageContext.params.domain ) }
-			/>
-		);
-		next();
-	},
-
-	domainManagementContactsPrivacy( pageContext, next ) {
-		pageContext.primary = (
-			<DomainManagementData
-				analyticsPath={ domainManagementContactsPrivacy( ':site', ':domain' ) }
-				analyticsTitle="Domain Management > Contacts"
-				component={ DomainManagement.ContactsPrivacy }
-				context={ pageContext }
-				needsDomains
-				selectedDomainName={ pageContext.params.domain }
 			/>
 		);
 		next();

--- a/client/my-sites/domains/domain-management/edit-contact-info-page/index.tsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info-page/index.tsx
@@ -16,7 +16,6 @@ import DomainHeader from 'calypso/my-sites/domains/domain-management/components/
 import {
 	domainManagementEdit,
 	domainManagementList,
-	domainManagementContactsPrivacy,
 	isUnderDomainManagementAll,
 } from 'calypso/my-sites/domains/paths';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
@@ -49,12 +48,6 @@ const EditContactInfoPage = ( {
 
 	const isDataLoading = () => {
 		return ! getSelectedDomain( { domains, selectedDomainName } ) || isRequestingWhois;
-	};
-
-	const goToContactsPrivacy = () => {
-		page(
-			domainManagementContactsPrivacy( selectedSite?.slug ?? '', selectedDomainName, currentRoute )
-		);
 	};
 
 	const renderHeader = () => {
@@ -191,7 +184,7 @@ const EditContactInfoPage = ( {
 	};
 
 	if ( isDataLoading() ) {
-		return <DomainMainPlaceholder goBack={ goToContactsPrivacy } />;
+		return <DomainMainPlaceholder />;
 	}
 
 	return (

--- a/client/my-sites/domains/domain-management/edit-contact-info/privacy-enabled-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/privacy-enabled-card.jsx
@@ -2,7 +2,7 @@ import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { useCurrentRoute } from 'calypso/components/route';
-import { domainManagementContactsPrivacy } from 'calypso/my-sites/domains/paths';
+import { domainManagementEdit } from 'calypso/my-sites/domains/paths';
 
 import './privacy-enabled-card.scss';
 
@@ -20,7 +20,7 @@ function EditContactInfoPrivacyEnabledCard( { selectedDomainName, selectedSiteSl
 						components: {
 							a: (
 								<a
-									href={ domainManagementContactsPrivacy(
+									href={ domainManagementEdit(
 										selectedSiteSlug,
 										selectedDomainName,
 										currentRoute

--- a/client/my-sites/domains/domain-management/manage-consent/index.jsx
+++ b/client/my-sites/domains/domain-management/manage-consent/index.jsx
@@ -11,7 +11,7 @@ import { getSelectedDomain } from 'calypso/lib/domains';
 import wpcom from 'calypso/lib/wp';
 import DomainMainPlaceholder from 'calypso/my-sites/domains/domain-management/components/domain/main-placeholder';
 import Header from 'calypso/my-sites/domains/domain-management/components/header';
-import { domainManagementContactsPrivacy } from 'calypso/my-sites/domains/paths';
+import { domainManagementEdit } from 'calypso/my-sites/domains/paths';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 
 class ManageConsent extends Component {
@@ -31,7 +31,7 @@ class ManageConsent extends Component {
 		const { translate } = this.props;
 
 		if ( this.isDataLoading() ) {
-			return <DomainMainPlaceholder goBack={ this.goToContactsPrivacy } />;
+			return <DomainMainPlaceholder />;
 		}
 
 		return (
@@ -108,7 +108,7 @@ class ManageConsent extends Component {
 
 	goToContactsPrivacy = () => {
 		page(
-			domainManagementContactsPrivacy(
+			domainManagementEdit(
 				this.props.selectedSite.slug,
 				this.props.selectedDomainName,
 				this.props.currentRoute

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -86,11 +86,6 @@ export default function () {
 	);
 
 	registerStandardDomainManagementPages(
-		paths.domainManagementContactsPrivacy,
-		domainManagementController.domainManagementContactsPrivacy
-	);
-
-	registerStandardDomainManagementPages(
 		paths.domainManagementEditContactInfo,
 		domainManagementController.domainManagementEditContactInfo
 	);

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -122,15 +122,6 @@ export function domainManagementEdit(
  * @param {string} domainName
  * @param {string?} relativeTo
  */
-export function domainManagementContactsPrivacy( siteName, domainName, relativeTo = null ) {
-	return domainManagementEditBase( siteName, domainName, 'contacts-privacy', relativeTo );
-}
-
-/**
- * @param {string} siteName
- * @param {string} domainName
- * @param {string?} relativeTo
- */
 export function domainManagementEditContactInfo( siteName, domainName, relativeTo = null ) {
 	return domainManagementEditBase( siteName, domainName, 'edit-contact-info', relativeTo );
 }


### PR DESCRIPTION
## Proposed Changes

This PR removes references to the deprecated `domainManagementContactsPrivacy` path.

For posterity, this is what the `domainManagementContactsPrivacy` page looked like:

![Markup on 2023-09-25 at 11_46_20](https://github.com/Automattic/wp-calypso/assets/5324818/0bb2ccae-7161-444a-ae9c-3b5c6598afdb)

---

There were only two places where this path was being linked to, none of which I believe are in use anymore:

- Card shown in the contact info edit page when the `must_remove_privacy_before_contact_update` domain property is true

> ![Markup on 2023-10-04 at 17:19:01](https://github.com/Automattic/wp-calypso/assets/5324818/f86d2f94-6d7b-41ff-b57c-e5cbb93597f9)

- GDPR consent page

> ![Markup on 2023-10-04 at 17:13:22](https://github.com/Automattic/wp-calypso/assets/5324818/b518300b-3231-4785-ac3c-0c0fb7ecdd27)

Related to #82090

## Testing Instructions

- Checking the places where the path was linked to depend on some hacking as they're not normally accessible, so I think code inspection should be enough
- You can also try to access the old URL directly and ensure it doesn't show anything:
  - `/domains/manage/:domain/contacts-privacy/:site`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
