### PR TITLE
Checkout: Add isBusy function to sidebar upsell button

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
@@ -101,6 +101,7 @@ export function CheckoutSidebarPlanUpsell() {
 			// This will already be displayed to the user
 			// eslint-disable-next-line no-console
 			console.error( error );
+			setIsClicked( false );
 		}
 	};
 

--- a/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
@@ -2,7 +2,7 @@ import { isPlan, isJetpackPlan } from '@automattic/calypso-products';
 import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import formatCurrency from '@automattic/format-currency';
 import { useShoppingCart } from '@automattic/shopping-cart';
-import { createElement, createInterpolateElement } from '@wordpress/element';
+import { createElement, createInterpolateElement, useState } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
@@ -16,7 +16,6 @@ import {
 	getItemVariantCompareToPrice,
 	getItemVariantDiscountPercentage,
 } from '../item-variation-picker/util';
-
 import './style.scss';
 
 const debug = debugFactory( 'calypso:checkout-sidebar-plan-upsell' );
@@ -25,6 +24,7 @@ export function CheckoutSidebarPlanUpsell() {
 	const { formStatus } = useFormStatus();
 	const reduxDispatch = useDispatch();
 	const isFormLoading = FormStatus.READY !== formStatus;
+	const [ isClicked, setIsClicked ] = useState( false );
 	const { __ } = useI18n();
 	const cartKey = useCartKey();
 	const { responseCart, replaceProductInCart } = useShoppingCart( cartKey );
@@ -32,6 +32,20 @@ export function CheckoutSidebarPlanUpsell() {
 		( product ) => isPlan( product ) && ! isJetpackPlan( product )
 	);
 	const variants = useGetProductVariants( plan );
+
+	function isBusy() {
+		// If the FormStatus is SUBMITTING and the user has not clicked this button, we want to return false for isBusy
+		if ( ! isClicked ) {
+			return false;
+		}
+
+		// If the FormStatus is LOADING, VALIDATING, or SUBMITTING, we want to return true for isBusy
+		if ( isFormLoading ) {
+			return true;
+		}
+		// If FormStatus is READY or COMPLETE, we want to return false for isBusy
+		return false;
+	}
 
 	if ( ! plan ) {
 		debug( 'no plan found in cart' );
@@ -63,7 +77,8 @@ export function CheckoutSidebarPlanUpsell() {
 		return null;
 	}
 
-	const onUpgradeClick = () => {
+	const onUpgradeClick = async () => {
+		setIsClicked( true );
 		if ( isFormLoading ) {
 			return;
 		}
@@ -79,7 +94,14 @@ export function CheckoutSidebarPlanUpsell() {
 				switching_to: newPlan.product_slug,
 			} )
 		);
-		replaceProductInCart( plan.uuid, newPlan );
+		try {
+			await replaceProductInCart( plan.uuid, newPlan );
+			setIsClicked( false );
+		} catch ( error ) {
+			// This will already be displayed to the user
+			// eslint-disable-next-line no-console
+			console.error( error );
+		}
 	};
 
 	const compareToPriceForVariantTerm = getItemVariantCompareToPrice(
@@ -153,7 +175,7 @@ export function CheckoutSidebarPlanUpsell() {
 			<PromoCardCTA
 				cta={ {
 					disabled: isFormLoading,
-					busy: isFormLoading,
+					busy: isBusy(),
 					text: __( 'Switch to a two-year plan' ),
 					action: onUpgradeClick,
 				} }


### PR DESCRIPTION
When a Checkout payment is submitted, both the submit button and sidebar plan upsell button show a 'busy' animation. Only the button that is clicked should show a busy animation while all other buttons show as 'disabled'.

This PR adds internal state to the sidebar plan upsell button in order to **only** show its 'isBusy' animation when the button is clicked, not _just_ when the Checkout form is submitted.

Before

![image](https://github.com/Automattic/wp-calypso/assets/16580129/6deabc13-7569-4005-ac9b-9d0891bc2911)


After

![image](https://github.com/Automattic/wp-calypso/assets/16580129/b2ace53f-6728-43b7-98ba-20fb20925933)


Related to https://github.com/Automattic/payments-shilling/issues/2041

## Testing Instructions

* Add a plan product to your cart, like a WPCOM Personal Plan
* Complete a test payment and watch the submit button and the sidebar upsell button, only the submit button should show the 'isBusy' animation
* PRO TIP - Use PayPal as the payment method as it won't charge you right away and will allow you to cancel payment before the transaction completes
