### PR TITLE
Stats: Date control - Add optional icon prop to Intervals component

### DIFF
--- a/client/blocks/stats-navigation/intervals.js
+++ b/client/blocks/stats-navigation/intervals.js
@@ -1,3 +1,4 @@
+import { Icon } from '@wordpress/icons';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -15,6 +16,7 @@ const Intervals = ( props ) => {
 		compact = true,
 		intervalValues = intervals,
 		onChange,
+		icon,
 	} = props;
 	const classes = classnames( 'stats-navigation__intervals', className, {
 		'is-standalone': standalone,
@@ -32,6 +34,7 @@ const Intervals = ( props ) => {
 						onClick={ () => onChange && onChange( i.value ) }
 					>
 						{ i.label }
+						{ icon && <Icon className="gridicon" icon={ icon } /> }{ ' ' }
 					</SegmentedControl.Item>
 				);
 			} ) }
@@ -46,6 +49,7 @@ Intervals.propTypes = {
 	standalone: PropTypes.bool,
 	intervalValues: PropTypes.array,
 	onChange: PropTypes.func,
+	icon: PropTypes.object,
 };
 
 Intervals.defaultProps = {

--- a/client/blocks/stats-navigation/intervals.js
+++ b/client/blocks/stats-navigation/intervals.js
@@ -34,7 +34,7 @@ const Intervals = ( props ) => {
 						onClick={ () => onChange && onChange( i.value ) }
 					>
 						{ i.label }
-						{ icon && <Icon className="gridicon" icon={ icon } /> }
+						{ icon && i.value === selected && <Icon className="gridicon" icon={ icon } /> }
 					</SegmentedControl.Item>
 				);
 			} ) }

--- a/client/blocks/stats-navigation/intervals.js
+++ b/client/blocks/stats-navigation/intervals.js
@@ -34,7 +34,7 @@ const Intervals = ( props ) => {
 						onClick={ () => onChange && onChange( i.value ) }
 					>
 						{ i.label }
-						{ icon && <Icon className="gridicon" icon={ icon } /> }{ ' ' }
+						{ icon && <Icon className="gridicon" icon={ icon } /> }
 					</SegmentedControl.Item>
 				);
 			} ) }

--- a/client/blocks/stats-navigation/intervals.scss
+++ b/client/blocks/stats-navigation/intervals.scss
@@ -8,9 +8,5 @@
 			margin: 16px auto;
 		}
 	}
-	.gridicon {
-		display: none; /* Hidden by default */
-	}
-
 }
 

--- a/client/blocks/stats-navigation/intervals.scss
+++ b/client/blocks/stats-navigation/intervals.scss
@@ -8,4 +8,9 @@
 			margin: 16px auto;
 		}
 	}
+	.gridicon {
+		display: none; /* Hidden by default */
+	}
+
 }
+

--- a/client/my-sites/stats/stats-interval-dropdown/index.jsx
+++ b/client/my-sites/stats/stats-interval-dropdown/index.jsx
@@ -1,4 +1,5 @@
 import { Button, Dropdown } from '@wordpress/components';
+import * as Icons from '@wordpress/icons';
 import React, { useState } from 'react';
 import Intervals from 'calypso/blocks/stats-navigation/intervals';
 import './style.scss';
@@ -16,6 +17,7 @@ const IntervalDropdown = ( { period, pathTemplate } ) => {
 	const getCurrentIntervalLabel = ( intervalValue ) => {
 		return intervalLabels[ intervalValue ] || intervalValue;
 	};
+	const { check } = Icons;
 
 	return (
 		<Dropdown
@@ -31,6 +33,7 @@ const IntervalDropdown = ( { period, pathTemplate } ) => {
 						pathTemplate={ pathTemplate }
 						compact={ false }
 						onChange={ setCurrentInterval }
+						icon={ check }
 					/>
 				</div>
 			) }

--- a/client/my-sites/stats/stats-interval-dropdown/index.jsx
+++ b/client/my-sites/stats/stats-interval-dropdown/index.jsx
@@ -1,5 +1,5 @@
 import { Button, Dropdown } from '@wordpress/components';
-import * as Icons from '@wordpress/icons';
+import { check } from '@wordpress/icons';
 import React, { useState } from 'react';
 import Intervals from 'calypso/blocks/stats-navigation/intervals';
 import './style.scss';
@@ -17,7 +17,6 @@ const IntervalDropdown = ( { period, pathTemplate } ) => {
 	const getCurrentIntervalLabel = ( intervalValue ) => {
 		return intervalLabels[ intervalValue ] || intervalValue;
 	};
-	const { check } = Icons;
 
 	return (
 		<Dropdown

--- a/client/my-sites/stats/stats-interval-dropdown/style.scss
+++ b/client/my-sites/stats/stats-interval-dropdown/style.scss
@@ -1,8 +1,9 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@automattic/components/src/styles/typography.scss";
 
-
 .stats-interval-dropdown__container {
+
+	width: 196px;
 
 	> .components-button {
 		border-radius: 2px;
@@ -20,17 +21,6 @@
 	.segmented-control.is-primary .segmented-control__item.is-selected .segmented-control__link:focus {
 		background-color: var(--studio-white);
 		color: var(--gutenberg-gray-900);
-	}
-
-	.components-popover__content {
-		width: 196px;
-		border-radius: 2px;
-		background-color: var(--studio-white);
-		box-shadow:
-			0 2.3px 3.3px -0.5px rgba(0, 0, 0, 0.1),
-			0 1.2px 1.7px -0.2px rgba(0, 0, 0, 0.1),
-			0 0.7px 1px 0 rgba(0, 0, 0, 0.1),
-			0 0 0 1px #ccc;
 	}
 
 	.segmented-control {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #82082

## Proposed Changes

* This PR adds a new, optional icon prop to the `<Intervals>` component. This is to allow us to display a check mark next to the currently selected option without altering the current style and display of the component. 
* The end goal is to display a check mark like in the design specs:
![image](https://github.com/Automattic/wp-calypso/assets/30754158/0a955293-4e68-43fe-b88a-69c5b9558db6)

* Note: this PR does not style the icons or their layout/location in relation to the element. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load this branch into your local calypso environment
* Navigate to `/stats/day/{site URL}`
* Confirm that everything remains unchanged without the feature flag applied
* Locate the file `/blocks/stats-navigation/intervals.scss`
* Comment out the following lines `11-13`
```css
	.gridicon {
		display: none; /* Hidden by default */
	}
```
* Append `?flags=stats/date-control` to the end of the URL
* Confirm each dropdown item on the interval dropdown displays a checkmark icon
* 
![image](https://github.com/Automattic/wp-calypso/assets/30754158/f8838c71-d945-4acd-a0b1-75720b678a04)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?