### PR TITLE
Add the sticky notice when previewing a theme

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/editor.js
+++ b/apps/wpcom-block-editor/src/wpcom/editor.js
@@ -1,4 +1,5 @@
 import { registerPlugin } from '@wordpress/plugins';
+import './features/live-preview';
 import './features/deprecate-coblocks-buttons';
 import './features/fix-block-invalidation-errors';
 import './features/fix-coblocks-fonts';

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview.tsx
@@ -1,0 +1,103 @@
+import { useDispatch, useSelect } from '@wordpress/data';
+import domReady from '@wordpress/dom-ready';
+import { __, sprintf } from '@wordpress/i18n';
+import { registerPlugin } from '@wordpress/plugins';
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
+import { getQueryArg } from '@wordpress/url';
+import { useEffect } from 'react';
+
+/**
+ * Return true if the user is currently previewing a theme.
+ * FIXME: This is copied from Gutenberg, and that should be accessed from the `core/edit-site` store.
+ * @see https://github.com/WordPress/gutenberg/blob/053c8f733c85d80c891fa308b071b9a18e5194e9/packages/edit-site/src/utils/is-previewing-theme.js#L6
+ * @returns {boolean} isPreviewingTheme
+ */
+function isPreviewingTheme() {
+	return getQueryArg( window.location.href, 'wp_theme_preview' ) !== undefined;
+}
+
+/**
+ * Return the theme slug if the user is currently previewing a theme.
+ * FIXME: This is copied from Gutenberg, and that should be accessed from the `core/edit-site` store.
+ * @see https://github.com/WordPress/gutenberg/blob/053c8f733c85d80c891fa308b071b9a18e5194e9/packages/edit-site/src/utils/is-previewing-theme.js#L6
+ * @returns {string|null} currentlyPreviewingTheme
+ */
+function currentlyPreviewingTheme() {
+	if ( isPreviewingTheme() ) {
+		return getQueryArg( window.location.href, 'wp_theme_preview' );
+	}
+	return null;
+}
+
+/**
+ * Sometimes Gutenberg doesn't allow you to re-register the module and throws an error.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let unlock: ( object: any ) => any | undefined;
+try {
+	unlock = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
+		'I know using unstable features means my plugin or theme will inevitably break on the next WordPress release.',
+		'@wordpress/edit-site'
+	).unlock;
+} catch ( error ) {
+	// eslint-disable-next-line no-console
+	console.error( 'Error: Unable to get the unlock api. Reason: %s', error );
+}
+
+const NOTICE_ID = 'wpcom-live-preview/notice';
+
+/**
+ * This is an interim solution to clarify to users that they are currently live previewing a theme.
+ * And this should be moved to jetpack-mu-wpcom.
+ * @see https://github.com/Automattic/wp-calypso/issues/82218
+ */
+const LivePreviewNotice = () => {
+	const { createWarningNotice } = useDispatch( 'core/notices' );
+	const { dashboardLink, previewingTheme } = useSelect( ( select ) => {
+		const { getSettings } = unlock( select( 'core/edit-site' ) );
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const theme = ( select( 'core' ) as any ).getTheme( currentlyPreviewingTheme() );
+		return {
+			previewingTheme: theme?.name?.rendered || 'new',
+			dashboardLink: getSettings().__experimentalDashboardLink,
+		};
+	}, [] );
+	useEffect( () => {
+		if ( ! isPreviewingTheme() ) {
+			return;
+		}
+		createWarningNotice(
+			sprintf(
+				// translators: %s: theme name
+				__( 'You are currently live-previewing the %s theme.', 'wpcom-live-preview' ),
+				previewingTheme
+			),
+			{
+				id: NOTICE_ID,
+				isDismissible: false,
+				actions: [
+					{
+						label: __( 'Back to Themes', 'wpcom-live-preview' ),
+						url: dashboardLink,
+						variant: 'primary',
+					},
+				],
+			}
+		);
+	}, [ dashboardLink, createWarningNotice, previewingTheme ] );
+	return null;
+};
+
+const registerLivePreviewPlugin = () => {
+	registerPlugin( 'wpcom-live-preview', {
+		render: () => (
+			<>
+				<LivePreviewNotice />
+			</>
+		),
+	} );
+};
+
+domReady( () => {
+	registerLivePreviewPlugin();
+} );

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview.tsx
@@ -8,7 +8,7 @@ import { useEffect } from 'react';
 
 /**
  * Return true if the user is currently previewing a theme.
- * FIXME: This is copied from Gutenberg, and that should be accessed from the `core/edit-site` store.
+ * FIXME: This is copied from Gutenberg; we should be creating a selector for the `core/edit-site` store.
  * @see https://github.com/WordPress/gutenberg/blob/053c8f733c85d80c891fa308b071b9a18e5194e9/packages/edit-site/src/utils/is-previewing-theme.js#L6
  * @returns {boolean} isPreviewingTheme
  */
@@ -18,7 +18,7 @@ function isPreviewingTheme() {
 
 /**
  * Return the theme slug if the user is currently previewing a theme.
- * FIXME: This is copied from Gutenberg, and that should be accessed from the `core/edit-site` store.
+ * FIXME: This is copied from Gutenberg; we should be creating a selector for the `core/edit-site` store.
  * @see https://github.com/WordPress/gutenberg/blob/053c8f733c85d80c891fa308b071b9a18e5194e9/packages/edit-site/src/utils/is-previewing-theme.js#L6
  * @returns {string|null} currentlyPreviewingTheme
  */
@@ -55,10 +55,11 @@ const LivePreviewNotice = () => {
 	const { createWarningNotice } = useDispatch( 'core/notices' );
 	const { dashboardLink, previewingTheme } = useSelect( ( select ) => {
 		const { getSettings } = unlock( select( 'core/edit-site' ) );
+		const themeSlug = currentlyPreviewingTheme();
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		const theme = ( select( 'core' ) as any ).getTheme( currentlyPreviewingTheme() );
+		const theme = ( select( 'core' ) as any ).getTheme( themeSlug );
 		return {
-			previewingTheme: theme?.name?.rendered || 'new',
+			previewingTheme: theme?.name?.rendered || themeSlug,
 			dashboardLink: getSettings().__experimentalDashboardLink,
 		};
 	}, [] );
@@ -69,7 +70,10 @@ const LivePreviewNotice = () => {
 		createWarningNotice(
 			sprintf(
 				// translators: %s: theme name
-				__( 'You are currently live-previewing the %s theme.', 'wpcom-live-preview' ),
+				__(
+					'You are previewing the %s theme. You can try out your own style customizations, which will only be saved if you activate this theme.',
+					'wpcom-live-preview'
+				),
 				previewingTheme
 			),
 			{
@@ -77,7 +81,7 @@ const LivePreviewNotice = () => {
 				isDismissible: false,
 				actions: [
 					{
-						label: __( 'Back to Themes', 'wpcom-live-preview' ),
+						label: __( 'Back to themes', 'wpcom-live-preview' ),
 						url: dashboardLink,
 						variant: 'primary',
 					},
@@ -90,11 +94,7 @@ const LivePreviewNotice = () => {
 
 const registerLivePreviewPlugin = () => {
 	registerPlugin( 'wpcom-live-preview', {
-		render: () => (
-			<>
-				<LivePreviewNotice />
-			</>
-		),
+		render: () => <LivePreviewNotice />,
 	} );
 };
 

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview.tsx
@@ -83,7 +83,7 @@ const LivePreviewNotice = () => {
 					{
 						label: __( 'Back to themes', 'wpcom-live-preview' ),
 						url: dashboardLink,
-						variant: 'primary',
+						variant: 'secondary',
 					},
 				],
 			}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Add the sticky notice when previewing a theme. See #82218.

### Related 

- This is done with [GB's notice list](https://github.com/WordPress/gutenberg/blob/053c8f733c85d80c891fa308b071b9a18e5194e9/packages/editor/src/components/editor-notices/index.js#L24). Sample implementation in Calyoso: https://github.com/Automattic/wp-calypso/blob/2a55443f97be919f19cd15230e1417e375a5e062/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notices.js#L164
- I tried to add this feature to Jetpack (see https://github.com/Automattic/jetpack/pull/33459 and https://github.com/Automattic/jetpack/pull/33461). Since we want to release Live Preview next week and this PR's solution is somewhat interim, I implemented it here `wpcom-block-editor`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Patch this PR to your sandbox with cd apps/wpcom-block-editor/ && yarn dev --sync
* Sandbox widgets.wp.com and your site
* Open https://horizon.wordpress.com
* Go to Appearance -> Editor. Verify that the modal is NOT shown because we're not live-previewing anything.
* Go to the Theme Detail page of a free theme
* Click the `Preview & Customize`
* See the sticky notice

<img width="879" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/69b44315-1d3b-46b9-afaf-88a368f31ea8">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
