### PR TITLE
E2E: work in coverage for the new user + free plan scenario into the existing `Onboarding: Write` flow.

### DIFF
--- a/packages/calypso-e2e/src/lib/flows/start-site-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-site-flow.ts
@@ -7,6 +7,7 @@ import { Page } from 'playwright';
  */
 export type StepName = 'goals' | 'vertical' | 'intent' | 'designSetup' | 'options';
 type Goals = 'Write' | 'Promote' | 'Import Site' | 'Sell' | 'DIFM' | 'Other';
+type WriteActions = 'Start writing' | 'Start learning' | 'View designs';
 
 const selectors = {
 	// Generic
@@ -121,6 +122,29 @@ export class StartSiteFlow {
 		const readBack = await locator.inputValue();
 		if ( readBack !== tagline ) {
 			throw new Error( `Failed to set blog tagline: expected ${ tagline }, got ${ readBack }` );
+		}
+	}
+
+	/* Write Goal */
+
+	/**
+	 * Performs action available in the Write intent.
+	 *
+	 * @param {WriteActions} action Actions for the Write intent.
+	 */
+	async clickWriteAction( action: WriteActions ) {
+		await this.page.getByRole( 'button', { name: action } ).click();
+
+		if ( action === 'Start writing' ) {
+			// Extended timeout because the site is being
+			// headstarted at this time.
+			await this.page.waitForURL( /setup\/site-setup\/processing/, { timeout: 20 * 1000 } );
+		}
+		if ( action === 'Start learning' ) {
+			await this.page.waitForURL( /setup\/site-setup\/courses/ );
+		}
+		if ( action === 'View designs' ) {
+			await this.page.waitForURL( /setup\/site-setup\/designSetup/ );
 		}
 	}
 

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -123,7 +123,7 @@ export class EditorPage {
 		// Lacking a perfect cross-site type (Simple/Atomic) way to check the loading state,
 		// it is a fairly good stand-in.
 		await Promise.all( [
-			this.page.waitForURL( /(post|page|post-new.php)/ ),
+			this.page.waitForURL( /(post|page|post-new.php)/, { timeout: 60 * 1000 } ),
 			this.page.waitForResponse( /.*posts.*/, { timeout: 60 * 1000 } ),
 		] );
 

--- a/packages/calypso-e2e/src/lib/pages/login-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/login-page.ts
@@ -129,7 +129,8 @@ export class LoginPage {
 	 * Clicks the "Create a new account" link.
 	 */
 	async clickCreateNewAccount(): Promise< Locator > {
-		const locator = await this.page.locator( ':text-is("Create a new account")' );
+		const locator = this.page.getByRole( 'link', { name: 'Create a new account' } );
+		await locator.waitFor();
 		await locator.click();
 
 		return locator;

--- a/packages/calypso-e2e/src/lib/pages/signup/user-signup-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup/user-signup-page.ts
@@ -87,29 +87,23 @@ export class UserSignupPage {
 	 * @see https://github.com/Automattic/wp-calypso/pull/82481
 	 *
 	 * @param {string} email Email address of the new user.
-	 * @returns Response from the REST API.
+	 * @returns {NewUserResponse} Response from the REST API.
 	 */
 	async signupSocialFirstWithEmail( email: string ): Promise< NewUserResponse > {
 		await this.page.getByRole( 'button', { name: 'Continue with Email' } ).click();
 
 		await this.page.fill( selectors.emailInput, email );
 
-		// Use CSS selector instead of text.
-		// Text displayed on button changes depending on the link directing
-		// user to this page.
-		const [ , response ] = await Promise.all( [
-			this.page.waitForNavigation(),
+		const [ response ] = await Promise.all( [
 			this.page.waitForResponse( /.*new\?.*/ ),
-			this.page.click( selectors.submitButton ),
+			this.page.getByRole( 'button', { name: 'Continue' } ).click(),
 		] );
 
 		if ( ! response ) {
-			throw new Error( 'Failed to create new user at signup.' );
+			throw new Error( `Failed to sign up as new user: no or unexpected API response.` );
 		}
 
-		const responseBody: NewUserResponse = await response.json();
-
-		return responseBody;
+		return await response.json();
 	}
 
 	/**

--- a/test/e2e/specs/onboarding/onboarding__write.ts
+++ b/test/e2e/specs/onboarding/onboarding__write.ts
@@ -6,37 +6,50 @@ import {
 	DataHelper,
 	StartSiteFlow,
 	RestAPIClient,
-	SecretsManager,
 	DomainSearchComponent,
 	SignupPickPlanPage,
 	NewSiteResponse,
-	TestAccount,
+	NewUserResponse,
+	LoginPage,
+	UserSignupPage,
 	EditorPage,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
-import { apiDeleteSite } from '../shared';
+import { apiCloseAccount } from '../shared';
 
 declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( 'Onboarding: Write Focus' ), function () {
 	const blogName = DataHelper.getBlogName();
 	const blogTagLine = `${ blogName } tagline`;
+	const testUser = DataHelper.getNewTestUser( {
+		usernamePrefix: 'signupfree',
+	} );
 
-	let siteCreatedFlag: boolean;
+	let newUserDetails: NewUserResponse;
 	let newSiteDetails: NewSiteResponse;
 	let page: Page;
 	let selectedFreeDomain: string;
 
 	beforeAll( async function () {
 		page = await browser.newPage();
-
-		const testAccount = new TestAccount( 'simpleSiteFreePlanUser' );
-		await testAccount.authenticate( page );
 	} );
 
-	describe( 'Create site', function () {
-		it( 'Navigate to /new', async function () {
-			await page.goto( DataHelper.getCalypsoURL( 'start' ) );
+	describe( 'Register as new user', function () {
+		let loginPage: LoginPage;
+
+		it( 'Navigate to the Login page', async function () {
+			loginPage = new LoginPage( page );
+			await loginPage.visit();
+		} );
+
+		it( 'Click on button to create a new account', async function () {
+			await loginPage.clickCreateNewAccount();
+		} );
+
+		it( 'Sign up as a new user', async function () {
+			const userSignupPage = new UserSignupPage( page );
+			newUserDetails = await userSignupPage.signupSocialFirstWithEmail( testUser.email );
 		} );
 
 		it( 'Select a .wordpress.com domain name', async function () {
@@ -48,8 +61,6 @@ describe( DataHelper.createSuiteTitle( 'Onboarding: Write Focus' ), function () 
 		it( `Select WordPress.com Free plan`, async function () {
 			const signupPickPlanPage = new SignupPickPlanPage( page, selectedFreeDomain );
 			newSiteDetails = await signupPickPlanPage.selectPlan( 'Free' );
-
-			siteCreatedFlag = true;
 		} );
 	} );
 
@@ -95,18 +106,14 @@ describe( DataHelper.createSuiteTitle( 'Onboarding: Write Focus' ), function () 
 		} );
 
 		it( 'Write first post', async function () {
-			await Promise.all( [
-				page.waitForNavigation(),
-				startSiteFlow.clickButton( 'Start writing' ),
-			] );
+			await startSiteFlow.clickWriteAction( 'Start writing' );
 		} );
 
 		it( 'Editor loads', async function () {
 			editorPage = new EditorPage( page );
 			await editorPage.waitUntilLoaded();
 
-			const urlRegex = `/post/${ newSiteDetails.blog_details.site_slug }`;
-			expect( page.url() ).toMatch( urlRegex );
+			await page.waitForURL( new RegExp( newSiteDetails.blog_details.site_slug ) );
 		} );
 
 		it( 'Enter blog title', async function () {
@@ -119,41 +126,54 @@ describe( DataHelper.createSuiteTitle( 'Onboarding: Write Focus' ), function () 
 
 		it( 'First post congratulatory message is shown', async function () {
 			const editorParent = await editorPage.getEditorParent();
-
-			await editorParent.locator( ':text("Your first post is published!")' ).waitFor();
-			await page.keyboard.press( 'Escape' );
+			await editorParent
+				.getByRole( 'heading', { name: 'Your first post is published!' } )
+				.waitFor();
 		} );
 
-		it( 'Dismiss Launchpad modal if shown', async function () {
+		it( 'View Next Steps', async function () {
 			const editorParent = await editorPage.getEditorParent();
+			await editorParent.getByRole( 'button', { name: 'Next steps' } ).click();
+		} );
+	} );
 
-			const selector = '.launchpad__save-modal-buttons button';
-			const locator = editorParent.locator( selector );
-			try {
-				await locator.click( { timeout: 2000 } );
-			} catch {
-				// 	// noop;
-			}
+	describe( 'Launchpad', function () {
+		it( 'Launchpad is shown', async function () {
+			await page.waitForURL( /launchpad/ );
 		} );
 
-		it( 'Exit editor', async function () {
-			await editorPage.exitEditor();
+		it( 'Launch site', async function () {
+			await page.getByRole( 'button', { name: 'Launch your site' } ).click();
+
+			await page.waitForURL( /setup\/write\/processing/ );
+		} );
+
+		it( 'Post-launch congratulatory message is shown', async function () {
+			// User is redirected to the Home dashboard.
+			await page.waitForURL( /home/ );
+
+			await page.getByRole( 'dialog' ).getByRole( 'heading', { name: 'Congrats' } ).waitFor();
+		} );
+
+		it( 'Close congratulatory message', async function () {
+			await page.getByRole( 'dialog' ).getByRole( 'button', { name: 'Close' } ).click();
 		} );
 	} );
 
 	afterAll( async function () {
-		if ( ! siteCreatedFlag ) {
+		if ( ! newUserDetails ) {
 			return;
 		}
 
 		const restAPIClient = new RestAPIClient(
-			SecretsManager.secrets.testAccounts.simpleSiteFreePlanUser
+			{ username: testUser.username, password: testUser.password },
+			newUserDetails.body.bearer_token
 		);
 
-		await apiDeleteSite( restAPIClient, {
-			url: newSiteDetails.blog_details.url,
-			id: newSiteDetails.blog_details.blogid,
-			name: newSiteDetails.blog_details.blogname,
+		await apiCloseAccount( restAPIClient, {
+			userID: newUserDetails.body.user_id,
+			username: newUserDetails.body.username,
+			email: testUser.email,
 		} );
 	} );
 } );


### PR DESCRIPTION
Parent: https://github.com/Automattic/wp-calypso/pull/82566
Context: p58i-fmC-p2

## Proposed Changes

This PR works in the coverage for the scenario covered in the incident report (p58i-fmC-p2) into the existing `Onboarding: Write` (formerly `FTME: Write`) flow. 

Key changes:
- alter the flow to sign up for a new account instead of using an existing account.
- instead of terminating the test once the post is published, interact with the prompts and the Launchpad.
- update affected POMs and methods to use newer code style.

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)
  - [x] Pre-Release E2E

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?