### PR TITLE
Site Profiler: change site profiler route patteren

### DIFF
--- a/client/lib/domains/get-domain-from-input.ts
+++ b/client/lib/domains/get-domain-from-input.ts
@@ -1,5 +1,8 @@
 import { parseUrl } from 'calypso/lib/importer/url-validation';
 export function extractDomainFromInput( input: string ) {
+	if ( ! isNaN( Number( input ) ) ) {
+		return input;
+	}
 	try {
 		const parsedUrl = parseUrl( input );
 		const { hostname } = parsedUrl;

--- a/client/site-profiler/components/domain-analyzer/index.tsx
+++ b/client/site-profiler/components/domain-analyzer/index.tsx
@@ -51,6 +51,7 @@ export default function DomainAnalyzer( props: Props ) {
 							autoComplete="off"
 							defaultValue={ domain }
 							placeholder={ translate( 'Enter a site URL' ) }
+							key={ domain || 'empty' }
 						/>
 					</div>
 					<div className="col-2">

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -1,10 +1,9 @@
 import { translate } from 'i18n-calypso';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import DocumentHead from 'calypso/components/data/document-head';
 import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-query';
 import { useDomainAnalyzerQuery } from 'calypso/data/site-profiler/use-domain-analyzer-query';
 import { useHostingProviderQuery } from 'calypso/data/site-profiler/use-hosting-provider-query';
-import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { LayoutBlock, LayoutBlockSection } from 'calypso/site-profiler/components/layout';
 import useDefineConversionAction from 'calypso/site-profiler/hooks/use-define-conversion-action';
 import useDomainQueryParam from 'calypso/site-profiler/hooks/use-domain-query-param';
@@ -17,9 +16,7 @@ import HostingIntro from './hosting-intro';
 import './styles.scss';
 
 export default function SiteProfiler() {
-	const location = useLocation();
 	const navigate = useNavigate();
-	const queryParams = useQuery();
 	const {
 		domain,
 		isValid: isDomainValid,
@@ -48,9 +45,11 @@ export default function SiteProfiler() {
 	const updateDomainQueryParam = ( value: string ) => {
 		// Update the domain query param;
 		// URL param is the source of truth
-		value ? queryParams.set( 'domain', value ) : queryParams.delete( 'domain' );
-
-		navigate( location.pathname + '?' + queryParams.toString() );
+		if ( ! value ) {
+			navigate( '/site-profiler' );
+			return;
+		}
+		navigate( '/site-profiler/' + value );
 	};
 	const noNeedToFetchApi = specialDomainMapping && isDomainSpecialInput;
 	const showResultScreen = siteProfilerData || noNeedToFetchApi;

--- a/client/site-profiler/controller.tsx
+++ b/client/site-profiler/controller.tsx
@@ -4,9 +4,16 @@ import { BrowserRouter } from 'react-router-dom';
 import Main from 'calypso/components/main';
 import SiteProfiler from 'calypso/site-profiler/components/site-profiler';
 
-export function redirectSiteProfilerRoot( domain?: string ) {
-	const queryParam = domain ? `?domain=${ domain }` : '';
-	page.redirect( `/site-profiler${ queryParam }` );
+export function redirectSiteProfilerResult( context: PageJS.Context, next: () => void ) {
+	const { querystring } = context;
+	const queryParams = new URLSearchParams( querystring );
+	const domainQueryParam = queryParams.get( 'domain' ) || '';
+
+	if ( ! domainQueryParam ) {
+		next();
+	} else {
+		page.redirect( `/site-profiler/${ domainQueryParam }` );
+	}
 }
 
 export function siteProfilerContext( context: PageJS.Context, next: () => void ): void {

--- a/client/site-profiler/hooks/use-domain-query-param.ts
+++ b/client/site-profiler/hooks/use-domain-query-param.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback } from 'react';
-import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
+import { useLocation } from 'react-router-dom';
 import { extractDomainFromInput, getFixedDomainSearch } from 'calypso/lib/domains';
 import {
 	isSpecialInput,
@@ -11,8 +11,8 @@ export default function useDomainQueryParam( sanitize = true ) {
 	const [ domain, setDomain ] = useState( '' );
 	const [ isValid, setIsValid ] = useState< undefined | boolean >();
 	const [ specialDomainMapping, setSpecialDomainMapping ] = useState< SPECIAL_DOMAIN_CASES >();
-	const queryParams = useQuery();
-	const _domain = ( queryParams.get( 'domain' ) || '' ).trim();
+	const location = useLocation();
+	const _domain = location.pathname.split( '/site-profiler/' )[ 1 ]?.trim() || '';
 	const isDomainSpecialInput = isSpecialInput( _domain );
 
 	const getFinalizedDomain = useCallback(

--- a/client/site-profiler/index.web.ts
+++ b/client/site-profiler/index.web.ts
@@ -1,9 +1,15 @@
 import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller/index.web';
-import { siteProfilerContext, redirectSiteProfilerRoot } from 'calypso/site-profiler/controller';
+import { siteProfilerContext, redirectSiteProfilerResult } from 'calypso/site-profiler/controller';
 
 export default function () {
-	page( '/site-profiler', siteProfilerContext, makeLayout, clientRender );
-	page( '/site-profiler/:domain', ( { params } ) => redirectSiteProfilerRoot( params.domain ) );
-	page( '/site-profiler/:domain/*', ( { params } ) => redirectSiteProfilerRoot( params.domain ) );
+	page(
+		'/site-profiler',
+		redirectSiteProfilerResult,
+		siteProfilerContext,
+		makeLayout,
+		clientRender
+	);
+	page( '/site-profiler/:domain', siteProfilerContext, makeLayout, clientRender );
+	page( '/site-profiler/:domain/*', siteProfilerContext, makeLayout, clientRender );
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/dotcom-forge#4098

## Proposed Changes

* Changing site-profiler route from `/site-profiler?domain=site` to `/site-profiler/site`
* Also support backward compatibility, if you type in `/site-profiler?domain=site` it brings you to `/site-profiler/site`
* Fix a small re-render bug in the input field

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /site-profiler
* Type in a domain and see if the URL address bar shows the pattern like `/site-profiler/site`, try to play around and see if everything remains the same.
* Try to go to `/site-profiler?domain=site` and see if it redirects you to `/site-profiler/site`
* Try to enter `/site-profiler/site` from the URL address bar and see if everything works as expected.
* Try to type in a special case like `localhost` or `127.0.0.1` and click on "Check another site", make sure the input field gets cleaned when you see it. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?