### PR TITLE
Site Profiler: move underline to login link in VerifiedProvider component

### DIFF
--- a/client/site-profiler/components/domain-information/index.tsx
+++ b/client/site-profiler/components/domain-information/index.tsx
@@ -7,7 +7,7 @@ import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { useDomainAnalyzerWhoisRawDataQuery } from 'calypso/data/site-profiler/use-domain-whois-raw-data-query';
 import { useFilteredWhoisData } from 'calypso/site-profiler/hooks/use-filtered-whois-data';
 import { normalizeWhoisField } from 'calypso/site-profiler/utils/normalize-whois-entry';
-import VerifiedProvider from './verified-provider';
+import VerifiedProvider from '../verified-provider';
 import type { HostingProvider, WhoIs } from 'calypso/data/site-profiler/types';
 import './styles.scss';
 

--- a/client/site-profiler/components/hosting-information/hosting-provider-name.tsx
+++ b/client/site-profiler/components/hosting-information/hosting-provider-name.tsx
@@ -3,7 +3,7 @@ import { UrlData } from 'calypso/blocks/import/types';
 import InfoPopover from 'calypso/components/info-popover';
 import useHostingProviderName from 'calypso/site-profiler/hooks/use-hosting-provider-name';
 import useHostingProviderURL from 'calypso/site-profiler/hooks/use-hosting-provider-url';
-import VerifiedProvider from '../domain-information/verified-provider';
+import VerifiedProvider from '../verified-provider';
 import HostingPopupContent from './popup-inline-content';
 import type { HostingProvider } from 'calypso/data/site-profiler/types';
 

--- a/client/site-profiler/components/verified-provider/index.tsx
+++ b/client/site-profiler/components/verified-provider/index.tsx
@@ -4,6 +4,7 @@ import { UrlData } from 'calypso/blocks/import/types';
 import { HostingProvider } from 'calypso/data/site-profiler/types';
 import useHostingProviderName from 'calypso/site-profiler/hooks/use-hosting-provider-name';
 import useHostingProviderURL from 'calypso/site-profiler/hooks/use-hosting-provider-url';
+import './styles.scss';
 
 interface Props {
 	hostingProvider?: HostingProvider;
@@ -18,7 +19,7 @@ export default function VerifiedProvider( props: Props ) {
 	const hostingProviderLogin = useHostingProviderURL( 'login', hostingProvider, urlData );
 
 	return (
-		<>
+		<div className="verified-provider">
 			<span className="status-icon status-icon--small blue">
 				{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
 				<Gridicon icon="checkmark" size={ 10 } />
@@ -26,10 +27,11 @@ export default function VerifiedProvider( props: Props ) {
 			<a href={ showHostingProvider ? hostingProviderHomepage : 'https://wordpress.com' }>
 				{ showHostingProvider ? hostingProviderName : translate( 'WordPress.com' ) }
 			</a>
-			&nbsp;&nbsp;
+			&nbsp;(
 			<a href={ showHostingProvider ? hostingProviderLogin : 'https://wordpress.com/login' }>
-				({ translate( 'login' ) })
+				{ translate( 'login' ) }
 			</a>
-		</>
+			)
+		</div>
 	);
 }

--- a/client/site-profiler/components/verified-provider/styles.scss
+++ b/client/site-profiler/components/verified-provider/styles.scss
@@ -1,0 +1,3 @@
+.verified-provider {
+	color: var(--wp-admin-theme-color);
+}


### PR DESCRIPTION
Fixes: https://github.com/Automattic/wp-calypso/issues/82632

## Proposed Changes

* Move the underline style to login link

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open https://wpcalypso.wordpress.com/site-profiler?domain=wecanwang.com
* Open http://calypso.localhost:3000/site-profiler?domain=wecanwang.com

Before:

<img width="221" alt="image" src="https://github.com/Automattic/wp-calypso/assets/167611/dafa9724-ff5d-4235-ad77-1100ab9c12e4">

After:

<img width="211" alt="image" src="https://github.com/Automattic/wp-calypso/assets/167611/d89db018-3f0a-44f9-80f1-e75e88eac0a4">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?