### PR TITLE
Multi-Domain: Update subheadline copy

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -962,6 +962,10 @@ export class RenderDomainsStep extends Component {
 			);
 		}
 
+		if ( this.shouldUseMultipleDomainsInCart() ) {
+			return translate( 'Find and claim one or more domain names' );
+		}
+
 		if ( isReskinned ) {
 			return (
 				! stepSectionName &&


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/4107

## Proposed Changes

When multi-domain selection is enabled, use the subheadline copy "Find and claim one or more domain names"

| Before | After |
| --- | --- |
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/5bd4b280-41d1-4d27-ab3f-da9950017e12) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/6b855757-dc2b-4ab2-ab3b-9fafa2aa85b6) |

## Testing Instructions

* Go to `/start/domains?flags=add/multiple-domains-select-and-list`
* Check the new copy
* Go to `/start/domains` (without the flag)
* Check for the old copy
