### PR TITLE
Jetpack E2E: address issues with AT accounts failing to load the editor.

### DIFF
--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -225,7 +225,7 @@ fun jetpackSimpleDeploymentE2eBuildType( targetDevice: String, buildUuid: String
 		uuid = buildUuid
 		name = "Jetpack Simple Deployment E2E Tests ($targetDevice)"
 		description = "Runs E2E tests validating the deployment of Jetpack on Simple sites on $targetDevice viewport"
-		
+
 		artifactRules = defaultE2eArtifactRules();
 
 		vcs {
@@ -281,13 +281,13 @@ fun jetpackSimpleDeploymentE2eBuildType( targetDevice: String, buildUuid: String
 
 fun jetpackAtomicDeploymentE2eBuildType( targetDevice: String, buildUuid: String ): BuildType {
 	val atomicVariations = listOf("default", "php-old", "php-new", "wp-beta", "wp-previous", "private", "ecomm-plan")
-	
+
 	return BuildType({
 		id("WPComTests_jetpack_atomic_deployment_e2e_$targetDevice")
 		uuid = buildUuid
 		name = "Jetpack Atomic Deployment E2E Tests ($targetDevice)"
 		description = "Runs E2E tests validating the deployment of Jetpack on Atomic sites on $targetDevice viewport"
-		
+
 		artifactRules = defaultE2eArtifactRules();
 
 		vcs {
@@ -301,6 +301,7 @@ fun jetpackAtomicDeploymentE2eBuildType( targetDevice: String, buildUuid: String
 			param("env.VIEWPORT_NAME", "$targetDevice")
 			param("env.JETPACK_TARGET", "wpcom-deployment")
 			param("env.TEST_ON_ATOMIC", "true")
+			param("env.AUTHENTICATE_ACCOUNTS", "jetpackAtomicDefaultUser,jetpackAtomicPhpOldUser,jetpackAtomicPhpNewUser,jetpackAtomicEcommPlanUser,jetpackAtomicPrivateUser,jetpackAtomicWpBetaUser,jetpackAtomicWpPreviousUser")
 		}
 
 		steps {

--- a/packages/calypso-e2e/src/jest-playwright-config/global-setup.ts
+++ b/packages/calypso-e2e/src/jest-playwright-config/global-setup.ts
@@ -59,7 +59,7 @@ async function loginAndSaveCookies( testAccount: TestAccount, browser: Browser )
 	const page = await browser.newPage( pwConfig.contextOptions );
 	page.setDefaultTimeout( envVariables.TIMEOUT );
 	try {
-		await testAccount.logInViaLoginPage( page );
+		await testAccount.authenticate( page, { waitUntilStable: true } );
 		await testAccount.saveAuthCookies( page.context() );
 	} finally {
 		await page.close();

--- a/packages/calypso-e2e/src/lib/pages/login-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/login-page.ts
@@ -41,10 +41,7 @@ export class LoginPage {
 		await this.fillUsername( username );
 		await this.clickSubmit();
 		await this.fillPassword( password );
-		await Promise.all( [
-			this.page.waitForNavigation( { timeout: 20 * 1000 } ),
-			this.clickSubmit(),
-		] );
+		await this.clickSubmit();
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/pages-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/pages-page.ts
@@ -1,8 +1,8 @@
-import { Page, Response } from 'playwright';
+import { Page } from 'playwright';
 import { getCalypsoURL } from '../../data-helper';
 
 /**
- * Represents the Pages page
+ * Represents the Pages page.
  */
 export class PagesPage {
 	private page: Page;
@@ -19,20 +19,27 @@ export class PagesPage {
 	/**
 	 * Opens the Pages page.
 	 *
+	 * @param param0 Keyed object parameter.
+	 * @param {string} param0.siteSlug Site slug.
+	 * @param {number} param0.timeout Custom timeout.
+	 *
 	 * Example {@link https://wordpress.com/pages}
+	 * Example {@link https://wordpress.com/pages/usersiteslug.wordpress.com}
 	 */
-	async visit(): Promise< Response | null > {
-		const response = await this.page.goto( getCalypsoURL( 'pages' ) );
-		return response;
+	async visit( { siteSlug, timeout }: { siteSlug?: string; timeout?: number } = {} ) {
+		const url = `pages/${ siteSlug }`;
+		await this.page.goto( getCalypsoURL( url ), { timeout: timeout } );
+
+		// Wait for page entries (if any) to load. This also waits for the page to settle.
+		await this.page
+			.locator( 'card.is-placeholder' )
+			.waitFor( { state: 'detached', timeout: timeout } );
 	}
 
 	/**
 	 * Start a new page using the 'Add new page' button.
 	 */
-	async addNewPage(): Promise< void > {
-		await Promise.all( [
-			this.page.waitForNavigation(),
-			this.page.getByRole( 'link', { name: /(Add new|Start a) page/ } ).click(),
-		] );
+	async addNewPage() {
+		await this.page.getByRole( 'link', { name: /(Add new|Start a) page/ } ).click();
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/pages-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/pages-page.ts
@@ -31,9 +31,7 @@ export class PagesPage {
 		await this.page.goto( getCalypsoURL( url ), { timeout: timeout } );
 
 		// Wait for page entries (if any) to load. This also waits for the page to settle.
-		await this.page
-			.locator( 'card.is-placeholder' )
-			.waitFor( { state: 'detached', timeout: timeout } );
+		await this.page.locator( '.is-placeholder' ).waitFor( { state: 'detached', timeout: timeout } );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/posts-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/posts-page.ts
@@ -1,4 +1,4 @@
-import { Page, Response } from 'playwright';
+import { Page } from 'playwright';
 import { getCalypsoURL } from '../../data-helper';
 import { reloadAndRetry, clickNavTab } from '../../element-helper';
 
@@ -10,7 +10,6 @@ type PostsPageTabs = 'Published' | 'Drafts' | 'Scheduled' | 'Trashed';
 
 const selectors = {
 	// General
-	placeholder: `div.is-placeholder`,
 	addNewPostButton: 'a.post-type-list__add-post',
 
 	// Post Item
@@ -40,11 +39,13 @@ export class PostsPage {
 	 * Opens the Posts page.
 	 *
 	 * Example {@link https://wordpress.com/posts}
+	 * Example {@link https://wordpress.com/posts/usersiteslug.wordpress.com}
 	 */
-	async visit(): Promise< Response | null > {
-		const response = await this.page.goto( getCalypsoURL( 'posts' ) );
-		await this.waitUntilLoaded();
-		return response;
+	async visit( { siteSlug, timeout }: { siteSlug?: string; timeout?: number } = {} ) {
+		const url = `posts/${ siteSlug }`;
+		await this.page.goto( getCalypsoURL( url ), { timeout: timeout } );
+
+		await this.waitUntilLoaded( timeout );
 	}
 
 	/**
@@ -67,8 +68,9 @@ export class PostsPage {
 	/**
 	 * Wait until the page is completely loaded.
 	 */
-	async waitUntilLoaded(): Promise< void > {
-		await this.page.waitForSelector( selectors.placeholder, { state: 'detached' } );
+	async waitUntilLoaded( timeout?: number ): Promise< void > {
+		// Wait for page entries (if any) to load. This also waits for the page to settle.
+		await this.page.locator( '.is-placeholder' ).waitFor( { state: 'detached', timeout: timeout } );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/test-account.ts
+++ b/packages/calypso-e2e/src/lib/test-account.ts
@@ -79,6 +79,13 @@ export class TestAccount {
 		if ( this.credentials.smsNumber ) {
 			return await loginPage.submitVerificationCode( await this.getSMSOTP() );
 		}
+
+		// Wait for the `/home` endpoint to load.
+		// Note, even for eCommerce users (which eventually loads the wp-admin screen),
+		// the `/home` endpoint attempts to load first.
+		// When saving cookies, it is important to wait until the `/home` endpoint is
+		// first loaded, otherwise the cookie is invalid.
+		await page.waitForURL( /(home|read)/ );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/test-account.ts
+++ b/packages/calypso-e2e/src/lib/test-account.ts
@@ -56,7 +56,15 @@ export class TestAccount {
 		}
 		if ( waitUntilStable ) {
 			const sidebarComponent = new SidebarComponent( page );
-			await sidebarComponent.waitForSidebarInitialization();
+
+			// Wait for either of the WP-Admin or Calypso
+			// sidebars to appear.
+			// @TODO Replace the raw WP-Admin selector with
+			// a POM.
+			await Promise.race( [
+				sidebarComponent.waitForSidebarInitialization(),
+				page.locator( 'div[id="adminmenuwrap"]' ).waitFor( { timeout: 20 * 1000 } ),
+			] );
 		}
 	}
 
@@ -79,13 +87,6 @@ export class TestAccount {
 		if ( this.credentials.smsNumber ) {
 			return await loginPage.submitVerificationCode( await this.getSMSOTP() );
 		}
-
-		// Wait for the `/home` endpoint to load.
-		// Note, even for eCommerce users (which eventually loads the wp-admin screen),
-		// the `/home` endpoint attempts to load first.
-		// When saving cookies, it is important to wait until the `/home` endpoint is
-		// first loaded, otherwise the cookie is invalid.
-		await page.waitForURL( /(home|read)/ );
 	}
 
 	/**

--- a/test/e2e/specs/editor/editor__page-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__page-basic-flow.ts
@@ -35,6 +35,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		[ { gutenberg: 'stable', siteType: 'simple', accountName: 'simpleSitePersonalPlanUser' } ]
 	);
 
+	let testAccount: TestAccount;
 	let page: Page;
 	let editorPage: EditorPage;
 	let pagesPage: PagesPage;
@@ -43,13 +44,13 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	beforeAll( async () => {
 		page = await browser.newPage();
 
-		const testAccount = new TestAccount( accountName );
+		testAccount = new TestAccount( accountName );
 		await testAccount.authenticate( page );
 	} );
 
 	it( 'Visit Pages page', async function () {
 		pagesPage = new PagesPage( page );
-		await pagesPage.visit();
+		await pagesPage.visit( { siteSlug: testAccount.credentials.testSites?.primary.url } );
 	} );
 
 	it( 'Start a new page', async function () {


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/80730, https://github.com/Automattic/wp-calypso/issues/82497.

## Proposed Changes

This PR seeks to address the fundamental reasons why the Jetpack AT accounts are failing to load the editor in CI.

Key changes:
- pre-authenticate all Jetpack AT users prior to test start.
- when warming cookies, use `TestAccount.authenticate` method instead of `TestAccount.logInViaLoginPage` to take advantage of stability fixes.

## Why?

The thinking goes as follows:
- Jetpack AT build runs ~210 test steps against 7 users. It works out to be ~1600 total test steps.
- the authentication flow repeats circa 20 times for each user. It works to be at least 140 authentications.
- trace files generated by previous builds that failed to launch the Editor all show repeated requests to `wp-login.php?action=jetpack-sso`, ultimately ending with a `net::ERR_TOO_MANY_REDIRECTS` error. This suggests a failure to authenticate the user, or a faulty cookie.


## Testing Instructions

Ensure the following build configurations are passing:
  - [ ] Calypso E2E (desktop)
  - [ ] Jetpack E2E Simple (mobile)
  - [ ] Jetpack E2E Simple (desktop)
  - [ ] Jetpack E2E AT (desktop)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?