### PR TITLE
state: refactor away from `_.times`

### DIFF
--- a/client/state/data-layer/wpcom/sites/users/test/index.js
+++ b/client/state/data-layer/wpcom/sites/users/test/index.js
@@ -1,4 +1,4 @@
-import { chunk, times } from 'lodash';
+import { chunk } from 'lodash';
 import { POST_REVISION_AUTHORS_RECEIVE } from 'calypso/state/action-types';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import {
@@ -11,6 +11,8 @@ import {
 	normalizeUser,
 	receivePostRevisionAuthorsSuccess,
 } from '../';
+
+const times = ( n, cb ) => [ ...new Array( n ).keys() ].map( ( k ) => cb?.( k ) ?? k );
 
 describe( '#normalizeRevision', () => {
 	test( 'should rename `id`, `name` and `slug`', () => {

--- a/client/state/data-layer/wpcom/sites/users/test/index.js
+++ b/client/state/data-layer/wpcom/sites/users/test/index.js
@@ -12,7 +12,7 @@ import {
 	receivePostRevisionAuthorsSuccess,
 } from '../';
 
-const times = ( n, cb ) => [ ...new Array( n ).keys() ].map( ( k ) => cb?.( k ) ?? k );
+const times = ( n ) => Array.from( { length: n } ).map( ( _, k ) => k );
 
 describe( '#normalizeRevision', () => {
 	test( 'should rename `id`, `name` and `slug`', () => {
@@ -104,7 +104,7 @@ describe( '#receiveSuccess', () => {
 	test( 'should fetch another page if it receives a full page of users (default per page)', () => {
 		const nbUsers = DEFAULT_PER_PAGE + 1;
 		const ids = times( nbUsers );
-		const users = times( nbUsers, ( id ) => ( { id } ) );
+		const users = ids.map( ( id ) => ( { id } ) );
 		const usersChunks = chunk( users, DEFAULT_PER_PAGE );
 
 		const requestAction = requestPostRevisionAuthors( 12345678, ids );
@@ -157,7 +157,7 @@ describe( '#receiveSuccess', () => {
 		const perPage = 4;
 		const nbUsers = perPage + 1;
 		const ids = times( nbUsers );
-		const users = times( nbUsers, ( id ) => ( { id } ) );
+		const users = ids.map( ( id ) => ( { id } ) );
 		const usersChunks = chunk( users, perPage );
 
 		const requestAction = { ...requestPostRevisionAuthors( 12345678, ids ), perPage };

--- a/client/state/selectors/get-billing-transaction-date-filter-values.js
+++ b/client/state/selectors/get-billing-transaction-date-filter-values.js
@@ -1,5 +1,5 @@
 import { createSelector } from '@automattic/state-utils';
-import { last, times } from 'lodash';
+import { last } from 'lodash';
 import moment from 'moment';
 import getBillingTransactionsByType from 'calypso/state/selectors/get-billing-transactions-by-type';
 
@@ -20,7 +20,7 @@ export default createSelector(
 			return [];
 		}
 
-		const result = times( 6, ( n ) => {
+		const result = [ 0, 1, 2, 3, 4, 5 ].map( ( n ) => {
 			const month = moment().subtract( n, 'months' );
 			return {
 				dateString: moment( month ).startOf( 'month' ).format( 'YYYY-MM-DD' ),


### PR DESCRIPTION
## Proposed Changes

PR refactors away from `_.times` in `client/state`.

## Testing Instructions

* Changes are partly covered with unit tests, 
* As with a lot of lodash methods it's good practice to ensure we don't accidentally miss guards for whether we operate on the expected data structure.
