### PR TITLE
Use href in Button elements to improve launchpad click/navigation UX

### DIFF
--- a/packages/launchpad/src/checklist-item/index.tsx
+++ b/packages/launchpad/src/checklist-item/index.tsx
@@ -23,6 +23,11 @@ const ChecklistItem = ( { task, isPrimaryAction }: { task: Task; isPrimaryAction
 		null !== task.repetition_count &&
 		undefined !== task.repetition_count;
 
+	// If the task says we should use the Calypso path, ensure we use that link for the button's href.
+	// This allows the UI routing code to hook into the URL changes and should reduce full-page (re)loads
+	// when clicking on the task list items.
+	const buttonHref = task.useCalypsoPath && task.calypso_path ? task.calypso_path : undefined;
+
 	return (
 		<li
 			className={ classnames( 'checklist-item__task', {
@@ -37,6 +42,7 @@ const ChecklistItem = ( { task, isPrimaryAction }: { task: Task; isPrimaryAction
 					className="checklist-item__checklist-primary-button"
 					disabled={ disabled }
 					data-task={ id }
+					href={ buttonHref }
 					onClick={ handlePrimaryAction }
 				>
 					{ title }
@@ -46,6 +52,7 @@ const ChecklistItem = ( { task, isPrimaryAction }: { task: Task; isPrimaryAction
 					className="checklist-item__task-content"
 					disabled={ disabled }
 					data-task={ id }
+					href={ buttonHref }
 					onClick={ actionDispatch }
 				>
 					{ completed && (

--- a/packages/launchpad/src/types.ts
+++ b/packages/launchpad/src/types.ts
@@ -15,6 +15,7 @@ export interface Task {
 	target_repetitions?: number;
 	repetition_count?: number;
 	order?: number;
+	useCalypsoPath?: boolean;
 }
 
 export type LaunchpadChecklist = Task[];


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* This PR updates the implementation of the launchpad `ChecklistItem` class to use the `href` attribute of the `Button` components it renders when we have determined that we should use the `calypso_path` value for the target URL.
* The rendering change is relatively small, while the general logic to decide if the `calypso_path` should be used has been added to the `setUpTasksForActions()` function, which we should be including by default (especially after we land a component to supply all these defaults in https://github.com/Automattic/wp-calypso/pull/82612).
* The main change from this refactor is that the client-side code can hook into the URL change stemming from the navigation, and we can avoid a full page reload, which is something we were seeing from the calls to `window.location.assign()`.
  - Note that this primarily applies to launchpad when rendered within Calypso, as the full-screen launchpad uses code to handle all navigation and will likely need a different approach/implementation.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch locally or via Calypso.live
* For a site where you are still being shown the fullscreen launchpad, navigate to the launchpad (either by clicking on My Home for an existing site, or by creating a new site with a valid intent)
* Verify that all the tasks still support the expected click actions
* Now navigate to Customer Home for a site where you are being shown a launchpad (which you can do by skipping the full-screen launchpad above)
* Verify that clicking on the various tasks still works _and_ doesn't trigger full reloads for all local-to-Calypso targets.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?