### PR TITLE
E2E WIP: update onboarding plan upsell modal handling.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -20,12 +20,6 @@ const selectors = {
 		}
 		return `button.is-${ name.toLowerCase() }-plan:visible`;
 	},
-	selectModalUpsellPlanButton: ( name: 'Free' | 'Personal' ) => {
-		if ( name === 'Free' ) {
-			return `button.is-upsell-modal-free-plan:visible`;
-		}
-		return `button.is-upsell-modal-${ name.toLowerCase() }-plan:visible`;
-	},
 
 	// Navigation
 	mobileNavTabsToggle: `button.section-nav__mobile-header`,
@@ -92,21 +86,6 @@ export class PlansPage {
 		const locator = this.page.locator( selectors.selectPlanButton( plan ) );
 		// In the `/plans` view, there are two buttons for "Upgrade" on the
 		// plan comparison chart. Select the first one.
-		await locator.first().click();
-	}
-
-	/**
-	 * Selects the plan on the modal upsell.
-	 *
-	 * @param {Plans} plan Plan to select.
-	 */
-	async selectModalUpsellPlan( plan: Plans ): Promise< void > {
-		if ( plan !== 'Free' && plan !== 'Personal' ) {
-			throw Error( `Unsupported plan to be selected in modal upsell: ${ plan }` );
-		}
-
-		const locator = this.page.locator( selectors.selectModalUpsellPlanButton( plan ) );
-
 		await locator.first().click();
 	}
 

--- a/test/e2e/specs/onboarding/ftme__write.ts
+++ b/test/e2e/specs/onboarding/ftme__write.ts
@@ -46,7 +46,7 @@ describe( DataHelper.createSuiteTitle( 'FTME: Write' ), function () {
 		} );
 
 		it( `Select WordPress.com Free plan`, async function () {
-			const signupPickPlanPage = new SignupPickPlanPage( page, selectedFreeDomain );
+			const signupPickPlanPage = new SignupPickPlanPage( page );
 			newSiteDetails = await signupPickPlanPage.selectPlan( 'Free' );
 
 			siteCreatedFlag = true;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
