### PR TITLE
Plans 2023: Compile manageHref out of the grid components

### DIFF
--- a/client/my-sites/plans-features-main/hooks/use-current-plan-manage-href.ts
+++ b/client/my-sites/plans-features-main/hooks/use-current-plan-manage-href.ts
@@ -1,0 +1,20 @@
+import { useSelector } from 'react-redux';
+import { getManagePurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
+import getCurrentPlanPurchaseId from 'calypso/state/selectors/get-current-plan-purchase-id';
+import getSiteSlug from 'calypso/state/sites/selectors/get-site-slug';
+import { IAppState } from 'calypso/state/types';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+const useCurrentPlanManageHref = () => {
+	const siteId = useSelector( getSelectedSiteId );
+	const purchaseId = useSelector( ( state: IAppState ) =>
+		siteId ? getCurrentPlanPurchaseId( state, siteId ) : null
+	);
+	const selectedSiteSlug = useSelector( ( state: IAppState ) => getSiteSlug( state, siteId ) );
+
+	return purchaseId && selectedSiteSlug
+		? getManagePurchaseUrlFor( selectedSiteSlug, purchaseId )
+		: `/plans/my-plan/${ siteId }`;
+};
+
+export default useCurrentPlanManageHref;

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -56,6 +56,7 @@ import { FreePlanPaidDomainDialog } from './components/free-plan-paid-domain-dia
 import { LoadingPlaceHolder } from './components/loading-placeholder';
 import usePricedAPIPlans from './hooks/data-store/use-priced-api-plans';
 import usePricingMetaForGridPlans from './hooks/data-store/use-pricing-meta-for-grid-plans';
+import useCurrentPlanManageHref from './hooks/use-current-plan-manage-href';
 import useFilterPlansForPlanFeatures from './hooks/use-filter-plans-for-plan-features';
 import useIsCustomDomainAllowedOnFreePlan from './hooks/use-is-custom-domain-allowed-on-free-plan';
 import useIsPlanUpsellEnabledOnFreeDomain from './hooks/use-is-plan-upsell-enabled-on-free-domain';
@@ -246,6 +247,7 @@ const PlansFeaturesMain = ( {
 	const domainFromHomeUpsellFlow = useSelector( getDomainFromHomeUpsellInQuery );
 	const showUpgradeableStorage = config.isEnabled( 'plans/upgradeable-storage' );
 	const observableForOdieRef = useObservableForOdie();
+	const currentPlanManageHref = useCurrentPlanManageHref();
 
 	const toggleShowPlansComparisonGrid = () => {
 		setShowPlansComparisonGrid( ! showPlansComparisonGrid );
@@ -737,6 +739,7 @@ const PlansFeaturesMain = ( {
 								allFeaturesList={ FEATURES_LIST }
 								planTypeSelectorProps={ planTypeSelectorProps }
 								onStorageAddOnClick={ handleStorageAddOnClick }
+								currentPlanManageHref={ currentPlanManageHref }
 							/>
 							{ ! hidePlansFeatureComparison && (
 								<>
@@ -777,6 +780,7 @@ const PlansFeaturesMain = ( {
 											allFeaturesList={ FEATURES_LIST }
 											planTypeSelectorProps={ planTypeSelectorProps }
 											onStorageAddOnClick={ handleStorageAddOnClick }
+											currentPlanManageHref={ currentPlanManageHref }
 										/>
 										<ComparisonGridToggle
 											onClick={ toggleShowPlansComparisonGrid }

--- a/client/my-sites/plans-grid/components/actions.tsx
+++ b/client/my-sites/plans-grid/components/actions.tsx
@@ -32,7 +32,7 @@ type PlanFeaturesActionsButtonProps = {
 	currentSitePlanSlug?: string | null;
 	trialPlan?: boolean;
 	freePlan: boolean;
-	manageHref: string;
+	currentPlanManageHref?: string;
 	isPopular?: boolean;
 	isInSignup?: boolean;
 	isLaunchPage?: boolean | null;
@@ -194,7 +194,7 @@ const LoggedInPlansFeatureActionButton = ( {
 	planTitle,
 	handleUpgradeButtonClick,
 	planSlug,
-	manageHref,
+	currentPlanManageHref,
 	canUserPurchasePlan,
 	currentSitePlanSlug,
 	buttonText,
@@ -209,7 +209,7 @@ const LoggedInPlansFeatureActionButton = ( {
 	planTitle: TranslateResult;
 	handleUpgradeButtonClick: () => void;
 	planSlug: string;
-	manageHref?: string;
+	currentPlanManageHref?: string;
 	canUserPurchasePlan?: boolean | null;
 	currentSitePlanSlug?: string | null;
 	buttonText?: string;
@@ -232,7 +232,7 @@ const LoggedInPlansFeatureActionButton = ( {
 				<Button
 					className={ classes }
 					onClick={ planActionOverrides.loggedInFreePlan.callback }
-					disabled={ ! manageHref } // not sure why this is here
+					disabled={ ! currentPlanManageHref } // not sure why this is here
 				>
 					{ planActionOverrides.loggedInFreePlan.text }
 				</Button>
@@ -248,7 +248,11 @@ const LoggedInPlansFeatureActionButton = ( {
 
 	if ( current && planSlug !== PLAN_P2_FREE ) {
 		return (
-			<Button className={ classes } href={ manageHref } disabled={ ! manageHref }>
+			<Button
+				className={ classes }
+				href={ currentPlanManageHref }
+				disabled={ ! currentPlanManageHref }
+			>
 				{ canUserPurchasePlan ? translate( 'Manage plan' ) : translate( 'View plan' ) }
 			</Button>
 		);
@@ -365,7 +369,7 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 	currentSitePlanSlug,
 	freePlan = false,
 	trialPlan = false,
-	manageHref,
+	currentPlanManageHref,
 	isInSignup,
 	isLaunchPage,
 	onUpgradeClick,
@@ -494,7 +498,7 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 			availableForPurchase={ availableForPurchase }
 			classes={ classes }
 			handleUpgradeButtonClick={ handleUpgradeButtonClick }
-			manageHref={ manageHref }
+			currentPlanManageHref={ currentPlanManageHref }
 			canUserPurchasePlan={ canUserPurchasePlan }
 			currentSitePlanSlug={ currentSitePlanSlug }
 			buttonText={ buttonText }

--- a/client/my-sites/plans-grid/components/comparison-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/comparison-grid/index.tsx
@@ -320,7 +320,7 @@ type ComparisonGridProps = {
 	isLaunchPage?: boolean | null;
 	flowName?: string | null;
 	currentSitePlanSlug?: string | null;
-	manageHref: string;
+	currentPlanManageHref?: string;
 	canUserPurchasePlan?: boolean | null;
 	onUpgradeClick: ( planSlug: PlanSlug ) => void;
 	siteId?: number | null;
@@ -348,7 +348,7 @@ type ComparisonGridHeaderProps = {
 	flowName?: string | null;
 	onPlanChange: ( currentPlan: PlanSlug, event: ChangeEvent< HTMLSelectElement > ) => void;
 	currentSitePlanSlug?: string | null;
-	manageHref: string;
+	currentPlanManageHref?: string;
 	canUserPurchasePlan?: boolean | null;
 	onUpgradeClick: ( planSlug: PlanSlug ) => void;
 	siteId?: number | null;
@@ -379,7 +379,7 @@ const ComparisonGridHeaderCell = ( {
 	onPlanChange,
 	displayedGridPlans,
 	currentSitePlanSlug,
-	manageHref,
+	currentPlanManageHref,
 	canUserPurchasePlan,
 	isLaunchPage,
 	flowName,
@@ -463,7 +463,7 @@ const ComparisonGridHeaderCell = ( {
 			</div>
 			<PlanFeatures2023GridActions
 				currentSitePlanSlug={ currentSitePlanSlug }
-				manageHref={ manageHref }
+				currentPlanManageHref={ currentPlanManageHref }
 				canUserPurchasePlan={ canUserPurchasePlan }
 				availableForPurchase={ gridPlan.availableForPurchase }
 				className={ getPlanClass( planSlug ) }
@@ -491,7 +491,7 @@ const ComparisonGridHeader = ( {
 	isFooter,
 	onPlanChange,
 	currentSitePlanSlug,
-	manageHref,
+	currentPlanManageHref,
 	canUserPurchasePlan,
 	onUpgradeClick,
 	siteId,
@@ -530,7 +530,7 @@ const ComparisonGridHeader = ( {
 					onPlanChange={ onPlanChange }
 					displayedGridPlans={ displayedGridPlans }
 					currentSitePlanSlug={ currentSitePlanSlug }
-					manageHref={ manageHref }
+					currentPlanManageHref={ currentPlanManageHref }
 					canUserPurchasePlan={ canUserPurchasePlan }
 					flowName={ flowName }
 					onUpgradeClick={ onUpgradeClick }
@@ -831,7 +831,7 @@ const ComparisonGrid = ( {
 	isLaunchPage,
 	flowName,
 	currentSitePlanSlug,
-	manageHref,
+	currentPlanManageHref,
 	canUserPurchasePlan,
 	onUpgradeClick,
 	siteId,
@@ -1028,7 +1028,7 @@ const ComparisonGrid = ( {
 					flowName={ flowName }
 					onPlanChange={ onPlanChange }
 					currentSitePlanSlug={ currentSitePlanSlug }
-					manageHref={ manageHref }
+					currentPlanManageHref={ currentPlanManageHref }
 					canUserPurchasePlan={ canUserPurchasePlan }
 					onUpgradeClick={ onUpgradeClick }
 					planActionOverrides={ planActionOverrides }
@@ -1099,7 +1099,7 @@ const ComparisonGrid = ( {
 					isFooter={ true }
 					onPlanChange={ onPlanChange }
 					currentSitePlanSlug={ currentSitePlanSlug }
-					manageHref={ manageHref }
+					currentPlanManageHref={ currentPlanManageHref }
 					canUserPurchasePlan={ canUserPurchasePlan }
 					onUpgradeClick={ onUpgradeClick }
 					siteId={ siteId }

--- a/client/my-sites/plans-grid/components/features-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/features-grid/index.tsx
@@ -47,7 +47,7 @@ interface FeaturesGridType extends PlansGridProps {
 	isLargeCurrency: boolean;
 	translate: LocalizeProps[ 'translate' ];
 	canUserPurchasePlan: boolean | null;
-	manageHref: string;
+	currentPlanManageHref?: string;
 	isPlanUpgradeCreditEligible: boolean;
 	handleUpgradeClick: ( planSlug: PlanSlug ) => void;
 }
@@ -358,7 +358,7 @@ class FeaturesGrid extends Component< FeaturesGridType > {
 			isLaunchPage,
 			flowName,
 			canUserPurchasePlan,
-			manageHref,
+			currentPlanManageHref,
 			currentSitePlanSlug,
 			translate,
 			planActionOverrides,
@@ -396,7 +396,7 @@ class FeaturesGrid extends Component< FeaturesGridType > {
 					isTableCell={ options?.isTableCell }
 				>
 					<PlanFeatures2023GridActions
-						manageHref={ manageHref }
+						currentPlanManageHref={ currentPlanManageHref }
 						canUserPurchasePlan={ canUserPurchasePlan }
 						availableForPurchase={ availableForPurchase }
 						className={ getPlanClass( planSlug ) }

--- a/client/my-sites/plans-grid/components/test/actions.tsx
+++ b/client/my-sites/plans-grid/components/test/actions.tsx
@@ -74,7 +74,6 @@ describe( 'PlanFeatures2023GridActions', () => {
 			className: '',
 			current: false,
 			freePlan: false,
-			manageHref: '',
 			isInSignup: false,
 			onUpgradeClick: jest.fn(),
 			flowName: 'foo-flow',

--- a/client/my-sites/plans-grid/index.tsx
+++ b/client/my-sites/plans-grid/index.tsx
@@ -1,11 +1,8 @@
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
-import getCurrentPlanPurchaseId from 'calypso/state/selectors/get-current-plan-purchase-id';
 import { isCurrentUserCurrentPlanOwner } from 'calypso/state/sites/plans/selectors/is-current-user-current-plan-owner';
-import getSiteSlug from 'calypso/state/sites/selectors/get-site-slug';
 import isCurrentPlanPaid from 'calypso/state/sites/selectors/is-current-plan-paid';
 import CalypsoShoppingCartProvider from '../checkout/calypso-shopping-cart-provider';
-import { getManagePurchaseUrlFor } from '../purchases/paths';
 import ComparisonGrid from './components/comparison-grid';
 import FeaturesGrid from './components/features-grid';
 import PlansGridContextProvider from './grid-context';
@@ -73,6 +70,7 @@ export interface PlansGridProps {
 	 * Normal react tree (like Popovers, Modals, etc) can also be forcibly hidden based on a tangible parameter
 	 */
 	isHidden?: boolean;
+	currentPlanManageHref?: string;
 }
 
 const WrappedComparisonGrid = ( {
@@ -94,6 +92,7 @@ const WrappedComparisonGrid = ( {
 	showUpgradeableStorage,
 	onStorageAddOnClick,
 	isHidden,
+	currentPlanManageHref,
 }: PlansGridProps ) => {
 	// TODO clk: canUserManagePlan should be passed through props instead of being calculated here
 	const canUserPurchasePlan = useSelector( ( state: IAppState ) =>
@@ -101,16 +100,6 @@ const WrappedComparisonGrid = ( {
 			? ! isCurrentPlanPaid( state, siteId ) || isCurrentUserCurrentPlanOwner( state, siteId )
 			: null
 	);
-	const purchaseId = useSelector( ( state: IAppState ) =>
-		siteId ? getCurrentPlanPurchaseId( state, siteId ) : null
-	);
-	// TODO clk: selectedSiteSlug has no other use than computing manageRef below. stop propagating it through props
-	const selectedSiteSlug = useSelector( ( state: IAppState ) => getSiteSlug( state, siteId ) );
-
-	const manageHref =
-		purchaseId && selectedSiteSlug
-			? getManagePurchaseUrlFor( selectedSiteSlug, purchaseId )
-			: `/plans/my-plan/${ siteId }`;
 
 	const handleUpgradeClick = useUpgradeClickHandler( {
 		gridPlans,
@@ -133,7 +122,7 @@ const WrappedComparisonGrid = ( {
 					isLaunchPage={ isLaunchPage }
 					flowName={ flowName }
 					currentSitePlanSlug={ currentSitePlanSlug }
-					manageHref={ manageHref }
+					currentPlanManageHref={ currentPlanManageHref }
 					canUserPurchasePlan={ canUserPurchasePlan }
 					onUpgradeClick={ handleUpgradeClick }
 					siteId={ siteId }
@@ -163,7 +152,7 @@ const WrappedComparisonGrid = ( {
 					isLaunchPage={ isLaunchPage }
 					flowName={ flowName }
 					currentSitePlanSlug={ currentSitePlanSlug }
-					manageHref={ manageHref }
+					currentPlanManageHref={ currentPlanManageHref }
 					canUserPurchasePlan={ canUserPurchasePlan }
 					onUpgradeClick={ handleUpgradeClick }
 					siteId={ siteId }
@@ -179,8 +168,15 @@ const WrappedComparisonGrid = ( {
 };
 
 const WrappedFeaturesGrid = ( props: PlansGridProps ) => {
-	const { siteId, intent, gridPlans, usePricingMetaForGridPlans, allFeaturesList, onUpgradeClick } =
-		props;
+	const {
+		siteId,
+		intent,
+		gridPlans,
+		usePricingMetaForGridPlans,
+		allFeaturesList,
+		onUpgradeClick,
+		currentPlanManageHref,
+	} = props;
 	const translate = useTranslate();
 	const isPlanUpgradeCreditEligible = useIsPlanUpgradeCreditVisible(
 		siteId,
@@ -200,16 +196,6 @@ const WrappedFeaturesGrid = ( props: PlansGridProps ) => {
 			? ! isCurrentPlanPaid( state, siteId ) || isCurrentUserCurrentPlanOwner( state, siteId )
 			: null
 	);
-	const purchaseId = useSelector( ( state: IAppState ) =>
-		siteId ? getCurrentPlanPurchaseId( state, siteId ) : null
-	);
-	// TODO clk: selectedSiteSlug has no other use than computing manageRef below. stop propagating it through props
-	const selectedSiteSlug = useSelector( ( state: IAppState ) => getSiteSlug( state, siteId ) );
-
-	const manageHref =
-		purchaseId && selectedSiteSlug
-			? getManagePurchaseUrlFor( selectedSiteSlug, purchaseId )
-			: `/plans/my-plan/${ siteId }`;
 
 	const handleUpgradeClick = useUpgradeClickHandler( {
 		gridPlans,
@@ -229,7 +215,7 @@ const WrappedFeaturesGrid = ( props: PlansGridProps ) => {
 					isPlanUpgradeCreditEligible={ isPlanUpgradeCreditEligible }
 					isLargeCurrency={ isLargeCurrency }
 					canUserPurchasePlan={ canUserPurchasePlan }
-					manageHref={ manageHref }
+					currentPlanManageHref={ currentPlanManageHref }
 					translate={ translate }
 					handleUpgradeClick={ handleUpgradeClick }
 				/>
@@ -250,7 +236,7 @@ const WrappedFeaturesGrid = ( props: PlansGridProps ) => {
 					isPlanUpgradeCreditEligible={ isPlanUpgradeCreditEligible }
 					isLargeCurrency={ isLargeCurrency }
 					canUserPurchasePlan={ canUserPurchasePlan }
-					manageHref={ manageHref }
+					currentPlanManageHref={ currentPlanManageHref }
 					translate={ translate }
 					handleUpgradeClick={ handleUpgradeClick }
 				/>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/78996
Fixes https://github.com/Automattic/wp-calypso/issues/78994

## Proposed Changes

* Refactors `manageHref` to `currentPlanManageHref`
* Moves the compilation into a hook in `plans-features-main` and passes the value through as prop to `plans-grid`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plans[site]` and ensure click on "manage plan" is active and working

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?