### PR TITLE
Plans 2023: Compile canUserPurchasePlan out of the grid components

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -47,8 +47,8 @@ import getDomainFromHomeUpsellInQuery from 'calypso/state/selectors/get-domain-f
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 import isEligibleForWpComMonthlyPlan from 'calypso/state/selectors/is-eligible-for-wpcom-monthly-plan';
 import { isUserEligibleForFreeHostingTrial } from 'calypso/state/selectors/is-user-eligible-for-free-hosting-trial';
-import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
-import { getSitePlanSlug, getSiteSlug } from 'calypso/state/sites/selectors';
+import { getCurrentPlan, isCurrentUserCurrentPlanOwner } from 'calypso/state/sites/plans/selectors';
+import { getSitePlanSlug, getSiteSlug, isCurrentPlanPaid } from 'calypso/state/sites/selectors';
 import useAddOns from '../add-ons/hooks/use-add-ons';
 import ComparisonGridToggle from './components/comparison-grid-toggle';
 import { FreePlanFreeDomainDialog } from './components/free-plan-free-domain-dialog';
@@ -248,6 +248,11 @@ const PlansFeaturesMain = ( {
 	const showUpgradeableStorage = config.isEnabled( 'plans/upgradeable-storage' );
 	const observableForOdieRef = useObservableForOdie();
 	const currentPlanManageHref = useCurrentPlanManageHref();
+	const canUserManageCurrentPlan = useSelector( ( state: IAppState ) =>
+		siteId
+			? ! isCurrentPlanPaid( state, siteId ) || isCurrentUserCurrentPlanOwner( state, siteId )
+			: null
+	);
 
 	const toggleShowPlansComparisonGrid = () => {
 		setShowPlansComparisonGrid( ! showPlansComparisonGrid );
@@ -740,6 +745,7 @@ const PlansFeaturesMain = ( {
 								planTypeSelectorProps={ planTypeSelectorProps }
 								onStorageAddOnClick={ handleStorageAddOnClick }
 								currentPlanManageHref={ currentPlanManageHref }
+								canUserManageCurrentPlan={ canUserManageCurrentPlan }
 							/>
 							{ ! hidePlansFeatureComparison && (
 								<>
@@ -781,6 +787,7 @@ const PlansFeaturesMain = ( {
 											planTypeSelectorProps={ planTypeSelectorProps }
 											onStorageAddOnClick={ handleStorageAddOnClick }
 											currentPlanManageHref={ currentPlanManageHref }
+											canUserManageCurrentPlan={ canUserManageCurrentPlan }
 										/>
 										<ComparisonGridToggle
 											onClick={ toggleShowPlansComparisonGrid }

--- a/client/my-sites/plans-grid/components/actions.tsx
+++ b/client/my-sites/plans-grid/components/actions.tsx
@@ -27,7 +27,7 @@ import type { PlanActionOverrides } from '../types';
 
 type PlanFeaturesActionsButtonProps = {
 	availableForPurchase: boolean;
-	canUserPurchasePlan?: boolean | null;
+	canUserManageCurrentPlan?: boolean | null;
 	className: string;
 	currentSitePlanSlug?: string | null;
 	trialPlan?: boolean;
@@ -195,7 +195,7 @@ const LoggedInPlansFeatureActionButton = ( {
 	handleUpgradeButtonClick,
 	planSlug,
 	currentPlanManageHref,
-	canUserPurchasePlan,
+	canUserManageCurrentPlan,
 	currentSitePlanSlug,
 	buttonText,
 	planActionOverrides,
@@ -210,7 +210,7 @@ const LoggedInPlansFeatureActionButton = ( {
 	handleUpgradeButtonClick: () => void;
 	planSlug: string;
 	currentPlanManageHref?: string;
-	canUserPurchasePlan?: boolean | null;
+	canUserManageCurrentPlan?: boolean | null;
 	currentSitePlanSlug?: string | null;
 	buttonText?: string;
 	planActionOverrides?: PlanActionOverrides;
@@ -253,7 +253,7 @@ const LoggedInPlansFeatureActionButton = ( {
 				href={ currentPlanManageHref }
 				disabled={ ! currentPlanManageHref }
 			>
-				{ canUserPurchasePlan ? translate( 'Manage plan' ) : translate( 'View plan' ) }
+				{ canUserManageCurrentPlan ? translate( 'Manage plan' ) : translate( 'View plan' ) }
 			</Button>
 		);
 	}
@@ -364,7 +364,7 @@ const LoggedInPlansFeatureActionButton = ( {
 
 const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( {
 	availableForPurchase = true,
-	canUserPurchasePlan,
+	canUserManageCurrentPlan,
 	className,
 	currentSitePlanSlug,
 	freePlan = false,
@@ -499,7 +499,7 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 			classes={ classes }
 			handleUpgradeButtonClick={ handleUpgradeButtonClick }
 			currentPlanManageHref={ currentPlanManageHref }
-			canUserPurchasePlan={ canUserPurchasePlan }
+			canUserManageCurrentPlan={ canUserManageCurrentPlan }
 			currentSitePlanSlug={ currentSitePlanSlug }
 			buttonText={ buttonText }
 			planActionOverrides={ planActionOverrides }

--- a/client/my-sites/plans-grid/components/comparison-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/comparison-grid/index.tsx
@@ -321,7 +321,7 @@ type ComparisonGridProps = {
 	flowName?: string | null;
 	currentSitePlanSlug?: string | null;
 	currentPlanManageHref?: string;
-	canUserPurchasePlan?: boolean | null;
+	canUserManageCurrentPlan?: boolean | null;
 	onUpgradeClick: ( planSlug: PlanSlug ) => void;
 	siteId?: number | null;
 	planActionOverrides?: PlanActionOverrides;
@@ -349,7 +349,7 @@ type ComparisonGridHeaderProps = {
 	onPlanChange: ( currentPlan: PlanSlug, event: ChangeEvent< HTMLSelectElement > ) => void;
 	currentSitePlanSlug?: string | null;
 	currentPlanManageHref?: string;
-	canUserPurchasePlan?: boolean | null;
+	canUserManageCurrentPlan?: boolean | null;
 	onUpgradeClick: ( planSlug: PlanSlug ) => void;
 	siteId?: number | null;
 	planActionOverrides?: PlanActionOverrides;
@@ -380,7 +380,7 @@ const ComparisonGridHeaderCell = ( {
 	displayedGridPlans,
 	currentSitePlanSlug,
 	currentPlanManageHref,
-	canUserPurchasePlan,
+	canUserManageCurrentPlan,
 	isLaunchPage,
 	flowName,
 	isLargeCurrency,
@@ -464,7 +464,7 @@ const ComparisonGridHeaderCell = ( {
 			<PlanFeatures2023GridActions
 				currentSitePlanSlug={ currentSitePlanSlug }
 				currentPlanManageHref={ currentPlanManageHref }
-				canUserPurchasePlan={ canUserPurchasePlan }
+				canUserManageCurrentPlan={ canUserManageCurrentPlan }
 				availableForPurchase={ gridPlan.availableForPurchase }
 				className={ getPlanClass( planSlug ) }
 				freePlan={ isFreePlan( planSlug ) }
@@ -492,7 +492,7 @@ const ComparisonGridHeader = ( {
 	onPlanChange,
 	currentSitePlanSlug,
 	currentPlanManageHref,
-	canUserPurchasePlan,
+	canUserManageCurrentPlan,
 	onUpgradeClick,
 	siteId,
 	planActionOverrides,
@@ -531,7 +531,7 @@ const ComparisonGridHeader = ( {
 					displayedGridPlans={ displayedGridPlans }
 					currentSitePlanSlug={ currentSitePlanSlug }
 					currentPlanManageHref={ currentPlanManageHref }
-					canUserPurchasePlan={ canUserPurchasePlan }
+					canUserManageCurrentPlan={ canUserManageCurrentPlan }
 					flowName={ flowName }
 					onUpgradeClick={ onUpgradeClick }
 					isLaunchPage={ isLaunchPage }
@@ -832,7 +832,7 @@ const ComparisonGrid = ( {
 	flowName,
 	currentSitePlanSlug,
 	currentPlanManageHref,
-	canUserPurchasePlan,
+	canUserManageCurrentPlan,
 	onUpgradeClick,
 	siteId,
 	planActionOverrides,
@@ -1029,7 +1029,7 @@ const ComparisonGrid = ( {
 					onPlanChange={ onPlanChange }
 					currentSitePlanSlug={ currentSitePlanSlug }
 					currentPlanManageHref={ currentPlanManageHref }
-					canUserPurchasePlan={ canUserPurchasePlan }
+					canUserManageCurrentPlan={ canUserManageCurrentPlan }
 					onUpgradeClick={ onUpgradeClick }
 					planActionOverrides={ planActionOverrides }
 					selectedPlan={ selectedPlan }
@@ -1100,7 +1100,7 @@ const ComparisonGrid = ( {
 					onPlanChange={ onPlanChange }
 					currentSitePlanSlug={ currentSitePlanSlug }
 					currentPlanManageHref={ currentPlanManageHref }
-					canUserPurchasePlan={ canUserPurchasePlan }
+					canUserManageCurrentPlan={ canUserManageCurrentPlan }
 					onUpgradeClick={ onUpgradeClick }
 					siteId={ siteId }
 					planActionOverrides={ planActionOverrides }

--- a/client/my-sites/plans-grid/components/features-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/features-grid/index.tsx
@@ -46,7 +46,7 @@ type PlanRowOptions = {
 interface FeaturesGridType extends PlansGridProps {
 	isLargeCurrency: boolean;
 	translate: LocalizeProps[ 'translate' ];
-	canUserPurchasePlan: boolean | null;
+	canUserManageCurrentPlan: boolean | null;
 	currentPlanManageHref?: string;
 	isPlanUpgradeCreditEligible: boolean;
 	handleUpgradeClick: ( planSlug: PlanSlug ) => void;
@@ -357,7 +357,7 @@ class FeaturesGrid extends Component< FeaturesGridType > {
 			isInSignup,
 			isLaunchPage,
 			flowName,
-			canUserPurchasePlan,
+			canUserManageCurrentPlan,
 			currentPlanManageHref,
 			currentSitePlanSlug,
 			translate,
@@ -397,7 +397,7 @@ class FeaturesGrid extends Component< FeaturesGridType > {
 				>
 					<PlanFeatures2023GridActions
 						currentPlanManageHref={ currentPlanManageHref }
-						canUserPurchasePlan={ canUserPurchasePlan }
+						canUserManageCurrentPlan={ canUserManageCurrentPlan }
 						availableForPurchase={ availableForPurchase }
 						className={ getPlanClass( planSlug ) }
 						trialPlan={ isFreeHostingTrial( planSlug ) }

--- a/client/my-sites/plans-grid/components/features-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/features-grid/index.tsx
@@ -46,7 +46,7 @@ type PlanRowOptions = {
 interface FeaturesGridType extends PlansGridProps {
 	isLargeCurrency: boolean;
 	translate: LocalizeProps[ 'translate' ];
-	canUserManageCurrentPlan: boolean | null;
+	canUserManageCurrentPlan?: boolean | null;
 	currentPlanManageHref?: string;
 	isPlanUpgradeCreditEligible: boolean;
 	handleUpgradeClick: ( planSlug: PlanSlug ) => void;

--- a/client/my-sites/plans-grid/components/test/actions.tsx
+++ b/client/my-sites/plans-grid/components/test/actions.tsx
@@ -70,7 +70,7 @@ describe( 'PlanFeatures2023GridActions', () => {
 		const contactSupport = 'Contact support';
 		const defaultProps = {
 			availableForPurchase: true,
-			canUserPurchasePlan: true,
+			canUserManageCurrentPlan: true,
 			className: '',
 			current: false,
 			freePlan: false,

--- a/client/my-sites/plans-grid/index.tsx
+++ b/client/my-sites/plans-grid/index.tsx
@@ -1,7 +1,4 @@
 import { useTranslate } from 'i18n-calypso';
-import { useSelector } from 'react-redux';
-import { isCurrentUserCurrentPlanOwner } from 'calypso/state/sites/plans/selectors/is-current-user-current-plan-owner';
-import isCurrentPlanPaid from 'calypso/state/sites/selectors/is-current-plan-paid';
 import CalypsoShoppingCartProvider from '../checkout/calypso-shopping-cart-provider';
 import ComparisonGrid from './components/comparison-grid';
 import FeaturesGrid from './components/features-grid';
@@ -20,7 +17,6 @@ import type { PlanTypeSelectorProps } from '../plans-features-main/components/pl
 import type { FeatureList, WPComStorageAddOnSlug } from '@automattic/calypso-products';
 import type { DomainSuggestion } from '@automattic/data-stores';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
-import type { IAppState } from 'calypso/state/types';
 import './style.scss';
 
 /*
@@ -71,6 +67,7 @@ export interface PlansGridProps {
 	 */
 	isHidden?: boolean;
 	currentPlanManageHref?: string;
+	canUserManageCurrentPlan?: boolean | null;
 }
 
 const WrappedComparisonGrid = ( {
@@ -93,14 +90,8 @@ const WrappedComparisonGrid = ( {
 	onStorageAddOnClick,
 	isHidden,
 	currentPlanManageHref,
+	canUserManageCurrentPlan,
 }: PlansGridProps ) => {
-	// TODO clk: canUserManagePlan should be passed through props instead of being calculated here
-	const canUserManageCurrentPlan = useSelector( ( state: IAppState ) =>
-		siteId
-			? ! isCurrentPlanPaid( state, siteId ) || isCurrentUserCurrentPlanOwner( state, siteId )
-			: null
-	);
-
 	const handleUpgradeClick = useUpgradeClickHandler( {
 		gridPlans,
 		onUpgradeClick,
@@ -176,6 +167,7 @@ const WrappedFeaturesGrid = ( props: PlansGridProps ) => {
 		allFeaturesList,
 		onUpgradeClick,
 		currentPlanManageHref,
+		canUserManageCurrentPlan,
 	} = props;
 	const translate = useTranslate();
 	const isPlanUpgradeCreditEligible = useIsPlanUpgradeCreditVisible(
@@ -189,13 +181,6 @@ const WrappedFeaturesGrid = ( props: PlansGridProps ) => {
 		prices,
 		currencyCode: currencyCode || 'USD',
 	} );
-
-	// TODO clk: canUserManagePlan should be passed through props instead of being calculated here
-	const canUserManageCurrentPlan = useSelector( ( state: IAppState ) =>
-		siteId
-			? ! isCurrentPlanPaid( state, siteId ) || isCurrentUserCurrentPlanOwner( state, siteId )
-			: null
-	);
 
 	const handleUpgradeClick = useUpgradeClickHandler( {
 		gridPlans,

--- a/client/my-sites/plans-grid/index.tsx
+++ b/client/my-sites/plans-grid/index.tsx
@@ -95,7 +95,7 @@ const WrappedComparisonGrid = ( {
 	currentPlanManageHref,
 }: PlansGridProps ) => {
 	// TODO clk: canUserManagePlan should be passed through props instead of being calculated here
-	const canUserPurchasePlan = useSelector( ( state: IAppState ) =>
+	const canUserManageCurrentPlan = useSelector( ( state: IAppState ) =>
 		siteId
 			? ! isCurrentPlanPaid( state, siteId ) || isCurrentUserCurrentPlanOwner( state, siteId )
 			: null
@@ -123,7 +123,7 @@ const WrappedComparisonGrid = ( {
 					flowName={ flowName }
 					currentSitePlanSlug={ currentSitePlanSlug }
 					currentPlanManageHref={ currentPlanManageHref }
-					canUserPurchasePlan={ canUserPurchasePlan }
+					canUserManageCurrentPlan={ canUserManageCurrentPlan }
 					onUpgradeClick={ handleUpgradeClick }
 					siteId={ siteId }
 					selectedPlan={ selectedPlan }
@@ -153,7 +153,7 @@ const WrappedComparisonGrid = ( {
 					flowName={ flowName }
 					currentSitePlanSlug={ currentSitePlanSlug }
 					currentPlanManageHref={ currentPlanManageHref }
-					canUserPurchasePlan={ canUserPurchasePlan }
+					canUserManageCurrentPlan={ canUserManageCurrentPlan }
 					onUpgradeClick={ handleUpgradeClick }
 					siteId={ siteId }
 					selectedPlan={ selectedPlan }
@@ -191,7 +191,7 @@ const WrappedFeaturesGrid = ( props: PlansGridProps ) => {
 	} );
 
 	// TODO clk: canUserManagePlan should be passed through props instead of being calculated here
-	const canUserPurchasePlan = useSelector( ( state: IAppState ) =>
+	const canUserManageCurrentPlan = useSelector( ( state: IAppState ) =>
 		siteId
 			? ! isCurrentPlanPaid( state, siteId ) || isCurrentUserCurrentPlanOwner( state, siteId )
 			: null
@@ -214,7 +214,7 @@ const WrappedFeaturesGrid = ( props: PlansGridProps ) => {
 					{ ...props }
 					isPlanUpgradeCreditEligible={ isPlanUpgradeCreditEligible }
 					isLargeCurrency={ isLargeCurrency }
-					canUserPurchasePlan={ canUserPurchasePlan }
+					canUserManageCurrentPlan={ canUserManageCurrentPlan }
 					currentPlanManageHref={ currentPlanManageHref }
 					translate={ translate }
 					handleUpgradeClick={ handleUpgradeClick }
@@ -235,7 +235,7 @@ const WrappedFeaturesGrid = ( props: PlansGridProps ) => {
 					{ ...props }
 					isPlanUpgradeCreditEligible={ isPlanUpgradeCreditEligible }
 					isLargeCurrency={ isLargeCurrency }
-					canUserPurchasePlan={ canUserPurchasePlan }
+					canUserManageCurrentPlan={ canUserManageCurrentPlan }
 					currentPlanManageHref={ currentPlanManageHref }
 					translate={ translate }
 					handleUpgradeClick={ handleUpgradeClick }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/78995

## Proposed Changes

* Renamed `canUserPurchasePlan` -> `canUserManageCurrentPlan`
* Movesit  to `plans-features-main` and passes through as prop

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plans[site]` with a site that you own and ensure you can "manage"
* Do the same with a site on free plan or that you don't own. should not be able to "manage"

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?