### PR TITLE
Plans 2023: Move plan comparison header out of the comparison-grid

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -96,6 +96,15 @@ const FreePlanSubHeader = styled.p`
 	}
 `;
 
+const PlanComparisonHeader = styled.h1`
+	.plans .step-container .step-container__content &&,
+	&& {
+		font-size: 2rem;
+		text-align: center;
+		margin: 48px 0;
+	}
+`;
+
 export interface PlansFeaturesMainProps {
 	siteId?: number | null;
 	intent?: PlansIntent | null;
@@ -759,6 +768,9 @@ const PlansFeaturesMain = ( {
 										ref={ observableForOdieRef }
 									/>
 									<div ref={ plansComparisonGridRef } className={ comparisonGridContainerClasses }>
+										<PlanComparisonHeader className="wp-brand-font">
+											{ translate( 'Compare our plans and find yours' ) }
+										</PlanComparisonHeader>
 										<ComparisonGrid
 											isHidden={ ! showPlansComparisonGrid }
 											gridPlans={ gridPlansForComparisonGrid }

--- a/client/my-sites/plans-grid/components/comparison-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/comparison-grid/index.tsx
@@ -72,15 +72,6 @@ const JetpackIconContainer = styled.div`
 	line-height: 1;
 `;
 
-const PlanComparisonHeader = styled.h1`
-	.plans .step-container .step-container__content &&,
-	&& {
-		font-size: 2rem;
-		text-align: center;
-		margin: 48px 0;
-	}
-`;
-
 const Title = styled.div< { isHiddenInMobile?: boolean } >`
 	font-weight: 500;
 	font-size: 20px;
@@ -842,7 +833,6 @@ const ComparisonGrid = ( {
 	onStorageAddOnClick,
 	isHidden,
 }: ComparisonGridProps ) => {
-	const translate = useTranslate();
 	const { gridPlans, allFeaturesList } = usePlansGridContext();
 	const [ activeTooltipId, setActiveTooltipId ] = useManageTooltipToggle();
 
@@ -1008,9 +998,6 @@ const ComparisonGrid = ( {
 
 	return (
 		<div className="plan-comparison-grid">
-			<PlanComparisonHeader className="wp-brand-font">
-				{ translate( 'Compare our plans and find yours' ) }
-			</PlanComparisonHeader>
 			{ isHidden ? null : (
 				<PlanTypeSelector
 					{ ...planTypeSelectorProps }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/78266

## Proposed Changes

* Moves the plan comparison header out of the comparison grid
* This will enable us to also move the plan type selector next (as an intermediate step to uncoupling that dependency)

### Media

<img width="700" alt="Screenshot 2023-10-05 at 2 35 07 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/11c8ecf2-3b2b-4a12-8fed-8465cf40b934">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plans/[site]` and click on "compare plans"
* Confirm the section header renders correctly on desktop and mobile
* Confirm the same in `/start/plans` and `/setup/link-in-bio`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?