### PR TITLE
Plans 2023: Move plan-type-selector out of the comparison-grid

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -770,9 +770,10 @@ const PlansFeaturesMain = ( {
 										<PlanComparisonHeader className="wp-brand-font">
 											{ translate( 'Compare our plans and find yours' ) }
 										</PlanComparisonHeader>
-										{ ! hidePlanSelector && <PlanTypeSelector { ...planTypeSelectorProps } /> }
+										{ ! hidePlanSelector && showPlansComparisonGrid && (
+											<PlanTypeSelector { ...planTypeSelectorProps } />
+										) }
 										<ComparisonGrid
-											isHidden={ ! showPlansComparisonGrid }
 											gridPlans={ gridPlansForComparisonGrid }
 											gridPlanForSpotlight={ gridPlanForSpotlight }
 											paidDomainName={ paidDomainName }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -751,7 +751,6 @@ const PlansFeaturesMain = ( {
 								stickyRowOffset={ masterbarHeight }
 								usePricingMetaForGridPlans={ usePricingMetaForGridPlans }
 								allFeaturesList={ FEATURES_LIST }
-								planTypeSelectorProps={ planTypeSelectorProps }
 								onStorageAddOnClick={ handleStorageAddOnClick }
 								currentPlanManageHref={ currentPlanManageHref }
 								canUserManageCurrentPlan={ canUserManageCurrentPlan }
@@ -771,6 +770,7 @@ const PlansFeaturesMain = ( {
 										<PlanComparisonHeader className="wp-brand-font">
 											{ translate( 'Compare our plans and find yours' ) }
 										</PlanComparisonHeader>
+										{ ! hidePlanSelector && <PlanTypeSelector { ...planTypeSelectorProps } /> }
 										<ComparisonGrid
 											isHidden={ ! showPlansComparisonGrid }
 											gridPlans={ gridPlansForComparisonGrid }
@@ -796,7 +796,6 @@ const PlansFeaturesMain = ( {
 											stickyRowOffset={ masterbarHeight }
 											usePricingMetaForGridPlans={ usePricingMetaForGridPlans }
 											allFeaturesList={ FEATURES_LIST }
-											planTypeSelectorProps={ planTypeSelectorProps }
 											onStorageAddOnClick={ handleStorageAddOnClick }
 											currentPlanManageHref={ currentPlanManageHref }
 											canUserManageCurrentPlan={ canUserManageCurrentPlan }

--- a/client/my-sites/plans-grid/components/comparison-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/comparison-grid/index.tsx
@@ -318,13 +318,6 @@ type ComparisonGridProps = {
 	showLegacyStorageFeature?: boolean;
 	showUpgradeableStorage: boolean;
 	onStorageAddOnClick?: ( addOnSlug: WPComStorageAddOnSlug ) => void;
-	/**
-	 * Due to the render heavy burden of the plans comparison grid the client consumer of this component, might chose to
-	 * hide the comparison grid with css but leave the render tree intact, mounted.
-	 * An isHidden prop is passed down the tree so that any elements that are not part of the
-	 * Normal react tree (like Popovers, Modals, etc) can also be forcibly hidden based on a tangible parameter
-	 */
-	isHidden?: boolean;
 };
 
 type ComparisonGridHeaderProps = {

--- a/client/my-sites/plans-grid/components/comparison-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/comparison-grid/index.tsx
@@ -20,7 +20,6 @@ import { useMemo } from '@wordpress/element';
 import classNames from 'classnames';
 import i18n, { useTranslate } from 'i18n-calypso';
 import { useState, useCallback, useEffect, ChangeEvent, Dispatch, SetStateAction } from 'react';
-import PlanTypeSelector from 'calypso/my-sites/plans-features-main/components/plan-type-selector';
 import { useIsPlanUpgradeCreditVisible } from 'calypso/my-sites/plans-grid/hooks/use-is-plan-upgrade-credit-visible';
 import { useManageTooltipToggle } from 'calypso/my-sites/plans-grid/hooks/use-manage-tooltip-toggle';
 import getPlanFeaturesObject from 'calypso/my-sites/plans-grid/lib/get-plan-features-object';
@@ -50,7 +49,6 @@ import type {
 	PlanSlug,
 	WPComStorageAddOnSlug,
 } from '@automattic/calypso-products';
-import type { PlanTypeSelectorProps } from 'calypso/my-sites/plans-features-main/components/plan-type-selector';
 
 function DropdownIcon() {
 	return (
@@ -306,7 +304,6 @@ const FeatureFootnote = styled.span`
 
 type ComparisonGridProps = {
 	intervalType: string;
-	planTypeSelectorProps: PlanTypeSelectorProps;
 	isInSignup: boolean;
 	isLaunchPage?: boolean | null;
 	flowName?: string | null;
@@ -817,7 +814,6 @@ const ComparisonGridFeatureGroupRow: React.FunctionComponent< {
 
 const ComparisonGrid = ( {
 	intervalType,
-	planTypeSelectorProps,
 	isInSignup,
 	isLaunchPage,
 	flowName,
@@ -831,7 +827,6 @@ const ComparisonGrid = ( {
 	selectedFeature,
 	showUpgradeableStorage,
 	onStorageAddOnClick,
-	isHidden,
 }: ComparisonGridProps ) => {
 	const { gridPlans, allFeaturesList } = usePlansGridContext();
 	const [ activeTooltipId, setActiveTooltipId ] = useManageTooltipToggle();
@@ -998,13 +993,6 @@ const ComparisonGrid = ( {
 
 	return (
 		<div className="plan-comparison-grid">
-			{ isHidden ? null : (
-				<PlanTypeSelector
-					{ ...planTypeSelectorProps }
-					kind="interval"
-					plans={ displayedGridPlans.map( ( { planSlug } ) => planSlug ) }
-				/>
-			) }
 			<Grid isInSignup={ isInSignup }>
 				<ComparisonGridHeader
 					siteId={ siteId }

--- a/client/my-sites/plans-grid/index.tsx
+++ b/client/my-sites/plans-grid/index.tsx
@@ -13,7 +13,6 @@ import type {
 	UsePricingMetaForGridPlans,
 } from './hooks/npm-ready/data-store/use-grid-plans';
 import type { DataResponse, PlanActionOverrides } from './types';
-import type { PlanTypeSelectorProps } from '../plans-features-main/components/plan-type-selector';
 import type { FeatureList, WPComStorageAddOnSlug } from '@automattic/calypso-products';
 import type { DomainSuggestion } from '@automattic/data-stores';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
@@ -58,14 +57,6 @@ export interface PlansGridProps {
 	showUpgradeableStorage: boolean; // feature flag used to show the storage add-on dropdown
 	stickyRowOffset: number;
 	usePricingMetaForGridPlans: UsePricingMetaForGridPlans;
-	planTypeSelectorProps: PlanTypeSelectorProps;
-	/**
-	 * Due to the render heavy burden of the plans comparison grid the client consumer of this component, might chose to
-	 * hide the comparison grid with css but leave the render tree intact, mounted.
-	 * An isHidden prop is passed down the tree so that any elements that are not part of the
-	 * Normal react tree (like Popovers, Modals, etc) can also be forcibly hidden based on a tangible parameter
-	 */
-	isHidden?: boolean;
 	currentPlanManageHref?: string;
 	canUserManageCurrentPlan?: boolean | null;
 }
@@ -77,7 +68,6 @@ const WrappedComparisonGrid = ( {
 	usePricingMetaForGridPlans,
 	allFeaturesList,
 	onUpgradeClick,
-	planTypeSelectorProps,
 	intervalType,
 	isInSignup,
 	isLaunchPage,
@@ -88,7 +78,6 @@ const WrappedComparisonGrid = ( {
 	showLegacyStorageFeature,
 	showUpgradeableStorage,
 	onStorageAddOnClick,
-	isHidden,
 	currentPlanManageHref,
 	canUserManageCurrentPlan,
 }: PlansGridProps ) => {
@@ -106,8 +95,6 @@ const WrappedComparisonGrid = ( {
 				allFeaturesList={ allFeaturesList }
 			>
 				<ComparisonGrid
-					isHidden={ isHidden }
-					planTypeSelectorProps={ planTypeSelectorProps }
 					intervalType={ intervalType }
 					isInSignup={ isInSignup }
 					isLaunchPage={ isLaunchPage }
@@ -136,8 +123,6 @@ const WrappedComparisonGrid = ( {
 		>
 			<CalypsoShoppingCartProvider>
 				<ComparisonGrid
-					isHidden={ isHidden }
-					planTypeSelectorProps={ planTypeSelectorProps }
 					intervalType={ intervalType }
 					isInSignup={ isInSignup }
 					isLaunchPage={ isLaunchPage }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/78266 , https://github.com/Automattic/wp-calypso/issues/81117

## Proposed Changes

* Moves the plan-type-selector out of the comparison-grid and into `plans-features-main`, uncoupling the dependency
* A full migration of plan-type-selector into the plans-grid will happen at a much later point (part of Milestone 4 in PT pau2Xa-59h-p2. Related issue: https://github.com/Automattic/wp-calypso/issues/81117)

### Media

<img width="705" alt="Screenshot 2023-10-05 at 2 53 28 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/06b777da-ef2b-4810-b4ec-8f7f38fbc195">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plans/[site]` and click to "compare plans"
* Ensure a plan-type-selector renders above the comparison grid and that it's functional

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?