### PR TITLE
Social First signup: Label email input

### DIFF
--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -257,8 +257,10 @@ class PasswordlessSignupForm extends Component {
 						<FormLabel htmlFor="email">{ this.getLabelText() }</FormLabel>
 						<FormTextInput
 							autoCapitalize="off"
+							autoCorrect="off"
 							className="signup-form__passwordless-email"
 							type="email"
+							id="email"
 							name="email"
 							value={ this.state.email }
 							onChange={ this.onInputChange }

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -254,14 +254,14 @@ class PasswordlessSignupForm extends Component {
 			<div className="signup-form__passwordless-form-wrapper">
 				<LoggedOutForm onSubmit={ this.onFormSubmit } noValidate>
 					<ValidationFieldset errorMessages={ errorMessages }>
-						<FormLabel htmlFor="email">{ this.getLabelText() }</FormLabel>
+						<FormLabel htmlFor="signup-email">{ this.getLabelText() }</FormLabel>
 						<FormTextInput
 							autoCapitalize="off"
 							autoCorrect="off"
 							className="signup-form__passwordless-email"
 							type="email"
-							id="email"
 							name="email"
+							id="signup-email"
 							value={ this.state.email }
 							onChange={ this.onInputChange }
 							disabled={ isSubmitting || !! this.props.disabled }


### PR DESCRIPTION
The input field for email, in the passwordless component, was missing an accessible name.
That's because, even if we has a label, we were missing an id in the input.


## Testing
1. Live link
2. `/start` in Incognito
3. `Continue with Email`
4. Inspect the input element and use an accessibility tool like axe devtools to assess that there is no "Form elements must have labels" issue


Fixes https://github.com/Automattic/wp-calypso/issues/82624