### PR TITLE
Multi-domains: Hide Already own domain when domains in cart

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -660,7 +660,11 @@ export class RenderDomainsStep extends Component {
 		const cartIsLoading = this.props.shoppingCartManager.isLoading;
 
 		const useYourDomain = ! this.shouldHideUseYourDomain() ? (
-			<div className="domains__domain-side-content">
+			<div
+				className={ classNames( 'domains__domain-side-content', {
+					'fade-out': this.shouldUseMultipleDomainsInCart() && domainsInCart.length > 0,
+				} ) }
+			>
 				<ReskinSideExplainer onClick={ this.handleUseYourDomainClick } type="use-your-domain" />
 			</div>
 		) : null;

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -64,6 +64,8 @@
 
 
 	.domains__domain-cart {
+		border-bottom: 0 !important;
+
 		.domains__domain-cart-title {
 			font-size: $font-body;
 			color: var(--studio-gray-90);
@@ -234,6 +236,12 @@ body.is-section-signup.is-white-signup {
 
 			@include break-wide {
 				margin: 0 0 0 80px;
+			}
+
+			&.fade-out {
+				opacity: 0;
+				visibility: hidden;
+				transition: all 0.4s ease-out;
 			}
 		}
 


### PR DESCRIPTION
Follow up from: https://github.com/Automattic/wp-calypso/pull/82487
Slack discussion: p1696490793238449/1696432937.134089-slack-CKZHG0QCR

## Proposed Changes

Hide `Already own a domain?` card when domain(s) in cart with multi-domails. 

## Testing Instructions

* Go to `/start/domains?flags=add/multiple-domains-select-and-list`
* Add a domain to the cart
* Check if the card is disappearing with an animat ion.
* Remove the domain and check if it appears again.
