### PR TITLE
Site Profiler: filter URLs got from IANA WHOIS

### DIFF
--- a/client/site-profiler/components/domain-information/index.tsx
+++ b/client/site-profiler/components/domain-information/index.tsx
@@ -8,6 +8,7 @@ import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { useDomainAnalyzerWhoisRawDataQuery } from 'calypso/data/site-profiler/use-domain-whois-raw-data-query';
 import { useFilteredWhoisData } from 'calypso/site-profiler/hooks/use-filtered-whois-data';
 import { normalizeWhoisField } from 'calypso/site-profiler/utils/normalize-whois-entry';
+import { normalizeWhoisURL } from 'calypso/site-profiler/utils/normalize-whois-url';
 import VerifiedProvider from '../verified-provider';
 import type { HostingProvider, WhoIs } from 'calypso/data/site-profiler/types';
 import './styles.scss';
@@ -90,7 +91,11 @@ export default function DomainInformation( props: Props ) {
 							) }
 							{ whois.registrar_url &&
 								! whois.registrar_url?.toLowerCase().includes( 'automattic' ) && (
-									<a href={ whois.registrar_url } target="_blank" rel="noopener noreferrer">
+									<a
+										href={ normalizeWhoisURL( whois.registrar_url ) }
+										target="_blank"
+										rel="noopener noreferrer"
+									>
 										{ whois.registrar }
 									</a>
 								) }

--- a/client/site-profiler/utils/normalize-whois-url.ts
+++ b/client/site-profiler/utils/normalize-whois-url.ts
@@ -1,0 +1,24 @@
+import { normalizeWhoisField } from './normalize-whois-entry';
+
+// Normalize a WHOIS URL.
+export function normalizeWhoisURL( url: string | string[] | undefined ): string {
+	let normalisedURL = normalizeWhoisField( url );
+
+	if ( normalisedURL === '' ) {
+		return normalisedURL;
+	}
+
+	// Add a protocol if one is missing (assume HTTPS).
+	if ( ! /^(http|https):\/\//.test( normalisedURL ) ) {
+		normalisedURL = `https://${ normalisedURL }`;
+	}
+
+	try {
+		// Throw an error if the URL is invalid.
+		const urlObject = new URL( normalisedURL );
+
+		return urlObject.href;
+	} catch ( error ) {
+		return '';
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/82661

## Proposed Changes

* Add a normalizer for URLs got from IANA.

## Testing Instructions

* Open http://calypso.localhost:3000/site-profiler/partizan.net
* Click the `ENOM, INC.` link registrar URL
* It should redirect you to `https://www.enomdomains.com/` and not `http://calypso.localhost:3000/site-profiler/WWW.ENOMDOMAINS.COM`

Important. The normalizer assumes the protocol to be HTTPS (if not specified), but that is an old URL that only supports HTTP. Enom is a company bought by Tucows.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?