### PR TITLE
Live Preview: Implement MVP education modal

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/block-editor-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/block-editor-nux.js
@@ -15,6 +15,7 @@ import { HasSeenSellerCelebrationModalProvider } from '../../dotcom-fse/lib/sell
 import { HasSeenVideoCelebrationModalProvider } from '../../dotcom-fse/lib/video-celebration-modal/has-seen-video-celebration-modal-context';
 import DraftPostModal from './draft-post-modal';
 import FirstPostPublishedModal from './first-post-published-modal';
+import LivePreviewModal from './live-preview-modal';
 import PurchaseNotice from './purchase-notice';
 import SellerCelebrationModal from './seller-celebration-modal';
 import PostPublishedSharingModal from './sharing-modal';
@@ -125,6 +126,7 @@ registerPlugin( 'wpcom-block-editor-nux', {
 					<SellerCelebrationModal />
 					<PurchaseNotice />
 					<VideoPressCelebrationModal />
+					<LivePreviewModal />
 				</ShouldShowFirstPostPublishedModalProvider>
 			</HasSeenVideoCelebrationModalProvider>
 		</HasSeenSellerCelebrationModalProvider>

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/live-preview-modal/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/live-preview-modal/index.tsx
@@ -94,7 +94,8 @@ export default function LivePreviewModal() {
 			</p>
 			<p>
 				{ translate(
-					'To exit the Editor preview and get back to the theme showcase, click the small arrow next to “Previewing”.'
+					'To exit the Editor preview and get back to the theme showcase, click the small arrow next to {{strong}}Previewing{{/strong}}.',
+					{ components: { strong: <strong /> } }
 				) }
 			</p>
 			<CheckboxControl

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/live-preview-modal/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/live-preview-modal/index.tsx
@@ -94,8 +94,7 @@ export default function LivePreviewModal() {
 			</p>
 			<p>
 				{ translate(
-					'To exit the Editor preview and get back to the theme showcase, click the small arrow next to {{strong}}Previewing{{/strong}}.',
-					{ components: { strong: <strong /> } }
+					'To exit the Editor preview and get back to the theme showcase, click the WordPress logo at the top left corner.'
 				) }
 			</p>
 			<CheckboxControl

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/live-preview-modal/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/live-preview-modal/index.tsx
@@ -1,0 +1,114 @@
+import { Dialog, Gridicon } from '@automattic/components';
+import { Button, CheckboxControl } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { getQueryArg } from '@wordpress/url';
+import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+
+import './style.scss';
+
+/**
+ * Return true if the user is currently previewing a theme.
+ * FIXME: This is copied from Gutenberg; we should be creating a selector for the `core/edit-site` store.
+ * @see https://github.com/WordPress/gutenberg/blob/053c8f733c85d80c891fa308b071b9a18e5194e9/packages/edit-site/src/utils/is-previewing-theme.js#L6
+ */
+function isPreviewingTheme() {
+	return getQueryArg( window.location.href, 'wp_theme_preview' ) !== undefined;
+}
+
+/**
+ * Return the theme slug if the user is currently previewing a theme.
+ * FIXME: This is copied from Gutenberg; we should be creating a selector for the `core/edit-site` store.
+ * @see https://github.com/WordPress/gutenberg/blob/053c8f733c85d80c891fa308b071b9a18e5194e9/packages/edit-site/src/utils/is-previewing-theme.js#L6
+ */
+function currentlyPreviewingTheme() {
+	if ( isPreviewingTheme() ) {
+		return getQueryArg( window.location.href, 'wp_theme_preview' );
+	}
+	return null;
+}
+
+/**
+ * This is an interim solution to educate users the first time they live-previewing a theme.
+ * And this should be moved to jetpack-mu-wpcom.
+ * @see https://github.com/Automattic/wp-calypso/issues/82187
+ */
+export default function LivePreviewModal() {
+	const translate = useTranslate();
+
+	const { suppressLivePreviewModal: suppressModal } = useDispatch(
+		'automattic/wpcom-welcome-guide'
+	);
+	const isModalSuppressed = useSelect(
+		( select ) =>
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			( select( 'automattic/wpcom-welcome-guide' ) as any ).getIsLivePreviewModalSuppressed(),
+		[]
+	);
+
+	const [ isModalOpen, setIsModalOpen ] = useState( isPreviewingTheme() && ! isModalSuppressed );
+	const [ shouldSuppressModal, setShouldSuppressModal ] = useState( false );
+
+	const themeSlug = currentlyPreviewingTheme();
+	const theme = useSelect(
+		( select ) =>
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			( select( 'core' ) as any ).getTheme( themeSlug ),
+		[]
+	);
+	const themeName = theme?.name?.rendered || themeSlug;
+
+	const onClose = () => {
+		setIsModalOpen( false );
+	};
+
+	const onContinue = () => {
+		if ( shouldSuppressModal ) {
+			suppressModal();
+		}
+		onClose();
+	};
+
+	return (
+		<Dialog
+			className="live-preview-modal"
+			additionalOverlayClassNames="live-preview-modal__overlay"
+			isVisible={ isModalOpen }
+			isFullScreen
+		>
+			<Button className="live-preview-modal__close-icon" onClick={ onClose }>
+				<Gridicon icon="cross" size={ 24 } />
+			</Button>
+			<h1>{ translate( 'Previewing %(themeName)s', { args: { themeName } } ) }</h1>
+			<p>
+				{ translate(
+					'Welcome to the WordPress Editor. You will be previewing {{strong}}%(themeName)s{{/strong}} in the Editor with your site’s content. If you like what you see, you can {{strong}}Activate{{/strong}} the theme directly in the Editor.',
+					{ args: { themeName }, components: { strong: <strong /> } }
+				) }
+			</p>
+			<p>
+				{ translate(
+					'Most users find the {{strong}}Styles{{/strong}} and {{strong}}Pages{{/strong}} features particularly helpful in evaluating the look and feel of a new theme.',
+					{ components: { strong: <strong /> } }
+				) }
+			</p>
+			<p>
+				{ translate(
+					'To exit the Editor preview and get back to the theme showcase, click the small arrow next to “Previewing”.'
+				) }
+			</p>
+			<CheckboxControl
+				className="live-preview-modal__checkbox"
+				label={ translate( 'Do not show this modal again.' ) }
+				checked={ shouldSuppressModal }
+				onChange={ ( checked ) => {
+					setShouldSuppressModal( checked );
+				} }
+			/>
+
+			<Button variant="primary" onClick={ onContinue }>
+				{ translate( 'Continue' ) }
+			</Button>
+		</Dialog>
+	);
+}

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/live-preview-modal/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/live-preview-modal/style.scss
@@ -8,6 +8,7 @@
 	padding: 48px 48px 28px;
 	max-width: 720px;
 	box-sizing: border-box;
+	text-wrap: pretty;
 
 	h1 {
 		@extend .wp-brand-font;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/live-preview-modal/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/live-preview-modal/style.scss
@@ -1,0 +1,47 @@
+@import "@automattic/typography/styles/variables";
+@import "@automattic/typography/styles/fonts";
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.dialog__content.live-preview-modal {
+	position: relative;
+	padding: 48px 48px 28px;
+	max-width: 720px;
+	box-sizing: border-box;
+
+	h1 {
+		@extend .wp-brand-font;
+		font-size: $font-title-large;
+		margin-top: 0;
+		margin-bottom: 32px;
+	}
+
+	p {
+		font-size: $font-body;
+	}
+
+	.live-preview-modal__close-icon {
+		cursor: pointer;
+		color: var(--color-text-subtle);
+		position: absolute;
+		top: 4px;
+		right: 12px;
+		padding: 0;
+	}
+
+	.live-preview-modal__checkbox {
+		margin: 32px 0;
+
+		.components-base-control__field {
+			display: flex;
+			align-items: center;
+		}
+		.components-checkbox-control__label {
+			font-size: $font-body;
+		}
+	}
+}
+
+.dialog__backdrop.live-preview-modal__overlay {
+	background-color: rgba(0, 0, 0, 0.7);
+}

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/store.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/store.js
@@ -72,12 +72,24 @@ const shouldShowFirstPostPublishedModalReducer = ( state = false, action ) => {
 	}
 };
 
+const livePreviewModalReducer = ( state = { suppressed: false }, action ) => {
+	switch ( action.type ) {
+		case 'WPCOM_LIVE_PREVIEW_MODAL_SUPPRESS':
+			return { suppressed: true };
+		case 'WPCOM_WELCOME_GUIDE_RESET_STORE':
+			return { suppressed: false };
+		default:
+			return state;
+	}
+};
+
 const reducer = combineReducers( {
 	welcomeGuideManuallyOpened: welcomeGuideManuallyOpenedReducer,
 	showWelcomeGuide: showWelcomeGuideReducer,
 	tourRating: tourRatingReducer,
 	welcomeGuideVariant: welcomeGuideVariantReducer,
 	shouldShowFirstPostPublishedModal: shouldShowFirstPostPublishedModalReducer,
+	livePreviewModal: livePreviewModalReducer,
 } );
 
 export const actions = {
@@ -120,6 +132,9 @@ export const actions = {
 	setUsedPageOrPatternsModal: () => {
 		return { type: 'WPCOM_HAS_USED_PATTERNS_MODAL' };
 	},
+	suppressLivePreviewModal: () => {
+		return { type: 'WPCOM_LIVE_PREVIEW_MODAL_SUPPRESS' };
+	},
 	// The `resetStore` action is only used for testing to reset the
 	// store inbetween tests.
 	resetStore: () => ( {
@@ -136,6 +151,7 @@ export const selectors = {
 	getWelcomeGuideVariant: ( state ) =>
 		state.welcomeGuideVariant === 'modal' ? DEFAULT_VARIANT : state.welcomeGuideVariant,
 	getShouldShowFirstPostPublishedModal: ( state ) => state.shouldShowFirstPostPublishedModal,
+	getIsLivePreviewModalSuppressed: ( state ) => state.livePreviewModal.suppressed,
 };
 
 export function register() {


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/wp-calypso/issues/82187

## Proposed Changes

Implement simple education modal for Live Preview in ETK.

It adds a `livePreviewModal` state to the `automattic/wpcom-welcome-guide` store, to track whether the user has suppressed the modal ("Do not show again").

### Screenshot

<img width="724" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/92c332c2-9956-4ef8-a501-cfa51d9a3734">


### Video

https://github.com/Automattic/wp-calypso/assets/1525580/dfdb882f-c4b7-4517-b235-3be422eb99b8


## Testing Instructions

1. Patch this change to your sandbox: `install-plugin.sh editing-toolkit live-preview-modal`.
1. Sandbox YOUR SITE.
1. Open `https://horizon.wordpress.com`.
1. Go to Appearance -> Editor. Verify that the modal is NOT shown because we're not live-previewing anything.
1. Now go to Appearance -> Themes.
1. Choose a Free theme and click "Preview & Customize".
1. Verify that the modal is shown and the correct theme name is shown.
1. Click close button at the top-right corner. Verify the modal is closed. Refresh the page. Verify that the modal is shown again. 
1. Click Continue button. Verify the modal is closed. Refresh the page. Verify that the modal is shown again. 
1. Tick "Do not show" checkbox then click Continue. Verify the modal is closed. Refresh the page. Verify that the modal is NEVER shown again on this site. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?