### PR TITLE
Site Profiler: add skeleton indicator to status info

### DIFF
--- a/client/site-profiler/components/heading-information/status-info.tsx
+++ b/client/site-profiler/components/heading-information/status-info.tsx
@@ -1,8 +1,10 @@
+import { isMobile } from '@automattic/viewport';
 import { translate } from 'i18n-calypso';
 import { UrlData } from 'calypso/blocks/import/types';
 import { HostingProvider } from 'calypso/data/site-profiler/types';
 import useHostingProviderName from 'calypso/site-profiler/hooks/use-hosting-provider-name';
 import { CONVERSION_ACTION } from '../../hooks/use-define-conversion-action';
+import { Skeleton } from '../skeleton-screen';
 import type { SPECIAL_DOMAIN_CASES } from '../../utils/get-special-domain-mapping';
 
 interface Props {
@@ -114,6 +116,6 @@ export default function StatusInfo( props: Props ) {
 				</p>
 			);
 		default:
-			return null;
+			return <Skeleton width={ isMobile() ? '100%' : '50%' } height={ 24 } />;
 	}
 }

--- a/client/site-profiler/components/heading-information/status-info.tsx
+++ b/client/site-profiler/components/heading-information/status-info.tsx
@@ -1,11 +1,11 @@
 import { isMobile } from '@automattic/viewport';
 import { translate } from 'i18n-calypso';
-import { UrlData } from 'calypso/blocks/import/types';
-import { HostingProvider } from 'calypso/data/site-profiler/types';
-import useHostingProviderName from 'calypso/site-profiler/hooks/use-hosting-provider-name';
 import { CONVERSION_ACTION } from '../../hooks/use-define-conversion-action';
+import useHostingProviderName from '../../hooks/use-hosting-provider-name';
 import { Skeleton } from '../skeleton-screen';
 import type { SPECIAL_DOMAIN_CASES } from '../../utils/get-special-domain-mapping';
+import type { UrlData } from 'calypso/blocks/import/types';
+import type { HostingProvider } from 'calypso/data/site-profiler/types';
 
 interface Props {
 	conversionAction?: CONVERSION_ACTION;
@@ -16,7 +16,7 @@ interface Props {
 export default function StatusInfo( props: Props ) {
 	const { conversionAction, hostingProvider, urlData, specialDomainMapping } = props;
 	const hostingProviderName = useHostingProviderName( hostingProvider, urlData );
-	// if there's a speical domain mapping, use that instead of the conversion action
+	// if there's a special domain mapping, use that instead of the conversion action
 	const finalStatus = specialDomainMapping ?? conversionAction;
 	switch ( finalStatus ) {
 		case 'wordpress-com':

--- a/client/site-profiler/components/skeleton-screen/index.tsx
+++ b/client/site-profiler/components/skeleton-screen/index.tsx
@@ -1,0 +1,19 @@
+import './style.scss';
+
+interface SkeletonProps {
+	width?: number | string;
+	height?: number | string;
+	isShow?: boolean;
+}
+
+export const Skeleton = ( { width = '100%', height = 20 }: SkeletonProps ) => {
+	return (
+		<div
+			className="site-profiler-skeleton"
+			style={ {
+				width,
+				height,
+			} }
+		/>
+	);
+};

--- a/client/site-profiler/components/skeleton-screen/style.scss
+++ b/client/site-profiler/components/skeleton-screen/style.scss
@@ -1,0 +1,28 @@
+@import "~@automattic/color-studio/dist/color-variables";
+@import "~@wordpress/base-styles/colors";
+
+@keyframes site-profiler-skeleton__animation {
+	0% {
+		opacity: 0.5;
+	}
+
+	50% {
+		opacity: 1;
+	}
+
+	100% {
+		opacity: 0.5;
+	}
+}
+
+.site-profiler-skeleton {
+	color: $studio-gray-0;
+	background-color: $studio-gray-5;
+	width: 100%;
+	border-radius: 4px;
+	animation: site-profiler-skeleton__animation 1.6s ease-in-out infinite;
+
+	&::after {
+		content: "";
+	}
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #82660

## Proposed Changes

* Adding a skeleton screen to the status info block. The reason not adding to the button and status cta block is because both of them might be null, so I lean towards keeping it empty as it is now. 

![Screen Shot 2023-10-05 at 11 57 40 PM](https://github.com/Automattic/wp-calypso/assets/4074459/466af180-6346-4206-8b6f-7377a86b56bd)



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `http://calypso.localhost:3000/site-profiler`
* Try out a few sites and see if you get a skeleton screen in the status info section

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?