### PR TITLE
Themes Discovery: Mobile carousel styles

### DIFF
--- a/client/components/theme-collection/index.tsx
+++ b/client/components/theme-collection/index.tsx
@@ -74,6 +74,11 @@ export default function ThemeCollection( {
 							// break-huge in wordpress breakpoints
 							'1440': {
 								slidesPerView: 4,
+								spaceBetween: 60,
+							},
+							// break-xhuge in wordpress breakpoints
+							'1920': {
+								spaceBetween: 100,
 							},
 						},
 						modules: [ Navigation, Keyboard, Mousewheel ],

--- a/client/components/theme-collection/index.tsx
+++ b/client/components/theme-collection/index.tsx
@@ -76,10 +76,12 @@ export default function ThemeCollection( {
 	}, [ swiperContainerId, isSwiperLoaded ] );
 
 	return (
-		<div className="theme-collection__container ">
-			<h2 className="theme-collection__title">{ title }</h2>
-			<div className="theme-collection__description">{ description }</div>
-			<div className="swiper-container" id={ swiperContainerId }>
+		<div className="theme-collection__container swiper-container" id={ swiperContainerId }>
+			<div className="theme-collection__meta">
+				<div className="theme-collection__headings">
+					<h2 className="theme-collection__title">{ title }</h2>
+					<div className="theme-collection__description">{ description }</div>
+				</div>
 				<div className="theme-collection__carousel-controls">
 					<Button className="theme-collection__carousel-nav-button theme-collection__carousel-nav-button--previous">
 						<Icon icon={ chevronLeft } />
@@ -88,8 +90,8 @@ export default function ThemeCollection( {
 						<Icon icon={ chevronRight } />
 					</Button>
 				</div>
-				<div className="theme-collection__list-wrapper swiper-wrapper">{ children }</div>
 			</div>
+			<div className="theme-collection__list-wrapper swiper-wrapper">{ children }</div>
 		</div>
 	);
 }

--- a/client/components/theme-collection/index.tsx
+++ b/client/components/theme-collection/index.tsx
@@ -60,9 +60,18 @@ export default function ThemeCollection( {
 							prevEl: '.theme-collection__carousel-nav-button--previous',
 						},
 						threshold: 5,
-						slideToClickedSlide: true,
-						slidesPerView: 'auto',
-						spaceBetween: 20,
+						spaceBetween: 40,
+						slidesPerView: 1.2,
+						breakpoints: {
+							// break-medium in wordpress breakpoints
+							'782': {
+								slidesPerView: 2,
+							},
+							// break-xlarge in wordpress breakpoints
+							'1080': {
+								slidesPerView: 3,
+							},
+						},
 						modules: [ Navigation, Keyboard, Mousewheel ],
 					} );
 					setSwiperLoaded( true );

--- a/client/components/theme-collection/index.tsx
+++ b/client/components/theme-collection/index.tsx
@@ -71,6 +71,10 @@ export default function ThemeCollection( {
 							'1080': {
 								slidesPerView: 3,
 							},
+							// break-huge in wordpress breakpoints
+							'1440': {
+								slidesPerView: 4,
+							},
 						},
 						modules: [ Navigation, Keyboard, Mousewheel ],
 					} );

--- a/client/components/theme-collection/style.scss
+++ b/client/components/theme-collection/style.scss
@@ -1,3 +1,22 @@
+.theme-collection__meta {
+	display: flex;
+	justify-content: space-between;
+}
+
+.theme-collection__headings {
+	flex-basis: 45%;
+}
+
+.theme-collection__title {
+	font-size: 1.75rem;
+	line-height: 1;
+}
+
+.theme-collection__description * {
+	margin-bottom: 0;
+}
+
+
 .theme-collection__list-item.swiper-slide {
 	/* TODO: Needs a better solution. Testing on more screen widths etc */
 	width: 32%;
@@ -13,28 +32,24 @@
 	justify-content: flex-end;
 	/*!rtl:ignore*/
 	direction: ltr;
+	align-self: end;
 
 	button {
 		width: 40px;
 		height: 40px;
 		background: #eee;
 		border-radius: 50%;
-		align-items: center;
 		display: flex;
 		justify-content: center;
-		transition: opacity 0.3s ease-in-out;
+		margin: 0 1em;
+		transition: opacity 0.3s linear;
 		pointer-events: all;
-		z-index: 2;
-
-		cursor: pointer;
 
 		&:hover {
-			opacity: 1;
-			fill: var(--studio-blue-50);
+			filter: brightness(0.9);
 		}
 
 		&.swiper-button-disabled {
-			visibility: hidden;
 			pointer-events: none;
 		}
 

--- a/client/components/theme-collection/style.scss
+++ b/client/components/theme-collection/style.scss
@@ -1,10 +1,19 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 .theme-collection__meta {
 	display: flex;
 	justify-content: space-between;
 }
 
 .theme-collection__headings {
-	flex-basis: 45%;
+	flex-basis: 100%;
+	@include break-medium {
+		flex-basis: 65%;
+	}
+	@include break-wide {
+		flex-basis: 45%;
+	}
 }
 
 .theme-collection__title {
@@ -16,23 +25,28 @@
 	margin-bottom: 0;
 }
 
-
 .theme-collection__list-item.swiper-slide {
-	/* TODO: Needs a better solution. Testing on more screen widths etc */
-	width: 32%;
+	.card.theme-card {
+		/* The horizontal space between themes is configured in JS by swiper `spaceBetween` */
+		margin-left: 0;
+		margin-right: 0;
+	}
 }
 
 .theme-collection__list-wrapper {
 	margin-top: 1em;
 }
 
-/* TODO: Don't display on mobile? */
 .theme-collection__carousel-controls {
-	display: flex;
-	justify-content: flex-end;
 	/*!rtl:ignore*/
 	direction: ltr;
-	align-self: end;
+	display: none;
+
+	@include break-medium {
+		display: flex;
+		justify-content: flex-end;
+		align-self: end;
+	}
 
 	button {
 		width: 40px;

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -256,8 +256,12 @@
 		margin: 0;
 	}
 
+	.themes__showcase {
+		margin-top: 32px;
+	}
+
 	.themes__selection .themes-list {
-		margin: 32px -16px 0;
+		margin: 0 -16px;
 	}
 
 	.themes__content .upsell-nudge {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4073 see also RcxiuWYjZGkFRdlWL7L02m-fi-1157_8895

## Proposed Changes

Make the discovery themes carousel work nicely on mobile:
 * Make the number of slides on display vary depending upon the width of the viewport
 * Vary how much width the title + description are allowed to take up
 * Remove the forward/back buttons on narrow screens and "peek" the next theme to hint that swiping is possible
 * Clear up some spacing issues

## Testing Instructions
1. Use the calypso live link below
2. In a logged out window, use /themes?flags=themes/discovery-lots
3. Go bonkers with the viewport

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Video showing two discovery carousels, and purely for comparisons sake, the current theme grid below 







## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?