### PR TITLE
Fediverse: disable on private sites

### DIFF
--- a/client/my-sites/site-settings/fediverse-settings/WpcomFediverseSettingsSection.js
+++ b/client/my-sites/site-settings/fediverse-settings/WpcomFediverseSettingsSection.js
@@ -9,7 +9,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { domainAddNew } from 'calypso/my-sites/domains/paths';
 import { useActivityPubStatus } from 'calypso/state/activitypub/use-activitypub-status';
 import { successNotice } from 'calypso/state/notices/actions';
-import { getSiteTitle, getSiteDomain } from 'calypso/state/sites/selectors';
+import { getSiteTitle, getSiteDomain, getSite } from 'calypso/state/sites/selectors';
 
 const DomainUpsellCard = ( { siteId } ) => {
 	const domain = useSelector( ( state ) => getSiteDomain( state, siteId ) );
@@ -107,6 +107,9 @@ export const WpcomFediverseSettingsSection = ( { siteId } ) => {
 	const translate = useTranslate();
 	const dispatchSuccessNotice = useDispatchSuccessNotice();
 	const siteTitle = useSelector( ( state ) => getSiteTitle( state, siteId ) );
+	const domain = useSelector( ( state ) => getSiteDomain( state, siteId ) );
+	const site = useSelector( ( state ) => getSite( state, siteId ) );
+	const isPrivate = site?.is_private || site?.is_coming_soon;
 	const noticeArgs = {
 		args: {
 			site_title: siteTitle,
@@ -121,8 +124,7 @@ export const WpcomFediverseSettingsSection = ( { siteId } ) => {
 			dispatchSuccessNotice( message );
 		}
 	);
-	const disabled = isLoading || isError;
-
+	const disabled = isLoading || isError || isPrivate;
 	return (
 		<>
 			<Card className="site-settings__card">
@@ -137,6 +139,18 @@ export const WpcomFediverseSettingsSection = ( { siteId } ) => {
 					checked={ isEnabled }
 					onChange={ ( value ) => setEnabled( value ) }
 				/>
+				{ isPrivate && (
+					<Notice status="is-warning" translate={ translate } isCompact={ true }>
+						{ translate(
+							'You cannot enter the fediverse until your site is publicly launched. {{link}}Review Privacy settings{{/link}}.',
+							{
+								components: {
+									link: <a href={ `/settings/general/${ domain }` } />,
+								},
+							}
+						) }
+					</Notice>
+				) }
 			</Card>
 			{ isEnabled && <EnabledSettingsSection data={ data } siteId={ siteId } /> }
 		</>


### PR DESCRIPTION
Enabling the fediverse on private sites seems like a path to futility and/or private content leakage.

## Proposed Changes

* Don't allow entering the fediverse with a Private or Coming Soon site

## Testing Instructions

A public site should remain unchanged. A Private or Coming Soon site will see:

<img width="731" alt="Screenshot 2023-10-05 at 12 32 59" src="https://github.com/Automattic/wp-calypso/assets/195089/0908063c-11a4-4e0f-bbea-b10803434f23">

You can adjust site privacy Settings under Settings --> General, scroll to the Privacy card (we need deep links in settings grrr)

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
