### PR TITLE
Site profiler: Show footer component for logged-in users

### DIFF
--- a/client/site-profiler/components/heading-information/index.tsx
+++ b/client/site-profiler/components/heading-information/index.tsx
@@ -2,7 +2,6 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button } from '@wordpress/components';
 import { translate } from 'i18n-calypso';
 import page from 'page';
-import { useEffect } from 'react';
 import { UrlData } from 'calypso/blocks/import/types';
 import { HostingProvider } from 'calypso/data/site-profiler/types';
 import StatusCtaInfo from '../heading-information/status-cta-info';
@@ -30,11 +29,6 @@ export default function HeadingInformation( props: Props ) {
 		specialDomainMapping,
 	} = props;
 	const finalStatus = specialDomainMapping ?? conversionAction;
-
-	useEffect( () => {
-		// Scroll to top when the component is mounted
-		window && window.scrollTo( 0, 0 );
-	}, [] );
 
 	const recordCtaEvent = ( ctaName: string ) => {
 		recordTracksEvent( 'calypso_site_profiler_cta', {

--- a/client/site-profiler/components/heading-information/index.tsx
+++ b/client/site-profiler/components/heading-information/index.tsx
@@ -2,6 +2,7 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button } from '@wordpress/components';
 import { translate } from 'i18n-calypso';
 import page from 'page';
+import { useEffect } from 'react';
 import { UrlData } from 'calypso/blocks/import/types';
 import { HostingProvider } from 'calypso/data/site-profiler/types';
 import StatusCtaInfo from '../heading-information/status-cta-info';
@@ -29,6 +30,11 @@ export default function HeadingInformation( props: Props ) {
 		specialDomainMapping,
 	} = props;
 	const finalStatus = specialDomainMapping ?? conversionAction;
+
+	useEffect( () => {
+		// Scroll to top when the component is mounted
+		window && window.scrollTo( 0, 0 );
+	}, [] );
 
 	const recordCtaEvent = ( ctaName: string ) => {
 		recordTracksEvent( 'calypso_site_profiler_cta', {

--- a/client/site-profiler/components/hosting-information/index.tsx
+++ b/client/site-profiler/components/hosting-information/index.tsx
@@ -28,7 +28,9 @@ export default function HostingInformation( props: Props ) {
 					<li>
 						<div className="name">{ translate( 'Support' ) }</div>
 						<div>
-							<a href={ supportUrl }>{ translate( 'Contact support' ) }</a>
+							<a href={ supportUrl } target="_blank" rel="nofollow noreferrer">
+								{ translate( 'Contact support' ) }
+							</a>
 						</div>
 					</li>
 				) }

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -8,6 +8,7 @@ import { LayoutBlock, LayoutBlockSection } from 'calypso/site-profiler/component
 import useDefineConversionAction from 'calypso/site-profiler/hooks/use-define-conversion-action';
 import useDomainQueryParam from 'calypso/site-profiler/hooks/use-domain-query-param';
 import useLongFetchingDetection from '../hooks/use-long-fetching-detection';
+import useScrollToTop from '../hooks/use-scroll-to-top';
 import useSiteProfilerRecordAnalytics from '../hooks/use-site-profiler-record-analytics';
 import DomainAnalyzer from './domain-analyzer';
 import DomainInformation from './domain-information';
@@ -40,6 +41,7 @@ export default function SiteProfiler() {
 		isErrorUrlData ? null : urlData
 	);
 
+	useScrollToTop( !! siteProfilerData );
 	useSiteProfilerRecordAnalytics(
 		domain,
 		isDomainValid,

--- a/client/site-profiler/components/styles.scss
+++ b/client/site-profiler/components/styles.scss
@@ -12,7 +12,9 @@
 	background: #fff;
 	padding: 0;
 	min-height: calc(100vh - 3.5rem);
+}
 
+.is-section-site-profiler .main {
 	h1 {
 		font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
 		/* stylelint-disable-next-line */
@@ -255,5 +257,4 @@
 	.domain-result-block::after {
 		height: 210px;
 	}
-
 }

--- a/client/site-profiler/controller.tsx
+++ b/client/site-profiler/controller.tsx
@@ -1,8 +1,10 @@
 import config from '@automattic/calypso-config';
+import { PureUniversalNavbarFooter } from '@automattic/wpcom-template-parts';
 import page from 'page';
 import { BrowserRouter } from 'react-router-dom';
 import Main from 'calypso/components/main';
 import SiteProfiler from 'calypso/site-profiler/components/site-profiler';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
 export function redirectSiteProfilerResult( context: PageJS.Context, next: () => void ) {
 	const { querystring } = context;
@@ -17,6 +19,8 @@ export function redirectSiteProfilerResult( context: PageJS.Context, next: () =>
 }
 
 export function siteProfilerContext( context: PageJS.Context, next: () => void ): void {
+	const isLoggedIn = isUserLoggedIn( context.store.getState() );
+
 	if ( ! config.isEnabled( 'site-profiler' ) ) {
 		page.redirect( '/' );
 		return;
@@ -27,6 +31,7 @@ export function siteProfilerContext( context: PageJS.Context, next: () => void )
 			<Main fullWidthLayout>
 				<SiteProfiler />
 			</Main>
+			{ isLoggedIn && <PureUniversalNavbarFooter isLoggedIn={ isLoggedIn } /> }
 		</BrowserRouter>
 	);
 

--- a/client/site-profiler/hooks/use-scroll-to-top.ts
+++ b/client/site-profiler/hooks/use-scroll-to-top.ts
@@ -1,0 +1,12 @@
+import { useEffect, useRef } from 'react';
+
+export default function useScrollToTop( exchange: boolean ) {
+	const exchangePrev = useRef( exchange );
+
+	useEffect( () => {
+		// Scroll to top when exchange param changes
+		// e.g. when user switches between domain and hosting results
+		exchange !== exchangePrev.current && window?.scrollTo( 0, 0 );
+		exchangePrev.current = exchange;
+	}, [ exchange ] );
+}


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/82399
Closes https://github.com/Automattic/wp-calypso/issues/82647

## Proposed Changes

* Show the Universal Footer component for the logged-in users
* Scroll the screen to the top when the heading block is mounted
* Configure the "Contact support" link to be opened in the new tab

## Testing Instructions

* Make sure you are logged-in
* Go to `/site-profiler`
* Check if there is a footer component
* Enter any domain
* Press enter and scroll down
* Check if the page is scrolling to the top

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?