### PR TITLE
Jetpack: In settings, credential form verify host input

### DIFF
--- a/client/components/advanced-credentials/form.ts
+++ b/client/components/advanced-credentials/form.ts
@@ -1,5 +1,6 @@
 import { TranslateResult, translate } from 'i18n-calypso';
 import { filePathValidator } from 'calypso/lib/validation';
+import { checkHostInput } from './utils';
 
 export enum FormMode {
 	Password,
@@ -104,7 +105,7 @@ export const validate = ( formState: FormState, mode: FormMode ): FormErrors => 
 		};
 	}
 	// host checking
-	if ( ! formState.host ) {
+	if ( ! formState.host || ! checkHostInput( formState.host ) ) {
 		formErrors.host = {
 			message: translate( 'Please enter a valid server address.' ),
 			waitForInteraction: true,

--- a/client/components/advanced-credentials/index.tsx
+++ b/client/components/advanced-credentials/index.tsx
@@ -25,6 +25,7 @@ import { ConnectionStatus, StatusState } from './connection-status';
 import CredentialsForm from './credentials-form';
 import { FormMode, FormState, INITIAL_FORM_ERRORS, INITIAL_FORM_STATE, validate } from './form';
 import HostSelection from './host-selection';
+import { getHostInput } from './utils';
 import Verification from './verification';
 import './style.scss';
 import type { ClickHandler } from 'calypso/components/step-progress';
@@ -263,6 +264,11 @@ const AdvancedCredentials: FunctionComponent< Props > = ( {
 			credentials.kpri = '';
 		} else if ( formMode === FormMode.PrivateKey ) {
 			credentials.pass = '';
+		}
+
+		const host = getHostInput( formState.host );
+		if ( host ) {
+			credentials.host = host;
 		}
 
 		dispatch( recordTracksEvent( 'calypso_jetpack_advanced_credentials_flow_credentials_update' ) );

--- a/client/components/advanced-credentials/test/utils.ts
+++ b/client/components/advanced-credentials/test/utils.ts
@@ -1,0 +1,45 @@
+import { checkHostInput, getHostInput } from '../utils';
+
+describe( 'checkHostInput', () => {
+	it( 'should return `true` when given a valid URL', () => {
+		const host = checkHostInput( 'https://www.example.com/path/to/resource' );
+		expect( host ).toEqual( true );
+	} );
+
+	it( 'should return `true` when given a valid URL without protocol', () => {
+		const host = checkHostInput( 'www.example.com/path/to/resource' );
+		expect( host ).toEqual( true );
+	} );
+
+	it( 'should return `false` when given an invalid URL', () => {
+		const host = checkHostInput( 'not a valid URL' );
+		expect( host ).toEqual( false );
+	} );
+
+	it( 'should return `false` when given an empty string', () => {
+		const host = checkHostInput( '' );
+		expect( host ).toEqual( false );
+	} );
+} );
+
+describe( 'getHostInput', () => {
+	it( 'should return the correct host name when given a valid URL', () => {
+		const host = getHostInput( 'https://example.com/path/to/resource' );
+		expect( host ).toEqual( 'example.com' );
+	} );
+
+	it( 'should return the correct host name when given a valid URL without protocol', () => {
+		const host = getHostInput( 'www.example.com/path/to/resource' );
+		expect( host ).toEqual( 'www.example.com' );
+	} );
+
+	it( 'should return empty string given an invalid URL', () => {
+		const host = getHostInput( 'not a valid URL' );
+		expect( host ).toEqual( '' );
+	} );
+
+	it( 'should return empty when given an empty string', () => {
+		const host = getHostInput( '' );
+		expect( host ).toEqual( '' );
+	} );
+} );

--- a/client/components/advanced-credentials/utils.ts
+++ b/client/components/advanced-credentials/utils.ts
@@ -1,0 +1,14 @@
+const getHostMatch = ( host: string ) => {
+	const urlPattern = /^(https?:\/\/)?([a-zA-Z0-9.-]+)(\/.*)?$/;
+	return host.match( urlPattern );
+};
+
+export const getHostInput = ( host: string ) => {
+	const match = getHostMatch( host );
+	return match?.[ 2 ] || '';
+};
+
+export const checkHostInput = ( host: string ) => {
+	const match = getHostMatch( host );
+	return !! match?.[ 2 ];
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack/issues/33563


## Proposed Changes

On `cloud.jetpack.com/settings/<sideId>` verify that host is in the correct format. This should show an error if it's not, and, also remove protocol if necessary.

If my measurements are correct we are getting around 210 of these including protocol (https) a month.
<img width="825" alt="Screenshot at Oct 10 10-44-13" src="https://github.com/Automattic/wp-calypso/assets/60262784/1fa483f7-822d-4f87-b1fe-baa36ea583e3">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Clone and run the branch locally  (`yarn start-jetpack-cloud`) OR use Jetpack Cloud Live link below
- Spin a new JN site and add Jetpack Backup to it for example
- Navigate to `[cloud.jetpack]//settings/[JN site]`, eg `http://jetpack.cloud.localhost:3000/settings/greasy-grebe.jurassic.ninja`
- On `Host Input` the verification should be improved.
<img width="486" alt="Screenshot at Oct 10 10-14-00" src="https://github.com/Automattic/wp-calypso/assets/60262784/f0fa4407-42cb-4216-9563-fbf4e21c8852">

- Also, now when adding a host like `http://greasy-grebe.jurassic.ninja/wp-admin` it will still allow to add, and will save correct host `greasy-grebe.jurassic.ninja`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?