### PR TITLE
Fix action button position on Magic Login page

### DIFF
--- a/client/login/magic-login/handle-emailed-link-form.jsx
+++ b/client/login/magic-login/handle-emailed-link-form.jsx
@@ -184,11 +184,13 @@ class HandleEmailedLinkForm extends Component {
 		}
 
 		const line = [
-			translate( 'Logging in as %(emailAddress)s', {
-				args: {
-					emailAddress,
-				},
-			} ),
+			<p>
+				{ translate( 'Logging in as %(emailAddress)s', {
+					args: {
+						emailAddress,
+					},
+				} ) }
+			</p>,
 		];
 
 		if ( currentUser && currentUser.username ) {


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/82681

## Proposed Changes

* Fix action button position on Magic Login page

**Before**
<img width="621" alt="Screenshot 2023-10-05 at 17 45 43" src="https://github.com/Automattic/wp-calypso/assets/3113712/e9b33b9d-89ee-4305-b07d-c3e589772213">

**After**
<img width="513" alt="Screenshot 2023-10-05 at 17 41 36" src="https://github.com/Automattic/wp-calypso/assets/3113712/fd08145b-58db-45c0-b0c6-7cf70c3bbfc8">

## Testing Instructions

* Apply this PR to your local
* Go to https://wordpress.com/log-in/link
* Type any wpcom/non-wpcom email and click on Get Link
* Open the email and copy the "Log in to WordPress.com" URL
* Replace the `https%3A%2F%2Fwordpress.com%2F` to `http%3A%2F%2Fcalypso.localhost%3A3000%2F`
* Open the updated URL, and you should see the button on a new line

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?