### PR TITLE
Multi-domain: Fix choose later button

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -324,7 +324,7 @@ export class RenderDomainsStep extends Component {
 		const { step } = this.props;
 		const { suggestion } = step;
 
-		if ( this.shouldUseMultipleDomainsInCart() ) {
+		if ( this.shouldUseMultipleDomainsInCart() && suggestion ) {
 			return this.handleDomainToDomainCart( {
 				googleAppsCartItem,
 				shouldHideFreePlan,
@@ -746,7 +746,7 @@ export class RenderDomainsStep extends Component {
 					<Button
 						borderless
 						className="domains__domain-cart-choose-later"
-						onClick={ this.handleUseYourDomainClick }
+						onClick={ () => this.handleSkip( undefined, false ) }
 					>
 						{ this.props.translate( 'Choose my domain later' ) }
 					</Button>

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -603,6 +603,22 @@ export class RenderDomainsStep extends Component {
 		}
 	}
 
+	removeAllDomains() {
+		const cartProducts = this.props.cart.products;
+		const domainsToRemove = cartProducts.filter( ( product ) =>
+			product.product_slug.includes( 'domain' )
+		);
+
+		if ( domainsToRemove.length ) {
+			domainsToRemove.forEach( ( domain ) => {
+				this.removeDomain( {
+					domain_name: domain.meta,
+					product_slug: domain.product_slug,
+				} );
+			} );
+		}
+	}
+
 	goToNext = () => {
 		return () => {
 			const shouldUseThemeAnnotation = this.shouldUseThemeAnnotation();
@@ -746,7 +762,10 @@ export class RenderDomainsStep extends Component {
 					<Button
 						borderless
 						className="domains__domain-cart-choose-later"
-						onClick={ () => this.handleSkip( undefined, false ) }
+						onClick={ () => {
+							this.removeAllDomains();
+							this.handleSkip( undefined, false );
+						} }
 					>
 						{ this.props.translate( 'Choose my domain later' ) }
 					</Button>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
thelinked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4120

## Proposed Changes

* There are two instances of the "Choose my domain later" button on domain multi-selection. This PR fixes those buttons so they go to the plans page correctly.
* When the user has domains in their cart, this PR removes those domains when they select "Choose my domain later"

Screenshot of two instances of the "Choose my domain later" buttons.

<img width="1502" alt="Screenshot 2023-10-05 at 5 39 10 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/95967f0f-dbb3-4d80-853f-530a098ecc6e">
<img width="1502" alt="Screenshot 2023-10-05 at 5 39 50 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/55a5dc78-ec92-4cb9-ae0c-9a688e149611">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

With feature flag
* Test with the feature flag enabled at http://calypso.localhost:3000/start/domains?flags=domains/add-multiple-domains-to-cart
* Go through the flow, selecting "Choose my domain later" with domains in your cart and with no domains in your cart.
* Make sure it behaves as you expect and try to break it.

Without feature flag
* Test without the feature flag to be sure there are no regressions http://calypso.localhost:3000/start/domains
* "Choose my domain later" should behave as you expect.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?