### PR TITLE
Multi-Domain: Add the mini-cart to mobile

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -724,13 +724,11 @@ export class RenderDomainsStep extends Component {
 			);
 		};
 
-<<<<<<< HEAD
-		const DomainsInCart =
-			shouldUseMultipleDomainsInCart( this.props.flowName, this.props.step?.suggestion ) &&
-			! cartIsLoading ? (
-=======
 		const DomainsInCart = () => {
-			if ( ! this.shouldUseMultipleDomainsInCart() || cartIsLoading ) {
+			if (
+				! shouldUseMultipleDomainsInCart( this.props.flowName, this.props.step?.suggestion ) ||
+				cartIsLoading
+			) {
 				return null;
 			}
 
@@ -790,7 +788,6 @@ export class RenderDomainsStep extends Component {
 			}
 
 			return (
->>>>>>> 4baf41cf88 (Update CSS)
 				<div className="domains__domain-side-content domains__domain-cart">
 					<div className="domains__domain-cart-title">
 						{ this.props.translate( 'Your domains' ) }

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -724,9 +724,73 @@ export class RenderDomainsStep extends Component {
 			);
 		};
 
+<<<<<<< HEAD
 		const DomainsInCart =
 			shouldUseMultipleDomainsInCart( this.props.flowName, this.props.step?.suggestion ) &&
 			! cartIsLoading ? (
+=======
+		const DomainsInCart = () => {
+			if ( ! this.shouldUseMultipleDomainsInCart() || cartIsLoading ) {
+				return null;
+			}
+
+			if ( isMobile() ) {
+				const MobileHeader = (
+					<div className="domains__domain-cart-title">
+						<div className="domains__domain-cart-total">
+							<div key="rowtotal" className="domains__domain-cart-total-items">
+								{ this.props.translate( '%d domain', '%d domains', {
+									count: domainsInCart.length,
+									args: [ domainsInCart.length ],
+								} ) }
+							</div>
+							<div key="rowtotalprice" className="domains__domain-cart-total-price">
+								{ formatCurrency(
+									domainsInCart.reduce( ( total, item ) => total + item.cost, 0 ),
+									domainsInCart ? domainsInCart[ 0 ].currency : 'USD'
+								) }
+							</div>
+						</div>
+						<Button primary className="domains__domain-cart-continue" onClick={ this.goToNext() }>
+							{ this.props.translate( 'Continue' ) }
+						</Button>
+					</div>
+				);
+
+				return (
+					<FoldableCard
+						clickableHeader
+						className="domains__domain-side-content domains__domain-cart-foldable-card"
+						header={ MobileHeader }
+						expanded={ false }
+						actionButton={
+							<button className="foldable-card__action foldable-card__expand">
+								<span className="screen-reader-text">More</span>
+								<Icon icon={ chevronDown } viewBox="6 4 12 14" size={ 16 } />
+							</button>
+						}
+						actionButtonExpanded={
+							<button className="foldable-card__action foldable-card__expand">
+								<span className="screen-reader-text">More</span>
+								<Icon icon={ chevronUp } viewBox="6 4 12 14" size={ 16 } />
+							</button>
+						}
+					>
+						<div className="domains__domain-side-content domains__domain-cart">
+							<div className="domains__domain-cart-rows">
+								{ domainsInCart.map( ( domain, i ) => (
+									<div key={ `row${ i }` } className="domains__domain-cart-row">
+										<DomainNameAndCost domain={ domain } />
+									</div>
+								) ) }
+							</div>
+						</div>
+					</FoldableCard>
+				);
+			}
+
+			return (
+>>>>>>> 4baf41cf88 (Update CSS)
 				<div className="domains__domain-side-content domains__domain-cart">
 					<div className="domains__domain-cart-title">
 						{ this.props.translate( 'Your domains' ) }
@@ -758,63 +822,13 @@ export class RenderDomainsStep extends Component {
 						{ this.props.translate( 'Choose my domain later' ) }
 					</Button>
 				</div>
-			) : null;
-
-		const DomainsInCartMobileHeader = (
-			<div class="domains__domain-cart-title">
-				<div key="rowtotal" className="domains__domain-cart-total">
-					{ this.props.translate( '%d domain', '%d domains', {
-						count: domainsInCart.length,
-						args: [ domainsInCart.length ],
-					} ) }
-				</div>
-				<Button primary className="domains__domain-cart-continue" onClick={ this.goToNext() }>
-					{ this.props.translate( 'Continue' ) }
-				</Button>
-			</div>
-		);
-
-		const DomainsInCartMobile =
-			this.shouldUseMultipleDomainsInCart() && ! cartIsLoading ? (
-				<FoldableCard
-					clickableHeader
-					className="domains__domain-side-content domains__domain-cart-foldable-card"
-					header={ DomainsInCartMobileHeader }
-					expanded={ false }
-					actionButton={
-						<button className="foldable-card__action foldable-card__expand">
-							<span className="screen-reader-text">More</span>
-							<Icon icon={ chevronDown } viewBox="6 4 12 14" size={ 16 } />
-						</button>
-					}
-					actionButtonExpanded={
-						<button className="foldable-card__action foldable-card__expand">
-							<span className="screen-reader-text">More</span>
-							<Icon icon={ chevronUp } viewBox="6 4 12 14" size={ 16 } />
-						</button>
-					}
-				>
-					<div className="domains__domain-side-content domains__domain-cart">
-						<div className="domains__domain-cart-title">
-							{ this.props.translate( 'Your domains' ) }
-						</div>
-						<div className="domains__domain-cart-rows">
-							{ domainsInCart.map( ( domain, i ) => (
-								<div key={ `row${ i }` } className="domains__domain-cart-row">
-									<DomainNameAndCost domain={ domain } />
-								</div>
-							) ) }
-						</div>
-					</div>
-				</FoldableCard>
-			) : null;
-
-		const showDomainsInCart = isMobile() ? DomainsInCartMobile : DomainsInCart;
+			);
+		};
 
 		return (
 			<div className="domains__domain-side-content-container">
 				{ domainsInCart.length > 0
-					? showDomainsInCart
+					? DomainsInCart()
 					: ! this.shouldHideDomainExplainer() &&
 					  this.props.isPlanSelectionAvailableLaterInFlow && (
 							<div className="domains__domain-side-content domains__free-domain">

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -141,7 +141,6 @@ export class RenderDomainsStep extends Component {
 			props.goToNextStep();
 		}
 		this.setCurrentFlowStep = this.setCurrentFlowStep.bind( this );
-		this.shouldUseMultipleDomainsInCart = this.shouldUseMultipleDomainsInCart.bind( this );
 		this.state = {
 			currentStep: null,
 			isCartPendingUpdateDomain: null,

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -141,6 +141,7 @@ export class RenderDomainsStep extends Component {
 			props.goToNextStep();
 		}
 		this.setCurrentFlowStep = this.setCurrentFlowStep.bind( this );
+		this.shouldUseMultipleDomainsInCart = this.shouldUseMultipleDomainsInCart.bind( this );
 		this.state = {
 			currentStep: null,
 			isCartPendingUpdateDomain: null,

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -3,6 +3,8 @@ import { formatCurrency } from '@automattic/format-currency';
 import { VIDEOPRESS_FLOW, isWithThemeFlow, isHostingSignupFlow } from '@automattic/onboarding';
 import { isTailoredSignupFlow } from '@automattic/onboarding/src';
 import { withShoppingCart } from '@automattic/shopping-cart';
+import { isMobile } from '@automattic/viewport';
+import { Icon, chevronDown, chevronUp } from '@wordpress/icons';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { defer, get, isEmpty } from 'lodash';
@@ -17,6 +19,7 @@ import RegisterDomainStep from 'calypso/components/domains/register-domain-step'
 import { recordUseYourDomainButtonClick } from 'calypso/components/domains/register-domain-step/analytics';
 import ReskinSideExplainer from 'calypso/components/domains/reskin-side-explainer';
 import UseMyDomain from 'calypso/components/domains/use-my-domain';
+import FoldableCard from 'calypso/components/foldable-card';
 import Notice from 'calypso/components/notice';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import {
@@ -757,10 +760,61 @@ export class RenderDomainsStep extends Component {
 				</div>
 			) : null;
 
+		const DomainsInCartMobileHeader = (
+			<div class="domains__domain-cart-title">
+				<div key="rowtotal" className="domains__domain-cart-total">
+					{ this.props.translate( '%d domain', '%d domains', {
+						count: domainsInCart.length,
+						args: [ domainsInCart.length ],
+					} ) }
+				</div>
+				<Button primary className="domains__domain-cart-continue" onClick={ this.goToNext() }>
+					{ this.props.translate( 'Continue' ) }
+				</Button>
+			</div>
+		);
+
+		const DomainsInCartMobile =
+			this.shouldUseMultipleDomainsInCart() && ! cartIsLoading ? (
+				<FoldableCard
+					clickableHeader
+					className="domains__domain-side-content domains__domain-cart-foldable-card"
+					header={ DomainsInCartMobileHeader }
+					expanded={ false }
+					actionButton={
+						<button className="foldable-card__action foldable-card__expand">
+							<span className="screen-reader-text">More</span>
+							<Icon icon={ chevronDown } viewBox="6 4 12 14" size={ 16 } />
+						</button>
+					}
+					actionButtonExpanded={
+						<button className="foldable-card__action foldable-card__expand">
+							<span className="screen-reader-text">More</span>
+							<Icon icon={ chevronUp } viewBox="6 4 12 14" size={ 16 } />
+						</button>
+					}
+				>
+					<div className="domains__domain-side-content domains__domain-cart">
+						<div className="domains__domain-cart-title">
+							{ this.props.translate( 'Your domains' ) }
+						</div>
+						<div className="domains__domain-cart-rows">
+							{ domainsInCart.map( ( domain, i ) => (
+								<div key={ `row${ i }` } className="domains__domain-cart-row">
+									<DomainNameAndCost domain={ domain } />
+								</div>
+							) ) }
+						</div>
+					</div>
+				</FoldableCard>
+			) : null;
+
+		const showDomainsInCart = isMobile() ? DomainsInCartMobile : DomainsInCart;
+
 		return (
 			<div className="domains__domain-side-content-container">
 				{ domainsInCart.length > 0
-					? DomainsInCart
+					? showDomainsInCart
 					: ! this.shouldHideDomainExplainer() &&
 					  this.props.isPlanSelectionAvailableLaterInFlow && (
 							<div className="domains__domain-side-content domains__free-domain">

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -66,15 +66,64 @@
 	.domains__domain-cart-foldable-card {
 		position: fixed;
 		width: 100%;
+		max-height: 75%;
 		bottom: 0;
 		left: 0;
 		z-index: 99;
+		padding-bottom: 6px !important;
+		box-shadow: 0 -3px 10px 0 rgba(0, 0, 0, 0.12);
 
 		.foldable-card__main {
 			max-width: 100%;
 			display: block;
 			width: 100%;
 			margin: 0;
+
+			.foldable-card__action {
+				right: auto;
+				left: 0;
+			}
+			.domains__domain-cart-title {
+				margin-left: 24px;
+				display: flex;
+				align-items: center;
+				justify-content: space-between;
+			}
+
+			.domains__domain-cart-total {
+				display: flex;
+				gap: 8px;
+				align-items: center;
+
+				.domains__domain-cart-total-items {
+					font-family: "SF Pro Display", $sans;
+					font-size: $font-body-extra-small;
+					font-weight: 400;
+					line-height: 20px;
+					letter-spacing: 0;
+					text-align: left;
+				}
+				.domains__domain-cart-total-price {
+					font-family: "SF Pro Display", $sans;
+					font-size: $font-body;
+					font-weight: 500;
+					line-height: 24px;
+					letter-spacing: -0.32px;
+					text-align: left;
+
+				}
+			}
+		}
+		.foldable-card__content {
+			border-top: 0;
+			padding: 0 16px;
+			overflow-y: auto;
+			.domains__domain-cart {
+				border-top: 1px solid var(--color-neutral-5);
+			}
+			.domains__domain-cart-rows {
+				padding-top: 6px;
+			}
 		}
 	}
 

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -7,6 +7,14 @@
 	width: 100%;
 }
 
+.signup__step.is-domains {
+	.action-buttons.step-wrapper__navigation {
+		@media ( max-width: $break-mobile ) {
+			display: none;
+		}
+	}
+}
+
 .is-section-signup .domains__step-content {
 	margin-bottom: 50px;
 

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -74,7 +74,6 @@
 	.domains__domain-cart-foldable-card {
 		position: fixed;
 		width: 100%;
-		max-height: 75%;
 		bottom: 0;
 		left: 0;
 		z-index: 99;
@@ -123,9 +122,10 @@
 			}
 		}
 		.foldable-card__content {
+			max-height: 70vh;
 			border-top: 0;
 			padding: 0 16px;
-			overflow-y: auto;
+			overflow-x: auto;
 			.domains__domain-cart {
 				border-top: 1px solid var(--color-neutral-5);
 			}

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -63,6 +63,21 @@
 	}
 
 
+	.domains__domain-cart-foldable-card {
+		position: fixed;
+		width: 100%;
+		bottom: 0;
+		left: 0;
+		z-index: 99;
+
+		.foldable-card__main {
+			max-width: 100%;
+			display: block;
+			width: 100%;
+			margin: 0;
+		}
+	}
+
 	.domains__domain-cart {
 		border-bottom: 0 !important;
 


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/4113

## Proposed Changes

Add multi-domains mini-cart to mobile. 

See the Figma Xf4qZLzOYeMwmTHUVl0w4a-fi-6_200 for details.

#### Screenshots

| Closed | Opened |
| --- | --- |
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/062133ec-0b64-417c-b7d7-94699a2551a7) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/99dd6b98-f9c1-4f4d-bc6d-e94a307fe144) |

## To Do
- [x] Remove `< Back to sites` 
- [x] Make the domains list scrollable.

## Testing Instructions

* Go to `/start/domains?flags=add/multiple-domains-select-and-list`
* Check for mini-cart on mobile view.
