### PR TITLE
Stats: Date control - Polish Styling for Interval Dropdown

### DIFF
--- a/client/my-sites/stats/stats-interval-dropdown/index.jsx
+++ b/client/my-sites/stats/stats-interval-dropdown/index.jsx
@@ -1,5 +1,5 @@
 import { Button, Dropdown } from '@wordpress/components';
-import { check } from '@wordpress/icons';
+import { check, Icon, chevronDown } from '@wordpress/icons';
 import React, { useState } from 'react';
 import Intervals from 'calypso/blocks/stats-navigation/intervals';
 import './style.scss';
@@ -23,6 +23,7 @@ const IntervalDropdown = ( { period, pathTemplate } ) => {
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<Button onClick={ onToggle } aria-expanded={ isOpen }>
 					{ getCurrentIntervalLabel( currentInterval ) }
+					<Icon className="gridicon" icon={ chevronDown } />
 				</Button>
 			) }
 			renderContent={ () => (

--- a/client/my-sites/stats/stats-interval-dropdown/index.jsx
+++ b/client/my-sites/stats/stats-interval-dropdown/index.jsx
@@ -20,6 +20,7 @@ const IntervalDropdown = ( { period, pathTemplate } ) => {
 
 	return (
 		<Dropdown
+			className="stats-interval-dropdown"
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<Button onClick={ onToggle } aria-expanded={ isOpen }>
 					{ getCurrentIntervalLabel( currentInterval ) }

--- a/client/my-sites/stats/stats-interval-dropdown/style.scss
+++ b/client/my-sites/stats/stats-interval-dropdown/style.scss
@@ -15,7 +15,7 @@
 
 	>.components-button {
 
-		border-radius: 4px;
+		border-radius: 2px;
 		border: 1px solid var(--gray-gray-10);
 		width: 146px;
 		display: flex;
@@ -27,6 +27,8 @@
 
 
 .stats-interval-dropdown__container {
+
+	position: relative;
 
 	width: 196px;
 

--- a/client/my-sites/stats/stats-interval-dropdown/style.scss
+++ b/client/my-sites/stats/stats-interval-dropdown/style.scss
@@ -13,6 +13,11 @@
 	font-size: 13px; /* stylelint-disable-line declaration-property-unit-allowed-list */
 	font-weight: 400;
 
+	>.components-button[aria-expanded="true"],
+	.components-button:hover {
+		color: var(--gutenberg-gray-900);
+	}
+
 	>.components-button {
 
 		border-radius: 2px;

--- a/client/my-sites/stats/stats-interval-dropdown/style.scss
+++ b/client/my-sites/stats/stats-interval-dropdown/style.scss
@@ -60,5 +60,11 @@
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
+
+		.gridicon {
+			max-height: 17.99px;
+		}
 	}
+
+
 }

--- a/client/my-sites/stats/stats-interval-dropdown/style.scss
+++ b/client/my-sites/stats/stats-interval-dropdown/style.scss
@@ -1,17 +1,34 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@automattic/components/src/styles/typography.scss";
 
+.stats-interval-dropdown,
+.stats-interval-dropdown__container {
+
+	font-style: normal;
+	--gray-gray-10: #c3c4c7;
+	--gutenberg-gray-900: #1e1e1e;
+	background: #fff;
+	color: var(--studio-black);
+	font-family: $font-sf-pro-text;
+	font-size: 13px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+	font-weight: 400;
+
+	>.components-button {
+
+		border-radius: 4px;
+		border: 1px solid var(--gray-gray-10);
+		width: 146px;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+
+	}
+}
+
+
 .stats-interval-dropdown__container {
 
 	width: 196px;
-
-	> .components-button {
-		border-radius: 2px;
-		color: var(--gutenberg-gray-900);
-		font-family: $font-sf-pro-text;
-		font-size: 13px; /* stylelint-disable-line declaration-property-unit-allowed-list */
-		font-weight: 400;
-	}
 
 	.segmented-control.is-primary.stats-navigation__intervals .segmented-control__item.is-selected .segmented-control__link:hover {
 		background-color: var(--color-neutral-0);

--- a/client/my-sites/stats/stats-interval-dropdown/style.scss
+++ b/client/my-sites/stats/stats-interval-dropdown/style.scss
@@ -86,7 +86,7 @@
 		justify-content: space-between;
 
 		.gridicon {
-			max-height: 17.99px;
+			height: 18px;
 		}
 	}
 

--- a/client/my-sites/stats/stats-interval-dropdown/style.scss
+++ b/client/my-sites/stats/stats-interval-dropdown/style.scss
@@ -55,4 +55,10 @@
 			transition: none;
 		}
 	}
+
+	.segmented-control__text {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+	}
 }

--- a/client/my-sites/stats/stats-period-header/style.scss
+++ b/client/my-sites/stats/stats-period-header/style.scss
@@ -38,17 +38,17 @@
 }
 
 // styling for both interval dropdown and date control picker drop down buttons inside the header
-.stats-date-control {
-	.components-dropdown > .components-button {
-		--gray-gray-10: #c3c4c7;
-		--gutenberg-gray-900: #1e1e1e;
-		background: #fff;
-		border-radius: 4px;
-		border: 1px solid var(--gray-gray-10);
-		color: var(--studio-black);
-		font-family: $font-sf-pro-display;
-		font-size: 14px; /* stylelint-disable-line declaration-property-unit-allowed-list */
-		font-weight: 500;
-	}
-}
+// .stats-date-control {
+// 	.components-dropdown > .components-button {
+// 		--gray-gray-10: #c3c4c7;
+// 		--gutenberg-gray-900: #1e1e1e;
+// 		background: #fff;
+// 		border-radius: 4px;
+// 		border: 1px solid var(--gray-gray-10);
+// 		color: var(--studio-black);
+// 		font-family: $font-sf-pro-display;
+// 		font-size: 14px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+// 		font-weight: 500;
+// 	}
+// }
 

--- a/client/my-sites/stats/stats-period-header/style.scss
+++ b/client/my-sites/stats/stats-period-header/style.scss
@@ -36,19 +36,3 @@
 		margin-top: 0;
 	}
 }
-
-// styling for both interval dropdown and date control picker drop down buttons inside the header
-// .stats-date-control {
-// 	.components-dropdown > .components-button {
-// 		--gray-gray-10: #c3c4c7;
-// 		--gutenberg-gray-900: #1e1e1e;
-// 		background: #fff;
-// 		border-radius: 4px;
-// 		border: 1px solid var(--gray-gray-10);
-// 		color: var(--studio-black);
-// 		font-family: $font-sf-pro-display;
-// 		font-size: 14px; /* stylelint-disable-line declaration-property-unit-allowed-list */
-// 		font-weight: 500;
-// 	}
-// }
-


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #82082

## Proposed Changes

* This PR polishes the styling for the Interval Dropdown component
	- adds a chevronDown icon to the dropdown button
	- increases the width of the dropdown button
	- styles the alignment of the check marks inside the dropdown element
	- moves all of the dropdown styles into the interval dropdown component styles (refactoring shared styles between interval dropdown and date control component into a shared location is to come in followup PR) 
	- updated border radius. 

## Testing Instructions

* Load this branch into your local calypso environment
* Navigate to `/stats/day/{site URL}`
* Confirm that everything remains unchanged without the feature flag applied
* Append `?flags=stats/date-control` to the end of the URL
* Confirm styling matches image below:

| Design Spec  | Currently |
| ------------- | ------------- |
| ![image](https://github.com/Automattic/wp-calypso/assets/30754158/0e449745-de25-4735-b20a-1b1fb1a72bc8)  | ![image](https://github.com/Automattic/wp-calypso/assets/30754158/604cf400-2b40-4c76-a517-c5240e082d19)  |

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?