### PR TITLE
Stats: Date control - Polish Styling for Datepicker Control Button

### DIFF
--- a/client/my-sites/stats/stats-date-control/stats-date-control-picker.tsx
+++ b/client/my-sites/stats/stats-date-control/stats-date-control-picker.tsx
@@ -76,12 +76,8 @@ const DateControlPicker = ( {
 	};
 
 	return (
-		<>
-			<Button
-				className="stats-date-control-picker__button"
-				onClick={ () => togglePopoverOpened( ! popoverOpened ) }
-				ref={ infoReferenceElement }
-			>
+		<div className="stats-date-control-picker">
+			<Button onClick={ () => togglePopoverOpened( ! popoverOpened ) } ref={ infoReferenceElement }>
 				{ `${ formatDate( inputStartDate ) } - ${ formatDate( inputEndDate ) }` }
 			</Button>
 			<Popover
@@ -103,7 +99,7 @@ const DateControlPicker = ( {
 					onClick={ handleShortcutSelected }
 				/>
 			</Popover>
-		</>
+		</div>
 	);
 };
 

--- a/client/my-sites/stats/stats-date-control/stats-date-control-picker.tsx
+++ b/client/my-sites/stats/stats-date-control/stats-date-control-picker.tsx
@@ -1,5 +1,6 @@
 import { Popover } from '@automattic/components';
 import { Button } from '@wordpress/components';
+import { Icon, calendar } from '@wordpress/icons';
 import moment from 'moment';
 import page from 'page';
 import qs from 'qs';
@@ -79,6 +80,7 @@ const DateControlPicker = ( {
 		<div className="stats-date-control-picker">
 			<Button onClick={ () => togglePopoverOpened( ! popoverOpened ) } ref={ infoReferenceElement }>
 				{ `${ formatDate( inputStartDate ) } - ${ formatDate( inputEndDate ) }` }
+				<Icon className="gridicon" icon={ calendar } />
 			</Button>
 			<Popover
 				position="bottom"

--- a/client/my-sites/stats/stats-date-control/style.scss
+++ b/client/my-sites/stats/stats-date-control/style.scss
@@ -55,5 +55,10 @@
 		font-weight: 500;
 		line-height: 20px;
 		letter-spacing: 0.32px;
+		display: flex;
+		padding: var(--grid-unit-15, 12px) var(--grid-unit-20, 16px);
+		justify-content: flex-end;
+		align-items: center;
+		gap: 8px;
 	}
 }

--- a/client/my-sites/stats/stats-date-control/style.scss
+++ b/client/my-sites/stats/stats-date-control/style.scss
@@ -37,3 +37,23 @@
 		background-color: var(--color-primary-0);
 	}
 }
+
+// Button styling for date control picker dropdown
+
+.stats-date-control-picker {
+
+	> .components-button {
+		--gray-gray-10: #c3c4c7;
+		--gutenberg-gray-900: #1e1e1e;
+		border-radius: 4px;
+		border: 1px solid var(--gray-gray-10, #c3c4c7);
+		background: #fff;
+		color: var(--studio-black);
+		font-family: $font-sf-pro-display;
+		font-size: 14px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		font-style: normal;
+		font-weight: 500;
+		line-height: 20px;
+		letter-spacing: 0.32px;
+	}
+}

--- a/client/my-sites/stats/stats-date-control/style.scss
+++ b/client/my-sites/stats/stats-date-control/style.scss
@@ -43,8 +43,6 @@
 .stats-date-control-picker {
 
 	> .components-button {
-		--gray-gray-10: #c3c4c7;
-		--gutenberg-gray-900: #1e1e1e;
 		border-radius: 4px;
 		border: 1px solid var(--gray-gray-10, #c3c4c7);
 		background: #fff;

--- a/client/my-sites/stats/stats-period-header/style.scss
+++ b/client/my-sites/stats/stats-period-header/style.scss
@@ -36,19 +36,3 @@
 		margin-top: 0;
 	}
 }
-
-// styling for both interval dropdown and date control picker drop down buttons inside the header
-.stats-date-control {
-	.components-dropdown > .components-button {
-		--gray-gray-10: #c3c4c7;
-		--gutenberg-gray-900: #1e1e1e;
-		background: #fff;
-		border-radius: 4px;
-		border: 1px solid var(--gray-gray-10);
-		color: var(--studio-black);
-		font-family: $font-sf-pro-display;
-		font-size: 14px; /* stylelint-disable-line declaration-property-unit-allowed-list */
-		font-weight: 500;
-	}
-}
-


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #82686

## Proposed Changes

* This PR polishes the styling for the Date Control Datepicker Button (button only, not drop down content) 
	- adds a calendar icon to the dropdown button
	- moves the styles into the components stylesheet for now (refactoring shared styles between interval dropdown and date control component into a shared location is to come in followup PR) 
	- updates some styling details such as border, font weight etc. 

## Testing Instructions

* Load this branch into your local calypso environment
* Navigate to `/stats/day/{site URL}`
* Confirm that everything remains unchanged without the feature flag applied
* Append `?flags=stats/date-control` to the end of the URL
* Confirm styling matches image below:

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->



| Design Spec  | Current |
| ------------- | ------------- |
| ![image](https://github.com/Automattic/wp-calypso/assets/30754158/057385ad-c1cf-4fdb-90c8-e376cb34539a)  | ![image](https://github.com/Automattic/wp-calypso/assets/30754158/358952a3-2d49-41c1-9284-2715a58e732b)  |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?