### PR TITLE
Hide phantom popover

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -751,6 +751,7 @@ const PlansFeaturesMain = ( {
 									/>
 									<div ref={ plansComparisonGridRef } className={ comparisonGridContainerClasses }>
 										<ComparisonGrid
+											isHidden={ ! showPlansComparisonGrid }
 											gridPlans={ gridPlansForComparisonGrid }
 											gridPlanForSpotlight={ gridPlanForSpotlight }
 											paidDomainName={ paidDomainName }

--- a/client/my-sites/plans-grid/components/comparison-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/comparison-grid/index.tsx
@@ -332,10 +332,10 @@ type ComparisonGridProps = {
 	showUpgradeableStorage: boolean;
 	onStorageAddOnClick?: ( addOnSlug: WPComStorageAddOnSlug ) => void;
 	/**
-	 * Due to the render heavy burden of the plans comparison grid the paren might chose to
-	 * hide the comparison grid with css but leave the render tree intact, unmounted.
+	 * Due to the render heavy burden of the plans comparison grid the client consumer of this component, might chose to
+	 * hide the comparison grid with css but leave the render tree intact, mounted.
 	 * An isHidden prop is passed down the tree so that any elements that are not part of the
-	 *  orthodox react tree like (Popovers, Modals, etc) can also be forcibly hidden
+	 * Normal react tree (like Popovers, Modals, etc) can also be forcibly hidden based on a tangible parameter
 	 */
 	isHidden?: boolean;
 };

--- a/client/my-sites/plans-grid/components/comparison-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/comparison-grid/index.tsx
@@ -331,6 +331,13 @@ type ComparisonGridProps = {
 	showLegacyStorageFeature?: boolean;
 	showUpgradeableStorage: boolean;
 	onStorageAddOnClick?: ( addOnSlug: WPComStorageAddOnSlug ) => void;
+	/**
+	 * Due to the render heavy burden of the plans comparison grid the paren might chose to
+	 * hide the comparison grid with css but leave the render tree intact, unmounted.
+	 * An isHidden prop is passed down the tree so that any elements that are not part of the
+	 *  orthodox react tree like (Popovers, Modals, etc) can also be forcibly hidden
+	 */
+	isHidden?: boolean;
 };
 
 type ComparisonGridHeaderProps = {
@@ -840,6 +847,7 @@ const ComparisonGrid = ( {
 	selectedFeature,
 	showUpgradeableStorage,
 	onStorageAddOnClick,
+	isHidden,
 }: ComparisonGridProps ) => {
 	const translate = useTranslate();
 	const { gridPlans, allFeaturesList } = usePlansGridContext();
@@ -1010,11 +1018,13 @@ const ComparisonGrid = ( {
 			<PlanComparisonHeader className="wp-brand-font">
 				{ translate( 'Compare our plans and find yours' ) }
 			</PlanComparisonHeader>
-			<PlanTypeSelector
-				{ ...planTypeSelectorProps }
-				kind="interval"
-				plans={ displayedGridPlans.map( ( { planSlug } ) => planSlug ) }
-			/>
+			{ isHidden ? null : (
+				<PlanTypeSelector
+					{ ...planTypeSelectorProps }
+					kind="interval"
+					plans={ displayedGridPlans.map( ( { planSlug } ) => planSlug ) }
+				/>
+			) }
 			<Grid isInSignup={ isInSignup }>
 				<ComparisonGridHeader
 					siteId={ siteId }

--- a/client/my-sites/plans-grid/index.tsx
+++ b/client/my-sites/plans-grid/index.tsx
@@ -67,10 +67,10 @@ export interface PlansGridProps {
 	usePricingMetaForGridPlans: UsePricingMetaForGridPlans;
 	planTypeSelectorProps: PlanTypeSelectorProps;
 	/**
-	 * Due to the render heavy burden of the plans comparison grid the paren might chose to
-	 * hide the comparison grid with css but leave the render tree intact, unmounted.
+	 * Due to the render heavy burden of the plans comparison grid the client consumer of this component, might chose to
+	 * hide the comparison grid with css but leave the render tree intact, mounted.
 	 * An isHidden prop is passed down the tree so that any elements that are not part of the
-	 *  orthodox react tree like (Popovers, Modals, etc) can also be forcibly hidden
+	 * Normal react tree (like Popovers, Modals, etc) can also be forcibly hidden based on a tangible parameter
 	 */
 	isHidden?: boolean;
 }

--- a/client/my-sites/plans-grid/index.tsx
+++ b/client/my-sites/plans-grid/index.tsx
@@ -66,6 +66,13 @@ export interface PlansGridProps {
 	stickyRowOffset: number;
 	usePricingMetaForGridPlans: UsePricingMetaForGridPlans;
 	planTypeSelectorProps: PlanTypeSelectorProps;
+	/**
+	 * Due to the render heavy burden of the plans comparison grid the paren might chose to
+	 * hide the comparison grid with css but leave the render tree intact, unmounted.
+	 * An isHidden prop is passed down the tree so that any elements that are not part of the
+	 *  orthodox react tree like (Popovers, Modals, etc) can also be forcibly hidden
+	 */
+	isHidden?: boolean;
 }
 
 const WrappedComparisonGrid = ( {
@@ -86,6 +93,7 @@ const WrappedComparisonGrid = ( {
 	showLegacyStorageFeature,
 	showUpgradeableStorage,
 	onStorageAddOnClick,
+	isHidden,
 }: PlansGridProps ) => {
 	// TODO clk: canUserManagePlan should be passed through props instead of being calculated here
 	const canUserPurchasePlan = useSelector( ( state: IAppState ) =>
@@ -118,6 +126,7 @@ const WrappedComparisonGrid = ( {
 				allFeaturesList={ allFeaturesList }
 			>
 				<ComparisonGrid
+					isHidden={ isHidden }
 					planTypeSelectorProps={ planTypeSelectorProps }
 					intervalType={ intervalType }
 					isInSignup={ isInSignup }
@@ -148,6 +157,7 @@ const WrappedComparisonGrid = ( {
 		>
 			<CalypsoShoppingCartProvider>
 				<ComparisonGrid
+					isHidden={ isHidden }
 					planTypeSelectorProps={ planTypeSelectorProps }
 					intervalType={ intervalType }
 					isInSignup={ isInSignup }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 
- https://github.com/Automattic/wp-calypso/pull/82403

## Proposed Changes

* We did a performance improvement related to the plans grid to not unmount the plans comparison grid
* However the popover lives outside the plans grid tree
* So css hiding does not effect this element
* This change unmounts the related popover forcibly if the comparison grid is hidden
![image](https://github.com/Automattic/wp-calypso/assets/3422709/012cf405-c2ad-4a34-94b5-d3cda8cce225)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start`
* Click on `monthly` interval
* A phantom popover should not be there in the top right hand corner

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?