### PR TITLE
HFT: Add selectors for querying HFT state

### DIFF
--- a/client/state/sites/plans/selectors/trials/get-hosting-trial-days-left.ts
+++ b/client/state/sites/plans/selectors/trials/get-hosting-trial-days-left.ts
@@ -1,0 +1,19 @@
+import moment, { Moment } from 'moment';
+import getHostingTrialExpiration from './get-hosting-trial-expiration';
+import type { AppState } from 'calypso/types';
+
+/**
+ * Get the number of days left in the hosting trial. If the trial is not active, returns null.
+ *
+ * @param {AppState} state - Global state tree
+ * @param {number} siteId - Site ID
+ * @returns {null|number} Number of days left in the trial as a float, or null if the trial is not active.
+ */
+export default function getHostingTrialDaysLeft( state: AppState, siteId: number ): number | null {
+	const trialExpirationDate: Moment | null = getHostingTrialExpiration( state, siteId );
+	if ( ! trialExpirationDate ) {
+		return null;
+	}
+
+	return trialExpirationDate.diff( moment().utc(), 'days', true );
+}

--- a/client/state/sites/plans/selectors/trials/get-hosting-trial-expiration.ts
+++ b/client/state/sites/plans/selectors/trials/get-hosting-trial-expiration.ts
@@ -1,0 +1,34 @@
+import { PLAN_HOSTING_TRIAL_MONTHLY } from '@automattic/calypso-products';
+import moment, { Moment } from 'moment';
+import { SitePlanData } from 'calypso/my-sites/checkout/src/hooks/product-variants';
+import { getCurrentPlan } from '../';
+import type { AppState } from 'calypso/types';
+
+/**
+ * Checks if the plan is a hosting trial.
+ *
+ * @param {SitePlanData} plan - Plan object
+ * @returns {boolean} returns true if the plan is an migration trial
+ */
+function isHostingTrialPlan( plan: SitePlanData ): boolean {
+	return plan.productSlug === PLAN_HOSTING_TRIAL_MONTHLY;
+}
+
+/**
+ * Returns the expiration date of the hosting trial. If the trial is not active, returns null.
+ *
+ * @param {AppState} state - Global state tree
+ * @param {number} siteId - Site ID
+ * @returns {Moment|null} Expiration date of the trial, or null if the trial is not active.
+ */
+export default function getHostingTrialExpiration(
+	state: AppState,
+	siteId: number
+): Moment | null {
+	const currentPlan = getCurrentPlan( state, siteId );
+	if ( ! currentPlan || ! isHostingTrialPlan( currentPlan as SitePlanData ) ) {
+		return null;
+	}
+
+	return moment.utc( currentPlan.expiryDate );
+}

--- a/client/state/sites/plans/selectors/trials/is-hosting-trial-expired.ts
+++ b/client/state/sites/plans/selectors/trials/is-hosting-trial-expired.ts
@@ -1,0 +1,19 @@
+import { AppState } from 'calypso/types';
+import getHostingTrialDaysLeft from './get-hosting-trial-days-left';
+
+/**
+ * Returns true if the hosting trial has expired. If the trial is not active, returns null.
+ *
+ * @param {AppState} state - Global state tree
+ * @param {number} siteId - Site ID
+ * @returns {boolean|null}
+ */
+export default function isHostingTrialExpired( state: AppState, siteId: number ): boolean | null {
+	const trialDaysLeft = getHostingTrialDaysLeft( state, siteId );
+
+	if ( trialDaysLeft === null ) {
+		return null;
+	}
+
+	return trialDaysLeft <= 0;
+}

--- a/client/state/sites/plans/selectors/trials/is-site-on-hosting-trial.ts
+++ b/client/state/sites/plans/selectors/trials/is-site-on-hosting-trial.ts
@@ -1,0 +1,19 @@
+import { PLAN_HOSTING_TRIAL_MONTHLY } from '@automattic/calypso-products';
+import { getSite } from 'calypso/state/sites/selectors';
+import { getCurrentPlan } from '..';
+import type { AppState } from 'calypso/types';
+
+/**
+ * Checks whether the current site is on the hosting trial.
+ *
+ * @param {AppState} state Global state tree
+ * @param {number} siteId - Site ID
+ * @returns {boolean} Returns true if the site is on the trial
+ */
+export default function isSiteOnHostingTrial( state: AppState, siteId: number ): boolean {
+	const currentPlan = getCurrentPlan( state, siteId );
+	const site = getSite( state, siteId );
+	const productSlug = currentPlan?.productSlug || site?.plan?.product_slug;
+
+	return productSlug === PLAN_HOSTING_TRIAL_MONTHLY;
+}

--- a/client/state/sites/plans/selectors/trials/trials-expiration.ts
+++ b/client/state/sites/plans/selectors/trials/trials-expiration.ts
@@ -2,11 +2,15 @@ import { Moment } from 'moment';
 import { AppState } from 'calypso/types';
 import getECommerceTrialDaysLeft from './get-ecommerce-trial-days-left';
 import getECommerceTrialExpiration from './get-ecommerce-trial-expiration';
+import getHostingTrialDaysLeft from './get-hosting-trial-days-left';
+import getHostingTrialExpiration from './get-hosting-trial-expiration';
 import getMigrationTrialDaysLeft from './get-migration-trial-days-left';
 import getMigrationTrialExpiration from './get-migration-trial-expiration';
 import isECommerceTrialExpired from './is-ecommerce-trial-expired';
+import isHostingTrialExpired from './is-hosting-trial-expired';
 import isMigrationTrialExpired from './is-migration-trial-expired';
 import isSiteOnECommerceTrial from './is-site-on-ecommerce-trial';
+import isSiteOnHostingTrial from './is-site-on-hosting-trial';
 import isSiteOnMigrationTrial from './is-site-on-migration-trial';
 
 export function getTrialDaysLeft( state: AppState, siteId: number ): number | null {
@@ -16,6 +20,10 @@ export function getTrialDaysLeft( state: AppState, siteId: number ): number | nu
 
 	if ( isSiteOnMigrationTrial( state, siteId ) ) {
 		return getMigrationTrialDaysLeft( state, siteId );
+	}
+
+	if ( isSiteOnHostingTrial( state, siteId ) ) {
+		return getHostingTrialDaysLeft( state, siteId );
 	}
 
 	return null;
@@ -30,6 +38,10 @@ export function getTrialExpiration( state: AppState, siteId: number ): Moment | 
 		return getMigrationTrialExpiration( state, siteId );
 	}
 
+	if ( isSiteOnHostingTrial( state, siteId ) ) {
+		return getHostingTrialExpiration( state, siteId );
+	}
+
 	return null;
 }
 
@@ -40,6 +52,10 @@ export function isTrialExpired( state: AppState, siteId: number ): boolean | nul
 
 	if ( isSiteOnMigrationTrial( state, siteId ) ) {
 		return isMigrationTrialExpired( state, siteId );
+	}
+
+	if ( isSiteOnHostingTrial( state, siteId ) ) {
+		return isHostingTrialExpired( state, siteId );
 	}
 
 	return null;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/4130

## Proposed Changes

* Title
* Also, fix the trial banner by using these selectors, so the remaining time is correct 

![image](https://github.com/Automattic/wp-calypso/assets/6851384/fd7815dd-0df8-4487-8994-62b33bacc5cd)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D123974-code to sandbox
* Check out this branch locally
* Go to `/setup/new-hosted-site/plans` and chose trial
* Complete the flow
* Visit `/plans/my-plan/:trial-site-slug` and confirm you see the banner with the correct time remaining

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?