### PR TITLE
FHT: Show confirmation page when hosting trial upgraded

### DIFF
--- a/client/state/selectors/was-business-trial-site.ts
+++ b/client/state/selectors/was-business-trial-site.ts
@@ -3,6 +3,5 @@ import type { AppState } from 'calypso/types';
 
 export default function wasBusinessTrialSite( state: AppState, siteId: number ) {
 	const site = getRawSite( state, siteId );
-
-	return site?.was_migration_trial;
+	return site?.was_migration_trial || site?.was_hosting_trial;
 }

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -132,6 +132,7 @@ export interface SiteDetails {
 	visible?: boolean;
 	was_ecommerce_trial?: boolean;
 	was_migration_trial?: boolean;
+	was_hosting_trial?: boolean;
 	wpcom_url?: string;
 	user_interactions?: string[];
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack/pull/33487
Related to D124373-code

## Proposed Changes

* Show a confirmation page when the hosting free trial plan was upgraded to Business
* Mostly existing logic from the migration free trial but needed a small update

![image](https://github.com/Automattic/wp-calypso/assets/6851384/2377ee3d-6201-4c57-a65a-6eb80bbb87d9)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D124373-code to your sandbox
* Start a free trial via `/setup/new-hosted-site/plans` 
* Upgrade plan in Calypso
* Checkout using credits or test store
* Confirm you see a white blank page at `/plans/my-plan/trial-upgraded/%s`
* Run `bin/jetpack-downloader test jetpack fht/add_was_hosting_trial_flag` on your sandbox and choose to apply it on top of D124373
* Checkout this branch and then refresh `/plans/my-plan/trial-upgraded/%s` and you will see the confirmation screen


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?