### PR TITLE
Global Styles: Always show premium badge

### DIFF
--- a/packages/design-preview/src/hooks/use-screens.tsx
+++ b/packages/design-preview/src/hooks/use-screens.tsx
@@ -71,7 +71,6 @@ const useScreens = ( {
 									globalStylesVariations={ variations as GlobalStylesObject[] }
 									selectedGlobalStylesVariation={ selectedVariation as GlobalStylesObject }
 									splitDefaultVariation={ splitDefaultVariation }
-									displayFreeLabel={ splitDefaultVariation }
 									showOnlyHoverViewDefaultVariation={ false }
 									onSelect={ ( globalStyleVariation: GlobalStylesObject ) =>
 										onSelectVariation( globalStyleVariation as StyleVariation )

--- a/packages/global-styles/src/components/color-palette-variations/index.tsx
+++ b/packages/global-styles/src/components/color-palette-variations/index.tsx
@@ -116,13 +116,13 @@ const ColorPaletteVariations = ( {
 					<span className="global-styles-variations__group-title-actual">
 						{ translate( 'Custom styles' ) }
 					</span>
-					{ limitGlobalStyles && (
-						<PremiumBadge
-							shouldHideTooltip
-							shouldCompactWithAnimation
-							labelText={ translate( 'Upgrade' ) }
-						/>
-					) }
+					<PremiumBadge
+						shouldHideTooltip
+						shouldCompactWithAnimation
+						labelText={
+							limitGlobalStyles ? translate( 'Upgrade' ) : translate( 'Included in your plan' )
+						}
+					/>
 				</h3>
 				<div className="color-palette-variations">
 					{ colorPaletteVariations.map( ( colorPaletteVariation, index ) => (

--- a/packages/global-styles/src/components/font-pairing-variations/index.tsx
+++ b/packages/global-styles/src/components/font-pairing-variations/index.tsx
@@ -117,13 +117,13 @@ const FontPairingVariations = ( {
 					<span className="global-styles-variations__group-title-actual">
 						{ translate( 'Custom fonts' ) }
 					</span>
-					{ limitGlobalStyles && (
-						<PremiumBadge
-							shouldHideTooltip
-							shouldCompactWithAnimation
-							labelText={ translate( 'Upgrade' ) }
-						/>
-					) }
+					<PremiumBadge
+						shouldHideTooltip
+						shouldCompactWithAnimation
+						labelText={
+							limitGlobalStyles ? translate( 'Upgrade' ) : translate( 'Included in your plan' )
+						}
+					/>
 				</h3>
 				<div className="font-pairing-variations">
 					{ fontPairingVariations.map( ( fontPairingVariation, index ) => (

--- a/packages/global-styles/src/components/global-styles-variations/index.tsx
+++ b/packages/global-styles/src/components/global-styles-variations/index.tsx
@@ -1,3 +1,4 @@
+import { PremiumBadge } from '@automattic/components';
 import { useState } from '@wordpress/element';
 import { ENTER } from '@wordpress/keycodes';
 import classnames from 'classnames';
@@ -19,7 +20,6 @@ interface GlobalStylesVariationProps {
 	isActive: boolean;
 	showOnlyHoverView?: boolean;
 	onSelect: () => void;
-	showFreeBadge: boolean;
 }
 
 interface GlobalStylesVariationsProps {
@@ -28,7 +28,6 @@ interface GlobalStylesVariationsProps {
 	description?: TranslateResult;
 	showOnlyHoverViewDefaultVariation?: boolean;
 	splitDefaultVariation?: boolean;
-	displayFreeLabel?: boolean;
 	onSelect: ( globalStylesVariation: GlobalStylesObject ) => void;
 }
 
@@ -39,7 +38,6 @@ const GlobalStylesVariation = ( {
 	globalStylesVariation,
 	isActive,
 	showOnlyHoverView,
-	showFreeBadge,
 	onSelect,
 }: GlobalStylesVariationProps ) => {
 	const [ isFocused, setIsFocused ] = useState( false );
@@ -79,11 +77,6 @@ const GlobalStylesVariation = ( {
 				} ) as string
 			}
 		>
-			{ showFreeBadge && (
-				<div className="global-styles-variations__free-badge">
-					<span>{ translate( 'Free' ) }</span>
-				</div>
-			) }
 			<div className="global-styles-variation__item-preview">
 				<GlobalStylesContext.Provider value={ context }>
 					<GlobalStylesVariationPreview
@@ -105,7 +98,6 @@ const GlobalStylesVariations = ( {
 	showOnlyHoverViewDefaultVariation,
 	onSelect,
 	splitDefaultVariation = true,
-	displayFreeLabel = true,
 }: GlobalStylesVariationsProps ) => {
 	const isRegisteredCoreBlocks = useRegisterCoreBlocks();
 	const premiumStylesDescription = translate(
@@ -132,7 +124,6 @@ const GlobalStylesVariations = ( {
 		( globalStylesVariation, index ) => (
 			<GlobalStylesVariation
 				key={ index }
-				showFreeBadge={ false }
 				globalStylesVariation={ globalStylesVariation }
 				isActive={ globalStylesVariation.slug === selectedGlobalStylesVariation?.slug }
 				onSelect={ () => onSelect( globalStylesVariation ) }
@@ -155,14 +146,7 @@ const GlobalStylesVariations = ( {
 					} ) }
 				>
 					<div className="global-styles-variations__header">
-						<h2>
-							{ headerText }
-							{ displayFreeLabel && (
-								<div className="global-styles-variations__free-badge">
-									<span>{ translate( 'Free' ) }</span>
-								</div>
-							) }
-						</h2>
+						<h2>{ headerText }</h2>
 						{ ! splitDefaultVariation && (
 							<div>
 								<p>{ translate( 'You can change your style at any time.' ) }</p>
@@ -172,7 +156,6 @@ const GlobalStylesVariations = ( {
 					<div className="global-styles-variations">
 						<GlobalStylesVariation
 							key="base"
-							showFreeBadge={ displayFreeLabel }
 							globalStylesVariation={ baseGlobalStyles }
 							isActive={
 								! selectedGlobalStylesVariation ||
@@ -188,9 +171,16 @@ const GlobalStylesVariations = ( {
 					<div className="global-styles-variations__type">
 						<div className="global-styles-variations__header">
 							<h2>
-								{ translate( 'Custom Style', 'Custom Styles', {
-									count: nonDefaultStyles.length,
-								} ) }
+								<span>
+									{ translate( 'Custom Style', 'Custom Styles', {
+										count: nonDefaultStyles.length,
+									} ) }
+								</span>
+								<PremiumBadge
+									shouldHideTooltip
+									shouldCompactWithAnimation
+									labelText={ translate( 'Upgrade' ) }
+								/>
 							</h2>
 							<p>{ nonDefaultStylesDescription }</p>
 						</div>

--- a/packages/global-styles/src/components/global-styles-variations/style.scss
+++ b/packages/global-styles/src/components/global-styles-variations/style.scss
@@ -43,20 +43,11 @@
 	width: 100%;
 	margin-left: 3px;
 	color: var(--studio-gray-50);
-
-	.global-styles-variations__free-badge {
-		display: none;
-	}
-
-	@include break-large {
-		.global-styles-variations__free-badge {
-			display: inline-flex;
-		}
-	}
 }
 
 .global-styles-variations__header h2 {
-	display: inline-block;
+	align-items: center;
+	display: inline-flex;
 	font-size: 1rem;
 	white-space: nowrap;
 	font-weight: 500;
@@ -77,22 +68,6 @@
 	@include break-large {
 		display: block;
 	}
-}
-
-.global-styles-variations__free-badge {
-	display: inline-flex;
-	align-items: center;
-	height: 20px;
-	line-height: 20px;
-	padding: 0 10px 0 9px;
-	border-radius: 20px; /* stylelint-disable-line scales/radii */
-	margin-left: 10px;
-	box-sizing: border-box;
-	font-size: 0.75rem;
-	font-weight: 500;
-	color: var(--studio-blue-80);
-	background: var(--studio-blue-5);
-	z-index: 1;
 }
 
 .global-styles-variations__item {
@@ -131,14 +106,5 @@
 
 	&:focus-visible {
 		outline: none;
-	}
-
-	.global-styles-variations__free-badge {
-		position: absolute;
-		top: 9px;
-		left: 0;
-		@include break-large {
-			display: none;
-		}
 	}
 }


### PR DESCRIPTION
## Proposed Changes

This PR changes the global styles so that non-default styles are always marked with the premium badge. This goal of this update is to show users the value of their premium plan.

Note that when the site plan supports GS, we show the badge with the copy "Included in your plan" instead of "Upgrade". @autumnfjeld @lucasmendes-design 

**Theme detail page - free plan**
| Before | After |
| --- | --- |
| ![Screenshot 2023-10-06 at 2 48 28 PM](https://github.com/Automattic/wp-calypso/assets/797888/98dd8676-8052-4208-9f88-8826a6873733) | ![Screenshot 2023-10-06 at 5 36 57 PM](https://github.com/Automattic/wp-calypso/assets/797888/3482bc2e-9e69-4c36-bd72-d0b01e4b9135)|

**Theme detail page - premium plan (NO CHANGE)**
![Screenshot 2023-10-06 at 2 47 44 PM](https://github.com/Automattic/wp-calypso/assets/797888/fc84e341-fd20-471c-823b-1d2d665e5038)

**Onboarding design picker - style variations - free plan**
| Before | After |
| --- | --- |
| ![Screenshot 2023-10-06 at 5 44 35 PM](https://github.com/Automattic/wp-calypso/assets/797888/a3d4c266-85ca-4816-a619-f5833364ffa2) | ![Screenshot 2023-10-06 at 5 44 07 PM](https://github.com/Automattic/wp-calypso/assets/797888/2c6617a4-9dfe-427c-9c01-144b6eca99c9) |

**Onboarding design picker - style variations - premium plan (NO CHANGE)**
![Screenshot 2023-10-06 at 5 43 35 PM](https://github.com/Automattic/wp-calypso/assets/797888/19afa732-38b7-4d91-8742-817735f846a4)


**Onboarding design picker - colors & fonts - free plan (NO CHANGE)**
| Before | After |
| --- | --- |
| ![Screenshot 2023-10-06 at 5 10 48 PM](https://github.com/Automattic/wp-calypso/assets/797888/014ca13a-9cac-4b67-9401-2c738182234f) | ![Screenshot 2023-10-06 at 5 10 48 PM](https://github.com/Automattic/wp-calypso/assets/797888/014ca13a-9cac-4b67-9401-2c738182234f) |

**Onboarding design picker - colors & fonts - premium plan**
| Before | After |
| --- | --- | 
| ![Screenshot 2023-10-06 at 5 26 37 PM](https://github.com/Automattic/wp-calypso/assets/797888/7738fee5-2a6c-4213-8bcb-54d83b6fbce3) | ![Screenshot 2023-10-06 at 5 11 19 PM](https://github.com/Automattic/wp-calypso/assets/797888/accc3c55-6a32-4267-80a5-27ae3a0347d4) |

**Assembler - free plan (NO CHANGE)**
| Before | After |
| --- | --- |
| ![Screenshot 2023-10-06 at 5 15 53 PM](https://github.com/Automattic/wp-calypso/assets/797888/9efd8b0a-b8e0-491e-befa-9eb90f1c2a0e) | ![Screenshot 2023-10-06 at 5 15 53 PM](https://github.com/Automattic/wp-calypso/assets/797888/9efd8b0a-b8e0-491e-befa-9eb90f1c2a0e)|

**Assembler - premium plan**
| Before | After |
| --- | --- |
| ![Screenshot 2023-10-06 at 5 31 58 PM](https://github.com/Automattic/wp-calypso/assets/797888/41f850b8-db5d-4c4c-81cf-584469e22a66) | ![Screenshot 2023-10-06 at 5 15 53 PM](https://github.com/Automattic/wp-calypso/assets/797888/9efd8b0a-b8e0-491e-befa-9eb90f1c2a0e)|


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use a site with the premium plan. 
* Head to the Theme Showcase `/themes`.
* Select any theme with style variations.
* Ensure that the global styles badge is updated as shown above.
* Head to the Onboarding Design Picker `/setup/site-setup/designSetup?siteSlug=${SITE_SLUG}`.
* Select any theme with style variations.
* Ensure that the global styles badge is updated as shown above.
* Head to the Assembler `/setup/with-theme-assembler/patternAssembler?siteSlug=${SITE_SLUG}`
* Ensure that the global styles badge is updated as shown above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?