### PR TITLE
Add: pause and save domain search

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -139,6 +139,8 @@ class RegisterDomainStep extends Component {
 		handleClickUseYourDomain: PropTypes.func,
 		wpcomSubdomainSelected: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ),
 
+		// when it's on, the user can still interact with the searchbar, but the actual search won't fire.
+		// once it is off, the saved search will then be resumed.
 		pauseAndSaveSearch: PropTypes.bool,
 	};
 
@@ -267,7 +269,7 @@ class RegisterDomainStep extends Component {
 			nextProps.suggestion && this.onSearch( nextProps.suggestion );
 		}
 
-		// Run the blocked search if it's unblocked
+		// Run the paused search when the flag is turned off
 		if ( ! nextProps.pauseAndSaveSearch && this.props.pauseAndSaveSearch ) {
 			this.doSavedSearch();
 		}

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -139,12 +139,12 @@ class RegisterDomainStep extends Component {
 		handleClickUseYourDomain: PropTypes.func,
 		wpcomSubdomainSelected: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ),
 
-		saveSearchForLater: PropTypes.bool,
+		pauseAndSaveSearch: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		analyticsSection: 'domains',
-		saveSearchForLater: false,
+		pauseAndSaveSearch: false,
 		deemphasiseTlds: [],
 		includeDotBlogSubdomain: false,
 		includeWordPressDotCom: false,
@@ -268,7 +268,7 @@ class RegisterDomainStep extends Component {
 		}
 
 		// Run the blocked search if it's unblocked
-		if ( ! nextProps.blockSearch && this.props.blockSearch ) {
+		if ( ! nextProps.pauseAndSaveSearch && this.props.pauseAndSaveSearch ) {
 			this.doSavedSearch();
 		}
 	}
@@ -1300,7 +1300,7 @@ class RegisterDomainStep extends Component {
 			this.save
 		);
 
-		if ( this.props.blockSearch ) {
+		if ( this.props.pauseAndSaveSearch ) {
 			return;
 		}
 

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1243,7 +1243,7 @@ class RegisterDomainStep extends Component {
 		const {
 			lastQuery: domain,
 			savedQuery: searchQuery,
-			savedArgs: { shouldQuerySubdomains },
+			savedArgs: { shouldQuerySubdomains = true },
 		} = this.state;
 
 		enqueueSearchStatReport(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/growth-foundations#212

## Proposed Changes

This PR adds the functionality to `<RegisterDomainStep>` component that the parent component can pause the actual domain search by the `pauseAndSaveSearch` flag. When it's on, users can still interact with the search bar, just that only the loading placeholder will be shown. Once the flag is turned off, the actual search will be resumed.

The particular use case of this is Automattic/growth-foundation#212, since we'd need time to load the experiment before we can decide on the actual value of the `includeWordPressDotCom` prop. See <PR> for the actual usage.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* The domain step should act as it is in production.
* There is no actual usage of `pauseAndSaveSearch` at the moment, so code review that confirms the semantic is identical with/without pausing is needed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
