### PR TITLE
BBE In-Progress page: fix formatting bug

### DIFF
--- a/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.tsx
@@ -86,7 +86,7 @@ function WebsiteContentSubmissionPending( { primaryDomain, siteId, siteSlug }: P
 	return (
 		<EmptyContent
 			title={ translate( 'Website content not submitted' ) }
-			line={ lineText }
+			line={ <h3 className="empty-content__line">{ lineText }</h3> }
 			action={ translate( 'Provide website content' ) }
 			actionURL={ `/start/site-content-collection/website-content?siteSlug=${ siteSlug }` }
 			illustration={ WebsiteContentRequiredIllustration }
@@ -118,23 +118,27 @@ function WebsiteContentSubmitted( { primaryDomain, siteSlug }: Props ) {
 	return (
 		<EmptyContent
 			title={ translate( 'Your content submission was successful!' ) }
-			line={ translate(
-				"We are currently building your site and will send you an email when it's ready, within %d business days.{{br}}{{/br}}" +
-					'{{SupportLink}}Contact support{{/SupportLink}} if you have any questions.',
-				{
-					components: {
-						br: <br />,
-						SupportLink: (
-							<a
-								href={ `mailto:builtby+express@wordpress.com?subject=${ encodeURIComponent(
-									`I need help with my site: ${ primaryDomain.domain }`
-								) }` }
-							/>
-						),
-					},
-					args: [ 4 ],
-				}
-			) }
+			line={
+				<h3 className="empty-content__line">
+					{ translate(
+						"We are currently building your site and will send you an email when it's ready, within %d business days.{{br}}{{/br}}" +
+							'{{SupportLink}}Contact support{{/SupportLink}} if you have any questions.',
+						{
+							components: {
+								br: <br />,
+								SupportLink: (
+									<a
+										href={ `mailto:builtby+express@wordpress.com?subject=${ encodeURIComponent(
+											`I need help with my site: ${ primaryDomain.domain }`
+										) }` }
+									/>
+								),
+							},
+							args: [ 4 ],
+						}
+					) }
+				</h3>
+			}
 			action={ translate( 'Manage domain' ) }
 			actionURL={ domainManagementList( siteSlug, currentRoute ) }
 			secondaryAction={ hasEmailWithUs ? translate( 'Manage email' ) : translate( 'Add email' ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#2286

## Proposed Changes

* Fixes the formatting issue on the BBE in-progress page. Please see screenshots for context.

| Before | After |
|--------|--------|
| <img width="732" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/f918d67d-b4f3-4421-8dda-7ed5bdbac8e7"> | <img width="780" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/26506400-2422-4ff7-94fe-55e680bfec9e"> | 
|<img width="842" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/b7d365fe-b124-4f85-93f4-62ab0ec033f6">| <img width="921" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/21a8f716-1227-4a21-a23b-2880fcf626df">|


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* If you already have a in-progress BBE purchase, go to `/home`, else follow the steps below.
* Go to `/start/do-it-for-me`.
* Go through the flow steps and complete the purchase.
* Do not fill out the website content form. Instead, go to `/home`.
* Confirm that the page matches the first screenshot.
* Click the CTA on this page to go to the website content form.
* After filling the form, you will be redirected to `/home`.
* Confirm that the page matches the second screenshot.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?