### PR TITLE
Implement the hiding free subdomain test

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1225,6 +1225,17 @@ class RegisterDomainStep extends Component {
 			this.props.analyticsSection
 		);
 
+		// This part handles the other end of the condition handled by the line 282:
+		// 1. The query request is sent.
+		// 2. `includeWordPressDotCom` is changed by the loaded result of the experiment. (this is where the line 282 won't handle)
+		// 3. The domain query result is returned and will be set here.
+		// The drawback is that it'd add unnecessary computation if `includeWordPressDotCom ` never changes.
+		if ( ! this.props.includeWordPressDotCom ) {
+			subdomainSuggestions = subdomainSuggestions.filter(
+				( subdomain ) => ! isFreeWordPressComDomain( subdomain )
+			);
+		}
+
 		this.setState(
 			{
 				subdomainSearchResults: subdomainSuggestions,

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1,5 +1,5 @@
 import config from '@automattic/calypso-config';
-import { isBlogger } from '@automattic/calypso-products';
+import { isBlogger, isFreeWordPressComDomain } from '@automattic/calypso-products';
 import { Button, CompactCard, ResponsiveToolbarGroup } from '@automattic/components';
 import Search from '@automattic/search';
 import { withShoppingCart } from '@automattic/shopping-cart';
@@ -262,6 +262,21 @@ class RegisterDomainStep extends Component {
 		) {
 			this.setState( this.getState( nextProps ) );
 			nextProps.suggestion && this.onSearch( nextProps.suggestion );
+		}
+
+		// Filter out the free wp.com subdomains to avoid doing another API request.
+		// Please note that it's intentional to be incomplete -- the complete version of this
+		// should be able to handle flag transition the other way around, i.e.
+		// when `includeWordPressDotCom` is first `false` and then transit to `true`. The
+		// same should also be ported to the dotblog subdomain flag. However, this code is likely
+		// temporary specific for the hiding free subdomain test, so it's not practical to implement
+		// the complete version for now.
+		if ( ! nextProps.includeWordPressDotCom && this.props.includeWordPressDotCom ) {
+			this.setState( {
+				subdomainSearchResults: this.state.subdomainSearchResults.filter(
+					( subdomain ) => ! isFreeWordPressComDomain( subdomain )
+				),
+			} );
 		}
 	}
 

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -140,11 +140,11 @@ class RegisterDomainStep extends Component {
 		wpcomSubdomainSelected: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ),
 
 		/**
-		 * Force the loading spinner to show even if the search request has been completed.
+		 * Force the loading placeholder to show even if the search request has been completed.
 		 * Although it is a general functionality, but it's only needed by the hiding free subdomain test for now.
 		 * It will be removed if there is still no need of it once the test concludes.
 		 */
-		forceLoadingSpinner: PropTypes.bool,
+		forceLoadingPlaceholder: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -163,7 +163,7 @@ class RegisterDomainStep extends Component {
 		showSkipButton: false,
 		useProvidedProductsList: false,
 		otherManagedSubdomains: null,
-		forceLoadingSpinner: false,
+		forceLoadingPlaceholder: false,
 	};
 
 	constructor( props ) {
@@ -279,7 +279,11 @@ class RegisterDomainStep extends Component {
 		// same should also be ported to the dotblog subdomain flag. However, this code is likely
 		// temporary specific for the hiding free subdomain test, so it's not practical to implement
 		// the complete version for now.
-		if ( ! nextProps.includeWordPressDotCom && this.props.includeWordPressDotCom ) {
+		if (
+			! nextProps.includeWordPressDotCom &&
+			this.props.includeWordPressDotCom &&
+			this.state.subdomainSearchResults
+		) {
 			this.setState( {
 				subdomainSearchResults: this.state.subdomainSearchResults.filter(
 					( subdomain ) => ! isFreeWordPressComDomain( subdomain )
@@ -1463,7 +1467,7 @@ class RegisterDomainStep extends Component {
 				tracksButtonClickSource="exact-match-top"
 				suggestions={ suggestions }
 				premiumDomains={ premiumDomains }
-				isLoadingSuggestions={ this.state.loadingResults || this.props.forceLoadingSpinner }
+				isLoadingSuggestions={ this.state.loadingResults || this.props.forceLoadingPlaceholder }
 				products={ this.props.products }
 				selectedSite={ this.props.selectedSite }
 				offerUnavailableOption={ this.props.offerUnavailableOption }

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -138,6 +138,13 @@ class RegisterDomainStep extends Component {
 		otherManagedSubdomainsCountOverride: PropTypes.number,
 		handleClickUseYourDomain: PropTypes.func,
 		wpcomSubdomainSelected: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ),
+
+		/**
+		 * Force the loading spinner to show even if the search request has been completed.
+		 * Although it is a general functionality, but it's only needed by the hiding free subdomain test for now.
+		 * It will be removed if there is still no need of it once the test concludes.
+		 */
+		forceLoadingSpinner: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -156,6 +163,7 @@ class RegisterDomainStep extends Component {
 		showSkipButton: false,
 		useProvidedProductsList: false,
 		otherManagedSubdomains: null,
+		forceLoadingSpinner: false,
 	};
 
 	constructor( props ) {
@@ -1455,7 +1463,7 @@ class RegisterDomainStep extends Component {
 				tracksButtonClickSource="exact-match-top"
 				suggestions={ suggestions }
 				premiumDomains={ premiumDomains }
-				isLoadingSuggestions={ this.state.loadingResults }
+				isLoadingSuggestions={ this.state.loadingResults || this.props.forceLoadingSpinner }
 				products={ this.props.products }
 				selectedSite={ this.props.selectedSite }
 				offerUnavailableOption={ this.props.offerUnavailableOption }

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1004,7 +1004,7 @@ export class RenderDomainsStep extends Component {
 								: undefined
 						}
 						wpcomSubdomainSelected={ this.state.wpcomSubdomainSelected }
-						forceLoadingPlaceholder={ isLoadingExperiment }
+						hasPendingRequests={ isLoadingExperiment }
 					/>
 				) }
 			</ProvideExperimentData>

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -947,7 +947,9 @@ export class RenderDomainsStep extends Component {
 		return (
 			<ProvideExperimentData
 				name="calypso_gf_signup_onboardingpm_domains_hide_free_subdomain"
-				options={ { isEligible: this.props.flowName === 'onboarding-pm' } }
+				options={ {
+					isEligible: includeWordPressDotCom && this.props.flowName === 'onboarding-pm',
+				} }
 			>
 				{ ( isLoadingExperiment, experimentAssignment ) => (
 					<RegisterDomainStep

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -946,7 +946,7 @@ export class RenderDomainsStep extends Component {
 
 		return (
 			<ProvideExperimentData
-				name="calypso_domains_hide_free_subdomain_onboarding_pm"
+				name="calypso_gf_signup_onboardingpm_domains_hide_free_subdomain"
 				options={ { isEligible: this.props.flowName === 'onboarding-pm' } }
 			>
 				{ ( isLoadingExperiment, experimentAssignment ) => (
@@ -1002,7 +1002,7 @@ export class RenderDomainsStep extends Component {
 								: undefined
 						}
 						wpcomSubdomainSelected={ this.state.wpcomSubdomainSelected }
-						pauseAndSaveSearch={ isLoadingExperiment }
+						forceLoadingPlaceholder={ isLoadingExperiment }
 					/>
 				) }
 			</ProvideExperimentData>

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -39,7 +39,7 @@ import {
 	getFixedDomainSearch,
 } from 'calypso/lib/domains';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
-import { loadExperimentAssignment } from 'calypso/lib/explat';
+import { loadExperimentAssignment, ProvideExperimentData } from 'calypso/lib/explat';
 import { getSitePropertyDefaults } from 'calypso/lib/signup/site-properties';
 import { maybeExcludeEmailsStep } from 'calypso/lib/signup/step-actions';
 import wpcom from 'calypso/lib/wp';
@@ -945,57 +945,67 @@ export class RenderDomainsStep extends Component {
 		const promoTlds = this.props?.queryObject?.tld?.split( ',' ) ?? null;
 
 		return (
-			<RegisterDomainStep
-				key="domainForm"
-				path={ this.props.path }
-				initialState={ initialState }
-				onAddDomain={ this.handleAddDomain }
-				isCartPendingUpdate={ this.props.shoppingCartManager.isPendingUpdate }
-				isCartPendingUpdateDomain={ this.state.isCartPendingUpdateDomain }
-				products={ this.props.productsList }
-				basePath={ this.props.path }
-				promoTlds={ promoTlds }
-				mapDomainUrl={ this.getUseYourDomainUrl() }
-				otherManagedSubdomains={ this.props.otherManagedSubdomains }
-				otherManagedSubdomainsCountOverride={ this.props.otherManagedSubdomainsCountOverride }
-				transferDomainUrl={ this.getUseYourDomainUrl() }
-				useYourDomainUrl={ this.getUseYourDomainUrl() }
-				onAddMapping={ this.handleAddMapping.bind( this, { sectionName: 'domainForm' } ) }
-				onSave={ this.handleSave.bind( this, 'domainForm' ) }
-				offerUnavailableOption={ ! this.props.isDomainOnly }
-				isDomainOnly={ this.props.isDomainOnly }
-				analyticsSection={ this.getAnalyticsSection() }
-				domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
-				includeWordPressDotCom={ includeWordPressDotCom }
-				includeDotBlogSubdomain={ this.shouldIncludeDotBlogSubdomain() }
-				isSignupStep
-				isPlanSelectionAvailableInFlow={ this.props.isPlanSelectionAvailableLaterInFlow }
-				showExampleSuggestions={ showExampleSuggestions }
-				suggestion={ initialQuery }
-				designType={ this.getDesignType() }
-				vendor={ getSuggestionsVendor( {
-					isSignup: true,
-					isDomainOnly: this.props.isDomainOnly,
-					flowName: this.props.flowName,
-				} ) }
-				deemphasiseTlds={ this.props.flowName === 'ecommerce' ? [ 'blog' ] : [] }
-				selectedSite={ this.props.selectedSite }
-				showSkipButton={ this.props.showSkipButton }
-				onSkip={ this.handleSkip }
-				hideFreePlan={ this.handleSkip }
-				forceHideFreeDomainExplainerAndStrikeoutUi={
-					this.props.forceHideFreeDomainExplainerAndStrikeoutUi
-				}
-				isReskinned={ this.props.isReskinned }
-				reskinSideContent={ this.getSideContent() }
-				isInLaunchFlow={ 'launch-site' === this.props.flowName }
-				promptText={
-					this.isHostingFlow()
-						? this.props.translate( 'Stand out with a short and memorable domain' )
-						: undefined
-				}
-				wpcomSubdomainSelected={ this.state.wpcomSubdomainSelected }
-			/>
+			<ProvideExperimentData
+				name="calypso_domains_hide_free_subdomain_onboarding_pm"
+				options={ { isEligible: this.props.flowName === 'onboarding-pm' } }
+			>
+				{ ( isLoadingExperiment, experimentAssignment ) => (
+					<RegisterDomainStep
+						key="domainForm"
+						path={ this.props.path }
+						initialState={ initialState }
+						onAddDomain={ this.handleAddDomain }
+						isCartPendingUpdate={ this.props.shoppingCartManager.isPendingUpdate }
+						isCartPendingUpdateDomain={ this.state.isCartPendingUpdateDomain }
+						products={ this.props.productsList }
+						basePath={ this.props.path }
+						promoTlds={ promoTlds }
+						mapDomainUrl={ this.getUseYourDomainUrl() }
+						otherManagedSubdomains={ this.props.otherManagedSubdomains }
+						otherManagedSubdomainsCountOverride={ this.props.otherManagedSubdomainsCountOverride }
+						transferDomainUrl={ this.getUseYourDomainUrl() }
+						useYourDomainUrl={ this.getUseYourDomainUrl() }
+						onAddMapping={ this.handleAddMapping.bind( this, { sectionName: 'domainForm' } ) }
+						onSave={ this.handleSave.bind( this, 'domainForm' ) }
+						offerUnavailableOption={ ! this.props.isDomainOnly }
+						isDomainOnly={ this.props.isDomainOnly }
+						analyticsSection={ this.getAnalyticsSection() }
+						domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
+						includeWordPressDotCom={
+							experimentAssignment?.variationName === 'treatment' ? false : includeWordPressDotCom
+						}
+						includeDotBlogSubdomain={ this.shouldIncludeDotBlogSubdomain() }
+						isSignupStep
+						isPlanSelectionAvailableInFlow={ this.props.isPlanSelectionAvailableLaterInFlow }
+						showExampleSuggestions={ showExampleSuggestions }
+						suggestion={ initialQuery }
+						designType={ this.getDesignType() }
+						vendor={ getSuggestionsVendor( {
+							isSignup: true,
+							isDomainOnly: this.props.isDomainOnly,
+							flowName: this.props.flowName,
+						} ) }
+						deemphasiseTlds={ this.props.flowName === 'ecommerce' ? [ 'blog' ] : [] }
+						selectedSite={ this.props.selectedSite }
+						showSkipButton={ this.props.showSkipButton }
+						onSkip={ this.handleSkip }
+						hideFreePlan={ this.handleSkip }
+						forceHideFreeDomainExplainerAndStrikeoutUi={
+							this.props.forceHideFreeDomainExplainerAndStrikeoutUi
+						}
+						isReskinned={ this.props.isReskinned }
+						reskinSideContent={ this.getSideContent() }
+						isInLaunchFlow={ 'launch-site' === this.props.flowName }
+						promptText={
+							this.isHostingFlow()
+								? this.props.translate( 'Stand out with a short and memorable domain' )
+								: undefined
+						}
+						wpcomSubdomainSelected={ this.state.wpcomSubdomainSelected }
+						pauseAndSaveSearch={ isLoadingExperiment }
+					/>
+				) }
+			</ProvideExperimentData>
 		);
 	};
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/growth-foundations#212

## Proposed Changes

This PR implements the hiding free subdomain test based on the functionality that will be introduced by https://github.com/Automattic/wp-calypso/pull/82706. In `/start/onboarding-pm`, 


Control:
<img width="1226" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1842898/7567f88d-ead5-4852-8692-277e9517df03">

Treatment: (same query; no free dotcom subdomain)
<img width="1238" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1842898/a23afca3-afa5-4039-b230-f8f845f7705f">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* For the `calypso_gf_signup_onboardingpm_domains_hide_free_subdomain` experiment, assign yourself as the control group on Abacus.
* Searching in `/start/onboarding-pm/domains`, there should be the free dotcom subdomain like in production.
* Assign yourself as the treatment group on Abacus
* Searching in `/startonboarding-pm/domains`, there should be no free dotcom subdomain.
* Outside `/start/onboarding-pm`, everything should work as it is without being affected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
