### PR TITLE
Site profiler: Improve the learn-more link handler

### DIFF
--- a/client/site-profiler/components/hosting-intro/index.tsx
+++ b/client/site-profiler/components/hosting-intro/index.tsx
@@ -3,6 +3,10 @@ import { Button } from '@wordpress/components';
 import { translate } from 'i18n-calypso';
 
 export default function HostingIntro() {
+	const onLearnMoreClick = () => {
+		window.open( localizeUrl( 'https://wordpress.com/hosting' ), '_blank' );
+	};
+
 	return (
 		<div className="l-block-col-2">
 			<div className="l-block-content">
@@ -15,7 +19,7 @@ export default function HostingIntro() {
 					) }
 				</p>
 				<p>{ translate( 'Bring your WordPress site to WordPress.com and get it all.' ) }</p>
-				<Button href={ localizeUrl( 'https://wordpress.com/hosting' ) } className="button-action">
+				<Button onClick={ onLearnMoreClick } className="button-action">
 					{ translate( 'Learn more' ) }
 				</Button>
 			</div>


### PR DESCRIPTION
## Proposed Changes

* Hosting intro block: Fix handler when the user clicks on the `Learn more` link on production env

## Testing Instructions

* Open site profiler `/site-profiler`
* Scroll down and click on Learn more link
* Check if opens in the new tab

<img width="876" alt="Screenshot 2023-10-06 at 12 39 46" src="https://github.com/Automattic/wp-calypso/assets/1241413/6ca0439b-5c9f-4691-b080-719d11ed104d">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?