### PR TITLE
Form Legend: Convert to TS

### DIFF
--- a/client/components/forms/form-legend/index.jsx
+++ b/client/components/forms/form-legend/index.jsx
@@ -1,9 +1,0 @@
-import classnames from 'classnames';
-
-const FormLegend = ( { className, children, ...otherProps } ) => (
-	<legend { ...otherProps } className={ classnames( className, 'form-legend' ) }>
-		{ children }
-	</legend>
-);
-
-export default FormLegend;

--- a/client/components/forms/form-legend/index.tsx
+++ b/client/components/forms/form-legend/index.tsx
@@ -1,0 +1,15 @@
+import classnames from 'classnames';
+import * as React from 'react';
+
+type FormLegendProps = {
+	className?: string;
+	children: React.ReactNode;
+} & React.HTMLAttributes< HTMLLegendElement >;
+
+const FormLegend = ( { className, children, ...otherProps }: FormLegendProps ) => (
+	<legend { ...otherProps } className={ classnames( className, 'form-legend' ) }>
+		{ children }
+	</legend>
+);
+
+export default FormLegend;

--- a/client/my-sites/earn/ads/form-settings.tsx
+++ b/client/my-sites/earn/ads/form-settings.tsx
@@ -168,7 +168,6 @@ const AdsFormSettings = () => {
 
 		return (
 			<FormFieldset>
-				{ /* @ts-expect-error FormRadio is not typed and is causing errors */ }
 				<FormLegend>{ translate( 'Ads Visibility' ) }</FormLegend>
 				<FormLabel>
 					{ /* @ts-expect-error FormRadio is not typed and is causing errors */ }
@@ -215,7 +214,6 @@ const AdsFormSettings = () => {
 		return (
 			<div>
 				<FormFieldset className="ads__settings-display-toggles">
-					{ /* @ts-expect-error FormRadio is not typed and is causing errors */ }
 					<FormLegend>{ translate( 'Display ads below posts on' ) }</FormLegend>
 					<ToggleControl
 						checked={ !! settings.display_options?.display_front_page }
@@ -243,7 +241,6 @@ const AdsFormSettings = () => {
 					/>
 				</FormFieldset>
 				<FormFieldset className="ads__settings-display-toggles">
-					{ /* @ts-expect-error FormRadio is not typed and is causing errors */ }
 					<FormLegend>{ translate( 'Additional ad placements' ) }</FormLegend>
 					<ToggleControl
 						checked={ !! settings.display_options?.enable_header_ad }

--- a/client/my-sites/site-settings/reader-settings/index.tsx
+++ b/client/my-sites/site-settings/reader-settings/index.tsx
@@ -1,4 +1,5 @@
 import { Card } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import FormLegend from 'calypso/components/forms/form-legend';
@@ -33,13 +34,12 @@ const ReaderSettingsSection = ( {
 			{ /* @ts-expect-error SettingsSectionHeader is not typed and is causing errors */ }
 			<SettingsSectionHeader title={ translate( 'Reader settings' ) } />
 			<Card className="site-settings__card">
-				{ /* @ts-expect-error FormLegend is not typed and has a className error */ }
 				<FormLegend>{ translate( 'Reader content' ) }</FormLegend>
 				<SupportInfo
 					text={ translate(
 						"Settings that control how the site's content is displayed in the Reader."
 					) }
-					link="https://wordpress.com/support/reader/"
+					link={ localizeUrl( 'https://wordpress.com/support/reader/' ) }
 					privacyLink={ siteIsJetpack && ! isAtomic }
 				/>
 				<ToggleControl

--- a/client/my-sites/site-settings/settings-newsletter/newsletter-section/EmailsTextSetting.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/newsletter-section/EmailsTextSetting.tsx
@@ -1,5 +1,3 @@
-import { useLocale } from '@automattic/i18n-utils';
-import { useI18n } from '@wordpress/react-i18n';
 import { useTranslate } from 'i18n-calypso';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
@@ -20,8 +18,6 @@ type SubscriptionOption = {
 
 export const EmailsTextSetting = ( { value, disabled, updateFields }: EmailsTextSettingProps ) => {
 	const translate = useTranslate();
-	const locale = useLocale();
-	const { hasTranslation } = useI18n();
 
 	const updateSubscriptionOptions =
 		( option: string ) => ( event: React.ChangeEvent< HTMLInputElement > ) => {
@@ -42,14 +38,11 @@ export const EmailsTextSetting = ( { value, disabled, updateFields }: EmailsText
 	return (
 		<div className="site-settings__emails-text-settings-container">
 			<FormFieldset>
-				{ /* @ts-expect-error FormLegend is not typed and is causing errors */ }
 				<FormLegend>
 					{ translate( 'These settings change the emails sent from your site to your readers' ) }
 				</FormLegend>
 				<FormLabel htmlFor="confirmation_email_message">
-					{ hasTranslation( 'Confirmation email message' ) || locale.startsWith( 'en' )
-						? translate( 'Confirmation email message' )
-						: translate( 'Welcome email text' ) }
+					{ translate( 'Confirmation email message' ) }
 				</FormLabel>
 				<FormTextarea
 					name="confirmation_email_message"
@@ -60,20 +53,12 @@ export const EmailsTextSetting = ( { value, disabled, updateFields }: EmailsText
 					autoCapitalize="none"
 				/>
 				<FormSettingExplanation>
-					{ hasTranslation(
+					{ translate(
 						'The confirmation message sent out to new readers when they subscribe to your blog.'
-					) || locale.startsWith( 'en' )
-						? translate(
-								'The confirmation message sent out to new readers when they subscribe to your blog.'
-						  )
-						: translate(
-								'The welcome message sent out to new readers when they subscribe to your blog.'
-						  ) }
+					) }
 				</FormSettingExplanation>
 				<FormLabel htmlFor="comment_follow_email_message">
-					{ hasTranslation( 'Comment follow email message' ) || locale.startsWith( 'en' )
-						? translate( 'Comment follow email message' )
-						: translate( 'Comment follow email text' ) }
+					{ translate( 'Comment follow email message' ) }
 				</FormLabel>
 				<FormTextarea
 					name="comment_follow_email_message"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Convert the simple FormLegend component so there is no need for disabling TS checks when using it
* Use `localizeUrl` function for wordpress.com support URL in Reading settings
  * This was requested by Lint, once I modified the file.
* Remove obsolete translation checks from Newsletter Settings

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test for no regressions
* Newsletter settings URL: https://wordpress.com/settings/newsletter/$site-slug

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?