### PR TITLE
Stats: Tweaks to shortcut rendering.

### DIFF
--- a/client/my-sites/stats/stats-date-control/stats-date-control-picker-shortcuts.tsx
+++ b/client/my-sites/stats/stats-date-control/stats-date-control-picker-shortcuts.tsx
@@ -31,7 +31,7 @@ const DateControlPickerShortcuts = ( {
 							} }
 						>
 							{ shortcut.label }
-							{ isSelectedShortcut( shortcut ) && <Icon className="gridicon" icon={ check } /> }
+							{ isSelectedShortcut( shortcut ) && <Icon icon={ check } /> }
 						</Button>
 					</li>
 				) ) }

--- a/client/my-sites/stats/stats-date-control/stats-date-control-picker-shortcuts.tsx
+++ b/client/my-sites/stats/stats-date-control/stats-date-control-picker-shortcuts.tsx
@@ -8,11 +8,15 @@ const DateControlPickerShortcuts = ( {
 	currentShortcut,
 	onClick,
 }: DateControlPickerShortcutsProps ) => {
+	// Simple selection test.
+	function isSelectedShortcut( shortcut: DateControlPickerShortcut ) {
+		return shortcut.id === currentShortcut;
+	}
 	// Apply selection state via CSS.
 	function classNameForShortcut( shortcut: DateControlPickerShortcut ): string {
 		const defaultClassName = 'date-control-picker-shortcuts__shortcut';
 		const selectedClassName = defaultClassName + ' is-selected';
-		return shortcut.id !== currentShortcut ? defaultClassName : selectedClassName;
+		return isSelectedShortcut( shortcut ) ? selectedClassName : defaultClassName;
 	}
 
 	return (
@@ -27,7 +31,7 @@ const DateControlPickerShortcuts = ( {
 							} }
 						>
 							{ shortcut.label }
-							<Icon className="gridicon" icon={ check } />
+							{ isSelectedShortcut( shortcut ) && <Icon className="gridicon" icon={ check } /> }
 						</Button>
 					</li>
 				) ) }

--- a/client/my-sites/stats/stats-date-control/style.scss
+++ b/client/my-sites/stats/stats-date-control/style.scss
@@ -19,9 +19,6 @@
 
 .date-control-picker-shortcuts__shortcut {
 	border-radius: 4px;
-	.gridicon {
-		display: none;
-	}
 	.components-button {
 		display: flex;
 		justify-content: space-between;
@@ -29,9 +26,6 @@
 	}
 	&.is-selected {
 		background-color: var(--color-accent-5);
-		.gridicon {
-			display: initial;
-		}
 	}
 	&:hover {
 		background-color: var(--color-primary-0);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #81939.

## Proposed Changes

Some clean-up under the hood.

1. Only renders the icon when needed.
2. Removes CSS rules that managed the icon visibility.
3. Removes unused class name on icons.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Load the Live branch.
2. Visit the **Stats → Traffic** page.
3. Enable the date picker: `?flags=stats/date-control`
4. Confirm that selection still works as expected in the date control.
5. Confirm (via the inspector) that icons are only rendered to the DOM for the selected row.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?