### PR TITLE
Newsletter Categories: Disable 'Confirmation email message' setting

### DIFF
--- a/client/my-sites/site-settings/settings-newsletter/newsletter-section/EmailsTextSetting.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/newsletter-section/EmailsTextSetting.tsx
@@ -56,19 +56,13 @@ export const EmailsTextSetting = ( { value, disabled, updateFields }: EmailsText
 					id="confirmation_email_message"
 					value={ value?.invitation }
 					onChange={ updateSubscriptionOptions( 'invitation' ) }
-					disabled={ disabled }
 					autoCapitalize="none"
+					disabled
 				/>
 				<FormSettingExplanation>
-					{ hasTranslation(
-						'The confirmation message sent out to new readers when they subscribe to your blog.'
-					) || locale.startsWith( 'en' )
-						? translate(
-								'The confirmation message sent out to new readers when they subscribe to your blog.'
-						  )
-						: translate(
-								'The welcome message sent out to new readers when they subscribe to your blog.'
-						  ) }
+					{ translate(
+						"The ability to customize the confirmation email message is now disabled for enhanced security. We're keeping the field visible for a short time, so you can copy your custom message if needed. Thank you for understanding as we prioritize safety."
+					) }
 				</FormSettingExplanation>
 				<FormLabel htmlFor="comment_follow_email_message">
 					{ hasTranslation( 'Comment follow email message' ) || locale.startsWith( 'en' )

--- a/client/my-sites/site-settings/settings-newsletter/newsletter-section/EmailsTextSetting.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/newsletter-section/EmailsTextSetting.tsx
@@ -54,7 +54,7 @@ export const EmailsTextSetting = ( { value, disabled, updateFields }: EmailsText
 				/>
 				<FormSettingExplanation>
 					{ translate(
-						"The ability to customize the confirmation email message is now disabled for enhanced security. We're keeping the field visible for a short time, so you can copy your custom message if needed."
+						'The ability to customize the confirmation email message had to be disabled to prevent abuse. It will revert to the default message for all new subscribers.'
 					) }
 				</FormSettingExplanation>
 				<FormLabel htmlFor="comment_follow_email_message">

--- a/client/my-sites/site-settings/settings-newsletter/newsletter-section/EmailsTextSetting.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/newsletter-section/EmailsTextSetting.tsx
@@ -54,7 +54,7 @@ export const EmailsTextSetting = ( { value, disabled, updateFields }: EmailsText
 				/>
 				<FormSettingExplanation>
 					{ translate(
-						"The ability to customize the confirmation email message is now disabled for enhanced security. We're keeping the field visible for a short time, so you can copy your custom message if needed. Thank you for understanding as we prioritize safety."
+						"The ability to customize the confirmation email message is now disabled for enhanced security. We're keeping the field visible for a short time, so you can copy your custom message if needed."
 					) }
 				</FormSettingExplanation>
 				<FormLabel htmlFor="comment_follow_email_message">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
<img width="895" alt="Screenshot on 2023-10-06 at 16-04-23" src="https://github.com/Automattic/wp-calypso/assets/2019970/2c767edf-1ac5-4559-8363-b4f31681f436">

## Proposed Changes

* Disable the 'Confirmation email message' as we are dropping this setting for security reasons
* Display a brief explanation of why the setting is disabled

## Related  
- p1696507364013669-slack-C02TCEHP3HA
- pdDOJh-2xU-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/settings/newsletter/$site-slug`
* Ensure that the field is disabled, but at the same time that the content can be selected and copied

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?