### PR TITLE
Plans 2023: (exp) refactor use-grid-plans hook. produce a limited list for intent

### DIFF
--- a/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
+++ b/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
@@ -266,17 +266,6 @@ const useGridPlans = ( {
 	storageAddOns,
 	shouldDisplayFreeHostingTrial,
 }: Props ): Omit< GridPlan, 'features' >[] | null => {
-	const availablePlanSlugs = usePlansFromTypes( {
-		planTypes: usePlanTypesWithIntent( {
-			intent: 'default',
-			selectedPlan,
-			sitePlanSlug,
-			hideEnterprisePlan,
-			isSubdomainNotGenerated,
-			shouldDisplayFreeHostingTrial,
-		} ),
-		term,
-	} );
 	const planSlugsForIntent = usePlansFromTypes( {
 		planTypes: usePlanTypesWithIntent( {
 			intent,
@@ -288,7 +277,7 @@ const useGridPlans = ( {
 		} ),
 		term,
 	} );
-	const planUpgradeability = usePlanUpgradeabilityCheck?.( { planSlugs: availablePlanSlugs } );
+	const planUpgradeability = usePlanUpgradeabilityCheck?.( { planSlugs: planSlugsForIntent } );
 
 	// only fetch highlights for the plans that are available for the intent
 	const highlightLabels = useHighlightLabels( {
@@ -300,9 +289,9 @@ const useGridPlans = ( {
 	} );
 
 	// TODO: pricedAPIPlans to be queried from data-store package
-	const pricedAPIPlans = usePricedAPIPlans( { planSlugs: availablePlanSlugs } );
+	const pricedAPIPlans = usePricedAPIPlans( { planSlugs: planSlugsForIntent } );
 	const pricingMeta = usePricingMetaForGridPlans( {
-		planSlugs: availablePlanSlugs,
+		planSlugs: planSlugsForIntent,
 		storageAddOns,
 	} );
 
@@ -311,7 +300,7 @@ const useGridPlans = ( {
 		return null;
 	}
 
-	return availablePlanSlugs.map( ( planSlug ) => {
+	return planSlugsForIntent.map( ( planSlug ) => {
 		const planConstantObj = applyTestFiltersToPlansList( planSlug, undefined );
 		const planObject = pricedAPIPlans[ planSlug ];
 		const isMonthlyPlan = isMonthly( planSlug );
@@ -346,7 +335,7 @@ const useGridPlans = ( {
 
 		return {
 			planSlug,
-			isVisible: planSlugsForIntent.includes( planSlug ),
+			isVisible: true,
 			tagline,
 			availableForPurchase,
 			productNameShort,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This will probably have ramifications in the comparison grid that expects the full list of plans for the features ticks. However, I am not certain if that is still the case. I recall this went through a couple of rounds of refactors (at one point we'd produce separate lists and "merge" them). 

The quickest way to check is to update `useGridPlans` to return only the respective list of plans for the corresponding intent. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plans/[site]` and try with sites produced from different intents (standard WPCOM, Newsletter, WooCommerce)
* Compare the features grid and comparison grid with production and confirm the features lists are identical
* Do this test for the different terms (monthly, yearly)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?