### PR TITLE
Stats: Remove client-side fix for URL encoding issue.

### DIFF
--- a/client/my-sites/stats/stats-list/action-link.jsx
+++ b/client/my-sites/stats/stats-list/action-link.jsx
@@ -27,17 +27,10 @@ class StatsActionLink extends PureComponent {
 			return '';
 		}
 
-		// The following fix is to address encoding issues with the URLs
-		// as returned to us from the API. If we fix that, we can remove this.
-		// https://github.com/Automattic/wp-calypso/issues/82510
-		const finalLink = href?.includes( '&#038;term' )
-			? href?.replace( '&#038;term', '&term' )
-			: href;
-
 		return (
 			<li className="stats-list__item-action module-content-list-item-action">
 				<a
-					href={ finalLink }
+					href={ href }
 					onClick={ this.onClick }
 					target="_blank"
 					rel="noopener noreferrer"


### PR DESCRIPTION
The API has been updated so we no longer need this check.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #82510

## Proposed Changes

Removes the URL handling that watched for URL-encoded ampersands and fixed them locally. Depends on API-side fix shipping first — D124317-code — This is now shipped so I'm opening this PR for review.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Confirm API fix has shipped first. (linked above)
* Follow steps outlined here: pejTkB-VK-p2#comment-807
* Confirm that URLs from API are valid.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?