### PR TITLE
Plans page for Jetpack App: Add tracking

### DIFF
--- a/client/jetpack-app/plans/main.tsx
+++ b/client/jetpack-app/plans/main.tsx
@@ -1,13 +1,14 @@
 import { getPlan, PLAN_FREE } from '@automattic/calypso-products';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import QueryPlans from 'calypso/components/data/query-plans';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import Main from 'calypso/components/main';
 import { getPlanCartItem } from 'calypso/lib/cart-values/cart-items';
 import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getPlanSlug } from 'calypso/state/plans/selectors';
 import type { Plan } from '@automattic/calypso-products';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
@@ -61,6 +62,7 @@ const Header: React.FC< HeaderProps > = ( { paidDomainName } ) => {
 };
 
 const JetpackAppPlans: React.FC< JetpackAppPlansProps > = ( { paidDomainName, originalUrl } ) => {
+	const dispatch = useDispatch();
 	const planSlug = useSelector( ( state: AppState ) =>
 		getPlanSlug( state, getPlan( PLAN_FREE )?.getProductId() || 0 )
 	) as string | null;
@@ -74,9 +76,20 @@ const JetpackAppPlans: React.FC< JetpackAppPlansProps > = ( { paidDomainName, or
 
 		if ( ! productSlug ) {
 			args = { plan_slug: PLAN_FREE };
+
+			dispatch(
+				recordTracksEvent( 'calypso_signup_free_plan_select', { from_section: 'default' } )
+			);
 		} else {
 			const plan = getPlan( productSlug ) as Plan;
 			args = { plan_id: plan.getProductId(), plan_slug: productSlug };
+
+			dispatch(
+				recordTracksEvent( 'calypso_signup_plan_select', {
+					product_slug: productSlug,
+					from_section: 'default',
+				} )
+			);
 		}
 
 		window.location.href = addQueryArgs( originalUrl, args );


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/82135

Added tracking of 2 events:
- `calypso_signup_plan_select` when a paid plan is selected
- `calypso_signup_free_plan_select` when a free plan is selected

These events are tracked for other plan selections during sign-up as well.

## Proposed Changes

Added events [based on documentation](https://github.com/Automattic/wp-calypso/blob/trunk/packages/calypso-analytics/README.md?plain=1#L19) by using `Analytics Middleware`.

## Testing Instructions

I tested the functionality locally by confirming that middleware `state/analytics/middleware.js` `ANALYTICS_EVENT_RECORD` is correctly triggered with the expected payload:

<img width="609" alt="image" src="https://github.com/Automattic/wp-calypso/assets/4062343/8a98dfe1-fd84-4b40-b9c8-d03c6ff72586">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?