### PR TITLE
Jetpack Cloud: Remove top navigation "masterbar" when jetpack/new-navigation is enabled

### DIFF
--- a/client/components/data/query-jetpack-partner-portal-partner/index.js
+++ b/client/components/data/query-jetpack-partner-portal-partner/index.js
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { fetchPartner } from 'calypso/state/partner-portal/partner/actions';
 import { hasFetchedPartner } from 'calypso/state/partner-portal/partner/selectors';
 
-export default function QueryJetpackPartnerPortalPartner() {
+export const useQueryJetpackPartnerPortalPartner = () => {
 	const dispatch = useDispatch();
 	const hasFetched = useSelector( hasFetchedPartner );
 
@@ -12,6 +12,10 @@ export default function QueryJetpackPartnerPortalPartner() {
 			dispatch( fetchPartner() );
 		}
 	}, [ hasFetched, dispatch ] );
+};
+
+export default function QueryJetpackPartnerPortalPartner() {
+	useQueryJetpackPartnerPortalPartner();
 
 	return null;
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-overview/index.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useQueryJetpackPartnerPortalPartner } from 'calypso/components/data/query-jetpack-partner-portal-partner';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import SelectPartnerKey from 'calypso/jetpack-cloud/sections/partner-portal/primary/select-partner-key';
 import { useSelector } from 'calypso/state';
@@ -19,6 +20,8 @@ export default function DashboardOverview( {
 	filter,
 	sort,
 }: DashboardOverviewContextInterface ) {
+	useQueryJetpackPartnerPortalPartner();
+
 	const hasFetched = useSelector( hasFetchedPartner );
 	const isFetching = useSelector( isFetchingPartner );
 	const hasActiveKey = useSelector( hasActivePartnerKey );

--- a/client/jetpack-cloud/style.scss
+++ b/client/jetpack-cloud/style.scss
@@ -24,8 +24,19 @@
 }
 
 // New navigation will not include a masterbar
-.theme-jetpack-cloud .is-jetpack-new-navigation {
+.theme-jetpack-cloud .layout.has-no-masterbar.is-jetpack-new-navigation {
 	--masterbar-height: 0;
+
+	// By default, there's 32px of top padding on the layout component.
+	// On mobile views this accommodates the masterbar, but we don't have one;
+	// so, we can remove it by default and re-add it when our width is >660px.
+	.layout__content {
+		padding-top: initial;
+	}
+
+	@include breakpoint-deprecated( ">660px" ) {
+		padding-top: 32px;
+	}
 }
 
 .button {

--- a/client/jetpack-cloud/style.scss
+++ b/client/jetpack-cloud/style.scss
@@ -23,6 +23,11 @@
 	}
 }
 
+// New navigation will not include a masterbar
+.theme-jetpack-cloud .is-jetpack-new-navigation {
+	--masterbar-height: 0;
+}
+
 .button {
 	color: var(--color-accent);
 	background: var(--studio-white);

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -235,6 +235,7 @@ class Layout extends Component {
 			'has-no-sidebar': this.props.sidebarIsHidden,
 			'has-no-masterbar': this.props.masterbarIsHidden,
 			'is-logged-in': this.props.isLoggedIn,
+			'is-jetpack-new-navigation': this.props.isJetpackNewNavigation,
 			'is-jetpack-login': this.props.isJetpackLogin,
 			'is-jetpack-site': this.props.isJetpack,
 			'is-jetpack-mobile-flow': this.props.isJetpackMobileFlow,
@@ -357,6 +358,7 @@ export default withCurrentRoute(
 		const isJetpack =
 			( isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ) ) ||
 			currentRoute.startsWith( '/checkout/jetpack' );
+		const isJetpackNewNavigation = config.isEnabled( 'jetpack/new-navigation' );
 		const isWooCoreProfilerFlow =
 			[ 'jetpack-connect', 'login' ].includes( sectionName ) &&
 			isWooCommerceCoreProfilerFlow( state );
@@ -369,7 +371,8 @@ export default withCurrentRoute(
 			noMasterbarForSection ||
 			noMasterbarForRoute ||
 			isWpMobileApp() ||
-			isWcMobileApp();
+			isWcMobileApp() ||
+			isJetpackNewNavigation;
 		const isJetpackMobileFlow = 'jetpack-connect' === sectionName && !! retrieveMobileRedirect();
 		const isJetpackWooCommerceFlow =
 			[ 'jetpack-connect', 'login' ].includes( sectionName ) &&
@@ -395,6 +398,7 @@ export default withCurrentRoute(
 			masterbarIsHidden,
 			sidebarIsHidden,
 			isJetpack,
+			isJetpackNewNavigation,
 			isJetpackLogin,
 			isJetpackWooCommerceFlow,
 			isJetpackWooDnaFlow,


### PR DESCRIPTION
This PR hides/prevents from rendering the top navigation "masterbar" present on all pages in Jetpack Cloud when the `jetpack/new-navigation` feature flag is enabled.

Resolves https://github.com/Automattic/jetpack-genesis/issues/40.

## Proposed Changes

* Extract the functionality of the `QueryJetpackPartnerPortalPartner` component into a hook (while maintaining backward compatibility).
* Call the aforementioned hook in the `SitesOverview` component, so that the sites management section of Jetpack Cloud continues to load correctly without a masterbar.
* Add a new condition to `client/components/layout`, such that `masterbarIsHidden` evaluates to true when `jetpack/new-navigation` is enabled.
* Add a new CSS class `is-jetpack-new-navigation` to `client/components/layout`, to allow for changes to margin/padding/etc when the feature flag is enabled and the masterbar hidden.
* Add a new CSS rule such that when the feature flag is enabled, `--masterbar-height` is set to `0` so that other elements on the page render with the correct position and spacing.
* Add a new CSS rule such that the main layout's top padding is set to `0` except on screens larger than 660px. (This removes padding on small screens that would normally accommodate a top navigation bar.)

## Testing Instructions

* In your testing environment, visit Jetpack Cloud.
* Without enabling the `jetpack/new-navigation` feature flag, verify that the top navigation bar is visible and you're able to reach all pages as normal (i.e., Dashboard, Licensing, and Manage Sites).
* Visit all the same pages you did in the previous step, but add `?flags=jetpack/new-navigation` to your browser's query string each time to enable the new navigation feature flag.
* Verify each page loads correctly (**especially** Dashboard), and the top navigation bar is no longer present while the flag is enabled.

### Reference screenshots

<img width="904" alt="image" src="https://github.com/Automattic/wp-calypso/assets/670067/04df9ac2-7f7c-4548-9aa3-f424622d4f82">
<img width="903" alt="image" src="https://github.com/Automattic/wp-calypso/assets/670067/c438e10b-c261-436c-b42b-f0e36789c73c">
<img width="865" alt="image" src="https://github.com/Automattic/wp-calypso/assets/670067/307cb95f-bea4-419a-8417-2562a10a71c6">