### PR TITLE
Social First Signup: Hide flow step indicator

### DIFF
--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -128,6 +128,11 @@
 
 body.is-section-accept-invite,
 body.is-section-signup {
+
+	.flow-progress-indicator {
+		display: none;
+	}
+
 	.signup-form__social-buttons {
 		display: flex;
 		flex-direction: column;


### PR DESCRIPTION
In the Social first signup step, we have an overlap between `Log In` and `Step x of y`. This PR hides the second one, without using the `hideProgressIndicator` property of the flow: in this way, the other steps can continue to have the indicator.

## Before

<img width="893" alt="image" src="https://github.com/Automattic/wp-calypso/assets/52076348/9f281315-ac81-4bf9-8f7f-e876b478c84b">

## After

<img width="979" alt="image" src="https://github.com/Automattic/wp-calypso/assets/52076348/c1f07f08-e273-497b-a34b-f3ebd44a8264">

## Testing
1. Live Link and visit a flow like `start/import` while in Incognito
2. There should be no overlap and no step indicator.

Fixes https://github.com/Automattic/wp-calypso/issues/82722