### PR TITLE
Reader post cards - hide bullets in byline when items wrap to next line.

### DIFF
--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -1,6 +1,6 @@
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
-import { Component } from 'react';
+import { Component, createRef } from 'react';
 import ReaderAuthorLink from 'calypso/blocks/reader-author-link';
 import ReaderAvatar from 'calypso/blocks/reader-avatar';
 import ReaderPostEllipsisMenu from 'calypso/blocks/reader-post-options-menu/reader-post-ellipsis-menu';
@@ -28,6 +28,66 @@ class PostByline extends Component {
 	static defaultProps = {
 		showAvatar: true,
 	};
+
+	constructor( props ) {
+		super( props );
+		this.secondaryBylineRef = createRef();
+		this.organizeBullets = this.organizeBullets.bind( this );
+	}
+
+	/**
+	 * Goes through items in the secondary byline ref and compares their height to determine whether
+	 * or not to hide the bullet separator.
+	 */
+	organizeBullets() {
+		// Query all items in the secondary byline, as well as the bullets between them.
+		const secondaryItems =
+			this.secondaryBylineRef.current?.querySelectorAll(
+				'.reader-post-card__byline-secondary-item'
+			) || [];
+		const bullets =
+			this.secondaryBylineRef.current?.querySelectorAll(
+				'.reader-post-card__byline-secondary-bullet'
+			) || [];
+
+		// Go through all the items to determine if the corresponding bullets should be shown.
+		let lastItem;
+		secondaryItems.forEach( ( item, index ) => {
+			// We cant compare heights unless we have a lastItem set.
+			if ( ! lastItem ) {
+				lastItem = item;
+				return;
+			}
+			// This should always exist given the elements below, but lets do a safe return if not.
+			if ( ! bullets[ index - 1 ] ) {
+				return;
+			}
+
+			// If the items arent at the same vertical position, hide the bullet.
+			if ( item.offsetTop !== lastItem.offsetTop ) {
+				// For now, hide it but keep spacing.
+				bullets[ index - 1 ].style.visibility = 'hidden';
+			} else {
+				// If the items were on the same line, reset the style overrides.
+				bullets[ index - 1 ].removeAttribute( 'style' );
+			}
+			// Prepare for next iteration.
+			lastItem = item;
+		} );
+	}
+
+	componentDidMount() {
+		this.organizeBullets();
+		window.addEventListener( 'resize', this.organizeBullets );
+	}
+
+	componentWillUnmount() {
+		window.removeEventListener( 'resize', this.organizeBullets );
+	}
+
+	componentDidUpdate() {
+		this.organizeBullets();
+	}
 
 	recordDateClick = () => {
 		recordPermalinkClick( 'timestamp_card', this.props.post );
@@ -88,11 +148,10 @@ class PostByline extends Component {
 					) }
 					<div className="reader-post-card__author-and-timestamp">
 						{ ( shouldDisplayAuthor || bylineSiteName || showDate ) && (
-							<span className="reader-post-card__byline-secondary">
+							<span className="reader-post-card__byline-secondary" ref={ this.secondaryBylineRef }>
 								{ shouldDisplayAuthor && (
 									<>
 										<ReaderAuthorLink
-											// className="reader-post-card__link"
 											className="reader-post-card__byline-secondary-item"
 											author={ post.author }
 											siteUrl={ streamUrl }
@@ -101,7 +160,9 @@ class PostByline extends Component {
 											{ post.author.name }
 										</ReaderAuthorLink>
 										{ ( bylineSiteName || showDate ) && (
-											<span className="reader-post-card__byline-secondary-bullet">·</span>
+											<span className="reader-post-card__byline-secondary-bullet-wrapper">
+												<span className="reader-post-card__byline-secondary-bullet">·</span>
+											</span>
 										) }
 									</>
 								) }
@@ -117,7 +178,9 @@ class PostByline extends Component {
 											{ bylineSiteName }
 										</a>
 										{ showDate && (
-											<span className="reader-post-card__byline-secondary-bullet">·</span>
+											<span className="reader-post-card__byline-secondary-bullet-wrapper">
+												<span className="reader-post-card__byline-secondary-bullet">·</span>
+											</span>
 										) }
 									</>
 								) }

--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -1,4 +1,4 @@
-import { get } from 'lodash';
+import { get, debounce } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, createRef } from 'react';
 import ReaderAuthorLink from 'calypso/blocks/reader-author-link';
@@ -33,6 +33,7 @@ class PostByline extends Component {
 		super( props );
 		this.secondaryBylineRef = createRef();
 		this.organizeBullets = this.organizeBullets.bind( this );
+		this.debouncedOrganizeBullets = debounce( this.organizeBullets, 100 );
 	}
 
 	/**
@@ -77,11 +78,11 @@ class PostByline extends Component {
 
 	componentDidMount() {
 		this.organizeBullets();
-		window.addEventListener( 'resize', this.organizeBullets );
+		window.addEventListener( 'resize', this.debouncedOrganizeBullets );
 	}
 
 	componentWillUnmount() {
-		window.removeEventListener( 'resize', this.organizeBullets );
+		window.removeEventListener( 'resize', this.debouncedOrganizeBullets );
 	}
 
 	componentDidUpdate() {

--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -65,10 +65,9 @@ class PostByline extends Component {
 
 			// If the items arent at the same vertical position, hide the bullet.
 			if ( item.offsetTop !== lastItem.offsetTop ) {
-				// For now, hide it but keep spacing.
 				bullets[ index - 1 ].style.visibility = 'hidden';
 			} else {
-				// If the items were on the same line, reset the style overrides.
+				// Otherwise, reset the inline style.
 				bullets[ index - 1 ].removeAttribute( 'style' );
 			}
 			// Prepare for next iteration.

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -370,10 +370,22 @@
 	outline: dotted 1px;
 }
 
-.reader-post-card__byline-secondary-bullet {
-	color: var(--color-text-subtle);
-	display: inline-block;
-	margin: 0 4px;
+.reader-post-card__byline-secondary-item {
+	// Add extra margin to give space for the bullet that may exist between items.
+	margin-right: 12px;
+	&:last-of-type {
+		margin-right: 0;
+	}
+}
+
+.reader-post-card__byline-secondary-bullet-wrapper {
+	position: relative;
+	// Set bullet as relative absoulte position so it doesnt affect the layout when hiding it.
+	.reader-post-card__byline-secondary-bullet {
+		color: var(--color-text-subtle);
+		position: absolute;
+		left: -8px;
+	}
 }
 
 .reader-post-card__byline-details {

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -380,11 +380,13 @@
 
 .reader-post-card__byline-secondary-bullet-wrapper {
 	position: relative;
+	display: inline-block;
 	// Set bullet as relative absoulte position so it doesnt affect the layout when hiding it.
 	.reader-post-card__byline-secondary-bullet {
 		color: var(--color-text-subtle);
 		position: absolute;
 		left: -8px;
+		bottom: -5px;
 	}
 }
 


### PR DESCRIPTION
Related to # https://github.com/Automattic/wp-calypso/pull/82483 and pe7F0s-1kb-p2#comment-1560

previous attempt at https://github.com/Automattic/wp-calypso/pull/82523 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

The goal of this PR is to hide bullets between items on the reader postcard byline, when those items are no longer on the same line.
* Removes bullets from the layout by positioning them as relative-absolute within another span container element.
* Moves the margin and spacing that was supplied by the bullets to the byline items.
* Uses a ref to query the specified area, and sets bullet visibility to `hidden` when the items surrounding them are not on the same lines. This is evaluated on mount, update, and resize (debounced to 100ms).

Before:
![no-bullet-hiding](https://github.com/Automattic/wp-calypso/assets/28742426/eed59c29-8a33-44b2-97dd-aa0bfbef0ca3)

After:
![bullet-hiding](https://github.com/Automattic/wp-calypso/assets/28742426/e4af7caf-be51-4fe9-9867-2a00d54cc554)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso PR
* Navigate to the reader.
* Try loading and resizing at different browser widths to verify bullets disappear when the items between them are not on the same line.
* Verify there is no residual spacing or layout shift supplied by the bullets.
* Attempt this with both full size and compact cards.
* Repeat with various browsers.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
