### PR TITLE
Membership tiers [rebased]

### DIFF
--- a/client/blocks/reader-site-subscription/helpers.tsx
+++ b/client/blocks/reader-site-subscription/helpers.tsx
@@ -1,6 +1,10 @@
 import { Reader } from '@automattic/data-stores';
 import { getCurrencyObject } from '@automattic/format-currency';
 import moment from 'moment';
+import {
+	PLAN_YEARLY_FREQUENCY,
+	PLAN_MONTHLY_FREQUENCY,
+} from 'calypso/my-sites/earn/memberships/constants';
 
 export type SiteSubscriptionDetailsProps = {
 	subscriptionId: number;
@@ -24,9 +28,9 @@ export type PaymentPlan = {
 export const getPaymentInterval = ( renew_interval: string ) => {
 	if ( renew_interval === null ) {
 		return 'one time';
-	} else if ( renew_interval === '1 month' ) {
+	} else if ( renew_interval === PLAN_MONTHLY_FREQUENCY ) {
 		return 'per month';
-	} else if ( renew_interval === '1 year' ) {
+	} else if ( renew_interval === PLAN_YEARLY_FREQUENCY ) {
 		return 'per year';
 	}
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -264,6 +264,7 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goToStep, flow }: SidebarPr
 						<RecurringPaymentsPlanAddEditModal
 							closeDialog={ () => setShowPlansModal( false ) }
 							product={ { subscribe_as_site_subscriber: true, price: 5 } }
+							annualProduct={ { subscribe_as_site_subscriber: true, price: 5 * 12 } }
 							siteId={ site.ID }
 						/>
 					) }

--- a/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
+++ b/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
@@ -284,11 +284,6 @@ const RecurringPaymentsPlanAddEditModal = ( {
 			<FormSectionHeading>{ editing ? editPlan : addPlan }</FormSectionHeading>
 			<div className="memberships__dialog-sections">
 				<FormFieldset>
-					<ToggleControl
-						onChange={ ( newValue ) => setEditedPostPaidNewsletter( newValue ) }
-						checked={ editedPostPaidNewsletter }
-						label={ translate( 'Paid newsletter tier' ) }
-					/>
 					<FormLabel htmlFor="title">
 						{ editedPostPaidNewsletter
 							? translate( 'Describe the tier name' )
@@ -422,6 +417,13 @@ const RecurringPaymentsPlanAddEditModal = ( {
 						</div>
 					</FormFieldset>
 				) }
+				<FormFieldset className="memberships__dialog-sections-type">
+					<ToggleControl
+						onChange={ ( newValue ) => setEditedPostPaidNewsletter( newValue ) }
+						checked={ editedPostPaidNewsletter }
+						label={ translate( 'Paid newsletter tier' ) }
+					/>
+				</FormFieldset>
 				<FormFieldset className="memberships__dialog-sections-message">
 					<FormLabel htmlFor="renewal_schedule">{ translate( 'Welcome message' ) }</FormLabel>
 					<CountedTextArea

--- a/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
+++ b/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
@@ -260,7 +260,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 				is_editable: true,
 			};
 
-			if ( editedPostPaidNewsletter ) {
+			if ( ! editedPostPaidNewsletter ) {
 				dispatch(
 					requestUpdateProduct(
 						siteId ?? selectedSiteId,

--- a/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
+++ b/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
@@ -33,7 +33,7 @@ import './style.scss';
 type RecurringPaymentsPlanAddEditModalProps = {
 	closeDialog: () => void;
 	product: Product;
-	annualProduct?: Product;
+	annualProduct: Product | null;
 	siteId?: number;
 };
 

--- a/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
+++ b/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
@@ -1,6 +1,7 @@
 import { Dialog, FormInputValidation } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import { ToggleControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import { useTranslate } from 'i18n-calypso';
 import { ChangeEvent, useState, useEffect, useMemo } from 'react';
 import FoldableCard from 'calypso/components/foldable-card';
@@ -26,6 +27,7 @@ import {
 	getconnectedAccountMinimumCurrencyForSiteId,
 } from 'calypso/state/memberships/settings/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+// eslint-disable-next-line import/order
 import { Product } from '../../types';
 
 import './style.scss';
@@ -35,6 +37,20 @@ type RecurringPaymentsPlanAddEditModalProps = {
 	product: Product;
 	annualProduct: Product | null;
 	siteId?: number;
+};
+
+type ProductDetails = {
+	ID?: number;
+	currency: string;
+	price: number;
+	title: string;
+	interval: string;
+	buyer_can_change_amount: boolean;
+	multiple_per_user: boolean;
+	welcome_email_content: string;
+	subscribe_as_site_subscriber: boolean;
+	type?: string;
+	is_editable: boolean;
 };
 
 type StripeMinimumCurrencyAmounts = {
@@ -216,19 +232,31 @@ const RecurringPaymentsPlanAddEditModal = ( {
 		setEditedProductName( name );
 	}, [ editedSchedule, editedPostPaidNewsletter ] );
 
+	const getAnnualProductDetailsFromProduct = (
+		productDetails: ProductDetails
+	): ProductDetails => ( {
+		...productDetails,
+		price: currentAnnualPrice,
+		interval: annualFrequency,
+		ID: annualProduct?.ID,
+		title: productDetails.title + __( '(yearly)', 'jetpack' ),
+	} );
+
+	const getCurrentProductDetails = (): ProductDetails => ( {
+		currency: currentCurrency,
+		price: currentPrice,
+		title: editedProductName,
+		interval: editedSchedule,
+		buyer_can_change_amount: editedPayWhatYouWant,
+		multiple_per_user: editedMultiplePerUser,
+		welcome_email_content: editedCustomConfirmationMessage,
+		subscribe_as_site_subscriber: editedPostPaidNewsletter,
+		is_editable: true,
+	} );
+
 	const onClose = ( reason: string | undefined ) => {
 		if ( reason === 'submit' && ( ! product || ! product.ID ) ) {
-			const productDetails = {
-				currency: currentCurrency,
-				price: currentPrice,
-				title: editedProductName,
-				interval: editedSchedule,
-				buyer_can_change_amount: editedPayWhatYouWant,
-				multiple_per_user: editedMultiplePerUser,
-				welcome_email_content: editedCustomConfirmationMessage,
-				subscribe_as_site_subscriber: editedPostPaidNewsletter,
-				is_editable: true,
-			};
+			const productDetails: ProductDetails = getCurrentProductDetails();
 
 			if ( editedPostPaidNewsletter ) {
 				const annualProductDetails = {
@@ -257,18 +285,8 @@ const RecurringPaymentsPlanAddEditModal = ( {
 				recordTracksEvent( 'calypso_earn_page_payment_added', productDetails );
 			}
 		} else if ( reason === 'submit' && product && product.ID ) {
-			const productDetails = {
-				ID: product.ID,
-				currency: currentCurrency,
-				price: currentPrice,
-				title: editedProductName,
-				interval: editedSchedule,
-				buyer_can_change_amount: editedPayWhatYouWant,
-				multiple_per_user: editedMultiplePerUser,
-				welcome_email_content: editedCustomConfirmationMessage,
-				subscribe_as_site_subscriber: editedPostPaidNewsletter,
-				is_editable: true,
-			};
+			const productDetails = getCurrentProductDetails();
+			productDetails.ID = product.ID;
 
 			if ( ! editedPostPaidNewsletter ) {
 				dispatch(
@@ -279,12 +297,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 					)
 				);
 			} else {
-				const annualProductDetails = {
-					...productDetails,
-					price: currentAnnualPrice,
-					interval: annualFrequency,
-					ID: annualProduct?.ID,
-				};
+				const annualProductDetails = getAnnualProductDetailsFromProduct( productDetails );
 
 				dispatch(
 					requestUpdateTier(

--- a/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
+++ b/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
@@ -364,40 +364,6 @@ const RecurringPaymentsPlanAddEditModal = ( {
 						showDismiss={ false }
 					/>
 				) }
-				{ ! isFormValid( 'price' ) && (
-					<FormInputValidation
-						isError
-						text={ translate( 'Please enter a price higher than %s', {
-							args: [
-								formatCurrency(
-									minimumCurrencyTransactionAmount(
-										connectedAccountMinimumCurrency,
-										currentCurrency,
-										connectedAccountDefaultCurrency
-									),
-									currentCurrency
-								),
-							],
-						} ) }
-					/>
-				) }
-				{ editedPostPaidNewsletter && ! isFormValid( 'prices' ) && (
-					<FormInputValidation
-						isError
-						text={ translate( 'Please enter a annual price higher than the monthly price', {
-							args: [
-								formatCurrency(
-									minimumCurrencyTransactionAmount(
-										connectedAccountMinimumCurrency,
-										currentCurrency,
-										connectedAccountDefaultCurrency
-									),
-									currentCurrency
-								),
-							],
-						} ) }
-					/>
-				) }
 				{ /* Price settings for a tier plan */ }
 				{ editedPostPaidNewsletter && (
 					<>

--- a/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
+++ b/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
@@ -17,7 +17,9 @@ import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
 	requestAddProduct,
+	requestAddTier,
 	requestUpdateProduct,
+	requestUpdateTier,
 } from 'calypso/state/memberships/product-list/actions';
 import {
 	getconnectedAccountDefaultCurrencyForSiteId,
@@ -217,14 +219,29 @@ const RecurringPaymentsPlanAddEditModal = ( {
 				subscribe_as_site_subscriber: editedPostPaidNewsletter,
 				is_editable: true,
 			};
-			dispatch(
-				requestAddProduct(
-					siteId ?? selectedSiteId,
-					product_details,
-					translate( 'Added "%s" payment plan.', { args: editedProductName } )
-				)
-			);
-			recordTracksEvent( 'calypso_earn_page_payment_added', product_details );
+
+			if ( editedPostPaidNewsletter ) {
+				const annual_product_details = { ...product_details, price: currentAnnualPrice };
+				dispatch(
+					requestAddTier(
+						siteId ?? selectedSiteId,
+						product,
+						annualProduct,
+						translate( 'Added "%s" payment plan.', { args: editedProductName } )
+					)
+				);
+				recordTracksEvent( 'calypso_earn_page_payment_added', product_details );
+				recordTracksEvent( 'calypso_earn_page_payment_added', annual_product_details );
+			} else {
+				dispatch(
+					requestAddProduct(
+						siteId ?? selectedSiteId,
+						product_details,
+						translate( 'Added "%s" payment plan.', { args: editedProductName } )
+					)
+				);
+				recordTracksEvent( 'calypso_earn_page_payment_added', product_details );
+			}
 		} else if ( reason === 'submit' && product && product.ID ) {
 			const product_details = {
 				ID: product.ID,
@@ -238,13 +255,24 @@ const RecurringPaymentsPlanAddEditModal = ( {
 				subscribe_as_site_subscriber: editedPostPaidNewsletter,
 				is_editable: true,
 			};
-			dispatch(
-				requestUpdateProduct(
-					siteId ?? selectedSiteId,
-					product_details,
-					translate( 'Updated "%s" payment plan.', { args: editedProductName } )
-				)
-			);
+
+			if ( editedPostPaidNewsletter ) {
+				dispatch(
+					requestUpdateProduct(
+						siteId ?? selectedSiteId,
+						product_details,
+						translate( 'Updated "%s" payment plan.', { args: editedProductName } )
+					)
+				);
+			} else {
+				dispatch(
+					requestUpdateProduct(
+						siteId ?? selectedSiteId,
+						product_details,
+						translate( 'Updated "%s" payment plan.', { args: editedProductName } )
+					)
+				);
+			}
 		}
 		closeDialog();
 	};

--- a/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
+++ b/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
@@ -345,6 +345,19 @@ const RecurringPaymentsPlanAddEditModal = ( {
 						<FormInputValidation isError text={ translate( 'Please input a name.' ) } />
 					) }
 				</FormFieldset>
+				<FormFieldset className="memberships__dialog-sections-type">
+					<ToggleControl
+						onChange={ handleMarkAsDonation }
+						checked={ 'donation' === editedMarkAsDonation }
+						label={ translate( 'Mark this plan as a donation' ) }
+					/>
+					<ToggleControl
+						onChange={ ( newValue ) => setEditedPostPaidNewsletter( newValue ) }
+						checked={ editedPostPaidNewsletter }
+						disabled={ !! product.ID }
+						label={ translate( 'Paid newsletter tier' ) }
+					/>
+				</FormFieldset>
 				{ editing && editedPrice && (
 					<Notice
 						text={ translate(

--- a/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
+++ b/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
@@ -449,6 +449,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 					<ToggleControl
 						onChange={ ( newValue ) => setEditedPostPaidNewsletter( newValue ) }
 						checked={ editedPostPaidNewsletter }
+						disabled={ !! product.ID }
 						label={ translate( 'Paid newsletter tier' ) }
 					/>
 				</FormFieldset>

--- a/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
+++ b/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
@@ -70,6 +70,8 @@ const RecurringPaymentsPlanAddEditModal = ( {
 	annualProduct /* annual product for tiers */,
 	siteId,
 }: RecurringPaymentsPlanAddEditModalProps ) => {
+	const monthlyFrequency = '1 month';
+	const annualFrequency = '1 year';
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) );
@@ -229,7 +231,11 @@ const RecurringPaymentsPlanAddEditModal = ( {
 			};
 
 			if ( editedPostPaidNewsletter ) {
-				const annualProductDetails = { ...productDetails, price: currentAnnualPrice };
+				const annualProductDetails = {
+					...productDetails,
+					interval: annualFrequency,
+					price: currentAnnualPrice,
+				};
 				dispatch(
 					requestAddTier(
 						siteId ?? selectedSiteId,
@@ -276,6 +282,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 				const annualProductDetails = {
 					...productDetails,
 					price: currentAnnualPrice,
+					interval: annualFrequency,
 					ID: annualProduct?.ID,
 				};
 
@@ -291,9 +298,6 @@ const RecurringPaymentsPlanAddEditModal = ( {
 		}
 		closeDialog();
 	};
-
-	const monthlyFrequency = '1 month';
-	const annualFrequency = '1 year';
 
 	const addPlan = editedPostPaidNewsletter
 		? translate( 'Set up newsletter tier options' )

--- a/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
+++ b/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
@@ -241,7 +241,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 						siteId ?? selectedSiteId,
 						productDetails,
 						annualProductDetails,
-						translate( 'Added "%s" payment plan.', { args: editedProductName } )
+						translate( 'Added "%s" tier payment plan.', { args: editedProductName } )
 					)
 				);
 				recordTracksEvent( 'calypso_earn_page_payment_added', productDetails );
@@ -291,7 +291,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 						siteId ?? selectedSiteId,
 						productDetails,
 						annualProductDetails,
-						translate( 'Updated "%s" payment plan.', { args: editedProductName } )
+						translate( 'Updated "%s" tier payment plan.', { args: editedProductName } )
 					)
 				);
 			}

--- a/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
+++ b/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
@@ -27,7 +27,6 @@ import {
 	getconnectedAccountMinimumCurrencyForSiteId,
 } from 'calypso/state/memberships/settings/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-// eslint-disable-next-line import/order
 import { Product } from '../../types';
 
 import './style.scss';
@@ -37,20 +36,6 @@ type RecurringPaymentsPlanAddEditModalProps = {
 	product: Product;
 	annualProduct: Product | null;
 	siteId?: number;
-};
-
-type ProductDetails = {
-	ID?: number;
-	currency: string;
-	price: number;
-	title: string;
-	interval: string;
-	buyer_can_change_amount: boolean;
-	multiple_per_user: boolean;
-	welcome_email_content: string;
-	subscribe_as_site_subscriber: boolean;
-	type?: string;
-	is_editable: boolean;
 };
 
 type StripeMinimumCurrencyAmounts = {
@@ -232,9 +217,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 		setEditedProductName( name );
 	}, [ editedSchedule, editedPostPaidNewsletter ] );
 
-	const getAnnualProductDetailsFromProduct = (
-		productDetails: ProductDetails
-	): ProductDetails => ( {
+	const getAnnualProductDetailsFromProduct = ( productDetails: Product ): Product => ( {
 		...productDetails,
 		price: currentAnnualPrice,
 		interval: annualFrequency,
@@ -242,7 +225,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 		title: productDetails.title + __( '(yearly)', 'jetpack' ),
 	} );
 
-	const getCurrentProductDetails = (): ProductDetails => ( {
+	const getCurrentProductDetails = (): Product => ( {
 		currency: currentCurrency,
 		price: currentPrice,
 		title: editedProductName,
@@ -256,7 +239,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 
 	const onClose = ( reason: string | undefined ) => {
 		if ( reason === 'submit' && ( ! product || ! product.ID ) ) {
-			const productDetails: ProductDetails = getCurrentProductDetails();
+			const productDetails: Product = getCurrentProductDetails();
 
 			if ( editedPostPaidNewsletter ) {
 				const annualProductDetails = {

--- a/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
+++ b/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
@@ -14,6 +14,11 @@ import FormSelect from 'calypso/components/forms/form-select';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import Notice from 'calypso/components/notice';
+import {
+	PLAN_YEARLY_FREQUENCY,
+	PLAN_MONTHLY_FREQUENCY,
+	PLAN_ONE_TIME_FREQUENCY,
+} from 'calypso/my-sites/earn/memberships/constants';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
@@ -28,7 +33,6 @@ import {
 } from 'calypso/state/memberships/settings/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { Product } from '../../types';
-
 import './style.scss';
 
 type RecurringPaymentsPlanAddEditModalProps = {
@@ -71,8 +75,6 @@ const RecurringPaymentsPlanAddEditModal = ( {
 	annualProduct /* annual product for tiers */,
 	siteId,
 }: RecurringPaymentsPlanAddEditModalProps ) => {
-	const monthlyFrequency = '1 month';
-	const annualFrequency = '1 year';
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) );
@@ -130,7 +132,9 @@ const RecurringPaymentsPlanAddEditModal = ( {
 	const [ editedPostPaidNewsletter, setEditedPostPaidNewsletter ] = useState(
 		product?.subscribe_as_site_subscriber ?? false
 	);
-	const [ editedSchedule, setEditedSchedule ] = useState( product?.renewal_schedule ?? '1 month' );
+	const [ editedSchedule, setEditedSchedule ] = useState(
+		product?.renewal_schedule ?? PLAN_MONTHLY_FREQUENCY
+	);
 	const [ focusedName, setFocusedName ] = useState( false );
 
 	const [ editedPrice, setEditedPrice ] = useState( false );
@@ -197,11 +201,10 @@ const RecurringPaymentsPlanAddEditModal = ( {
 	// though there's no strong technical reason to do so - nothing is going to
 	// break if they fall out of sync.
 	// https://github.com/Automattic/jetpack/blob/trunk/projects/plugins/jetpack/extensions/shared/components/product-management-controls/utils.js#L95
-	const defaultNames: DefaultNames = {
-		'1 month': translate( 'Monthly Subscription' ),
-		'1 year': translate( 'Yearly Subscription' ),
-		'one-time': translate( 'Subscription' ),
-	};
+	const defaultNames: DefaultNames = {};
+	defaultNames[ PLAN_MONTHLY_FREQUENCY ] = translate( 'Monthly Subscription' );
+	defaultNames[ PLAN_YEARLY_FREQUENCY ] = translate( 'Yearly Subscription' );
+	defaultNames[ PLAN_ONE_TIME_FREQUENCY ] = translate( 'Subscription' );
 
 	const defaultNameTier = translate( 'Newsletter Tier' );
 
@@ -220,7 +223,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 	const getAnnualProductDetailsFromProduct = ( productDetails: Product ): Product => ( {
 		...productDetails,
 		price: currentAnnualPrice,
-		interval: annualFrequency,
+		interval: PLAN_YEARLY_FREQUENCY,
 		ID: annualProduct?.ID,
 		title: productDetails.title + __( '(yearly)', 'jetpack' ),
 	} );
@@ -244,7 +247,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 			if ( editedPostPaidNewsletter ) {
 				const annualProductDetails = {
 					...productDetails,
-					interval: annualFrequency,
+					interval: PLAN_YEARLY_FREQUENCY,
 					price: currentAnnualPrice,
 				};
 				dispatch(
@@ -445,9 +448,9 @@ const RecurringPaymentsPlanAddEditModal = ( {
 								value={ editedSchedule }
 								onChange={ onSelectSchedule }
 							>
-								<option value={ monthlyFrequency }>{ translate( 'Monthly' ) }</option>
-								<option value={ annualFrequency }>{ translate( 'Yearly' ) }</option>
-								<option value="one-time">{ translate( 'One time sale' ) }</option>
+								<option value={ PLAN_MONTHLY_FREQUENCY }>{ translate( 'Monthly' ) }</option>
+								<option value={ PLAN_YEARLY_FREQUENCY }>{ translate( 'Yearly' ) }</option>
+								<option value={ PLAN_ONE_TIME_FREQUENCY }>{ translate( 'One time sale' ) }</option>
 							</FormSelect>
 						</div>
 						<div className="memberships__dialog-sections-price-field-container">

--- a/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
+++ b/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
@@ -147,7 +147,10 @@ const RecurringPaymentsPlanAddEditModal = ( {
 		) {
 			return false;
 		}
-		if ( ( field === 'prices' || ! field ) && currentPrice >= currentAnnualPrice ) {
+		if (
+			( field === 'prices' || ( editedPostPaidNewsletter && ! field ) ) &&
+			currentPrice >= currentAnnualPrice
+		) {
 			return false;
 		}
 		if ( ( field === 'name' || ! field ) && editedProductName.length === 0 ) {

--- a/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
+++ b/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
@@ -403,10 +403,10 @@ const RecurringPaymentsPlanAddEditModal = ( {
 					<>
 						<FormFieldset className="memberships__dialog-sections-price">
 							<div className="memberships__dialog-sections-price-field-container">
-								<FormLabel htmlFor="currency">{ translate( 'Monthly Price' ) }</FormLabel>
+								<FormLabel htmlFor="currency_monthly">{ translate( 'Monthly Price' ) }</FormLabel>
 								<FormCurrencyInput
-									name="currency"
-									id="currency"
+									name="currency_monthly"
+									id="currency_monthly"
 									value={ currentPrice }
 									onChange={ handlePriceChange( false ) }
 									currencySymbolPrefix={ currentCurrency }
@@ -419,10 +419,10 @@ const RecurringPaymentsPlanAddEditModal = ( {
 								/>
 							</div>
 							<div className="memberships__dialog-sections-price-field-container">
-								<FormLabel htmlFor="currency">{ translate( 'Annual Price' ) }</FormLabel>
+								<FormLabel htmlFor="currency_annual">{ translate( 'Annual Price' ) }</FormLabel>
 								<FormCurrencyInput
-									name="currency"
-									id="currency"
+									name="currency_annual"
+									id="currency_annual"
 									value={ currentAnnualPrice }
 									onChange={ handlePriceChange( true ) }
 									currencySymbolPrefix={ currentCurrency }

--- a/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
+++ b/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
@@ -33,7 +33,7 @@ import './style.scss';
 type RecurringPaymentsPlanAddEditModalProps = {
 	closeDialog: () => void;
 	product: Product;
-	annual_product?: Product;
+	annualProduct?: Product;
 	siteId?: number;
 };
 
@@ -67,7 +67,7 @@ const MAX_LENGTH_CUSTOM_CONFIRMATION_EMAIL_MESSAGE = 2000;
 const RecurringPaymentsPlanAddEditModal = ( {
 	closeDialog,
 	product,
-	annual_product /* annual product for tiers */,
+	annualProduct /* annual product for tiers */,
 	siteId,
 }: RecurringPaymentsPlanAddEditModalProps ) => {
 	const translate = useTranslate();
@@ -115,7 +115,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 	);
 
 	const [ currentAnnualPrice, setCurrentAnnualPrice ] = useState(
-		annual_product?.price ??
+		annualProduct?.price ??
 			minimumCurrencyTransactionAmount(
 				connectedAccountMinimumCurrency,
 				currentCurrency,
@@ -212,7 +212,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 
 	const onClose = ( reason: string | undefined ) => {
 		if ( reason === 'submit' && ( ! product || ! product.ID ) ) {
-			const product_details = {
+			const productDetails = {
 				currency: currentCurrency,
 				price: currentPrice,
 				title: editedProductName,
@@ -225,29 +225,29 @@ const RecurringPaymentsPlanAddEditModal = ( {
 			};
 
 			if ( editedPostPaidNewsletter ) {
-				const annual_product_details = { ...product_details, price: currentAnnualPrice };
+				const annualProductDetails = { ...productDetails, price: currentAnnualPrice };
 				dispatch(
 					requestAddTier(
 						siteId ?? selectedSiteId,
-						product,
-						annual_product,
+						productDetails,
+						annualProductDetails,
 						translate( 'Added "%s" payment plan.', { args: editedProductName } )
 					)
 				);
-				recordTracksEvent( 'calypso_earn_page_payment_added', product_details );
-				recordTracksEvent( 'calypso_earn_page_payment_added', annual_product_details );
+				recordTracksEvent( 'calypso_earn_page_payment_added', productDetails );
+				recordTracksEvent( 'calypso_earn_page_payment_added', annualProductDetails );
 			} else {
 				dispatch(
 					requestAddProduct(
 						siteId ?? selectedSiteId,
-						product_details,
+						productDetails,
 						translate( 'Added "%s" payment plan.', { args: editedProductName } )
 					)
 				);
-				recordTracksEvent( 'calypso_earn_page_payment_added', product_details );
+				recordTracksEvent( 'calypso_earn_page_payment_added', productDetails );
 			}
 		} else if ( reason === 'submit' && product && product.ID ) {
-			const product_details = {
+			const productDetails = {
 				ID: product.ID,
 				currency: currentCurrency,
 				price: currentPrice,
@@ -264,22 +264,22 @@ const RecurringPaymentsPlanAddEditModal = ( {
 				dispatch(
 					requestUpdateProduct(
 						siteId ?? selectedSiteId,
-						product_details,
+						productDetails,
 						translate( 'Updated "%s" payment plan.', { args: editedProductName } )
 					)
 				);
 			} else {
-				const annual_product_details = {
-					...product_details,
+				const annualProductDetails = {
+					...productDetails,
 					price: currentAnnualPrice,
-					ID: annual_product?.ID,
+					ID: annualProduct?.ID,
 				};
 
 				dispatch(
 					requestUpdateTier(
 						siteId ?? selectedSiteId,
-						product_details,
-						annual_product_details,
+						productDetails,
+						annualProductDetails,
 						translate( 'Updated "%s" payment plan.', { args: editedProductName } )
 					)
 				);

--- a/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
+++ b/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
@@ -116,10 +116,11 @@ const RecurringPaymentsPlanAddEditModal = ( {
 
 	const [ currentAnnualPrice, setCurrentAnnualPrice ] = useState(
 		annualProduct?.price ??
-			minimumCurrencyTransactionAmount(
-				connectedAccountMinimumCurrency,
-				currentCurrency,
-				connectedAccountDefaultCurrency
+			12 *
+				minimumCurrencyTransactionAmount(
+					connectedAccountMinimumCurrency,
+					currentCurrency,
+					connectedAccountDefaultCurrency
 			)
 	);
 	const [ editedProductName, setEditedProductName ] = useState( product?.title ?? '' );

--- a/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
+++ b/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
@@ -121,7 +121,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 					connectedAccountMinimumCurrency,
 					currentCurrency,
 					connectedAccountDefaultCurrency
-			)
+				)
 	);
 	const [ editedProductName, setEditedProductName ] = useState( product?.title ?? '' );
 	const [ editedPostPaidNewsletter, setEditedPostPaidNewsletter ] = useState(
@@ -347,11 +347,6 @@ const RecurringPaymentsPlanAddEditModal = ( {
 				</FormFieldset>
 				<FormFieldset className="memberships__dialog-sections-type">
 					<ToggleControl
-						onChange={ handleMarkAsDonation }
-						checked={ 'donation' === editedMarkAsDonation }
-						label={ translate( 'Mark this plan as a donation' ) }
-					/>
-					<ToggleControl
 						onChange={ ( newValue ) => setEditedPostPaidNewsletter( newValue ) }
 						checked={ editedPostPaidNewsletter }
 						disabled={ !! product.ID }
@@ -473,14 +468,43 @@ const RecurringPaymentsPlanAddEditModal = ( {
 						</div>
 					</FormFieldset>
 				) }
-				<FormFieldset className="memberships__dialog-sections-type">
-					<ToggleControl
-						onChange={ ( newValue ) => setEditedPostPaidNewsletter( newValue ) }
-						checked={ editedPostPaidNewsletter }
-						disabled={ !! product.ID }
-						label={ translate( 'Paid newsletter tier' ) }
+
+				{ /* Error fields */ }
+				{ ! isFormValid( 'price' ) && (
+					<FormInputValidation
+						isError
+						text={ translate( 'Please enter a price higher than %s', {
+							args: [
+								formatCurrency(
+									minimumCurrencyTransactionAmount(
+										connectedAccountMinimumCurrency,
+										currentCurrency,
+										connectedAccountDefaultCurrency
+									),
+									currentCurrency
+								),
+							],
+						} ) }
 					/>
-				</FormFieldset>
+				) }
+				{ editedPostPaidNewsletter && ! isFormValid( 'prices' ) && (
+					<FormInputValidation
+						isError
+						text={ translate( 'Please enter a annual price higher than the monthly price', {
+							args: [
+								formatCurrency(
+									minimumCurrencyTransactionAmount(
+										connectedAccountMinimumCurrency,
+										currentCurrency,
+										connectedAccountDefaultCurrency
+									),
+									currentCurrency
+								),
+							],
+						} ) }
+					/>
+				) }
+
 				<FormFieldset className="memberships__dialog-sections-message">
 					<FormLabel htmlFor="renewal_schedule">{ translate( 'Welcome message' ) }</FormLabel>
 					<CountedTextArea

--- a/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
+++ b/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
@@ -427,7 +427,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 									onChange={ handlePriceChange( true ) }
 									currencySymbolPrefix={ currentCurrency }
 									onCurrencyChange={ handleCurrencyChange }
-									currencyList={ currencyList }
+									currencyList={ currencyList.map( ( code ) => ( { code } ) ) }
 									placeholder="0.00"
 									noWrap
 									className={ null }

--- a/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
+++ b/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
@@ -33,7 +33,7 @@ import './style.scss';
 type RecurringPaymentsPlanAddEditModalProps = {
 	closeDialog: () => void;
 	product: Product;
-	annualProduct?: Product;
+	annual_product?: Product;
 	siteId?: number;
 };
 
@@ -67,7 +67,7 @@ const MAX_LENGTH_CUSTOM_CONFIRMATION_EMAIL_MESSAGE = 2000;
 const RecurringPaymentsPlanAddEditModal = ( {
 	closeDialog,
 	product,
-	annualProduct /* annual product for tiers */,
+	annual_product /* annual product for tiers */,
 	siteId,
 }: RecurringPaymentsPlanAddEditModalProps ) => {
 	const translate = useTranslate();
@@ -115,8 +115,12 @@ const RecurringPaymentsPlanAddEditModal = ( {
 	);
 
 	const [ currentAnnualPrice, setCurrentAnnualPrice ] = useState(
-		annualProduct?.price ??
-			minimumCurrencyTransactionAmount( connectedAccountMinimumCurrency, currentCurrency, connectedAccountDefaultCurrency )
+		annual_product?.price ??
+			minimumCurrencyTransactionAmount(
+				connectedAccountMinimumCurrency,
+				currentCurrency,
+				connectedAccountDefaultCurrency
+			)
 	);
 	const [ editedProductName, setEditedProductName ] = useState( product?.title ?? '' );
 	const [ editedPostPaidNewsletter, setEditedPostPaidNewsletter ] = useState(
@@ -226,7 +230,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 					requestAddTier(
 						siteId ?? selectedSiteId,
 						product,
-						annualProduct,
+						annual_product,
 						translate( 'Added "%s" payment plan.', { args: editedProductName } )
 					)
 				);
@@ -265,10 +269,17 @@ const RecurringPaymentsPlanAddEditModal = ( {
 					)
 				);
 			} else {
+				const annual_product_details = {
+					...product_details,
+					price: currentAnnualPrice,
+					ID: annual_product?.ID,
+				};
+
 				dispatch(
-					requestUpdateProduct(
+					requestUpdateTier(
 						siteId ?? selectedSiteId,
 						product_details,
+						annual_product_details,
 						translate( 'Updated "%s" payment plan.', { args: editedProductName } )
 					)
 				);

--- a/client/my-sites/earn/customers/index.tsx
+++ b/client/my-sites/earn/customers/index.tsx
@@ -27,6 +27,11 @@ import {
 	getOwnershipsForSiteId,
 } from 'calypso/state/memberships/subscribers/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+import {
+	PLAN_YEARLY_FREQUENCY,
+	PLAN_MONTHLY_FREQUENCY,
+	PLAN_ONE_TIME_FREQUENCY,
+} from '../memberships/constants';
 
 type Subscriber = {
 	id: string;
@@ -234,7 +239,7 @@ function CustomerSection() {
 
 	function renderSubscriberSubscriptionSummary( subscriber: Subscriber ) {
 		const title = subscriber.plan.title ? ` (${ subscriber.plan.title }) ` : ' ';
-		if ( subscriber.plan.renew_interval === 'one-time' ) {
+		if ( subscriber.plan.renew_interval === PLAN_ONE_TIME_FREQUENCY ) {
 			/* translators: Information about a one-time payment made by a subscriber to a site owner.
 				%(amount)s - the amount paid,
 				%(formattedDate) - the date it was paid
@@ -246,7 +251,7 @@ function CustomerSection() {
 					title,
 				},
 			} );
-		} else if ( subscriber.plan.renew_interval === '1 year' ) {
+		} else if ( subscriber.plan.renew_interval === PLAN_YEARLY_FREQUENCY ) {
 			/* translators: Information about a recurring yearly payment made by a subscriber to a site owner.
 				%(amount)s - the amount paid,
 				%(formattedDate)s - the date it was first paid
@@ -263,7 +268,7 @@ function CustomerSection() {
 					},
 				}
 			);
-		} else if ( subscriber.plan.renew_interval === '1 month' ) {
+		} else if ( subscriber.plan.renew_interval === PLAN_MONTHLY_FREQUENCY ) {
 			/* translators: Information about a recurring monthly payment made by a subscriber to a site owner.
 				%(amount)s - the amount paid,
 				%(formattedDate)s - the date it was first paid

--- a/client/my-sites/earn/main.tsx
+++ b/client/my-sites/earn/main.tsx
@@ -18,8 +18,8 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
 import AdsWrapper from './ads/wrapper';
 import CustomerSection from './customers';
 import Home from './home';
-import MembershipsSection from './memberships';
 import MembershipsProductsSection from './memberships/products';
+import MembershipsSection from './memberships/section';
 import ReferAFriendSection from './refer-a-friend';
 import { Query } from './types';
 

--- a/client/my-sites/earn/memberships/constants.ts
+++ b/client/my-sites/earn/memberships/constants.ts
@@ -1,3 +1,4 @@
 export const ADD_NEW_PAYMENT_PLAN_HASH = '#add-new-payment-plan';
 export const ADD_NEWSLETTER_PAYMENT_PLAN_HASH = '#add-newsletter-payment-plan';
 export const LAUNCHPAD_HASH = '#launchpad';
+ 

--- a/client/my-sites/earn/memberships/constants.ts
+++ b/client/my-sites/earn/memberships/constants.ts
@@ -2,3 +2,8 @@ export const ADD_NEW_PAYMENT_PLAN_HASH = '#add-new-payment-plan';
 export const ADD_NEWSLETTER_PAYMENT_PLAN_HASH = '#add-newsletter-payment-plan';
 export const LAUNCHPAD_HASH = '#launchpad';
 
+export const PLAN_MONTHLY_FREQUENCY = '1 month';
+
+export const PLAN_YEARLY_FREQUENCY = '1 year';
+
+export const PLAN_ONE_TIME_FREQUENCY = 'one-time';

--- a/client/my-sites/earn/memberships/constants.ts
+++ b/client/my-sites/earn/memberships/constants.ts
@@ -1,4 +1,4 @@
 export const ADD_NEW_PAYMENT_PLAN_HASH = '#add-new-payment-plan';
 export const ADD_NEWSLETTER_PAYMENT_PLAN_HASH = '#add-newsletter-payment-plan';
 export const LAUNCHPAD_HASH = '#launchpad';
- 
+

--- a/client/my-sites/earn/memberships/delete-plan-modal.tsx
+++ b/client/my-sites/earn/memberships/delete-plan-modal.tsx
@@ -9,11 +9,13 @@ import { Product } from '../types';
 type RecurringPaymentsPlanDeleteModalProps = {
 	closeDialog: () => void;
 	product: Product;
+	annualProduct?: Product;
 };
 
 const RecurringPaymentsPlanDeleteModal = ( {
 	closeDialog,
 	product,
+	annualProduct,
 }: RecurringPaymentsPlanDeleteModalProps ) => {
 	const translate = useTranslate();
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
@@ -25,6 +27,7 @@ const RecurringPaymentsPlanDeleteModal = ( {
 				requestDeleteProduct(
 					siteId,
 					product,
+					annualProduct,
 					translate( '"%s" was deleted.', { args: product.title } )
 				)
 			);

--- a/client/my-sites/earn/memberships/delete-plan-modal.tsx
+++ b/client/my-sites/earn/memberships/delete-plan-modal.tsx
@@ -9,7 +9,7 @@ import { Product } from '../types';
 type RecurringPaymentsPlanDeleteModalProps = {
 	closeDialog: () => void;
 	product: Product;
-	annualProduct?: Product;
+	annualProduct: Product | null;
 };
 
 const RecurringPaymentsPlanDeleteModal = ( {

--- a/client/my-sites/earn/memberships/index.tsx
+++ b/client/my-sites/earn/memberships/index.tsx
@@ -23,8 +23,10 @@ import {
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import CommissionFees from '../components/commission-fees';
 import { Query } from '../types';
-import { ADD_NEWSLETTER_PAYMENT_PLAN_HASH, LAUNCHPAD_HASH } from './constants';
-
+import {
+	ADD_NEWSLETTER_PAYMENT_PLAN_HASH,
+	LAUNCHPAD_HASH,
+} from './constants';
 import './style.scss';
 
 type MembershipsSectionProps = {
@@ -42,6 +44,9 @@ function MembershipsSection( { query }: MembershipsSectionProps ) {
 	const connectedAccountId = useSelector( ( state ) =>
 		getConnectedAccountIdForSiteId( state, site?.ID )
 	);
+
+	const products = useSelector( ( state ) => getProductsForSiteId( state, site?.ID ) );
+
 	const connectedAccountDescription = useSelector( ( state ) =>
 		getConnectedAccountDescriptionForSiteId( state, site?.ID )
 	);
@@ -173,17 +178,24 @@ function MembershipsSection( { query }: MembershipsSectionProps ) {
 		const stripe_connect_success = query?.stripe_connect_success;
 
 		if ( stripe_connect_success === 'earn' ) {
+			const siteHasPlans = products.length !== 0;
+
+			let congratsText = '';
+			if ( ! siteHasPlans ) {
+				congratsText = translate(
+					'Congrats! Your site is now connected to Stripe. You can now add your first payment plan.'
+				);
+			} else {
+				congratsText = translate( 'Congrats! Your site is now connected to Stripe.' );
+			}
+
 			return (
-				<Notice
-					status="is-success"
-					showDismiss={ false }
-					text={ translate(
-						'Congrats! Your site is now connected to Stripe. You can now add your first payment plan.'
+				<Notice status="is-success" showDismiss={ false } text={ congratsText }>
+					{ ! siteHasPlans && (
+						<NoticeAction href={ `/earn/payments-plans/${ site?.slug }` } icon="create">
+							{ translate( 'Add a payment plan' ) }
+						</NoticeAction>
 					) }
-				>
-					<NoticeAction href={ `/earn/payments-plans/${ site?.slug }` } icon="create">
-						{ translate( 'Add a payment plan' ) }
-					</NoticeAction>
 				</Notice>
 			);
 		}

--- a/client/my-sites/earn/memberships/products.tsx
+++ b/client/my-sites/earn/memberships/products.tsx
@@ -157,23 +157,32 @@ function MembershipsProductsSection( { query }: MembersProductsSectionProps ) {
 						const currentAnnualProduct = products.find(
 							( _prod ) => _prod.tier === currentProduct.ID
 						);
+						const price = formatCurrency(
+							currentProduct?.price || 0,
+							currentProduct?.currency || ''
+						);
+						let annualPrice = '';
+						if ( currentAnnualProduct ) {
+							annualPrice = formatCurrency(
+								currentAnnualProduct?.price || 0,
+								currentAnnualProduct?.currency || ''
+							);
+						}
 						return (
 							<CompactCard
 								className="memberships__products-product-card"
 								key={ currentProduct?.ID }
 							>
 								<div className="memberships__products-product-details">
-									<div className="memberships__products-product-price">
-										{ formatCurrency( currentProduct?.price || 0, currentProduct?.currency || '' ) }
-										{ currentAnnualProduct &&
-											formatCurrency(
-												currentAnnualProduct?.price || 0,
-												currentAnnualProduct?.currency || ''
-											) }
-									</div>
 									<div className="memberships__products-product-title">
 										{ currentProduct?.title }
 									</div>
+									<sub className="memberships__products-product-price">
+										{ currentProduct.subscribe_as_site_subscriber
+											? translate( '%s/month', { args: price } )
+											: price }
+										{ currentAnnualProduct && translate( ' (%s/year)', { args: annualPrice } ) }
+									</sub>
 									{ currentProduct?.subscribe_as_site_subscriber && (
 										<div className="memberships__products-product-badge">
 											<Badge type="info">{ translate( 'Newsletter tier' ) }</Badge>

--- a/client/my-sites/earn/memberships/products.tsx
+++ b/client/my-sites/earn/memberships/products.tsx
@@ -61,20 +61,6 @@ function MembershipsProductsSection( { query }: MembersProductsSectionProps ) {
 		siteHasFeature( state, site?.ID ?? null, FEATURE_RECURRING_PAYMENTS )
 	);
 
-	useEffect( () => {
-		// Everytime we change the product, we set the according annualProduct
-		if ( products == null || product == null || ! product.ID ) {
-			setAnnualProduct( null );
-			return;
-		}
-
-		// We check for the right tier
-		const currentAnnualProduct = products.find(
-			( currentProduct ) => currentProduct.tier === product.ID
-		);
-		setAnnualProduct( currentAnnualProduct ?? null );
-	}, [ product, products ] );
-
 	const hasStripeFeature =
 		hasDonationsFeature || hasPremiumContentFeature || hasRecurringPaymentsFeature;
 
@@ -104,20 +90,25 @@ function MembershipsProductsSection( { query }: MembersProductsSectionProps ) {
 
 	function openAddEditDialog( productId: string | null ) {
 		if ( productId ) {
-			const currentProduct = products.find( ( currentProduct ) => currentProduct.ID === productId );
+			const currentProduct = products.find( ( prod ) => prod.ID === productId );
+			const currentAnnualProduct = products.find( ( prod ) => prod.tier === productId );
 			setShowAddEditDialog( true );
 			setProduct( currentProduct ?? null );
+			setAnnualProduct( currentAnnualProduct ?? null );
 		} else {
 			setShowAddEditDialog( true );
 			setProduct( null );
+			setAnnualProduct( null );
 		}
 	}
 
 	function openDeleteDialog( productId: string | null ) {
 		if ( productId ) {
-			const currentProduct = products.find( ( currentProduct ) => currentProduct.ID === productId );
+			const currentProduct = products.find( ( prod ) => prod.ID === productId );
+			const currentAnnualProduct = products.find( ( prod ) => prod.tier === productId );
 			setShowDeleteDialog( true );
 			setProduct( currentProduct ?? null );
+			setAnnualProduct( currentAnnualProduct ?? null );
 		}
 	}
 
@@ -161,31 +152,47 @@ function MembershipsProductsSection( { query }: MembersProductsSectionProps ) {
 			) }
 			{ hasLoadedFeatures &&
 				products
-					.filter(
-						( currentProduct ) =>
-							currentProduct.type == null || ! currentProduct.type.startsWith( 'tier' )
-					) // We remove the "tiers" (the annual products with "tier" type)
-					.map( ( currentProduct ) => (
-						<CompactCard className="memberships__products-product-card" key={ currentProduct?.ID }>
-							<div className="memberships__products-product-details">
-								<div className="memberships__products-product-price">
-									{ formatCurrency( currentProduct?.price || 0, currentProduct?.currency || '' ) }
+					.filter( ( currentProduct ) => currentProduct.tier === null ) // We remove the "tiers" (the annual products with "tier" type)
+					.map( ( currentProduct ) => {
+						const currentAnnualProduct = products.find(
+							( _prod ) => _prod.tier === currentProduct.ID
+						);
+						console.info( '______' );
+						console.info( currentProduct );
+						console.info( currentAnnualProduct );
+						console.info( '______' );
+						return (
+							<CompactCard
+								className="memberships__products-product-card"
+								key={ currentProduct?.ID }
+							>
+								<div className="memberships__products-product-details">
+									<div className="memberships__products-product-price">
+										{ formatCurrency( currentProduct?.price || 0, currentProduct?.currency || '' ) }
+										{ currentAnnualProduct &&
+											formatCurrency(
+												currentAnnualProduct?.price || 0,
+												currentAnnualProduct?.currency || ''
+											) }
+									</div>
+									<div className="memberships__products-product-title">
+										{ currentProduct?.title }
+									</div>
+									{ currentProduct?.subscribe_as_site_subscriber && (
+										<div className="memberships__products-product-badge">
+											<Badge type="info">{ translate( 'Newsletter tier' ) }</Badge>
+										</div>
+									) }
+									{ currentProduct?.type === 'donation' && (
+										<div className="memberships__products-product-badge">
+											<Badge type="info">{ translate( 'Donation' ) }</Badge>
+										</div>
+									) }
 								</div>
-								<div className="memberships__products-product-title">{ currentProduct?.title }</div>
-								{ currentProduct?.subscribe_as_site_subscriber && (
-									<div className="memberships__products-product-badge">
-										<Badge type="info">{ translate( 'Newsletter tier' ) }</Badge>
-									</div>
-								) }
-								{ currentProduct?.type === 'donation' && (
-									<div className="memberships__products-product-badge">
-										<Badge type="info">{ translate( 'Donation' ) }</Badge>
-									</div>
-								) }
-							</div>
-							{ renderEllipsisMenu( currentProduct?.ID ?? null ) }
-						</CompactCard>
-					) ) }
+								{ renderEllipsisMenu( currentProduct?.ID ?? null ) }
+							</CompactCard>
+						);
+					} ) }
 			{ hasLoadedFeatures && showAddEditDialog && hasStripeFeature && connectedAccountId && (
 				<RecurringPaymentsPlanAddEditModal
 					closeDialog={ closeDialog }
@@ -199,7 +206,8 @@ function MembershipsProductsSection( { query }: MembersProductsSectionProps ) {
 				<RecurringPaymentsPlanDeleteModal
 					closeDialog={ closeDialog }
 					product={ product }
-					annual_product={ annualProduct } />
+					annual_product={ annualProduct }
+				/>
 			) }
 			{ ! hasLoadedFeatures && (
 				<div className="memberships__loading">

--- a/client/my-sites/earn/memberships/products.tsx
+++ b/client/my-sites/earn/memberships/products.tsx
@@ -6,7 +6,7 @@ import {
 import { Badge, Button, CompactCard, Gridicon } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import QueryMembershipProducts from 'calypso/components/data/query-memberships';
 import QueryMembershipsSettings from 'calypso/components/data/query-memberships-settings';
@@ -43,6 +43,7 @@ function MembershipsProductsSection( { query }: MembersProductsSectionProps ) {
 	const [ showAddEditDialog, setShowAddEditDialog ] = useState( showAddEditDialogInitially );
 	const [ showDeleteDialog, setShowDeleteDialog ] = useState( false );
 	const [ product, setProduct ] = useState< Product | null >( null );
+	const [ annualProduct, setAnnualProduct ] = useState< Product | null >( null );
 	const site = useSelector( ( state ) => getSelectedSite( state ) );
 	const features = useSelector( ( state ) => getFeaturesBySiteId( state, site?.ID ) );
 	const hasLoadedFeatures = features?.active.length > 0;
@@ -59,6 +60,21 @@ function MembershipsProductsSection( { query }: MembersProductsSectionProps ) {
 	const hasRecurringPaymentsFeature = useSelector( ( state ) =>
 		siteHasFeature( state, site?.ID ?? null, FEATURE_RECURRING_PAYMENTS )
 	);
+
+	useEffect( () => {
+		// Everytime we change the product, we set the according annualProduct
+		if ( products == null || product == null || ! product.ID ) {
+			setAnnualProduct( null );
+			return;
+		}
+
+		// We check for the right tier
+		const currentAnnualProduct = products.find(
+			( currentProduct ) => currentProduct.type === 'tier-' + product.ID
+		);
+		setAnnualProduct( currentAnnualProduct ?? null );
+	}, [ product, products ] );
+
 	const hasStripeFeature =
 		hasDonationsFeature || hasPremiumContentFeature || hasRecurringPaymentsFeature;
 
@@ -144,38 +160,46 @@ function MembershipsProductsSection( { query }: MembersProductsSectionProps ) {
 				</SectionHeader>
 			) }
 			{ hasLoadedFeatures &&
-				products.map( ( currentProduct ) => (
-					<CompactCard className="memberships__products-product-card" key={ currentProduct?.ID }>
-						<div className="memberships__products-product-details">
-							<div className="memberships__products-product-price">
-								{ formatCurrency( currentProduct?.price || 0, currentProduct?.currency || '' ) }
+				products
+					.filter(
+						( currentProduct ) =>
+							currentProduct.type == null || ! currentProduct.type.startsWith( 'tier' )
+					) // We remove the "tiers" (the annual products with "tier" type)
+					.map( ( currentProduct ) => (
+						<CompactCard className="memberships__products-product-card" key={ currentProduct?.ID }>
+							<div className="memberships__products-product-details">
+								<div className="memberships__products-product-price">
+									{ formatCurrency( currentProduct?.price || 0, currentProduct?.currency || '' ) }
+								</div>
+								<div className="memberships__products-product-title">{ currentProduct?.title }</div>
+								{ currentProduct?.subscribe_as_site_subscriber && (
+									<div className="memberships__products-product-badge">
+										<Badge type="info">{ translate( 'Newsletter tier' ) }</Badge>
+									</div>
+								) }
+								{ currentProduct?.type === 'donation' && (
+									<div className="memberships__products-product-badge">
+										<Badge type="info">{ translate( 'Donation' ) }</Badge>
+									</div>
+								) }
 							</div>
-							<div className="memberships__products-product-title">{ currentProduct?.title }</div>
-							{ currentProduct?.subscribe_as_site_subscriber && (
-								<div className="memberships__products-product-badge">
-									<Badge type="info">{ translate( 'Newsletter' ) }</Badge>
-								</div>
-							) }
-							{ currentProduct?.type === 'donation' && (
-								<div className="memberships__products-product-badge">
-									<Badge type="info">{ translate( 'Donation' ) }</Badge>
-								</div>
-							) }
-						</div>
-
-						{ renderEllipsisMenu( currentProduct?.ID ?? null ) }
-					</CompactCard>
-				) ) }
+							{ renderEllipsisMenu( currentProduct?.ID ?? null ) }
+						</CompactCard>
+					) ) }
 			{ hasLoadedFeatures && showAddEditDialog && hasStripeFeature && connectedAccountId && (
 				<RecurringPaymentsPlanAddEditModal
 					closeDialog={ closeDialog }
 					product={ Object.assign( product ?? {}, {
 						subscribe_as_site_subscriber: subscribe_as_site_subscriber,
 					} ) }
+					annual_product={ annualProduct }
 				/>
 			) }
 			{ hasLoadedFeatures && showDeleteDialog && product && (
-				<RecurringPaymentsPlanDeleteModal closeDialog={ closeDialog } product={ product } />
+				<RecurringPaymentsPlanDeleteModal
+					closeDialog={ closeDialog }
+					product={ product }
+					annual_product={ annualProduct } />
 			) }
 			{ ! hasLoadedFeatures && (
 				<div className="memberships__loading">

--- a/client/my-sites/earn/memberships/products.tsx
+++ b/client/my-sites/earn/memberships/products.tsx
@@ -71,7 +71,7 @@ function MembershipsProductsSection( { query }: MembersProductsSectionProps ) {
 	const trackUpgrade = () =>
 		dispatch( bumpStat( 'calypso_earn_page', 'payment-plans-upgrade-button' ) );
 
-	function renderEllipsisMenu( productId: string | null ) {
+	function renderEllipsisMenu( productId: number ) {
 		return (
 			<EllipsisMenu position="bottom left">
 				{ hasStripeFeature && (
@@ -88,7 +88,7 @@ function MembershipsProductsSection( { query }: MembersProductsSectionProps ) {
 		);
 	}
 
-	function openAddEditDialog( productId: string | null ) {
+	function openAddEditDialog( productId?: number ) {
 		if ( productId ) {
 			const currentProduct = products.find( ( prod ) => prod.ID === productId );
 			const currentAnnualProduct = products.find( ( prod ) => prod.tier === productId );
@@ -102,7 +102,7 @@ function MembershipsProductsSection( { query }: MembersProductsSectionProps ) {
 		}
 	}
 
-	function openDeleteDialog( productId: string | null ) {
+	function openDeleteDialog( productId: number ) {
 		if ( productId ) {
 			const currentProduct = products.find( ( prod ) => prod.ID === productId );
 			const currentAnnualProduct = products.find( ( prod ) => prod.tier === productId );
@@ -145,7 +145,7 @@ function MembershipsProductsSection( { query }: MembersProductsSectionProps ) {
 			{ hasLoadedFeatures && ! connectedAccountId && <MembershipsSection query={ query } /> }
 			{ hasLoadedFeatures && hasStripeFeature && connectedAccountId && (
 				<SectionHeader>
-					<Button primary compact onClick={ () => openAddEditDialog( null ) }>
+					<Button primary compact onClick={ () => openAddEditDialog() }>
 						{ translate( 'Add a new payment plan' ) }
 					</Button>
 				</SectionHeader>
@@ -185,7 +185,7 @@ function MembershipsProductsSection( { query }: MembersProductsSectionProps ) {
 										</div>
 									) }
 								</div>
-								{ renderEllipsisMenu( currentProduct?.ID ?? null ) }
+								{ currentProduct && currentProduct.ID && renderEllipsisMenu( currentProduct.ID ) }
 							</CompactCard>
 						);
 					} ) }

--- a/client/my-sites/earn/memberships/products.tsx
+++ b/client/my-sites/earn/memberships/products.tsx
@@ -70,7 +70,7 @@ function MembershipsProductsSection( { query }: MembersProductsSectionProps ) {
 
 		// We check for the right tier
 		const currentAnnualProduct = products.find(
-			( currentProduct ) => currentProduct.type === 'tier-' + product.ID
+			( currentProduct ) => currentProduct.tier === product.ID
 		);
 		setAnnualProduct( currentAnnualProduct ?? null );
 	}, [ product, products ] );

--- a/client/my-sites/earn/memberships/products.tsx
+++ b/client/my-sites/earn/memberships/products.tsx
@@ -90,8 +90,8 @@ function MembershipsProductsSection( { query }: MembersProductsSectionProps ) {
 
 	function openAddEditDialog( productId?: number ) {
 		if ( productId ) {
-			const currentProduct = products.find( ( prod ) => prod.ID === productId );
-			const currentAnnualProduct = products.find( ( prod ) => prod.tier === productId );
+			const currentProduct = products.find( ( prod: Product ) => prod.ID === productId );
+			const currentAnnualProduct = products.find( ( prod: Product ) => prod.tier === productId );
 			setShowAddEditDialog( true );
 			setProduct( currentProduct ?? null );
 			setAnnualProduct( currentAnnualProduct ?? null );
@@ -104,8 +104,8 @@ function MembershipsProductsSection( { query }: MembersProductsSectionProps ) {
 
 	function openDeleteDialog( productId: number ) {
 		if ( productId ) {
-			const currentProduct = products.find( ( prod ) => prod.ID === productId );
-			const currentAnnualProduct = products.find( ( prod ) => prod.tier === productId );
+			const currentProduct = products.find( ( prod: Product ) => prod.ID === productId );
+			const currentAnnualProduct = products.find( ( prod: Product ) => prod.tier === productId );
 			setShowDeleteDialog( true );
 			setProduct( currentProduct ?? null );
 			setAnnualProduct( currentAnnualProduct ?? null );
@@ -152,10 +152,10 @@ function MembershipsProductsSection( { query }: MembersProductsSectionProps ) {
 			) }
 			{ hasLoadedFeatures &&
 				products
-					.filter( ( currentProduct ) => ! currentProduct.tier ) // We remove the "tiers" (the annual products with "tier" type)
-					.map( ( currentProduct ) => {
+					.filter( ( currentProduct: Product ) => ! currentProduct.tier ) // We remove the "tiers" (the annual products with "tier" type)
+					.map( function ( currentProduct: Product ) {
 						const currentAnnualProduct = products.find(
-							( _prod ) => _prod.tier === currentProduct.ID
+							( _prod: Product ) => _prod.tier === currentProduct.ID
 						);
 						const price = formatCurrency(
 							currentProduct?.price || 0,

--- a/client/my-sites/earn/memberships/products.tsx
+++ b/client/my-sites/earn/memberships/products.tsx
@@ -152,7 +152,7 @@ function MembershipsProductsSection( { query }: MembersProductsSectionProps ) {
 			) }
 			{ hasLoadedFeatures &&
 				products
-					.filter( ( currentProduct ) => currentProduct.tier === null ) // We remove the "tiers" (the annual products with "tier" type)
+					.filter( ( currentProduct ) => ! currentProduct.tier ) // We remove the "tiers" (the annual products with "tier" type)
 					.map( ( currentProduct ) => {
 						const currentAnnualProduct = products.find(
 							( _prod ) => _prod.tier === currentProduct.ID

--- a/client/my-sites/earn/memberships/products.tsx
+++ b/client/my-sites/earn/memberships/products.tsx
@@ -6,7 +6,7 @@ import {
 import { Badge, Button, CompactCard, Gridicon } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import QueryMembershipProducts from 'calypso/components/data/query-memberships';
 import QueryMembershipsSettings from 'calypso/components/data/query-memberships-settings';
@@ -157,10 +157,6 @@ function MembershipsProductsSection( { query }: MembersProductsSectionProps ) {
 						const currentAnnualProduct = products.find(
 							( _prod ) => _prod.tier === currentProduct.ID
 						);
-						console.info( '______' );
-						console.info( currentProduct );
-						console.info( currentAnnualProduct );
-						console.info( '______' );
 						return (
 							<CompactCard
 								className="memberships__products-product-card"
@@ -199,14 +195,14 @@ function MembershipsProductsSection( { query }: MembersProductsSectionProps ) {
 					product={ Object.assign( product ?? {}, {
 						subscribe_as_site_subscriber: subscribe_as_site_subscriber,
 					} ) }
-					annual_product={ annualProduct }
+					annualProduct={ annualProduct }
 				/>
 			) }
 			{ hasLoadedFeatures && showDeleteDialog && product && (
 				<RecurringPaymentsPlanDeleteModal
 					closeDialog={ closeDialog }
 					product={ product }
-					annual_product={ annualProduct }
+					annualProduct={ annualProduct }
 				/>
 			) }
 			{ ! hasLoadedFeatures && (

--- a/client/my-sites/earn/memberships/products.tsx
+++ b/client/my-sites/earn/memberships/products.tsx
@@ -26,7 +26,7 @@ import RecurringPaymentsPlanAddEditModal from '../components/add-edit-plan-modal
 import { Product, Query } from '../types';
 import { ADD_NEW_PAYMENT_PLAN_HASH, ADD_NEWSLETTER_PAYMENT_PLAN_HASH } from './constants';
 import RecurringPaymentsPlanDeleteModal from './delete-plan-modal';
-import MembershipsSection from './';
+import MembershipsSection from './section';
 import './style.scss';
 
 type MembersProductsSectionProps = {

--- a/client/my-sites/earn/memberships/section.tsx
+++ b/client/my-sites/earn/memberships/section.tsx
@@ -14,6 +14,7 @@ import { userCan } from 'calypso/lib/site/utils';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getEarningsWithDefaultsForSiteId } from 'calypso/state/memberships/earnings/selectors';
+import { getProductsForSiteId } from 'calypso/state/memberships/product-list/selectors';
 import { requestDisconnectSiteStripeAccount } from 'calypso/state/memberships/settings/actions';
 import {
 	getConnectedAccountIdForSiteId,
@@ -23,10 +24,7 @@ import {
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import CommissionFees from '../components/commission-fees';
 import { Query } from '../types';
-import {
-	ADD_NEWSLETTER_PAYMENT_PLAN_HASH,
-	LAUNCHPAD_HASH,
-} from './constants';
+import { ADD_NEWSLETTER_PAYMENT_PLAN_HASH, LAUNCHPAD_HASH } from './constants';
 import './style.scss';
 
 type MembershipsSectionProps = {
@@ -180,7 +178,7 @@ function MembershipsSection( { query }: MembershipsSectionProps ) {
 		if ( stripe_connect_success === 'earn' ) {
 			const siteHasPlans = products.length !== 0;
 
-			let congratsText = '';
+			let congratsText;
 			if ( ! siteHasPlans ) {
 				congratsText = translate(
 					'Congrats! Your site is now connected to Stripe. You can now add your first payment plan.'
@@ -190,13 +188,13 @@ function MembershipsSection( { query }: MembershipsSectionProps ) {
 			}
 
 			return (
-				<Notice status="is-success" showDismiss={ false } text={ congratsText }>
-					{ ! siteHasPlans && (
+				! siteHasPlans && (
+					<Notice status="is-success" showDismiss={ false } text={ congratsText }>
 						<NoticeAction href={ `/earn/payments-plans/${ site?.slug }` } icon="create">
 							{ translate( 'Add a payment plan' ) }
 						</NoticeAction>
-					) }
-				</Notice>
+					</Notice>
+				)
 			);
 		}
 

--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -277,13 +277,14 @@
 	flex-grow: 1;
 }
 .memberships__products-product-price {
-	color: var(--color-neutral-70);
-	font-size: $font-body;
+	color: var(--color-text-subtle);
+	font-size: $font-body-small;
 	line-height: 1.5;
 }
 .memberships__products-product-title {
-	color: var(--color-text-subtle);
-	font-size: $font-body-small;
+	color: var(--color-text);
+	font-size: $font-body;
+	font-weight: bold;
 }
 .memberships__products-product-badge {
 	margin-top: 10px;

--- a/client/my-sites/earn/types.ts
+++ b/client/my-sites/earn/types.ts
@@ -1,5 +1,5 @@
 export type Product = {
-	ID?: string;
+	ID?: number;
 	currency?: string;
 	price?: number;
 	title?: string;

--- a/client/my-sites/earn/types.ts
+++ b/client/my-sites/earn/types.ts
@@ -11,6 +11,7 @@ export type Product = {
 	renewal_schedule?: string;
 	type?: string;
 	is_editable?: boolean;
+	tier?: number;
 };
 
 export type Query = {

--- a/client/my-sites/subscribers/hooks/use-subscription-plans.ts
+++ b/client/my-sites/subscribers/hooks/use-subscription-plans.ts
@@ -1,6 +1,10 @@
 import { getCurrencyObject } from '@automattic/format-currency';
 import { useTranslate } from 'i18n-calypso';
 import { ReactNode, useMemo } from 'react';
+import {
+	PLAN_YEARLY_FREQUENCY,
+	PLAN_MONTHLY_FREQUENCY,
+} from 'calypso/my-sites/earn/memberships/constants';
 import { Subscriber, SubscriptionPlan } from '../types';
 
 type SubscriptionPlanData = {
@@ -16,9 +20,9 @@ const useSubscriptionPlans = ( subscriber: Subscriber ): SubscriptionPlanData[] 
 	const getPaymentInterval = ( renew_interval: string ) => {
 		if ( renew_interval === null ) {
 			return translate( 'one time' );
-		} else if ( renew_interval === '1 month' ) {
+		} else if ( renew_interval === PLAN_MONTHLY_FREQUENCY ) {
 			return translate( 'Monthly' );
-		} else if ( renew_interval === '1 year' ) {
+		} else if ( renew_interval === PLAN_YEARLY_FREQUENCY ) {
 			return translate( 'Yearly' );
 		}
 	};

--- a/client/state/data-layer/wpcom/sites/memberships/index.js
+++ b/client/state/data-layer/wpcom/sites/memberships/index.js
@@ -18,7 +18,7 @@ export const membershipProductFromApi = ( product ) => ( {
 	ID: parseInt( product.id || product.connected_account_product_id ),
 	currency: product.currency,
 	formatted_price: product.price,
-	price: product.price,
+	price: parseFloat( product.price ),
 	title: product.title,
 	renewal_schedule: product.interval,
 	buyer_can_change_amount: product.buyer_can_change_amount,

--- a/client/state/data-layer/wpcom/sites/memberships/index.js
+++ b/client/state/data-layer/wpcom/sites/memberships/index.js
@@ -26,6 +26,7 @@ export const membershipProductFromApi = ( product ) => ( {
 	subscribe_as_site_subscriber: product.subscribe_as_site_subscriber,
 	welcome_email_content: product.welcome_email_content,
 	type: product.type,
+	tier: product.tier,
 } );
 
 export const handleMembershipProductsList = dispatchRequest( {

--- a/client/state/memberships/product-list/actions.js
+++ b/client/state/memberships/product-list/actions.js
@@ -189,11 +189,14 @@ export const requestDeleteProduct = ( siteId, product, annualProduct, noticeText
 	};
 };
 
-const addNewAnnualProduct = ( annualProduct, siteId, noticeText ) => ( membershipProduct ) => {
+const addOrUpdateAnnualProduct = ( annualProduct, siteId, noticeText ) => ( membershipProduct ) => {
 	const newMembershipProductId = membershipProduct.ID;
-	annualProduct.type = 'tier-' + newMembershipProductId;
+	annualProduct.tier = newMembershipProductId;
 	return ( dispatch ) => {
-		requestAddProduct( siteId, annualProduct, noticeText )( dispatch );
+		if ( annualProduct.ID ) {
+			return requestAddProduct( siteId, annualProduct, noticeText )( dispatch );
+		}
+		return requestUpdateProduct( siteId, annualProduct, noticeText )( dispatch );
 	};
 };
 
@@ -204,7 +207,9 @@ export const requestAddTier = ( siteId, product, annualProduct, noticeText ) => 
 			product,
 			noticeText
 		)( dispatch ).then( ( membershipProduct ) => {
-			addNewAnnualProduct( annualProduct, siteId, noticeText )( membershipProduct )( dispatch );
+			addOrUpdateAnnualProduct( annualProduct, siteId, noticeText )( membershipProduct )(
+				dispatch
+			);
 		} );
 };
 
@@ -220,7 +225,7 @@ export const requestUpdateTier = ( siteId, product, annualProduct, noticeText ) 
 			}
 
 			// The annual product does not exist yet
-			return addNewAnnualProduct( annualProduct, siteId, noticeText )( membershipProduct )(
+			return addOrUpdateAnnualProduct( annualProduct, siteId, noticeText )( membershipProduct )(
 				dispatch
 			);
 		} );

--- a/client/state/memberships/product-list/actions.js
+++ b/client/state/memberships/product-list/actions.js
@@ -58,11 +58,13 @@ export const requestAddProduct = ( siteId, product, noticeText ) => {
 				}
 				const membershipProduct = membershipProductFromApi( newProduct );
 				dispatch( receiveUpdateProduct( siteId, membershipProduct ) );
-				dispatch(
-					successNotice( noticeText, {
-						duration: 5000,
-					} )
-				);
+				if ( noticeText ) {
+					dispatch(
+						successNotice( noticeText, {
+							duration: 5000,
+						} )
+					);
+				}
 				return membershipProduct;
 			} )
 			.catch( ( error ) => {
@@ -100,11 +102,13 @@ export const requestUpdateProduct = ( siteId, product, noticeText ) => {
 			.then( ( newProduct ) => {
 				const membershipProduct = membershipProductFromApi( newProduct.product );
 				dispatch( receiveUpdateProduct( siteId, membershipProduct ) );
-				dispatch(
-					successNotice( noticeText, {
-						duration: 5000,
-					} )
-				);
+				if ( noticeText ) {
+					dispatch(
+						successNotice( noticeText, {
+							duration: 5000,
+						} )
+					);
+				}
 				return membershipProduct;
 			} )
 			.catch( ( error ) => {
@@ -203,7 +207,7 @@ export const requestAddTier = ( siteId, product, annualProduct, noticeText ) => 
 		requestAddProduct(
 			siteId,
 			product,
-			noticeText
+			null // We don't want to show a message when adding the first product
 		)( dispatch ).then( ( membershipProduct ) => {
 			addOrUpdateAnnualProduct( siteId, annualProduct, noticeText )( membershipProduct )(
 				dispatch
@@ -216,7 +220,7 @@ export const requestUpdateTier = ( siteId, product, annualProduct, noticeText ) 
 		return requestUpdateProduct(
 			siteId,
 			product,
-			noticeText
+			null // We don't want to show a message on the first product update
 		)( dispatch ).then( ( membershipProduct ) => {
 			// The annual product does not exist yet
 			return addOrUpdateAnnualProduct( siteId, annualProduct, noticeText )( membershipProduct )(

--- a/client/state/memberships/product-list/actions.js
+++ b/client/state/memberships/product-list/actions.js
@@ -189,15 +189,13 @@ export const requestDeleteProduct = ( siteId, product, annualProduct, noticeText
 	};
 };
 
-const addOrUpdateAnnualProduct = ( annualProduct, siteId, noticeText ) => ( membershipProduct ) => {
+const addOrUpdateAnnualProduct = ( siteId, annualProduct, noticeText ) => ( membershipProduct ) => {
 	const newMembershipProductId = membershipProduct.ID;
 	annualProduct.tier = newMembershipProductId;
-	return ( dispatch ) => {
-		if ( annualProduct.ID ) {
-			return requestAddProduct( siteId, annualProduct, noticeText )( dispatch );
-		}
-		return requestUpdateProduct( siteId, annualProduct, noticeText )( dispatch );
-	};
+	if ( annualProduct.ID ) {
+		return requestUpdateProduct( siteId, annualProduct, noticeText );
+	}
+	return requestAddProduct( siteId, annualProduct, noticeText );
 };
 
 export const requestAddTier = ( siteId, product, annualProduct, noticeText ) => {
@@ -207,7 +205,7 @@ export const requestAddTier = ( siteId, product, annualProduct, noticeText ) => 
 			product,
 			noticeText
 		)( dispatch ).then( ( membershipProduct ) => {
-			addOrUpdateAnnualProduct( annualProduct, siteId, noticeText )( membershipProduct )(
+			addOrUpdateAnnualProduct( siteId, annualProduct, noticeText )( membershipProduct )(
 				dispatch
 			);
 		} );
@@ -220,12 +218,8 @@ export const requestUpdateTier = ( siteId, product, annualProduct, noticeText ) 
 			product,
 			noticeText
 		)( dispatch ).then( ( membershipProduct ) => {
-			if ( annualProduct.ID ) {
-				return requestUpdateProduct( siteId, annualProduct, noticeText )( dispatch );
-			}
-
 			// The annual product does not exist yet
-			return addOrUpdateAnnualProduct( annualProduct, siteId, noticeText )( membershipProduct )(
+			return addOrUpdateAnnualProduct( siteId, annualProduct, noticeText )( membershipProduct )(
 				dispatch
 			);
 		} );

--- a/client/state/memberships/product-list/actions.js
+++ b/client/state/memberships/product-list/actions.js
@@ -134,7 +134,7 @@ export const requestDeleteProduct = ( siteId, product, annualProduct, noticeText
 			dispatch( {
 				type: MEMBERSHIPS_PRODUCT_DELETE,
 				siteId,
-				annual_product: annualProduct,
+				product: annualProduct,
 			} );
 		}
 
@@ -177,7 +177,7 @@ export const requestDeleteProduct = ( siteId, product, annualProduct, noticeText
 						type: MEMBERSHIPS_PRODUCT_DELETE_FAILURE,
 						siteId,
 						error,
-						annual_product: annualProduct,
+						product: annualProduct,
 					} );
 				}
 				dispatch(

--- a/client/state/memberships/product-list/actions.js
+++ b/client/state/memberships/product-list/actions.js
@@ -159,3 +159,27 @@ export const requestDeleteProduct = ( siteId, product, noticeText ) => {
 			} );
 	};
 };
+
+const addNewAnnualProduct = ( annualProduct, siteId, noticeText ) => ( membershipProduct ) => {
+	debugger;
+	const newMembershipProductId = membershipProduct.id;
+	annualProduct.type = 'tier-' + newMembershipProductId;
+	return requestAddProduct( siteId, annualProduct, noticeText );
+};
+
+export const requestAddTier = ( siteId, product, annualProduct, noticeText ) => {
+	return requestAddProduct( siteId, product, noticeText ).then(
+		addNewAnnualProduct( annualProduct, siteId, noticeText )
+	);
+};
+
+export const requestUpdateTier = ( siteId, product, annualProduct, noticeText ) => {
+	return requestUpdateProduct( siteId, product, noticeText ).then( ( membershipProduct ) => {
+		if ( annualProduct.ID ) {
+			return requestUpdateProduct( siteId, annualProduct, noticeText );
+		}
+
+		// The annual product does not exist yet
+		return addNewAnnualProduct( annualProduct, siteId, noticeText )( membershipProduct );
+	} );
+};

--- a/client/state/memberships/product-list/schema.js
+++ b/client/state/memberships/product-list/schema.js
@@ -10,6 +10,7 @@ export const metadataSchema = {
 	formatted_price: { type: 'string', metaKey: 'spay_formatted_price' },
 	renewal_schedule: { type: 'string' },
 	type: { type: 'string' },
+	tier: { type: 'number' },
 };
 
 /**


### PR DESCRIPTION
Rebased of https://github.com/Automattic/wp-calypso/pull/81014

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes to https://github.com/Automattic/gold/issues/140
Fixes https://github.com/Automattic/gold/issues/162
Related to https://github.com/Automattic/jetpack/pull/32658
And D121694-code



## Proposed Changes

* Change plan list according to Figma
* Add Newsletter tier to bundle 2 plans
* Change the add/edit modal to handle such changes
* Lock the Newsletter selector when a plan was added as-is.
* It should be retro-compatible with existing plans.
* Display only one success notice for tiers
* Fix: only show "you can now add your first payment plan" if needed  (cannot be tested as Stripe sends you back to WP.com)

| list | modal |
| ---- | ---- |
|  <img width="1146" alt="Screenshot 2023-08-24 at 19 44 08" src="https://github.com/Automattic/wp-calypso/assets/790558/81e4d779-3c98-4877-9383-60adb2cd29a6"> |  <img width="769" alt="Screenshot 2023-08-24 at 19 44 17" src="https://github.com/Automattic/wp-calypso/assets/790558/0dcd5420-2a6d-4e97-878b-b085ddfd1c75"> | 



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Patch D121694-code on your sandbox
* Add new plans, delete and modify to test
* Have a site with a monthly newsletter plan and a yearly newsletter plan. Try to edit them with this patch on. It should created bundled plans.

CC @crisbusquets for designs recitifications