### PR TITLE
Activitypub: disable user-based profiles

### DIFF
--- a/client/my-sites/site-settings/fediverse-settings/WpcomFediverseSettingsSection.js
+++ b/client/my-sites/site-settings/fediverse-settings/WpcomFediverseSettingsSection.js
@@ -52,24 +52,6 @@ const DomainPendingWarning = ( { siteId } ) => {
 	);
 };
 
-const DomainCongratsCard = ( { user, isPending, siteId } ) => {
-	const translate = useTranslate();
-	return (
-		<Card className="site-settings__card">
-			<p>{ translate( 'Your site is using a custom domain! 🎉' ) }</p>
-			<p>
-				{ translate(
-					'Owning your domain unlocks account portability and a separate profile for each blog author. Here’s yours:'
-				) }
-			</p>
-			{ isPending && <DomainPendingWarning siteId={ siteId } /> }
-			<p>
-				<ClipboardButtonInput value={ user } />
-			</p>
-		</Card>
-	);
-};
-
 const EnabledSettingsSection = ( { data, siteId } ) => {
 	const translate = useTranslate();
 	const { blogIdentifier = '', userIdentifier } = data;
@@ -87,13 +69,6 @@ const EnabledSettingsSection = ( { data, siteId } ) => {
 					<ClipboardButtonInput value={ blogIdentifier } />
 				</p>
 			</Card>
-			{ hasDomain && (
-				<DomainCongratsCard
-					user={ userIdentifier }
-					isPending={ isDomainPending }
-					siteId={ siteId }
-				/>
-			) }
 		</>
 	);
 };


### PR DESCRIPTION
User-based profiles are not a good fit for dotcom because they will split followers between the user-based profile and the blog-based profile. Users who want both blog and user profiles can use Business. 

Discussion: p1696603662872759-slack-C04TJ8P900J

## Proposed Changes

* Don't show the user-based account

## Testing Instructions

* Go to Settings -> Discussion with a mapped domain active
* There should no longer be a user-based alias

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?