### PR TITLE
Update Support Doc Links on Two-Step Authentication Screens

### DIFF
--- a/client/me/application-passwords/index.jsx
+++ b/client/me/application-passwords/index.jsx
@@ -1,4 +1,5 @@
 import { Button, Card, Gridicon } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { Fragment, useState } from 'react';
 import { useDispatch } from 'react-redux';
@@ -91,11 +92,22 @@ function ApplicationPasswords() {
 				) }
 
 				<p className="application-passwords__nobot">
-					{ translate(
-						'With Two-Step Authentication active, you can generate a custom password for ' +
-							'each third-party application you authorize to use your WordPress.com account. ' +
-							'You can revoke access for an individual application here if you ever need to.'
-					) }
+					<>
+						{ translate(
+							'With Two-Step Authentication active, you can generate a custom password for ' +
+								'each third-party application you authorize to use your WordPress.com account. ' +
+								'You can revoke access for an individual application here if you ever need to.'
+						) }{ ' ' }
+						<a
+							href={ localizeUrl(
+								' wordpress.com/support/security/two-step-authentication/application-specific-passwords'
+							) }
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							{ translate( 'Learn more' ) }
+						</a>
+					</>
 				</p>
 
 				<AppPasswordsList appPasswords={ appPasswords } />

--- a/client/me/application-passwords/index.jsx
+++ b/client/me/application-passwords/index.jsx
@@ -100,7 +100,7 @@ function ApplicationPasswords() {
 						) }{ ' ' }
 						<a
 							href={ localizeUrl(
-								' wordpress.com/support/security/two-step-authentication/application-specific-passwords'
+								'https://wordpress.com/support/security/two-step-authentication/application-specific-passwords'
 							) }
 							target="_blank"
 							rel="noopener noreferrer"

--- a/client/me/security-2fa-key/index.jsx
+++ b/client/me/security-2fa-key/index.jsx
@@ -1,4 +1,5 @@
 import { Button, Card, Gridicon } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
 import { Component } from 'react';
@@ -112,7 +113,20 @@ class Security2faKey extends Component {
 				{ ! addingKey && ! security2faKeys.length && (
 					<Card>
 						{ isBrowserSupported && (
-							<p>{ this.props.translate( 'Use a second factor security key to sign in.' ) }</p>
+							<p>
+								<>
+									{ this.props.translate( 'Use a second factor security key to sign in.' ) }{ ' ' }
+									<a
+										href={ localizeUrl(
+											'https://wordpress.com/support/security/two-step-authentication/security-key-authentication'
+										) }
+										target="_blank"
+										rel="noopener noreferrer"
+									>
+										{ translate( 'Learn more' ) }
+									</a>
+								</>
+							</p>
 						) }
 						{ ! isBrowserSupported && (
 							<p>


### PR DESCRIPTION
Security Key Authentication: [wordpress.com/support/security/two-step-authentication/security-key-authentication](https://wordpress.com/support/security/two-step-authentication/security-key-authentication/)
Application-Specific Passwords: [wordpress.com/support/security/two-step-authentication/application-specific-passwords](https://wordpress.com/support/security/two-step-authentication/application-specific-passwords/)

This PR places `Learn more` links to these docs in the UI of `/me/security/two-step`, since the information can no longer be found in the main 2SA doc.

<img width="1147" alt="image" src="https://github.com/Automattic/wp-calypso/assets/52076348/5d4cd70f-b252-42c4-8d17-6b514371e428">

## Testing
1. Live link
2. Visit `/me/security/two-step`
3. Check the two new links

Fixes https://github.com/Automattic/wp-calypso/issues/81159