### PR TITLE
Activitypub: better domain detection

### DIFF
--- a/client/my-sites/site-settings/fediverse-settings/WpcomFediverseSettingsSection.js
+++ b/client/my-sites/site-settings/fediverse-settings/WpcomFediverseSettingsSection.js
@@ -1,3 +1,4 @@
+import { FEATURE_CUSTOM_DOMAIN } from '@automattic/calypso-products';
 import { Card, Button } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
 import { addQueryArgs } from '@wordpress/url';
@@ -9,6 +10,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { domainAddNew } from 'calypso/my-sites/domains/paths';
 import { useActivityPubStatus } from 'calypso/state/activitypub/use-activitypub-status';
 import { successNotice } from 'calypso/state/notices/actions';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSiteTitle, getSiteDomain, getSite } from 'calypso/state/sites/selectors';
 
 const DomainUpsellCard = ( { siteId } ) => {
@@ -54,10 +56,12 @@ const DomainPendingWarning = ( { siteId } ) => {
 
 const EnabledSettingsSection = ( { data, siteId } ) => {
 	const translate = useTranslate();
-	const { blogIdentifier = '', userIdentifier } = data;
-	const hasDomain = !! userIdentifier;
+	const { blogIdentifier = '' } = data;
+	const hasDomain = useSelector( ( state ) =>
+		siteHasFeature( state, siteId, FEATURE_CUSTOM_DOMAIN )
+	);
 	// if the domain has been purchased, but isn't active yet because the site is still using *.wordpress.com
-	const isDomainPending = hasDomain && userIdentifier.match( /\.wordpress\.com$/ );
+	const isDomainPending = hasDomain && blogIdentifier.match( /\.wordpress\.com$/ );
 
 	return (
 		<>


### PR DESCRIPTION
Following on from #82729 this PR refactors our custom domain detection routine to be more correct. We were inferring it from `userIdentifier` before, based on enabling it on the backend through the custom domain feature check. No longer inferring, just asking directly.

## Proposed Changes

* Detect custom domain properly

## Testing Instructions

Go to Settings --> Discussion
You should see the domain upsell if you don't have a custom domain
You should see the warning if you have a custom domain that isn't active. You can get yourself in this state by going to Upgrades --> Domains and setting your old `*.wordpress.com` site to primary. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?