### PR TITLE
Multi-Domain: Fix exception error

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -138,6 +138,7 @@ export class RenderDomainsStep extends Component {
 
 			props.goToNextStep();
 		}
+		this.shouldUseMultipleDomainsInCart = this.shouldUseMultipleDomainsInCart.bind( this );
 		this.setCurrentFlowStep = this.setCurrentFlowStep.bind( this );
 		this.state = {
 			currentStep: null,


### PR DESCRIPTION
Fix error reported by Sentry on Slack: p1696534010008959-slack-C04U5A26MJB

## Proposed Changes

To fix `thrown: this.shouldUseMultipleDomainsInCart is not a function`, we bind `shouldUseMultipleDomainsInCart` to `this` as we did with `setCurrentFlowStep` [here](https://github.com/Automattic/wp-calypso/blob/dd611d806f83ae3cd498581ff09c76e862cb3453/client/signup/steps/domains/index.jsx#L141C8-L141C26)
