### PR TITLE
Reader topics page tracking - add relevance and date suffixes ui_algo value

### DIFF
--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -36,6 +36,8 @@ export function recordPermalinkClick( source, post, eventProperties = {} ) {
 }
 
 function getLocation( path ) {
+	const searchParams = new URLSearchParams( path.slice( path.indexOf( '?' ) ) );
+
 	if ( path === undefined || path === '' ) {
 		return 'unknown';
 	}
@@ -49,7 +51,8 @@ function getLocation( path ) {
 		return 'following_p2';
 	}
 	if ( path.indexOf( '/tag/' ) === 0 ) {
-		return 'topic_page';
+		const sort = searchParams.get( 'sort' );
+		return `topic_page:${ sort || 'relevance' }`;
 	}
 	if ( path.match( /^\/read\/(blogs|feeds)\/([0-9]+)\/posts\/([0-9]+)$/i ) ) {
 		return 'single_post';
@@ -73,7 +76,6 @@ function getLocation( path ) {
 		return 'following_manage';
 	}
 	if ( path.indexOf( '/discover' ) === 0 ) {
-		const searchParams = new URLSearchParams( path.slice( path.indexOf( '?' ) ) );
 		const selectedTab = searchParams.get( 'selectedTab' );
 
 		if ( ! selectedTab || selectedTab === 'recommended' ) {

--- a/client/reader/tag-stream/controller.js
+++ b/client/reader/tag-stream/controller.js
@@ -11,6 +11,7 @@ import {
 } from 'calypso/reader/controller-helper';
 import { recordTrack } from 'calypso/reader/stats';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import renderHeaderSection from '../lib/header-section';
 
@@ -34,13 +35,16 @@ export const tagListing = ( context, next ) => {
 	const mcKey = 'topic';
 	const startDate = getStartDate( context );
 
+	const currentRoute = getCurrentRoute( state );
+	const currentQueryArgs = new URLSearchParams( getCurrentQueryArguments( state ) ).toString();
+
 	trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 	recordTrack(
 		'calypso_reader_tag_loaded',
 		{
 			tag: tagSlug,
 		},
-		{ pathnameOverride: getCurrentRoute( state ) }
+		{ pathnameOverride: `${ currentRoute }?${ currentQueryArgs }` }
 	);
 
 	if ( ! isUserLoggedIn( state ) ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # pe7F0s-1gP-p2

## Proposed Changes

* Updates the default reader tracking prop `ui_algo`'s value for topic pages from `topic_page` to `topic_page:relevance` or `topic_page:date` given our recent addition of an extra tab to view these feeds differently (pe7F0s-1gP-p2). This will allow us to have better tracking info to know which stream type is being referred to by this prop for tags pages.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch
* Visit a tags page.
* You should see a `calypso_reader_tag_loaded` event (tracks vigilante helps). Verify the `ui_algo` prop is `topic_page:relevance`. 
* Change tabs from popularity to recent and notice this value changes to have the `date` suffix instead.
* Click a card to visit the full post page in the reader, verify the `calypso_reader_article_opened` event has a `ui_algo` prop corresponding to the stream type you came from.
* Test other events on the tags streams, such as likes, follows etc. verify the ui_algo prop's value is as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?