### PR TITLE
Multi-Domain: Added back multi-domain check for in cart button

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -27,6 +27,7 @@ import {
 	isDotGayNoticeRequired,
 } from 'calypso/lib/domains';
 import { HTTPS_SSL } from 'calypso/lib/url/support';
+import { shouldUseMultipleDomainsInCart } from 'calypso/signup/steps/domains/utils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import { getProductsList } from 'calypso/state/products-list/selectors';
@@ -133,6 +134,7 @@ class DomainRegistrationSuggestion extends Component {
 			pendingCheckSuggestion,
 			premiumDomain,
 			isCartPendingUpdateDomain,
+			flowName,
 		} = this.props;
 		const { domain_name: domain } = suggestion;
 		const isAdded = hasDomainInCart( cart, domain );
@@ -141,12 +143,21 @@ class DomainRegistrationSuggestion extends Component {
 		let buttonStyles = this.props.buttonStyles;
 
 		if ( isAdded ) {
-			buttonContent = translate( '{{checkmark/}} Selected', {
+			buttonContent = translate( '{{checkmark/}} In Cart', {
 				context: 'Domain is already added to shopping cart',
 				components: { checkmark: <Gridicon icon="checkmark" /> },
 			} );
 
-			buttonStyles = { ...buttonStyles, primary: false, borderless: true };
+			buttonStyles = { ...buttonStyles, primary: false };
+
+			if ( shouldUseMultipleDomainsInCart( flowName, suggestion ) ) {
+				buttonStyles = { ...buttonStyles, borderless: true };
+
+				buttonContent = translate( '{{checkmark/}} Selected', {
+					context: 'Domain is already added to shopping cart',
+					components: { checkmark: <Gridicon icon="checkmark" /> },
+				} );
+			}
 		} else {
 			buttonContent =
 				! isSignupStep &&
@@ -212,7 +223,6 @@ class DomainRegistrationSuggestion extends Component {
 	 * becomes the tld. This is not very comprehensive since there can be
 	 * subdomains which would fail this test. However, for our purpose of
 	 * highlighting the TLD in domain suggestions, this is good enough.
-	 *
 	 * @param {string} domain The domain to be parsed
 	 */
 	getDomainParts( domain ) {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { formatCurrency } from '@automattic/format-currency';
 import { VIDEOPRESS_FLOW, isWithThemeFlow, isHostingSignupFlow } from '@automattic/onboarding';
@@ -68,7 +67,7 @@ import { isPlanStepExistsAndSkipped } from 'calypso/state/signup/progress/select
 import { setDesignType } from 'calypso/state/signup/steps/design-type/actions';
 import { getDesignType } from 'calypso/state/signup/steps/design-type/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import { getExternalBackUrl } from './utils';
+import { getExternalBackUrl, shouldUseMultipleDomainsInCart } from './utils';
 
 import './style.scss';
 
@@ -116,7 +115,7 @@ export class RenderDomainsStep extends Component {
 			this.skipRender = true;
 			const productSlug = getDomainProductSlug( domain );
 			const domainItem = domainRegistration( { productSlug, domain } );
-			const domainCart = this.shouldUseMultipleDomainsInCart()
+			const domainCart = shouldUseMultipleDomainsInCart( props.flowName, props.step?.suggestion )
 				? getDomainRegistrations( this.props.cart )
 				: {};
 
@@ -304,34 +303,17 @@ export class RenderDomainsStep extends Component {
 		}
 	};
 
-	shouldUseMultipleDomainsInCart = () => {
-		const { step, flowName } = this.props;
-		if ( ! step ) {
-			return;
-		}
-		const { suggestion } = step;
-
-		const enabledFlows = [ 'onboarding' ];
-
-		return (
-			isEnabled( 'domains/add-multiple-domains-to-cart' ) &&
-			enabledFlows.includes( flowName ) &&
-			( ! suggestion || ( suggestion && ! suggestion.is_free ) )
-		);
-	};
-
 	submitWithDomain = ( { googleAppsCartItem, shouldHideFreePlan = false, signupDomainOrigin } ) => {
-		const { step } = this.props;
+		const { step, flowName } = this.props;
 		const { suggestion } = step;
 
-		if ( this.shouldUseMultipleDomainsInCart() && suggestion ) {
+		if ( shouldUseMultipleDomainsInCart( flowName, suggestion ) && suggestion ) {
 			return this.handleDomainToDomainCart( {
 				googleAppsCartItem,
 				shouldHideFreePlan,
 				signupDomainOrigin,
 			} );
 		}
-		const { flowName } = this.props;
 		const shouldUseThemeAnnotation = this.shouldUseThemeAnnotation();
 		const useThemeHeadstartItem = shouldUseThemeAnnotation
 			? { useThemeHeadstart: shouldUseThemeAnnotation }
@@ -669,8 +651,8 @@ export class RenderDomainsStep extends Component {
 	};
 
 	getSideContent = () => {
-		const { translate } = this.props;
-		const domainsInCart = this.shouldUseMultipleDomainsInCart()
+		const { translate, flowName, step } = this.props;
+		const domainsInCart = shouldUseMultipleDomainsInCart( flowName, step?.suggestion )
 			? getDomainRegistrations( this.props.cart )
 			: [];
 		const cartIsLoading = this.props.shoppingCartManager.isLoading;
@@ -678,7 +660,9 @@ export class RenderDomainsStep extends Component {
 		const useYourDomain = ! this.shouldHideUseYourDomain() ? (
 			<div
 				className={ classNames( 'domains__domain-side-content', {
-					'fade-out': this.shouldUseMultipleDomainsInCart() && domainsInCart.length > 0,
+					'fade-out':
+						shouldUseMultipleDomainsInCart( flowName, step?.suggestion ) &&
+						domainsInCart.length > 0,
 				} ) }
 			>
 				<ReskinSideExplainer onClick={ this.handleUseYourDomainClick } type="use-your-domain" />
@@ -738,7 +722,8 @@ export class RenderDomainsStep extends Component {
 		};
 
 		const DomainsInCart =
-			this.shouldUseMultipleDomainsInCart() && ! cartIsLoading ? (
+			shouldUseMultipleDomainsInCart( this.props.flowName, this.props.step?.suggestion ) &&
+			! cartIsLoading ? (
 				<div className="domains__domain-side-content domains__domain-cart">
 					<div className="domains__domain-cart-title">
 						{ this.props.translate( 'Your domains' ) }
@@ -940,7 +925,7 @@ export class RenderDomainsStep extends Component {
 	isHostingFlow = () => isHostingSignupFlow( this.props.flowName );
 
 	getSubHeaderText() {
-		const { flowName, isAllDomains, stepSectionName, isReskinned, translate } = this.props;
+		const { flowName, isAllDomains, stepSectionName, isReskinned, translate, step } = this.props;
 
 		if ( isAllDomains ) {
 			return translate( 'Find the domain that defines you' );
@@ -981,14 +966,14 @@ export class RenderDomainsStep extends Component {
 			);
 		}
 
-		if ( this.shouldUseMultipleDomainsInCart() ) {
+		if ( shouldUseMultipleDomainsInCart( flowName, step?.suggestion ) ) {
 			return translate( 'Find and claim one or more domain names' );
 		}
 
 		if ( isReskinned ) {
 			return (
 				! stepSectionName &&
-				'domain-transfer' !== this.props.flowName &&
+				'domain-transfer' !== flowName &&
 				translate( 'Enter some descriptive keywords to get started' )
 			);
 		}
@@ -999,9 +984,10 @@ export class RenderDomainsStep extends Component {
 	}
 
 	getHeaderText() {
-		const { headerText, isAllDomains, isReskinned, stepSectionName, translate } = this.props;
+		const { headerText, isAllDomains, isReskinned, stepSectionName, translate, flowName, step } =
+			this.props;
 
-		if ( stepSectionName === 'use-your-domain' || 'domain-transfer' === this.props.flowName ) {
+		if ( stepSectionName === 'use-your-domain' || 'domain-transfer' === flowName ) {
 			return '';
 		}
 
@@ -1014,7 +1000,7 @@ export class RenderDomainsStep extends Component {
 		}
 
 		if ( isReskinned ) {
-			if ( this.shouldUseMultipleDomainsInCart() ) {
+			if ( shouldUseMultipleDomainsInCart( flowName, step?.suggestion ) ) {
 				return ! stepSectionName && translate( 'Choose your domains' );
 			}
 			return ! stepSectionName && translate( 'Choose a domain' );

--- a/client/signup/steps/domains/utils.js
+++ b/client/signup/steps/domains/utils.js
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import validUrl from 'valid-url';
 
 // Only override the back button from an external URL source on the below step(s) which is typically where we'd send them to as the 'entry'.
@@ -27,4 +28,18 @@ export function getExternalBackUrl( source, sectionName = null ) {
 	}
 
 	return false;
+}
+
+/**
+ * Check if we should use multiple domains in domain flows.
+ */
+export function shouldUseMultipleDomainsInCart( flowName, suggestion ) {
+	const enabledFlows = [ 'onboarding' ];
+
+	const status =
+		isEnabled( 'domains/add-multiple-domains-to-cart' ) &&
+		enabledFlows.includes( flowName ) &&
+		( ! suggestion || ( suggestion && ! suggestion.is_free ) );
+
+	return status;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Follow-up of https://github.com/Automattic/wp-calypso/pull/82684#issuecomment-1749990872
Slack thread: p1696591704239639-slack-CKZHG0QCR

## Proposed Changes

* Added back multi-domain check for in cart button

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access multi-domains http://calypso.localhost:3000/start/domains?flags=domains/add-multiple-domains-to-cart
* Ensure everything still works as expected
* Ensure "selected" will only show for multi-domain:

![image](https://github.com/Automattic/wp-calypso/assets/1044309/a50361c1-52e2-4795-8fcf-df2d156ff5e9)



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?