### PR TITLE
add Squarespace for free transfers to the copy

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/intro.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-intro/intro.tsx
@@ -63,10 +63,10 @@ const Intro: React.FC< Props > = ( { onSubmit, variantSlug } ) => {
 							<p>
 								{ isEnglishLocale ||
 								hasTranslation(
-									"Review your payment and contact details. If you're transferring a domain from Google, we'll pay for an additional year of registration if your domain was registered before July 1, 2023."
+									"Review your payment and contact details. If you're transferring a domain from Google or Squarespace, we'll pay for an additional year of registration if your domain was registered before July 1, 2023."
 								)
 									? __(
-											"Review your payment and contact details. If you're transferring a domain from Google, we'll pay for an additional year of registration if your domain was registered before July 1, 2023."
+											"Review your payment and contact details. If you're transferring a domain from Google or Squarespace, we'll pay for an additional year of registration if your domain was registered before July 1, 2023."
 									  )
 									: __(
 											"Review your payment and contact details. If you're transferring a domain from Google, we'll pay for an additional year of registration."


### PR DESCRIPTION
## Proposed Changes

This adds `Squarespace` to the copy to clarify that transfers from Squarespace are also free. This can be viewed [here](https://wordpress.com/setup/domain-transfer/intro)

<img width="619" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1080253/b7f55db4-7086-4996-9608-5e8341bc3b17">