### PR TITLE
Multi-domains: Add busy/disabled styles for buttons

### DIFF
--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -448,13 +448,29 @@ body.is-section-signup.is-white-signup {
 
 			.domain-suggestion__action.is-borderless {
 				color: var(--color-text);
-				padding: 0.57em 1.5em;
+				padding: 0 1.5em;
+				line-height: 24px;
 				@include break-mobile {
 					width: auto;
 				}
 
 				.gridicons-checkmark {
 					color: var(--studio-green-60);
+				}
+
+				&:disabled {
+					color: var(--color-neutral-20);
+
+					.gridicons-checkmark {
+						color: var(--color-neutral-20);
+					}
+				}
+
+				&.is-busy {
+					pointer-events: none;
+					animation: button__busy-animation 3000ms infinite linear;
+					background-size: 120px 100%;
+					background-image: linear-gradient(-45deg, var(--color-neutral-10) 28%, var(--studio-gray-5) 28%, var(--studio-gray-5) 72%, var(--color-neutral-10) 72%);
 				}
 			}
 			.domain-suggestion__action:not(.is-borderless) {
@@ -516,6 +532,21 @@ body.is-section-signup.is-white-signup {
 
 			.gridicons-checkmark {
 				color: var(--studio-green-60);
+			}
+
+			&:disabled {
+				color: var(--color-neutral-20);
+
+				.gridicons-checkmark {
+					color: var(--color-neutral-20);
+				}
+			}
+
+			&.is-busy {
+				pointer-events: none;
+				animation: button__busy-animation 3000ms infinite linear;
+				background-size: 120px 100%;
+				background-image: linear-gradient(-45deg, var(--color-neutral-10) 28%, var(--studio-gray-5) 28%, var(--studio-gray-5) 72%, var(--color-neutral-10) 72%);
 			}
 		}
 	}


### PR DESCRIPTION
## Proposed Changes

As I noticed the new borderless buttons doesn't have the busy & disabled styles, I added to them.

<img width="710" alt="image" src="https://github.com/Automattic/wp-calypso/assets/402286/a11bbde2-12fb-42af-9b06-5d2b24753233">

## Testing Instructions

* Go to `/start/domains?flags=domains/add-multiple-domains-to-cart`
* Add a featured domain to cart and remove it
* You should see an animation while is deleting
* Test the same with non-featured domain.
