### PR TITLE
Handle free subdomain CTA clicks

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -191,7 +191,10 @@ export class RenderDomainsStep extends Component {
 	};
 
 	handleAddDomain = ( suggestion, position ) => {
-		if ( this.shouldUseMultipleDomainsInCart() && suggestion?.isSubDomainSuggestion ) {
+		if (
+			shouldUseMultipleDomainsInCart( this.props.flowName, this.props.step?.suggestion ) &&
+			suggestion?.isSubDomainSuggestion
+		) {
 			this.handleIsSubDomainSuggestion();
 			return;
 		}
@@ -738,7 +741,8 @@ export class RenderDomainsStep extends Component {
 		};
 
 		const DomainsInCart =
-			( shouldUseMultipleDomainsInCart( this.props.flowName, this.props.step?.suggestion ) && ! cartIsLoading ) ||
+			( shouldUseMultipleDomainsInCart( this.props.flowName, this.props.step?.suggestion ) &&
+				! cartIsLoading ) ||
 			this.state.showFreeSubdomain ? (
 				<div className="domains__domain-side-content domains__domain-cart">
 					<div className="domains__domain-cart-title">

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -143,6 +143,7 @@ export class RenderDomainsStep extends Component {
 		this.state = {
 			currentStep: null,
 			isCartPendingUpdateDomain: null,
+			showFreeSubdomain: JSON.parse( localStorage.getItem( 'showFreeSubdomain' ) || 'false' ),
 		};
 	}
 
@@ -181,7 +182,22 @@ export class RenderDomainsStep extends Component {
 		);
 	};
 
+	state = { showFreeSubdomain: false };
+
+	handleIsSubDomainSuggestion = () => {
+		// Toggle the value based on the current state
+		const newShowFreeSubdomainValue = ! this.state.showFreeSubdomain;
+
+		this.setState( { showFreeSubdomain: newShowFreeSubdomainValue } );
+		localStorage.setItem( 'showFreeSubdomain', String( newShowFreeSubdomainValue ) );
+	};
+
 	handleAddDomain = ( suggestion, position ) => {
+		if ( this.shouldUseMultipleDomainsInCart() && suggestion?.isSubDomainSuggestion ) {
+			this.handleIsSubDomainSuggestion();
+			return;
+		}
+
 		const signupDomainOrigin = suggestion?.is_free
 			? SIGNUP_DOMAIN_ORIGIN.FREE
 			: SIGNUP_DOMAIN_ORIGIN.CUSTOM;
@@ -310,15 +326,10 @@ export class RenderDomainsStep extends Component {
 		if ( ! step ) {
 			return;
 		}
-		const { suggestion } = step;
 
 		const enabledFlows = [ 'onboarding' ];
 
-		return (
-			isEnabled( 'domains/add-multiple-domains-to-cart' ) &&
-			enabledFlows.includes( flowName ) &&
-			( ! suggestion || ( suggestion && ! suggestion.is_free ) )
-		);
+		return isEnabled( 'domains/add-multiple-domains-to-cart' ) && enabledFlows.includes( flowName );
 	};
 
 	submitWithDomain = ( { googleAppsCartItem, shouldHideFreePlan = false, signupDomainOrigin } ) => {
@@ -739,12 +750,38 @@ export class RenderDomainsStep extends Component {
 		};
 
 		const DomainsInCart =
-			this.shouldUseMultipleDomainsInCart() && ! cartIsLoading ? (
+			( this.shouldUseMultipleDomainsInCart() && ! cartIsLoading ) ||
+			this.state.showFreeSubdomain ? (
 				<div className="domains__domain-side-content domains__domain-cart">
 					<div className="domains__domain-cart-title">
 						{ this.props.translate( 'Your domains' ) }
 					</div>
 					<div className="domains__domain-cart-rows">
+						{ this.state.showFreeSubdomain && (
+							<div className="domains__domain-cart-row free-subdomain">
+								<div>
+									<div className="domains__domain-cart-domain">
+										<span>test</span>
+										<b>.wordpress.com</b>
+									</div>
+									<div className="domain-product-price__price">
+										<span className="domains__price">Free</span>
+									</div>
+								</div>
+								<div>
+									<button
+										type="button"
+										className="button domains__domain-cart-remove is-borderless"
+										onClick={ () => {
+											localStorage.setItem( 'showFreeSubdomain', 'false' );
+											this.setState( { showFreeSubdomain: false } );
+										} }
+									>
+										Remove
+									</button>
+								</div>
+							</div>
+						) }
 						{ domainsInCart.map( ( domain, i ) => (
 							<div key={ `row${ i }` } className="domains__domain-cart-row">
 								<DomainNameAndCost domain={ domain } />
@@ -775,7 +812,7 @@ export class RenderDomainsStep extends Component {
 
 		return (
 			<div className="domains__domain-side-content-container">
-				{ domainsInCart.length > 0
+				{ domainsInCart.length > 0 || this.state.showFreeSubdomain
 					? DomainsInCart
 					: ! this.shouldHideDomainExplainer() &&
 					  this.props.isPlanSelectionAvailableLaterInFlow && (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
