### PR TITLE
Live preview: remove 'Back to themes' link when Gutenberg is disabled

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview.tsx
@@ -53,27 +53,20 @@ const NOTICE_ID = 'wpcom-live-preview/notice';
  */
 const LivePreviewNotice = () => {
 	const { createWarningNotice } = useDispatch( 'core/notices' );
-	const siteEditorStore = useSelect( ( select ) => select( 'core/edit-site' ), [] );
-	const { dashboardLink, previewingTheme } = useSelect(
-		( select ) => {
-			if ( ! siteEditorStore ) {
-				return {
-					previewingTheme: undefined,
-					dashboardLink: undefined,
-				};
-			}
 
-			const { getSettings } = unlock( siteEditorStore );
-			const themeSlug = currentlyPreviewingTheme();
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			const theme = ( select( 'core' ) as any ).getTheme( themeSlug );
-			return {
-				previewingTheme: theme?.name?.rendered || themeSlug,
-				dashboardLink: getSettings().__experimentalDashboardLink,
-			};
-		},
-		[ siteEditorStore ]
-	);
+	const themeSlug = currentlyPreviewingTheme();
+	const previewingTheme = useSelect( ( select ) => {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const theme = ( select( 'core' ) as any ).getTheme( themeSlug );
+		return theme?.name?.rendered || themeSlug;
+	}, [] );
+
+	const siteEditorStore = useSelect( ( select ) => select( 'core/edit-site' ), [] );
+	const dashboardLink =
+		unlock &&
+		siteEditorStore &&
+		unlock( siteEditorStore ).getSettings().__experimentalDashboardLink;
+
 	useEffect( () => {
 		// Do nothing in the Post Editor context.
 		if ( ! siteEditorStore ) {
@@ -94,7 +87,7 @@ const LivePreviewNotice = () => {
 			{
 				id: NOTICE_ID,
 				isDismissible: false,
-				actions: [
+				actions: dashboardLink && [
 					{
 						label: __( 'Back to themes', 'wpcom-live-preview' ),
 						url: dashboardLink,


### PR DESCRIPTION
Related to p1696799750463389/1696570833.645759-slack-C02FMH4G8

## Proposed Changes

When an Atomic site disables Gutenberg plugin, the `core/edit-site` store cannot be unlocked, causing the plugin to crash when trying to get the "Back to themes" link. This PR removes the link temporarily in such situation. We should figure out how to show the link later.

## Testing Instructions

1. Sandbox `widgets.wp.com`
2. Patch this PR to your sandbox (`install-plugin.sh wpcom-block-editor live-preview-widget-fix`)
3. Re-test using the instructions from https://github.com/Automattic/wp-calypso/pull/82698.
4. Re-test with Atomic site that has Gutenberg plugin disabled. Verify that Site Editor works when previewing theme and when NOT previewing theme.


## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?