### PR TITLE
Jetpack E2E: re-enable the Newsletter Subscribe spec.

### DIFF
--- a/test/e2e/specs/users/newsletter__subscribe-remove.ts
+++ b/test/e2e/specs/users/newsletter__subscribe-remove.ts
@@ -1,4 +1,6 @@
 /**
+ * @group jetpack-wpcom-integration
+ * @group calypso-release
  */
 
 import {


### PR DESCRIPTION
Reverts Automattic/wp-calypso#81751.

This PR re-enables the Newsletter Subscribe/Remove spec.

