### PR TITLE
Add track for Woo Express in trial expired page

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/ecommerce-trial-expired/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/ecommerce-trial-expired/index.tsx
@@ -15,6 +15,7 @@ import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import './style.scss';
+import useOneDollarOfferTrack from '../../hooks/use-onedollar-offer-track';
 
 const ECommerceTrialExpired = (): JSX.Element => {
 	const translate = useTranslate();
@@ -29,6 +30,8 @@ const ECommerceTrialExpired = (): JSX.Element => {
 			sitePurchases.filter( ( purchase ) => purchase.productSlug !== PLAN_ECOMMERCE_TRIAL_MONTHLY ),
 		[ sitePurchases ]
 	);
+
+	useOneDollarOfferTrack( siteId, 'trialexpired' );
 
 	const [ interval, setInterval ] = useState( 'monthly' as 'monthly' | 'yearly' );
 


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/wp-calypso/pull/82099, where I missed adding `trialexpired`

Discussion: p1696830562572049/1696608289.267929-slack-C05KSH7B4UV

## Proposed Changes

* Add `trialexpired` track to the Woo Express free trial expiry page

## Testing Instructions

* You need to use an a12n account and proxy
* Use an existing Woo Express free trial site
* Alternatively, go to https://woocommerce.com/start/#/ and go through the whole NUX flow and set up a free trial site
* After the site is created, go to http://calypso.localhost:3000/plans and open up developer console
* Run `localStorage.setItem('debug', 'calypso:analytics');` to enable debugging
* Open up http://calypso.localhost:3000/plans/my-plan/trial-expired/SITE_URL
* In console, look for the track `calypso_wooexpress_one_dollar_offer` with props `location: trialexpired`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
