### PR TITLE
Jetpack E2E: use colon instead of dash as prefix for the Form AI block spec.

### DIFF
--- a/test/e2e/specs/blocks/blocks__jetpack-forms.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-forms.ts
@@ -35,7 +35,7 @@ const blockFlows: BlockFlow[] = [
 		prompt:
 			// The prefix part of the prompt isn't necessary for the test to be stable and have value
 			// but it doesn't hurt and will make debugging easier!
-			'Please create a small and simple registration form for a conference. Please prefix all field labels and the submit button with "AI".',
+			'Please create a small and simple registration form for a conference. Please prefix all field labels and the submit button with "AI:".',
 	} ),
 ];
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/82754.

## Proposed Changes

This PR changes the query to the AI to explicitly prefix with a colon, not a dash.

This is because WordPress often replaces dashes with an em-dash, which isn't exactly the same from a text matching perspective.

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Calypso E2E (desktop)
  - [x] Jetpack E2E Simple (mobile)
  - [x] Jetpack E2E Simple (desktop)
  - [x] Jetpack E2E AT (desktop)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?