### PR TITLE
Jetpack E2E: re-enable Newsletter spec and update expectation.

### DIFF
--- a/test/e2e/specs/users/newsletter__subscribe-remove.ts
+++ b/test/e2e/specs/users/newsletter__subscribe-remove.ts
@@ -1,4 +1,5 @@
 /**
+ * @group jetpack-wpcom-integration
  */
 
 import {
@@ -13,7 +14,6 @@ import {
 	EmailClient,
 	SecretsManager,
 	SubscribersPage,
-	SubscriptionManagementPage,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 import { skipDescribeIf } from '../../jest-helpers';
@@ -83,13 +83,6 @@ skipDescribeIf( envVariables.ATOMIC_VARIATION === 'private' )(
 				expect( confirmationURL ).not.toBe( null );
 
 				await page.goto( confirmationURL as string );
-			} );
-
-			it( 'Land in Subscription Management page', async function () {
-				const subscriptionManagementPage = new SubscriptionManagementPage( page );
-				await subscriptionManagementPage.validateSiteSubscribed(
-					testAccount.getSiteURL( { protocol: false } )
-				);
 			} );
 		} );
 


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/82206. **Blocked by task 1.**

## Proposed Changes

This PR re-enables the spec for Jetpack environments and removes a step that is no longer expected.
The spec could not be re-enabled for `calypso-release` group due to an issue with the test site.

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Calypso E2E (desktop)
  - [x] Jetpack E2E Simple (mobile)
  - [x] Jetpack E2E Simple (desktop)
  - [x] Jetpack E2E AT (desktop)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?