### PR TITLE
Multi-Domain: Remove domains primary CTA when minicart is showing

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -192,10 +192,6 @@ class DomainRegistrationSuggestion extends Component {
 			buttonStyles = { ...buttonStyles, disabled: true };
 		}
 
-		if ( shouldUseMultipleDomainsInCart( flowName, suggestion ) ) {
-			buttonStyles = { ...buttonStyles, primary: false };
-		}
-
 		return {
 			buttonContent,
 			buttonStyles,

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1121,7 +1121,11 @@ export class RenderDomainsStep extends Component {
 		return (
 			<div
 				key={ this.props.step + this.props.stepSectionName }
-				className="domains__step-content domains__step-content-domain-step"
+				className={ classNames( 'domains__step-content', 'domains__step-content-domain-step', {
+					'domains__step-has-domains-in-cart':
+						shouldUseMultipleDomainsInCart( this.props.flowName, this.props.step?.suggestion ) &&
+						getDomainRegistrations( this.props.cart ).length > 0,
+				} ) }
 			>
 				{ content }
 				{ sideContent }

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -38,6 +38,15 @@
 
 	&.domains__step-content-domain-step {
 		margin-bottom: 20px;
+		&.domains__step-has-domains-in-cart {
+			.featured-domain-suggestion .domain-suggestion__action.is-primary:not(.is-busy) {
+				background: transparent;
+				border-style: solid;
+				border-width: 1px;
+				border-color: var(--color-neutral-10);
+				color: var(--color-neutral-70);
+			}
+		}
 	}
 
 	.search-component .search-component__icon-navigation {


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/4140

## Proposed Changes

When the mini-cart is showing, the CTA on featured domains should not be primary.

| No domains in cart | Domain(s) in cart |
| --- | --- |
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/7a9a1867-f627-4545-9203-f8e7861903ff) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/69dff7d0-988e-4c0c-a468-8ccaec4fb7e7) |

## Testing Instructions

* Go to `/start/domains?flags=domains/add-multiple-domains-to-cart`
* Add a not-featured domain to the cart
* The featured domains should not show as primary buttons

