### PR TITLE
Plans page: show price at purchase for the current plan

### DIFF
--- a/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
+++ b/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
@@ -1,16 +1,17 @@
+import { isMonthly, type PlanSlug } from '@automattic/calypso-products';
 import { Plans, WpcomPlansUI } from '@automattic/data-stores';
 import { useSelect } from '@wordpress/data';
 import { useSelector } from 'react-redux';
 import usePricedAPIPlans from 'calypso/my-sites/plans-features-main/hooks/data-store/use-priced-api-plans';
 import { getPlanPrices } from 'calypso/state/plans/selectors';
 import { PlanPrices } from 'calypso/state/plans/types';
+import { getByPurchaseId } from 'calypso/state/purchases/selectors';
 import {
+	getCurrentPlan,
 	getSitePlanRawPrice,
 	isPlanAvailableForPurchase,
 } from 'calypso/state/sites/plans/selectors';
-import getSitePlanSlug from 'calypso/state/sites/selectors/get-site-plan-slug';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
-import type { PlanSlug } from '@automattic/calypso-products';
 import type { AddOnMeta } from '@automattic/data-stores';
 import type {
 	UsePricingMetaForGridPlans,
@@ -51,14 +52,20 @@ const usePricingMetaForGridPlans: UsePricingMetaForGridPlans = ( {
 	storageAddOns,
 }: Props ) => {
 	const selectedSiteId = useSelector( getSelectedSiteId ) ?? undefined;
-	const currentSitePlanSlug = useSelector( ( state: IAppState ) =>
-		getSitePlanSlug( state, selectedSiteId )
+	const currentPlan = useSelector( ( state: IAppState ) =>
+		getCurrentPlan( state, selectedSiteId )
 	);
+	const currentSitePlanSlug = currentPlan?.productSlug;
+
 	const pricedAPIPlans = usePricedAPIPlans( { planSlugs: planSlugs } );
 	const sitePlans = Plans.useSitePlans( { siteId: selectedSiteId } );
 	const selectedStorageOptions = useSelect( ( select ) => {
 		return select( WpcomPlansUI.store ).getSelectedStorageOptions();
 	}, [] );
+
+	const purchasedPlan = useSelector(
+		( state: IAppState ) => currentPlan && getByPurchaseId( state, currentPlan.id || 0 )
+	);
 	const planPrices = useSelector( ( state: IAppState ) => {
 		return planSlugs.reduce(
 			( acc, planSlug ) => {
@@ -91,14 +98,30 @@ const usePricingMetaForGridPlans: UsePricingMetaForGridPlans = ( {
 
 				// raw prices for current site's plan
 				if ( selectedSiteId && currentSitePlanSlug === planSlug ) {
-					const monthlyPrice = getSitePlanRawPrice( state, selectedSiteId, planSlug, {
+					let monthlyPrice = getSitePlanRawPrice( state, selectedSiteId, planSlug, {
 						returnMonthly: true,
 						returnSmallestUnit: true,
 					} );
-					const yearlyPrice = getSitePlanRawPrice( state, selectedSiteId, planSlug, {
+					let yearlyPrice = getSitePlanRawPrice( state, selectedSiteId, planSlug, {
 						returnMonthly: false,
 						returnSmallestUnit: true,
 					} );
+
+					/**
+					 * Ensure the spotlight plan shows the price with which the plans was purchased.
+					 */
+					if ( purchasedPlan ) {
+						if (
+							isMonthly( purchasedPlan.productSlug ) &&
+							monthlyPrice !== purchasedPlan.priceInteger
+						) {
+							monthlyPrice = purchasedPlan.priceInteger;
+							yearlyPrice = Math.floor( purchasedPlan.priceInteger * 12 );
+						} else if ( yearlyPrice !== purchasedPlan.priceInteger ) {
+							monthlyPrice = Math.floor( purchasedPlan.priceInteger / 12 );
+							yearlyPrice = purchasedPlan.priceInteger;
+						}
+					}
 
 					return {
 						...acc,

--- a/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
+++ b/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
@@ -1,4 +1,8 @@
-import { isMonthly, type PlanSlug } from '@automattic/calypso-products';
+import {
+	PLAN_ANNUAL_PERIOD,
+	PLAN_MONTHLY_PERIOD,
+	type PlanSlug,
+} from '@automattic/calypso-products';
 import { Plans, WpcomPlansUI } from '@automattic/data-stores';
 import { useSelect } from '@wordpress/data';
 import { useSelector } from 'react-redux';
@@ -111,13 +115,13 @@ const usePricingMetaForGridPlans: UsePricingMetaForGridPlans = ( {
 					 * Ensure the spotlight plan shows the price with which the plans was purchased.
 					 */
 					if ( purchasedPlan ) {
-						if (
-							isMonthly( purchasedPlan.productSlug ) &&
-							monthlyPrice !== purchasedPlan.priceInteger
-						) {
+						const isMonthly = purchasedPlan.billPeriodDays === PLAN_MONTHLY_PERIOD;
+						const isYearly = purchasedPlan.billPeriodDays === PLAN_ANNUAL_PERIOD;
+
+						if ( isMonthly && monthlyPrice !== purchasedPlan.priceInteger ) {
 							monthlyPrice = purchasedPlan.priceInteger;
 							yearlyPrice = Math.floor( purchasedPlan.priceInteger * 12 );
-						} else if ( yearlyPrice !== purchasedPlan.priceInteger ) {
+						} else if ( isYearly && yearlyPrice !== purchasedPlan.priceInteger ) {
 							monthlyPrice = Math.floor( purchasedPlan.priceInteger / 12 );
 							yearlyPrice = purchasedPlan.priceInteger;
 						}

--- a/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
+++ b/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
@@ -1,7 +1,10 @@
 import {
 	PLAN_ANNUAL_PERIOD,
 	PLAN_MONTHLY_PERIOD,
+	calculateMonthlyPrice,
 	type PlanSlug,
+	calculateYearlyPrice,
+	TERM_ANNUALLY,
 } from '@automattic/calypso-products';
 import { Plans, WpcomPlansUI } from '@automattic/data-stores';
 import { useSelect } from '@wordpress/data';
@@ -120,9 +123,9 @@ const usePricingMetaForGridPlans: UsePricingMetaForGridPlans = ( {
 
 						if ( isMonthly && monthlyPrice !== purchasedPlan.priceInteger ) {
 							monthlyPrice = purchasedPlan.priceInteger;
-							yearlyPrice = Math.floor( purchasedPlan.priceInteger * 12 );
+							yearlyPrice = calculateYearlyPrice( TERM_ANNUALLY, purchasedPlan.priceInteger );
 						} else if ( isYearly && yearlyPrice !== purchasedPlan.priceInteger ) {
-							monthlyPrice = Math.floor( purchasedPlan.priceInteger / 12 );
+							monthlyPrice = calculateMonthlyPrice( TERM_ANNUALLY, purchasedPlan.priceInteger );
 							yearlyPrice = purchasedPlan.priceInteger;
 						}
 					}

--- a/client/my-sites/plans-features-main/hooks/test/use-pricing-meta-for-grid-plans.ts
+++ b/client/my-sites/plans-features-main/hooks/test/use-pricing-meta-for-grid-plans.ts
@@ -14,14 +14,18 @@ jest.mock( 'calypso/state/plans/selectors', () => ( {
 	getPlanPrices: jest.fn(),
 } ) );
 jest.mock( 'calypso/state/sites/plans/selectors', () => ( {
+	getCurrentPlan: jest.fn(),
 	getSitePlanRawPrice: jest.fn(),
 	isPlanAvailableForPurchase: jest.fn(),
 } ) );
-jest.mock( 'calypso/state/sites/selectors/get-site-plan-slug', () => jest.fn() );
 jest.mock( 'calypso/state/ui/selectors/get-selected-site-id', () => jest.fn() );
 jest.mock( 'calypso/my-sites/plans-features-main/hooks/data-store/use-priced-api-plans', () =>
 	jest.fn()
 );
+jest.mock( 'calypso/state/purchases/selectors', () => ( {
+	getByPurchaseId: jest.fn(),
+} ) );
+
 jest.mock( '@automattic/data-stores', () => ( {
 	Plans: {
 		useSitePlans: jest.fn(),
@@ -32,11 +36,12 @@ import { PLAN_PERSONAL, PLAN_PREMIUM } from '@automattic/calypso-products';
 import { Plans } from '@automattic/data-stores';
 import usePricedAPIPlans from 'calypso/my-sites/plans-features-main/hooks/data-store/use-priced-api-plans';
 import { getPlanPrices } from 'calypso/state/plans/selectors';
+import { getByPurchaseId } from 'calypso/state/purchases/selectors';
 import {
+	getCurrentPlan,
 	getSitePlanRawPrice,
 	isPlanAvailableForPurchase,
 } from 'calypso/state/sites/plans/selectors';
-import getSitePlanSlug from 'calypso/state/sites/selectors/get-site-plan-slug';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import usePricingMetaForGridPlans from '../data-store/use-pricing-meta-for-grid-plans';
 
@@ -47,6 +52,7 @@ describe( 'usePricingMetaForGridPlans', () => {
 			isFetching: false,
 			data: null,
 		} ) );
+		getByPurchaseId.mockImplementation( () => undefined );
 		usePricedAPIPlans.mockImplementation( () => ( {
 			[ PLAN_PREMIUM ]: {
 				bill_period: 365,
@@ -60,7 +66,7 @@ describe( 'usePricingMetaForGridPlans', () => {
 	} );
 
 	it( 'should return the original price as the site plan price and discounted price as Null for the current plan', () => {
-		getSitePlanSlug.mockImplementation( () => PLAN_PREMIUM );
+		getCurrentPlan.mockImplementation( () => ( { productSlug: PLAN_PREMIUM } ) );
 		getSelectedSiteId.mockImplementation( () => 100 );
 		getPlanPrices.mockImplementation( () => null );
 		getSitePlanRawPrice.mockImplementation( () => 300 );
@@ -90,7 +96,7 @@ describe( 'usePricingMetaForGridPlans', () => {
 	} );
 
 	it( 'should return the original price as the site plan price and discounted price as Null for plans not available for purchase', () => {
-		getSitePlanSlug.mockImplementation( () => PLAN_PREMIUM );
+		getCurrentPlan.mockImplementation( () => ( { productSlug: PLAN_PREMIUM } ) );
 		getSelectedSiteId.mockImplementation( () => 100 );
 		getPlanPrices.mockImplementation( () => ( {
 			rawPrice: 300,
@@ -124,7 +130,7 @@ describe( 'usePricingMetaForGridPlans', () => {
 	} );
 
 	it( 'should return the original price and discounted price without pro-rated credits when withoutProRatedCredits is true', () => {
-		getSitePlanSlug.mockImplementation( () => PLAN_PREMIUM );
+		getCurrentPlan.mockImplementation( () => ( { productSlug: PLAN_PREMIUM } ) );
 		getSelectedSiteId.mockImplementation( () => 100 );
 		getPlanPrices.mockImplementation( () => ( {
 			rawPrice: 300,
@@ -158,7 +164,7 @@ describe( 'usePricingMetaForGridPlans', () => {
 	} );
 
 	it( 'should return the original price and discounted price with pro-rated credits when withoutProRatedCredits is false', () => {
-		getSitePlanSlug.mockImplementation( () => PLAN_PREMIUM );
+		getCurrentPlan.mockImplementation( () => ( { productSlug: PLAN_PREMIUM } ) );
 		getSelectedSiteId.mockImplementation( () => 100 );
 		getPlanPrices.mockImplementation( () => ( {
 			rawPrice: 300,

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -42,7 +42,6 @@ import useGridPlans from 'calypso/my-sites/plans-grid/hooks/npm-ready/data-store
 import usePlanFeaturesForGridPlans from 'calypso/my-sites/plans-grid/hooks/npm-ready/data-store/use-plan-features-for-grid-plans';
 import useRestructuredPlanFeaturesForComparisonGrid from 'calypso/my-sites/plans-grid/hooks/npm-ready/data-store/use-restructured-plan-features-for-comparison-grid';
 import { getCurrentUserName } from 'calypso/state/current-user/selectors';
-import { getByPurchaseId } from 'calypso/state/purchases/selectors';
 import canUpgradeToPlan from 'calypso/state/selectors/can-upgrade-to-plan';
 import getDomainFromHomeUpsellInQuery from 'calypso/state/selectors/get-domain-from-home-upsell-in-query';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
@@ -237,11 +236,6 @@ const PlansFeaturesMain = ( {
 	);
 	const shouldDisplayFreeHostingTrial = useSelector( isUserEligibleForFreeHostingTrial );
 	const currentPlan = useSelector( ( state: IAppState ) => getCurrentPlan( state, siteId ) );
-
-	const purchase = useSelector(
-		( state: IAppState ) => currentPlan && getByPurchaseId( state, currentPlan.id || 0 )
-	);
-
 	const eligibleForWpcomMonthlyPlans = useSelector( ( state: IAppState ) =>
 		isEligibleForWpComMonthlyPlan( state, siteId )
 	);
@@ -537,23 +531,6 @@ const PlansFeaturesMain = ( {
 					( { planSlug } ) => getPlanClass( planSlug ) === getPlanClass( sitePlanSlug )
 			  )
 			: undefined;
-
-	/**
-	 * Ensure the spotlight plan shows the price with which the plans was purchased.
-	 */
-	if (
-		gridPlanForSpotlight &&
-		purchase &&
-		gridPlanForSpotlight.planSlug === purchase.productSlug
-	) {
-		if ( gridPlanForSpotlight.isMonthlyPlan ) {
-			gridPlanForSpotlight.pricing.originalPrice.monthly = purchase.priceInteger;
-			gridPlanForSpotlight.pricing.originalPrice.full = Math.floor( purchase.priceInteger * 12 );
-		} else {
-			gridPlanForSpotlight.pricing.originalPrice.monthly = Math.floor( purchase.priceInteger / 12 );
-			gridPlanForSpotlight.pricing.originalPrice.full = purchase.priceInteger;
-		}
-	}
 
 	const [ masterbarHeight, setMasterbarHeight ] = useState( 0 );
 	/**

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -42,6 +42,7 @@ import useGridPlans from 'calypso/my-sites/plans-grid/hooks/npm-ready/data-store
 import usePlanFeaturesForGridPlans from 'calypso/my-sites/plans-grid/hooks/npm-ready/data-store/use-plan-features-for-grid-plans';
 import useRestructuredPlanFeaturesForComparisonGrid from 'calypso/my-sites/plans-grid/hooks/npm-ready/data-store/use-restructured-plan-features-for-comparison-grid';
 import { getCurrentUserName } from 'calypso/state/current-user/selectors';
+import { getByPurchaseId } from 'calypso/state/purchases/selectors';
 import canUpgradeToPlan from 'calypso/state/selectors/can-upgrade-to-plan';
 import getDomainFromHomeUpsellInQuery from 'calypso/state/selectors/get-domain-from-home-upsell-in-query';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
@@ -236,6 +237,11 @@ const PlansFeaturesMain = ( {
 	);
 	const shouldDisplayFreeHostingTrial = useSelector( isUserEligibleForFreeHostingTrial );
 	const currentPlan = useSelector( ( state: IAppState ) => getCurrentPlan( state, siteId ) );
+
+	const purchase = useSelector(
+		( state: IAppState ) => currentPlan && getByPurchaseId( state, currentPlan.id || 0 )
+	);
+
 	const eligibleForWpcomMonthlyPlans = useSelector( ( state: IAppState ) =>
 		isEligibleForWpComMonthlyPlan( state, siteId )
 	);
@@ -531,6 +537,23 @@ const PlansFeaturesMain = ( {
 					( { planSlug } ) => getPlanClass( planSlug ) === getPlanClass( sitePlanSlug )
 			  )
 			: undefined;
+
+	/**
+	 * Ensure the spotlight plan shows the price with which the plans was purchased.
+	 */
+	if (
+		gridPlanForSpotlight &&
+		purchase &&
+		gridPlanForSpotlight.planSlug === purchase.productSlug
+	) {
+		if ( gridPlanForSpotlight.isMonthlyPlan ) {
+			gridPlanForSpotlight.pricing.originalPrice.monthly = purchase.priceInteger;
+			gridPlanForSpotlight.pricing.originalPrice.full = Math.floor( purchase.priceInteger * 12 );
+		} else {
+			gridPlanForSpotlight.pricing.originalPrice.monthly = Math.floor( purchase.priceInteger / 12 );
+			gridPlanForSpotlight.pricing.originalPrice.full = purchase.priceInteger;
+		}
+	}
 
 	const [ masterbarHeight, setMasterbarHeight ] = useState( 0 );
 	/**

--- a/packages/calypso-products/src/main.ts
+++ b/packages/calypso-products/src/main.ts
@@ -565,6 +565,11 @@ export function calculateMonthlyPrice( term: string, termPrice: number ): number
 	return parseFloat( ( termPrice / divisor ).toFixed( 2 ) );
 }
 
+export function calculateYearlyPrice( term: string, termPrice: number ): number {
+	const multiplier = getBillingMonthsForTerm( term );
+	return parseFloat( ( termPrice * multiplier ).toFixed( 2 ) );
+}
+
 export function getBillingMonthsForTerm( term: string ): number {
 	if ( term === TERM_MONTHLY ) {
 		return 1;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

On `/plans`, the currently active plan is shown with the latest pricing.
This can be different from the price with which the plan has been purchased initially (and used for renewal).

This is problematic for pricing experiments, such as the one from D124539-code, where you can see one price on `/plans` (`treatment` variation) and another on renewal checkout.

This PR attempts to fix the issue by fetching the purchased plan subscription and using its price for the spotlighted plan.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through D124539-code
* Assign your self `treatment` to an account that already has a Personal plan (ie. these plans were purchased as `control`)
* Go to /plans/[SITE_ID]
* Ensure `Your plan` shows the `control` price
* The other plan (Premium) should show the `treatment` price

### Simpler instructions
* Go to the SA panel
* Assign yourself a plan that is not purchasable ex. (WordPress.com Personal Yearly 2021-10-01)
* Ensure the plan's price is correctly shown on /plans


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
