### PR TITLE
Updated the logic to only remove primary-cta when the mini-cart is showing

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -18,6 +18,7 @@ import {
 	getDomainPriceRule,
 	hasDomainInCart,
 	isPaidDomain,
+	getDomainRegistrations,
 } from 'calypso/lib/cart-values/cart-items';
 import {
 	getDomainPrice,
@@ -192,7 +193,10 @@ class DomainRegistrationSuggestion extends Component {
 			buttonStyles = { ...buttonStyles, disabled: true };
 		}
 
-		if ( shouldUseMultipleDomainsInCart( flowName, suggestion ) ) {
+		if (
+			shouldUseMultipleDomainsInCart( flowName, suggestion ) &&
+			getDomainRegistrations( cart ).length > 0
+		) {
 			buttonStyles = { ...buttonStyles, primary: false };
 		}
 


### PR DESCRIPTION
Related to 4140-gh-Automattic/dotcom-forge

## Proposed Changes

When the mini-cart is showing, the CTA on featured domains should not be primary.

| No domains in cart | Domain(s) in cart |
| --- | --- |
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/7a9a1867-f627-4545-9203-f8e7861903ff) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/69dff7d0-988e-4c0c-a468-8ccaec4fb7e7) |

## Testing Instructions

* Go to `/start/domains?flags=domains/add-multiple-domains-to-cart`
* Add a not-featured domain to the cart
* The featured domains should not show as primary buttons
* When the mini-cart is clean, the primary buttons should appear in the featured domains