### PR TITLE
Multi-Domains: Fix broken long currencies

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -799,11 +799,21 @@ export class RenderDomainsStep extends Component {
 							</div>
 						) ) }
 					</div>
-					<div key="rowtotal" className="domains__domain-cart-total">
-						{ this.props.translate( '%d domain', '%d domains', {
-							count: domainsInCart.length,
-							args: [ domainsInCart.length ],
-						} ) }
+					<div className="domains__domain-cart-total">
+						<div key="rowtotal" className="domains__domain-cart-count">
+							{ this.props.translate( '%d domain', '%d domains', {
+								count: domainsInCart.length,
+								args: [ domainsInCart.length ],
+							} ) }
+						</div>
+						<div key="rowtotalprice" className="domains__domain-cart-total-price">
+							<strong>
+								{ formatCurrency(
+									domainsInCart.reduce( ( total, item ) => total + item.cost, 0 ),
+									domainsInCart ? domainsInCart[ 0 ].currency : 'USD'
+								) }
+							</strong>
+						</div>
 					</div>
 					<Button primary className="domains__domain-cart-continue" onClick={ this.goToNext() }>
 						{ this.props.translate( 'Continue' ) }

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -175,7 +175,7 @@
 				}
 
 				&.limit-width {
-					width: 35%;
+					width: 32%;
 				}
 			}
 

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -175,7 +175,7 @@
 				}
 
 				&.limit-width {
-					width: 45%;
+					width: 35%;
 				}
 			}
 

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -175,13 +175,15 @@
 				}
 
 				&.limit-width {
-					width: 45%;
+					width: 35%;
 				}
 			}
 
 			.domains__domain-cart-remove {
 				color: var(--studio-gray-50);
 				font-size: $font-body-extra-small;
+				min-width: 50px;
+				margin-right: 10px;
 			}
 
 			.domain-product-price__price {
@@ -191,7 +193,8 @@
 
 				del {
 					font-size: 0.75rem;
-					margin-right: 5px;
+					margin-right: 7px;
+					margin-left: 7px;
 				}
 			}
 		}

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -159,7 +159,7 @@
 				color: var(--studio-green);
 				display: flex;
 				align-items: center;
-				font-size: 0.875rem;
+				font-size: 0.75rem;
 			}
 
 			.domains__domain-cart-domain {
@@ -175,7 +175,7 @@
 				}
 
 				&.limit-width {
-					width: 32%;
+					width: 45%;
 				}
 			}
 
@@ -184,6 +184,7 @@
 				font-size: $font-body-extra-small;
 				min-width: 50px;
 				margin-right: 10px;
+				text-align: left;
 			}
 
 			.domain-product-price__price {
@@ -202,11 +203,13 @@
 		.domains__domain-cart-total {
 			border-top: 1px solid;
 			border-top-color: var(--studio-gray-5);
-			padding-top: 10px;
-			margin-bottom: 10px;
+			padding-top: 28px;
+			margin-bottom: 28px;
 			margin-top: 12px;
 			color: var(--studio-gray-60);
 			font-size: $font-body-small;
+			display: flex;
+			justify-content: space-between;
 		}
 
 		.domains__domain-cart-continue {
@@ -222,6 +225,7 @@
 			height: 40px;
 			color: var(--studio-gray-100);
 			text-decoration: underline;
+			margin-top: 5px;
 		}
 	}
 }
@@ -310,7 +314,7 @@ body.is-section-signup.is-white-signup {
 			}
 
 			@include break-wide {
-				margin: 0 0 0 80px;
+				margin: 0 0 0 60px;
 			}
 
 			&.fade-out {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 4138-gh-Automattic/dotcom-forge and 4141-gh-Automattic/dotcom-forge
Slack thread: p1696853959197839-slack-CKZHG0QCR

## Proposed Changes

* Better domain alignment (specially with long currencies)
* Fixed CTA margins spacing
* Added domains total price

## Testing Instructions

Access the new domain start flow: http://calypso.localhost:3000/start/domains?flags=domains/add-multiple-domains-to-cart

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

| Before | After |
|--------|--------|
| ![image](https://github.com/Automattic/wp-calypso/assets/1044309/36b7b05b-6980-48ec-b800-2d0f7fa81c6c) | ![image](https://github.com/Automattic/wp-calypso/assets/1044309/e6157bb5-363c-42f9-982c-6e45ef1a792a) | 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?