### PR TITLE
Prevents breaking the plugins page if the sections property is empty

### DIFF
--- a/client/my-sites/plugins/plugin-sections/index.jsx
+++ b/client/my-sites/plugins/plugin-sections/index.jsx
@@ -195,10 +195,6 @@ class PluginSections extends Component {
 		const banner = this.props.plugin?.banners?.high || this.props.plugin?.banners?.low;
 		const videoUrl = this.props.plugin?.banner_video_src;
 
-		if ( ! this.getSelected() ) {
-			return null;
-		}
-
 		/*eslint-disable react/no-danger*/
 		if (
 			! this.props.addBanner ||
@@ -261,7 +257,12 @@ class PluginSections extends Component {
 	render() {
 		const availableSections = this.getAvailableSections();
 		// Defensively check if this plugin has sections. If not, don't render anything.
-		if ( ! this.props.plugin || ! this.props.plugin.sections || ! availableSections ) {
+		if (
+			! this.props.plugin ||
+			! this.props.plugin.sections ||
+			! availableSections ||
+			! this.getSelected()
+		) {
 			return null;
 		}
 
@@ -271,7 +272,7 @@ class PluginSections extends Component {
 
 		return (
 			<div className="plugin-sections">
-				{ this.getSelected() && ! hasOnlyDescriptionSection && (
+				{ ! hasOnlyDescriptionSection && (
 					<div className="plugin-sections__header">
 						<SectionNav selectedText={ this.getNavTitle( this.getSelected() ) }>
 							<NavTabs>

--- a/client/my-sites/plugins/plugin-sections/index.jsx
+++ b/client/my-sites/plugins/plugin-sections/index.jsx
@@ -163,7 +163,7 @@ class PluginSections extends Component {
 		const sections = this.props.plugin.sections;
 		return find( this.getFilteredSections(), function ( section ) {
 			return sections[ section.key ];
-		} ).key;
+		} )?.key;
 	};
 
 	getAvailableSections = () => {
@@ -194,6 +194,10 @@ class PluginSections extends Component {
 		const contentClasses = classNames( 'plugin-sections__content' );
 		const banner = this.props.plugin?.banners?.high || this.props.plugin?.banners?.low;
 		const videoUrl = this.props.plugin?.banner_video_src;
+
+		if ( ! this.getSelected() ) {
+			return null;
+		}
 
 		/*eslint-disable react/no-danger*/
 		if (
@@ -267,7 +271,7 @@ class PluginSections extends Component {
 
 		return (
 			<div className="plugin-sections">
-				{ ! hasOnlyDescriptionSection && (
+				{ this.getSelected() && ! hasOnlyDescriptionSection && (
 					<div className="plugin-sections__header">
 						<SectionNav selectedText={ this.getNavTitle( this.getSelected() ) }>
 							<NavTabs>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1696852942663739-slack-C04U5A26MJB

## Proposed Changes

* The plugins page would break if the "sections" property that comes from wporg is empty.
* I prevented the rendering of the sections if the "sections" property is empty.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso Live link below
* Navigate to `/plugins/wp-angular`
* The page should not break anymore and you should see the plugin info.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?