### PR TITLE
Theme Showcase: Move the All Category Outside of the More Menu

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -161,8 +161,8 @@ class ThemeShowcase extends Component {
 				MYTHEMES: staticFilters.MYTHEMES,
 			} ),
 			RECOMMENDED: staticFilters.RECOMMENDED,
-			...this.subjectFilters,
 			ALL: staticFilters.ALL,
+			...this.subjectFilters,
 		};
 	};
 


### PR DESCRIPTION
## Proposed Changes

* Move the All theme category outside of the More menu and near Recommended.

The All category is both useful (e.g. to find non-curated themes) and well-used (it's the search result tab), but we have been hiding it at the very end of the list, tucked away in the More menu.

While moving it to the top is not the perfect solution, it's a reasonable workaround while we are working on the full Showcase redesign.

| Before | After (LoTS) | After (LiTS Simple) | After (LiTS Atomic) |
|--------|--------|--------|--------|
| <img width="1022" alt="Screenshot 2023-10-09 at 16 08 06" src="https://github.com/Automattic/wp-calypso/assets/2070010/2f52a44a-ed67-4c01-b0ae-a0478848bb55"> | <img width="1293" alt="Screenshot 2023-10-09 at 16 08 28" src="https://github.com/Automattic/wp-calypso/assets/2070010/696f5906-022d-4d58-aa2c-13bb4bf48074"> | <img width="1022" alt="Screenshot 2023-10-09 at 16 05 45" src="https://github.com/Automattic/wp-calypso/assets/2070010/c2d76599-e0cf-4db6-a962-0a3026038881"> | <img width="1022" alt="Screenshot 2023-10-09 at 16 05 26" src="https://github.com/Automattic/wp-calypso/assets/2070010/f642cf68-03cc-42f9-aa78-fdedf1f481d4"> |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/themes` on a Simple site, an Atomic site, and logged-out.
* Ensure the All category is positioned besides the Recommended one.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?