### PR TITLE
[GB 16.7.1] Revert "[ETK][GB 16.5.0] Workaround for disappearing toolbar settings

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/common/force-show-settings-button-icon-mobile.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/force-show-settings-button-icon-mobile.js
@@ -1,1 +1,0 @@
-import './force-show-settings-button-icon-mobile.scss';

--- a/apps/editing-toolkit/editing-toolkit-plugin/common/force-show-settings-button-icon-mobile.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/force-show-settings-button-icon-mobile.scss
@@ -1,9 +1,0 @@
-@import "@wordpress/base-styles/mixins";
-@import "@wordpress/base-styles/variables";
-@import "@wordpress/base-styles/breakpoints";
-
-.interface-pinned-items button[aria-label="Settings"] {
-	@media ( max-width: $break-medium ) {
-		display: block;
-	}
-}

--- a/apps/editing-toolkit/editing-toolkit-plugin/common/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/index.php
@@ -268,25 +268,3 @@ function enqueue_override_preview_button_url() {
 }
 
 add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_override_preview_button_url' );
-
-/**
- * Force-show the settings button icon in the post editor to fix a bug introduced in
- * Gutenberg 16.5 where the icon disappears in some mobile viewport sizes.
- *
- * Related discussion: https://a8c.slack.com/archives/CBTN58FTJ/p1692639188443899
- * Gutenberg issue: https://github.com/WordPress/gutenberg/issues/53899#
- *
- * This is meant to be a temporary workaround until a proper fix is implemented in core.
- */
-function enqueue_force_show_settings_button_icon_mobile_style() {
-	$style_file = is_rtl()
-		? 'force-show-settings-button-icon-mobile.rtl.css'
-		: 'force-show-settings-button-icon-mobile.css';
-	wp_enqueue_style(
-		'a8c-force-show-settings-button-icon-mobile',
-		plugins_url( 'dist/' . $style_file, __FILE__ ),
-		array(),
-		filemtime( plugin_dir_path( __FILE__ ) . 'dist/' . $style_file )
-	);
-}
-add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_force_show_settings_button_icon_mobile_style' );

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -16,7 +16,7 @@
 	"scripts": {
 		"build": "NODE_ENV=production yarn dev",
 		"build:block-inserter-modifications": "calypso-build --env source='block-inserter-modifications/contextual-tips'",
-		"build:common": " calypso-build --env source='common','common/data-stores','common/hide-plugin-buttons-mobile','common/disable-heic-images','common/override-preview-button-url','common/force-show-settings-button-icon-mobile'",
+		"build:common": " calypso-build --env source='common','common/data-stores','common/hide-plugin-buttons-mobile','common/disable-heic-images','common/override-preview-button-url'",
 		"build:error-reporting": "calypso-build --env source='error-reporting'",
 		"build:event-countdown-block": "calypso-build --env source='event-countdown-block'",
 		"build:global-styles": "calypso-build --env source='global-styles'",


### PR DESCRIPTION
This reverts commit 1a50a7edfdb8a689d42c57c21bdb5b2a00580ce2 (PR: https://github.com/Automattic/wp-calypso/pull/81050)

This is not needed anymore. For more info, see this P2 post: p9Jlb4-93O-p2.

