### PR TITLE
Launchpad: Fix paid newsletter task

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -16,7 +16,6 @@ import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { ResponseDomain } from 'calypso/lib/domains/types';
 import wpcom from 'calypso/lib/wp';
-import RecurringPaymentsPlanAddEditModal from 'calypso/my-sites/earn/components/add-edit-plan-modal';
 import { useSelector } from 'calypso/state';
 import { isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
 import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
@@ -67,7 +66,6 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goToStep, flow }: SidebarPr
 	const clipboardButtonEl = useRef< HTMLButtonElement >( null );
 	const [ clipboardCopied, setClipboardCopied ] = useState( false );
 	const [ stripeConnectUrl, setStripeConnectUrl ] = useState< string >( '' );
-	const [ showPlansModal, setShowPlansModal ] = useState( false );
 	const [ showConfirmModal, setShowConfirmModal ] = useState( false );
 	const queryClient = useQueryClient();
 
@@ -113,16 +111,15 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goToStep, flow }: SidebarPr
 			submit,
 			globalStylesInUse && shouldLimitGlobalStyles,
 			PLAN_PREMIUM,
-			setShowPlansModal,
 			queryClient,
-			goToStep,
 			flow,
 			isEmailVerified,
 			checklistStatuses,
+			() => setShowConfirmModal( true ),
+			goToStep,
 			getPlanCartItem(),
 			getDomainCartItem(),
 			stripeConnectUrl,
-			() => setShowConfirmModal( true ),
 			isDomainEmailUnverified
 		);
 
@@ -260,14 +257,6 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goToStep, flow }: SidebarPr
 						taskFilter={ () => enhancedTasks || [] }
 						makeLastTaskPrimaryAction={ true }
 					/>
-					{ showPlansModal && site?.ID && (
-						<RecurringPaymentsPlanAddEditModal
-							closeDialog={ () => setShowPlansModal( false ) }
-							product={ { subscribe_as_site_subscriber: true, price: 5 } }
-							annualProduct={ { subscribe_as_site_subscriber: true, price: 5 * 12 } }
-							siteId={ site.ID }
-						/>
-					) }
 				</div>
 			</div>
 			<Dialog

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -24,7 +24,6 @@ import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
-import { Dispatch, SetStateAction } from 'react';
 import { PLANS_LIST } from 'calypso/../packages/calypso-products/src/plans-list';
 import { NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import useCheckout from 'calypso/landing/stepper/hooks/use-checkout';
@@ -50,16 +49,15 @@ export function getEnhancedTasks(
 	submit: NavigationControls[ 'submit' ],
 	displayGlobalStylesWarning: boolean,
 	globalStylesMinimumPlan: string,
-	setShowPlansModal: Dispatch< SetStateAction< boolean > >,
 	queryClient: QueryClient,
-	goToStep?: NavigationControls[ 'goToStep' ],
 	flow: string | null = '',
 	isEmailVerified = false,
 	checklistStatuses: LaunchpadStatuses = {},
+	setShowConfirmModal: () => void,
+	goToStep?: NavigationControls[ 'goToStep' ],
 	planCartItem?: MinimalRequestCartProduct | null,
 	domainCartItem?: MinimalRequestCartProduct | null,
 	stripeConnectUrl?: string,
-	setShowConfirmModal: () => void = () => {},
 	isDomainEmailUnverified = false
 ) {
 	if ( ! tasks ) {
@@ -584,11 +582,9 @@ export function getEnhancedTasks(
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							completePaidNewsletterTask();
-							site?.ID
-								? setShowPlansModal( true )
-								: window.location.assign(
-										`/earn/payments-plans/${ siteSlug }?launchpad=add-product#add-newsletter-payment-plan`
-								  );
+							window.location.assign(
+								`/earn/payments-plans/${ siteSlug }?launchpad=add-product#add-newsletter-payment-plan`
+							);
 						},
 					};
 					break;


### PR DESCRIPTION
## Proposed Changes

Fixes the Launchpad's 'Create paid newsletter' task. Before this PR, clicking this task results in a white screen due to a bug in the modal to add/edit paid plans. This PR updates the task to redirect to the Earn page and open the same modal there, where it works without issue. 

In a follow up, we'll want a more complete fix for this actually resolves the bug with the modal and keeps the user on Launchpad.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1) Start a new launchpad site at http://calypso.localhost:3000/setup/newsletter/intro, select the Paid newsletter option, and proceed to Launchpad. 

2) Confirm the Create paid newsletter task now redirects to Earn and opens the modal to add a paid plan. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?