### PR TITLE
Launchpad: Use the data store to get the active slug in the Navigator

### DIFF
--- a/packages/launchpad-navigator/src/floating-navigator/index.tsx
+++ b/packages/launchpad-navigator/src/floating-navigator/index.tsx
@@ -1,5 +1,7 @@
 import { Card } from '@automattic/components';
+import { LaunchpadNavigator } from '@automattic/data-stores';
 import { DefaultWiredLaunchpad } from '@automattic/launchpad';
+import { select } from '@wordpress/data';
 
 import './style.scss';
 
@@ -9,7 +11,11 @@ export type FloatingNavigatorProps = {
 
 const FloatingNavigator = ( { siteSlug }: FloatingNavigatorProps ) => {
 	const launchpadContext = 'launchpad-navigator';
-	const checklistSlug = 'intent-build';
+	const checklistSlug = select( LaunchpadNavigator.store ).getActiveChecklistSlug() || null;
+
+	if ( ! checklistSlug ) {
+		return null;
+	}
 
 	return (
 		<Card className="launchpad-navigator__floating-navigator">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/82612

## Proposed Changes

* Removes the hardcoded checklist slug and uses the Launchpad Navigator data store to fetch it.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso Live link
* Navigate to `/home/:siteSlug?flags=launchpad/navigator` on a site with post-launch Launchpad active
* Click on one of the tasks to ensure we set the checklist as active
* Click on the navigator. You should see the checklist:
![Screen Shot 2023-10-09 at 17 36 28](https://github.com/Automattic/wp-calypso/assets/1234758/f6452014-6375-4972-8f47-1681260b4bbe)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?