### PR TITLE
Added temporary fix for dependency error

### DIFF
--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -76,7 +76,7 @@ export function generateSteps( {
 				'siteSlug',
 				'themeItem',
 				'useThemeHeadstart',
-				'domainCart',
+				...( config.isEnabled( 'domains/add-multiple-domains-to-cart' ) ? [ 'domainCart' ] : [] ),
 			],
 			optionalDependencies: [
 				'shouldHideFreePlan',
@@ -446,7 +446,7 @@ export function generateSteps( {
 				'siteUrl',
 				'lastDomainSearched',
 				'useThemeHeadstart',
-				'domainCart',
+				...( config.isEnabled( 'domains/add-multiple-domains-to-cart' ) ? [ 'domainCart' ] : [] ),
 			],
 			optionalDependencies: [
 				'shouldHideFreePlan',
@@ -492,7 +492,7 @@ export function generateSteps( {
 				'shouldHideFreePlan',
 				'themeItem',
 				'useThemeHeadstart',
-				'domainCart',
+				...( config.isEnabled( 'domains/add-multiple-domains-to-cart' ) ? [ 'domainCart' ] : [] ),
 			], // note: siteId, siteSlug are not provided when used in domain flow
 			optionalDependencies: [
 				'signupDomainOrigin',
@@ -523,7 +523,7 @@ export function generateSteps( {
 				'shouldHideFreePlan',
 				'signupDomainOrigin',
 				'useThemeHeadstart',
-				'domainCart',
+				...( config.isEnabled( 'domains/add-multiple-domains-to-cart' ) ? [ 'domainCart' ] : [] ),
 			],
 			optionalDependencies: [
 				'siteUrl',
@@ -554,7 +554,7 @@ export function generateSteps( {
 				'siteUrl',
 				'lastDomainSearched',
 				'isManageSiteFlow',
-				'domainCart',
+				...( config.isEnabled( 'domains/add-multiple-domains-to-cart' ) ? [ 'domainCart' ] : [] ),
 			],
 			optionalDependencies: [
 				'shouldHideFreePlan',
@@ -584,7 +584,7 @@ export function generateSteps( {
 				'shouldHideFreePlan',
 				'siteUrl',
 				'useThemeHeadstart',
-				'domainCart',
+				...( config.isEnabled( 'domains/add-multiple-domains-to-cart' ) ? [ 'domainCart' ] : [] ),
 			],
 			optionalDependencies: [
 				'signupDomainOrigin',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1696866404150999-slack-CKZHG0QCR

## Proposed Changes

* Temporary fix for dependency error

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open http://calypso.localhost:3000/start/domains
* Ensure you can select a domain and add it to cart
* Open http://calypso.localhost:3000/start/domains?flags=domains/add-multiple-domains-to-cart
* Ensure everything also works as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?