### PR TITLE
Site profiler: Refactoring: useDomainParam hook and site profiler main component

### DIFF
--- a/client/site-profiler/components/heading-information/index.tsx
+++ b/client/site-profiler/components/heading-information/index.tsx
@@ -7,7 +7,7 @@ import { HostingProvider } from 'calypso/data/site-profiler/types';
 import StatusCtaInfo from '../heading-information/status-cta-info';
 import StatusInfo from '../heading-information/status-info';
 import type { CONVERSION_ACTION } from '../../hooks/use-define-conversion-action';
-import type { SPECIAL_DOMAIN_CASES } from '../../utils/get-special-domain-mapping';
+import type { SPECIAL_DOMAIN_CATEGORY } from '../../utils/get-domain-category';
 import './styles.scss';
 
 interface Props {
@@ -16,7 +16,7 @@ interface Props {
 	hostingProvider?: HostingProvider;
 	urlData?: UrlData;
 	onCheckAnotherSite?: () => void;
-	specialDomainMapping?: SPECIAL_DOMAIN_CASES;
+	specialDomainMapping?: SPECIAL_DOMAIN_CATEGORY;
 }
 
 export default function HeadingInformation( props: Props ) {

--- a/client/site-profiler/components/heading-information/index.tsx
+++ b/client/site-profiler/components/heading-information/index.tsx
@@ -29,7 +29,7 @@ export default function HeadingInformation( props: Props ) {
 			domain,
 			cta_name: ctaName,
 			conversion_action: conversionAction,
-			special_domain_mapping: domainCategory,
+			domain_category: domainCategory,
 		} );
 	};
 

--- a/client/site-profiler/components/heading-information/index.tsx
+++ b/client/site-profiler/components/heading-information/index.tsx
@@ -12,30 +12,24 @@ import './styles.scss';
 
 interface Props {
 	domain: string;
+	domainCategory?: SPECIAL_DOMAIN_CATEGORY;
 	conversionAction?: CONVERSION_ACTION;
 	hostingProvider?: HostingProvider;
 	urlData?: UrlData;
 	onCheckAnotherSite?: () => void;
-	specialDomainMapping?: SPECIAL_DOMAIN_CATEGORY;
 }
 
 export default function HeadingInformation( props: Props ) {
-	const {
-		domain,
-		conversionAction,
-		hostingProvider,
-		urlData,
-		onCheckAnotherSite,
-		specialDomainMapping,
-	} = props;
-	const finalStatus = specialDomainMapping ?? conversionAction;
+	const { domain, domainCategory, conversionAction, hostingProvider, urlData, onCheckAnotherSite } =
+		props;
+	const finalStatus = domainCategory ?? conversionAction;
 
 	const recordCtaEvent = ( ctaName: string ) => {
 		recordTracksEvent( 'calypso_site_profiler_cta', {
 			domain,
 			cta_name: ctaName,
 			conversion_action: conversionAction,
-			special_domain_mapping: specialDomainMapping,
+			special_domain_mapping: domainCategory,
 		} );
 	};
 
@@ -97,15 +91,12 @@ export default function HeadingInformation( props: Props ) {
 				<StatusInfo
 					conversionAction={ conversionAction }
 					hostingProvider={ hostingProvider }
+					domainCategory={ domainCategory }
 					urlData={ urlData }
-					specialDomainMapping={ specialDomainMapping }
 				/>
 			</summary>
 			<footer>
-				<StatusCtaInfo
-					conversionAction={ conversionAction }
-					specialDomainMapping={ specialDomainMapping }
-				/>
+				<StatusCtaInfo conversionAction={ conversionAction } domainCategory={ domainCategory } />
 				<div className="cta-wrapper">
 					{ ( finalStatus === 'wordpress-com' ||
 						finalStatus === 'local-development' ||

--- a/client/site-profiler/components/heading-information/status-cta-info.tsx
+++ b/client/site-profiler/components/heading-information/status-cta-info.tsx
@@ -4,12 +4,12 @@ import type { SPECIAL_DOMAIN_CATEGORY } from '../../utils/get-domain-category';
 
 interface Props {
 	conversionAction?: CONVERSION_ACTION;
-	specialDomainMapping?: SPECIAL_DOMAIN_CATEGORY;
+	domainCategory?: SPECIAL_DOMAIN_CATEGORY;
 }
 export default function StatusCtaInfo( props: Props ) {
-	const { conversionAction, specialDomainMapping } = props;
+	const { conversionAction, domainCategory } = props;
 	// if there's a special domain mapping, use that instead of the conversion action
-	const finalStatus = specialDomainMapping ?? conversionAction;
+	const finalStatus = domainCategory ?? conversionAction;
 
 	switch ( finalStatus ) {
 		case 'wordpress-com':

--- a/client/site-profiler/components/heading-information/status-cta-info.tsx
+++ b/client/site-profiler/components/heading-information/status-cta-info.tsx
@@ -1,10 +1,10 @@
 import { translate } from 'i18n-calypso';
 import { CONVERSION_ACTION } from '../../hooks/use-define-conversion-action';
-import type { SPECIAL_DOMAIN_CASES } from '../../utils/get-special-domain-mapping';
+import type { SPECIAL_DOMAIN_CATEGORY } from '../../utils/get-domain-category';
 
 interface Props {
 	conversionAction?: CONVERSION_ACTION;
-	specialDomainMapping?: SPECIAL_DOMAIN_CASES;
+	specialDomainMapping?: SPECIAL_DOMAIN_CATEGORY;
 }
 export default function StatusCtaInfo( props: Props ) {
 	const { conversionAction, specialDomainMapping } = props;

--- a/client/site-profiler/components/heading-information/status-cta-info.tsx
+++ b/client/site-profiler/components/heading-information/status-cta-info.tsx
@@ -8,7 +8,7 @@ interface Props {
 }
 export default function StatusCtaInfo( props: Props ) {
 	const { conversionAction, domainCategory } = props;
-	// if there's a special domain mapping, use that instead of the conversion action
+	// if there's a domain category, use that instead of the conversion action
 	const finalStatus = domainCategory ?? conversionAction;
 
 	switch ( finalStatus ) {

--- a/client/site-profiler/components/heading-information/status-info.tsx
+++ b/client/site-profiler/components/heading-information/status-info.tsx
@@ -3,7 +3,7 @@ import { translate } from 'i18n-calypso';
 import { CONVERSION_ACTION } from '../../hooks/use-define-conversion-action';
 import useHostingProviderName from '../../hooks/use-hosting-provider-name';
 import { Skeleton } from '../skeleton-screen';
-import type { SPECIAL_DOMAIN_CASES } from '../../utils/get-special-domain-mapping';
+import type { SPECIAL_DOMAIN_CATEGORY } from '../../utils/get-domain-category';
 import type { UrlData } from 'calypso/blocks/import/types';
 import type { HostingProvider } from 'calypso/data/site-profiler/types';
 
@@ -11,7 +11,7 @@ interface Props {
 	conversionAction?: CONVERSION_ACTION;
 	hostingProvider?: HostingProvider;
 	urlData?: UrlData;
-	specialDomainMapping?: SPECIAL_DOMAIN_CASES;
+	specialDomainMapping?: SPECIAL_DOMAIN_CATEGORY;
 }
 export default function StatusInfo( props: Props ) {
 	const { conversionAction, hostingProvider, urlData, specialDomainMapping } = props;

--- a/client/site-profiler/components/heading-information/status-info.tsx
+++ b/client/site-profiler/components/heading-information/status-info.tsx
@@ -11,13 +11,15 @@ interface Props {
 	conversionAction?: CONVERSION_ACTION;
 	hostingProvider?: HostingProvider;
 	urlData?: UrlData;
-	specialDomainMapping?: SPECIAL_DOMAIN_CATEGORY;
+	domainCategory?: SPECIAL_DOMAIN_CATEGORY;
 }
 export default function StatusInfo( props: Props ) {
-	const { conversionAction, hostingProvider, urlData, specialDomainMapping } = props;
+	const { conversionAction, hostingProvider, urlData, domainCategory } = props;
 	const hostingProviderName = useHostingProviderName( hostingProvider, urlData );
-	// if there's a special domain mapping, use that instead of the conversion action
-	const finalStatus = specialDomainMapping ?? conversionAction;
+
+	// if there's a domain category, use that instead of the conversion action
+	const finalStatus = domainCategory ?? conversionAction;
+
 	switch ( finalStatus ) {
 		case 'wordpress-com':
 			return <p>{ translate( 'Well yes, WordPress.com runs on WordPress.com!' ) }</p>;

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -18,17 +18,17 @@ import HostingIntro from './hosting-intro';
 import './styles.scss';
 
 interface Props {
-	domain?: string;
+	routerDomain?: string;
 }
 
 export default function SiteProfiler( props: Props ) {
-	const { domain: domainFromUrl } = props;
+	const { routerDomain } = props;
 	const {
 		domain,
 		isValid: isDomainValid,
 		specialDomainMapping,
 		isDomainSpecialInput,
-	} = useDomainParam( domainFromUrl );
+	} = useDomainParam( routerDomain );
 
 	const {
 		data: siteProfilerData,

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -1,5 +1,5 @@
 import { translate } from 'i18n-calypso';
-import { useNavigate } from 'react-router-dom';
+import page from 'page';
 import DocumentHead from 'calypso/components/data/document-head';
 import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-query';
 import { useDomainAnalyzerQuery } from 'calypso/data/site-profiler/use-domain-analyzer-query';
@@ -17,14 +17,18 @@ import HostingInformation from './hosting-information';
 import HostingIntro from './hosting-intro';
 import './styles.scss';
 
-export default function SiteProfiler() {
-	const navigate = useNavigate();
+interface Props {
+	domain?: string;
+}
+
+export default function SiteProfiler( props: Props ) {
+	const { domain: domainFromUrl } = props;
 	const {
 		domain,
 		isValid: isDomainValid,
 		specialDomainMapping,
 		isDomainSpecialInput,
-	} = useDomainParam();
+	} = useDomainParam( domainFromUrl );
 
 	const {
 		data: siteProfilerData,
@@ -51,14 +55,10 @@ export default function SiteProfiler() {
 		urlData
 	);
 
-	const updateDomainQueryParam = ( value: string ) => {
-		// Update the domain query param;
+	const updateDomainRouteParam = ( value: string ) => {
+		// Update the domain param;
 		// URL param is the source of truth
-		if ( ! value ) {
-			navigate( '/site-profiler' );
-			return;
-		}
-		navigate( '/site-profiler/' + value );
+		value ? page( `/site-profiler/${ value }` ) : page( '/site-profiler' );
 	};
 	const noNeedToFetchApi = specialDomainMapping && isDomainSpecialInput;
 	const showResultScreen = siteProfilerData || noNeedToFetchApi;
@@ -74,7 +74,7 @@ export default function SiteProfiler() {
 						isBusy={ isFetchingSP }
 						isBusyForWhile={ isBusyForWhile }
 						domainFetchingError={ errorSP instanceof Error ? errorSP : undefined }
-						onFormSubmit={ updateDomainQueryParam }
+						onFormSubmit={ updateDomainRouteParam }
 					/>
 				</LayoutBlock>
 			) }
@@ -92,7 +92,7 @@ export default function SiteProfiler() {
 								<HeadingInformation
 									domain={ domain }
 									conversionAction={ conversionAction }
-									onCheckAnotherSite={ () => updateDomainQueryParam( '' ) }
+									onCheckAnotherSite={ () => updateDomainRouteParam( '' ) }
 									hostingProvider={ hostingProviderData?.hosting_provider }
 									urlData={ urlData }
 									specialDomainMapping={ specialDomainMapping }

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -28,15 +28,19 @@ export default function SiteProfiler( props: Props ) {
 		category: domainCategory,
 		isValid: isDomainValid,
 		isSpecial: isDomainSpecial,
+		readyForDataFetch,
 	} = useDomainParam( routerDomain );
 
 	const {
 		data: siteProfilerData,
 		error: errorSP,
 		isFetching: isFetchingSP,
-	} = useDomainAnalyzerQuery( domain, isDomainValid );
-	const { data: urlData, isError: isErrorUrlData } = useAnalyzeUrlQuery( domain, isDomainValid );
-	const { data: hostingProviderData } = useHostingProviderQuery( domain, isDomainValid );
+	} = useDomainAnalyzerQuery( domain, readyForDataFetch );
+	const { data: urlData, isError: isErrorUrlData } = useAnalyzeUrlQuery(
+		domain,
+		readyForDataFetch
+	);
+	const { data: hostingProviderData } = useHostingProviderQuery( domain, readyForDataFetch );
 	const isBusyForWhile = useLongFetchingDetection( domain, isFetchingSP );
 	const conversionAction = useDefineConversionAction(
 		domain,

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -25,8 +25,8 @@ export default function SiteProfiler( props: Props ) {
 	const { routerDomain } = props;
 	const {
 		domain,
+		category: domainCategory,
 		isValid: isDomainValid,
-		specialDomainMapping,
 		isSpecial,
 	} = useDomainParam( routerDomain );
 
@@ -48,9 +48,9 @@ export default function SiteProfiler( props: Props ) {
 	useScrollToTop( !! siteProfilerData );
 	useSiteProfilerRecordAnalytics(
 		domain,
+		domainCategory,
 		isDomainValid,
 		conversionAction,
-		specialDomainMapping,
 		hostingProviderData?.hosting_provider,
 		urlData
 	);
@@ -60,7 +60,7 @@ export default function SiteProfiler( props: Props ) {
 		// URL param is the source of truth
 		value ? page( `/site-profiler/${ value }` ) : page( '/site-profiler' );
 	};
-	const noNeedToFetchApi = specialDomainMapping && isSpecial;
+	const noNeedToFetchApi = domainCategory && isSpecial;
 	const showResultScreen = siteProfilerData || noNeedToFetchApi;
 
 	return (
@@ -87,7 +87,7 @@ export default function SiteProfiler( props: Props ) {
 							// Translators: %s is the domain name searched
 							<DocumentHead title={ translate( '%s ‹ Site Profiler', { args: [ domain ] } ) } />
 						}
-						{ ( siteProfilerData || specialDomainMapping ) && (
+						{ ( siteProfilerData || isSpecial ) && (
 							<LayoutBlockSection>
 								<HeadingInformation
 									domain={ domain }
@@ -95,7 +95,7 @@ export default function SiteProfiler( props: Props ) {
 									onCheckAnotherSite={ () => updateDomainRouteParam( '' ) }
 									hostingProvider={ hostingProviderData?.hosting_provider }
 									urlData={ urlData }
-									specialDomainMapping={ specialDomainMapping }
+									domainCategory={ domainCategory }
 								/>
 							</LayoutBlockSection>
 						) }

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -48,6 +48,7 @@ export default function SiteProfiler( props: Props ) {
 		hostingProviderData,
 		isErrorUrlData ? null : urlData
 	);
+	const showResultScreen = siteProfilerData || isDomainSpecial;
 
 	useScrollToTop( !! siteProfilerData );
 	useSiteProfilerRecordAnalytics(
@@ -64,8 +65,6 @@ export default function SiteProfiler( props: Props ) {
 		// URL param is the source of truth
 		value ? page( `/site-profiler/${ value }` ) : page( '/site-profiler' );
 	};
-	const noNeedToFetchApi = domainCategory && isDomainSpecial;
-	const showResultScreen = siteProfilerData || noNeedToFetchApi;
 
 	return (
 		<>
@@ -128,9 +127,7 @@ export default function SiteProfiler( props: Props ) {
 
 			<LayoutBlock
 				className="hosting-intro-block globe-bg"
-				isMonoBg={
-					!! showResultScreen && conversionAction !== 'register-domain' && ! noNeedToFetchApi
-				}
+				isMonoBg={ showResultScreen && conversionAction !== 'register-domain' && ! isDomainSpecial }
 			>
 				<HostingIntro />
 			</LayoutBlock>

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -27,7 +27,7 @@ export default function SiteProfiler( props: Props ) {
 		domain,
 		isValid: isDomainValid,
 		specialDomainMapping,
-		isDomainSpecialInput,
+		isSpecial,
 	} = useDomainParam( routerDomain );
 
 	const {
@@ -60,7 +60,7 @@ export default function SiteProfiler( props: Props ) {
 		// URL param is the source of truth
 		value ? page( `/site-profiler/${ value }` ) : page( '/site-profiler' );
 	};
-	const noNeedToFetchApi = specialDomainMapping && isDomainSpecialInput;
+	const noNeedToFetchApi = specialDomainMapping && isSpecial;
 	const showResultScreen = siteProfilerData || noNeedToFetchApi;
 
 	return (

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -6,7 +6,7 @@ import { useDomainAnalyzerQuery } from 'calypso/data/site-profiler/use-domain-an
 import { useHostingProviderQuery } from 'calypso/data/site-profiler/use-hosting-provider-query';
 import { LayoutBlock, LayoutBlockSection } from 'calypso/site-profiler/components/layout';
 import useDefineConversionAction from 'calypso/site-profiler/hooks/use-define-conversion-action';
-import useDomainQueryParam from 'calypso/site-profiler/hooks/use-domain-query-param';
+import useDomainParam from 'calypso/site-profiler/hooks/use-domain-param';
 import useLongFetchingDetection from '../hooks/use-long-fetching-detection';
 import useScrollToTop from '../hooks/use-scroll-to-top';
 import useSiteProfilerRecordAnalytics from '../hooks/use-site-profiler-record-analytics';
@@ -24,7 +24,7 @@ export default function SiteProfiler() {
 		isValid: isDomainValid,
 		specialDomainMapping,
 		isDomainSpecialInput,
-	} = useDomainQueryParam();
+	} = useDomainParam();
 
 	const {
 		data: siteProfilerData,

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -124,7 +124,7 @@ export default function SiteProfiler( props: Props ) {
 
 			<LayoutBlock
 				className="hosting-intro-block globe-bg"
-				isMonoBg={ showResultScreen && conversionAction !== 'register-domain' && ! isDomainSpecial }
+				isMonoBg={ showResultScreen && conversionAction && conversionAction !== 'register-domain' }
 			>
 				<HostingIntro />
 			</LayoutBlock>

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -27,7 +27,7 @@ export default function SiteProfiler( props: Props ) {
 		domain,
 		category: domainCategory,
 		isValid: isDomainValid,
-		isSpecial,
+		isSpecial: isDomainSpecial,
 	} = useDomainParam( routerDomain );
 
 	const {
@@ -60,7 +60,7 @@ export default function SiteProfiler( props: Props ) {
 		// URL param is the source of truth
 		value ? page( `/site-profiler/${ value }` ) : page( '/site-profiler' );
 	};
-	const noNeedToFetchApi = domainCategory && isSpecial;
+	const noNeedToFetchApi = domainCategory && isDomainSpecial;
 	const showResultScreen = siteProfilerData || noNeedToFetchApi;
 
 	return (
@@ -80,14 +80,14 @@ export default function SiteProfiler( props: Props ) {
 			) }
 
 			{
-				// For special valid domain mapping, we need to wait until the result comes back
+				// For special valid domain category, we need to wait until the result comes back
 				showResultScreen && (
 					<LayoutBlock className="domain-result-block">
 						{
 							// Translators: %s is the domain name searched
 							<DocumentHead title={ translate( '%s ‹ Site Profiler', { args: [ domain ] } ) } />
 						}
-						{ ( siteProfilerData || isSpecial ) && (
+						{ ( siteProfilerData || isDomainSpecial ) && (
 							<LayoutBlockSection>
 								<HeadingInformation
 									domain={ domain }

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -82,48 +82,45 @@ export default function SiteProfiler( props: Props ) {
 				</LayoutBlock>
 			) }
 
-			{
-				// For special valid domain category, we need to wait until the result comes back
-				showResultScreen && (
-					<LayoutBlock className="domain-result-block">
-						{
-							// Translators: %s is the domain name searched
-							<DocumentHead title={ translate( '%s ‹ Site Profiler', { args: [ domain ] } ) } />
-						}
-						{ ( siteProfilerData || isDomainSpecial ) && (
+			{ showResultScreen && (
+				<LayoutBlock className="domain-result-block">
+					{
+						// Translators: %s is the domain name searched
+						<DocumentHead title={ translate( '%s ‹ Site Profiler', { args: [ domain ] } ) } />
+					}
+					{ showResultScreen && (
+						<LayoutBlockSection>
+							<HeadingInformation
+								domain={ domain }
+								conversionAction={ conversionAction }
+								onCheckAnotherSite={ () => updateDomainRouteParam( '' ) }
+								hostingProvider={ hostingProviderData?.hosting_provider }
+								urlData={ urlData }
+								domainCategory={ domainCategory }
+							/>
+						</LayoutBlockSection>
+					) }
+					{ siteProfilerData && ! siteProfilerData.is_domain_available && (
+						<>
 							<LayoutBlockSection>
-								<HeadingInformation
-									domain={ domain }
-									conversionAction={ conversionAction }
-									onCheckAnotherSite={ () => updateDomainRouteParam( '' ) }
-									hostingProvider={ hostingProviderData?.hosting_provider }
+								<HostingInformation
+									dns={ siteProfilerData.dns }
 									urlData={ urlData }
-									domainCategory={ domainCategory }
+									hostingProvider={ hostingProviderData?.hosting_provider }
 								/>
 							</LayoutBlockSection>
-						) }
-						{ siteProfilerData && ! siteProfilerData.is_domain_available && (
-							<>
-								<LayoutBlockSection>
-									<HostingInformation
-										dns={ siteProfilerData.dns }
-										urlData={ urlData }
-										hostingProvider={ hostingProviderData?.hosting_provider }
-									/>
-								</LayoutBlockSection>
-								<LayoutBlockSection>
-									<DomainInformation
-										domain={ domain }
-										whois={ siteProfilerData.whois }
-										hostingProvider={ hostingProviderData?.hosting_provider }
-										urlData={ urlData }
-									/>
-								</LayoutBlockSection>
-							</>
-						) }
-					</LayoutBlock>
-				)
-			}
+							<LayoutBlockSection>
+								<DomainInformation
+									domain={ domain }
+									whois={ siteProfilerData.whois }
+									hostingProvider={ hostingProviderData?.hosting_provider }
+									urlData={ urlData }
+								/>
+							</LayoutBlockSection>
+						</>
+					) }
+				</LayoutBlock>
+			) }
 
 			<LayoutBlock
 				className="hosting-intro-block globe-bg"

--- a/client/site-profiler/controller.tsx
+++ b/client/site-profiler/controller.tsx
@@ -41,6 +41,7 @@ export function redirectToBaseSiteProfilerRoute( context: PageJS.Context ) {
 export function siteProfilerContext( context: PageJS.Context, next: () => void ): void {
 	const isLoggedIn = isUserLoggedIn( context.store.getState() );
 	const pathName = context.pathname || '';
+	const routerDomain = pathName.split( '/site-profiler/' )[ 1 ]?.trim() || '';
 
 	const onLanguageChange = ( e: ChangeEvent< HTMLSelectElement > ) => {
 		page( `/${ e.target.value + pathName }` );
@@ -50,7 +51,7 @@ export function siteProfilerContext( context: PageJS.Context, next: () => void )
 	context.primary = (
 		<>
 			<Main fullWidthLayout>
-				<SiteProfiler routerDomain={ context.params?.domain } />
+				<SiteProfiler routerDomain={ routerDomain } />
 			</Main>
 			<PureUniversalNavbarFooter isLoggedIn={ isLoggedIn } onLanguageChange={ onLanguageChange } />
 		</>

--- a/client/site-profiler/controller.tsx
+++ b/client/site-profiler/controller.tsx
@@ -50,7 +50,7 @@ export function siteProfilerContext( context: PageJS.Context, next: () => void )
 	context.primary = (
 		<>
 			<Main fullWidthLayout>
-				<SiteProfiler domain={ context.params?.domain } />
+				<SiteProfiler routerDomain={ context.params?.domain } />
 			</Main>
 			<PureUniversalNavbarFooter isLoggedIn={ isLoggedIn } onLanguageChange={ onLanguageChange } />
 		</>

--- a/client/site-profiler/controller.tsx
+++ b/client/site-profiler/controller.tsx
@@ -2,7 +2,6 @@ import config from '@automattic/calypso-config';
 import { PureUniversalNavbarFooter } from '@automattic/wpcom-template-parts';
 import page from 'page';
 import { ChangeEvent } from 'react';
-import { BrowserRouter } from 'react-router-dom';
 import Main from 'calypso/components/main';
 import SiteProfiler from 'calypso/site-profiler/components/site-profiler';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -49,12 +48,12 @@ export function siteProfilerContext( context: PageJS.Context, next: () => void )
 	};
 
 	context.primary = (
-		<BrowserRouter>
+		<>
 			<Main fullWidthLayout>
-				<SiteProfiler />
+				<SiteProfiler domain={ context.params?.domain } />
 			</Main>
 			<PureUniversalNavbarFooter isLoggedIn={ isLoggedIn } onLanguageChange={ onLanguageChange } />
-		</BrowserRouter>
+		</>
 	);
 
 	next();

--- a/client/site-profiler/hooks/use-domain-param.ts
+++ b/client/site-profiler/hooks/use-domain-param.ts
@@ -1,16 +1,16 @@
 import { useEffect, useState, useCallback } from 'react';
 import { extractDomainFromInput, getFixedDomainSearch } from 'calypso/lib/domains';
 import {
-	SPECIAL_DOMAIN_CASES,
-	getSpecialDomainMapping,
-} from 'calypso/site-profiler/utils/get-special-domain-mapping';
+	SPECIAL_DOMAIN_CATEGORY,
+	getDomainCategory,
+} from 'calypso/site-profiler/utils/get-domain-category';
 import validateDomain from 'calypso/site-profiler/utils/validate-domain';
 import isSpecialDomain from '../utils/is-special-domain';
 
 export default function useDomainParam( value?: string, sanitize = true ) {
 	const [ domain, setDomain ] = useState( value || '' );
 	const [ isValid, setIsValid ] = useState< undefined | boolean >();
-	const [ specialDomainMapping, setSpecialDomainMapping ] = useState< SPECIAL_DOMAIN_CASES >();
+	const [ specialDomainMapping, setSpecialDomainMapping ] = useState< SPECIAL_DOMAIN_CATEGORY >();
 	const isDomainSpecialInput = isSpecialDomain( domain );
 
 	const getFinalizedDomain = useCallback(
@@ -33,7 +33,7 @@ export default function useDomainParam( value?: string, sanitize = true ) {
 	useEffect( () => {
 		setIsValid( validateDomain( value || '' ) );
 		const finalizedDomain = getFinalizedDomain( value || '' );
-		const specialDomains = getSpecialDomainMapping( finalizedDomain );
+		const specialDomains = getDomainCategory( finalizedDomain );
 		setSpecialDomainMapping( specialDomains );
 		setDomain( finalizedDomain );
 	}, [ value, getFinalizedDomain, isDomainSpecialInput ] );

--- a/client/site-profiler/hooks/use-domain-param.ts
+++ b/client/site-profiler/hooks/use-domain-param.ts
@@ -12,6 +12,7 @@ export default function useDomainParam( value: string = '' ) {
 	const [ isValid, setIsValid ] = useState< undefined | boolean >();
 	const [ isSpecial, setIsSpecial ] = useState( isSpecialDomain( value ) );
 	const [ category, setCategory ] = useState< SPECIAL_DOMAIN_CATEGORY >();
+	const [ readyForDataFetch, setReadyForDataFetch ] = useState( false );
 
 	useEffect( () => {
 		const preparedDomain = prepareDomain( value, isSpecial );
@@ -20,9 +21,10 @@ export default function useDomainParam( value: string = '' ) {
 		setIsSpecial( isSpecialDomain( preparedDomain ) );
 		setCategory( getDomainCategory( preparedDomain ) );
 		setDomain( preparedDomain );
-	}, [ value, isSpecial ] );
+		setReadyForDataFetch( ! isSpecial && !! domain && !! isValid );
+	}, [ value, isSpecial, isValid ] );
 
-	return { domain, isValid, isSpecial, category };
+	return { domain, isValid, isSpecial, category, readyForDataFetch };
 }
 
 function prepareDomain( domain: string, isSpecial: boolean ) {

--- a/client/site-profiler/hooks/use-domain-param.ts
+++ b/client/site-profiler/hooks/use-domain-param.ts
@@ -7,7 +7,7 @@ import {
 	getSpecialDomainMapping,
 } from 'calypso/site-profiler/utils/get-special-domain-mapping';
 
-export default function useDomainQueryParam( sanitize = true ) {
+export default function useDomainParam( sanitize = true ) {
 	const [ domain, setDomain ] = useState( '' );
 	const [ isValid, setIsValid ] = useState< undefined | boolean >();
 	const [ specialDomainMapping, setSpecialDomainMapping ] = useState< SPECIAL_DOMAIN_CASES >();

--- a/client/site-profiler/hooks/use-domain-param.ts
+++ b/client/site-profiler/hooks/use-domain-param.ts
@@ -17,8 +17,9 @@ export default function useDomainParam( value: string = '' ) {
 	useEffect( () => {
 		const preparedDomain = prepareDomain( value, isSpecial );
 
+		// check if domain is special before preparing domain value
+		setIsSpecial( isSpecialDomain( value ) );
 		setIsValid( validateDomain( preparedDomain ) );
-		setIsSpecial( isSpecialDomain( preparedDomain ) );
 		setCategory( getDomainCategory( preparedDomain ) );
 		setDomain( preparedDomain );
 		setReadyForDataFetch( ! isSpecial && !! domain && !! isValid );

--- a/client/site-profiler/hooks/use-domain-param.ts
+++ b/client/site-profiler/hooks/use-domain-param.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState } from 'react';
 import { extractDomainFromInput, getFixedDomainSearch } from 'calypso/lib/domains';
 import {
 	SPECIAL_DOMAIN_CATEGORY,
@@ -10,29 +10,29 @@ import isSpecialDomain, { prepareSpecialDomain } from '../utils/is-special-domai
 export default function useDomainParam( value?: string ) {
 	const [ domain, setDomain ] = useState( value || '' );
 	const [ isValid, setIsValid ] = useState< undefined | boolean >();
-	const [ isSpecial, setIsSpecial ] = useState< undefined | boolean >();
-	const [ specialDomainMapping, setSpecialDomainMapping ] = useState< SPECIAL_DOMAIN_CATEGORY >();
-
-	const getFinalizedDomain = useCallback(
-		( _domain: string ) => {
-			const domain_lc = _domain.toLowerCase();
-
-			return isSpecial
-				? prepareSpecialDomain( domain_lc )
-				: getFixedDomainSearch( extractDomainFromInput( domain_lc ) );
-		},
-		[ isSpecial ]
-	);
+	const [ isSpecial, setIsSpecial ] = useState( isSpecialDomain( value || '' ) );
+	const [ category, setCategory ] = useState< SPECIAL_DOMAIN_CATEGORY >();
 
 	useEffect( () => {
-		const finalizedDomain = getFinalizedDomain( value || '' );
-		const specialDomains = getDomainCategory( finalizedDomain );
+		const finalizedDomain = prepareDomain( value || '', isSpecial );
 
 		setDomain( finalizedDomain );
+		setCategory( getDomainCategory( finalizedDomain ) );
 		setIsValid( validateDomain( value || '' ) );
 		setIsSpecial( isSpecialDomain( value || '' ) );
-		setSpecialDomainMapping( specialDomains );
-	}, [ value, getFinalizedDomain ] );
+	}, [ value ] );
 
-	return { domain, isValid, isSpecial, specialDomainMapping };
+	return { domain, isValid, isSpecial, category };
+}
+
+function prepareDomain( domain: string, isSpecial: boolean ) {
+	if ( ! domain ) {
+		return '';
+	}
+
+	const domain_lc = domain.toLowerCase();
+
+	return isSpecial
+		? prepareSpecialDomain( domain_lc )
+		: getFixedDomainSearch( extractDomainFromInput( domain_lc ) );
 }

--- a/client/site-profiler/hooks/use-domain-param.ts
+++ b/client/site-profiler/hooks/use-domain-param.ts
@@ -12,7 +12,6 @@ export default function useDomainParam( value?: string, sanitize = true ) {
 	const [ isValid, setIsValid ] = useState< undefined | boolean >();
 	const [ isSpecial, setIsSpecial ] = useState< undefined | boolean >();
 	const [ specialDomainMapping, setSpecialDomainMapping ] = useState< SPECIAL_DOMAIN_CATEGORY >();
-	const isDomainSpecialInput = isSpecialDomain( domain );
 
 	const getFinalizedDomain = useCallback(
 		( _domain: string ) => {
@@ -38,7 +37,7 @@ export default function useDomainParam( value?: string, sanitize = true ) {
 		setSpecialDomainMapping( specialDomains );
 		setDomain( finalizedDomain );
 		setIsSpecial( isSpecialDomain( value || '' ) );
-	}, [ value, getFinalizedDomain, isDomainSpecialInput ] );
+	}, [ value, getFinalizedDomain ] );
 
 	return { domain, isValid, isSpecial, specialDomainMapping };
 }

--- a/client/site-profiler/hooks/use-domain-param.ts
+++ b/client/site-profiler/hooks/use-domain-param.ts
@@ -7,20 +7,20 @@ import {
 import validateDomain from 'calypso/site-profiler/utils/validate-domain';
 import isSpecialDomain, { prepareSpecialDomain } from '../utils/is-special-domain';
 
-export default function useDomainParam( value?: string ) {
-	const [ domain, setDomain ] = useState( value || '' );
+export default function useDomainParam( value: string = '' ) {
+	const [ domain, setDomain ] = useState( value );
 	const [ isValid, setIsValid ] = useState< undefined | boolean >();
-	const [ isSpecial, setIsSpecial ] = useState( isSpecialDomain( value || '' ) );
+	const [ isSpecial, setIsSpecial ] = useState( isSpecialDomain( value ) );
 	const [ category, setCategory ] = useState< SPECIAL_DOMAIN_CATEGORY >();
 
 	useEffect( () => {
-		const finalizedDomain = prepareDomain( value || '', isSpecial );
+		const preparedDomain = prepareDomain( value, isSpecial );
 
-		setDomain( finalizedDomain );
-		setCategory( getDomainCategory( finalizedDomain ) );
-		setIsValid( validateDomain( value || '' ) );
-		setIsSpecial( isSpecialDomain( value || '' ) );
-	}, [ value ] );
+		setIsValid( validateDomain( preparedDomain ) );
+		setIsSpecial( isSpecialDomain( preparedDomain ) );
+		setCategory( getDomainCategory( preparedDomain ) );
+		setDomain( preparedDomain );
+	}, [ value, isSpecial ] );
 
 	return { domain, isValid, isSpecial, category };
 }
@@ -30,9 +30,9 @@ function prepareDomain( domain: string, isSpecial: boolean ) {
 		return '';
 	}
 
-	const domain_lc = domain.toLowerCase();
+	const domainLc = domain.toLowerCase();
 
 	return isSpecial
-		? prepareSpecialDomain( domain_lc )
-		: getFixedDomainSearch( extractDomainFromInput( domain_lc ) );
+		? prepareSpecialDomain( domainLc )
+		: getFixedDomainSearch( extractDomainFromInput( domainLc ) );
 }

--- a/client/site-profiler/hooks/use-domain-param.ts
+++ b/client/site-profiler/hooks/use-domain-param.ts
@@ -1,17 +1,17 @@
 import { useEffect, useState, useCallback } from 'react';
 import { extractDomainFromInput, getFixedDomainSearch } from 'calypso/lib/domains';
 import {
-	isSpecialInput,
 	SPECIAL_DOMAIN_CASES,
 	getSpecialDomainMapping,
 } from 'calypso/site-profiler/utils/get-special-domain-mapping';
 import validateDomain from 'calypso/site-profiler/utils/validate-domain';
+import isSpecialDomain from '../utils/is-special-domain';
 
 export default function useDomainParam( value?: string, sanitize = true ) {
 	const [ domain, setDomain ] = useState( value || '' );
 	const [ isValid, setIsValid ] = useState< undefined | boolean >();
 	const [ specialDomainMapping, setSpecialDomainMapping ] = useState< SPECIAL_DOMAIN_CASES >();
-	const isDomainSpecialInput = isSpecialInput( domain );
+	const isDomainSpecialInput = isSpecialDomain( domain );
 
 	const getFinalizedDomain = useCallback(
 		( _domain: string ) => {

--- a/client/site-profiler/hooks/use-domain-param.ts
+++ b/client/site-profiler/hooks/use-domain-param.ts
@@ -10,13 +10,14 @@ import isSpecialDomain from '../utils/is-special-domain';
 export default function useDomainParam( value?: string, sanitize = true ) {
 	const [ domain, setDomain ] = useState( value || '' );
 	const [ isValid, setIsValid ] = useState< undefined | boolean >();
+	const [ isSpecial, setIsSpecial ] = useState< undefined | boolean >();
 	const [ specialDomainMapping, setSpecialDomainMapping ] = useState< SPECIAL_DOMAIN_CATEGORY >();
 	const isDomainSpecialInput = isSpecialDomain( domain );
 
 	const getFinalizedDomain = useCallback(
 		( _domain: string ) => {
 			const domain_lc = _domain.toLowerCase();
-			if ( isDomainSpecialInput ) {
+			if ( isSpecial ) {
 				if ( domain_lc.includes( 'wordpress.com/site-profiler' ) ) {
 					return 'wordpress.com/site-profiler';
 				} else if ( domain_lc.includes( 'localhost' ) ) {
@@ -27,7 +28,7 @@ export default function useDomainParam( value?: string, sanitize = true ) {
 			}
 			return sanitize ? getFixedDomainSearch( extractDomainFromInput( domain_lc ) ) : domain_lc;
 		},
-		[ isDomainSpecialInput, sanitize ]
+		[ isSpecial, sanitize ]
 	);
 
 	useEffect( () => {
@@ -36,7 +37,8 @@ export default function useDomainParam( value?: string, sanitize = true ) {
 		const specialDomains = getDomainCategory( finalizedDomain );
 		setSpecialDomainMapping( specialDomains );
 		setDomain( finalizedDomain );
+		setIsSpecial( isSpecialDomain( value || '' ) );
 	}, [ value, getFinalizedDomain, isDomainSpecialInput ] );
 
-	return { domain, isValid, specialDomainMapping, isDomainSpecialInput };
+	return { domain, isValid, isSpecial, specialDomainMapping };
 }

--- a/client/site-profiler/hooks/use-site-profiler-record-analytics.ts
+++ b/client/site-profiler/hooks/use-site-profiler-record-analytics.ts
@@ -11,9 +11,9 @@ import type { CONVERSION_ACTION } from 'calypso/site-profiler/hooks/use-define-c
  */
 export default function useSiteProfilerRecordAnalytics(
 	domain: string,
+	domainCategory?: SPECIAL_DOMAIN_CATEGORY,
 	isDomainValid?: boolean,
 	conversionAction?: CONVERSION_ACTION,
-	specialDomainMapping?: SPECIAL_DOMAIN_CATEGORY,
 	hostingProvider?: HostingProvider,
 	urlData?: UrlData
 ) {
@@ -22,15 +22,15 @@ export default function useSiteProfilerRecordAnalytics(
 	}, [] );
 
 	useEffect( () => {
-		const noNeedToFetchApi = specialDomainMapping && ! isDomainValid;
+		const noNeedToFetchApi = domainCategory && ! isDomainValid;
 
 		domain &&
 			( conversionAction || noNeedToFetchApi ) &&
 			recordTracksEvent( 'calypso_site_profiler_domain_analyze', {
 				domain,
+				domain_category: domainCategory,
 				is_domain_valid: isDomainValid,
 				conversion_action: conversionAction,
-				special_domain_mapping: specialDomainMapping,
 			} );
 	}, [ domain, isDomainValid, conversionAction ] );
 

--- a/client/site-profiler/hooks/use-site-profiler-record-analytics.ts
+++ b/client/site-profiler/hooks/use-site-profiler-record-analytics.ts
@@ -1,6 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useEffect } from 'react';
-import { SPECIAL_DOMAIN_CASES } from 'calypso/site-profiler/utils/get-special-domain-mapping';
+import { SPECIAL_DOMAIN_CATEGORY } from 'calypso/site-profiler/utils/get-domain-category';
 import type { UrlData } from 'calypso/blocks/import/types';
 import type { HostingProvider } from 'calypso/data/site-profiler/types';
 import type { CONVERSION_ACTION } from 'calypso/site-profiler/hooks/use-define-conversion-action';
@@ -13,7 +13,7 @@ export default function useSiteProfilerRecordAnalytics(
 	domain: string,
 	isDomainValid?: boolean,
 	conversionAction?: CONVERSION_ACTION,
-	specialDomainMapping?: SPECIAL_DOMAIN_CASES,
+	specialDomainMapping?: SPECIAL_DOMAIN_CATEGORY,
 	hostingProvider?: HostingProvider,
 	urlData?: UrlData
 ) {

--- a/client/site-profiler/utils/get-domain-category.ts
+++ b/client/site-profiler/utils/get-domain-category.ts
@@ -1,4 +1,4 @@
-export type SPECIAL_DOMAIN_CASES =
+export type SPECIAL_DOMAIN_CATEGORY =
 	| 'wordpress-com'
 	| 'wordpress-org'
 	| 'automattic-com'
@@ -9,9 +9,9 @@ export type SPECIAL_DOMAIN_CASES =
 	| 'wpcom-sp'
 	| 'local-development';
 
-export function getSpecialDomainMapping( domain: string ): SPECIAL_DOMAIN_CASES | undefined {
+export function getDomainCategory( domain: string ): SPECIAL_DOMAIN_CATEGORY | undefined {
 	const domain_lc = domain.toLowerCase();
-	let specialDomainCase: SPECIAL_DOMAIN_CASES | undefined;
+	let specialDomainCase: SPECIAL_DOMAIN_CATEGORY | undefined;
 
 	switch ( domain_lc ) {
 		case 'wordpress.com':

--- a/client/site-profiler/utils/get-special-domain-mapping.ts
+++ b/client/site-profiler/utils/get-special-domain-mapping.ts
@@ -9,8 +9,6 @@ export type SPECIAL_DOMAIN_CASES =
 	| 'wpcom-sp'
 	| 'local-development';
 
-const SPECIAL_CASES = [ /wordpress\.com\/site-profiler/, /localhost/, /127\.0\.0\.1/ ];
-
 export function getSpecialDomainMapping( domain: string ): SPECIAL_DOMAIN_CASES | undefined {
 	const domain_lc = domain.toLowerCase();
 	let specialDomainCase: SPECIAL_DOMAIN_CASES | undefined;
@@ -56,10 +54,4 @@ export function getSpecialDomainMapping( domain: string ): SPECIAL_DOMAIN_CASES 
 	}
 
 	return specialDomainCase;
-}
-
-export function isSpecialInput( domain: string ): boolean {
-	const domain_lc = domain.toLowerCase();
-
-	return SPECIAL_CASES.some( ( pattern ) => pattern.test( domain_lc ) );
 }

--- a/client/site-profiler/utils/is-special-domain.ts
+++ b/client/site-profiler/utils/is-special-domain.ts
@@ -5,3 +5,15 @@ export default function isSpecialDomain( domain: string ): boolean {
 
 	return SPECIAL_DOMAIN_RGX.some( ( pattern ) => pattern.test( domain_lc ) );
 }
+
+export function prepareSpecialDomain( domain: string ) {
+	const domain_lc = domain.toLowerCase();
+
+	if ( domain_lc.includes( 'wordpress.com/site-profiler' ) ) {
+		return 'wordpress.com/site-profiler';
+	} else if ( domain_lc.includes( 'localhost' ) ) {
+		return 'localhost';
+	} else if ( domain_lc.includes( '127.0.0.1' ) ) {
+		return '127.0.0.1';
+	}
+}

--- a/client/site-profiler/utils/is-special-domain.ts
+++ b/client/site-profiler/utils/is-special-domain.ts
@@ -1,0 +1,7 @@
+const SPECIAL_DOMAIN_RGX = [ /wordpress\.com\/site-profiler/, /localhost/, /127\.0\.0\.1/ ];
+
+export default function isSpecialDomain( domain: string ): boolean {
+	const domain_lc = domain.toLowerCase();
+
+	return SPECIAL_DOMAIN_RGX.some( ( pattern ) => pattern.test( domain_lc ) );
+}

--- a/client/site-profiler/utils/validate-domain.ts
+++ b/client/site-profiler/utils/validate-domain.ts
@@ -1,0 +1,27 @@
+export default function validateDomain( value: string ) {
+	try {
+		if ( value ) {
+			// Only allow domains with a dot in them (not localhost, for example).
+			if ( ! value.includes( '.' ) ) {
+				throw new Error( 'Invalid domain' );
+			}
+
+			let normalised = value;
+
+			// If the domain doesn't start with http:// or https://, add https://
+			if ( ! normalised.startsWith( 'http://' ) && ! normalised.startsWith( 'https://' ) ) {
+				normalised = 'https://' + normalised;
+			}
+
+			// Test if we can parse the URL. If we can't, it's invalid.
+			const url = new URL( normalised );
+
+			// Check if the protocol is 'http' or 'https'.
+			return url.protocol === 'http:' || url.protocol === 'https:';
+		}
+
+		return undefined;
+	} catch ( e ) {
+		return false;
+	}
+}


### PR DESCRIPTION
## Proposed Changes

* Refactored hook for preparing a domain value (the most important change in the PR)
* Got rid of the `react-router-dom` package and relied on `page.js` since there was a minor conflict between them; mostly with updating route;
* Moved validation logic into a separate file for better readability
* Moved isSpecialDomain logic into a separate file for better readability
* Better naming for some of the functions/fields
* Introduced **readyForDataFetch** constant

## Testing Instructions

* Go to `/site-profiler`
* Test the flow with different domain options;
* Test the special domains
* Test domains from the special categories, such as (automattic.com, wordpress.com, etc.)
* Overall, it should work the same as it was before the refactoring

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?