### PR TITLE
FHT: Override storage option for hosting trial to be 3gb

### DIFF
--- a/client/my-sites/plans-grid/util.ts
+++ b/client/my-sites/plans-grid/util.ts
@@ -1,5 +1,6 @@
 import {
 	FEATURE_1GB_STORAGE,
+	FEATURE_3GB_STORAGE,
 	FEATURE_6GB_STORAGE,
 	FEATURE_13GB_STORAGE,
 	FEATURE_50GB_STORAGE,
@@ -16,6 +17,8 @@ export const getStorageStringFromFeature = ( storageFeature: string ) => {
 			return translate( '1 GB' );
 		case FEATURE_6GB_STORAGE:
 			return translate( '6 GB' );
+		case FEATURE_3GB_STORAGE:
+			return translate( '3 GB' );
 		case FEATURE_13GB_STORAGE:
 			return translate( '13 GB' );
 		case FEATURE_50GB_STORAGE:

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -3634,4 +3634,23 @@ PLANS_LIST[ PLAN_HOSTING_TRIAL_MONTHLY ] = {
 	getTitle: () => i18n.translate( 'Business trial' ),
 	getDescription: () => i18n.translate( 'Hosting free trial' ),
 	getTagline: () => i18n.translate( 'Get a taste of unlimited performance and unbeatable uptime' ),
+	get2023PricingGridSignupStorageOptions: ( showLegacyStorageFeature ) => {
+		let storageOptionSlugs = [];
+		const storageAddOns = [ FEATURE_50GB_STORAGE_ADD_ON, FEATURE_100GB_STORAGE_ADD_ON ];
+
+		if ( showLegacyStorageFeature ) {
+			storageOptionSlugs = [ FEATURE_200GB_STORAGE ];
+		} else {
+			storageOptionSlugs = isEnabled( 'plans/updated-storage-labels' )
+				? [ FEATURE_3GB_STORAGE, ...storageAddOns ]
+				: [ FEATURE_200GB_STORAGE ];
+		}
+
+		return storageOptionSlugs.map( ( slug ) => {
+			return {
+				slug: slug,
+				isAddOn: storageAddOns.includes( slug ),
+			};
+		} );
+	},
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/4115

## Proposed Changes

Method `get2023PricingGridSignupStorageOptions` is used to fetch the storage option for Business Plans. since Hosting trial is a business plan it's returning the default `50GB`. This PR overrides that method to return `3GB`

We could add an extra `isTrial` to the `get2023PricingGridSignupStorageOptions` and pass it down then returns 3GB if isTrial but I think that could result in more branching if different trials have different storage requirements. I think overriding the method on the trial plan itself is more flexible even though the function is basically an exact copy with only the `FEATURE_3GB_STORAGE` added.

* Override `get2023PricingGridSignupStorageOptions` for free trial plan to return `3GB` storage

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/new-hosted-site/plans`
* Verify Business Trial Plan shows `3GB` storage

![image](https://github.com/Automattic/wp-calypso/assets/47489215/dd18a7e7-b854-4ad1-83e5-9ac8d9d95727)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?