### PR TITLE
Live preview: fix close icon and refine copy in the education modal

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/live-preview-modal/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/live-preview-modal/index.tsx
@@ -1,4 +1,4 @@
-import { Dialog, Gridicon } from '@automattic/components';
+import { Dialog } from '@automattic/components';
 import { Button, CheckboxControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { getQueryArg } from '@wordpress/url';
@@ -77,7 +77,9 @@ export default function LivePreviewModal() {
 			isFullScreen
 		>
 			<Button className="live-preview-modal__close-icon" onClick={ onClose }>
-				<Gridicon icon="cross" size={ 24 } />
+				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" height="24" width="24">
+					<path d="M18.36 19.78L12 13.41l-6.36 6.37-1.42-1.42L10.59 12 4.22 5.64l1.42-1.42L12 10.59l6.36-6.36 1.41 1.41L13.41 12l6.36 6.36z" />
+				</svg>
 			</Button>
 			<h1>{ translate( 'Previewing %(themeName)s', { args: { themeName } } ) }</h1>
 			<p>
@@ -94,7 +96,8 @@ export default function LivePreviewModal() {
 			</p>
 			<p>
 				{ translate(
-					'To exit the Editor preview and get back to the theme showcase, click the WordPress logo at the top left corner.'
+					'To exit the Editor preview and go back to the theme showcase, click the small arrow next to {{strong}}Previewing{{/strong}} or the site icon in the top left corner.',
+					{ components: { strong: <strong /> } }
 				) }
 			</p>
 			<CheckboxControl


### PR DESCRIPTION
Related to: p1696862381245319-slack-C048CUFRGFQ

## Proposed Changes

1. Replace the gridicon with inline SVG. This is because in PRODUCTION Simple sites, the assets get optimized and served from `https://s0.wp.com`, which has different origin from `*.wordpress.com`, so the [SVG request gets blocked](https://oreillymedia.github.io/Using_SVG/extras/ch10-cors.html). So, this PR inlines the SVG. Actually, this is a common trick in the ETK plugin, we can search for `<svg` in the codebase 😅 

<img width="866" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/82e73941-c1bf-4b79-88df-397c4632b88c">

2. Refine the copy because the WP logo is replaced with the site logo when there is any.

<img width="723" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/a519bb67-4002-44d6-b22a-e955a9a4ff1f">


## Testing Instructions

1. Patch this change to your sandbox: `install-plugin.sh editing-toolkit live-preview-modal-fix`.
1. Sandbox YOUR SITE.
1. Open `https://horizon.wordpress.com`.
1. Go to Appearance -> Themes.
1. Choose a Free theme and click "Preview & Customize".
1. Verify that the close icon is still visible.
1. Verify that the copy has been changed accordingly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?