### PR TITLE
Change Button border radius from 2px to 4px

### DIFF
--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -20,7 +20,7 @@
 	box-sizing: border-box;
 	font-size: $font-body-small;
 	line-height: 22px;
-	border-radius: 2px;
+	border-radius: 4px;
 	padding: 8px 14px;
 	appearance: none;
 


### PR DESCRIPTION
Started a slack discussion p1696914883651479-slack-C9EJ7KSGH

There is growing number of border-radius 4px buttons floating around calypso. These seem to be getting copy pasted in from figma.

I created this PR to have a calypso live link to show #dotcom-design what this change might look like site wide.

## Proposed Changes

Before
![Screenshot 2023-10-10 at 15-31-38 My Home ‹ Site Title — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/c67161fb-95d3-4c5b-9ed2-1e0ee67cab44)

After
![Screenshot 2023-10-10 at 15-31-56 My Home ‹ Site Title — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/e8adf873-cdc0-4464-8edd-3ac3704939d9)

## Testing

This updates the border radius of most buttons in calypso. 

Full size button's look ok, compact ones seem like they need more padding. e.g. logout in /me

The 4px radius looks a bit off next to 2px radius input boxes, e.g. in /me/account