### PR TITLE
Remove box shadow from domains select buttons

### DIFF
--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -491,6 +491,7 @@ body.is-section-signup.is-white-signup {
 
 				&:focus {
 					border-color: var(--color-primary);
+					box-shadow: 0 0 0 2px var(--color-primary-light);
 				}
 			}
 

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -480,7 +480,6 @@ body.is-section-signup.is-white-signup {
 				padding: 0.57em 1.17em;
 				font-weight: 500;
 				border-radius: 4px;
-				box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
 				border: 1px solid #c3c4c7;
 				letter-spacing: 0.32px;
 				font-size: 0.875rem;
@@ -492,7 +491,6 @@ body.is-section-signup.is-white-signup {
 
 				&:focus {
 					border-color: var(--color-primary);
-					box-shadow: 0 0 0 2px var(--color-primary-light);
 				}
 			}
 

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -201,7 +201,6 @@ body.is-section-signup.is-white-signup .step-wrapper .featured-domain-suggestion
 		font-weight: 500;
 		padding: 0.57em 1.17em;
 		border-radius: 4px;
-		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
 		font-size: 0.875rem;
 		height: auto;
 
@@ -212,7 +211,6 @@ body.is-section-signup.is-white-signup .step-wrapper .featured-domain-suggestion
 
 		&:focus {
 			border-color: var(--color-primary);
-			box-shadow: 0 0 0 2px var(--color-primary-light);
 		}
 	}
 

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -211,6 +211,7 @@ body.is-section-signup.is-white-signup .step-wrapper .featured-domain-suggestion
 
 		&:focus {
 			border-color: var(--color-primary);
+			box-shadow: 0 0 0 2px var(--color-primary-light);
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/4139

## Proposed Changes

* Removes box shadow from domain select cta buttons

## Testing Instructions

* http://calypso.localhost:3000/start/domains

The buttons should no longer have a box shadow.

After
![Screenshot 2023-10-10 at 16-57-56 Create a site — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/265ac7a6-0674-4a7b-9e12-606bbe53f77c)

Before
![Screenshot 2023-10-10 at 16-57-42 Create a site — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/d973802b-85fa-45a9-9014-102ba8ea7e44)
