### PR TITLE
FHT: update UI to (mostly) match UI when in a migration free trial

### DIFF
--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -13,7 +13,7 @@ import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import { domainManagementList } from 'calypso/my-sites/domains/paths';
-import { isMigrationTrialSite } from 'calypso/sites-dashboard/utils';
+import { isHostingTrialSite, isMigrationTrialSite } from 'calypso/sites-dashboard/utils';
 import getActiveDiscount from 'calypso/state/selectors/get-active-discount';
 import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
 import isSiteMigrationActiveRoute from 'calypso/state/selectors/is-site-migration-active-route';
@@ -204,7 +204,7 @@ export default connect( ( state, ownProps ) => {
 		activeDiscount: getActiveDiscount( state ),
 		isSiteWPForTeams: isSiteWPForTeams( state, siteId ),
 		isWpcomStagingSite: isSiteWpcomStaging( state, siteId ),
-		isTrialSite: isMigrationTrialSite( site ),
+		isTrialSite: isMigrationTrialSite( site ) || isHostingTrialSite( site ),
 		isMigrationInProgress,
 	};
 } )( localize( SiteNotice ) );

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -1,16 +1,17 @@
 import { isEnabled } from '@automattic/calypso-config';
 import {
-	getPlan,
+	FEATURE_LEGACY_STORAGE_200GB,
 	getIntervalTypeForTerm,
-	PLAN_FREE,
-	PLAN_ECOMMERCE_TRIAL_MONTHLY,
+	getPlan,
 	isFreePlanProduct,
-	PLAN_WOOEXPRESS_SMALL,
-	PLAN_WOOEXPRESS_SMALL_MONTHLY,
+	PLAN_ECOMMERCE_TRIAL_MONTHLY,
+	PLAN_FREE,
+	PLAN_HOSTING_TRIAL_MONTHLY,
+	PLAN_MIGRATION_TRIAL_MONTHLY,
 	PLAN_WOOEXPRESS_MEDIUM,
 	PLAN_WOOEXPRESS_MEDIUM_MONTHLY,
-	FEATURE_LEGACY_STORAGE_200GB,
-	PLAN_MIGRATION_TRIAL_MONTHLY,
+	PLAN_WOOEXPRESS_SMALL,
+	PLAN_WOOEXPRESS_SMALL_MONTHLY,
 } from '@automattic/calypso-products';
 import { WpcomPlansUI } from '@automattic/data-stores';
 import { withShoppingCart } from '@automattic/shopping-cart';
@@ -336,16 +337,17 @@ class Plans extends Component {
 		);
 	}
 
-	renderMainContent( { isEcommerceTrial, isBusinessTrial, isWooExpressPlan } ) {
+	renderMainContent( { isEcommerceTrial, isBusinessTrial, isWooExpressPlan, isHostingTrial } ) {
 		if ( isEcommerceTrial ) {
 			return this.renderEcommerceTrialPage();
 		}
 		if ( isWooExpressPlan ) {
 			return this.renderWooExpressPlansPage();
 		}
-		if ( isBusinessTrial ) {
+		if ( isBusinessTrial || isHostingTrial ) {
 			return this.renderBusinessTrialPage();
 		}
+
 		return this.renderPlansMain();
 	}
 
@@ -373,6 +375,7 @@ class Plans extends Component {
 		const currentPlanSlug = selectedSite?.plan?.product_slug;
 		const isEcommerceTrial = currentPlanSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY;
 		const isBusinessTrial = currentPlanSlug === PLAN_MIGRATION_TRIAL_MONTHLY;
+		const isHostingTrial = currentPlanSlug === PLAN_HOSTING_TRIAL_MONTHLY;
 		const isWooExpressPlan = [
 			PLAN_WOOEXPRESS_MEDIUM,
 			PLAN_WOOEXPRESS_MEDIUM_MONTHLY,
@@ -453,6 +456,7 @@ class Plans extends Component {
 									isEcommerceTrial,
 									isBusinessTrial,
 									isWooExpressPlan,
+									isHostingTrial,
 								} ) }
 								<PerformanceTrackerStop />
 							</Main>

--- a/client/sites-dashboard/utils.ts
+++ b/client/sites-dashboard/utils.ts
@@ -1,6 +1,7 @@
 import {
 	PLAN_MIGRATION_TRIAL_MONTHLY,
 	PLAN_ECOMMERCE_TRIAL_MONTHLY,
+	PLAN_HOSTING_TRIAL_MONTHLY,
 } from '@automattic/calypso-products';
 import { SiteExcerptNetworkData } from 'calypso/data/sites/site-excerpt-types';
 
@@ -59,6 +60,10 @@ export const isStagingSite = ( site: SiteExcerptNetworkData | undefined ) => {
 
 export const isMigrationTrialSite = ( site: SiteExcerptNetworkData ) => {
 	return site?.plan?.product_slug === PLAN_MIGRATION_TRIAL_MONTHLY;
+};
+
+export const isHostingTrialSite = ( site: SiteExcerptNetworkData ) => {
+	return site?.plan?.product_slug === PLAN_HOSTING_TRIAL_MONTHLY;
 };
 
 export const isECommerceTrialSite = ( site: SiteExcerptNetworkData ) => {

--- a/client/state/sites/plans/selectors/index.js
+++ b/client/state/sites/plans/selectors/index.js
@@ -23,4 +23,8 @@ export { default as isMigrationTrialExpired } from './trials/is-migration-trial-
 export { default as isSiteOnEcommerce } from './trials/is-site-on-ecommerce';
 export { default as isSiteOnECommerceTrial } from './trials/is-site-on-ecommerce-trial';
 export { default as isSiteOnWooExpressEcommerceTrial } from './is-site-on-woo-express-ecommerce-trial';
+export { default as isSiteOnHostingTrial } from './trials/is-site-on-hosting-trial';
+export { default as getHostingTrialDaysLeft } from './trials/get-hosting-trial-days-left';
+export { default as getHostingTrialExpiration } from './trials/get-hosting-trial-expiration';
+export { default as isHostingTrialExpired } from './trials/is-hosting-trial-expired';
 export { default as isTrialSite } from './trials/is-trial-site';

--- a/client/state/sites/plans/selectors/trials/is-trial-site.ts
+++ b/client/state/sites/plans/selectors/trials/is-trial-site.ts
@@ -1,4 +1,4 @@
-import { isSiteOnMigrationTrial, isSiteOnECommerceTrial } from '..';
+import { isSiteOnMigrationTrial, isSiteOnECommerceTrial, isSiteOnHostingTrial } from '..';
 import type { AppState } from 'calypso/types';
 
 /**
@@ -9,5 +9,9 @@ import type { AppState } from 'calypso/types';
  * @returns {boolean} Returns true if the site is on a trial
  */
 export default function isTrialSite( state: AppState, siteId: number ): boolean {
-	return isSiteOnECommerceTrial( state, siteId ) || isSiteOnMigrationTrial( state, siteId );
+	return (
+		isSiteOnECommerceTrial( state, siteId ) ||
+		isSiteOnMigrationTrial( state, siteId ) ||
+		isSiteOnHostingTrial( state, siteId )
+	);
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/4048
Closes https://github.com/Automattic/dotcom-forge/issues/4054
Closes https://github.com/Automattic/dotcom-forge/issues/4045
Closes https://github.com/Automattic/dotcom-forge/issues/4063


## Proposed Changes

* Show "Trial" label on `/sites` page. Should be shown in list and grid mode.
* Show banner in sidebar "N days left in your trial"
* Show "Trial" label under the site name in sidebar
* Show only Business and VIP plans at `/plans/:trial-site' - **is this correct? It is the same for migration trials**

![image](https://github.com/Automattic/wp-calypso/assets/6851384/af827d49-bc51-4205-b92d-47b8cffdbb34)

<img width="906" alt="Screenshot 2566-10-10 at 15 29 34" src="https://github.com/Automattic/wp-calypso/assets/6851384/cf35cb7f-4eea-40b5-afe7-4138729999e1">

![image](https://github.com/Automattic/wp-calypso/assets/6851384/a195008b-361b-4450-884f-dba00e48125f)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D124373-code to you sandbox
* Verify the changes above are applied and are consistent with migration trials where appropriate

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?