### PR TITLE
Jetpack Manage: Implement a component to show the guided tour

### DIFF
--- a/client/jetpack-cloud/components/guided-tour/index.tsx
+++ b/client/jetpack-cloud/components/guided-tour/index.tsx
@@ -1,0 +1,92 @@
+import { Popover, Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { useState, useEffect } from 'react';
+import { useDispatch, useSelector } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getJetpackDashboardPreference as getPreference } from 'calypso/state/jetpack-agency-dashboard/selectors';
+import { savePreference } from 'calypso/state/preferences/actions';
+import { preferencesLastFetchedTimestamp } from 'calypso/state/preferences/selectors';
+
+import './style.scss';
+
+export interface Tour {
+	id: string;
+	title: string;
+	description: string;
+}
+
+interface Props {
+	tours: Tour[];
+	preferenceName: string;
+}
+
+const GuidedTour = ( { tours, preferenceName }: Props ) => {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const [ currentStep, setCurrentStep ] = useState( 0 );
+	const [ targetElement, setTargetElement ] = useState< HTMLElement | null >( null );
+	const [ isVisible, setIsVisible ] = useState( false );
+
+	const preference = useSelector( ( state ) => getPreference( state, preferenceName ) );
+	const hasFetched = !! useSelector( preferencesLastFetchedTimestamp );
+
+	const isDismissed = preference?.dismiss;
+
+	const { title, description, id } = tours[ currentStep ];
+
+	// Set the target element for the popover
+	useEffect( () => {
+		if ( id ) {
+			const element = document.querySelector( `#${ id }` ) as HTMLElement | null;
+			setTargetElement( element );
+		}
+	}, [ id ] );
+
+	// Show the popover after a short delay to allow the popover to be positioned correctly
+	useEffect( () => {
+		if ( targetElement && ! isDismissed && hasFetched ) {
+			setTimeout( () => {
+				setIsVisible( true );
+				dispatch(
+					recordTracksEvent( 'calypso_jetpack_cloud_start_tour', {
+						tour: preferenceName,
+					} )
+				);
+			}, 100 );
+		}
+	}, [ dispatch, isDismissed, preferenceName, targetElement, hasFetched ] );
+
+	const endTour = () => {
+		dispatch( savePreference( preferenceName, { ...preference, dismiss: true } ) );
+		dispatch(
+			recordTracksEvent( 'calypso_jetpack_cloud_end_tour', {
+				tour: preferenceName,
+			} )
+		);
+	};
+
+	const nextStep = () => {
+		if ( currentStep < tours.length - 1 ) {
+			setCurrentStep( currentStep + 1 );
+		} else {
+			endTour();
+		}
+	};
+
+	if ( isDismissed ) {
+		return null;
+	}
+
+	return (
+		<Popover isVisible={ isVisible } context={ targetElement } className="guided-tour__popover">
+			<h2 className="guided-tour__popover-heading">{ title }</h2>
+			<p className="guided-tour__popover-description">{ description }</p>
+			<Button className="guided-tour__popover-button" onClick={ nextStep }>
+				{ translate( 'Got it' ) }
+			</Button>
+		</Popover>
+	);
+};
+
+export default GuidedTour;

--- a/client/jetpack-cloud/components/guided-tour/index.tsx
+++ b/client/jetpack-cloud/components/guided-tour/index.tsx
@@ -10,7 +10,7 @@ import { preferencesLastFetchedTimestamp } from 'calypso/state/preferences/selec
 import './style.scss';
 
 export interface Tour {
-	id: string;
+	targetId: string;
 	title: string;
 	description: string;
 }
@@ -33,15 +33,15 @@ const GuidedTour = ( { tours, preferenceName }: Props ) => {
 
 	const isDismissed = preference?.dismiss;
 
-	const { title, description, id } = tours[ currentStep ];
+	const { title, description, targetId } = tours[ currentStep ];
 
 	// Set the target element for the popover
 	useEffect( () => {
-		if ( id ) {
-			const element = document.querySelector( `#${ id }` ) as HTMLElement | null;
+		if ( targetId ) {
+			const element = document.querySelector( `#${ targetId }` ) as HTMLElement | null;
 			setTargetElement( element );
 		}
-	}, [ id ] );
+	}, [ targetId ] );
 
 	// Show the popover after a short delay to allow the popover to be positioned correctly
 	useEffect( () => {
@@ -78,13 +78,39 @@ const GuidedTour = ( { tours, preferenceName }: Props ) => {
 		return null;
 	}
 
+	const lastTourLabel = tours.length === 1 ? translate( 'Got it' ) : translate( 'Done' );
+
 	return (
 		<Popover isVisible={ isVisible } context={ targetElement } className="guided-tour__popover">
 			<h2 className="guided-tour__popover-heading">{ title }</h2>
 			<p className="guided-tour__popover-description">{ description }</p>
-			<Button className="guided-tour__popover-button" onClick={ nextStep }>
-				{ translate( 'Got it' ) }
-			</Button>
+			<div className="guided-tour__popover-footer">
+				<div>
+					{
+						// Show the step count if there are multiple steps and we're not on the last step
+						tours.length > 1 && (
+							<span className="guided-tour__popover-step-count">
+								{ translate( 'Step %(currentStep)d of %(totalSteps)d', {
+									args: { currentStep: currentStep + 1, totalSteps: tours.length },
+								} ) }
+							</span>
+						)
+					}
+				</div>
+				<div className="guided-tour__popover-footer-right-content">
+					{
+						// Show the skip button if there are multiple steps and we're not on the last step
+						tours.length > 1 && currentStep < tours.length - 1 && (
+							<Button borderless onClick={ endTour }>
+								{ translate( 'Skip' ) }
+							</Button>
+						)
+					}
+					<Button onClick={ nextStep }>
+						{ currentStep === tours.length - 1 ? lastTourLabel : translate( 'Next' ) }
+					</Button>
+				</div>
+			</div>
 		</Popover>
 	);
 };

--- a/client/jetpack-cloud/components/guided-tour/style.scss
+++ b/client/jetpack-cloud/components/guided-tour/style.scss
@@ -26,7 +26,24 @@
 	margin-block-end: 0;
 }
 
-.guided-tour__popover-button {
-	padding: 4px 8px;
-	font-size: rem(12px);
+.guided-tour__popover-footer {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	width: 100%;
+
+	.guided-tour__popover-step-count {
+		color: var(--studio-gray-60);
+		font-size: rem(12px);
+	}
+
+	.guided-tour__popover-footer-right-content {
+		display: flex;
+		gap: 8px;
+
+		button {
+			padding: 4px 8px;
+			font-size: rem(12px);
+		}
+	}
 }

--- a/client/jetpack-cloud/components/guided-tour/style.scss
+++ b/client/jetpack-cloud/components/guided-tour/style.scss
@@ -1,0 +1,32 @@
+.guided-tour__popover {
+	.popover__inner {
+		display: flex;
+		gap: 16px;
+		padding: 16px;
+		flex-direction: column;
+		align-items: flex-start;
+		/* stylelint-disable-next-line scales/radii */
+		border-radius: 8px;
+	}
+}
+
+.guided-tour__popover-heading {
+	color: var(--studio-gray-100);
+	font-size: rem(14px);
+	line-height: 1.5;
+	font-weight: 500;
+}
+
+.guided-tour__popover-description {
+	color: var(--studio-gray-80);
+	font-size: rem(12px);
+	line-height: 1.5;
+	max-width: 220px;
+	text-align: left;
+	margin-block-end: 0;
+}
+
+.guided-tour__popover-button {
+	padding: 4px 8px;
+	font-size: rem(12px);
+}


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/41

## Proposed Changes

- This PR implements a component to show the guided tour 

### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Run `git checkout add/jetpack-cloud-guided-tour` and `yarn start-jetpack-cloud`.
2. Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
3. Append the URL with `?flags=jetpack/new-navigation`
4. You need to make some changes in the code to make the guided tour visible

Visit client/jetpack-cloud/components/sidebar/index.tsx and add the below line at the end of the component

```
.....
import GuidedTour from 'calypso/jetpack-cloud/components/guided-tour';
```

```
const tours = [
	{
		targetId: 'step1',
		title: 'Switch Sites Easily',
		description: `Easily switch between viewing all sites or focusing on individual ones you're managing.`,
	},
	{
		targetId: 'step2',
		title: 'Step2',
		description: 'This is the second step of the tour!',
	},
	{
		targetId: 'step3',
		title: 'Step3',
		description: 'This is the third step of the tour!',
	},
];
```

```
<GuidedTour tours={ tours } preferenceName="test-tour" />
```

5. Add the IDs to the target elements. Add the ID to the below places:

client/jetpack-cloud/components/sidebar/index.tsx

Line 35: 

```
<header id="step1" className="jetpack-cloud-sidebar__header">
	Header
</header>
```

Line 51:

```
<div id="step2" className="jetpack-cloud-sidebar__footer">
	Footer
</div>
```

client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content-header.tsx

Line 28:

```
<h2 id="step3" className="sites-overview__page-title">
	{ pageTitle }
</h2>
```

6. Refresh the page and verify that you can see the onboarding tour steps being displayed and that it is not shown again after all the steps are shown or after clicking on the `Skip` button.

<img width="270" alt="Screenshot 2023-10-11 at 5 41 19 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/9942a5cd-e221-41e5-ba32-a77e494668ed">

<img width="360" alt="Screenshot 2023-10-11 at 5 41 26 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/c67889a4-26f9-4441-88b5-4929be4754d8">

7. Verify that no Skip button is shown when there is only 1 step and the button text says `Got it`

<img width="282" alt="Screenshot 2023-10-11 at 5 41 48 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/fe8e8828-503f-4163-bf99-2b2616232f2d">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?