### PR TITLE
Site profiler: UX: Improve site profiler form

### DIFF
--- a/client/site-profiler/components/domain-analyzer/index.tsx
+++ b/client/site-profiler/components/domain-analyzer/index.tsx
@@ -48,6 +48,8 @@ export default function DomainAnalyzer( props: Props ) {
 						<input
 							type="text"
 							name="domain"
+							// eslint-disable-next-line jsx-a11y/no-autofocus
+							autoFocus={ true }
 							autoComplete="off"
 							defaultValue={ domain }
 							placeholder={ translate( 'Enter a site URL' ) }

--- a/client/site-profiler/components/domain-analyzer/index.tsx
+++ b/client/site-profiler/components/domain-analyzer/index.tsx
@@ -2,7 +2,7 @@ import { Button } from '@wordpress/components';
 import { Icon, info } from '@wordpress/icons';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { FormEvent } from 'react';
+import { FormEvent, KeyboardEvent } from 'react';
 import './styles.scss';
 
 interface Props {
@@ -30,6 +30,13 @@ export default function DomainAnalyzer( props: Props ) {
 		onFormSubmit( domain );
 	};
 
+	const onInputEscape = ( e: KeyboardEvent< HTMLInputElement > ) => {
+		if ( e.key === 'Escape' ) {
+			e.currentTarget.value = '';
+			onFormSubmit( '' );
+		}
+	};
+
 	return (
 		<div className="domain-analyzer">
 			<h1>{ translate( 'Site Profiler' ) }</h1>
@@ -54,6 +61,7 @@ export default function DomainAnalyzer( props: Props ) {
 							defaultValue={ domain }
 							placeholder={ translate( 'Enter a site URL' ) }
 							key={ domain || 'empty' }
+							onKeyDown={ onInputEscape }
 						/>
 					</div>
 					<div className="col-2">


### PR DESCRIPTION
## Proposed Changes

* Added autofocus functionality on the form render
* Added clearing input value functionality on the escape key down

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the `/site-profiler` route
* Check if there is an initial input focus
* Enter anything and press the Esc key
* Check if the input is clear out
* Enter invalid domain value
* Press the Esc key
* Check if the input is clear out

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?