### PR TITLE
Stats: Add cancel button to date picker

### DIFF
--- a/client/my-sites/stats/stats-date-control/stats-date-control-picker-date.tsx
+++ b/client/my-sites/stats/stats-date-control/stats-date-control-picker-date.tsx
@@ -8,12 +8,8 @@ const DateControlPickerDate = ( {
 	onStartChange,
 	onEndChange,
 	onApply,
+	onCancel,
 }: DateControlPickerDateProps ) => {
-	// Handle Cancel button.
-	// Should call back to parent to handle closing of popover.
-	const onCancel = () => {
-		console.log( 'cancel button clicked' );
-	};
 	return (
 		<>
 			<div>

--- a/client/my-sites/stats/stats-date-control/stats-date-control-picker-date.tsx
+++ b/client/my-sites/stats/stats-date-control/stats-date-control-picker-date.tsx
@@ -9,6 +9,11 @@ const DateControlPickerDate = ( {
 	onEndChange,
 	onApply,
 }: DateControlPickerDateProps ) => {
+	// Handle Cancel button.
+	// Should call back to parent to handle closing of popover.
+	const onCancel = () => {
+		console.log( 'cancel button clicked' );
+	};
 	return (
 		<>
 			<div>
@@ -17,6 +22,7 @@ const DateControlPickerDate = ( {
 			<div>
 				<TextControl value={ endDate } onChange={ onEndChange } />
 			</div>
+			<Button onClick={ onCancel }>Cancel</Button>
 			<Button variant="primary" onClick={ onApply }>
 				Apply
 			</Button>

--- a/client/my-sites/stats/stats-date-control/stats-date-control-picker.tsx
+++ b/client/my-sites/stats/stats-date-control/stats-date-control-picker.tsx
@@ -51,7 +51,7 @@ const DateControlPicker = ( {
 	};
 
 	const handleOnCancel = () => {
-		console.log( 'handle the Cancel button' );
+		togglePopoverOpened( false );
 	};
 
 	const handleShortcutSelected = ( shortcut: DateControlPickerShortcut ) => {

--- a/client/my-sites/stats/stats-date-control/stats-date-control-picker.tsx
+++ b/client/my-sites/stats/stats-date-control/stats-date-control-picker.tsx
@@ -50,6 +50,10 @@ const DateControlPicker = ( {
 		page( href );
 	};
 
+	const handleOnCancel = () => {
+		console.log( 'handle the Cancel button' );
+	};
+
 	const handleShortcutSelected = ( shortcut: DateControlPickerShortcut ) => {
 		// Shared date math.
 		const calcNewDateWithOffset = ( date: Date, offset: number ): Date => {
@@ -98,6 +102,7 @@ const DateControlPicker = ( {
 					onStartChange={ changeStartDate }
 					onEndChange={ changeEndDate }
 					onApply={ handleOnApply }
+					onCancel={ handleOnCancel }
 				/>
 				<DateControlPickerShortcuts
 					shortcutList={ shortcutList }

--- a/client/my-sites/stats/stats-date-control/types.d.ts
+++ b/client/my-sites/stats/stats-date-control/types.d.ts
@@ -32,6 +32,7 @@ interface DateControlPickerDateProps {
 	onStartChange: ( value: string ) => void;
 	onEndChange: ( value: string ) => void;
 	onApply: () => void;
+	onCancel: () => void;
 }
 
 export {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #82221.

## Proposed Changes

Adds a cancel button to the date picker that closes the popover when clicked. Currently looks like this:

![SCR-20231010-qtyb](https://github.com/Automattic/wp-calypso/assets/40267301/a886d145-b5b0-47e6-a8c8-dadf752ce4ce)

**A few things of note:**

1. Styling for the buttons/inputs will be part of #82702.
2. Changes are pushed to the parent prematurely meaning that if you change the dates via inputs or shortcut, the parent will display the wrong range.
3. There's a weird flashing behaviour that can happen when dismissing the popover and triggering a tooltip on the chart. Not new with these changes but something we'll need to investigate.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up the Live branch.
* Visit **Stats → Traffic**.
* Enable date picker control: `?flags=stats/date-control`
* Click date picker button to open the popover.
* Confirm clicking the Cancel button dismisses the popover.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?