### PR TITLE
Change DSP widget JS URL in production

### DIFF
--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -66,12 +66,8 @@ declare global {
 	}
 }
 
-const shouldUseTestWidgetURL = () => getMobileDeviceInfo()?.version === '22.9.blaze';
-
 const getWidgetDSPJSURL = () => {
-	let dspWidgetJS: string = shouldUseTestWidgetURL()
-		? config( 'dsp_widget_js_test_src' )
-		: config( 'dsp_widget_js_src' );
+	let dspWidgetJS: string = config( 'dsp_widget_js_src' );
 
 	if ( config.isEnabled( 'promote-post/widget-i2' ) ) {
 		dspWidgetJS = dspWidgetJS.replace( '/promote/', '/promote-v2/' );
@@ -85,11 +81,7 @@ export async function loadDSPWidgetJS(): Promise< void > {
 		return;
 	}
 
-	let src = `${ getWidgetDSPJSURL() }?ver=${ Math.round( Date.now() / ( 1000 * 60 * 60 ) ) }`;
-
-	if ( shouldUseTestWidgetURL() || getWidgetDSPJSURL().startsWith( 'https://dsp.wp.com' ) ) {
-		src = `${ getWidgetDSPJSURL() }`;
-	}
+	const src = `${ getWidgetDSPJSURL() }?ver=${ Math.round( Date.now() / ( 1000 * 60 * 60 ) ) }`;
 
 	await loadScript( src );
 	// Load the strings so that translations get associated with the module and loaded properly.

--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -67,12 +67,7 @@ declare global {
 }
 
 const getWidgetDSPJSURL = () => {
-	let dspWidgetJS: string = config( 'dsp_widget_js_src' );
-
-	if ( config.isEnabled( 'promote-post/widget-i2' ) ) {
-		dspWidgetJS = dspWidgetJS.replace( '/promote/', '/promote-v2/' );
-	}
-	return dspWidgetJS;
+	return config( 'dsp_widget_js_src' );
 };
 
 export async function loadDSPWidgetJS(): Promise< void > {

--- a/config/production.json
+++ b/config/production.json
@@ -12,7 +12,7 @@
 	"facebook_app_id": "2373049596",
 	"bilmur_url": "/wp-content/js/bilmur.min.js",
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0oHFYHpzmHGpuUAXZ6ygDAFxM4XkRArRsET0orrofmsynkd9DhFaOGEsDZ3RC4f8mgI0zhEyN000X8i0Mqx",
-	"dsp_widget_js_src": "https://widgets.wp.com/promote/widget.js",
+	"dsp_widget_js_src": "https://dsp.wp.com/widget.js",
 	"dsp_widget_js_test_src": "https://dsp.wp.com/widget.js",
 	"advertising_dashboard_path_prefix": "/advertising",
 	"zendesk_presales_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",


### PR DESCRIPTION
As we have bundled widget JS in a single file and fixed the chunks issue we had on Android, we are now changing the URL on production to the new one

## Proposed Changes

* Change the config value for `dsp_widget_js_src` in production to use the same as in development (`dsp_widget_js_test_src` config properties will be cleaned up in a subsequent PR)

## Testing Instructions

* Code review
* Checkout this branch locally
* Visit http://calypso.localhost:3000/advertising/your-site.com
* Press the "promote" button from the post list to launch the advertising widget
* Confirm that the widget works as expected

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
