### PR TITLE
Reader/First-Posts: Enable the feature in all environments

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -101,7 +101,7 @@
 		"purchases/new-payment-methods": true,
 		"reader": true,
 		"reader/discover-stream": false,
-		"reader/first-posts-stream": false,
+		"reader/first-posts-stream": true,
 		"reader/list-management": true,
 		"reader/public-tag-pages": true,
 		"redirect-fallback-browsers": true,

--- a/config/production.json
+++ b/config/production.json
@@ -126,7 +126,7 @@
 		"push-notifications": true,
 		"reader": true,
 		"reader/discover-stream": false,
-		"reader/first-posts-stream": false,
+		"reader/first-posts-stream": true,
 		"reader/full-errors": false,
 		"reader/list-management": true,
 		"reader/public-tag-pages": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -123,7 +123,7 @@
 		"push-notifications": true,
 		"reader": true,
 		"reader/discover-stream": false,
-		"reader/first-posts-stream": false,
+		"reader/first-posts-stream": true,
 		"reader/full-errors": false,
 		"reader/list-management": true,
 		"reader/public-tag-pages": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This enables the first-posts flag so that users will see the new First Posts tab in the Reader.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch.
* Run `yarn run feature-search "first-posts"`
* Verify that the feature is enabled in all environments where the flag is set:
 
<img width="518" alt="CleanShot 2023-10-10 at 08 06 12@2x" src="https://github.com/Automattic/wp-calypso/assets/917632/5caa486e-4952-4226-a95e-b43bfc2954bb">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
