### PR TITLE
Stats: Update layout and styling for date picker

### DIFF
--- a/client/my-sites/stats/stats-date-control/stats-date-control-picker-date.tsx
+++ b/client/my-sites/stats/stats-date-control/stats-date-control-picker-date.tsx
@@ -10,11 +10,6 @@ const DateControlPickerDate = ( {
 	onApply,
 	onCancel,
 }: DateControlPickerDateProps ) => {
-	// Handle Cancel button.
-	// Should call back to parent to handle closing of popover.
-	const onCancel = () => {
-		console.log( 'cancel button clicked' );
-	};
 	return (
 		<>
 			<div>

--- a/client/my-sites/stats/stats-date-control/stats-date-control-picker-date.tsx
+++ b/client/my-sites/stats/stats-date-control/stats-date-control-picker-date.tsx
@@ -15,16 +15,16 @@ const DateControlPickerDate = ( {
 	// of appropriate names once hierarchy is finalized.
 	return (
 		<div className="date-control-picker-date">
-			<div>
+			<div className="stats-date-control-picker-dates__inputs">
 				<TextControl value={ startDate } onChange={ onStartChange } />
-			</div>
-			<div>
 				<TextControl value={ endDate } onChange={ onEndChange } />
 			</div>
-			<Button onClick={ onCancel }>Cancel</Button>
-			<Button variant="primary" onClick={ onApply }>
-				Apply
-			</Button>
+			<div className="stats-date-control-picker-dates__buttons">
+				<Button onClick={ onCancel }>Cancel</Button>
+				<Button variant="primary" onClick={ onApply }>
+					Apply
+				</Button>
+			</div>
 		</div>
 	);
 };

--- a/client/my-sites/stats/stats-date-control/stats-date-control-picker-date.tsx
+++ b/client/my-sites/stats/stats-date-control/stats-date-control-picker-date.tsx
@@ -10,8 +10,11 @@ const DateControlPickerDate = ( {
 	onApply,
 	onCancel,
 }: DateControlPickerDateProps ) => {
+	// TODO: Rename component?
+	// Feels a bit confusing now. Should have a better idea
+	// of appropriate names once hierarchy is finalized.
 	return (
-		<>
+		<div className="date-control-picker-date">
 			<div>
 				<TextControl value={ startDate } onChange={ onStartChange } />
 			</div>
@@ -22,7 +25,7 @@ const DateControlPickerDate = ( {
 			<Button variant="primary" onClick={ onApply }>
 				Apply
 			</Button>
-		</>
+		</div>
 	);
 };
 

--- a/client/my-sites/stats/stats-date-control/stats-date-control-picker-date.tsx
+++ b/client/my-sites/stats/stats-date-control/stats-date-control-picker-date.tsx
@@ -10,6 +10,11 @@ const DateControlPickerDate = ( {
 	onApply,
 	onCancel,
 }: DateControlPickerDateProps ) => {
+	// Handle Cancel button.
+	// Should call back to parent to handle closing of popover.
+	const onCancel = () => {
+		console.log( 'cancel button clicked' );
+	};
 	return (
 		<>
 			<div>

--- a/client/my-sites/stats/stats-date-control/stats-date-control-picker.tsx
+++ b/client/my-sites/stats/stats-date-control/stats-date-control-picker.tsx
@@ -93,22 +93,22 @@ const DateControlPicker = ( {
 				position="bottom"
 				context={ infoReferenceElement?.current }
 				isVisible={ popoverOpened }
-				// TODO: Remove this inline CSS.
-				style={ { minWidth: '260px' } }
 			>
-				<DateControlPickerDate
-					startDate={ inputStartDate }
-					endDate={ inputEndDate }
-					onStartChange={ changeStartDate }
-					onEndChange={ changeEndDate }
-					onApply={ handleOnApply }
-					onCancel={ handleOnCancel }
-				/>
-				<DateControlPickerShortcuts
-					shortcutList={ shortcutList }
-					currentShortcut={ currentShortcut }
-					onClick={ handleShortcutSelected }
-				/>
+				<div className="stats-date-control-picker__popover-content">
+					<DateControlPickerDate
+						startDate={ inputStartDate }
+						endDate={ inputEndDate }
+						onStartChange={ changeStartDate }
+						onEndChange={ changeEndDate }
+						onApply={ handleOnApply }
+						onCancel={ handleOnCancel }
+					/>
+					<DateControlPickerShortcuts
+						shortcutList={ shortcutList }
+						currentShortcut={ currentShortcut }
+						onClick={ handleShortcutSelected }
+					/>
+				</div>
 			</Popover>
 		</div>
 	);

--- a/client/my-sites/stats/stats-date-control/style.scss
+++ b/client/my-sites/stats/stats-date-control/style.scss
@@ -56,7 +56,8 @@
 }
 
 .stats-date-control-picker__popover-content {
-	min-width: 220px;
+	display: flex;
+	min-width: 320px;
 }
 
 .date-control-picker-date {

--- a/client/my-sites/stats/stats-date-control/style.scss
+++ b/client/my-sites/stats/stats-date-control/style.scss
@@ -58,3 +58,7 @@
 .stats-date-control-picker__popover-content {
 	min-width: 220px;
 }
+
+.date-control-picker-date {
+	margin: 16px;
+}

--- a/client/my-sites/stats/stats-date-control/style.scss
+++ b/client/my-sites/stats/stats-date-control/style.scss
@@ -68,3 +68,8 @@
 	flex-direction: column;
 	justify-content: space-between;
 }
+
+.stats-date-control-picker-dates__buttons {
+	display: flex;
+	justify-content: flex-end;
+}

--- a/client/my-sites/stats/stats-date-control/style.scss
+++ b/client/my-sites/stats/stats-date-control/style.scss
@@ -54,3 +54,7 @@
 		gap: 8px;
 	}
 }
+
+.stats-date-control-picker__popover-content {
+	min-width: 220px;
+}

--- a/client/my-sites/stats/stats-date-control/style.scss
+++ b/client/my-sites/stats/stats-date-control/style.scss
@@ -62,4 +62,9 @@
 
 .date-control-picker-date {
 	margin: 16px;
+
+	// internal layout
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #82702.

## Proposed Changes

Some initial updates to the layout/hierarchy of the date picker popover content. Puts the inputs to the left and the shortcuts to the right. With these changes in place it will be easier to do targeted styling of individual sections.

![SCR-20231010-rrvh](https://github.com/Automattic/wp-calypso/assets/40267301/7aedb714-991a-496a-9387-4b1ab15411e5)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up the Live branch.
* Visit **Stats → Traffic**.
* Enable date picker control: `?flags=stats/date-control`
* Click date picker button to open the popover.
* Confirm the layout matches the screenshot above.

More specific styles to match designs will happen in follow-up PRs.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?