### PR TITLE
Block support links: fix incorrect link for paywall

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/src/block-links-map.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/src/block-links-map.ts
@@ -1,3 +1,5 @@
+/* URLs are localized within the function where these URLs are used. */
+/* eslint-disable wpcalypso/i18n-unlocalized-url */
 const blockLinks: { [ key: string ]: string } = {
 	/**
 	 * Core Blocks
@@ -185,6 +187,8 @@ const blockLinks: { [ key: string ]: string } = {
 	'jetpack/layout-grid': 'https://wordpress.com/support/wordpress-editor/blocks/layout-grid-block/',
 
 	'jetpack/mailchimp': 'https://wordpress.com/support/wordpress-editor/blocks/mailchimp-block/',
+
+	'jetpack/paywall': 'https://wordpress.com/support/paid-newsletters/#use-the-paywall-block',
 };
 
 export const blockLinksWithVariations: {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/src/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/src/index.tsx
@@ -44,8 +44,11 @@ const addBlockSupportLinks = (
 	name: string
 ) => {
 	// If block has a parent, use the parents name in the switch. This will apply the link to all nested blocks.
-	const isChild = settings[ 'parent' ];
-	const blockName = isChild ? settings[ 'parent' ].toString() : name;
+	// The exception is "post content" block because it's used to allow blocks like "more" and "jetpack/paywall" only in post content areas & post editor
+	// `parent` is actually an array of strings, so converting to string is going to join multiple blocks together, making the method buggy.
+	const parentName = settings?.parent?.toString();
+	const isChild = parentName && parentName !== 'core/post-content';
+	const blockName = isChild ? parentName : name;
 
 	/**
 	 * This is needed because the `blocks.registerBlockType` filter is also triggered for deprecations.


### PR DESCRIPTION
Fixes incorrect support link in block descriptions.

<img width="306" alt="Screenshot 2023-10-10 at 15 53 43" src="https://github.com/Automattic/wp-calypso/assets/87168/1142163d-a8d2-486e-8600-2daa2aceff8b">

Before: https://wordpress.com/support/full-site-editing/theme-blocks/post-content-block/
After: https://wordpress.com/support/paid-newsletters/#use-the-paywall-block

## Proposed Changes

* When attaching support links to blocks, check if parent isn't "core/post-content". Otherwise we apply "post content" links to blocks merely meant to be limited to post editor.

The script adding support links checks if the block is "child block" (think inputs of forms block) and relies on parent block support link for the chil blocks. This works fine, except if block declares to be child block of "core/post-content" like [Jetpack Paywall  does](https://github.com/Automattic/jetpack/blob/a2a72661c86ea37791a714c4099aae7067bf32a2/projects/plugins/jetpack/extensions/blocks/paywall/index.js#L55). From memory, also "next" block does the same, but I didn't see it having wrong links.

The "post-content" as parent is used to limit block to only post content, and post-editor. 

## Testing Instructions

* See how to test ETK plugin (PCYsg-ly5-p2) — basically sync the PR to your sandbox
* In the post editor, insert paywall block
* See link under block description

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?