### PR TITLE
Add/limited time offer bell notification css

### DIFF
--- a/apps/notifications/src/panel/boot/stylesheets/shared/buttons.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/shared/buttons.scss
@@ -112,7 +112,9 @@
 			background-color: $wpnc__rich-blue;
 			border-color: $wpnc__rich-blue;
 
-			&:hover:not(:disabled) {
+			&:active:not(:disabled),
+			&:hover:not(:disabled),
+			&:focus:not(:disabled) {
 				background-color: $wpnc__dark-rich-blue;
 				border-color: $wpnc__dark-rich-blue;
 			}

--- a/apps/notifications/src/panel/boot/stylesheets/shared/buttons.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/shared/buttons.scss
@@ -82,7 +82,6 @@
 			height: 18px;
 		}
 	}
-
 	// Primary buttons
 	.wpnc__button.is-primary {
 		background-color: var(--color-accent);
@@ -107,6 +106,16 @@
 
 		&.is-compact {
 			color: var(--color-text-inverted);
+		}
+
+		&.is-rich {
+			background-color: $wpnc__rich-blue;
+			border-color: $wpnc__rich-blue;
+
+			&:hover:not(:disabled) {
+				background-color: $wpnc__dark-rich-blue;
+				border-color: $wpnc__dark-rich-blue;
+			}
 		}
 	}
 

--- a/apps/notifications/src/panel/boot/stylesheets/shared/colors.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/shared/colors.scss
@@ -1,3 +1,5 @@
 $wpnc__yellow-dark: var(--color-warning-60);
 $wpnc__red-darker: var(--color-error-90);
 $wpnc__yellow-lighter: var(--color-warning-0);
+$wpnc__rich-blue: #3858e9;
+$wpnc__dark-rich-blue: #183ad6;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
This is from https://github.com/Automattic/martech/issues/2176
## Proposed Changes
Adds the blue color to the CTA button in the Bell notifications for Limited time offers.

## Testing Instructions
Follow instructions here 
D124987-code
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?