### PR TITLE
Reader/Discover: Enable the new discover feature in all environments

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -100,7 +100,7 @@
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
 		"reader": true,
-		"reader/discover-stream": false,
+		"reader/discover-stream": true,
 		"reader/first-posts-stream": true,
 		"reader/list-management": true,
 		"reader/public-tag-pages": true,

--- a/config/production.json
+++ b/config/production.json
@@ -125,7 +125,7 @@
 		"purchases/new-payment-methods": true,
 		"push-notifications": true,
 		"reader": true,
-		"reader/discover-stream": false,
+		"reader/discover-stream": true,
 		"reader/first-posts-stream": true,
 		"reader/full-errors": false,
 		"reader/list-management": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -122,7 +122,7 @@
 		"purchases/new-payment-methods": true,
 		"push-notifications": true,
 		"reader": true,
-		"reader/discover-stream": false,
+		"reader/discover-stream": true,
 		"reader/first-posts-stream": true,
 		"reader/full-errors": false,
 		"reader/list-management": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->



## Proposed Changes

This enables the discover flag in all environments so users will hit the new `/wpcom/v2/read/stream/discover` endpoint when loading the Discover tab of the Reader.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch
* Run `yarn run feature-search "reader/discover"
* Verify that the feature is enabled in all environments where the flag is set:
![CleanShot 2023-10-10 at 11 42 05](https://github.com/Automattic/wp-calypso/assets/917632/4ae1a1c4-29db-4ba7-bf0d-a8392b703499)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
