### PR TITLE
Newsletter: Fetch memberships before consuming its data

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -19,7 +19,7 @@ import { ResponseDomain } from 'calypso/lib/domains/types';
 import RecurringPaymentsPlanAddEditModal from 'calypso/my-sites/earn/components/add-edit-plan-modal';
 import { useSelector } from 'calypso/state';
 import { isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
-import { getconnectedConnectUrlForSiteId } from 'calypso/state/memberships/settings/selectors';
+import { getConnectUrlForSiteId } from 'calypso/state/memberships/settings/selectors';
 import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
 import { getEnhancedTasks } from './task-helper';
 import { getLaunchpadTranslations } from './translations';
@@ -71,7 +71,7 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goToStep, flow }: SidebarPr
 	);
 
 	const stripeConnectUrl = useSelector( ( state ) =>
-		getconnectedConnectUrlForSiteId( state, site?.ID ?? 0 )
+		getConnectUrlForSiteId( state, site?.ID ?? 0 )
 	);
 
 	const showDomain =

--- a/client/state/memberships/settings/selectors.js
+++ b/client/state/memberships/settings/selectors.js
@@ -24,6 +24,11 @@ export function getconnectedAccountMinimumCurrencyForSiteId( state, siteId ) {
 		null
 	);
 }
+
+export function getconnectedConnectUrlForSiteId( state, siteId ) {
+	return get( state, [ 'memberships', 'settings', siteId, 'connectUrl' ], null );
+}
+
 export function getConnectUrlForSiteId( state, siteId ) {
 	return get( state, [ 'memberships', 'settings', siteId, 'connectUrl' ], '' );
 }

--- a/client/state/memberships/settings/selectors.js
+++ b/client/state/memberships/settings/selectors.js
@@ -24,7 +24,6 @@ export function getconnectedAccountMinimumCurrencyForSiteId( state, siteId ) {
 		null
 	);
 }
-
 export function getConnectUrlForSiteId( state, siteId ) {
 	return get( state, [ 'memberships', 'settings', siteId, 'connectUrl' ], '' );
 }

--- a/client/state/memberships/settings/selectors.js
+++ b/client/state/memberships/settings/selectors.js
@@ -25,10 +25,6 @@ export function getconnectedAccountMinimumCurrencyForSiteId( state, siteId ) {
 	);
 }
 
-export function getconnectedConnectUrlForSiteId( state, siteId ) {
-	return get( state, [ 'memberships', 'settings', siteId, 'connectUrl' ], null );
-}
-
 export function getConnectUrlForSiteId( state, siteId ) {
 	return get( state, [ 'memberships', 'settings', siteId, 'connectUrl' ], '' );
 }


### PR DESCRIPTION
## Proposed Changes

Fixes issue with RecurringPaymentsPlanAddEditModal component not loading on Launchpad. That component requires membership data be available, which is now done via QueryMembershipsSettings. 

## Testing Instructions

Start a newsletter site at http://calypso.localhost:3000/setup/newsletter/intro, select the paid option, proceed to Launchpad, click the 'Create paid newsletter' task and confirm that the modal opens and works as expected. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?