### PR TITLE
hexToRgb: Discard alpha channel if exists

### DIFF
--- a/packages/onboarding/src/utils/contrastChecker.ts
+++ b/packages/onboarding/src/utils/contrastChecker.ts
@@ -35,14 +35,20 @@ export const hasMinContrast = (
 
 // Works also with shorthand hex triplets such as "#03F"
 export const hexToRgb = ( hex: string ) => {
-	const rgbHex = hex
-		.replace( /^#?([a-f\d])([a-f\d])([a-f\d])$/i, ( _m, r, g, b ) => '#' + r + r + g + g + b + b )
+	const expandedHex = hex
+		.replace(
+			/^#?([a-f\d])([a-f\d])([a-f\d])([a-f\d])?$/i,
+			( _m, r, g, b, a ) => '#' + r + r + g + g + b + b + ( a ? a + a : '' )
+		)
 		.substring( 1 )
 		.match( /.{2}/g );
 
-	if ( rgbHex?.length !== 3 ) {
-		throw 'Unexpected RGB hex value';
+	if ( ! expandedHex ) {
+		throw new Error( `Invalid hex color: ${ hex }` );
 	}
+
+	// Discard the alpha channel if it exists
+	const rgbHex = expandedHex.length > 3 ? expandedHex.slice( 0, 3 ) : expandedHex;
 
 	const [ r, g, b ] = rgbHex.map( ( x ) => parseInt( x, 16 ) );
 	return { r, g, b };

--- a/packages/onboarding/src/utils/contrastChecker.ts
+++ b/packages/onboarding/src/utils/contrastChecker.ts
@@ -43,7 +43,7 @@ export const hexToRgb = ( hex: string ) => {
 		.substring( 1 )
 		.match( /.{2}/g );
 
-	if ( ! expandedHex ) {
+	if ( ! expandedHex || expandedHex.length < 3 ) {
 		throw new Error( `Invalid hex color: ${ hex }` );
 	}
 


### PR DESCRIPTION
## Proposed Changes

* hexToRgb will no longer crash if passed a color like `#f7f8f2cc`. Rather, it will simply drop the alpha channel.
* It will also accept 4-digit hex color notation (shorthand for 8-digit) and throw away the alpha channel.

## Testing Instructions

* Find an atomic site and visit `http://calypso.localhost:3000/themes/<SITE>`. You may have to undo changes that are being made right now to remove the alpha channel from a theme's colors.

