### PR TITLE
Domain selection: Decrease padding/margin on mobile

### DIFF
--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -414,7 +414,7 @@ body.is-section-signup.is-white-signup {
 	.signup__step.is-domain-only,
 	.signup__step.is-domains,
 	.signup__step.is-mailbox-domain {
-		padding: 0 20px;
+		padding: 0 12px;
 	}
 }
 

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -237,6 +237,33 @@
 body.is-section-signup.is-white-signup {
 	$light-white: #f3f4f5;
 
+	#primary {
+		.signup__step.is-domains,
+		.signup__step.is-domain-only,
+		.signup__step.is-mailbox-domain {
+			@media (max-width: $break-mobile) {
+				.step-wrapper__header {
+					margin-left: 0;
+					margin-right: 0;
+					margin-top: 36px;
+				}
+
+				.formatted-header__title {
+					padding-left: 0;
+					padding-right: 0;
+					font-size: rem(32px);
+				}
+
+				.formatted-header__subtitle {
+					padding-left: 0;
+					padding-right: 0;
+					margin-top: 8px;
+					font-size: rem(16px);
+				}
+			}
+		}
+	}
+
 	.domains__step-content {
 		display: flex;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4110

## Proposed Changes

* Update margins for the domain selection page on mobile.

Before | After
--|--
<img width="374" alt="Screenshot 2023-10-10 at 2 36 28 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/1d51a82c-f369-4b3a-af5f-3aed8eceae56"> | <img width="375" alt="Screenshot 2023-10-10 at 2 36 38 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/ea102aa3-dfcb-4815-8119-5c589bd28e62">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* View the following pages and make sure it looks good on mobile
* http://calypso.localhost:3000/start/domains?flags=domains/add-multiple-domains-to-cart
* http://calypso.localhost:3000/start/domains
* http://calypso.localhost:3000/start/domain/domain-only
* http://calypso.localhost:3000/start/onboarding-with-email/mailbox-domain

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?