### PR TITLE
Adds an error page on the Promote post widget

### DIFF
--- a/client/components/blazepress-widget/index.tsx
+++ b/client/components/blazepress-widget/index.tsx
@@ -7,6 +7,7 @@ import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { useEffect, useRef, useState } from 'react';
+import { useDispatch } from 'react-redux';
 import { BlankCanvas } from 'calypso/components/blank-canvas';
 import BlazeLogo from 'calypso/components/blaze-logo';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
@@ -37,6 +38,7 @@ const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
 	// eslint-disable-next-line @typescript-eslint/no-empty-function
 	const { isVisible = false, keyValue, siteId } = props;
 	const [ isLoading, setIsLoading ] = useState( true );
+	const [ error, setError ] = useState( false );
 	const [ showCancelDialog, setShowCancelDialog ] = useState( false );
 	const [ showCancelButton, setShowCancelButton ] = useState( true );
 	const [ hiddenHeader, setHiddenHeader ] = useState( true );
@@ -50,6 +52,7 @@ const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
 	const { closeModal } = useRouteModal( 'blazepress-widget', keyValue );
 	const queryClient = useQueryClient();
 	const localeSlug = useLocale();
+	const dispatch = useDispatch();
 
 	// Scroll to top on initial load regardless of previous page position
 	useEffect( () => {
@@ -85,20 +88,26 @@ const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
 				}
 				const source = props.source || 'blazepress';
 
-				await showDSP(
-					selectedSiteSlug,
-					props.siteId,
-					props.postId,
-					onClose,
-					source,
-					translate,
-					localizeUrl,
-					widgetContainer.current,
-					handleShowCancel,
-					handleShowTopBar,
-					localeSlug,
-					config.isEnabled( 'promote-post/widget-i2' )
-				);
+				try {
+					await showDSP(
+						selectedSiteSlug,
+						props.siteId,
+						props.postId,
+						onClose,
+						source,
+						translate,
+						localizeUrl,
+						widgetContainer.current,
+						handleShowCancel,
+						handleShowTopBar,
+						localeSlug,
+						config.isEnabled( 'promote-post/widget-i2' ),
+						dispatch
+					);
+				} catch ( error ) {
+					setError( true );
+					setHiddenHeader( false );
+				}
 				setIsLoading( false );
 			} )();
 	}, [ isVisible, props.postId, props.siteId, selectedSiteSlug ] );
@@ -140,7 +149,15 @@ const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
 							className={ classNames( 'blazepress-widget__header-bar', {
 								'no-back-button': ! showCancelButton,
 							} ) }
-							onBackClick={ () => setShowCancelDialog( true ) }
+							onBackClick={ () => {
+								if ( error ) {
+									// Close without dialog if we are displaying the error page (no need to confirmation there)
+									setShowCancelDialog( false );
+									onClose();
+								} else {
+									setShowCancelDialog( true );
+								}
+							} }
 						>
 							<h2>{ translate( 'Blaze - Powered by Jetpack' ) }</h2>
 						</BlankCanvas.Header>
@@ -162,11 +179,7 @@ const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
 						</div>
 					) }
 
-					<div
-						className={
-							isLoading ? 'blazepress-widget__content loading' : 'blazepress-widget__content'
-						}
-					>
+					<div className={ classNames( 'blazepress-widget__content', { loading: isLoading } ) }>
 						<Dialog
 							showCloseIcon={ true }
 							additionalOverlayClassNames="blazepress-widget"
@@ -182,6 +195,26 @@ const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
 							</p>
 						</Dialog>
 						{ isLoading && <LoadingEllipsis /> }
+						{ error && (
+							<div className="error-notice">
+								<h3 className="error-notice__title">
+									{ translate( 'Oops, something went wrong' ) }
+								</h3>
+								<p className="error-notice__body">
+									{ translate( 'Please try again soon or {{a}}contact support{{/a}} for help.', {
+										components: {
+											a: (
+												<a
+													href="https://wordpress.com/help/contact"
+													target="_blank"
+													rel="noopener noreferrer"
+												/>
+											),
+										},
+									} ) }
+								</p>
+							</div>
+						) }
 						<div className="blazepress-widget__widget-container" ref={ widgetContainer }></div>
 					</div>
 				</BlankCanvas>

--- a/client/components/blazepress-widget/style.scss
+++ b/client/components/blazepress-widget/style.scss
@@ -64,6 +64,23 @@ $heading-font-body-small: 15px;
 		flex: auto;
 		flex-direction: row;
 	}
+	.blazepress-widget__content .error-notice {
+		margin-top: 64px;
+		width: 80%;
+		align-self: center;
+		text-align: center;
+
+		.error-notice__title {
+			font-size: $font-title-medium;
+			font-style: normal;
+			font-weight: 500;
+			margin-bottom: 20px;
+		}
+		.error-notice__notice {
+			font-size: $font-body-large;
+		}
+	}
+
 	.blazepress-widget__widget-container {
 		height: 100%;
 


### PR DESCRIPTION
This PR aims to add more analytics when the user tries to load the Promote post widget. Additionally, I added a more user-friendly error page when the worst happens :( 

![Screenshot 2023-10-10 at 16 18 19](https://github.com/Automattic/wp-calypso/assets/1258162/4e96f943-3c7e-4929-9340-0b16f5e9dfa7)

## Proposed Changes

* Add an Error page when we fail to load the DSP widget
* Adds more tracking events in the event of failure

## Testing Instructions

* Open the live preview and go to Tools->Advertising
* Open your network tab and filter by `widget.js`
* Click on the Promote button in the Advertising page
* Verify that the widget load correctly
* Click on the Back button in the header and verify that you see the close confirmation modal

* In the network tab, block the request URL for the `widget.js` file
![Screenshot 2023-10-10 at 16 25 24](https://github.com/Automattic/wp-calypso/assets/1258162/a0c987af-7537-439e-a7a9-505e9cc1ee90)
* Exit the widget, and then refresh the page to clear the widget.js local cache
* In the network tab, filter by `t.gif`
* Click on the promote button. Now that the request is blocked, the error page should be shown
* Verify that the error page is shown in the widget, and that the event `calypso_dsp_widget_failed_to_load` was triggered
* Click on back and verify that the confirmation modal is not shown
* Unblock the widget and click on Promote again
* Verify that now it loads correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?