### PR TITLE
Multi-Domain: Add plan to cart to show correct promo on mini-cart

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -753,9 +753,7 @@ export class RenderDomainsStep extends Component {
 						</Button>
 						{ hasPromotion && (
 							<span className="savings-message">
-								{ translate( 'Up to %(costDifference)s off for a domain.', {
-									args: { costDifference: formatCurrency( costDifference, domain.currency ) },
-								} ) }
+								{ translate( 'Free for the first year with annual paid plans.' ) }
 							</span>
 						) }
 					</div>

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -158,7 +158,6 @@ export class RenderDomainsStep extends Component {
 			currentStep: null,
 			isCartPendingUpdateDomain: null,
 			wpcomSubdomainSelected: false,
-			isCheckingMultiDomainPlan: false,
 		};
 	}
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -744,6 +744,11 @@ export class RenderDomainsStep extends Component {
 						</div>
 					</div>
 					<div>
+						{ hasPromotion && domain.item_subtotal === 0 && (
+							<span className="savings-message">
+								{ translate( 'Free for the first year with annual paid plans.' ) }
+							</span>
+						) }
 						<Button
 							borderless
 							className="domains__domain-cart-remove"
@@ -751,11 +756,6 @@ export class RenderDomainsStep extends Component {
 						>
 							{ this.props.translate( 'Remove' ) }
 						</Button>
-						{ hasPromotion && (
-							<span className="savings-message">
-								{ translate( 'Free for the first year with annual paid plans.' ) }
-							</span>
-						) }
 					</div>
 				</>
 			);

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -158,6 +158,7 @@ export class RenderDomainsStep extends Component {
 			currentStep: null,
 			isCartPendingUpdateDomain: null,
 			wpcomSubdomainSelected: false,
+			isCheckingMultiDomainPlan: false,
 		};
 	}
 
@@ -763,8 +764,26 @@ export class RenderDomainsStep extends Component {
 			);
 		};
 
+		const addMultiDomainPlanToCart = () => {
+			if ( ! cartIsLoading && ! this.state.isCheckingMultiDomainPlan ) {
+				this.setState( { isCheckingMultiDomainPlan: true } );
+				if ( ! hasPlan( this.props.cart ) ) {
+					this.props.shoppingCartManager
+						.addProductsToCart( [ this.props.multiDomainDefaultPlan ] )
+						.then( () => {
+							this.setState( { isCheckingMultiDomainPlan: false } );
+						} );
+				}
+				return;
+			}
+		};
+
 		const DomainsInCart = () => {
 			if ( ! shouldUseMultipleDomainsInCart( this.props.flowName ) || cartIsLoading ) {
+				return null;
+			}
+			if ( ! cartIsLoading && ! hasPlan( this.props.cart ) ) {
+				addMultiDomainPlanToCart();
 				return null;
 			}
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1,3 +1,4 @@
+import { PLAN_PERSONAL } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { formatCurrency } from '@automattic/format-currency';
 import { VIDEOPRESS_FLOW, isWithThemeFlow, isHostingSignupFlow } from '@automattic/onboarding';
@@ -29,6 +30,7 @@ import {
 	getDomainRegistrations,
 	updatePrivacyForDomain,
 	hasDomainInCart,
+	planItem,
 } from 'calypso/lib/cart-values/cart-items';
 import {
 	getDomainProductSlug,
@@ -172,6 +174,8 @@ export class RenderDomainsStep extends Component {
 				}
 			);
 		}
+
+		this.props.shoppingCartManager.addProductsToCart( [ this.props.multiDomainDefaultPlan ] );
 
 		// the A/A tests for identifying SRM issue. See peP6yB-11Y-p2
 		if ( this.props.flowName === 'onboarding' ) {
@@ -1347,6 +1351,7 @@ const RenderDomainsStepConnect = connect(
 		const isPlanStepSkipped = isPlanStepExistsAndSkipped( state );
 		const selectedSite = getSelectedSite( state );
 		const eligibleForProPlan = isEligibleForProPlan( state, selectedSite?.ID );
+		const multiDomainDefaultPlan = planItem( PLAN_PERSONAL );
 
 		return {
 			designType: getDesignType( state ),
@@ -1360,6 +1365,7 @@ const RenderDomainsStepConnect = connect(
 				[ 'pro', 'starter' ].includes( flowName ),
 			userLoggedIn: isUserLoggedIn( state ),
 			eligibleForProPlan,
+			multiDomainDefaultPlan,
 		};
 	},
 	{

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -763,26 +763,8 @@ export class RenderDomainsStep extends Component {
 			);
 		};
 
-		const addMultiDomainPlanToCart = () => {
-			if ( ! cartIsLoading && ! this.state.isCheckingMultiDomainPlan ) {
-				this.setState( { isCheckingMultiDomainPlan: true } );
-				if ( ! hasPlan( this.props.cart ) ) {
-					this.props.shoppingCartManager
-						.addProductsToCart( [ this.props.multiDomainDefaultPlan ] )
-						.then( () => {
-							this.setState( { isCheckingMultiDomainPlan: false } );
-						} );
-				}
-				return;
-			}
-		};
-
 		const DomainsInCart = () => {
 			if ( ! shouldUseMultipleDomainsInCart( this.props.flowName ) || cartIsLoading ) {
-				return null;
-			}
-			if ( ! cartIsLoading && ! hasPlan( this.props.cart ) ) {
-				addMultiDomainPlanToCart();
 				return null;
 			}
 

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -154,12 +154,16 @@
 				display: flex;
 				justify-content: space-between;
 			}
+			.domains__domain-cart-row > div:nth-child(2) {
+				display: block;
+			}
 
 			.savings-message {
 				color: var(--studio-green);
 				display: flex;
 				align-items: center;
 				font-size: 0.75rem;
+				margin-top: 10px;
 			}
 
 			.domains__domain-cart-domain {


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/4126

## Proposed Changes

The cart price discount is not working right if no-plan is in the cart.
We add a plan to the cart and remove it when we go to the next step.

## Testing Instructions

* Apply this diff: D125026-code
* Go to `/start/domains?flags=domains/add-multiple-domains-to-cart`
* Add one domain
* You should see $0 on the domain price at the mini-cart
* Add another domain. 
* It should show the full price for this domain (or a discount if it is a `.blog` domain)
* Remove the first domain
* The remaining domain should show the $0 price.

