### PR TITLE
Revert "Reader/Discover: Enable the new discover feature in all environments"

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -100,7 +100,7 @@
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
 		"reader": true,
-		"reader/discover-stream": true,
+		"reader/discover-stream": false,
 		"reader/first-posts-stream": true,
 		"reader/list-management": true,
 		"reader/public-tag-pages": true,

--- a/config/production.json
+++ b/config/production.json
@@ -125,7 +125,7 @@
 		"purchases/new-payment-methods": true,
 		"push-notifications": true,
 		"reader": true,
-		"reader/discover-stream": true,
+		"reader/discover-stream": false,
 		"reader/first-posts-stream": true,
 		"reader/full-errors": false,
 		"reader/list-management": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -122,7 +122,7 @@
 		"purchases/new-payment-methods": true,
 		"push-notifications": true,
 		"reader": true,
-		"reader/discover-stream": true,
+		"reader/discover-stream": false,
 		"reader/first-posts-stream": true,
 		"reader/full-errors": false,
 		"reader/list-management": true,


### PR DESCRIPTION
Reverts Automattic/wp-calypso#82817

Caching broke the stream cursor and we need more time to look into it, so disabling the new Discover stream for now!

Ref: p1696970080155309-slack-C0Q664T29