### PR TITLE
Manage Purchases: Hide price heading on manage purchases page

### DIFF
--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -1277,13 +1277,17 @@ class ManagePurchase extends Component<
 									} ) }
 								</div>
 							) : (
-								<PlanPrice
-									rawPrice={ purchase.regularPriceInteger }
-									isSmallestUnit
-									currencyCode={ purchase.currencyCode }
-									taxText={ purchase.taxText }
-									isOnSale={ !! purchase.saleAmount }
-								/>
+								<>
+									{ isOneTimePurchase( purchase ) && (
+										<PlanPrice
+											rawPrice={ purchase.regularPriceInteger }
+											isSmallestUnit
+											currencyCode={ purchase.currencyCode }
+											taxText={ purchase.taxText }
+											isOnSale={ !! purchase.saleAmount }
+										/>
+									) }
+								</>
 							) }
 						</div>
 					</header>


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/81944

### Summary:

When you go to manage a purchase in Calypso, we show the price twice:

![6KpqQd.png](https://github.com/Automattic/wp-calypso/assets/552016/6b8f37d3-015f-4d26-8bfe-e7f4c29e7741)

## Proposed Changes

To avoid the confusion, we will hide the PlanPrice component that first appears as a header causing it to look like

![z4EMJv.png](https://github.com/Automattic/wp-calypso/assets/552016/e8ad3872-958e-4079-8ba4-07068d8532f9)

Now, for one time purchase products like certain themes or others, they will continue functioning like earlier:

![wJChGk.png](https://github.com/Automattic/wp-calypso/assets/552016/1d26a29c-5b03-497d-9b5f-1b50fd5607d5)


## Testing Instructions
0. Visit the manage purchases page for a purchased plan from `/purchases/subscriptions/SiteName/OrderNumber`
1. Check that we see the cost of the plan appearing as a header similar to the first screenshot above
2. Apply the PR
3. Sandbox if needed
4. Now we should see that the PlanPrice component does not show as a header similar to the second screenshot
5. I have added a condition to continue displaying the PlanPrice as header if it is a one time product based on https://github.com/Automattic/wp-calypso/issues/81944#issuecomment-1736032328