### PR TITLE
Fix undefined domain_name fatal error

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -303,7 +303,7 @@ class DomainSearchResults extends Component {
 						isDomainOnly={ isDomainOnly }
 						suggestion={ suggestion }
 						suggestionSelected={
-							this.props.wpcomSubdomainSelected?.domain_name === suggestion.domain_name
+							this.props.wpcomSubdomainSelected?.domain_name === suggestion?.domain_name
 						}
 						key={ suggestion.domain_name }
 						cart={ this.props.cart }

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -303,7 +303,7 @@ class DomainSearchResults extends Component {
 						isDomainOnly={ isDomainOnly }
 						suggestion={ suggestion }
 						suggestionSelected={
-							this.props.wpcomSubdomainSelected.domain_name === suggestion.domain_name
+							this.props.wpcomSubdomainSelected?.domain_name === suggestion.domain_name
 						}
 						key={ suggestion.domain_name }
 						cart={ this.props.cart }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
thelinked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/82744

## Proposed Changes

* Fixes Fatal errors caused by undefined `domain_name` 
* See: p1696971645633139-slack-C04U5A26MJB
* See: p1696972719766159-slack-C04U5A26MJB

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load this PR
* Visit http://calypso.localhost:3000/setup/videopress/chooseADomain
* Visit http://calypso.localhost:3000/setup/domain-upsell/domains

Both of the above URLs are currently broken in production. This PR should fix them.

Double check there are no regressions on http://calypso.localhost:3000/start/

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?