### PR TITLE
Storage Add-ons: Fix calypso_signup_storage_add_on_upgrade_click tracks event

### DIFF
--- a/client/my-sites/plans-grid/hooks/npm-ready/use-upgrade-click-handler.ts
+++ b/client/my-sites/plans-grid/hooks/npm-ready/use-upgrade-click-handler.ts
@@ -29,6 +29,7 @@ const useUpgradeClickHandler = ( { gridPlans, onUpgradeClick }: Props ) => {
 				product_slug: storageAddOn.productSlug,
 				quantity: storageAddOn.quantity,
 				volume: 1,
+				extra: { feature_slug: selectedStorageOption },
 			};
 
 			if ( cartItemForPlan ) {


### PR DESCRIPTION
The logic to include the extra property when generating a storage add on cart item appears to have been unintentionally removed. We reimplement it in this patch

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* There was a line of code that implemented an `extra` property in this PR https://github.com/Automattic/wp-calypso/pull/81816/files#diff-e268185bf1c246017f6796f5f74ff3c0ae49b12e2acf525d8074859449573a19R444
* It appears to have been unintentionally removed when migrating the ugprade click handler into a reusable hook https://github.com/Automattic/wp-calypso/pull/82054/files#diff-81f229ba12e8360b575efc28420e442628868e55e82c2f0cb7170bca7fb58993R23-R27, affecting the storage add-on `calypso_signup_storage_add_on_upgrade_click` tracks event

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/start`
* Select a storage add-on for either the business plan or the WooCommerce plan
* Verify that, when the plan upgrade button is clicked, the `calypso_signup_storage_add_on_upgrade_click` tracks event is dispatched using either the tracks vigilante chrome dev tool or or searching for `.gif storage` in the dev tools network tab

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?