### PR TITLE
Checkout and Payment Methods: Remove useTotal from payment methods

### DIFF
--- a/client/me/purchases/add-new-payment-method/index.tsx
+++ b/client/me/purchases/add-new-payment-method/index.tsx
@@ -20,6 +20,7 @@ import { useCreateCreditCard } from 'calypso/my-sites/checkout/src/hooks/use-cre
 import { useSelector, useDispatch } from 'calypso/state';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import { errorNotice } from 'calypso/state/notices/actions';
+import { PaymentMethodSelectorSubmitButtonContent } from '../manage-purchase/payment-method-selector/payment-method-selector-submit-button-content';
 
 function AddNewPaymentMethod() {
 	const goToPaymentMethods = () => page( paymentMethods );
@@ -32,7 +33,9 @@ function AddNewPaymentMethod() {
 		stripeLoadingError,
 		shouldUseEbanx: false,
 		shouldShowTaxFields: true,
-		submitButtonContent: translate( 'Save card' ),
+		submitButtonContent: (
+			<PaymentMethodSelectorSubmitButtonContent text={ translate( 'Save card' ) } />
+		),
 		allowUseForAllSubscriptions: true,
 		initialUseForAllSubscriptions: true,
 	} );

--- a/client/me/purchases/add-new-payment-method/index.tsx
+++ b/client/me/purchases/add-new-payment-method/index.tsx
@@ -32,7 +32,7 @@ function AddNewPaymentMethod() {
 		stripeLoadingError,
 		shouldUseEbanx: false,
 		shouldShowTaxFields: true,
-		activePayButtonText: String( translate( 'Save card' ) ),
+		submitButtonContent: translate( 'Save card' ),
 		allowUseForAllSubscriptions: true,
 		initialUseForAllSubscriptions: true,
 	} );

--- a/client/me/purchases/manage-purchase/change-payment-method/use-create-assignable-payment-methods.ts
+++ b/client/me/purchases/manage-purchase/change-payment-method/use-create-assignable-payment-methods.ts
@@ -29,7 +29,7 @@ export default function useCreateAssignablePaymentMethods(
 		stripeLoadingError,
 		shouldUseEbanx: false,
 		shouldShowTaxFields: true,
-		activePayButtonText: String( translate( 'Save card' ) ),
+		submitButtonContent: translate( 'Save card' ),
 		allowUseForAllSubscriptions: true,
 	} );
 
@@ -46,7 +46,7 @@ export default function useCreateAssignablePaymentMethods(
 		isStripeLoading,
 		stripeLoadingError,
 		storedCards,
-		activePayButtonText: String( translate( 'Use this card' ) ),
+		submitButtonContent: translate( 'Use this card' ),
 		allowEditingTaxInfo: true,
 		isTaxInfoRequired: true,
 	} );

--- a/client/me/purchases/manage-purchase/change-payment-method/use-create-assignable-payment-methods.tsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/use-create-assignable-payment-methods.tsx
@@ -9,9 +9,18 @@ import {
 } from 'calypso/my-sites/checkout/src/hooks/use-create-payment-methods';
 import { useStoredPaymentMethods } from 'calypso/my-sites/checkout/src/hooks/use-stored-payment-methods';
 import { translateCheckoutPaymentMethodToWpcomPaymentMethod } from 'calypso/my-sites/checkout/src/lib/translate-payment-method-names';
+import { PaymentMethodSelectorSubmitButtonContent } from '../payment-method-selector/payment-method-selector-submit-button-content';
 import useFetchAvailablePaymentMethods from './use-fetch-available-payment-methods';
 import type { PaymentMethod } from '@automattic/composite-checkout';
 
+/**
+ * Hook to create the payment method objects required by the
+ * PaymentMethodSelector for assigning payment methods to existing
+ * subscriptions.
+ *
+ * Payment methods created for checkout use a quite different hook although a
+ * similar system.
+ */
 export default function useCreateAssignablePaymentMethods(
 	currentPaymentMethodId: string
 ): PaymentMethod[] {
@@ -29,7 +38,9 @@ export default function useCreateAssignablePaymentMethods(
 		stripeLoadingError,
 		shouldUseEbanx: false,
 		shouldShowTaxFields: true,
-		submitButtonContent: translate( 'Save card' ),
+		submitButtonContent: (
+			<PaymentMethodSelectorSubmitButtonContent text={ translate( 'Save card' ) } />
+		),
 		allowUseForAllSubscriptions: true,
 	} );
 
@@ -46,7 +57,9 @@ export default function useCreateAssignablePaymentMethods(
 		isStripeLoading,
 		stripeLoadingError,
 		storedCards,
-		submitButtonContent: translate( 'Use this card' ),
+		submitButtonContent: (
+			<PaymentMethodSelectorSubmitButtonContent text={ translate( 'Use this card' ) } />
+		),
 		allowEditingTaxInfo: true,
 		isTaxInfoRequired: true,
 	} );

--- a/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
+++ b/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
@@ -95,6 +95,11 @@ const TOSItemWrapper = styled.div`
 	}
 `;
 
+/**
+ * A component to handle assigning payment methods to existing subscriptions.
+ * This is quite different than the payment methods step of checkout even
+ * though they use many of the same systems.
+ */
 export default function PaymentMethodSelector( {
 	purchase,
 	paymentMethods,

--- a/client/me/purchases/manage-purchase/payment-method-selector/payment-method-selector-submit-button-content.tsx
+++ b/client/me/purchases/manage-purchase/payment-method-selector/payment-method-selector-submit-button-content.tsx
@@ -1,0 +1,31 @@
+import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
+import { styled } from '@automattic/wpcom-checkout';
+import { useI18n } from '@wordpress/react-i18n';
+
+const CreditCardPayButtonWrapper = styled.span`
+	display: inline-flex;
+	align-items: flex-end;
+`;
+
+/**
+ * The interior of the main submit button in the PaymentMethodSelector for most
+ * payment methods. Payment methods which have a special button (eg: PayPal,
+ * Google Pay, Apple Pay) will not use this. See each payment method to be sure
+ * how it works.
+ *
+ * This is different from the submit button used by checkout.
+ */
+export function PaymentMethodSelectorSubmitButtonContent( { text }: { text: string } ) {
+	const { __ } = useI18n();
+	const { formStatus } = useFormStatus();
+
+	if ( formStatus === FormStatus.SUBMITTING ) {
+		return <>{ __( 'Processing…' ) }</>;
+	}
+
+	if ( formStatus !== FormStatus.READY ) {
+		return <>{ __( 'Please wait…' ) }</>;
+	}
+
+	return <CreditCardPayButtonWrapper>{ text }</CreditCardPayButtonWrapper>;
+}

--- a/client/my-sites/checkout/src/components/checkout-submit-button-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-submit-button-content.tsx
@@ -1,0 +1,66 @@
+import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
+import { formatCurrency } from '@automattic/format-currency';
+import { useShoppingCart } from '@automattic/shopping-cart';
+import { styled } from '@automattic/wpcom-checkout';
+import { sprintf } from '@wordpress/i18n';
+import { useI18n } from '@wordpress/react-i18n';
+import MaterialIcon from 'calypso/components/material-icon';
+import useCartKey from '../../use-cart-key';
+
+const CreditCardPayButtonWrapper = styled.span`
+	display: inline-flex;
+	align-items: flex-end;
+`;
+
+const StyledMaterialIcon = styled( MaterialIcon )`
+	fill: ${ ( { theme } ) => theme.colors.surface };
+	margin-right: 0.7em;
+
+	.rtl & {
+		margin-right: 0;
+		margin-left: 0.7em;
+	}
+`;
+
+/**
+ * The interior of the main submit button in checkout for most payment methods.
+ * Payment methods which have a special button (eg: PayPal, Google Pay, Apple
+ * Pay) will not use this. See each payment method to be sure how it works.
+ *
+ * There are also checkout-like forms (eg: "add credit card") which do not use
+ * this because they want their submit button to render something different.
+ */
+export function CheckoutSubmitButtonContent() {
+	const { __ } = useI18n();
+	const cartKey = useCartKey();
+	const { responseCart } = useShoppingCart( cartKey );
+	const isPurchaseFree = responseCart.total_cost_integer === 0;
+	const { formStatus } = useFormStatus();
+
+	if ( formStatus === FormStatus.SUBMITTING ) {
+		return <>{ __( 'Processing…' ) }</>;
+	}
+
+	if ( formStatus !== FormStatus.READY ) {
+		return <>{ __( 'Please wait…' ) }</>;
+	}
+
+	if ( isPurchaseFree ) {
+		return <CreditCardPayButtonWrapper>{ __( 'Complete Checkout' ) }</CreditCardPayButtonWrapper>;
+	}
+
+	const total = formatCurrency( responseCart.total_cost_integer, responseCart.currency, {
+		isSmallestUnit: true,
+		stripZeros: true,
+	} );
+	return (
+		<CreditCardPayButtonWrapper>
+			<StyledMaterialIcon icon="credit_card" />
+			{ sprintf(
+				/* translators: %s is the total to be paid in localized currency */
+				__( 'Pay %s now' ),
+				total
+			) }
+		</CreditCardPayButtonWrapper>
+	);
+}

--- a/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
@@ -278,6 +278,7 @@ function useCreateNetbanking(): PaymentMethod {
 		() =>
 			createNetBankingMethod( {
 				store: paymentMethodStore,
+				submitButtonContent: <CheckoutSubmitButtonContent />,
 			} ),
 		[ paymentMethodStore ]
 	);

--- a/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
@@ -123,6 +123,7 @@ function useCreateAlipay( {
 			shouldLoad
 				? createAlipayMethod( {
 						store: paymentMethodStore,
+						submitButtonContent: <CheckoutSubmitButtonContent />,
 				  } )
 				: null,
 		[ shouldLoad, paymentMethodStore ]

--- a/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
@@ -443,6 +443,7 @@ export default function useCreatePaymentMethods( {
 		isStripeLoading,
 		stripeLoadingError,
 		storedCards,
+		submitButtonContent: <CheckoutSubmitButtonContent />,
 	} );
 
 	// The order is the order of Payment Methods in Checkout.

--- a/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
@@ -23,6 +23,7 @@ import { useMemo } from 'react';
 import { StoredPaymentMethod } from 'calypso/lib/checkout/payment-methods';
 import { translateCheckoutPaymentMethodToWpcomPaymentMethod } from 'calypso/my-sites/checkout/src/lib/translate-payment-method-names';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
+import { CheckoutSubmitButtonContent } from '../../components/checkout-submit-button-content';
 import {
 	createCreditCardPaymentMethodStore,
 	createCreditCardMethod,
@@ -63,8 +64,8 @@ export function useCreateCreditCard( {
 	isStripeLoading,
 	stripeLoadingError,
 	shouldUseEbanx,
-	shouldShowTaxFields = false,
-	activePayButtonText = undefined,
+	shouldShowTaxFields,
+	submitButtonContent,
 	initialUseForAllSubscriptions,
 	allowUseForAllSubscriptions,
 }: {
@@ -72,7 +73,7 @@ export function useCreateCreditCard( {
 	stripeLoadingError: StripeLoadingError;
 	shouldUseEbanx: boolean;
 	shouldShowTaxFields?: boolean;
-	activePayButtonText?: ReactNode;
+	submitButtonContent: ReactNode;
 	initialUseForAllSubscriptions?: boolean;
 	allowUseForAllSubscriptions?: boolean;
 } ): PaymentMethod | null {
@@ -92,7 +93,7 @@ export function useCreateCreditCard( {
 						store: stripePaymentMethodStore,
 						shouldUseEbanx,
 						shouldShowTaxFields,
-						activePayButtonText,
+						submitButtonContent,
 						allowUseForAllSubscriptions,
 				  } )
 				: null,
@@ -101,7 +102,7 @@ export function useCreateCreditCard( {
 			stripePaymentMethodStore,
 			shouldUseEbanx,
 			shouldShowTaxFields,
-			activePayButtonText,
+			submitButtonContent,
 			allowUseForAllSubscriptions,
 		]
 	);
@@ -417,6 +418,7 @@ export default function useCreatePaymentMethods( {
 		stripeLoadingError,
 		shouldUseEbanx,
 		allowUseForAllSubscriptions,
+		submitButtonContent: <CheckoutSubmitButtonContent />,
 	} );
 
 	const freePaymentMethod = useCreateFree();

--- a/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
@@ -229,6 +229,7 @@ function useCreateIdeal( {
 			shouldLoad
 				? createIdealMethod( {
 						store: paymentMethodStore,
+						submitButtonContent: <CheckoutSubmitButtonContent />,
 				  } )
 				: null,
 		[ shouldLoad, paymentMethodStore ]

--- a/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
@@ -185,6 +185,7 @@ function useCreateGiropay( {
 			shouldLoad
 				? createGiropayMethod( {
 						store: paymentMethodStore,
+						submitButtonContent: <CheckoutSubmitButtonContent />,
 				  } )
 				: null,
 		[ shouldLoad, paymentMethodStore ]

--- a/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
@@ -251,6 +251,7 @@ function useCreateSofort( {
 			shouldLoad
 				? createSofortMethod( {
 						store: paymentMethodStore,
+						submitButtonContent: <CheckoutSubmitButtonContent />,
 				  } )
 				: null,
 		[ shouldLoad, paymentMethodStore ]

--- a/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
@@ -164,6 +164,7 @@ function useCreateBancontact( {
 			shouldLoad
 				? createBancontactMethod( {
 						store: paymentMethodStore,
+						submitButtonContent: <CheckoutSubmitButtonContent />,
 				  } )
 				: null,
 		[ shouldLoad, paymentMethodStore ]

--- a/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
@@ -144,6 +144,7 @@ function useCreateP24( {
 			shouldLoad
 				? createP24Method( {
 						store: paymentMethodStore,
+						submitButtonContent: <CheckoutSubmitButtonContent />,
 				  } )
 				: null,
 		[ shouldLoad, paymentMethodStore ]

--- a/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
@@ -268,6 +268,7 @@ function useCreateEps( {
 			shouldLoad
 				? createEpsMethod( {
 						store: paymentMethodStore,
+						submitButtonContent: <CheckoutSubmitButtonContent />,
 				  } )
 				: null,
 		[ shouldLoad, paymentMethodStore ]

--- a/client/my-sites/checkout/src/hooks/use-create-payment-methods/use-create-existing-cards.ts
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-methods/use-create-existing-cards.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { ReactNode, useMemo } from 'react';
 import { useMemoCompare } from 'calypso/lib/use-memo-compare';
 import { createExistingCardMethod } from 'calypso/my-sites/checkout/src/payment-methods/existing-credit-card';
 import type { StripeLoadingError } from '@automattic/calypso-stripe';
@@ -12,14 +12,14 @@ export default function useCreateExistingCards( {
 	isStripeLoading,
 	stripeLoadingError,
 	storedCards,
-	activePayButtonText = undefined,
+	submitButtonContent,
 	allowEditingTaxInfo,
 	isTaxInfoRequired,
 }: {
 	isStripeLoading: boolean;
 	stripeLoadingError: StripeLoadingError;
 	storedCards: StoredPaymentMethod[];
-	activePayButtonText?: string;
+	submitButtonContent: ReactNode;
 	allowEditingTaxInfo?: boolean;
 	isTaxInfoRequired?: boolean;
 } ): PaymentMethod[] {
@@ -52,13 +52,13 @@ export default function useCreateExistingCards( {
 					storedDetailsId: storedDetails.stored_details_id,
 					paymentMethodToken: storedDetails.mp_ref,
 					paymentPartnerProcessorId: storedDetails.payment_partner,
-					activePayButtonText,
+					submitButtonContent,
 					allowEditingTaxInfo,
 					isTaxInfoRequired,
 				} )
 			) ?? []
 		);
-	}, [ memoizedStoredCards, activePayButtonText, allowEditingTaxInfo, isTaxInfoRequired ] );
+	}, [ memoizedStoredCards, submitButtonContent, allowEditingTaxInfo, isTaxInfoRequired ] );
 
 	return shouldLoad ? existingCardMethods : [];
 }

--- a/client/my-sites/checkout/src/payment-methods/credit-card/index.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/index.tsx
@@ -24,13 +24,13 @@ export function createCreditCardMethod( {
 	store,
 	shouldUseEbanx,
 	shouldShowTaxFields,
-	activePayButtonText,
+	submitButtonContent,
 	allowUseForAllSubscriptions,
 }: {
 	store: CardStoreType;
 	shouldUseEbanx?: boolean;
 	shouldShowTaxFields?: boolean;
-	activePayButtonText?: ReactNode;
+	submitButtonContent: ReactNode;
 	allowUseForAllSubscriptions?: boolean;
 } ) {
 	return {
@@ -48,7 +48,7 @@ export function createCreditCardMethod( {
 			<CreditCardPayButton
 				store={ store }
 				shouldUseEbanx={ shouldUseEbanx }
-				activeButtonText={ activePayButtonText }
+				submitButtonContent={ submitButtonContent }
 			/>
 		),
 		inactiveContent: <CreditCardSummary />,

--- a/client/my-sites/checkout/src/payment-methods/existing-credit-card/index.tsx
+++ b/client/my-sites/checkout/src/payment-methods/existing-credit-card/index.tsx
@@ -1,13 +1,10 @@
 import { Button, FormStatus, useFormStatus } from '@automattic/composite-checkout';
-import { formatCurrency } from '@automattic/format-currency';
-import { useShoppingCart } from '@automattic/shopping-cart';
 import { styled, PaymentLogo } from '@automattic/wpcom-checkout';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
-import { Fragment } from 'react';
-import MaterialIcon from 'calypso/components/material-icon';
+import { Fragment, ReactNode } from 'react';
 import {
 	TaxInfoArea,
 	usePaymentMethodTaxInfo,
@@ -17,7 +14,6 @@ import {
 	SummaryLine,
 	SummaryDetails,
 } from 'calypso/my-sites/checkout/src/components/summary-details';
-import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { useDispatch } from 'calypso/state';
 import { errorNotice } from 'calypso/state/notices/actions';
 import type { PaymentMethod, ProcessPayment } from '@automattic/composite-checkout';
@@ -33,7 +29,7 @@ export function createExistingCardMethod( {
 	storedDetailsId,
 	paymentMethodToken,
 	paymentPartnerProcessorId,
-	activePayButtonText,
+	submitButtonContent,
 	allowEditingTaxInfo,
 	isTaxInfoRequired,
 }: {
@@ -45,7 +41,7 @@ export function createExistingCardMethod( {
 	storedDetailsId: string;
 	paymentMethodToken: string;
 	paymentPartnerProcessorId: string;
-	activePayButtonText?: string;
+	submitButtonContent: ReactNode;
 	allowEditingTaxInfo?: boolean;
 	isTaxInfoRequired?: boolean;
 } ): PaymentMethod {
@@ -78,7 +74,7 @@ export function createExistingCardMethod( {
 				storedDetailsId={ storedDetailsId }
 				paymentMethodToken={ paymentMethodToken }
 				paymentPartnerProcessorId={ paymentPartnerProcessorId }
-				activeButtonText={ activePayButtonText }
+				submitButtonContent={ submitButtonContent }
 				isTaxInfoRequired={ isTaxInfoRequired }
 			/>
 		),
@@ -174,7 +170,7 @@ function ExistingCardPayButton( {
 	storedDetailsId,
 	paymentMethodToken,
 	paymentPartnerProcessorId,
-	activeButtonText,
+	submitButtonContent,
 	isTaxInfoRequired,
 }: {
 	disabled?: boolean;
@@ -183,12 +179,9 @@ function ExistingCardPayButton( {
 	storedDetailsId: string;
 	paymentMethodToken: string;
 	paymentPartnerProcessorId: string;
-	activeButtonText?: string;
+	submitButtonContent: ReactNode;
 	isTaxInfoRequired?: boolean;
 } ) {
-	const cartKey = useCartKey();
-	const { responseCart } = useShoppingCart( cartKey );
-
 	const { formStatus } = useFormStatus();
 	const translate = useTranslate();
 
@@ -230,71 +223,9 @@ function ExistingCardPayButton( {
 			isBusy={ FormStatus.SUBMITTING === formStatus }
 			fullWidth
 		>
-			<ButtonContents
-				formStatus={ formStatus }
-				total={ formatCurrency( responseCart.total_cost_integer, responseCart.currency, {
-					isSmallestUnit: true,
-					stripZeros: true,
-				} ) }
-				isPurchaseFree={ responseCart.total_cost_integer === 0 }
-				activeButtonText={ activeButtonText }
-			/>
+			{ submitButtonContent }
 		</Button>
 	);
-}
-
-const CreditCardPayButtonWrapper = styled[ 'span' ]`
-	display: inline-flex;
-	align-items: flex-end;
-`;
-
-const StyledMaterialIcon = styled( MaterialIcon )`
-	fill: ${ ( { theme } ) => theme.colors.surface };
-	margin-right: 0.7em;
-
-	.rtl & {
-		margin-right: 0;
-		margin-left: 0.7em;
-	}
-`;
-
-function ButtonContents( {
-	formStatus,
-	total,
-	isPurchaseFree,
-	activeButtonText,
-}: {
-	formStatus: string;
-	total: string;
-	isPurchaseFree: boolean;
-	activeButtonText?: string;
-} ) {
-	const { __ } = useI18n();
-	if ( formStatus === FormStatus.SUBMITTING ) {
-		return <>{ __( 'Processing…' ) }</>;
-	}
-	if ( formStatus === FormStatus.READY && isPurchaseFree ) {
-		const defaultText = (
-			<CreditCardPayButtonWrapper>{ __( 'Complete Checkout' ) }</CreditCardPayButtonWrapper>
-		);
-		/* translators: %s is the total to be paid in localized currency */
-		return <>{ activeButtonText || defaultText }</>;
-	}
-	if ( formStatus === FormStatus.READY ) {
-		const defaultText = (
-			<CreditCardPayButtonWrapper>
-				<StyledMaterialIcon icon="credit_card" />
-				{ sprintf(
-					/* translators: %s is the total to be paid in localized currency */
-					__( 'Pay %s now' ),
-					total
-				) }
-			</CreditCardPayButtonWrapper>
-		);
-		/* translators: %s is the total to be paid in localized currency */
-		return <>{ activeButtonText || defaultText }</>;
-	}
-	return <>{ __( 'Please wait…' ) }</>;
 }
 
 function ExistingCardSummary( {

--- a/client/my-sites/checkout/src/test/credit-card.tsx
+++ b/client/my-sites/checkout/src/test/credit-card.tsx
@@ -71,6 +71,7 @@ function useCreateCreditCardMethod( store: CardStoreType, additionalArgs = {} ) 
 	const [ method ] = useState( () =>
 		createCreditCardMethod( {
 			store,
+			submitButtonContent: activePayButtonText,
 			...additionalArgs,
 		} )
 	);

--- a/client/my-sites/checkout/src/test/existing-credit-card.tsx
+++ b/client/my-sites/checkout/src/test/existing-credit-card.tsx
@@ -52,7 +52,7 @@ function getExistingCardPaymentMethod( additionalArgs = {} ) {
 		storedDetailsId,
 		paymentMethodToken,
 		paymentPartnerProcessorId,
-		activePayButtonText,
+		submitButtonContent: activePayButtonText,
 		...additionalArgs,
 	} );
 }

--- a/client/my-sites/checkout/src/test/netbanking.tsx
+++ b/client/my-sites/checkout/src/test/netbanking.tsx
@@ -54,6 +54,7 @@ function getPaymentMethod( additionalArgs = {} ) {
 	const store = createNetBankingPaymentMethodStore();
 	return createNetBankingMethod( {
 		store,
+		submitButtonContent: activePayButtonText,
 		...additionalArgs,
 	} );
 }

--- a/client/my-sites/purchases/payment-methods/index.tsx
+++ b/client/my-sites/purchases/payment-methods/index.tsx
@@ -20,6 +20,7 @@ import { getStripeConfiguration } from 'calypso/lib/store-transactions';
 import PaymentMethodLoader from 'calypso/me/purchases/components/payment-method-loader';
 import PaymentMethodSidebar from 'calypso/me/purchases/components/payment-method-sidebar';
 import PaymentMethodSelector from 'calypso/me/purchases/manage-purchase/payment-method-selector';
+import { PaymentMethodSelectorSubmitButtonContent } from 'calypso/me/purchases/manage-purchase/payment-method-selector/payment-method-selector-submit-button-content';
 import PaymentMethodList from 'calypso/me/purchases/payment-methods/payment-method-list';
 import titles from 'calypso/me/purchases/titles';
 import { useCreateCreditCard } from 'calypso/my-sites/checkout/src/hooks/use-create-payment-methods';
@@ -103,7 +104,9 @@ function SiteLevelAddNewPaymentMethodForm( { siteSlug }: { siteSlug: string } ) 
 		stripeLoadingError,
 		shouldUseEbanx: false,
 		shouldShowTaxFields: true,
-		submitButtonContent: translate( 'Save card' ),
+		submitButtonContent: (
+			<PaymentMethodSelectorSubmitButtonContent text={ translate( 'Save card' ) } />
+		),
 		allowUseForAllSubscriptions: true,
 		initialUseForAllSubscriptions: true,
 	} );

--- a/client/my-sites/purchases/payment-methods/index.tsx
+++ b/client/my-sites/purchases/payment-methods/index.tsx
@@ -103,7 +103,7 @@ function SiteLevelAddNewPaymentMethodForm( { siteSlug }: { siteSlug: string } ) 
 		stripeLoadingError,
 		shouldUseEbanx: false,
 		shouldShowTaxFields: true,
-		activePayButtonText: String( translate( 'Save card' ) ),
+		submitButtonContent: translate( 'Save card' ),
 		allowUseForAllSubscriptions: true,
 		initialUseForAllSubscriptions: true,
 	} );

--- a/packages/wpcom-checkout/src/payment-methods/alipay.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/alipay.tsx
@@ -1,10 +1,9 @@
-import { Button, FormStatus, useTotal, useFormStatus } from '@automattic/composite-checkout';
+import { Button, FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import styled from '@emotion/styled';
 import { useSelect, useDispatch, registerStore } from '@wordpress/data';
-import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
-import { Fragment } from 'react';
+import { Fragment, ReactNode } from 'react';
 import Field from '../field';
 import { PaymentMethodLogos } from '../payment-method-logos';
 import { SummaryLine, SummaryDetails } from '../summary-details';
@@ -15,7 +14,7 @@ import type {
 	StoreActions,
 	StoreState,
 } from '../payment-method-store';
-import type { PaymentMethod, ProcessPayment, LineItem } from '@automattic/composite-checkout';
+import type { PaymentMethod, ProcessPayment } from '@automattic/composite-checkout';
 import type { AnyAction } from 'redux';
 
 const debug = debugFactory( 'wpcom-checkout:alipay-payment-method' );
@@ -69,14 +68,20 @@ function useCustomerName() {
 	return customerName;
 }
 
-export function createAlipayMethod( { store }: { store: AlipayStore } ): PaymentMethod {
+export function createAlipayMethod( {
+	store,
+	submitButtonContent,
+}: {
+	store: AlipayStore;
+	submitButtonContent: ReactNode;
+} ): PaymentMethod {
 	return {
 		id: 'alipay',
 		paymentProcessorId: 'alipay',
 		label: <AlipayLabel />,
 		activeContent: <AlipayFields />,
 		inactiveContent: <AlipaySummary />,
-		submitButton: <AlipayPayButton store={ store } />,
+		submitButton: <AlipayPayButton store={ store } submitButtonContent={ submitButtonContent } />,
 		getAriaLabel: () => 'Alipay',
 	};
 }
@@ -139,12 +144,13 @@ function AlipayPayButton( {
 	disabled,
 	onClick,
 	store,
+	submitButtonContent,
 }: {
 	disabled?: boolean;
 	onClick?: ProcessPayment;
 	store: AlipayStore;
+	submitButtonContent: ReactNode;
 } ) {
-	const total = useTotal();
 	const { formStatus } = useFormStatus();
 	const customerName = useCustomerName();
 
@@ -172,21 +178,9 @@ function AlipayPayButton( {
 			isBusy={ FormStatus.SUBMITTING === formStatus }
 			fullWidth
 		>
-			<ButtonContents formStatus={ formStatus } total={ total } />
+			{ submitButtonContent }
 		</Button>
 	);
-}
-
-function ButtonContents( { formStatus, total }: { formStatus: FormStatus; total: LineItem } ) {
-	const { __ } = useI18n();
-	if ( formStatus === FormStatus.SUBMITTING ) {
-		return <>{ __( 'Processing…' ) }</>;
-	}
-	if ( formStatus === FormStatus.READY ) {
-		/* translators: %s is the total to be paid in localized currency */
-		return <>{ sprintf( __( 'Pay %s' ), total.amount.displayValue ) }</>;
-	}
-	return <>{ __( 'Please wait…' ) }</>;
 }
 
 function isFormValid( store: AlipayStore ) {

--- a/packages/wpcom-checkout/src/payment-methods/bancontact.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/bancontact.tsx
@@ -1,10 +1,9 @@
-import { Button, FormStatus, useTotal, useFormStatus } from '@automattic/composite-checkout';
+import { Button, FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import styled from '@emotion/styled';
 import { useSelect, useDispatch, registerStore } from '@wordpress/data';
-import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
-import { Fragment } from 'react';
+import { Fragment, ReactNode } from 'react';
 import Field from '../field';
 import { PaymentMethodLogos } from '../payment-method-logos';
 import { SummaryLine, SummaryDetails } from '../summary-details';
@@ -15,7 +14,7 @@ import type {
 	StoreActions,
 	StoreState,
 } from '../payment-method-store';
-import type { PaymentMethod, ProcessPayment, LineItem } from '@automattic/composite-checkout';
+import type { PaymentMethod, ProcessPayment } from '@automattic/composite-checkout';
 import type { AnyAction } from 'redux';
 
 const debug = debugFactory( 'wpcom-checkout:bancontact-payment-method' );
@@ -60,14 +59,22 @@ export function createBancontactPaymentMethodStore(): BancontactStore {
 	return store;
 }
 
-export function createBancontactMethod( { store }: { store: BancontactStore } ): PaymentMethod {
+export function createBancontactMethod( {
+	store,
+	submitButtonContent,
+}: {
+	store: BancontactStore;
+	submitButtonContent: ReactNode;
+} ): PaymentMethod {
 	return {
 		id: 'bancontact',
 		paymentProcessorId: 'bancontact',
 		label: <BancontactLabel />,
 		activeContent: <BancontactFields />,
 		inactiveContent: <BancontactSummary />,
-		submitButton: <BancontactPayButton store={ store } />,
+		submitButton: (
+			<BancontactPayButton store={ store } submitButtonContent={ submitButtonContent } />
+		),
 		getAriaLabel: () => 'Bancontact',
 	};
 }
@@ -141,12 +148,13 @@ function BancontactPayButton( {
 	disabled,
 	onClick,
 	store,
+	submitButtonContent,
 }: {
 	disabled?: boolean;
 	onClick?: ProcessPayment;
 	store: BancontactStore;
+	submitButtonContent: ReactNode;
 } ) {
-	const total = useTotal();
 	const { formStatus } = useFormStatus();
 	const customerName = useCustomerName();
 	if ( ! onClick ) {
@@ -170,21 +178,9 @@ function BancontactPayButton( {
 			isBusy={ FormStatus.SUBMITTING === formStatus }
 			fullWidth
 		>
-			<ButtonContents formStatus={ formStatus } total={ total } />
+			{ submitButtonContent }
 		</Button>
 	);
-}
-
-function ButtonContents( { formStatus, total }: { formStatus: FormStatus; total: LineItem } ) {
-	const { __ } = useI18n();
-	if ( formStatus === FormStatus.SUBMITTING ) {
-		return <>{ __( 'Processing…' ) }</>;
-	}
-	if ( formStatus === FormStatus.READY ) {
-		/* translators: %s is the total to be paid in localized currency */
-		return <>{ sprintf( __( 'Pay %s' ), total.amount.displayValue ) }</>;
-	}
-	return <>{ __( 'Please wait…' ) }</>;
 }
 
 function isFormValid( store: BancontactStore ) {

--- a/packages/wpcom-checkout/src/payment-methods/eps.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/eps.tsx
@@ -1,10 +1,9 @@
-import { Button, FormStatus, useTotal, useFormStatus } from '@automattic/composite-checkout';
+import { Button, FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import styled from '@emotion/styled';
 import { useSelect, useDispatch, registerStore } from '@wordpress/data';
-import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
-import { Fragment } from 'react';
+import { Fragment, ReactNode } from 'react';
 import Field from '../field';
 import { PaymentMethodLogos } from '../payment-method-logos';
 import { SummaryLine, SummaryDetails } from '../summary-details';
@@ -15,7 +14,7 @@ import type {
 	StoreActions,
 	StoreState,
 } from '../payment-method-store';
-import type { PaymentMethod, ProcessPayment, LineItem } from '@automattic/composite-checkout';
+import type { PaymentMethod, ProcessPayment } from '@automattic/composite-checkout';
 import type { AnyAction } from 'redux';
 
 const debug = debugFactory( 'wpcom-checkout:eps-payment-method' );
@@ -59,13 +58,19 @@ export function createEpsPaymentMethodStore(): EpsStore {
 	return store;
 }
 
-export function createEpsMethod( { store }: { store: EpsStore } ): PaymentMethod {
+export function createEpsMethod( {
+	store,
+	submitButtonContent,
+}: {
+	store: EpsStore;
+	submitButtonContent: ReactNode;
+} ): PaymentMethod {
 	return {
 		id: 'eps',
 		paymentProcessorId: 'eps',
 		label: <EpsLabel />,
 		activeContent: <EpsFields />,
-		submitButton: <EpsPayButton store={ store } />,
+		submitButton: <EpsPayButton store={ store } submitButtonContent={ submitButtonContent } />,
 		inactiveContent: <EpsSummary />,
 		getAriaLabel: ( __ ) => __( 'EPS e-Pay' ),
 	};
@@ -140,12 +145,13 @@ function EpsPayButton( {
 	disabled,
 	onClick,
 	store,
+	submitButtonContent,
 }: {
 	disabled?: boolean;
 	onClick?: ProcessPayment;
 	store: EpsStore;
+	submitButtonContent: ReactNode;
 } ) {
-	const total = useTotal();
 	const { formStatus } = useFormStatus();
 	const customerName = useCustomerName();
 
@@ -173,21 +179,9 @@ function EpsPayButton( {
 			isBusy={ FormStatus.SUBMITTING === formStatus }
 			fullWidth
 		>
-			<ButtonContents formStatus={ formStatus } total={ total } />
+			{ submitButtonContent }
 		</Button>
 	);
-}
-
-function ButtonContents( { formStatus, total }: { formStatus: FormStatus; total: LineItem } ) {
-	const { __ } = useI18n();
-	if ( formStatus === FormStatus.SUBMITTING ) {
-		return <>{ __( 'Processing…' ) }</>;
-	}
-	if ( formStatus === FormStatus.READY ) {
-		/* translators: %s is the total to be paid in localized currency */
-		return <>{ sprintf( __( 'Pay %s' ), total.amount.displayValue ) }</>;
-	}
-	return <>{ __( 'Please wait…' ) }</>;
 }
 
 function EpsSummary() {

--- a/packages/wpcom-checkout/src/payment-methods/giropay.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/giropay.tsx
@@ -1,10 +1,9 @@
-import { Button, FormStatus, useTotal, useFormStatus } from '@automattic/composite-checkout';
+import { Button, FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import styled from '@emotion/styled';
 import { useSelect, useDispatch, registerStore } from '@wordpress/data';
-import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
-import { Fragment } from 'react';
+import { Fragment, ReactNode } from 'react';
 import Field from '../field';
 import { PaymentMethodLogos } from '../payment-method-logos';
 import { SummaryLine, SummaryDetails } from '../summary-details';
@@ -15,7 +14,7 @@ import type {
 	StoreActions,
 	StoreState,
 } from '../payment-method-store';
-import type { PaymentMethod, ProcessPayment, LineItem } from '@automattic/composite-checkout';
+import type { PaymentMethod, ProcessPayment } from '@automattic/composite-checkout';
 import type { AnyAction } from 'redux';
 
 const debug = debugFactory( 'wpcom-checkout:giropay-payment-method' );
@@ -72,14 +71,20 @@ function useCustomerName() {
 	return customerName;
 }
 
-export function createGiropayMethod( { store }: { store: GiropayStore } ): PaymentMethod {
+export function createGiropayMethod( {
+	store,
+	submitButtonContent,
+}: {
+	store: GiropayStore;
+	submitButtonContent: ReactNode;
+} ): PaymentMethod {
 	return {
 		id: 'giropay',
 		paymentProcessorId: 'giropay',
 		label: <GiropayLabel />,
 		activeContent: <GiropayFields />,
 		inactiveContent: <GiropaySummary />,
-		submitButton: <GiropayPayButton store={ store } />,
+		submitButton: <GiropayPayButton store={ store } submitButtonContent={ submitButtonContent } />,
 		getAriaLabel: () => 'Giropay',
 	};
 }
@@ -142,12 +147,13 @@ function GiropayPayButton( {
 	disabled,
 	onClick,
 	store,
+	submitButtonContent,
 }: {
 	disabled?: boolean;
 	onClick?: ProcessPayment;
 	store: GiropayStore;
+	submitButtonContent: ReactNode;
 } ) {
-	const total = useTotal();
 	const { formStatus } = useFormStatus();
 	const customerName = useCustomerName();
 
@@ -175,21 +181,9 @@ function GiropayPayButton( {
 			isBusy={ FormStatus.SUBMITTING === formStatus }
 			fullWidth
 		>
-			<ButtonContents formStatus={ formStatus } total={ total } />
+			{ submitButtonContent }
 		</Button>
 	);
-}
-
-function ButtonContents( { formStatus, total }: { formStatus: FormStatus; total: LineItem } ) {
-	const { __ } = useI18n();
-	if ( formStatus === FormStatus.SUBMITTING ) {
-		return <>{ __( 'Processing…' ) }</>;
-	}
-	if ( formStatus === FormStatus.READY ) {
-		/* translators: %s is the total to be paid in localized currency */
-		return <>{ sprintf( __( 'Pay %s' ), total.amount.displayValue ) }</>;
-	}
-	return <>{ __( 'Please wait…' ) }</>;
 }
 
 function isFormValid( store: GiropayStore ): boolean {

--- a/packages/wpcom-checkout/src/payment-methods/ideal.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/ideal.tsx
@@ -1,10 +1,9 @@
-import { Button, FormStatus, useTotal, useFormStatus } from '@automattic/composite-checkout';
+import { Button, FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import styled from '@emotion/styled';
 import { useSelect, useDispatch, registerStore } from '@wordpress/data';
-import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
-import { Fragment } from 'react';
+import { Fragment, ReactNode } from 'react';
 import Field from '../field';
 import { PaymentMethodLogos } from '../payment-method-logos';
 import { SummaryLine, SummaryDetails } from '../summary-details';
@@ -15,7 +14,7 @@ import type {
 	StoreActions,
 	StoreState,
 } from '../payment-method-store';
-import type { PaymentMethod, ProcessPayment, LineItem } from '@automattic/composite-checkout';
+import type { PaymentMethod, ProcessPayment } from '@automattic/composite-checkout';
 import type { AnyAction } from 'redux';
 
 const debug = debugFactory( 'wpcom-checkout:ideal-payment-method' );
@@ -69,13 +68,19 @@ export function createIdealPaymentMethodStore(): IdealStore {
 	return store;
 }
 
-export function createIdealMethod( { store }: { store: IdealStore } ): PaymentMethod {
+export function createIdealMethod( {
+	store,
+	submitButtonContent,
+}: {
+	store: IdealStore;
+	submitButtonContent: ReactNode;
+} ): PaymentMethod {
 	return {
 		id: 'ideal',
 		paymentProcessorId: 'ideal',
 		label: <IdealLabel />,
 		activeContent: <IdealFields />,
-		submitButton: <IdealPayButton store={ store } />,
+		submitButton: <IdealPayButton store={ store } submitButtonContent={ submitButtonContent } />,
 		inactiveContent: <IdealSummary />,
 		getAriaLabel: ( __ ) => __( 'iDEAL' ),
 	};
@@ -273,12 +278,13 @@ function IdealPayButton( {
 	disabled,
 	onClick,
 	store,
+	submitButtonContent,
 }: {
 	disabled?: boolean;
 	onClick?: ProcessPayment;
 	store: IdealStore;
+	submitButtonContent: ReactNode;
 } ) {
-	const total = useTotal();
 	const { formStatus } = useFormStatus();
 	const { customerName, customerBank } = useCustomerData();
 
@@ -307,21 +313,9 @@ function IdealPayButton( {
 			isBusy={ FormStatus.SUBMITTING === formStatus }
 			fullWidth
 		>
-			<ButtonContents formStatus={ formStatus } total={ total } />
+			{ submitButtonContent }
 		</Button>
 	);
-}
-
-function ButtonContents( { formStatus, total }: { formStatus: FormStatus; total: LineItem } ) {
-	const { __ } = useI18n();
-	if ( formStatus === FormStatus.SUBMITTING ) {
-		return <>{ __( 'Processing…' ) }</>;
-	}
-	if ( formStatus === FormStatus.READY ) {
-		/* translators: %s is the total to be paid in localized currency */
-		return <>{ sprintf( __( 'Pay %s' ), total.amount.displayValue ) }</>;
-	}
-	return <>{ __( 'Please wait…' ) }</>;
 }
 
 function IdealSummary() {

--- a/packages/wpcom-checkout/src/payment-methods/p24.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/p24.tsx
@@ -1,10 +1,9 @@
-import { Button, FormStatus, useTotal, useFormStatus } from '@automattic/composite-checkout';
+import { Button, FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import styled from '@emotion/styled';
 import { useSelect, useDispatch, registerStore } from '@wordpress/data';
-import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
-import { Fragment } from 'react';
+import { Fragment, ReactNode } from 'react';
 import Field from '../field';
 import { PaymentMethodLogos } from '../payment-method-logos';
 import { SummaryLine, SummaryDetails } from '../summary-details';
@@ -15,7 +14,7 @@ import type {
 	StoreActions,
 	StoreState,
 } from '../payment-method-store';
-import type { PaymentMethod, ProcessPayment, LineItem } from '@automattic/composite-checkout';
+import type { PaymentMethod, ProcessPayment } from '@automattic/composite-checkout';
 import type { AnyAction } from 'redux';
 
 // Disabling this to make migration easier
@@ -85,14 +84,20 @@ function useCustomerData() {
 	};
 }
 
-export function createP24Method( { store }: { store: P24Store } ): PaymentMethod {
+export function createP24Method( {
+	store,
+	submitButtonContent,
+}: {
+	store: P24Store;
+	submitButtonContent: ReactNode;
+} ): PaymentMethod {
 	return {
 		id: 'p24',
 		paymentProcessorId: 'p24',
 		label: <P24Label />,
 		activeContent: <P24Fields />,
 		inactiveContent: <P24Summary />,
-		submitButton: <P24PayButton store={ store } />,
+		submitButton: <P24PayButton store={ store } submitButtonContent={ submitButtonContent } />,
 		getAriaLabel: () => 'Przelewy24',
 	};
 }
@@ -166,12 +171,13 @@ function P24PayButton( {
 	disabled,
 	onClick,
 	store,
+	submitButtonContent,
 }: {
 	disabled?: boolean;
 	onClick?: ProcessPayment;
 	store: P24Store;
+	submitButtonContent: ReactNode;
 } ) {
-	const total = useTotal();
 	const { formStatus } = useFormStatus();
 	const { customerName, customerEmail } = useCustomerData();
 
@@ -200,21 +206,9 @@ function P24PayButton( {
 			isBusy={ FormStatus.SUBMITTING === formStatus }
 			fullWidth
 		>
-			<ButtonContents formStatus={ formStatus } total={ total } />
+			{ submitButtonContent }
 		</Button>
 	);
-}
-
-function ButtonContents( { formStatus, total }: { formStatus: FormStatus; total: LineItem } ) {
-	const { __ } = useI18n();
-	if ( formStatus === FormStatus.SUBMITTING ) {
-		return <>{ __( 'Processing…' ) }</>;
-	}
-	if ( formStatus === FormStatus.READY ) {
-		/* translators: %s is the total to be paid in localized currency */
-		return <>{ sprintf( __( 'Pay %s' ), total.amount.displayValue ) }</>;
-	}
-	return <>{ __( 'Please wait…' ) }</>;
 }
 
 function isFormValid( store: P24Store ): boolean {

--- a/packages/wpcom-checkout/src/payment-methods/sofort.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/sofort.tsx
@@ -1,10 +1,9 @@
-import { Button, FormStatus, useTotal, useFormStatus } from '@automattic/composite-checkout';
+import { Button, FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import styled from '@emotion/styled';
 import { useSelect, useDispatch, registerStore } from '@wordpress/data';
-import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
-import { Fragment } from 'react';
+import { Fragment, ReactNode } from 'react';
 import Field from '../field';
 import { PaymentMethodLogos } from '../payment-method-logos';
 import { SummaryLine, SummaryDetails } from '../summary-details';
@@ -15,7 +14,7 @@ import type {
 	StoreActions,
 	StoreState,
 } from '../payment-method-store';
-import type { PaymentMethod, ProcessPayment, LineItem } from '@automattic/composite-checkout';
+import type { PaymentMethod, ProcessPayment } from '@automattic/composite-checkout';
 import type { AnyAction } from 'redux';
 
 const debug = debugFactory( 'wpcom-checkout:sofort-payment-method' );
@@ -71,13 +70,19 @@ export function createSofortPaymentMethodStore(): SofortStore {
 	return store;
 }
 
-export function createSofortMethod( { store }: { store: SofortStore } ): PaymentMethod {
+export function createSofortMethod( {
+	store,
+	submitButtonContent,
+}: {
+	store: SofortStore;
+	submitButtonContent: ReactNode;
+} ): PaymentMethod {
 	return {
 		id: 'sofort',
 		paymentProcessorId: 'sofort',
 		label: <SofortLabel />,
 		activeContent: <SofortFields />,
-		submitButton: <SofortPayButton store={ store } />,
+		submitButton: <SofortPayButton store={ store } submitButtonContent={ submitButtonContent } />,
 		inactiveContent: <SofortSummary />,
 		getAriaLabel: () => 'Sofort',
 	};
@@ -141,12 +146,13 @@ function SofortPayButton( {
 	disabled,
 	onClick,
 	store,
+	submitButtonContent,
 }: {
 	disabled?: boolean;
 	onClick?: ProcessPayment;
 	store: SofortStore;
+	submitButtonContent: ReactNode;
 } ) {
-	const total = useTotal();
 	const { formStatus } = useFormStatus();
 	const customerName = useCustomerName();
 
@@ -174,21 +180,9 @@ function SofortPayButton( {
 			isBusy={ FormStatus.SUBMITTING === formStatus }
 			fullWidth
 		>
-			<ButtonContents formStatus={ formStatus } total={ total } />
+			{ submitButtonContent }
 		</Button>
 	);
-}
-
-function ButtonContents( { formStatus, total }: { formStatus: FormStatus; total: LineItem } ) {
-	const { __ } = useI18n();
-	if ( formStatus === FormStatus.SUBMITTING ) {
-		return <>{ __( 'Processing…' ) }</>;
-	}
-	if ( formStatus === FormStatus.READY ) {
-		/* translators: %s is the total to be paid in localized currency */
-		return <>{ sprintf( __( 'Pay %s' ), total.amount.displayValue ) }</>;
-	}
-	return <>{ __( 'Please wait…' ) }</>;
 }
 
 function SofortSummary() {


### PR DESCRIPTION
In https://github.com/Automattic/wp-calypso/pull/81807 we removed a bunch of exports from the `@automattic/composite-checkout` package. Many were unused, some were leaky abstractions, and others didn't fit the vision of the package in its current form. One of the exports that was not removed was `useTotal` because it is still used in many places.

When `CheckoutProvider` was first implemented, the idea was that it would be provided a list of line items and a total in a standardized format and would then display those line items in a particular way automatically. However, as time passed it became clear that consumers needed full control over how line items were rendered, making the whole standardized line item feature a liability and a second source of truth. In https://github.com/Automattic/wp-calypso/pull/63720 we finally removed `useLineItems` from all payment methods. However, `useTotal` remained because most payment methods used it to display the total inside their submit button.

Fortunately, the shopping cart knows the total and that can be provided to each payment method directly.

## Proposed Changes

This PR replaces `useTotal` in every payment method that still uses it with the shopping cart total instead. It also de-duplicates the code of each payment method to require a React Node for its submit button content (effectively using dependency injection for the button content). 

This was a necessary refactor because some payment methods might be used outside the context of a shopping cart (eg: the "add payment method" page) and have their own submit button text. However, the "Pay X" text which (now) requires the shopping cart was the default, which means that `useShoppingCart` had to be called for every payment method. This would throw an error if the payment method was not inside a `ShoppingCartProvider` even if it didn't plan on using the cart at all. (It has the side benefit of also not needing us to move all payment methods into the `client` directory to have access to `useCartKey` which is required by `useShoppingCart`.)

Once this is complete we'll be able to remove `useTotal` entirely in https://github.com/Automattic/wp-calypso/pull/82750

## Screenshots (before and after)

Jetpack checkout, ready state.

<img width="619" alt="Screenshot 2023-10-10 at 11 41 50 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/790ef9bc-26f9-40b1-997e-d5a17ad5ce46">

WPCom checkout, ready state.

<img width="598" alt="Screenshot 2023-10-10 at 11 42 14 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/5eda0bf9-21fb-4de1-9371-c0ecc7d6a9e7">

WPCom checkout, submitting state.

<img width="596" alt="Screenshot 2023-10-10 at 11 46 57 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/38ef852e-6ced-4e96-a5ce-1d40adf0b919">

WPCom checkout, loading state.

<img width="514" alt="Screenshot 2023-10-11 at 12 04 30 AM" src="https://github.com/Automattic/wp-calypso/assets/2036909/be7f6634-c2da-4f41-a5be-79db2583ccd1">

Change payment method form, ready state.

<img width="697" alt="Screenshot 2023-10-10 at 11 42 51 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/bb059b5c-3c2a-4520-98a6-b657892de8eb">

## Testing Instructions

This PR should not change any behavior or UI so the goal of testing is to make sure that nothing has changed from production.

Visit checkout with a product in the cart and try selecting different payment methods. Verify that their submit buttons look the same before and after this PR.

Use an account with at least one active subscription. Visit `/me/purchases`, click on the subscription, and click "Change payment method" (or "Add payment method" if none is assigned). Try selecting different payment methods and verify that the submit buttons look the same before and after this PR.