### PR TITLE
Domains multi select first always free

### DIFF
--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -4,6 +4,7 @@ import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import { getDomainRegistrations } from 'calypso/lib/cart-values/cart-items';
 import { DOMAINS_WITH_PLANS_ONLY } from 'calypso/state/current-user/constants';
 import { currentUserHasFlag, getCurrentUser } from 'calypso/state/current-user/selectors';
 import { getSitePlanSlug } from 'calypso/state/sites/plans/selectors';
@@ -62,7 +63,7 @@ class DomainProductPrice extends Component {
 	}
 
 	renderReskinFreeWithPlanText() {
-		const { isMappingProduct, translate, isCurrentPlan100YearPlan } = this.props;
+		const { isMappingProduct, translate, isCurrentPlan100YearPlan, cart } = this.props;
 
 		const domainPriceElement = ( message ) => (
 			<div className="domain-product-price__free-text">{ message }</div>
@@ -76,6 +77,10 @@ class DomainProductPrice extends Component {
 			return domainPriceElement( translate( 'Free with your plan' ) );
 		}
 
+		if ( getDomainRegistrations( cart )?.length > 0 ) {
+			return domainPriceElement( '' );
+		}
+
 		const message = translate( '{{span}}Free for the first year with annual paid plans{{/span}}', {
 			components: { span: <span className="domain-product-price__free-price" /> },
 		} );
@@ -87,6 +92,9 @@ class DomainProductPrice extends Component {
 		const priceText = this.props.translate( '%(cost)s/year', {
 			args: { cost: this.props.price },
 		} );
+		if ( this.props.cart && getDomainRegistrations( this.props?.cart )?.length > 0 ) {
+			return <div className="domain-product-price__price">{ priceText }</div>;
+		}
 
 		return (
 			<div className="domain-product-price__price">

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -435,6 +435,7 @@ class DomainRegistrationSuggestion extends Component {
 				isFeatured={ isFeatured }
 				showStrikedOutPrice={ showStrikedOutPrice }
 				isReskinned={ isReskinned }
+				cart={ this.props?.cart }
 			>
 				{ this.renderDomain() }
 				{ this.renderMatchReason() }

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -18,6 +18,7 @@ class DomainSuggestion extends Component {
 		domain: PropTypes.string,
 		hidePrice: PropTypes.bool,
 		showChevron: PropTypes.bool,
+		cart: PropTypes.object,
 	};
 
 	static defaultProps = {
@@ -34,6 +35,7 @@ class DomainSuggestion extends Component {
 			isSignupStep,
 			showStrikedOutPrice,
 			isReskinned,
+			cart,
 		} = this.props;
 
 		if ( hidePrice ) {
@@ -52,6 +54,7 @@ class DomainSuggestion extends Component {
 				isSignupStep={ isSignupStep }
 				showStrikedOutPrice={ showStrikedOutPrice }
 				isReskinned={ isReskinned }
+				cart={ cart }
 			/>
 		);
 	}

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -699,12 +699,18 @@ export class RenderDomainsStep extends Component {
 			</div>
 		) : null;
 
-		const DomainNameAndCost = ( { domain } ) => {
+		const DomainNameAndCost = ( { domain, index } ) => {
 			const priceText = translate( '%(cost)s/year', {
 				args: { cost: domain.item_original_cost_display },
 			} );
 			const costDifference = domain.item_original_cost - domain.cost;
-			const hasPromotion = costDifference > 0;
+			let hasPromotion = costDifference > 0;
+			let displayCost = domain.item_subtotal_display;
+
+			if ( index === 0 ) {
+				hasPromotion = false;
+				displayCost = formatCurrency( 0, domain.currency );
+			}
 
 			return (
 				<>
@@ -718,7 +724,7 @@ export class RenderDomainsStep extends Component {
 						</div>
 						<div className="domain-product-price__price">
 							{ hasPromotion && <del>{ priceText }</del> }
-							<span className="domains__price">{ domain.item_subtotal_display }</span>
+							<span className="domains__price">{ displayCost }</span>
 						</div>
 					</div>
 					<div>
@@ -734,6 +740,11 @@ export class RenderDomainsStep extends Component {
 								{ translate( 'Up to %(costDifference)s off for a domain.', {
 									args: { costDifference: formatCurrency( costDifference, domain.currency ) },
 								} ) }
+							</span>
+						) }
+						{ index === 0 && (
+							<span className="savings-message">
+								{ translate( 'First year free with an annual paid plan.' ) }
 							</span>
 						) }
 					</div>
@@ -832,7 +843,7 @@ export class RenderDomainsStep extends Component {
 						) }
 						{ domainsInCart.map( ( domain, i ) => (
 							<div key={ `row${ i }` } className="domains__domain-cart-row">
-								<DomainNameAndCost domain={ domain } />
+								<DomainNameAndCost domain={ domain } index={ i } />
 							</div>
 						) ) }
 					</div>

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -704,13 +704,8 @@ export class RenderDomainsStep extends Component {
 				args: { cost: domain.item_original_cost_display },
 			} );
 			const costDifference = domain.item_original_cost - domain.cost;
-			let hasPromotion = costDifference > 0;
-			let displayCost = domain.item_subtotal_display;
-
-			if ( index === 0 ) {
-				hasPromotion = false;
-				displayCost = formatCurrency( 0, domain.currency );
-			}
+			const hasPromotion = costDifference > 0;
+			const displayCost = domain.item_subtotal_display;
 
 			return (
 				<>
@@ -722,10 +717,17 @@ export class RenderDomainsStep extends Component {
 						>
 							<BoldTLD domain={ domain.meta } />
 						</div>
-						<div className="domain-product-price__price">
-							{ hasPromotion && <del>{ priceText }</del> }
-							<span className="domains__price">{ displayCost }</span>
-						</div>
+						{ index > 0 && (
+							<div className="domain-product-price__price">
+								{ hasPromotion && <del>{ priceText }</del> }
+								<span className="domains__price">{ displayCost }</span>
+							</div>
+						) }
+						{ index === 0 && (
+							<div className="domain-product-price__price">
+								<span className="domains__price-free">{ translate( 'Free' ) }</span>
+							</div>
+						) }
 					</div>
 					<div>
 						<Button
@@ -733,9 +735,9 @@ export class RenderDomainsStep extends Component {
 							className="domains__domain-cart-remove"
 							onClick={ this.removeDomainClickHandler( domain ) }
 						>
-							{ this.props.translate( 'Remove' ) }
+							{ translate( 'Remove' ) }
 						</Button>
-						{ hasPromotion && (
+						{ index > 0 && hasPromotion && (
 							<span className="savings-message">
 								{ translate( 'Up to %(costDifference)s off for a domain.', {
 									args: { costDifference: formatCurrency( costDifference, domain.currency ) },


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/4126

Exploration, don't think I like this plan.

## Proposed Changes

* Always sets the first domain price to $0 ignoring what's in the cart.
* Removes "Free domain" text after selecting a domain as that only applies to the first domain chosen

Problems with this approach:
* Hard coding this cart rule here seems dubious, is there a way we can make the cart report the right thing up front with something on the backend to make it assume there is a plan applied for this pricing? 
* Other domain flows needs to not do this, premium domains if we support them one day likely won't work the same.
* What happens when the user selects a free plan in the next step, we seem to be dropping the entire cart contents and shipping them off to the intention step instead of checking out with the domains selected (and no plan)

## Testing Instructions

http://calypso.localhost:3000/start/domains?flags=domains/add-multiple-domains-to-cart

Before
![Screenshot 2023-10-11 at 14-42-37 Create a site — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/2f702d9f-2065-4e79-ae02-8f7df82af3ec)

After
![Screenshot 2023-10-11 at 14-42-27 Create a site — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/d1ef88b0-d1bb-464a-9ab9-115a916df92b)
