### PR TITLE
Add support for not standard name servers list

### DIFF
--- a/client/data/site-profiler/types.ts
+++ b/client/data/site-profiler/types.ts
@@ -26,7 +26,7 @@ export interface WhoIs {
 	admin_street?: string | string[];
 	creation_date?: string;
 	domain_name?: string;
-	name_server?: string[];
+	name_server?: string | string[];
 	registrant_city?: string;
 	registrant_country?: string;
 	registrant_email?: string;

--- a/client/site-profiler/components/domain-information/index.tsx
+++ b/client/site-profiler/components/domain-information/index.tsx
@@ -8,6 +8,7 @@ import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { useDomainAnalyzerWhoisRawDataQuery } from 'calypso/data/site-profiler/use-domain-whois-raw-data-query';
 import { useFilteredWhoisData } from 'calypso/site-profiler/hooks/use-filtered-whois-data';
 import { normalizeWhoisField } from 'calypso/site-profiler/utils/normalize-whois-entry';
+import { normalizeWhoisList } from 'calypso/site-profiler/utils/normalize-whois-list';
 import { normalizeWhoisURL } from 'calypso/site-profiler/utils/normalize-whois-url';
 import VerifiedProvider from '../verified-provider';
 import type { HostingProvider, WhoIs } from 'calypso/data/site-profiler/types';
@@ -39,7 +40,7 @@ export default function DomainInformation( props: Props ) {
 	useEffect( () => {
 		fetchWhoisRawData &&
 			recordTracksEvent( 'calypso_site_profiler_domain_whois_raw_data_fetch', { domain } );
-	}, [ fetchWhoisRawData ] );
+	}, [ domain, fetchWhoisRawData ] );
 
 	const contactArgs = ( args?: string | string[] ): TranslateOptions => {
 		return {
@@ -126,7 +127,7 @@ export default function DomainInformation( props: Props ) {
 						<div className="name">{ translate( 'Name servers' ) }</div>
 						<div>
 							<ul>
-								{ whois.name_server.map( ( x, i ) => (
+								{ normalizeWhoisList( whois.name_server ).map( ( x, i ) => (
 									<li key={ i }>{ x }</li>
 								) ) }
 							</ul>

--- a/client/site-profiler/utils/normalize-whois-list.ts
+++ b/client/site-profiler/utils/normalize-whois-list.ts
@@ -1,0 +1,8 @@
+// Normalize a whois entry field to an array of strings
+export function normalizeWhoisList( field: string | string[] | undefined ): string[] {
+	if ( Array.isArray( field ) ) {
+		return field;
+	}
+
+	return field ? [ field ] : [];
+}


### PR DESCRIPTION
Context: p1697007064199639-slack-C01A60HCGUA
Fixes: https://github.com/Automattic/wp-calypso/issues/82846

## Proposed Changes

* Add normalization for single string name servers array

## Testing Instructions
This test must be performed on various Poland (.pl) domains.

1. Bugged PL domain: http://calypso.localhost:3000/site-profiler/onet.pl
2. Bugged PL domain with not standard NS URL: http://calypso.localhost:3000/site-profiler/home.pl
3. For sale PL: http://calypso.localhost:3000/site-profiler/three.pl
4. Not registered PL: http://calypso.localhost:3000/site-profiler/unknownpldomain.pl

Preexisting edge-case already working tests must continue working:

1. Missing protocol: http://calypso.localhost:3000/site-profiler/partizan.net
2. Array of registrars: http://calypso.localhost:3000/site-profiler/jeroenpf.nl
3. Invalid registered date: http://calypso.localhost:3000/site-profiler/google.it
5. Invalid expiry date: http://calypso.localhost:3000/site-profiler?domain=amazon.it

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?