### PR TITLE
Update domain upsell copy to include prices

### DIFF
--- a/client/my-sites/domains/domain-management/list/empty-domains-list-card-skeleton.tsx
+++ b/client/my-sites/domains/domain-management/list/empty-domains-list-card-skeleton.tsx
@@ -10,6 +10,7 @@ interface EmptyDomainsListCardSkeletonProps {
 	isCompact?: boolean;
 	title?: string;
 	line?: string;
+	secondLine?: string;
 	actionURL: string;
 	contentType: string;
 	action: string;
@@ -22,6 +23,7 @@ export const EmptyDomainsListCardSkeleton = ( {
 	isCompact,
 	title,
 	line,
+	secondLine,
 	actionURL,
 	contentType,
 	action,
@@ -58,6 +60,7 @@ export const EmptyDomainsListCardSkeleton = ( {
 					<div className="empty-domains-list-card__text">
 						{ title ? <h2>{ title }</h2> : null }
 						{ line ? <h3>{ line }</h3> : null }
+						{ secondLine ? <h3 style={ { fontStyle: 'italic' } }>{ secondLine }</h3> : null }
 					</div>
 					<div className="empty-domains-list-card__actions">
 						<Button

--- a/client/my-sites/domains/domain-management/list/empty-domains-list-card.jsx
+++ b/client/my-sites/domains/domain-management/list/empty-domains-list-card.jsx
@@ -1,14 +1,19 @@
-import { PLAN_100_YEARS, isFreePlan } from '@automattic/calypso-products';
+import { PLAN_100_YEARS, domainProductSlugs, isFreePlan } from '@automattic/calypso-products';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
+import QueryProductsList from 'calypso/components/data/query-products-list';
 import { domainAddNew, domainUseMyDomain } from 'calypso/my-sites/domains/paths';
+import { useSelector } from 'calypso/state';
+import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import { EmptyDomainsListCardSkeleton } from './empty-domains-list-card-skeleton';
 
 import './empty-domains-list-card-styles.scss';
 
 function EmptyDomainsListCard( { selectedSite, hasDomainCredit, isCompact, hasNonWpcomDomains } ) {
 	const translate = useTranslate();
+	const hasEnTranslation = useHasEnTranslation();
 
 	const siteHasPaidPlan =
 		selectedSite?.plan?.product_slug && ! isFreePlan( selectedSite.plan.product_slug );
@@ -19,11 +24,17 @@ function EmptyDomainsListCard( { selectedSite, hasDomainCredit, isCompact, hasNo
 	let line = translate(
 		'Get a free one-year domain registration or transfer with any annual paid plan.'
 	);
+	let secondLine;
 	let action = translate( 'Upgrade to a plan' );
 	let actionURL = `/plans/${ selectedSite.slug }`;
 	let secondaryAction = translate( 'Just search for a domain' );
 	let secondaryActionURL = domainAddNew( selectedSite.slug );
 	let contentType = 'no_plan';
+
+	const domainRegistrationProduct = useSelector( ( state ) =>
+		getProductBySlug( state, domainProductSlugs.DOTCOM_DOMAIN_REGISTRATION )
+	);
+	const domainProductCost = domainRegistrationProduct?.combined_cost_display;
 
 	if ( siteHasPaidPlan && ! hasDomainCredit ) {
 		if ( hasNonWpcomDomains ) {
@@ -40,11 +51,25 @@ function EmptyDomainsListCard( { selectedSite, hasDomainCredit, isCompact, hasNo
 
 	if ( siteHasPaidPlan && hasDomainCredit ) {
 		title = translate( 'Claim your free domain' );
-		line = siteHasHundredYearPlan
-			? translate( 'You have a free domain registration or transfer included with your plan.' )
-			: translate(
-					'You have a free one-year domain registration or transfer included with your plan.'
-			  );
+		if ( siteHasHundredYearPlan ) {
+			line = translate(
+				'You have a free domain registration or transfer included with your plan.'
+			);
+		} else {
+			line = translate(
+				'You have a free one-year domain registration or transfer included with your plan.'
+			);
+			secondLine = hasEnTranslation
+				? translate(
+						'Don’t worry about expensive domain renewals—.com, .net, and .org start at just %(domainPrice)s.',
+						{
+							args: {
+								domainPrice: domainProductCost,
+							},
+						}
+				  )
+				: null;
+		}
 		action = translate( 'Search for a domain' );
 		actionURL = domainAddNew( selectedSite.slug );
 		secondaryAction = translate( 'I have a domain' );
@@ -57,17 +82,21 @@ function EmptyDomainsListCard( { selectedSite, hasDomainCredit, isCompact, hasNo
 	} );
 
 	return (
-		<EmptyDomainsListCardSkeleton
-			className={ className }
-			isCompact={ isCompact }
-			title={ title }
-			line={ line }
-			contentType={ contentType }
-			action={ action }
-			actionURL={ actionURL }
-			secondaryAction={ secondaryAction }
-			secondaryActionURL={ secondaryActionURL }
-		/>
+		<>
+			{ siteHasPaidPlan && hasDomainCredit && ! siteHasHundredYearPlan && <QueryProductsList /> }
+			<EmptyDomainsListCardSkeleton
+				className={ className }
+				isCompact={ isCompact }
+				title={ title }
+				line={ line }
+				secondLine={ secondLine }
+				contentType={ contentType }
+				action={ action }
+				actionURL={ actionURL }
+				secondaryAction={ secondaryAction }
+				secondaryActionURL={ secondaryActionURL }
+			/>
+		</>
 	);
 }
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/4028

## Proposed Changes

| Before  | After |
| :-------------: | :-------------: |
| <img src="https://github.com/Automattic/wp-calypso/assets/6586048/344cb4ed-5d6a-4206-a04a-ec2636d0dce3">  | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/f1fadeb8-4c20-4dee-8b1a-ff67016c77b5">|


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/domains/manage` with a site that has a plan but haven't claimed the free domain yet
* Should show the new copy update

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?