### PR TITLE
Jetpack E2E: check phpMyAdmin referral link has token.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/hosting-configuration-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/hosting-configuration-page.ts
@@ -1,0 +1,36 @@
+import { Page } from 'playwright';
+import { getCalypsoURL } from '../../data-helper';
+
+/**
+ * Represents the Settings > Hosting Configuration page.
+ */
+export class HostingConfigurationPage {
+	private page: Page;
+
+	/**
+	 * Constructs an instance of the component.
+	 *
+	 * @param {Page} page The underlying page.
+	 */
+	constructor( page: Page ) {
+		this.page = page;
+	}
+
+	/**
+	 * Navigates to the page.
+	 *
+	 * @param {string} siteSlug Site slug.
+	 */
+	async visit( siteSlug: string ) {
+		await this.page.goto( getCalypsoURL( `hosting-config/${ siteSlug }` ) );
+	}
+
+	/**
+	 * Given text, clicks on a button with matching text.
+	 *
+	 * @param {string} text Text to search on the button.
+	 */
+	async clickButton( text: string ) {
+		await this.page.getByRole( 'button', { name: text } ).click();
+	}
+}

--- a/packages/calypso-e2e/src/lib/pages/index.ts
+++ b/packages/calypso-e2e/src/lib/pages/index.ts
@@ -36,6 +36,7 @@ export * from './blaze-campaign-page';
 export * from './feedback-inbox-page';
 export * from './subscribers-page';
 export * from './subscription-management-page';
+export * from './hosting-configuration-page';
 
 export * from './external';
 export * from './me';

--- a/test/e2e/specs/jetpack/settings__hosting-config-phpmyadmin.ts
+++ b/test/e2e/specs/jetpack/settings__hosting-config-phpmyadmin.ts
@@ -1,0 +1,72 @@
+/**
+ * @group jetpack-wpcom-integration
+ */
+
+import {
+	DataHelper,
+	TestAccount,
+	envVariables,
+	getTestAccountByFeature,
+	envToFeatureKey,
+	HostingConfigurationPage,
+} from '@automattic/calypso-e2e';
+import { Page, Browser } from 'playwright';
+import { skipDescribeIf } from '../../jest-helpers';
+
+declare const browser: Browser;
+
+/**
+ * Checks the phpMyAdmin page opens with the proper bearer token.
+ *
+ * See: https://github.com/Automattic/wp-calypso/issues/82850.
+ *
+ * Keywords: Settings, Jetpack, Hosting Configuration, phpMyAdmin
+ */
+skipDescribeIf( ! envVariables.TEST_ON_ATOMIC )(
+	DataHelper.createSuiteTitle( 'Settings: Accewss phpMyAdmin' ),
+	function () {
+		const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ) );
+
+		let page: Page;
+		let popupPage: Page;
+		let testAccount: TestAccount;
+		let hostingConfigurationPage: HostingConfigurationPage;
+
+		beforeAll( async function () {
+			page = await browser.newPage();
+
+			testAccount = new TestAccount( accountName );
+
+			if ( accountName === 'jetpackAtomicEcommPlanUser' ) {
+				// Switching to or logging into eCommerce plan sites inevitably
+				// loads WP-Admin instead of Calypso, but the rediret occurs
+				// only after Calypso attempts to load.
+				await testAccount.authenticate( page, { url: /wp-admin/ } );
+			} else {
+				await testAccount.authenticate( page );
+			}
+		} );
+
+		it( 'Navigate to Settings > Hosting Configuration', async function () {
+			hostingConfigurationPage = new HostingConfigurationPage( page );
+
+			await hostingConfigurationPage.visit( testAccount.getSiteURL( { protocol: false } ) );
+		} );
+
+		it( 'Open phpMyAdmin', async function () {
+			const waitForPopup = page.waitForEvent( 'popup' );
+			await hostingConfigurationPage.clickButton( 'Open phpMyAdmin' );
+
+			popupPage = await waitForPopup;
+		} );
+
+		it( 'phpMyAdmin page URL contains token', async function () {
+			const url = popupPage.url();
+			expect( url ).toMatch( /token=([A-Za-z0-9-_]*\.[A-Za-z0-9-_]*\.[A-Za-z0-9-_]*$)/ );
+		} );
+
+		it( 'Land in phpMyAdmin', async function () {
+			await popupPage.waitForURL( /_pma/ );
+		} );
+	}
+);

--- a/test/e2e/specs/jetpack/settings__hosting-config-phpmyadmin.ts
+++ b/test/e2e/specs/jetpack/settings__hosting-config-phpmyadmin.ts
@@ -67,6 +67,7 @@ skipDescribeIf( ! envVariables.TEST_ON_ATOMIC )(
 
 		it( 'Land in phpMyAdmin', async function () {
 			await popupPage.waitForURL( /_pma/ );
+			await popupPage.getByRole( 'link', { name: 'phpMyAdmin', exact: true } ).waitFor();
 		} );
 	}
 );


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/82850.
Closes https://github.com/Automattic/wp-calypso/issues/82827.

## Proposed Changes

This PR implements an E2E to validate the phpMyAdmin link accessed from Settings > Hosting Configuration has the required bearer token.

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Calypso E2E (desktop)
  - [x] Jetpack E2E Simple (mobile)
  - [x] Jetpack E2E Simple (desktop)
  - [x] Jetpack E2E AT (desktop)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?