### PR TITLE
Stepper: site-setup-flow: fix showing a proper TrialAcknowledge CTA

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/index.tsx
@@ -1,4 +1,4 @@
-import { StepContainer, NEW_HOSTED_SITE_FLOW } from '@automattic/onboarding';
+import { StepContainer, isNewHostedSiteCreationFlow } from '@automattic/onboarding';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { HostingTrialAcknowledge } from './hosting-trial-acknowledge';
 import { MigrationTrialAcknowledge } from './migration-trial-acknowledge';
@@ -9,7 +9,7 @@ const TrialAcknowledge: Step = function TrialAcknowledge( { navigation, flow, st
 	const { goBack } = navigation;
 
 	const getStepContent = () => {
-		if ( flow === NEW_HOSTED_SITE_FLOW ) {
+		if ( isNewHostedSiteCreationFlow( flow ) ) {
 			return (
 				<HostingTrialAcknowledge flow={ flow } navigation={ navigation } stepName={ stepName } />
 			);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/index.tsx
@@ -1,15 +1,22 @@
 import { StepContainer, isAnyMigrationFlow } from '@automattic/onboarding';
+import { useSelect } from '@wordpress/data';
+import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { HostingTrialAcknowledge } from './hosting-trial-acknowledge';
 import { MigrationTrialAcknowledge } from './migration-trial-acknowledge';
+import type { OnboardSelect } from '@automattic/data-stores';
 import type { Step } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import './style.scss';
 
 const TrialAcknowledge: Step = function TrialAcknowledge( { navigation, flow, stepName } ) {
 	const { goBack } = navigation;
+	const intent = useSelect(
+		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getIntent(),
+		[]
+	);
 
 	const getStepContent = () => {
-		if ( isAnyMigrationFlow( flow ) ) {
+		if ( isAnyMigrationFlow( flow ) || intent === 'import' ) {
 			return (
 				<MigrationTrialAcknowledge flow={ flow } stepName={ stepName } navigation={ navigation } />
 			);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/index.tsx
@@ -1,29 +1,22 @@
-import { StepContainer, isAnyMigrationFlow } from '@automattic/onboarding';
-import { useSelect } from '@wordpress/data';
-import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
+import { StepContainer, NEW_HOSTED_SITE_FLOW } from '@automattic/onboarding';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { HostingTrialAcknowledge } from './hosting-trial-acknowledge';
 import { MigrationTrialAcknowledge } from './migration-trial-acknowledge';
-import type { OnboardSelect } from '@automattic/data-stores';
 import type { Step } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import './style.scss';
 
 const TrialAcknowledge: Step = function TrialAcknowledge( { navigation, flow, stepName } ) {
 	const { goBack } = navigation;
-	const intent = useSelect(
-		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getIntent(),
-		[]
-	);
 
 	const getStepContent = () => {
-		if ( isAnyMigrationFlow( flow ) || intent === 'import' ) {
+		if ( flow === NEW_HOSTED_SITE_FLOW ) {
 			return (
-				<MigrationTrialAcknowledge flow={ flow } stepName={ stepName } navigation={ navigation } />
+				<HostingTrialAcknowledge flow={ flow } navigation={ navigation } stepName={ stepName } />
 			);
 		}
 
 		return (
-			<HostingTrialAcknowledge flow={ flow } navigation={ navigation } stepName={ stepName } />
+			<MigrationTrialAcknowledge flow={ flow } stepName={ stepName } navigation={ navigation } />
 		);
 	};
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/82672

Context: p1697015853305419-slack-C01A60HCGUA

## Proposed Changes

*  Show the migration trial CTA if the intent is 'import' in addition to `isAnyMigrationFlow` check.

## Testing Instructions

* Go to the `/start` route
* Pass through the flow steps
* In the goals screen step, select the "Import my existing website content" option
* Go through the rest of the steps
* Check if the "Try before you buy" screen has "Start the trial and migrate" CTA

<img width="773" alt="Screenshot 2023-10-11 at 12 50 21" src="https://github.com/Automattic/wp-calypso/assets/1241413/4af68d30-6706-48a2-9b85-e6091a3f58be">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?