### PR TITLE
Jetpack Manage: Add site selector component in the new sidebar.

### DIFF
--- a/client/jetpack-cloud/components/sidebar/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/index.tsx
@@ -1,4 +1,10 @@
+import config from '@automattic/calypso-config';
+import { Button } from '@wordpress/components';
 import classNames from 'classnames';
+import SiteSelector from 'calypso/components/site-selector';
+import { useDispatch } from 'calypso/state';
+import { setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
+
 import './style.scss';
 
 // This is meant to be the "base" sidebar component. All context-specific sidebars
@@ -7,25 +13,53 @@ import './style.scss';
 
 type Props = {
 	className?: string;
+	path: string;
 };
-const Sidebar = ( { className }: Props ) => (
-	<nav className={ classNames( 'jetpack-cloud-sidebar', className ) }>
-		<header className="jetpack-cloud-sidebar__header">Header</header>
-		<div className="jetpack-cloud-sidebar__main">
-			<ul role="menu" className="jetpack-cloud-sidebar__navigation-list">
-				<li
-					className={ classNames(
-						'jetpack-cloud-sidebar__navigation-item',
-						'jetpack-cloud-sidebar__navigation-item--highlighted'
-					) }
-				>
-					Navigation items
-				</li>
-				<li className="jetpack-cloud-sidebar__navigation-item">Will go here</li>
-			</ul>
-		</div>
-		<div className="jetpack-cloud-sidebar__footer">Footer</div>
-	</nav>
-);
+const Sidebar = ( { className, path }: Props ) => {
+	const isAtomicSiteCreationEnabled = config.isEnabled(
+		'jetpack/pro-dashboard-wpcom-atomic-hosting'
+	);
+
+	const dispatch = useDispatch();
+
+	const onSwitchSite = () => {
+		dispatch( setLayoutFocus( 'sites' ) );
+	};
+
+	return (
+		<>
+			<nav className={ classNames( 'jetpack-cloud-sidebar', className ) }>
+				<header className="jetpack-cloud-sidebar__header">
+					Header
+					<Button onClick={ onSwitchSite }>Switch Site</Button>
+				</header>
+				<div className="jetpack-cloud-sidebar__main">
+					<ul role="menu" className="jetpack-cloud-sidebar__navigation-list">
+						<li
+							className={ classNames(
+								'jetpack-cloud-sidebar__navigation-item',
+								'jetpack-cloud-sidebar__navigation-item--highlighted'
+							) }
+						>
+							Navigation items
+						</li>
+						<li className="jetpack-cloud-sidebar__navigation-item">Will go here</li>
+					</ul>
+				</div>
+				<div className="jetpack-cloud-sidebar__footer">Footer</div>
+			</nav>
+
+			<SiteSelector
+				showAddNewSite
+				showAllSites
+				isJetpackAgencyDashboard={ isAtomicSiteCreationEnabled }
+				className="jetpack-cloud-sidebar__site-selector"
+				allSitesPath={ path }
+				siteBasePath="/backup"
+				wpcomSiteBasePath={ isAtomicSiteCreationEnabled && 'https://wordpress.com/home' }
+			/>
+		</>
+	);
+};
 
 export default Sidebar;

--- a/client/jetpack-cloud/sections/agency-dashboard/controller.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/controller.tsx
@@ -27,7 +27,7 @@ export function agencyDashboardContext( context: PageJS.Context, next: VoidFunct
 	context.header = <Header />;
 
 	if ( config.isEnabled( 'jetpack/new-navigation' ) ) {
-		context.secondary = <NewJetpackManageSidebar />;
+		context.secondary = <NewJetpackManageSidebar path={ context.path } />;
 	} else {
 		context.secondary = <DashboardSidebar path={ context.path } />;
 	}

--- a/client/jetpack-cloud/sections/partner-portal/controller.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/controller.tsx
@@ -40,7 +40,7 @@ import type PageJS from 'page';
 
 const setSidebar = ( context: PageJS.Context ): void => {
 	if ( isEnabled( 'jetpack/new-navigation' ) ) {
-		context.secondary = <NewPurchasesSidebar />;
+		context.secondary = <NewPurchasesSidebar path={ context.path } />;
 	} else {
 		context.secondary = <PartnerPortalSidebar path={ context.path } />;
 	}

--- a/client/jetpack-cloud/sections/sidebar-navigation/jetpack-manage.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/jetpack-manage.tsx
@@ -4,10 +4,10 @@ import NewSidebar from 'calypso/jetpack-cloud/components/sidebar';
 // navigate around Jetpack Cloud with no specific site selected.
 // It'll display menu options like Sites Management, Plugin Management,
 // and Purchases.
-const JetpackManageSidebar = () => (
+const JetpackManageSidebar = ( { path }: { path: string } ) => (
 	<>
 		-- Jetpack Manage sidebar --
-		<NewSidebar />
+		<NewSidebar path={ path } />
 	</>
 );
 

--- a/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
@@ -2,10 +2,10 @@ import NewSidebar from 'calypso/jetpack-cloud/components/sidebar';
 
 // This sidebar is what people will see when they pick a site from the site
 // selector. It'll display menu options like Activity Log, Backup, Social, etc.
-const ManageSelectedSiteSidebar = () => (
+const ManageSelectedSiteSidebar = ( { path }: { path: string } ) => (
 	<>
 		-- Manage selected site sidebar --
-		<NewSidebar />
+		<NewSidebar path={ path } />
 	</>
 );
 

--- a/client/jetpack-cloud/sections/sidebar-navigation/purchases.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/purchases.tsx
@@ -3,10 +3,10 @@ import NewSidebar from 'calypso/jetpack-cloud/components/sidebar';
 // This sidebar is what Jetpack Manage customers will see when they select the
 // Purchases item from the top-level navigation sidebar. It'll display options
 // like Licenses, Invoices, Billing, etc.
-const PurchasesSidebar = () => (
+const PurchasesSidebar = ( { path }: { path: string } ) => (
 	<>
 		-- Purchases sidebar --
-		<NewSidebar />
+		<NewSidebar path={ path } />
 	</>
 );
 


### PR DESCRIPTION

Closes to https://github.com/Automattic/jetpack-genesis/issues/35

## Proposed Changes

*

## Testing Instructions


*

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?