### PR TITLE
Clean up promote post widget test URLs

### DIFF
--- a/apps/blaze-dashboard/webpack.config.js
+++ b/apps/blaze-dashboard/webpack.config.js
@@ -112,7 +112,6 @@ module.exports = {
 							'features',
 							'dsp_stripe_pub_key',
 							'dsp_widget_js_src',
-							'dsp_widget_js_test_src',
 							'client_slug',
 							'hotjar_enabled',
 						],

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -31,7 +31,6 @@
 	"livechat_support_locales": [ "en", "en-gb" ],
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0oHFYHpzmHGpuUAXZ6ygDAFxM4XkRArRsET0orrofmsynkd9DhFaOGEsDZ3RC4f8mgI0zhEyN000X8i0Mqx",
 	"dsp_widget_js_src": "https://dsp.wp.com/widget.js",
-	"dsp_widget_js_test_src": "https://dsp.wp.com/widget.js",
 	"advertising_dashboard_path_prefix": "/advertising",
 	"zendesk_presales_chat_key": false,
 	"zendesk_presales_chat_key_akismet": false,

--- a/config/development.json
+++ b/config/development.json
@@ -23,7 +23,6 @@
 	"facebook_api_key": "249643311490",
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0oHFYHpzmHGpuUAXZ6ygDAFxM4XkRArRsET0orrofmsynkd9DhFaOGEsDZ3RC4f8mgI0zhEyN000X8i0Mqx",
 	"dsp_widget_js_src": "https://dsp.wp.com/widget.js",
-	"dsp_widget_js_test_src": "https://dsp.wp.com/widget.js",
 	"advertising_dashboard_path_prefix": "/advertising",
 	"zendesk_presales_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",
 	"zendesk_presales_chat_key_akismet": "7ce13115-7b34-4069-9d64-228d90f148d1",

--- a/config/production.json
+++ b/config/production.json
@@ -13,7 +13,6 @@
 	"bilmur_url": "/wp-content/js/bilmur.min.js",
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0oHFYHpzmHGpuUAXZ6ygDAFxM4XkRArRsET0orrofmsynkd9DhFaOGEsDZ3RC4f8mgI0zhEyN000X8i0Mqx",
 	"dsp_widget_js_src": "https://dsp.wp.com/widget.js",
-	"dsp_widget_js_test_src": "https://dsp.wp.com/widget.js",
 	"advertising_dashboard_path_prefix": "/advertising",
 	"zendesk_presales_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",
 	"zendesk_presales_chat_key_akismet": "7ce13115-7b34-4069-9d64-228d90f148d1",

--- a/config/stage.json
+++ b/config/stage.json
@@ -11,7 +11,6 @@
 	"facebook_api_key": "249643311490",
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0oHFYHpzmHGpuUAXZ6ygDAFxM4XkRArRsET0orrofmsynkd9DhFaOGEsDZ3RC4f8mgI0zhEyN000X8i0Mqx",
 	"dsp_widget_js_src": "https://dsp.wp.com/widget.js",
-	"dsp_widget_js_test_src": "https://dsp.wp.com/widget.js",
 	"advertising_dashboard_path_prefix": "/advertising",
 	"zendesk_presales_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",
 	"zendesk_presales_chat_key_akismet": "7ce13115-7b34-4069-9d64-228d90f148d1",

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -11,7 +11,6 @@
 	"facebook_api_key": "249643311490",
 	"dsp_stripe_pub_key": "pk_live_51LYYzQF53KN4RFN0oHFYHpzmHGpuUAXZ6ygDAFxM4XkRArRsET0orrofmsynkd9DhFaOGEsDZ3RC4f8mgI0zhEyN000X8i0Mqx",
 	"dsp_widget_js_src": "https://dsp.wp.com/widget.js",
-	"dsp_widget_js_test_src": "https://dsp.wp.com/widget.js",
 	"advertising_dashboard_path_prefix": "/advertising",
 	"zendesk_presales_chat_key": "216bf91d-f10f-4f66-bf65-a0cba220cd38",
 	"zendesk_presales_chat_key_akismet": "7ce13115-7b34-4069-9d64-228d90f148d1",


### PR DESCRIPTION
Since we have finished testing and changed the URL in production, we are now cleaning up unused promote post test URL config properties

## Proposed Changes

* Clean up promote post widget test URLs  - `dsp_widget_js_test_src` config properties

## Testing Instructions

* Code review

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
