### PR TITLE
Plans 2023: Add useStorageAddOns hook, memo'd

### DIFF
--- a/client/my-sites/add-ons/hooks/use-storage-add-ons.ts
+++ b/client/my-sites/add-ons/hooks/use-storage-add-ons.ts
@@ -1,0 +1,19 @@
+import { PRODUCT_1GB_SPACE } from '@automattic/calypso-products';
+import { useMemo } from '@wordpress/element';
+import useAddOns from './use-add-ons';
+
+interface Props {
+	siteId?: number | null;
+	isInSignup?: boolean;
+}
+
+const useStorageAddOns = ( { siteId, isInSignup }: Props ) => {
+	const addOns = useAddOns( siteId ?? undefined, isInSignup );
+
+	return useMemo(
+		() => addOns.filter( ( addOn ) => addOn?.productSlug === PRODUCT_1GB_SPACE ),
+		[ addOns ]
+	);
+};
+
+export default useStorageAddOns;

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -56,7 +56,7 @@ import isEligibleForWpComMonthlyPlan from 'calypso/state/selectors/is-eligible-f
 import { isUserEligibleForFreeHostingTrial } from 'calypso/state/selectors/is-user-eligible-for-free-hosting-trial';
 import { getCurrentPlan, isCurrentUserCurrentPlanOwner } from 'calypso/state/sites/plans/selectors';
 import { getSitePlanSlug, getSiteSlug, isCurrentPlanPaid } from 'calypso/state/sites/selectors';
-import useAddOns from '../add-ons/hooks/use-add-ons';
+import useStorageAddOns from '../add-ons/hooks/use-storage-add-ons';
 import ComparisonGridToggle from './components/comparison-grid-toggle';
 import { FreePlanFreeDomainDialog } from './components/free-plan-free-domain-dialog';
 import { FreePlanPaidDomainDialog } from './components/free-plan-paid-domain-dialog';
@@ -238,9 +238,7 @@ const PlansFeaturesMain = ( {
 	const [ isFreePlanFreeDomainDialogOpen, setIsFreePlanFreeDomainDialogOpen ] = useState( false );
 	const [ showPlansComparisonGrid, setShowPlansComparisonGrid ] = useState( false );
 	const translate = useTranslate();
-	const storageAddOns = useAddOns( siteId ?? undefined, isInSignup ).filter(
-		( addOn ) => addOn?.productSlug === PRODUCT_1GB_SPACE
-	);
+	const storageAddOns = useStorageAddOns( { siteId, isInSignup } );
 	const shouldDisplayFreeHostingTrial = useSelector( isUserEligibleForFreeHostingTrial );
 	const currentPlan = useSelector( ( state: IAppState ) => getCurrentPlan( state, siteId ) );
 	const eligibleForWpcomMonthlyPlans = useSelector( ( state: IAppState ) =>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

- refactors the storage add-ons from inline transformation in `plans-features-main` to a separate hook
- memoized to maintain reference integrity

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/plans` and confirm storage add-ons are functioning as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?