### PR TITLE
PricingPlansBlock: ensure tabs wrap on small screens

### DIFF
--- a/apps/happy-blocks/block-library/pricing-plans/view.scss
+++ b/apps/happy-blocks/block-library/pricing-plans/view.scss
@@ -90,6 +90,7 @@ $brand-display: "SF Pro Display", $sans;
 		padding: 4px;
 		width: fit-content;
 		margin-bottom: 16px;
+		flex-wrap: wrap;
 
 		&-label {
 			background: $studio-gray-0;


### PR DESCRIPTION
p1696738449935489-slack-C02T4NVL4JJ

We received a report that the pricing block tabs don't wrap properly on small devices.
This PR provides a fix for that.

Related to #

## Proposed Changes

* Add flex wrapping

## Testing Instructions
- Sync this PR
- Test on small devices the block. For example:  https://wordpress.com/support/domains/register-domain/ 

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?