### PR TITLE
P2: Fix the style of the social signup buttons

### DIFF
--- a/client/assets/stylesheets/_p2-extends.scss
+++ b/client/assets/stylesheets/_p2-extends.scss
@@ -77,7 +77,7 @@
 %p2-form-button {
 	background-color: var(--p2-color-button);
 	color: var(--p2-color-text);
-	border: none;
+	border: none !important;
 	border-radius: 50px; /* stylelint-disable-line scales/radii */
 	display: flex;
 	align-items: center;
@@ -87,7 +87,7 @@
 	justify-content: center;
 	line-height: 1.5;
 	margin: 0 0 1em;
-	padding: 1em 2em;
+	padding: 1em 2em !important;
 	transition: 0.2s ease-in-out;
 	height: auto;
 	width: 100%;

--- a/client/blocks/signup-form/p2.scss
+++ b/client/blocks/signup-form/p2.scss
@@ -65,6 +65,7 @@
 		display: flex;
 		flex-direction: column;
 		align-items: center;
+		gap: 0;
 	}
 
 	.signup-form__social-buttons-tos {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 6182-Automattic/p2

## Proposed Changes

* Fix the side-effect of the style of the social signup button

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this PR
* Go to: http://calypso.localhost:3000/start/p2/user?ref=p2-lp
* The social signup buttons should look as below:

| Before | After |
| - | - |
| <img width="710" alt="截圖 2023-10-11 晚上8 17 01" src="https://github.com/Automattic/wp-calypso/assets/21308003/011be49e-81f3-4176-b853-c86ba6a42c74"> | <img width="571" alt="截圖 2023-10-11 晚上8 17 18" src="https://github.com/Automattic/wp-calypso/assets/21308003/5d94d42b-2607-496d-8273-1c6c20241481"> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
