### PR TITLE
Launchpad: Fixes the ordering of the tasks in the Navigator

### DIFF
--- a/packages/launchpad/src/default-wired-launchpad.tsx
+++ b/packages/launchpad/src/default-wired-launchpad.tsx
@@ -1,5 +1,9 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { LaunchpadNavigator, useLaunchpad } from '@automattic/data-stores';
+import {
+	LaunchpadNavigator,
+	sortLaunchpadTasksByCompletionStatus,
+	useLaunchpad,
+} from '@automattic/data-stores';
 import { useDispatch } from '@wordpress/data';
 import { useEffect } from 'react';
 import Launchpad from './launchpad';
@@ -71,8 +75,17 @@ const DefaultWiredLaunchpad = ( {
 		} );
 	};
 
+	const launchpadOptions = {
+		onSuccess: sortLaunchpadTasksByCompletionStatus,
+	};
+
 	return (
-		<Launchpad siteSlug={ siteSlug } checklistSlug={ checklistSlug } taskFilter={ taskFilter } />
+		<Launchpad
+			siteSlug={ siteSlug }
+			checklistSlug={ checklistSlug }
+			taskFilter={ taskFilter }
+			useLaunchpadOptions={ launchpadOptions }
+		/>
 	);
 };
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

As mentioned by Dale at https://github.com/Automattic/wp-calypso/pull/82601
> There seems to be a weird race condition where the tasks for the Customer Home and navigator task lists get re-sorted for some reason. Not sure what's going on for this yet.

The problem was that the Navigator component that renders the Launchpad was not ordering the task list. Then, it would also refresh the cache with the out-of-order task list, affecting the Customer Home Launchpad and making it out of order, too.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On a site with the "build" intent, navigate to `/home/:siteSlug?flags=launchpad/navigator`
* Click on the progress ring on the master bar
* Complete some of the tasks in random order
* Refresh the page and open the Launchpad Navigator again(by clicking on the progress ring)
* Make sure that the task list is ordered in a manner in which the complete tasks are above the incomplete tasks

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?