### PR TITLE
Plans page: show price at purchase for the current plan (all billing periods) 

### DIFF
--- a/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
+++ b/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
@@ -1,4 +1,9 @@
-import { PLAN_MONTHLY_PERIOD, type PlanSlug } from '@automattic/calypso-products';
+import {
+	PLAN_MONTHLY_PERIOD,
+	getBillingTermForPeriod,
+	type PlanSlug,
+	getBillingMonthsForTerm,
+} from '@automattic/calypso-products';
 import { Plans, WpcomPlansUI } from '@automattic/data-stores';
 import { useSelect } from '@wordpress/data';
 import { useSelector } from 'react-redux';
@@ -117,7 +122,8 @@ const usePricingMetaForGridPlans: UsePricingMetaForGridPlans = ( {
 							monthlyPrice = purchasedPlan.priceInteger;
 							fullPrice = parseFloat( ( purchasedPlan.priceInteger * 12 ).toFixed( 2 ) );
 						} else if ( fullPrice !== purchasedPlan.priceInteger ) {
-							const months = Math.ceil( purchasedPlan.billPeriodDays / PLAN_MONTHLY_PERIOD );
+							const term = getBillingTermForPeriod( purchasedPlan.billPeriodDays );
+							const months = getBillingMonthsForTerm( term );
 							monthlyPrice = parseFloat( ( purchasedPlan.priceInteger / months ).toFixed( 2 ) );
 							fullPrice = purchasedPlan.priceInteger;
 						}

--- a/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
+++ b/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
@@ -1,8 +1,8 @@
 import {
 	PLAN_MONTHLY_PERIOD,
 	type PlanSlug,
-	getBillingMonthsForTerm,
 	getTermFromDuration,
+	calculateMonthlyPrice,
 } from '@automattic/calypso-products';
 import { Plans, WpcomPlansUI } from '@automattic/data-stores';
 import { useSelect } from '@wordpress/data';
@@ -123,8 +123,7 @@ const usePricingMetaForGridPlans: UsePricingMetaForGridPlans = ( {
 							fullPrice = parseFloat( ( purchasedPlan.priceInteger * 12 ).toFixed( 2 ) );
 						} else if ( fullPrice !== purchasedPlan.priceInteger ) {
 							const term = getTermFromDuration( purchasedPlan.billPeriodDays ) || '';
-							const months = getBillingMonthsForTerm( term );
-							monthlyPrice = parseFloat( ( purchasedPlan.priceInteger / months ).toFixed( 2 ) );
+							monthlyPrice = calculateMonthlyPrice( term, purchasedPlan.priceInteger );
 							fullPrice = purchasedPlan.priceInteger;
 						}
 					}

--- a/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
+++ b/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
@@ -1,11 +1,4 @@
-import {
-	PLAN_ANNUAL_PERIOD,
-	PLAN_MONTHLY_PERIOD,
-	calculateMonthlyPrice,
-	type PlanSlug,
-	calculateYearlyPrice,
-	TERM_ANNUALLY,
-} from '@automattic/calypso-products';
+import { PLAN_MONTHLY_PERIOD, type PlanSlug } from '@automattic/calypso-products';
 import { Plans, WpcomPlansUI } from '@automattic/data-stores';
 import { useSelect } from '@wordpress/data';
 import { useSelector } from 'react-redux';
@@ -119,13 +112,13 @@ const usePricingMetaForGridPlans: UsePricingMetaForGridPlans = ( {
 					 */
 					if ( purchasedPlan ) {
 						const isMonthly = purchasedPlan.billPeriodDays === PLAN_MONTHLY_PERIOD;
-						const isYearly = purchasedPlan.billPeriodDays === PLAN_ANNUAL_PERIOD;
 
 						if ( isMonthly && monthlyPrice !== purchasedPlan.priceInteger ) {
 							monthlyPrice = purchasedPlan.priceInteger;
-							yearlyPrice = calculateYearlyPrice( TERM_ANNUALLY, purchasedPlan.priceInteger );
-						} else if ( isYearly && yearlyPrice !== purchasedPlan.priceInteger ) {
-							monthlyPrice = calculateMonthlyPrice( TERM_ANNUALLY, purchasedPlan.priceInteger );
+							yearlyPrice = parseFloat( ( purchasedPlan.priceInteger * 12 ).toFixed( 2 ) );
+						} else if ( yearlyPrice !== purchasedPlan.priceInteger ) {
+							const months = Math.round( purchasedPlan.billPeriodDays / PLAN_MONTHLY_PERIOD );
+							monthlyPrice = parseFloat( ( purchasedPlan.priceInteger / months ).toFixed( 2 ) );
 							yearlyPrice = purchasedPlan.priceInteger;
 						}
 					}

--- a/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
+++ b/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
@@ -102,7 +102,7 @@ const usePricingMetaForGridPlans: UsePricingMetaForGridPlans = ( {
 						returnMonthly: true,
 						returnSmallestUnit: true,
 					} );
-					let yearlyPrice = getSitePlanRawPrice( state, selectedSiteId, planSlug, {
+					let fullPrice = getSitePlanRawPrice( state, selectedSiteId, planSlug, {
 						returnMonthly: false,
 						returnSmallestUnit: true,
 					} );
@@ -115,11 +115,11 @@ const usePricingMetaForGridPlans: UsePricingMetaForGridPlans = ( {
 
 						if ( isMonthly && monthlyPrice !== purchasedPlan.priceInteger ) {
 							monthlyPrice = purchasedPlan.priceInteger;
-							yearlyPrice = parseFloat( ( purchasedPlan.priceInteger * 12 ).toFixed( 2 ) );
-						} else if ( yearlyPrice !== purchasedPlan.priceInteger ) {
+							fullPrice = parseFloat( ( purchasedPlan.priceInteger * 12 ).toFixed( 2 ) );
+						} else if ( fullPrice !== purchasedPlan.priceInteger ) {
 							const months = Math.ceil( purchasedPlan.billPeriodDays / PLAN_MONTHLY_PERIOD );
 							monthlyPrice = parseFloat( ( purchasedPlan.priceInteger / months ).toFixed( 2 ) );
-							yearlyPrice = purchasedPlan.priceInteger;
+							fullPrice = purchasedPlan.priceInteger;
 						}
 					}
 
@@ -128,7 +128,7 @@ const usePricingMetaForGridPlans: UsePricingMetaForGridPlans = ( {
 						[ planSlug ]: {
 							originalPrice: {
 								monthly: monthlyPrice ? monthlyPrice + storageAddOnPriceMonthly : null,
-								full: yearlyPrice ? yearlyPrice + storageAddOnPriceYearly : null,
+								full: fullPrice ? fullPrice + storageAddOnPriceYearly : null,
 							},
 							discountedPrice: {
 								monthly: null,

--- a/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
+++ b/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
@@ -1,8 +1,8 @@
 import {
 	PLAN_MONTHLY_PERIOD,
-	getBillingTermForPeriod,
 	type PlanSlug,
 	getBillingMonthsForTerm,
+	getTermFromDuration,
 } from '@automattic/calypso-products';
 import { Plans, WpcomPlansUI } from '@automattic/data-stores';
 import { useSelect } from '@wordpress/data';
@@ -122,7 +122,7 @@ const usePricingMetaForGridPlans: UsePricingMetaForGridPlans = ( {
 							monthlyPrice = purchasedPlan.priceInteger;
 							fullPrice = parseFloat( ( purchasedPlan.priceInteger * 12 ).toFixed( 2 ) );
 						} else if ( fullPrice !== purchasedPlan.priceInteger ) {
-							const term = getBillingTermForPeriod( purchasedPlan.billPeriodDays );
+							const term = getTermFromDuration( purchasedPlan.billPeriodDays ) || '';
 							const months = getBillingMonthsForTerm( term );
 							monthlyPrice = parseFloat( ( purchasedPlan.priceInteger / months ).toFixed( 2 ) );
 							fullPrice = purchasedPlan.priceInteger;

--- a/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
+++ b/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
@@ -117,7 +117,7 @@ const usePricingMetaForGridPlans: UsePricingMetaForGridPlans = ( {
 							monthlyPrice = purchasedPlan.priceInteger;
 							yearlyPrice = parseFloat( ( purchasedPlan.priceInteger * 12 ).toFixed( 2 ) );
 						} else if ( yearlyPrice !== purchasedPlan.priceInteger ) {
-							const months = Math.round( purchasedPlan.billPeriodDays / PLAN_MONTHLY_PERIOD );
+							const months = Math.ceil( purchasedPlan.billPeriodDays / PLAN_MONTHLY_PERIOD );
 							monthlyPrice = parseFloat( ( purchasedPlan.priceInteger / months ).toFixed( 2 ) );
 							yearlyPrice = purchasedPlan.priceInteger;
 						}

--- a/packages/calypso-products/src/main.ts
+++ b/packages/calypso-products/src/main.ts
@@ -41,6 +41,18 @@ import {
 	WOO_EXPRESS_PLANS,
 	TERM_CENTENNIALLY,
 	TYPE_HOSTING_TRIAL,
+	PLAN_MONTHLY_PERIOD,
+	PLAN_ANNUAL_PERIOD,
+	PLAN_BIENNIAL_PERIOD,
+	PLAN_TRIENNIAL_PERIOD,
+	PLAN_QUADRENNIAL_PERIOD,
+	PLAN_QUINQUENNIAL_PERIOD,
+	PLAN_SEXENNIAL_PERIOD,
+	PLAN_SEPTENNIAL_PERIOD,
+	PLAN_OCTENNIAL_PERIOD,
+	PLAN_NOVENNIAL_PERIOD,
+	PLAN_DECENNIAL_PERIOD,
+	PLAN_CENTENNIAL_PERIOD,
 } from './constants';
 import { featureGroups, wooExpressFeatureGroups } from './feature-group-plan-map';
 import { PLANS_LIST } from './plans-list';
@@ -563,6 +575,35 @@ export function calculateMonthlyPriceForPlan( planSlug: string, termPrice: numbe
 export function calculateMonthlyPrice( term: string, termPrice: number ): number {
 	const divisor = getBillingMonthsForTerm( term );
 	return parseFloat( ( termPrice / divisor ).toFixed( 2 ) );
+}
+
+export function getBillingTermForPeriod( days: number ): string {
+	if ( days === PLAN_MONTHLY_PERIOD ) {
+		return TERM_MONTHLY;
+	} else if ( days === PLAN_ANNUAL_PERIOD ) {
+		return TERM_ANNUALLY;
+	} else if ( days === PLAN_BIENNIAL_PERIOD ) {
+		return TERM_BIENNIALLY;
+	} else if ( days === PLAN_TRIENNIAL_PERIOD ) {
+		return TERM_TRIENNIALLY;
+	} else if ( days === PLAN_QUADRENNIAL_PERIOD ) {
+		return TERM_QUADRENNIALLY;
+	} else if ( days === PLAN_QUINQUENNIAL_PERIOD ) {
+		return TERM_QUINQUENNIALLY;
+	} else if ( days === PLAN_SEXENNIAL_PERIOD ) {
+		return TERM_SEXENNIALLY;
+	} else if ( days === PLAN_SEPTENNIAL_PERIOD ) {
+		return TERM_SEPTENNIALLY;
+	} else if ( days === PLAN_OCTENNIAL_PERIOD ) {
+		return TERM_OCTENNIALLY;
+	} else if ( days === PLAN_NOVENNIAL_PERIOD ) {
+		return TERM_NOVENNIALLY;
+	} else if ( days === PLAN_DECENNIAL_PERIOD ) {
+		return TERM_DECENNIALLY;
+	} else if ( days === PLAN_CENTENNIAL_PERIOD ) {
+		return TERM_CENTENNIALLY;
+	}
+	throw new Error( `Unknown period: ${ days }` );
 }
 
 export function getBillingMonthsForTerm( term: string ): number {

--- a/packages/calypso-products/src/main.ts
+++ b/packages/calypso-products/src/main.ts
@@ -565,11 +565,6 @@ export function calculateMonthlyPrice( term: string, termPrice: number ): number
 	return parseFloat( ( termPrice / divisor ).toFixed( 2 ) );
 }
 
-export function calculateYearlyPrice( term: string, termPrice: number ): number {
-	const multiplier = getBillingMonthsForTerm( term );
-	return parseFloat( ( termPrice * multiplier ).toFixed( 2 ) );
-}
-
 export function getBillingMonthsForTerm( term: string ): number {
 	if ( term === TERM_MONTHLY ) {
 		return 1;

--- a/packages/calypso-products/src/main.ts
+++ b/packages/calypso-products/src/main.ts
@@ -41,18 +41,6 @@ import {
 	WOO_EXPRESS_PLANS,
 	TERM_CENTENNIALLY,
 	TYPE_HOSTING_TRIAL,
-	PLAN_MONTHLY_PERIOD,
-	PLAN_ANNUAL_PERIOD,
-	PLAN_BIENNIAL_PERIOD,
-	PLAN_TRIENNIAL_PERIOD,
-	PLAN_QUADRENNIAL_PERIOD,
-	PLAN_QUINQUENNIAL_PERIOD,
-	PLAN_SEXENNIAL_PERIOD,
-	PLAN_SEPTENNIAL_PERIOD,
-	PLAN_OCTENNIAL_PERIOD,
-	PLAN_NOVENNIAL_PERIOD,
-	PLAN_DECENNIAL_PERIOD,
-	PLAN_CENTENNIAL_PERIOD,
 } from './constants';
 import { featureGroups, wooExpressFeatureGroups } from './feature-group-plan-map';
 import { PLANS_LIST } from './plans-list';
@@ -575,35 +563,6 @@ export function calculateMonthlyPriceForPlan( planSlug: string, termPrice: numbe
 export function calculateMonthlyPrice( term: string, termPrice: number ): number {
 	const divisor = getBillingMonthsForTerm( term );
 	return parseFloat( ( termPrice / divisor ).toFixed( 2 ) );
-}
-
-export function getBillingTermForPeriod( days: number ): string {
-	if ( days === PLAN_MONTHLY_PERIOD ) {
-		return TERM_MONTHLY;
-	} else if ( days === PLAN_ANNUAL_PERIOD ) {
-		return TERM_ANNUALLY;
-	} else if ( days === PLAN_BIENNIAL_PERIOD ) {
-		return TERM_BIENNIALLY;
-	} else if ( days === PLAN_TRIENNIAL_PERIOD ) {
-		return TERM_TRIENNIALLY;
-	} else if ( days === PLAN_QUADRENNIAL_PERIOD ) {
-		return TERM_QUADRENNIALLY;
-	} else if ( days === PLAN_QUINQUENNIAL_PERIOD ) {
-		return TERM_QUINQUENNIALLY;
-	} else if ( days === PLAN_SEXENNIAL_PERIOD ) {
-		return TERM_SEXENNIALLY;
-	} else if ( days === PLAN_SEPTENNIAL_PERIOD ) {
-		return TERM_SEPTENNIALLY;
-	} else if ( days === PLAN_OCTENNIAL_PERIOD ) {
-		return TERM_OCTENNIALLY;
-	} else if ( days === PLAN_NOVENNIAL_PERIOD ) {
-		return TERM_NOVENNIALLY;
-	} else if ( days === PLAN_DECENNIAL_PERIOD ) {
-		return TERM_DECENNIALLY;
-	} else if ( days === PLAN_CENTENNIAL_PERIOD ) {
-		return TERM_CENTENNIALLY;
-	}
-	throw new Error( `Unknown period: ${ days }` );
 }
 
 export function getBillingMonthsForTerm( term: string ): number {

--- a/packages/calypso-products/src/plans-utilities.ts
+++ b/packages/calypso-products/src/plans-utilities.ts
@@ -35,7 +35,6 @@ export function isBestValue( plan: string ): boolean {
 
 /**
  * Return estimated duration of given PLAN_TERM in days
- *
  * @param {string} term TERM_ constant
  * @returns {number} Term duration
  */
@@ -68,12 +67,45 @@ export function getTermDuration( term: string ): number | undefined {
 	}
 }
 
+/**
+ * Gvien duration in days returnn the PLAN_TERM
+ * @param {number} days Term duration in days
+ * @returns {string} TERM_ constant
+ */
+export function getTermFromDuration( days: number ): string | undefined {
+	switch ( days ) {
+		case PLAN_MONTHLY_PERIOD:
+			return TERM_MONTHLY;
+		case PLAN_ANNUAL_PERIOD:
+			return TERM_ANNUALLY;
+		case PLAN_BIENNIAL_PERIOD:
+			return TERM_BIENNIALLY;
+		case PLAN_TRIENNIAL_PERIOD:
+			return TERM_TRIENNIALLY;
+		case PLAN_QUADRENNIAL_PERIOD:
+			return TERM_QUADRENNIALLY;
+		case PLAN_QUINQUENNIAL_PERIOD:
+			return TERM_QUINQUENNIALLY;
+		case PLAN_SEXENNIAL_PERIOD:
+			return TERM_SEXENNIALLY;
+		case PLAN_SEPTENNIAL_PERIOD:
+			return TERM_SEPTENNIALLY;
+		case PLAN_OCTENNIAL_PERIOD:
+			return TERM_OCTENNIALLY;
+		case PLAN_NOVENNIAL_PERIOD:
+			return TERM_NOVENNIALLY;
+		case PLAN_DECENNIAL_PERIOD:
+			return TERM_DECENNIALLY;
+		case PLAN_CENTENNIAL_PERIOD:
+			return TERM_CENTENNIALLY;
+	}
+}
+
 export const redirectCheckoutToWpAdmin = (): boolean => !! JETPACK_REDIRECT_CHECKOUT_TO_WPADMIN;
 
 /**
  * Given an array of plan Features and an array of Product slugs, it returns which products are
  * included in the plan Features.
- *
  * @param {ReadonlyArray< string >} planFeatures Array of plan Feature slugs
  * @param {ReadonlyArray< string >} products Array of Product slugs
  * @returns {string[]} Array of Product slugs

--- a/packages/calypso-products/test/plan-other.js
+++ b/packages/calypso-products/test/plan-other.js
@@ -15,7 +15,7 @@ import {
 import {
 	calculateMonthlyPrice,
 	getBillingMonthsForTerm,
-	getBillingTermForPeriod,
+	getTermFromDuration,
 	getTermDuration,
 } from '../src/index';
 
@@ -50,36 +50,6 @@ describe( 'calculateMonthlyPrice', () => {
 		expect( calculateMonthlyPrice( TERM_TRIENNIALLY, 36 ) ).toBe( 1.0 );
 		expect( calculateMonthlyPrice( TERM_TRIENNIALLY, 72 ) ).toBe( 2.0 );
 		expect( calculateMonthlyPrice( TERM_TRIENNIALLY, 252 ) ).toBe( 7.0 );
-	} );
-} );
-
-describe( 'getBillingTermForPeriod', () => {
-	it( 'should return the correct billing term for a monthly period', () => {
-		expect( getBillingTermForPeriod( PLAN_MONTHLY_PERIOD ) ).toEqual( TERM_MONTHLY );
-	} );
-
-	it( 'should return the correct billing term for an annual period', () => {
-		expect( getBillingTermForPeriod( PLAN_ANNUAL_PERIOD ) ).toEqual( TERM_ANNUALLY );
-	} );
-
-	it( 'should return the correct billing term for a biennial period', () => {
-		expect( getBillingTermForPeriod( PLAN_BIENNIAL_PERIOD ) ).toEqual( TERM_BIENNIALLY );
-	} );
-
-	it( 'should return the correct billing term for a triennial period', () => {
-		expect( getBillingTermForPeriod( PLAN_TRIENNIAL_PERIOD ) ).toEqual( TERM_TRIENNIALLY );
-	} );
-
-	it( 'should return the correct billing term for a decennial period', () => {
-		expect( getBillingTermForPeriod( PLAN_DECENNIAL_PERIOD ) ).toEqual( TERM_DECENNIALLY );
-	} );
-
-	it( 'should return the correct billing term for a centennial period', () => {
-		expect( getBillingTermForPeriod( PLAN_CENTENNIAL_PERIOD ) ).toEqual( TERM_CENTENNIALLY );
-	} );
-
-	it( 'should throw an error for an unknown period', () => {
-		expect( () => getBillingTermForPeriod( 30 ) ).toThrow( 'Unknown period: 30' );
 	} );
 } );
 
@@ -119,5 +89,35 @@ describe( 'getTermDuration', () => {
 	} );
 	test( 'should return undefined for unknown term', () => {
 		expect( getTermDuration( 'fake' ) ).toBeUndefined();
+	} );
+} );
+
+describe( 'getTermFromDuration', () => {
+	it( 'should return the correct billing term for a monthly period', () => {
+		expect( getTermFromDuration( PLAN_MONTHLY_PERIOD ) ).toEqual( TERM_MONTHLY );
+	} );
+
+	it( 'should return the correct billing term for an annual period', () => {
+		expect( getTermFromDuration( PLAN_ANNUAL_PERIOD ) ).toEqual( TERM_ANNUALLY );
+	} );
+
+	it( 'should return the correct billing term for a biennial period', () => {
+		expect( getTermFromDuration( PLAN_BIENNIAL_PERIOD ) ).toEqual( TERM_BIENNIALLY );
+	} );
+
+	it( 'should return the correct billing term for a triennial period', () => {
+		expect( getTermFromDuration( PLAN_TRIENNIAL_PERIOD ) ).toEqual( TERM_TRIENNIALLY );
+	} );
+
+	it( 'should return the correct billing term for a decennial period', () => {
+		expect( getTermFromDuration( PLAN_DECENNIAL_PERIOD ) ).toEqual( TERM_DECENNIALLY );
+	} );
+
+	it( 'should return the correct billing term for a centennial period', () => {
+		expect( getTermFromDuration( PLAN_CENTENNIAL_PERIOD ) ).toEqual( TERM_CENTENNIALLY );
+	} );
+
+	test( 'should return undefined for unknown term', () => {
+		expect( getTermFromDuration( 3.14 ) ).toBeUndefined();
 	} );
 } );

--- a/packages/calypso-products/test/plan-other.js
+++ b/packages/calypso-products/test/plan-other.js
@@ -4,8 +4,20 @@ import {
 	TERM_CENTENNIALLY,
 	TERM_MONTHLY,
 	TERM_TRIENNIALLY,
+	TERM_DECENNIALLY,
+	PLAN_MONTHLY_PERIOD,
+	PLAN_ANNUAL_PERIOD,
+	PLAN_BIENNIAL_PERIOD,
+	PLAN_TRIENNIAL_PERIOD,
+	PLAN_DECENNIAL_PERIOD,
+	PLAN_CENTENNIAL_PERIOD,
 } from '../src/constants';
-import { calculateMonthlyPrice, getBillingMonthsForTerm, getTermDuration } from '../src/index';
+import {
+	calculateMonthlyPrice,
+	getBillingMonthsForTerm,
+	getBillingTermForPeriod,
+	getTermDuration,
+} from '../src/index';
 
 describe( 'calculateMonthlyPrice', () => {
 	test( 'should return same number for monthly term', () => {
@@ -38,6 +50,36 @@ describe( 'calculateMonthlyPrice', () => {
 		expect( calculateMonthlyPrice( TERM_TRIENNIALLY, 36 ) ).toBe( 1.0 );
 		expect( calculateMonthlyPrice( TERM_TRIENNIALLY, 72 ) ).toBe( 2.0 );
 		expect( calculateMonthlyPrice( TERM_TRIENNIALLY, 252 ) ).toBe( 7.0 );
+	} );
+} );
+
+describe( 'getBillingTermForPeriod', () => {
+	it( 'should return the correct billing term for a monthly period', () => {
+		expect( getBillingTermForPeriod( PLAN_MONTHLY_PERIOD ) ).toEqual( TERM_MONTHLY );
+	} );
+
+	it( 'should return the correct billing term for an annual period', () => {
+		expect( getBillingTermForPeriod( PLAN_ANNUAL_PERIOD ) ).toEqual( TERM_ANNUALLY );
+	} );
+
+	it( 'should return the correct billing term for a biennial period', () => {
+		expect( getBillingTermForPeriod( PLAN_BIENNIAL_PERIOD ) ).toEqual( TERM_BIENNIALLY );
+	} );
+
+	it( 'should return the correct billing term for a triennial period', () => {
+		expect( getBillingTermForPeriod( PLAN_TRIENNIAL_PERIOD ) ).toEqual( TERM_TRIENNIALLY );
+	} );
+
+	it( 'should return the correct billing term for a decennial period', () => {
+		expect( getBillingTermForPeriod( PLAN_DECENNIAL_PERIOD ) ).toEqual( TERM_DECENNIALLY );
+	} );
+
+	it( 'should return the correct billing term for a centennial period', () => {
+		expect( getBillingTermForPeriod( PLAN_CENTENNIAL_PERIOD ) ).toEqual( TERM_CENTENNIALLY );
+	} );
+
+	it( 'should throw an error for an unknown period', () => {
+		expect( () => getBillingTermForPeriod( 30 ) ).toThrow( 'Unknown period: 30' );
 	} );
 } );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #82761

## Proposed Changes

This is a follow-up to #82761 where the fix was restricted only to monthly and yearly plans ([more details](https://github.com/Automattic/wp-calypso/pull/82761#pullrequestreview-1664775028)).
This extends the fix for biannual, triannual and any billing periods.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*Go to the SA panel
* Assign yourself a plan that is not purchasable - make sure to cover multiple billing periods (monthly, yearly, etc.)
* Ensure the plan's price is correctly shown on /plans - ie. it should match the credit notification

<img width="320" alt="Screenshot 2023-10-11 at 16 50 14" src="https://github.com/Automattic/wp-calypso/assets/2749938/29324ec5-1c65-4901-ad92-450d93791054">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
