### PR TITLE
Flaky E2E: remove `networkidle` load state specifier from `plans__signup-business.ts` spec.

### DIFF
--- a/test/e2e/specs/plans/plans__signup-business.ts
+++ b/test/e2e/specs/plans/plans__signup-business.ts
@@ -69,23 +69,11 @@ describe(
 			} );
 
 			it( 'Make purchase', async function () {
-				try {
-					await cartCheckoutPage.purchase( { timeout: 75 * 1000 } );
-				} catch {
-					// Work around an issue where purchase flow does not
-					// complete and redirect the user to the next screen
-					// beyond the timeout.
-					// See: https://github.com/Automattic/wp-calypso/issues/75867
-					await page.goto(
-						DataHelper.getCalypsoURL(
-							`setup/site-setup/goals?siteSlug=${ newSiteDetails.blog_details.site_slug }&notice=purchase-success`
-						)
-					);
-				}
+				await cartCheckoutPage.purchase( { timeout: 75 * 1000 } );
 			} );
 
 			it( 'Skip Onboarding', async function () {
-				await page.waitForURL( /setup\/site-setup\/goals/, { waitUntil: 'networkidle' } );
+				await page.waitForURL( /setup\/site-setup\/goals/ );
 				const startSiteFlow = new StartSiteFlow( page );
 				await startSiteFlow.clickButton( 'Skip to dashboard' );
 			} );


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/82877.

## Proposed Changes

This PR removes the `networkidle` load state specifier from a `waitForURL` method from the `Plans: Create a WordPress.com Business site as exising user` spec.

This PR also removes a try/catch block that was added before the retry mechanism was added.

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)
  - [x] Pre-Release E2E

![image](https://github.com/Automattic/wp-calypso/assets/6549265/05d80b91-4d0f-4420-b393-414364466e12)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?