### PR TITLE
Launchpad: Use the tooltip component from package

### DIFF
--- a/client/my-sites/customer-home/components/share-site-modal.scss
+++ b/client/my-sites/customer-home/components/share-site-modal.scss
@@ -136,3 +136,26 @@
 		text-decoration: underline;
 	}
 }
+
+.share-site-modal__popover {
+	outline: none;
+	z-index: 100000;
+	.popover__inner {
+		border: 0;
+		box-shadow: none;
+		border-radius: 2px;
+		color: var(--color-text-inverted);
+		background: var(--color-neutral-60);
+		font-size: $font-body-extra-small;
+		padding: 6px 10px;
+		text-align: left;
+	}
+
+	.popover__arrow {
+		border-color: var(--color-neutral-60);
+
+		&::before {
+			display: none;
+		}
+	}
+}

--- a/client/my-sites/customer-home/components/share-site-modal.scss
+++ b/client/my-sites/customer-home/components/share-site-modal.scss
@@ -152,10 +152,6 @@
 	}
 
 	.popover__arrow {
-		border-color: var(--color-neutral-60);
-
-		&::before {
-			display: none;
-		}
+		display: none;
 	}
 }

--- a/client/my-sites/customer-home/components/share-site-modal.tsx
+++ b/client/my-sites/customer-home/components/share-site-modal.tsx
@@ -1,10 +1,10 @@
+import { Popover } from '@automattic/components';
 import { updateLaunchpadSettings } from '@automattic/data-stores';
 import { useQueryClient } from '@tanstack/react-query';
 import { Button, Modal } from '@wordpress/components';
 import { Icon, link } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useRef } from 'react';
-import Tooltip from 'calypso/components/tooltip';
 import type { SiteDetails } from '@automattic/data-stores';
 
 import './share-site-modal.scss';
@@ -54,13 +54,14 @@ const ShareSiteModal = ( { setModalIsOpen, site }: ShareSiteModalProps ) => {
 									{ site?.slug }
 								</p>
 
-								<Tooltip
-									context={ clipboardTextEl.current }
+								<Popover
+									className="share-site-modal__popover"
 									isVisible={ clipboardCopied }
+									context={ clipboardTextEl.current }
 									position="top"
 								>
 									{ translate( 'Copied to clipboard!' ) }
-								</Tooltip>
+								</Popover>
 							</div>
 
 							<Button onClick={ copyHandler } className="share-site-modal__modal-view-site">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/82669

## Proposed Changes

* We should use external dependencies so we can move this component to a package. The Share Site Modal was using the Tooltip component from Calypso, which wouldn't be accessible when we move the Share Site Modal to the Launchpad package. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso Live link or apply this PR to your local environment
* On a site with the "Build" intent, navigate to `/home/:siteSlug?flags=nagivator/launchpad`
* Click on the "Share your site" task
* Make sure you see the tooltip when you click on the "Copy" button.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?