### PR TITLE
Activitypub: consistent lowercase "fediverse"

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-registration.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-registration.tsx
@@ -97,7 +97,7 @@ const domainRegistrationThankYouProps = ( {
 
 	const fediverseSettingsStep = {
 		stepKey: 'domain_registration_whats_next_fediverse_settings',
-		stepTitle: translate( 'Connect to the Fediverse' ),
+		stepTitle: translate( 'Connect to the fediverse' ),
 		stepDescription: translate(
 			'You’ve unlocked a durable, portable social networking presence with your domain!'
 		),


### PR DESCRIPTION
"fediverse" should be lowercase. We had one instance, on the thank-you screen after purchasing a domain, where it was uppercase.

## Proposed Changes

* "Connect to the fediverse" on the thank-you screen

<img width="759" alt="Screenshot 2023-10-11 at 10 24 49" src="https://github.com/Automattic/wp-calypso/assets/195089/dd4130ad-82c7-4e0c-bf16-f261422537b5">


## Testing Instructions

Purchase a domain on a site with the fediverse enabled. The thank you screen should look like the above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?