### PR TITLE
IGNORE: Fake tests to compare wp-admin to editor SSO auth

### DIFF
--- a/test/e2e/specs/blocks/blocks__media.ts
+++ b/test/e2e/specs/blocks/blocks__media.ts
@@ -28,7 +28,7 @@ declare const browser: Browser;
  *
  * Keywords: Media, Video, VideoPress, Image, Audio, File
  */
-describe( DataHelper.createSuiteTitle( 'Blocks: Media (Upload)' ), function () {
+describe.skip( DataHelper.createSuiteTitle( 'Blocks: Media (Upload)' ), function () {
 	const features = envToFeatureKey( envVariables );
 
 	// Default to `defaultUser` as it has WordPress.com Premium enabled, which is required

--- a/test/e2e/specs/blocks/blocks__story.ts
+++ b/test/e2e/specs/blocks/blocks__story.ts
@@ -27,7 +27,7 @@ declare const browser: Browser;
  *
  * Keywords: Jetpack, Media Block, Story
  */
-describe( DataHelper.createSuiteTitle( 'Blocks: Jetpack Story' ), function () {
+describe.skip( DataHelper.createSuiteTitle( 'Blocks: Jetpack Story' ), function () {
 	const features = envToFeatureKey( envVariables );
 	const accountName = getTestAccountByFeature( features );
 	const testFiles: TestFile[] = [];

--- a/test/e2e/specs/blocks/shared/block-smoke-testing.ts
+++ b/test/e2e/specs/blocks/shared/block-smoke-testing.ts
@@ -20,7 +20,7 @@ declare const browser: Browser;
  * @param blockFlows A list of block flows to put under test.
  */
 export function createBlockTests( specName: string, blockFlows: BlockFlow[] ): void {
-	describe( DataHelper.createSuiteTitle( specName ), function () {
+	describe.skip( DataHelper.createSuiteTitle( specName ), function () {
 		const features = envToFeatureKey( envVariables );
 		// @todo Does it make sense to create a `simpleSitePersonalPlanUserEdge` with GB edge?
 		// for now, it will pick up the default `gutenbergAtomicSiteEdgeUser` if edge is set.

--- a/test/e2e/specs/editor/editor__page-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__page-basic-flow.ts
@@ -22,7 +22,7 @@ const customUrlSlug = `about-${ DataHelper.getTimestamp() }-${ DataHelper.getRan
 	100
 ) }`;
 
-describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () {
+describe.skip( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () {
 	const features = envToFeatureKey( envVariables );
 	const accountName = getTestAccountByFeature(
 		features,

--- a/test/e2e/specs/editor/editor__post-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__post-basic-flow.ts
@@ -25,7 +25,7 @@ const seoDescription = 'SEO example description';
 
 declare const browser: Browser;
 
-describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () {
+describe.skip( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () {
 	const features = envToFeatureKey( envVariables );
 	const accountName = getTestAccountByFeature( features, [
 		{ gutenberg: 'stable', siteType: 'simple', accountName: 'simpleSitePersonalPlanUser' },

--- a/test/e2e/specs/fse/fse__temp-smoke-test.ts
+++ b/test/e2e/specs/fse/fse__temp-smoke-test.ts
@@ -27,7 +27,7 @@ declare const browser: Browser;
  *
  * Keywords: FSE, Full Site Editor, Gutenberg
  */
-describe( DataHelper.createSuiteTitle( 'Site Editor Smoke Test' ), function () {
+describe.skip( DataHelper.createSuiteTitle( 'Site Editor Smoke Test' ), function () {
 	let page: Page;
 	let testAccount: TestAccount;
 	let fullSiteEditorPage: FullSiteEditorPage;

--- a/test/e2e/specs/jetpack/jetpack__dashboard-smoke.ts
+++ b/test/e2e/specs/jetpack/jetpack__dashboard-smoke.ts
@@ -13,7 +13,7 @@ import {
 	SettingsTabs,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
-import { skipDescribeIf, skipItIf } from '../../jest-helpers';
+import { skipItIf } from '../../jest-helpers';
 
 declare const browser: Browser;
 
@@ -25,72 +25,67 @@ declare const browser: Browser;
  *
  * Keywords: Jetpack, Smoke Test
  */
-skipDescribeIf( envVariables.TEST_ON_ATOMIC !== true )(
-	DataHelper.createSuiteTitle( 'Jetpack: Dashboard Smoke Test' ),
-	function () {
-		const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ) );
-		const testAccount = new TestAccount( accountName );
+describe.skip( DataHelper.createSuiteTitle( 'Jetpack: Dashboard Smoke Test' ), function () {
+	const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ) );
+	const testAccount = new TestAccount( accountName );
 
-		let page: Page;
-		let jetpackDashboardPage: JetpackDashboardPage;
+	let page: Page;
+	let jetpackDashboardPage: JetpackDashboardPage;
 
-		beforeAll( async function () {
-			page = await browser.newPage();
+	beforeAll( async function () {
+		page = await browser.newPage();
 
-			if ( accountName === 'jetpackAtomicEcommPlanUser' ) {
-				// eCommerce plan sites attempt to load Calypso, but with
-				// third-party cookies disabled the fallback route to WP-Admin
-				// kicks in after some time.
-				await testAccount.authenticate( page, { url: /wp-admin/ } );
-			} else {
-				await testAccount.authenticate( page );
-			}
+		if ( accountName === 'jetpackAtomicEcommPlanUser' ) {
+			// eCommerce plan sites attempt to load Calypso, but with
+			// third-party cookies disabled the fallback route to WP-Admin
+			// kicks in after some time.
+			await testAccount.authenticate( page, { url: /wp-admin/ } );
+		} else {
+			await testAccount.authenticate( page );
+		}
 
-			jetpackDashboardPage = new JetpackDashboardPage( page );
-		} );
+		jetpackDashboardPage = new JetpackDashboardPage( page );
+	} );
 
-		it( 'Navigate to Jetpack dashboard', async function () {
-			await jetpackDashboardPage.visit( testAccount.getSiteURL( { protocol: false } ) );
-		} );
+	it( 'Navigate to Jetpack dashboard', async function () {
+		await jetpackDashboardPage.visit( testAccount.getSiteURL( { protocol: false } ) );
+	} );
 
-		describe( 'Dashboard', function () {
-			it.each( [ { tab: 'At a Glance' }, { tab: 'My Plan' } ] )(
-				'Click on $tab tab in the Dashboard view',
-				async function ( { tab } ) {
-					await jetpackDashboardPage.clickTab( { view: 'Dashboard', tab: tab as DashboardTabs } );
-
-					await page
-						.getByRole( 'heading', { name: tab, level: 1 } )
-						.waitFor( { state: 'attached' } );
-				}
-			);
-		} );
-
-		describe( 'Settings', function () {
-			it.each( [
-				{ tab: 'Security' },
-				{ tab: 'Performance' },
-				{ tab: 'Writing' },
-				{ tab: 'Sharing' },
-				{ tab: 'Discussion' },
-				{ tab: 'Traffic' },
-				{ tab: 'Newsletter' },
-			] )( 'Click on $tab tab in the Settings view', async function ( { tab } ) {
-				await jetpackDashboardPage.clickTab( { view: 'Settings', tab: tab as SettingsTabs } );
+	describe( 'Dashboard', function () {
+		it.each( [ { tab: 'At a Glance' }, { tab: 'My Plan' } ] )(
+			'Click on $tab tab in the Dashboard view',
+			async function ( { tab } ) {
+				await jetpackDashboardPage.clickTab( { view: 'Dashboard', tab: tab as DashboardTabs } );
 
 				await page.getByRole( 'heading', { name: tab, level: 1 } ).waitFor( { state: 'attached' } );
-			} );
+			}
+		);
+	} );
 
-			skipItIf( envVariables.ATOMIC_VARIATION === 'private' )(
-				'Click on Earn tab in the Settings view',
-				async function () {
-					await jetpackDashboardPage.clickTab( { view: 'Settings', tab: 'Earn' } );
+	describe( 'Settings', function () {
+		it.each( [
+			{ tab: 'Security' },
+			{ tab: 'Performance' },
+			{ tab: 'Writing' },
+			{ tab: 'Sharing' },
+			{ tab: 'Discussion' },
+			{ tab: 'Traffic' },
+			{ tab: 'Newsletter' },
+		] )( 'Click on $tab tab in the Settings view', async function ( { tab } ) {
+			await jetpackDashboardPage.clickTab( { view: 'Settings', tab: tab as SettingsTabs } );
 
-					await page
-						.getByRole( 'heading', { name: 'Earn', level: 1 } )
-						.waitFor( { state: 'attached' } );
-				}
-			);
+			await page.getByRole( 'heading', { name: tab, level: 1 } ).waitFor( { state: 'attached' } );
 		} );
-	}
-);
+
+		skipItIf( envVariables.ATOMIC_VARIATION === 'private' )(
+			'Click on Earn tab in the Settings view',
+			async function () {
+				await jetpackDashboardPage.clickTab( { view: 'Settings', tab: 'Earn' } );
+
+				await page
+					.getByRole( 'heading', { name: 'Earn', level: 1 } )
+					.waitFor( { state: 'attached' } );
+			}
+		);
+	} );
+} );

--- a/test/e2e/specs/media/media__edit.ts
+++ b/test/e2e/specs/media/media__edit.ts
@@ -25,7 +25,7 @@ declare const browser: Browser;
  *
  * Keywords: Media, Image, Gallery, Upload
  */
-describe( DataHelper.createSuiteTitle( 'Media: Edit Media' ), function () {
+describe.skip( DataHelper.createSuiteTitle( 'Media: Edit Media' ), function () {
 	let page: Page;
 	let mediaPage: MediaPage;
 	let testAccount: TestAccount;

--- a/test/e2e/specs/media/media__upload.ts
+++ b/test/e2e/specs/media/media__upload.ts
@@ -30,7 +30,7 @@ declare const browser: Browser;
  *
  * Keywords: Media, Image, Video, Audio, Gallery, Upload
  */
-describe( DataHelper.createSuiteTitle( 'Media: Upload' ), () => {
+describe.skip( DataHelper.createSuiteTitle( 'Media: Upload' ), () => {
 	let page: Page;
 	let mediaPage: MediaPage;
 	let testAccount: TestAccount;

--- a/test/e2e/specs/media/settings__media.ts
+++ b/test/e2e/specs/media/settings__media.ts
@@ -26,7 +26,7 @@ declare const browser: Browser;
  *
  * Keywords: Jetpack, Media, Carousel, Settings
  */
-describe( DataHelper.createSuiteTitle( 'Jetpack Settings: Media' ), function () {
+describe.skip( DataHelper.createSuiteTitle( 'Jetpack Settings: Media' ), function () {
 	let page: Page;
 	let testAccount: TestAccount;
 

--- a/test/e2e/specs/published-content/forms__submissions.ts
+++ b/test/e2e/specs/published-content/forms__submissions.ts
@@ -32,7 +32,7 @@ declare const browser: Browser;
  *
  * Keywords: Jetpack, Forms, Feedback
  */
-describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function () {
+describe.skip( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function () {
 	const features = envToFeatureKey( envVariables );
 	const accountName = getTestAccountByFeature( features );
 	const testAccount = new TestAccount( accountName );

--- a/test/e2e/specs/search/search__jetpack-instant.ts
+++ b/test/e2e/specs/search/search__jetpack-instant.ts
@@ -24,7 +24,7 @@ declare const browser: Browser;
 	So on atomic, we're limited to validating the integtity and interactability of the search modal.
 */
 
-describe( DataHelper.createSuiteTitle( 'Jetpack Instant Search' ), function () {
+describe.skip( DataHelper.createSuiteTitle( 'Jetpack Instant Search' ), function () {
 	const searchString = DataHelper.getRandomPhrase();
 
 	let page: Page;

--- a/test/e2e/specs/stats/stats.ts
+++ b/test/e2e/specs/stats/stats.ts
@@ -22,7 +22,7 @@ declare const browser: Browser;
  *
  * Keywords: Stats, Jetpack, Odyssey Stats
  */
-describe( DataHelper.createSuiteTitle( 'Stats' ), function () {
+describe.skip( DataHelper.createSuiteTitle( 'Stats' ), function () {
 	let page: Page;
 	let testAccount: TestAccount;
 	let statsPage: StatsPage;

--- a/test/e2e/specs/tools/advertising__promote.ts
+++ b/test/e2e/specs/tools/advertising__promote.ts
@@ -17,7 +17,6 @@ import {
 	PostResponse,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
-import { skipDescribeIf } from '../../jest-helpers';
 import { TEST_IMAGE_PATH } from '../constants';
 
 declare const browser: Browser;
@@ -31,96 +30,93 @@ declare const browser: Browser;
  *
  * Keywords: Jetpack, Blaze, Advertising
  */
-skipDescribeIf( envVariables.ATOMIC_VARIATION === 'private' )(
-	DataHelper.createSuiteTitle( 'Advertising: Promote' ),
-	function () {
-		const pageTitle = DataHelper.getRandomPhrase();
-		const snippet = Array( 2 ).fill( DataHelper.getRandomPhrase() ).toString();
+describe.skip( DataHelper.createSuiteTitle( 'Advertising: Promote' ), function () {
+	const pageTitle = DataHelper.getRandomPhrase();
+	const snippet = Array( 2 ).fill( DataHelper.getRandomPhrase() ).toString();
 
-		let newPostDetails: PostResponse;
-		let page: Page;
-		let restAPIClient: RestAPIClient;
-		let testAccount: TestAccount;
-		let advertisingPage: AdvertisingPage;
-		let blazeCampaignPage: BlazeCampaignPage;
+	let newPostDetails: PostResponse;
+	let page: Page;
+	let restAPIClient: RestAPIClient;
+	let testAccount: TestAccount;
+	let advertisingPage: AdvertisingPage;
+	let blazeCampaignPage: BlazeCampaignPage;
 
-		beforeAll( async () => {
-			page = await browser.newPage();
+	beforeAll( async () => {
+		page = await browser.newPage();
 
-			const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ), [
-				{ gutenberg: 'stable', siteType: 'simple', accountName: 'defaultUser' },
-			] );
+		const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ), [
+			{ gutenberg: 'stable', siteType: 'simple', accountName: 'defaultUser' },
+		] );
 
-			testAccount = new TestAccount( accountName );
+		testAccount = new TestAccount( accountName );
 
-			restAPIClient = new RestAPIClient( testAccount.credentials );
+		restAPIClient = new RestAPIClient( testAccount.credentials );
 
-			// Createa a new test post before starting the test if site has no published post.
-			const hasPosts = await restAPIClient.siteHasPost(
+		// Createa a new test post before starting the test if site has no published post.
+		const hasPosts = await restAPIClient.siteHasPost(
+			testAccount.credentials.testSites?.primary.id as number,
+			{ state: 'publish' }
+		);
+
+		if ( ! hasPosts ) {
+			newPostDetails = await restAPIClient.createPost(
 				testAccount.credentials.testSites?.primary.id as number,
-				{ state: 'publish' }
+				{
+					title: pageTitle,
+				}
 			);
+		}
 
-			if ( ! hasPosts ) {
-				newPostDetails = await restAPIClient.createPost(
-					testAccount.credentials.testSites?.primary.id as number,
-					{
-						title: pageTitle,
-					}
-				);
-			}
+		await testAccount.authenticate( page );
 
-			await testAccount.authenticate( page );
+		advertisingPage = new AdvertisingPage( page );
+	} );
 
-			advertisingPage = new AdvertisingPage( page );
-		} );
+	it( 'Navigate to Tools > Advertising page', async function () {
+		if ( envVariables.ATOMIC_VARIATION === 'ecomm-plan' ) {
+			await advertisingPage.visit( testAccount.getSiteURL( { protocol: false } ) );
+		} else {
+			const sidebarComponent = new SidebarComponent( page );
+			await sidebarComponent.navigate( 'Tools', 'Advertising' );
+		}
+	} );
 
-		it( 'Navigate to Tools > Advertising page', async function () {
-			if ( envVariables.ATOMIC_VARIATION === 'ecomm-plan' ) {
-				await advertisingPage.visit( testAccount.getSiteURL( { protocol: false } ) );
-			} else {
-				const sidebarComponent = new SidebarComponent( page );
-				await sidebarComponent.navigate( 'Tools', 'Advertising' );
-			}
-		} );
+	it( 'Click on Promote for the first post', async function () {
+		await advertisingPage.clickButtonByNameOnRow( 'Promote', { row: 1 } );
+	} );
 
-		it( 'Click on Promote for the first post', async function () {
-			await advertisingPage.clickButtonByNameOnRow( 'Promote', { row: 1 } );
-		} );
+	it( 'Land in Blaze campaign landing page', async function () {
+		await page.waitForURL( /advertising/ );
 
-		it( 'Land in Blaze campaign landing page', async function () {
-			await page.waitForURL( /advertising/ );
+		blazeCampaignPage = new BlazeCampaignPage( page );
+	} );
 
-			blazeCampaignPage = new BlazeCampaignPage( page );
-		} );
+	it( 'Click on Get started', async function () {
+		await blazeCampaignPage.clickButton( 'Get started' );
+	} );
 
-		it( 'Click on Get started', async function () {
-			await blazeCampaignPage.clickButton( 'Get started' );
-		} );
+	it( 'Upload image', async function () {
+		const testFile = await MediaHelper.createTestFile( TEST_IMAGE_PATH );
+		await blazeCampaignPage.uploadImage( testFile );
+	} );
 
-		it( 'Upload image', async function () {
-			const testFile = await MediaHelper.createTestFile( TEST_IMAGE_PATH );
-			await blazeCampaignPage.uploadImage( testFile );
-		} );
+	it( 'Enter title and snippet', async function () {
+		await blazeCampaignPage.enterText( 'Page title', pageTitle );
+		await blazeCampaignPage.enterText( 'Ad text', snippet );
+	} );
 
-		it( 'Enter title and snippet', async function () {
-			await blazeCampaignPage.enterText( 'Page title', pageTitle );
-			await blazeCampaignPage.enterText( 'Ad text', snippet );
-		} );
+	it( 'Validate preview', async function () {
+		await blazeCampaignPage.validatePreview( { title: pageTitle, snippet: snippet } );
+	} );
 
-		it( 'Validate preview', async function () {
-			await blazeCampaignPage.validatePreview( { title: pageTitle, snippet: snippet } );
-		} );
+	afterAll( async function () {
+		if ( ! newPostDetails ) {
+			return;
+		}
 
-		afterAll( async function () {
-			if ( ! newPostDetails ) {
-				return;
-			}
-
-			await restAPIClient.deletePost(
-				testAccount.credentials.testSites?.primary.id as number,
-				newPostDetails.ID
-			);
-		} );
-	}
-);
+		await restAPIClient.deletePost(
+			testAccount.credentials.testSites?.primary.id as number,
+			newPostDetails.ID
+		);
+	} );
+} );

--- a/test/e2e/specs/tools/marketing__seo.ts
+++ b/test/e2e/specs/tools/marketing__seo.ts
@@ -24,7 +24,7 @@ declare const browser: Browser;
  *
  * Keywords: Jetpack, SEO, Traffic, Marketing.
  */
-describe( DataHelper.createSuiteTitle( 'Marketing: SEO Preview' ), function () {
+describe.skip( DataHelper.createSuiteTitle( 'Marketing: SEO Preview' ), function () {
 	const externalPreviewText = DataHelper.getRandomPhrase();
 
 	let page: Page;

--- a/test/e2e/specs/tools/social-connections__tumblr.ts
+++ b/test/e2e/specs/tools/social-connections__tumblr.ts
@@ -13,7 +13,6 @@ import {
 	SecretsManager,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
-import { skipDescribeIf } from '../../jest-helpers';
 
 declare const browser: Browser;
 
@@ -24,62 +23,57 @@ declare const browser: Browser;
  *
  * Keywords: Social Connections, Marketing, Jetpack, Tumblr, Publicize
  */
-skipDescribeIf( envVariables.ATOMIC_VARIATION === 'private' )(
-	DataHelper.createSuiteTitle( 'Social Connections: Set up Tumblr' ),
-	function () {
-		let page: Page;
-		let popup: Page;
+describe.skip( DataHelper.createSuiteTitle( 'Social Connections: Set up Tumblr' ), function () {
+	let page: Page;
+	let popup: Page;
 
-		let testAccount: TestAccount;
-		let restAPIClient: RestAPIClient;
-		let marketingPage: MarketingPage;
+	let testAccount: TestAccount;
+	let restAPIClient: RestAPIClient;
+	let marketingPage: MarketingPage;
 
-		beforeAll( async () => {
-			page = await browser.newPage();
+	beforeAll( async () => {
+		page = await browser.newPage();
 
-			const features = envToFeatureKey( envVariables );
-			const accountName = getTestAccountByFeature( features );
-			testAccount = new TestAccount( accountName );
-			await testAccount.authenticate( page );
+		const features = envToFeatureKey( envVariables );
+		const accountName = getTestAccountByFeature( features );
+		testAccount = new TestAccount( accountName );
+		await testAccount.authenticate( page );
 
-			restAPIClient = new RestAPIClient( testAccount.credentials );
+		restAPIClient = new RestAPIClient( testAccount.credentials );
 
-			// Check whether a Tumblr connection exists.
-			const connections = await restAPIClient.getAllPublicizeConnections(
-				testAccount.credentials.testSites?.primary.id as number
-			);
+		// Check whether a Tumblr connection exists.
+		const connections = await restAPIClient.getAllPublicizeConnections(
+			testAccount.credentials.testSites?.primary.id as number
+		);
 
-			// If it does, remove the connection.
-			for ( const connection of connections ) {
-				if ( connection.label === 'Tumblr' ) {
-					console.info(
-						`Removing existing connection for Tumblr for accountName ${ accountName }.`
-					);
-					await restAPIClient.deletePublicizeConnection( connection.site_ID, connection.ID );
-				}
+		// If it does, remove the connection.
+		for ( const connection of connections ) {
+			if ( connection.label === 'Tumblr' ) {
+				console.info( `Removing existing connection for Tumblr for accountName ${ accountName }.` );
+				await restAPIClient.deletePublicizeConnection( connection.site_ID, connection.ID );
 			}
+		}
 
-			marketingPage = new MarketingPage( page );
-		} );
+		marketingPage = new MarketingPage( page );
+	} );
 
-		it( 'Navigate to Tools > Marketing page', async function () {
-			await marketingPage.visit( testAccount.getSiteURL( { protocol: false } ) );
-		} );
+	it( 'Navigate to Tools > Marketing page', async function () {
+		await marketingPage.visit( testAccount.getSiteURL( { protocol: false } ) );
+	} );
 
-		it( 'Click on Connections tab', async function () {
-			await marketingPage.clickTab( 'Connections' );
-		} );
+	it( 'Click on Connections tab', async function () {
+		await marketingPage.clickTab( 'Connections' );
+	} );
 
-		it( 'Click on the "Connect" button for Tumblr', async function () {
-			popup = await marketingPage.clickSocialConnectButton( 'Tumblr' );
-		} );
+	it( 'Click on the "Connect" button for Tumblr', async function () {
+		popup = await marketingPage.clickSocialConnectButton( 'Tumblr' );
+	} );
 
-		it( 'Set up Tumblr', async function () {
-			await marketingPage.setupTumblr( popup, SecretsManager.secrets.socialAccounts.tumblr );
-		} );
+	it( 'Set up Tumblr', async function () {
+		await marketingPage.setupTumblr( popup, SecretsManager.secrets.socialAccounts.tumblr );
+	} );
 
-		it( 'Tumblr is connected', async function () {
-			await marketingPage.validateSocialConnected( 'Tumblr' );
-		} );
-	}
-);
+	it( 'Tumblr is connected', async function () {
+		await marketingPage.validateSocialConnected( 'Tumblr' );
+	} );
+} );

--- a/test/e2e/specs/tools/test__editor.ts
+++ b/test/e2e/specs/tools/test__editor.ts
@@ -32,7 +32,7 @@ describe.only( DataHelper.createSuiteTitle( 'Fake editor load' ), function () {
 		// Simple sites do not have the ability to change SEO parameters.
 		const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ) );
 		testAccount = new TestAccount( accountName );
-		await testAccount.authenticate( page );
+		await testAccount.authenticate( page, { waitUntilStable: true } );
 	} );
 
 	it( 'Navigate to the editor', async function () {

--- a/test/e2e/specs/tools/test__editor.ts
+++ b/test/e2e/specs/tools/test__editor.ts
@@ -1,0 +1,43 @@
+/**
+ * @group jetpack-wpcom-integration
+ */
+
+import {
+	getTestAccountByFeature,
+	envToFeatureKey,
+	envVariables,
+	DataHelper,
+	TestAccount,
+	EditorPage,
+} from '@automattic/calypso-e2e';
+import { Page, Browser } from 'playwright';
+
+declare const browser: Browser;
+
+/**
+ * Quick test to verify various SEO text fields and previews render.
+ *
+ * This is a feature exclusive to Business plans and higher.
+ *
+ * Keywords: Jetpack, SEO, Traffic, Marketing.
+ */
+// eslint-disable-next-line jest/no-focused-tests
+describe.only( DataHelper.createSuiteTitle( 'Marketing: SEO Preview' ), function () {
+	let page: Page;
+	let testAccount: TestAccount;
+
+	beforeAll( async () => {
+		page = await browser.newPage();
+
+		// Simple sites do not have the ability to change SEO parameters.
+		const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ) );
+		testAccount = new TestAccount( accountName );
+		await testAccount.authenticate( page );
+	} );
+
+	it( 'Navigate to the editor', async function () {
+		const editor = new EditorPage( page );
+		await editor.visit( 'post', { siteSlug: testAccount.getSiteURL( { protocol: false } ) } );
+		await editor.waitUntilLoaded();
+	} );
+} );

--- a/test/e2e/specs/tools/test__editor.ts
+++ b/test/e2e/specs/tools/test__editor.ts
@@ -32,12 +32,11 @@ describe.only( DataHelper.createSuiteTitle( 'Fake editor load' ), function () {
 		// Simple sites do not have the ability to change SEO parameters.
 		const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ) );
 		testAccount = new TestAccount( accountName );
-		await testAccount.authenticate( page, { waitUntilStable: true } );
+		await testAccount.authenticate( page );
 	} );
 
 	it( 'Navigate to the editor', async function () {
 		const editor = new EditorPage( page );
 		await editor.visit( 'post', { siteSlug: testAccount.getSiteURL( { protocol: false } ) } );
-		await editor.waitUntilLoaded();
 	} );
 } );

--- a/test/e2e/specs/tools/test__editor.ts
+++ b/test/e2e/specs/tools/test__editor.ts
@@ -22,7 +22,7 @@ declare const browser: Browser;
  * Keywords: Jetpack, SEO, Traffic, Marketing.
  */
 // eslint-disable-next-line jest/no-focused-tests
-describe.only( DataHelper.createSuiteTitle( 'Marketing: SEO Preview' ), function () {
+describe.only( DataHelper.createSuiteTitle( 'Fake editor load' ), function () {
 	let page: Page;
 	let testAccount: TestAccount;
 

--- a/test/e2e/specs/tools/test__wp-admin.ts
+++ b/test/e2e/specs/tools/test__wp-admin.ts
@@ -31,7 +31,7 @@ describe.only( DataHelper.createSuiteTitle( 'Fake wp-admin load' ), function () 
 		// Simple sites do not have the ability to change SEO parameters.
 		const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ) );
 		testAccount = new TestAccount( accountName );
-		await testAccount.authenticate( page );
+		await testAccount.authenticate( page, { waitUntilStable: true } );
 	} );
 
 	it( 'Navigate to wp-admin', async function () {

--- a/test/e2e/specs/tools/test__wp-admin.ts
+++ b/test/e2e/specs/tools/test__wp-admin.ts
@@ -1,0 +1,42 @@
+/**
+ * @group jetpack-wpcom-integration
+ */
+
+import {
+	getTestAccountByFeature,
+	envToFeatureKey,
+	envVariables,
+	DataHelper,
+	TestAccount,
+} from '@automattic/calypso-e2e';
+import { Page, Browser } from 'playwright';
+
+declare const browser: Browser;
+
+/**
+ * Quick test to verify various SEO text fields and previews render.
+ *
+ * This is a feature exclusive to Business plans and higher.
+ *
+ * Keywords: Jetpack, SEO, Traffic, Marketing.
+ */
+// eslint-disable-next-line jest/no-focused-tests
+describe.only( DataHelper.createSuiteTitle( 'Marketing: SEO Preview' ), function () {
+	let page: Page;
+	let testAccount: TestAccount;
+
+	beforeAll( async () => {
+		page = await browser.newPage();
+
+		// Simple sites do not have the ability to change SEO parameters.
+		const accountName = getTestAccountByFeature( envToFeatureKey( envVariables ) );
+		testAccount = new TestAccount( accountName );
+		await testAccount.authenticate( page );
+	} );
+
+	it( 'Navigate to wp-admin', async function () {
+		const url = new URL( 'wp-admin', testAccount.getSiteURL( { protocol: true } ) ).href;
+		await page.goto( url, { timeout: 20 * 1000 } );
+		await page.getByRole( 'heading', { name: 'Dashboard' } ).waitFor( { timeout: 20 * 1000 } );
+	} );
+} );

--- a/test/e2e/specs/tools/test__wp-admin.ts
+++ b/test/e2e/specs/tools/test__wp-admin.ts
@@ -21,7 +21,7 @@ declare const browser: Browser;
  * Keywords: Jetpack, SEO, Traffic, Marketing.
  */
 // eslint-disable-next-line jest/no-focused-tests
-describe.only( DataHelper.createSuiteTitle( 'Marketing: SEO Preview' ), function () {
+describe.only( DataHelper.createSuiteTitle( 'Fake wp-admin load' ), function () {
 	let page: Page;
 	let testAccount: TestAccount;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
