### PR TITLE
Launchpad: Add event handlers to the setup actions function

### DIFF
--- a/client/my-sites/customer-home/cards/launchpad/index.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/index.tsx
@@ -5,12 +5,7 @@ import {
 	sortLaunchpadTasksByCompletionStatus,
 	LaunchpadNavigator,
 } from '@automattic/data-stores';
-import {
-	Launchpad,
-	Task,
-	setUpActionsForTasks,
-	ShareSiteModal,
-} from '@automattic/launchpad';
+import { Launchpad, Task, setUpActionsForTasks, ShareSiteModal } from '@automattic/launchpad';
 import { select, useDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';

--- a/client/my-sites/customer-home/cards/launchpad/index.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/index.tsx
@@ -7,7 +7,6 @@ import {
 } from '@automattic/data-stores';
 import {
 	Launchpad,
-	PermittedActions,
 	Task,
 	setUpActionsForTasks,
 	ShareSiteModal,
@@ -26,12 +25,12 @@ import './style.scss';
 
 interface CustomerHomeLaunchpadProps {
 	checklistSlug: string;
-	extraActions?: Omit< PermittedActions, 'setActiveChecklist' >;
+	onSiteLaunched?: () => void;
 }
 
 const CustomerHomeLaunchpad = ( {
 	checklistSlug,
-	extraActions = {},
+	onSiteLaunched,
 }: CustomerHomeLaunchpadProps ): JSX.Element => {
 	const launchpadContext = 'customer-home';
 	const siteId = useSelector( getSelectedSiteId );
@@ -63,7 +62,6 @@ const CustomerHomeLaunchpad = ( {
 
 	const defaultExtraActions = {
 		...( hasShareSiteTask ? { setShareSiteModalIsOpen } : {} ),
-		...extraActions,
 		setActiveChecklist,
 	};
 
@@ -82,6 +80,9 @@ const CustomerHomeLaunchpad = ( {
 			siteSlug,
 			tracksData,
 			extraActions: defaultExtraActions,
+			eventHandlers: {
+				onSiteLaunched,
+			},
 		} );
 	};
 

--- a/client/my-sites/customer-home/cards/launchpad/pre-launch.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/pre-launch.tsx
@@ -34,13 +34,13 @@ const LaunchpadPreLaunch = (): JSX.Element => {
 		}
 	};
 
-	const siteLaunched = () => {
+	const onSiteLaunched = () => {
 		setCelebrateLaunchModalIsOpenWrapper( true );
 	};
 
 	return (
 		<>
-			<CustomerHomeLaunchpad checklistSlug={ checklistSlug } extraActions={ { siteLaunched } } />
+			<CustomerHomeLaunchpad checklistSlug={ checklistSlug } onSiteLaunched={ onSiteLaunched } />
 			{ celebrateLaunchModalIsOpen && (
 				<CelebrateLaunchModal
 					setModalIsOpen={ setCelebrateLaunchModalIsOpenWrapper }

--- a/packages/launchpad/src/default-wired-launchpad.tsx
+++ b/packages/launchpad/src/default-wired-launchpad.tsx
@@ -14,12 +14,14 @@ type DefaultWiredLaunchpadProps = {
 	siteSlug: string | null;
 	checklistSlug: string;
 	launchpadContext: string;
+	onSiteLaunched?: () => void;
 };
 
 const DefaultWiredLaunchpad = ( {
 	siteSlug,
 	checklistSlug,
 	launchpadContext,
+	onSiteLaunched,
 }: DefaultWiredLaunchpadProps ) => {
 	const {
 		data: { checklist },
@@ -71,6 +73,9 @@ const DefaultWiredLaunchpad = ( {
 			tracksData,
 			extraActions: {
 				setActiveChecklist,
+			},
+			eventHandlers: {
+				onSiteLaunched,
 			},
 		} );
 	};

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -19,10 +19,12 @@ export const setUpActionsForTasks = ( {
 	tasks,
 	tracksData,
 	extraActions,
+	eventHandlers,
 	uiContext = 'calypso',
 }: LaunchpadTaskActionsProps ): Task[] => {
 	const { recordTracksEvent, checklistSlug, tasklistCompleted, launchpadContext } = tracksData;
 	const { setShareSiteModalIsOpen, siteLaunched, setActiveChecklist } = extraActions;
+	const { onSiteLaunched } = eventHandlers || {};
 
 	//Record click events for tasks
 	const recordTaskClickTracksEvent = ( task: Task ) => {
@@ -125,7 +127,13 @@ export const setUpActionsForTasks = ( {
 							apiVersion: '1.1',
 							method: 'post',
 						} );
-						siteLaunched?.();
+						// TODO: Remove this check once we migrate the siteLaunched event
+						// to the new event handler
+						if ( onSiteLaunched ) {
+							onSiteLaunched();
+						} else {
+							siteLaunched?.();
+						}
 					};
 					useCalypsoPath = false;
 					break;

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -23,7 +23,7 @@ export const setUpActionsForTasks = ( {
 	uiContext = 'calypso',
 }: LaunchpadTaskActionsProps ): Task[] => {
 	const { recordTracksEvent, checklistSlug, tasklistCompleted, launchpadContext } = tracksData;
-	const { setShareSiteModalIsOpen, siteLaunched, setActiveChecklist } = extraActions;
+	const { setShareSiteModalIsOpen, setActiveChecklist } = extraActions;
 	const { onSiteLaunched } = eventHandlers || {};
 
 	//Record click events for tasks
@@ -127,13 +127,7 @@ export const setUpActionsForTasks = ( {
 							apiVersion: '1.1',
 							method: 'post',
 						} );
-						// TODO: Remove this check once we migrate the siteLaunched event
-						// to the new event handler
-						if ( onSiteLaunched ) {
-							onSiteLaunched();
-						} else {
-							siteLaunched?.();
-						}
+						onSiteLaunched?.();
 					};
 					useCalypsoPath = false;
 					break;

--- a/packages/launchpad/src/types.ts
+++ b/packages/launchpad/src/types.ts
@@ -62,10 +62,15 @@ export interface PermittedActions {
 	setActiveChecklist: ( siteSlug: string, activeChecklistSlug: string ) => void;
 }
 
+export type EventHandlers = {
+	onSiteLaunched?: () => void;
+};
+
 export interface LaunchpadTaskActionsProps {
 	siteSlug: string | null;
 	tasks: Task[];
 	tracksData: LaunchpadTracksData;
 	extraActions: PermittedActions;
 	uiContext?: 'calypso';
+	eventHandlers?: EventHandlers;
 }

--- a/packages/launchpad/src/types.ts
+++ b/packages/launchpad/src/types.ts
@@ -58,7 +58,6 @@ export interface LaunchpadResponse {
 
 export interface PermittedActions {
 	setShareSiteModalIsOpen?: ( isOpen: boolean ) => void;
-	siteLaunched?: () => void;
 	setActiveChecklist: ( siteSlug: string, activeChecklistSlug: string ) => void;
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Adds a new property to the `setupAction` function to lie the event handles. This will initially be used to receive the `onSiteLaunched` event, which should be fired when a launch task is completed.
* Refactor the pre-launch Launchpad to use the new `onSiteLaunched` event. I also removed the `extraActions` support on the `CustomerHomeLaunchpad` component. Instead, the component should receive the `onSiteLaunched` prop.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso Live link to test or apply this PR to your local environment
* Create a site with the Build intent
* Go through the flow until you reach the Fullscreen Launchpad
* Skip the Fullscreen Launchpad
* You should be redirected to the Customer Home
* Click on "Launch your site" task to launch your site
* Ensure that the celebration modal is shown

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?