### PR TITLE
Jetpack Cloud: Add profile dropdown menu to new sidebar

### DIFF
--- a/client/jetpack-cloud/components/sidebar/header/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/header/index.tsx
@@ -6,6 +6,7 @@ import Site from 'calypso/blocks/site';
 import { setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import JetpackLogo from './jetpack-logo.svg';
+import ProfileDropdown from './profile-dropdown';
 
 type Props = {
 	forceAllSitesView?: boolean;
@@ -46,6 +47,7 @@ const Header = ( { forceAllSitesView = false }: Props ) => {
 					onSelect={ onSelectSite }
 				/>
 			) }
+			<ProfileDropdown />
 		</div>
 	);
 };

--- a/client/jetpack-cloud/components/sidebar/header/profile-dropdown.tsx
+++ b/client/jetpack-cloud/components/sidebar/header/profile-dropdown.tsx
@@ -1,0 +1,95 @@
+import { Gravatar } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useRef, useState } from 'react';
+import { useDispatch, useSelector } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
+import { redirectToLogout } from 'calypso/state/current-user/actions';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import useOutsideClickCallback from './use-outside-click-callback';
+import './style.scss';
+
+type DropdownMenuProps = {
+	isExpanded: boolean;
+};
+const DropdownMenu = ( { isExpanded }: DropdownMenuProps ) => {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+
+	const onGetHelp = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_jetpack_sidebar_gethelp' ) );
+	}, [ dispatch ] );
+	const onSignOut = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_jetpack_sidebar_signout' ) );
+		dispatch( redirectToLogout() );
+	}, [ dispatch ] );
+
+	return (
+		<ul className="jetpack-cloud-sidebar__profile-dropdown-menu" hidden={ ! isExpanded }>
+			<li className="jetpack-cloud-sidebar__profile-dropdown-menu-item">
+				<a
+					href="https://jetpack.com/support"
+					rel="noreferrer"
+					target="_blank"
+					onClick={ onGetHelp }
+				>
+					{ translate( 'Get help' ) }
+				</a>
+			</li>
+			<li className="jetpack-cloud-sidebar__profile-dropdown-menu-item">
+				<button onClick={ onSignOut }>{ translate( 'Sign out' ) }</button>
+			</li>
+		</ul>
+	);
+};
+
+const ProfileDropdown = () => {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+	const user = useSelector( getCurrentUser );
+
+	const [ isMenuExpanded, setMenuExpanded ] = useState( false );
+	const onToggleMenu = useCallback( () => {
+		setMenuExpanded( ( current ) => ! current );
+		dispatch( recordTracksEvent( 'calypso_jetpack_sidebar_profile_toggle' ) );
+	}, [ dispatch ] );
+	const onCloseMenu = useCallback( () => {
+		if ( ! isMenuExpanded ) {
+			return;
+		}
+
+		setMenuExpanded( false );
+		dispatch( recordTracksEvent( 'calypso_jetpack_sidebar_profile_close' ) );
+	}, [ dispatch, isMenuExpanded ] );
+
+	const dropdownRef = useRef( null );
+	useOutsideClickCallback( dropdownRef, onCloseMenu );
+
+	return (
+		<nav
+			ref={ dropdownRef }
+			className="jetpack-cloud-sidebar__profile-dropdown"
+			aria-label={
+				translate( 'User menu', {
+					comment: 'Label used to differentiate navigation landmarks in screen readers',
+				} ) as string
+			}
+		>
+			<button
+				className="jetpack-cloud-sidebar__profile-dropdown-button"
+				onClick={ onToggleMenu }
+				aria-expanded={ isMenuExpanded }
+				aria-controls="menu-list"
+			>
+				<Gravatar
+					className="jetpack-cloud-sidebar__profile-dropdown-button-icon"
+					user={ user }
+					size={ 32 }
+					alt={ translate( 'My Profile', { textOnly: true } ) }
+				/>
+			</button>
+			<DropdownMenu isExpanded={ isMenuExpanded } />
+		</nav>
+	);
+};
+
+export default ProfileDropdown;

--- a/client/jetpack-cloud/components/sidebar/header/profile-dropdown.tsx
+++ b/client/jetpack-cloud/components/sidebar/header/profile-dropdown.tsx
@@ -1,4 +1,4 @@
-import { Gravatar } from '@automattic/components';
+import { Button, Gravatar } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'calypso/state';
@@ -27,17 +27,20 @@ const DropdownMenu = ( { isExpanded }: DropdownMenuProps ) => {
 	return (
 		<ul className="jetpack-cloud-sidebar__profile-dropdown-menu" hidden={ ! isExpanded }>
 			<li className="jetpack-cloud-sidebar__profile-dropdown-menu-item">
-				<a
+				<Button
+					borderless
 					href="https://jetpack.com/support"
 					rel="noreferrer"
 					target="_blank"
 					onClick={ onGetHelp }
 				>
 					{ translate( 'Get help' ) }
-				</a>
+				</Button>
 			</li>
 			<li className="jetpack-cloud-sidebar__profile-dropdown-menu-item">
-				<button onClick={ onSignOut }>{ translate( 'Sign out' ) }</button>
+				<Button borderless onClick={ onSignOut }>
+					{ translate( 'Sign out' ) }
+				</Button>
 			</li>
 		</ul>
 	);
@@ -75,7 +78,8 @@ const ProfileDropdown = () => {
 				} ) as string
 			}
 		>
-			<button
+			<Button
+				borderless
 				className="jetpack-cloud-sidebar__profile-dropdown-button"
 				onClick={ onToggleMenu }
 				aria-expanded={ isMenuExpanded }
@@ -87,7 +91,7 @@ const ProfileDropdown = () => {
 					size={ 32 }
 					alt={ translate( 'My Profile', { textOnly: true } ) }
 				/>
-			</button>
+			</Button>
 			<DropdownMenu isExpanded={ isMenuExpanded } />
 		</nav>
 	);

--- a/client/jetpack-cloud/components/sidebar/header/profile-dropdown.tsx
+++ b/client/jetpack-cloud/components/sidebar/header/profile-dropdown.tsx
@@ -6,6 +6,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import { redirectToLogout } from 'calypso/state/current-user/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import useOutsideClickCallback from './use-outside-click-callback';
+
 import './style.scss';
 
 type DropdownMenuProps = {

--- a/client/jetpack-cloud/components/sidebar/header/style.scss
+++ b/client/jetpack-cloud/components/sidebar/header/style.scss
@@ -1,0 +1,79 @@
+// Rules in this file inspired by:
+// client/components/jetpack/profile-dropdown/style.scss
+
+.jetpack-cloud-sidebar__profile-dropdown {
+	position: relative;
+}
+
+.jetpack-cloud-sidebar__profile-dropdown-button {
+	position: relative;
+	z-index: 1;
+
+	display: flex;
+	justify-content: center;
+	align-items: center;
+
+	height: 100%;
+
+	cursor: pointer;
+}
+
+html.accessible-focus .jetpack-cloud-sidebar__profile-dropdown-button:focus {
+	box-shadow: inset 0 0 0 2px var(--color-primary-light);
+}
+
+.jetpack-cloud-sidebar__profile-dropdown-menu {
+	// Required for older browsers
+	&[hidden] {
+		display: none;
+	}
+
+	position: absolute;
+	// 4px below the bottom of the icon
+	top: calc(100% + 4px);
+
+	// The menu should render "on top" of the profile picture
+	z-index: 1;
+
+	width: 220px;
+	margin: 0;
+	padding: 8px;
+
+	background: var(--color-surface);
+	border: 1px solid var(--studio-gray-0);
+	border-radius: 2px;
+	box-shadow:
+		0 4px 6px rgba(var(--studio-gray-100-rgb), 0.1),
+		0 1px 2px rgba(var(--studio-gray-100-rgb), 0.1);
+	list-style-type: none;
+
+	font-size: $font-body-small;
+}
+
+.jetpack-cloud-sidebar__profile-dropdown-menu-item {
+	padding: 8px;
+	border-radius: 4px;
+
+	&:hover,
+	&:focus {
+		background: var(--color-sidebar-menu-hover-background);
+	}
+
+	a,
+	a:visited,
+	a:hover,
+	a:focus {
+		display: block;
+		width: 100%;
+		height: 100%;
+
+		color: var(--color-text);
+	}
+
+	button {
+		width: 100%;
+		height: 100%;
+		text-align: start;
+		cursor: pointer;
+	}
+}

--- a/client/jetpack-cloud/components/sidebar/header/style.scss
+++ b/client/jetpack-cloud/components/sidebar/header/style.scss
@@ -32,6 +32,13 @@ html.accessible-focus .jetpack-cloud-sidebar__profile-dropdown-button:focus {
 	// 4px below the bottom of the icon
 	top: calc(100% + 4px);
 
+	// Float the dropdown to the left on small screens,
+	// and to the right on larger screens
+	right: 0;
+	@include breakpoint-deprecated( ">660px" ) {
+		right: initial;
+	}
+
 	// The menu should render "on top" of the profile picture
 	z-index: 1;
 
@@ -70,10 +77,10 @@ html.accessible-focus .jetpack-cloud-sidebar__profile-dropdown-button:focus {
 		color: var(--color-text);
 	}
 
-	button {
+	.button {
 		width: 100%;
 		height: 100%;
 		text-align: start;
-		cursor: pointer;
+		// cursor: pointer;
 	}
 }

--- a/client/jetpack-cloud/components/sidebar/header/style.scss
+++ b/client/jetpack-cloud/components/sidebar/header/style.scss
@@ -81,6 +81,5 @@ html.accessible-focus .jetpack-cloud-sidebar__profile-dropdown-button:focus {
 		width: 100%;
 		height: 100%;
 		text-align: start;
-		// cursor: pointer;
 	}
 }

--- a/client/jetpack-cloud/components/sidebar/header/use-outside-click-callback.ts
+++ b/client/jetpack-cloud/components/sidebar/header/use-outside-click-callback.ts
@@ -1,0 +1,42 @@
+import { useCallback, useEffect } from 'react';
+import * as React from 'react';
+
+/**
+ * Hook that executes `callback` is the 'Escape' key is pressed
+ * or if the user clicks outside of `ref`.
+ *
+ * @param ref       Ref to an HTML element
+ * @param callback  Function to be executed
+ */
+export default function useOutsideClickCallback(
+	ref: React.MutableRefObject< null | HTMLElement >,
+	callback: () => void
+): void {
+	const handleEscape = useCallback(
+		( event: KeyboardEvent ) => {
+			if ( event.key === 'Escape' ) {
+				callback();
+			}
+		},
+		[ callback ]
+	);
+
+	const handleClick = useCallback(
+		( { target }: MouseEvent ) => {
+			if ( ref.current && ! ref.current.contains( target as Node ) ) {
+				callback();
+			}
+		},
+		[ ref, callback ]
+	);
+
+	useEffect( () => {
+		document.addEventListener( 'keydown', handleEscape );
+		document.addEventListener( 'click', handleClick );
+
+		return () => {
+			document.removeEventListener( 'keydown', handleEscape );
+			document.removeEventListener( 'click', handleClick );
+		};
+	}, [ handleClick, handleEscape ] );
+}

--- a/client/jetpack-cloud/components/sidebar/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/index.tsx
@@ -10,23 +10,28 @@ import './style.scss';
 type Props = {
 	className?: string;
 	isJetpackManage?: boolean;
+	navItems?: React.ReactNode[];
+	footer?: React.ReactNode;
 };
-const Sidebar = ( { className, isJetpackManage = false }: Props ) => (
+const Sidebar = ( { className, isJetpackManage = false, navItems = [], footer }: Props ) => (
 	<nav className={ classNames( 'jetpack-cloud-sidebar', className ) }>
 		<Header forceAllSitesView={ isJetpackManage } />
 		<div className="jetpack-cloud-sidebar__main">
-			<ul role="menu" className="jetpack-cloud-sidebar__navigation-list">
-				<li
-					className={ classNames(
-						'jetpack-cloud-sidebar__navigation-item',
-						'jetpack-cloud-sidebar__navigation-item--highlighted'
-					) }
-				>
-					Navigation items
-				</li>
-				<li className="jetpack-cloud-sidebar__navigation-item">Will go here</li>
+			<ul className="jetpack-cloud-sidebar__navigation-list">
+				{ navItems.map( ( item, index ) => (
+					<li
+						key={ index }
+						className={ classNames(
+							'jetpack-cloud-sidebar__navigation-item',
+							'jetpack-cloud-sidebar__navigation-item--highlighted'
+						) }
+					>
+						{ item }
+					</li>
+				) ) }
 			</ul>
 		</div>
+		{ footer && <div className="jetpack-cloud-sidebar__footer">{ footer }</div> }
 
 		<SiteSelector
 			showAddNewSite

--- a/client/jetpack-cloud/components/sidebar/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/index.tsx
@@ -10,28 +10,23 @@ import './style.scss';
 type Props = {
 	className?: string;
 	isJetpackManage?: boolean;
-	navItems?: React.ReactNode[];
-	footer?: React.ReactNode;
 };
-const Sidebar = ( { className, isJetpackManage = false, navItems = [], footer }: Props ) => (
+const Sidebar = ( { className, isJetpackManage = false }: Props ) => (
 	<nav className={ classNames( 'jetpack-cloud-sidebar', className ) }>
 		<Header forceAllSitesView={ isJetpackManage } />
 		<div className="jetpack-cloud-sidebar__main">
 			<ul className="jetpack-cloud-sidebar__navigation-list">
-				{ navItems.map( ( item, index ) => (
-					<li
-						key={ index }
-						className={ classNames(
-							'jetpack-cloud-sidebar__navigation-item',
-							'jetpack-cloud-sidebar__navigation-item--highlighted'
-						) }
-					>
-						{ item }
-					</li>
-				) ) }
+				<li
+					className={ classNames(
+						'jetpack-cloud-sidebar__navigation-item',
+						'jetpack-cloud-sidebar__navigation-item--highlighted'
+					) }
+				>
+					Navigation items
+				</li>
+				<li className="jetpack-cloud-sidebar__navigation-item">Will go here</li>
 			</ul>
 		</div>
-		{ footer && <div className="jetpack-cloud-sidebar__footer">{ footer }</div> }
 
 		<SiteSelector
 			showAddNewSite

--- a/client/jetpack-cloud/sections/sidebar-navigation/jetpack-manage.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/jetpack-manage.tsx
@@ -4,6 +4,6 @@ import NewSidebar from 'calypso/jetpack-cloud/components/sidebar';
 // navigate around Jetpack Cloud with no specific site selected.
 // It'll display menu options like Sites Management, Plugin Management,
 // and Purchases.
-const JetpackManageSidebar = () => <NewSidebar isJetpackManage />;
+const JetpackManageSidebar = () => <NewSidebar isJetpackManage items={ [] } footer={ [] } />;
 
 export default JetpackManageSidebar;

--- a/client/jetpack-cloud/sections/sidebar-navigation/jetpack-manage.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/jetpack-manage.tsx
@@ -4,6 +4,6 @@ import NewSidebar from 'calypso/jetpack-cloud/components/sidebar';
 // navigate around Jetpack Cloud with no specific site selected.
 // It'll display menu options like Sites Management, Plugin Management,
 // and Purchases.
-const JetpackManageSidebar = () => <NewSidebar isJetpackManage items={ [] } footer={ [] } />;
+const JetpackManageSidebar = () => <NewSidebar isJetpackManage />;
 
 export default JetpackManageSidebar;

--- a/client/jetpack-cloud/style.scss
+++ b/client/jetpack-cloud/style.scss
@@ -42,6 +42,9 @@
 .theme-jetpack-cloud .is-jetpack-new-navigation .layout__secondary {
 	border-right: initial;
 
+	// Allow visible overflow, so the profile dropdown menu can be displayed
+	overflow: initial;
+
 	// Make the selected-site navigation full-height
 	.my-sites__navigation {
 		height: 100%;


### PR DESCRIPTION
This PR adds a profile dropdown control to the new navigation sidebar, with menu options to *Get help* or *Sign out*. The button to activate the dropdown menu is the current user's profile image.

Resolves https://github.com/Automattic/jetpack-genesis/issues/36.
Depends on #82881.

## Proposed Changes

* Create a new component `ProfileDropdown`, and add it to the new sidebar's `Header` component.
* Add styling to match the prototype shown in `Ra0o7IPph3bCS2xUCnAusZ-fi-4361%3A51432`.

## Testing Instructions

* Visit your Jetpack Cloud test environment and enable the required feature flag by adding `?flags=jetpack/new-navigation` to your browser's query string.
* Verify that in the sidebar, you see the correct Gravatar for your logged-in account.
* Click the Gravatar and verify a menu is displayed with two options: *Get help*, followed by *Sign out*. Hovering over either option should highlight it.
* Click the *Get help* button, and verify you're directed to Jetpack's support page in a new tab.
* Click the *Sign out* button, and verify you're logged out and sent to jetpack.com.

https://github.com/Automattic/wp-calypso/assets/670067/553408fe-36a5-4603-ae47-9b8384324db9