### PR TITLE
Domain Suggestions: Align buttons for featured and not featured domains

### DIFF
--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -421,7 +421,7 @@ body.is-section-signup.is-white-signup {
 			padding: 16px 20px;
 
 			@include break-mobile {
-				padding: 16px 5px;
+				padding: 16px 24px;
 			}
 
 			.domain-registration-suggestion__domain-title {


### PR DESCRIPTION

Related to https://github.com/Automattic/dotcom-forge/issues/4109

## Proposed Changes

Align domains suggestions CTA for featured and not featured domains.


| Before | After |
| --- | --- |
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/7a0ce038-0158-41ac-99a9-ecf0a4556de8) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/e2037ff8-86df-496f-aa8b-548ef5947426) |

## Testing Instructions

* Go to `/start/domains`
* Check the alignment of the buttons
