### PR TITLE
Create a new split e2e testing approach for Jetpack on Atomic, and scale back parallelization

### DIFF
--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -305,6 +305,10 @@ fun jetpackAtomicDeploymentE2eBuildType( targetDevice: String, buildUuid: String
 			param("env.VIEWPORT_NAME", "$targetDevice")
 			param("env.JETPACK_TARGET", "wpcom-deployment")
 			param("env.TEST_ON_ATOMIC", "true")
+			// We run all the tests on all variations, and go through each variation sequentially.
+			// We can easily overwhlem the target Atomic site under test if we have too much parallelization.
+			// This number of works plays nicely with the expected load handling on these Atomic sites.
+			param("JEST_E2E_WORKERS", "5")
 		}
 
 		steps {
@@ -355,6 +359,10 @@ fun jetpackAtomicBuildSmokeE2eBuildType( targetDevice: String, buildUuid: String
 			param("env.JETPACK_TARGET", "wpcom-deployment")
 			param("env.TEST_ON_ATOMIC", "true")
 			param("env.ATOMIC_VARIATION", "mixed")
+			// We need to be careful of overwhelming the Atomic sites under test.
+			// The mixing of Atomic variations happens per-worker.
+			// There are currently 7 variations. So let's do 2 workers per variation for 14 workers total.
+			param("JEST_E2E_WORKERS", "14")
 		}
 
 		steps {

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -308,6 +308,7 @@ fun jetpackAtomicDeploymentE2eBuildType( targetDevice: String, buildUuid: String
 			// We run all the tests on all variations, and go through each variation sequentially.
 			// We can easily overwhlem the target Atomic site under test if we have too much parallelization.
 			// This number of works plays nicely with the expected load handling on these Atomic sites.
+			// See: pMz3w-ix0-p2
 			param("JEST_E2E_WORKERS", "8")
 		}
 

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -308,7 +308,7 @@ fun jetpackAtomicDeploymentE2eBuildType( targetDevice: String, buildUuid: String
 			// We run all the tests on all variations, and go through each variation sequentially.
 			// We can easily overwhlem the target Atomic site under test if we have too much parallelization.
 			// This number of works plays nicely with the expected load handling on these Atomic sites.
-			param("JEST_E2E_WORKERS", "5")
+			param("JEST_E2E_WORKERS", "8")
 		}
 
 		steps {

--- a/packages/calypso-e2e/src/types/env-variables.types.ts
+++ b/packages/calypso-e2e/src/types/env-variables.types.ts
@@ -15,7 +15,8 @@ export type AtomicVariation =
 	| 'wp-beta'
 	| 'wp-previous'
 	| 'private'
-	| 'ecomm-plan';
+	| 'ecomm-plan'
+	| 'mixed';
 
 export interface SupportedEnvVariables extends EnvVariables {
 	VIEWPORT_NAME: ViewportName;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes
Context: p1696837958442599-slack-CDLH4C1UZ and #82076 

Right now, we are running every test on every Atomic variation for every new Jetpack build. That's a bit much! It's way too much haha...

It's still useful to smoke test a Jetpack build on Atomic sites as soon as it's made, because it helps us catch breakages earlier. But since we will run the full set of suite on every atomic variation right before the full WPCOM deployment, we can scale back the smoke testing.

This introduces a `mixed` value for `ATOMIC_VARIATION`. In this setting, we run every test in the Jetpack Atomic suite only once, and we mix up the Atomic variation as we do. It's not true randomization, but rather a combination of the current hour and the Jest worker ID. This allows for variation throughout the day, but keeps the variation among the tests _within_ a single TeamCity run more even than just true randomness.

It also makes a new TeamCity build for this build smoke testing.

Finally, this also seemed like the right place to scale back our parallelization as per: pMz3w-ix0-p2

Here's what I settled on:
- For the big pre-deployment run, I set it at 8. This will still generate a lot of traffic for the Atomic sites, but it's not outlandish. I think this number is a good balance of overall speed and flakiness. We have to avoid hitting the 20 minute timeout!
- For the multi-times daily smoke test, I set it at 14. There are 7 variations, so this effectively means mean 2 concurrent threads per variation. I realize this is pretty conservative, but with how often this runs, we can really make a lot of noise, so I think this is worth playing conservative. 

With that, this also closes #82840 

## Testing Instructions

Can't test the TeamCity build until merge. But, you can run this locally and effectively see the variation:
`JETPACK_TARGET='wpcom-deployment' TEST_ON_ATOMIC=true ATOMIC_VARIATION=mixed yarn jest --group='jetpack-wpcom-integration' --maxWorkers=(something more than 7)`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?