### PR TITLE
Add VCS trigger for combined app builds

### DIFF
--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -147,6 +147,10 @@ object CalypsoApps: BuildType({
 				set -x
 				apps=""
 				for dir in ./apps/*/; do
+					# Only include apps which define the "teamcity:build-app" script.
+					if [ "$(cat ${'$'}dir/package.json | jq -r '.scripts["teamcity:build-app"]')" = "null" ] ; then
+						continue
+					fi
 					apps+="${'$'}(cat ${'$'}dir/package.json | jq -r '.name'),"
 				done
 

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -76,6 +76,7 @@ object CalypsoApps: BuildType({
 
 	// Incremented to 4 to make sure ETK updates continue to work:
 	params { param("build.prefix", "4") }
+	buildNumberPattern = "%build.prefix%.%build.counter%"
 	features {
 		perfmon {
 		}

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -11,6 +11,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.perfmon
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.PullRequests
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.pullRequests
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.commitStatusPublisher
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 
 object WPComPlugins : Project({
 	id("WPComPlugins")

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -98,6 +98,21 @@ object CalypsoApps: BuildType({
 		}
 	}
 
+	triggers {
+		vcs {
+			branchFilter = """
+				+:*
+				-:pull*
+			""".trimIndent()
+			triggerRules = """
+				-:test/e2e/**
+				-:docs/**.md
+				-:comment=stress test:**
+				-:packages/calypso-e2e/**
+			""".trimIndent()
+		}
+	}
+
 	vcs {
 		root(Settings.WpCalypso)
 		cleanCheckout = true

--- a/bin/process-calypso-app-artifacts.mjs
+++ b/bin/process-calypso-app-artifacts.mjs
@@ -14,7 +14,9 @@ const IS_DEFAULT_BRANCH = process.env.is_default_branch === 'true';
 const dirname = fileURLToPath( new URL( '.', import.meta.url ) );
 const appRoot = path.resolve( dirname, '../apps' );
 
-// Most apps don't need extra config, but some do.
+// Most apps don't need extra config, but some do. To enable slack notifications
+// when a trunk build changes an app, set "slackNotify: true" for the app which
+// requires it.
 const APP_CONFIG = {
 	'editing-toolkit': {
 		artifactDir: path.resolve( appRoot, 'editing-toolkit/editing-toolkit-plugin' ),
@@ -24,7 +26,6 @@ const APP_CONFIG = {
 	},
 	'happy-blocks': {
 		artifactDir: path.resolve( appRoot, 'happy-blocks/release-files' ),
-		slackNotify: true,
 	},
 };
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #81571 

## Proposed Changes
- Add VCS trigger for new combined app build
- Update app build logic to only build apps that define the "teamcity:build-app" script. It's a good safeguard for the future, even if it doesn't impact anything today :)
- Fix build number format, so that it increments from 4. (This is required because ETK is currently on 3.x. Since x is now a high number, we need to jump to 4.x so that WordPress considers it a newer version.)

## Testing Instructions
Run the https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WPComPlugins_Build_Plugins build for this branch and verify it works as expected.
