### PR TITLE
Start with theme: redirect partners themes to the Thank You page with onboarding flag

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -601,7 +601,11 @@ async function addExternalManagedThemeToCart( state, dispatch, themeId, siteSlug
 		.forCartKey( cartKey )
 		.actions.addProductsToCart( cartItems )
 		.then( () => {
-			page( `/checkout/${ siteSlug }` );
+			page(
+				`/checkout/${ siteSlug }?redirect_to=${ encodeURIComponent(
+					`/marketplace/thank-you/${ siteSlug }?themes=${ themeId }&onboarding`
+				) }`
+			);
 		} )
 		.finally( () => {
 			dispatch( setIsLoadingCart( false ) );


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/82837

## Proposed Changes

Update the `with-theme` start flow to redirect Partner Themes to the Thank You page with the `onboarding` flag.
Currently, this flag allows the user to activate the theme without showing a Home replacement warning.

## Testing Instructions

**Prod**

* Go to `/start/with-theme?ref=calypshowcase&theme=:theme_id&theme_type=marketplace`. For `:theme_id`, any Marketplace theme can be used as `olsen-fse` and `beleco`.
* Go through the flow by selecting a domain and a Business or higher plan
* You should land on the Checkout page
* Complete the purchase and you should land the Congrats page
* Activate the theme and a Home Replacement warning should be displayed

**This branch**

* Go to `/start/with-theme?ref=calypshowcase&theme=:theme_id&theme_type=marketplace`. For `:theme_id`, any Marketplace theme can be used as `olsen-fse` and `beleco`.
* Go through the flow by selecting a domain and a Business or higher plan
* You should be redirected to the Checkout with a `redirect_to` parameter in the end that will contain the keyword `onboarding`
* Complete the purchase and you should land the Congrats page
* Activate the theme, and no Home Replacement warning should be displayed

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
