### PR TITLE
Stats: Move date picker into navigation header and adjust styles

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -320,6 +320,7 @@ class StatsSite extends Component {
 								activeTab={ getActiveTab( this.props.chartTab ) }
 								activeLegend={ this.state.activeLegend }
 								onChangeLegend={ this.onChangeLegend }
+								isWithNewDateControl={ isDateControlEnabled }
 							>
 								{ ' ' }
 								<DatePicker

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -322,6 +322,7 @@ class StatsSite extends Component {
 								activeLegend={ this.state.activeLegend }
 								onChangeLegend={ this.onChangeLegend }
 								isWithNewDateControl={ isDateControlEnabled }
+								slug={ slug }
 							>
 								{ ' ' }
 								<DatePicker

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -315,6 +315,11 @@ class StatsSite extends Component {
 								url={ `/stats/${ period }/${ slug }` }
 								queryParams={ context.query }
 								pathTemplate={ pathTemplate }
+								charts={ CHARTS }
+								availableLegend={ this.getAvailableLegend() }
+								activeTab={ getActiveTab( this.props.chartTab ) }
+								activeLegend={ this.state.activeLegend }
+								onChangeLegend={ this.onChangeLegend }
 							>
 								{ ' ' }
 								<DatePicker
@@ -341,6 +346,7 @@ class StatsSite extends Component {
 							chartTab={ this.props.chartTab }
 							customQuantity={ this.state.customChartQuantity }
 							customRange={ customChartRange }
+							hideLegend={ true }
 						/>
 					</>
 

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -14,6 +14,7 @@ import illustration404 from 'calypso/assets/images/illustrations/illustration-40
 import JetpackBackupCredsBanner from 'calypso/blocks/jetpack-backup-creds-banner';
 import StatsNavigation from 'calypso/blocks/stats-navigation';
 import { AVAILABLE_PAGE_MODULES } from 'calypso/blocks/stats-navigation/constants';
+import Intervals from 'calypso/blocks/stats-navigation/intervals';
 import AsyncLoad from 'calypso/components/async-load';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
@@ -332,6 +333,9 @@ class StatsSite extends Component {
 									isShort
 								/>
 							</StatsPeriodNavigation>
+							{ ! isDateControlEnabled && (
+								<Intervals selected={ period } pathTemplate={ pathTemplate } compact={ false } />
+							) }
 						</StatsPeriodHeader>
 
 						<ChartTabs

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -45,7 +45,6 @@ import MiniCarousel from './mini-carousel';
 import PromoCards from './promo-cards';
 import ChartTabs from './stats-chart-tabs';
 import Countries from './stats-countries';
-import StatsDateControl from './stats-date-control';
 import DatePicker from './stats-date-picker';
 import StatsModule from './stats-module';
 import StatsModuleEmails from './stats-module-emails';
@@ -310,55 +309,24 @@ class StatsSite extends Component {
 				<HighlightsSection siteId={ siteId } currentPeriod={ defaultPeriod } />
 				<div id="my-stats-content" className={ wrapperClass }>
 					<>
-						{ isDateControlEnabled ? (
-							<>
-								<StatsPeriodHeader>
-									<StatsPeriodNavigation
-										date={ date }
-										period={ period }
-										url={ `/stats/${ period }/${ slug }` }
-										queryParams={ context.query }
-									>
-										{ ' ' }
-										<DatePicker
-											period={ period }
-											date={ date }
-											query={ query }
-											statsType="statsTopPosts"
-											showQueryDate
-											isShort
-										/>
-									</StatsPeriodNavigation>
-									<StatsDateControl
-										slug={ slug }
-										queryParams={ context.query }
-										period={ period }
-										pathTemplate={ pathTemplate }
-										onChangeChartQuantity={ this.onChangeChartQuantity }
-									/>
-								</StatsPeriodHeader>
-							</>
-						) : (
-							<StatsPeriodHeader>
-								<StatsPeriodNavigation
-									date={ date }
+						<StatsPeriodHeader>
+							<StatsPeriodNavigation
+								date={ date }
+								period={ period }
+								url={ `/stats/${ period }/${ slug }` }
+								queryParams={ context.query }
+							>
+								{ ' ' }
+								<DatePicker
 									period={ period }
-									url={ `/stats/${ period }/${ slug }` }
-									queryParams={ context.query }
-								>
-									{ ' ' }
-									<DatePicker
-										period={ period }
-										date={ date }
-										query={ query }
-										statsType="statsTopPosts"
-										showQueryDate
-										isShort
-									/>
-								</StatsPeriodNavigation>
-								<Intervals selected={ period } pathTemplate={ pathTemplate } compact={ false } />
-							</StatsPeriodHeader>
-						) }
+									date={ date }
+									query={ query }
+									statsType="statsTopPosts"
+									showQueryDate
+									isShort
+								/>
+							</StatsPeriodNavigation>
+						</StatsPeriodHeader>
 
 						<ChartTabs
 							activeTab={ getActiveTab( this.props.chartTab ) }

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -14,7 +14,6 @@ import illustration404 from 'calypso/assets/images/illustrations/illustration-40
 import JetpackBackupCredsBanner from 'calypso/blocks/jetpack-backup-creds-banner';
 import StatsNavigation from 'calypso/blocks/stats-navigation';
 import { AVAILABLE_PAGE_MODULES } from 'calypso/blocks/stats-navigation/constants';
-import Intervals from 'calypso/blocks/stats-navigation/intervals';
 import AsyncLoad from 'calypso/components/async-load';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
@@ -315,6 +314,7 @@ class StatsSite extends Component {
 								period={ period }
 								url={ `/stats/${ period }/${ slug }` }
 								queryParams={ context.query }
+								pathTemplate={ pathTemplate }
 							>
 								{ ' ' }
 								<DatePicker

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -48,6 +48,7 @@ class StatModuleChartTabs extends Component {
 		),
 		isActiveTabLoading: PropTypes.bool,
 		onChangeLegend: PropTypes.func.isRequired,
+		hideLegend: PropTypes.bool,
 	};
 
 	intervalId = null;
@@ -103,13 +104,15 @@ class StatModuleChartTabs extends Component {
 		/* pass bars count as `key` to disable transitions between tabs with different column count */
 		return (
 			<div className={ classNames( ...classes ) }>
-				<Legend
-					activeCharts={ this.props.activeLegend }
-					activeTab={ this.props.activeTab }
-					availableCharts={ this.props.availableLegend }
-					clickHandler={ this.onLegendClick }
-					tabs={ this.props.charts }
-				/>
+				{ ! this.props.hideLegend && (
+					<Legend
+						activeCharts={ this.props.activeLegend }
+						activeTab={ this.props.activeTab }
+						availableCharts={ this.props.availableLegend }
+						clickHandler={ this.onLegendClick }
+						tabs={ this.props.charts }
+					/>
+				) }
 				{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
 				<StatsModulePlaceholder className="is-chart" isLoading={ isActiveTabLoading } />
 				<Chart barClick={ this.props.barClick } data={ this.props.chartData } minBarWidth={ 35 }>

--- a/client/my-sites/stats/stats-date-control/index.tsx
+++ b/client/my-sites/stats/stats-date-control/index.tsx
@@ -102,7 +102,7 @@ const StatsDateControl = ( { slug, queryParams, period, pathTemplate }: StatsDat
 
 	return (
 		<div className={ COMPONENT_CLASS_NAME }>
-			<IntervalDropdown period={ period } pathTemplate={ pathTemplate } />
+			{ /* <IntervalDropdown period={ period } pathTemplate={ pathTemplate } /> */ }
 			<DateControlPicker
 				shortcutList={ shortcutList }
 				onShortcut={ onShortcutHandler }

--- a/client/my-sites/stats/stats-date-control/index.tsx
+++ b/client/my-sites/stats/stats-date-control/index.tsx
@@ -2,7 +2,6 @@ import moment from 'moment';
 import page from 'page';
 import qs from 'qs';
 import React from 'react';
-import IntervalDropdown from '../stats-interval-dropdown';
 import DateControlPicker from './stats-date-control-picker';
 import { StatsDateControlProps, DateControlPickerShortcut } from './types';
 import './style.scss';
@@ -47,7 +46,7 @@ const shortcutList = [
 	},
 ];
 
-const StatsDateControl = ( { slug, queryParams, period, pathTemplate }: StatsDateControlProps ) => {
+const StatsDateControl = ( { slug, queryParams }: StatsDateControlProps ) => {
 	// ToDo: Consider removing period from shortcuts.
 	// We could use the bestPeriodForDays() helper and keep the shortcuts
 	// consistent with the custom ranges.
@@ -102,7 +101,6 @@ const StatsDateControl = ( { slug, queryParams, period, pathTemplate }: StatsDat
 
 	return (
 		<div className={ COMPONENT_CLASS_NAME }>
-			{ /* <IntervalDropdown period={ period } pathTemplate={ pathTemplate } /> */ }
 			<DateControlPicker
 				shortcutList={ shortcutList }
 				onShortcut={ onShortcutHandler }

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { localize, withRtl } from 'i18n-calypso';
 import { flowRight } from 'lodash';
 import page from 'page';
@@ -8,6 +9,9 @@ import { connect } from 'react-redux';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import { recordGoogleEvent as recordGoogleEventAction } from 'calypso/state/analytics/actions';
 import NavigationArrows from '../navigation-arrows';
+import IntervalDropdown from '../stats-interval-dropdown';
+import StatsDateControl from '../stats-date-control';
+import Intervals from 'calypso/blocks/stats-navigation/intervals';
 
 import './style.scss';
 
@@ -83,21 +87,60 @@ class StatsPeriodNavigation extends PureComponent {
 	};
 
 	render() {
-		const { children, date, moment, period, showArrows, disablePreviousArrow, disableNextArrow } =
-			this.props;
+		const {
+			children,
+			date,
+			moment,
+			period,
+			showArrows,
+			disablePreviousArrow,
+			disableNextArrow,
+			queryParams,
+			slug,
+			pathTemplate,
+			onChangeChartQuantity,
+		} = this.props;
 
 		const isToday = moment( date ).isSame( moment(), period );
+		// For the new date picker
+		const isDateControlEnabled = config.isEnabled( 'stats/date-control' );
 
 		return (
 			<div className="stats-period-navigation">
 				<div className="stats-period-navigation__children">{ children }</div>
-				{ showArrows && (
-					<NavigationArrows
-						disableNextArrow={ disableNextArrow || isToday }
-						disablePreviousArrow={ disablePreviousArrow }
-						onClickNext={ this.handleArrowNext }
-						onClickPrevious={ this.handleArrowPrevious }
-					/>
+				{ isDateControlEnabled ? (
+					<div className="stats-period-navigation__date-control">
+						<StatsDateControl
+							slug={ slug }
+							queryParams={ queryParams }
+							period={ period }
+							pathTemplate={ pathTemplate }
+							onChangeChartQuantity={ onChangeChartQuantity }
+						/>
+						<div className="stats-period-navigation__period-control">
+							{ showArrows && (
+								<NavigationArrows
+									disableNextArrow={ disableNextArrow || isToday }
+									disablePreviousArrow={ disablePreviousArrow }
+									onClickNext={ this.handleArrowNext }
+									onClickPrevious={ this.handleArrowPrevious }
+								/>
+							) }
+							<IntervalDropdown period={ period } pathTemplate={ pathTemplate } />
+						</div>
+					</div>
+				) : (
+					<>
+						{ showArrows && (
+							<NavigationArrows
+								disableNextArrow={ disableNextArrow || isToday }
+								disablePreviousArrow={ disablePreviousArrow }
+								onClickNext={ this.handleArrowNext }
+								onClickPrevious={ this.handleArrowPrevious }
+							/>
+						) }
+						<Intervals selected={ period } pathTemplate={ pathTemplate } compact={ false } />
+					</>
 				) }
 			</div>
 		);

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -88,6 +88,7 @@ class StatsPeriodNavigation extends PureComponent {
 		this.handleArrowEvent( 'previous', href );
 	};
 
+	// Copied from`client/my-sites/stats/stats-chart-tabs/index.jsx`
 	onLegendClick = ( chartItem ) => {
 		const activeLegend = this.props.activeLegend.slice();
 		const chartIndex = activeLegend.indexOf( chartItem );

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -6,12 +6,13 @@ import PropTypes from 'prop-types';
 import qs from 'qs';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
+import Intervals from 'calypso/blocks/stats-navigation/intervals';
+import Legend from 'calypso/components/chart/legend';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import { recordGoogleEvent as recordGoogleEventAction } from 'calypso/state/analytics/actions';
 import NavigationArrows from '../navigation-arrows';
-import IntervalDropdown from '../stats-interval-dropdown';
 import StatsDateControl from '../stats-date-control';
-import Intervals from 'calypso/blocks/stats-navigation/intervals';
+import IntervalDropdown from '../stats-interval-dropdown';
 
 import './style.scss';
 
@@ -86,6 +87,24 @@ class StatsPeriodNavigation extends PureComponent {
 		this.handleArrowEvent( 'previous', href );
 	};
 
+	onLegendClick = ( chartItem ) => {
+		const activeLegend = this.props.activeLegend.slice();
+		const chartIndex = activeLegend.indexOf( chartItem );
+		let gaEventAction;
+		if ( -1 === chartIndex ) {
+			activeLegend.push( chartItem );
+			gaEventAction = ' on';
+		} else {
+			activeLegend.splice( chartIndex );
+			gaEventAction = ' off';
+		}
+		this.props.recordGoogleEvent(
+			'Stats',
+			`Toggled Nested Chart ${ chartItem } ${ gaEventAction }`
+		);
+		this.props.onChangeLegend( activeLegend );
+	};
+
 	render() {
 		const {
 			children,
@@ -118,6 +137,13 @@ class StatsPeriodNavigation extends PureComponent {
 							onChangeChartQuantity={ onChangeChartQuantity }
 						/>
 						<div className="stats-period-navigation__period-control">
+							<Legend
+								activeCharts={ this.props.activeLegend }
+								activeTab={ this.props.activeTab }
+								availableCharts={ this.props.availableLegend }
+								clickHandler={ this.onLegendClick }
+								tabs={ this.props.charts }
+							/>
 							{ showArrows && (
 								<NavigationArrows
 									disableNextArrow={ disableNextArrow || isToday }

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import qs from 'qs';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
-import Intervals from 'calypso/blocks/stats-navigation/intervals';
 import Legend from 'calypso/components/chart/legend';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import { recordGoogleEvent as recordGoogleEventAction } from 'calypso/state/analytics/actions';
@@ -126,45 +125,31 @@ class StatsPeriodNavigation extends PureComponent {
 		const isToday = moment( date ).isSame( moment(), period );
 
 		return (
-			<>
-				<div
-					className={ classNames( 'stats-period-navigation', {
-						'stats-period-navigation__is-with-new-date-control': isWithNewDateControl,
-					} ) }
-				>
-					<div className="stats-period-navigation__children">{ children }</div>
-					{ isWithNewDateControl ? (
-						<div className="stats-period-navigation__date-control">
-							<StatsDateControl
-								slug={ slug }
-								queryParams={ queryParams }
-								period={ period }
-								pathTemplate={ pathTemplate }
-								onChangeChartQuantity={ onChangeChartQuantity }
-							/>
-							<div className="stats-period-navigation__period-control">
-								{ this.props.activeTab && (
-									<Legend
-										activeCharts={ this.props.activeLegend }
-										activeTab={ this.props.activeTab }
-										availableCharts={ this.props.availableLegend }
-										clickHandler={ this.onLegendClick }
-										tabs={ this.props.charts }
-									/>
-								) }
-								{ showArrows && (
-									<NavigationArrows
-										disableNextArrow={ disableNextArrow || isToday }
-										disablePreviousArrow={ disablePreviousArrow }
-										onClickNext={ this.handleArrowNext }
-										onClickPrevious={ this.handleArrowPrevious }
-									/>
-								) }
-								<IntervalDropdown period={ period } pathTemplate={ pathTemplate } />
-							</div>
-						</div>
-					) : (
-						<>
+			<div
+				className={ classNames( 'stats-period-navigation', {
+					'stats-period-navigation__is-with-new-date-control': isWithNewDateControl,
+				} ) }
+			>
+				<div className="stats-period-navigation__children">{ children }</div>
+				{ isWithNewDateControl ? (
+					<div className="stats-period-navigation__date-control">
+						<StatsDateControl
+							slug={ slug }
+							queryParams={ queryParams }
+							period={ period }
+							pathTemplate={ pathTemplate }
+							onChangeChartQuantity={ onChangeChartQuantity }
+						/>
+						<div className="stats-period-navigation__period-control">
+							{ this.props.activeTab && (
+								<Legend
+									activeCharts={ this.props.activeLegend }
+									activeTab={ this.props.activeTab }
+									availableCharts={ this.props.availableLegend }
+									clickHandler={ this.onLegendClick }
+									tabs={ this.props.charts }
+								/>
+							) }
 							{ showArrows && (
 								<NavigationArrows
 									disableNextArrow={ disableNextArrow || isToday }
@@ -173,13 +158,22 @@ class StatsPeriodNavigation extends PureComponent {
 									onClickPrevious={ this.handleArrowPrevious }
 								/>
 							) }
-						</>
-					) }
-				</div>
-				{ ! isWithNewDateControl && (
-					<Intervals selected={ period } pathTemplate={ pathTemplate } compact={ false } />
+							<IntervalDropdown period={ period } pathTemplate={ pathTemplate } />
+						</div>
+					</div>
+				) : (
+					<>
+						{ showArrows && (
+							<NavigationArrows
+								disableNextArrow={ disableNextArrow || isToday }
+								disablePreviousArrow={ disablePreviousArrow }
+								onClickNext={ this.handleArrowNext }
+								onClickPrevious={ this.handleArrowPrevious }
+							/>
+						) }
+					</>
 				) }
-			</>
+			</div>
 		);
 	}
 }

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import classNames from 'classnames';
 import { localize, withRtl } from 'i18n-calypso';
 import { flowRight } from 'lodash';
 import page from 'page';
@@ -125,25 +126,43 @@ class StatsPeriodNavigation extends PureComponent {
 		const isDateControlEnabled = config.isEnabled( 'stats/date-control' );
 
 		return (
-			<div className="stats-period-navigation">
-				<div className="stats-period-navigation__children">{ children }</div>
-				{ isDateControlEnabled ? (
-					<div className="stats-period-navigation__date-control">
-						<StatsDateControl
-							slug={ slug }
-							queryParams={ queryParams }
-							period={ period }
-							pathTemplate={ pathTemplate }
-							onChangeChartQuantity={ onChangeChartQuantity }
-						/>
-						<div className="stats-period-navigation__period-control">
-							<Legend
-								activeCharts={ this.props.activeLegend }
-								activeTab={ this.props.activeTab }
-								availableCharts={ this.props.availableLegend }
-								clickHandler={ this.onLegendClick }
-								tabs={ this.props.charts }
+			<>
+				<div
+					className={ classNames( 'stats-period-navigation', {
+						'stats-period-navigation__is-with-new-date-control': isDateControlEnabled,
+					} ) }
+				>
+					<div className="stats-period-navigation__children">{ children }</div>
+					{ isDateControlEnabled ? (
+						<div className="stats-period-navigation__date-control">
+							<StatsDateControl
+								slug={ slug }
+								queryParams={ queryParams }
+								period={ period }
+								pathTemplate={ pathTemplate }
+								onChangeChartQuantity={ onChangeChartQuantity }
 							/>
+							<div className="stats-period-navigation__period-control">
+								<Legend
+									activeCharts={ this.props.activeLegend }
+									activeTab={ this.props.activeTab }
+									availableCharts={ this.props.availableLegend }
+									clickHandler={ this.onLegendClick }
+									tabs={ this.props.charts }
+								/>
+								{ showArrows && (
+									<NavigationArrows
+										disableNextArrow={ disableNextArrow || isToday }
+										disablePreviousArrow={ disablePreviousArrow }
+										onClickNext={ this.handleArrowNext }
+										onClickPrevious={ this.handleArrowPrevious }
+									/>
+								) }
+								<IntervalDropdown period={ period } pathTemplate={ pathTemplate } />
+							</div>
+						</div>
+					) : (
+						<>
 							{ showArrows && (
 								<NavigationArrows
 									disableNextArrow={ disableNextArrow || isToday }
@@ -152,23 +171,13 @@ class StatsPeriodNavigation extends PureComponent {
 									onClickPrevious={ this.handleArrowPrevious }
 								/>
 							) }
-							<IntervalDropdown period={ period } pathTemplate={ pathTemplate } />
-						</div>
-					</div>
-				) : (
-					<>
-						{ showArrows && (
-							<NavigationArrows
-								disableNextArrow={ disableNextArrow || isToday }
-								disablePreviousArrow={ disablePreviousArrow }
-								onClickNext={ this.handleArrowNext }
-								onClickPrevious={ this.handleArrowPrevious }
-							/>
-						) }
-						<Intervals selected={ period } pathTemplate={ pathTemplate } compact={ false } />
-					</>
+						</>
+					) }
+				</div>
+				{ ! isDateControlEnabled && (
+					<Intervals selected={ period } pathTemplate={ pathTemplate } compact={ false } />
 				) }
-			</div>
+			</>
 		);
 	}
 }

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import classNames from 'classnames';
 import { localize, withRtl } from 'i18n-calypso';
 import { flowRight } from 'lodash';
@@ -27,6 +26,7 @@ class StatsPeriodNavigation extends PureComponent {
 		queryParams: PropTypes.object,
 		startDate: PropTypes.bool,
 		endDate: PropTypes.bool,
+		isWithNewDateControl: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -37,6 +37,7 @@ class StatsPeriodNavigation extends PureComponent {
 		queryParams: {},
 		startDate: false,
 		endDate: false,
+		isWithNewDateControl: false,
 	};
 
 	handleArrowEvent = ( arrow, href ) => {
@@ -119,21 +120,20 @@ class StatsPeriodNavigation extends PureComponent {
 			slug,
 			pathTemplate,
 			onChangeChartQuantity,
+			isWithNewDateControl,
 		} = this.props;
 
 		const isToday = moment( date ).isSame( moment(), period );
-		// For the new date picker
-		const isDateControlEnabled = config.isEnabled( 'stats/date-control' );
 
 		return (
 			<>
 				<div
 					className={ classNames( 'stats-period-navigation', {
-						'stats-period-navigation__is-with-new-date-control': isDateControlEnabled,
+						'stats-period-navigation__is-with-new-date-control': isWithNewDateControl,
 					} ) }
 				>
 					<div className="stats-period-navigation__children">{ children }</div>
-					{ isDateControlEnabled ? (
+					{ isWithNewDateControl ? (
 						<div className="stats-period-navigation__date-control">
 							<StatsDateControl
 								slug={ slug }
@@ -143,13 +143,15 @@ class StatsPeriodNavigation extends PureComponent {
 								onChangeChartQuantity={ onChangeChartQuantity }
 							/>
 							<div className="stats-period-navigation__period-control">
-								<Legend
-									activeCharts={ this.props.activeLegend }
-									activeTab={ this.props.activeTab }
-									availableCharts={ this.props.availableLegend }
-									clickHandler={ this.onLegendClick }
-									tabs={ this.props.charts }
-								/>
+								{ this.props.activeTab && (
+									<Legend
+										activeCharts={ this.props.activeLegend }
+										activeTab={ this.props.activeTab }
+										availableCharts={ this.props.availableLegend }
+										clickHandler={ this.onLegendClick }
+										tabs={ this.props.charts }
+									/>
+								) }
 								{ showArrows && (
 									<NavigationArrows
 										disableNextArrow={ disableNextArrow || isToday }
@@ -174,7 +176,7 @@ class StatsPeriodNavigation extends PureComponent {
 						</>
 					) }
 				</div>
-				{ ! isDateControlEnabled && (
+				{ ! isWithNewDateControl && (
 					<Intervals selected={ period } pathTemplate={ pathTemplate } compact={ false } />
 				) }
 			</>

--- a/client/my-sites/stats/stats-period-navigation/style.scss
+++ b/client/my-sites/stats/stats-period-navigation/style.scss
@@ -21,4 +21,13 @@
 		font-size: $font-body-small;
 		line-height: 16px;
 	}
+
+	.stats-period-navigation__date-control {
+		display: flex;
+		flex-flow: column nowrap;
+
+		.stats-period-navigation__period-control {
+			display: flex;
+		}
+	}
 }

--- a/client/my-sites/stats/stats-period-navigation/style.scss
+++ b/client/my-sites/stats/stats-period-navigation/style.scss
@@ -28,6 +28,7 @@
 
 		.stats-period-navigation__period-control {
 			display: flex;
+			justify-content: flex-end;
 		}
 	}
 }

--- a/client/my-sites/stats/stats-period-navigation/style.scss
+++ b/client/my-sites/stats/stats-period-navigation/style.scss
@@ -1,7 +1,8 @@
 .stats-period-navigation {
 	display: flex;
+	flex-flow: row wrap;
 	justify-content: space-between;
-	align-items: baseline;
+	align-items: center;
 	margin: 1.5em 0;
 	padding: 0 20px;
 
@@ -42,4 +43,8 @@
 	.chart__legend {
 		margin-bottom: initial;
 	}
+}
+
+.stats-period-navigation.stats-period-navigation__is-with-new-date-control {
+	padding: 0;
 }

--- a/client/my-sites/stats/stats-period-navigation/style.scss
+++ b/client/my-sites/stats/stats-period-navigation/style.scss
@@ -1,7 +1,7 @@
 .stats-period-navigation {
 	display: flex;
 	justify-content: space-between;
-	align-items: center;
+	align-items: baseline;
 	margin: 1.5em 0;
 	padding: 0 20px;
 
@@ -29,6 +29,17 @@
 		.stats-period-navigation__period-control {
 			display: flex;
 			justify-content: flex-end;
+
+			padding-top: 16px;
+
+			.stats-navigation-arrows {
+				margin-left: 24px;
+				margin-right: 24px;
+			}
 		}
+	}
+
+	.chart__legend {
+		margin-bottom: initial;
 	}
 }

--- a/client/my-sites/stats/stats-period-navigation/style.scss
+++ b/client/my-sites/stats/stats-period-navigation/style.scss
@@ -47,4 +47,5 @@
 
 .stats-period-navigation.stats-period-navigation__is-with-new-date-control {
 	padding: 0;
+	align-items: flex-start;
 }


### PR DESCRIPTION
Related to #82082

## Proposed Changes

The PR proposes to move the date picker into the navigation header, so that we could implement the layout in the design. As the navigation is used elsewhere too, so we added an option to turn on the new date control and make sure it's compatible.

## Testing Instructions

* Open Calypso Live Branch
* Open `/stats/day/:siteSlug?flags=stats/date-control`
* Ensure it looks like the following

<img width="1112" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/9386beaa-87fe-4475-80d9-aa3fbbed6969">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?