### PR TITLE
Jetpack Manage: Add a button on the dashboard to go to an editor on a new site

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons/index.tsx
@@ -28,8 +28,13 @@ export default function SiteTopHeaderButtons() {
 			path: '/jetpack-licensing/create-simple-site',
 		} );
 
-		const { blog_id } = response;
-		window.location = `https://wordpress.com/post/${ blog_id }`;
+		const { siteurl } = response;
+		const editorPageUrl = `${ decodeURI(
+			siteurl
+		) }/wp-admin/site-editor.php?postType=wp_template&postId=${ encodeURIComponent(
+			'pub/twentytwentythree//home'
+		) }&canvas=edit`;
+		window.location = editorPageUrl;
 	};
 
 	return (
@@ -51,7 +56,7 @@ export default function SiteTopHeaderButtons() {
 			</Button>
 
 			<Button className="sites-overview__issue-license-button" onClick={ handleNewLandingPage }>
-				New Landing Page
+				{ translate( 'New landing page' ) }
 			</Button>
 
 			{ isWPCOMAtomicSiteCreationEnabled ? (

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons/index.tsx
@@ -5,6 +5,7 @@ import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useRef, useState } from 'react';
 import AddNewSiteButton from 'calypso/components/jetpack/add-new-site-button';
+import { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import WPCOMHostingPopover from './wpcom-hosting-popover';
@@ -20,6 +21,16 @@ export default function SiteTopHeaderButtons() {
 
 	const buttonRef = useRef< HTMLElement | null >( null );
 	const [ toggleIsOpen, setToggleIsOpen ] = useState( false );
+
+	const handleNewLandingPage = async () => {
+		const response = await wpcomJpl.req.post( {
+			apiNamespace: 'wpcom/v2',
+			path: '/jetpack-licensing/create-simple-site',
+		} );
+
+		const { blog_id } = response;
+		window.location = `https://wordpress.com/post/${ blog_id }`;
+	};
 
 	return (
 		<div
@@ -37,6 +48,10 @@ export default function SiteTopHeaderButtons() {
 				}
 			>
 				{ translate( 'Issue License', { context: 'button label' } ) }
+			</Button>
+
+			<Button className="sites-overview__issue-license-button" onClick={ handleNewLandingPage }>
+				New Landing Page
 			</Button>
 
 			{ isWPCOMAtomicSiteCreationEnabled ? (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Have a frictionless way to create a site and jump straight into content creation

## Testing Instructions


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* You have to apply a patch to your sandbox to test this D125128-code

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?