### PR TITLE
Design Picker: Remove the "Skip for now" button

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/test/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/test/unified-design-picker.tsx
@@ -3,7 +3,6 @@
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import React from 'react';
 import { Provider } from 'react-redux';
@@ -129,7 +128,6 @@ const renderComponent = ( component, initialState = {} ) => {
 
 describe( 'UnifiedDesignPickerStep', () => {
 	let originalScrollTo;
-	const user = userEvent.setup();
 
 	const navigation = {
 		goBack: jest.fn(),
@@ -184,17 +182,6 @@ describe( 'UnifiedDesignPickerStep', () => {
 					1
 				);
 			} );
-		} );
-	} );
-
-	describe( 'Skip for now', () => {
-		it( 'should call submit successfully', async () => {
-			renderComponent( <UnifiedDesignPickerStep flow="site-setup" navigation={ navigation } /> );
-
-			await waitFor( () => screen.getByText( 'Pick a design' ) );
-			await user.click( screen.getByText( 'Skip for now' ) );
-
-			expect( navigation.submit ).toHaveBeenCalled();
 		} );
 	} );
 } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -907,12 +907,8 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 			className="unified-design-picker__has-categories"
 			skipButtonAlign="top"
 			hideFormattedHeader
+			hideSkip
 			backLabelText={ translate( 'Back' ) }
-			skipLabelText={
-				intent === SiteIntent.Write
-					? translate( 'Skip and draft first post' )
-					: translate( 'Skip for now' )
-			}
 			stepContent={ stepContent }
 			recordTracksEvent={ recordStepContainerTracksEvent }
 			goNext={ handleSubmit }


### PR DESCRIPTION
## Proposed Changes

See p1696554848500839-slack-C048CUFRGFQ. This is an experiment with the hypothesis that the dotcom experience would be improved by removing the Skip button from the design picker.

| Before | After |
| --- | --- |
| ![Screenshot 2023-10-12 at 10 21 43 AM](https://github.com/Automattic/wp-calypso/assets/797888/771df172-26cf-4f64-aedd-cdb96885396c) |  ![Screenshot 2023-10-12 at 10 21 10 AM](https://github.com/Automattic/wp-calypso/assets/797888/a2468a9a-4a76-460b-8992-1381ad283f56)|

Once approved, we should follow up in two weeks and observe the changes to the following metrics:

1. Assembler completion rate.
2. Onboarding completion rate.
3. Onboarding global styles selection rate.
4. Design Picker back button click rate.

cc: @ianstewart @autumnfjeld 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the design picker `/setup/designSetup?siteSlug=${site_slug}`
* Ensure that the Skip for now button is no longer present.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?