### PR TITLE
Hosting trial: display upgrade CTA on sites

### DIFF
--- a/client/sites-dashboard/components/sites-grid-action-renew.tsx
+++ b/client/sites-dashboard/components/sites-grid-action-renew.tsx
@@ -12,7 +12,7 @@ import { PLAN_RENEW_NAG_EVENT_NAMES } from '../utils';
 
 interface SitesGridActionRenewProps {
 	site: SiteExcerptData;
-	hideRenewLink?: boolean;
+	isUpgradeable: boolean;
 }
 
 const Container = styled.div( {
@@ -37,7 +37,7 @@ const RenewLink = styled.a( {
 	},
 } );
 
-export function SitesGridActionRenew( { site, hideRenewLink }: SitesGridActionRenewProps ) {
+export function SitesGridActionRenew( { site, isUpgradeable }: SitesGridActionRenewProps ) {
 	const { __ } = useI18n();
 	const userId = useSelector( ( state ) => getCurrentUserId( state ) );
 	const isSiteOwner = site.site_owner === userId;
@@ -64,9 +64,11 @@ export function SitesGridActionRenew( { site, hideRenewLink }: SitesGridActionRe
 						sprintf( __( '%s Plan expired.' ), site.plan?.product_name_short )
 					}
 				</span>
-				{ isSiteOwner && ! hideRenewLink && (
+				{ isSiteOwner && (
 					<RenewLink
-						href={ `/checkout/${ site.slug }/${ productSlug }` }
+						href={
+							isUpgradeable ? `/plans/${ site.slug }` : `/checkout/${ site.slug }/${ productSlug }`
+						}
 						onClick={ () => {
 							recordTracksEvent( PLAN_RENEW_NAG_EVENT_NAMES.ON_CLICK, {
 								product_slug: productSlug,
@@ -74,7 +76,7 @@ export function SitesGridActionRenew( { site, hideRenewLink }: SitesGridActionRe
 							} );
 						} }
 					>
-						{ __( 'Renew' ) }
+						{ isUpgradeable ? __( 'Upgrade' ) : __( 'Renew' ) }
 					</RenewLink>
 				) }
 			</Notice>

--- a/client/sites-dashboard/components/sites-grid-item.tsx
+++ b/client/sites-dashboard/components/sites-grid-item.tsx
@@ -143,7 +143,7 @@ export const SitesGridItem = memo( ( props: SitesGridItemProps ) => {
 						/>
 					</ThumbnailWrapper>
 					{ showSiteRenewLink && site.plan?.expired && (
-						<SitesGridActionRenew site={ site } hideRenewLink={ isTrialSitePlan } />
+						<SitesGridActionRenew site={ site } isUpgradeable={ isTrialSitePlan } />
 					) }
 				</>
 			}

--- a/client/sites-dashboard/components/sites-plan-renew-nag.tsx
+++ b/client/sites-dashboard/components/sites-plan-renew-nag.tsx
@@ -12,7 +12,7 @@ interface PlanRenewProps {
 	plan: Site.SiteDetailsPlan;
 	isSiteOwner: boolean;
 	checkoutUrl: string;
-	hideRenewLink?: boolean;
+	isUpgradeable?: boolean;
 }
 
 const PlanRenewContainer = styled.div( {
@@ -54,7 +54,7 @@ export const PlanRenewNag = ( {
 	isSiteOwner,
 	plan,
 	checkoutUrl,
-	hideRenewLink,
+	isUpgradeable,
 }: PlanRenewProps ) => {
 	const { __ } = useI18n();
 	const trackCallback = useCallback(
@@ -70,7 +70,8 @@ export const PlanRenewNag = ( {
 		onChange: ( inView ) => inView && trackCallback(),
 	} );
 
-	const renewText = __( 'Renew plan' );
+	const actionText = isUpgradeable ? __( 'Upgrade' ) : __( 'Renew plan' );
+
 	return (
 		<PlanRenewContainer ref={ ref }>
 			<IconContainer>
@@ -87,7 +88,7 @@ export const PlanRenewNag = ( {
 						) }
 					</PlanRenewNoticeExpireText>
 				</PlanRenewNoticeTextContainer>
-				{ isSiteOwner && ! hideRenewLink && (
+				{ isSiteOwner && (
 					<PlanRenewLink
 						onClick={ () => {
 							recordTracksEvent( PLAN_RENEW_NAG_EVENT_NAMES.ON_CLICK, {
@@ -96,9 +97,9 @@ export const PlanRenewNag = ( {
 							} );
 						} }
 						href={ checkoutUrl }
-						title={ renewText }
+						title={ actionText }
 					>
-						{ renewText }
+						{ actionText }
 					</PlanRenewLink>
 				) }
 			</PlanRenewNotice>

--- a/client/sites-dashboard/components/sites-site-plan.tsx
+++ b/client/sites-dashboard/components/sites-site-plan.tsx
@@ -1,8 +1,6 @@
 import styled from '@emotion/styled';
 import JetpackLogo from 'calypso/components/jetpack-logo';
-import { isTrialSite } from 'calypso/state/sites/plans/selectors';
-import { useSelector } from '../../state';
-import { isNotAtomicJetpack } from '../utils';
+import { isNotAtomicJetpack, isTrialSite } from '../utils';
 import { PlanRenewNag } from './sites-plan-renew-nag';
 import type { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
 
@@ -32,7 +30,7 @@ const STAGING_PLAN_LABEL = 'Staging';
 
 export const SitePlan = ( { site, userId }: SitePlanProps ) => {
 	const isWpcomStagingSite = site?.is_wpcom_staging_site ?? false;
-	const trialSite = useSelector( ( state ) => isTrialSite( state, site.ID ) );
+	const trialSite = isTrialSite( site );
 
 	return (
 		<SitePlanContainer>

--- a/client/sites-dashboard/components/sites-site-plan.tsx
+++ b/client/sites-dashboard/components/sites-site-plan.tsx
@@ -1,7 +1,8 @@
-import { PLAN_ECOMMERCE_TRIAL_MONTHLY } from '@automattic/calypso-products';
 import styled from '@emotion/styled';
 import JetpackLogo from 'calypso/components/jetpack-logo';
-import { isNotAtomicJetpack, isMigrationTrialSite } from '../utils';
+import { isTrialSite } from 'calypso/state/sites/plans/selectors';
+import { useSelector } from '../../state';
+import { isNotAtomicJetpack } from '../utils';
 import { PlanRenewNag } from './sites-plan-renew-nag';
 import type { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
 
@@ -31,8 +32,7 @@ const STAGING_PLAN_LABEL = 'Staging';
 
 export const SitePlan = ( { site, userId }: SitePlanProps ) => {
 	const isWpcomStagingSite = site?.is_wpcom_staging_site ?? false;
-	const isECommerceTrialSite = site.plan?.product_slug === PLAN_ECOMMERCE_TRIAL_MONTHLY;
-	const isMigrationTrialPlanSite = isMigrationTrialSite( site );
+	const trialSite = useSelector( ( state ) => isTrialSite( state, site.ID ) );
 
 	return (
 		<SitePlanContainer>
@@ -48,8 +48,12 @@ export const SitePlan = ( { site, userId }: SitePlanProps ) => {
 							<PlanRenewNag
 								plan={ site.plan }
 								isSiteOwner={ site?.site_owner === userId }
-								checkoutUrl={ `/checkout/${ site.slug }/${ site.plan?.product_slug }` }
-								hideRenewLink={ isECommerceTrialSite || isMigrationTrialPlanSite }
+								checkoutUrl={
+									trialSite
+										? `/plans/${ site.slug }`
+										: `/checkout/${ site.slug }/${ site.plan?.product_slug }`
+								}
+								isUpgradeable={ trialSite }
 							/>
 						</PlanRenewNagContainer>
 					) : (

--- a/client/sites-dashboard/components/test/sites-site-plan.tsx
+++ b/client/sites-dashboard/components/test/sites-site-plan.tsx
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+import { PLAN_HOSTING_TRIAL_MONTHLY } from '@automattic/calypso-products';
 import { render } from '@testing-library/react';
 import { SitePlan } from '../sites-site-plan';
 
@@ -31,6 +32,28 @@ const expiredBusinessSite = {
 	plan: {
 		expired: true,
 		product_name_short: 'Business',
+	},
+};
+
+const activeTrialSite = {
+	ID: 1,
+	site_owner: siteOwnerId,
+	title: 'Active Business Trial',
+	plan: {
+		expired: false,
+		product_name_short: 'Business Trial',
+		product_slug: PLAN_HOSTING_TRIAL_MONTHLY,
+	},
+};
+
+const expiredTrialSite = {
+	ID: 1,
+	site_owner: siteOwnerId,
+	title: 'Expired Business Trial',
+	plan: {
+		expired: true,
+		product_name_short: 'Business Trial',
+		product_slug: PLAN_HOSTING_TRIAL_MONTHLY,
 	},
 };
 
@@ -74,6 +97,34 @@ describe( '<SitePlan>', () => {
 		expect( getByRole( 'link', { name: 'Renew plan' } ) ).toHaveAttribute(
 			'href',
 			expect.stringMatching( /\/checkout\// )
+		);
+	} );
+
+	test( 'shows "Business Trial" as label for a site with an active Business Trial plan', () => {
+		const { container, queryAllByRole } = render(
+			<SitePlan site={ activeTrialSite } userId={ siteOwnerId } />
+		);
+		expect( container.textContent ).toBe( 'Business Trial' );
+		expect( queryAllByRole( 'link' ) ).toHaveLength( 0 );
+	} );
+
+	test( 'shows "Business Trial" as label to an administrator for site with an expired Business Trial plan', () => {
+		const { container, queryAllByRole } = render(
+			<SitePlan site={ expiredTrialSite } userId={ otherAdminId } />
+		);
+		expect( container.textContent ).toBe( 'Business Trial - Expired' );
+		expect( queryAllByRole( 'link' ) ).toHaveLength( 0 );
+	} );
+
+	test( 'shows "Business Trial" as label to a site owner for a site with an expired Business Trial plan', () => {
+		const { getByText, queryAllByRole, getByRole } = render(
+			<SitePlan site={ expiredTrialSite } userId={ siteOwnerId } />
+		);
+		expect( getByText( 'Business Trial - Expired' ) ).toBeInTheDocument();
+		expect( queryAllByRole( 'link' ) ).toHaveLength( 1 );
+		expect( getByRole( 'link', { name: 'Upgrade' } ) ).toHaveAttribute(
+			'href',
+			expect.stringMatching( /\/plans\// )
 		);
 	} );
 } );

--- a/client/sites-dashboard/utils.ts
+++ b/client/sites-dashboard/utils.ts
@@ -70,6 +70,10 @@ export const isECommerceTrialSite = ( site: SiteExcerptNetworkData ) => {
 	return site?.plan?.product_slug === PLAN_ECOMMERCE_TRIAL_MONTHLY;
 };
 
+export const isTrialSite = ( site: SiteExcerptNetworkData ) => {
+	return isMigrationTrialSite( site ) || isHostingTrialSite( site ) || isECommerceTrialSite( site );
+};
+
 export const SMALL_MEDIA_QUERY = 'screen and ( max-width: 600px )';
 
 export const MEDIA_QUERIES = {


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/80307. Closes https://github.com/Automattic/dotcom-forge/issues/4055.

## Proposed Changes

Display a nag to upgrade the site after the trial has ended:

<img width="735" alt="image" src="https://github.com/Automattic/wp-calypso/assets/26530524/00b06394-cc0e-4a34-a7de-ac08061884d9">

@Automattic/caribou I see there was a decision not to display the "Upgrade" CTA. I didn't see the discussion itself, though. Could you please elaborate? I think it'd be beneficial to display the CTA to the plans page directly.

## Testing Instructions

1. Apply D124373-code to your sandbox and proxy yourself (ignore if the diff has been already deployed)
2. Expire a trial site in your user's Store Admin
3. Check that the Sites page gets updated (unfocus and focus it so that the data is refetched)
4. Check that the "Trial - Expired" message is shown in the Plan column and you have a CTA to upgrade your site