### PR TITLE
Hosting trial: Display trial expired page

### DIFF
--- a/client/my-sites/plans/trials/business-trial-expired/index.tsx
+++ b/client/my-sites/plans/trials/business-trial-expired/index.tsx
@@ -1,5 +1,8 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { PLAN_MIGRATION_TRIAL_MONTHLY } from '@automattic/calypso-products';
+import {
+	PLAN_HOSTING_TRIAL_MONTHLY,
+	PLAN_MIGRATION_TRIAL_MONTHLY,
+} from '@automattic/calypso-products';
 import { Button, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
@@ -26,7 +29,12 @@ const BusinessTrialExpired = (): JSX.Element => {
 
 	const nonBusinessTrialPurchases = useMemo(
 		() =>
-			sitePurchases.filter( ( purchase ) => purchase.productSlug !== PLAN_MIGRATION_TRIAL_MONTHLY ),
+			sitePurchases.filter(
+				( purchase ) =>
+					! [ PLAN_HOSTING_TRIAL_MONTHLY, PLAN_MIGRATION_TRIAL_MONTHLY ].includes(
+						purchase.productSlug
+					)
+			),
 		[ sitePurchases ]
 	);
 

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -24,6 +24,7 @@ export const SITE_REQUEST_FIELDS = [
 	'is_wpcom_staging_site',
 	'was_ecommerce_trial',
 	'was_migration_trial',
+	'was_hosting_trial',
 	'description',
 	'user_interactions',
 ].join();


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/4013. Closes https://github.com/Automattic/dotcom-forge/issues/4051.


## Proposed Changes

Mimics the migration trial expired page introduced on https://github.com/Automattic/wp-calypso/pull/80693:

<img width="1137" alt="image" src="https://github.com/Automattic/wp-calypso/assets/26530524/177ba980-c104-4820-a9b7-794b5fc67529">

## Testing Instructions

For some reason I was not getting the `was_hosting_trial` field returned while sandboxed. That's why adding the sticker manually is quicker here. @mpkelly do you know why the field isn't being returned when I'm proxying the API to my sandbox?

1. Grab an expired trial site and add the `had-hosting-trial` sticker to it
2. Browse `/home/%s` and you should be redirected to the expired trial page
3. Check that the previous purchases button do not show up

<img width="573" alt="image" src="https://github.com/Automattic/wp-calypso/assets/26530524/ee96f8b8-551d-4ccb-8bc1-ccced5bf1362">
