### PR TITLE
Remove free trial upsell for Woo Express introductory offer

### DIFF
--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -22,6 +22,7 @@ import {
 	isPremium,
 	isBusiness,
 	isEcommerce,
+	isWooExpressPlan,
 } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
@@ -705,6 +706,11 @@ function CheckoutSummaryAnnualUpsell( props: {
 		return null;
 	}
 
+	// Woo Express plans with introductory offer does not provide free domain.
+	const shouldShowFreeDomainUpsell = ! (
+		isWooExpressPlan( productSlug ) && Boolean( props.plan.introductory_offer_terms?.enabled )
+	);
+
 	return (
 		<CheckoutSummaryFeaturesUpsell>
 			<CheckoutSummaryFeaturesTitle>
@@ -715,10 +721,12 @@ function CheckoutSummaryAnnualUpsell( props: {
 				/>
 			</CheckoutSummaryFeaturesTitle>
 			<CheckoutSummaryFeaturesListWrapper>
-				<CheckoutSummaryFeaturesListItem isSupported={ false }>
-					<WPCheckoutCheckIcon id="annual-domain-credit" />
-					{ translate( 'Free domain for one year' ) }
-				</CheckoutSummaryFeaturesListItem>
+				{ shouldShowFreeDomainUpsell && (
+					<CheckoutSummaryFeaturesListItem isSupported={ false }>
+						<WPCheckoutCheckIcon id="annual-domain-credit" />
+						{ translate( 'Free domain for one year' ) }
+					</CheckoutSummaryFeaturesListItem>
+				) }
 				{ ! isWpComPersonalPlan( productSlug ) && (
 					<CheckoutSummaryFeaturesListItem isSupported={ false }>
 						<WPCheckoutCheckIcon id="annual-live-chat" />


### PR DESCRIPTION
## Proposed Changes

* Remove free domain upsell when checking out monthly Woo Express plan with introductory offer

## Testing Instructions

### Testing with a new site
* You need to use an a12n account and proxy
* Use an existing Woo Express free trial site
* Alternatively, go to https://woocommerce.com/start/#/ and go through the whole NUX flow and set up a free trial site
* After the site is created, go to http://calypso.localhost:3000/plans/SITE_URL
* Make sure to select the monthly tab 
* Checkout Essentials or Performance plan
* Observe the upsell does not say `Free domain for one year` as per screenshot

<img width="364" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3747241/d1684cb3-3591-4495-9921-b357f595e758">


### Testing with existing monthly subscription Essentials plan 
* With an existing Essentials plan site, go to http://calypso.localhost:3000/plans/SITE_URL
* Checkout performance plan
* Observe the site is not eligible for $1 offer and `Free domain for one year` upsell is shown

### Negative test
* With an existing free plan site, go to http://calypso.localhost:3000/plans/SITE_URL
* Select monthly plan and checkout with Business or Commerce plan
* Observe the `Free domain for one year` upsell is shown


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
