### PR TITLE
Jetpack E2E: add test for the stats tracking pixel.

### DIFF
--- a/test/e2e/specs/editor/editor__post-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__post-basic-flow.ts
@@ -185,12 +185,21 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 				)
 			);
 			await newPage.goto( publishedURL.href );
-			response = await trackingPixelLoaded;
+
+			// Wrap the `waitForResponse` wait so it does not fail this step should the tracking pixel
+			// fail to load.
+			// This way if the tracking pixel ever fails to load, the most accurate test step fails.
+			try {
+				response = await trackingPixelLoaded;
+			} catch {
+				// noop - will throw in next step.
+			}
 
 			expect( publishedURL.href ).toStrictEqual( newPage.url() );
 		} );
 
 		it( 'Jetpack Stats tracking pixel is loaded', async function () {
+			expect( response ).toBeDefined();
 			expect( response.status() ).toBe( 200 );
 		} );
 

--- a/test/e2e/specs/editor/editor__post-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__post-basic-flow.ts
@@ -32,6 +32,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	] );
 
 	let page: Page;
+	let testAccount: TestAccount;
 	let editorPage: EditorPage;
 	let publishedPostPage: PublishedPostPage;
 
@@ -39,7 +40,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		page = await browser.newPage();
 		editorPage = new EditorPage( page );
 
-		const testAccount = new TestAccount( accountName );
+		testAccount = new TestAccount( accountName );
 		await testAccount.authenticate( page );
 	} );
 
@@ -166,6 +167,12 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		it( 'Publish and visit post', async function () {
 			const publishedURL: URL = await editorPage.publish( { visit: true } );
 			expect( publishedURL.href ).toStrictEqual( page.url() );
+		} );
+
+		it( 'Stats tracking pixel is loaded', async function () {
+			await page.waitForResponse(
+				new RegExp( `pixel.wp.com/g.gif?blog=${ testAccount.credentials.testSites?.primary.id }` )
+			);
 		} );
 
 		it( 'Post content is found in published post', async function () {

--- a/test/e2e/specs/editor/editor__post-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__post-basic-flow.ts
@@ -13,7 +13,7 @@ import {
 	envToFeatureKey,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
-import { skipItIf } from '../../jest-helpers';
+import { skipDescribeIf, skipItIf } from '../../jest-helpers';
 
 const quote =
 	'The problem with quotes on the Internet is that it is hard to verify their authenticity.\n- Abraham Lincoln';
@@ -168,7 +168,8 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		} );
 	} );
 
-	describe( 'View post', function () {
+	// Skip test on Private site, because posts are not visible to non-logged out users.
+	skipDescribeIf( envVariables.ATOMIC_VARIATION === 'private' )( 'View post', function () {
 		let newPage: Page;
 
 		beforeAll( async function () {
@@ -182,8 +183,8 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 			);
 			await newPage.goto( publishedURL.href );
 			const response = await trackingPixelLoaded;
-
 			expect( response.status() ).toBe( 200 );
+
 			expect( publishedURL.href ).toStrictEqual( newPage.url() );
 		} );
 
@@ -200,13 +201,12 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 
 		// Not checking the `Press This` button as it is not available on AT.
 		// @see: paYJgx-1lp-p2
-		// Skip test on Private user because social sharing only works on public sites.
-		skipItIf( accountName === 'jetpackAtomicPrivateUser' ).each( [
-			{ name: 'Twitter' },
-			{ name: 'Facebook' },
-		] )( 'Social sharing button for $name can be clicked', async function ( { name } ) {
-			publishedPostPage = new PublishedPostPage( newPage );
-			await publishedPostPage.validateSocialButton( name, { click: true } );
-		} );
+		it.each( [ { name: 'Twitter' }, { name: 'Facebook' } ] )(
+			'Social sharing button for $name can be clicked',
+			async function ( { name } ) {
+				publishedPostPage = new PublishedPostPage( newPage );
+				await publishedPostPage.validateSocialButton( name, { click: true } );
+			}
+		);
 	} );
 } );


### PR DESCRIPTION
Related to: https://github.com/Automattic/wp-calypso/issues/80730

## Proposed Changes

This PR adds coverage for the tracking pixel, used to count stats. 

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Calypso E2E (desktop)
  - [x] Jetpack E2E Simple (mobile)
  - [ ] Jetpack E2E Simple (desktop)
  - [x] Jetpack E2E AT (desktop)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?