### PR TITLE
Social previews | Convert Twitter to X

### DIFF
--- a/client/blocks/sharing-preview-pane/index.jsx
+++ b/client/blocks/sharing-preview-pane/index.jsx
@@ -35,7 +35,7 @@ import './style.scss';
 const serviceNames = {
 	facebook: 'Facebook',
 	'instagram-business': 'Instagram',
-	twitter: 'Twitter',
+	x: 'X',
 	linkedin: 'LinkedIn',
 	tumblr: 'Tumblr',
 	mastodon: 'Mastodon',
@@ -101,7 +101,6 @@ class SharingPreviewPane extends PureComponent {
 		/**
 		 * Props to pass to the preview component. Will be populated with the connection
 		 * specific data if the selected service is connected.
-		 *
 		 * @type {Object}
 		 */
 		const previewProps = {
@@ -146,7 +145,7 @@ class SharingPreviewPane extends PureComponent {
 				);
 			case 'linkedin':
 				return <LinkedinSharePreview { ...previewProps } />;
-			case 'twitter':
+			case 'x':
 				return <TwitterSharePreview { ...previewProps } />;
 			case 'mastodon':
 				return (

--- a/client/components/seo-preview-pane/index.jsx
+++ b/client/components/seo-preview-pane/index.jsx
@@ -200,7 +200,7 @@ export class SeoPreviewPane extends PureComponent {
 
 		const { selectedService } = this.state;
 
-		const services = compact( [ post && 'wordpress', 'google', 'facebook', 'twitter' ] );
+		const services = compact( [ post && 'wordpress', 'google', 'facebook', 'x' ] );
 
 		if ( showNudge ) {
 			return <SeoPreviewUpgradeNudge { ...{ site } } />;
@@ -234,7 +234,7 @@ export class SeoPreviewPane extends PureComponent {
 									wordpress: ReaderPost( site, post, frontPageMetaDescription ),
 									facebook: FacebookPost( site, post, frontPageMetaDescription ),
 									google: GooglePost( site, post, frontPageMetaDescription ),
-									twitter: TwitterPost( site, post, frontPageMetaDescription ),
+									x: TwitterPost( site, post, frontPageMetaDescription ),
 								},
 								selectedService,
 								ComingSoonMessage( translate )
@@ -244,7 +244,7 @@ export class SeoPreviewPane extends PureComponent {
 								{
 									facebook: FacebookSite( site, frontPageMetaDescription ),
 									google: GoogleSite( site, frontPageMetaDescription ),
-									twitter: TwitterSite( site, frontPageMetaDescription ),
+									x: TwitterSite( site, frontPageMetaDescription ),
 								},
 								selectedService,
 								ComingSoonMessage( translate )

--- a/client/components/vertical-menu/items/social-item.jsx
+++ b/client/components/vertical-menu/items/social-item.jsx
@@ -14,7 +14,7 @@ const services = ( translate = ( string ) => string ) => ( {
 	linkedin: { icon: 'linkedin', label: translate( 'LinkedIn' ) },
 	tumblr: { icon: 'tumblr', label: translate( 'Tumblr' ) },
 	mastodon: { icon: 'mastodon', label: translate( 'Mastodon' ) },
-	twitter: { icon: 'twitter', label: translate( 'Twitter' ) },
+	x: { icon: 'x', label: translate( 'X' ) },
 	wordpress: { icon: 'wordpress', label: translate( 'WordPress.com Reader' ) },
 } );
 

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -412,9 +412,7 @@ export class SiteSettingsFormSEO extends Component {
 											{ translate( 'Show Previews' ) }
 										</Button>
 										<span className="seo-settings__preview-explanation">
-											{ translate(
-												'See how this will look on ' + 'Google, Facebook, and Twitter.'
-											) }
+											{ translate( 'See how this will look on Google, Facebook, and X.' ) }
 										</span>
 									</FormSettingExplanation>
 								</Card>

--- a/packages/social-previews/CHANGELOG.md
+++ b/packages/social-previews/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fixed hyperlinks for Facebook
 - Fixed multiple empty lines issue in preview text
 - Fixed video previews for Instagram and Tumblr
+- Changed Twitter text and icon to X
 
 ## v2.0.0 (2023-05-24)
 

--- a/packages/social-previews/package.json
+++ b/packages/social-previews/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/social-previews",
-	"version": "2.0.1-beta.8",
+	"version": "2.0.1-beta.9",
 	"description": "A suite of components to generate previews for a post for both social and search engines.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",

--- a/packages/social-previews/src/twitter-preview/previews.tsx
+++ b/packages/social-previews/src/twitter-preview/previews.tsx
@@ -26,7 +26,7 @@ export const TwitterPreviews: React.FC< TwitterPreviewsProps > = ( {
 						}
 					</SectionHeading>
 					<p className="social-preview__section-desc">
-						{ __( 'This is what your social post will look like on Twitter:', 'social-previews' ) }
+						{ __( 'This is what your social post will look like on X:', 'social-previews' ) }
 					</p>
 					{ tweets.map( ( tweet, index ) => {
 						const isLast = index + 1 === tweets.length;
@@ -50,7 +50,7 @@ export const TwitterPreviews: React.FC< TwitterPreviewsProps > = ( {
 					</SectionHeading>
 					<p className="social-preview__section-desc">
 						{ __(
-							'This is what it will look like when someone shares the link to your WordPress post on Twitter.',
+							'This is what it will look like when someone shares the link to your WordPress post on X.',
 							'social-previews'
 						) }
 						&nbsp;


### PR DESCRIPTION
This PR updates the Social Previews package and its consumer components to replace Twitter with X. It changes only the user-facing text and icon to X. It does not rename the components or file names.

## Proposed Changes

* Update Social Previews package to read X instead of Twitter
* Update post list preview to use X icon instead of Twitter
* Update SEO preview UI to show X in place of Twitter

## Testing Instructions

* Boot up this PR or click on the Calypso live link below
* Goto `/posts/:site`
* For any post, click on the 3 dots and click on _"Share"_
* Click on _"Preview"_
* Confirm that Twitter text and icon is replaced with X
* Goto `marketing/traffic/:site`
* In "Website Meta" section, confirm that
_"See how this will look on Google, Facebook, and Twitter."_ is changed to
_"See how this will look on Google, Facebook, and X."_
* Click on "Show Previews"
* Confirm that Twitter text and icon is replaced with X

<table>
    <thead>
        <tr>
            <th>BEFORE</th>
            <th>AFTER</th>
        </tr>
    </thead>
    <tbody>
        <tr>
            <th colspan="2"><code>marketing/traffic/:site</code></th>
        </tr>
        <tr>
            <td>
                <img width="479" alt="Screenshot 2023-10-12 at 11 51 42 AM"
                    src="https://github.com/Automattic/wp-calypso/assets/18226415/88895039-5b62-4de8-b8ca-179a0519760d">
            </td>
            <td>
                <img width="534" alt="Screenshot 2023-10-12 at 11 52 23 AM"
                    src="https://github.com/Automattic/wp-calypso/assets/18226415/b3ae33f8-aefa-4aeb-8871-0c4fcee49abd">
            </td>
        </tr>
        <tr>
            <th colspan="2"><code>/posts/:site</code></th>
        </tr>
        <tr>
            <td>
                <img width="1123" alt="Screenshot 2023-10-12 at 11 53 23 AM"
                    src="https://github.com/Automattic/wp-calypso/assets/18226415/51bf3d30-bd3c-4719-8fbd-935403bc2ab1">
            </td>
            <td>
                <img width="1121" alt="Screenshot 2023-10-12 at 11 54 06 AM"
                    src="https://github.com/Automattic/wp-calypso/assets/18226415/ceb7c41b-a56c-40c1-8b62-52f172d162a1">
            </td>
        </tr>
        <tr>
            <th colspan="2">Website Meta</th>
        </tr>
        <tr>
            <td>
                <img width="1010" alt="Screenshot 2023-10-12 at 12 03 45 PM"
                    src="https://github.com/Automattic/wp-calypso/assets/18226415/4ad6e6d1-f74e-471b-9958-10402eb59715">
            </td>
            <td>
                <img width="1009" alt="Screenshot 2023-10-12 at 12 04 21 PM"
                    src="https://github.com/Automattic/wp-calypso/assets/18226415/7f280c00-c7b0-4111-a29c-c526166595b3">
            </td>
        </tr>
</table>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?