### PR TITLE
E2E: add coverage for cancelling a plan.

### DIFF
--- a/packages/calypso-e2e/src/lib/components/notice-component.ts
+++ b/packages/calypso-e2e/src/lib/components/notice-component.ts
@@ -47,14 +47,18 @@ export class NoticeComponent {
 	 * @param {string} text Full or partial text to validate on page.
 	 * @param param1 Optional parameters.
 	 * @param {NoticeType} param1.type Type of notice to limit validation to.
+	 * @param {number} param1.timeout Custom timeout value.
 	 */
-	async noticeShown( text: string, { type }: { type?: NoticeType } = {} ): Promise< void > {
+	async noticeShown(
+		text: string,
+		{ type, timeout }: { type?: NoticeType; timeout?: number } = {}
+	): Promise< void > {
 		const noticeType = type ? `.is-${ type?.toLowerCase() }` : '';
 
 		const selector = `div.notice${ noticeType } :text("${ text }")`;
 
 		const locator = this.page.locator( selector );
-		await locator.waitFor( { state: 'visible' } );
+		await locator.waitFor( { state: 'visible', timeout: timeout } );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/flows/cancel-purchase-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/cancel-purchase-flow.ts
@@ -3,7 +3,7 @@ import { Page } from 'playwright';
 type CancelReason = 'Another reason…';
 
 /**
- *
+ * Cancels a purchased plan.
  */
 export async function cancelPurchaseFlow(
 	page: Page,

--- a/packages/calypso-e2e/src/lib/flows/cancel-purchase-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/cancel-purchase-flow.ts
@@ -1,0 +1,26 @@
+import { Page } from 'playwright';
+
+type CancelReason = 'Another reason…';
+
+/**
+ *
+ */
+export async function cancelPurchaseFlow(
+	page: Page,
+	feedback: {
+		reason: CancelReason;
+		customReasonText: string;
+	}
+) {
+	await page
+		.getByRole( 'combobox', { name: 'WHY WOULD YOU LIKE TO CANCEL?' } )
+		.selectOption( feedback.reason );
+
+	await page
+		.getByRole( 'textbox', { name: 'CAN YOU PLEASE SPECIFY?' } )
+		.fill( feedback.customReasonText );
+
+	await page.getByRole( 'button', { name: 'Submit' } ).click();
+
+	await page.getByRole( 'button', { name: /Submit and (remove|cancel) plan/ } ).click();
+}

--- a/packages/calypso-e2e/src/lib/flows/index.ts
+++ b/packages/calypso-e2e/src/lib/flows/index.ts
@@ -5,3 +5,6 @@ export * from './start-import-flow';
 export * from './start-site-flow';
 export * from './change-ui-language-flow';
 export * from './free-signup-flow';
+
+// Newer style flows (without a class)
+export * from './cancel-purchase-flow';

--- a/packages/calypso-e2e/src/lib/pages/me/index.ts
+++ b/packages/calypso-e2e/src/lib/pages/me/index.ts
@@ -1,1 +1,3 @@
 export * from './account-settings-page';
+export * from './my-profile-page';
+export * from './purchases-page';

--- a/packages/calypso-e2e/src/lib/pages/me/my-profile-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/me/my-profile-page.ts
@@ -1,0 +1,25 @@
+import { Page } from 'playwright';
+import { getCalypsoURL } from '../../../data-helper';
+
+/**
+ * Represents the /me endpoint.
+ */
+export class MyProfilePage {
+	private page: Page;
+
+	/**
+	 * Constructs an instance of the component.
+	 *
+	 * @param {Page} page The underlying page.
+	 */
+	constructor( page: Page ) {
+		this.page = page;
+	}
+
+	/**
+	 * Visits the /me endpoint.
+	 */
+	async visit() {
+		await this.page.goto( getCalypsoURL( 'me' ) );
+	}
+}

--- a/packages/calypso-e2e/src/lib/pages/me/purchases-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/me/purchases-page.ts
@@ -33,9 +33,10 @@ export class PurchasesPage {
 	/* Purchases list view */
 
 	/**
+	 * Clicks on the matching purchase.
 	 *
-	 * @param name
-	 * @param siteSlug
+	 * @param {string} name Name of the purchased subscription.
+	 * @param {string} siteSlug Site slug.
 	 */
 	async clickOnPurchase( name: string, siteSlug: string ) {
 		await this.page

--- a/packages/calypso-e2e/src/lib/pages/me/purchases-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/me/purchases-page.ts
@@ -1,0 +1,70 @@
+import { Page } from 'playwright';
+import { getCalypsoURL } from '../../../data-helper';
+
+type PurchaseActions =
+	| 'Renew annually'
+	| 'Renew monthly'
+	| 'Pick another plan'
+	| 'Remove plan'
+	| 'Cancel plan';
+
+/**
+ * Represents the /me endpoint.
+ */
+export class PurchasesPage {
+	private page: Page;
+
+	/**
+	 * Constructs an instance of the component.
+	 *
+	 * @param {Page} page The underlying page.
+	 */
+	constructor( page: Page ) {
+		this.page = page;
+	}
+
+	/**
+	 * Visits the /me endpoint.
+	 */
+	async visit() {
+		await this.page.goto( getCalypsoURL( 'me/purchases' ) );
+	}
+
+	/* Purchases list view */
+
+	/**
+	 *
+	 * @param name
+	 * @param siteSlug
+	 */
+	async clickOnPurchase( name: string, siteSlug: string ) {
+		await this.page
+			.locator( '.card.purchase-item' )
+			.filter( { hasText: name } )
+			.filter( { hasText: siteSlug } )
+			.click();
+	}
+
+	/* Purchase detail view */
+
+	/**
+	 * Clicks on an action for the purchase.
+	 *
+	 * @param {PurchaseActions} action Action to click.
+	 */
+	async purchaseAction( action: PurchaseActions ) {
+		if ( action === 'Pick another plan' ) {
+			await this.page.getByRole( 'link', { name: action } ).click();
+			return await this.page.waitForURL( /plan/ );
+		}
+
+		await Promise.race( [
+			this.page.getByRole( 'button', { name: action } ).click(),
+			this.page.getByRole( 'link', { name: action } ).click(),
+		] );
+
+		if ( action === 'Cancel plan' ) {
+			await this.page.getByRole( 'button', { name: 'Cancel Subscription' } ).click();
+		}
+	}
+}


### PR DESCRIPTION
Related to p1696470382661749-slack-C02FMH4G8, https://github.com/Automattic/wp-calypso/pull/82622, https://github.com/Automattic/wp-calypso/issues/82621.

## Proposed Changes

This PR adds coverage for cancelling a plan as part of the signup and onboarding E2E. 

Key changes:
- addition of new POMs to handle pages under `/me`, and the cancellation flow.
- rename spec formerly known as `Onboarding: Sell Focus` to `Lifecyle: Signup, onboard, launch and cancel subscription` to better reflect the coverage scope of the updated spec.

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)
  - [x] Pre-Release E2E

![image](https://github.com/Automattic/wp-calypso/assets/6549265/d0051cc8-a515-411b-af46-bd1932b6a50e)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?