### PR TITLE
Site Profiler: replace PureUniversalNavbarFooter with UniversalNavbarFooter

### DIFF
--- a/client/site-profiler/controller.tsx
+++ b/client/site-profiler/controller.tsx
@@ -1,5 +1,5 @@
 import config from '@automattic/calypso-config';
-import { PureUniversalNavbarFooter } from '@automattic/wpcom-template-parts';
+import { UniversalNavbarFooter } from '@automattic/wpcom-template-parts';
 import page from 'page';
 import { ChangeEvent } from 'react';
 import Main from 'calypso/components/main';
@@ -53,7 +53,7 @@ export function siteProfilerContext( context: PageJS.Context, next: () => void )
 			<Main fullWidthLayout>
 				<SiteProfiler routerDomain={ routerDomain } />
 			</Main>
-			<PureUniversalNavbarFooter isLoggedIn={ isLoggedIn } onLanguageChange={ onLanguageChange } />
+			<UniversalNavbarFooter isLoggedIn={ isLoggedIn } onLanguageChange={ onLanguageChange } />
 		</>
 	);
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #82921

## Proposed Changes

*  Automattic logo is missing on the footer of the page. Instead of using `PureUniversalNavbarFooter`, we replace it with `UniversalNavbarFooter`.
<img width="1197" alt="Screen Shot 2023-10-12 at 4 26 39 PM" src="https://github.com/Automattic/wp-calypso/assets/4074459/2d97e7a8-92fe-4143-92a4-b20c8c5dd64a">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to http://calypso.localhost:3000/site-profiler
* Scroll to the bottom of the page and see if Automattic logo shows up
* Try both logged in and logout scenario
* Make sure we don't break anything

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?