### PR TITLE
Match sensei domain filter button and search bar height

### DIFF
--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -3,7 +3,7 @@
 
 .search-filters__dropdown-filters {
 	align-items: center;
-	height: 51px; // same as .search
+	height: 48px;
 	z-index: z-index("root", ".search");
 	margin-left: 12px;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-domain/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-domain/style.scss
@@ -176,12 +176,10 @@
 
 	.search-component {
 		border: 1px solid var(--color-border-subtle);
-		border-radius: 4px;
 	}
 
 	.search-component.is-open {
-		border: 1px solid #a7aaad;
-		border-radius: 4px;
+		border: 1px solid var(--color-border-subtle);
 		height: 48px;
 	}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/82582

## Proposed Changes

* Height should be 48px for both the filter and the search

![image](https://github.com/Automattic/wp-calypso/assets/6586048/7911cba1-d0c7-4179-ab2f-37663dce0293)
 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /setup/sensei and check the domain flow

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you checked for TypeScript, React or other console errors?