### PR TITLE
Support subdomains for Domain Connect

### DIFF
--- a/client/my-sites/domains/domain-management/domain-connect/domain-connect-authorize.jsx
+++ b/client/my-sites/domains/domain-management/domain-connect/domain-connect-authorize.jsx
@@ -130,7 +130,8 @@ class DomainConnectAuthorize extends Component {
 
 	render() {
 		const { params, translate } = this.props;
-		const { domain } = params;
+		const { domain: rootDomain, host } = params;
+		const domain = host ? `${ host }.${ rootDomain }` : rootDomain;
 
 		return (
 			<Main className="domain-connect__main">


### PR DESCRIPTION
We got a report that we're not honouring the `host` param for Domain Connect. So here's a small patch to fix this in Calypso.

## Proposed Changes

* Use the `host` param to show the proper subdomain name in the preview screen

## Testing Instructions

* See the instructions in D124552-code

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?