### PR TITLE
Jetpack Manage: Add sidebar v2 layout for the new navigation.

### DIFF
--- a/client/jetpack-cloud/components/sidebar/header/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/header/index.tsx
@@ -3,6 +3,7 @@ import { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import AllSites from 'calypso/blocks/all-sites';
 import Site from 'calypso/blocks/site';
+import SidebarHeader from 'calypso/layout/sidebar-v2/header';
 import { setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import JetpackLogo from './jetpack-logo.svg';
@@ -31,7 +32,7 @@ const Header = ( { forceAllSitesView = false }: Props ) => {
 	}, [ dispatch ] );
 
 	return (
-		<div className="jetpack-cloud-sidebar__header">
+		<SidebarHeader className="jetpack-cloud-sidebar__header">
 			{ forceAllSitesView ? (
 				<AllSites
 					showIcon
@@ -48,7 +49,7 @@ const Header = ( { forceAllSitesView = false }: Props ) => {
 				/>
 			) }
 			<ProfileDropdown />
-		</div>
+		</SidebarHeader>
 	);
 };
 

--- a/client/jetpack-cloud/components/sidebar/header/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/header/index.tsx
@@ -3,7 +3,7 @@ import { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import AllSites from 'calypso/blocks/all-sites';
 import Site from 'calypso/blocks/site';
-import SidebarHeader from 'calypso/layout/sidebar-v2/header';
+import { SidebarV2Header as SidebarHeader } from 'calypso/layout/sidebar-v2';
 import { setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import JetpackLogo from './jetpack-logo.svg';

--- a/client/jetpack-cloud/components/sidebar/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/index.tsx
@@ -1,8 +1,14 @@
 import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import JetpackIcons from 'calypso/components/jetpack/sidebar/menu-items/jetpack-icons';
 import SiteSelector from 'calypso/components/site-selector';
+import SidebarItem from 'calypso/layout/sidebar/item';
 import Sidebar from 'calypso/layout/sidebar-v2';
 import SidebarFooter from 'calypso/layout/sidebar-v2/footer';
 import SidebarMain from 'calypso/layout/sidebar-v2/main';
+import { useSelector } from 'calypso/state';
+import getJetpackAdminUrl from 'calypso/state/sites/selectors/get-jetpack-admin-url';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import Header from './header';
 
 import './style.scss';
@@ -15,36 +21,55 @@ type Props = {
 	className?: string;
 	isJetpackManage?: boolean;
 };
-const JetpackCloudSidebar = ( { className, isJetpackManage = false }: Props ) => (
-	<Sidebar className={ classNames( 'jetpack-cloud-sidebar', className ) }>
-		<Header forceAllSitesView={ isJetpackManage } />
+const JetpackCloudSidebar = ( { className, isJetpackManage }: Props ) => {
+	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const jetpackAdminUrl = useSelector( ( state ) =>
+		siteId ? getJetpackAdminUrl( state, siteId ) : null
+	);
 
-		<SidebarMain>
-			<ul role="menu" className="jetpack-cloud-sidebar__navigation-list">
-				<li
-					className={ classNames(
-						'jetpack-cloud-sidebar__navigation-item',
-						'jetpack-cloud-sidebar__navigation-item--highlighted'
-					) }
-				>
-					Navigation items
-				</li>
-				<li className="jetpack-cloud-sidebar__navigation-item">Will go here</li>
-			</ul>
-		</SidebarMain>
+	const translate = useTranslate();
 
-		<SidebarFooter>Footer v2</SidebarFooter>
+	return (
+		<Sidebar className={ classNames( 'jetpack-cloud-sidebar', className ) }>
+			<Header forceAllSitesView={ isJetpackManage } />
 
-		<SiteSelector
-			showAddNewSite
-			showAllSites={ isJetpackManage }
-			isJetpackAgencyDashboard={ isJetpackManage }
-			className="jetpack-cloud-sidebar__site-selector"
-			allSitesPath="/dashboard"
-			siteBasePath="/landing"
-			wpcomSiteBasePath="https://wordpress.com/home"
-		/>
-	</Sidebar>
-);
+			<SidebarMain>
+				<ul role="menu" className="jetpack-cloud-sidebar__navigation-list">
+					<li
+						className={ classNames(
+							'jetpack-cloud-sidebar__navigation-item',
+							'jetpack-cloud-sidebar__navigation-item--highlighted'
+						) }
+					>
+						Navigation items
+					</li>
+					<li className="jetpack-cloud-sidebar__navigation-item">Will go here</li>
+				</ul>
+			</SidebarMain>
+
+			<SidebarFooter>
+				{ jetpackAdminUrl && (
+					<SidebarItem
+						label={ translate( 'WP Admin', {
+							comment: 'Jetpack Cloud sidebar navigation item',
+						} ) }
+						link={ jetpackAdminUrl }
+						customIcon={ <JetpackIcons icon="wordpress" /> }
+					/>
+				) }
+			</SidebarFooter>
+
+			<SiteSelector
+				showAddNewSite
+				showAllSites={ isJetpackManage }
+				isJetpackAgencyDashboard={ isJetpackManage }
+				className="jetpack-cloud-sidebar__site-selector"
+				allSitesPath="/dashboard"
+				siteBasePath="/landing"
+				wpcomSiteBasePath="https://wordpress.com/home"
+			/>
+		</Sidebar>
+	);
+};
 
 export default JetpackCloudSidebar;

--- a/client/jetpack-cloud/components/sidebar/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/index.tsx
@@ -47,8 +47,8 @@ const JetpackCloudSidebar = ( { className, isJetpackManage }: Props ) => {
 				</ul>
 			</SidebarMain>
 
-			<SidebarFooter>
-				{ ! isJetpackManage && (
+			{ ! isJetpackManage && (
+				<SidebarFooter>
 					<SidebarItem
 						label={ translate( 'WP Admin', {
 							comment: 'Jetpack Cloud sidebar navigation item',
@@ -56,8 +56,8 @@ const JetpackCloudSidebar = ( { className, isJetpackManage }: Props ) => {
 						link={ jetpackAdminUrl }
 						customIcon={ <JetpackIcons icon="wordpress" /> }
 					/>
-				) }
-			</SidebarFooter>
+				</SidebarFooter>
+			) }
 
 			<SiteSelector
 				showAddNewSite

--- a/client/jetpack-cloud/components/sidebar/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/index.tsx
@@ -9,7 +9,7 @@ import SidebarMain from 'calypso/layout/sidebar-v2/main';
 import { useSelector } from 'calypso/state';
 import getJetpackAdminUrl from 'calypso/state/sites/selectors/get-jetpack-admin-url';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import Header from './header';
+import SidebarHeader from './header';
 
 import './style.scss';
 
@@ -31,7 +31,7 @@ const JetpackCloudSidebar = ( { className, isJetpackManage }: Props ) => {
 
 	return (
 		<Sidebar className={ classNames( 'jetpack-cloud-sidebar', className ) }>
-			<Header forceAllSitesView={ isJetpackManage } />
+			<SidebarHeader forceAllSitesView={ isJetpackManage } />
 
 			<SidebarMain>
 				<ul role="menu" className="jetpack-cloud-sidebar__navigation-list">
@@ -48,7 +48,7 @@ const JetpackCloudSidebar = ( { className, isJetpackManage }: Props ) => {
 			</SidebarMain>
 
 			<SidebarFooter>
-				{ jetpackAdminUrl && (
+				{ ! isJetpackManage && (
 					<SidebarItem
 						label={ translate( 'WP Admin', {
 							comment: 'Jetpack Cloud sidebar navigation item',

--- a/client/jetpack-cloud/components/sidebar/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/index.tsx
@@ -3,9 +3,10 @@ import { useTranslate } from 'i18n-calypso';
 import JetpackIcons from 'calypso/components/jetpack/sidebar/menu-items/jetpack-icons';
 import SiteSelector from 'calypso/components/site-selector';
 import SidebarItem from 'calypso/layout/sidebar/item';
-import Sidebar from 'calypso/layout/sidebar-v2';
-import SidebarFooter from 'calypso/layout/sidebar-v2/footer';
-import SidebarMain from 'calypso/layout/sidebar-v2/main';
+import Sidebar, {
+	SidebarV2Main as SidebarMain,
+	SidebarV2Footer as SidebarFooter,
+} from 'calypso/layout/sidebar-v2';
 import { useSelector } from 'calypso/state';
 import getJetpackAdminUrl from 'calypso/state/sites/selectors/get-jetpack-admin-url';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';

--- a/client/jetpack-cloud/components/sidebar/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/index.tsx
@@ -1,6 +1,9 @@
 import classNames from 'classnames';
 import SiteSelector from 'calypso/components/site-selector';
+import Sidebar from 'calypso/layout/sidebar-v2';
+import SidebarFooter from 'calypso/layout/sidebar-v2/footer';
 import Header from './header';
+
 import './style.scss';
 
 // This is meant to be the "base" sidebar component. All context-specific sidebars
@@ -11,9 +14,10 @@ type Props = {
 	className?: string;
 	isJetpackManage?: boolean;
 };
-const Sidebar = ( { className, isJetpackManage = false }: Props ) => (
-	<nav className={ classNames( 'jetpack-cloud-sidebar', className ) }>
+const JetpackCloudSidebar = ( { className, isJetpackManage = false }: Props ) => (
+	<Sidebar className={ classNames( 'jetpack-cloud-sidebar', className ) }>
 		<Header forceAllSitesView={ isJetpackManage } />
+
 		<div className="jetpack-cloud-sidebar__main">
 			<ul className="jetpack-cloud-sidebar__navigation-list">
 				<li
@@ -28,6 +32,8 @@ const Sidebar = ( { className, isJetpackManage = false }: Props ) => (
 			</ul>
 		</div>
 
+		<SidebarFooter>Footer v2</SidebarFooter>
+
 		<SiteSelector
 			showAddNewSite
 			showAllSites={ isJetpackManage }
@@ -37,7 +43,7 @@ const Sidebar = ( { className, isJetpackManage = false }: Props ) => (
 			siteBasePath="/landing"
 			wpcomSiteBasePath="https://wordpress.com/home"
 		/>
-	</nav>
+	</Sidebar>
 );
 
-export default Sidebar;
+export default JetpackCloudSidebar;

--- a/client/jetpack-cloud/components/sidebar/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/index.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames';
 import SiteSelector from 'calypso/components/site-selector';
 import Sidebar from 'calypso/layout/sidebar-v2';
 import SidebarFooter from 'calypso/layout/sidebar-v2/footer';
+import SidebarMain from 'calypso/layout/sidebar-v2/main';
 import Header from './header';
 
 import './style.scss';
@@ -18,8 +19,8 @@ const JetpackCloudSidebar = ( { className, isJetpackManage = false }: Props ) =>
 	<Sidebar className={ classNames( 'jetpack-cloud-sidebar', className ) }>
 		<Header forceAllSitesView={ isJetpackManage } />
 
-		<div className="jetpack-cloud-sidebar__main">
-			<ul className="jetpack-cloud-sidebar__navigation-list">
+		<SidebarMain>
+			<ul role="menu" className="jetpack-cloud-sidebar__navigation-list">
 				<li
 					className={ classNames(
 						'jetpack-cloud-sidebar__navigation-item',
@@ -30,7 +31,7 @@ const JetpackCloudSidebar = ( { className, isJetpackManage = false }: Props ) =>
 				</li>
 				<li className="jetpack-cloud-sidebar__navigation-item">Will go here</li>
 			</ul>
-		</div>
+		</SidebarMain>
 
 		<SidebarFooter>Footer v2</SidebarFooter>
 

--- a/client/jetpack-cloud/components/sidebar/style.scss
+++ b/client/jetpack-cloud/components/sidebar/style.scss
@@ -2,22 +2,6 @@
 // sidebar will implement by default.
 
 .jetpack-cloud-sidebar {
-	// Make the sidebar full-height, minus top and bottom padding
-	padding: 16px;
-	height: calc(100% - 16px * 2);
-
-	display: flex;
-	flex-direction: column;
-
-	border-radius: 4px;
-
-	// TODO: Existing variables, overridden with values directly from designs;
-	// confirm these colors are correct and refactor as necessary
-	--color-sidebar-menu-hover-background: var(--studio-gray-0);
-	--color-sidebar-background: #fcfcfc;
-
-	background-color: var(--color-sidebar-background);
-
 	.jetpack-cloud-sidebar__site-selector {
 		background-color: var(--color-sidebar-background);
 	}
@@ -58,9 +42,4 @@
 		// confirm this weight is correct and refactor as necessary
 		font-weight: 500;
 	}
-}
-
-.jetpack-cloud-sidebar__main {
-	padding: 16px 0;
-	flex-grow: 1;
 }

--- a/client/layout/sidebar-v2/footer.tsx
+++ b/client/layout/sidebar-v2/footer.tsx
@@ -3,9 +3,6 @@ type Props = {
 };
 
 const SidebarV2Footer = ( { children }: Props ) => {
-	if ( ! children ) {
-		return null;
-	}
 	return <div className="sidebar-v2__footer">{ children }</div>;
 };
 

--- a/client/layout/sidebar-v2/footer.tsx
+++ b/client/layout/sidebar-v2/footer.tsx
@@ -1,0 +1,12 @@
+type Props = {
+	children: React.ReactNode;
+};
+
+const SidebarV2Footer = ( { children }: Props ) => {
+	if ( ! children ) {
+		return null;
+	}
+	return <div className="sidebar-v2__footer">{ children }</div>;
+};
+
+export default SidebarV2Footer;

--- a/client/layout/sidebar-v2/footer.tsx
+++ b/client/layout/sidebar-v2/footer.tsx
@@ -2,8 +2,6 @@ type Props = {
 	children: React.ReactNode;
 };
 
-const SidebarV2Footer = ( { children }: Props ) => {
+export const SidebarV2Footer = ( { children }: Props ) => {
 	return <div className="sidebar-v2__footer">{ children }</div>;
 };
-
-export default SidebarV2Footer;

--- a/client/layout/sidebar-v2/header.tsx
+++ b/client/layout/sidebar-v2/header.tsx
@@ -1,0 +1,9 @@
+type Props = {
+	children: React.ReactNode;
+};
+
+const SidebarV2Header = ( { children }: Props ) => {
+	return <div className="sidebar-v2__header">{ children }</div>;
+};
+
+export default SidebarV2Header;

--- a/client/layout/sidebar-v2/header.tsx
+++ b/client/layout/sidebar-v2/header.tsx
@@ -1,9 +1,12 @@
+import classNames from 'classnames';
+
 type Props = {
 	children: React.ReactNode;
+	className?: string;
 };
 
-const SidebarV2Header = ( { children }: Props ) => {
-	return <div className="sidebar-v2__header">{ children }</div>;
+const SidebarV2Header = ( { children, className }: Props ) => {
+	return <div className={ classNames( 'sidebar-v2__header', className ) }>{ children }</div>;
 };
 
 export default SidebarV2Header;

--- a/client/layout/sidebar-v2/header.tsx
+++ b/client/layout/sidebar-v2/header.tsx
@@ -5,8 +5,6 @@ type Props = {
 	className?: string;
 };
 
-const SidebarV2Header = ( { children, className }: Props ) => {
+export const SidebarV2Header = ( { children, className }: Props ) => {
 	return <div className={ classNames( 'sidebar-v2__header', className ) }>{ children }</div>;
 };
-
-export default SidebarV2Header;

--- a/client/layout/sidebar-v2/index.tsx
+++ b/client/layout/sidebar-v2/index.tsx
@@ -1,0 +1,14 @@
+import classNames from 'classnames';
+
+import './style.scss';
+
+type Props = {
+	className?: string;
+	children: React.ReactNode;
+};
+
+const SidebarV2 = ( { children, className = '' }: Props ) => {
+	return <nav className={ classNames( 'sidebar-v2', className ) }>{ children }</nav>;
+};
+
+export default SidebarV2;

--- a/client/layout/sidebar-v2/index.tsx
+++ b/client/layout/sidebar-v2/index.tsx
@@ -1,3 +1,7 @@
+export * from './header';
+export * from './main';
+export * from './footer';
+
 import classNames from 'classnames';
 
 import './style.scss';

--- a/client/layout/sidebar-v2/main.tsx
+++ b/client/layout/sidebar-v2/main.tsx
@@ -1,0 +1,9 @@
+type Props = {
+	children: React.ReactNode;
+};
+
+const SidebarV2Main = ( { children }: Props ) => {
+	return <div className="sidebar-v2__main">{ children }</div>;
+};
+
+export default SidebarV2Main;

--- a/client/layout/sidebar-v2/main.tsx
+++ b/client/layout/sidebar-v2/main.tsx
@@ -2,8 +2,6 @@ type Props = {
 	children: React.ReactNode;
 };
 
-const SidebarV2Main = ( { children }: Props ) => {
+export const SidebarV2Main = ( { children }: Props ) => {
 	return <div className="sidebar-v2__main">{ children }</div>;
 };
-
-export default SidebarV2Main;

--- a/client/layout/sidebar-v2/style.scss
+++ b/client/layout/sidebar-v2/style.scss
@@ -18,6 +18,8 @@
 
 .sidebar-v2__main {
 	flex-grow: 1;
+	overflow-y: auto;
+	height: 0;  // To support scrollable in the main content area, we set height to 0.
 }
 
 .sidebar-v2__footer {

--- a/client/layout/sidebar-v2/style.scss
+++ b/client/layout/sidebar-v2/style.scss
@@ -1,6 +1,7 @@
 .sidebar-v2 {
 	margin: 0;
-	padding: 0;
+	padding: 16px;
+	box-sizing: border-box;
 
 	display: flex;
 	flex-direction: column;
@@ -9,7 +10,10 @@
 	height: 100%;
 }
 
+.sidebar-v2__main {
+	flex-grow: 1;
+}
+
 .sidebar-v2__footer {
 	margin-block-start: auto;
-	padding: 0 16px 16px;
 }

--- a/client/layout/sidebar-v2/style.scss
+++ b/client/layout/sidebar-v2/style.scss
@@ -1,13 +1,19 @@
 .sidebar-v2 {
-	margin: 0;
-	padding: 16px;
-	box-sizing: border-box;
+	// TODO: Existing variables, overridden with values directly from designs;
+	// confirm these colors are correct and refactor as necessary
+	--color-sidebar-menu-hover-background: var(--studio-gray-0);
+	--color-sidebar-background: #fcfcfc;
 
 	display: flex;
 	flex-direction: column;
 	gap: 16px;
 
 	height: 100vh;
+	background-color: var(--color-sidebar-background);
+
+	margin: 0;
+	padding: 16px;
+	box-sizing: border-box;
 }
 
 .sidebar-v2__main {

--- a/client/layout/sidebar-v2/style.scss
+++ b/client/layout/sidebar-v2/style.scss
@@ -7,7 +7,7 @@
 	flex-direction: column;
 	gap: 16px;
 
-	height: 100%;
+	height: 100vh;
 }
 
 .sidebar-v2__main {

--- a/client/layout/sidebar-v2/style.scss
+++ b/client/layout/sidebar-v2/style.scss
@@ -1,0 +1,15 @@
+.sidebar-v2 {
+	margin: 0;
+	padding: 0;
+
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+
+	height: 100%;
+}
+
+.sidebar-v2__footer {
+	margin-block-start: auto;
+	padding: 0 16px 16px;
+}


### PR DESCRIPTION
This PR adds a new Sidebar V2 layout in Calypso, which will serve as the base layout for the new navigation. **The discussion is ongoing, and the PR should be evaluated as a proof of concept.**

Related to https://github.com/Automattic/jetpack-genesis/issues/39
Depends on #82881

## Proposed Changes

* The PR adds new sidebar V2 layout components in the`/calypso/client/layout` directory. The layout comprises three main areas (header, main, footer). The layout is based on compound component patterns, allowing flexibility to the consuming component while maintaining consistent styling. This also will enable consumers to pass information directly to the sub-components without props drilling.
* To demo the new layout, I have refactored the existing Sidebar (Jetpack context-specific) to use the new usable layout in its current form. In addition, a conditional footer content is also included.

## Testing Instructions
Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

* Use the Cloud Live link and go to `/dashboard?flags=jetpack/new-navigation`
* Confirm that the sidebar renders correctly with the Header component (Site selector) working as expected.
<img width="286" alt="Screen Shot 2023-10-13 at 3 00 40 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/4246c526-9c72-44a2-ab29-ff8bae70f77c">


* Now go to any single site page (e., `/activity-log/<SITE>?flags=jetpack/new-navigation`)
* Confirm that the footer is visible with the WP-Admin link.
<img width="296" alt="Screen Shot 2023-10-13 at 3 00 03 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/c9c9425d-d308-4f6e-8663-70c9bc13b3cc">


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?