### PR TITLE
Fix with theme signup flow for partner and community themes

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -160,10 +160,10 @@ function getWithThemeDestination( {
 	themeParameter,
 	styleVariation,
 	themeType,
-	cartItem,
+	cartItems,
 } ) {
 	if (
-		! cartItem &&
+		! cartItems &&
 		[ DOT_ORG_THEME, PREMIUM_THEME, MARKETPLACE_THEME, WOOCOMMERCE_THEME ].includes( themeType )
 	) {
 		return `/setup/site-setup/designSetup?siteSlug=${ siteSlug }`;
@@ -171,6 +171,10 @@ function getWithThemeDestination( {
 
 	if ( DOT_ORG_THEME === themeType ) {
 		return `/marketplace/theme/${ themeParameter }/install/${ siteSlug }`;
+	}
+
+	if ( MARKETPLACE_THEME === themeType ) {
+		return `/marketplace/thank-you/${ siteSlug }?onboarding=&themes=${ themeParameter }`;
 	}
 
 	const style = styleVariation ? `&style=${ styleVariation }` : '';


### PR DESCRIPTION
Instead of using the page function to redirect the user to checkout, we are now using the callback approach that's used in other addToCart flows.

This is needed in order for the checkout page to be properly displayed. Previously, the user was pointed to log-in again even though they just signed up for an account on WP.com

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4102, https://github.com/Automattic/wp-calypso/issues/82102

## Proposed Changes

* Redirect the user to checkout with the `callback` function from the stepper library.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the live link and open an incognito window
* Go to /themes
* Search for `olsen` partner theme
* Click on the Pick this design
* In the signup page, click on the `Continue with email` where you'll create a new account (you can use a `+` suffix for the email to have a unique email). **This step is mandatory in order to reproduce the issue.** 
* Pick a site name and go to the plans page
* Click on Business
* You'll be redirected to checkout, however, because of a bug (unrelated) in Calypso live/localhost, we are still being redirected to login.
* Go to SA and add some credits to your newly created account.
* To test the flow, make sure that the URL contains a path to /checkout/your-site?signup=1 (the query param is important).
* Manually, go to WordPress.com/checkout/your-site?signup=1 and you'll notice that the checkout actually loads.
* Purchase the plan and theme.
* Notice that after purchase you are redirected to the Partner theme install page
* The theme was installed successfully on your site
* **Make sure you delete the theme subscription from your test site.** 

### Repeat the above steps for Community themes.
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?