### PR TITLE
Staging Sites: Add labels for remaining staging site sync options

### DIFF
--- a/client/my-sites/hosting/staging-site-card/card-content/staging-sync-card.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/staging-sync-card.tsx
@@ -31,14 +31,14 @@ const synchronizationOptions: CheckboxOptionItem[] = [
 	{
 		name: 'themes',
 		label: translate( 'Themes' ),
-		subTitle: translate( 'Everything in the themes directory.' ),
+		subTitle: translate( 'All files and directories in the themes directory.' ),
 		checked: false,
 		isDangerous: false,
 	},
 	{
 		name: 'plugins',
 		label: translate( 'Plugins' ),
-		subTitle: translate( 'Everything in the plugins directory.' ),
+		subTitle: translate( 'All files and directories in the plugins directory.' ),
 		checked: false,
 		isDangerous: false,
 	},
@@ -46,7 +46,7 @@ const synchronizationOptions: CheckboxOptionItem[] = [
 		name: 'uploads',
 		label: translate( 'Media Uploads' ),
 		subTitle: translate(
-			'Everything in the media library. You must also select ‘Site database‘ for restored media uploads to appear.'
+			'All files and directories in the uploads directory. You must also select ‘Site database‘ if it is necessary for the files to appear as media uploads in WordPress.'
 		),
 		checked: false,
 		isDangerous: false,
@@ -55,7 +55,7 @@ const synchronizationOptions: CheckboxOptionItem[] = [
 		name: 'contents',
 		label: translate( 'wp-content Directory' ),
 		subTitle: translate(
-			'Everything in the wp-content directory, excluding themes, plugins, and uploads.'
+			'All files and directories in the wp-content directory other than themes, plugins, and uploads.'
 		),
 		checked: false,
 		isDangerous: false,
@@ -63,7 +63,9 @@ const synchronizationOptions: CheckboxOptionItem[] = [
 	{
 		name: 'roots',
 		label: translate( 'Web Root' ),
-		subTitle: translate( 'Everything in the WordPress root, including any non WordPress files.' ),
+		subTitle: translate(
+			'All files and directories in the WordPress root, including any non WordPress files.'
+		),
 		checked: false,
 		isDangerous: false,
 	},

--- a/client/my-sites/hosting/staging-site-card/card-content/staging-sync-card.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/staging-sync-card.tsx
@@ -64,7 +64,7 @@ const synchronizationOptions: CheckboxOptionItem[] = [
 		name: 'roots',
 		label: translate( 'Web Root' ),
 		subTitle: translate(
-			'All files and directories in the WordPress root, including any non WordPress files.'
+			'All files and directories in the WordPress root other than wp-content, including any non WordPress files.'
 		),
 		checked: false,
 		isDangerous: false,

--- a/client/my-sites/hosting/staging-site-card/card-content/staging-sync-card.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/staging-sync-card.tsx
@@ -31,18 +31,23 @@ const synchronizationOptions: CheckboxOptionItem[] = [
 	{
 		name: 'themes',
 		label: translate( 'Themes' ),
+		subTitle: translate( 'Everything in the themes directory.' ),
 		checked: false,
 		isDangerous: false,
 	},
 	{
 		name: 'plugins',
 		label: translate( 'Plugins' ),
+		subTitle: translate( 'Everything in the plugins directory.' ),
 		checked: false,
 		isDangerous: false,
 	},
 	{
 		name: 'uploads',
 		label: translate( 'Media Uploads' ),
+		subTitle: translate(
+			'Everything in the media library. You must also select ‘Site database‘ for restored media uploads to appear.'
+		),
 		checked: false,
 		isDangerous: false,
 	},
@@ -50,7 +55,7 @@ const synchronizationOptions: CheckboxOptionItem[] = [
 		name: 'contents',
 		label: translate( 'wp-content Directory' ),
 		subTitle: translate(
-			'Everything in the wp-content directory, excluding themes, plugins, and uploads'
+			'Everything in the wp-content directory, excluding themes, plugins, and uploads.'
 		),
 		checked: false,
 		isDangerous: false,
@@ -58,7 +63,7 @@ const synchronizationOptions: CheckboxOptionItem[] = [
 	{
 		name: 'roots',
 		label: translate( 'Web Root' ),
-		subTitle: translate( 'Everything in the WordPress root, including any non WordPress files' ),
+		subTitle: translate( 'Everything in the WordPress root, including any non WordPress files.' ),
 		checked: false,
 		isDangerous: false,
 	},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4162

## Proposed Changes

In this PR, I propose to add additional description text for synchronization options that don't have them yet.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create an Atomic site
2. Navigate to the Settings -> Hosting Configuration
3. Add staging site
4. Select "Staging into production" and confirm descriptions look correctly

![Screenshot 2023-10-13 at 11 09 20](https://github.com/Automattic/wp-calypso/assets/727413/ae0a00f8-7122-46db-b187-fba1749a0f24)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?