### PR TITLE
Jetpack Manage: Change default href of the Add New Site button

### DIFF
--- a/client/components/jetpack/add-new-site-button/index.tsx
+++ b/client/components/jetpack/add-new-site-button/index.tsx
@@ -36,7 +36,7 @@ const AddNewSiteButton = ( {
 			toggleIcon={ showMainButtonLabel ? undefined : 'plus' }
 			onToggle={ onToggleMenu }
 			onClick={ onClickAddNewSite }
-			href="/partner-portal/create-site"
+			href="https://wordpress.com/jetpack/connect"
 		>
 			<PopoverMenuItem onClick={ onClickWpcomMenuItem } href="/partner-portal/create-site">
 				<WordPressLogo className="gridicon" size={ 18 } />


### PR DESCRIPTION
## Proposed Changes

* This PR changes the default behavior of the "Add new site" button in Jetpack Manage. Currently the default action is to create a new WPCOM site - instead it should be to connect a Jetpack site.

* Click on the "Add new site" button in Jetpack Manage. The default action should lead to the connection flow rather than the WPCOM product selector page.
* Both of the actions in the split button should still lead to their logical places.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?