### PR TITLE
JP tooltip: Remove en locale checks

### DIFF
--- a/client/my-sites/plans-grid/components/comparison-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/comparison-grid/index.tsx
@@ -10,12 +10,11 @@ import {
 	getPlans,
 } from '@automattic/calypso-products';
 import { Gridicon, JetpackLogo } from '@automattic/components';
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useMemo } from '@wordpress/element';
 import classNames from 'classnames';
-import i18n, { useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { useState, useCallback, useEffect, ChangeEvent, Dispatch, SetStateAction } from 'react';
 import { useIsPlanUpgradeCreditVisible } from 'calypso/my-sites/plans-grid/hooks/use-is-plan-upgrade-credit-visible';
 import { useManageTooltipToggle } from 'calypso/my-sites/plans-grid/hooks/use-manage-tooltip-toggle';
@@ -735,10 +734,6 @@ const ComparisonGridFeatureGroupRow: React.FunctionComponent< {
 	const featureSlug = feature?.getSlug() ?? '';
 	const footnote = planFeatureFootnotes?.footnotesByFeature?.[ featureSlug ];
 	const tooltipId = `${ feature?.getSlug() }-comparison-grid`;
-	const isEnglishLocale = useIsEnglishLocale();
-	const shouldShowNewJPTooltipCopy =
-		isEnglishLocale ||
-		i18n.hasTranslation( 'Security, performance, and growth tools—powered by Jetpack.' );
 
 	return (
 		<Row
@@ -776,13 +771,9 @@ const ComparisonGridFeatureGroupRow: React.FunctionComponent< {
 								{ allJetpackFeatures.has( feature.getSlug() ) ? (
 									<JetpackIconContainer>
 										<Plans2023Tooltip
-											text={
-												shouldShowNewJPTooltipCopy
-													? translate(
-															'Security, performance, and growth tools—powered by Jetpack.'
-													  )
-													: ''
-											}
+											text={ translate(
+												'Security, performance, and growth tools—powered by Jetpack.'
+											) }
 											setActiveTooltipId={ setActiveTooltipId }
 											activeTooltipId={ activeTooltipId }
 											id={ `jp-${ tooltipId }` }

--- a/client/my-sites/plans-grid/components/plan-features-container.tsx
+++ b/client/my-sites/plans-grid/components/plan-features-container.tsx
@@ -1,6 +1,5 @@
 import { JetpackLogo } from '@automattic/components';
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
-import i18n, { LocalizeProps } from 'i18n-calypso';
+import { LocalizeProps } from 'i18n-calypso';
 import { useManageTooltipToggle } from 'calypso/my-sites/plans-grid/hooks/use-manage-tooltip-toggle';
 import { DataResponse } from '../types';
 import PlanFeatures2023GridFeatures from './features';
@@ -29,10 +28,6 @@ const PlanFeaturesContainer: React.FC< {
 	isTableCell,
 } ) => {
 	const [ activeTooltipId, setActiveTooltipId ] = useManageTooltipToggle();
-	const isEnglishLocale = useIsEnglishLocale();
-	const shouldShowNewJPTooltipCopy =
-		isEnglishLocale ||
-		i18n.hasTranslation( 'Security, performance, and growth tools—powered by Jetpack.' );
 
 	return plansWithFeatures.map(
 		( { planSlug, features: { wpcomFeatures, jetpackFeatures } }, mapIndex ) => {
@@ -56,13 +51,7 @@ const PlanFeaturesContainer: React.FC< {
 					{ jetpackFeatures.length !== 0 && (
 						<div className="plan-features-2023-grid__jp-logo" key="jp-logo">
 							<Plans2023Tooltip
-								text={
-									shouldShowNewJPTooltipCopy
-										? translate( 'Security, performance, and growth tools—powered by Jetpack.' )
-										: translate(
-												'Security, performance and growth tools made by the WordPress experts.'
-										  )
-								}
+								text={ translate( 'Security, performance, and growth tools—powered by Jetpack.' ) }
 								setActiveTooltipId={ setActiveTooltipId }
 								activeTooltipId={ activeTooltipId }
 								id={ `${ planSlug }-jp-logo-${ mapIndex }` }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Translations have completed for https://github.com/Automattic/wp-calypso/pull/82457/, so this PR removes the `en` only locale checks.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit /start/plans and hover mouse over the Jetpack icon. Verify that the tooltip includes "Powered by Jetpack." in the end.
* Verify in non-EN that the translations for the new content appear.
