### PR TITLE
Staging Sites: Tweak language used for sync explanations and labels

### DIFF
--- a/client/my-sites/hosting/staging-site-card/card-content/staging-sync-card.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/staging-sync-card.tsx
@@ -256,6 +256,7 @@ const ProductionToStagingSync = ( {
 
 const SyncCardContainer = ( {
 	children,
+	currentSiteType,
 	progress,
 	isSyncInProgress,
 	siteToSync,
@@ -263,6 +264,7 @@ const SyncCardContainer = ( {
 	error,
 }: {
 	children: React.ReactNode;
+	currentSiteType: 'production' | 'staging';
 	progress: number;
 	isSyncInProgress: boolean;
 	siteToSync: 'production' | 'staging' | null;
@@ -274,14 +276,18 @@ const SyncCardContainer = ( {
 
 	return (
 		<StagingSyncCardBody>
-			<SyncContainerTitle>{ translate( 'Data and File synchronization' ) }</SyncContainerTitle>
+			<SyncContainerTitle>{ translate( 'Database and file synchronization' ) }</SyncContainerTitle>
 
 			{ ! isSyncInProgress && (
 				<>
 					<SyncContainerContent>
-						{ translate(
-							'Sync your database and files between your staging and production environments—in either direction.'
-						) }
+						{ currentSiteType === 'production'
+							? translate(
+									'Pull changes from your staging site into production, or refresh staging with the current production data.'
+							  )
+							: translate(
+									'Refresh your staging site with the latest from production, or push changes in your staging site to production.'
+							  ) }
 					</SyncContainerContent>
 					{ error && (
 						<Notice
@@ -299,13 +305,11 @@ const SyncCardContainer = ( {
 					) }
 					{ ! error && (
 						<>
-							<SyncContainerTitle>
-								{ translate( 'Choose synchronization direction' ) }
-							</SyncContainerTitle>
+							<SyncContainerTitle>{ translate( 'Choose direction:' ) }</SyncContainerTitle>
 							{ children }
 							<StagingSyncCardFooter>
 								{ translate(
-									"We'll automatically back up your site before synchronization starts. Need to restore a backup? Head to the {{link}}Activity Log.{{/link}}",
+									"We'll automatically back up your site before synchronization starts. Need to restore a backup? Head to the {{link}}Activity Log{{/link}}.",
 									{
 										components: {
 											link: <a href={ `/activity-log/${ siteSlug }` } />,
@@ -410,6 +414,7 @@ export const SiteSyncCard = ( {
 
 	return (
 		<SyncCardContainer
+			currentSiteType={ type }
 			siteToSync={ targetSiteType }
 			progress={ progress }
 			isSyncInProgress={ isSyncInProgress }
@@ -429,8 +434,8 @@ export const SiteSyncCard = ( {
 						className="staging-site-sync-card__radio"
 						label={
 							type === 'production'
-								? translate( 'Pull from staging' )
-								: translate( 'Pull from production' )
+								? translate( 'Pull staging into production' )
+								: translate( 'Pull production into staging' )
 						}
 						value="pull"
 						checked={ selectedOption === 'pull' }
@@ -444,8 +449,8 @@ export const SiteSyncCard = ( {
 						className="staging-site-sync-card__radio"
 						label={
 							type === 'production'
-								? translate( 'Push to staging' )
-								: translate( 'Push to production' )
+								? translate( 'Push production to staging' )
+								: translate( 'Push staging to production' )
 						}
 						value="push"
 						checked={ selectedOption === 'push' }

--- a/client/my-sites/hosting/staging-site-card/card-content/staging-sync-card.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/staging-sync-card.tsx
@@ -305,7 +305,9 @@ const SyncCardContainer = ( {
 					) }
 					{ ! error && (
 						<>
-							<SyncContainerTitle>{ translate( 'Choose direction:' ) }</SyncContainerTitle>
+							<SyncContainerTitle>
+								{ translate( 'Choose synchronization direction:' ) }
+							</SyncContainerTitle>
 							{ children }
 							<StagingSyncCardFooter>
 								{ translate(
@@ -434,8 +436,8 @@ export const SiteSyncCard = ( {
 						className="staging-site-sync-card__radio"
 						label={
 							type === 'production'
-								? translate( 'Pull staging into production' )
-								: translate( 'Pull production into staging' )
+								? translate( 'Staging into production' )
+								: translate( 'Production into staging' )
 						}
 						value="pull"
 						checked={ selectedOption === 'pull' }
@@ -449,8 +451,8 @@ export const SiteSyncCard = ( {
 						className="staging-site-sync-card__radio"
 						label={
 							type === 'production'
-								? translate( 'Push production to staging' )
-								: translate( 'Push staging to production' )
+								? translate( 'Production to staging' )
+								: translate( 'Staging to production' )
 						}
 						value="push"
 						checked={ selectedOption === 'push' }


### PR DESCRIPTION
Somewhat related to https://github.com/Automattic/dotcom-forge/issues/4135

## Proposed Changes

Tweaks the language used for sync explanations and labels. The language is more specific to production context vs. staging context. I took the screenshots with https://github.com/Automattic/wp-calypso/pull/82807 applied.

### Production

<img width="750" alt="CleanShot 2023-10-12 at 06 50 01@2x" src="https://github.com/Automattic/wp-calypso/assets/36432/061c94a2-7ad1-4a90-a5a4-926342dcd093">


### Staging

<img width="761" alt="CleanShot 2023-10-12 at 06 48 53@2x" src="https://github.com/Automattic/wp-calypso/assets/36432/e5797fe5-1c35-4350-8f05-b9bb183d1e66">



## Testing Instructions

1. Verify everything looks better.