### PR TITLE
Update /start/domains search filter bar for mobile

### DIFF
--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -279,7 +279,12 @@ body.is-section-signup.is-white-signup {
 		.search-component.is-open {
 			border: 1px solid #a7aaad;
 			border-radius: 4px;
-			height: 48px;
+			box-sizing: border-box;
+			height: 40px;
+
+			@include break-mobile {
+				height: 48px;
+			}
 		}
 
 		.search-component.is-open.has-focus {
@@ -422,7 +427,11 @@ body.is-section-signup.is-white-signup {
 	}
 
 	.search-filters__dropdown-filters {
-		height: 48px;
+		height: 40px;
+
+		@include break-mobile {
+			height: 48px;
+		}
 
 		&.search-filters__dropdown-filters--is-open {
 			box-shadow: none;

--- a/packages/search/src/style.scss
+++ b/packages/search/src/style.scss
@@ -5,6 +5,7 @@
 @import "@automattic/typography/styles/variables";
 @import "@wordpress/base-styles/variables";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/breakpoints";
 
 $input-z-index: 20;
 
@@ -91,10 +92,14 @@ $input-z-index: 20;
 	&__open-icon,
 	&__close-icon {
 		flex: 0 0 auto;
-		width: 50px;
+		width: 19px;
 		z-index: 20;
 		color: var(--color-primary);
 		cursor: pointer;
+
+		@include break-mobile {
+			width: 50px;
+		}
 	}
 
 	&__open-icon:hover {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4112

## Proposed Changes

| Before  | After |
| :-------------: | :-------------: |
| <img src="https://github.com/Automattic/wp-calypso/assets/6586048/3eb3263b-c6cd-4c26-a9d3-b5131b922935">  | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/b16d06e5-8bb7-44ae-8002-b12da99506db">|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/domains`
* Check mobile view
* Please also check the following to make sure we're not breaking them (these are also TODOs since we want to update globally, but can be in a separate PR)
- [ ] /domains/add/:site
- [ ] /setup/sensei/senseiDomain
- [ ] /setup/newsletter/domains

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?