### PR TITLE
Comments Moderation - fix textarea styles for reply

### DIFF
--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -384,40 +384,41 @@
 	display: none;
 	padding: 0 16px 16px;
 	position: relative;
-}
 
-.comment__reply-textarea {
-	font-size: $font-body-small;
-	height: 47px; // 1 line
-	line-height: 21px;
-	min-height: 47px; // 1 line
-	overflow: hidden;
-	padding: 12px 70px 12px 16px;
-	resize: vertical;
-	transition: min-height 0.15s linear;
-	white-space: pre-wrap;
-	word-wrap: break-word;
-
-	&::placeholder {
-		color: var(--color-text-subtle);
+	.comment__reply-textarea {
+		font-size: $font-body-small;
+		height: 47px; // 1 line
+		line-height: 21px;
+		min-height: 47px; // 1 line
 		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
-	}
+		padding: 12px 70px 12px 16px;
+		resize: vertical;
+		transition: min-height 0.15s linear;
+		white-space: pre-wrap;
+		word-wrap: break-word;
 
-	&:not(:focus) {
-		resize: none;
-	}
+		&::placeholder {
+			color: var(--color-text-subtle);
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+		}
 
-	&:focus,
-	&.has-focus {
-		min-height: 68px; // 2 lines
-	}
+		&:not(:focus) {
+			resize: none;
+		}
 
-	&.has-scrollbar {
-		overflow-y: auto;
+		&:focus,
+		&.has-focus {
+			min-height: 68px; // 2 lines
+		}
+
+		&.has-scrollbar {
+			overflow-y: auto;
+		}
 	}
 }
+
 
 .comment__reply-submit.button.is-compact.is-borderless {
 	color: var(--color-neutral-light);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # pe7F0s-1kj-p2

## Proposed Changes

* Fixes an issue where the "Send" button in replying via comments moderation is obscured by the reply text in the textarea.
* The correct styles were already written, but were overridden by general styles for textareas since these two style declarations have the same specificity (one class selector) and thus falls subject to the cascading effects of CSS. To fix we simply nest the styles for `.comment__reply-textarea` under `.comment__reply` so that it has specificity over the general styles given to `.form-textarea`.

Before:

![comments-reply-before](https://github.com/Automattic/wp-calypso/assets/28742426/abc8e08a-60a7-47ed-8ec3-dab66042509e)


After:

![comment-reply-fix](https://github.com/Automattic/wp-calypso/assets/28742426/6f4d36a0-3a0a-48a2-aff4-f4824a07c211)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this PR
* Open comments moderation
* Reply to a comment
* type enough content to wrap onto the next line, verify the text does not bleed underneath the send button.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?