### PR TITLE
Thank You: Auto-activate theme when its an onboarding flow

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
@@ -3,7 +3,7 @@ import { Gridicon, Button } from '@automattic/components';
 import { DesignPreviewImage, isDefaultGlobalStylesVariationSlug } from '@automattic/design-picker';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import QueryActiveTheme from 'calypso/components/data/query-active-theme';
 import { useActiveThemeQuery } from 'calypso/data/themes/use-active-theme-query';
 import ActivationModal from 'calypso/my-sites/themes/activation-modal';
@@ -143,7 +143,7 @@ export const ThankYouThemeSection = ( {
 		[ siteId, theme ]
 	);
 
-	const handleActivateTheme = () => {
+	const handleActivateTheme = useCallback( () => {
 		if ( isActive ) {
 			return;
 		}
@@ -151,7 +151,13 @@ export const ThankYouThemeSection = ( {
 		dispatch(
 			activate( theme.id, siteId, 'marketplace-thank-you', false, false, isOnboardingFlow )
 		);
-	};
+	}, [ theme.id, siteId, isOnboardingFlow, dispatch, isActive, sendTrackEvent ] );
+
+	useEffect( () => {
+		if ( isOnboardingFlow ) {
+			handleActivateTheme();
+		}
+	}, [ isOnboardingFlow, handleActivateTheme ] );
 
 	return (
 		<ThemeSectionContainer>


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/82836

## Proposed Changes

Try to auto-activate the theme when arriving on the Thank You page during onboarding.

![CleanShot 2023-10-12 at 11 32 34](https://github.com/Automattic/wp-calypso/assets/5039531/fd59ad8a-bb67-4eb6-a3e6-9fa547a41749)



## Testing Instructions

* Go to `/marketplace/thank-you/:site?themes=:theme_slug&onboarding` with a partner and already purchased theme. The site should be atomic.
* You should see the `Activate this design` in a loading state
* After a few moments, you should see the `Customize your site` button.

* Follow the instructions on #81929 to install a theme from the Design Picker, this theme should also be auto-activated. Try this with a non-atomic site.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
