### PR TITLE
Checkout: Convert RegionAddressFieldsets to TypeScript

### DIFF
--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/region-address-fieldsets.tsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/region-address-fieldsets.tsx
@@ -1,10 +1,8 @@
 import { localize, LocalizeProps } from 'i18n-calypso';
 import { includes } from 'lodash';
-import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { Input, HiddenInput } from 'calypso/my-sites/domains/components/form';
 import {
-	CONTACT_DETAILS_FORM_FIELDS,
 	CHECKOUT_EU_ADDRESS_FORMAT_COUNTRY_CODES,
 	CHECKOUT_UK_ADDRESS_FORMAT_COUNTRY_CODES,
 } from './constants';

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/region-address-fieldsets.tsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/region-address-fieldsets.tsx
@@ -1,4 +1,4 @@
-import { localize } from 'i18n-calypso';
+import { localize, LocalizeProps } from 'i18n-calypso';
 import { includes } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -11,24 +11,29 @@ import {
 import EuAddressFieldset from './eu-address-fieldset';
 import UkAddressFieldset from './uk-address-fieldset';
 import UsAddressFieldset from './us-address-fieldset';
+import type { FieldProps } from '../managed-contact-details-form-fields';
+import type { DomainContactDetailsErrors } from '@automattic/wpcom-checkout';
 
 const noop = () => {};
 
-export class RegionAddressFieldsets extends Component {
-	static propTypes = {
-		getFieldProps: PropTypes.func,
-		translate: PropTypes.func,
-		arePostalCodesSupported: PropTypes.bool,
-		countryCode: PropTypes.string,
-		shouldAutoFocusAddressField: PropTypes.bool,
-		hasCountryStates: PropTypes.bool,
-		contactDetailsErrors: PropTypes.shape(
-			Object.fromEntries(
-				CONTACT_DETAILS_FORM_FIELDS.map( ( field ) => [ field, PropTypes.node ] )
-			)
-		),
-	};
+export interface RegionAddressFieldsetsProps {
+	countryCode: string;
+	shouldAutoFocusAddressField?: boolean;
+	arePostalCodesSupported?: boolean;
+	hasCountryStates?: boolean;
+	contactDetailsErrors: DomainContactDetailsErrors;
+	getFieldProps: (
+		name: string,
+		options: {
+			customErrorMessage?: DomainContactDetailsErrors[ 'firstName' ];
+			needsChildRef?: boolean;
+		}
+	) => FieldProps;
+}
 
+export class RegionAddressFieldsets extends Component<
+	RegionAddressFieldsetsProps & LocalizeProps
+> {
 	static defaultProps = {
 		getFieldProps: noop,
 		countryCode: 'US',
@@ -37,7 +42,7 @@ export class RegionAddressFieldsets extends Component {
 		hasCountryStates: false,
 	};
 
-	inputRefCallback( input ) {
+	inputRefCallback( input: { focus: () => void } | undefined | null ) {
 		input && input.focus();
 	}
 

--- a/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.tsx
+++ b/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.tsx
@@ -33,12 +33,33 @@ import {
 } from './custom-form-fieldsets/constants';
 import RegionAddressFieldsets from './custom-form-fieldsets/region-address-fieldsets';
 import { GSuiteFields } from './g-suite-fields';
-import type { DomainContactDetails as DomainContactDetailsData } from '@automattic/shopping-cart';
+import type {
+	DomainContactDetails as DomainContactDetailsData,
+	DomainContactDetailsExtra,
+} from '@automattic/shopping-cart';
 import type { DomainContactDetailsErrors, ManagedContactDetails } from '@automattic/wpcom-checkout';
 import type { IAppState } from 'calypso/state/types';
 import './style.scss';
 
 const debug = debugFactory( 'calypso:managed-contact-details-form-fields' );
+
+export interface FieldProps {
+	labelClass: string;
+	additionalClasses: string;
+	disabled: boolean;
+	isError: boolean;
+	errorMessage:
+		| React.ReactElement
+		| string
+		| number
+		| DomainContactDetailsErrors[ 'extra' ]
+		| undefined;
+	onChange: ( event: React.ChangeEvent< HTMLInputElement > ) => void;
+	onBlur: () => void;
+	value: string | DomainContactDetailsExtra | undefined;
+	name: string;
+	eventFormName: string | undefined;
+}
 
 export interface ManagedContactDetailsFormFieldsProps {
 	eventFormName?: string;
@@ -161,7 +182,10 @@ export class ManagedContactDetailsFormFields extends Component<
 		this.updateParentState( updatedParentState );
 	};
 
-	getFieldProps = ( name: string, { customErrorMessage = null } ) => {
+	getFieldProps = (
+		name: string,
+		{ customErrorMessage }: { customErrorMessage?: DomainContactDetailsErrors[ 'firstName' ] }
+	) => {
 		const { eventFormName, getIsFieldDisabled } = this.props;
 		const camelName = camelCase( name );
 


### PR DESCRIPTION

![xQPjF6](https://github.com/Automattic/wp-calypso/assets/552016/c3684484-b7a2-489d-91d0-9b6e258b101c)
Fixes https://github.com/Automattic/payments-shilling/issues/2082

## Proposed Changes

* This converts the `RegionAddressFieldsets` component to TypeScript.

## Testing Instructions

1. Apply the patch
2. Sandbox your setup
3. Add a domain to cart
4. Fill out the address fields on the checkout as the `RegionAddressFieldsets` should be rendered like this <!-- Uploading d.pr/i/xQPjF6 to GitHub… -->
5. Ensure it works as expected
6. Watch for errors in dev console
7. Static Analysis also would be helpful


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?