### PR TITLE
Make BlazePress e2e input interactions more stable

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/blaze-campaign-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/blaze-campaign-page.ts
@@ -32,6 +32,8 @@ export class BlazeCampaignPage {
 	 * @param {string} text Text to enter.
 	 */
 	async enterText( name: string, text: string ) {
+		// Clear out the field first.
+		await this.page.getByRole( 'textbox', { name: name } ).clear();
 		await this.page.getByRole( 'textbox', { name: name } ).fill( text );
 	}
 

--- a/test/e2e/specs/tools/advertising__promote.ts
+++ b/test/e2e/specs/tools/advertising__promote.ts
@@ -35,6 +35,8 @@ skipDescribeIf( envVariables.ATOMIC_VARIATION === 'private' )(
 	DataHelper.createSuiteTitle( 'Advertising: Promote' ),
 	function () {
 		const pageTitle = DataHelper.getRandomPhrase();
+		// The input has a limit, so let's stay way under to be safe!
+		const pageTitleInAd = pageTitle.slice( 0, 20 );
 		const snippet = Array( 2 ).fill( DataHelper.getRandomPhrase() ).toString();
 
 		let newPostDetails: PostResponse;
@@ -104,12 +106,12 @@ skipDescribeIf( envVariables.ATOMIC_VARIATION === 'private' )(
 		} );
 
 		it( 'Enter title and snippet', async function () {
-			await blazeCampaignPage.enterText( 'Page title', pageTitle );
+			await blazeCampaignPage.enterText( 'Page title', pageTitleInAd );
 			await blazeCampaignPage.enterText( 'Ad text', snippet );
 		} );
 
 		it( 'Validate preview', async function () {
-			await blazeCampaignPage.validatePreview( { title: pageTitle, snippet: snippet } );
+			await blazeCampaignPage.validatePreview( { title: pageTitleInAd, snippet: snippet } );
 		} );
 
 		afterAll( async function () {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

We were having some flakiness in our Advertising (BlazePress) spec because the title input in the ad has a character limit that we were occasionally going over. This made our following checks fail. We now limit the expected input value.

Also, now that there's often text pre-populated by AI, we were sometimes doubling up the text, which makes our assertions less meaningful. We now clear the inputs before adding text to them.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- [x] PR tests pass
- [x] Jetpack Atomic Tests Pass

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?