### PR TITLE
Multi-Domain: Add to domain-only flow

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -96,9 +96,15 @@ export function createSiteOrDomain( callback, dependencies, data, reduxStore ) {
 			siteId,
 			siteSlug,
 		};
-		const products = [ dependencies.domainItem, dependencies.privacyItem, dependencies.cartItem ]
-			.filter( Boolean )
-			.map( ( item ) => prepareItemForAddingToCart( item ) );
+
+		const products =
+			domainCart && domainCart.length > 0
+				? [ ...Object.values( domainCart ), dependencies.privacyItem, dependencies.cartItem ]
+						.filter( Boolean )
+						.map( ( item ) => prepareItemForAddingToCart( item ) )
+				: [ dependencies.domainItem, dependencies.privacyItem, dependencies.cartItem ]
+						.filter( Boolean )
+						.map( ( item ) => prepareItemForAddingToCart( item ) );
 
 		cartManagerClient
 			.forCartKey( siteId )

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -60,7 +60,7 @@ const debug = debugFactory( 'calypso:signup:step-actions' );
 
 export function createSiteOrDomain( callback, dependencies, data, reduxStore ) {
 	const { siteId, siteSlug } = data;
-	const { cartItem, designType, siteUrl, themeSlugWithRepo } = dependencies;
+	const { cartItem, domainCart, designType, siteUrl, themeSlugWithRepo } = dependencies;
 	const reduxState = reduxStore.getState();
 	const domainItem = dependencies.domainItem
 		? prepareItemForAddingToCart(
@@ -77,7 +77,11 @@ export function createSiteOrDomain( callback, dependencies, data, reduxStore ) {
 			domainItem,
 		};
 
-		const domainChoiceCart = [ domainItem ].filter( Boolean );
+		const domainChoiceCart =
+			domainCart && domainCart.length > 0
+				? domainCart.filter( Boolean )
+				: [ domainItem ].filter( Boolean );
+
 		cartManagerClient
 			.forCartKey( cartKey )
 			.actions.replaceProductsInCart( domainChoiceCart )

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -116,6 +116,7 @@ export function createSiteOrDomain( callback, dependencies, data, reduxStore ) {
 			isPurchasingItem: true,
 			siteUrl,
 			themeSlugWithRepo,
+			domainCart,
 		};
 
 		createSiteWithCart(

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -665,6 +665,7 @@ export function generateSteps( {
 				'siteUrl',
 				'domainItem',
 				'themeSlugWithRepo',
+				'domainCart',
 			],
 			defaultDependencies: {
 				themeSlugWithRepo: 'pub/twentytwentytwo',
@@ -679,7 +680,7 @@ export function generateSteps( {
 				},
 			},
 			providesDependencies: [ 'siteId', 'siteSlug', 'domainItem', 'themeSlugWithRepo' ],
-			dependencies: [ 'designType', 'domainItem', 'siteUrl', 'themeSlugWithRepo' ],
+			dependencies: [ 'designType', 'domainItem', 'siteUrl', 'themeSlugWithRepo', 'domainCart' ],
 			delayApiRequestUntilComplete: true,
 		},
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -875,16 +875,18 @@ export class RenderDomainsStep extends Component {
 					<Button primary className="domains__domain-cart-continue" onClick={ this.goToNext() }>
 						{ this.props.translate( 'Continue' ) }
 					</Button>
-					<Button
-						borderless
-						className="domains__domain-cart-choose-later"
-						onClick={ () => {
-							this.removeAllDomains();
-							this.handleSkip( undefined, false );
-						} }
-					>
-						{ this.props.translate( 'Choose my domain later' ) }
-					</Button>
+					{ this.props.flowName !== 'domain' && (
+						<Button
+							borderless
+							className="domains__domain-cart-choose-later"
+							onClick={ () => {
+								this.removeAllDomains();
+								this.handleSkip( undefined, false );
+							} }
+						>
+							{ this.props.translate( 'Choose my domain later' ) }
+						</Button>
+					) }
 				</div>
 			);
 		};

--- a/client/signup/steps/domains/utils.js
+++ b/client/signup/steps/domains/utils.js
@@ -34,7 +34,7 @@ export function getExternalBackUrl( source, sectionName = null ) {
  * Check if we should use multiple domains in domain flows.
  */
 export function shouldUseMultipleDomainsInCart( flowName ) {
-	const enabledFlows = [ 'onboarding' ];
+	const enabledFlows = [ 'onboarding', 'domain' ];
 
 	const status =
 		isEnabled( 'domains/add-multiple-domains-to-cart' ) && enabledFlows.includes( flowName );

--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -224,6 +224,7 @@ class SiteOrDomain extends Component {
 
 	handleClickChoice = ( designType ) => {
 		const { goToStep, goToNextStep } = this.props;
+		const domainCart = this.getDomainCart();
 
 		this.submitDomain( designType );
 
@@ -233,7 +234,7 @@ class SiteOrDomain extends Component {
 			goToNextStep();
 		} else {
 			this.props.submitSignupStep(
-				{ stepName: 'site-picker', wasSkipped: true },
+				{ stepName: 'site-picker', wasSkipped: true, domainCart },
 				{ themeSlugWithRepo: 'pub/twentysixteen' }
 			);
 			goToStep( 'plans-site-selected' );

--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -31,9 +31,16 @@ class SiteOrDomain extends Component {
 				const productSlug = getDomainProductSlug( domain );
 				isValidDomain = !! this.props.productsList[ productSlug ];
 			}
+			return isValidDomain && domain;
 		}
 
-		return isValidDomain && domain;
+		const domainCart = this.getDomainCart();
+		if ( domainCart.length ) {
+			const productSlug = domainCart[ 0 ].product_slug;
+			isValidDomain = !! this.props.productsList[ productSlug ];
+			return isValidDomain && domainCart[ 0 ].meta;
+		}
+		return false;
 	}
 
 	getDomainCart() {

--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -36,6 +36,13 @@ class SiteOrDomain extends Component {
 		return isValidDomain && domain;
 	}
 
+	getDomainCart() {
+		const { signupDependencies } = this.props;
+		const domainCart = get( signupDependencies, 'domainCart', [] );
+
+		return domainCart;
+	}
+
 	isLeanDomainSearch() {
 		const { signupDependencies } = this.props;
 		return 'leandomainsearch' === signupDependencies?.refParameter;
@@ -179,6 +186,7 @@ class SiteOrDomain extends Component {
 		const { stepName } = this.props;
 
 		const domain = this.getDomainName();
+		const domainCart = this.getDomainCart();
 		const productSlug = getDomainProductSlug( domain );
 		const domainItem = domainRegistration( { productSlug, domain } );
 		const siteUrl = domain;
@@ -191,18 +199,20 @@ class SiteOrDomain extends Component {
 				siteSlug: domain,
 				siteUrl,
 				isPurchasingItem: true,
+				domainCart,
 			},
-			{ designType, domainItem, siteUrl }
+			{ designType, domainItem, siteUrl, domainCart }
 		);
 	}
 
 	submitDomainOnlyChoice() {
 		const { goToStep } = this.props;
 
+		const domainCart = this.getDomainCart();
 		// we can skip the next two steps in the `domain-first` flow if the
 		// user is only purchasing a domain
 		this.props.submitSignupStep(
-			{ stepName: 'site-picker', wasSkipped: true },
+			{ stepName: 'site-picker', wasSkipped: true, domainCart },
 			{ themeSlugWithRepo: 'pub/twentysixteen' }
 		);
 		this.props.submitSignupStep(


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/4205

## Proposed Changes

Enable Multi Domain for domain-only flow behind the feature flag.

## Testing Instructions

* Go to `/start/domain/domain-only?flags=domains/add-multiple-domains-to-cart`.
* Check all the flow by selecting multiple domains.
* Check without the flag and see if nothing is broken.
* Check other flows that might use the `site-picker` step.
* Try to break it.
