### PR TITLE
Help Center: remove a8c button from Odie

### DIFF
--- a/client/components/forms/form-button/index.jsx
+++ b/client/components/forms/form-button/index.jsx
@@ -1,4 +1,4 @@
-import { Button } from '@automattic/components';
+import { Button } from '@wordpress/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { omit } from 'lodash';
@@ -20,14 +20,15 @@ class FormButton extends Component {
 	};
 
 	render() {
-		const { children, className, isPrimary, ...props } = this.props;
+		const { children, className, isPrimary, isSubmitting, ...props } = this.props;
 		const buttonClasses = classNames( className, 'form-button' );
 
 		return (
 			<Button
 				{ ...omit( props, [ 'isSubmitting', 'moment', 'numberFormat', 'translate' ] ) }
-				primary={ isPrimary }
+				variant={ isPrimary ? 'primary' : 'secondary' }
 				className={ buttonClasses }
+				isBusy={ isSubmitting }
 			>
 				{ Children.count( children ) ? children : this.getDefaultButtonAction() }
 			</Button>

--- a/client/components/forms/form-button/index.jsx
+++ b/client/components/forms/form-button/index.jsx
@@ -1,4 +1,4 @@
-import { Button } from '@wordpress/components';
+import { Button } from '@automattic/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { omit } from 'lodash';
@@ -20,15 +20,14 @@ class FormButton extends Component {
 	};
 
 	render() {
-		const { children, className, isPrimary, isSubmitting, ...props } = this.props;
+		const { children, className, isPrimary, ...props } = this.props;
 		const buttonClasses = classNames( className, 'form-button' );
 
 		return (
 			<Button
 				{ ...omit( props, [ 'isSubmitting', 'moment', 'numberFormat', 'translate' ] ) }
-				variant={ isPrimary ? 'primary' : 'secondary' }
+				primary={ isPrimary }
 				className={ buttonClasses }
-				isBusy={ isSubmitting }
 			>
 				{ Children.count( children ) ? children : this.getDefaultButtonAction() }
 			</Button>

--- a/client/components/forms/form-text-input-with-action/index.jsx
+++ b/client/components/forms/form-text-input-with-action/index.jsx
@@ -1,7 +1,7 @@
+import { Button } from '@wordpress/components';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import { useState, useCallback } from 'react';
-import FormButton from 'calypso/components/forms/form-button';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 
 import './style.scss';
@@ -92,13 +92,14 @@ function FormTextInputWithAction( {
 				onBlur={ handleBlur }
 				onKeyDown={ handleKeyDown }
 			/>
-			<FormButton
-				className="form-text-input-with-action__button is-compact"
+			<Button
+				size="compact"
+				className="form-text-input-with-action__button"
 				disabled={ disabled || ! value }
 				onClick={ handleAction }
 			>
 				{ action }
-			</FormButton>
+			</Button>
 		</div>
 	);
 }

--- a/client/odie/message/send-message-button.tsx
+++ b/client/odie/message/send-message-button.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@automattic/components';
+import { Button } from '@wordpress/components';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { WAPUU_ERROR_MESSAGE } from '..';
@@ -20,9 +20,8 @@ export const SendMessageButton = ( {
 	const dispatch = useDispatch();
 	return (
 		<Button
-			borderless
+			variant="primary"
 			className="odie-chatbox-message-action-button"
-			primary
 			onClick={ async ( event: { preventDefault: () => void } ) => {
 				try {
 					event.preventDefault();


### PR DESCRIPTION
Fixes: p1697133351273199-slack-C03N25JPCE4
## Proposed Changes

<table>
<tr>
 <td>Before
 <td>After
<tr>
 <td><img src="https://github.com/Automattic/wp-calypso/assets/17054134/c80b499a-bc65-4801-8c06-649df9117a72">
 <td><img src="https://github.com/Automattic/wp-calypso/assets/17054134/49b2062c-b414-4222-abe7-3a34afed5774">
</table>


This change also affects the Reader tags input

<table>
<tr>
 <td>Before
 <td>After
<tr>
 <td><img src="https://github.com/Automattic/wp-calypso/assets/17054134/bf2241cf-fdd4-49af-ac78-314c462273fc">
 <td><img src="https://github.com/Automattic/wp-calypso/assets/17054134/bd02c748-c5a2-436c-960f-60a2ebc32567">
</table>

## Testing Instructions

1. Follow [these steps](https://github.com/Automattic/wp-calypso/pull/81645#:~:text=Testing%20Instructions) from 3 and on.
2. The send button should look and work well. 
3. To verify it actually fixes the issue,
4. cd into apps/editing-toolkit.
5. Run `yarn dev --sync`.
6. Verify the issue isn't reproducible in a sandboxed simple site. 