### PR TITLE
Use events to refocus header in editor e2e for resiliency

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-gutenberg-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-gutenberg-component.ts
@@ -45,7 +45,8 @@ export class EditorGutenbergComponent {
 	async resetSelectedBlock(): Promise< void > {
 		const editorCanvas = await this.editor.canvas();
 		const locator = editorCanvas.locator( selectors.title );
-		await locator.click();
+		// Every now and then, a block toolbar can cover the title, so we "force" the click by doing it via the event directly.
+		await locator.dispatchEvent( 'click' );
 	}
 
 	/* Title block */

--- a/packages/calypso-e2e/src/lib/components/editor-gutenberg-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-gutenberg-component.ts
@@ -31,24 +31,6 @@ export class EditorGutenbergComponent {
 		this.editor = editor;
 	}
 
-	/**
-	 * Resets the selected block.
-	 *
-	 * The Gutenberg block-based editor 'remembers' what block was last
-	 * selected. This behavior impacts the block options that are shown
-	 * in the block inserter.
-	 *
-	 * For instance, if a Contact Form block is currently selected, the
-	 * block inserter will display a filtered set of blocks that are
-	 * permitted to be inserted within the parent Contact Form block.
-	 */
-	async resetSelectedBlock(): Promise< void > {
-		const editorCanvas = await this.editor.canvas();
-		const locator = editorCanvas.locator( selectors.title );
-		// Every now and then, a block toolbar can cover the title, so we "force" the click by doing it via the event directly.
-		await locator.dispatchEvent( 'click' );
-	}
-
 	/* Title block */
 
 	/**

--- a/packages/calypso-e2e/src/lib/components/editor-gutenberg-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-gutenberg-component.ts
@@ -31,6 +31,24 @@ export class EditorGutenbergComponent {
 		this.editor = editor;
 	}
 
+	/**
+	 * Resets the selected block.
+	 *
+	 * The Gutenberg block-based editor 'remembers' what block was last
+	 * selected. This behavior impacts the block options that are shown
+	 * in the block inserter.
+	 *
+	 * For instance, if a Contact Form block is currently selected, the
+	 * block inserter will display a filtered set of blocks that are
+	 * permitted to be inserted within the parent Contact Form block.
+	 */
+	async resetSelectedBlock(): Promise< void > {
+		const editorCanvas = await this.editor.canvas();
+		const locator = editorCanvas.locator( selectors.title );
+		// Every now and then, a block toolbar can cover the title, so we "force" the click by doing it via the event directly.
+		await locator.dispatchEvent( 'click' );
+	}
+
 	/* Title block */
 
 	/**

--- a/packages/calypso-e2e/src/lib/components/editor-gutenberg-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-gutenberg-component.ts
@@ -45,8 +45,9 @@ export class EditorGutenbergComponent {
 	async resetSelectedBlock(): Promise< void > {
 		const editorCanvas = await this.editor.canvas();
 		const locator = editorCanvas.locator( selectors.title );
-		// Every now and then, a block toolbar can cover the title, so we "force" the click by doing it via the event directly.
+		// Every now and then, a block toolbar can cover the title, so we "force" using click events and the direct focus method.
 		await locator.dispatchEvent( 'click' );
+		await locator.focus();
 	}
 
 	/* Title block */

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -253,22 +253,6 @@ export class EditorPage {
 	//#region Block and Pattern Insertion
 
 	/**
-	 * Resets the selected block.
-	 *
-	 * The Gutenberg block-based editor 'remembers' what block was last
-	 * selected. This behavior impacts the block options that are shown
-	 * in the block inserter.
-	 *
-	 * For instance, if a Contact Form block is currently selected, the
-	 * block inserter will display a filtered set of blocks that are
-	 * permitted to be inserted within the parent Contact Form block.
-	 */
-	async resetSelectedBlock() {
-		const editorParent = await this.getEditorParent();
-		await editorParent.getByRole( 'region', { name: 'Editor top bar' } ).dispatchEvent( 'click' );
-	}
-
-	/**
 	 * Adds a Gutenberg block from the sidebar block inserter panel.
 	 *
 	 * The name is expected to be formatted in the same manner as it
@@ -290,7 +274,7 @@ export class EditorPage {
 		blockEditorSelector: string,
 		{ noSearch }: { noSearch?: boolean } = {}
 	): Promise< ElementHandle > {
-		await this.resetSelectedBlock();
+		await this.editorGutenbergComponent.resetSelectedBlock();
 		await this.editorToolbarComponent.openBlockInserter();
 		await this.addBlockFromInserter( blockName, this.editorSidebarBlockInserterComponent, {
 			noSearch: noSearch,
@@ -382,7 +366,7 @@ export class EditorPage {
 	 * @param {string} patternName Name of the pattern to insert.
 	 */
 	async addPatternFromSidebar( patternName: string ): Promise< void > {
-		await this.resetSelectedBlock();
+		await this.editorGutenbergComponent.resetSelectedBlock();
 		await this.editorToolbarComponent.openBlockInserter();
 		await this.addPatternFromInserter( patternName, this.editorSidebarBlockInserterComponent );
 	}

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -253,6 +253,22 @@ export class EditorPage {
 	//#region Block and Pattern Insertion
 
 	/**
+	 * Resets the selected block.
+	 *
+	 * The Gutenberg block-based editor 'remembers' what block was last
+	 * selected. This behavior impacts the block options that are shown
+	 * in the block inserter.
+	 *
+	 * For instance, if a Contact Form block is currently selected, the
+	 * block inserter will display a filtered set of blocks that are
+	 * permitted to be inserted within the parent Contact Form block.
+	 */
+	async resetSelectedBlock() {
+		const editorParent = await this.getEditorParent();
+		await editorParent.getByRole( 'region', { name: 'Editor top bar' } ).dispatchEvent( 'click' );
+	}
+
+	/**
 	 * Adds a Gutenberg block from the sidebar block inserter panel.
 	 *
 	 * The name is expected to be formatted in the same manner as it
@@ -274,7 +290,7 @@ export class EditorPage {
 		blockEditorSelector: string,
 		{ noSearch }: { noSearch?: boolean } = {}
 	): Promise< ElementHandle > {
-		await this.editorGutenbergComponent.resetSelectedBlock();
+		await this.resetSelectedBlock();
 		await this.editorToolbarComponent.openBlockInserter();
 		await this.addBlockFromInserter( blockName, this.editorSidebarBlockInserterComponent, {
 			noSearch: noSearch,
@@ -366,7 +382,7 @@ export class EditorPage {
 	 * @param {string} patternName Name of the pattern to insert.
 	 */
 	async addPatternFromSidebar( patternName: string ): Promise< void > {
-		await this.editorGutenbergComponent.resetSelectedBlock();
+		await this.resetSelectedBlock();
 		await this.editorToolbarComponent.openBlockInserter();
 		await this.addPatternFromInserter( patternName, this.editorSidebarBlockInserterComponent );
 	}


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

I noticed in a test run recently that sometimes the block toolbar can cover the main header, which eats the click when we are trying to reset the block focus.

This makes that more resilient by just dispatching the click event directly.

## Testing Instructions

All builds should pass!

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?