### PR TITLE
VideoPress onboarding: Fixes to videopress login form style

### DIFF
--- a/client/signup/videopress-step-wrapper/style.scss
+++ b/client/signup/videopress-step-wrapper/style.scss
@@ -48,7 +48,7 @@
 	--videopress-font-size-form-xxl: 32px;
 }
 
-.videopress-step-wrapper {
+body.is-section-signup .videopress-step-wrapper {
 	box-sizing: border-box;
 	display: flex;
 	flex-direction: column;
@@ -164,18 +164,25 @@
 	}
 
 	.signup-form__social-buttons button {
-		background: none;
-		border: none;
+		background: none !important;
+		border: none !important;
 		border-radius: 0;
-		color: var(--videopress-color-text);
 		box-shadow: none;
 		margin: 0;
 		transition: 0.3s;
 
+		span {
+			color: var(--videopress-color-text);
+			margin-left: 8px;
+		}
+
 		&:focus {
 			outline: none;
 			border: none;
-			color: var(--videopress-color-link);
+
+			span {
+				color: var(--videopress-color-link);
+			}
 
 			.social-icons {
 				border-color: var(--videopress-color-link);
@@ -183,7 +190,9 @@
 		}
 
 		&:hover {
-			color: var(--videopress-color-link);
+			span {
+				color: var(--videopress-color-link);
+			}
 
 			.social-icons {
 				border-color: var(--videopress-color-link);
@@ -191,7 +200,7 @@
 		}
 
 		.social-icons {
-			padding: 12px;
+			padding: 12px !important;
 			border: 1px solid var(--videopress-color-separator-light);
 			// We deserve circles
 			// stylelint-disable-next-line scales/radii


### PR DESCRIPTION
This PR adds reorganises the css and adds new overrides for more specificity and to support the new button layout that appears to be recently deployed.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes


| before | after |
| -- | -- |
| ![image (3)](https://github.com/Automattic/wp-calypso/assets/4081020/f4aa9b0e-4386-4fd4-af98-0d9c12c9ed5a) | <img  alt="SCR-20231012-osqb" src="https://github.com/Automattic/wp-calypso/assets/4081020/a35ad662-ba91-4ff8-b492-2c27eebe4479"> |

* adds specificity to better override button hover and default styling
* reorganizes some classes for new layout (a new span for button text)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `yarn && yarn start` or use the calypso build below
* visit `/setup/videopress` in a private browser
* choose the "Showcase your work" flow, continue through the steps until signup
* the Social login buttons should look nice and have yellow hover states

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?