### PR TITLE
Clear textSearch filter when the input box is cleared

### DIFF
--- a/client/my-sites/activity/filterbar/text-selector.tsx
+++ b/client/my-sites/activity/filterbar/text-selector.tsx
@@ -35,6 +35,15 @@ const TextSelector: FunctionComponent< Props > = ( { siteId, filter } ) => {
 	};
 
 	const onChange = ( value: string ) => {
+		if ( value !== searchQuery && value.length === 0 ) {
+			// Field was cleared, so clear the filter without waiting for enter
+			dispatch( updateFilter( siteId, { textSearch: '' } ) );
+			dispatch(
+				recordTracksEvent( 'calypso_activitylog_filterbar_text_search', {
+					characters: value.length,
+				} )
+			);
+		}
 		setSearchQuery( value );
 	};
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-roadmap/issues/671

## Proposed Changes

* Clears the ActivityLog search when the input field is cleared

https://github.com/Automattic/wp-calypso/assets/1992658/07f71941-0e60-4ff1-a22e-da4f8afbb860

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open a live branch and visit the Activity Log
* Enter something into the search field and press enter to update the filter
* Delete the contents of the search field with the keyboard or by clicking the x to clear the field
* The results should return to their original state

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?