### PR TITLE
Add Zendesk chat to feature comparison page on cloud.jetpack.com

### DIFF
--- a/client/jetpack-cloud/sections/comparison/table/index.tsx
+++ b/client/jetpack-cloud/sections/comparison/table/index.tsx
@@ -2,6 +2,7 @@ import { TERM_ANNUALLY, PLAN_JETPACK_FREE } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { Fragment, useCallback, useMemo } from 'react';
+import { usePresalesChat } from 'calypso/lib/presales-chat';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import ProductLightbox from 'calypso/my-sites/plans/jetpack-plans/product-lightbox';
 import StoreItemInfoContext, {
@@ -32,6 +33,8 @@ export const Table: React.FC = () => {
 	const { currentProduct, setCurrentProduct, onClickMoreInfoFactory } = useProductLightbox();
 	const { getCheckoutURL, getCtaLabel, getIsExternal, getOnClickPurchase } =
 		useStoreItemInfoContext();
+
+	usePresalesChat( 'jpGeneral' );
 
 	const sectionHeadingColSpan = productsToCompare.length + 1;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pbNhbs-8la-p2

## Proposed Changes

* Add presales chat widget to /features/comparison

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Do one of the below:
  * Open the Jetpack Cloud live link during chat available hours
  * Checkout this branch locally, run yarn start-jetpack-cloud, update line 37 to the following to bypass the availability check
   ```js
       usePresalesChat( 'jpGeneral', true, true );
    ```
* Visit `/features/comparison`
* Confirm the chat shows up

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?