### PR TITLE
Remove all the SRM A/A tests

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -38,7 +38,6 @@ import {
 	planItem as getCartItemForPlan,
 	getPlanCartItem,
 } from 'calypso/lib/cart-values/cart-items';
-import { loadExperimentAssignment } from 'calypso/lib/explat';
 import { isValidFeatureKey, FEATURES_LIST } from 'calypso/lib/plans/features-list';
 import scrollIntoViewport from 'calypso/lib/scroll-into-viewport';
 import { addQueryArgs } from 'calypso/lib/url';
@@ -283,16 +282,6 @@ const PlansFeaturesMain = ( {
 		useGetFreeSubdomainSuggestion(
 			paidDomainName || siteTitle || signupFlowUserName || currentUserName
 		);
-
-	// the A/A tests for identifying SRM issue. See peP6yB-11Y-p2
-	// We can use `useExperiment()` and its `isEligible` check to avoid the condition, but it's intentional to use loadExperimentAssignment() here
-	// to be consistent with the other A/A tests.
-	useEffect( () => {
-		if ( flowName === 'onboarding' ) {
-			loadExperimentAssignment( 'calypso_srm_test_plans_page_view_free_plan_modal_view' );
-			loadExperimentAssignment( 'calypso_srm_test_plans_page_view_free_plan_button_click' );
-		}
-	}, [] );
 
 	const resolvedSubdomainName: DataResponse< string > = useMemo( () => {
 		return {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -180,12 +180,6 @@ export class RenderDomainsStep extends Component {
 		if ( shouldUseMultipleDomainsInCart( this.props.flowName ) ) {
 			this.props.shoppingCartManager.addProductsToCart( [ this.props.multiDomainDefaultPlan ] );
 		}
-
-		// the A/A tests for identifying SRM issue. See peP6yB-11Y-p2
-		if ( this.props.flowName === 'onboarding' ) {
-			loadExperimentAssignment( 'calypso_srm_test_domain_page_view_free_plan_button_click' );
-			loadExperimentAssignment( 'calypso_srm_test_domain_page_view_free_plan_modal_view' );
-		}
 	}
 
 	getLocale() {
@@ -372,10 +366,6 @@ export class RenderDomainsStep extends Component {
 					loadExperimentAssignment(
 						'calypso_onboarding_plans_paid_domain_on_free_plan_confidence_check'
 					);
-
-					// the A/A tests for identifying SRM issue. See peP6yB-11Y-p2
-					loadExperimentAssignment( 'calypso_srm_test_paid_domain_click_free_plan_button_click' );
-					loadExperimentAssignment( 'calypso_srm_test_paid_domain_click_free_plan_modal_view' );
 				} else {
 					loadExperimentAssignment(
 						'calypso_gf_signup_onboarding_free_free_dont_miss_out_modal_v3'


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/growth-foundations#205

## Proposed Changes

This PR cleans up the A/A tests added by https://github.com/Automattic/wp-calypso/pull/82042 for identifying the SRM issues, since the investigation has been concluded by @aaronyan here: p2-peP6yB-11Y#comment-527

## Testing Instructions

* `/start/domains` and `/start/plans` should work as it is.
* All fetches for the `calypso_srm_test_*` tests are properly removed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
