### PR TITLE
FHT: Hide CTA if user not eligible for trial

### DIFF
--- a/client/lib/user/shared-utils/filter-user-object.js
+++ b/client/lib/user/shared-utils/filter-user-object.js
@@ -32,6 +32,7 @@ const allowedKeys = [
 	'i18n_empathy_mode',
 	'use_fallback_for_incomplete_languages',
 	'is_google_domain_owner',
+	'had_hosting_trial',
 ];
 const requiredKeys = [ 'ID' ];
 const decodedKeys = [ 'display_name', 'description', 'user_URL' ];

--- a/client/lib/user/user.d.ts
+++ b/client/lib/user/user.d.ts
@@ -43,4 +43,5 @@ export type OptionalUserData = {
 	visible_site_count: number;
 	jetpack_visible_site_count?: number;
 	is_google_domain_owner: boolean;
+	had_hosting_trial: boolean;
 };

--- a/client/state/selectors/is-user-eligible-for-free-hosting-trial.ts
+++ b/client/state/selectors/is-user-eligible-for-free-hosting-trial.ts
@@ -1,10 +1,17 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { getCurrentUser } from '../current-user/selectors';
+import type { AppState } from '../../types';
 
-export const isUserEligibleForFreeHostingTrial = () => {
-	/**
-	 * TODO: Possible criteria
-	 * - if the user has tried the platform already
-	 * - maybe if they already have a paid site
-	 */
-	return isEnabled( 'plans/hosting-trial' );
+export const isUserEligibleForFreeHostingTrial = ( state: AppState ) => {
+	if ( ! isEnabled( 'plans/hosting-trial' ) ) {
+		return false;
+	}
+
+	const currentUser = getCurrentUser( state );
+
+	if ( ! currentUser ) {
+		return false;
+	}
+
+	return ! currentUser.had_hosting_trial;
 };


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/4052.

## Proposed Changes

* check user for `had_hosting_trial` flag to tell if the user is eligible for free trial.

## Testing Instructions
**Pre-req**

- Apply D125230-code to sandbox
- Ensure store sandbox is true.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go `/new-hosted-site/plans` and start a free trial.
* After site being redirected to `/home` again go to `/new-hosted-site/plans`
* verify the free trial plan is no longer available.

![image](https://github.com/Automattic/wp-calypso/assets/47489215/a3e9483c-94a5-451c-8fed-054fec78555c)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?