### PR TITLE
Add product to be activated on connection/authorization page.

### DIFF
--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -222,8 +222,14 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 }
 
 .jetpack-connect__logged-in-form {
-	.jetpack-connect__logged-in-form-user-text {
+	.jetpack-connect__logged-in-form-user-text,
+	.jetpack-connect__activate-product-text {
 		text-align: center;
+	}
+
+	.jetpack-connect__activate-product-text {
+		/* stylelint-disable-next-line scales/font-sizes */
+		font-size: 0.9rem;
 	}
 
 	.gravatar {

--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -1,10 +1,11 @@
 import config from '@automattic/calypso-config';
+import { getUrlParts } from '@automattic/calypso-url';
 import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
-import { useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import QueryOrderTransaction from 'calypso/components/data/query-order-transaction';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import Main from 'calypso/components/main';
@@ -84,7 +85,7 @@ function CheckoutPending( {
 }: CheckoutPendingProps ) {
 	const orderId = isValidOrderId( orderIdOrPlaceholder ) ? orderIdOrPlaceholder : undefined;
 
-	useRedirectOnTransactionSuccess( {
+	const { headingText } = useRedirectOnTransactionSuccess( {
 		orderId,
 		receiptId,
 		siteSlug,
@@ -104,18 +105,15 @@ function CheckoutPending( {
 				title="Checkout Pending"
 				properties={ { order_id: orderId, ...( siteSlug && { site: siteSlug } ) } }
 			/>
-			<PendingContent />
+			<PendingContent heading={ headingText } />
 		</Main>
 	);
 }
 
-function PendingContent() {
-	const translate = useTranslate();
+function PendingContent( { heading }: { heading: React.ReactNode } ) {
 	return (
 		<div className="pending-content__wrapper">
-			<div className="pending-content__title">
-				{ translate( "Almost there – we're currently finalizing your order." ) }
-			</div>
+			<div className="pending-content__title">{ heading }</div>
 			<LoadingEllipsis />
 		</div>
 	);
@@ -164,7 +162,7 @@ function useRedirectOnTransactionSuccess( {
 	 * logged in).
 	 */
 	fromSiteSlug?: string;
-} ): void {
+} ): { headingText: React.ReactNode } {
 	const translate = useTranslate();
 	const transaction: OrderTransaction | null = useSelector( ( state ) =>
 		orderId ? getOrderTransaction( state, orderId ) : null
@@ -187,6 +185,19 @@ function useRedirectOnTransactionSuccess( {
 	const productName = firstPurchase?.productName ?? '';
 	const willAutoRenew = firstPurchase?.willAutoRenew ?? false;
 	const saasRedirectUrl = getSaaSProductRedirectUrl( receipt );
+
+	const { searchParams } = getUrlParts( redirectTo || '/' );
+	const isConnectAfterCheckoutFlow =
+		Boolean( searchParams.size ) &&
+		searchParams.get( 'from' ) === 'connect-after-checkout' &&
+		searchParams.get( 'connect_url_redirect' ) === 'true';
+
+	const defaultPendingText = translate( "Almost there – we're currently finalizing your order." );
+	const connectingJetpackText = translate(
+		"Transaction finalized – We're now connecting Jetpack."
+	);
+
+	const [ headingText, setHeadingText ] = useState( defaultPendingText );
 
 	// Fetch receipt data once we have a receipt Id.
 	const didFetchReceipt = useRef( false );
@@ -237,6 +248,10 @@ function useRedirectOnTransactionSuccess( {
 		}
 
 		didRedirect.current = true;
+		if ( isConnectAfterCheckoutFlow ) {
+			setHeadingText( connectingJetpackText );
+		}
+
 		triggerPostRedirectNotices( {
 			redirectInstructions,
 			isRenewal,
@@ -263,6 +278,8 @@ function useRedirectOnTransactionSuccess( {
 		willAutoRenew,
 		fromSiteSlug,
 	] );
+
+	return { headingText };
 }
 
 function isTransactionSuccessful(

--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -1,11 +1,10 @@
 import config from '@automattic/calypso-config';
-import { getUrlParts } from '@automattic/calypso-url';
 import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
-import React, { useState, useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import QueryOrderTransaction from 'calypso/components/data/query-order-transaction';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import Main from 'calypso/components/main';
@@ -85,7 +84,7 @@ function CheckoutPending( {
 }: CheckoutPendingProps ) {
 	const orderId = isValidOrderId( orderIdOrPlaceholder ) ? orderIdOrPlaceholder : undefined;
 
-	const { headingText } = useRedirectOnTransactionSuccess( {
+	useRedirectOnTransactionSuccess( {
 		orderId,
 		receiptId,
 		siteSlug,
@@ -105,15 +104,18 @@ function CheckoutPending( {
 				title="Checkout Pending"
 				properties={ { order_id: orderId, ...( siteSlug && { site: siteSlug } ) } }
 			/>
-			<PendingContent heading={ headingText } />
+			<PendingContent />
 		</Main>
 	);
 }
 
-function PendingContent( { heading }: { heading: React.ReactNode } ) {
+function PendingContent() {
+	const translate = useTranslate();
 	return (
 		<div className="pending-content__wrapper">
-			<div className="pending-content__title">{ heading }</div>
+			<div className="pending-content__title">
+				{ translate( "Almost there – we're currently finalizing your order." ) }
+			</div>
 			<LoadingEllipsis />
 		</div>
 	);
@@ -162,7 +164,7 @@ function useRedirectOnTransactionSuccess( {
 	 * logged in).
 	 */
 	fromSiteSlug?: string;
-} ): { headingText: React.ReactNode } {
+} ): void {
 	const translate = useTranslate();
 	const transaction: OrderTransaction | null = useSelector( ( state ) =>
 		orderId ? getOrderTransaction( state, orderId ) : null
@@ -185,19 +187,6 @@ function useRedirectOnTransactionSuccess( {
 	const productName = firstPurchase?.productName ?? '';
 	const willAutoRenew = firstPurchase?.willAutoRenew ?? false;
 	const saasRedirectUrl = getSaaSProductRedirectUrl( receipt );
-
-	const { searchParams } = getUrlParts( redirectTo || '/' );
-	const isConnectAfterCheckoutFlow =
-		Boolean( searchParams.size ) &&
-		searchParams.get( 'from' ) === 'connect-after-checkout' &&
-		searchParams.get( 'connect_url_redirect' ) === 'true';
-
-	const defaultPendingText = translate( "Almost there – we're currently finalizing your order." );
-	const connectingJetpackText = translate(
-		"Transaction finalized – We're now connecting Jetpack."
-	);
-
-	const [ headingText, setHeadingText ] = useState( defaultPendingText );
 
 	// Fetch receipt data once we have a receipt Id.
 	const didFetchReceipt = useRef( false );
@@ -248,10 +237,6 @@ function useRedirectOnTransactionSuccess( {
 		}
 
 		didRedirect.current = true;
-		if ( isConnectAfterCheckoutFlow ) {
-			setHeadingText( connectingJetpackText );
-		}
-
 		triggerPostRedirectNotices( {
 			redirectInstructions,
 			isRenewal,
@@ -278,8 +263,6 @@ function useRedirectOnTransactionSuccess( {
 		willAutoRenew,
 		fromSiteSlug,
 	] );
-
-	return { headingText };
 }
 
 function isTransactionSuccessful(

--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -258,6 +258,7 @@ export default function getThankYouPageUrl( {
 					receiptId: receiptIdOrPlaceholder,
 					siteId: jetpackTemporarySiteId && parseInt( jetpackTemporarySiteId ),
 					fromSiteSlug,
+					productSlug,
 				},
 				`${ calypsoHost }/checkout/jetpack/thank-you/licensing-auto-activate/${ productSlug }`
 			);

--- a/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
@@ -1807,7 +1807,7 @@ describe( 'getThankYouPageUrl', () => {
 				receiptId: 'invalid receipt ID' as any,
 			} );
 
-			const redirectAfterAuth = `https://wordpress.com/checkout/jetpack/thank-you/licensing-auto-activate/${ productSlug }?fromSiteSlug=${ fromSiteSlug }`;
+			const redirectAfterAuth = `https://wordpress.com/checkout/jetpack/thank-you/licensing-auto-activate/${ productSlug }?fromSiteSlug=${ fromSiteSlug }&productSlug=${ productSlug }`;
 
 			expect( url ).toBe(
 				addQueryArgs(

--- a/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
@@ -1807,7 +1807,7 @@ describe( 'getThankYouPageUrl', () => {
 				receiptId: 'invalid receipt ID' as any,
 			} );
 
-			const redirectAfterAuth = `https://wordpress.com/checkout/jetpack/thank-you/licensing-auto-activate/${ productSlug }?fromSiteSlug=${ fromSiteSlug }&productSlug=${ productSlug }`;
+			const redirectAfterAuth = `https://wordpress.com/checkout/jetpack/thank-you/licensing-auto-activate/${ productSlug }?fromSiteSlug=${ fromSiteSlug }`;
 
 			expect( url ).toBe(
 				addQueryArgs(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound 
label to
the linked issue.
-->
Connect-"After"-Checkout flow: This PR adds some additional text to the Authorization page form, making it more clear to users that once connected they can then activate the product they just purchased on their site. (See Screenshot)

Related to: **PT: Jetpack: Update purchase/connect flow for non-connected sites (logged-in)**: pbNhbs-8dz-p2

#### Screenshot

![Markup 2023-10-12 at 23 21 05](https://github.com/Automattic/wp-calypso/assets/11078128/ffe1ad4f-8aea-48f9-a039-d6c6af93e3a9)

## Testing Instructions

- Spin up a Jurassic.ninja site with the Jetpack Beta plugin running Jetpack branch `update/my-jetpack-connect-after-checkout` - ( https://github.com/Automattic/jetpack/pull/33257 )
- Checkout this PR and `yarn start`.
- On your Jurassic.ninja site, go to: `/wp-admin/admin.php?page=my-jetpack&calypso_env=development` - (don't overlook adding the `&calypso_env=development` url query arg, it's important!)
- On the VaultPress Backup Card, click the "Purchase" button.
- Next, Click "Get Jetpack VaultPress Backup" button.
- Verify you are taken to checkout with Jetpack VaultPress Backup (10GB) in the cart.
- On the checkout page, use A81N credits, and select "Assign a payment method later".
- Click "Complete checkout"
- Once purchase is completed, you should be redirected to the Connection/Authorization page.
- Verify the Authorization card/form looks similar to the screenshot above and you can see the text, "You purchased VaultPress Backup. Once connected, you can activate it on website [YOUR jurassic.ninja SITE].

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?