### PR TITLE
Modify copy on domain registration thank you to support multiple domain checkout

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/domains/domain-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/domain-thank-you.tsx
@@ -23,6 +23,7 @@ import './style.scss';
 
 interface DomainThankYouContainerProps {
 	domain: string;
+	domains: string[];
 	email: string;
 	hasProfessionalEmail: boolean;
 	hideProfessionalEmailStep: boolean;
@@ -34,6 +35,7 @@ interface DomainThankYouContainerProps {
 
 const DomainThankYou: React.FC< DomainThankYouContainerProps > = ( {
 	domain,
+	domains,
 	email,
 	hasProfessionalEmail,
 	selectedSiteSlug,
@@ -66,6 +68,7 @@ const DomainThankYou: React.FC< DomainThankYouContainerProps > = ( {
 		return propsGetter( {
 			selectedSiteSlug,
 			domain,
+			domains,
 			email,
 			shouldDisplayVerifyEmailStep: isEmailUnverified,
 			onResendEmailVerificationClick: onResendVerificationEmail,
@@ -81,6 +84,7 @@ const DomainThankYou: React.FC< DomainThankYouContainerProps > = ( {
 	}, [
 		type,
 		domain,
+		domains,
 		selectedSiteSlug,
 		email,
 		isEmailUnverified,

--- a/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-registration.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-registration.tsx
@@ -52,9 +52,12 @@ const domainRegistrationThankYouProps = ( {
 	const confirmEmailStep = {
 		stepKey: 'domain_registration_whats_next_confirm-email',
 		stepTitle: translate( 'Confirm email address' ),
-		stepDescription: translate(
-			'You must confirm your email address to avoid your domain getting suspended.'
-		),
+		stepDescription:
+			domains.length > 1
+				? translate( 'You must confirm your email address to avoid your domains being suspended.' )
+				: translate(
+						'You must confirm your email address to avoid your domain getting suspended.'
+				  ),
 		stepCta: (
 			<FullWidthButton onClick={ onResendEmailVerificationClick } busy={ false } disabled={ false }>
 				{ translate( 'Resend email' ) }

--- a/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-registration.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/thank-you-content/domain-registration.tsx
@@ -14,6 +14,7 @@ import type {
 
 const domainRegistrationThankYouProps = ( {
 	domain,
+	domains,
 	email,
 	hasProfessionalEmail,
 	hideProfessionalEmailStep,
@@ -114,9 +115,10 @@ const domainRegistrationThankYouProps = ( {
 
 	const returnProps: DomainThankYouProps = {
 		thankYouNotice: {
-			noticeTitle: translate(
-				'It may take up to 30 minutes for your domain to start working properly.'
-			),
+			noticeTitle:
+				domains.length > 1
+					? translate( 'It may take up to 30 minutes for your domains to start working properly.' )
+					: translate( 'It may take up to 30 minutes for your domain to start working properly.' ),
 			noticeIconCustom: <Icon icon={ info } size={ 24 } />,
 		},
 		sections: [
@@ -140,15 +142,15 @@ const domainRegistrationThankYouProps = ( {
 			height: 'auto',
 		},
 		thankYouTitle: translate( 'All ready to go!' ),
-		thankYouSubtitle: translate(
-			'Your new domain {{strong}}%(domain)s{{/strong}} is being set up.',
-			{
-				args: {
-					domain,
-				},
-				components: { strong: <strong /> },
-			}
-		),
+		thankYouSubtitle:
+			domains.length > 1
+				? translate( 'Your new domains are being set up.' )
+				: translate( 'Your new domain {{strong}}%(domain)s{{/strong}} is being set up.', {
+						args: {
+							domain,
+						},
+						components: { strong: <strong /> },
+				  } ),
 	};
 	return returnProps;
 };

--- a/client/my-sites/checkout/checkout-thank-you/domains/types.ts
+++ b/client/my-sites/checkout/checkout-thank-you/domains/types.ts
@@ -10,6 +10,7 @@ export type DomainThankYouProps = Required<
 
 export type DomainThankYouParams = {
 	domain: string;
+	domains: string[];
 	email?: string;
 	shouldDisplayVerifyEmailStep?: boolean;
 	onResendEmailVerificationClick?(): void;

--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -657,6 +657,7 @@ export class CheckoutThankYou extends Component<
 			return (
 				<DomainThankYou
 					domain={ domainName ?? '' }
+					domains={ purchases.filter( isDomainProduct ).map( ( purchase ) => purchase?.meta ) }
 					email={ professionalEmailPurchase ? professionalEmailPurchase.meta : emailFallback }
 					hasProfessionalEmail={ wasTitanEmailProduct }
 					hideProfessionalEmailStep={ wasGSuiteOrGoogleWorkspace || wasDomainOnly }

--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -657,7 +657,7 @@ export class CheckoutThankYou extends Component<
 			return (
 				<DomainThankYou
 					domain={ domainName ?? '' }
-					domains={ purchases.filter( isDomainProduct ).map( ( purchase ) => purchase?.meta ) }
+					domains={ purchases.filter( predicate ).map( ( purchase ) => purchase?.meta ) }
 					email={ professionalEmailPurchase ? professionalEmailPurchase.meta : emailFallback }
 					hasProfessionalEmail={ wasTitanEmailProduct }
 					hideProfessionalEmailStep={ wasGSuiteOrGoogleWorkspace || wasDomainOnly }


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/4207

## Proposed Changes

* Updates checkout thank you page copy to better handle when a purchase contains multiple domains

## Testing Instructions

* Depends on, apply: https://github.com/Automattic/wp-calypso/pull/82949
* Test via: http://calypso.localhost:3000/start/domain/domain-only?flags=domains/add-multiple-domains-to-cart
* Make a domains purchase with more than one domain, confirm text is updated as shown in the screenshot.
* Single domain purchases should continue to show the old text.
* Urls under test: 
* Multi purchase receipt: http://calypso.localhost:3000/checkout/thank-you/no-site/85658764
* Single purchase receipt: http://calypso.localhost:3000/checkout/thank-you/no-site/85659029
* Also test a separate checkout flow using this code, e.g. domain transfer or domain mapping.

Before

![Screenshot 2023-10-13 at 15-16-38 Thank You — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/5dd686f3-0360-4d0a-a3eb-08566885a515)


After

![Screenshot 2023-10-13 at 15-15-46 Thank You — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/48d34f38-e49e-4991-af1a-680675350402)
