### PR TITLE
Jetpack Manage: bug fixes in the filter & pagination on the dashboard

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -172,7 +172,7 @@ export default function SitesOverview() {
 
 	const selectedTab = navItems.find( ( i ) => i.selected ) || navItems[ 0 ];
 	const hasAppliedFilter = !! search || filter?.issueTypes?.length > 0;
-	const showEmptyState = ! isLoading && ! isError && ! data?.sites?.length;
+	const showEmptyState = ! isLoading && ! isError && ! data?.total;
 
 	let emptyState;
 	if ( showEmptyState ) {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/sites-overview.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/sites-overview.tsx
@@ -42,6 +42,9 @@ describe( '<SitesOverview>', () => {
 		currentUser: {
 			capabilities: {},
 		},
+		productsList: {
+			isFetching: false,
+		},
 	};
 	const middlewares = [ thunk ];
 
@@ -71,7 +74,7 @@ describe( '<SitesOverview>', () => {
 	const setData = (): void => {
 		const data = {
 			sites: [],
-			total: 1,
+			total: 0,
 			perPage: 1,
 			totalFavorites: 1,
 		};

--- a/client/my-sites/activity/filterbar/type-selector/type-selector.jsx
+++ b/client/my-sites/activity/filterbar/type-selector/type-selector.jsx
@@ -83,14 +83,20 @@ export class TypeSelector extends Component {
 	};
 
 	handleClose = () => {
-		const { onClose, selectType } = this.props;
+		const { onClose } = this.props;
 
-		selectType( this.getSelectedCheckboxes() );
 		this.setState( {
 			userHasSelected: false,
 			selectedCheckboxes: [],
 		} );
 		onClose();
+	};
+
+	handleApplyFilters = () => {
+		const { selectType } = this.props;
+		const selectedCheckboxes = this.getSelectedCheckboxes();
+		selectType( selectedCheckboxes );
+		this.handleClose();
 	};
 
 	humanReadable = ( count ) => {
@@ -164,7 +170,7 @@ export class TypeSelector extends Component {
 								primary
 								compact
 								disabled={ ! this.state.userHasSelected }
-								onClick={ this.handleClose }
+								onClick={ this.handleApplyFilters }
 							>
 								{ translate( 'Apply' ) }
 							</Button>

--- a/client/my-sites/activity/filterbar/type-selector/type-selector.jsx
+++ b/client/my-sites/activity/filterbar/type-selector/type-selector.jsx
@@ -196,15 +196,6 @@ export class TypeSelector extends Component {
 
 	isSelected = ( key ) => this.getSelectedCheckboxes().includes( key );
 
-	handleButtonClick = () => {
-		const { isVisible, onButtonClick } = this.props;
-
-		if ( isVisible ) {
-			this.handleClose();
-		}
-		onButtonClick();
-	};
-
 	render() {
 		const { title, isVisible, isNested } = this.props;
 		const selectedCheckboxes = this.getSelectedCheckboxes();
@@ -221,7 +212,7 @@ export class TypeSelector extends Component {
 					className={ buttonClass }
 					compact
 					borderless
-					onClick={ this.handleButtonClick }
+					onClick={ this.props.onButtonClick }
 					ref={ this.typeButton }
 				>
 					{ ( ! isNested || ( isNested && ! hasSelectedCheckboxes ) ) && title }


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/55
Resolves https://github.com/Automattic/jetpack-genesis/issues/56


## Proposed Changes

This PR fixes the issues below.

- We show the empty state content when the current page count is 0. Instead, we will now show the empty content if the total count is 0.
- The filter is applied even when clicked outside without clicking on the `Apply` button. This is now fixed.
- The filter popover is not closed when clicking on the filter button. This is now fixed.

### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Open the Jetpack Cloud live link
2. Visit the /dashboard
3. Manually append the URL with ?page=X where X is a page number without any sites > Verify that you don't see the `Let's get started with Jetpack Manage` screen anymore > Click the `All` tab and verify that you can now see the sites

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="1920" alt="Screenshot 2023-10-13 at 9 17 30 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/080b3d09-5f72-4f11-a046-9e5395b62e0c">
</td>
<td>
<img width="1917" alt="Screenshot 2023-10-13 at 10 38 59 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/a69dcac1-a8f5-4b96-9c9a-d1465bfd3417">
</td>
</tr>
</table>

4. Click the Filter By: `Issue Type` button > Select any filter > Click on the button again and verify that the filter popover is closed and no filter is applied > Repeat the step and now click outside the popover is verify that no filter is applied and filter popover is closed.

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>

https://github.com/Automattic/wp-calypso/assets/10586875/917cbfef-cd00-4da0-99c3-555388dccb3c

</td>
<td>

https://github.com/Automattic/wp-calypso/assets/10586875/cbefc623-be00-4d6d-a6d8-9579cf96b1c2

</td>
</tr>
</table>






5. Verify step 4 for the `Activity Type` filter in the Activity Log(`activity-log/{siteUrl}`)page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?