### PR TITLE
Checkout pending - display different text when connecting.

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -194,7 +194,7 @@ function useRedirectOnTransactionSuccess( {
 
 	const defaultPendingText = translate( "Almost there – we're currently finalizing your order." );
 	const connectingJetpackText = translate(
-		"Transaction finalized – We're now connecting Jetpack."
+		"Transaction finalized – we're now connecting Jetpack."
 	);
 
 	const [ headingText, setHeadingText ] = useState( defaultPendingText );

--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -1,10 +1,11 @@
 import config from '@automattic/calypso-config';
+import { getUrlParts } from '@automattic/calypso-url';
 import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
-import { useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import QueryOrderTransaction from 'calypso/components/data/query-order-transaction';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import Main from 'calypso/components/main';
@@ -84,7 +85,7 @@ function CheckoutPending( {
 }: CheckoutPendingProps ) {
 	const orderId = isValidOrderId( orderIdOrPlaceholder ) ? orderIdOrPlaceholder : undefined;
 
-	useRedirectOnTransactionSuccess( {
+	const { headingText } = useRedirectOnTransactionSuccess( {
 		orderId,
 		receiptId,
 		siteSlug,
@@ -104,18 +105,15 @@ function CheckoutPending( {
 				title="Checkout Pending"
 				properties={ { order_id: orderId, ...( siteSlug && { site: siteSlug } ) } }
 			/>
-			<PendingContent />
+			<PendingContent heading={ headingText } />
 		</Main>
 	);
 }
 
-function PendingContent() {
-	const translate = useTranslate();
+function PendingContent( { heading }: { heading: React.ReactNode } ) {
 	return (
 		<div className="pending-content__wrapper">
-			<div className="pending-content__title">
-				{ translate( "Almost there – we're currently finalizing your order." ) }
-			</div>
+			<div className="pending-content__title">{ heading }</div>
 			<LoadingEllipsis />
 		</div>
 	);
@@ -164,7 +162,7 @@ function useRedirectOnTransactionSuccess( {
 	 * logged in).
 	 */
 	fromSiteSlug?: string;
-} ): void {
+} ): { headingText: React.ReactNode } {
 	const translate = useTranslate();
 	const transaction: OrderTransaction | null = useSelector( ( state ) =>
 		orderId ? getOrderTransaction( state, orderId ) : null
@@ -187,6 +185,19 @@ function useRedirectOnTransactionSuccess( {
 	const productName = firstPurchase?.productName ?? '';
 	const willAutoRenew = firstPurchase?.willAutoRenew ?? false;
 	const saasRedirectUrl = getSaaSProductRedirectUrl( receipt );
+
+	const { searchParams } = getUrlParts( redirectTo || '/' );
+	const isConnectAfterCheckoutFlow =
+		Boolean( searchParams.size ) &&
+		searchParams.get( 'from' ) === 'connect-after-checkout' &&
+		searchParams.get( 'connect_url_redirect' ) === 'true';
+
+	const defaultPendingText = translate( "Almost there – we're currently finalizing your order." );
+	const connectingJetpackText = translate(
+		"Transaction finalized – We're now connecting Jetpack."
+	);
+
+	const [ headingText, setHeadingText ] = useState( defaultPendingText );
 
 	// Fetch receipt data once we have a receipt Id.
 	const didFetchReceipt = useRef( false );
@@ -237,6 +248,9 @@ function useRedirectOnTransactionSuccess( {
 		}
 
 		didRedirect.current = true;
+		if ( isConnectAfterCheckoutFlow ) {
+			setHeadingText( connectingJetpackText );
+		}
 		triggerPostRedirectNotices( {
 			redirectInstructions,
 			isRenewal,
@@ -263,6 +277,8 @@ function useRedirectOnTransactionSuccess( {
 		willAutoRenew,
 		fromSiteSlug,
 	] );
+
+	return { headingText };
 }
 
 function isTransactionSuccessful(

--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -188,7 +188,7 @@ function useRedirectOnTransactionSuccess( {
 
 	const { searchParams } = getUrlParts( redirectTo || '/' );
 	const isConnectAfterCheckoutFlow =
-		Boolean( searchParams.size ) &&
+		searchParams.size &&
 		searchParams.get( 'from' ) === 'connect-after-checkout' &&
 		searchParams.get( 'connect_url_redirect' ) === 'true';
 


### PR DESCRIPTION
Connect-"After"-Checkout flow: This PR updates the text displayed on the checkout pending page. When the transaction is completed it changes to, ""Transaction finalized – We're now connecting Jetpack."  (See screenshot and screencast video)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to: **PT: Jetpack: Update purchase/connect flow for non-connected sites (logged-in)**: pbNhbs-8dz-p2

## Proposed Changes

* When in the "connect-after-checkout" flow,  the checkout pending page displays, "Almost there – we're currently finalizing your order.", but now when transaction is completed, the text changes to , "Transaction finalized – We're now connecting Jetpack." while the connection process is taking place.

#### Screenshot

![Markup 2023-10-13 at 01 05 41](https://github.com/Automattic/wp-calypso/assets/11078128/924be1cb-65df-4675-84ff-46515f1111b1)

Video of the  "connect-after-checkout" transaction and connection taking progress:

https://github.com/Automattic/wp-calypso/assets/11078128/73523003-5f4d-456d-884a-b507317ed838


## Testing Instructions

- Spin up a Jurassic.ninja site with the Jetpack Beta plugin running Jetpack branch `update/my-jetpack-connect-after-checkout` ( https://github.com/Automattic/jetpack/pull/33257 )
- Checkout this PR and `yarn start`.
- On your Jurassic.ninja site, go to: `/wp-admin/admin.php?page=my-jetpack&calypso_env=development` - (don't overlook adding the `&calypso_env=development` url query arg, it's important!)
- On the VaultPress Backup Card, click the "Purchase" button.
- Next, Click "Get Jetpack VaultPress Backup" button.
- Verify you are taken to checkout with Jetpack VaultPress Backup (10GB) in the cart.
- On the checkout page, use A81N credits, and select "Assign a payment method later".
- Click "Complete checkout"
- While the transaction is processing, you should see, "Almost there – we're currently finalizing your order." (This is same behavior as before, nothing new.)
- After transaction completes successfully, verify the text changes to, "Transaction finalized – We're now connecting Jetpack."
- Then you should be redirected to the Jetpack connection/authorization page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?