### PR TITLE
Plans step: Make the VIP Learn more button totally clickable

### DIFF
--- a/client/my-sites/plans-grid/components/actions.tsx
+++ b/client/my-sites/plans-grid/components/actions.tsx
@@ -11,11 +11,10 @@ import {
 } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { formatCurrency } from '@automattic/format-currency';
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { isMobile } from '@automattic/viewport';
 import styled from '@emotion/styled';
 import classNames from 'classnames';
-import i18n, { localize, TranslateResult, useTranslate } from 'i18n-calypso';
+import { localize, TranslateResult, useTranslate } from 'i18n-calypso';
 import ExternalLinkWithTracking from 'calypso/components/external-link/with-tracking';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useManageTooltipToggle } from 'calypso/my-sites/plans-grid/hooks/use-manage-tooltip-toggle';
@@ -383,7 +382,6 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 	isLargeCurrency,
 } ) => {
 	const translate = useTranslate();
-	const isEnglishLocale = useIsEnglishLocale();
 	const { gridPlansIndex } = usePlansGridContext();
 	const {
 		planTitle,
@@ -408,34 +406,19 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 		onUpgradeClick && onUpgradeClick();
 	};
 
-	const vipLandingPageUrlWithoutUtmCampaign =
-		'https://wpvip.com/wordpress-vip-agile-content-platform?utm_source=WordPresscom&utm_medium=automattic_referral';
-
 	if ( isWpcomEnterpriseGridPlan ) {
-		const translateComponents = {
-			ExternalLink: (
-				<ExternalLinkWithTracking
-					href={ `${ vipLandingPageUrlWithoutUtmCampaign }&utm_campaign=calypso_signup` }
-					target="_blank"
-					tracksEventName="calypso_plan_step_enterprise_click"
-					tracksEventProps={ { flow: flowName } }
-				/>
-			),
-		};
-
-		const shouldShowNewCta =
-			isEnglishLocale || i18n.hasTranslation( '{{ExternalLink}}Learn more{{/ExternalLink}}' );
+		const vipLandingPageUrlWithoutUtmCampaign =
+			'https://wpvip.com/wordpress-vip-agile-content-platform?utm_source=WordPresscom&utm_medium=automattic_referral';
 
 		return (
-			<Button className={ classes }>
-				{ shouldShowNewCta
-					? translate( '{{ExternalLink}}Learn more{{/ExternalLink}}', {
-							components: translateComponents,
-					  } )
-					: translate( '{{ExternalLink}}Get in touch{{/ExternalLink}}', {
-							components: translateComponents,
-					  } ) }
-			</Button>
+			<ExternalLinkWithTracking
+				href={ `${ vipLandingPageUrlWithoutUtmCampaign }&utm_campaign=calypso_signup` }
+				target="_blank"
+				tracksEventName="calypso_plan_step_enterprise_click"
+				tracksEventProps={ { flow: flowName } }
+			>
+				<Button className={ classNames( classes ) }>{ translate( 'Learn more' ) }</Button>
+			</ExternalLinkWithTracking>
 		);
 	}
 

--- a/client/my-sites/plans-grid/style.scss
+++ b/client/my-sites/plans-grid/style.scss
@@ -102,9 +102,7 @@ $mobile-card-max-width: 440px;
 
 			&.is-wpcom-enterprise-grid-plan {
 				background-color: var(--studio-gray-80);
-				a {
-					color: var(--studio-gray-0);
-				}
+				color: var(--studio-gray-0);
 
 				&:focus {
 					box-shadow: 0 0 0 2px var(--studio-white), 0 0 0 4px var(--studio-gray-80);


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/4209

The learn more link in the plans step for VIP was only clickable on the words "Learn more" clicking anywhere else on the button resulted in what looked like a broken link.
 
## Proposed Changes

- Wraps the button in the link so the entire button is clickable, probably a better way to fix this but I didn't want to mess around with the tracking.
- Cleaned up the has translation logic, no longer required as "Learn more" is translated elsewhere.

## Testing Instructions

* Clicking here should now work:

![Screenshot(32)](https://github.com/Automattic/wp-calypso/assets/811776/0adddb00-f70b-4a95-8305-7ff62d600313)

