### PR TITLE
E2E: do not create new variable when slicing title in `Advertising: Promote` spec.

### DIFF
--- a/test/e2e/specs/tools/advertising__promote.ts
+++ b/test/e2e/specs/tools/advertising__promote.ts
@@ -34,9 +34,8 @@ declare const browser: Browser;
 skipDescribeIf( envVariables.ATOMIC_VARIATION === 'private' )(
 	DataHelper.createSuiteTitle( 'Advertising: Promote' ),
 	function () {
-		const pageTitle = DataHelper.getRandomPhrase();
 		// The input has a limit, so let's stay way under to be safe!
-		const pageTitleInAd = pageTitle.slice( 0, 20 );
+		const pageTitle = DataHelper.getRandomPhrase().slice( 0, 20 );
 		const snippet = Array( 2 ).fill( DataHelper.getRandomPhrase() ).toString();
 
 		let newPostDetails: PostResponse;
@@ -106,12 +105,12 @@ skipDescribeIf( envVariables.ATOMIC_VARIATION === 'private' )(
 		} );
 
 		it( 'Enter title and snippet', async function () {
-			await blazeCampaignPage.enterText( 'Page title', pageTitleInAd );
+			await blazeCampaignPage.enterText( 'Page title', pageTitle );
 			await blazeCampaignPage.enterText( 'Ad text', snippet );
 		} );
 
 		it( 'Validate preview', async function () {
-			await blazeCampaignPage.validatePreview( { title: pageTitleInAd, snippet: snippet } );
+			await blazeCampaignPage.validatePreview( { title: pageTitle, snippet: snippet } );
 		} );
 
 		afterAll( async function () {


### PR DESCRIPTION
Related to #82948

## Proposed Changes

Instead of defining a new variable that's sliced, slice the `pageTitle` variable.

## Testing Instructions

Jetpack AT - php-old variation:
```
 PASS  specs/tools/advertising__promote.ts (14.952 s)
  Advertising: Promote (Atomic: default)
    ✓ Navigate to Tools > Advertising page (3534 ms)
    ✓ Click on Promote for the first post (1921 ms)
    ✓ Land in Blaze campaign landing page (1 ms)
    ✓ Click on Get started (1364 ms)
    ✓ Upload image (1650 ms)
    ✓ Enter title and snippet (339 ms)
    ✓ Validate preview (21 ms)

Test Suites: 1 passed, 1 total
Tests:       7 passed, 7 total
Snapshots:   0 total
Time:        15.087 s, estimated 20 s
```

Jetpack Simple
```
 PASS  specs/tools/advertising__promote.ts (12.069 s)
  Advertising: Promote
    ✓ Navigate to Tools > Advertising page (1254 ms)
    ✓ Click on Promote for the first post (1386 ms)
    ✓ Land in Blaze campaign landing page (2 ms)
    ✓ Click on Get started (1369 ms)
    ✓ Upload image (587 ms)
    ✓ Enter title and snippet (222 ms)
    ✓ Validate preview (11 ms)

Test Suites: 1 passed, 1 total
Tests:       7 passed, 7 total
Snapshots:   0 total
Time:        12.214 s, estimated 20 s
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?