### PR TITLE
Jetpack Manage: Add link to the Boost score to redirect to WP Admin

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/index.tsx
@@ -1,4 +1,5 @@
 import { getUrlParts } from '@automattic/calypso-url';
+import { Button } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
@@ -25,29 +26,33 @@ export default function SiteBoostColumn( { site }: Props ) {
 		setShowBoostModal( true );
 	};
 
+	const { origin, pathname } = getUrlParts( adminUrl ?? '' );
+
+	const href = adminUrl
+		? `${ origin }${ pathname }?page=jetpack-boost`
+		: `https://${ site.url }/wp-admin/admin.php?page=jetpack`;
+
 	if ( overallScore ) {
 		return (
-			<div
+			<Button
+				borderless
 				className={ classNames(
 					'sites-overview__boost-score',
 					getBoostRatingClass( overallScore )
 				) }
+				href={ href }
+				target="_blank"
 			>
 				{ getBoostRating( overallScore ) }
-			</div>
+			</Button>
 		);
 	}
 
 	if ( hasBoost ) {
-		const { origin, pathname } = getUrlParts( adminUrl ?? '' );
 		return (
 			<a
 				className="sites-overview__column-action-button is-link"
-				href={
-					adminUrl
-						? `${ origin }${ pathname }?page=jetpack-boost`
-						: `https://${ site.url }/wp-admin/admin.php?page=jetpack`
-				}
+				href={ href }
 				target="_blank"
 				rel="noreferrer"
 			>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -495,7 +495,20 @@
 	color: var(--studio-red-50);
 }
 
-.sites-overview__boost-score {
+@mixin boost-score-style($color, $background-color) {
+	@extend .sites-overview__column-content;
+	color: $color;
+	background-color: $background-color;
+
+	&:hover,
+	&:active,
+	&:focus {
+		color: $color;
+		background-color: $background-color;
+	}
+}
+
+a.sites-overview__boost-score {
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
@@ -506,21 +519,15 @@
 	user-select: none;
 
 	&.boost-score-good {
-		@extend .sites-overview__column-content;
-		color: var(--studio-green-50);
-		background-color: var(--studio-green-0);
+		@include boost-score-style(var(--studio-green-50), var(--studio-green-0));
 	}
 
 	&.boost-score-okay {
-		@extend .sites-overview__column-content;
-		color: var(--studio-yellow-50);
-		background-color: var(--studio-yellow-0);
+		@include boost-score-style(var(--studio-yellow-50), var(--studio-yellow-0));
 	}
 
 	&.boost-score-bad {
-		@extend .sites-overview__column-content;
-		color: var(--studio-red-50);
-		background-color: var(--studio-red-0);
+		@include boost-score-style(var(--studio-red-50), var(--studio-red-0));
 	}
 }
 


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/54

## Proposed Changes

This PR adds a link to the Boost score to redirect to WP Admin in the dashboard.

### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Open the Jetpack Cloud live link
2. Visit the /dashboard
3. Install Boost(paid or free) for a site -> Verify that you can now click, and the link opens you in a new tab. The link for an atomic site should be `/wp-admin/admin.php?page=jetpack#/dashboard`, and for a Jetpack site should be `/wp-admin/admin.php?page=jetpack-boost`

<img width="196" alt="Screenshot 2023-10-13 at 1 21 53 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/79c04a81-8a9f-44c3-b491-73f66a24692a">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?