### PR TITLE
Jetpack E2E: add handler to update WordPress database for `wp-beta` and `wp-previous` users.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -136,20 +136,6 @@ export class EditorPage {
 				// noop
 			}
 		}
-
-		// In a typical loading scenario, this request is one of the last to fire.
-		// Lacking a perfect cross-site type (Simple/Atomic) way to check the loading state,
-		// it is a fairly good stand-in.
-		await Promise.all( [
-			this.page.waitForURL( /(post|page|post-new.php)/, { timeout: 60 * 1000 } ),
-			this.page.waitForResponse( /.*posts.*/, { timeout: 60 * 1000 } ),
-		] );
-
-		// Dismiss the Welcome Tour.
-		await this.editorWelcomeTourComponent.forceDismissWelcomeTour();
-
-		// Accept the Cookie banner.
-		await this.cookieBannerComponent.acceptCookie();
 	}
 
 	/**
@@ -271,22 +257,6 @@ export class EditorPage {
 	//#region Block and Pattern Insertion
 
 	/**
-	 * Resets the selected block.
-	 *
-	 * The Gutenberg block-based editor 'remembers' what block was last
-	 * selected. This behavior impacts the block options that are shown
-	 * in the block inserter.
-	 *
-	 * For instance, if a Contact Form block is currently selected, the
-	 * block inserter will display a filtered set of blocks that are
-	 * permitted to be inserted within the parent Contact Form block.
-	 */
-	async resetSelectedBlock() {
-		const editorParent = await this.getEditorParent();
-		await editorParent.getByRole( 'region', { name: 'Editor top bar' } ).dispatchEvent( 'click' );
-	}
-
-	/**
 	 * Adds a Gutenberg block from the sidebar block inserter panel.
 	 *
 	 * The name is expected to be formatted in the same manner as it
@@ -308,7 +278,7 @@ export class EditorPage {
 		blockEditorSelector: string,
 		{ noSearch }: { noSearch?: boolean } = {}
 	): Promise< ElementHandle > {
-		await this.resetSelectedBlock();
+		await this.editorGutenbergComponent.resetSelectedBlock();
 		await this.editorToolbarComponent.openBlockInserter();
 		await this.addBlockFromInserter( blockName, this.editorSidebarBlockInserterComponent, {
 			noSearch: noSearch,
@@ -400,7 +370,7 @@ export class EditorPage {
 	 * @param {string} patternName Name of the pattern to insert.
 	 */
 	async addPatternFromSidebar( patternName: string ): Promise< void > {
-		await this.resetSelectedBlock();
+		await this.editorGutenbergComponent.resetSelectedBlock();
 		await this.editorToolbarComponent.openBlockInserter();
 		await this.addPatternFromInserter( patternName, this.editorSidebarBlockInserterComponent );
 	}

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -119,6 +119,24 @@ export class EditorPage {
 	 * Initialization steps to ensure the page is fully loaded.
 	 */
 	async waitUntilLoaded(): Promise< void > {
+		// When the WordPress version updates on Jetpack AT sites,
+		// `wp-beta` and`wp-previous` require a database update.
+		// @see https://github.com/Automattic/wp-calypso/issues/82412
+		if (
+			envVariables.ATOMIC_VARIATION === 'wp-beta' ||
+			envVariables.ATOMIC_VARIATION === 'wp-previous'
+		) {
+			try {
+				const databaseUpdateButton = this.page.getByRole( 'link', {
+					name: 'Update WordPress Database',
+				} );
+				await databaseUpdateButton.waitFor( { timeout: 5 * 1000 } );
+				await databaseUpdateButton.click();
+			} catch {
+				// noop
+			}
+		}
+
 		// In a typical loading scenario, this request is one of the last to fire.
 		// Lacking a perfect cross-site type (Simple/Atomic) way to check the loading state,
 		// it is a fairly good stand-in.
@@ -253,6 +271,22 @@ export class EditorPage {
 	//#region Block and Pattern Insertion
 
 	/**
+	 * Resets the selected block.
+	 *
+	 * The Gutenberg block-based editor 'remembers' what block was last
+	 * selected. This behavior impacts the block options that are shown
+	 * in the block inserter.
+	 *
+	 * For instance, if a Contact Form block is currently selected, the
+	 * block inserter will display a filtered set of blocks that are
+	 * permitted to be inserted within the parent Contact Form block.
+	 */
+	async resetSelectedBlock() {
+		const editorParent = await this.getEditorParent();
+		await editorParent.getByRole( 'region', { name: 'Editor top bar' } ).dispatchEvent( 'click' );
+	}
+
+	/**
 	 * Adds a Gutenberg block from the sidebar block inserter panel.
 	 *
 	 * The name is expected to be formatted in the same manner as it
@@ -274,7 +308,7 @@ export class EditorPage {
 		blockEditorSelector: string,
 		{ noSearch }: { noSearch?: boolean } = {}
 	): Promise< ElementHandle > {
-		await this.editorGutenbergComponent.resetSelectedBlock();
+		await this.resetSelectedBlock();
 		await this.editorToolbarComponent.openBlockInserter();
 		await this.addBlockFromInserter( blockName, this.editorSidebarBlockInserterComponent, {
 			noSearch: noSearch,
@@ -366,7 +400,7 @@ export class EditorPage {
 	 * @param {string} patternName Name of the pattern to insert.
 	 */
 	async addPatternFromSidebar( patternName: string ): Promise< void > {
-		await this.editorGutenbergComponent.resetSelectedBlock();
+		await this.resetSelectedBlock();
 		await this.editorToolbarComponent.openBlockInserter();
 		await this.addPatternFromInserter( patternName, this.editorSidebarBlockInserterComponent );
 	}

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -147,7 +147,9 @@ export class EditorPage {
 	}
 
 	/**
+	 * Waits for the editor to be fully loaded by keying off of requests.
 	 *
+	 * @param {number} timeout Timeout for waiting for the final requests.
 	 */
 	private async waitForEditorLoadedRequests( timeout: number = 60 * 1000 ): Promise< void > {
 		// In a typical loading scenario, this request is one of the last to fire.
@@ -160,7 +162,7 @@ export class EditorPage {
 	}
 
 	/**
-	 *
+	 * Accepts the WordPress version database update prompt that can happen on lagging AT sites.
 	 */
 	private async acceptDatabaseUpdate(): Promise< void > {
 		const databaseUpdateButton = this.page.getByRole( 'link', {


### PR DESCRIPTION
Closes #82412

## Proposed Changes

This PR is one proposed implementation to fix https://github.com/Automattic/wp-calypso/issues/82412. 

## Testing Instructions

Going to run a bunch of Gutenberg and Jetpack tests, make sure they all still pass.

We'll see if this works when there's actually a database update required! Before then, we just have to make sure it doesn't cause regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?