### PR TITLE
Plans page for Jetpack App: Handle all unhandled jetpack-app/* routes by showing 404 page

### DIFF
--- a/client/jetpack-app/controller.tsx
+++ b/client/jetpack-app/controller.tsx
@@ -1,5 +1,6 @@
 import page from 'page';
 import { isWpMobileApp } from 'calypso/lib/mobile-app';
+import JetpackAppEmptyContent from './empty';
 import JetpackAppPlans from './plans/main';
 
 export function jetpackAppPlans( context: PageJS.Context, next: () => void ) {
@@ -19,4 +20,9 @@ export function redirectIfNotJetpackApp( _context: PageJS.Context, next: () => v
 	} else {
 		next();
 	}
+}
+
+export function pageNotFound( context: PageJS.Context, next: () => void ) {
+	context.primary = <JetpackAppEmptyContent />;
+	next();
 }

--- a/client/jetpack-app/empty.tsx
+++ b/client/jetpack-app/empty.tsx
@@ -1,0 +1,21 @@
+import { useTranslate } from 'i18n-calypso';
+import EmptyContent from 'calypso/components/empty-content';
+import Main from 'calypso/components/main';
+
+const JetpackAppEmptyContent: React.FC = () => {
+	const translate = useTranslate();
+
+	return (
+		<Main>
+			<EmptyContent
+				illustration="/calypso/images/illustrations/illustration-404.svg"
+				title={ translate( 'Uh oh. Page not found.' ) }
+				line={ translate(
+					"Sorry, the page you were looking for doesn't exist or has been moved."
+				) }
+			/>
+		</Main>
+	);
+};
+
+export default JetpackAppEmptyContent;

--- a/client/jetpack-app/index.ts
+++ b/client/jetpack-app/index.ts
@@ -1,6 +1,6 @@
 import page from 'page';
 import { render as clientRender } from 'calypso/controller';
-import { jetpackAppPlans, redirectIfNotJetpackApp } from './controller';
+import { jetpackAppPlans, pageNotFound, redirectIfNotJetpackApp } from './controller';
 import { makeJetpackAppLayout } from './page-middleware/layout';
 
 export default function () {
@@ -14,4 +14,7 @@ export default function () {
 
 	// Default to /plans page until we have more pages
 	page( '/jetpack-app', '/jetpack-app/plans' );
+
+	// Show 404 page in all the other cases
+	page( '/jetpack-app/*', pageNotFound, makeJetpackAppLayout, clientRender );
 }


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/82135

Handle all unhandled `jetpack-app/*` routes by showing a 404 page

## Proposed Changes

- Use `EmptyContent` component with images, titles, and descriptions from similar empty content components
- Keep default styles
- Reuse existing translations

https://github.com/Automattic/wp-calypso/assets/4062343/2ec0edbc-1936-4c0b-9e8d-8bbfa5c603eb

## Testing Instructions

- `jetpack-app/` should continue routing to `jetpack-app/plans`
- `jetpack-app/plans` should continue displaying Plans page with `wp-iphone` and `wp-android` user agent
- `jetpack-app/*` routes should display 404 page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?