### PR TITLE
Update domain search bar and filter height in stepper

### DIFF
--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -3,12 +3,13 @@
 
 .search-filters__dropdown-filters {
 	align-items: center;
-	height: 48px;
+	height: 40px;
 	z-index: z-index("root", ".search");
 	margin-left: 12px;
 
 	@include break-mobile {
 		margin-left: 20px;
+		height: 48px;
 	}
 
 	.button {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
@@ -115,7 +115,12 @@
 		.search-component.is-open {
 			border: 1px solid #a7aaad;
 			border-radius: 4px;
-			height: 48px;
+			box-sizing: border-box;
+			height: 40px;
+
+			@include break-mobile {
+				height: 48px;
+			}
 		}
 
 		.search-component.is-open.has-focus {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-domain/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-domain/style.scss
@@ -198,15 +198,6 @@
 		}
 	}
 
-	.search-filters__dropdown-filters {
-		height: 40px;
-
-		@include break-mobile {
-			height: 48px;
-
-		}
-	}
-
 	.domain-suggestion {
 
 		.domain-suggestion__action {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4112

## Proposed Changes

| Before  | After |
| :-------------: | :-------------: |
| <img src="https://github.com/Automattic/wp-calypso/assets/6586048/50bd292d-c962-4504-b1bc-1af25f005545">  | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/3c6b1920-ef0a-41b6-9692-76fa3728b4a8">|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /setup/newsletter (as it is using the domain step in stepper)
* Check the mobile view of the domain step
* Go to /setup/sensei
* Check the mobile view of the domain step

Other places to test
- [ ] /domains/add/:site
- [ ] /domains/start

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?