### PR TITLE
Stepper: Add selected site to the Stepper analytics super props

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -19,6 +19,8 @@ import {
 	getSignupCompleteFlowNameAndClear,
 	getSignupCompleteStepNameAndClear,
 } from 'calypso/signup/storageUtils';
+import { useSelector } from 'calypso/state';
+import { getSite } from 'calypso/state/sites/selectors';
 import { useSite } from '../../hooks/use-site';
 import useSyncRoute from '../../hooks/use-sync-route';
 import { ONBOARD_STORE } from '../../stores';
@@ -64,6 +66,7 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 	const urlQueryParams = useQuery();
 
 	const site = useSite();
+	const selectedSite = useSelector( ( state ) => site && getSite( state, site.ID ) );
 	const ref = urlQueryParams.get( 'ref' ) || '';
 
 	const stepProgress = useSelect(
@@ -134,7 +137,7 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 
 	useEffect( () => {
 		// We record the event only when the step is not empty. Additionally, we should not fire this event whenever the intent is changed
-		if ( ! currentStepRoute ) {
+		if ( ! currentStepRoute || ! selectedSite ) {
 			return;
 		}
 
@@ -158,7 +161,7 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 		// We leave out intent from the dependency list, due to the ONBOARD_STORE being reset in the exit flow.
 		// This causes the intent to become empty, and thus this event being fired again.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ flow.name, currentStepRoute ] );
+	}, [ flow.name, currentStepRoute, selectedSite ] );
 
 	const assertCondition = flow.useAssertConditions?.( _navigate ) ?? {
 		state: AssertConditionState.SUCCESS,

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -21,7 +21,7 @@ import {
 } from 'calypso/signup/storageUtils';
 import { useSelector } from 'calypso/state';
 import { getSite } from 'calypso/state/sites/selectors';
-import { useSite } from '../../hooks/use-site';
+import { useSiteData } from '../../hooks/use-site-data';
 import useSyncRoute from '../../hooks/use-sync-route';
 import { ONBOARD_STORE } from '../../stores';
 import kebabCase from '../../utils/kebabCase';
@@ -64,12 +64,11 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 	);
 
 	const urlQueryParams = useQuery();
-	const siteSlugOrIdInUrl = urlQueryParams.get( 'siteSlug' ) || urlQueryParams.get( 'siteId' );
 	const ref = urlQueryParams.get( 'ref' ) || '';
 
-	const site = useSite();
+	const { site, siteSlugOrId } = useSiteData();
 	const selectedSite = useSelector( ( state ) => site && getSite( state, site.ID ) );
-	const isFetchingSelectedSite = siteSlugOrIdInUrl && ! selectedSite;
+	const isFetchingSelectedSite = siteSlugOrId && ! selectedSite;
 
 	const stepProgress = useSelect(
 		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getStepProgress(),

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -64,10 +64,12 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 	);
 
 	const urlQueryParams = useQuery();
+	const siteSlugOrIdInUrl = urlQueryParams.get( 'siteSlug' ) || urlQueryParams.get( 'siteId' );
+	const ref = urlQueryParams.get( 'ref' ) || '';
 
 	const site = useSite();
 	const selectedSite = useSelector( ( state ) => site && getSite( state, site.ID ) );
-	const ref = urlQueryParams.get( 'ref' ) || '';
+	const isFetchingSelectedSite = siteSlugOrIdInUrl && ! selectedSite;
 
 	const stepProgress = useSelect(
 		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getStepProgress(),
@@ -137,7 +139,7 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 
 	useEffect( () => {
 		// We record the event only when the step is not empty. Additionally, we should not fire this event whenever the intent is changed
-		if ( ! currentStepRoute || ! selectedSite ) {
+		if ( ! currentStepRoute || isFetchingSelectedSite ) {
 			return;
 		}
 
@@ -161,7 +163,7 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 		// We leave out intent from the dependency list, due to the ONBOARD_STORE being reset in the exit flow.
 		// This causes the intent to become empty, and thus this event being fired again.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ flow.name, currentStepRoute, selectedSite ] );
+	}, [ flow.name, currentStepRoute, isFetchingSelectedSite ] );
 
 	const assertCondition = flow.useAssertConditions?.( _navigate ) ?? {
 		state: AssertConditionState.SUCCESS,

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -1,6 +1,6 @@
 import '@automattic/calypso-polyfills';
 import accessibleFocus from '@automattic/accessible-focus';
-import { initializeAnalytics, getGenericSuperPropsGetter } from '@automattic/calypso-analytics';
+import { initializeAnalytics } from '@automattic/calypso-analytics';
 import { CurrentUser } from '@automattic/calypso-analytics/dist/types/utils/current-user';
 import config from '@automattic/calypso-config';
 import { User as UserStore } from '@automattic/data-stores';
@@ -17,6 +17,7 @@ import { setupLocale } from 'calypso/boot/locale';
 import AsyncLoad from 'calypso/components/async-load';
 import CalypsoI18nProvider from 'calypso/components/calypso-i18n-provider';
 import { addHotJarScript } from 'calypso/lib/analytics/hotjar';
+import getSuperProps from 'calypso/lib/analytics/super-props';
 import { initializeCurrentUser } from 'calypso/lib/user/shared-utils';
 import { createReduxStore } from 'calypso/state';
 import { setCurrentUser } from 'calypso/state/current-user/actions';
@@ -99,14 +100,13 @@ window.AppBoot = async () => {
 
 	const queryClient = await createQueryClient( userId );
 
-	initializeAnalytics( user, getGenericSuperPropsGetter( config ) );
-
 	const initialState = getInitialState( initialReducer, userId );
 	const reduxStore = createReduxStore( initialState, initialReducer );
 	setStore( reduxStore, getStateFromCache( userId ) );
 	setupLocale( user, reduxStore );
 
 	user && initializeCalypsoUserStore( reduxStore, user as CurrentUser );
+	initializeAnalytics( user, getSuperProps( reduxStore ) );
 
 	setupErrorLogger( reduxStore );
 

--- a/client/lib/analytics/utils/should-report-omit-blog-id.js
+++ b/client/lib/analytics/utils/should-report-omit-blog-id.js
@@ -19,5 +19,10 @@ export default ( path ) => {
 		return false;
 	}
 
+	// Stepper routes start with /setup/, and might contain site slug or ID via URL parameters.
+	if ( path.startsWith( '/setup/' ) ) {
+		return false;
+	}
+
 	return ! getSiteFragment( path );
 };


### PR DESCRIPTION
## Proposed Changes

See p1696970864009909-slack-C048CUFRGFQ. This PR adds more super props to the Stepper analytics based on the selected site. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to any Stepper flow.
* Ensure that each Tracks events has super props such as `site_id_label` and `site_plan_id`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?