### PR TITLE
Jetpack Manage: Add track events to the Boost feature changes

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/index.tsx
@@ -29,7 +29,7 @@ export default function SiteCard( { rows, columns }: Props ) {
 	const dispatch = useDispatch();
 	const isPartnerOAuthTokenLoaded = useSelector( getIsPartnerOAuthTokenLoaded );
 
-	const recordEvent = useJetpackAgencyDashboardRecordTrackEvent( null, true );
+	const recordEvent = useJetpackAgencyDashboardRecordTrackEvent( null, false );
 
 	const [ isExpanded, setIsExpanded ] = useState( false );
 	const [ expandedColumn, setExpandedColumn ] = useState< AllowedTypes | null >( null );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
@@ -80,7 +80,7 @@ export default function BoostSitePerformance( { site, trackEvent, hasError }: Pr
 				{
 					label: translate( 'Boost Settings' ),
 					href: `${ siteUrlWithScheme }/wp-admin/admin.php?page=jetpack-boost`,
-					onClick: () => trackEvent( 'boost_expandable_block_settings_click' ),
+					onClick: () => trackEvent( 'boost_expandable_block_boost_settings_click' ),
 				},
 			];
 		}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
@@ -30,7 +30,6 @@ export default function BoostSitePerformance( { site, trackEvent, hasError }: Pr
 	const {
 		blog_id: siteId,
 		url_with_scheme: siteUrlWithScheme,
-		url: siteUrl,
 		is_atomic: isAtomicSite,
 		has_boost: hasBoost,
 		jetpack_boost_scores: boostData,
@@ -200,8 +199,7 @@ export default function BoostSitePerformance( { site, trackEvent, hasError }: Pr
 			{ boostModalState.show && (
 				<BoostLicenseInfoModal
 					onClose={ () => setBoostModalState( { show: false } ) }
-					siteId={ siteId }
-					siteUrl={ siteUrl }
+					site={ site }
 					upgradeOnly={ boostModalState.upgradeOnly }
 				/>
 			) }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
@@ -62,7 +62,7 @@ export default function BoostSitePerformance( { site, trackEvent, hasError }: Pr
 				{
 					label: translate( 'Auto-optimize' ),
 					onClick: () => {
-						trackEvent( 'expandable_block_auto_optimize_click' );
+						trackEvent( 'boost_expandable_block_auto_optimize_click' );
 						showBoostModal( true );
 					},
 					primary: true,
@@ -70,7 +70,7 @@ export default function BoostSitePerformance( { site, trackEvent, hasError }: Pr
 				{
 					label: translate( 'Settings' ),
 					href: `${ siteUrlWithScheme }/wp-admin/admin.php?page=${ jetpackDashboardPage }`,
-					onClick: () => trackEvent( 'expandable_block_settings_click' ),
+					onClick: () => trackEvent( 'boost_expandable_block_settings_click' ),
 				},
 			];
 		}
@@ -80,7 +80,7 @@ export default function BoostSitePerformance( { site, trackEvent, hasError }: Pr
 				{
 					label: translate( 'Boost Settings' ),
 					href: `${ siteUrlWithScheme }/wp-admin/admin.php?page=jetpack-boost`,
-					onClick: () => trackEvent( 'expandable_block_settings_click' ),
+					onClick: () => trackEvent( 'boost_expandable_block_settings_click' ),
 				},
 			];
 		}
@@ -89,7 +89,7 @@ export default function BoostSitePerformance( { site, trackEvent, hasError }: Pr
 			{
 				label: translate( 'Optimize performance' ),
 				href: `${ siteUrlWithScheme }/wp-admin/admin.php?page=jetpack-boost`,
-				onClick: () => trackEvent( 'expandable_block_optimize_performance_click' ),
+				onClick: () => trackEvent( 'boost_expandable_block_optimize_performance_click' ),
 				primary: true,
 			},
 		];

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
@@ -110,6 +110,7 @@ export default function BoostSitePerformance( { site, trackEvent, hasError }: Pr
 				// Allow to click on the card only if Boost is not active
 				onClick={ () => {
 					if ( ! isEnabled ) {
+						trackEvent( 'boost_expandable_block_get_score_click' );
 						showBoostModal( false );
 					}
 				} }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/test/boost-site-performance.test.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/test/boost-site-performance.test.tsx
@@ -67,7 +67,7 @@ describe( 'BoostSitePerformance', () => {
 		);
 
 		fireEvent.click( settingsButton );
-		expect( trackEventMock ).toHaveBeenCalledWith( 'expandable_block_settings_click' );
+		expect( trackEventMock ).toHaveBeenCalledWith( 'boost_expandable_block_settings_click' );
 	} );
 
 	test( 'renders the Boost settings button when there is a high score and has boost', () => {
@@ -90,7 +90,7 @@ describe( 'BoostSitePerformance', () => {
 		);
 
 		fireEvent.click( button );
-		expect( trackEventMock ).toHaveBeenCalledWith( 'expandable_block_settings_click' );
+		expect( trackEventMock ).toHaveBeenCalledWith( 'boost_expandable_block_boost_settings_click' );
 	} );
 
 	test( 'renders the Boost settings button when there is a low score and has boost', () => {
@@ -113,6 +113,8 @@ describe( 'BoostSitePerformance', () => {
 		);
 
 		fireEvent.click( button );
-		expect( trackEventMock ).toHaveBeenCalledWith( 'expandable_block_optimize_performance_click' );
+		expect( trackEventMock ).toHaveBeenCalledWith(
+			'boost_expandable_block_optimize_performance_click'
+		);
 	} );
 } );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/boost-license-info-modal.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/boost-license-info-modal.tsx
@@ -2,7 +2,9 @@ import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useContext, useEffect, useMemo } from 'react';
 import ExternalLink from 'calypso/components/external-link';
+import { useJetpackAgencyDashboardRecordTrackEvent } from '../../../hooks';
 import SitesOverviewContext from '../../context';
+import DashboardDataContext from '../../dashboard-data-context';
 import useInstallBoost from '../../hooks/use-install-boost';
 import LicenseInfoModal from '../../license-info-modal';
 import type { Site } from '../../types';
@@ -19,6 +21,10 @@ export default function BoostLicenseInfoModal( { onClose, site, upgradeOnly }: P
 	const translate = useTranslate();
 
 	const { filter, search, currentPage, sort } = useContext( SitesOverviewContext );
+	const { isLargeScreen } = useContext( DashboardDataContext );
+
+	const recordEvent = useJetpackAgencyDashboardRecordTrackEvent( [ site ], isLargeScreen );
+
 	const { blog_id: siteId, url: siteUrl } = site;
 
 	// queryKey is needed to optimistically update the site list
@@ -30,15 +36,15 @@ export default function BoostLicenseInfoModal( { onClose, site, upgradeOnly }: P
 
 	const handleInstallBoost = () => {
 		installBoost();
-		// TODO: Track events here
+		recordEvent( 'boost_info_modal_start_free_click' );
 	};
 
 	const handlePurchaseBoost = () => {
-		// TODO: Track events here
+		recordEvent( 'boost_info_modal_purchase_click' );
 	};
 
 	const onJetpackBoostClick = () => {
-		// TODO: Track events here
+		recordEvent( 'boost_info_modal_jetpack_boost_click' );
 	};
 
 	const inProgress = status === 'loading';

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/boost-license-info-modal.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/boost-license-info-modal.tsx
@@ -5,20 +5,21 @@ import ExternalLink from 'calypso/components/external-link';
 import SitesOverviewContext from '../../context';
 import useInstallBoost from '../../hooks/use-install-boost';
 import LicenseInfoModal from '../../license-info-modal';
+import type { Site } from '../../types';
 
 import './style.scss';
 
 interface Props {
 	onClose: () => void;
-	siteId: number;
-	siteUrl: string;
+	site: Site;
 	upgradeOnly?: boolean;
 }
 
-export default function BoostLicenseInfoModal( { onClose, siteId, siteUrl, upgradeOnly }: Props ) {
+export default function BoostLicenseInfoModal( { onClose, site, upgradeOnly }: Props ) {
 	const translate = useTranslate();
 
 	const { filter, search, currentPage, sort } = useContext( SitesOverviewContext );
+	const { blog_id: siteId, url: siteUrl } = site;
 
 	// queryKey is needed to optimistically update the site list
 	const queryKey = useMemo(

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/index.tsx
@@ -2,9 +2,11 @@ import { getUrlParts } from '@automattic/calypso-url';
 import { Button } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
+import { useContext, useState } from 'react';
 import { useSelector } from 'calypso/state';
 import getJetpackAdminUrl from 'calypso/state/sites/selectors/get-jetpack-admin-url';
+import { useJetpackAgencyDashboardRecordTrackEvent } from '../../../hooks';
+import DashboardDataContext from '../../dashboard-data-context';
 import { getBoostRating, getBoostRatingClass } from '../../lib/boost';
 import BoostLicenseInfoModal from './boost-license-info-modal';
 import type { Site } from '../../types';
@@ -16,6 +18,9 @@ interface Props {
 export default function SiteBoostColumn( { site }: Props ) {
 	const translate = useTranslate();
 
+	const { isLargeScreen } = useContext( DashboardDataContext );
+	const recordEvent = useJetpackAgencyDashboardRecordTrackEvent( [ site ], isLargeScreen );
+
 	const overallScore = site.jetpack_boost_scores?.overall;
 	const hasBoost = site.has_boost;
 	const adminUrl = useSelector( ( state ) => getJetpackAdminUrl( state, site.blog_id ) );
@@ -24,6 +29,7 @@ export default function SiteBoostColumn( { site }: Props ) {
 
 	const handleGetBoostScoreAction = () => {
 		setShowBoostModal( true );
+		recordEvent( 'boost_column_get_score_click' );
 	};
 
 	const { origin, pathname } = getUrlParts( adminUrl ?? '' );
@@ -42,6 +48,11 @@ export default function SiteBoostColumn( { site }: Props ) {
 				) }
 				href={ href }
 				target="_blank"
+				onClick={ () =>
+					recordEvent( 'boost_column_score_click', {
+						score: overallScore,
+					} )
+				}
 			>
 				{ getBoostRating( overallScore ) }
 			</Button>
@@ -55,6 +66,7 @@ export default function SiteBoostColumn( { site }: Props ) {
 				href={ href }
 				target="_blank"
 				rel="noreferrer"
+				onClick={ () => recordEvent( 'boost_column_configure_click' ) }
 			>
 				{ translate( 'Configure Boost' ) }
 			</a>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/index.tsx
@@ -70,11 +70,7 @@ export default function SiteBoostColumn( { site }: Props ) {
 				{ translate( 'Get Score' ) }
 			</button>
 			{ showBoostModal && (
-				<BoostLicenseInfoModal
-					onClose={ () => setShowBoostModal( false ) }
-					siteId={ site.blog_id }
-					siteUrl={ site.url }
-				/>
+				<BoostLicenseInfoModal onClose={ () => setShowBoostModal( false ) } site={ site } />
 			) }
 		</>
 	);


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/42

## Proposed Changes

This PR adds track events to the Boost feature changes.

### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Open the Jetpack Cloud live link
2. Visit the /dashboard
3. Open the dev tool, go to the network tab, and apply the filters - `jetpack-cloud-development` as search and select `Img` filters.

<img width="739" alt="Screenshot 2023-01-19 at 12 43 57 PM" src="https://user-images.githubusercontent.com/10586875/213378720-624de9b6-dc14-489e-a9a2-d7f04cfa478c.png">

4. Perform the below actions and verify that the API call to track the event is made with the right action names on large and small screen devices

`L: Large screen(>1280px)`
`S: Small Screen(<1280px)`

------

<img width="546" alt="Screenshot 2023-10-13 at 2 06 45 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/03cbffe3-fd22-4849-8fbc-57f5768b4dff">

#### 1) Click the Boost score in the column

Event name: 

L: calypso_jetpack_agency_dashboard_boost_column_score_click_large_screen
S: calypso_jetpack_agency_dashboard_boost_column_score_click_small_screen

####  2) Click the `Get Score` button in the column

Event name: 

L: calypso_jetpack_agency_dashboard_boost_column_get_score_click_large_screen
S: calypso_jetpack_agency_dashboard_boost_column_get_score_click_small_screen

####  3) Click the `Configure Boost` button in the column

Event name: 

L: calypso_jetpack_agency_dashboard_boost_column_configure_click_large_screen
S: calypso_jetpack_agency_dashboard_boost_column_configure_click_small_screen

------

<img width="1061" alt="Screenshot 2023-10-13 at 2 00 56 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/bf5749e7-79fb-4abb-bc39-36e58d3441de">

####  4) Click the `Purchase Boost License` button in the modal

Event name: 

L: calypso_jetpack_agency_dashboard_boost_info_modal_purchase_click_large_screen
S: calypso_jetpack_agency_dashboard_boost_info_modal_purchase_click_small_screen

####  5) Click the `Start Free` button in the modal

Event name: 

L: calypso_jetpack_agency_dashboard_boost_info_modal_start_free_click_large_screen
S: calypso_jetpack_agency_dashboard_boost_info_modal_start_free_click_small_screen

####  6) Click the `Jetpack Boost` link in the modal

Event name: 

L: calypso_jetpack_agency_dashboard_boost_info_modal_jetpack_boost_click_large_screen
S: calypso_jetpack_agency_dashboard_boost_info_modal_jetpack_boost_click_small_screen

------

<img width="348" alt="Screenshot 2023-10-13 at 2 00 29 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/5a887a2f-3963-4478-8423-2f8a70e6f413">

####  7) Click the `Auto-optimize` button in the expanded area

Event name: 

L: calypso_jetpack_agency_dashboard_boost_expandable_block_auto_optimize_click_large_screen
S: calypso_jetpack_agency_dashboard_boost_expandable_block_auto_optimize_click_small_screen

####  8) Click the `Settings` button in the expanded area

Event name: 

L: calypso_jetpack_agency_dashboard_boost_expandable_block_settings_click_large_screen
S: calypso_jetpack_agency_dashboard_boost_expandable_block_settings_click_small_screen

------

<img width="347" alt="Screenshot 2023-10-13 at 2 00 38 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/4f584da5-e436-41c8-b2bb-ac9e5a44cc5f">

####  9) Click the `Boost Settings` button in the expanded area

Event name: 

L: calypso_jetpack_agency_dashboard_boost_expandable_block_boost_settings_click_large_screen
S: calypso_jetpack_agency_dashboard_boost_expandable_block_boost_settings_click_small_screen

------

<img width="344" alt="Screenshot 2023-10-13 at 2 04 17 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/85e458b2-0e8b-4ed3-b16e-d82b3abd4f40">

####  10) Click the `Optimize performance` button in the expanded area

Event name: 

L: calypso_jetpack_agency_dashboard_boost_expandable_block_optimize_performance_click_large_screen
S: calypso_jetpack_agency_dashboard_boost_expandable_block_optimize_performance_click_small_screen

------

<img width="378" alt="275456183-2a858e05-f30b-400c-b93d-1251e71ab6fa" src="https://github.com/Automattic/wp-calypso/assets/10586875/e46f26f1-44f7-4d81-9db4-fe651a33d73c">

####  11) Click the whole card (Get Score to see your site performance scores) in the expanded area

Event name: 

L: calypso_jetpack_agency_dashboard_boost_expandable_block_get_score_click_large_screen
S: calypso_jetpack_agency_dashboard_boost_expandable_block_get_score_click_small_screen

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?