### PR TITLE
Jetpack Manage: Fix broken backup links and remove scan links for Atomic sites.

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/backup-storage.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/backup-storage.tsx
@@ -27,11 +27,13 @@ const BACKUP_ERROR_STATUSES = [ 'rewind_backup_error', 'backup_only_error' ];
 const BackupStorageContent = ( {
 	siteId,
 	siteUrl,
+	isAtomicSite,
 	trackEvent,
 }: {
 	siteId: number;
 	siteUrl: string;
 	trackEvent: ( eventName: string ) => void;
+	isAtomicSite?: boolean;
 } ) => {
 	const translate = useTranslate();
 
@@ -92,11 +94,16 @@ const BackupStorageContent = ( {
 			<div className="site-expanded-content__card-footer">
 				<Button
 					onClick={ () => trackEvent( 'expandable_block_activity_log_click' ) }
-					href={ `/activity-log/${ urlToSlug( siteUrl ) }` }
+					href={
+						isAtomicSite
+							? `https://wordpress.com/activity-log/${ urlToSlug( siteUrl ) }`
+							: `/activity-log/${ urlToSlug( siteUrl ) }`
+					}
+					target={ isAtomicSite ? '_blank' : undefined }
 					className="site-expanded-content__card-button"
 					compact
 				>
-					{ translate( 'Activity log' ) }
+					{ translate( 'Activity log' ) } { isAtomicSite && <Gridicon icon="external" /> }
 				</Button>
 			</div>
 		</div>
@@ -194,6 +201,7 @@ export default function BackupStorage( { site, trackEvent, hasError }: Props ) {
 				<BackupStorageContent
 					siteId={ site.blog_id }
 					siteUrl={ site.url }
+					isAtomicSite={ site.is_atomic }
 					trackEvent={ trackEvent }
 				/>
 			) }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/hooks/test/use-row-metadata.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/hooks/test/use-row-metadata.ts
@@ -56,6 +56,7 @@ const FAKE_SITE: Site = {
 		desktop: 10,
 	},
 	php_version_num: 7.4,
+	is_atomic: false,
 };
 
 const scanThreats = 4;
@@ -127,6 +128,44 @@ describe( 'useRowMetadata', () => {
 		expect( metadata ).toEqual( expected );
 	} );
 
+	it( 'should return the expected Backup metadata for atomic sites.', () => {
+		const {
+			result: { current: metadata },
+		} = renderHook( () =>
+			useRowMetadata(
+				{
+					...rows,
+					site: {
+						...rows.site,
+						value: { ...FAKE_SITE, is_atomic: true },
+					},
+					backup: {
+						type: 'backup',
+						value: 'success',
+						status: 'success',
+					},
+				},
+				'backup',
+				true
+			)
+		);
+
+		const expected = {
+			eventName: 'calypso_jetpack_agency_dashboard_backup_success_click_large_screen',
+			isExternalLink: true,
+			link: `https://wordpress.com/backup/${ FAKE_SITE.url }`,
+			row: {
+				type: 'backup',
+				value: 'success',
+				status: 'success',
+			},
+			siteDown: false,
+			tooltip: 'Latest backup completed successfully',
+			tooltipId: `${ FAKE_SITE.blog_id }-backup`,
+		};
+		expect( metadata ).toEqual( expected );
+	} );
+
 	it( 'should return the expected Scan metadata', () => {
 		const {
 			result: { current: metadata },
@@ -136,6 +175,35 @@ describe( 'useRowMetadata', () => {
 			eventName: 'calypso_jetpack_agency_dashboard_scan_threats_click_large_screen',
 			isExternalLink: false,
 			link: `/scan/${ FAKE_SITE.url }`,
+			row: rows.scan,
+			siteDown: false,
+			tooltip: 'Potential threats found',
+			tooltipId: `${ FAKE_SITE.blog_id }-scan`,
+		};
+		expect( metadata ).toEqual( expected );
+	} );
+
+	it( 'should return the expected Scan metadata for atomic sites.', () => {
+		const {
+			result: { current: metadata },
+		} = renderHook( () =>
+			useRowMetadata(
+				{
+					...rows,
+					site: {
+						...rows.site,
+						value: { ...FAKE_SITE, is_atomic: true },
+					},
+				},
+				'scan',
+				true
+			)
+		);
+
+		const expected = {
+			eventName: 'calypso_jetpack_agency_dashboard_scan_threats_click_large_screen',
+			isExternalLink: false,
+			link: '',
 			row: rows.scan,
 			siteDown: false,
 			tooltip: 'Potential threats found',

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/hooks/use-row-metadata.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/hooks/use-row-metadata.ts
@@ -21,7 +21,13 @@ const useRowMetadata = (
 		const siteUrlWithScheme = rows.site?.value?.url_with_scheme;
 		const siteId = rows.site?.value?.blog_id;
 
-		const { link, isExternalLink } = getLinks( type, row.status, siteUrl, siteUrlWithScheme );
+		const { link, isExternalLink } = getLinks(
+			type,
+			row.status,
+			siteUrl,
+			siteUrlWithScheme,
+			rows.site?.value?.is_atomic
+		);
 		const eventName = getRowEventName( type, row.status, isLargeScreen );
 
 		return {
@@ -38,6 +44,7 @@ const useRowMetadata = (
 		row,
 		rows.monitor.error,
 		rows.site?.value?.blog_id,
+		rows.site?.value?.is_atomic,
 		rows.site?.value?.url,
 		rows.site?.value?.url_with_scheme,
 		tooltip,

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/lib/get-links.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/lib/get-links.ts
@@ -12,7 +12,8 @@ const getLinks = (
 	type: AllowedTypes,
 	status: string,
 	siteUrl: string,
-	siteUrlWithScheme: string
+	siteUrlWithScheme: string,
+	isAtomicSite: boolean
 ): {
 	link: string;
 	isExternalLink: boolean;
@@ -25,7 +26,10 @@ const getLinks = (
 	switch ( type ) {
 		case 'backup': {
 			if ( status !== 'inactive' ) {
-				link = `/backup/${ siteUrlWithMultiSiteSupport }`;
+				link = isAtomicSite
+					? `https://wordpress.com/backup/${ siteUrlWithMultiSiteSupport }`
+					: `/backup/${ siteUrlWithMultiSiteSupport }`;
+				isExternalLink = isAtomicSite;
 			}
 			break;
 		}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/lib/get-links.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/lib/get-links.ts
@@ -34,7 +34,8 @@ const getLinks = (
 			break;
 		}
 		case 'scan': {
-			if ( status !== 'inactive' ) {
+			// Scan link should not be available for Atomic sites.
+			if ( status !== 'inactive' && ! isAtomicSite ) {
 				link = `/scan/${ siteUrlWithMultiSiteSupport }`;
 			}
 			break;


### PR DESCRIPTION
This PR fixes the broken backup links and removes the Scan redirect for Atomic sites in the Jetpack Manage dashboard.

Closes https://github.com/Automattic/jetpack-genesis/issues/47
Closes https://github.com/Automattic/jetpack-genesis/issues/49

## Proposed Changes

* Update the Backup links for Atomic sites to redirect to the correct wordpress.com equivalent pages (Backup and Activity logs).
* Remove the Scan link for Atomic sites, as this WPCOM Atomic site has its security for scanning threats.

## Testing Instructions
Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

### Backup links 
* Make sure you have a Jetpack and WPCOM Atomic sites. You can spin a JN site, connect it with your Jetpack account, and create an Atomic site from the dashboard.
* Use the live link below and go to `/dashboard`
* Confirm that for Atomic sites, clicking the **Checkbox** under Backup column will redirect to `https://wordpress.com/backup/<SITE>`
<img width="894" alt="Screen Shot 2023-10-13 at 5 02 47 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/18b26469-ee13-4343-b6c1-399899118a16">

* Confirm that for Atomic sites, clicking the **Activity log** button under Expandable block will redirect user to `https://wordpress.com/activity-log/<SITE>`
<img width="385" alt="Screen Shot 2023-10-13 at 5 02 08 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/825cd43d-b5d7-4014-84c9-c7c62ad54af2">

* Confirm that for Jetpack sites, both the **Checkbox** and **Activity log** button works the same way as production.

### Scan links
* Confirm that for Atomic sites, the **Checkbox** under the Scan column is not clickable.
<img width="1024" alt="Screen Shot 2023-10-13 at 5 05 38 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/9347ca2d-e7fa-426e-a8b8-7ae3f6cc8c67">

* Confirm that for Jetpack sites, the **Checkbox** under the Scan column works the same way as production.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?