### PR TITLE
Newsletter flow: skip intro when coming from support page CTA

### DIFF
--- a/client/landing/stepper/declarative-flow/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/newsletter.ts
@@ -27,11 +27,13 @@ const newsletter: Flow = {
 	},
 	useSteps() {
 		const query = useQuery();
-		const isComingFromMarketingPage = query.get( 'ref' ) === 'newsletter-lp';
+		const ref = query.get( 'ref' ) ?? '';
+		// Marketing page (/newsletter) and support page (/support/launch-a-newsletter/) skip the intro.
+		const skipIntro = [ 'newsletter-lp', 'support-site-inline' ].includes( ref );
 
 		return [
-			// Load intro step component only when not coming from the marketing page
-			...( ! isComingFromMarketingPage
+			// Load intro step component only when not skipping intro
+			...( ! skipIntro
 				? [
 						{ slug: 'intro', asyncComponent: () => import( './internals/steps-repository/intro' ) },
 				  ]


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Skip intro step when coming from support page.

The support page itself is enough context/intro, and we want them onto action asap instead of asking _again_ to start. Slack convo (p1697035720638429-slack-C02NQ4HMJKV).

<img width="1064" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/0cbea3b3-0954-40fc-ac55-5f4e151bb578">


## Proposed Changes

* Skip intro when coming from [marketing](https://wordpress.com/newsletter/) or [support](https://wordpress.com/support/launch-a-newsletter/) pages (defined by `?ref=` in the URL), otherwise show the intro.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Try all these:**

* No intro:
   * /setup/newsletter?ref=newsletter-lp
   * /setup/newsletter?ref=support-site-inline 
   * /setup/newsletter/intro?ref=newsletter-lp
   * /setup/newsletter/intro?ref=support-site-inline 
* Yes intro:   
   * /setup/newsletter

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?