### PR TITLE
Jetpack Manage: Update the Boost premium feature list

### DIFF
--- a/client/components/jetpack/jetpack-product-info/style.scss
+++ b/client/components/jetpack/jetpack-product-info/style.scss
@@ -148,33 +148,6 @@
 		font-weight: 400;
 		font-size: $font-body;
 		color: var(--studio-gray-70);
-		margin-block: 2px;
-
-		.premium-feature {
-			display: flex;
-			align-items: center;
-
-			strong {
-				flex: auto;
-			}
-
-			span {
-				background-color: var(--studio-jetpack-green-5);
-				color: var(--studio-jetpack-green-50);
-				padding: 2px 8px;
-				border-radius: 4px;
-				font-weight: bold;
-				font-size: rem(11px);
-			}
-
-			@include break-medium {
-				width: 90%;
-			}
-
-			@include break-xlarge {
-				width: 80%;
-			}
-		}
 	}
 
 	&:not(.jetpack-product-info__faq-list) li {

--- a/client/components/jetpack/jetpack-product-info/style.scss
+++ b/client/components/jetpack/jetpack-product-info/style.scss
@@ -148,6 +148,33 @@
 		font-weight: 400;
 		font-size: $font-body;
 		color: var(--studio-gray-70);
+		margin-block: 2px;
+
+		.premium-feature {
+			display: flex;
+			align-items: center;
+
+			strong {
+				flex: auto;
+			}
+
+			span {
+				background-color: var(--studio-jetpack-green-5);
+				color: var(--studio-jetpack-green-50);
+				padding: 2px 8px;
+				border-radius: 4px;
+				font-weight: bold;
+				font-size: rem(11px);
+			}
+
+			@include break-medium {
+				width: 90%;
+			}
+
+			@include break-xlarge {
+				width: 80%;
+			}
+		}
 	}
 
 	&:not(.jetpack-product-info__faq-list) li {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/license-info-modal/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/license-info-modal/index.tsx
@@ -10,6 +10,7 @@ import DashboardDataContext from '../dashboard-data-context';
 import { DASHBOARD_PRODUCT_SLUGS_BY_TYPE } from '../lib/constants';
 
 interface Props {
+	className?: string;
 	label?: string;
 	currentLicenseInfo: string | null;
 	onClose?: () => void;
@@ -20,6 +21,7 @@ interface Props {
 }
 
 export default function LicenseInfoModal( {
+	className,
 	label,
 	currentLicenseInfo,
 	onClose,
@@ -75,6 +77,7 @@ export default function LicenseInfoModal( {
 	return (
 		currentLicenseProduct && (
 			<LicenseLightbox
+				className={ className }
 				product={ currentLicenseProduct }
 				ctaLabel={ label ?? translate( 'Issue License' ) }
 				isDisabled={ isDisabled }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/boost-license-info-modal.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/boost-license-info-modal.tsx
@@ -57,6 +57,7 @@ export default function BoostLicenseInfoModal( { onClose, site, upgradeOnly }: P
 
 	return (
 		<LicenseInfoModal
+			className="site-boost-column__upgrade-modal"
 			currentLicenseInfo="boost"
 			label={
 				upgradeOnly

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/style.scss
@@ -1,5 +1,3 @@
-@import "@wordpress/base-styles/mixins";
-
 .site-boost-column__extra-button {
 	margin-block-start: 1rem;
 	margin-block-end: 0;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 .site-boost-column__extra-button {
 	margin-block-start: 1rem;
 	margin-block-end: 0;
@@ -15,3 +18,43 @@
 		font-weight: 600;
 	}
 }
+
+.site-boost-column__upgrade-modal {
+	.jetpack-product-info__regular-list {
+
+		li {
+			margin-block: 2px;
+		}
+
+		.premium-feature {
+			display: flex;
+			align-items: center;
+
+			.premium-feature-title {
+				font-weight: 600;
+				flex: auto;
+			}
+
+			span.premium-feature-badge {
+				// Using !important is the only way to override the inline style
+				display: inline-block !important;
+				margin-inline-start: 20px;
+				background-color: var(--studio-jetpack-green-5);
+				color: var(--studio-jetpack-green-50);
+				padding: 2px 8px;
+				border-radius: 4px;
+				font-weight: bold;
+				font-size: rem(11px);
+			}
+
+			@include break-medium {
+				width: 90%;
+			}
+
+			@include break-xlarge {
+				width: 80%;
+			}
+		}
+	}
+}
+

--- a/client/jetpack-cloud/sections/partner-portal/license-lightbox/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-lightbox/index.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@automattic/components';
 import { useBreakpoint } from '@automattic/viewport-react';
+import classNames from 'classnames';
 import { FunctionComponent, useCallback } from 'react';
 import JetpackLightbox, {
 	JetpackLightboxAside,
@@ -21,6 +22,7 @@ export type LicenseLightBoxProps = {
 	onClose: () => void;
 	product: APIProductFamilyProduct;
 	extraAsideContent?: JSX.Element;
+	className?: string;
 };
 
 const LicenseLightbox: FunctionComponent< LicenseLightBoxProps > = ( {
@@ -31,6 +33,7 @@ const LicenseLightbox: FunctionComponent< LicenseLightBoxProps > = ( {
 	onClose,
 	product,
 	extraAsideContent,
+	className,
 } ) => {
 	const isLargeScreen = useBreakpoint( '>782px' );
 	const { title, product: productInfo } = useLicenseLightboxData( product );
@@ -44,7 +47,7 @@ const LicenseLightbox: FunctionComponent< LicenseLightBoxProps > = ( {
 
 	return (
 		<JetpackLightbox
-			className="license-lightbox"
+			className={ classNames( 'license-lightbox', className ) }
 			isOpen={ true }
 			onClose={ onClose }
 			onAfterOpen={ initMobileSidebar }

--- a/client/my-sites/checkout/src/lib/get-jetpack-product-features.ts
+++ b/client/my-sites/checkout/src/lib/get-jetpack-product-features.ts
@@ -59,7 +59,11 @@ function getFeatureStrings(
 			];
 		case 'boost':
 			return [
-				translate( 'Automated critical CSS (Premium)' ),
+				translate( 'Automated critical CSS generation (Premium)' ),
+				translate( 'Reduce image sizes with image guide (Premium)' ),
+				translate( 'Historical site performance chart (Premium)' ),
+				translate( 'Additional image quality control options (Premium)' ),
+				translate( 'Priority support (Premium)' ),
 				translate( 'Site performance scores' ),
 				translate( 'One-click optimization' ),
 				translate( 'Deferred non-essential JavaScript' ),

--- a/client/my-sites/checkout/src/lib/get-jetpack-product-features.ts
+++ b/client/my-sites/checkout/src/lib/get-jetpack-product-features.ts
@@ -70,7 +70,6 @@ function getFeatureStrings(
 				translate( 'Optimized CSS loading' ),
 				translate( 'Lazy image loading' ),
 				translate( 'CDN for images' ),
-				translate( 'Image optimization guide' ),
 			];
 		case 'complete':
 			return [

--- a/client/my-sites/checkout/src/lib/get-jetpack-product-features.ts
+++ b/client/my-sites/checkout/src/lib/get-jetpack-product-features.ts
@@ -59,11 +59,11 @@ function getFeatureStrings(
 			];
 		case 'boost':
 			return [
-				translate( 'Automated critical CSS generation (Premium)' ),
-				translate( 'Reduce image sizes with image guide (Premium)' ),
-				translate( 'Historical site performance chart (Premium)' ),
-				translate( 'Additional image quality control options (Premium)' ),
-				translate( 'Priority support (Premium)' ),
+				translate( 'Automated critical CSS generation' ),
+				translate( 'Reduce image sizes with Image Guide' ),
+				translate( 'Historical site performance chart' ),
+				translate( 'Additional image quality control options' ),
+				translate( 'Priority support' ),
 				translate( 'Site performance scores' ),
 				translate( 'One-click optimization' ),
 				translate( 'Deferred non-essential JavaScript' ),

--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -1128,7 +1128,6 @@ export const getJetpackProductsWhatIsIncluded = (): Record< string, Array< Trans
 		translate( 'Defer non-essential JavaScript' ),
 		translate( 'Optimize CSS loading' ),
 		translate( 'Lazy image loading' ),
-		translate( 'Image Guide to discover and fix large images on your site' ),
 	];
 	const socialBasicIncludesInfo = [
 		translate( 'Automatically share your posts and products on social media' ),

--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -1076,7 +1076,27 @@ export const getJetpackProductsWhatIsIncluded = (): Record< string, Array< Trans
 		translate( 'Quick and accurate spelling correction' ),
 	];
 	const boostIncludesInfo = [
-		translate( '{{strong}}Automated critical CSS (Premium){{/strong}}', {
+		translate( '{{strong}}Automated critical CSS generation (Premium){{/strong}}', {
+			components: {
+				strong: <strong />,
+			},
+		} ),
+		translate( '{{strong}}Reduce image sizes with image guide (Premium){{/strong}}', {
+			components: {
+				strong: <strong />,
+			},
+		} ),
+		translate( '{{strong}}Historical site performance chart (Premium){{/strong}}', {
+			components: {
+				strong: <strong />,
+			},
+		} ),
+		translate( '{{strong}}Additional image quality control options (Premium){{/strong}}', {
+			components: {
+				strong: <strong />,
+			},
+		} ),
+		translate( '{{strong}}Priority support (Premium){{/strong}}', {
 			components: {
 				strong: <strong />,
 			},

--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -1076,29 +1076,51 @@ export const getJetpackProductsWhatIsIncluded = (): Record< string, Array< Trans
 		translate( 'Quick and accurate spelling correction' ),
 	];
 	const boostIncludesInfo = [
-		translate( '{{strong}}Automated critical CSS generation (Premium){{/strong}}', {
+		translate(
+			'{{div}}{{strong}}Automated critical CSS generation{{/strong}} {{badge}}PREMIUM{{/badge}}{{/div}}',
+			{
+				components: {
+					div: <div className="premium-feature" />,
+					strong: <strong />,
+					badge: <span />,
+				},
+			}
+		),
+		translate(
+			'{{div}}{{strong}}Reduce image sizes with image guide{{/strong}} {{badge}}PREMIUM{{/badge}}{{/div}}',
+			{
+				components: {
+					div: <div className="premium-feature" />,
+					strong: <strong />,
+					badge: <span />,
+				},
+			}
+		),
+		translate(
+			'{{div}}{{strong}}Historical site performance chart{{/strong}} {{badge}}PREMIUM{{/badge}}{{/div}}',
+			{
+				components: {
+					div: <div className="premium-feature" />,
+					strong: <strong />,
+					badge: <span />,
+				},
+			}
+		),
+		translate(
+			'{{div}}{{strong}}Additional image quality control options{{/strong}} {{badge}}PREMIUM{{/badge}}{{/div}}',
+			{
+				components: {
+					div: <div className="premium-feature" />,
+					strong: <strong />,
+					badge: <span />,
+				},
+			}
+		),
+		translate( '{{div}}{{strong}}Priority support{{/strong}} {{badge}}PREMIUM{{/badge}}{{/div}}', {
 			components: {
+				div: <div className="premium-feature" />,
 				strong: <strong />,
-			},
-		} ),
-		translate( '{{strong}}Reduce image sizes with image guide (Premium){{/strong}}', {
-			components: {
-				strong: <strong />,
-			},
-		} ),
-		translate( '{{strong}}Historical site performance chart (Premium){{/strong}}', {
-			components: {
-				strong: <strong />,
-			},
-		} ),
-		translate( '{{strong}}Additional image quality control options (Premium){{/strong}}', {
-			components: {
-				strong: <strong />,
-			},
-		} ),
-		translate( '{{strong}}Priority support (Premium){{/strong}}', {
-			components: {
-				strong: <strong />,
+				badge: <span />,
 			},
 		} ),
 		translate( 'Site performance scores' ),

--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -1075,53 +1075,40 @@ export const getJetpackProductsWhatIsIncluded = (): Record< string, Array< Trans
 		translate( 'Supports 38 languages' ),
 		translate( 'Quick and accurate spelling correction' ),
 	];
+
+	const boostPremiumFeatureComponents = {
+		div: <div className="premium-feature" />,
+		strong: <span className="premium-feature-title" />,
+		badge: <span style={ { display: 'none' } } className="premium-feature-badge" />,
+	};
+
 	const boostIncludesInfo = [
 		translate(
 			'{{div}}{{strong}}Automated critical CSS generation{{/strong}} {{badge}}PREMIUM{{/badge}}{{/div}}',
 			{
-				components: {
-					div: <div className="premium-feature" />,
-					strong: <strong />,
-					badge: <span />,
-				},
+				components: boostPremiumFeatureComponents,
 			}
 		),
 		translate(
-			'{{div}}{{strong}}Reduce image sizes with image guide{{/strong}} {{badge}}PREMIUM{{/badge}}{{/div}}',
+			'{{div}}{{strong}}Reduce image sizes with Image Guide{{/strong}} {{badge}}PREMIUM{{/badge}}{{/div}}',
 			{
-				components: {
-					div: <div className="premium-feature" />,
-					strong: <strong />,
-					badge: <span />,
-				},
+				components: boostPremiumFeatureComponents,
 			}
 		),
 		translate(
 			'{{div}}{{strong}}Historical site performance chart{{/strong}} {{badge}}PREMIUM{{/badge}}{{/div}}',
 			{
-				components: {
-					div: <div className="premium-feature" />,
-					strong: <strong />,
-					badge: <span />,
-				},
+				components: boostPremiumFeatureComponents,
 			}
 		),
 		translate(
 			'{{div}}{{strong}}Additional image quality control options{{/strong}} {{badge}}PREMIUM{{/badge}}{{/div}}',
 			{
-				components: {
-					div: <div className="premium-feature" />,
-					strong: <strong />,
-					badge: <span />,
-				},
+				components: boostPremiumFeatureComponents,
 			}
 		),
 		translate( '{{div}}{{strong}}Priority support{{/strong}} {{badge}}PREMIUM{{/badge}}{{/div}}', {
-			components: {
-				div: <div className="premium-feature" />,
-				strong: <strong />,
-				badge: <span />,
-			},
+			components: boostPremiumFeatureComponents,
 		} ),
 		translate( 'Site performance scores' ),
 		translate( 'One-click optimization' ),


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-manage/issues/33

## Proposed Changes

This PR updated the feature list in the Boost license info modal.

### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Open the Jetpack Cloud live link
2. Visit the /dashboard.
3. Click the Boost score column on the dashboard
4. Verify that you can now see the extra premium features that are added without the `PREMIUM` label and bold text for premium features, as shown in the screenshot below. Also, verify this for the /pricing page

<img width="1067" alt="Screenshot 2023-10-18 at 11 13 26 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/568d5859-1e11-46d6-a7bd-c42fad280892">

5. Create a new JN site > Click the Get Score link > Verify that you can now see the extra premium features that are added along with the `PREMIUM label` and bold text for premium features, as shown in the screenshot below

<img width="1064" alt="Screenshot 2023-10-18 at 11 13 37 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/84a6f53e-0306-45e3-968d-2052ca898b2e">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?