### PR TITLE
Assembler: Add pattern count indicator

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/index.ts
@@ -5,6 +5,7 @@ export { default as useDotcomPatterns } from './use-dotcom-patterns';
 export { default as useGlobalStylesUpgradeProps } from './use-global-styles-upgrade-props';
 export { default as useInitialPath } from './use-initial-path';
 export { default as usePatternCategories } from './use-pattern-categories';
+export { default as usePatternCountMapByCategory } from './use-pattern-count-map-by-category';
 export { default as usePatternsMapByCategory } from './use-patterns-map-by-category';
 export { default as useRecipe } from './use-recipe';
 export { default as useScreen } from './use-screen';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-count-map-by-category.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-count-map-by-category.ts
@@ -1,0 +1,22 @@
+import { useMemo } from 'react';
+import type { Pattern } from '../types';
+
+const usePatternCountMapByCategory = ( patterns: Pattern[] ) => {
+	return useMemo(
+		() =>
+			patterns.reduce( ( acc: Record< string, number >, pattern ) => {
+				const categoryName = pattern.category?.name;
+				if ( ! categoryName ) {
+					return acc;
+				}
+
+				return {
+					...acc,
+					[ categoryName ]: ( acc[ categoryName ] || 0 ) + 1,
+				};
+			}, {} ),
+		[ patterns ]
+	);
+};
+
+export default usePatternCountMapByCategory;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -523,7 +523,7 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 						onMainItemSelect={ onMainItemSelect }
 						surveyDismissed={ surveyDismissed }
 						setSurveyDismissed={ setSurveyDismissed }
-						hasSections={ sections.length > 0 }
+						sectionsCount={ sections.length }
 						hasHeader={ !! header }
 						hasFooter={ !! footer }
 						onContinueClick={ onContinue }
@@ -534,6 +534,7 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 					<ScreenSections
 						categories={ categories }
 						patternsMapByCategory={ patternsMapByCategory }
+						sections={ sections }
 						onContinueClick={ onContinue }
 						recordTracksEvent={ recordTracksEvent }
 					/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-category-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-category-list.tsx
@@ -7,12 +7,14 @@ import {
 } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useCategoriesOrder } from './hooks';
+import PatternCount from './pattern-count';
 import type { Pattern, Category } from './types';
 import './pattern-category-list.scss';
 
 interface Props {
 	categories: Category[];
-	patternsMapByCategory: { [ key: string ]: Pattern[] };
+	patternsMapByCategory: Record< string, Pattern[] >;
+	patternCountMapByCategory: Record< string, number >;
 	selectedCategory: string;
 	onSelectCategory: ( selectedCategory: string ) => void;
 }
@@ -20,6 +22,7 @@ interface Props {
 const PatternCategoryList = ( {
 	categories,
 	patternsMapByCategory,
+	patternCountMapByCategory,
 	selectedCategory,
 	onSelectCategory,
 }: Props ) => {
@@ -56,7 +59,12 @@ const PatternCategoryList = ( {
 							aria-current={ isActive }
 							onClick={ () => onSelectCategory( name ) }
 						>
-							<NavigatorItem active={ isActive }>{ label }</NavigatorItem>
+							<NavigatorItem active={ isActive }>
+								<>
+									{ label }
+									<PatternCount count={ patternCountMapByCategory[ name ] } />
+								</>
+							</NavigatorItem>
 						</CompositeItem>
 					);
 				} ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-count/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-count/index.tsx
@@ -1,0 +1,15 @@
+import './style.scss';
+
+interface Props {
+	count?: number;
+}
+
+const PatternCount = ( { count = 0 }: Props ) => {
+	if ( ! count ) {
+		return null;
+	}
+
+	return <span className="pattern-count">{ count }</span>;
+};
+
+export default PatternCount;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-count/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-count/style.scss
@@ -1,0 +1,3 @@
+.pattern-count {
+	margin-left: auto;
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-count/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-count/style.scss
@@ -1,3 +1,13 @@
+@import "@automattic/typography/styles/variables";
+
 .pattern-count {
 	margin-left: auto;
+	font-family: "SF Pro Text", $sans;
+	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+	font-size: 12px;
+	color: var(--studio-gray-50);
+
+	.navigator-item.navigator-item--active & {
+		color: inherit;
+	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -9,6 +9,7 @@ import { useTranslate } from 'i18n-calypso';
 import { NAVIGATOR_PATHS, INITIAL_CATEGORY } from './constants';
 import { useScreen } from './hooks';
 import NavigatorTitle from './navigator-title';
+import PatternCount from './pattern-count';
 import Survey from './survey';
 import { PatternType } from './types';
 
@@ -16,7 +17,7 @@ interface Props {
 	onMainItemSelect: ( name: string ) => void;
 	surveyDismissed: boolean;
 	setSurveyDismissed: ( dismissed: boolean ) => void;
-	hasSections: boolean;
+	sectionsCount: number;
 	hasHeader: boolean;
 	hasFooter: boolean;
 	onContinueClick: () => void;
@@ -26,7 +27,7 @@ const ScreenMain = ( {
 	onMainItemSelect,
 	surveyDismissed,
 	setSurveyDismissed,
-	hasSections,
+	sectionsCount,
 	hasHeader,
 	hasFooter,
 	onContinueClick,
@@ -35,7 +36,8 @@ const ScreenMain = ( {
 	const { title, description, continueLabel } = useScreen( 'main' );
 	const { location, params, goTo } = useNavigator();
 	const selectedCategory = params.categorySlug as string;
-	const isButtonDisabled = ! hasSections && ! hasHeader && ! hasFooter;
+	const totalPatternCount = Number( hasHeader ) + sectionsCount + Number( hasFooter );
+	const isButtonDisabled = totalPatternCount === 0;
 
 	const handleNavigatorItemSelect = ( type: PatternType, path: string, category: string ) => {
 		const nextPath = category !== selectedCategory ? `${ path }/${ category }` : path;
@@ -62,17 +64,23 @@ const ScreenMain = ( {
 							}
 							active={ location.path === NAVIGATOR_PATHS.MAIN_HEADER }
 						>
-							{ translate( 'Header' ) }
+							<>
+								{ translate( 'Header' ) }
+								<PatternCount count={ Number( hasHeader ) } />
+							</>
 						</NavigatorItem>
 						<NavigatorItem
-							checked={ hasSections }
+							checked={ !! sectionsCount }
 							icon={ layout }
 							aria-label={ translate( 'Sections' ) }
 							onClick={ () =>
 								handleNavigatorItemSelect( 'section', NAVIGATOR_PATHS.SECTIONS, INITIAL_CATEGORY )
 							}
 						>
-							{ translate( 'Sections' ) }
+							<>
+								{ translate( 'Sections' ) }
+								<PatternCount count={ sectionsCount } />
+							</>
 						</NavigatorItem>
 
 						<NavigatorItem
@@ -84,13 +92,27 @@ const ScreenMain = ( {
 							}
 							active={ location.path === NAVIGATOR_PATHS.MAIN_FOOTER }
 						>
-							{ translate( 'Footer' ) }
+							<>
+								{ translate( 'Footer' ) }
+								<PatternCount count={ Number( hasFooter ) } />
+							</>
 						</NavigatorItem>
 					</NavigatorItemGroup>
 				</VStack>
 				{ ! surveyDismissed && <Survey setSurveyDismissed={ setSurveyDismissed } /> }
 			</div>
 			<div className="screen-container__footer">
+				<span className="screen-container__footer-description">
+					{ totalPatternCount > 0 &&
+						translate( 'You’ve added {{strong}}%(count)s{{/strong}} patterns.', {
+							args: {
+								count: totalPatternCount,
+							},
+							components: {
+								strong: <strong />,
+							},
+						} ) }
+				</span>
 				<Button
 					className="pattern-assembler__button"
 					disabled={ isButtonDisabled }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-sections.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-sections.tsx
@@ -4,16 +4,18 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalUseNavigator as useNavigator,
 } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
 import { NAVIGATOR_PATHS } from './constants';
 import { PATTERN_ASSEMBLER_EVENTS } from './events';
-import { useScreen } from './hooks';
+import { useScreen, usePatternCountMapByCategory } from './hooks';
 import NavigatorTitle from './navigator-title';
 import PatternCategoryList from './pattern-category-list';
 import { Pattern, Category } from './types';
 
 interface Props {
 	categories: Category[];
-	patternsMapByCategory: { [ key: string ]: Pattern[] };
+	patternsMapByCategory: Record< string, Pattern[] >;
+	sections: Pattern[];
 	onContinueClick: () => void;
 	recordTracksEvent: ( name: string, eventProperties?: any ) => void;
 }
@@ -21,12 +23,15 @@ interface Props {
 const ScreenSections = ( {
 	categories,
 	patternsMapByCategory,
+	sections,
 	onContinueClick,
 	recordTracksEvent,
 }: Props ) => {
+	const translate = useTranslate();
 	const { title, description, continueLabel } = useScreen( 'sections' );
 	const { params, goTo } = useNavigator();
 	const selectedCategory = params.categorySlug as string;
+	const patternCountMapByCategory = usePatternCountMapByCategory( sections );
 
 	const onSelectSectionCategory = ( category: string ) => {
 		const nextPath =
@@ -52,12 +57,24 @@ const ScreenSections = ( {
 					<PatternCategoryList
 						categories={ categories }
 						patternsMapByCategory={ patternsMapByCategory }
+						patternCountMapByCategory={ patternCountMapByCategory }
 						selectedCategory={ selectedCategory }
 						onSelectCategory={ onSelectSectionCategory }
 					/>
 				</VStack>
 			</div>
 			<div className="screen-container__footer">
+				<span className="screen-container__footer-description">
+					{ sections.length > 0 &&
+						translate( 'You’ve added {{strong}}%(count)s{{/strong}} sections.', {
+							args: {
+								count: sections.length,
+							},
+							components: {
+								strong: <strong />,
+							},
+						} ) }
+				</span>
 				<Button className="pattern-assembler__button" variant="primary" onClick={ onContinueClick }>
 					{ continueLabel }
 				</Button>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -309,6 +309,13 @@ $font-family: "SF Pro Text", $sans;
 
 	.screen-container__footer {
 		margin-top: auto;
+
+		.screen-container__footer-description {
+			display: inline-block;
+			margin-bottom: 8px;
+			font-size: $font-body-small;
+			color: var(--studio-gray-80);
+		}
 	}
 
 	.screen-container__description {

--- a/packages/onboarding/src/navigator/navigator-buttons/index.tsx
+++ b/packages/onboarding/src/navigator/navigator-buttons/index.tsx
@@ -26,10 +26,14 @@ export function NavigatorItem( { icon, checked, active, children, ...props }: Na
 	const content = icon ? (
 		<HStack justify="flex-start">
 			<Icon className="navigator-item__icon" icon={ checked ? check : icon } size={ 24 } />
-			<FlexItem className="navigator-item__text">{ children }</FlexItem>
+			<FlexItem className="navigator-item__text" display="flex" isBlock>
+				{ children }
+			</FlexItem>
 		</HStack>
 	) : (
-		<FlexItem>{ children }</FlexItem>
+		<FlexItem display="flex" isBlock>
+			{ children }
+		</FlexItem>
 	);
 
 	const forwardIcon = isRTL() ? chevronLeft : chevronRight;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/82838

## Proposed Changes

* Display the pattern count on both main screen and section screen

| Before | After |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/44b99572-e98d-415d-a923-6c092df91306) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/8a74e5c9-f720-40e3-b29b-cbfe51b7d51c) |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/3c96a927-0ce5-44f6-9f31-c2649bbba27c) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/f81a570a-c588-4c34-8419-23a95224e135) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Theme Showcase
* Select Assembler CTA
* Select any patterns
* Ensure the pattern count shows up

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?