### PR TITLE
Plans 2023: Grid perf - more consistent mem in comparison grid

### DIFF
--- a/client/my-sites/plans-grid/components/comparison-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/comparison-grid/index.tsx
@@ -4,13 +4,13 @@ import {
 	isFreePlan,
 	isWooExpressPlan,
 	FEATURE_GROUP_ESSENTIAL_FEATURES,
-	PLAN_WOOEXPRESS_PLUS,
 	getPlanFeaturesGrouped,
 	getWooExpressFeaturesGrouped,
-	PLAN_ENTERPRISE_GRID_WPCOM,
 	FEATURE_GROUP_PAYMENT_TRANSACTION_FEES,
 	getPlans,
 	PLAN_HOSTING_TRIAL_MONTHLY,
+	PLAN_WOOEXPRESS_PLUS,
+	PLAN_ENTERPRISE_GRID_WPCOM,
 } from '@automattic/calypso-products';
 import { Gridicon, JetpackLogo } from '@automattic/components';
 import { useIsEnglishLocale } from '@automattic/i18n-utils';
@@ -1031,6 +1031,32 @@ const ComparisonGrid = ( {
 		setVisiblePlans( newVisiblePlans );
 	}, [ isLargeBreakpoint, isMediumBreakpoint, isSmallBreakpoint, displayedGridPlans, isInSignup ] );
 
+	const visibleGridPlans = useMemo(
+		() =>
+			visiblePlans.reduce( ( acc, planSlug ) => {
+				const gridPlan = displayedGridPlans.find( ( gridPlan ) => gridPlan.planSlug === planSlug );
+
+				if ( gridPlan ) {
+					acc.push( gridPlan );
+				}
+
+				return acc;
+			}, [] as GridPlan[] ),
+		[ visiblePlans, displayedGridPlans ]
+	);
+
+	const onPlanChange = useCallback(
+		( currentPlan: PlanSlug, event: ChangeEvent< HTMLSelectElement > ) => {
+			const newPlan = event.currentTarget.value;
+			const newVisiblePlans = visiblePlans.map( ( plan ) =>
+				plan === currentPlan ? ( newPlan as PlanSlug ) : plan
+			);
+
+			setVisiblePlans( newVisiblePlans );
+		},
+		[ visiblePlans ]
+	);
+
 	const planFeatureFootnotes = useMemo( () => {
 		// This is the main list of all footnotes. It is displayed at the bottom of the comparison grid.
 		const footnoteList: string[] = [];
@@ -1063,32 +1089,6 @@ const ComparisonGrid = ( {
 			footnotesByFeature,
 		};
 	}, [ featureGroupMap ] );
-
-	const onPlanChange = useCallback(
-		( currentPlan: PlanSlug, event: ChangeEvent< HTMLSelectElement > ) => {
-			const newPlan = event.currentTarget.value;
-			const newVisiblePlans = visiblePlans.map( ( plan ) =>
-				plan === currentPlan ? ( newPlan as PlanSlug ) : plan
-			);
-
-			setVisiblePlans( newVisiblePlans );
-		},
-		[ visiblePlans ]
-	);
-
-	const visibleGridPlans = useMemo(
-		() =>
-			visiblePlans.reduce( ( acc, planSlug ) => {
-				const gridPlan = displayedGridPlans.find( ( gridPlan ) => gridPlan.planSlug === planSlug );
-
-				if ( gridPlan ) {
-					acc.push( gridPlan );
-				}
-
-				return acc;
-			}, [] as GridPlan[] ),
-		[ visiblePlans, displayedGridPlans ]
-	);
 
 	return (
 		<div className="plan-comparison-grid">

--- a/client/my-sites/plans-grid/components/comparison-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/comparison-grid/index.tsx
@@ -376,7 +376,7 @@ const ComparisonGridHeaderCell = ( {
 	const { gridPlansIndex } = usePlansGridContext();
 	const gridPlan = gridPlansIndex[ planSlug ];
 	const highlightAdjacencyMatrix = useHighlightAdjacencyMatrix( {
-		renderedPlans: visibleGridPlans.map( ( { planSlug } ) => planSlug ),
+		renderedGridPlans: visibleGridPlans,
 	} );
 
 	if ( ! gridPlan ) {
@@ -559,7 +559,7 @@ const ComparisonGridFeatureGroupRowCell: React.FunctionComponent< {
 	const gridPlan = gridPlansIndex[ planSlug ];
 	const translate = useTranslate();
 	const highlightAdjacencyMatrix = useHighlightAdjacencyMatrix( {
-		renderedPlans: visibleGridPlans.map( ( { planSlug } ) => planSlug ),
+		renderedGridPlans: visibleGridPlans,
 	} );
 
 	if ( ! gridPlan ) {

--- a/client/my-sites/plans-grid/components/plan-logo.tsx
+++ b/client/my-sites/plans-grid/components/plan-logo.tsx
@@ -33,7 +33,7 @@ const PlanLogo: React.FunctionComponent< {
 	const { gridPlansIndex } = usePlansGridContext();
 	const { current } = gridPlansIndex[ planSlug ];
 	const highlightAdjacencyMatrix = useHighlightAdjacencyMatrix( {
-		renderedPlans: renderedGridPlans.map( ( gridPlan ) => gridPlan.planSlug ),
+		renderedGridPlans,
 	} );
 	const headerClasses = classNames(
 		'plan-features-2023-grid__header-logo',

--- a/client/my-sites/plans-grid/hooks/npm-ready/use-highlight-adjacency-matrix.ts
+++ b/client/my-sites/plans-grid/hooks/npm-ready/use-highlight-adjacency-matrix.ts
@@ -14,25 +14,15 @@ interface Props {
 	renderedGridPlans: GridPlan[];
 }
 
-const useHighlightIndices = ( { renderedGridPlans }: Props ) => {
-	return useMemo(
-		() =>
-			renderedGridPlans.reduce< number[] >( ( acc, gridPlan, index ) => {
-				if ( gridPlan.highlightLabel ) {
-					acc.push( index );
-				}
-
-				return acc;
-			}, [] ),
-		[ renderedGridPlans ]
-	);
-};
-
 const useHighlightAdjacencyMatrix = ( { renderedGridPlans }: Props ) => {
-	const highlightIndices = useHighlightIndices( { renderedGridPlans } );
-
 	return useMemo( () => {
 		const adjacencyMatrix = {} as HighlightAdjacencyMatrix;
+		const highlightIndices = renderedGridPlans.reduce( ( acc, gridPlan, index ) => {
+			if ( gridPlan.highlightLabel ) {
+				acc.push( index );
+			}
+			return acc;
+		}, [] as number[] );
 
 		renderedGridPlans.forEach( ( { planSlug }, index ) => {
 			adjacencyMatrix[ planSlug ] = { leftOfHighlight: false, rightOfHighlight: false };
@@ -52,7 +42,7 @@ const useHighlightAdjacencyMatrix = ( { renderedGridPlans }: Props ) => {
 		}
 
 		return adjacencyMatrix;
-	}, [ renderedGridPlans, highlightIndices ] );
+	}, [ renderedGridPlans ] );
 };
 
 export default useHighlightAdjacencyMatrix;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Applies more consistent memoising to cover missed transformations in the comparison grid. Also some more code design/ hygiene:

* Memoizes `visibleGridPlans` (every other transformation seems to be memoized in the file)
* Abstracts a little better feature group toggle and wraps in `useCallback` for reference integrity
* Memoizes `useHighlightIndices` and rewrite the parameter to accept grid plans directly (more consistent, less need to transform `gridGlans -> planSlugs`)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Confirm comparison grid and operations behave normally against trunk
    * change plans in the comparison grid
    * resize window
    * toggle monthly/yearly term when on a free plan

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?