### PR TITLE
Jetpack Manage: Disable monitoring functionality for Atomic sites in the dashboard.

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/edit-button.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/edit-button.tsx
@@ -23,8 +23,7 @@ export default function EditButton( { sites, isLargeScreen, isLoading }: Props )
 	const handleToggleSelect = () => {
 		// Filter sites with site error or monitor error or is Atomic site as they are not selectable.
 		const filteredSite = sites.filter(
-			( site ) =>
-				site.site.value.is_connected && ! site.monitor.error && ! site.site.value.is_atomic
+			( { site, monitor } ) => site.value.is_connected && ! monitor.error && ! site.value.is_atomic
 		);
 		setSelectedSites( filteredSite.map( ( item ) => item.site.value ) );
 	};

--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/edit-button.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/edit-button.tsx
@@ -21,9 +21,10 @@ export default function EditButton( { sites, isLargeScreen, isLoading }: Props )
 	const recordEvent = useJetpackAgencyDashboardRecordTrackEvent( null, isLargeScreen );
 
 	const handleToggleSelect = () => {
-		// Filter sites with site error or monitor error as they are not selectable.
+		// Filter sites with site error or monitor error or is Atomic site as they are not selectable.
 		const filteredSite = sites.filter(
-			( site ) => site.site.value.is_connected && ! site.monitor.error
+			( site ) =>
+				site.site.value.is_connected && ! site.monitor.error && ! site.site.value.is_atomic
 		);
 		setSelectedSites( filteredSite.map( ( item ) => item.site.value ) );
 	};

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
@@ -47,7 +47,7 @@ export default function ToggleActivateMonitoring( {
 	const isPaidTierEnabled = isEnabled( 'jetpack/pro-dashboard-monitor-paid-tier' );
 
 	const shouldDisplayUpgradePopover =
-		status === 'success' && isPaidTierEnabled && ! site.has_paid_agency_monitor;
+		status === 'success' && isPaidTierEnabled && ! site.has_paid_agency_monitor && ! site.is_atomic;
 
 	const handleShowTooltip = () => {
 		setShowTooltip( true );
@@ -144,11 +144,12 @@ export default function ToggleActivateMonitoring( {
 	};
 
 	const toggleContent = (
+		// For Atomic sites which do not support monitoring, we show the toggle as disabled while in active state.
 		<ToggleControl
 			onChange={ handleToggleActivateMonitoring }
-			checked={ isChecked }
-			disabled={ isLoading || siteError }
-			label={ isChecked && currentSettings() }
+			checked={ site.is_atomic || isChecked }
+			disabled={ site.is_atomic || isLoading || siteError }
+			label={ ! site.is_atomic && isChecked && currentSettings() }
 		/>
 	);
 
@@ -172,10 +173,14 @@ export default function ToggleActivateMonitoring( {
 				/>
 			);
 		}
+
 		let tooltipText = tooltip;
-		if ( isPaidTierEnabled && smsLimitReached && status === 'success' ) {
+		if ( site.is_atomic ) {
+			tooltipText = translate( 'Monitoring is managed by host.' );
+		} else if ( isPaidTierEnabled && smsLimitReached && status === 'success' ) {
 			tooltipText = translate( 'You have reached the SMS limit' );
 		}
+
 		if ( tooltipText ) {
 			return (
 				<Tooltip

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
@@ -144,10 +144,10 @@ export default function ToggleActivateMonitoring( {
 	};
 
 	const toggleContent = (
-		// For Atomic sites which do not support monitoring, we show the toggle as disabled while in active state.
+		// For Atomic sites which do not support monitoring, we show the toggle as disabled.
 		<ToggleControl
 			onChange={ handleToggleActivateMonitoring }
-			checked={ site.is_atomic || isChecked }
+			checked={ isChecked }
 			disabled={ site.is_atomic || isLoading || siteError }
 			label={ ! site.is_atomic && isChecked && currentSettings() }
 		/>

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
@@ -176,7 +176,7 @@ export default function ToggleActivateMonitoring( {
 
 		let tooltipText = tooltip;
 		if ( site.is_atomic ) {
-			tooltipText = translate( 'Monitoring is managed by host' );
+			tooltipText = translate( 'Monitoring is managed by WordPress.com' );
 		} else if ( isPaidTierEnabled && smsLimitReached && status === 'success' ) {
 			tooltipText = translate( 'You have reached the SMS limit' );
 		}

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
@@ -176,7 +176,7 @@ export default function ToggleActivateMonitoring( {
 
 		let tooltipText = tooltip;
 		if ( site.is_atomic ) {
-			tooltipText = translate( 'Monitoring is managed by host.' );
+			tooltipText = translate( 'Monitoring is managed by host' );
 		} else if ( isPaidTierEnabled && smsLimitReached && status === 'success' ) {
 			tooltipText = translate( 'You have reached the SMS limit' );
 		}

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/style.scss
@@ -26,10 +26,9 @@
 		}
 	}
 
-	&.sites-overview__disabled {
-		.components-form-toggle__input {
-			cursor: not-allowed;
-		}
+	&.sites-overview__disabled .components-form-toggle__input,
+	.components-form-toggle__input:disabled {
+		cursor: not-allowed;
 	}
 }
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-bulk-select/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-bulk-select/index.tsx
@@ -32,8 +32,7 @@ export default function SiteBulkSelect( { sites, isLoading, isLargeScreen }: Pro
 	const handleToggleSelect = () => {
 		// Filter sites with site error or monitor error or is an Atomic sites as they are not selectable
 		const filteredSites = sites.filter(
-			( site ) =>
-				site.site.value.is_connected && ! site.monitor.error && ! site.site.value.is_atomic
+			( { site, monitor } ) => site.value.is_connected && ! monitor.error && ! site.value.is_atomic
 		);
 		const isChecked = isAllChecked( filteredSites );
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-bulk-select/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-bulk-select/index.tsx
@@ -83,7 +83,7 @@ export default function SiteBulkSelect( { sites, isLoading, isLargeScreen }: Pro
 				</div>
 			</div>
 			<DashboardBulkActions
-				selectedSites={ selectedSites }
+				selectedSites={ selectedSites.filter( ( site ) => ! site.is_atomic ) } // Bulk action (Monitoring) is not supported for Atomic sites.
 				bulkUpdateSettings={ sites?.[ 0 ]?.monitor?.settings }
 				isLargeScreen={ isLargeScreen }
 			/>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-bulk-select/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-bulk-select/index.tsx
@@ -30,9 +30,10 @@ export default function SiteBulkSelect( { sites, isLoading, isLargeScreen }: Pro
 	};
 
 	const handleToggleSelect = () => {
-		// Filter sites with site error or monitor error as they are not selectable.
+		// Filter sites with site error or monitor error or is an Atomic sites as they are not selectable
 		const filteredSites = sites.filter(
-			( site ) => site.site.value.is_connected && ! site.monitor.error
+			( site ) =>
+				site.site.value.is_connected && ! site.monitor.error && ! site.site.value.is_atomic
 		);
 		const isChecked = isAllChecked( filteredSites );
 
@@ -83,7 +84,7 @@ export default function SiteBulkSelect( { sites, isLoading, isLargeScreen }: Pro
 				</div>
 			</div>
 			<DashboardBulkActions
-				selectedSites={ selectedSites.filter( ( site ) => ! site.is_atomic ) } // Bulk action (Monitoring) is not supported for Atomic sites.
+				selectedSites={ selectedSites }
 				bulkUpdateSettings={ sites?.[ 0 ]?.monitor?.settings }
 				isLargeScreen={ isLargeScreen }
 			/>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-select-checkbox/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-select-checkbox/index.tsx
@@ -29,7 +29,7 @@ export default function SiteSelectCheckbox( { item, siteError, isLargeScreen }: 
 				onClick={ handleCheckboxClick }
 				checked={ item.isSelected }
 				readOnly={ true }
-				disabled={ siteError }
+				disabled={ item.site?.value?.is_atomic || siteError }
 			/>
 		</span>
 	);

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-select-checkbox/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-select-checkbox/index.tsx
@@ -43,36 +43,34 @@ export default function SiteSelectCheckbox( {
 	};
 
 	return (
-		<>
-			<span
-				className="site-select-checkbox"
-				ref={ checkboxRef }
-				role="button"
-				tabIndex={ 0 }
-				onMouseEnter={ handleShowTooltip }
-				onMouseLeave={ handleHideTooltip }
-				onMouseDown={ handleHideTooltip }
-			>
-				<FormInputCheckbox
-					className="disable-card-expand"
-					id={ `${ item.site.value.blog_id }` }
-					onClick={ handleCheckboxClick }
-					checked={ item.isSelected }
-					readOnly={ true }
-					disabled={ disabled || siteError }
-				/>
+		<span
+			className="site-select-checkbox"
+			ref={ checkboxRef }
+			role="button"
+			tabIndex={ 0 }
+			onMouseEnter={ handleShowTooltip }
+			onMouseLeave={ handleHideTooltip }
+			onMouseDown={ handleHideTooltip }
+		>
+			<FormInputCheckbox
+				className="disable-card-expand"
+				id={ `${ item.site.value.blog_id }` }
+				onClick={ handleCheckboxClick }
+				checked={ item.isSelected }
+				readOnly={ true }
+				disabled={ disabled || siteError }
+			/>
 
-				{ tooltip && (
-					<Tooltip
-						context={ checkboxRef.current }
-						isVisible={ showTooltip }
-						position="bottom"
-						className="site-select-checkbox__tooltip"
-					>
-						{ tooltip }
-					</Tooltip>
-				) }
-			</span>
-		</>
+			{ tooltip && (
+				<Tooltip
+					context={ checkboxRef.current }
+					isVisible={ showTooltip }
+					position="bottom"
+					className="site-select-checkbox__tooltip"
+				>
+					{ tooltip }
+				</Tooltip>
+			) }
+		</span>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-select-checkbox/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-select-checkbox/index.tsx
@@ -1,4 +1,6 @@
+import { useRef, useState } from 'react';
 import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
+import Tooltip from 'calypso/components/tooltip';
 import { useJetpackAgencyDashboardRecordTrackEvent } from '../../hooks';
 import type { SiteData } from '../types';
 
@@ -8,29 +10,69 @@ interface Props {
 	item: SiteData;
 	siteError: boolean;
 	isLargeScreen?: boolean;
+	disabled?: boolean;
+	tooltip?: string;
 }
 
-export default function SiteSelectCheckbox( { item, siteError, isLargeScreen }: Props ) {
+export default function SiteSelectCheckbox( {
+	item,
+	siteError,
+	isLargeScreen,
+	disabled,
+	tooltip,
+}: Props ) {
+	const [ showTooltip, setShowTooltip ] = useState( false );
+	const checkboxRef = useRef< HTMLSpanElement | null >( null );
+
 	const recordEvent = useJetpackAgencyDashboardRecordTrackEvent(
 		[ item.site.value ],
 		isLargeScreen
 	);
 
-	function handleCheckboxClick() {
+	const handleCheckboxClick = () => {
 		item.onSelect?.();
 		recordEvent( item.isSelected ? 'site_unselected' : 'site_selected' );
-	}
+	};
+
+	const handleShowTooltip = () => {
+		setShowTooltip( true );
+	};
+
+	const handleHideTooltip = () => {
+		setShowTooltip( false );
+	};
 
 	return (
-		<span className="site-select-checkbox">
-			<FormInputCheckbox
-				className="disable-card-expand"
-				id={ `${ item.site.value.blog_id }` }
-				onClick={ handleCheckboxClick }
-				checked={ item.isSelected }
-				readOnly={ true }
-				disabled={ item.site?.value?.is_atomic || siteError }
-			/>
-		</span>
+		<>
+			<span
+				className="site-select-checkbox"
+				ref={ checkboxRef }
+				role="button"
+				tabIndex={ 0 }
+				onMouseEnter={ handleShowTooltip }
+				onMouseLeave={ handleHideTooltip }
+				onMouseDown={ handleHideTooltip }
+			>
+				<FormInputCheckbox
+					className="disable-card-expand"
+					id={ `${ item.site.value.blog_id }` }
+					onClick={ handleCheckboxClick }
+					checked={ item.isSelected }
+					readOnly={ true }
+					disabled={ disabled || siteError }
+				/>
+
+				{ tooltip && (
+					<Tooltip
+						context={ checkboxRef.current }
+						isVisible={ showTooltip }
+						position="bottom"
+						className="site-select-checkbox__tooltip"
+					>
+						{ tooltip }
+					</Tooltip>
+				) }
+			</span>
+		</>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-select-checkbox/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-select-checkbox/style.scss
@@ -10,3 +10,7 @@
 		inset-inline-start: 16px;
 	}
 }
+
+.site-select-checkbox__tooltip {
+	margin-top: 20px;
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-select-checkbox/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-select-checkbox/style.scss
@@ -12,5 +12,5 @@
 }
 
 .site-select-checkbox__tooltip {
-	margin-top: 20px;
+	margin-block-start: 20px;
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/index.tsx
@@ -177,6 +177,10 @@ export default function SiteStatusContent( {
 						isLargeScreen={ isLargeScreen }
 						item={ rows }
 						siteError={ hasAnyError }
+						disabled={ rows.site.value.is_atomic }
+						tooltip={
+							rows.site.value.is_atomic ? translate( 'Monitoring is managed by host.' ) : undefined
+						}
 					/>
 				) : (
 					<SiteSetFavorite

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/index.tsx
@@ -179,7 +179,7 @@ export default function SiteStatusContent( {
 						siteError={ hasAnyError }
 						disabled={ rows.site.value.is_atomic }
 						tooltip={
-							rows.site.value.is_atomic ? translate( 'Monitoring is managed by host.' ) : undefined
+							rows.site.value.is_atomic ? translate( 'Monitoring is managed by host' ) : undefined
 						}
 					/>
 				) : (

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/index.tsx
@@ -179,7 +179,9 @@ export default function SiteStatusContent( {
 						siteError={ hasAnyError }
 						disabled={ rows.site.value.is_atomic }
 						tooltip={
-							rows.site.value.is_atomic ? translate( 'Monitoring is managed by host' ) : undefined
+							rows.site.value.is_atomic
+								? translate( 'Monitoring is managed by WordPress.com' )
+								: undefined
 						}
 					/>
 				) : (


### PR DESCRIPTION
This PR aims to disable monitoring functionality for Atomic sites in Jetpack Manage. Atomic sites have their monitoring managed by WordPress.com. 

There are two areas where users can access the Monitoring configuration, and we need to ensure the UI does not allow users to reach it.
<img width="1543" alt="Screen Shot 2023-10-13 at 7 24 14 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/968ca51b-8846-4ad2-bcb7-604f1a9eafd8">


Closes https://github.com/Automattic/jetpack-genesis/issues/48

## Proposed Changes

* We will have to disable the selection for atomic sites in `Edit All` functionality.
* We also need to update the Monitoring toggle to be **'Disabled'** all the time for Atomic sites.

## Testing Instructions
Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

### Monitoring Toggle
* Ensure that you have Atomic sites in your list. If not, please add a new atomic site via the Dashboard.
* Use the Jetpack cloud live link below and Go to `/dashboard`
* Confirm that for Atomic sites, the Monitoring toggle is 'Active' and 'Disabled', and the Notification button is not visible. Hovering the disabled toggle should also explain why it is disabled on a tooltip.
<img width="1520" alt="Screen Shot 2023-10-13 at 7 31 25 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/d4548f1c-2967-4edb-afbc-6f5924f5af62">
* Confirm that when disabling Downtime Monitoring in WPCOM, the toggle reflects the correct state.

<img width="300" alt="Screen Shot 2023-10-17 at 3 55 18 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/304a43e2-19ff-404d-aba6-b1c47ee0e504">

### Bulk Update
* Click the 'Edit All'** button at the top right side of the table.
<img width="268" alt="Screen Shot 2023-10-13 at 7 34 58 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/f7afcb53-3050-48f4-9da2-e6c7c0a92753">

* Confirm that all atomic sites cannot be selected. Hovering the disabled checkbox will show a tooltip explaining why it was disabled.
<img width="392" alt="Screen Shot 2023-10-17 at 3 50 25 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/e4c854f3-9e88-44dc-980c-3912c667f44f">



## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?