### PR TITLE
Importer: Get rid of 'onboarding/import-redesign' feature flag

### DIFF
--- a/client/blocks/import/util.ts
+++ b/client/blocks/import/util.ts
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { capitalize } from 'lodash';
 import { ImporterPlatform } from './types';
 
@@ -82,7 +81,7 @@ export function getWpComOnboardingUrl(
 ): string {
 	let route;
 
-	if ( platform === 'wordpress' && isEnabled( 'onboarding/import-redesign' ) ) {
+	if ( platform === 'wordpress' ) {
 		route = 'importer{importer}?siteSlug={siteSlug}&from={fromSite}&option=everything';
 	} else {
 		route = 'importer{importer}?siteSlug={siteSlug}&from={fromSite}';

--- a/client/blocks/importer/wordpress/import-everything/confirm-upgrade-plan.tsx
+++ b/client/blocks/importer/wordpress/import-everything/confirm-upgrade-plan.tsx
@@ -1,7 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { isEnabled } from '@automattic/calypso-config';
 import { getPlan, PLAN_BUSINESS, PLAN_WPCOM_PRO } from '@automattic/calypso-products';
-import { sprintf } from '@wordpress/i18n';
 import { check, plus, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
@@ -25,7 +23,7 @@ export const ConfirmUpgradePlan: FunctionComponent< Props > = ( props ) => {
 	const { __ } = useI18n();
 	const initialFeaturesNumber = 6;
 
-	const { sourceSiteSlug, targetSite } = props;
+	const { targetSite } = props;
 	const targetSiteEligibleForProPlan = useSelector( ( state ) =>
 		isEligibleForProPlan( state, targetSite?.ID )
 	);
@@ -71,17 +69,6 @@ export const ConfirmUpgradePlan: FunctionComponent< Props > = ( props ) => {
 	return (
 		<div className={ classnames( 'import__upgrade-plan' ) }>
 			<QueryPlans />
-			{ ! isEnabled( 'onboarding/import-redesign' ) && (
-				<p>
-					{ sprintf(
-						/* translators: the website could be any domain (eg: "yourname.com") */
-						__(
-							'To import your themes, plugins, users, and settings from %(website)s we need to upgrade your WordPress.com site. Select a plan below:'
-						),
-						{ website: sourceSiteSlug }
-					) }
-				</p>
-			) }
 
 			<div className={ classnames( 'import__upgrade-plan-container' ) }>
 				<div className={ classnames( 'import__upgrade-plan-price' ) }>

--- a/client/blocks/importer/wordpress/import-everything/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/index.tsx
@@ -26,7 +26,6 @@ import NotAuthorized from '../../components/not-authorized';
 import { isTargetSitePlanCompatible } from '../../util';
 import { MigrationStatus } from '../types';
 import { retrieveMigrateSource, clearMigrateSource } from '../utils';
-import { Confirm } from './confirm';
 import type { SiteDetails } from '@automattic/data-stores';
 import type { UrlData } from 'calypso/blocks/import/types';
 import type { StepNavigator } from 'calypso/blocks/importer/types';
@@ -159,11 +158,8 @@ export class ImportEverything extends SectionMigrate {
 		const {
 			sourceSite,
 			targetSite,
-			targetSiteSlug,
-			sourceUrlAnalyzedData,
 			isTargetSitePlanCompatible,
 			stepNavigator,
-			showConfirmDialog = true,
 			isMigrateFromWp,
 			onContentOnlySelection,
 			translate,
@@ -184,50 +180,25 @@ export class ImportEverything extends SectionMigrate {
 			);
 		}
 
-		if ( isEnabled( 'onboarding/import-redesign' ) ) {
-			return (
-				<PreMigrationScreen
-					startImport={ this.startMigration }
-					initImportRun={ this.props.initImportRun }
-					isTargetSitePlanCompatible={ isTargetSitePlanCompatible }
-					targetSite={ targetSite }
-					isMigrateFromWp={ isMigrateFromWp }
-					isTrial={ isMigrationTrialSite( this.props.targetSite ) }
-					onContentOnlyClick={ onContentOnlySelection }
-					sourceSite={ sourceSite }
-					onFreeTrialClick={ () => {
-						stepNavigator?.navigate( `trialAcknowledge${ window.location.search }` );
-					} }
-					onNotAuthorizedClick={ () => {
-						recordTracksEvent( 'calypso_site_importer_skip_to_dashboard', {
-							from: 'pre-migration',
-						} );
-						stepNavigator?.goToDashboardPage();
-					} }
-				/>
-			);
-		}
-
-		if ( sourceSite ) {
-			return (
-				<Confirm
-					startImport={ this.startMigration }
-					isMigrateFromWp={ isMigrateFromWp }
-					isTargetSitePlanCompatible={ isTargetSitePlanCompatible }
-					targetSite={ targetSite }
-					targetSiteSlug={ targetSiteSlug }
-					sourceSite={ sourceSite }
-					sourceSiteUrl={ sourceSite.URL }
-					sourceUrlAnalyzedData={ sourceUrlAnalyzedData }
-					showConfirmDialog={ showConfirmDialog }
-				/>
-			);
-		}
-
 		return (
-			<NotAuthorized
-				onStartBuilding={ stepNavigator?.goToIntentPage }
-				onBackToStart={ stepNavigator?.goToImportCapturePage }
+			<PreMigrationScreen
+				startImport={ this.startMigration }
+				initImportRun={ this.props.initImportRun }
+				isTargetSitePlanCompatible={ isTargetSitePlanCompatible }
+				targetSite={ targetSite }
+				isMigrateFromWp={ isMigrateFromWp }
+				isTrial={ isMigrationTrialSite( this.props.targetSite ) }
+				onContentOnlyClick={ onContentOnlySelection }
+				sourceSite={ sourceSite }
+				onFreeTrialClick={ () => {
+					stepNavigator?.navigate( `trialAcknowledge${ window.location.search }` );
+				} }
+				onNotAuthorizedClick={ () => {
+					recordTracksEvent( 'calypso_site_importer_skip_to_dashboard', {
+						from: 'pre-migration',
+					} );
+					stepNavigator?.goToDashboardPage();
+				} }
 			/>
 		);
 	}

--- a/client/blocks/importer/wordpress/import-everything/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { ProgressBar } from '@automattic/components';
 import { Hooray, Progress, SubTitle, Title, NextButton } from '@automattic/onboarding';
 import { createElement, createInterpolateElement } from '@wordpress/element';
@@ -251,14 +250,11 @@ export class ImportEverything extends SectionMigrate {
 	renderMigrationComplete() {
 		const { isMigrateFromWp } = this.props;
 		return (
-			<>
-				<Hooray>
-					{ ! isMigrateFromWp
-						? this.renderDefaultHoorayScreen()
-						: this.renderHoorayScreenWithDomainInfo() }
-				</Hooray>
-				{ ! isEnabled( 'onboarding/import-redesign' ) && <GettingStartedVideo /> }
-			</>
+			<Hooray>
+				{ ! isMigrateFromWp
+					? this.renderDefaultHoorayScreen()
+					: this.renderHoorayScreenWithDomainInfo() }
+			</Hooray>
 		);
 	}
 

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
@@ -1,8 +1,6 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { SiteDetails } from '@automattic/data-stores';
 import { NextButton, Title } from '@automattic/onboarding';
-import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -256,11 +254,7 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 						} }
 					/>
 				) }
-				<div
-					className={ classnames( 'import__pre-migration import__import-everything', {
-						'import__import-everything--redesign': isEnabled( 'onboarding/import-redesign' ),
-					} ) }
-				>
+				<div className="import__pre-migration import__import-everything import__import-everything--redesign">
 					<div className="import__heading-title">
 						<Title>{ translate( 'You are ready to migrate' ) }</Title>
 					</div>

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/update-plugins.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/update-plugins.tsx
@@ -1,8 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { isEnabled } from '@automattic/calypso-config';
 import { Button, Gridicon } from '@automattic/components';
 import { Title, SubTitle, SelectItems } from '@automattic/onboarding';
-import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import React, { useEffect } from 'react';
 import { preventWidows } from 'calypso/lib/formatting';
@@ -91,11 +89,7 @@ export const UpdatePluginInfo: React.FunctionComponent< Props > = ( props: Props
 	}
 
 	return (
-		<div
-			className={ classnames( 'import__import-everything', {
-				'import__import-everything--redesign': isEnabled( 'onboarding/import-redesign' ),
-			} ) }
-		>
+		<div className="import__import-everything import__import-everything--redesign">
 			<div className="import__heading-title">
 				<Title>{ renderTitle() }</Title>
 				<SubTitle>{ renderSubTitle() }</SubTitle>

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/upgrade-plan.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/upgrade-plan.tsx
@@ -3,7 +3,6 @@ import { getPlan, PLAN_BUSINESS } from '@automattic/calypso-products';
 import { Button, Popover } from '@automattic/components';
 import { SiteDetails } from '@automattic/data-stores';
 import { Title, SubTitle, NextButton } from '@automattic/onboarding';
-import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import React, { useRef, useState, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
@@ -52,11 +51,7 @@ export const PreMigrationUpgradePlan: React.FunctionComponent< Props > = ( props
 	}, [] );
 
 	return (
-		<div
-			className={ classnames( 'import__import-everything', {
-				'import__import-everything--redesign': isEnabled( 'onboarding/import-redesign' ),
-			} ) }
-		>
+		<div className="import__import-everything import__import-everything--redesign">
 			<div className="import__heading-title">
 				<Title>{ translate( 'Upgrade your plan' ) }</Title>
 				<SubTitle>

--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Design, isAssemblerDesign, isAssemblerSupported } from '@automattic/design-picker';
 import { IMPORT_FOCUSED_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -170,20 +169,15 @@ const importFlow: Flow = {
 					}
 
 					if ( providedDependencies?.siteSlug ) {
-						if ( isEnabled( 'onboarding/import-redesign' ) && fromParam ) {
-							const slectedSiteSlug = providedDependencies?.siteSlug as string;
-							urlQueryParams.set( 'siteSlug', slectedSiteSlug );
+						if ( fromParam ) {
+							const selectedSiteSlug = providedDependencies?.siteSlug as string;
+							urlQueryParams.set( 'siteSlug', selectedSiteSlug );
 							urlQueryParams.set( 'from', fromParam );
 							urlQueryParams.set( 'option', 'everything' );
 
 							return navigate( `importerWordpress?${ urlQueryParams.toString() }` );
 						}
-
-						return ! fromParam
-							? navigate( `import?siteSlug=${ providedDependencies?.siteSlug }` )
-							: navigate(
-									`import?siteSlug=${ providedDependencies?.siteSlug }&from=${ fromParam }`
-							  );
+						return navigate( `import?siteSlug=${ providedDependencies?.siteSlug }` );
 					}
 					// End of Pattern Assembler flow
 					if ( isAssemblerDesign( selectedDesign ) ) {

--- a/client/landing/stepper/declarative-flow/import-hosted-site.ts
+++ b/client/landing/stepper/declarative-flow/import-hosted-site.ts
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { IMPORT_HOSTED_SITE_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useLayoutEffect } from 'react';
@@ -171,20 +170,15 @@ const importHostedSiteFlow: Flow = {
 					}
 
 					if ( providedDependencies?.siteSlug ) {
-						if ( isEnabled( 'onboarding/import-redesign' ) && fromParam ) {
-							const slectedSiteSlug = providedDependencies?.siteSlug as string;
-							urlQueryParams.set( 'siteSlug', slectedSiteSlug );
+						if ( fromParam ) {
+							const selectedSiteSlug = providedDependencies?.siteSlug as string;
+							urlQueryParams.set( 'siteSlug', selectedSiteSlug );
 							urlQueryParams.set( 'from', fromParam );
 							urlQueryParams.set( 'option', 'everything' );
 
 							return navigate( `importerWordpress?${ urlQueryParams.toString() }` );
 						}
-
-						return ! fromParam
-							? navigate( `import?siteSlug=${ providedDependencies?.siteSlug }` )
-							: navigate(
-									`import?siteSlug=${ providedDependencies?.siteSlug }&from=${ fromParam }`
-							  );
+						return navigate( `import?siteSlug=${ providedDependencies?.siteSlug }` );
 					}
 
 					return exitFlow( `/home/${ siteSlugParam }` );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
-import { isEnabled } from '@automattic/calypso-config';
 import { StepContainer } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
@@ -194,9 +193,9 @@ export function withImporterWrapper( Importer: ImporterCompType ) {
 						'import__onboarding-page',
 						'import-layout__center',
 						'importer-wrapper',
+						'import__onboarding-page--redesign',
 						{
 							[ `importer-wrapper__${ importer }` ]: !! importer,
-							'import__onboarding-page--redesign': isEnabled( 'onboarding/import-redesign' ),
 						}
 					) }
 					stepName="importer-step"

--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { planHasFeature, FEATURE_UPLOAD_THEMES_PLUGINS } from '@automattic/calypso-products';
 import { Button, Card, CompactCard, ProgressBar, Gridicon, Spinner } from '@automattic/components';
 import { getLocaleSlug, localize } from 'i18n-calypso';
@@ -234,7 +233,6 @@ export class SectionMigrate extends Component {
 
 	startMigration = ( trackingProps = {} ) => {
 		const { sourceSiteId, targetSiteId, targetSite, isMigrateFromWp } = this.props;
-		const shouldCheckMigrationPlugin = isMigrateFromWp && isEnabled( 'onboarding/import-redesign' );
 
 		if ( ! sourceSiteId || ! targetSiteId ) {
 			return;
@@ -259,7 +257,7 @@ export class SectionMigrate extends Component {
 				path: `/sites/${ targetSiteId }/migrate-from/${ sourceSiteId }`,
 				apiNamespace: 'wpcom/v2',
 				body: {
-					check_migration_plugin: shouldCheckMigrationPlugin,
+					check_migration_plugin: isMigrateFromWp,
 				},
 			} )
 			.then( () => this.updateFromAPI() )

--- a/config/development.json
+++ b/config/development.json
@@ -135,7 +135,6 @@
 		"onboarding/import-from-wordpress": true,
 		"onboarding/import-light": false,
 		"onboarding/import-redirect-to-themes": true,
-		"onboarding/import-redesign": true,
 		"p2/p2-plus": true,
 		"page/export": true,
 		"plans/hosting-trial": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -80,7 +80,6 @@
 		"me/vat-details": true,
 		"my-sites/add-ons": true,
 		"network-connection": true,
-		"onboarding/import-redesign": true,
 		"p2/p2-plus": true,
 		"plans/hosting-trial": false,
 		"plans/migration-trial": true,

--- a/config/production.json
+++ b/config/production.json
@@ -102,7 +102,6 @@
 		"onboarding/import-from-wix": true,
 		"onboarding/import-from-wordpress": true,
 		"onboarding/import-redirect-to-themes": true,
-		"onboarding/import-redesign": true,
 		"p2/p2-plus": true,
 		"plans/hosting-trial": false,
 		"plans/migration-trial": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -98,7 +98,6 @@
 		"onboarding/import-from-wix": true,
 		"onboarding/import-from-wordpress": true,
 		"onboarding/import-redirect-to-themes": true,
-		"onboarding/import-redesign": true,
 		"p2/p2-plus": true,
 		"page/export": true,
 		"plans/hosting-trial": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -109,7 +109,6 @@
 		"onboarding/import-from-wordpress": true,
 		"onboarding/import-light": false,
 		"onboarding/import-redirect-to-themes": true,
-		"onboarding/import-redesign": true,
 		"p2/p2-plus": true,
 		"plans/hosting-trial": false,
 		"plans/migration-trial": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/82758

## Proposed Changes

* Removed the "onboarding/import-redesign" feature flag
* The introduced redesign logic is default now

## Testing Instructions

* Go to `/setup/import`
* Try `simple` and `atomic` sites as target site
* It should work as it is now

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?