### PR TITLE
Plans Comparison: fix alignment issue

### DIFF
--- a/client/my-sites/plans-grid/components/comparison-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/comparison-grid/index.tsx
@@ -148,6 +148,7 @@ const PlanRow = styled( Row )`
 
 	${ plansBreakSmall( css`
 		border-bottom: none;
+		align-items: stretch;
 
 		&:last-of-type {
 			display: flex;

--- a/client/my-sites/plans-grid/style.scss
+++ b/client/my-sites/plans-grid/style.scss
@@ -816,6 +816,7 @@ body.is-section-signup.is-white-signup,
 			padding-top: 34px;
 
 			&.popular-plan-parent-class {
+				justify-content: space-between;
 				&::before,
 				&::after {
 					height: 100%;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1697115620921479-slack-CV2TX2PAN

## Proposed Changes

* Fixes alignment issue with the free plan on the pricing comparison grid.

|Context| Before | After |
|--------|--------|--------|
|`/start`| <img width="1303" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/6b813b26-bb14-4de0-93d1-fc072d09c3cd"> | <img width="1345" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/46b0b6b2-fef5-4416-98c0-37aa71705747"> |
|`/plans<site slug>`| <img width="1388" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/cb7aaa2c-b934-4105-a077-494e479c7e38"> | <img width="1346" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/caad340c-4969-4f39-a291-c6f48343619d"> | 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Change your currency to INR, go to `/start/plans`, and open the comparison grid.
* Confirm that the Free plan header cell is properly aligned.
* Change your currency to INR, go to `/plans/<site slug>`, and open the comparison grid.
* Confirm that the Free plan header cell is properly aligned.

-----

Also check the above for:
* Mobile & tablet screen sizes.
* Any currency other than INR.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?