### PR TITLE
Plans 2023: Fix (patch) flicker in comparison grid when switching terms

### DIFF
--- a/client/my-sites/plans-grid/components/comparison-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/comparison-grid/index.tsx
@@ -1022,7 +1022,9 @@ const ComparisonGrid = ( {
 	const visibleGridPlans = useMemo(
 		() =>
 			visiblePlans.reduce( ( acc, planSlug ) => {
-				const gridPlan = displayedGridPlans.find( ( gridPlan ) => gridPlan.planSlug === planSlug );
+				const gridPlan = displayedGridPlans.find(
+					( gridPlan ) => getPlanClass( gridPlan.planSlug ) === getPlanClass( planSlug )
+				);
 
 				if ( gridPlan ) {
 					acc.push( gridPlan );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # (I believe there was an existing issue somewhere that we can reference)

## Proposed Changes

As the title suggests, this is (hopefully) an intermediate fix (patch) to the flickering in the comparison grid when switching terms (monthly/yearly).

The fix is indicative of a deeper underlying issue, where `visiblePlans` go (perhaps intermittently) out of sync with `gridPlans` and `displayedGridPlans` (which always carry the correct/latest plans). We are trying to sync these structures through a series of transformations and `useEffect` hooks, which lead to this scenario e.g. `visiblePlans` carrying the previous "monthly" plans when switching the toggle to "yearly", and vice versa - hence leading to slugs not matching for a single pass/rerender.

### Media

**Before**

https://github.com/Automattic/wp-calypso/assets/1705499/5949a398-e532-4d0f-8d84-6c0e290bc717

**After**

https://github.com/Automattic/wp-calypso/assets/1705499/5535db3e-5070-4a04-ac0c-fc3808bf5a7c



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plans/[ free site ]` and open the comparison grid
* Switch terms and confirm it doesn't flicker between empty and populated grid
    * Confirm nothing else misbehaves
        * prices and grid features are updated
        * changing plans works
        * viewport breakpoints work as before)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?