### PR TITLE
Plans 2023: Avoid showing the loader (or reduce periodicity) on plans page when fetching site-plans data

### DIFF
--- a/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
+++ b/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
@@ -191,7 +191,7 @@ const usePricingMetaForGridPlans: UsePricingMetaForGridPlans = ( {
 	 * - For now a simple loader is shown until these are resolved
 	 * - We can optimise Error states in the UI / when everything gets ported into data-stores
 	 */
-	if ( sitePlans.isFetching || ! pricedAPIPlans ) {
+	if ( ! sitePlans.data || ! pricedAPIPlans ) {
 		return null;
 	}
 

--- a/client/my-sites/plans-features-main/hooks/test/use-pricing-meta-for-grid-plans.ts
+++ b/client/my-sites/plans-features-main/hooks/test/use-pricing-meta-for-grid-plans.ts
@@ -49,8 +49,7 @@ describe( 'usePricingMetaForGridPlans', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 		Plans.useSitePlans.mockImplementation( () => ( {
-			isFetching: false,
-			data: null,
+			data: {},
 		} ) );
 		getByPurchaseId.mockImplementation( () => undefined );
 		usePricedAPIPlans.mockImplementation( () => ( {

--- a/packages/data-stores/src/plans/queries/use-site-plans.ts
+++ b/packages/data-stores/src/plans/queries/use-site-plans.ts
@@ -68,7 +68,7 @@ function useSitePlans( { siteId }: Props ) {
 			}, {} );
 		}, [] ),
 		refetchOnWindowFocus: false,
-		staleTime: 1000 * 60 * 30, // 30 minutes
+		staleTime: 1000 * 60 * 5, // 5 minutes
 		enabled: !! siteId,
 	} );
 }

--- a/packages/data-stores/src/plans/queries/use-site-plans.ts
+++ b/packages/data-stores/src/plans/queries/use-site-plans.ts
@@ -68,7 +68,7 @@ function useSitePlans( { siteId }: Props ) {
 			}, {} );
 		}, [] ),
 		refetchOnWindowFocus: false,
-		staleTime: 1000 * 60 * 5, // 5 minutes
+		staleTime: 1000 * 60 * 50, // 50 minutes
 		enabled: !! siteId,
 	} );
 }

--- a/packages/data-stores/src/plans/queries/use-site-plans.ts
+++ b/packages/data-stores/src/plans/queries/use-site-plans.ts
@@ -68,7 +68,7 @@ function useSitePlans( { siteId }: Props ) {
 			}, {} );
 		}, [] ),
 		refetchOnWindowFocus: false,
-		staleTime: 1000 * 60 * 50, // 50 minutes
+		staleTime: 1000 * 60 * 30, // 30 minutes
 		enabled: !! siteId,
 	} );
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

<img width="400" alt="Screenshot 2023-10-19 at 4 28 01 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/4ce1df20-b458-4470-a850-45c3f1663e97">

- Reduces the periodicity of the small loader on the plans page resulting from stale site-plans data
- Loader shown on initial fetching, but updates/refetches will just update the existing pricing

This is a quick patch/fix as the loader does feel pretty annoying coming up on every 5-minute session with the plans. However, a more proper solution should be investigated, perhaps at a later stage when we have everything ported to data-stores e.g. we may explore rendering the grid plans without pricing and inject the prices when they are ready, or let prices be rendered as they are fetched (which may not be the ideal, to overlay prices this way on initial render). The loader ought to go at some point, or only show in admin where things are just a tad slower. So there are multiple options that shouldn't be a big deal to tackle.

The loader was added due to having multiple prices being fetched from multiple endpoints (`/plans` and `/site/[id]/plans`) and other data required for the grids. Previously, we'd just wait it out on an empty screen.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review
* Confirm loader isn't popping up every ~5 minutes when on the plans page (`/plans` or `/start/plans`)
    * The quick way to confirm this is to force `refetchInterval: 1000 * 10, // 10 secs` on the useSitePlans hook (in trunk). It will show the loader every 10 secs.
* When proxied, go through `/setup/wooexpress` and confirm `/plans/[ fresh woo site ]` shows the discounted promo pricing (`$1`) past the initial loader

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?