### PR TITLE
Stepper: Use function to retrieve login url, instead of hardcoding it

### DIFF
--- a/client/landing/stepper/declarative-flow/blog.ts
+++ b/client/landing/stepper/declarative-flow/blog.ts
@@ -10,6 +10,7 @@ import {
 } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { useLoginUrl } from '../utils/path';
 
 const Blog: Flow = {
 	name: 'blog',
@@ -43,10 +44,11 @@ const Blog: Flow = {
 		const pathLocaleSlug = getLocaleFromPathname();
 		const locale = queryLocaleSlug || pathLocaleSlug || useLocaleSlug;
 
-		const logInUrl =
-			locale && locale !== 'en'
-				? `/start/account/user/${ locale }?redirect_to=/setup/blog&variationName=blogger-intent`
-				: `/start/account/user?redirect_to=/setup/blog&variationName=blogger-intent`;
+		const logInUrl = useLoginUrl( {
+			variationName: 'blogger-intent',
+			redirectTo: `/setup/blog`,
+			locale,
+		} );
 
 		// Despite sending a CHECKING state, this function gets called again with the
 		// /setup/blog/blogger-intent route which has no locale in the path so we need to

--- a/client/landing/stepper/declarative-flow/connect-domain.ts
+++ b/client/landing/stepper/declarative-flow/connect-domain.ts
@@ -58,14 +58,10 @@ const connectDomain: Flow = {
 			};
 		}
 
-		const redirectTo = encodeURIComponent(
-			`/setup/${ flowName }/plans?domain=${ domain }&provider=${ provider }}`
-		);
-
 		const logInUrl = useLoginUrl( {
 			variationName: flowName,
-			redirectTo: redirectTo,
-			pageTitle: 'Connect%20your%20Domain',
+			redirectTo: `/setup/${ flowName }/plans?domain=${ domain }&provider=${ provider }}`,
+			pageTitle: 'Connect your Domain',
 			locale,
 		} );
 

--- a/client/landing/stepper/declarative-flow/connect-domain.ts
+++ b/client/landing/stepper/declarative-flow/connect-domain.ts
@@ -14,6 +14,7 @@ import {
 } from 'calypso/signup/storageUtils';
 import { useDomainParams } from '../hooks/use-domain-params';
 import { USER_STORE, ONBOARD_STORE } from '../stores';
+import { useLoginUrl } from '../utils/path';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import { redirect } from './internals/steps-repository/import/util';
 import {
@@ -60,10 +61,13 @@ const connectDomain: Flow = {
 		const redirectTo = encodeURIComponent(
 			`/setup/${ flowName }/plans?domain=${ domain }&provider=${ provider }}`
 		);
-		const logInUrl =
-			locale && locale !== 'en'
-				? `/start/account/user/${ locale }?variationName=${ flowName }&pageTitle=Connect%20your%20Domain&redirect_to=${ redirectTo }`
-				: `/start/account/user?variationName=${ flowName }&pageTitle=Connect%20your%20Domain&redirect_to=${ redirectTo }`;
+
+		const logInUrl = useLoginUrl( {
+			variationName: flowName,
+			redirectTo: redirectTo,
+			pageTitle: 'Connect%20your%20Domain',
+			locale,
+		} );
 
 		// Despite sending a CHECKING state, this function gets called again with the
 		// /setup/blog/blogger-intent route which has no locale in the path so we need to

--- a/client/landing/stepper/declarative-flow/design-first.ts
+++ b/client/landing/stepper/declarative-flow/design-first.ts
@@ -21,6 +21,7 @@ import { freeSiteAddressType } from 'calypso/lib/domains/constants';
 import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { requestSiteAddressChange } from 'calypso/state/site-address-change/actions';
 import { useSiteIdParam } from '../hooks/use-site-id-param';
+import { useLoginUrl } from '../utils/path';
 
 const designFirst: Flow = {
 	name: DESIGN_FIRST_FLOW,
@@ -233,16 +234,13 @@ const designFirst: Flow = {
 		const queryLocaleSlug = getLocaleFromQueryParam();
 		const pathLocaleSlug = getLocaleFromPathname();
 		const locale = queryLocaleSlug || pathLocaleSlug || useLocaleSlug;
-		const logInParams = new URLSearchParams( {
-			variationName: flowName,
-			pageTitle: 'Pick a design',
-			redirect_to: window.location.href.replace( window.location.origin, '' ),
-		} ).toString();
 
-		const logInUrl =
-			locale && locale !== 'en'
-				? `/start/account/user/${ locale }?${ logInParams }`
-				: `/start/account/user?${ logInParams }`;
+		const logInUrl = useLoginUrl( {
+			variationName: flowName,
+			redirectTo: window.location.href.replace( window.location.origin, '' ),
+			pageTitle: 'Pick a design',
+			locale,
+		} );
 
 		// Despite sending a CHECKING state, this function gets called again with the
 		// /setup/design-first/site-creation-step route which has no locale in the path so we need to

--- a/client/landing/stepper/declarative-flow/domain-transfer.ts
+++ b/client/landing/stepper/declarative-flow/domain-transfer.ts
@@ -65,7 +65,7 @@ const domainTransfer: Flow = {
 		const logInUrl = useLoginUrl( {
 			variationName: flowName,
 			redirectTo: `/setup/${ flowName }/domains`,
-			pageTitle: 'Bulk+Transfer',
+			pageTitle: 'Bulk Transfer',
 		} );
 
 		const submit = ( providedDependencies: ProvidedDependencies = {} ) => {

--- a/client/landing/stepper/declarative-flow/domain-transfer.ts
+++ b/client/landing/stepper/declarative-flow/domain-transfer.ts
@@ -1,4 +1,3 @@
-import { useLocale } from '@automattic/i18n-utils';
 import { DOMAIN_TRANSFER } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
 import { translate } from 'i18n-calypso';
@@ -11,6 +10,7 @@ import {
 } from 'calypso/signup/storageUtils';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { USER_STORE } from '../stores';
+import { useLoginUrl } from '../utils/path';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import {
 	Flow,
@@ -61,12 +61,12 @@ const domainTransfer: Flow = {
 			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
 			[]
 		);
-		const locale = useLocale();
 
-		const logInUrl =
-			locale && locale !== 'en'
-				? `/start/account/user/${ locale }?variationName=${ flowName }&pageTitle=Bulk+Transfer&redirect_to=/setup/${ flowName }/domains`
-				: `/start/account/user?variationName=${ flowName }&pageTitle=Bulk+Transfer&redirect_to=/setup/${ flowName }/domains`;
+		const logInUrl = useLoginUrl( {
+			variationName: flowName,
+			redirectTo: `/setup/${ flowName }/domains`,
+			pageTitle: 'Bulk+Transfer',
+		} );
 
 		const submit = ( providedDependencies: ProvidedDependencies = {} ) => {
 			recordSubmitStep( providedDependencies, '', flowName, _currentStepSlug );

--- a/client/landing/stepper/declarative-flow/domain-user-transfer.ts
+++ b/client/landing/stepper/declarative-flow/domain-user-transfer.ts
@@ -12,6 +12,7 @@ import {
 import { useDomainParams } from 'calypso/landing/stepper/hooks/use-domain-params';
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { useLoginUrl } from '../utils/path';
 import DomainContactInfo from './internals/steps-repository/domain-contact-info';
 
 const domainUserTransfer: Flow = {
@@ -61,10 +62,12 @@ const domainUserTransfer: Flow = {
 
 		const { domain } = useDomainParams();
 
-		const logInUrl =
-			locale && locale !== 'en'
-				? `/start/account/user/${ locale }?variationName=${ flowName }&pageTitle=Receive%20domain&redirect_to=/setup/${ flowName }?domain=${ domain }`
-				: `/start/account/user?variationName=${ flowName }&pageTitle=Receive%20domain&redirect_to=/setup/${ flowName }?domain=${ domain }`;
+		const logInUrl = useLoginUrl( {
+			variationName: flowName,
+			redirectTo: `/setup/${ flowName }?domain=${ domain }`,
+			pageTitle: 'Receive%20domain',
+			locale,
+		} );
 
 		useEffect( () => {
 			if ( ! isLoggedIn ) {

--- a/client/landing/stepper/declarative-flow/domain-user-transfer.ts
+++ b/client/landing/stepper/declarative-flow/domain-user-transfer.ts
@@ -65,7 +65,7 @@ const domainUserTransfer: Flow = {
 		const logInUrl = useLoginUrl( {
 			variationName: flowName,
 			redirectTo: `/setup/${ flowName }?domain=${ domain }`,
-			pageTitle: 'Receive%20domain',
+			pageTitle: 'Receive domain',
 			locale,
 		} );
 

--- a/client/landing/stepper/declarative-flow/free.ts
+++ b/client/landing/stepper/declarative-flow/free.ts
@@ -20,6 +20,7 @@ import {
 import { useSiteIdParam } from '../hooks/use-site-id-param';
 import { useSiteSlug } from '../hooks/use-site-slug';
 import { USER_STORE, ONBOARD_STORE } from '../stores';
+import { getLoginUrl } from '../utils/path';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import DesignSetup from './internals/steps-repository/design-setup';
 import ErrorStep from './internals/steps-repository/error-step';
@@ -234,12 +235,13 @@ const free: Flow = {
 				window?.location?.pathname +
 				( hasFlowParams ? encodeURIComponent( '?' + flowParams.toString() ) : '' );
 
-			const url =
-				locale && locale !== 'en'
-					? `/start/account/user/${ locale }?variationName=${ flowName }&redirect_to=${ redirectTarget }`
-					: `/start/account/user?variationName=${ flowName }&redirect_to=${ redirectTarget }`;
+			const logInUrl = getLoginUrl( {
+				variationName: flowName,
+				redirectTo: redirectTarget,
+				locale,
+			} );
 
-			return url + ( flags ? `&flags=${ flags }` : '' );
+			return logInUrl + ( flags ? `&flags=${ flags }` : '' );
 		};
 
 		// Despite sending a CHECKING state, this function gets called again with the

--- a/client/landing/stepper/declarative-flow/link-in-bio-domain.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio-domain.ts
@@ -1,5 +1,4 @@
 import { PLAN_PERSONAL } from '@automattic/calypso-products';
-import { useLocale } from '@automattic/i18n-utils';
 import { useFlowProgress, LINK_IN_BIO_FLOW, LINK_IN_BIO_DOMAIN_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { translate } from 'i18n-calypso';
@@ -13,6 +12,7 @@ import {
 } from 'calypso/signup/storageUtils';
 import { useDomainParams } from '../hooks/use-domain-params';
 import { USER_STORE, ONBOARD_STORE } from '../stores';
+import { useLoginUrl } from '../utils/path';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import { redirect } from './internals/steps-repository/import/util';
 import {
@@ -74,7 +74,6 @@ const linkInBioDomain: Flow = {
 			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
 			[]
 		);
-		const locale = useLocale();
 
 		setStepProgress( flowProgress );
 
@@ -93,10 +92,11 @@ const linkInBioDomain: Flow = {
 		const redirectTo = encodeURIComponent(
 			`/setup/${ variantSlug }/patterns?domain=${ domain }&provider=${ provider }`
 		);
-		const logInUrl =
-			locale && locale !== 'en'
-				? `/start/account/user/${ locale }?variationName=${ variantSlug }&pageTitle=Link%20in%20Bio&redirect_to=${ redirectTo }`
-				: `/start/account/user?variationName=${ variantSlug }&pageTitle=Link%20in%20Bio&redirect_to=${ redirectTo }`;
+		const logInUrl = useLoginUrl( {
+			variationName: variantSlug,
+			redirectTo: redirectTo,
+			pageTitle: 'Link%20in%20Bio',
+		} );
 
 		const submit = ( providedDependencies: ProvidedDependencies = {} ) => {
 			recordSubmitStep( providedDependencies, '', flowName, _currentStepSlug, variantSlug, {

--- a/client/landing/stepper/declarative-flow/link-in-bio-tld.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio-tld.ts
@@ -1,5 +1,4 @@
 import { updateLaunchpadSettings, type UserSelect } from '@automattic/data-stores';
-import { useLocale } from '@automattic/i18n-utils';
 import { useFlowProgress, LINK_IN_BIO_TLD_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
@@ -14,6 +13,7 @@ import {
 import { useSiteIdParam } from '../hooks/use-site-id-param';
 import { useSiteSlug } from '../hooks/use-site-slug';
 import { USER_STORE, ONBOARD_STORE } from '../stores';
+import { useLoginUrl } from '../utils/path';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import DesignCarousel from './internals/steps-repository/design-carousel';
 import DomainsStep from './internals/steps-repository/domains';
@@ -51,7 +51,6 @@ const linkInBio: Flow = {
 			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
 			[]
 		);
-		const locale = useLocale();
 
 		setStepProgress( flowProgress );
 
@@ -67,10 +66,11 @@ const linkInBio: Flow = {
 			}
 		);
 
-		const logInUrl =
-			locale && locale !== 'en'
-				? `/start/account/user/${ locale }?variationName=${ flowName }&pageTitle=Link%20in%20Bio&redirect_to=/setup/${ flowName }/patterns`
-				: `/start/account/user?variationName=${ flowName }&pageTitle=Link%20in%20Bio&redirect_to=/setup/${ flowName }/patterns`;
+		const logInUrl = useLoginUrl( {
+			variationName: flowName,
+			redirectTo: `/setup/${ flowName }/patterns`,
+			pageTitle: 'Link%20in%20Bio',
+		} );
 
 		const submit = ( providedDependencies: ProvidedDependencies = {} ) => {
 			recordSubmitStep( providedDependencies, '', flowName, _currentStepSlug );

--- a/client/landing/stepper/declarative-flow/link-in-bio.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio.ts
@@ -86,7 +86,7 @@ const linkInBio: Flow = {
 		const logInUrl = useLoginUrl( {
 			variationName: flowName,
 			redirectTo: `/setup/${ flowName }/patterns`,
-			pageTitle: 'Link%20in%20Bio',
+			pageTitle: 'Link in Bio',
 		} );
 
 		const submit = ( providedDependencies: ProvidedDependencies = {} ) => {

--- a/client/landing/stepper/declarative-flow/link-in-bio.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio.ts
@@ -1,5 +1,4 @@
 import { updateLaunchpadSettings, type UserSelect } from '@automattic/data-stores';
-import { useLocale } from '@automattic/i18n-utils';
 import { useFlowProgress, LINK_IN_BIO_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
@@ -15,6 +14,7 @@ import {
 import { useSiteIdParam } from '../hooks/use-site-id-param';
 import { useSiteSlug } from '../hooks/use-site-slug';
 import { USER_STORE, ONBOARD_STORE } from '../stores';
+import { useLoginUrl } from '../utils/path';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import type { Flow, ProvidedDependencies } from './internals/types';
 
@@ -68,7 +68,6 @@ const linkInBio: Flow = {
 			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
 			[]
 		);
-		const locale = useLocale();
 
 		setStepProgress( flowProgress );
 
@@ -84,10 +83,11 @@ const linkInBio: Flow = {
 			}
 		);
 
-		const logInUrl =
-			locale && locale !== 'en'
-				? `/start/account/user/${ locale }?variationName=${ flowName }&pageTitle=Link%20in%20Bio&redirect_to=/setup/${ flowName }/patterns`
-				: `/start/account/user?variationName=${ flowName }&pageTitle=Link%20in%20Bio&redirect_to=/setup/${ flowName }/patterns`;
+		const logInUrl = useLoginUrl( {
+			variationName: flowName,
+			redirectTo: `/setup/${ flowName }/patterns`,
+			pageTitle: 'Link%20in%20Bio',
+		} );
 
 		const submit = ( providedDependencies: ProvidedDependencies = {} ) => {
 			recordSubmitStep( providedDependencies, '', flowName, _currentStepSlug );

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -223,7 +223,7 @@ const startWriting: Flow = {
 		const logInUrl = useLoginUrl( {
 			variationName: flowName,
 			redirectTo: `/setup/${ flowName }`,
-			pageTitle: 'Start%20writing',
+			pageTitle: 'Start writing',
 			locale,
 		} );
 		// Despite sending a CHECKING state, this function gets called again with the

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -20,6 +20,7 @@ import { useSelector } from 'calypso/state';
 import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { requestSiteAddressChange } from 'calypso/state/site-address-change/actions';
 import { useSiteIdParam } from '../hooks/use-site-id-param';
+import { useLoginUrl } from '../utils/path';
 
 const startWriting: Flow = {
 	name: START_WRITING_FLOW,
@@ -219,11 +220,12 @@ const startWriting: Flow = {
 		const pathLocaleSlug = getLocaleFromPathname();
 		const locale = queryLocaleSlug || pathLocaleSlug || useLocaleSlug;
 
-		const logInUrl =
-			locale && locale !== 'en'
-				? `/start/account/user/${ locale }?variationName=${ flowName }&pageTitle=Start%20writing&redirect_to=/setup/${ flowName }`
-				: `/start/account/user?variationName=${ flowName }&pageTitle=Start%20writing&redirect_to=/setup/${ flowName }`;
-
+		const logInUrl = useLoginUrl( {
+			variationName: flowName,
+			redirectTo: `/setup/${ flowName }`,
+			pageTitle: 'Start%20writing',
+			locale,
+		} );
 		// Despite sending a CHECKING state, this function gets called again with the
 		// /setup/start-writing/site-creation-step route which has no locale in the path so we need to
 		// redirect off of the first render.

--- a/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
+++ b/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
@@ -18,6 +18,7 @@ import {
 import { useSite } from '../hooks/use-site';
 import { useSiteSlugParam } from '../hooks/use-site-slug-param';
 import { USER_STORE, ONBOARD_STORE, SITE_STORE } from '../stores';
+import { getLoginUrl } from '../utils/path';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import CheckPlan from './internals/steps-repository/check-plan';
 import DesignCarousel from './internals/steps-repository/design-carousel';
@@ -118,12 +119,13 @@ const ecommerceFlow: Flow = {
 			const redirectTarget =
 				`/setup/ecommerce/storeProfiler` +
 				( hasFlowParams ? encodeURIComponent( '?' + flowParams.toString() ) : '' );
-			const url =
-				locale && locale !== 'en'
-					? `/start/account/user/${ locale }?variationName=${ flowName }&redirect_to=${ redirectTarget }`
-					: `/start/account/user?variationName=${ flowName }&redirect_to=${ redirectTarget }`;
+			const logInUrl = getLoginUrl( {
+				variationName: flowName,
+				redirectTo: redirectTarget,
+				locale,
+			} );
 
-			return url + ( flags ? `&flags=${ flags }` : '' );
+			return logInUrl + ( flags ? `&flags=${ flags }` : '' );
 		};
 
 		// Despite sending a CHECKING state, this function gets called again with the

--- a/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
+++ b/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
@@ -6,6 +6,7 @@ import recordGTMDatalayerEvent from 'calypso/lib/analytics/ad-tracking/woo/recor
 import { useSiteSetupFlowProgress } from '../hooks/use-site-setup-flow-progress';
 import { useSiteSlugParam } from '../hooks/use-site-slug-param';
 import { USER_STORE, ONBOARD_STORE, SITE_STORE } from '../stores';
+import { getLoginUrl } from '../utils/path';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import AssignTrialPlanStep from './internals/steps-repository/assign-trial-plan';
 import { AssignTrialResult } from './internals/steps-repository/assign-trial-plan/constants';
@@ -96,12 +97,12 @@ const wooexpress: Flow = {
 				queryString = `${ queryString }&${ queryParams.toString() }`;
 			}
 
-			// Early return approach
-			if ( locale || locale === 'en' ) {
-				return `/start/account/user/${ locale }?variationName=${ flowName }&${ queryString }`;
-			}
+			const logInUrl = getLoginUrl( {
+				variationName: flowName,
+				locale,
+			} );
 
-			return `/start/account/user?variationName=${ flowName }&${ queryString }`;
+			return `${ logInUrl }&${ queryString }`;
 		};
 
 		// Despite sending a CHECKING state, this function gets called again with the

--- a/client/landing/stepper/declarative-flow/write.ts
+++ b/client/landing/stepper/declarative-flow/write.ts
@@ -10,6 +10,7 @@ import wpcom from 'calypso/lib/wp';
 import { useSiteIdParam } from '../hooks/use-site-id-param';
 import { useSiteSlug } from '../hooks/use-site-slug';
 import { USER_STORE, ONBOARD_STORE } from '../stores';
+import { getLoginUrl } from '../utils/path';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import LaunchPad from './internals/steps-repository/launchpad';
 import Processing from './internals/steps-repository/processing-step';
@@ -131,12 +132,13 @@ const write: Flow = {
 				window?.location?.pathname +
 				( hasFlowParams ? encodeURIComponent( '?' + flowParams.toString() ) : '' );
 
-			const url =
-				locale && locale !== 'en'
-					? `/start/account/user/${ locale }?variationName=${ flowName }&redirect_to=${ redirectTarget }`
-					: `/start/account/user?variationName=${ flowName }&redirect_to=${ redirectTarget }`;
+			const logInUrl = getLoginUrl( {
+				variationName: flowName,
+				redirectTo: redirectTarget,
+				locale,
+			} );
 
-			return url + ( flags ? `&flags=${ flags }` : '' );
+			return logInUrl + ( flags ? `&flags=${ flags }` : '' );
 		};
 
 		// Despite sending a CHECKING state, this function gets called again with the

--- a/client/landing/stepper/utils/path.ts
+++ b/client/landing/stepper/utils/path.ts
@@ -3,6 +3,7 @@ import { useLocale } from '@automattic/i18n-utils';
 import languages from '@automattic/languages';
 import { addQueryArgs } from '@wordpress/url';
 import { useMatch } from 'react-router-dom';
+import { trailingslashit } from 'calypso/lib/route';
 
 const plansPaths = Plans.plansSlugs;
 
@@ -60,7 +61,8 @@ export const getLoginUrl = ( {
 	loginPath?: string;
 	locale?: string;
 } ) => {
-	const localizedLoginPath = locale && locale !== 'en' ? `${ loginPath }${ locale }` : loginPath;
+	const localizedLoginPath =
+		locale && locale !== 'en' ? `${ trailingslashit( loginPath ) }${ locale }` : loginPath;
 
 	// Empty values are ignored down the call stack, so we don't need to check for them here.
 	return addQueryArgs( localizedLoginPath, {

--- a/client/landing/stepper/utils/path.ts
+++ b/client/landing/stepper/utils/path.ts
@@ -58,7 +58,7 @@ export const getLoginUrl = ( {
 	redirectTo?: string | null;
 	pageTitle?: string | null;
 	loginPath?: string;
-	locale?: string | null;
+	locale?: string;
 } ) => {
 	const localizedLoginPath = locale && locale !== 'en' ? `${ loginPath }${ locale }` : loginPath;
 

--- a/client/landing/stepper/utils/path.ts
+++ b/client/landing/stepper/utils/path.ts
@@ -44,11 +44,12 @@ export function useLangRouteParam() {
 	return match?.params.lang;
 }
 
-export const useLoginUrl = ( {
+export const getLoginUrl = ( {
 	variationName,
 	redirectTo,
 	pageTitle,
 	loginPath = `/start/account/user/`,
+	locale,
 }: {
 	/**
 	 * Variation name is used to track the relevant login flow in the signup framework as explained in https://github.com/Automattic/wp-calypso/issues/67173
@@ -57,8 +58,8 @@ export const useLoginUrl = ( {
 	redirectTo?: string | null;
 	pageTitle?: string | null;
 	loginPath?: string;
-} ): string => {
-	const locale = useLocale();
+	locale?: string | null;
+} ) => {
 	const localizedLoginPath = locale && locale !== 'en' ? `${ loginPath }${ locale }` : loginPath;
 
 	// Empty values are ignored down the call stack, so we don't need to check for them here.
@@ -67,5 +68,31 @@ export const useLoginUrl = ( {
 		redirect_to: redirectTo,
 		pageTitle,
 		toStepper: true,
+	} );
+};
+
+export const useLoginUrl = ( {
+	variationName,
+	redirectTo,
+	pageTitle,
+	loginPath = `/start/account/user/`,
+	locale,
+}: {
+	/**
+	 * Variation name is used to track the relevant login flow in the signup framework as explained in https://github.com/Automattic/wp-calypso/issues/67173
+	 */
+	variationName?: string | null;
+	redirectTo?: string | null;
+	pageTitle?: string | null;
+	loginPath?: string;
+	locale?: string;
+} ): string => {
+	const currentLocale = useLocale();
+	return getLoginUrl( {
+		variationName,
+		redirectTo,
+		pageTitle,
+		loginPath,
+		locale: locale ?? currentLocale,
 	} );
 };


### PR DESCRIPTION
This is a PR preparatory to https://github.com/Automattic/wp-calypso/pull/82814. I created a new PR to simplify testing.

## The problem

The work we're doing on the new Social first signup step (https://github.com/Automattic/wp-calypso/pull/82814) will create a new user step, `user-social`. 

Most of the Stepper flows redirect to the `User` step when the user is logged out, using this code:

```
const logInUrl =
			locale && locale !== 'en'
				? `/start/account/user/${ locale }?redirect_to=/setup/blog&variationName=blogger-intent`
				: `/start/account/user?redirect_to=/setup/blog&variationName=blogger-intent`;
```

As we can see, `user` is hardcoded in all the flows, so it is difficult to manage. We'll need to conditionally, based on a flag, decide whether direct users to `user` or the new `user-social`.

## The solution

We used the existing [useLoginUrl](https://github.com/Automattic/wp-calypso/blob/update/stepper-use-login/client/landing/stepper/utils/path.ts#L74) in all the flows that were directly hardcoding the login url. 
We needed to extend in though, as in many flows there is an added complexity in retrieving the locale due to a race condition. [Example of what I mean.](https://github.com/Automattic/wp-calypso/blob/trunk/client/landing/stepper/declarative-flow/blog.ts#L36-L44)

## Testing
1. Live Link
2. See the flows affected in Stepper and try to go through them while in Incognito
3. Some flows like `write` use query parameters that you should try too.
4. Try some flows not in Incognito, to be sure they work.