### PR TITLE
Staging Sites: Record tracks events for staging synchronization success

### DIFF
--- a/client/my-sites/hosting/staging-site-card/index.js
+++ b/client/my-sites/hosting/staging-site-card/index.js
@@ -212,6 +212,7 @@ export const StagingSiteCard = ( {
 
 	const { pushToStaging } = usePushToStagingMutation( siteId, stagingSite?.id, {
 		onSuccess: () => {
+			dispatch( recordTracksEvent( 'calypso_hosting_configuration_staging_site_push_success' ) );
 			setSyncError( null );
 		},
 		onError: ( error ) => {
@@ -226,6 +227,7 @@ export const StagingSiteCard = ( {
 
 	const { pullFromStaging } = usePullFromStagingMutation( siteId, stagingSite?.id, {
 		onSuccess: () => {
+			dispatch( recordTracksEvent( 'calypso_hosting_configuration_staging_site_pull_success' ) );
 			setSyncError( null );
 		},
 		onError: ( error ) => {

--- a/client/my-sites/hosting/staging-site-card/staging-site-production-card.tsx
+++ b/client/my-sites/hosting/staging-site-card/staging-site-production-card.tsx
@@ -77,6 +77,7 @@ function StagingSiteProductionCard( { disabled, siteId, translate }: CardProps )
 
 	const { pushToStaging } = usePushToStagingMutation( productionSite?.id as number, siteId, {
 		onSuccess: () => {
+			dispatch( recordTracksEvent( 'calypso_hosting_configuration_staging_site_push_success' ) );
 			setSyncError( null );
 		},
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -92,6 +93,7 @@ function StagingSiteProductionCard( { disabled, siteId, translate }: CardProps )
 
 	const { pullFromStaging } = usePullFromStagingMutation( productionSite?.id as number, siteId, {
 		onSuccess: () => {
+			dispatch( recordTracksEvent( 'calypso_hosting_configuration_staging_site_pull_success' ) );
 			setSyncError( null );
 		},
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4197

## Proposed Changes

In this PR, I propose to log `calypso_hosting_configuration_staging_site_push_success` and `calypso_hosting_configuration_staging_site_pull_success` track events to see how many times users started synchronization in each direction.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
As we are testing tracks here, enable tracks debug by pasting the following in browser JS console:

```
localStorage.setItem( 'debug', 'calypso:analytics*' );
```

1. Create an Atomic site with a staging site
2. Navigate to Settings -> Hosting Configuration
3. Choose the 'Staging into production' synchronization direction and any options
4. Fill confirmation form and click `Synchronize`
5. Confirm `calypso_hosting_configuration_staging_site_pull_success` event was logged in the console
6. Choose the 'Production to staging' synchronization direction
7. Click `Synchronize`
8. Confirm `calypso_hosting_configuration_staging_site_push_success` event was logged in the console

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?