### PR TITLE
Update wpcom-proxy-request for 7.0.5 release

### DIFF
--- a/packages/wpcom-proxy-request/History.md
+++ b/packages/wpcom-proxy-request/History.md
@@ -2,12 +2,16 @@
 
 ## Next / TBD
 
-- Don't modify a falsy boolean JSON response body by defaulting it.
+## 7.0.5 / 2023-10-13
+
+- Don't reference `window` from module initialization code.
 - Trigger request error when proxy iframe is not present and loaded.
+- Updates to linting rules.
 
 ## 7.0.4 / 2023-07-11
 
 - Remove dependendy `progress-event`. This polyfill is no longer needed due to ProgressEvent being widely supported now.
+- Don't modify a falsy boolean JSON response body by defaulting it.
 
 ## 6.0.0 / 2021-03-19
 

--- a/packages/wpcom-proxy-request/History.md
+++ b/packages/wpcom-proxy-request/History.md
@@ -2,7 +2,7 @@
 
 ## Next / TBD
 
-## 7.0.5 / 2023-10-13
+## 7.0.5 / 2023-10-18
 
 - Don't reference `window` from module initialization code.
 - Trigger request error when proxy iframe is not present and loaded.

--- a/packages/wpcom-proxy-request/package.json
+++ b/packages/wpcom-proxy-request/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wpcom-proxy-request",
-	"version": "7.0.4",
+	"version": "7.0.5",
 	"description": "Proxied cookie-authenticated REST API requests to WordPress.com.",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* This PR pulls together a 7.0.5 release for `wpcom-proxy-request`, mostly because I'm working on consuming some downstream packages, specifically `@automattic/launchpad-navigator` which depend on the package, and I'd prefer to run the latest version of this code.
* The one minor note is that I moved one of the changes to do with falsy responses down to the 7.0.4 release, which may not be 100% accurate, as I don't know whether it was actually folded into an earlier release

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Not much to test here -- this just documents the changes to the package since ~July in #79245, which released 7.0.4.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
