### PR TITLE
Fix support for IDN domains

### DIFF
--- a/client/site-profiler/components/domain-analyzer/index.tsx
+++ b/client/site-profiler/components/domain-analyzer/index.tsx
@@ -16,8 +16,15 @@ interface Props {
 
 export default function DomainAnalyzer( props: Props ) {
 	const translate = useTranslate();
-	const { domain, isBusy, isBusyForWhile, isDomainValid, domainFetchingError, onFormSubmit } =
-		props;
+	const {
+		domain,
+		rawDomain,
+		isBusy,
+		isBusyForWhile,
+		isDomainValid,
+		domainFetchingError,
+		onFormSubmit,
+	} = props;
 
 	const showError = isDomainValid === false || domainFetchingError;
 
@@ -58,9 +65,9 @@ export default function DomainAnalyzer( props: Props ) {
 							// eslint-disable-next-line jsx-a11y/no-autofocus
 							autoFocus={ true }
 							autoComplete="off"
-							defaultValue={ domain }
+							defaultValue={ rawDomain }
 							placeholder={ translate( 'Enter a site URL' ) }
-							key={ domain || 'empty' }
+							key={ rawDomain || 'empty' }
 							onKeyDown={ onInputEscape }
 							spellCheck="false"
 						/>

--- a/client/site-profiler/components/heading-information/index.tsx
+++ b/client/site-profiler/components/heading-information/index.tsx
@@ -12,6 +12,7 @@ import './styles.scss';
 
 interface Props {
 	domain: string;
+	rawDomain: string;
 	domainCategory?: SPECIAL_DOMAIN_CATEGORY;
 	conversionAction?: CONVERSION_ACTION;
 	hostingProvider?: HostingProvider;
@@ -20,8 +21,15 @@ interface Props {
 }
 
 export default function HeadingInformation( props: Props ) {
-	const { domain, domainCategory, conversionAction, hostingProvider, urlData, onCheckAnotherSite } =
-		props;
+	const {
+		domain,
+		rawDomain,
+		domainCategory,
+		conversionAction,
+		hostingProvider,
+		urlData,
+		onCheckAnotherSite,
+	} = props;
 	const finalStatus = domainCategory ?? conversionAction;
 
 	const recordCtaEvent = ( ctaName: string ) => {
@@ -87,7 +95,7 @@ export default function HeadingInformation( props: Props ) {
 		<div className="heading-information">
 			<summary>
 				<h5>{ translate( 'Site Profiler' ) }</h5>
-				<div className="domain">{ domain }</div>
+				<div className="domain">{ rawDomain }</div>
 				<StatusInfo
 					conversionAction={ conversionAction }
 					hostingProvider={ hostingProvider }

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -25,6 +25,7 @@ export default function SiteProfiler( props: Props ) {
 	const { routerDomain } = props;
 	const {
 		domain,
+		rawDomain,
 		category: domainCategory,
 		isValid: isDomainValid,
 		isSpecial: isDomainSpecial,
@@ -73,6 +74,7 @@ export default function SiteProfiler( props: Props ) {
 					<DocumentHead title={ translate( 'Site Profiler' ) } />
 					<DomainAnalyzer
 						domain={ domain }
+						rawDomain={ rawDomain }
 						isDomainValid={ isDomainValid }
 						isBusy={ isFetchingSP }
 						isBusyForWhile={ isBusyForWhile }
@@ -86,12 +88,13 @@ export default function SiteProfiler( props: Props ) {
 				<LayoutBlock className="domain-result-block">
 					{
 						// Translators: %s is the domain name searched
-						<DocumentHead title={ translate( '%s ‹ Site Profiler', { args: [ domain ] } ) } />
+						<DocumentHead title={ translate( '%s ‹ Site Profiler', { args: [ rawDomain ] } ) } />
 					}
 					{ showResultScreen && (
 						<LayoutBlockSection>
 							<HeadingInformation
 								domain={ domain }
+								rawDomain={ rawDomain }
 								conversionAction={ conversionAction }
 								onCheckAnotherSite={ () => updateDomainRouteParam( '' ) }
 								hostingProvider={ hostingProviderData?.hosting_provider }

--- a/client/site-profiler/hooks/use-domain-param.ts
+++ b/client/site-profiler/hooks/use-domain-param.ts
@@ -9,6 +9,7 @@ import isSpecialDomain, { prepareSpecialDomain } from '../utils/is-special-domai
 
 export default function useDomainParam( value = '' ) {
 	const [ domain, setDomain ] = useState( value );
+	const [ rawDomain, setRawDomain ] = useState( value );
 	const [ isValid, setIsValid ] = useState< undefined | boolean >();
 	const [ isSpecial, setIsSpecial ] = useState( isSpecialDomain( value ) );
 	const [ category, setCategory ] = useState< SPECIAL_DOMAIN_CATEGORY >();
@@ -26,12 +27,15 @@ export default function useDomainParam( value = '' ) {
 		}
 
 		const preparedDomain = prepareDomain( value, isSpecial );
+		const preparedRawDomain = prepareRawDomain( value );
+
 		setCategory( getDomainCategory( preparedDomain ) );
 		setDomain( preparedDomain );
+		setRawDomain( preparedRawDomain );
 		setReadyForDataFetch( ! isSpecial && !! domain && !! isValid );
-	}, [ value, isSpecial, isValid ] );
+	}, [ value, rawDomain, isSpecial, isValid, domain ] );
 
-	return { domain, isValid, isSpecial, category, readyForDataFetch };
+	return { domain, rawDomain, isValid, isSpecial, category, readyForDataFetch };
 }
 
 function prepareDomain( domain: string, isSpecial: boolean ) {
@@ -44,4 +48,12 @@ function prepareDomain( domain: string, isSpecial: boolean ) {
 	return isSpecial
 		? prepareSpecialDomain( domainLc )
 		: getFixedDomainSearch( extractDomainFromInput( domainLc ) );
+}
+
+function prepareRawDomain( domain: string ) {
+	if ( ! domain ) {
+		return '';
+	}
+
+	return decodeURIComponent( domain.toLowerCase() );
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/82941

## Proposed Changes

* Add support for raw encoded IDN URLs

## Testing Instructions

On http://calypso.localhost:3000/site-profiler try these URLs:

1. `räksmörgås.josefsson.org`
2. `богдан-николић.срб`
3. `example.com`
4. `https://example.com`
5. Etc.

Example for the first one:
1. Check if the URL in the heading is `räksmörgås.josefsson.org` and not `xn--rksmrgs-5wao1o.josefsson.org`
2. Check if the page title is `räksmörgås.josefsson.org ‹ Site Profiler — WordPress.com`

Check also that the REST calls are:
1. `/wpcom/v2/site-profiler/xn--rksmrgs-5wao1o.josefsson.org?_envelope=1`
2. `/wpcom/v2/imports/analyze-url?site_url=xn--rksmrgs-5wao1o.josefsson.org`
3. `/wpcom/v2/site-profiler/hosting-provider/xn--rksmrgs-5wao1o.josefsson.org`

<img width="980" alt="image" src="https://github.com/Automattic/wp-calypso/assets/167611/4a4cb6e1-4c11-4715-8ab7-305745b04c03">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?