### PR TITLE
Update copy on 'Choose how to use your domain' page

### DIFF
--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -655,7 +655,10 @@ export function generateSteps( {
 					return i18n.translate( 'Choose how to use your domain' );
 				},
 				get subHeaderText() {
-					return i18n.translate( 'Don’t worry, you can easily add a site later' );
+					return i18n.getLocaleSlug() === 'en' ||
+						i18n.hasTranslation( 'Don’t worry, you can easily change it later.' )
+						? i18n.translate( 'Don’t worry, you can easily change it later.' )
+						: i18n.translate( 'Don’t worry, you can easily add a site later' );
 				},
 			},
 			providesDependencies: [
@@ -665,7 +668,6 @@ export function generateSteps( {
 				'siteUrl',
 				'domainItem',
 				'themeSlugWithRepo',
-				'domainCart',
 			],
 			defaultDependencies: {
 				themeSlugWithRepo: 'pub/twentytwentytwo',
@@ -680,7 +682,7 @@ export function generateSteps( {
 				},
 			},
 			providesDependencies: [ 'siteId', 'siteSlug', 'domainItem', 'themeSlugWithRepo' ],
-			dependencies: [ 'designType', 'domainItem', 'siteUrl', 'themeSlugWithRepo', 'domainCart' ],
+			dependencies: [ 'designType', 'domainItem', 'siteUrl', 'themeSlugWithRepo' ],
 			delayApiRequestUntilComplete: true,
 		},
 

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -668,6 +668,7 @@ export function generateSteps( {
 				'siteUrl',
 				'domainItem',
 				'themeSlugWithRepo',
+				'domainCart',
 			],
 			defaultDependencies: {
 				themeSlugWithRepo: 'pub/twentytwentytwo',
@@ -682,7 +683,7 @@ export function generateSteps( {
 				},
 			},
 			providesDependencies: [ 'siteId', 'siteSlug', 'domainItem', 'themeSlugWithRepo' ],
-			dependencies: [ 'designType', 'domainItem', 'siteUrl', 'themeSlugWithRepo' ],
+			dependencies: [ 'designType', 'domainItem', 'siteUrl', 'themeSlugWithRepo', 'domainCart' ],
 			delayApiRequestUntilComplete: true,
 		},
 

--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -88,15 +88,29 @@ class SiteOrDomain extends Component {
 			choices.push( {
 				key: 'page',
 				title: translate( 'New site' ),
-				description: translate(
-					'Customize and launch your site.{{br/}}{{strong}}Free domain for the first year*{{/strong}}',
-					{
-						components: {
-							strong: <strong />,
-							br: <br />,
-						},
-					}
-				),
+				description:
+					i18n.getLocaleSlug() === 'en' ||
+					i18n.hasTranslation(
+						'Customize and launch your site.{{br/}}{{strong}}Free domain for the first year on annual plans.{{/strong}}'
+					)
+						? translate(
+								'Customize and launch your site.{{br/}}{{strong}}Free domain for the first year on annual plans.{{/strong}}',
+								{
+									components: {
+										strong: <strong />,
+										br: <br />,
+									},
+								}
+						  )
+						: translate(
+								'Customize and launch your site.{{br/}}{{strong}}Free domain for the first year*{{/strong}}',
+								{
+									components: {
+										strong: <strong />,
+										br: <br />,
+									},
+								}
+						  ),
 				icon: null,
 				titleIcon: addCard,
 				value: 'page',
@@ -107,15 +121,29 @@ class SiteOrDomain extends Component {
 				choices.push( {
 					key: 'existing-site',
 					title: translate( 'Existing WordPress.com site' ),
-					description: translate(
-						'Use with a site you already started.{{br/}}{{strong}}Free domain for the first year*{{/strong}}',
-						{
-							components: {
-								strong: <strong />,
-								br: <br />,
-							},
-						}
-					),
+					description:
+						i18n.getLocaleSlug() === 'en' ||
+						i18n.hasTranslation(
+							'Use the domain with a site you already started.{{br/}}{{strong}}Free domain for the first year on annual plans.{{/strong}}'
+						)
+							? translate(
+									'Use the domain with a site you already started.{{br/}}{{strong}}Free domain for the first year on annual plans.{{/strong}}',
+									{
+										components: {
+											strong: <strong />,
+											br: <br />,
+										},
+									}
+							  )
+							: translate(
+									'Use with a site you already started.{{br/}}{{strong}}Free domain for the first year*{{/strong}}',
+									{
+										components: {
+											strong: <strong />,
+											br: <br />,
+										},
+									}
+							  ),
 					icon: null,
 					titleIcon: layout,
 					value: 'existing-site',


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/4199

## Proposed Changes

Update copy on "Choose how to use your domain" page using the actual copy as fallback
- `Don’t worry, you can easily add a site later` > `Don’t worry, you can easily change it later.`
- `Free domain for the first year*` > `Free domain for the first year on annual plans.`
- `Use with a site you already started.` > `Use the domain with a site you already started.`

<img width="763" alt="Screen Shot 2023-10-13 at 11 16 53 AM" src="https://github.com/Automattic/wp-calypso/assets/1689238/3708a525-e96f-4255-a3f0-dda67309706f">


## Testing Instructions

* Go to `/start/domain/domain-only`
* Select a domain (or domains)
* Check the new copy on "Choose how to use your domain" page
* Check other language fallback changing your interface language at `/me/account`
