### PR TITLE
Try/load different editr for atomic

### DIFF
--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -225,7 +225,7 @@ fun jetpackSimpleDeploymentE2eBuildType( targetDevice: String, buildUuid: String
 		uuid = buildUuid
 		name = "Jetpack Simple Deployment E2E Tests ($targetDevice)"
 		description = "Runs E2E tests validating the deployment of Jetpack on Simple sites on $targetDevice viewport"
-
+		
 		artifactRules = defaultE2eArtifactRules();
 
 		vcs {
@@ -281,13 +281,13 @@ fun jetpackSimpleDeploymentE2eBuildType( targetDevice: String, buildUuid: String
 
 fun jetpackAtomicDeploymentE2eBuildType( targetDevice: String, buildUuid: String ): BuildType {
 	val atomicVariations = listOf("default", "php-old", "php-new", "wp-beta", "wp-previous", "private", "ecomm-plan")
-
+	
 	return BuildType({
 		id("WPComTests_jetpack_atomic_deployment_e2e_$targetDevice")
 		uuid = buildUuid
 		name = "Jetpack Atomic Deployment E2E Tests ($targetDevice)"
 		description = "Runs E2E tests validating the deployment of Jetpack on Atomic sites on $targetDevice viewport"
-
+		
 		artifactRules = defaultE2eArtifactRules();
 
 		vcs {
@@ -301,7 +301,6 @@ fun jetpackAtomicDeploymentE2eBuildType( targetDevice: String, buildUuid: String
 			param("env.VIEWPORT_NAME", "$targetDevice")
 			param("env.JETPACK_TARGET", "wpcom-deployment")
 			param("env.TEST_ON_ATOMIC", "true")
-			param("JEST_E2E_WORKERS", "2")
 		}
 
 		steps {

--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -225,7 +225,7 @@ fun jetpackSimpleDeploymentE2eBuildType( targetDevice: String, buildUuid: String
 		uuid = buildUuid
 		name = "Jetpack Simple Deployment E2E Tests ($targetDevice)"
 		description = "Runs E2E tests validating the deployment of Jetpack on Simple sites on $targetDevice viewport"
-		
+
 		artifactRules = defaultE2eArtifactRules();
 
 		vcs {
@@ -281,13 +281,13 @@ fun jetpackSimpleDeploymentE2eBuildType( targetDevice: String, buildUuid: String
 
 fun jetpackAtomicDeploymentE2eBuildType( targetDevice: String, buildUuid: String ): BuildType {
 	val atomicVariations = listOf("default", "php-old", "php-new", "wp-beta", "wp-previous", "private", "ecomm-plan")
-	
+
 	return BuildType({
 		id("WPComTests_jetpack_atomic_deployment_e2e_$targetDevice")
 		uuid = buildUuid
 		name = "Jetpack Atomic Deployment E2E Tests ($targetDevice)"
 		description = "Runs E2E tests validating the deployment of Jetpack on Atomic sites on $targetDevice viewport"
-		
+
 		artifactRules = defaultE2eArtifactRules();
 
 		vcs {
@@ -301,6 +301,7 @@ fun jetpackAtomicDeploymentE2eBuildType( targetDevice: String, buildUuid: String
 			param("env.VIEWPORT_NAME", "$targetDevice")
 			param("env.JETPACK_TARGET", "wpcom-deployment")
 			param("env.TEST_ON_ATOMIC", "true")
+			param("JEST_E2E_WORKERS", "2")
 		}
 
 		steps {

--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -298,7 +298,10 @@ export class EditorToolbarComponent {
 
 		// To support i18n tests.
 		const translatedTargetName = await this.translateFromPage( target );
-		const button = editorParent.getByRole( 'button', { name: translatedTargetName, exact: true } );
+		const translatedEditorTopBarName = await this.translateFromPage( 'Editor top bar' );
+		const button = editorParent
+			.getByRole( 'region', { name: translatedEditorTopBarName } )
+			.getByRole( 'button', { name: translatedTargetName, exact: true } );
 
 		if ( await this.targetIsOpen( button ) ) {
 			return;

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -100,8 +100,10 @@ export class EditorPage {
 	/**
 	 * Opens the "new post/page" page. By default it will open the "new post" page.
 	 *
-	 * Example "new post": {@link https://wordpress.com/post}
-	 * Example "new page": {@link https://wordpress.com/page}
+	 * Example "calypsofy new post": {@link https://wordpress.com/post}
+	 * Example "calypsofy new page": {@link https://wordpress.com/page}
+	 * Example "calypsofy new page": {@link https://siteslug.wordpress.com/wp-admin/post-new.php?post_type=page}
+	 *
 	 */
 	async visit( type: 'post' | 'page' = 'post', { siteSlug = '' }: { siteSlug?: string } = {} ) {
 		if ( envVariables.TEST_ON_ATOMIC ) {
@@ -123,15 +125,12 @@ export class EditorPage {
 	 * Initialization steps to ensure the page is fully loaded.
 	 */
 	async waitUntilLoaded(): Promise< void > {
-		// In a typical loading scenario, this request is one of the last to fire.
-		// Lacking a perfect cross-site type (Simple/Atomic) way to check the loading state,
-		// it is a fairly good stand-in.
-		await Promise.all( [
-			this.page.waitForURL( /(post|page|post-new.php)/, { timeout: 60 * 1000 } ),
-		] );
+		// Wait for the editor ULR to load.
+		await this.page.waitForURL( /(post|page|post-new.php)/, { timeout: 60 * 1000 } );
 
-		const editorParent = await this.getEditorParent();
-		editorParent.waitFor( { timeout: 60 * 1000 } );
+		// Then wait for the editor parent to load.
+		const editorCanvas = await this.getEditorCanvas();
+		await editorCanvas.waitFor( { timeout: 60 * 1000 } );
 
 		// Dismiss the Welcome Tour.
 		await this.editorWelcomeTourComponent.forceDismissWelcomeTour();

--- a/test/e2e/specs/blocks/shared/block-smoke-testing.ts
+++ b/test/e2e/specs/blocks/shared/block-smoke-testing.ts
@@ -33,6 +33,7 @@ export function createBlockTests( specName: string, blockFlows: BlockFlow[] ): v
 		] );
 
 		let page: Page;
+		let testAccount: TestAccount;
 		let editorPage: EditorPage;
 		let editorContext: EditorContext;
 		let publishedPostContext: PublishedPostContext;
@@ -40,12 +41,14 @@ export function createBlockTests( specName: string, blockFlows: BlockFlow[] ): v
 		beforeAll( async () => {
 			page = await browser.newPage();
 			editorPage = new EditorPage( page );
-			const testAccount = new TestAccount( accountName );
+			testAccount = new TestAccount( accountName );
 			await testAccount.authenticate( page );
 		} );
 
 		it( 'Go to the new post page', async () => {
-			await editorPage.visit( 'post' );
+			await editorPage.visit( 'post', {
+				siteSlug: testAccount.getSiteURL( { protocol: false } ),
+			} );
 		} );
 
 		it( 'Enter post title', async () => {

--- a/test/e2e/specs/editor/editor__post-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__post-basic-flow.ts
@@ -32,6 +32,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	] );
 
 	let page: Page;
+	let testAccount: TestAccount;
 	let editorPage: EditorPage;
 	let publishedPostPage: PublishedPostPage;
 
@@ -39,12 +40,12 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		page = await browser.newPage();
 		editorPage = new EditorPage( page );
 
-		const testAccount = new TestAccount( accountName );
+		testAccount = new TestAccount( accountName );
 		await testAccount.authenticate( page );
 	} );
 
 	it( 'Go to the new post page', async function () {
-		await editorPage.visit( 'post' );
+		await editorPage.visit( 'post', { siteSlug: testAccount.getSiteURL( { protocol: false } ) } );
 	} );
 
 	describe( 'Blocks', function () {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
