### PR TITLE
Plugin Details: Update .org download section layout

### DIFF
--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -1,4 +1,4 @@
-import { Button, Card, Gridicon } from '@automattic/components';
+import { Button } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useBreakpoint } from '@automattic/viewport-react';
 import classnames from 'classnames';
@@ -439,17 +439,22 @@ function PluginDetails( props ) {
 						</div>
 
 						{ ! showPlaceholder && ! requestingPluginsForSites && isWporgPluginFetched && (
-							<Card className="plugin-details-download-card">
-								<Gridicon icon="cloud-download" size={ 48 } />
-								<p>{ downloadText }</p>
-								<Button
-									href={ `https://downloads.wordpress.org/plugin/${ fullPlugin?.slug || '' }.zip` }
-									rel="nofollow"
-								>
-									{ translate( 'Download' ) }
-								</Button>
+							<div className="plugin-details__plugin-download">
+								<div className="plugin-details__plugin-download-text">
+									<span>{ downloadText }</span>
+								</div>
+								<div className="plugin-details__plugin-download-cta">
+									<Button
+										href={ `https://downloads.wordpress.org/plugin/${
+											fullPlugin?.slug || ''
+										}.zip` }
+										rel="nofollow"
+									>
+										{ translate( 'Download' ) }
+									</Button>
+								</div>
 								<script type="application/ld+json">{ structuredData }</script>
-							</Card>
+							</div>
 						) }
 					</div>
 				</div>

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -159,6 +159,25 @@ $calypso-header-height: 31px;
 			@include grid-column( 3, 1 );
 		}
 	}
+
+	.plugin-details__plugin-download {
+		margin-top: 20px;
+		gap: 5px;
+		display: flex;
+		font-size: $font-body-extra-small;
+
+		@include breakpoint-deprecated( "<1280px" ) {
+			flex-direction: column;
+			gap: 10px;
+		}
+
+		.plugin-details__plugin-download-cta {
+			a {
+				font-size: $font-body-extra-small;
+				padding: 6px 14px;
+			}
+		}
+	}
 }
 
 .plugin-details__page {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/82114

## Proposed Changes

Update the layout of the Download section displayed for .org plugins.

![CleanShot 2023-10-13 at 09 59 44@2x](https://github.com/Automattic/wp-calypso/assets/5039531/fd065fcb-7c36-486b-bfcc-3d85e219ce85)

Layout suggested here: p1695306398983349-slack-C9EJ7KSGH


## Testing Instructions

* Go to a .org plugin page (`/plugins/:plugin_slug`). Ex: `/plugins/mailpoet`
* Check if the layout section matches the layout below
* Please also check the responsive version

| Currently in Prod  | PR desktop | PR mobile |
| ------------- | ------------- | ------------- |
|![CleanShot 2023-10-13 at 10 04 52@2x](https://github.com/Automattic/wp-calypso/assets/5039531/04c123ad-c622-4035-8336-316f3ad92088)|![CleanShot 2023-10-13 at 10 02 43@2x](https://github.com/Automattic/wp-calypso/assets/5039531/f0558a0a-f913-401b-ae7b-bfc1297a489e)|![CleanShot 2023-10-13 at 10 03 55@2x](https://github.com/Automattic/wp-calypso/assets/5039531/e1c62e12-6299-466b-919d-8d67bfa2ebda)|



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
