### PR TITLE
Storage Add-ons: Expose add-on upsells to plans page

### DIFF
--- a/client/my-sites/add-ons/hooks/use-add-on-checkout-link.ts
+++ b/client/my-sites/add-ons/hooks/use-add-on-checkout-link.ts
@@ -1,3 +1,4 @@
+import { useCallback } from '@wordpress/element';
 import { useSelector } from 'react-redux';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
@@ -10,20 +11,23 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 const useAddOnCheckoutLink = (): ( ( addOnSlug: string, quantity?: number ) => string ) => {
 	const selectedSite = useSelector( getSelectedSite );
+	const checkoutLinkCallback = useCallback(
+		( addOnSlug: string, quantity?: number ): string => {
+			// If no site is provided, return the checkout link with the add-on (will render site-selector).
+			if ( ! selectedSite ) {
+				return `/checkout/${ addOnSlug }`;
+			}
 
-	return ( addOnSlug: string, quantity?: number ): string => {
-		// If no site is provided, return the checkout link with the add-on (will render site-selector).
-		if ( ! selectedSite ) {
-			return `/checkout/${ addOnSlug }`;
-		}
+			const checkoutLinkFormat = `/checkout/${ selectedSite?.slug }/${ addOnSlug }`;
 
-		const checkoutLinkFormat = `/checkout/${ selectedSite?.slug }/${ addOnSlug }`;
-
-		if ( quantity ) {
-			return checkoutLinkFormat + `:-q-${ quantity }`;
-		}
-		return checkoutLinkFormat;
-	};
+			if ( quantity ) {
+				return checkoutLinkFormat + `:-q-${ quantity }`;
+			}
+			return checkoutLinkFormat;
+		},
+		[ selectedSite ]
+	);
+	return checkoutLinkCallback;
 };
 
 export default useAddOnCheckoutLink;

--- a/client/my-sites/add-ons/hooks/use-add-ons.ts
+++ b/client/my-sites/add-ons/hooks/use-add-ons.ts
@@ -32,6 +32,7 @@ import jetpackStatsIcon from '../icons/jetpack-stats';
 import spaceUpgradeIcon from '../icons/space-upgrade';
 import unlimitedThemesIcon from '../icons/unlimited-themes';
 import isStorageAddonEnabled from '../is-storage-addon-enabled';
+import useAddOnCheckoutLink from './use-add-on-checkout-link';
 import useAddOnDisplayCost from './use-add-on-display-cost';
 import useAddOnFeatureSlugs from './use-add-on-feature-slugs';
 import useAddOnPrices from './use-add-on-prices';
@@ -44,7 +45,7 @@ const useSpaceUpgradesPurchased = ( {
 	isInSignup: boolean;
 	siteId?: number;
 } ) => {
-	const { billingTransactions } = usePastBillingTransactions( isInSignup );
+	const { billingTransactions, isLoading } = usePastBillingTransactions( isInSignup );
 	const filter = useSelector( ( state ) => getBillingTransactionFilters( state, 'past' ) );
 
 	return useMemo( () => {
@@ -64,12 +65,13 @@ const useSpaceUpgradesPurchased = ( {
 			}
 		}
 
-		return spaceUpgradesPurchased;
-	}, [ billingTransactions, filter, isInSignup, siteId ] );
+		return { isLoading, spaceUpgradesPurchased };
+	}, [ billingTransactions, filter, isInSignup, siteId, isLoading ] );
 };
 
 const useActiveAddOnsDefs = () => {
 	const translate = useTranslate();
+	const checkoutLink = useAddOnCheckoutLink();
 
 	/*
 	 * TODO: `useAddOnFeatureSlugs` be refactored instead to return an index of `{ [ slug ]: featureSlug[] }`
@@ -142,6 +144,7 @@ const useActiveAddOnsDefs = () => {
 				),
 				featured: false,
 				purchased: false,
+				checkoutLink: checkoutLink( PRODUCT_1GB_SPACE, 50 ),
 			},
 			{
 				productSlug: PRODUCT_1GB_SPACE,
@@ -156,6 +159,7 @@ const useActiveAddOnsDefs = () => {
 				),
 				featured: false,
 				purchased: false,
+				checkoutLink: checkoutLink( PRODUCT_1GB_SPACE, 100 ),
 			},
 			{
 				productSlug: PRODUCT_JETPACK_STATS_PWYW_YEARLY,
@@ -218,12 +222,6 @@ const getAddOnsTransformed = createSelector(
 
 		return activeAddOns
 			.filter( ( addOn: any ) => {
-				// if a user already has purchased a storage upgrade
-				// remove all upgrades smaller than the smallest purchased upgrade (we only allow purchasing upgrades in ascending order)
-				if ( spaceUpgradesPurchased.length && addOn.productSlug === PRODUCT_1GB_SPACE ) {
-					return ( addOn.quantity ?? 0 ) >= Math.min( ...spaceUpgradesPurchased );
-				}
-
 				// remove the Jetpack AI add-on if the site already supports the feature
 				if (
 					addOn.productSlug === PRODUCT_JETPACK_AI_MONTHLY &&
@@ -315,7 +313,12 @@ const getAddOnsTransformed = createSelector(
 
 					// if the current storage add on option is greater than the available upgrade, remove it
 					if ( ( addOn.quantity ?? 0 ) > availableStorageUpgrade ) {
-						return null;
+						return {
+							...addOn,
+							name,
+							description,
+							exceedsSiteStorageLimits: true,
+						};
 					}
 				}
 
@@ -355,8 +358,7 @@ const useAddOns = ( siteId?: number, isInSignup = false ): ( AddOnMeta | null )[
 	// if upgrade is bought - show as manage
 	// if upgrade is not bought - only show it if available storage and if it's larger than previously bought upgrade
 	const { data: mediaStorage } = useMediaStorageQuery( siteId );
-	const { isLoading } = usePastBillingTransactions( isInSignup );
-	const spaceUpgradesPurchased = useSpaceUpgradesPurchased( { isInSignup, siteId } );
+	const { isLoading, spaceUpgradesPurchased } = useSpaceUpgradesPurchased( { isInSignup, siteId } );
 	const activeAddOns = useActiveAddOnsDefs();
 
 	return useSelector( ( state ): ( AddOnMeta | null )[] => {

--- a/client/my-sites/add-ons/hooks/use-add-ons.ts
+++ b/client/my-sites/add-ons/hooks/use-add-ons.ts
@@ -311,7 +311,7 @@ const getAddOnsTransformed = createSelector(
 					const currentMaxStorage = mediaStorage?.max_storage_bytes / Math.pow( 1024, 3 );
 					const availableStorageUpgrade = STORAGE_LIMIT - currentMaxStorage;
 
-					// if the current storage add on option is greater than the available upgrade, remove it
+					// if the current storage add on option is greater than the available upgrade
 					if ( ( addOn.quantity ?? 0 ) > availableStorageUpgrade ) {
 						return {
 							...addOn,

--- a/client/my-sites/add-ons/main.tsx
+++ b/client/my-sites/add-ons/main.tsx
@@ -98,6 +98,8 @@ const AddOnsMain: React.FunctionComponent< Props > = () => {
 	const translate = useTranslate();
 	const selectedSite = useSelector( getSelectedSite );
 	const addOns = useAddOns( selectedSite?.ID );
+	const filteredAddOns = addOns.filter( ( addOn ) => ! addOn?.exceedsSiteStorageLimits );
+
 	const checkoutLink = useAddOnCheckoutLink();
 
 	const canManageSite = useSelector( ( state ) => {
@@ -131,7 +133,7 @@ const AddOnsMain: React.FunctionComponent< Props > = () => {
 					actionPrimary={ { text: translate( 'Buy add-on' ), handler: handleActionPrimary } }
 					actionSecondary={ { text: translate( 'Manage add-on' ), handler: handleActionSelected } }
 					useAddOnAvailabilityStatus={ useAddOnPurchaseStatus }
-					addOns={ addOns }
+					addOns={ filteredAddOns }
 					highlightFeatured={ true }
 				/>
 			</ContentWithHeader>

--- a/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
+++ b/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
@@ -80,9 +80,12 @@ const usePricingMetaForGridPlans: UsePricingMetaForGridPlans = ( {
 						? isPlanAvailableForPurchase( state, selectedSiteId, planSlug )
 						: false );
 				const selectedStorageOption = selectedStorageOptions?.[ planSlug ];
-				const storageAddOnPrices = storageAddOns?.find( ( addOn ) => {
-					return addOn?.featureSlugs?.includes( selectedStorageOption || '' );
-				} )?.prices;
+				const selectedStorageAddOn = storageAddOns?.find( ( addOn ) => {
+					return selectedStorageOption && addOn?.featureSlugs?.includes( selectedStorageOption );
+				} );
+				const storageAddOnPrices = selectedStorageAddOn?.purchased
+					? null
+					: selectedStorageAddOn?.prices;
 				const storageAddOnPriceMonthly = storageAddOnPrices?.monthlyPrice || 0;
 				const storageAddOnPriceYearly = storageAddOnPrices?.yearlyPrice || 0;
 

--- a/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
+++ b/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
@@ -83,9 +83,10 @@ const usePricingMetaForGridPlans: UsePricingMetaForGridPlans = ( {
 				const selectedStorageAddOn = storageAddOns?.find( ( addOn ) => {
 					return selectedStorageOption && addOn?.featureSlugs?.includes( selectedStorageOption );
 				} );
-				const storageAddOnPrices = selectedStorageAddOn?.purchased
-					? null
-					: selectedStorageAddOn?.prices;
+				const storageAddOnPrices =
+					selectedStorageAddOn?.purchased || selectedStorageAddOn?.exceedsSiteStorageLimits
+						? null
+						: selectedStorageAddOn?.prices;
 				const storageAddOnPriceMonthly = storageAddOnPrices?.monthlyPrice || 0;
 				const storageAddOnPriceYearly = storageAddOnPrices?.yearlyPrice || 0;
 

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -339,7 +339,6 @@ const PlansFeaturesMain = ( {
 			const cartItemForStorageAddOn = cartItems?.find(
 				( items ) => items.product_slug === PRODUCT_1GB_SPACE
 			);
-
 			if ( cartItemForStorageAddOn?.extra ) {
 				recordTracksEvent( 'calypso_signup_storage_add_on_upgrade_click', {
 					add_on_slug: cartItemForStorageAddOn.extra.feature_slug,

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -338,6 +338,7 @@ const PlansFeaturesMain = ( {
 			const cartItemForStorageAddOn = cartItems?.find(
 				( items ) => items.product_slug === PRODUCT_1GB_SPACE
 			);
+
 			if ( cartItemForStorageAddOn?.extra ) {
 				recordTracksEvent( 'calypso_signup_storage_add_on_upgrade_click', {
 					add_on_slug: cartItemForStorageAddOn.extra.feature_slug,
@@ -352,9 +353,14 @@ const PlansFeaturesMain = ( {
 			const planPath = cartItemForPlan?.product_slug
 				? getPlanPath( cartItemForPlan.product_slug )
 				: '';
+
+			const checkoutUrl = cartItemForStorageAddOn
+				? `/checkout/${ siteSlug }/${ planPath },${ cartItemForStorageAddOn.product_slug }:-q-${ cartItemForStorageAddOn.quantity }`
+				: `/checkout/${ siteSlug }/${ planPath }`;
+
 			const checkoutUrlWithArgs = addQueryArgs(
 				{ ...( withDiscount && { coupon: withDiscount } ) },
-				`/checkout/${ siteSlug }/${ planPath }`
+				checkoutUrl
 			);
 
 			page( checkoutUrlWithArgs );

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -34,6 +34,7 @@ import page from 'page';
 import { useSelector } from 'react-redux';
 import QueryActivePromotions from 'calypso/components/data/query-active-promotions';
 import QueryPlans from 'calypso/components/data/query-plans';
+import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import QuerySites from 'calypso/components/data/query-sites';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -657,6 +658,7 @@ const PlansFeaturesMain = ( {
 			<QuerySites siteId={ siteId } />
 			<QuerySitePlans siteId={ siteId } />
 			<QueryActivePromotions />
+			<QueryProductsList />
 			<PlanUpsellModal
 				isModalOpen={ isModalOpen }
 				paidDomainName={ paidDomainName }

--- a/client/my-sites/plans-features-main/test/index.jsx
+++ b/client/my-sites/plans-features-main/test/index.jsx
@@ -27,6 +27,7 @@ jest.mock( 'calypso/state/selectors/is-eligible-for-wpcom-monthly-plan', () => j
 jest.mock( 'calypso/state/selectors/can-upgrade-to-plan', () => jest.fn() );
 jest.mock( 'calypso/state/ui/selectors', () => ( {
 	getSelectedSiteId: jest.fn(),
+	getSelectedSite: jest.fn(),
 } ) );
 jest.mock(
 	'calypso/my-sites/plans-grid/hooks/npm-ready/data-store/use-plan-features-for-grid-plans',
@@ -44,6 +45,7 @@ jest.mock( 'calypso/my-sites/plans-features-main/hooks/data-store/use-priced-api
 	jest.fn()
 );
 jest.mock( 'calypso/components/data/query-active-promotions', () => jest.fn() );
+jest.mock( 'calypso/components/data/query-products-list', () => jest.fn() );
 
 import {
 	PLAN_FREE,

--- a/client/my-sites/plans-grid/components/actions.tsx
+++ b/client/my-sites/plans-grid/components/actions.tsx
@@ -51,7 +51,7 @@ type PlanFeaturesActionsButtonProps = {
 	siteId?: number | null;
 	isStuck: boolean;
 	isLargeCurrency?: boolean;
-	storageOptions: StorageOption[];
+	storageOptions?: StorageOption[];
 };
 
 const DummyDisabledButton = styled.div`
@@ -231,13 +231,13 @@ const LoggedInPlansFeatureActionButton = ( {
 	isLargeCurrency: boolean;
 	planTitle: TranslateResult;
 	handleUpgradeButtonClick: () => void;
-	planSlug: string;
+	planSlug: PlanSlug;
 	currentPlanManageHref?: string;
 	canUserManageCurrentPlan?: boolean | null;
 	currentSitePlanSlug?: string | null;
 	buttonText?: string;
 	planActionOverrides?: PlanActionOverrides;
-	storageOptions: StorageOption[];
+	storageOptions?: StorageOption[];
 } ) => {
 	const [ activeTooltipId, setActiveTooltipId ] = useManageTooltipToggle();
 	const translate = useTranslate();
@@ -247,10 +247,17 @@ const LoggedInPlansFeatureActionButton = ( {
 		[ planSlug ]
 	);
 	const { current, storageAddOnsForPlan } = gridPlansIndex[ planSlug ];
-	const defaultStorageOption = useDefaultStorageOption( { storageOptions, storageAddOnsForPlan } );
+	const defaultStorageOption = useDefaultStorageOption( {
+		storageOptions,
+		storageAddOnsForPlan,
+	} );
 	const canPurchaseStorageAddOns = storageAddOnsForPlan?.some(
-		( storageAddOn ) => ! storageAddOn?.purchased
+		( storageAddOn ) => ! storageAddOn?.purchased && ! storageAddOn?.exceedsSiteStorageLimits
 	);
+	const storageAddOnCheckoutHref = storageAddOnsForPlan?.find(
+		( addOn ) =>
+			selectedStorageOptionForPlan && addOn?.featureSlugs?.includes( selectedStorageOptionForPlan )
+	)?.checkoutLink;
 	const nonDefaultStorageOptionSelected = defaultStorageOption !== selectedStorageOptionForPlan;
 	const currentPlanBillPeriod = useSelector( ( state ) => {
 		return currentSitePlanSlug ? getPlanBillPeriod( state, currentSitePlanSlug ) : null;
@@ -287,8 +294,7 @@ const LoggedInPlansFeatureActionButton = ( {
 			return (
 				<Button
 					className={ classNames( classes, 'is-storage-upgradeable' ) }
-					href={ currentPlanManageHref }
-					disabled={ ! currentPlanManageHref }
+					href={ storageAddOnCheckoutHref }
 				>
 					{ translate( 'Upgrade' ) }
 				</Button>

--- a/client/my-sites/plans-grid/components/actions.tsx
+++ b/client/my-sites/plans-grid/components/actions.tsx
@@ -40,6 +40,7 @@ type PlanFeaturesActionsButtonProps = {
 	isPopular?: boolean;
 	isInSignup?: boolean;
 	isLaunchPage?: boolean | null;
+	isMonthlyPlan?: boolean;
 	onUpgradeClick: ( overridePlanSlug?: PlanSlug ) => void;
 	planSlug: PlanSlug;
 	flowName?: string | null;
@@ -213,6 +214,7 @@ const LoggedInPlansFeatureActionButton = ( {
 	priceString,
 	isStuck,
 	isLargeCurrency,
+	isMonthlyPlan,
 	planTitle,
 	handleUpgradeButtonClick,
 	planSlug,
@@ -229,6 +231,7 @@ const LoggedInPlansFeatureActionButton = ( {
 	priceString: string | null;
 	isStuck: boolean;
 	isLargeCurrency: boolean;
+	isMonthlyPlan?: boolean;
 	planTitle: TranslateResult;
 	handleUpgradeButtonClick: () => void;
 	planSlug: PlanSlug;
@@ -290,7 +293,7 @@ const LoggedInPlansFeatureActionButton = ( {
 	}
 
 	if ( current && planSlug !== PLAN_P2_FREE ) {
-		if ( canPurchaseStorageAddOns && nonDefaultStorageOptionSelected ) {
+		if ( canPurchaseStorageAddOns && nonDefaultStorageOptionSelected && ! isMonthlyPlan ) {
 			return (
 				<Button
 					className={ classNames( classes, 'is-storage-upgradeable' ) }
@@ -441,6 +444,7 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 	planActionOverrides,
 	isStuck,
 	isLargeCurrency,
+	isMonthlyPlan,
 	storageOptions,
 } ) => {
 	const translate = useTranslate();
@@ -557,6 +561,7 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 			priceString={ priceString }
 			isStuck={ isStuck }
 			isLargeCurrency={ !! isLargeCurrency }
+			isMonthlyPlan={ isMonthlyPlan }
 			planTitle={ planTitle }
 			storageOptions={ storageOptions }
 		/>

--- a/client/my-sites/plans-grid/components/actions.tsx
+++ b/client/my-sites/plans-grid/components/actions.tsx
@@ -9,8 +9,8 @@ import {
 	TERM_ANNUALLY,
 	type PlanSlug,
 	PLAN_HOSTING_TRIAL_MONTHLY,
+	type StorageOption,
 } from '@automattic/calypso-products';
-import { StorageOption } from '@automattic/calypso-products/src';
 import { Button, Gridicon } from '@automattic/components';
 import { WpcomPlansUI } from '@automattic/data-stores';
 import { formatCurrency } from '@automattic/format-currency';

--- a/client/my-sites/plans-grid/components/actions.tsx
+++ b/client/my-sites/plans-grid/components/actions.tsx
@@ -283,12 +283,16 @@ const LoggedInPlansFeatureActionButton = ( {
 	}
 
 	if ( current && planSlug !== PLAN_P2_FREE ) {
-		let buttonText = translate( 'View plan' );
-
 		if ( canPurchaseStorageAddOns && nonDefaultStorageOptionSelected ) {
-			buttonText = translate( 'Upgrade' );
-		} else if ( canUserManageCurrentPlan ) {
-			buttonText = translate( 'Manage plan' );
+			return (
+				<Button
+					className={ classNames( classes, 'is-storage-upgradeable' ) }
+					href={ currentPlanManageHref }
+					disabled={ ! currentPlanManageHref }
+				>
+					{ translate( 'Upgrade' ) }
+				</Button>
+			);
 		}
 
 		return (
@@ -297,7 +301,7 @@ const LoggedInPlansFeatureActionButton = ( {
 				href={ currentPlanManageHref }
 				disabled={ ! currentPlanManageHref }
 			>
-				{ buttonText }
+				{ canUserManageCurrentPlan ? translate( 'Manage plan' ) : translate( 'View plan' ) }
 			</Button>
 		);
 	}

--- a/client/my-sites/plans-grid/components/actions.tsx
+++ b/client/my-sites/plans-grid/components/actions.tsx
@@ -341,10 +341,16 @@ const LoggedInPlansFeatureActionButton = ( {
 			comment: '%(priceString)s is the full price including the currency. Eg: Get Upgrade - $10',
 		} );
 	} else if ( isStuck && isLargeCurrency ) {
-		buttonTextFallback = translate( 'Upgrade – %(plan)s', {
-			context: 'verb',
-			args: { plan: planTitle ?? '' },
-			comment: '%(plan)s is the name of the plan ',
+		buttonTextFallback = translate( 'Get %(plan)s {{span}}%(priceString)s{{/span}}', {
+			args: {
+				plan: planTitle,
+				priceString: priceString ?? '',
+			},
+			comment:
+				'%(plan)s is the name of the plan and %(priceString)s is the full price including the currency. Eg: Get Premium - $10',
+			components: {
+				span: <span className="plan-features-2023-grid__actions-signup-plan-text" />,
+			},
 		} );
 	} else {
 		buttonTextFallback = translate( 'Upgrade', { context: 'verb' } );

--- a/client/my-sites/plans-grid/components/actions.tsx
+++ b/client/my-sites/plans-grid/components/actions.tsx
@@ -10,10 +10,13 @@ import {
 	type PlanSlug,
 	PLAN_HOSTING_TRIAL_MONTHLY,
 } from '@automattic/calypso-products';
+import { StorageOption } from '@automattic/calypso-products/src';
 import { Button, Gridicon } from '@automattic/components';
+import { WpcomPlansUI } from '@automattic/data-stores';
 import { formatCurrency } from '@automattic/format-currency';
 import { isMobile } from '@automattic/viewport';
 import styled from '@emotion/styled';
+import { useSelect } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 import classNames from 'classnames';
 import { localize, TranslateResult, useTranslate } from 'i18n-calypso';
@@ -23,6 +26,7 @@ import { useManageTooltipToggle } from 'calypso/my-sites/plans-grid/hooks/use-ma
 import { useSelector } from 'calypso/state';
 import { getPlanBillPeriod } from 'calypso/state/plans/selectors';
 import { usePlansGridContext } from '../grid-context';
+import useDefaultStorageOption from '../hooks/npm-ready/data-store/use-default-storage-option';
 import { Plans2023Tooltip } from './plans-2023-tooltip';
 import type { PlanActionOverrides } from '../types';
 
@@ -47,6 +51,7 @@ type PlanFeaturesActionsButtonProps = {
 	siteId?: number | null;
 	isStuck: boolean;
 	isLargeCurrency?: boolean;
+	storageOptions: StorageOption[];
 };
 
 const DummyDisabledButton = styled.div`
@@ -216,6 +221,7 @@ const LoggedInPlansFeatureActionButton = ( {
 	currentSitePlanSlug,
 	buttonText,
 	planActionOverrides,
+	storageOptions,
 }: {
 	freePlan: boolean;
 	availableForPurchase?: boolean;
@@ -231,11 +237,21 @@ const LoggedInPlansFeatureActionButton = ( {
 	currentSitePlanSlug?: string | null;
 	buttonText?: string;
 	planActionOverrides?: PlanActionOverrides;
+	storageOptions: StorageOption[];
 } ) => {
 	const [ activeTooltipId, setActiveTooltipId ] = useManageTooltipToggle();
 	const translate = useTranslate();
 	const { gridPlansIndex } = usePlansGridContext();
-	const { current } = gridPlansIndex[ planSlug ];
+	const selectedStorageOptionForPlan = useSelect(
+		( select ) => select( WpcomPlansUI.store ).getSelectedStorageOptionForPlan( planSlug ),
+		[ planSlug ]
+	);
+	const { current, storageAddOnsForPlan } = gridPlansIndex[ planSlug ];
+	const defaultStorageOption = useDefaultStorageOption( { storageOptions, storageAddOnsForPlan } );
+	const canPurchaseStorageAddOns = storageAddOnsForPlan?.some(
+		( storageAddOn ) => ! storageAddOn?.purchased
+	);
+	const nonDefaultStorageOptionSelected = defaultStorageOption !== selectedStorageOptionForPlan;
 	const currentPlanBillPeriod = useSelector( ( state ) => {
 		return currentSitePlanSlug ? getPlanBillPeriod( state, currentSitePlanSlug ) : null;
 	} );
@@ -243,7 +259,10 @@ const LoggedInPlansFeatureActionButton = ( {
 		return planSlug ? getPlanBillPeriod( state, planSlug ) : null;
 	} );
 
-	if ( freePlan ) {
+	if (
+		freePlan ||
+		( storageAddOnsForPlan && ! canPurchaseStorageAddOns && nonDefaultStorageOptionSelected )
+	) {
 		if ( planActionOverrides?.loggedInFreePlan ) {
 			return (
 				<Button
@@ -264,13 +283,21 @@ const LoggedInPlansFeatureActionButton = ( {
 	}
 
 	if ( current && planSlug !== PLAN_P2_FREE ) {
+		let buttonText = translate( 'View plan' );
+
+		if ( canPurchaseStorageAddOns && nonDefaultStorageOptionSelected ) {
+			buttonText = translate( 'Upgrade' );
+		} else if ( canUserManageCurrentPlan ) {
+			buttonText = translate( 'Manage plan' );
+		}
+
 		return (
 			<Button
 				className={ classes }
 				href={ currentPlanManageHref }
 				disabled={ ! currentPlanManageHref }
 			>
-				{ canUserManageCurrentPlan ? translate( 'Manage plan' ) : translate( 'View plan' ) }
+				{ buttonText }
 			</Button>
 		);
 	}
@@ -404,6 +431,7 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 	planActionOverrides,
 	isStuck,
 	isLargeCurrency,
+	storageOptions,
 } ) => {
 	const translate = useTranslate();
 	const { gridPlansIndex } = usePlansGridContext();
@@ -520,6 +548,7 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 			isStuck={ isStuck }
 			isLargeCurrency={ !! isLargeCurrency }
 			planTitle={ planTitle }
+			storageOptions={ storageOptions }
 		/>
 	);
 };

--- a/client/my-sites/plans-grid/components/features-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/features-grid/index.tsx
@@ -520,10 +520,10 @@ class FeaturesGrid extends Component< FeaturesGridType > {
 
 			const shouldRenderStorageTitle =
 				storageOptions.length > 0 &&
-				( storageOptions.length === 1 || intervalType !== 'yearly' || ! showUpgradeableStorage );
-			// TODO: Revisit what conditions are necessary to continue hiding in stepper flows
-			// ! isInSignup ||
-			// ! ( flowName === 'onboarding' ) );
+				( storageOptions.length === 1 ||
+					intervalType !== 'yearly' ||
+					! showUpgradeableStorage ||
+					( isInSignup && ! ( flowName === 'onboarding' ) ) );
 
 			const canUpgradeStorageForPlan = isStorageUpgradeableForPlan( {
 				flowName: flowName ?? '',

--- a/client/my-sites/plans-grid/components/features-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/features-grid/index.tsx
@@ -516,11 +516,10 @@ class FeaturesGrid extends Component< FeaturesGridType > {
 
 			const shouldRenderStorageTitle =
 				storageOptions.length > 0 &&
-				( storageOptions.length === 1 ||
-					intervalType !== 'yearly' ||
-					! showUpgradeableStorage ||
-					! isInSignup ||
-					! ( flowName === 'onboarding' ) );
+				( storageOptions.length === 1 || intervalType !== 'yearly' || ! showUpgradeableStorage );
+			// TODO: Revisit what conditions are necessary to continue hiding in stepper flows
+			// ! isInSignup ||
+			// ! ( flowName === 'onboarding' ) );
 
 			const canUpgradeStorageForPlan = isStorageUpgradeableForPlan( {
 				flowName: flowName ?? '',

--- a/client/my-sites/plans-grid/components/features-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/features-grid/index.tsx
@@ -147,6 +147,7 @@ class FeaturesGrid extends Component< FeaturesGridType > {
 					{ this.renderPlanTagline( [ gridPlanForSpotlight ] ) }
 					{ this.renderPlanPrice( [ gridPlanForSpotlight ] ) }
 					{ this.renderBillingTimeframe( [ gridPlanForSpotlight ] ) }
+					{ this.renderPlanStorageOptions( [ gridPlanForSpotlight ] ) }
 					{ this.renderTopButtons( [ gridPlanForSpotlight ] ) }
 				</div>
 			</div>

--- a/client/my-sites/plans-grid/components/features-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/features-grid/index.tsx
@@ -365,56 +365,59 @@ class FeaturesGrid extends Component< FeaturesGridType > {
 			handleUpgradeClick,
 		} = this.props;
 
-		return renderedGridPlans.map( ( { planSlug, availableForPurchase } ) => {
-			const classes = classNames( 'plan-features-2023-grid__table-item', 'is-top-buttons' );
+		return renderedGridPlans.map(
+			( { planSlug, availableForPurchase, features: { storageOptions } } ) => {
+				const classes = classNames( 'plan-features-2023-grid__table-item', 'is-top-buttons' );
 
-			// Leaving it `undefined` makes it use the default label
-			let buttonText;
+				// Leaving it `undefined` makes it use the default label
+				let buttonText;
 
-			if (
-				isWooExpressMediumPlan( planSlug ) &&
-				! isWooExpressMediumPlan( currentSitePlanSlug || '' )
-			) {
-				buttonText = translate( 'Get Performance', { textOnly: true } );
-			} else if (
-				isWooExpressSmallPlan( planSlug ) &&
-				! isWooExpressSmallPlan( currentSitePlanSlug || '' )
-			) {
-				buttonText = translate( 'Get Essential', { textOnly: true } );
+				if (
+					isWooExpressMediumPlan( planSlug ) &&
+					! isWooExpressMediumPlan( currentSitePlanSlug || '' )
+				) {
+					buttonText = translate( 'Get Performance', { textOnly: true } );
+				} else if (
+					isWooExpressSmallPlan( planSlug ) &&
+					! isWooExpressSmallPlan( currentSitePlanSlug || '' )
+				) {
+					buttonText = translate( 'Get Essential', { textOnly: true } );
+				}
+
+				return (
+					<PlanDivOrTdContainer
+						key={ planSlug }
+						className={ classes }
+						isTableCell={ options?.isTableCell }
+					>
+						<PlanFeatures2023GridActions
+							currentPlanManageHref={ currentPlanManageHref }
+							canUserManageCurrentPlan={ canUserManageCurrentPlan }
+							availableForPurchase={ availableForPurchase }
+							className={ getPlanClass( planSlug ) }
+							freePlan={ isFreePlan( planSlug ) }
+							isWpcomEnterpriseGridPlan={ isWpcomEnterpriseGridPlan( planSlug ) }
+							isWooExpressPlusPlan={ isWooExpressPlusPlan( planSlug ) }
+							isInSignup={ isInSignup }
+							isLaunchPage={ isLaunchPage }
+							onUpgradeClick={ ( overridePlanSlug ) =>
+								handleUpgradeClick( overridePlanSlug ?? planSlug )
+							}
+							planSlug={ planSlug }
+							flowName={ flowName }
+							currentSitePlanSlug={ currentSitePlanSlug }
+							buttonText={ buttonText }
+							planActionOverrides={ planActionOverrides }
+							showMonthlyPrice={ true }
+							siteId={ siteId }
+							isStuck={ options?.isStuck || false }
+							isLargeCurrency={ isLargeCurrency }
+							storageOptions={ storageOptions }
+						/>
+					</PlanDivOrTdContainer>
+				);
 			}
-
-			return (
-				<PlanDivOrTdContainer
-					key={ planSlug }
-					className={ classes }
-					isTableCell={ options?.isTableCell }
-				>
-					<PlanFeatures2023GridActions
-						currentPlanManageHref={ currentPlanManageHref }
-						canUserManageCurrentPlan={ canUserManageCurrentPlan }
-						availableForPurchase={ availableForPurchase }
-						className={ getPlanClass( planSlug ) }
-						freePlan={ isFreePlan( planSlug ) }
-						isWpcomEnterpriseGridPlan={ isWpcomEnterpriseGridPlan( planSlug ) }
-						isWooExpressPlusPlan={ isWooExpressPlusPlan( planSlug ) }
-						isInSignup={ isInSignup }
-						isLaunchPage={ isLaunchPage }
-						onUpgradeClick={ ( overridePlanSlug ) =>
-							handleUpgradeClick( overridePlanSlug ?? planSlug )
-						}
-						planSlug={ planSlug }
-						flowName={ flowName }
-						currentSitePlanSlug={ currentSitePlanSlug }
-						buttonText={ buttonText }
-						planActionOverrides={ planActionOverrides }
-						showMonthlyPrice={ true }
-						siteId={ siteId }
-						isStuck={ options?.isStuck || false }
-						isLargeCurrency={ isLargeCurrency }
-					/>
-				</PlanDivOrTdContainer>
-			);
-		} );
+		);
 	}
 
 	renderEnterpriseClientLogos() {

--- a/client/my-sites/plans-grid/components/features-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/features-grid/index.tsx
@@ -366,7 +366,7 @@ class FeaturesGrid extends Component< FeaturesGridType > {
 		} = this.props;
 
 		return renderedGridPlans.map(
-			( { planSlug, availableForPurchase, features: { storageOptions } } ) => {
+			( { planSlug, availableForPurchase, isMonthlyPlan, features: { storageOptions } } ) => {
 				const classes = classNames( 'plan-features-2023-grid__table-item', 'is-top-buttons' );
 
 				// Leaving it `undefined` makes it use the default label
@@ -400,6 +400,7 @@ class FeaturesGrid extends Component< FeaturesGridType > {
 							isWooExpressPlusPlan={ isWooExpressPlusPlan( planSlug ) }
 							isInSignup={ isInSignup }
 							isLaunchPage={ isLaunchPage }
+							isMonthlyPlan={ isMonthlyPlan }
 							onUpgradeClick={ ( overridePlanSlug ) =>
 								handleUpgradeClick( overridePlanSlug ?? planSlug )
 							}

--- a/client/my-sites/plans-grid/components/storage-add-on-dropdown.tsx
+++ b/client/my-sites/plans-grid/components/storage-add-on-dropdown.tsx
@@ -29,13 +29,9 @@ const getStorageOptionPrice = (
 	storageAddOnsForPlan: ( AddOnMeta | null )[] | null,
 	storageOptionSlug: string
 ) => {
-	const matchedStorageAddOn = storageAddOnsForPlan?.find(
+	return storageAddOnsForPlan?.find(
 		( addOn ) => addOn?.featureSlugs?.includes( storageOptionSlug )
-	);
-
-	return matchedStorageAddOn?.purchased
-		? undefined
-		: matchedStorageAddOn?.prices?.formattedMonthlyPrice;
+	)?.prices?.formattedMonthlyPrice;
 };
 
 const StorageAddOnOption = ( {
@@ -96,10 +92,14 @@ export const StorageAddOnDropdown = ( {
 		( select ) => select( WpcomPlansUI.store ).getSelectedStorageOptionForPlan( planSlug ),
 		[ planSlug ]
 	);
-	const defaultStorageOption = useDefaultStorageOption( { storageOptions, storageAddOnsForPlan } );
+	const defaultStorageOption = useDefaultStorageOption( {
+		storageOptions,
+		storageAddOnsForPlan,
+	} );
 
 	useEffect( () => {
-		setSelectedStorageOptionForPlan( { addOnSlug: defaultStorageOption, planSlug } );
+		defaultStorageOption &&
+			setSelectedStorageOptionForPlan( { addOnSlug: defaultStorageOption, planSlug } );
 	}, [] );
 
 	const selectControlOptions = storageOptions.map( ( storageOption ) => {

--- a/client/my-sites/plans-grid/components/storage-add-on-dropdown.tsx
+++ b/client/my-sites/plans-grid/components/storage-add-on-dropdown.tsx
@@ -98,8 +98,9 @@ export const StorageAddOnDropdown = ( {
 	} );
 
 	useEffect( () => {
-		defaultStorageOption &&
+		if ( storageAddOnsForPlan && defaultStorageOption && ! selectedStorageOptionForPlan ) {
 			setSelectedStorageOptionForPlan( { addOnSlug: defaultStorageOption, planSlug } );
+		}
 	}, [] );
 
 	const selectControlOptions = storageOptions.map( ( storageOption ) => {

--- a/client/my-sites/plans-grid/components/storage-add-on-dropdown.tsx
+++ b/client/my-sites/plans-grid/components/storage-add-on-dropdown.tsx
@@ -1,9 +1,10 @@
 import { WpcomPlansUI } from '@automattic/data-stores';
 import { CustomSelectControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useCallback, useMemo } from '@wordpress/element';
+import { useCallback, useEffect, useMemo } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import { usePlansGridContext } from '../grid-context';
+import useDefaultStorageOption from '../hooks/npm-ready/data-store/use-default-storage-option';
 import useIsLargeCurrency from '../hooks/npm-ready/use-is-large-currency';
 import { getStorageStringFromFeature } from '../util';
 import type { PlanSlug, StorageOption, WPComStorageAddOnSlug } from '@automattic/calypso-products';
@@ -28,9 +29,13 @@ const getStorageOptionPrice = (
 	storageAddOnsForPlan: ( AddOnMeta | null )[] | null,
 	storageOptionSlug: string
 ) => {
-	return storageAddOnsForPlan?.find( ( addOn ) => {
-		return addOn?.featureSlugs?.includes( storageOptionSlug );
-	} )?.prices?.formattedMonthlyPrice;
+	const matchedStorageAddOn = storageAddOnsForPlan?.find(
+		( addOn ) => addOn?.featureSlugs?.includes( storageOptionSlug )
+	);
+
+	return matchedStorageAddOn?.purchased
+		? undefined
+		: matchedStorageAddOn?.prices?.formattedMonthlyPrice;
 };
 
 const StorageAddOnOption = ( {
@@ -91,6 +96,12 @@ export const StorageAddOnDropdown = ( {
 		( select ) => select( WpcomPlansUI.store ).getSelectedStorageOptionForPlan( planSlug ),
 		[ planSlug ]
 	);
+	const defaultStorageOption = useDefaultStorageOption( { storageOptions, storageAddOnsForPlan } );
+
+	useEffect( () => {
+		setSelectedStorageOptionForPlan( { addOnSlug: defaultStorageOption, planSlug } );
+	}, [] );
+
 	const selectControlOptions = storageOptions.map( ( storageOption ) => {
 		const title = getStorageStringFromFeature( storageOption.slug ) || '';
 		const price = getStorageOptionPrice( storageAddOnsForPlan, storageOption.slug );
@@ -102,7 +113,7 @@ export const StorageAddOnDropdown = ( {
 
 	const selectedOptionKey = selectedStorageOptionForPlan
 		? selectedStorageOptionForPlan
-		: storageOptions.find( ( storageOption ) => ! storageOption.isAddOn )?.slug;
+		: defaultStorageOption;
 	const selectedOptionPrice =
 		selectedOptionKey && getStorageOptionPrice( storageAddOnsForPlan, selectedOptionKey );
 	const selectedOptionTitle =

--- a/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-default-storage-option.ts
+++ b/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-default-storage-option.ts
@@ -1,18 +1,26 @@
-import type { StorageOption } from '@automattic/calypso-products';
+import type { StorageOption, WPComStorageAddOnSlug } from '@automattic/calypso-products';
 import type { AddOnMeta } from '@automattic/data-stores';
 
 type Props = {
 	storageAddOnsForPlan: ( AddOnMeta | null )[] | null;
-	storageOptions: StorageOption[];
+	storageOptions?: StorageOption[];
 };
 
+/**
+ * Returns the storage add-on upsell option to display to
+ * the user on initial load. If the user has purchased a
+ * storage add-on, that will be the default. Otherwise,
+ * the storage included with any given plan will be used.
+ *
+ */
 export default function useDefaultStorageOption( { storageOptions, storageAddOnsForPlan }: Props ) {
-	const [ purchasedStorageAddOn ] =
-		storageAddOnsForPlan?.find( ( storageAddOn ) => storageAddOn?.purchased )?.featureSlugs ?? [];
+	const [ purchasedStorageAddOnSlug ]: [ WPComStorageAddOnSlug ] =
+		( storageAddOnsForPlan?.find( ( storageAddOn ) => storageAddOn?.purchased )?.featureSlugs as [
+			WPComStorageAddOnSlug,
+		] ) ?? [];
 
-	const defaultStorageOption =
-		purchasedStorageAddOn ||
-		storageOptions?.find( ( storageOption ) => ! storageOption.isAddOn )?.slug;
-
-	return defaultStorageOption;
+	return (
+		purchasedStorageAddOnSlug ||
+		storageOptions?.find( ( storageOption ) => ! storageOption.isAddOn )?.slug
+	);
 }

--- a/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-default-storage-option.ts
+++ b/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-default-storage-option.ts
@@ -1,0 +1,18 @@
+import type { StorageOption } from '@automattic/calypso-products';
+import type { AddOnMeta } from '@automattic/data-stores';
+
+type Props = {
+	storageAddOnsForPlan: ( AddOnMeta | null )[] | null;
+	storageOptions: StorageOption[];
+};
+
+export default function useDefaultStorageOption( { storageOptions, storageAddOnsForPlan }: Props ) {
+	const [ purchasedStorageAddOn ] =
+		storageAddOnsForPlan?.find( ( storageAddOn ) => storageAddOn?.purchased )?.featureSlugs ?? [];
+
+	const defaultStorageOption =
+		purchasedStorageAddOn ||
+		storageOptions?.find( ( storageOption ) => ! storageOption.isAddOn )?.slug;
+
+	return defaultStorageOption;
+}

--- a/client/my-sites/plans-grid/hooks/npm-ready/use-upgrade-click-handler.ts
+++ b/client/my-sites/plans-grid/hooks/npm-ready/use-upgrade-click-handler.ts
@@ -25,12 +25,13 @@ const useUpgradeClickHandler = ( { gridPlans, onUpgradeClick }: Props ) => {
 					? addOn.featureSlugs?.includes( selectedStorageOption )
 					: false;
 			} );
-			const storageAddOnCartItem = storageAddOn && {
-				product_slug: storageAddOn.productSlug,
-				quantity: storageAddOn.quantity,
-				volume: 1,
-				extra: { feature_slug: selectedStorageOption },
-			};
+			const storageAddOnCartItem = storageAddOn &&
+				! storageAddOn.purchased && {
+					product_slug: storageAddOn.productSlug,
+					quantity: storageAddOn.quantity,
+					volume: 1,
+					extra: { feature_slug: selectedStorageOption },
+				};
 
 			if ( cartItemForPlan ) {
 				onUpgradeClick?.( [

--- a/client/my-sites/plans-grid/lib/is-storage-upgradeable-for-plan.ts
+++ b/client/my-sites/plans-grid/lib/is-storage-upgradeable-for-plan.ts
@@ -1,9 +1,9 @@
 import type { StorageOption } from '@automattic/calypso-products';
 
 export const isStorageUpgradeableForPlan = ( {
-	// flowName,
+	flowName,
 	intervalType,
-	// isInSignup,
+	isInSignup,
 	showUpgradeableStorage,
 	storageOptions,
 }: {
@@ -14,7 +14,7 @@ export const isStorageUpgradeableForPlan = ( {
 	storageOptions: StorageOption[];
 } ) =>
 	// Don't show for the enterprise plan which has no storage options
-	storageOptions.length > 1 && intervalType === 'yearly' && showUpgradeableStorage;
-// TODO: Revisit what conditions are necessary to continue hiding in stepper flows
-// isInSignup &&
-// flowName === 'onboarding';
+	storageOptions.length > 1 &&
+	intervalType === 'yearly' &&
+	showUpgradeableStorage &&
+	( flowName === 'onboarding' || ! isInSignup );

--- a/client/my-sites/plans-grid/lib/is-storage-upgradeable-for-plan.ts
+++ b/client/my-sites/plans-grid/lib/is-storage-upgradeable-for-plan.ts
@@ -1,9 +1,9 @@
 import type { StorageOption } from '@automattic/calypso-products';
 
 export const isStorageUpgradeableForPlan = ( {
-	flowName,
+	// flowName,
 	intervalType,
-	isInSignup,
+	// isInSignup,
 	showUpgradeableStorage,
 	storageOptions,
 }: {
@@ -14,8 +14,7 @@ export const isStorageUpgradeableForPlan = ( {
 	storageOptions: StorageOption[];
 } ) =>
 	// Don't show for the enterprise plan which has no storage options
-	storageOptions.length > 1 &&
-	intervalType === 'yearly' &&
-	showUpgradeableStorage &&
-	isInSignup &&
-	flowName === 'onboarding';
+	storageOptions.length > 1 && intervalType === 'yearly' && showUpgradeableStorage;
+// TODO: Revisit what conditions are necessary to continue hiding in stepper flows
+// isInSignup &&
+// flowName === 'onboarding';

--- a/client/my-sites/plans-grid/style.scss
+++ b/client/my-sites/plans-grid/style.scss
@@ -134,6 +134,11 @@ $mobile-card-max-width: 440px;
 				color: var(--studio-gray-100);
 				box-shadow: inset 0 0 0 1px var(--studio-gray-10);
 
+				&.is-storage-upgradeable {
+					background-color: var(--color-accent);
+					color: var(--color-text-inverted);
+				}
+
 				&:hover {
 					box-shadow: inset 0 0 0 1px var(--studio-gray-80);
 				}

--- a/client/my-sites/plans-grid/style.scss
+++ b/client/my-sites/plans-grid/style.scss
@@ -433,14 +433,20 @@ $mobile-card-max-width: 440px;
 			}
 
 			&.plan-features-2023-grid__header-billing-info {
-				padding-bottom: 32px;
+				padding-bottom: 16px;
 				@include plans-2023-break-small {
-					padding-bottom: 32px;
+					padding-bottom: 16px;
 				}
 			}
 
 			&.popular-plan-parent-class .plan-features-2023-grid__popular-badge {
 				padding-bottom: 23px;
+			}
+
+			&.plan-features-2023-grid__storage {
+				padding-top: 0;
+				padding-bottom: 32px;
+				width: 205px;
 			}
 
 			.plan-features-2023-grid__header-title {

--- a/client/my-sites/plans-grid/style.scss
+++ b/client/my-sites/plans-grid/style.scss
@@ -461,6 +461,10 @@ $mobile-card-max-width: 440px;
 			.plan-features-2023-grid__header-logo {
 				display: none;
 			}
+
+			.plan-features-2023-gridrison__actions {
+				width: 200px;
+			}
 		}
 	}
 }

--- a/packages/data-stores/src/add-ons/types.ts
+++ b/packages/data-stores/src/add-ons/types.ts
@@ -17,4 +17,6 @@ export interface AddOnMeta {
 		formattedMonthlyPrice: string;
 		formattedYearlyPrice: string;
 	} | null;
+	checkoutLink?: string;
+	exceedsSiteStorageLimits?: boolean;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/2023

## Proposed Changes

* Add storage add-on upsells to business and WooCommerce plans in the /plans page
* Add storage add-on upsell to spotlight card if business or WooCommerce plan
* Don't show add-on price if the storage add-on has already been purchased
* Don't show add-on prices if the user can no longer purchase storage add-ons given the 150GB max site storage limits

**Important:**
* Currently, the user can purchase a 50GB storage upgrade add-on for a total of 100GB site storage. They can, alternatively, purchase a 100GB storage upgrade for 150GB total site storage. Users cannot, however, purchase both, for a total of 200GB site storage. p1694555758071819/1694555365.713609-slack-CFFF01Q4V
* Storage add-on upsell UI is stale if revisiting the `/plans` page after recently purchasing a storage add-on. Normally the storage add-on dropdown will default to the most recently purchased plan. For a few minutes after a recent purchase though, it will not. This behavior is what we see in the `/add-ons` page as well.

## GIFs

![2023-10-24 10 29 58](https://github.com/Automattic/wp-calypso/assets/5414230/326d31f5-0c00-42c6-b8dd-b923411e1f44)

![2023-10-26 01 08 30](https://github.com/Automattic/wp-calypso/assets/5414230/a42907ba-7265-4660-a58d-d07f210305ce)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to /plans/{SITE_SLUG}
* Verify that storage add-on upsell dropdowns are displayed for business and WooCommerce plans
* Verify that, when a storage add-on upsell is selected, plan header prices and billing timeframes update accordingly
* Verify that storage add-ons upgrades are added to the checkout cart as expected
* Repeat the same verifications when the business or WooCommerce plan are in the spotlight card
* Verify that, when a storage add-on is purchased, it is rendered in the dropdown as the default on initial page load ( for recently purchased add-ons, stale data may be presented for a minute or two until updated. This same behavior is seen in the /add-ons page )
* Verify that, after a storage add-on has been purchased, selecting a lower tier storage add-on option disables the plan's CTA and asks the user to contact support

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?