### PR TITLE
Comments Moderation - update nav menu on comment status change

### DIFF
--- a/client/my-sites/comments/comment/comment-actions.jsx
+++ b/client/my-sites/comments/comment/comment-actions.jsx
@@ -7,6 +7,7 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import scrollTo from 'calypso/lib/scroll-to';
 import { getMinimumComment } from 'calypso/my-sites/comments/comment/utils';
+import { requestAdminMenu } from 'calypso/state/admin-menu/actions';
 import {
 	bumpStat,
 	composeAnalytics,
@@ -81,6 +82,9 @@ export class CommentActions extends Component {
 		}
 
 		this.showNotice( status );
+
+		// Refresh the admin menu on update of status to ensure count shown is not stale.
+		this.props.refreshAdminMenu();
 	};
 
 	setTrash = () => this.setStatus( 'trash' );
@@ -324,6 +328,7 @@ const mapDispatchToProps = ( dispatch, { siteId, postId, commentId, commentsList
 				unlikeComment( siteId, postId, commentId )
 			)
 		),
+	refreshAdminMenu: () => dispatch( requestAdminMenu( siteId ) ),
 } );
 
 export default connect( mapStateToProps, mapDispatchToProps )( localize( CommentActions ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # pe7F0s-1kj-p2

## Proposed Changes

* This resolves an issue where the comment count in the nav menu does not update when approving pending comments, or more generally the changing status of comments in the comments moderation form.
* Here we ensure to dispatch a call to refresh the admin menu whenever a comment status change is submitted in the form.

Before:

![comments-approve-before](https://github.com/Automattic/wp-calypso/assets/28742426/6904f0c8-eb34-4b42-a2ec-cb23b90e2be6)


After:

![comments-approve-after](https://github.com/Automattic/wp-calypso/assets/28742426/8a30e2d7-3f72-43e5-a595-7582e054521b)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch.
* In my-sites, select a site that has some pending un-approved comments.
* Go to "Comments" section, the "pending" tab, and approve a pending comment.
* verify the count in the nav sidebar updates as expected.
* unapproving an approved comment, trashing a pending comment, etc. should also update the number as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?