### PR TITLE
Importer WP PreMigration: Refactor credentials part

### DIFF
--- a/client/blocks/importer/util.ts
+++ b/client/blocks/importer/util.ts
@@ -20,7 +20,7 @@ export function formatSlugToURL( inputUrl: string ) {
 		return inputUrl;
 	}
 	let url = inputUrl.trim().toLowerCase();
-	if ( url && url.substr( 0, 4 ) !== 'http' ) {
+	if ( url && ! url.startsWith( 'http' ) ) {
 		url = 'http://' + url;
 	}
 	url = url.replace( /wp-admin\/?$/, '' );

--- a/client/blocks/importer/wordpress/import-everything/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/index.tsx
@@ -181,14 +181,14 @@ export class ImportEverything extends SectionMigrate {
 
 		return (
 			<PreMigrationScreen
-				startImport={ this.startMigration }
-				initImportRun={ this.props.initImportRun }
-				isTargetSitePlanCompatible={ isTargetSitePlanCompatible }
-				targetSite={ targetSite }
-				isMigrateFromWp={ isMigrateFromWp }
-				isTrial={ isMigrationTrialSite( this.props.targetSite ) }
-				onContentOnlyClick={ onContentOnlySelection }
 				sourceSite={ sourceSite }
+				targetSite={ targetSite }
+				initImportRun={ this.props.initImportRun }
+				isTrial={ isMigrationTrialSite( this.props.targetSite ) }
+				isMigrateFromWp={ isMigrateFromWp }
+				isTargetSitePlanCompatible={ isTargetSitePlanCompatible }
+				startImport={ this.startMigration }
+				onContentOnlyClick={ onContentOnlySelection }
 				onFreeTrialClick={ () => {
 					stepNavigator?.navigate( `trialAcknowledge${ window.location.search }` );
 				} }

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/credentials-cta.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/credentials-cta.tsx
@@ -1,0 +1,31 @@
+import { Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import React from 'react';
+
+interface Props {
+	onButtonClick: () => void;
+}
+
+export const CredentialsCta = ( props: Props ) => {
+	const translate = useTranslate();
+	const { onButtonClick } = props;
+
+	return (
+		<div className="pre-migration__content pre-migration__credentials">
+			{ translate(
+				'Want to speed up the migration? {{button}}Provide the server credentials{{/button}} of your site',
+				{
+					components: {
+						button: (
+							<Button
+								borderless={ true }
+								className="action-buttons__borderless"
+								onClick={ onButtonClick }
+							/>
+						),
+					},
+				}
+			) }
+		</div>
+	);
+};

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/credentials-form.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/credentials-form.tsx
@@ -4,7 +4,7 @@ import { NextButton } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import CredentialsForm from 'calypso/components/advanced-credentials/credentials-form';
+import CredentialsFormAdvanced from 'calypso/components/advanced-credentials/credentials-form';
 import {
 	FormMode,
 	INITIAL_FORM_ERRORS,
@@ -29,7 +29,7 @@ interface Props {
 	onChangeProtocol: ( protocol: CredentialsProtocol ) => void;
 }
 
-export const MigrationCredentialsForm: React.FunctionComponent< Props > = ( props ) => {
+export const CredentialsForm: React.FunctionComponent< Props > = ( props ) => {
 	const { sourceSite, targetSite, migrationTrackingProps, startImport } = props;
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -171,7 +171,7 @@ export const MigrationCredentialsForm: React.FunctionComponent< Props > = ( prop
 				/>
 			) }
 			<form onSubmit={ submitCredentials }>
-				<CredentialsForm
+				<CredentialsFormAdvanced
 					disabled={ isFormSubmissionPending || isLoading }
 					formErrors={ formErrors }
 					formMode={ formMode }
@@ -236,4 +236,4 @@ export const MigrationCredentialsForm: React.FunctionComponent< Props > = ( prop
 	);
 };
 
-export default MigrationCredentialsForm;
+export default CredentialsForm;

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/credentials.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/credentials.tsx
@@ -2,8 +2,8 @@ import { SiteDetails } from '@automattic/data-stores';
 import { Title } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import React, { useState } from 'react';
+import { CredentialsForm } from './credentials-form';
 import { CredentialsHelper } from './credentials-helper';
-import MigrationCredentialsForm from './migration-credentials-form';
 import type { StartImportTrackingProps } from './types';
 
 interface Props {
@@ -39,7 +39,7 @@ export function Credentials( props: Props ) {
 
 			<div className="pre-migration__form-container pre-migration__credentials-form">
 				<div className="pre-migration__form">
-					<MigrationCredentialsForm
+					<CredentialsForm
 						sourceSite={ sourceSite }
 						targetSite={ targetSite }
 						startImport={ startImport }

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/credentials.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/credentials.tsx
@@ -1,0 +1,57 @@
+import { SiteDetails } from '@automattic/data-stores';
+import { Title } from '@automattic/onboarding';
+import { useTranslate } from 'i18n-calypso';
+import React, { useState } from 'react';
+import { CredentialsHelper } from './credentials-helper';
+import MigrationCredentialsForm from './migration-credentials-form';
+import type { StartImportTrackingProps } from './types';
+
+interface Props {
+	sourceSite?: SiteDetails;
+	targetSite: SiteDetails;
+	migrationTrackingProps: StartImportTrackingProps;
+	startImport: ( props?: StartImportTrackingProps ) => void;
+}
+
+export function Credentials( props: Props ) {
+	const translate = useTranslate();
+	const { sourceSite, targetSite, migrationTrackingProps, startImport } = props;
+	const [ selectedHost, setSelectedHost ] = useState( 'generic' );
+	const [ selectedProtocol, setSelectedProtocol ] = useState< 'ftp' | 'ssh' >( 'ftp' );
+
+	const onChangeProtocol = ( protocol: 'ftp' | 'ssh' ) => {
+		setSelectedProtocol( protocol );
+	};
+
+	const onHostChange = ( host: string ) => {
+		setSelectedHost( host );
+	};
+
+	if ( ! sourceSite ) {
+		return null;
+	}
+
+	return (
+		<div className="import__pre-migration import__import-everything import__import-everything--redesign">
+			<div className="import__heading-title">
+				<Title>{ translate( 'You are ready to migrate' ) }</Title>
+			</div>
+
+			<div className="pre-migration__form-container pre-migration__credentials-form">
+				<div className="pre-migration__form">
+					<MigrationCredentialsForm
+						sourceSite={ sourceSite }
+						targetSite={ targetSite }
+						startImport={ startImport }
+						selectedHost={ selectedHost }
+						migrationTrackingProps={ migrationTrackingProps }
+						onChangeProtocol={ onChangeProtocol }
+					/>
+				</div>
+				<div className="pre-migration__credentials-help">
+					<CredentialsHelper onHostChange={ onHostChange } selectedProtocol={ selectedProtocol } />
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
@@ -29,15 +29,15 @@ import { StartImportTrackingProps } from './types';
 import './style.scss';
 
 interface PreMigrationProps {
-	targetSite: SiteDetails;
-	startImport: ( props?: StartImportTrackingProps ) => void;
-	initImportRun?: boolean;
-	isTargetSitePlanCompatible: boolean;
-	isMigrateFromWp: boolean;
-	isTrial?: boolean;
-	onContentOnlyClick: () => void;
 	sourceSite?: SiteDetails;
+	targetSite: SiteDetails;
+	initImportRun?: boolean;
+	isTrial?: boolean;
+	isMigrateFromWp: boolean;
+	isTargetSitePlanCompatible: boolean;
+	startImport: ( props?: StartImportTrackingProps ) => void;
 	onFreeTrialClick: () => void;
+	onContentOnlyClick: () => void;
 	onNotAuthorizedClick: () => void;
 }
 
@@ -45,15 +45,15 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 	props: PreMigrationProps
 ) => {
 	const {
-		startImport,
-		initImportRun,
+		sourceSite,
 		targetSite,
+		initImportRun,
 		isTargetSitePlanCompatible,
 		isMigrateFromWp,
 		isTrial,
-		onContentOnlyClick,
+		startImport,
 		onFreeTrialClick,
-		sourceSite,
+		onContentOnlyClick,
 		onNotAuthorizedClick,
 	} = props;
 

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
@@ -210,10 +210,12 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 		}
 
 		if ( ! sourceSite || ( sourceSite && sourceSite.ID !== sourceSiteId ) ) {
-			<NotAuthorized
-				onStartBuilding={ onNotAuthorizedClick }
-				onStartBuildingText={ translate( 'Skip to dashboard' ) }
-			/>;
+			return (
+				<NotAuthorized
+					onStartBuilding={ onNotAuthorizedClick }
+					onStartBuildingText={ translate( 'Skip to dashboard' ) }
+				/>
+			);
 		}
 
 		return (

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
@@ -78,7 +78,7 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 		siteCanMigrate,
 	} = useSiteMigrateInfo( targetSite.ID, sourceSiteSlug, isTargetSitePlanCompatible );
 
-	const showUpdatePluginInfo = typeof siteCanMigrate === 'boolean' ? ! siteCanMigrate : false;
+	const requiresPluginUpdate = siteCanMigrate === false;
 
 	const migrationTrackingProps = {
 		source_site_id: sourceSiteId,
@@ -144,7 +144,7 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 	// We want to record the tracks event, so we use the same condition as the one in the render function
 	// This should be better handled by using a state after the refactor
 	useEffect( () => {
-		if ( ! showUpdatePluginInfo && isTargetSitePlanCompatible ) {
+		if ( ! requiresPluginUpdate && isTargetSitePlanCompatible ) {
 			const _migrationTrackingProps: { [ key: string ]: unknown } = { ...migrationTrackingProps };
 			// There is a case where source_site_id is 0|undefined, so we need to delete it
 			delete _migrationTrackingProps?.source_site_id;
@@ -153,7 +153,7 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 				recordTracksEvent( 'calypso_site_migration_ready_screen', _migrationTrackingProps )
 			);
 		}
-	}, [ showUpdatePluginInfo, isTargetSitePlanCompatible ] );
+	}, [ requiresPluginUpdate, isTargetSitePlanCompatible ] );
 
 	// Initiate the migration if initImportRun is set
 	useEffect( () => {
@@ -169,13 +169,13 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 
 	useEffect( () => {
 		// If we are blocked by plugin upgrade check or has continueImport set to false, we do not start the migration
-		if ( showUpdatePluginInfo || ! continueImport ) {
+		if ( requiresPluginUpdate || ! continueImport ) {
 			return;
 		}
 		if ( sourceSiteId ) {
 			startImport( migrationTrackingProps );
 		}
-	}, [ continueImport, sourceSiteId, startImport, showUpdatePluginInfo ] );
+	}, [ continueImport, sourceSiteId, startImport, requiresPluginUpdate ] );
 
 	function renderCredentialsFormSection() {
 		// We do not show the credentials form if we already have credentials
@@ -329,7 +329,7 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 
 	function render() {
 		// If the source site is not capable of being migrated, we show the update info screen
-		if ( showUpdatePluginInfo ) {
+		if ( requiresPluginUpdate ) {
 			return renderUpdatePluginInfo();
 		}
 

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
@@ -141,6 +141,22 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 		fetchMigrationEnabledStatus();
 	};
 
+	function displayConfirmModal() {
+		dispatch(
+			recordTracksEvent( 'calypso_site_migration_confirm_modal_display', migrationTrackingProps )
+		);
+
+		setShowConfirmModal( true );
+	}
+
+	function hideConfirmModal() {
+		dispatch(
+			recordTracksEvent( 'calypso_site_migration_confirm_modal_hide', migrationTrackingProps )
+		);
+
+		setShowConfirmModal( false );
+	}
+
 	// We want to record the tracks event, so we use the same condition as the one in the render function
 	// This should be better handled by using a state after the refactor
 	useEffect( () => {
@@ -276,22 +292,6 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 				</div>
 			</>
 		);
-	}
-
-	function displayConfirmModal() {
-		dispatch(
-			recordTracksEvent( 'calypso_site_migration_confirm_modal_display', migrationTrackingProps )
-		);
-
-		setShowConfirmModal( true );
-	}
-
-	function hideConfirmModal() {
-		dispatch(
-			recordTracksEvent( 'calypso_site_migration_confirm_modal_hide', migrationTrackingProps )
-		);
-
-		setShowConfirmModal( false );
 	}
 
 	function renderUpdatePluginInfo() {

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
@@ -59,6 +59,9 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+	const urlQueryParams = useQuery();
+	const sourceSiteSlug = urlQueryParams.get( 'from' ) ?? '';
+	const sourceSiteUrl = formatSlugToURL( sourceSiteSlug );
 
 	const [ showCredentials, setShowCredentials ] = useState( false );
 	const [ showConfirmModal, setShowConfirmModal ] = useState( false );
@@ -67,9 +70,6 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 	const [ selectedProtocol, setSelectedProtocol ] = useState< 'ftp' | 'ssh' >( 'ftp' );
 	const [ hasLoaded, setHasLoaded ] = useState( false );
 	const [ continueImport, setContinueImport ] = useState( false );
-	const urlQueryParams = useQuery();
-	const sourceSiteSlug = urlQueryParams.get( 'from' ) ?? '';
-	const sourceSiteUrl = formatSlugToURL( sourceSiteSlug );
 
 	const {
 		sourceSiteId,

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
@@ -300,26 +300,22 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 		);
 	}
 
-	function render() {
-		// If the source site is not capable of being migrated, we show the update info screen
-		if ( requiresPluginUpdate ) {
-			return renderUpdatePluginInfo();
-		}
-
-		if ( showCredentials && sourceSite ) {
-			return renderCredentials();
-		}
-
-		// If the target site is plan compatible, we show the pre-migration screen
-		if ( isTargetSitePlanCompatible ) {
-			return renderPreMigration();
-		}
-
-		// If the target site is not plan compatible, we show the upgrade plan screen
-		return renderUpgradePlan();
+	// If the source site is not capable of being migrated, we show the update info screen
+	if ( requiresPluginUpdate ) {
+		return renderUpdatePluginInfo();
 	}
 
-	return render();
+	if ( showCredentials && sourceSite ) {
+		return renderCredentials();
+	}
+
+	// If the target site is plan compatible, we show the pre-migration screen
+	if ( isTargetSitePlanCompatible ) {
+		return renderPreMigration();
+	}
+
+	// If the target site is not plan compatible, we show the upgrade plan screen
+	return renderUpgradePlan();
 };
 
 export default PreMigrationScreen;

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
@@ -1,4 +1,3 @@
-import { Button } from '@automattic/components';
 import { SiteDetails } from '@automattic/data-stores';
 import { NextButton, Title } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
@@ -23,6 +22,7 @@ import { isRequestingSitePlans } from 'calypso/state/sites/plans/selectors';
 import NotAuthorized from '../../../components/not-authorized';
 import ConfirmModal from './confirm-modal';
 import { Credentials } from './credentials';
+import { CredentialsCta } from './credentials-cta';
 import { StartImportTrackingProps } from './types';
 
 import './style.scss';
@@ -182,27 +182,6 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 		}
 	}, [ continueImport, sourceSiteId, startImport, requiresPluginUpdate ] );
 
-	const CredentialsFormCTA = function () {
-		return (
-			<div className="pre-migration__content pre-migration__credentials">
-				{ translate(
-					'Want to speed up the migration? {{button}}Provide the server credentials{{/button}} of your site',
-					{
-						components: {
-							button: (
-								<Button
-									borderless={ true }
-									className="action-buttons__borderless"
-									onClick={ toggleCredentialsForm }
-								/>
-							),
-						},
-					}
-				) }
-			</div>
-		);
-	};
-
 	function renderPreMigration() {
 		// Show a loading state when we are trying to fetch existing credentials
 		if ( ! hasLoaded || isRequestingCredentials ) {
@@ -236,7 +215,7 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 					<div className="import__heading-title">
 						<Title>{ translate( 'You are ready to migrate' ) }</Title>
 					</div>
-					{ ! hasCredentials && <CredentialsFormCTA /> }
+					{ ! hasCredentials && <CredentialsCta onButtonClick={ toggleCredentialsForm } /> }
 					{ ! showCredentials && (
 						<div className="import__footer-button-container pre-migration__proceed">
 							<NextButton


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/82758

## Proposed Changes

* Introduced a wrapper component for adding Credentials logic
* Renamed existing credentials component files to follow the naming convention with proper prefixes (credentials)
* Replaced deprecated function call

Note: This PR is branched out from the previous refactoring branch (https://github.com/Automattic/wp-calypso/issues/82758); Trying to manage multiple smaller PRs for more straightforward review.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/site-setup/importerWordpress?siteSlug={ATOMIC_SLUG}&from={JN_JETPACK_CONNECTED_URL}&option=everything`
* Click on "Provide the server credentials"
* Check if everything works in the same way (compare with production)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?