### PR TITLE
Multi-Domain: Sort domains so user gets the best free domain bundle promo

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -595,7 +595,12 @@ export class RenderDomainsStep extends Component {
 		} );
 
 		// Sort products to ensure the user gets the best deal with the free domain bundle promotion.
-		this.sortProductsByPriceDescending();
+		const sortedProducts = await this.sortProductsByPriceDescending();
+
+		// Replace the products in the cart with the freshly sorted products.
+		await this.props.shoppingCartManager.replaceProductsInCart( sortedProducts ).then( () => {
+			this.setState( { isCartPendingUpdateDomain: null } );
+		} );
 	}
 
 	async sortProductsByPriceDescending() {
@@ -623,10 +628,7 @@ export class RenderDomainsStep extends Component {
 			return getSortingValue( b ) - getSortingValue( a );
 		} );
 
-		// Replace the products in the cart with the freshly sorted products.
-		await this.props.shoppingCartManager.replaceProductsInCart( productsInCart ).then( () => {
-			this.setState( { isCartPendingUpdateDomain: null } );
-		} );
+		return productsInCart;
 	}
 
 	removeDomainClickHandler = ( domain ) => {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -594,13 +594,15 @@ export class RenderDomainsStep extends Component {
 			this.setState( { isCartPendingUpdateDomain: null } );
 		} );
 
-		// Sort products to ensure the user gets the best deal with the free domain bundle promotion.
-		const sortedProducts = await this.sortProductsByPriceDescending();
+		if ( shouldUseMultipleDomainsInCart( this.props.flowName ) ) {
+			// Sort products to ensure the user gets the best deal with the free domain bundle promotion.
+			const sortedProducts = await this.sortProductsByPriceDescending();
 
-		// Replace the products in the cart with the freshly sorted products.
-		await this.props.shoppingCartManager.replaceProductsInCart( sortedProducts ).then( () => {
-			this.setState( { isCartPendingUpdateDomain: null } );
-		} );
+			// Replace the products in the cart with the freshly sorted products.
+			await this.props.shoppingCartManager.replaceProductsInCart( sortedProducts ).then( () => {
+				this.setState( { isCartPendingUpdateDomain: null } );
+			} );
+		}
 	}
 
 	async sortProductsByPriceDescending() {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -593,6 +593,44 @@ export class RenderDomainsStep extends Component {
 		await this.props.shoppingCartManager.addProductsToCart( productsToAdd ).then( () => {
 			this.setState( { isCartPendingUpdateDomain: null } );
 		} );
+
+		// The first product in the cart gets the free domain promotion applied to it. So, we sort the products to give
+		// the user the best deal and avoid encouraging them to "game" the cart for the best deal.
+		this.sortProductsByPriceDescending();
+	}
+
+	async sortProductsByPriceDescending() {
+		// We aim to sort domains, but we sort all products to keep it "simple."
+		const productsInCart = this.props.cart.products;
+
+		// Sort the domains descending by item_subtotal_integer. However, the most expensive domain already in the cart
+		// has a item_subtotal_integer = 0 because the bundle promotion has been applied. So, if item_subtotal_integer
+		// is 0, we use the lowest non-zero new_price in cost_overrides (multiplied by 100). This is price after all
+		// promotions have been applied. If there are no non-zero new_prices, we assume the only promo being applied is
+		// free domain with bundle, so we use item_original_cost_integer.
+		productsInCart.sort( ( a, b ) => {
+			const getSortingValue = ( product ) => {
+				if ( product.item_subtotal_integer !== 0 ) {
+					return product.item_subtotal_integer;
+				}
+				// Find the lowest non-zero new_price in cost_overrides (multiplied by 100 because its in dollars). If
+				// none is found, use item_original_cost_integer.
+				const nonZeroPrices =
+					product.cost_overrides
+						?.map( ( override ) => override.new_price * 100 )
+						.filter( ( price ) => price > 0 ) || [];
+				return nonZeroPrices.length
+					? Math.min( ...nonZeroPrices )
+					: product.item_original_cost_integer;
+			};
+
+			return getSortingValue( b ) - getSortingValue( a );
+		} );
+
+		// Replace the products in the cart with the freshly sorted products.
+		await this.props.shoppingCartManager.replaceProductsInCart( productsInCart ).then( () => {
+			this.setState( { isCartPendingUpdateDomain: null } );
+		} );
 	}
 
 	removeDomainClickHandler = ( domain ) => {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -594,31 +594,27 @@ export class RenderDomainsStep extends Component {
 			this.setState( { isCartPendingUpdateDomain: null } );
 		} );
 
-		// The first product in the cart gets the free domain promotion applied to it. So, we sort the products to give
-		// the user the best deal and avoid encouraging them to "game" the cart for the best deal.
+		// Sort products to ensure the user gets the best deal with the free domain bundle promotion.
 		this.sortProductsByPriceDescending();
 	}
 
 	async sortProductsByPriceDescending() {
-		// We aim to sort domains, but we sort all products to keep it "simple."
+		// Get products from cart.
 		const productsInCart = this.props.cart.products;
 
-		// Sort the domains descending by item_subtotal_integer. However, the most expensive domain already in the cart
-		// has a item_subtotal_integer = 0 because the bundle promotion has been applied. So, if item_subtotal_integer
-		// is 0, we use the lowest non-zero new_price in cost_overrides (multiplied by 100). This is price after all
-		// promotions have been applied. If there are no non-zero new_prices, we assume the only promo being applied is
-		// free domain with bundle, so we use item_original_cost_integer.
+		// Sort products by price descending, considering promotions.
 		productsInCart.sort( ( a, b ) => {
 			const getSortingValue = ( product ) => {
 				if ( product.item_subtotal_integer !== 0 ) {
 					return product.item_subtotal_integer;
 				}
-				// Find the lowest non-zero new_price in cost_overrides (multiplied by 100 because its in dollars). If
-				// none is found, use item_original_cost_integer.
+
+				// Use the lowest non-zero new_price or fallback to item_original_cost_integer.
 				const nonZeroPrices =
 					product.cost_overrides
 						?.map( ( override ) => override.new_price * 100 )
 						.filter( ( price ) => price > 0 ) || [];
+
 				return nonZeroPrices.length
 					? Math.min( ...nonZeroPrices )
 					: product.item_original_cost_integer;

--- a/client/signup/steps/domains/test/index.js
+++ b/client/signup/steps/domains/test/index.js
@@ -1,0 +1,146 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { RenderDomainsStep } from '../index.jsx';
+
+describe( 'sortProductsByPriceDescending', () => {
+	let instance;
+
+	beforeEach( () => {
+		const mockProps = {
+			cart: {
+				products: [],
+			},
+			shoppingCartManager: jest.fn(),
+			forceDesignType: 'type',
+			domainsWithPlansOnly: false,
+			flowName: 'flowName',
+			goToNextStep: jest.fn(),
+			isDomainOnly: false,
+			locale: 'en',
+			path: '/path',
+			positionInFlow: 1,
+			queryObject: {
+				new: false,
+				search: 'yes',
+			},
+			step: {},
+			stepName: 'stepName',
+			stepSectionName: 'sectionName',
+			selectedSite: {},
+			isReskinned: false,
+			signupDependencies: {
+				suggestedDomain: 'example.com',
+			},
+		};
+
+		instance = new RenderDomainsStep( mockProps );
+	} );
+
+	test( 'should sort products by item_subtotal_integer', async () => {
+		instance.props.cart.products = [
+			{
+				meta: 'domain.com',
+				item_subtotal_integer: 200,
+				cost_overrides: [],
+				item_original_cost_integer: 200,
+			},
+			{
+				meta: 'domain.net',
+				item_subtotal_integer: 100,
+				cost_overrides: [],
+				item_original_cost_integer: 100,
+			},
+		];
+
+		const sortedProducts = await instance.sortProductsByPriceDescending();
+		expect( sortedProducts[ 0 ].meta ).toBe( 'domain.com' );
+		expect( sortedProducts[ 1 ].meta ).toBe( 'domain.net' );
+	} );
+
+	test( 'should sort products by item_original_cost_integer', async () => {
+		instance.props.cart.products = [
+			{
+				meta: 'domain.com',
+				item_subtotal_integer: 2000,
+				cost_overrides: [],
+				item_original_cost_integer: 2000,
+			},
+			{
+				meta: 'domain.kitchen',
+				item_subtotal_integer: 0,
+				cost_overrides: [
+					{
+						old_price: 40,
+						new_price: 0,
+						reason: 'bundled domain credit for 1st year',
+					},
+				],
+				item_original_cost_integer: 4000,
+			},
+		];
+
+		const sortedProducts = await instance.sortProductsByPriceDescending();
+		expect( sortedProducts[ 0 ].meta ).toBe( 'domain.kitchen' );
+		expect( sortedProducts[ 1 ].meta ).toBe( 'domain.com' );
+	} );
+
+	test( 'should sort products considering cost_overrides', async () => {
+		instance.props.cart.products = [
+			{
+				meta: 'domain.store',
+				item_subtotal_integer: 96,
+				cost_overrides: [
+					{
+						old_price: 48,
+						new_price: 0.96,
+						reason: 'Sale_Coupon->apply_sale_discount',
+					},
+				],
+				item_original_cost_integer: 4800,
+			},
+			{
+				meta: 'domain.blog',
+				item_subtotal_integer: 484,
+				cost_overrides: [
+					{
+						old_price: 22,
+						new_price: 4.84,
+						reason: 'Sale_Coupon->apply_sale_discount',
+					},
+				],
+				item_original_cost_integer: 2200,
+			},
+			{
+				meta: 'domain.fish',
+				item_subtotal_integer: 3000,
+				cost_overrides: [],
+				item_original_cost_integer: 3000,
+			},
+			{
+				meta: 'domain.kitchen',
+				item_subtotal_integer: 0,
+				cost_overrides: [
+					{
+						old_price: 40,
+						new_price: 19.6, // This is the price when disregarding the free with plan discount.
+						reason: 'Sale_Coupon->apply_sale_discount',
+					},
+					{
+						old_price: 19.6,
+						new_price: 0,
+						reason: 'bundled domain credit for 1st year',
+					},
+				],
+				item_original_cost_integer: 4000,
+			},
+		];
+
+		const sortedProducts = await instance.sortProductsByPriceDescending();
+		expect( sortedProducts[ 0 ].meta ).toBe( 'domain.fish' );
+		expect( sortedProducts[ 1 ].meta ).toBe( 'domain.kitchen' );
+		expect( sortedProducts[ 2 ].meta ).toBe( 'domain.blog' );
+		expect( sortedProducts[ 3 ].meta ).toBe( 'domain.store' );
+	} );
+} );

--- a/client/signup/steps/domains/test/index.js
+++ b/client/signup/steps/domains/test/index.js
@@ -42,13 +42,13 @@ describe( 'sortProductsByPriceDescending', () => {
 		instance.props.cart.products = [
 			{
 				meta: 'domain.com',
-				item_subtotal_integer: 200,
+				item_subtotal_integer: 200, // The price we consider when sorting.
 				cost_overrides: [],
 				item_original_cost_integer: 200,
 			},
 			{
 				meta: 'domain.net',
-				item_subtotal_integer: 100,
+				item_subtotal_integer: 100, // The price we consider when sorting.
 				cost_overrides: [],
 				item_original_cost_integer: 100,
 			},
@@ -63,7 +63,7 @@ describe( 'sortProductsByPriceDescending', () => {
 		instance.props.cart.products = [
 			{
 				meta: 'domain.com',
-				item_subtotal_integer: 2000,
+				item_subtotal_integer: 2000, // The price we consider when sorting.
 				cost_overrides: [],
 				item_original_cost_integer: 2000,
 			},
@@ -77,7 +77,7 @@ describe( 'sortProductsByPriceDescending', () => {
 						reason: 'bundled domain credit for 1st year',
 					},
 				],
-				item_original_cost_integer: 4000,
+				item_original_cost_integer: 4000, // The price we consider when sorting.
 			},
 		];
 
@@ -94,7 +94,7 @@ describe( 'sortProductsByPriceDescending', () => {
 				cost_overrides: [
 					{
 						old_price: 48,
-						new_price: 0.96,
+						new_price: 0.96, // The price we consider when sorting.
 						reason: 'Sale_Coupon->apply_sale_discount',
 					},
 				],
@@ -106,7 +106,7 @@ describe( 'sortProductsByPriceDescending', () => {
 				cost_overrides: [
 					{
 						old_price: 22,
-						new_price: 4.84,
+						new_price: 4.84, // The price we consider when sorting.
 						reason: 'Sale_Coupon->apply_sale_discount',
 					},
 				],
@@ -114,7 +114,7 @@ describe( 'sortProductsByPriceDescending', () => {
 			},
 			{
 				meta: 'domain.fish',
-				item_subtotal_integer: 3000,
+				item_subtotal_integer: 3000, // The price we consider when sorting.
 				cost_overrides: [],
 				item_original_cost_integer: 3000,
 			},
@@ -124,7 +124,7 @@ describe( 'sortProductsByPriceDescending', () => {
 				cost_overrides: [
 					{
 						old_price: 40,
-						new_price: 19.6, // This is the price when disregarding the free with plan discount.
+						new_price: 19.6, // The price we consider when sorting.
 						reason: 'Sale_Coupon->apply_sale_discount',
 					},
 					{


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
thelinked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4182

To do

- [x] Maybe make comments less wordy
- [x] Maybe write a unit test

## Proposed Changes

* Sorts the domain in the multi-domain selection mini-cart by price descending to give the user the best promotional deal, because the first domain in the cart get the free domain with plan bundle promotion.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply the PR, add and remove different TLDs with different promotions, and double-check check the result is correct.
* Check that the mini-cart and Checkout page agree with each other.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?