### PR TITLE
Update Activity Log upsell copy to be less confusing.

### DIFF
--- a/client/my-sites/activity/activity-log-banner/intro-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/intro-banner.jsx
@@ -13,6 +13,7 @@ import DismissibleCard from 'calypso/blocks/dismissible-card';
 import CardHeading from 'calypso/components/card-heading';
 import QuerySiteFeatures from 'calypso/components/data/query-site-features';
 import ExternalLink from 'calypso/components/external-link';
+import { preventWidows } from 'calypso/lib/formatting';
 import { PRODUCT_UPSELLS_BY_FEATURE } from 'calypso/my-sites/plans/jetpack-plans/constants';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
@@ -29,6 +30,23 @@ class IntroBanner extends Component {
 
 	recordDismiss = () => this.props.recordTracksEvent( 'calypso_activitylog_intro_banner_dismiss' );
 
+	renderUpgradeIntroText() {
+		const { translate, siteIsJetpack, siteHasFullActivityLog } = this.props;
+		if ( siteHasFullActivityLog ) {
+			return preventWidows(
+				translate( 'Looking for something specific? You can filter the events by type and date.' )
+			);
+		}
+		if ( siteIsJetpack ) {
+			return preventWidows(
+				translate( 'You currently have access to the 20 most recent events on your site.' )
+			);
+		}
+		return preventWidows(
+			translate( 'With your free plan, you can monitor the 20 most recent events on your site.' )
+		);
+	}
+
 	renderCardContent() {
 		const { siteIsAtomic, siteIsJetpack, siteSlug, translate, siteHasFullActivityLog } = this.props;
 		const buttonHref =
@@ -42,17 +60,17 @@ class IntroBanner extends Component {
 					{ translate(
 						'We’ll keep track of all the events that take place on your site to help manage things easier. '
 					) }
-					{ siteHasFullActivityLog
-						? translate(
-								'Looking for something specific? You can filter the events by type and date.'
-						  )
-						: translate(
-								'With your free plan, you can monitor the 20 most recent events on your site.'
-						  ) }
+					{ this.renderUpgradeIntroText() }
 				</p>
 				{ ! siteHasFullActivityLog && (
 					<>
-						<p>{ translate( 'Upgrade to a paid plan to unlock powerful features:' ) }</p>
+						<p>
+							{ siteIsJetpack
+								? translate(
+										'Upgrade to Jetpack VaultPress Backup or Jetpack Security to unlock powerful features:'
+								  )
+								: translate( 'Upgrade to a paid plan to unlock powerful features:' ) }
+						</p>
 						<ul className="activity-log-banner__intro-list">
 							<li>
 								<Gridicon icon="checkmark" size={ 18 } />

--- a/client/my-sites/activity/activity-log-banner/upgrade-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/upgrade-banner.jsx
@@ -8,6 +8,7 @@ import { localize } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
+import { preventWidows } from 'calypso/lib/formatting';
 import { PRODUCT_UPSELLS_BY_FEATURE } from 'calypso/my-sites/plans/jetpack-plans/constants';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
@@ -26,10 +27,12 @@ class UpgradeBanner extends Component {
 						feature={ WPCOM_FEATURES_FULL_ACTIVITY_LOG }
 						href={ `/checkout/${ siteSlug }/${ PRODUCT_UPSELLS_BY_FEATURE[ FEATURE_ACTIVITY_LOG ] }` }
 						title={ translate( 'Unlock more activities now' ) }
-						description={ translate(
-							'You currently have access to the 20 most recent events ' +
-								'on your site. Upgrade to Jetpack VaultPress Backup ' +
-								'or Jetpack Security to unlock powerful features:'
+						description={ preventWidows(
+							translate(
+								'You currently have access to the 20 most recent events ' +
+									'on your site. Upgrade to Jetpack VaultPress Backup ' +
+									'or Jetpack Security to unlock powerful features:'
+							)
 						) }
 						showIcon={ true }
 						list={ [
@@ -45,10 +48,12 @@ class UpgradeBanner extends Component {
 						feature={ FEATURE_JETPACK_ESSENTIAL }
 						plan={ PLAN_PERSONAL }
 						title={ translate( 'Unlock more activities now' ) }
-						description={ translate(
-							'With your free plan, you can monitor the 20 most ' +
-								'recent events on your site. Upgrade to a paid plan to ' +
-								'unlock powerful features:'
+						description={ preventWidows(
+							translate(
+								'With your free plan, you can monitor the 20 most ' +
+									'recent events on your site. Upgrade to a paid plan to ' +
+									'unlock powerful features:'
+							)
 						) }
 						showIcon={ true }
 						list={ [

--- a/client/my-sites/activity/activity-log-banner/upgrade-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/upgrade-banner.jsx
@@ -27,9 +27,9 @@ class UpgradeBanner extends Component {
 						href={ `/checkout/${ siteSlug }/${ PRODUCT_UPSELLS_BY_FEATURE[ FEATURE_ACTIVITY_LOG ] }` }
 						title={ translate( 'Unlock more activities now' ) }
 						description={ translate(
-							'With your free plan, you can monitor the 20 most ' +
-								'recent events on your site. Upgrade to a paid plan to ' +
-								'unlock powerful features:'
+							'You currently have access to the 20 most recent events ' +
+								'on your site. Upgrade to Jetpack VaultPress Backup ' +
+								'or Jetpack Security to unlock powerful features:'
 						) }
 						showIcon={ true }
 						list={ [

--- a/client/my-sites/activity/activity-log-v2/index.tsx
+++ b/client/my-sites/activity/activity-log-v2/index.tsx
@@ -14,6 +14,7 @@ import Main from 'calypso/components/main';
 import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import useActivityLogQuery from 'calypso/data/activity-log/use-activity-log-query';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { preventWidows } from 'calypso/lib/formatting';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { backupClonePath } from 'calypso/my-sites/backup/paths';
 import { useSelector, useDispatch } from 'calypso/state';
@@ -71,8 +72,13 @@ const ActivityLogV2: FunctionComponent = () => {
 	) : (
 		<Upsell
 			headerText={ translate( 'Activity Log' ) }
-			bodyText={ translate(
-				'With your free plan, you can monitor the 20 most recent events. A paid plan unlocks more powerful features. You can access all site activity for the last 30 days and filter events by type and date range to quickly find the information you need. '
+			bodyText={ preventWidows(
+				translate(
+					'You currently have access to the 20 most recent events. Upgrade to Jetpack ' +
+						'VaultPress Backup or Jetpack Security to unlock more powerful features. ' +
+						'You can access all site activity for the last 30 days and filter events ' +
+						'by type and date range to quickly find the information you need.'
+				)
 			) }
 			buttonLink={ `https://cloud.jetpack.com/pricing/${ selectedSiteSlug }` }
 			buttonText={ translate( 'Upgrade Now' ) }


### PR DESCRIPTION
This PR updates the Activity Log upsell to be more clear/less confusing.

The issue was that the upsell said, "With your free plan, you can monitor the 20 most recent events on your site. Upgrade to a paid plan to unlock powerful features."

**BEFORE:**

<img width="1099" alt="Screenshot on 2023-09-27 at 18-11-04 (1)" src="https://github.com/Automattic/wp-calypso/assets/11078128/177530c5-103d-420f-95c4-cbd4a1291d6e">

This makes sense for wordpress.com Simple site users, but a Jetpack site user with a purchased/paid "product", such as Boost, or Social, etc. may wonder why this ⤴️ says, "**_With your free plan_** you can monitor...".  (My free plan? I have Jetpack Boost!)

The confusion here is with the term "Plan".
A Jetpack site is always subscribed to a "Plan", which can be either Free, Security, or Complete.
Then also we have "products", such as Backup, Scan, Boost, Social, etc...
Most users don't know about this distinction between a "Plan" and a "product", so if they purchase a product such as Boost, or Social, etc., they would expect that they are no longer on a free plan, when actually they _are_ still on the free plan.

Here's the rules for the Activity Log (Jetpack sites):
Customers on the free plan have access to their 20 most recent site events. Upgrading to Backup or Security extends this: you can see events from the last 30 days, and if you have Complete, you’ll see events from the last year.

This PR updates the copy to be more clear/less confusing for Jetpack sites. The upsell copy for WordPress.com simple sites remains the same.

#### Screenshots

**AFTER:**

Activity Log - Selected site is a Jetpack site:

(Intro-banner)
![Markup 2023-10-15 at 14 28 39](https://github.com/Automattic/wp-calypso/assets/11078128/63cbd8ca-9278-4bbe-b302-462b59c2b4c7)

(Upsell-banner)
![Markup 2023-10-15 at 14 29 53](https://github.com/Automattic/wp-calypso/assets/11078128/4c653bd7-4103-4218-82a1-6cf13de7c426)

Activity Log - Selected site is a WordPress.com Simple site (No change):

(Intro-banner)
![Markup 2023-10-15 at 14 31 30](https://github.com/Automattic/wp-calypso/assets/11078128/96af701f-e5ee-4f54-bae9-712939467b2a)

(Upsell- banner)
![Screenshot on 2023-10-15 at 14-32-12](https://github.com/Automattic/wp-calypso/assets/11078128/056ecf97-3838-45a9-a55f-d41774a763f1)

Activity Log - Jetpack Cloud

![Markup 2023-10-15 at 14 53 15](https://github.com/Automattic/wp-calypso/assets/11078128/2d37afe0-3680-4f60-a8c5-707e0b598599)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to: https://github.com/Automattic/jetpack-marketing/issues/199
From Slack discussion: p1695827640837169-slack-C01264051NE

## Proposed Changes

* Activity Log dismissible "intro-banner": Updated copy to make more sense for Jetpack sites (for Simple sites, copy is unchanged)
* Activity Log upsell banner: Updated copy to make more sense for Jetpack sites (for Simple sites, copy is unchanged)
* Jetpack Cloud Activity Log upsell banner: Updated copy to make more sense for Jetpack sites (for Simple sites, copy is unchanged)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Do either one of these:
    - Checkout this PR branch and run Calypso blue and green concurrently (In separate terminal windows, run `yarn start` and `yarn start-jetpack-cloud-p`)
    - OR:
    - Click/open both the "Calypso Live (direct link)" and the "Jetpack Cloud live (direct link)" below.
- In Calypso blue, select a Jetpack site that **does not** have a subscription to either Jetpack Backup, Jetpack Security, or Jetpack Complete. (You can create and connect a Jurassic.Ninja site if you don't already have one connected)
- Go to Jetpack --> Activity Log
- Verify the Intro-Banner looks like the Screenshot above, and that the copy makes more sense and is less confusing.
    - (If you don't see the Intro-banner, you can open Calypso Preferences from the Calypso Dev Tools in the bottom-right corner of Calypso, and un-check the `dismissable-card-activity-introduction-banner` preference and then Save.) 
- Click the X in the Intro-banner to dismiss it.
- You should now see the Upsell-banner.
- Verify the Upsell banner looks like the Screenshot above, and that the copy makes more sense and is less confusing.
- Now select a wordpress.com Simple site and verify the Activity Log Intro-banner and Upsell-banner look the the screenshots above and that they remain unchanged.
- Finally, Open calypso green and select a site that **does not** have a subscription to either Jetpack Backup, Jetpack Security, or Jetpack Complete.
-Go to Activity Log
- Verify the Upsell banner looks like the Screenshot above, and that the copy makes more sense and is less confusing.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?