### PR TITLE
Honor redirect_to during signup from login screen

### DIFF
--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -60,6 +60,15 @@ export function getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, 
 	 */
 	const isFromPublicAPIConnectFlow = includes( redirectTo, 'public.api/connect/?action=verify' );
 
+	// When there is a redirect_to provided we want to pass that down to the signup page
+	// we also want to skip the normal onboarding flow using /start/account to bypass it.
+	if ( redirectTo ) {
+		const params = new URLSearchParams( {
+			redirect_to: redirectTo,
+		} );
+		signupUrl = `/start/account?${ params.toString() }`;
+	}
+
 	if (
 		// Match locales like `/log-in/jetpack/es`
 		startsWith( currentRoute, '/log-in/jetpack' )


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/71027

## Proposed Changes

* When visiting /log-in with a ?redirect_to= param and they choose the "Create a new account" option, we now land the user on that redirect_to value straight after account creation. That is, we skip the standard /start onboarding flow that creates a site and asks for domain selection.

## Testing Instructions

* While logged out visit:
* http://calypso.localhost:3000/me
* You should be landed there after creating an account using the "Create a new account" button

Todo:

Figure out what oauth flows need a similar fix.

![Screenshot(33)](https://github.com/Automattic/wp-calypso/assets/811776/de4553e5-e258-4192-a177-90f08a994d80)
