### PR TITLE
Use wpcc onboarding flow for account creation during oauth login by default

### DIFF
--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -45,7 +45,7 @@ export function pathWithLeadingSlash( path ) {
 }
 
 export function getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, pathname ) {
-	let signupUrl = config( 'signup_url' );
+	const signupUrl = config( 'signup_url' );
 
 	const redirectTo = get( currentQuery, 'redirect_to', '' );
 	const signupFlow = get( currentQuery, 'signup_flow' );
@@ -74,14 +74,11 @@ export function getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, 
 			 * this case, the redirect_to will handle signups as part of the flow. Use the
 			 * `redirect_to` parameter directly for signup.
 			 */
-			signupUrl = currentQuery.redirect_to;
-		} else {
-			signupUrl = '/jetpack/connect';
+			return currentQuery.redirect_to;
 		}
+		return '/jetpack/connect';
 	} else if ( '/jetpack-connect' === pathname ) {
-		signupUrl = '/jetpack/connect';
-	} else if ( signupFlow ) {
-		signupUrl += '/' + signupFlow;
+		return '/jetpack/connect';
 	}
 
 	if ( isAkismetOAuth2Client( oauth2Client ) || isIntenseDebateOAuth2Client( oauth2Client ) ) {
@@ -90,23 +87,29 @@ export function getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, 
 			oauth2_client_id: oauth2Client.id,
 			oauth2_redirect: redirectTo,
 		} );
-		signupUrl = `${ signupUrl }/${ oauth2Flow }?${ oauth2Params.toString() }`;
-	} else if ( isGravPoweredOAuth2Client( oauth2Client ) ) {
+		return `${ signupUrl }/${ oauth2Flow }?${ oauth2Params.toString() }`;
+	}
+
+	if ( isGravPoweredOAuth2Client( oauth2Client ) ) {
 		// Gravatar powered clients signup via the magic login page
-		signupUrl = login( {
+		return login( {
 			locale,
 			twoFactorAuthType: 'link',
 			oauth2ClientId: oauth2Client.id,
 			redirectTo: redirectTo,
 		} );
-	} else if ( isCrowdsignalOAuth2Client( oauth2Client ) ) {
+	}
+
+	if ( isCrowdsignalOAuth2Client( oauth2Client ) ) {
 		const oauth2Flow = 'crowdsignal';
 		const oauth2Params = new URLSearchParams( {
 			oauth2_client_id: oauth2Client.id,
 			oauth2_redirect: redirectTo,
 		} );
-		signupUrl = `${ signupUrl }/${ oauth2Flow }?${ oauth2Params.toString() }`;
-	} else if ( oauth2Client && isWooOAuth2Client( oauth2Client ) ) {
+		return `${ signupUrl }/${ oauth2Flow }?${ oauth2Params.toString() }`;
+	}
+
+	if ( oauth2Client && isWooOAuth2Client( oauth2Client ) ) {
 		const oauth2Params = new URLSearchParams( {
 			oauth2_client_id: oauth2Client.id,
 			oauth2_redirect: redirectTo,
@@ -114,20 +117,36 @@ export function getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, 
 		if ( wccomFrom ) {
 			oauth2Params.set( 'wccom-from', wccomFrom );
 		}
-		signupUrl = `${ signupUrl }/wpcc?${ oauth2Params.toString() }`;
-	} else if ( oauth2Client && isJetpackCloudOAuth2Client( oauth2Client ) ) {
+		return `${ signupUrl }/wpcc?${ oauth2Params.toString() }`;
+	}
+
+	if ( oauth2Client && isJetpackCloudOAuth2Client( oauth2Client ) ) {
 		const oauth2Params = new URLSearchParams( {
 			oauth2_client_id: oauth2Client.id,
 			oauth2_redirect: redirectTo,
 		} );
-		signupUrl = `${ signupUrl }/wpcc?${ oauth2Params.toString() }`;
-	} else if ( oauth2Client ) {
+		return `${ signupUrl }/wpcc?${ oauth2Params.toString() }`;
+	}
+
+	if ( oauth2Client ) {
 		const oauth2Params = new URLSearchParams( {
 			oauth2_client_id: oauth2Client.id,
 			oauth2_redirect: redirectTo,
 		} );
-		signupUrl = `${ signupUrl }/wpcc?${ oauth2Params.toString() }`;
-	} else if (
+		return `${ signupUrl }/wpcc?${ oauth2Params.toString() }`;
+	}
+
+	if ( signupFlow ) {
+		if ( redirectTo ) {
+			const params = new URLSearchParams( {
+				redirect_to: redirectTo,
+			} );
+			return `${ signupUrl }/${ signupFlow }?${ params.toString() }`;
+		}
+		return `${ signupUrl }/${ signupFlow }`;
+	}
+
+	if (
 		isFromMigrationPlugin ||
 		isFromPublicAPIConnectFlow ||
 		( includes( redirectTo, 'action=jetpack-sso' ) && includes( redirectTo, 'sso_nonce=' ) ) ||
@@ -136,7 +155,7 @@ export function getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, 
 		const params = new URLSearchParams( {
 			redirect_to: redirectTo,
 		} );
-		signupUrl = `/start/account?${ params.toString() }`;
+		return `${ signupUrl }/account?${ params.toString() }`;
 	}
 
 	return signupUrl;

--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -82,37 +82,32 @@ export function getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, 
 		signupUrl = '/jetpack/connect';
 	} else if ( signupFlow ) {
 		signupUrl += '/' + signupFlow;
-	}
-
-	if ( isAkismetOAuth2Client( oauth2Client ) || isIntenseDebateOAuth2Client( oauth2Client ) ) {
+	} else if (
+		isAkismetOAuth2Client( oauth2Client ) ||
+		isIntenseDebateOAuth2Client( oauth2Client )
+	) {
 		const oauth2Flow = 'wpcc';
 		const oauth2Params = new URLSearchParams( {
 			oauth2_client_id: oauth2Client.id,
 			oauth2_redirect: redirectTo,
 		} );
 		signupUrl = `${ signupUrl }/${ oauth2Flow }?${ oauth2Params.toString() }`;
-	}
-
-	// Gravatar powered clients signup via the magic login page
-	if ( isGravPoweredOAuth2Client( oauth2Client ) ) {
+	} else if ( isGravPoweredOAuth2Client( oauth2Client ) ) {
+		// Gravatar powered clients signup via the magic login page
 		signupUrl = login( {
 			locale,
 			twoFactorAuthType: 'link',
 			oauth2ClientId: oauth2Client.id,
 			redirectTo: redirectTo,
 		} );
-	}
-
-	if ( isCrowdsignalOAuth2Client( oauth2Client ) ) {
+	} else if ( isCrowdsignalOAuth2Client( oauth2Client ) ) {
 		const oauth2Flow = 'crowdsignal';
 		const oauth2Params = new URLSearchParams( {
 			oauth2_client_id: oauth2Client.id,
 			oauth2_redirect: redirectTo,
 		} );
 		signupUrl = `${ signupUrl }/${ oauth2Flow }?${ oauth2Params.toString() }`;
-	}
-
-	if ( oauth2Client && isWooOAuth2Client( oauth2Client ) ) {
+	} else if ( oauth2Client && isWooOAuth2Client( oauth2Client ) ) {
 		const oauth2Params = new URLSearchParams( {
 			oauth2_client_id: oauth2Client.id,
 			oauth2_redirect: redirectTo,
@@ -121,17 +116,19 @@ export function getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, 
 			oauth2Params.set( 'wccom-from', wccomFrom );
 		}
 		signupUrl = `${ signupUrl }/wpcc?${ oauth2Params.toString() }`;
-	}
-
-	if ( oauth2Client && isJetpackCloudOAuth2Client( oauth2Client ) ) {
+	} else if ( oauth2Client && isJetpackCloudOAuth2Client( oauth2Client ) ) {
 		const oauth2Params = new URLSearchParams( {
 			oauth2_client_id: oauth2Client.id,
 			oauth2_redirect: redirectTo,
 		} );
 		signupUrl = `${ signupUrl }/wpcc?${ oauth2Params.toString() }`;
-	}
-
-	if (
+	} else if ( oauth2Client ) {
+		const oauth2Params = new URLSearchParams( {
+			oauth2_client_id: oauth2Client.id,
+			oauth2_redirect: redirectTo,
+		} );
+		signupUrl = `${ signupUrl }/wpcc?${ oauth2Params.toString() }`;
+	} else if (
 		isFromMigrationPlugin ||
 		isFromPublicAPIConnectFlow ||
 		( includes( redirectTo, 'action=jetpack-sso' ) && includes( redirectTo, 'sso_nonce=' ) )

--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -131,7 +131,8 @@ export function getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, 
 	} else if (
 		isFromMigrationPlugin ||
 		isFromPublicAPIConnectFlow ||
-		( includes( redirectTo, 'action=jetpack-sso' ) && includes( redirectTo, 'sso_nonce=' ) )
+		( includes( redirectTo, 'action=jetpack-sso' ) && includes( redirectTo, 'sso_nonce=' ) ) ||
+		redirectTo
 	) {
 		const params = new URLSearchParams( {
 			redirect_to: redirectTo,

--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -82,10 +82,9 @@ export function getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, 
 		signupUrl = '/jetpack/connect';
 	} else if ( signupFlow ) {
 		signupUrl += '/' + signupFlow;
-	} else if (
-		isAkismetOAuth2Client( oauth2Client ) ||
-		isIntenseDebateOAuth2Client( oauth2Client )
-	) {
+	}
+
+	if ( isAkismetOAuth2Client( oauth2Client ) || isIntenseDebateOAuth2Client( oauth2Client ) ) {
 		const oauth2Flow = 'wpcc';
 		const oauth2Params = new URLSearchParams( {
 			oauth2_client_id: oauth2Client.id,

--- a/client/lib/login/test/index.js
+++ b/client/lib/login/test/index.js
@@ -1,4 +1,4 @@
-import { pathWithLeadingSlash } from 'calypso/lib/login';
+import { pathWithLeadingSlash, getSignupUrl } from 'calypso/lib/login';
 
 describe( 'pathWithLeadingSlash', () => {
 	test( 'should add leading slash', () => {
@@ -18,5 +18,129 @@ describe( 'pathWithLeadingSlash', () => {
 		for ( const i in values ) {
 			expect( pathWithLeadingSlash( values[ i ] ) ).toEqual( '' );
 		}
+	} );
+} );
+
+jest.mock( '@automattic/calypso-config', () => ( {
+	__esModule: true,
+	default: jest.fn( ( key ) => {
+		switch ( key ) {
+			case 'signup_url':
+				return '/start';
+			default:
+				return null;
+		}
+	} ),
+} ) );
+
+describe( 'getSignupUrl', () => {
+	test( 'should work for /log-in route', () => {
+		const currentRoute = '/log-in';
+		expect( getSignupUrl( undefined, currentRoute, null, 'en', '' ) ).toEqual( '/start' );
+	} );
+
+	test( 'should work for /log-in route with redirect_to', () => {
+		const currentQuery = {
+			redirect_to: '/me/',
+		};
+		const currentRoute = '/log-in';
+		expect( getSignupUrl( currentQuery, currentRoute, null, 'en', '' ) ).toEqual(
+			'/start/account?redirect_to=%2Fme%2F'
+		);
+	} );
+
+	test( 'should work for VaultPress route', () => {
+		const currentQuery = {
+			client_id: '930',
+			redirect_to:
+				'https://public-api.wordpress.com/oauth2/authorize?client_id=930&response_type=code&blog_id=0&state=1234&redirect_uri=https%3A%2F%2Fvaultpress.com%2Flogin%2F%3Faction%3Drequest_access_token&from-calypso=1',
+		};
+		const currentRoute = '/log-in';
+		const oauth2Client = {
+			id: 930,
+			name: 'vaultpress',
+			title: 'VaultPress',
+			icon: 'https://vaultpress.com/images/vaultpress-wpcc-nav-2x.png',
+			url: 'http://vaultpress.com/',
+		};
+		expect( getSignupUrl( currentQuery, currentRoute, oauth2Client, 'en', '' ) ).toEqual(
+			'/start/wpcc?oauth2_client_id=930&oauth2_redirect=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D930%26response_type%3Dcode%26blog_id%3D0%26state%3D1234%26redirect_uri%3Dhttps%253A%252F%252Fvaultpress.com%252Flogin%252F%253Faction%253Drequest_access_token%26from-calypso%3D1'
+		);
+	} );
+
+	test( 'should work for IntenseDebate route', () => {
+		const currentQuery = {
+			client_id: '2665',
+			redirect_to:
+				'https://public-api.wordpress.com/oauth2/authorize?client_id=2665&response_type=code&blog_id=0&state=1234&redirect_uri=https%3A%2F%2Fintensedebate.com%2Fconnect%2F%3Faction%3Drequest_access_token&from-calypso=1',
+		};
+		const currentRoute = '/log-in';
+		const oauth2Client = {
+			id: 2665,
+			name: 'intensedebate',
+			title: 'IntenseDebate',
+			icon: 'https://intensedebate.com/images/svg/intensedebate-logo.svg',
+			url: 'https://intensedebate.com/',
+		};
+		expect( getSignupUrl( currentQuery, currentRoute, oauth2Client, 'en', '' ) ).toEqual(
+			'/start/wpcc?oauth2_client_id=2665&oauth2_redirect=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D2665%26response_type%3Dcode%26blog_id%3D0%26state%3D1234%26redirect_uri%3Dhttps%253A%252F%252Fintensedebate.com%252Fconnect%252F%253Faction%253Drequest_access_token%26from-calypso%3D1'
+		);
+	} );
+
+	test( 'should work for Gravatar route', () => {
+		const currentQuery = {
+			redirect_to:
+				'https://public-api.wordpress.com/oauth2/authorize?client_id=1854&response_type=code&blog_id=0&state=1234&redirect_uri=https%3A%2F%2Fgravatar.com%2Fconnect%2F%3Faction%3Drequest_access_token&from-calypso=1',
+			client_id: '1854',
+		};
+		const currentRoute = '/log-in';
+		const oauth2Client = {
+			id: 1854,
+			name: 'gravatar',
+			title: 'Gravatar',
+			icon: 'https://gravatar.com/images/grav-logo-blue.svg',
+			favicon: 'https://gravatar.com/favicon.ico',
+			url: 'https://gravatar.com/',
+		};
+		expect( getSignupUrl( currentQuery, currentRoute, oauth2Client, 'en', '' ) ).toEqual(
+			'/log-in/link?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D1854%26response_type%3Dcode%26blog_id%3D0%26state%3D1234%26redirect_uri%3Dhttps%253A%252F%252Fgravatar.com%252Fconnect%252F%253Faction%253Drequest_access_token%26from-calypso%3D1&client_id=1854'
+		);
+	} );
+
+	test( 'should work for WooCommmerce route', () => {
+		const currentQuery = {
+			client_id: '50916',
+			redirect_to:
+				'https://public-api.wordpress.com/oauth2/authorize/?response_type=code&client_id=50916&state=1234&redirect_uri=https%3A%2F%2Fwoocommerce.com%2Fwc-api%2Fwpcom-signin%3Fnext%3D%252F&blog_id=0&wpcom_connect=1&wccom-from&calypso_env=production&from-calypso=1',
+		};
+		const currentRoute = '/log-in';
+		const oauth2Client = {
+			id: 50916,
+			name: 'woo',
+			title: 'WooCommerce.com',
+			icon: 'https://woocommerce.com/wp-content/themes/woo/images/logo-woocommerce@2x.png',
+			url: 'https://woocommerce.com',
+		};
+		expect( getSignupUrl( currentQuery, currentRoute, oauth2Client, 'en', '' ) ).toEqual(
+			'/start/wpcc?oauth2_client_id=50916&oauth2_redirect=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3D1234%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.com%252Fwc-api%252Fwpcom-signin%253Fnext%253D%25252F%26blog_id%3D0%26wpcom_connect%3D1%26wccom-from%26calypso_env%3Dproduction%26from-calypso%3D1'
+		);
+	} );
+
+	test( 'should work for Jetpack Cloud route', () => {
+		const currentQuery = {
+			client_id: '69040',
+			redirect_to:
+				'https://public-api.wordpress.com/oauth2/authorize?response_type=token&client_id=69040&redirect_uri=https%3A%2F%2Fcloud.jetpack.com%2Fconnect%2Foauth%2Ftoken%3Fnext%3D%252Fpricing&scope=global&blog_id=0&from-calypso=1',
+		};
+		const currentRoute = '/log-in';
+		const oauth2Client = {
+			id: 69040,
+			name: 'jetpack-cloud',
+			title: 'Jetpack.com Staging',
+			url: 'https://jetpack.com',
+		};
+		expect( getSignupUrl( currentQuery, currentRoute, oauth2Client, 'en', '' ) ).toEqual(
+			'/start/wpcc?oauth2_client_id=69040&oauth2_redirect=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fresponse_type%3Dtoken%26client_id%3D69040%26redirect_uri%3Dhttps%253A%252F%252Fcloud.jetpack.com%252Fconnect%252Foauth%252Ftoken%253Fnext%253D%25252Fpricing%26scope%3Dglobal%26blog_id%3D0%26from-calypso%3D1'
+		);
 	} );
 } );

--- a/client/lib/login/test/index.js
+++ b/client/lib/login/test/index.js
@@ -183,4 +183,18 @@ describe( 'getSignupUrl', () => {
 			getSignupUrl( { redirect_to: 'https://example.com' }, '/log-in/jetpack', null, 'en', '' )
 		).toEqual( '/jetpack/connect' );
 	} );
+
+	test( 'redirect_to=public.api/connect/?action=verify uses /start/account with ?redirect_to passthrough', () => {
+		expect(
+			getSignupUrl(
+				{ redirect_to: 'https://public-api.wordpress.com/public.api/connect/?action=verify' },
+				'/log-in',
+				null,
+				'en',
+				''
+			)
+		).toEqual(
+			'/start/account?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Fpublic.api%2Fconnect%2F%3Faction%3Dverify'
+		);
+	} );
 } );

--- a/client/lib/login/test/index.js
+++ b/client/lib/login/test/index.js
@@ -143,4 +143,44 @@ describe( 'getSignupUrl', () => {
 			'/start/wpcc?oauth2_client_id=69040&oauth2_redirect=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fresponse_type%3Dtoken%26client_id%3D69040%26redirect_uri%3Dhttps%253A%252F%252Fcloud.jetpack.com%252Fconnect%252Foauth%252Ftoken%253Fnext%253D%25252Fpricing%26scope%3Dglobal%26blog_id%3D0%26from-calypso%3D1'
 		);
 	} );
+
+	test( 'signup_flow modifies /start base', () => {
+		expect( getSignupUrl( { signup_flow: 'test' }, '/log-in', null, 'en', '' ) ).toEqual(
+			'/start/test'
+		);
+		expect(
+			getSignupUrl(
+				{ signup_flow: 'test', redirect_to: 'https://example.com' },
+				'/log-in',
+				null,
+				'en',
+				''
+			)
+		).toEqual( '/start/test' );
+	} );
+
+	test( '/log-in/jetpack uses /jetpack/connect', () => {
+		expect( getSignupUrl( {}, '/log-in/jetpack', null, 'en', '' ) ).toEqual( '/jetpack/connect' );
+		expect( getSignupUrl( {}, '/log-in/jetpack/es', null, 'es', '' ) ).toEqual(
+			'/jetpack/connect'
+		);
+	} );
+
+	test( '/log-in/jetpack?redirect_to with nonce uses redirect_to', () => {
+		expect(
+			getSignupUrl(
+				{ redirect_to: 'https://example.com/jetpack/connect/authorize?&_wp_nonce=example' },
+				'/log-in/jetpack',
+				null,
+				'en',
+				''
+			)
+		).toEqual( 'https://example.com/jetpack/connect/authorize?&_wp_nonce=example' );
+	} );
+
+	test( '/log-in/jetpack?redirect_to without nonce uses /jetpack/connect', () => {
+		expect(
+			getSignupUrl( { redirect_to: 'https://example.com' }, '/log-in/jetpack', null, 'en', '' )
+		).toEqual( '/jetpack/connect' );
+	} );
 } );

--- a/client/lib/login/test/index.js
+++ b/client/lib/login/test/index.js
@@ -156,7 +156,16 @@ describe( 'getSignupUrl', () => {
 				'en',
 				''
 			)
-		).toEqual( '/start/test' );
+		).toEqual( '/start/test?redirect_to=https%3A%2F%2Fexample.com' );
+		expect(
+			getSignupUrl(
+				{ signup_flow: 'account', redirect_to: 'https://example.com' },
+				'/log-in',
+				null,
+				'en',
+				''
+			)
+		).toEqual( '/start/account?redirect_to=https%3A%2F%2Fexample.com' );
 	} );
 
 	test( '/log-in/jetpack uses /jetpack/connect', () => {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/71027

## Proposed Changes

There are two issues being resolved here:
- #71027 outlines how redirect_to is ignored when creating an account from the login screen as the redirect_to param gets dropped when moving to /start. Even if it was passed in it would be ignored by the /start/onboarding flow. This PR both ensures the redirect_to is passed through and that /start/account is used in place of /start/onboarding (aka /start) when a redirect_to query param is provided. 
- p1697220716421119-slack-C02T4NVL4JJ discusses account creation when logging in to e.g. vaultpress via oauth. This PR routes all signups via oauth through /start/wpcc if there isn't a specific flow already defined in `signupUrl`

Todo:

Could use help testing
- [x] Each oauth client flow, especially jetpack and woocommerce.com
- [x] Jetpack connections
- [x] Comment / like signups

## Testing Instructions

Redirect to & /start/account handling:

* While logged out visit:
* http://calypso.localhost:3000/me
* You should be landed there after creating an account using the "Create a new account" button

Wpcc login paths:

* While logged out of wordpress.com visit:
* https://vaultpress.com/
* Click login
* You'll be taken to wordpress.com login screen: e.g. `https://wordpress.com/log-in?client_id=930&redirect_to=https%......`
* Change the `wordpress.com` part to `calypso.localhost:3000` for testing.
* Click "Create a new account"
* You should be taken to the /start/wpcc sign up flow and ultimately logged in to vaultpress after signup.

![Screenshot(33)](https://github.com/Automattic/wp-calypso/assets/811776/de4553e5-e258-4192-a177-90f08a994d80)