### PR TITLE
Site Profiler: Add registrar to tracks

### DIFF
--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -10,6 +10,7 @@ import useDomainParam from 'calypso/site-profiler/hooks/use-domain-param';
 import useLongFetchingDetection from '../hooks/use-long-fetching-detection';
 import useScrollToTop from '../hooks/use-scroll-to-top';
 import useSiteProfilerRecordAnalytics from '../hooks/use-site-profiler-record-analytics';
+import { normalizeWhoisField } from '../utils/normalize-whois-entry';
 import DomainAnalyzer from './domain-analyzer';
 import DomainInformation from './domain-information';
 import HeadingInformation from './heading-information';
@@ -57,6 +58,7 @@ export default function SiteProfiler( props: Props ) {
 		isDomainValid,
 		conversionAction,
 		hostingProviderData?.hosting_provider,
+		normalizeWhoisField( siteProfilerData?.whois?.registrar ),
 		urlData
 	);
 

--- a/client/site-profiler/hooks/use-site-profiler-record-analytics.ts
+++ b/client/site-profiler/hooks/use-site-profiler-record-analytics.ts
@@ -2,7 +2,7 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useEffect } from 'react';
 import { SPECIAL_DOMAIN_CATEGORY } from 'calypso/site-profiler/utils/get-domain-category';
 import type { UrlData } from 'calypso/blocks/import/types';
-import type { HostingProvider } from 'calypso/data/site-profiler/types';
+import type { HostingProvider, Whois } from 'calypso/data/site-profiler/types';
 import type { CONVERSION_ACTION } from 'calypso/site-profiler/hooks/use-define-conversion-action';
 
 /**
@@ -15,6 +15,7 @@ export default function useSiteProfilerRecordAnalytics(
 	isDomainValid?: boolean,
 	conversionAction?: CONVERSION_ACTION,
 	hostingProvider?: HostingProvider,
+	registrar?: Whois.registrar,
 	urlData?: UrlData
 ) {
 	useEffect( () => {
@@ -31,8 +32,9 @@ export default function useSiteProfilerRecordAnalytics(
 				domain_category: domainCategory,
 				is_domain_valid: isDomainValid,
 				conversion_action: conversionAction,
+				registrar,
 			} );
-	}, [ domain, isDomainValid, conversionAction ] );
+	}, [ domain, isDomainValid, conversionAction, domainCategory, registrar ] );
 
 	useEffect( () => {
 		hostingProvider &&
@@ -42,7 +44,7 @@ export default function useSiteProfilerRecordAnalytics(
 				provider_slug: hostingProvider?.slug,
 				provider_name: hostingProvider?.name,
 			} );
-	}, [ hostingProvider ] );
+	}, [ domain, hostingProvider ] );
 
 	useEffect( () => {
 		urlData &&
@@ -54,5 +56,5 @@ export default function useSiteProfilerRecordAnalytics(
 				platform_is_wpengine: urlData?.platform_data?.is_wpengine,
 				platform_is_pressable: urlData?.platform_data?.is_pressable,
 			} );
-	}, [ urlData ] );
+	}, [ domain, urlData ] );
 }

--- a/client/site-profiler/hooks/use-site-profiler-record-analytics.ts
+++ b/client/site-profiler/hooks/use-site-profiler-record-analytics.ts
@@ -2,7 +2,7 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useEffect } from 'react';
 import { SPECIAL_DOMAIN_CATEGORY } from 'calypso/site-profiler/utils/get-domain-category';
 import type { UrlData } from 'calypso/blocks/import/types';
-import type { HostingProvider, Whois } from 'calypso/data/site-profiler/types';
+import type { HostingProvider, WhoIs } from 'calypso/data/site-profiler/types';
 import type { CONVERSION_ACTION } from 'calypso/site-profiler/hooks/use-define-conversion-action';
 
 /**
@@ -15,7 +15,7 @@ export default function useSiteProfilerRecordAnalytics(
 	isDomainValid?: boolean,
 	conversionAction?: CONVERSION_ACTION,
 	hostingProvider?: HostingProvider,
-	registrar?: Whois.registrar,
+	registrar?: WhoIs[ 'registrar' ],
 	urlData?: UrlData
 ) {
 	useEffect( () => {


### PR DESCRIPTION
## Proposed Changes

This adds registrar field to the `calypso_site_profiler_domain_analyze` tracks event.

## Testing Instructions

1. Make sure you have `localStorage.setItem( 'debug', 'calypso:analytics*' );` set up in console.
1. Enter a domain in `/site-profiler`
2. Make sure you see registrar recorded in  `calypso_site_profiler_domain_analyze` 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
