### PR TITLE
Migration trial: Fix check eligibility migration trial regression

### DIFF
--- a/client/blocks/importer/wordpress/import-everything/pre-migration/upgrade-plan.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/upgrade-plan.tsx
@@ -40,7 +40,10 @@ export const PreMigrationUpgradePlan: React.FunctionComponent< Props > = ( props
 	const { data: migrationTrialEligibility } = useCheckEligibilityMigrationTrialPlan(
 		targetSite.ID
 	);
-	const isEligibleForTrialPlan = migrationTrialEligibility?.eligible;
+	const isEligibleForTrialPlan =
+		migrationTrialEligibility?.eligible ||
+		// If the user's email is unverified, we still want to show the trial plan option
+		migrationTrialEligibility?.error_code === 'email-unverified';
 	const [ popoverVisible, setPopoverVisible ] = useState( false );
 	const trialBtnRef: React.RefObject< HTMLButtonElement > = useRef( null );
 

--- a/client/data/plans/use-check-eligibility-migration-trial-plan.ts
+++ b/client/data/plans/use-check-eligibility-migration-trial-plan.ts
@@ -3,9 +3,17 @@ import { useQuery, UseQueryResult } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 import type { SiteSlug, SiteId } from 'calypso/types';
 
+type ErrorCode =
+	| 'invalid-plan-slug'
+	| 'email-unverified'
+	| 'has-had-business-trial'
+	| 'existing-trial'
+	| 'no-upgrades-permitted';
+
 interface Response {
 	blog_id: SiteId;
 	eligible: boolean;
+	error_code: ErrorCode;
 	message: string;
 }
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/migration-trial-acknowledge.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/migration-trial-acknowledge.tsx
@@ -5,6 +5,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs } from '@wordpress/url';
+import { useEffect } from 'react';
 import { useCheckoutUrl } from 'calypso/blocks/importer/hooks/use-checkout-url';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import useAddHostingTrialMutation from 'calypso/data/hosting/use-add-hosting-trial-mutation';
@@ -39,6 +40,7 @@ const MigrationTrialAcknowledgeInternal = function ( props: Props ) {
 	const { data: migrationTrialEligibility, isLoading: isCheckingEligibility } =
 		useCheckEligibilityMigrationTrialPlan( site?.ID );
 	const isEligibleForTrialPlan = migrationTrialEligibility?.eligible;
+	const eligibilityErrorCode = migrationTrialEligibility?.error_code;
 
 	const plan = getPlan( PLAN_BUSINESS );
 	const checkoutUrl = useCheckoutUrl( site.ID, siteSlug );
@@ -73,6 +75,15 @@ const MigrationTrialAcknowledgeInternal = function ( props: Props ) {
 			addHostingTrial( site.ID, PLAN_MIGRATION_TRIAL_MONTHLY );
 		}
 	}
+
+	useEffect( () => {
+		switch ( eligibilityErrorCode ) {
+			case 'email-unverified':
+			default:
+				navigateToVerifyEmailStep();
+				break;
+		}
+	}, [ eligibilityErrorCode ] );
 
 	if ( isAddingTrial || isCheckingEligibility ) {
 		return <LoadingEllipsis />;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/migration-trial-acknowledge.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/migration-trial-acknowledge.tsx
@@ -79,7 +79,6 @@ const MigrationTrialAcknowledgeInternal = function ( props: Props ) {
 	useEffect( () => {
 		switch ( eligibilityErrorCode ) {
 			case 'email-unverified':
-			default:
 				navigateToVerifyEmailStep();
 				break;
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Context: p1697445251379839-slack-C01A60HCGUA
Endpoint update: D125399-code

## Proposed Changes

Fixed regression on checking if the user is eligible to run the migration trial.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Login with a non-verified user
* Pass through the `/start` flow
* or go directly: `/setup/site-setup/importerWordpress?siteSlug={SITE_SLUG}&from={SELF_HOSTED_SITE}&option=everything`
* Check if there is no tooltip above the "Try it for free" button
* Click on "Try it for free"
* Check if the "Verify your email address" is rendered

NOTE: The verification email step will be shown after the CTA button click

<img width="807" alt="Screenshot 2023-10-16 at 11 05 39" src="https://github.com/Automattic/wp-calypso/assets/1241413/7811e476-26f6-4c1d-bf0c-fab8de69f40d">


<table>
  <tr>
    <td width=50%>
      Before:
<img width="787" alt="Screenshot 2023-10-16 at 13 47 40" src="https://github.com/Automattic/wp-calypso/assets/1241413/57749424-2b71-4343-8d9f-0fd21da1190e">
</td>
    <td width=50%>
      After:
      <img width="749" alt="Screenshot 2023-10-16 at 13 48 00" src="https://github.com/Automattic/wp-calypso/assets/1241413/82a0e45d-5060-44dc-9d15-081064ef9f6f">
</td>
</tr>
</table>


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?