### PR TITLE
Multi-domain: Clicking Back from Checkout sends domain flow to /start

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import {
 	PREMIUM_THEME,
 	DOT_ORG_THEME,
@@ -25,7 +26,12 @@ function getCheckoutUrl( dependencies, localeSlug, flowName ) {
 		{
 			signup: 1,
 			ref: getQueryArgs()?.ref,
-			...( [ 'domain' ].includes( flowName ) && { isDomainOnly: 1 } ),
+			...( [ 'domain' ].includes( flowName ) && {
+				isDomainOnly: 1,
+				checkoutBackUrl: `http://${ config( 'hostname' ) }${
+					config( 'port' ) ? ':' + config( 'port' ) : ''
+				}/start/domain`,
+			} ),
 		},
 		checkoutURL
 	);


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/4214

When you click on the back arrow at the checkout page  during the domain-only flow, it redirects you to `/start` instead of going back to the flow.

## Proposed Changes

We added the `checkoutBackUrl` param on the checkout Query param to start 

## Testing Instructions

* Go to `/start/domain/domain-only`
* Select 1 or more domains
* Check the `Just buy a domain` option
* At the checkout, click on the `Back` button on the top left of the site.
* You should be redirected to the start of the flow.
