### PR TITLE
Facebook: update color code

### DIFF
--- a/packages/calypso-color-schemes/src/shared/color-schemes/_classic-dark.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_classic-dark.scss
@@ -299,7 +299,7 @@
 
 	--color-blogger: #ff5722;
 	--color-eventbrite: #ff8000;
-	--color-facebook: #1877f2;
+	--color-facebook: #0866ff;
 	--color-godaddy: #5ea95a;
 	--color-google-plus: #df4a32;
 	--color-instagram: #d93174;

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_classic-dark.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_classic-dark.scss
@@ -299,7 +299,7 @@
 
 	--color-blogger: #ff5722;
 	--color-eventbrite: #ff8000;
-	--color-facebook: #39579a;
+	--color-facebook: #1877f2;
 	--color-godaddy: #5ea95a;
 	--color-google-plus: #df4a32;
 	--color-instagram: #d93174;

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
@@ -299,7 +299,7 @@
 
 	--color-blogger: #ff5722;
 	--color-eventbrite: #ff8000;
-	--color-facebook: #1877f2;
+	--color-facebook: #0866ff;
 	--color-godaddy: #5ea95a;
 	--color-google-plus: #df4a32;
 	--color-instagram: #d93174;

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
@@ -299,7 +299,7 @@
 
 	--color-blogger: #ff5722;
 	--color-eventbrite: #ff8000;
-	--color-facebook: #39579a;
+	--color-facebook: #1877f2;
 	--color-godaddy: #5ea95a;
 	--color-google-plus: #df4a32;
 	--color-instagram: #d93174;


### PR DESCRIPTION
## Proposed Changes

Facebook's color code was updated a few years ago. Let's update its color here too.

References:

- https://github.com/Automattic/jetpack/pull/13681

## Testing Instructions

* In the Calypso live link, go to Marketing > Connections
* Check the color of the Facebook logo

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
