### PR TITLE
Stats: Initial support for chart ranges via URL params

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -211,8 +211,8 @@ class StatsSite extends Component {
 			const chartStart = context.query?.chartStart;
 			const chartStartMoment = moment( chartStart );
 			const isValidStartDate = chartStartMoment.isValid();
-			const isBeforeEndDate = chartStartMoment.isBefore( chartEndMoment );
-			if ( isValidStartDate && isBeforeEndDate ) {
+			const isSameOrBefore = chartStartMoment.isSameOrBefore( chartEndMoment );
+			if ( isValidStartDate && isSameOrBefore ) {
 				const diff = chartEndMoment.diff( chartStartMoment, 'days' );
 				// Make sure quantity includes start date.
 				this.state.customChartQuantity = diff + 1;

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -202,7 +202,7 @@ class StatsSite extends Component {
 			if ( chartEnd && isValidEndDate ) {
 				customChartRange = { chartEnd };
 			} else {
-				customChartRange = { chartEnd: '2023-10-07', note: 'Dont forget to update me!' };
+				customChartRange = { chartEnd: moment().format( 'YYYY-MM-DD' ) };
 			}
 			// Quantity should come from URL params too!
 			this.state.customChartQuantity = 7;

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -196,7 +196,13 @@ class StatsSite extends Component {
 		// Dependant on new date range picker controls.
 		let customChartRange = null;
 		if ( isDateControlEnabled ) {
-			customChartRange = { chartEnd: '2023-10-07', note: 'Custom range yo!' };
+			const chartEnd = context.query?.chartEnd;
+			if ( chartEnd ) {
+				customChartRange = { chartEnd };
+			} else {
+				customChartRange = { chartEnd: '2023-10-07', note: 'Dont forget to update me!' };
+			}
+			// Quantity should come from URL params too!
 			this.state.customChartQuantity = 7;
 		}
 

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -166,6 +166,14 @@ class StatsSite extends Component {
 		}
 	}
 
+	getValidDateOrNullFromInput( inputDate ) {
+		if ( inputDate === undefined ) {
+			return null;
+		}
+		const isValid = moment( inputDate ).isValid();
+		return isValid ? inputDate : null;
+	}
+
 	renderStats() {
 		const {
 			date,
@@ -198,22 +206,18 @@ class StatsSite extends Component {
 		let customChartRange = null;
 		if ( isDateControlEnabled ) {
 			// Sort out end date for chart.
-			const chartEnd = context.query?.chartEnd;
-			const chartEndMoment = moment( chartEnd );
-			const isValidEndDate = chartEndMoment.isValid();
-			if ( chartEnd && isValidEndDate ) {
+			const chartEnd = this.getValidDateOrNullFromInput( context.query?.chartEnd );
+			if ( chartEnd ) {
 				customChartRange = { chartEnd };
 			} else {
 				customChartRange = { chartEnd: moment().format( 'YYYY-MM-DD' ) };
 			}
 			// Sort out quantity for chart.
 			// ToDo: Update to take period into account.
-			const chartStart = context.query?.chartStart;
-			const chartStartMoment = moment( chartStart );
-			const isValidStartDate = chartStartMoment.isValid();
-			const isSameOrBefore = chartStartMoment.isSameOrBefore( chartEndMoment );
-			if ( isValidStartDate && isSameOrBefore ) {
-				const diff = chartEndMoment.diff( chartStartMoment, 'days' );
+			const chartStart = this.getValidDateOrNullFromInput( context.query?.chartStart );
+			const isSameOrBefore = moment( chartStart ).isSameOrBefore( moment( chartEnd ) );
+			if ( chartStart && isSameOrBefore ) {
+				const diff = moment( chartEnd ).diff( moment( chartStart ), 'days' );
 				// Make sure quantity includes start date.
 				this.state.customChartQuantity = diff + 1;
 			} else {

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -192,6 +192,14 @@ class StatsSite extends Component {
 		// For the new date picker
 		const isDateControlEnabled = config.isEnabled( 'stats/date-control' );
 
+		// Set up a custom range for the chart.
+		// Dependant on new date range picker controls.
+		let customChartRange = null;
+		if ( isDateControlEnabled ) {
+			customChartRange = { chartEnd: '2023-10-07', note: 'Custom range yo!' };
+			this.state.customChartQuantity = 7;
+		}
+
 		const query = memoizedQuery( period, endOf.format( 'YYYY-MM-DD' ) );
 
 		// For period option links
@@ -314,6 +322,7 @@ class StatsSite extends Component {
 							period={ this.props.period }
 							chartTab={ this.props.chartTab }
 							customQuantity={ this.state.customChartQuantity }
+							customRange={ customChartRange }
 						/>
 					</>
 

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -197,15 +197,29 @@ class StatsSite extends Component {
 		// Dependant on new date range picker controls.
 		let customChartRange = null;
 		if ( isDateControlEnabled ) {
+			// Sort out end date for chart.
 			const chartEnd = context.query?.chartEnd;
-			const isValidEndDate = moment( chartEnd ).isValid();
+			const chartEndMoment = moment( chartEnd );
+			const isValidEndDate = chartEndMoment.isValid();
 			if ( chartEnd && isValidEndDate ) {
 				customChartRange = { chartEnd };
 			} else {
 				customChartRange = { chartEnd: moment().format( 'YYYY-MM-DD' ) };
 			}
-			// Quantity should come from URL params too!
-			this.state.customChartQuantity = 7;
+			// Sort out quantity for chart.
+			// ToDo: Update to take period into account.
+			const chartStart = context.query?.chartStart;
+			const chartStartMoment = moment( chartStart );
+			const isValidStartDate = chartStartMoment.isValid();
+			const isBeforeEndDate = chartStartMoment.isBefore( chartEndMoment );
+			if ( isValidStartDate && isBeforeEndDate ) {
+				const diff = chartEndMoment.diff( chartStartMoment, 'days' );
+				// Make sure quantity includes start date.
+				this.state.customChartQuantity = diff + 1;
+			} else {
+				// If we have a goofy start date, ignore it.
+				this.state.customChartQuantity = 7;
+			}
 		}
 
 		const query = memoizedQuery( period, endOf.format( 'YYYY-MM-DD' ) );

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -5,6 +5,7 @@ import { Icon, people, starEmpty, commentContent } from '@wordpress/icons';
 import classNames from 'classnames';
 import { localize, translate } from 'i18n-calypso';
 import { find } from 'lodash';
+import moment from 'moment';
 import page from 'page';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -197,7 +198,8 @@ class StatsSite extends Component {
 		let customChartRange = null;
 		if ( isDateControlEnabled ) {
 			const chartEnd = context.query?.chartEnd;
-			if ( chartEnd ) {
+			const isValidEndDate = moment( chartEnd ).isValid();
+			if ( chartEnd && isValidEndDate ) {
 				customChartRange = { chartEnd };
 			} else {
 				customChartRange = { chartEnd: '2023-10-07', note: 'Dont forget to update me!' };

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -144,21 +144,31 @@ const memoizedQuery = memoizeLast( ( chartTab, date, period, quantity, siteId ) 
 } ) );
 
 const connectComponent = connect(
-	( state, { activeLegend, period: { period }, chartTab, queryDate, customQuantity } ) => {
+	(
+		state,
+		{ activeLegend, period: { period }, chartTab, queryDate, customQuantity, customRange }
+	) => {
 		const siteId = getSelectedSiteId( state );
 		if ( ! siteId ) {
 			return NO_SITE_STATE;
 		}
 
+		// Set up quantity for API call.
 		const defaultQuantity = 'year' === period ? 10 : 30;
-
 		const quantity = customQuantity ? customQuantity : defaultQuantity;
+
 		const counts = getCountRecords( state, siteId, period );
 		const chartData = buildChartData( activeLegend, chartTab, counts, period, queryDate );
 		const loadingTabs = getLoadingTabs( state, siteId, period );
 		const isActiveTabLoading = loadingTabs.includes( chartTab ) || chartData.length !== quantity;
 		const timezoneOffset = getSiteOption( state, siteId, 'gmt_offset' ) || 0;
-		const date = getQueryDate( queryDate, timezoneOffset, period, quantity );
+
+		// The end date of the chart depends on the customRange.
+		// If not provided we compute the value. (maintains previous behaviour)
+		const date = customRange
+			? customRange.chartEnd
+			: getQueryDate( queryDate, timezoneOffset, period, quantity );
+
 		const queryKey = `${ date }-${ period }-${ quantity }-${ siteId }`;
 		const query = memoizedQuery( chartTab, date, period, quantity, siteId );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #83039 

## Proposed Changes

Adds support for `chartStart` and `chartEnd` URL parameters with basic validation and extends our chart wrapper to use this for API requests. Breaks existing shortcut, text inputs, and interval logic. Those will need to be updated to use `page()` as part of their update logic.

https://github.com/Automattic/wp-calypso/assets/40267301/a3c7073d-6341-4817-b38e-b3fbc9907261

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Launch the Live branch.
* Visit Stats → Traffic.
* Confirm chart shows correctly.
* Enable new date range picker: `?flags=stats/date-control`
* Confirm chart redraws. Should show 7 slices of data. (the new default)
* Edit URL to add an anchor date: `&chartEnd=2023-10-12`
* Confirm chart redraws. Should show 7 days ending on Oct 12th.
* Edit URL to add a start date: `@chartStart=2023-10-01`
* Confirm chart redraws. Should show custom range of 12 days.
* Confirm that chart behaves reasonably if bogus dates are provided. (defaults to `chartEnd` of today and a quantity of 7)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?