### PR TITLE
Plans Comparison: add sticky behaviour to the header bar

### DIFF
--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -73,10 +73,6 @@
 	}
 }
 
-.is-section-plans .plans-wrapper {
-	transform: translateY(-20px);
-}
-
 .plans-features-main__comparison-grid-container {
 	&.is-hidden {
 		display: none;

--- a/client/my-sites/plans-grid/components/comparison-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/comparison-grid/index.tsx
@@ -1124,7 +1124,6 @@ const ComparisonGrid = ( {
 					disabled={ isBottomHeaderInView }
 					stickyClass="is-sticky-header-row"
 					stickyOffset={ stickyRowOffset }
-					topOffset={ stickyRowOffset + ( isInSignup ? 0 : 20 ) }
 				>
 					{ ( isStuck: boolean ) => (
 						<ComparisonGridHeader

--- a/client/my-sites/plans-grid/components/comparison-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/comparison-grid/index.tsx
@@ -15,7 +15,16 @@ import styled from '@emotion/styled';
 import { useMemo } from '@wordpress/element';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useCallback, useEffect, ChangeEvent, Dispatch, SetStateAction } from 'react';
+import {
+	useState,
+	useCallback,
+	useEffect,
+	ChangeEvent,
+	Dispatch,
+	SetStateAction,
+	forwardRef,
+} from 'react';
+import { useInView } from 'react-intersection-observer';
 import { useIsPlanUpgradeCreditVisible } from 'calypso/my-sites/plans-grid/hooks/use-is-plan-upgrade-credit-visible';
 import { useManageTooltipToggle } from 'calypso/my-sites/plans-grid/hooks/use-manage-tooltip-toggle';
 import getPlanFeaturesObject from 'calypso/my-sites/plans-grid/lib/get-plan-features-object';
@@ -32,6 +41,7 @@ import PlanFeatures2023GridBillingTimeframe from '../billing-timeframe';
 import PlanFeatures2023GridHeaderPrice from '../header-price';
 import { Plans2023Tooltip } from '../plans-2023-tooltip';
 import PopularBadge from '../popular-badge';
+import { StickyContainer } from '../sticky-container';
 import StorageAddOnDropdown from '../storage-add-on-dropdown';
 import type {
 	GridPlan,
@@ -104,6 +114,11 @@ const Grid = styled.div< { isInSignup?: boolean } >`
 	${ plansBreakSmall( css`
 		border-radius: 5px;
 	` ) }
+
+	> .is-sticky-header-row {
+		border-bottom: solid 1px #e0e0e0;
+		background: #fff;
+	}
 `;
 
 const Row = styled.div< {
@@ -140,7 +155,7 @@ const Row = styled.div< {
 
 const PlanRow = styled( Row )`
 	&:last-of-type {
-		display: none;
+		display: ${ ( props ) => ( props.isHiddenInMobile ? 'none' : 'flex' ) };
 	}
 
 	${ plansBreakSmall( css`
@@ -212,6 +227,10 @@ const Cell = styled.div< { textAlign?: 'start' | 'center' | 'end' } >`
 		&:last-of-type {
 			padding-inline-end: 0;
 			border-right: none;
+		}
+
+		&.is-stuck {
+			padding-bottom: 16px;
 		}
 	` ) }
 `;
@@ -316,6 +335,7 @@ type ComparisonGridProps = {
 	selectedFeature?: string;
 	showLegacyStorageFeature?: boolean;
 	showUpgradeableStorage: boolean;
+	stickyRowOffset: number;
 	onStorageAddOnClick?: ( addOnSlug: WPComStorageAddOnSlug ) => void;
 	showRefundPeriod?: boolean;
 };
@@ -336,6 +356,8 @@ type ComparisonGridHeaderProps = {
 	planActionOverrides?: PlanActionOverrides;
 	selectedPlan?: string;
 	showRefundPeriod?: boolean;
+	isStuck: boolean;
+	isHiddenInMobile?: boolean;
 };
 
 type ComparisonGridHeaderCellProps = ComparisonGridHeaderProps & {
@@ -371,6 +393,7 @@ const ComparisonGridHeaderCell = ( {
 	isPlanUpgradeCreditEligible,
 	siteId,
 	showRefundPeriod,
+	isStuck,
 }: ComparisonGridHeaderCellProps ) => {
 	const { gridPlansIndex } = usePlansGridContext();
 	const gridPlan = gridPlansIndex[ planSlug ];
@@ -390,9 +413,11 @@ const ComparisonGridHeaderCell = ( {
 		'is-right-of-highlight': highlightAdjacencyMatrix[ planSlug ]?.rightOfHighlight,
 		'is-only-highlight': highlightAdjacencyMatrix[ planSlug ]?.isOnlyHighlight,
 		'is-current-plan': gridPlan.current,
+		'is-stuck': isStuck,
 	} );
 	const popularBadgeClasses = classNames( {
 		'is-current-plan': gridPlan.current,
+		'popular-badge-is-stuck': isStuck,
 	} );
 	const showPlanSelect = ! allVisible && ! gridPlan.current;
 
@@ -468,70 +493,78 @@ const ComparisonGridHeaderCell = ( {
 	);
 };
 
-const ComparisonGridHeader = ( {
-	displayedGridPlans,
-	visibleGridPlans,
-	isInSignup,
-	isLaunchPage,
-	flowName,
-	isFooter,
-	onPlanChange,
-	currentSitePlanSlug,
-	currentPlanManageHref,
-	canUserManageCurrentPlan,
-	onUpgradeClick,
-	siteId,
-	planActionOverrides,
-	selectedPlan,
-	showRefundPeriod,
-}: ComparisonGridHeaderProps ) => {
-	const allVisible = visibleGridPlans.length === displayedGridPlans.length;
-	const { prices, currencyCode } = usePlanPricingInfoFromGridPlans( {
-		gridPlans: displayedGridPlans,
-	} );
+const ComparisonGridHeader = forwardRef< HTMLDivElement, ComparisonGridHeaderProps >(
+	(
+		{
+			displayedGridPlans,
+			visibleGridPlans,
+			isInSignup,
+			isLaunchPage,
+			flowName,
+			isFooter,
+			onPlanChange,
+			currentSitePlanSlug,
+			currentPlanManageHref,
+			canUserManageCurrentPlan,
+			onUpgradeClick,
+			siteId,
+			planActionOverrides,
+			selectedPlan,
+			isHiddenInMobile,
+			showRefundPeriod,
+			isStuck,
+		},
+		ref
+	) => {
+		const allVisible = visibleGridPlans.length === displayedGridPlans.length;
+		const { prices, currencyCode } = usePlanPricingInfoFromGridPlans( {
+			gridPlans: displayedGridPlans,
+		} );
 
-	const isLargeCurrency = useIsLargeCurrency( {
-		prices,
-		currencyCode: currencyCode || 'USD',
-	} );
-	const isPlanUpgradeCreditEligible = useIsPlanUpgradeCreditVisible(
-		siteId ?? 0,
-		displayedGridPlans.map( ( { planSlug } ) => planSlug )
-	);
-	return (
-		<PlanRow>
-			<RowTitleCell
-				key="feature-name"
-				className="plan-comparison-grid__header-cell plan-comparison-grid__interval-toggle is-placeholder-header-cell"
-			/>
-			{ visibleGridPlans.map( ( { planSlug }, index ) => (
-				<ComparisonGridHeaderCell
-					planSlug={ planSlug }
-					isPlanUpgradeCreditEligible={ isPlanUpgradeCreditEligible }
-					key={ planSlug }
-					isLastInRow={ index === visibleGridPlans.length - 1 }
-					isFooter={ isFooter }
-					allVisible={ allVisible }
-					isInSignup={ isInSignup }
-					visibleGridPlans={ visibleGridPlans }
-					onPlanChange={ onPlanChange }
-					displayedGridPlans={ displayedGridPlans }
-					currentSitePlanSlug={ currentSitePlanSlug }
-					currentPlanManageHref={ currentPlanManageHref }
-					canUserManageCurrentPlan={ canUserManageCurrentPlan }
-					flowName={ flowName }
-					onUpgradeClick={ onUpgradeClick }
-					isLaunchPage={ isLaunchPage }
-					isLargeCurrency={ isLargeCurrency }
-					planActionOverrides={ planActionOverrides }
-					selectedPlan={ selectedPlan }
-					siteId={ siteId }
-					showRefundPeriod={ showRefundPeriod }
+		const isLargeCurrency = useIsLargeCurrency( {
+			prices,
+			currencyCode: currencyCode || 'USD',
+		} );
+		const isPlanUpgradeCreditEligible = useIsPlanUpgradeCreditVisible(
+			siteId ?? 0,
+			displayedGridPlans.map( ( { planSlug } ) => planSlug )
+		);
+		return (
+			<PlanRow isHiddenInMobile={ isHiddenInMobile } ref={ ref }>
+				<RowTitleCell
+					key="feature-name"
+					className="plan-comparison-grid__header-cell plan-comparison-grid__interval-toggle is-placeholder-header-cell"
 				/>
-			) ) }
-		</PlanRow>
-	);
-};
+				{ visibleGridPlans.map( ( { planSlug }, index ) => (
+					<ComparisonGridHeaderCell
+						planSlug={ planSlug }
+						isPlanUpgradeCreditEligible={ isPlanUpgradeCreditEligible }
+						key={ planSlug }
+						isLastInRow={ index === visibleGridPlans.length - 1 }
+						isFooter={ isFooter }
+						allVisible={ allVisible }
+						isInSignup={ isInSignup }
+						visibleGridPlans={ visibleGridPlans }
+						onPlanChange={ onPlanChange }
+						displayedGridPlans={ displayedGridPlans }
+						currentSitePlanSlug={ currentSitePlanSlug }
+						currentPlanManageHref={ currentPlanManageHref }
+						canUserManageCurrentPlan={ canUserManageCurrentPlan }
+						flowName={ flowName }
+						onUpgradeClick={ onUpgradeClick }
+						isLaunchPage={ isLaunchPage }
+						isLargeCurrency={ isLargeCurrency }
+						planActionOverrides={ planActionOverrides }
+						selectedPlan={ selectedPlan }
+						siteId={ siteId }
+						showRefundPeriod={ showRefundPeriod }
+						isStuck={ isStuck }
+					/>
+				) ) }
+			</PlanRow>
+		);
+	}
+);
 
 const ComparisonGridFeatureGroupRowCell: React.FunctionComponent< {
 	feature?: FeatureObject;
@@ -958,6 +991,7 @@ const ComparisonGrid = ( {
 	selectedPlan,
 	selectedFeature,
 	showUpgradeableStorage,
+	stickyRowOffset,
 	onStorageAddOnClick,
 	showRefundPeriod,
 }: ComparisonGridProps ) => {
@@ -1080,25 +1114,38 @@ const ComparisonGrid = ( {
 		};
 	}, [ featureGroupMap ] );
 
+	// 100px is the padding of the footer row
+	const [ bottomHeaderRef, isBottomHeaderInView ] = useInView( { rootMargin: '-100px' } );
+
 	return (
 		<div className="plan-comparison-grid">
 			<Grid isInSignup={ isInSignup }>
-				<ComparisonGridHeader
-					siteId={ siteId }
-					displayedGridPlans={ displayedGridPlans }
-					visibleGridPlans={ visibleGridPlans }
-					isInSignup={ isInSignup }
-					isLaunchPage={ isLaunchPage }
-					flowName={ flowName }
-					onPlanChange={ onPlanChange }
-					currentSitePlanSlug={ currentSitePlanSlug }
-					currentPlanManageHref={ currentPlanManageHref }
-					canUserManageCurrentPlan={ canUserManageCurrentPlan }
-					onUpgradeClick={ onUpgradeClick }
-					planActionOverrides={ planActionOverrides }
-					selectedPlan={ selectedPlan }
-					showRefundPeriod={ showRefundPeriod }
-				/>
+				<StickyContainer
+					disabled={ isBottomHeaderInView }
+					stickyClass="is-sticky-header-row"
+					stickyOffset={ stickyRowOffset }
+					topOffset={ stickyRowOffset + ( isInSignup ? 0 : 20 ) }
+				>
+					{ ( isStuck: boolean ) => (
+						<ComparisonGridHeader
+							siteId={ siteId }
+							displayedGridPlans={ displayedGridPlans }
+							visibleGridPlans={ visibleGridPlans }
+							isInSignup={ isInSignup }
+							isLaunchPage={ isLaunchPage }
+							flowName={ flowName }
+							onPlanChange={ onPlanChange }
+							currentSitePlanSlug={ currentSitePlanSlug }
+							currentPlanManageHref={ currentPlanManageHref }
+							canUserManageCurrentPlan={ canUserManageCurrentPlan }
+							onUpgradeClick={ onUpgradeClick }
+							planActionOverrides={ planActionOverrides }
+							selectedPlan={ selectedPlan }
+							showRefundPeriod={ showRefundPeriod }
+							isStuck={ isStuck }
+						/>
+					) }
+				</StickyContainer>
 				{ Object.values( featureGroupMap ).map( ( featureGroup: FeatureGroup ) => (
 					<FeatureGroup
 						key={ featureGroup.slug }
@@ -1132,6 +1179,9 @@ const ComparisonGrid = ( {
 					planActionOverrides={ planActionOverrides }
 					selectedPlan={ selectedPlan }
 					showRefundPeriod={ showRefundPeriod }
+					isStuck={ false }
+					isHiddenInMobile={ true }
+					ref={ bottomHeaderRef }
 				/>
 			</Grid>
 

--- a/client/my-sites/plans-grid/components/features-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/features-grid/index.tsx
@@ -52,7 +52,7 @@ interface FeaturesGridType extends PlansGridProps {
 
 class FeaturesGrid extends Component< FeaturesGridType > {
 	renderTable( renderedGridPlans: GridPlan[] ) {
-		const { translate, gridPlanForSpotlight, stickyRowOffset, isInSignup } = this.props;
+		const { translate, gridPlanForSpotlight, stickyRowOffset } = this.props;
 		// Do not render the spotlight plan if it exists
 		const gridPlansWithoutSpotlight = ! gridPlanForSpotlight
 			? renderedGridPlans
@@ -79,7 +79,6 @@ class FeaturesGrid extends Component< FeaturesGridType > {
 						stickyClass="is-sticky-top-buttons-row"
 						element="tr"
 						stickyOffset={ stickyRowOffset }
-						topOffset={ stickyRowOffset + ( isInSignup ? 0 : 20 ) }
 					>
 						{ ( isStuck: boolean ) =>
 							this.renderTopButtons( gridPlansWithoutSpotlight, { isTableCell: true, isStuck } )

--- a/client/my-sites/plans-grid/components/sticky-container.tsx
+++ b/client/my-sites/plans-grid/components/sticky-container.tsx
@@ -4,20 +4,35 @@ import { useRef, type ElementType, useState, useLayoutEffect, ReactNode } from '
 
 type Props = {
 	children: ( isStuck: boolean ) => ReactNode;
-	stickyClass?: string;
-	element?: ElementType;
+	stickyClass?: string; // class to apply when the element is "stuck"
+	element?: ElementType; // which element to render, defaults to div
 	stickyOffset?: number; // offset from the top of the scrolling container to control when the element should start sticking, default 0
 	topOffset?: number; // offset from the top of the scrolling container to control the position of the sticky element, default 0
+	disabled?: boolean; // force disabled sticky behaviour if set to true
 };
 
-const Container = styled.div< { topOffset: number } >`
-	position: sticky;
-	top: ${ ( props ) => props.topOffset + 'px' };
-	z-index: 1;
+const styles = ( { disabled, topOffset }: { disabled: boolean; topOffset: number } ) =>
+	disabled
+		? ''
+		: css`
+				position: sticky;
+				top: ${ topOffset + 'px' };
+				z-index: 1;
+		  `;
+
+const Container = styled.div`
+	${ styles }
 `;
 
 export function StickyContainer( props: Props ) {
-	const { stickyOffset = 0, topOffset = 0, stickyClass = '', element = 'div', children } = props;
+	const {
+		stickyOffset = 0,
+		topOffset = 0,
+		stickyClass = '',
+		element = 'div',
+		disabled = false,
+		children,
+	} = props;
 
 	const stickyRef = useRef( null );
 	const [ isStuck, setIsStuck ] = useState( false );
@@ -29,6 +44,9 @@ export function StickyContainer( props: Props ) {
 	 * So when position:sticky takes effect, the intersection ratio will always be ~99%
 	 */
 	useLayoutEffect( () => {
+		if ( ! IntersectionObserver ) {
+			return;
+		}
 		const observer = new IntersectionObserver(
 			( [ entry ] ) => {
 				if ( entry.intersectionRatio === 0 ) {
@@ -75,6 +93,7 @@ export function StickyContainer( props: Props ) {
 				as={ element }
 				ref={ stickyRef }
 				topOffset={ topOffset }
+				disabled={ disabled }
 				className={ isStuck ? stickyClass : '' }
 			>
 				{ children( isStuck ) }

--- a/client/my-sites/plans-grid/components/sticky-container.tsx
+++ b/client/my-sites/plans-grid/components/sticky-container.tsx
@@ -36,7 +36,7 @@ export function StickyContainer( props: Props ) {
 	 * So when position:sticky takes effect, the intersection ratio will always be ~99%
 	 */
 	useLayoutEffect( () => {
-		if ( ! IntersectionObserver ) {
+		if ( ! window || ! window[ 'IntersectionObserver' ] ) {
 			return;
 		}
 		const observer = new IntersectionObserver(

--- a/client/my-sites/plans-grid/components/sticky-container.tsx
+++ b/client/my-sites/plans-grid/components/sticky-container.tsx
@@ -16,7 +16,7 @@ const styles = ( { disabled, stickyOffset }: { disabled: boolean; stickyOffset: 
 		: css`
 				position: sticky;
 				top: ${ stickyOffset + 'px' };
-				z-index: 1;
+				z-index: 2;
 		  `;
 
 const Container = styled.div`

--- a/client/my-sites/plans-grid/components/sticky-container.tsx
+++ b/client/my-sites/plans-grid/components/sticky-container.tsx
@@ -7,16 +7,15 @@ type Props = {
 	stickyClass?: string; // class to apply when the element is "stuck"
 	element?: ElementType; // which element to render, defaults to div
 	stickyOffset?: number; // offset from the top of the scrolling container to control when the element should start sticking, default 0
-	topOffset?: number; // offset from the top of the scrolling container to control the position of the sticky element, default 0
 	disabled?: boolean; // force disabled sticky behaviour if set to true
 };
 
-const styles = ( { disabled, topOffset }: { disabled: boolean; topOffset: number } ) =>
+const styles = ( { disabled, stickyOffset }: { disabled: boolean; stickyOffset: number } ) =>
 	disabled
 		? ''
 		: css`
 				position: sticky;
-				top: ${ topOffset + 'px' };
+				top: ${ stickyOffset + 'px' };
 				z-index: 1;
 		  `;
 
@@ -25,14 +24,7 @@ const Container = styled.div`
 `;
 
 export function StickyContainer( props: Props ) {
-	const {
-		stickyOffset = 0,
-		topOffset = 0,
-		stickyClass = '',
-		element = 'div',
-		disabled = false,
-		children,
-	} = props;
+	const { stickyOffset = 0, stickyClass = '', element = 'div', disabled = false, children } = props;
 
 	const stickyRef = useRef( null );
 	const [ isStuck, setIsStuck ] = useState( false );
@@ -85,6 +77,7 @@ export function StickyContainer( props: Props ) {
 				 */
 					.layout__content {
 						overflow: unset;
+						min-height: unset;
 					}
 				` }
 			/>
@@ -92,7 +85,7 @@ export function StickyContainer( props: Props ) {
 				{ ...props }
 				as={ element }
 				ref={ stickyRef }
-				topOffset={ topOffset }
+				stickyOffset={ stickyOffset }
 				disabled={ disabled }
 				className={ isStuck ? stickyClass : '' }
 			>

--- a/client/my-sites/plans-grid/components/sticky-container.tsx
+++ b/client/my-sites/plans-grid/components/sticky-container.tsx
@@ -36,7 +36,7 @@ export function StickyContainer( props: Props ) {
 	 * So when position:sticky takes effect, the intersection ratio will always be ~99%
 	 */
 	useLayoutEffect( () => {
-		if ( ! window || ! window[ 'IntersectionObserver' ] ) {
+		if ( typeof IntersectionObserver === 'undefined' ) {
 			return;
 		}
 		const observer = new IntersectionObserver(

--- a/client/my-sites/plans-grid/components/sticky-container.tsx
+++ b/client/my-sites/plans-grid/components/sticky-container.tsx
@@ -77,7 +77,6 @@ export function StickyContainer( props: Props ) {
 				 */
 					.layout__content {
 						overflow: unset;
-						min-height: unset;
 					}
 				` }
 			/>

--- a/client/my-sites/plans-grid/index.tsx
+++ b/client/my-sites/plans-grid/index.tsx
@@ -80,6 +80,7 @@ const WrappedComparisonGrid = ( {
 	onStorageAddOnClick,
 	currentPlanManageHref,
 	canUserManageCurrentPlan,
+	stickyRowOffset,
 	...otherProps
 }: PlansGridProps ) => {
 	const handleUpgradeClick = useUpgradeClickHandler( {
@@ -109,6 +110,7 @@ const WrappedComparisonGrid = ( {
 					selectedFeature={ selectedFeature }
 					showLegacyStorageFeature={ showLegacyStorageFeature }
 					showUpgradeableStorage={ showUpgradeableStorage }
+					stickyRowOffset={ stickyRowOffset }
 					onStorageAddOnClick={ onStorageAddOnClick }
 					{ ...otherProps }
 				/>
@@ -138,6 +140,7 @@ const WrappedComparisonGrid = ( {
 					selectedFeature={ selectedFeature }
 					showLegacyStorageFeature={ showLegacyStorageFeature }
 					showUpgradeableStorage={ showUpgradeableStorage }
+					stickyRowOffset={ stickyRowOffset }
 					onStorageAddOnClick={ onStorageAddOnClick }
 					{ ...otherProps }
 				/>

--- a/client/my-sites/plans-grid/style.scss
+++ b/client/my-sites/plans-grid/style.scss
@@ -910,6 +910,11 @@ body.is-section-signup.is-white-signup,
 					/* stylelint-disable-next-line */
 					border-radius: 5px 5px 0 0;
 					border-style: solid;
+					transition: top 0.2s ease;
+				}
+
+				.popular-badge-is-stuck {
+					top: -10px;
 				}
 
 				&.is-left-of-highlight {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the slinked issue.
-->

Fixes Automattic/martech#1392
Fixes https://github.com/Automattic/martech/issues/2227

## Proposed Changes

* Adds sticky behaviour to the header bar of the plans comparison grid.

<img width="1370" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/881317ec-5294-44f1-85fd-32f3f502ab84">

Note: This does not contain the plan type selector in sticky mode that is currently available on `/pricing`.

<img width="1573" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/df6c7189-000c-4c8a-b3fd-bb21c29c62d9">



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/plans` and open the comparison grid by clicking on "Compare Plans".
* Scroll down and confirm that the header bar sticks to the top of the screen.
* The header bar should stop being sticky after the bottom header bar comes into view.

-----

* Test this for mobile and tablet screen sizes.
* Test the same on `/plans/<site slug>`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?