### PR TITLE
Plans page for Jetpack App: Return selected domain_name back from Plan selection

### DIFF
--- a/client/jetpack-app/plans/main.tsx
+++ b/client/jetpack-app/plans/main.tsx
@@ -1,6 +1,7 @@
 import { getPlan, PLAN_FREE } from '@automattic/calypso-products';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
+import { useRef } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import QueryPlans from 'calypso/components/data/query-plans';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -11,6 +12,7 @@ import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getPlanSlug } from 'calypso/state/plans/selectors';
 import type { Plan } from '@automattic/calypso-products';
+import type { DomainSuggestion } from '@automattic/data-stores';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import type { AppState } from 'calypso/types';
 
@@ -68,21 +70,23 @@ const JetpackAppPlans: React.FC< JetpackAppPlansProps > = ( { paidDomainName, or
 	) as string | null;
 	const plansLoaded = Boolean( planSlug );
 
+	const freeDomainSuggestionNameRef = useRef< string | undefined >( undefined );
+
 	const onUpgradeClick = ( cartItems?: MinimalRequestCartProduct[] | null | undefined ) => {
 		const productSlug = getPlanCartItem( cartItems )?.product_slug;
 
-		type PlansParameters = { plan_id?: number; plan_slug: string };
+		type PlansParameters = { plan_id?: number; plan_slug: string; domain_name?: string };
 		let args: PlansParameters;
 
 		if ( ! productSlug ) {
-			args = { plan_slug: PLAN_FREE };
+			args = { plan_slug: PLAN_FREE, domain_name: freeDomainSuggestionNameRef.current };
 
 			dispatch(
 				recordTracksEvent( 'calypso_signup_free_plan_select', { from_section: 'default' } )
 			);
 		} else {
 			const plan = getPlan( productSlug ) as Plan;
-			args = { plan_id: plan.getProductId(), plan_slug: productSlug };
+			args = { plan_id: plan.getProductId(), plan_slug: productSlug, domain_name: paidDomainName };
 
 			dispatch(
 				recordTracksEvent( 'calypso_signup_plan_select', {
@@ -93,6 +97,10 @@ const JetpackAppPlans: React.FC< JetpackAppPlansProps > = ( { paidDomainName, or
 		}
 
 		window.location.href = addQueryArgs( originalUrl, args );
+	};
+
+	const setSiteUrlAsFreeDomainSuggestion = ( freeDomainSuggestion: DomainSuggestion ) => {
+		freeDomainSuggestionNameRef.current = freeDomainSuggestion.domain_name;
 	};
 
 	return (
@@ -110,6 +118,7 @@ const JetpackAppPlans: React.FC< JetpackAppPlansProps > = ( { paidDomainName, or
 						plansWithScroll={ false }
 						hidePlanTypeSelector
 						hidePlansFeatureComparison
+						setSiteUrlAsFreeDomainSuggestion={ setSiteUrlAsFreeDomainSuggestion }
 					/>
 				</>
 			) : (


### PR DESCRIPTION
Related to https://github.com/wordpress-mobile/WordPress-iOS/issues/21787

## Proposed Changes

Users can opt for a free domain name in the Plan selection view, we need to return the `domain_name` selection to the app.

For consistency:
- If `paid_domain_name` is passed, then `domain_name` is always returned
- If `paid_domain_name` is not passed, then `domain_name` is never returned

Using `use_ref` instead of `use_state` since we don't need any re-rerenders when we use `setSiteUrlAsFreeDomainSuggestion` callback to set free domain suggestion

## Testing Instructions

Before testing, set wp-iphone or wp-android user agents.

### paid_domain_name + free plan selection
1. Pass `paid_domain_name` parameter (.com/jetpack-app/plans?paid_domain_name=greatdomain.com)
2. Select Free Plan
3. Confirm tapping on Free plan opens redirection URL with a selected free plan slug and free domain name (.com/jetpack-app/plans?plan_slug=free_plan&domain_name={randomaddress}.wordpress.com)

### paid_domain_name + paid plan selection
1. Pass `paid_domain_name` parameter (.com/jetpack-app/plans?paid_domain_name=greatdomain.com)
2. Select Paid Plan
3. Confirm tapping on Paid plan open redirection URL with a selected paid domain name, plan slug, and plan id (.com/jetpack-app/plans?plan_slug=value_bundle&plan_id=1009&domain_name=greatdomain.com)

### no parameters + free plan selection
1. Open plans page without any parameters (.com/jetpack-app/plans)
2. Select Free Plan
3. Confirm tapping on Free plan opens redirection URL with a free plan slug (.com/jetpack-app/plans?plan_slug=free_plan)

### no parameters + paid plan selection
1. Open plans page without any parameters (.com/jetpack-app/plans)
2. Select Paid Plan
3. Confirm tapping on Paid plan opens redirection URL with a paid plan slug and plan id (.com/jetpack-app/plans?plan_slug=value_bundle&plan_id=1003)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- x ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?