### PR TITLE
Google Enhanced Conversions: Providing hashed user email via gtag.js

### DIFF
--- a/client/lib/analytics/ad-tracking/record-order.ts
+++ b/client/lib/analytics/ad-tracking/record-order.ts
@@ -459,6 +459,15 @@ function recordOrderInGoogleAds(
 	// MCC-level event.
 	// WPCOM
 	if ( mayWeTrackByTracker( 'googleAds' ) ) {
+		const currentUser = getCurrentUser();
+
+		// SHA256 hash of current user's email address for enhanced conversion matching.
+		const currentUserHashedEmail = currentUser?.hashedPii?.email ?? '';
+
+		window.gtag( 'set', 'user_data', {
+			sha256_email_address: currentUserHashedEmail,
+		} );
+
 		const params = [
 			'event',
 			'conversion',


### PR DESCRIPTION
Related to: Automattic/martech#[2292](https://github.com/Automattic/martech/issues/2292)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Provide SHA256 hashed user email to enable enhanced conversions for Google Ads

Here are more details on the implementation: https://support.google.com/google-ads/answer/13258081?visit_id=638330582917319159-1081178456&rd=1#mec_gtag&zippy=%2Cidentify-and-define-your-enhanced-conversions-fields%2Cvalidate-your-implementation-using-chrome-developer-tools


## Testing Instructions

* In `development.json`, turn `ad-tracking` and `cookie-banner` to `true`. 
* Start Calypso locally, turn on store sandbox and sandbox `public-api.wordpress.com`
* Open developer tools, go to the network tab, and ensure you persist the logs.


* Go through the signup flow at calypso.localhost:3000/start/. If you're prompted to accept the cookie banner, accept it fully, and make sure you don't already have a `sensitive_pixel_options` cookie set.

* Complete the purchase
* In the network tab, look for requests to either `googleadservices.com/pagead` or `google.com/pagead/1p-conversion/`. One or more of these requests should have an `em` query parameter, with a value like `tv.1~em` (or something similar). This indicates that we are sending hashed data to Google.
* Ensure no console errors.


![Screenshot 2023-10-16 at 15 41 30](https://github.com/Automattic/wp-calypso/assets/52675688/d59f06e8-be20-4e47-a7e8-b7ebdf0a7d74)

To make testing easier, you can also add one or more `debugger` statements in the code, and ensure that the `currentUserHashedEmail` constant is defined.

![Screenshot 2023-10-16 at 15 41 47](https://github.com/Automattic/wp-calypso/assets/52675688/faaf2708-01fd-4f35-8e17-dcde5c6a364d)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
