### PR TITLE
Marketplace: Retrieve transfer status when getting Plugin data

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
@@ -8,6 +8,7 @@ import { ThankYouData, ThankYouSectionProps } from 'calypso/components/thank-you
 import { useWPCOMPlugins } from 'calypso/data/marketplace/use-wpcom-plugins-query';
 import { waitFor } from 'calypso/my-sites/marketplace/util';
 import { useSelector, useDispatch } from 'calypso/state';
+import { fetchAutomatedTransferStatus } from 'calypso/state/automated-transfer/actions';
 import { transferStates } from 'calypso/state/automated-transfer/constants';
 import {
 	getAutomatedTransferStatus,

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
@@ -9,7 +9,10 @@ import { useWPCOMPlugins } from 'calypso/data/marketplace/use-wpcom-plugins-quer
 import { waitFor } from 'calypso/my-sites/marketplace/util';
 import { useSelector, useDispatch } from 'calypso/state';
 import { transferStates } from 'calypso/state/automated-transfer/constants';
-import { getAutomatedTransferStatus } from 'calypso/state/automated-transfer/selectors';
+import {
+	getAutomatedTransferStatus,
+	isFetchingAutomatedTransferStatus,
+} from 'calypso/state/automated-transfer/selectors';
 import { pluginInstallationStateChange } from 'calypso/state/marketplace/purchase-flow/actions';
 import { MARKETPLACE_ASYNC_PROCESS_STATUS } from 'calypso/state/marketplace/types';
 import { fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
@@ -78,6 +81,9 @@ export default function usePluginsThankYouData( pluginSlugs: string[] ): ThankYo
 	const isAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, siteId ) );
 	const isJetpackSelfHosted = isJetpack && ! isAtomic;
 
+	const isFetchingTransferStatus = useSelector( ( state ) =>
+		isFetchingAutomatedTransferStatus( state, siteId )
+	);
 	// Consolidate the plugin information from the .org and .com sources in a single list
 	const pluginsInformationList = useMemo( () => {
 		return pluginsOnSite.reduce(
@@ -118,6 +124,12 @@ export default function usePluginsThankYouData( pluginSlugs: string[] ): ThankYo
 		// we only rerun when areWporgPluginsFetched changes
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ areAllWporgPluginsFetched, areWporgPluginsFetched, pluginSlugs, dispatch, wporgPlugins ] );
+
+	useEffect( () => {
+		if ( ! isFetchingTransferStatus && transferStatus !== transferStates.COMPLETE ) {
+			dispatch( fetchAutomatedTransferStatus( siteId as number ) );
+		}
+	}, [ dispatch, isFetchingTransferStatus, siteId, transferStatus ] );
 
 	// Site is already Atomic (or just transferred).
 	// Poll the plugin installation status.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related p1697226233714089-slack-C029JEQRVRT

## Proposed Changes

The `use-plugins-thank-you-data.tsx` hook was using the `transferStatus` state but it was not retrieving it, so there could be some scenarios where the `transferStatus` was not correct and the condition `transferStatus !== transferStates.COMPLETE` was not correctly evaluated.

- The `fetchAutomatedTransferStatus` is now being called by `use-plugins-thank-you-data.tsx` under similar conditions to the `use-atomic-transfer.tsx` hook

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful -->

### No site selected


1. Navigate to the following plugin without selecting a site: `/plugins/:pluginSlug` with a Marketplace plugin, e.g. `/plugins/woocommerce-bookings`
2. Click on `Manage sites`
3. Select `Purchase and activate` on an Atomic site
4. Complete the checkout process
5. Make sure the `Thank You` page is displayed indicating the plugin is installed successfully

### Site selected
1. Select a Simple site
2. Navigate to plugins and select a Marketplace plugin, e.g. `Woocommerce Bookings` 
3. Click on `Purchase and activate`
4. Complete the checkout process
5. Make sure the `Thank You` page is displayed indicating the plugin is installed successfully
en the change is visual.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?