### PR TITLE
VideoPress Flow: Make premium url not hardcoded to WPCOM

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/videopress-onboarding-intent-modal-blog.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/videopress-onboarding-intent-modal-blog.tsx
@@ -27,7 +27,7 @@ const VideoPressOnboardingIntentModalBlog: React.FC< IntroModalContentProps > = 
 			actionButton={ {
 				type: 'link',
 				text: translate( 'Get started with premium' ),
-				href: 'https://wordpress.com/start/premium/?ref=videopress',
+				href: '/start/premium/?ref=videopress',
 			} }
 		/>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->



## Proposed Changes

[Videopress](https://wordpress.com/setup/videopress/intro) premium URL was hard-coded using `www.wordpress.com` which was making annoying while testing the flow. This PR simply makes it not hard-coded, it should respect the user's base URL.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use live link 
* Go incognito to videopress flow `/setup/videopress/intro`
* Select an option that requires premium.
<img width="377" alt="image" src="https://github.com/Automattic/wp-calypso/assets/2653810/47403c26-491b-48f6-812d-151a61fb72d6">

* Clicking on start with premium should not redirect you to `wordpress.com` site.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?