### PR TITLE
Theme Showcase: Prevent Widows in LoTS Headings

### DIFF
--- a/client/my-sites/themes/theme-showcase-header.jsx
+++ b/client/my-sites/themes/theme-showcase-header.jsx
@@ -4,6 +4,7 @@ import DocumentHead from 'calypso/components/data/document-head';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import NavigationHeader from 'calypso/components/navigation-header';
 import ScreenOptionsTab from 'calypso/components/screen-options-tab';
+import { preventWidows } from 'calypso/lib/formatting';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import InstallThemeButton from './install-theme-button';
 import useThemeShowcaseDescription from './use-theme-showcase-description';
@@ -74,8 +75,8 @@ export default function ThemeShowcaseHeader( { canonicalUrl, filter, tier, verti
 			) : (
 				<div className="themes__header-logged-out">
 					<div className="themes__page-heading">
-						<h1>{ themesHeaderTitle }</h1>
-						<p className="page-sub-header">{ themesHeaderDescription }</p>
+						<h1>{ preventWidows( themesHeaderTitle ) }</h1>
+						<p className="page-sub-header">{ preventWidows( themesHeaderDescription ) }</p>
 					</div>
 				</div>
 			) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #83021

## Proposed Changes

* Prevent widowed words in the Logged-out Theme Showcase headings — both title and description.

| Before | After |
|--------|--------|
| <img width="708" alt="Screenshot 2023-10-16 at 16 42 45" src="https://github.com/Automattic/wp-calypso/assets/2070010/743af38e-1fa3-4ff6-898e-25da9c2bc5e3"> | <img width="708" alt="Screenshot 2023-10-16 at 16 42 41" src="https://github.com/Automattic/wp-calypso/assets/2070010/4fb8d576-10e1-48c3-b180-7b544966e203"> | 

## Testing Instructions

* Open `/themes` in an incognito tab.
* Play with the window width until the title (or description)'s last word wraps to a new line.
* Ensure the text never wraps the last word alone, but two words at the same time.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?