### PR TITLE
Social First Signup: missing parameter in flow

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -173,6 +173,7 @@ export function generateFlows( {
 				'Paid media version of the onboarding flow. Read more in https://wp.me/pau2Xa-4Kk.',
 			lastModified: '2023-07-18',
 			showRecaptcha: true,
+			hideProgressIndicator: true,
 		},
 		{
 			name: 'onboarding-media',


### PR DESCRIPTION
With https://github.com/Automattic/wp-calypso/pull/83053 we missed introducing the `hideProgressIndicator: true,` in the `onboarding-pm` flow