### PR TITLE
Multi-domain: Fix domain-only flow back button on checkout

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -28,9 +28,9 @@ function getCheckoutUrl( dependencies, localeSlug, flowName ) {
 			ref: getQueryArgs()?.ref,
 			...( [ 'domain' ].includes( flowName ) && {
 				isDomainOnly: 1,
-				checkoutBackUrl: `http://${ config( 'hostname' ) }${
-					config( 'port' ) ? ':' + config( 'port' ) : ''
-				}/start/domain`,
+				checkoutBackUrl: `${ config( 'protocol' ) ? config( 'protocol' ) : 'https' }://${ config(
+					'hostname'
+				) }${ config( 'port' ) ? ':' + config( 'port' ) : '' }/start/domain`,
 			} ),
 		},
 		checkoutURL


### PR DESCRIPTION
Follow up of https://github.com/Automattic/wp-calypso/pull/83033

## Proposed Changes

In the previous PR the protocol was not checked causing `https` not working on WPCOM

