### PR TITLE
Multi-domain: Fix domain-only flow back on checkout based on environment

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -28,9 +28,12 @@ function getCheckoutUrl( dependencies, localeSlug, flowName ) {
 			ref: getQueryArgs()?.ref,
 			...( [ 'domain' ].includes( flowName ) && {
 				isDomainOnly: 1,
-				checkoutBackUrl: `${ config( 'protocol' ) ? config( 'protocol' ) : 'https' }://${ config(
-					'hostname'
-				) }${ config( 'port' ) ? ':' + config( 'port' ) : '' }/start/domain`,
+				checkoutBackUrl:
+					config( 'env' ) === 'production'
+						? `https://${ config( 'hostname' ) }/start/domain/domain-only`
+						: `${ config( 'protocol' ) ? config( 'protocol' ) : 'https' }://${ config(
+								'hostname'
+						  ) }${ config( 'port' ) ? ':' + config( 'port' ) : '' }/start/domain/domain-only`,
 			} ),
 		},
 		checkoutURL


### PR DESCRIPTION
Follow up of https://github.com/Automattic/wp-calypso/pull/83060

## Proposed Changes

Updated how to check the environment to generate the URL for domain-only checkout back button

