### PR TITLE
Earn: Use DefaultWiredLaunchpad wrapper

### DIFF
--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -510,11 +510,7 @@ const Home = () => {
 			{ ! isLoading && (
 				<div>
 					{ shouldLoadLaunchpad() ? (
-						<EarnLaunchpad
-							tasklistCompleted={ tasklistCompleted }
-							numberOfSteps={ numberOfSteps }
-							completedSteps={ completedSteps }
-						/>
+						<EarnLaunchpad numberOfSteps={ numberOfSteps } completedSteps={ completedSteps } />
 					) : (
 						<StatsSection />
 					) }

--- a/client/my-sites/earn/launchpad/index.tsx
+++ b/client/my-sites/earn/launchpad/index.tsx
@@ -1,44 +1,18 @@
 import { CircularProgressBar } from '@automattic/components';
-import { LaunchpadNavigator } from '@automattic/data-stores';
-import { Launchpad, Task, setUpActionsForTasks } from '@automattic/launchpad';
-import { useDispatch } from '@wordpress/data';
+import { Launchpad } from '@automattic/launchpad';
 import { useTranslate } from 'i18n-calypso';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector } from 'calypso/state';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 type EarnLaunchpadProps = {
-	tasklistCompleted: boolean;
 	numberOfSteps: number;
 	completedSteps: number;
 };
 
-const EarnLaunchpad = ( {
-	tasklistCompleted,
-	numberOfSteps,
-	completedSteps,
-}: EarnLaunchpadProps ) => {
+const EarnLaunchpad = ( { numberOfSteps, completedSteps }: EarnLaunchpadProps ) => {
 	const translate = useTranslate();
 
 	const site = useSelector( ( state ) => getSelectedSite( state ) );
-
-	const { setActiveChecklist } = useDispatch( LaunchpadNavigator.store );
-
-	const tracksData = {
-		recordTracksEvent,
-		checklistSlug: 'earn',
-		tasklistCompleted,
-		launchpadContext: 'earn',
-	};
-
-	const taskFilter = ( tasks: Task[] ) => {
-		return setUpActionsForTasks( {
-			tasks,
-			siteSlug: site?.slug ?? null,
-			tracksData,
-			extraActions: { setActiveChecklist },
-		} );
-	};
 
 	return (
 		<div className="earn__launchpad">
@@ -58,7 +32,7 @@ const EarnLaunchpad = ( {
 					{ translate( 'Let your fans support your art, writing, or project directly.' ) }
 				</p>
 			</div>
-			<Launchpad siteSlug={ site?.slug ?? null } checklistSlug="earn" taskFilter={ taskFilter } />
+			<Launchpad siteSlug={ site?.slug ?? null } checklistSlug="earn" />
 		</div>
 	);
 };

--- a/client/my-sites/earn/launchpad/index.tsx
+++ b/client/my-sites/earn/launchpad/index.tsx
@@ -1,5 +1,5 @@
 import { CircularProgressBar } from '@automattic/components';
-import { Launchpad } from '@automattic/launchpad';
+import { DefaultWiredLaunchpad } from '@automattic/launchpad';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'calypso/state';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
@@ -32,7 +32,11 @@ const EarnLaunchpad = ( { numberOfSteps, completedSteps }: EarnLaunchpadProps ) 
 					{ translate( 'Let your fans support your art, writing, or project directly.' ) }
 				</p>
 			</div>
-			<Launchpad siteSlug={ site?.slug ?? null } checklistSlug="earn" />
+			<DefaultWiredLaunchpad
+				siteSlug={ site?.slug ?? null }
+				checklistSlug="earn"
+				launchpadContext="earn"
+			/>
 		</div>
 	);
 };


### PR DESCRIPTION
## Proposed Changes

- Uses DefaultWiredLaunchpad wrapper rather than Launchpad component directly. This allows us to remove some extra code/boilerplate around the taskFilter. See comment here: https://github.com/Automattic/wp-calypso/pull/81930/files#r1346408394

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/earn/YOURDOMAIN for any test simple site that does not have Stripe connected or have a paid plan. 
* Test clicking on the Launchpad links to confirm they behave as expected (ie, take you to stripe connect page or add plans page)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?