### PR TITLE
Subscription Management: Add null check to avoid runtime errors when reading undefined newsletter categories array

### DIFF
--- a/client/blocks/reader-site-subscription/subscribe-to-newsletter-categories.tsx
+++ b/client/blocks/reader-site-subscription/subscribe-to-newsletter-categories.tsx
@@ -21,7 +21,7 @@ const SubscribeToNewsletterCategories = ( { siteId }: SubscribeToNewsletterCateg
 	const subscribedCategoryIds = useMemo(
 		() =>
 			subscribedNewsletterCategoriesData?.newsletterCategories
-				.filter( ( category ) => !! category.subscribed )
+				?.filter( ( category ) => !! category.subscribed )
 				.map( ( category ) => category.id ) || [],
 		[ subscribedNewsletterCategoriesData ]
 	);


### PR DESCRIPTION
## Proposed Changes

* Add null check to avoid runtime errors when reading undefined newsletter categories array. This error usually happens when the backend returns error on a request, so it's hard to reproduce without changes on the API side.
<img width="478" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3113712/6f8ed8f2-ac42-4223-bebb-5b4d6adf5d01">
<img width="689" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3113712/e392d609-6940-4085-89d4-587e4948abed">

## Testing Instructions

* Perform regression tests on the subscription details page (using blogs with newsletter categories on and off)
  * http://calypso.localhost:3000/read/subscriptions/{subscription-id}
  * http://calypso.localhost:3000/read/site/subscription/{blog-id}

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?