### PR TITLE
Headers: Update/navigation header component

### DIFF
--- a/client/components/header-cake/docs/example.jsx
+++ b/client/components/header-cake/docs/example.jsx
@@ -1,6 +1,7 @@
 import { Button } from '@automattic/components';
 import { PureComponent } from 'react';
 import HeaderCake from 'calypso/components/header-cake';
+import NavigationHeader from 'calypso/components/navigation-header';
 
 /**
  * Module vars
@@ -35,6 +36,16 @@ export default class extends PureComponent {
 				>
 					Header Cake with a custom action button
 				</HeaderCake>
+
+				<NavigationHeader
+					compactBreadcrumb={ false }
+					navigationItems={ [] }
+					mobileItem={ null }
+					title="My Home"
+					subtitle="NavigationHeader header with action button."
+				>
+					<Button target="_blank">Visit site</Button>
+				</NavigationHeader>
 			</div>
 		);
 	}

--- a/client/components/navigation-header/docs/example.jsx
+++ b/client/components/navigation-header/docs/example.jsx
@@ -1,25 +1,59 @@
-import styled from '@emotion/styled';
-import NavigationHeader from 'calypso/components/fixed-navigation-header';
+import { Button } from '@automattic/components';
+import { Component } from 'react';
+import NavigationHeader from 'calypso/components/navigation-header';
 
-const NavigationHeaderStyled = styled( NavigationHeader )`
-	position: relative;
-	top: inherit;
-	left: inherit;
-	width: 100%;
-`;
-
-const NavigationHeaderExample = () => {
-	const navigationItems = [
+class NavigationHeaderExample extends Component {
+	navigationItems = [
 		{ label: 'Plugins', href: `/plugins` },
 		{ label: 'Search', href: `/plugins?s=woo` },
 	];
-	return (
-		<NavigationHeaderStyled navigationItems={ navigationItems }>
-			Some Children Elements
-		</NavigationHeaderStyled>
-	);
-};
+	state = {
+		page: 1,
+		compact: false,
+	};
 
-NavigationHeaderExample.displayName = 'NavigationHeader';
+	updatePage = ( page ) => {
+		this.setState( { page } );
+	};
+
+	toggleCompact = () => {
+		this.setState( { compact: ! this.state.compact } );
+	};
+
+	render() {
+		return (
+			<div>
+				<NavigationHeader
+					compactBreadcrumb={ this.state.compact }
+					navigationItems={ [] }
+					mobileItem={ null }
+					title="My Home"
+					subtitle="Your hub for posting, editing, and growing your site."
+				>
+					<Button target="_blank">Visit site</Button>
+				</NavigationHeader>
+
+				<NavigationHeader
+					compactBreadcrumb={ this.state.compact }
+					navigationItems={ [
+						{ label: 'Domains', href: `/domains` },
+						{
+							label: 'thisisanexample.wordpress.com',
+							href: `/domains/thisisanexample.wordpress.com`,
+						},
+						{
+							label: 'Transfer',
+							href: `/domains/thisisanexample.wordpress.com/transfer`,
+						},
+					] }
+					mobileItem={ null }
+					title="Title example"
+					subtitle="Subtitle example"
+				></NavigationHeader>
+			</div>
+		);
+	}
+}
+NavigationHeaderExample.displayName = 'NavigationHeaderExample';
 
 export default NavigationHeaderExample;

--- a/client/components/navigation-header/style.scss
+++ b/client/components/navigation-header/style.scss
@@ -5,24 +5,13 @@
 	box-sizing: border-box;
 	width: 100%;
 	background-color: var(--studio-white);
-	padding: 0 16px;
+	padding: 16px 16px 0 16px;
+	margin: 0;
 
 	@include break-small {
+		margin-bottom: 24px;
 		margin-top: 0;
 		padding: 0;
-	}
-
-	@include breakpoint-deprecated( ">660px" ) {
-		margin-top: calc(-1 * var(--masterbar-height) + 20px);
-		padding: 0;
-	}
-
-	@include break-medium {
-		margin-top: calc(-1 * var(--masterbar-height) - 7px);
-	}
-
-	@include break-large {
-		margin-top: calc(-1 * var(--masterbar-height) - 16px);
 	}
 
 	.breadcrumbs-back {
@@ -38,20 +27,21 @@
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
-	min-height: 70px;
 	box-sizing: border-box;
-	padding: 24px 0;
 
 	> .formatted-header {
 		flex: 1;
 	}
 
 	.formatted-header__title {
-		font-size: $font-title-small;
+		font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
+		font-size: $font-title-medium;
 		font-weight: 500;
-		margin: 0;
+		margin-bottom: 4px;
+		min-height: 33px;
 	}
 	.formatted-header__subtitle {
+		min-height: 20px;
 		margin: 0;
 	}
 }

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -80,6 +80,7 @@ import ListEnd from 'calypso/components/list-end/docs/example';
 import Main from 'calypso/components/main';
 import MarkedLinesExample from 'calypso/components/marked-lines/docs/example';
 import MultipleChoiceQuestionExample from 'calypso/components/multiple-choice-question/docs/example';
+import NavigationHeader from 'calypso/components/navigation-header/docs/example';
 import Notices from 'calypso/components/notice/docs/example';
 import PaginationExample from 'calypso/components/pagination/docs/example';
 import PaymentLogo from 'calypso/components/payment-logo/docs/example';
@@ -245,6 +246,7 @@ export default class DesignAssets extends Component {
 					<ProductLogoExample />
 					<MarkedLinesExample readmeFilePath="marked-lines" />
 					<MultipleChoiceQuestionExample readmeFilePath="multiple-choice-question" />
+					<NavigationHeader readmeFilePath="navigation-header" />
 					<Notices readmeFilePath="notice" />
 					<PaginationExample readmeFilePath="pagination" />
 					<PaymentLogo readmeFilePath="payment-logo" />

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -11,9 +11,9 @@ import AsyncLoad from 'calypso/components/async-load';
 import DocumentHead from 'calypso/components/data/document-head';
 import QuerySiteChecklist from 'calypso/components/data/query-site-checklist';
 import EmptyContent from 'calypso/components/empty-content';
-import FormattedHeader from 'calypso/components/formatted-header';
 import { JetpackConnectionHealthBanner } from 'calypso/components/jetpack/connection-health';
 import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import { useGetDomainsQuery } from 'calypso/data/domains/use-get-domains-query';
 import useHomeLayoutQuery, { getCacheKey } from 'calypso/data/home/use-home-layout-query';
 import { addHotJarScript } from 'calypso/lib/analytics/hotjar';
@@ -140,13 +140,17 @@ const Home = ( {
 
 	const header = (
 		<div className="customer-home__heading">
-			<FormattedHeader
-				brandFont
-				headerText={ translate( 'My Home' ) }
-				subHeaderText={ translate( 'Your hub for posting, editing, and growing your site.' ) }
-				align="left"
-				hasScreenOptions
-			/>
+			<NavigationHeader
+				compactBreadcrumb={ false }
+				navigationItems={ [] }
+				mobileItem={ null }
+				title="My Home"
+				subtitle="Your hub for posting, editing, and growing your site."
+			>
+				<Button href={ site.URL } onClick={ trackViewSiteAction } target="_blank">
+					{ translate( 'Visit site' ) }
+				</Button>
+			</NavigationHeader>
 
 			<div className="customer-home__site-content">
 				<SiteIcon site={ site } size={ 58 } />
@@ -160,12 +164,6 @@ const Home = ( {
 						<span className="customer-home__site-domain-text">{ site.domain }</span>
 					</ExternalLink>
 				</div>
-			</div>
-
-			<div className="customer-home__view-site-button">
-				<Button href={ site.URL } onClick={ trackViewSiteAction } target="_blank">
-					{ translate( 'Visit site' ) }
-				</Button>
 			</div>
 		</div>
 	);

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -9,7 +9,6 @@ body.is-section-home.theme-default.color-scheme {
 .customer-home__heading {
 	display: block;
 
-	.customer-home__view-site-button,
 	.formatted-header__subtitle {
 		display: none;
 	}
@@ -65,23 +64,6 @@ body.is-section-home.theme-default.color-scheme {
 		margin-bottom: 4px;
 	}
 
-	.formatted-header {
-		margin-right: 12px;
-	}
-
-	.formatted-header__subtitle {
-		margin: 0;
-	}
-
-	.customer-home__view-site-button {
-		margin: auto;
-		margin-right: 0;
-
-		.button {
-			text-align: center;
-			white-space: nowrap;
-		}
-	}
 	@include break-medium {
 		display: flex;
 		flex: 0 0 auto;
@@ -90,7 +72,6 @@ body.is-section-home.theme-default.color-scheme {
 			display: none;
 		}
 
-		.customer-home__view-site-button,
 		.formatted-header__subtitle {
 			display: block;
 		}

--- a/client/my-sites/domains/style.scss
+++ b/client/my-sites/domains/style.scss
@@ -53,6 +53,8 @@ body.is-section-domains.is-domain-plan-package-flow {
 	}
 }
 
-.is-section-domains #primary header.formatted-header {
-	margin: 24px 0;
+@media screen and (max-width: $break-small) {
+	.is-section-domains .navigation-header {
+		margin-bottom: 10px;
+	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 4219-gh-Automattic/dotcom-forge

TODO:

- Polish the CSS style to ensure it matches the latest design specs: p9Jlb4-8ec-p2#comment-8802 (will probably do it after more screens are converted)

## Proposed Changes

* Updated NavigationHeader to be more generic
* [Added it on /devdocs Componentes UI](http://calypso.localhost:3000/devdocs/design/navigation-header) to help increase its usage
* Updated `Home` header to use `NavigationHeader` instead of `FormattedHeader`

![image](https://github.com/Automattic/wp-calypso/assets/1044309/b485e0b3-0edd-4ecc-b112-1baa043b868e)


## Testing Instructions

We're using this Design specs as reference: p9Jlb4-8ec-p2#comment-8802

* Ensure [NavigationHeader on /devdocs](http://calypso.localhost:3000/devdocs/design/navigation-header) works as expected
* Ensure [NavigationHeader on /devdocs (Headers)](http://calypso.localhost:3000/devdocs/design/headers) works as expected
* Ensure the Domains page works as before (with Figma updates)
* Ensure the Home page works as before (with Figma updates)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?