### PR TITLE
Earn: Revert "Allow PromoCard to show feature status"

### DIFF
--- a/client/components/promo-section/index.tsx
+++ b/client/components/promo-section/index.tsx
@@ -28,7 +28,6 @@ const PromoSectionCard: FunctionComponent< PromoSectionCardProps > = ( {
 } ) => {
 	const cta = actions?.cta;
 	const learnMoreLink = actions?.learnMoreLink;
-	const featureIncludedInPlan = actions?.featureIncludedInPlan;
 	const getCtaComponent = () => {
 		if ( ! cta ) {
 			return null;
@@ -36,13 +35,7 @@ const PromoSectionCard: FunctionComponent< PromoSectionCardProps > = ( {
 		if ( 'component' in cta && cta.component ) {
 			return cta.component;
 		}
-		return (
-			<PromoCardCta
-				cta={ cta }
-				learnMoreLink={ learnMoreLink }
-				featureIncludedInPlan={ featureIncludedInPlan }
-			/>
-		);
+		return <PromoCardCta cta={ cta } learnMoreLink={ learnMoreLink } />;
 	};
 	const ctaComponent = getCtaComponent();
 	return (

--- a/client/components/promo-section/promo-card/cta.tsx
+++ b/client/components/promo-section/promo-card/cta.tsx
@@ -1,4 +1,4 @@
-import { Button, Gridicon } from '@automattic/components';
+import { Button } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate, TranslateResult } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
@@ -25,11 +25,6 @@ export interface CtaButton {
 export interface Props {
 	cta: CtaButton;
 	learnMoreLink?: CtaAction | null;
-	/**
-	 * Displays "Included in your current plan" if true or "Not included in your current plan" if false.
-	 * Ignored if undefined or if `learnMoreLink` is set.
-	 */
-	featureIncludedInPlan?: boolean;
 	isPrimary?: boolean;
 }
 
@@ -66,12 +61,7 @@ function buttonProps( button: CtaButton, isPrimary: boolean ) {
 		...actionProps,
 	};
 }
-const PromoCardCta: FunctionComponent< Props > = ( {
-	cta,
-	learnMoreLink,
-	featureIncludedInPlan,
-	isPrimary,
-} ) => {
+const PromoCardCta: FunctionComponent< Props > = ( { cta, learnMoreLink, isPrimary } ) => {
 	const ctaBtnProps = ( button: CtaButton ) => buttonProps( button, true === isPrimary );
 	const translate = useTranslate();
 	let learnMore = null;
@@ -89,23 +79,6 @@ const PromoCardCta: FunctionComponent< Props > = ( {
 			  };
 	}
 
-	const getAvailabilityNotice = () => {
-		if ( featureIncludedInPlan === undefined ) {
-			return null;
-		}
-		return featureIncludedInPlan ? (
-			<div className="promo-card__availability">
-				<Gridicon icon="checkmark" className="promo-card__checkmark" size={ 18 } />
-				<span>{ translate( 'Included in your plan' ) }</span>
-			</div>
-		) : (
-			<div className="promo-card__availability">
-				<Gridicon icon="cross-small" className="promo-card__cross" size={ 18 } />
-				<span>{ translate( 'Not included in your current plan' ) }</span>
-			</div>
-		);
-	};
-
 	return (
 		<ActionPanelCta>
 			<Button { ...ctaBtnProps( cta ) }>{ cta.text }</Button>
@@ -114,7 +87,6 @@ const PromoCardCta: FunctionComponent< Props > = ( {
 					{ learnMoreLink?.label || translate( 'Learn more' ) }
 				</Button>
 			) }
-			{ ! learnMore && getAvailabilityNotice() }
 		</ActionPanelCta>
 	);
 };

--- a/client/components/promo-section/promo-card/style.scss
+++ b/client/components/promo-section/promo-card/style.scss
@@ -93,9 +93,6 @@
 	}
 
 	.action-panel__cta {
-		display: flex;
-		align-items: center;
-		flex-wrap: wrap;
 		.button {
 			margin: 0 1em 4px 0;
 		}
@@ -124,20 +121,6 @@
 			font-size: $font-body-small;
 			color: var(--studio-green-50);
 			margin-left: 8px;
-		}
-	}
-	.promo-card__availability {
-		display: flex;
-		align-items: center;
-		gap: 0.5em;
-		margin: 8px 0;
-
-		.promo-card__checkmark {
-			color: var(--studio-green-30);
-		}
-
-		.promo-card__cross {
-			color: var(--studio-red-30);
 		}
 	}
 }

--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -350,7 +350,7 @@ const Home = () => {
 			return;
 		}
 		const cta = {
-			text: translate( 'Learn more' ),
+			text: translate( 'Learn how to get started' ),
 			action: () => {
 				trackCtaButton( 'learn-paid-newsletters' );
 				if ( window && window.location ) {
@@ -369,7 +369,6 @@ const Home = () => {
 			icon: 'mail',
 			actions: {
 				cta,
-				featureIncludedInPlan: true,
 			},
 		};
 	};

--- a/client/my-sites/earn/style.scss
+++ b/client/my-sites/earn/style.scss
@@ -62,7 +62,7 @@
 	}
 }
 
-.earn .promo-section__promos  .action-panel__figure .gridicon {
+.earn .promo-section__promos .gridicon {
 	fill: var(--color-primary-10);
 	position: relative;
 	top: -8px;


### PR DESCRIPTION
## Proposed Changes

* Reverts Automattic/wp-calypso#81915. The designs for new Monetize page changed and we no longer need the ability to show a notification for whether a feature is included. To keep code clean, rather than leave the unneeded code in place, I'm reverting. 
* This PR was prepared entirely via Github's revert functionality. I checked file histories, and no changes have been made/stacked on top of my changes since the original PR. I particularly wanted to check/confirm this for the changes to generic components. 

<img width="1068" alt="revert" src="https://github.com/Automattic/wp-calypso/assets/21228350/540a6460-ad16-46e1-a7b5-54fd149ff485">

## Testing Instructions

1) Checkout this branch and go to http://calypso.localhost:3000/earn/YOURDOMAIN
2) Confirm all Earn feature cards render as expected and that buttons / links work. 
3) Bonus: Find other screens that use the PromoSection components and confirm those continue to look and work as expected. Example: https://wordpress.com/backup/YOURDOMAIN