### PR TITLE
Stats: Date Picker - Style Input Fields

### DIFF
--- a/client/my-sites/stats/stats-date-control/stats-date-control-picker-date.tsx
+++ b/client/my-sites/stats/stats-date-control/stats-date-control-picker-date.tsx
@@ -16,8 +16,14 @@ const DateControlPickerDate = ( {
 	return (
 		<div className="date-control-picker-date">
 			<div className="stats-date-control-picker-dates__inputs">
-				<TextControl value={ startDate } onChange={ onStartChange } />
-				<TextControl value={ endDate } onChange={ onEndChange } />
+				<div className="input-group">
+					<label htmlFor="startDate">From</label>
+					<TextControl id="startDate" value={ startDate } onChange={ onStartChange } />
+				</div>
+				<div className="input-group">
+					<label htmlFor="endDate">To</label>
+					<TextControl id="endDate" value={ endDate } onChange={ onEndChange } />
+				</div>
 			</div>
 			<div className="stats-date-control-picker-dates__buttons">
 				<Button onClick={ onCancel }>Cancel</Button>

--- a/client/my-sites/stats/stats-date-control/stats-date-control-picker-date.tsx
+++ b/client/my-sites/stats/stats-date-control/stats-date-control-picker-date.tsx
@@ -16,11 +16,11 @@ const DateControlPickerDate = ( {
 	return (
 		<div className="date-control-picker-date">
 			<div className="stats-date-control-picker-dates__inputs">
-				<div className="input-group">
+				<div className="stats-date-control-picker-dates__inputs-input-group">
 					<label htmlFor="startDate">From</label>
 					<TextControl id="startDate" value={ startDate } onChange={ onStartChange } />
 				</div>
-				<div className="input-group">
+				<div className="stats-date-control-picker-dates__inputs-input-group">
 					<label htmlFor="endDate">To</label>
 					<TextControl id="endDate" value={ endDate } onChange={ onEndChange } />
 				</div>

--- a/client/my-sites/stats/stats-date-control/style.scss
+++ b/client/my-sites/stats/stats-date-control/style.scss
@@ -73,6 +73,10 @@
 	}
 }
 
+.date-control-picker-date .stats-date-control-picker-dates__inputs input[type="text"] {
+	padding: 10px 16px;
+}
+
 .stats-date-control-picker__popover-content {
 	display: flex;
 	min-width: 320px;

--- a/client/my-sites/stats/stats-date-control/style.scss
+++ b/client/my-sites/stats/stats-date-control/style.scss
@@ -43,7 +43,7 @@
 	margin-bottom: 16px; // spacing between "From" and "To" groups
 
 	label {
-		margin-bottom: 8px; // Adjust based on the design's spacing
+		margin-bottom: 0;
 		text-align: left;
 	}
 }
@@ -54,7 +54,7 @@
 }
 
 .date-control-picker-date .stats-date-control-picker-dates__inputs .input-group .components-base-control .components-base-control__field input.components-text-control__input {
-	max-width: 90px; //todo find a way to shorten this chain, and perhaps stop hard coding the max-width
+	max-width: 120px;
 }
 
 .stats-date-control-picker {
@@ -85,6 +85,8 @@
 	gap: 16px; // spacing between the "From" input and the "To" input
 
 	input[type="text"] {
+		border: 1px solid var(--gray-gray-10, #c3c4c7);
+		background: var(--black-white-white, #fff);
 		padding: 10px 16px;
 		width: auto;
 		max-width: 95%; // this is to ensure it doesn't overflow its container

--- a/client/my-sites/stats/stats-date-control/style.scss
+++ b/client/my-sites/stats/stats-date-control/style.scss
@@ -1,12 +1,14 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@automattic/components/src/styles/typography.scss";
 
-.stats-date-control {
-	display: flex;
-	flex-direction: row-reverse;
-}
+.date-control-picker-date {
+	margin: 16px;
 
-// TODO: Add final colors to shortcuts.
+	// Internal layout
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+}
 
 .date-control-picker-shortcuts {
 	margin: 10px 0;
@@ -19,39 +21,55 @@
 
 .date-control-picker-shortcuts__shortcut {
 	border-radius: 4px;
+
+	&.is-selected {
+		background-color: var(--color-accent-5);
+	}
+
+	&:hover {
+		background-color: var(--color-primary-0);
+	}
+
 	.components-button {
 		display: flex;
 		justify-content: space-between;
 		width: 100%;
 	}
-	&.is-selected {
-		background-color: var(--color-accent-5);
-	}
-	&:hover {
-		background-color: var(--color-primary-0);
+}
+
+.input-group {
+	display: flex;
+	flex-direction: column;
+	margin-bottom: 16px; // spacing between "From" and "To" groups
+
+	label {
+		margin-bottom: 8px; // Adjust based on the design's spacing
+		text-align: left;
 	}
 }
 
-// Button styling for date control picker dropdown
+.stats-date-control {
+	display: flex;
+	flex-direction: row-reverse;
+}
 
 .stats-date-control-picker {
-
 	> .components-button {
-		border-radius: 4px;
-		border: 1px solid var(--gray-gray-10, #c3c4c7);
+		align-items: center;
 		background: #fff;
+		border: 1px solid var(--gray-gray-10, #c3c4c7);
+		border-radius: 4px;
 		color: var(--studio-black);
+		display: flex;
 		font-family: $font-sf-pro-display;
-		font-size: 14px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		font-size: 14px; // stylelint-disable-line declaration-property-unit-allowed-list
 		font-style: normal;
 		font-weight: 500;
-		line-height: 20px;
-		letter-spacing: 0.32px;
-		display: flex;
-		padding: var(--grid-unit-15, 12px) var(--grid-unit-20, 16px);
-		justify-content: flex-end;
-		align-items: center;
 		gap: 8px;
+		justify-content: flex-end;
+		letter-spacing: 0.32px;
+		line-height: 20px;
+		padding: var(--grid-unit-15, 12px) var(--grid-unit-20, 16px);
 	}
 }
 
@@ -60,16 +78,14 @@
 	min-width: 320px;
 }
 
-.date-control-picker-date {
-	margin: 16px;
-
-	// internal layout
-	display: flex;
-	flex-direction: column;
-	justify-content: space-between;
-}
-
 .stats-date-control-picker-dates__buttons {
 	display: flex;
 	justify-content: flex-end;
 }
+
+.stats-date-control-picker-dates__inputs {
+	display: flex; // to position "From" and "To" groups side by side
+	gap: 16px; // spacing between the "From" input and the "To" input
+}
+
+// TODO: Add final colors to shortcuts.

--- a/client/my-sites/stats/stats-date-control/style.scss
+++ b/client/my-sites/stats/stats-date-control/style.scss
@@ -53,7 +53,12 @@
 	flex-direction: row-reverse;
 }
 
+.date-control-picker-date .stats-date-control-picker-dates__inputs .input-group .components-base-control .components-base-control__field input.components-text-control__input {
+	max-width: 90px; //todo find a way to shorten this chain, and perhaps stop hard coding the max-width
+}
+
 .stats-date-control-picker {
+
 	> .components-button {
 		align-items: center;
 		background: #fff;
@@ -73,23 +78,29 @@
 	}
 }
 
-.date-control-picker-date .stats-date-control-picker-dates__inputs input[type="text"] {
-	padding: 10px 16px;
+.stats-date-control-picker-dates__inputs {
+
+	align-items: flex-start; // this prevents flex children from stretching
+	display: flex; // to position "From" and "To" groups side by side
+	gap: 16px; // spacing between the "From" input and the "To" input
+
+	input[type="text"] {
+		padding: 10px 16px;
+		width: auto;
+		max-width: 95%; // this is to ensure it doesn't overflow its container
+		box-sizing: content-box; // this ensures padding isn't included in the total width
+	}
 }
 
 .stats-date-control-picker__popover-content {
 	display: flex;
 	min-width: 320px;
+
 }
 
 .stats-date-control-picker-dates__buttons {
 	display: flex;
 	justify-content: flex-end;
-}
-
-.stats-date-control-picker-dates__inputs {
-	display: flex; // to position "From" and "To" groups side by side
-	gap: 16px; // spacing between the "From" input and the "To" input
 }
 
 // TODO: Add final colors to shortcuts.

--- a/client/my-sites/stats/stats-date-control/style.scss
+++ b/client/my-sites/stats/stats-date-control/style.scss
@@ -85,6 +85,12 @@
 	gap: 16px; // spacing between the "From" input and the "To" input
 
 	input[type="text"] {
+		font-family: $font-sf-pro-text;
+		font-size: 14px; // stylelint-disable-line declaration-property-unit-allowed-list
+		font-style: normal;
+		font-weight: 400;
+		line-height: 20px;
+		letter-spacing: -0.15px;
 		border: 1px solid var(--gray-gray-10, #c3c4c7);
 		background: var(--black-white-white, #fff);
 		padding: 10px 16px;

--- a/client/my-sites/stats/stats-date-control/style.scss
+++ b/client/my-sites/stats/stats-date-control/style.scss
@@ -37,7 +37,7 @@
 	}
 }
 
-.input-group {
+.stats-date-control-picker-dates__inputs-input-group {
 	display: flex;
 	flex-direction: column;
 	margin-bottom: 16px; // spacing between "From" and "To" groups
@@ -53,7 +53,7 @@
 	flex-direction: row-reverse;
 }
 
-.date-control-picker-date .stats-date-control-picker-dates__inputs .input-group .components-base-control .components-base-control__field input.components-text-control__input {
+.date-control-picker-date .stats-date-control-picker-dates__inputs .stats-date-control-picker-dates__inputs-input-group .components-base-control .components-base-control__field input.components-text-control__input {
 	max-width: 120px;
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #82702

## Proposed Changes

* This PR updates some of the styling in the date picker, specifically the input fields to match the design specs in c6yabERlJE06tKLECfpnch-fi-8178%3A15560

	- adds the `to` and `from` labels
	- moves the alignment of the input fields to horizontal
	- adds padding inside the input fields
	- shortens the length of the input fields
	- styles the input text content

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load the Calypso live branch 
* Navigate to `/stats/day/{site URL}`
* Confirm that everything remains unchanged without the feature flag applied
* Append `?flags=stats/date-control` to the end of the URL
* Confirm styling matches image below:

| Before  | After | Design |
| ------------- | ------------- | ------------- |
| ![image](https://github.com/Automattic/wp-calypso/assets/30754158/9a37c5da-bfdf-42eb-b3da-cc35527f3098) | ![image](https://github.com/Automattic/wp-calypso/assets/30754158/4ad28110-5c75-478d-bf1b-acd6516cbcb8) | ![image](https://github.com/Automattic/wp-calypso/assets/30754158/2b9952e2-cebb-490f-ae37-6b76f9b57051) |


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?