### PR TITLE
Stats: Update interval to fit the selected period

### DIFF
--- a/client/my-sites/stats/stats-date-control/index.tsx
+++ b/client/my-sites/stats/stats-date-control/index.tsx
@@ -1,4 +1,7 @@
+import { useTranslate } from 'i18n-calypso';
 import moment from 'moment';
+import page from 'page';
+import qs from 'qs';
 import React from 'react';
 import IntervalDropdown from '../stats-interval-dropdown';
 import DateControlPicker from './stats-date-control-picker';
@@ -14,34 +17,36 @@ const StatsDateControl = ( {
 	pathTemplate,
 	onChangeChartQuantity,
 }: StatsDateControlProps ) => {
+	const translate = useTranslate();
+
 	const shortcutList = [
 		{
 			id: 'today',
-			label: 'Today',
+			label: translate( 'Today' ),
 			offset: 0,
 			range: 0,
 		},
 		{
 			id: 'yesterday',
-			label: 'Yesterday',
+			label: translate( 'Yesterday' ),
 			offset: 1,
 			range: 0,
 		},
 		{
 			id: 'last-7-days',
-			label: 'Last 7 Days',
+			label: translate( 'Last 7 Days' ),
 			offset: 0,
 			range: 7,
 		},
 		{
 			id: 'last-30-days',
-			label: 'Last 30 Days',
+			label: translate( 'Last 30 Days' ),
 			offset: 0,
 			range: 30,
 		},
 		{
 			id: 'last-year',
-			label: 'Last Year',
+			label: translate( 'Last Year' ),
 			offset: 0,
 			range: 365,
 		},
@@ -58,20 +63,37 @@ const StatsDateControl = ( {
 		// TODO: take period into account
 		const offset = Math.abs( moment( endDate ).diff( moment( startDate ), 'days' ) );
 
-		// TODO: add period update if the offet is too big to accomodate the chart
+		if ( offset <= 30 ) {
+			// 30 bars, one day is one bar
+			onChangeChartQuantity( offset + 1 );
+		} else {
+			const nextDay = startDate;
+			const nextDayQuery = qs.stringify( Object.assign( {}, queryParams, { startDate: nextDay } ), {
+				addQueryPrefix: true,
+			} );
+			let period;
 
-		onChangeChartQuantity( offset + 1 );
+			if ( offset <= 7 * 25 ) {
+				// 25 bars, 7 days one bar
+				period = 'week';
+			} else if ( offset <= 30 * 25 ) {
+				// 25 bars, 30 days one bar
+				period = 'month';
+			} else {
+				period = 'year';
+			}
+
+			const url = `/stats/${ period }/${ slug }`;
+			const href = `${ url }${ nextDayQuery }`;
+
+			page( href );
+		}
 	};
 
 	return (
 		<div className={ COMPONENT_CLASS_NAME }>
 			<IntervalDropdown period={ period } pathTemplate={ pathTemplate } />
-			<DateControlPicker
-				slug={ slug }
-				queryParams={ queryParams }
-				shortcutList={ shortcutList }
-				handleApply={ handleApply }
-			/>
+			<DateControlPicker shortcutList={ shortcutList } handleApply={ handleApply } />
 		</div>
 	);
 };

--- a/client/my-sites/stats/stats-date-control/index.tsx
+++ b/client/my-sites/stats/stats-date-control/index.tsx
@@ -63,31 +63,33 @@ const StatsDateControl = ( {
 		// TODO: take period into account
 		const offset = Math.abs( moment( endDate ).diff( moment( startDate ), 'days' ) );
 
+		// set quntiry
+		onChangeChartQuantity( offset + 1 );
+
+		const nextDay = startDate;
+		const nextDayQuery = qs.stringify( Object.assign( {}, queryParams, { startDate: nextDay } ), {
+			addQueryPrefix: true,
+		} );
+		let period;
+
 		if ( offset <= 30 ) {
 			// 30 bars, one day is one bar
-			onChangeChartQuantity( offset + 1 );
+			period = 'day';
+		} else if ( offset <= 7 * 25 ) {
+			// 25 bars, 7 days one bar
+			period = 'week';
+		} else if ( offset <= 30 * 25 ) {
+			// 25 bars, 30 days one bar
+			period = 'month';
 		} else {
-			const nextDay = startDate;
-			const nextDayQuery = qs.stringify( Object.assign( {}, queryParams, { startDate: nextDay } ), {
-				addQueryPrefix: true,
-			} );
-			let period;
-
-			if ( offset <= 7 * 25 ) {
-				// 25 bars, 7 days one bar
-				period = 'week';
-			} else if ( offset <= 30 * 25 ) {
-				// 25 bars, 30 days one bar
-				period = 'month';
-			} else {
-				period = 'year';
-			}
-
-			const url = `/stats/${ period }/${ slug }`;
-			const href = `${ url }${ nextDayQuery }`;
-
-			page( href );
+			period = 'year';
 		}
+
+		const url = `/stats/${ period }/${ slug }`;
+		const href = `${ url }${ nextDayQuery }`;
+
+		// apply an interval
+		page( href );
 	};
 
 	return (

--- a/client/my-sites/stats/stats-date-control/stats-date-control-picker-date.tsx
+++ b/client/my-sites/stats/stats-date-control/stats-date-control-picker-date.tsx
@@ -1,4 +1,5 @@
 import { TextControl, Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import { DateControlPickerDateProps } from './types';
 
@@ -13,6 +14,9 @@ const DateControlPickerDate = ( {
 	// TODO: Rename component?
 	// Feels a bit confusing now. Should have a better idea
 	// of appropriate names once hierarchy is finalized.
+
+	const translate = useTranslate();
+
 	return (
 		<div className="date-control-picker-date">
 			<div className="stats-date-control-picker-dates__inputs">
@@ -20,9 +24,9 @@ const DateControlPickerDate = ( {
 				<TextControl value={ endDate } onChange={ onEndChange } />
 			</div>
 			<div className="stats-date-control-picker-dates__buttons">
-				<Button onClick={ onCancel }>Cancel</Button>
+				<Button onClick={ onCancel }>{ translate( 'Cancel' ) }</Button>
 				<Button variant="primary" onClick={ onApply }>
-					Apply
+					{ translate( 'Apply' ) }
 				</Button>
 			</div>
 		</div>

--- a/client/my-sites/stats/stats-date-control/stats-date-control-picker.tsx
+++ b/client/my-sites/stats/stats-date-control/stats-date-control-picker.tsx
@@ -2,20 +2,13 @@ import { Popover } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { Icon, calendar } from '@wordpress/icons';
 import moment from 'moment';
-import page from 'page';
-import qs from 'qs';
 import React, { useState, useRef } from 'react';
 import DateControlPickerDate from './stats-date-control-picker-date';
 import DateControlPickerShortcuts from './stats-date-control-picker-shortcuts';
 import { DateControlPickerProps, DateControlPickerShortcut } from './types';
 import './style.scss';
 
-const DateControlPicker = ( {
-	slug,
-	queryParams,
-	shortcutList,
-	handleApply,
-}: DateControlPickerProps ) => {
+const DateControlPicker = ( { shortcutList, handleApply }: DateControlPickerProps ) => {
 	// TODO: remove placeholder values
 	const [ inputStartDate, setInputStartDate ] = useState( new Date().toISOString().slice( 0, 10 ) );
 	const [ inputEndDate, setInputEndDate ] = useState(
@@ -36,18 +29,8 @@ const DateControlPicker = ( {
 	};
 
 	const handleOnApply = () => {
-		const nextDay = inputStartDate;
-		const nextDayQuery = qs.stringify( Object.assign( {}, queryParams, { startDate: nextDay } ), {
-			addQueryPrefix: true,
-		} );
-		const period = 'day'; // TODO: make this dynamic
-		const url = `/stats/${ period }/${ slug }`;
-		const href = `${ url }${ nextDayQuery }`;
-
 		// expose the values externally
 		handleApply( inputStartDate, inputEndDate );
-
-		page( href );
 	};
 
 	const handleOnCancel = () => {

--- a/client/my-sites/stats/stats-date-control/types.d.ts
+++ b/client/my-sites/stats/stats-date-control/types.d.ts
@@ -7,8 +7,6 @@ interface StatsDateControlProps {
 }
 
 interface DateControlPickerProps {
-	slug: string;
-	queryParams: string;
 	shortcutList: DateControlPickerShortcut[];
 	handleApply: ( startDate: string, endDate: string ) => void;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #83071 

## Proposed Changes

* Update visible chart interval for larger periods that wouldn't fit all data points
* Wrap strings with translations

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* verify that the page on the live branch is not broken and you can navigate to a day other than the default day on the Traffic page and you can change visible interval
* apply `stats/date-control` feature flag to the live branch
* start selecting different periods from the date control component
* check interval used:
  * days for less or equal to 30 days between start and end dates
  * weeks for more than 30 days but less or equal to 175 (7 * 25) days between start and end dates
  * months for more than 175 days but less or equal to 750 (30 * 25) days between start and end dates
  * years for more than 750 days

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?