### PR TITLE
Create Reusable Sidebar Navigator Components for Calypso 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -499,6 +499,7 @@ module.exports = {
 					'__experimentalItemGroup',
 					'__experimentalNavigationBackButton',
 					'__experimentalNavigatorBackButton',
+					'__experimentalNavigatorToParentButton',
 					'__experimentalNavigatorButton',
 					'__experimentalNavigatorProvider',
 					'__experimentalNavigatorScreen',

--- a/client/jetpack-cloud/components/sidebar/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/index.tsx
@@ -32,6 +32,7 @@ type Props = {
 		title: string;
 		onClickMenuItem: ( path: string ) => void;
 		withChevron?: boolean;
+		isExternalLink?: boolean;
 	}[];
 	description?: string;
 	backButtonProps?: {

--- a/client/jetpack-cloud/components/sidebar/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/index.tsx
@@ -33,6 +33,7 @@ type Props = {
 		onClickMenuItem: ( path: string ) => void;
 		withChevron?: boolean;
 		isExternalLink?: boolean;
+		isSelected: boolean;
 	}[];
 	description?: string;
 	backButtonProps?: {

--- a/client/jetpack-cloud/components/sidebar/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/index.tsx
@@ -6,6 +6,9 @@ import SidebarItem from 'calypso/layout/sidebar/item';
 import Sidebar, {
 	SidebarV2Main as SidebarMain,
 	SidebarV2Footer as SidebarFooter,
+	SidebarNavigator,
+	SidebarNavigatorMenu,
+	SidebarNavigatorMenuItem,
 } from 'calypso/layout/sidebar-v2';
 import { useSelector } from 'calypso/state';
 import getJetpackAdminUrl from 'calypso/state/sites/selectors/get-jetpack-admin-url';
@@ -21,8 +24,31 @@ import './style.scss';
 type Props = {
 	className?: string;
 	isJetpackManage?: boolean;
+	path: string;
+	menuItems: {
+		icon: JSX.Element;
+		path: string;
+		link: string;
+		title: string;
+		onClickMenuItem: ( path: string ) => void;
+		withChevron?: boolean;
+	}[];
+	description?: string;
+	backButtonProps?: {
+		icon: JSX.Element;
+		label: string;
+		onClick: () => void;
+	};
 };
-const JetpackCloudSidebar = ( { className, isJetpackManage }: Props ) => {
+
+const JetpackCloudSidebar = ( {
+	className,
+	isJetpackManage,
+	path,
+	menuItems,
+	description,
+	backButtonProps,
+}: Props ) => {
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const jetpackAdminUrl = useSelector( ( state ) =>
 		siteId ? getJetpackAdminUrl( state, siteId ) : null
@@ -35,17 +61,17 @@ const JetpackCloudSidebar = ( { className, isJetpackManage }: Props ) => {
 			<SidebarHeader forceAllSitesView={ isJetpackManage } />
 
 			<SidebarMain>
-				<ul role="menu" className="jetpack-cloud-sidebar__navigation-list">
-					<li
-						className={ classNames(
-							'jetpack-cloud-sidebar__navigation-item',
-							'jetpack-cloud-sidebar__navigation-item--highlighted'
-						) }
+				<SidebarNavigator initialPath={ path }>
+					<SidebarNavigatorMenu
+						path={ path }
+						description={ description }
+						backButtonProps={ backButtonProps }
 					>
-						Navigation items
-					</li>
-					<li className="jetpack-cloud-sidebar__navigation-item">Will go here</li>
-				</ul>
+						{ menuItems.map( ( item ) => (
+							<SidebarNavigatorMenuItem key={ item.link } { ...item } />
+						) ) }
+					</SidebarNavigatorMenu>
+				</SidebarNavigator>
 			</SidebarMain>
 
 			{ ! isJetpackManage && (

--- a/client/jetpack-cloud/components/sidebar/style.scss
+++ b/client/jetpack-cloud/components/sidebar/style.scss
@@ -8,8 +8,8 @@
 
 	.sidebar-v2__menu-item {
 		&.is-active {
-			background: var(--studio-green-0) !important;
-			color: var(--studio-green-50) !important;
+			background: var(--studio-green-0);
+			color: var(--studio-green-50);
 		}
 	}
 }

--- a/client/jetpack-cloud/components/sidebar/style.scss
+++ b/client/jetpack-cloud/components/sidebar/style.scss
@@ -5,6 +5,13 @@
 	.jetpack-cloud-sidebar__site-selector {
 		background-color: var(--color-sidebar-background);
 	}
+
+	.sidebar-v2__menu-item {
+		&.is-active {
+			background: var(--studio-green-0) !important;
+			color: var(--studio-green-50) !important;
+		}
+	}
 }
 
 .jetpack-cloud-sidebar__header {

--- a/client/jetpack-cloud/sections/sidebar-navigation/jetpack-manage.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/jetpack-manage.tsx
@@ -4,6 +4,9 @@ import NewSidebar from 'calypso/jetpack-cloud/components/sidebar';
 // navigate around Jetpack Cloud with no specific site selected.
 // It'll display menu options like Sites Management, Plugin Management,
 // and Purchases.
-const JetpackManageSidebar = () => <NewSidebar isJetpackManage />;
+// FIXME: Add menu items
+const JetpackManageSidebar = () => {
+	return <NewSidebar isJetpackManage path="/" menuItems={ [] } />;
+};
 
 export default JetpackManageSidebar;

--- a/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
@@ -2,6 +2,7 @@ import NewSidebar from 'calypso/jetpack-cloud/components/sidebar';
 
 // This sidebar is what people will see when they pick a site from the site
 // selector. It'll display menu options like Activity Log, Backup, Social, etc.
-const ManageSelectedSiteSidebar = () => <NewSidebar />;
+// FIXME: Add menu items and the right path
+const ManageSelectedSiteSidebar = () => <NewSidebar path="/" menuItems={ [] } />;
 
 export default ManageSelectedSiteSidebar;

--- a/client/jetpack-cloud/sections/sidebar-navigation/purchases.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/purchases.tsx
@@ -3,6 +3,9 @@ import NewSidebar from 'calypso/jetpack-cloud/components/sidebar';
 // This sidebar is what Jetpack Manage customers will see when they select the
 // Purchases item from the top-level navigation sidebar. It'll display options
 // like Licenses, Invoices, Billing, etc.
-const PurchasesSidebar = () => <NewSidebar isJetpackManage />;
+// FIXME: Add menu items
+const PurchasesSidebar = () => {
+	return <NewSidebar path="/partner-portal" menuItems={ [] } />;
+};
 
 export default PurchasesSidebar;

--- a/client/layout/sidebar-v2/index.tsx
+++ b/client/layout/sidebar-v2/index.tsx
@@ -1,6 +1,9 @@
 export * from './header';
 export * from './main';
 export * from './footer';
+export * from './navigator';
+export * from './navigator/navigator-menu';
+export * from './navigator/navigator-menu-item';
 
 import classNames from 'classnames';
 

--- a/client/layout/sidebar-v2/navigator/README.md
+++ b/client/layout/sidebar-v2/navigator/README.md
@@ -1,0 +1,60 @@
+# Sidebar Navigator Components
+
+A collection of components designed to create a navigational sidebar using the experimental Navigator components from the WordPress package.
+
+## Components
+
+### SidebarNavigator
+
+Main container for the navigator.
+
+**Props:**
+
+- `initialPath`: The initial path of the navigator.
+- `children`: Children to render inside the navigator.
+
+### SidebarNavigatorMenu
+
+A container for navigational menu items.
+
+**Props:**
+
+- `description`: Description of the menu.
+- `backButtonProps`:
+  - `icon`: Icon for the back button.
+  - `label`: Text label for the back button.
+  - `onClick`: Callback when the back button is clicked.
+- `path`: Path for the navigator screen.
+- `children`: Children to render inside the menu.
+
+### SidebarNavigatorMenuItem
+
+A component representing an individual menu item.
+
+**Props:**
+
+- `icon`: Icon for the menu item.
+- `path`: Path for the navigator.
+- `link`: URL link for the menu item.
+- `title`: Text for the menu item.
+- `onClickMenuItem`: Callback when the menu item is clicked.
+- `withChevron`: If true, a chevron icon is shown.
+- `isExternalLink`: If true, an external link icon is shown.
+- `isSelected`: If true, the menu item appears as selected.
+
+## Usage
+
+```jsx
+<SidebarNavigator initialPath="/initial-path">
+	<SidebarNavigatorMenu path="/menu-path" description="My Menu">
+		<SidebarNavigatorMenuItem
+			icon={ SampleIcon }
+			path="/item-path"
+			link="/item-link"
+			title="Menu Item 1"
+			onClickMenuItem={ handleClick }
+			isSelected={ true }
+		/>
+	</SidebarNavigatorMenu>
+</SidebarNavigator>
+```

--- a/client/layout/sidebar-v2/navigator/index.tsx
+++ b/client/layout/sidebar-v2/navigator/index.tsx
@@ -1,3 +1,6 @@
+export * from './navigator-menu';
+export * from './navigator-menu-item';
+
 import { __experimentalNavigatorProvider as NavigatorProvider } from '@wordpress/components';
 
 interface Props {

--- a/client/layout/sidebar-v2/navigator/index.tsx
+++ b/client/layout/sidebar-v2/navigator/index.tsx
@@ -1,0 +1,10 @@
+import { __experimentalNavigatorProvider as NavigatorProvider } from '@wordpress/components';
+
+interface Props {
+	initialPath: string;
+	children: React.ReactNode;
+}
+
+export const SidebarNavigator = ( { initialPath, children }: Props ) => {
+	return <NavigatorProvider initialPath={ initialPath }>{ children }</NavigatorProvider>;
+};

--- a/client/layout/sidebar-v2/navigator/index.tsx
+++ b/client/layout/sidebar-v2/navigator/index.tsx
@@ -3,11 +3,17 @@ export * from './navigator-menu-item';
 
 import { __experimentalNavigatorProvider as NavigatorProvider } from '@wordpress/components';
 
+import './style.scss';
+
 interface Props {
 	initialPath: string;
 	children: React.ReactNode;
 }
 
 export const SidebarNavigator = ( { initialPath, children }: Props ) => {
-	return <NavigatorProvider initialPath={ initialPath }>{ children }</NavigatorProvider>;
+	return (
+		<NavigatorProvider className="sidebar-v2__navigator" initialPath={ initialPath }>
+			{ children }
+		</NavigatorProvider>
+	);
 };

--- a/client/layout/sidebar-v2/navigator/navigator-menu-item.tsx
+++ b/client/layout/sidebar-v2/navigator/navigator-menu-item.tsx
@@ -4,7 +4,7 @@ import {
 	__experimentalHStack as HStack,
 	FlexBlock,
 } from '@wordpress/components';
-import { Icon, chevronRightSmall } from '@wordpress/icons';
+import { Icon, chevronRightSmall, external } from '@wordpress/icons';
 import classnames from 'classnames';
 
 import './style.scss';
@@ -18,6 +18,7 @@ interface Props {
 	title: string;
 	onClickMenuItem: ( path: string ) => void;
 	withChevron?: boolean;
+	isExternalLink?: boolean;
 }
 
 export const SidebarNavigatorMenuItem = ( {
@@ -27,6 +28,7 @@ export const SidebarNavigatorMenuItem = ( {
 	title,
 	onClickMenuItem,
 	withChevron,
+	isExternalLink,
 }: Props ) => {
 	const pathname = window.location.pathname;
 
@@ -42,6 +44,9 @@ export const SidebarNavigatorMenuItem = ( {
 					{ icon && <Icon style={ { fill: 'currentcolor' } } icon={ icon } size={ ICON_SIZE } /> }
 					<FlexBlock>{ children }</FlexBlock>
 					{ withChevron && <Icon icon={ chevronRightSmall } size={ ICON_SIZE } /> }
+					{ isExternalLink && (
+						<Icon className="sidebar-v2__external-icon" icon={ external } size={ ICON_SIZE } />
+					) }
 				</HStack>
 			</Item>
 		);

--- a/client/layout/sidebar-v2/navigator/navigator-menu-item.tsx
+++ b/client/layout/sidebar-v2/navigator/navigator-menu-item.tsx
@@ -1,0 +1,55 @@
+import {
+	__experimentalNavigatorButton as NavigatorButton,
+	__experimentalItem as Item,
+	__experimentalHStack as HStack,
+	FlexBlock,
+} from '@wordpress/components';
+import { Icon, chevronRightSmall } from '@wordpress/icons';
+import classnames from 'classnames';
+
+import './style.scss';
+
+const ICON_SIZE = 24;
+
+interface Props {
+	icon: JSX.Element;
+	path: string;
+	link: string;
+	title: string;
+	onClickMenuItem: ( path: string ) => void;
+	withChevron?: boolean;
+}
+
+export const SidebarNavigatorMenuItem = ( {
+	icon,
+	path,
+	link,
+	title,
+	onClickMenuItem,
+	withChevron,
+}: Props ) => {
+	const pathname = window.location.pathname;
+
+	const SidebarItem = ( { children }: { children?: JSX.Element } ) => {
+		return (
+			<Item
+				className={ classnames( 'sidebar-v2__menu-item', {
+					'is-active': pathname === link,
+				} ) }
+				onClick={ () => onClickMenuItem( link ) }
+			>
+				<HStack justify="flex-start">
+					{ icon && <Icon style={ { fill: 'currentcolor' } } icon={ icon } size={ ICON_SIZE } /> }
+					<FlexBlock>{ children }</FlexBlock>
+					{ withChevron && <Icon icon={ chevronRightSmall } size={ ICON_SIZE } /> }
+				</HStack>
+			</Item>
+		);
+	};
+
+	return (
+		<NavigatorButton as={ SidebarItem } path={ path }>
+			{ title }
+		</NavigatorButton>
+	);
+};

--- a/client/layout/sidebar-v2/navigator/navigator-menu-item.tsx
+++ b/client/layout/sidebar-v2/navigator/navigator-menu-item.tsx
@@ -19,6 +19,7 @@ interface Props {
 	onClickMenuItem: ( path: string ) => void;
 	withChevron?: boolean;
 	isExternalLink?: boolean;
+	isSelected: boolean;
 }
 
 export const SidebarNavigatorMenuItem = ( {
@@ -29,14 +30,13 @@ export const SidebarNavigatorMenuItem = ( {
 	onClickMenuItem,
 	withChevron,
 	isExternalLink,
+	isSelected,
 }: Props ) => {
-	const pathname = window.location.pathname;
-
 	const SidebarItem = ( { children }: { children?: JSX.Element } ) => {
 		return (
 			<Item
 				className={ classnames( 'sidebar-v2__menu-item', {
-					'is-active': pathname === link,
+					'is-active': isSelected,
 				} ) }
 				onClick={ () => onClickMenuItem( link ) }
 			>

--- a/client/layout/sidebar-v2/navigator/navigator-menu.tsx
+++ b/client/layout/sidebar-v2/navigator/navigator-menu.tsx
@@ -1,0 +1,46 @@
+import {
+	__experimentalNavigatorScreen as NavigatorScreen,
+	__experimentalNavigatorToParentButton as NavigatorToParentButton,
+	__experimentalVStack as VStack,
+	Card,
+	CardBody,
+} from '@wordpress/components';
+
+import './style.scss';
+
+interface Props {
+	description?: string;
+	backButtonProps?: {
+		icon: JSX.Element;
+		label: string;
+		onClick: () => void;
+	};
+	path: string;
+	children: React.ReactNode;
+}
+
+export const SidebarNavigatorMenu = ( { description, backButtonProps, path, children }: Props ) => {
+	return (
+		<NavigatorScreen path={ path }>
+			<Card>
+				<CardBody className="sidebar-v2__navigator-sub-menu">
+					<VStack spacing={ 0 } justify="flex-start">
+						{ backButtonProps && (
+							<NavigatorToParentButton
+								icon={ backButtonProps.icon }
+								onClick={ backButtonProps.onClick }
+								text={ backButtonProps.label }
+							/>
+						) }
+						<div>
+							{ description && (
+								<div className="sidebar-v2__navigator-group-description">{ description }</div>
+							) }
+							{ children }
+						</div>
+					</VStack>
+				</CardBody>
+			</Card>
+		</NavigatorScreen>
+	);
+};

--- a/client/layout/sidebar-v2/navigator/style.scss
+++ b/client/layout/sidebar-v2/navigator/style.scss
@@ -27,8 +27,6 @@
 
 	&.is-active {
 		border-radius: 4px !important;
-		background: var(--studio-green-0) !important;
-		color: var(--studio-green-50) !important;
 	}
 
 	&:hover:not(.is-active) {

--- a/client/layout/sidebar-v2/navigator/style.scss
+++ b/client/layout/sidebar-v2/navigator/style.scss
@@ -4,12 +4,12 @@
 	}
 }
 
-.sidebar-v2__navigator-sub-menu {
-	padding: 0 !important;
+.sidebar-v2__navigator-sub-menu.components-card-body {
+	padding: 0;
 
 	.components-navigator-back-button {
-		margin-block-end: 8px !important;
-		color: var(--studio-gray-90) !important;
+		margin-block-end: 8px;
+		color: var(--studio-gray-90);
 		font-size: rem(16px);
 		font-weight: 600;
 		justify-content: start;
@@ -21,25 +21,25 @@
 }
 
 .sidebar-v2__navigator-group-description {
-	color: var(--studio-gray-50) !important;
+	color: var(--studio-gray-50);
 	font-size: rem(12px);
-	margin-block-end: 16px !important;
+	margin-block-end: 16px;
 	padding: 0 12px;
 }
 
-.sidebar-v2__menu-item {
-	color: var(--studio-gray-90) !important;
+.sidebar-v2__menu-item.components-item {
 	font-size: rem(12px);
 
 	&.is-active {
-		border-radius: 4px !important;
+		border-radius: 4px;
 	}
 
 	&:hover:not(.is-active) {
-		background: var(--studio-gray-0) !important;
+		background: var(--studio-gray-0);
+		color: initial;
 	}
 }
 
 .sidebar-v2__external-icon {
-	color: var(--studio-gray-30) !important;
+	color: var(--studio-gray-30);
 }

--- a/client/layout/sidebar-v2/navigator/style.scss
+++ b/client/layout/sidebar-v2/navigator/style.scss
@@ -33,3 +33,7 @@
 		background: var(--studio-gray-0) !important;
 	}
 }
+
+.sidebar-v2__external-icon {
+	color: var(--studio-gray-30) !important;
+}

--- a/client/layout/sidebar-v2/navigator/style.scss
+++ b/client/layout/sidebar-v2/navigator/style.scss
@@ -1,3 +1,9 @@
+.sidebar-v2__navigator {
+	.components-surface.components-card {
+		background-color: var(--color-sidebar-background);
+	}
+}
+
 .sidebar-v2__navigator-sub-menu {
 	padding: 0 !important;
 

--- a/client/layout/sidebar-v2/navigator/style.scss
+++ b/client/layout/sidebar-v2/navigator/style.scss
@@ -1,0 +1,22 @@
+.sidebar-v2__navigator-sub-menu {
+	padding: 0 !important;
+
+	.components-navigator-back-button {
+		margin-block-end: 8px !important;
+		color: var(--studio-gray-90) !important;
+		font-size: rem(16px);
+		font-weight: 600;
+		justify-content: start;
+
+		&:focus {
+			box-shadow: none;
+		}
+	}
+}
+
+.sidebar-v2__navigator-group-description {
+	color: var(--studio-gray-50) !important;
+	font-size: rem(12px);
+	margin-block-end: 16px !important;
+	padding: 0 12px;
+}

--- a/client/layout/sidebar-v2/navigator/style.scss
+++ b/client/layout/sidebar-v2/navigator/style.scss
@@ -20,3 +20,18 @@
 	margin-block-end: 16px !important;
 	padding: 0 12px;
 }
+
+.sidebar-v2__menu-item {
+	color: var(--studio-gray-90) !important;
+	font-size: rem(12px);
+
+	&.is-active {
+		border-radius: 4px !important;
+		background: var(--studio-green-0) !important;
+		color: var(--studio-green-50) !important;
+	}
+
+	&:hover:not(.is-active) {
+		background: var(--studio-gray-0) !important;
+	}
+}


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/57

## Proposed Changes

This PR adds Navigator components(SidebarNavigator, SidebarNavigatorMenu & SidebarNavigatorMenuItem) to the existing SidebarV2 component. 

https://github.com/Automattic/wp-calypso/assets/10586875/5086c2f1-c57d-477b-873e-a96f8e1c8b3e

### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

- Switch to the `add/implement-sidebar-navigation` branch > Set `jetpack/new-navigation` to true in `config/jetpack-cloud-development.json` file >  Start the server 
- Go to `client/jetpack-cloud/sections/sidebar-navigation/jetpack-manage.tsx` and make the below changes:

Feel free to add more items if needed.

```
import { key, currencyDollar } from '@wordpress/icons';
import { useTranslate } from 'i18n-calypso';
import page from 'page';
import NewSidebar from 'calypso/jetpack-cloud/components/sidebar';

const JetpackManageSidebar = () => {
	const translate = useTranslate();

	const onClickMenuItem = ( path: string ) => {
		page.redirect( path );
	};

	const menuItems = [
		{
			icon: key,
			path: '/',
			link: '/partner-portal/licenses',
			title: translate( 'Licenses' ),
			onClickMenuItem: onClickMenuItem,
                         isSelected: true,
		},
		{
			icon: currencyDollar,
			path: '/partner-portal/',
			link: '/partner-portal/billing',
			title: translate( 'Purchases' ),
			onClickMenuItem: onClickMenuItem,
			withChevron: true,
		},
	];
	return <NewSidebar isJetpackManage path="/" menuItems={ menuItems } />;
};

export default JetpackManageSidebar;
```

- Go to `client/jetpack-cloud/sections/sidebar-navigation/purchases.tsx` and make the below changes

```
import { store, chevronLeft } from '@wordpress/icons';
import { useTranslate } from 'i18n-calypso';
import page from 'page';
import NewSidebar from 'calypso/jetpack-cloud/components/sidebar';

const PurchasesSidebar = () => {
	const translate = useTranslate();

	const onClickMenuItem = ( path: string ) => {
		page.redirect( path );
	};

	const menuItems = [
		{
			icon: store,
			path: '/partner-portal',
			link: '/partner-portal/billing',
			title: translate( 'Billing' ),
			onClickMenuItem: onClickMenuItem,
                          isSelected: true
		},
	];
	return (
		<NewSidebar
			isJetpackManage
			path="/partner-portal"
			menuItems={ menuItems }
			description={ translate( 'Manage all your billing related settings from one place.' ) }
			backButtonProps={ {
				label: translate( 'Purchases' ),
				icon: chevronLeft,
				onClick: () => onClickMenuItem( '/dashboard' ),
			} }
		/>
	);
};

export default PurchasesSidebar;
```

- Verify that you can see the sidebar menu items loaded for /dashboard

<img width="271" alt="Screenshot 2023-10-17 at 11 25 08 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/9c5caced-e863-4290-ae9e-c525cf6a20c2">


- Click on the Purchases tab > Verify that the billing page is loaded and you can see the updated sidebar menu items for the Purchases tab along with back button and the description.

<img width="270" alt="Screenshot 2023-10-17 at 11 24 44 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/0d15df6e-ad0a-4925-a56d-c6fd30731577">

- Now, refresh the page and verify that the current page is highlighted and the sidebar items are shown as expected
- Click the back button (`< Purchases`) and verify that you are redirected to the Dashboard and the sidebar menu items are updated accordingly. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?