### PR TITLE
Multi-domain: Add loading state on continue button

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -159,6 +159,7 @@ export class RenderDomainsStep extends Component {
 			isCartPendingUpdateDomain: null,
 			wpcomSubdomainSelected: false,
 			isRemovingDomain: null,
+			isGoingToNextStep: false,
 		};
 	}
 
@@ -677,61 +678,60 @@ export class RenderDomainsStep extends Component {
 	}
 
 	goToNext = () => {
-		return () => {
-			const shouldUseThemeAnnotation = this.shouldUseThemeAnnotation();
-			const useThemeHeadstartItem = shouldUseThemeAnnotation
-				? { useThemeHeadstart: shouldUseThemeAnnotation }
-				: {};
+		this.setState( { isGoingToNextStep: true } );
+		const shouldUseThemeAnnotation = this.shouldUseThemeAnnotation();
+		const useThemeHeadstartItem = shouldUseThemeAnnotation
+			? { useThemeHeadstart: shouldUseThemeAnnotation }
+			: {};
 
-			const { step } = this.props;
-			const { lastDomainSearched } = step.domainForm ?? {};
+		const { step } = this.props;
+		const { lastDomainSearched } = step.domainForm ?? {};
 
-			const { suggestion } = step;
-			const isPurchasingItem = suggestion && Boolean( suggestion.product_slug );
-			const siteUrl =
-				suggestion &&
-				( isPurchasingItem
-					? suggestion.domain_name
-					: suggestion.domain_name.replace( '.wordpress.com', '' ) );
+		const { suggestion } = step;
+		const isPurchasingItem = suggestion && Boolean( suggestion.product_slug );
+		const siteUrl =
+			suggestion &&
+			( isPurchasingItem
+				? suggestion.domain_name
+				: suggestion.domain_name.replace( '.wordpress.com', '' ) );
 
-			const domainItem = isPurchasingItem
-				? domainRegistration( {
-						domain: suggestion.domain_name,
-						productSlug: suggestion.product_slug,
-				  } )
-				: undefined;
-			const domainCart = getDomainRegistrations( this.props.cart );
+		const domainItem = isPurchasingItem
+			? domainRegistration( {
+					domain: suggestion.domain_name,
+					productSlug: suggestion.product_slug,
+			  } )
+			: undefined;
+		const domainCart = getDomainRegistrations( this.props.cart );
 
-			this.props.submitSignupStep(
-				Object.assign(
-					{
-						stepName: this.props.stepName,
-						domainItem,
-						isPurchasingItem,
-						siteUrl,
-						stepSectionName: this.props.stepSectionName,
-						domainCart,
-					},
-					this.getThemeArgs()
-				),
-				Object.assign(
-					{ domainItem, domainCart },
-					useThemeHeadstartItem,
-					suggestion?.domain_name ? { siteUrl: suggestion?.domain_name } : {},
-					lastDomainSearched ? { lastDomainSearched } : {},
-					{ domainCart }
-				)
-			);
+		this.props.submitSignupStep(
+			Object.assign(
+				{
+					stepName: this.props.stepName,
+					domainItem,
+					isPurchasingItem,
+					siteUrl,
+					stepSectionName: this.props.stepSectionName,
+					domainCart,
+				},
+				this.getThemeArgs()
+			),
+			Object.assign(
+				{ domainItem, domainCart },
+				useThemeHeadstartItem,
+				suggestion?.domain_name ? { siteUrl: suggestion?.domain_name } : {},
+				lastDomainSearched ? { lastDomainSearched } : {},
+				{ domainCart }
+			)
+		);
 
-			const productToRemove = this.props.cart.products.find(
-				( product ) => product.product_slug === this.props.multiDomainDefaultPlan.product_slug
-			);
-			const uuidToRemove = productToRemove.uuid;
+		const productToRemove = this.props.cart.products.find(
+			( product ) => product.product_slug === this.props.multiDomainDefaultPlan.product_slug
+		);
+		const uuidToRemove = productToRemove.uuid;
 
-			this.props.shoppingCartManager.removeProductFromCart( uuidToRemove ).then( () => {
-				this.props.goToNextStep();
-			} );
-		};
+		this.props.shoppingCartManager.removeProductFromCart( uuidToRemove ).then( () => {
+			this.props.goToNextStep();
+		} );
 	};
 
 	getSideContent = () => {
@@ -817,7 +817,12 @@ export class RenderDomainsStep extends Component {
 								) }
 							</div>
 						</div>
-						<Button primary className="domains__domain-cart-continue" onClick={ this.goToNext() }>
+						<Button
+							primary
+							className="domains__domain-cart-continue"
+							onClick={ this.goToNext }
+							busy={ this.state.isGoingToNextStep }
+						>
 							{ this.props.translate( 'Continue' ) }
 						</Button>
 					</div>
@@ -906,7 +911,12 @@ export class RenderDomainsStep extends Component {
 							</strong>
 						</div>
 					</div>
-					<Button primary className="domains__domain-cart-continue" onClick={ this.goToNext() }>
+					<Button
+						primary
+						className="domains__domain-cart-continue"
+						onClick={ this.goToNext }
+						busy={ this.state.isGoingToNextStep }
+					>
 						{ this.props.translate( 'Continue' ) }
 					</Button>
 					{ this.props.flowName !== 'domain' && (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4212

## Proposed Changes

![after](https://github.com/Automattic/wp-calypso/assets/6586048/641290e9-7457-4f55-9226-656ab37eda45)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/domain/domain-only`
* Select a domain so that the side cart shows up
* Click on continue
* Test for mobile and desktop

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?