### PR TITLE
Migration flow: Add event props to in-product flow

### DIFF
--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -13,6 +13,7 @@ import { Interval, EVERY_TEN_SECONDS, EVERY_FIVE_SECONDS } from 'calypso/lib/int
 import { urlToSlug } from 'calypso/lib/url';
 import wpcom from 'calypso/lib/wp';
 import { isEligibleForProPlan } from 'calypso/my-sites/plans-comparison';
+import { isMigrationTrialSite } from 'calypso/sites-dashboard/utils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
@@ -50,6 +51,9 @@ export class SectionMigrate extends Component {
 	};
 
 	componentDidMount() {
+		const { targetSite, targetSiteId, targetSiteSlug, sourceSite, sourceSiteId } = this.props;
+		const sourceSiteUrl = get( sourceSite, 'URL', sourceSiteId );
+
 		if ( this.isNonAtomicJetpack() ) {
 			return page( `/import/${ this.props.targetSiteSlug }` );
 		}
@@ -62,7 +66,16 @@ export class SectionMigrate extends Component {
 			this._startedMigrationFromCart = true;
 			this._timeStartedMigrationFromCart = new Date().getTime();
 			this.setMigrationState( { migrationStatus: 'backing-up' } );
-			this.startMigration();
+			const trackEventProps = {
+				source_site_id: sourceSiteId,
+				source_site_url: sourceSiteUrl,
+				target_site_id: targetSiteId,
+				target_site_slug: targetSiteSlug,
+				is_migrate_from_wp: false,
+				is_trial: isMigrationTrialSite( targetSite ),
+				type: 'in-product-from-cart',
+			};
+			this.startMigration( trackEventProps );
 		}
 
 		this.fetchSourceSitePluginsAndThemes();

--- a/client/my-sites/migrate/step-confirm-migration.jsx
+++ b/client/my-sites/migrate/step-confirm-migration.jsx
@@ -9,6 +9,7 @@ import { connect } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
 import HeaderCake from 'calypso/components/header-cake';
 import SitesBlock from 'calypso/my-sites/migrate/components/sites-block';
+import { isMigrationTrialSite } from 'calypso/sites-dashboard/utils';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import MigrateButton from './migrate-button.jsx';
 
@@ -27,9 +28,11 @@ class StepConfirmMigration extends Component {
 	}
 
 	handleClick = () => {
-		const { sourceSite, startMigration, targetSiteSlug } = this.props;
+		const { sourceSite, startMigration, targetSiteSlug, targetSite } = this.props;
 		const sourceSiteId = get( sourceSite, 'ID' );
+		const targetSiteId = get( targetSite, 'ID' );
 		const sourceSiteSlug = get( sourceSite, 'slug', sourceSiteId );
+		const sourceSiteUrl = get( sourceSite, 'URL', sourceSiteId );
 
 		const hasCompatiblePlan = this.isTargetSitePlanCompatible();
 
@@ -38,7 +41,16 @@ class StepConfirmMigration extends Component {
 		} );
 
 		if ( hasCompatiblePlan ) {
-			return startMigration();
+			const trackEventProps = {
+				source_site_id: sourceSiteId,
+				source_site_url: sourceSiteUrl,
+				target_site_id: targetSiteId,
+				target_site_slug: targetSiteSlug,
+				is_migrate_from_wp: false,
+				is_trial: isMigrationTrialSite( targetSite ),
+				type: 'in-product',
+			};
+			return startMigration( trackEventProps );
 		}
 
 		page( `/migrate/upgrade/from/${ sourceSiteSlug }/to/${ targetSiteSlug }` );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/dotcom-forge#4145

## Proposed Changes

* Currently we're not passing event props to `calypso_site_migration_start_migration` event when users come from the in-product flow. This makes the event data inconsistent. In this PR, we've added the event props to the in-product flow under two conditions.
1. When a user has an Atomic site and starts the migration from the in-product flow.
2. When a user has a simple site and starts the migration from the in-product flow after purchasing a plan.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Enable event records in the inspect tool by typing `localStorage.setItem('debug', 'calypso:analytics');` in the browser developer console.
* Navigate to http://calypso.localhost:3000/migrate/${target_site_slug}. (Try with an Atomic site first)
* Fill in the source site URL and continue. When the migration starts, make sure the `calypso_site_migration_start_migration` event is triggered with the following event props.

```
source_site_id: sourceSiteId,
source_site_url: sourceSiteUrl,
target_site_id: targetSiteId,
target_site_slug: targetSiteSlug,
is_migrate_from_wp: false,
is_trial: Boolean,
type: 'in-product',
```

* Navigate to http://calypso.localhost:3000/migrate/${target_site_slug}. (Try with an simple site now)
* Fill in the source site URL and continue. When the migration starts, make sure the `calypso_site_migration_start_migration` event is triggered with the following event props. Notice that you'll be brought to a cart first and once you purchase a plan it'll redirect to the migration page and start the migration directly. Feel free to give yourself credits via the store admin.

```
source_site_id: sourceSiteId,
source_site_url: sourceSiteUrl,
target_site_id: targetSiteId,
target_site_slug: targetSiteSlug,
is_migrate_from_wp: false,
is_trial: Boolean,
type: 'in-product-from-cart',
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?