### PR TITLE
Multi-domains: Add removing state

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -158,6 +158,7 @@ export class RenderDomainsStep extends Component {
 			currentStep: null,
 			isCartPendingUpdateDomain: null,
 			wpcomSubdomainSelected: false,
+			isRemovingDomain: null,
 		};
 	}
 
@@ -633,9 +634,9 @@ export class RenderDomainsStep extends Component {
 		return productsInCart;
 	}
 
-	removeDomainClickHandler = ( domain ) => {
-		return () =>
-			this.removeDomain( { domain_name: domain.meta, product_slug: domain.product_slug } );
+	removeDomainClickHandler = ( domain ) => () => {
+		this.setState( { isRemovingDomain: domain.meta } );
+		this.removeDomain( { domain_name: domain.meta, product_slug: domain.product_slug } );
 	};
 
 	removeDomain( { domain_name, product_slug } ) {
@@ -652,6 +653,9 @@ export class RenderDomainsStep extends Component {
 				} )
 				.catch( () => {
 					this.setState( { isCartPendingUpdateDomain: null } );
+				} )
+				.finally( () => {
+					this.setState( { isRemovingDomain: null } );
 				} );
 		}
 	}
@@ -782,7 +786,9 @@ export class RenderDomainsStep extends Component {
 							className="domains__domain-cart-remove"
 							onClick={ this.removeDomainClickHandler( domain ) }
 						>
-							{ this.props.translate( 'Remove' ) }
+							{ domain.meta === this.state.isRemovingDomain
+								? this.props.translate( 'Removing' )
+								: this.props.translate( 'Remove' ) }
 						</Button>
 					</div>
 				</>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4212

## Proposed Changes

https://github.com/Automattic/wp-calypso/assets/6586048/10ad541f-816e-4703-89f8-0d525b66ab91



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/domain/domain-only`
* Add a couple of domains to side cart
* Remove and check if any errors

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?