### PR TITLE
Jetpack Manage: Update WP Admin link to use SidebarNavigatorMenuItem component.

### DIFF
--- a/client/jetpack-cloud/components/sidebar/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/index.tsx
@@ -2,7 +2,6 @@ import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import JetpackIcons from 'calypso/components/jetpack/sidebar/menu-items/jetpack-icons';
 import SiteSelector from 'calypso/components/site-selector';
-import SidebarItem from 'calypso/layout/sidebar/item';
 import Sidebar, {
 	SidebarV2Main as SidebarMain,
 	SidebarV2Footer as SidebarFooter,
@@ -76,14 +75,18 @@ const JetpackCloudSidebar = ( {
 				</SidebarNavigator>
 			</SidebarMain>
 
-			{ ! isJetpackManage && (
+			{ ! isJetpackManage && jetpackAdminUrl && (
 				<SidebarFooter>
-					<SidebarItem
-						label={ translate( 'WP Admin', {
-							comment: 'Jetpack Cloud sidebar navigation item',
-						} ) }
+					<SidebarNavigatorMenuItem
+						title={ translate( 'WP Admin' ) }
 						link={ jetpackAdminUrl }
-						customIcon={ <JetpackIcons icon="wordpress" /> }
+						path={ jetpackAdminUrl }
+						icon={ <JetpackIcons icon="wordpress" /> }
+						onClickMenuItem={ ( link ) => {
+							// TODO: Add track event here.
+							window.open( link, '_blank' );
+						} }
+						isExternalLink
 					/>
 				</SidebarFooter>
 			) }

--- a/client/jetpack-cloud/components/sidebar/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/index.tsx
@@ -88,6 +88,7 @@ const JetpackCloudSidebar = ( {
 							window.open( link, '_blank' );
 						} }
 						isExternalLink
+						isSelected={ false }
 					/>
 				</SidebarFooter>
 			) }

--- a/client/jetpack-cloud/components/sidebar/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/index.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import JetpackIcons from 'calypso/components/jetpack/sidebar/menu-items/jetpack-icons';
@@ -83,7 +84,7 @@ const JetpackCloudSidebar = ( {
 						path={ jetpackAdminUrl }
 						icon={ <JetpackIcons icon="wordpress" /> }
 						onClickMenuItem={ ( link ) => {
-							// TODO: Add track event here.
+							recordTracksEvent( 'calypso_jetpack_sidebar_wp_admin_link_click' );
 							window.open( link, '_blank' );
 						} }
 						isExternalLink


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack-genesis/issues/39
depends on #83073 

## Proposed Changes

* Update WP Admin link to use `SidebarNavigatorMenuItem` component.

## Testing Instructions
Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

* Use the Jetpack cloud live link and go to single site page (e,g. `/activity-log/<SITE>?flags=jetpack/new-navigation`)
* Confirm that the WP Admin link in the sidebar footer renders using the `SidebarNavigatorMenuItem`.
<img width="292" alt="Screen Shot 2023-10-17 at 5 47 26 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/f8b14ce3-6ce7-4a03-99a7-e3a4c8a62fbd">


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?