### PR TITLE
Headers: Replace ThemesHeader with NavigationHeader in /themes (logged-in only)

### DIFF
--- a/client/components/navigation-header/docs/example.jsx
+++ b/client/components/navigation-header/docs/example.jsx
@@ -1,6 +1,8 @@
-import { Button } from '@automattic/components';
+import { translate } from 'i18n-calypso';
 import { Component } from 'react';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import NavigationHeader from 'calypso/components/navigation-header';
+import InstallThemeButton from 'calypso/my-sites/themes/install-theme-button';
 
 class NavigationHeaderExample extends Component {
 	navigationItems = [
@@ -25,16 +27,6 @@ class NavigationHeaderExample extends Component {
 			<div>
 				<NavigationHeader
 					compactBreadcrumb={ this.state.compact }
-					navigationItems={ [] }
-					mobileItem={ null }
-					title="My Home"
-					subtitle="Your hub for posting, editing, and growing your site."
-				>
-					<Button target="_blank">Visit site</Button>
-				</NavigationHeader>
-
-				<NavigationHeader
-					compactBreadcrumb={ this.state.compact }
 					navigationItems={ [
 						{ label: 'Domains', href: `/domains` },
 						{
@@ -50,6 +42,23 @@ class NavigationHeaderExample extends Component {
 					title="Title example"
 					subtitle="Subtitle example"
 				></NavigationHeader>
+
+				<NavigationHeader
+					compactBreadcrumb={ false }
+					navigationItems={ [] }
+					mobileItem={ null }
+					title={ translate( 'Themes' ) }
+					subtitle={ translate(
+						'Select or update the visual design for your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+						{
+							components: {
+								learnMoreLink: <InlineSupportLink supportContext="themes" showIcon={ false } />,
+							},
+						}
+					) }
+				>
+					<InstallThemeButton />
+				</NavigationHeader>
 			</div>
 		);
 	}

--- a/client/my-sites/themes/theme-showcase-header.jsx
+++ b/client/my-sites/themes/theme-showcase-header.jsx
@@ -70,6 +70,7 @@ export default function ThemeShowcaseHeader( { canonicalUrl, filter, tier, verti
 					) }
 				>
 					<InstallThemeButton />
+					<ScreenOptionsTab wpAdminPath="themes.php" />
 				</NavigationHeader>
 			) : (
 				<ThemesHeader title={ themesHeaderTitle } description={ themesHeaderDescription }>

--- a/client/my-sites/themes/theme-showcase-header.jsx
+++ b/client/my-sites/themes/theme-showcase-header.jsx
@@ -2,6 +2,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import InlineSupportLink from 'calypso/components/inline-support-link';
+import NavigationHeader from 'calypso/components/navigation-header';
 import ScreenOptionsTab from 'calypso/components/screen-options-tab';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import InstallThemeButton from './install-theme-button';
@@ -53,16 +54,31 @@ export default function ThemeShowcaseHeader( { canonicalUrl, filter, tier, verti
 	return (
 		<>
 			<DocumentHead title={ documentHeadTitle } meta={ metas } />
-			<ThemesHeader title={ themesHeaderTitle } description={ themesHeaderDescription }>
-				{ isLoggedIn && (
-					<>
-						<div className="themes__install-theme-button-container">
-							<InstallThemeButton />
-						</div>
-						<ScreenOptionsTab wpAdminPath="themes.php" />
-					</>
-				) }
-			</ThemesHeader>
+			{ isLoggedIn ? (
+				<NavigationHeader
+					compactBreadcrumb={ false }
+					navigationItems={ [] }
+					mobileItem={ null }
+					title={ translate( 'Themes' ) }
+					subtitle={ translate(
+						'Select or update the visual design for your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+						{
+							components: {
+								learnMoreLink: <InlineSupportLink supportContext="themes" showIcon={ false } />,
+							},
+						}
+					) }
+				>
+					<InstallThemeButton />
+				</NavigationHeader>
+			) : (
+				<ThemesHeader title={ themesHeaderTitle } description={ themesHeaderDescription }>
+					<div className="themes__install-theme-button-container">
+						<InstallThemeButton />
+					</div>
+					<ScreenOptionsTab wpAdminPath="themes.php" />
+				</ThemesHeader>
+			) }
 		</>
 	);
 }

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -7,7 +7,7 @@
 	}
 
 	.layout:not(.has-no-sidebar) .layout__content {
-		padding-top: var(--masterbar-height);
+		// padding-top: var(--masterbar-height);
 	}
 	.main > .notice.is-error {
 		margin-top: 24px;
@@ -193,26 +193,9 @@
 .theme-showcase {
 
 	.navigation-header {
-		@media (min-width: $break-mobile) {
-			margin-left: -32px;
-			margin-right: -32px;
-			padding: 24px 32px;
-			width: calc(100% + 64px);
-		}
-
-		@media (min-width: $break-small) {
-			border-bottom: 1px solid #eee;
-		}
-
 		@media (max-width: $break-small) {
-			padding: 24px 48px;
+			padding-bottom: 16px;
 		}
-
-		@media (max-width: $break-mobile) {
-			margin: 0;
-			padding: 16px;
-		}
-
 	}
 
 	.theme__search {

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -192,6 +192,29 @@
 
 .theme-showcase {
 
+	.navigation-header {
+		@media (min-width: $break-mobile) {
+			margin-left: -32px;
+			margin-right: -32px;
+			padding: 24px 32px;
+			width: calc(100% + 64px);
+		}
+
+		@media (min-width: $break-small) {
+			border-bottom: 1px solid #eee;
+		}
+
+		@media (max-width: $break-small) {
+			padding: 24px 48px;
+		}
+
+		@media (max-width: $break-mobile) {
+			margin: 0;
+			padding: 16px;
+		}
+
+	}
+
 	.theme__search {
 		.keyed-suggestions {
 			top: 42px;
@@ -411,7 +434,7 @@
 
 	.themes__controls,
 	.themes__showcase {
-		@include breakpoint-deprecated( "<660px" ) {
+		@media (max-width: $break-small) {
 			padding: 0 16px;
 		}
 	}

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -6,9 +6,6 @@
 		--color-surface-backdrop: var(--studio-white);
 	}
 
-	.layout:not(.has-no-sidebar) .layout__content {
-		// padding-top: var(--masterbar-height);
-	}
 	.main > .notice.is-error {
 		margin-top: 24px;
 		margin-bottom: 0;


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/4222

## Proposed Changes

As we are consolidating the pages header under `NavigationHeader`, we replace the `ThemesHeader` component with `NavigationHeader` for only logged-in users since logged-out users see a modified variant of ThemesHeader

- [x] Logged in users should see NavigationHeader. 
- [x] Logged out users they should see ThemesHeader.

### Before
| Desktop | Mobile |
| --- | --- |
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/463bd3ad-afcf-46ba-b139-f96073f02edf) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/91c193f5-cf75-4af9-8374-639e9e1bc5d1) |

### After
| Desktop | Mobile |
| --- | --- |
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/c98042c2-548e-4830-9bd3-7550deab3a57) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/cfcf5122-ec2d-431f-a011-4f5ca6b223f4) |


## Testing Instructions

* Logged in, go to `/themes`, and check the new header component.
* Logged out, go to `/themes`, and check if nothing is broken. It should not have any changes.
