### PR TITLE
Importer: Refactor: Create MigrationReady component to unload the parent component

### DIFF
--- a/client/blocks/importer/wordpress/import-everything/pre-migration/migration-ready.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/migration-ready.tsx
@@ -1,0 +1,87 @@
+import { NextButton, Title } from '@automattic/onboarding';
+import { useTranslate } from 'i18n-calypso';
+import React, { useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { StartImportTrackingProps } from 'calypso/blocks/importer/wordpress/import-everything/pre-migration/types';
+import useMigrationConfirmation from 'calypso/landing/stepper/hooks/use-migration-confirmation';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import ConfirmModal from './confirm-modal';
+import { CredentialsCta } from './credentials-cta';
+import type { SiteSlug } from 'calypso/types';
+
+interface Props {
+	sourceSiteSlug: SiteSlug;
+	sourceSiteHasCredentials: boolean;
+	targetSiteSlug: SiteSlug;
+	migrationTrackingProps?: Record< string, unknown >;
+	startImport: ( props?: StartImportTrackingProps ) => void;
+	onProvideCredentialsClick: () => void;
+}
+
+export function MigrationReady( props: Props ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const {
+		sourceSiteSlug,
+		sourceSiteHasCredentials,
+		targetSiteSlug,
+		migrationTrackingProps = {},
+		startImport,
+		onProvideCredentialsClick,
+	} = props;
+
+	const [ showConfirmModal, setShowConfirmModal ] = useState( false );
+	const [ migrationConfirmed, setMigrationConfirmed ] = useMigrationConfirmation();
+
+	function displayConfirmModal() {
+		dispatch(
+			recordTracksEvent( 'calypso_site_migration_confirm_modal_display', migrationTrackingProps )
+		);
+		setShowConfirmModal( true );
+	}
+
+	function hideConfirmModal() {
+		dispatch(
+			recordTracksEvent( 'calypso_site_migration_confirm_modal_hide', migrationTrackingProps )
+		);
+		setShowConfirmModal( false );
+	}
+
+	return (
+		<>
+			{ showConfirmModal && (
+				<ConfirmModal
+					sourceSiteSlug={ sourceSiteSlug }
+					targetSiteSlug={ targetSiteSlug }
+					onClose={ hideConfirmModal }
+					onConfirm={ () => {
+						// reset migration confirmation to initial state
+						setMigrationConfirmed( false );
+						startImport( { type: 'without-credentials', ...migrationTrackingProps } );
+					} }
+				/>
+			) }
+			<div className="import__pre-migration import__import-everything import__import-everything--redesign">
+				<div className="import__heading-title">
+					<Title>{ translate( 'You are ready to migrate' ) }</Title>
+				</div>
+				{ ! sourceSiteHasCredentials && (
+					<CredentialsCta onButtonClick={ onProvideCredentialsClick } />
+				) }
+				<div className="import__footer-button-container pre-migration__proceed">
+					<NextButton
+						type="button"
+						onClick={ () => {
+							migrationConfirmed
+								? startImport( { type: 'without-credentials', ...migrationTrackingProps } )
+								: displayConfirmModal();
+						} }
+					>
+						{ translate( 'Start migration' ) }
+					</NextButton>
+				</div>
+			</div>
+		</>
+	);
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/82758

## Proposed Changes

* Refactored the pre-migration component by ejecting the MigrationReady logic and creating a dedicated component

## Testing Instructions

* Go to `/setup/import-focused/?siteSlug={ATOMIC_SITE}&from={JP_CONNECTED_SITE}&option=everything`
* Check if everything works as before

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?