### PR TITLE
Migration flow: Fix migrate ready screen event triggering issue

### DIFF
--- a/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
@@ -118,20 +118,6 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 		fetchMigrationEnabledStatus();
 	};
 
-	// We want to record the tracks event, so we use the same condition as the one in the render function
-	// This should be better handled by using a state after the refactor
-	useEffect( () => {
-		if ( siteCanMigrate === true && isTargetSitePlanCompatible ) {
-			const _migrationTrackingProps: { [ key: string ]: unknown } = { ...migrationTrackingProps };
-			// There is a case where source_site_id is 0|undefined, so we need to delete it
-			delete _migrationTrackingProps?.source_site_id;
-
-			dispatch(
-				recordTracksEvent( 'calypso_site_migration_ready_screen', _migrationTrackingProps )
-			);
-		}
-	}, [ siteCanMigrate, isTargetSitePlanCompatible, migrationTrackingProps, dispatch ] );
-
 	// Initiate the migration if initImportRun is set
 	useEffect( () => {
 		initImportRun && startImport( { type: 'without-credentials', ...migrationTrackingProps } );

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
@@ -1,6 +1,6 @@
 import { SiteDetails } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useSiteMigrateInfo } from 'calypso/blocks/importer/hooks/use-site-can-migrate';
 import { useSiteCredentialsInfo } from 'calypso/blocks/importer/hooks/use-site-credentials-info';
@@ -70,14 +70,16 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 
 	const requiresPluginUpdate = siteCanMigrate === false;
 
-	const migrationTrackingProps = {
-		source_site_id: sourceSiteId,
-		source_site_url: sourceSiteUrl,
-		target_site_id: targetSite.ID,
-		target_site_slug: targetSite.slug,
-		is_migrate_from_wp: isMigrateFromWp,
-		is_trial: isTrial,
-	};
+	const migrationTrackingProps = useMemo( () => {
+		return {
+			source_site_id: sourceSiteId,
+			source_site_url: sourceSiteUrl,
+			target_site_id: targetSite.ID,
+			target_site_slug: targetSite.slug,
+			is_migrate_from_wp: isMigrateFromWp,
+			is_trial: isTrial,
+		};
+	}, [ sourceSiteId, sourceSiteUrl, targetSite.ID, targetSite.slug, isMigrateFromWp, isTrial ] );
 
 	const toggleCredentialsForm = () => {
 		setShowCredentials( ! showCredentials );
@@ -119,7 +121,7 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 	// We want to record the tracks event, so we use the same condition as the one in the render function
 	// This should be better handled by using a state after the refactor
 	useEffect( () => {
-		if ( ! requiresPluginUpdate && isTargetSitePlanCompatible ) {
+		if ( siteCanMigrate === true && isTargetSitePlanCompatible ) {
 			const _migrationTrackingProps: { [ key: string ]: unknown } = { ...migrationTrackingProps };
 			// There is a case where source_site_id is 0|undefined, so we need to delete it
 			delete _migrationTrackingProps?.source_site_id;
@@ -128,7 +130,7 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 				recordTracksEvent( 'calypso_site_migration_ready_screen', _migrationTrackingProps )
 			);
 		}
-	}, [ requiresPluginUpdate, isTargetSitePlanCompatible ] );
+	}, [ siteCanMigrate, isTargetSitePlanCompatible, migrationTrackingProps, dispatch ] );
 
 	// Initiate the migration if initImportRun is set
 	useEffect( () => {

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/migration-ready.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/migration-ready.tsx
@@ -1,6 +1,6 @@
 import { NextButton, Title } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { StartImportTrackingProps } from 'calypso/blocks/importer/wordpress/import-everything/pre-migration/types';
 import useMigrationConfirmation from 'calypso/landing/stepper/hooks/use-migration-confirmation';
@@ -33,6 +33,14 @@ export function MigrationReady( props: Props ) {
 
 	const [ showConfirmModal, setShowConfirmModal ] = useState( false );
 	const [ migrationConfirmed, setMigrationConfirmed ] = useMigrationConfirmation();
+
+	useEffect( () => {
+		const _migrationTrackingProps: { [ key: string ]: unknown } = { ...migrationTrackingProps };
+		// There is a case where source_site_id is 0|undefined, so we need to delete it
+		delete _migrationTrackingProps?.source_site_id;
+
+		dispatch( recordTracksEvent( 'calypso_site_migration_ready_screen', _migrationTrackingProps ) );
+	}, [ migrationTrackingProps, dispatch ] );
 
 	function displayConfirmModal() {
 		dispatch(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #82923 

## Proposed Changes

* Currently the `calypso_site_migration_ready_screen` event gets triggered when the Jetpack install screen shows up and this is not the expected behavior. The root cause is because `requiresPluginUpdate` might be `false` when first rendered and change to `true` later. We change and use `siteCanMigrate === true` instead so we can make sure we get the correct status. We also move `migrationTrackingProps` to useMemo so it won't be identified as a new object on every render and triggers the event multiple times.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*  Navigate to http://calypso.localhost:3000/setup/import-focused/import?siteSlug=${target_site}
*  Fill in a source site without the Jetpack connection and go through the flow until you're on the Jetpack install screen, check and make sure only `calypso_site_importer_show_update_info` event gets triggered.
* Try to connect the Jetpack during the flow and once the screen switches to the migrate ready screen `calypso_site_migration_ready_screen` should get triggered.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?