### PR TITLE
Assembler: Update copy for the pattern count indicator

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -104,14 +104,19 @@ const ScreenMain = ( {
 			<div className="screen-container__footer">
 				<span className="screen-container__footer-description">
 					{ totalPatternCount > 0 &&
-						translate( 'You’ve added {{strong}}%(count)s{{/strong}} patterns.', {
-							args: {
+						translate(
+							'You’ve selected {{strong}}%(count)s{{/strong}} pattern.',
+							'You’ve selected {{strong}}%(count)s{{/strong}} patterns.',
+							{
 								count: totalPatternCount,
-							},
-							components: {
-								strong: <strong />,
-							},
-						} ) }
+								args: {
+									count: totalPatternCount,
+								},
+								components: {
+									strong: <strong />,
+								},
+							}
+						) }
 				</span>
 				<Button
 					className="pattern-assembler__button"
@@ -119,7 +124,9 @@ const ScreenMain = ( {
 					showTooltip={ isButtonDisabled }
 					onClick={ onContinueClick }
 					label={
-						isButtonDisabled ? translate( 'Add your first pattern to get started.' ) : continueLabel
+						isButtonDisabled
+							? translate( 'Select your first pattern to get started.' )
+							: continueLabel
 					}
 					variant="primary"
 					text={ continueLabel }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-sections.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-sections.tsx
@@ -66,14 +66,19 @@ const ScreenSections = ( {
 			<div className="screen-container__footer">
 				<span className="screen-container__footer-description">
 					{ sections.length > 0 &&
-						translate( 'You’ve added {{strong}}%(count)s{{/strong}} sections.', {
-							args: {
+						translate(
+							'You’ve selected {{strong}}%(count)s{{/strong}} section.',
+							'You’ve selected {{strong}}%(count)s{{/strong}} sections.',
+							{
 								count: sections.length,
-							},
-							components: {
-								strong: <strong />,
-							},
-						} ) }
+								args: {
+									count: sections.length,
+								},
+								components: {
+									strong: <strong />,
+								},
+							}
+						) }
 				</span>
 				<Button className="pattern-assembler__button" variant="primary" onClick={ onContinueClick }>
 					{ continueLabel }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/82986#discussion_r1360007608

## Proposed Changes

* This is a follow-up PR of https://github.com/Automattic/wp-calypso/pull/82986#discussion_r1360007608 to update the copy as suggested
  * You’ve n selected pattern(s).
  * You’ve n selected section(s).

| Main | Sections
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/bb331fb3-96a2-4344-960b-c6618929963c) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/b1e3d52e-6554-4cb3-8130-d92b3439a4e6) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Theme Showcase
* Select Assembler CTA
* Select any patterns
* Ensure the copy is expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?