### PR TITLE
Plans 2023: Migrate and refactor use of useCalculateMaxPlanUpgradeCredit

### DIFF
--- a/client/my-sites/plans-features-main/components/plan-notice.tsx
+++ b/client/my-sites/plans-features-main/components/plan-notice.tsx
@@ -8,7 +8,6 @@ import Notice from 'calypso/components/notice';
 import { getDiscountByName } from 'calypso/lib/discounts';
 import { ActiveDiscount } from 'calypso/lib/discounts/active-discounts';
 import { usePlanUpgradeCreditsApplicable } from 'calypso/my-sites/plans-features-main/hooks/use-plan-upgrade-credits-applicable';
-import { useCalculateMaxPlanUpgradeCredit } from 'calypso/my-sites/plans-grid/hooks/use-calculate-max-plan-upgrade-credit';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import { getByPurchaseId } from 'calypso/state/purchases/selectors';
@@ -86,7 +85,7 @@ export default function PlanNotice( props: PlanNoticeProps ) {
 	let activeDiscount =
 		discountInformation &&
 		getDiscountByName( discountInformation.withDiscount, discountInformation.discountEndDate );
-	const creditsValue = useCalculateMaxPlanUpgradeCredit( { siteId, plans: visiblePlans } );
+	const proRatedCreditsApplicable = useProRatedCreditsApplicable( siteId, visiblePlans );
 	const currencyCode = useSelector( ( state ) => getCurrentUserCurrencyCode( state ) );
 
 	switch ( noticeType ) {
@@ -128,7 +127,7 @@ export default function PlanNotice( props: PlanNoticeProps ) {
 				</Notice>
 			);
 		case PLAN_UPGRADE_CREDIT_NOTICE:
-			return (
+			return proRatedCreditsApplicable ? (
 				<Notice
 					className="plan-features-main__notice"
 					showDismiss={ true }
@@ -141,7 +140,7 @@ export default function PlanNotice( props: PlanNoticeProps ) {
 						'We’ve applied the {{b}}%(amountInCurrency)s{{/b}} {{a}}upgrade credit{{/a}} from your current plan as a deduction to your new plan, below. This remaining credit will be applied at checkout if you upgrade today!',
 						{
 							args: {
-								amountInCurrency: formatCurrency( creditsValue, currencyCode ?? '' ),
+								amountInCurrency: formatCurrency( proRatedCreditsApplicable, currencyCode ?? '' ),
 							},
 							components: {
 								b: <strong />,
@@ -157,7 +156,7 @@ export default function PlanNotice( props: PlanNoticeProps ) {
 						}
 					) }
 				</Notice>
-			);
+			) : null;
 		case PLAN_RETIREMENT_NOTICE:
 			return (
 				<Notice

--- a/client/my-sites/plans-features-main/components/plan-notice.tsx
+++ b/client/my-sites/plans-features-main/components/plan-notice.tsx
@@ -85,7 +85,7 @@ export default function PlanNotice( props: PlanNoticeProps ) {
 	let activeDiscount =
 		discountInformation &&
 		getDiscountByName( discountInformation.withDiscount, discountInformation.discountEndDate );
-	const proRatedCreditsApplicable = useProRatedCreditsApplicable( siteId, visiblePlans );
+	const planUpgradeCreditsApplicable = usePlanUpgradeCreditsApplicable( siteId, visiblePlans );
 	const currencyCode = useSelector( ( state ) => getCurrentUserCurrencyCode( state ) );
 
 	switch ( noticeType ) {
@@ -127,7 +127,7 @@ export default function PlanNotice( props: PlanNoticeProps ) {
 				</Notice>
 			);
 		case PLAN_UPGRADE_CREDIT_NOTICE:
-			return proRatedCreditsApplicable ? (
+			return planUpgradeCreditsApplicable ? (
 				<Notice
 					className="plan-features-main__notice"
 					showDismiss={ true }
@@ -140,7 +140,10 @@ export default function PlanNotice( props: PlanNoticeProps ) {
 						'We’ve applied the {{b}}%(amountInCurrency)s{{/b}} {{a}}upgrade credit{{/a}} from your current plan as a deduction to your new plan, below. This remaining credit will be applied at checkout if you upgrade today!',
 						{
 							args: {
-								amountInCurrency: formatCurrency( proRatedCreditsApplicable, currencyCode ?? '' ),
+								amountInCurrency: formatCurrency(
+									planUpgradeCreditsApplicable,
+									currencyCode ?? ''
+								),
 							},
 							components: {
 								b: <strong />,

--- a/client/my-sites/plans-features-main/components/test/plan-notice.tsx
+++ b/client/my-sites/plans-features-main/components/test/plan-notice.tsx
@@ -16,7 +16,6 @@ import { getDiscountByName } from 'calypso/lib/discounts';
 import { Purchase } from 'calypso/lib/purchases/types';
 import PlanNotice from 'calypso/my-sites/plans-features-main/components/plan-notice';
 import { usePlanUpgradeCreditsApplicable } from 'calypso/my-sites/plans-features-main/hooks/use-plan-upgrade-credits-applicable';
-import { useCalculateMaxPlanUpgradeCredit } from 'calypso/my-sites/plans-grid/hooks/use-calculate-max-plan-upgrade-credit';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import { getByPurchaseId } from 'calypso/state/purchases/selectors';
 import { isCurrentUserCurrentPlanOwner } from 'calypso/state/sites/plans/selectors';
@@ -51,7 +50,7 @@ jest.mock(
 	} )
 );
 jest.mock( 'calypso/my-sites/plans-grid/hooks/use-calculate-max-plan-upgrade-credit', () => ( {
-	useCalculateMaxPlanUpgradeCredit: jest.fn(),
+	useMaxProRatedCreditsForPlans: jest.fn(),
 } ) );
 jest.mock( 'calypso/state/currency-code/selectors', () => ( {
 	getCurrentUserCurrencyCode: jest.fn(),
@@ -68,8 +67,8 @@ const mIsCurrentUserCurrentPlanOwner = isCurrentUserCurrentPlanOwner as jest.Moc
 const mUsePlanUpgradeCreditsApplicable = usePlanUpgradeCreditsApplicable as jest.MockedFunction<
 	typeof usePlanUpgradeCreditsApplicable
 >;
-const mUseCalculateMaxPlanUpgradeCredit = useCalculateMaxPlanUpgradeCredit as jest.MockedFunction<
-	typeof useCalculateMaxPlanUpgradeCredit
+const mUseMaxProRatedCreditsForPlans = useMaxProRatedCreditsForPlans as jest.MockedFunction<
+	typeof useMaxProRatedCreditsForPlans
 >;
 const mGetCurrentUserCurrencyCode = getCurrentUserCurrencyCode as jest.MockedFunction<
 	typeof getCurrentUserCurrencyCode
@@ -101,14 +100,12 @@ describe( '<PlanNotice /> Tests', () => {
 		mIsCurrentUserCurrentPlanOwner.mockImplementation( () => true );
 		mGetCurrentUserCurrencyCode.mockImplementation( () => 'USD' );
 		mUsePlanUpgradeCreditsApplicable.mockImplementation( () => 1 );
-		mUseCalculateMaxPlanUpgradeCredit.mockImplementation( () => 100 );
 		mGetByPurchaseId.mockImplementation( () => ( { isInAppPurchase: false } ) as Purchase );
 		mIsProPlan.mockImplementation( () => false );
 	} );
 
 	test( 'A contact site owner <PlanNotice /> should be shown no matter what other conditions are met, when the current site owner is not logged in, and the site plan is paid', () => {
 		mGetDiscountByName.mockImplementation( () => discount );
-		mUseCalculateMaxPlanUpgradeCredit.mockImplementation( () => 100 );
 		mUsePlanUpgradeCreditsApplicable.mockImplementation( () => 1 );
 		mIsCurrentPlanPaid.mockImplementation( () => true );
 		mIsCurrentUserCurrentPlanOwner.mockImplementation( () => false );
@@ -131,7 +128,6 @@ describe( '<PlanNotice /> Tests', () => {
 		mIsCurrentPlanPaid.mockImplementation( () => true );
 		mGetDiscountByName.mockImplementation( () => discount );
 		mUsePlanUpgradeCreditsApplicable.mockImplementation( () => 1 );
-		mUseCalculateMaxPlanUpgradeCredit.mockImplementation( () => 100 );
 
 		renderWithProvider(
 			<PlanNotice
@@ -149,7 +145,6 @@ describe( '<PlanNotice /> Tests', () => {
 		mIsCurrentPlanPaid.mockImplementation( () => true );
 		mGetDiscountByName.mockImplementation( () => false );
 		mUsePlanUpgradeCreditsApplicable.mockImplementation( () => 1 );
-		mUseCalculateMaxPlanUpgradeCredit.mockImplementation( () => 100 );
 
 		renderWithProvider(
 			<PlanNotice
@@ -169,7 +164,6 @@ describe( '<PlanNotice /> Tests', () => {
 		mIsCurrentPlanPaid.mockImplementation( () => true );
 		mGetDiscountByName.mockImplementation( () => false );
 		mUsePlanUpgradeCreditsApplicable.mockImplementation( () => null );
-		mUseCalculateMaxPlanUpgradeCredit.mockImplementation( () => 0 );
 		mUseMarketingMessage.mockImplementation( () => [
 			false,
 			[ { id: '12121', text: 'An important marketing message' } ],
@@ -192,7 +186,6 @@ describe( '<PlanNotice /> Tests', () => {
 		mIsCurrentPlanPaid.mockImplementation( () => true );
 		mGetDiscountByName.mockImplementation( () => false );
 		mUsePlanUpgradeCreditsApplicable.mockImplementation( () => null );
-		mUseCalculateMaxPlanUpgradeCredit.mockImplementation( () => 0 );
 		mUseMarketingMessage.mockImplementation( () => [
 			false,
 			[ { id: '12121', text: 'An important marketing message' } ],

--- a/client/my-sites/plans-features-main/components/test/plan-notice.tsx
+++ b/client/my-sites/plans-features-main/components/test/plan-notice.tsx
@@ -49,8 +49,8 @@ jest.mock(
 		usePlanUpgradeCreditsApplicable: jest.fn(),
 	} )
 );
-jest.mock( 'calypso/my-sites/plans-grid/hooks/use-calculate-max-plan-upgrade-credit', () => ( {
-	useMaxProRatedCreditsForPlans: jest.fn(),
+jest.mock( 'calypso/my-sites/plans-features-main/hooks/use-max-plan-upgrade-credits', () => ( {
+	useMaxPlanUpgradeCredits: jest.fn(),
 } ) );
 jest.mock( 'calypso/state/currency-code/selectors', () => ( {
 	getCurrentUserCurrencyCode: jest.fn(),
@@ -66,9 +66,6 @@ const mIsCurrentUserCurrentPlanOwner = isCurrentUserCurrentPlanOwner as jest.Moc
 >;
 const mUsePlanUpgradeCreditsApplicable = usePlanUpgradeCreditsApplicable as jest.MockedFunction<
 	typeof usePlanUpgradeCreditsApplicable
->;
-const mUseMaxProRatedCreditsForPlans = useMaxProRatedCreditsForPlans as jest.MockedFunction<
-	typeof useMaxProRatedCreditsForPlans
 >;
 const mGetCurrentUserCurrencyCode = getCurrentUserCurrencyCode as jest.MockedFunction<
 	typeof getCurrentUserCurrencyCode

--- a/client/my-sites/plans-features-main/components/test/plan-notice.tsx
+++ b/client/my-sites/plans-features-main/components/test/plan-notice.tsx
@@ -141,7 +141,7 @@ describe( '<PlanNotice /> Tests', () => {
 		mIsCurrentUserCurrentPlanOwner.mockImplementation( () => true );
 		mIsCurrentPlanPaid.mockImplementation( () => true );
 		mGetDiscountByName.mockImplementation( () => false );
-		mUsePlanUpgradeCreditsApplicable.mockImplementation( () => 1 );
+		mUsePlanUpgradeCreditsApplicable.mockImplementation( () => 100 );
 
 		renderWithProvider(
 			<PlanNotice

--- a/client/my-sites/plans-features-main/hooks/test/use-max-plan-upgrade-credits.tsx
+++ b/client/my-sites/plans-features-main/hooks/test/use-max-plan-upgrade-credits.tsx
@@ -12,7 +12,7 @@ import { getPlanDiscountedRawPrice } from 'calypso/state/sites/plans/selectors';
 import { getSitePlanRawPrice } from 'calypso/state/sites/plans/selectors/get-site-plan-raw-price';
 import isPlanAvailableForPurchase from 'calypso/state/sites/plans/selectors/is-plan-available-for-purchase';
 import { renderHookWithProvider } from 'calypso/test-helpers/testing-library';
-import { useCalculateMaxPlanUpgradeCredit } from '../use-calculate-max-plan-upgrade-credit';
+import { useMaxPlanUpgradeCredits } from '../use-max-plan-upgrade-credits';
 import type { PlanSlug } from '@automattic/calypso-products';
 
 jest.mock( 'calypso/state/sites/plans/selectors/is-plan-available-for-purchase', () => ( {
@@ -81,7 +81,7 @@ describe( 'useCalculateMaxPlanUpgradeCredit hook', () => {
 
 	test( 'Return the correct amount of credits given a plan list', () => {
 		const { result } = renderHookWithProvider( () =>
-			useCalculateMaxPlanUpgradeCredit( { siteId, plans } )
+			useMaxPlanUpgradeCredits( { siteId, plans } )
 		);
 		expect( result.current ).toEqual( 1000 );
 	} );
@@ -92,7 +92,7 @@ describe( 'useCalculateMaxPlanUpgradeCredit hook', () => {
 		);
 
 		const { result } = renderHookWithProvider( () =>
-			useCalculateMaxPlanUpgradeCredit( { siteId, plans } )
+			useMaxPlanUpgradeCredits( { siteId, plans } )
 		);
 		expect( result.current ).toEqual( 800 );
 	} );

--- a/client/my-sites/plans-features-main/hooks/test/use-plan-upgrade-credits-applicable.tsx
+++ b/client/my-sites/plans-features-main/hooks/test/use-plan-upgrade-credits-applicable.tsx
@@ -24,7 +24,7 @@ jest.mock( 'calypso/state/sites/selectors', () => ( {
 jest.mock( 'calypso/state/sites/plans/selectors', () => ( {
 	getSitePlanSlug: jest.fn(),
 } ) );
-jest.mock( 'calypso/my-sites/plans-grid/hooks/use-calculate-max-plan-upgrade-credits', () => ( {
+jest.mock( 'calypso/my-sites/plans-features-main/hooks/use-max-plan-upgrade-credits', () => ( {
 	useMaxPlanUpgradeCredits: jest.fn(),
 } ) );
 jest.mock( 'calypso/state/selectors/is-site-automated-transfer', () => ( {

--- a/client/my-sites/plans-features-main/hooks/test/use-plan-upgrade-credits-applicable.tsx
+++ b/client/my-sites/plans-features-main/hooks/test/use-plan-upgrade-credits-applicable.tsx
@@ -10,6 +10,7 @@ import {
 	PLAN_FREE,
 	PlanSlug,
 } from '@automattic/calypso-products';
+import { useMaxPlanUpgradeCredits } from 'calypso/my-sites/plans-features-main/hooks/use-max-plan-upgrade-credits';
 import { usePlanUpgradeCreditsApplicable } from 'calypso/my-sites/plans-features-main/hooks/use-plan-upgrade-credits-applicable';
 import isAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { getSitePlanSlug } from 'calypso/state/sites/plans/selectors';
@@ -23,8 +24,8 @@ jest.mock( 'calypso/state/sites/selectors', () => ( {
 jest.mock( 'calypso/state/sites/plans/selectors', () => ( {
 	getSitePlanSlug: jest.fn(),
 } ) );
-jest.mock( 'calypso/my-sites/plans-grid/hooks/use-calculate-max-plan-upgrade-credit', () => ( {
-	useMaxProRatedCreditsForPlans: jest.fn(),
+jest.mock( 'calypso/my-sites/plans-grid/hooks/use-calculate-max-plan-upgrade-credits', () => ( {
+	useMaxPlanUpgradeCredits: jest.fn(),
 } ) );
 jest.mock( 'calypso/state/selectors/is-site-automated-transfer', () => ( {
 	__esModule: true,
@@ -32,8 +33,8 @@ jest.mock( 'calypso/state/selectors/is-site-automated-transfer', () => ( {
 } ) );
 
 // Mocked types
-const mUsePlanUpgradeCredits = useMaxProRatedCreditsForPlans as jest.MockedFunction<
-	typeof useMaxProRatedCreditsForPlans
+const mUsePlanUpgradeCredits = useMaxPlanUpgradeCredits as jest.MockedFunction<
+	typeof useMaxPlanUpgradeCredits
 >;
 const mIsAutomatedTransfer = isAutomatedTransfer as jest.MockedFunction<
 	typeof isAutomatedTransfer

--- a/client/my-sites/plans-features-main/hooks/test/use-plan-upgrade-credits-applicable.tsx
+++ b/client/my-sites/plans-features-main/hooks/test/use-plan-upgrade-credits-applicable.tsx
@@ -11,7 +11,6 @@ import {
 	PlanSlug,
 } from '@automattic/calypso-products';
 import { usePlanUpgradeCreditsApplicable } from 'calypso/my-sites/plans-features-main/hooks/use-plan-upgrade-credits-applicable';
-import { useCalculateMaxPlanUpgradeCredit } from 'calypso/my-sites/plans-grid/hooks/use-calculate-max-plan-upgrade-credit';
 import isAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { getSitePlanSlug } from 'calypso/state/sites/plans/selectors';
 import { isCurrentPlanPaid, isJetpackSite } from 'calypso/state/sites/selectors';
@@ -25,7 +24,7 @@ jest.mock( 'calypso/state/sites/plans/selectors', () => ( {
 	getSitePlanSlug: jest.fn(),
 } ) );
 jest.mock( 'calypso/my-sites/plans-grid/hooks/use-calculate-max-plan-upgrade-credit', () => ( {
-	useCalculateMaxPlanUpgradeCredit: jest.fn(),
+	useMaxProRatedCreditsForPlans: jest.fn(),
 } ) );
 jest.mock( 'calypso/state/selectors/is-site-automated-transfer', () => ( {
 	__esModule: true,
@@ -33,8 +32,8 @@ jest.mock( 'calypso/state/selectors/is-site-automated-transfer', () => ( {
 } ) );
 
 // Mocked types
-const mUsePlanUpgradeCredits = useCalculateMaxPlanUpgradeCredit as jest.MockedFunction<
-	typeof useCalculateMaxPlanUpgradeCredit
+const mUsePlanUpgradeCredits = useMaxProRatedCreditsForPlans as jest.MockedFunction<
+	typeof useMaxProRatedCreditsForPlans
 >;
 const mIsAutomatedTransfer = isAutomatedTransfer as jest.MockedFunction<
 	typeof isAutomatedTransfer

--- a/client/my-sites/plans-features-main/hooks/use-max-plan-upgrade-credits.ts
+++ b/client/my-sites/plans-features-main/hooks/use-max-plan-upgrade-credits.ts
@@ -14,7 +14,7 @@ interface Props {
  * This is the maximum possible credit value possible when comparing credits per plan
  * @returns {number} The maximum amount of credits possible for a given set of plans
  */
-export function useMaxProRatedCreditsForPlans( { siteId, plans }: Props ): number {
+export function useMaxPlanUpgradeCredits( { siteId, plans }: Props ): number {
 	const plansDetails = useSelector( ( state ) =>
 		plans.map( ( planName ) => ( {
 			isPlanAvailableForPurchase: isPlanAvailableForPurchase( state, siteId ?? 0, planName ),

--- a/client/my-sites/plans-features-main/hooks/use-max-pro-rated-credits-for-plans.ts
+++ b/client/my-sites/plans-features-main/hooks/use-max-pro-rated-credits-for-plans.ts
@@ -14,7 +14,7 @@ interface Props {
  * This is the maximum possible credit value possible when comparing credits per plan
  * @returns {number} The maximum amount of credits possible for a given set of plans
  */
-export function useCalculateMaxPlanUpgradeCredit( { siteId, plans }: Props ): number {
+export function useMaxProRatedCreditsForPlans( { siteId, plans }: Props ): number {
 	const plansDetails = useSelector( ( state ) =>
 		plans.map( ( planName ) => ( {
 			isPlanAvailableForPurchase: isPlanAvailableForPurchase( state, siteId ?? 0, planName ),

--- a/client/my-sites/plans-features-main/hooks/use-plan-upgrade-credits-applicable.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plan-upgrade-credits-applicable.ts
@@ -1,5 +1,5 @@
 import { PlanSlug, PLAN_ENTERPRISE_GRID_WPCOM } from '@automattic/calypso-products';
-import { useCalculateMaxPlanUpgradeCredit } from 'calypso/my-sites/plans-grid/hooks/use-calculate-max-plan-upgrade-credit';
+import { useMaxProRatedCreditsForPlans } from 'calypso/my-sites/plans-features-main/hooks/use-max-pro-rated-credits-for-plans';
 import { useSelector } from 'calypso/state';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { getSitePlanSlug } from 'calypso/state/sites/plans/selectors';
@@ -22,7 +22,7 @@ export function usePlanUpgradeCreditsApplicable(
 	const currentSitePlanSlug = useSelector( ( state ) =>
 		siteId ? getSitePlanSlug( state, siteId ) : undefined
 	);
-	const creditsValue = useCalculateMaxPlanUpgradeCredit( { siteId, plans: visiblePlans } );
+	const creditsValue = useMaxProRatedCreditsForPlans( { siteId, plans: visiblePlans } );
 	const isJetpackNotAtomic = useSelector(
 		( state ) => isJetpackSite( state, siteId ) && ! isSiteAutomatedTransfer( state, siteId )
 	);

--- a/client/my-sites/plans-features-main/hooks/use-plan-upgrade-credits-applicable.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plan-upgrade-credits-applicable.ts
@@ -1,5 +1,5 @@
 import { PlanSlug, PLAN_ENTERPRISE_GRID_WPCOM } from '@automattic/calypso-products';
-import { useMaxProRatedCreditsForPlans } from 'calypso/my-sites/plans-features-main/hooks/use-max-pro-rated-credits-for-plans';
+import { useMaxPlanUpgradeCredits } from 'calypso/my-sites/plans-features-main/hooks/use-max-plan-upgrade-credits';
 import { useSelector } from 'calypso/state';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { getSitePlanSlug } from 'calypso/state/sites/plans/selectors';
@@ -22,7 +22,7 @@ export function usePlanUpgradeCreditsApplicable(
 	const currentSitePlanSlug = useSelector( ( state ) =>
 		siteId ? getSitePlanSlug( state, siteId ) : undefined
 	);
-	const creditsValue = useMaxProRatedCreditsForPlans( { siteId, plans: visiblePlans } );
+	const creditsValue = useMaxPlanUpgradeCredits( { siteId, plans: visiblePlans } );
 	const isJetpackNotAtomic = useSelector(
 		( state ) => isJetpackSite( state, siteId ) && ! isSiteAutomatedTransfer( state, siteId )
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/78999

## Proposed Changes

* Migrates `useCalculateMaxPlanUpgradeCredit` out of the plans-grid. Some refactor, renaming `useCalculateMaxPlanUpgradeCredit` to `useMaxProRatedCreditsForPlans`
* Stops consuming this outside of `useProRatedCreditsApplicable` (technically becomes a local concern to this hook, but I guess easier to mock if imported separately)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

These should be applicable:

- go to /plans[paid site]
    - ensure pro-rated credits are displayed in the notice
    - ensure badges read "credits applied"
- go to /plans/[free] 
    - ensure no notice is visible with credits

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?