### PR TITLE
Importer: Refactor pre-migration component render logic

### DIFF
--- a/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
@@ -18,7 +18,7 @@ import { getCredentials } from 'calypso/state/jetpack/credentials/actions';
 import { isRequestingSitePlans } from 'calypso/state/sites/plans/selectors';
 import NotAuthorized from '../../../components/not-authorized';
 import { Credentials } from './credentials';
-import type { StartImportTrackingProps } from './types';
+import type { PreMigrationState, StartImportTrackingProps } from './types';
 
 import './style.scss';
 
@@ -57,6 +57,7 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 	const sourceSiteSlug = urlQueryParams.get( 'from' ) ?? '';
 	const sourceSiteUrl = formatSlugToURL( sourceSiteSlug );
 
+	const [ renderState, setRenderState ] = useState< PreMigrationState >( 'loading' );
 	const [ showCredentials, setShowCredentials ] = useState( false );
 	const [ hasLoaded, setHasLoaded ] = useState( false );
 	const [ continueImport, setContinueImport ] = useState( false );
@@ -152,93 +153,96 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 		}
 	}, [ continueImport, sourceSiteId, startImport, requiresPluginUpdate ] );
 
-	function renderPreMigration() {
-		// Show a loading state when we are trying to fetch existing credentials
-		if ( ! hasLoaded || isRequestingCredentials ) {
-			return <LoadingEllipsis />;
+	// Set the render state based on the current component state
+	useEffect( () => {
+		if ( requiresPluginUpdate ) {
+			setRenderState( 'update-plugin' );
+		} else if ( showCredentials ) {
+			setRenderState( 'credentials' );
+		} else if ( ! isTargetSitePlanCompatible ) {
+			setRenderState( 'upgrade-plan' );
+		} else if ( ! hasLoaded || isRequestingCredentials ) {
+			setRenderState( 'loading' );
+		} else if ( ! sourceSite || ( sourceSite && sourceSite.ID !== sourceSiteId ) ) {
+			setRenderState( 'not-authorized' );
+		} else {
+			setRenderState( 'ready' );
 		}
+	}, [
+		hasLoaded,
+		isRequestingCredentials,
+		sourceSite,
+		sourceSiteId,
+		requiresPluginUpdate,
+		showCredentials,
+		isTargetSitePlanCompatible,
+	] );
 
-		if ( ! sourceSite || ( sourceSite && sourceSite.ID !== sourceSiteId ) ) {
+	switch ( renderState ) {
+		case 'loading':
+			return <LoadingEllipsis />;
+
+		case 'not-authorized':
 			return (
 				<NotAuthorized
 					onStartBuilding={ onNotAuthorizedClick }
 					onStartBuildingText={ translate( 'Skip to dashboard' ) }
 				/>
 			);
-		}
 
-		return (
-			<MigrationReady
-				sourceSiteSlug={ sourceSiteSlug }
-				sourceSiteHasCredentials={ hasCredentials }
-				targetSiteSlug={ targetSite.slug }
-				migrationTrackingProps={ migrationTrackingProps }
-				startImport={ startImport }
-				onProvideCredentialsClick={ toggleCredentialsForm }
-			/>
-		);
-	}
-
-	function renderUpdatePluginInfo() {
-		return (
-			<>
-				<UpdatePluginInfo
-					isMigrateFromWp={ isMigrateFromWp }
-					sourceSiteUrl={ sourceSiteUrl }
-					migrationTrackingProps={ migrationTrackingProps }
-				/>
-				<Interval onTick={ fetchMigrationEnabledStatus } period={ EVERY_FIVE_SECONDS } />
-			</>
-		);
-	}
-
-	function renderUpgradePlan() {
-		return (
-			<>
-				{ queryTargetSitePlanStatus === 'fetching' && <QuerySites siteId={ targetSite.ID } /> }
-				<PreMigrationUpgradePlan
-					sourceSiteSlug={ sourceSiteSlug }
-					sourceSiteUrl={ sourceSiteUrl }
+		case 'credentials':
+			return (
+				<Credentials
+					sourceSite={ sourceSite }
 					targetSite={ targetSite }
-					startImport={ onUpgradeAndMigrateClick }
-					onFreeTrialClick={ onFreeTrialClick }
-					onContentOnlyClick={ onContentOnlyClick }
-					isBusy={
-						isFetchingMigrationData || isAddingTrial || queryTargetSitePlanStatus === 'fetched'
-					}
 					migrationTrackingProps={ migrationTrackingProps }
+					startImport={ startImport }
 				/>
-			</>
-		);
-	}
+			);
 
-	function renderCredentials() {
-		return (
-			<Credentials
-				sourceSite={ sourceSite }
-				targetSite={ targetSite }
-				migrationTrackingProps={ migrationTrackingProps }
-				startImport={ startImport }
-			/>
-		);
-	}
+		case 'update-plugin':
+			return (
+				<>
+					<UpdatePluginInfo
+						isMigrateFromWp={ isMigrateFromWp }
+						sourceSiteUrl={ sourceSiteUrl }
+						migrationTrackingProps={ migrationTrackingProps }
+					/>
+					<Interval onTick={ fetchMigrationEnabledStatus } period={ EVERY_FIVE_SECONDS } />
+				</>
+			);
 
-	// If the source site is not capable of being migrated, we show the update info screen
-	if ( requiresPluginUpdate ) {
-		return renderUpdatePluginInfo();
-	}
+		case 'upgrade-plan':
+			return (
+				<>
+					{ queryTargetSitePlanStatus === 'fetching' && <QuerySites siteId={ targetSite.ID } /> }
+					<PreMigrationUpgradePlan
+						sourceSiteSlug={ sourceSiteSlug }
+						sourceSiteUrl={ sourceSiteUrl }
+						targetSite={ targetSite }
+						startImport={ onUpgradeAndMigrateClick }
+						onFreeTrialClick={ onFreeTrialClick }
+						onContentOnlyClick={ onContentOnlyClick }
+						isBusy={
+							isFetchingMigrationData || isAddingTrial || queryTargetSitePlanStatus === 'fetched'
+						}
+						migrationTrackingProps={ migrationTrackingProps }
+					/>
+				</>
+			);
 
-	if ( showCredentials && sourceSite ) {
-		return renderCredentials();
+		case 'ready':
+			return (
+				<MigrationReady
+					sourceSiteSlug={ sourceSiteSlug }
+					sourceSiteHasCredentials={ hasCredentials }
+					targetSiteSlug={ targetSite.slug }
+					migrationTrackingProps={ migrationTrackingProps }
+					startImport={ startImport }
+					onProvideCredentialsClick={ toggleCredentialsForm }
+				/>
+			);
 	}
-
-	// If the target site is not plan compatible, we show the upgrade plan screen
-	if ( ! isTargetSitePlanCompatible ) {
-		return renderUpgradePlan();
-	}
-
-	// If the target site is plan compatible, we show the pre-migration screen
-	return renderPreMigration();
 };
 
 export default PreMigrationScreen;

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/test/index.test.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/test/index.test.tsx
@@ -6,6 +6,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { useSiteMigrateInfo } from 'calypso/blocks/importer/hooks/use-site-can-migrate';
+import useCheckEligibilityMigrationTrialPlan from 'calypso/data/plans/use-check-eligibility-migration-trial-plan';
 import { createReduxStore } from 'calypso/state';
 import { getInitialState, getStateFromCache } from 'calypso/state/initial-state';
 import initialReducer from 'calypso/state/reducer';
@@ -45,6 +46,8 @@ jest.mock( 'react-router-dom', () => ( {
 
 jest.mock( 'calypso/blocks/importer/hooks/use-site-can-migrate' );
 jest.mock( 'calypso/state/selectors/is-requesting-site-credentials' );
+jest.mock( 'calypso/state/selectors/get-jetpack-credentials' );
+jest.mock( 'calypso/data/plans/use-check-eligibility-migration-trial-plan' );
 
 function renderPreMigrationScreen( props?: any ) {
 	const initialState = getInitialState( initialReducer, user.ID );
@@ -82,13 +85,20 @@ describe( 'PreMigration', () => {
 		// @ts-ignore
 		useSiteMigrateInfo.mockReturnValue( {
 			sourceSiteId: 777712,
-			sourceSite: sourceSite as SiteDetails,
 			fetchMigrationEnabledStatus: jest.fn(),
 			isFetchingData: false,
 			siteCanMigrate: true,
 		} );
 
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
+		useCheckEligibilityMigrationTrialPlan.mockReturnValue( {
+			blog_id: 777712,
+			eligible: false,
+		} );
+
 		renderPreMigrationScreen( {
+			sourceSite: sourceSite,
 			targetSite: targetSite,
 			isTargetSitePlanCompatible: false,
 			isMigrateFromWp: true,
@@ -108,15 +118,22 @@ describe( 'PreMigration', () => {
 	test( 'should show "Move to wordpress.com" plugin update', () => {
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-ignore
-		useSiteMigrateInfo.mockImplementationOnce( () => ( {
+		useSiteMigrateInfo.mockReturnValue( {
 			sourceSiteId: 777712,
-			sourceSite: sourceSite as SiteDetails,
 			fetchMigrationEnabledStatus: jest.fn(),
 			isFetchingData: false,
 			siteCanMigrate: false,
+		} );
+
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
+		useCheckEligibilityMigrationTrialPlan.mockImplementationOnce( () => ( {
+			blog_id: 777712,
+			eligible: true,
 		} ) );
 
 		renderPreMigrationScreen( {
+			sourceSite: sourceSite,
 			targetSite: targetSite,
 			isTargetSitePlanCompatible: false,
 			isMigrateFromWp: true,
@@ -130,15 +147,15 @@ describe( 'PreMigration', () => {
 	test( 'should show "Jetpack" plugin update', () => {
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-ignore
-		useSiteMigrateInfo.mockImplementationOnce( () => ( {
+		useSiteMigrateInfo.mockReturnValue( {
 			sourceSiteId: 777712,
-			sourceSite: sourceSite as SiteDetails,
 			fetchMigrationEnabledStatus: jest.fn(),
 			isFetchingData: false,
 			siteCanMigrate: false,
-		} ) );
+		} );
 
 		renderPreMigrationScreen( {
+			sourceSite: sourceSite as SiteDetails,
 			targetSite: targetSite,
 			isTargetSitePlanCompatible: false,
 			isMigrateFromWp: false,
@@ -155,18 +172,17 @@ describe( 'PreMigration', () => {
 		// @ts-ignore
 		useSiteMigrateInfo.mockReturnValue( {
 			sourceSiteId: 777712,
-			sourceSite: sourceSite as SiteDetails,
 			fetchMigrationEnabledStatus: jest.fn(),
 			isFetchingData: false,
 			siteCanMigrate: true,
 		} );
 
 		renderPreMigrationScreen( {
+			sourceSite: sourceSite,
 			targetSite: targetSite,
 			isTargetSitePlanCompatible: true,
 			isMigrateFromWp: true,
 			onContentOnlyClick,
-			sourceSite: sourceSite,
 		} );
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-ignore

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/types.ts
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/types.ts
@@ -6,3 +6,11 @@ export interface StartImportTrackingProps {
 export type CredentialsStatus = 'unsubmitted' | 'pending' | 'success' | 'failed';
 
 export type CredentialsProtocol = 'ftp' | 'ssh';
+
+export type PreMigrationState =
+	| 'loading'
+	| 'not-authorized'
+	| 'credentials'
+	| 'upgrade-plan'
+	| 'update-plugin'
+	| 'ready';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/82758

## Proposed Changes

* Refactored pre-migration component render logic
* Got rid of the render functions to avoid unnecessary re-renders

Note: We kept the way of making decisions on what to render, so it should not be a problem to review.

## Testing Instructions

* Go to `/setup/import-focused?siteSlug={SLUG}
* Pass through the flow with different combination
  * JP connected and without JP connection
  * Simple or Atomic target site
* Check if everything works as it is now on production

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?