### PR TITLE
Launchpad Add the Share Site Modal component to the Navigator

### DIFF
--- a/client/my-sites/customer-home/cards/launchpad/index.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/index.tsx
@@ -5,12 +5,7 @@ import {
 	sortLaunchpadTasksByCompletionStatus,
 	LaunchpadNavigator,
 } from '@automattic/data-stores';
-import {
-	Launchpad,
-	Task,
-	setUpActionsForTasks,
-	ShareSiteModal,
-} from '@automattic/launchpad';
+import { Launchpad, Task, setUpActionsForTasks, ShareSiteModal } from '@automattic/launchpad';
 import { select, useDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';

--- a/client/my-sites/customer-home/cards/launchpad/index.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/index.tsx
@@ -7,7 +7,6 @@ import {
 } from '@automattic/data-stores';
 import {
 	Launchpad,
-	PermittedActions,
 	Task,
 	setUpActionsForTasks,
 	ShareSiteModal,
@@ -26,12 +25,12 @@ import './style.scss';
 
 interface CustomerHomeLaunchpadProps {
 	checklistSlug: string;
-	extraActions?: Omit< PermittedActions, 'setActiveChecklist' >;
+	onSiteLaunched?: () => void;
 }
 
 const CustomerHomeLaunchpad = ( {
 	checklistSlug,
-	extraActions = {},
+	onSiteLaunched,
 }: CustomerHomeLaunchpadProps ): JSX.Element => {
 	const launchpadContext = 'customer-home';
 	const siteId = useSelector( getSelectedSiteId );
@@ -63,7 +62,6 @@ const CustomerHomeLaunchpad = ( {
 
 	const defaultExtraActions = {
 		...( hasShareSiteTask ? { setShareSiteModalIsOpen } : {} ),
-		...extraActions,
 		setActiveChecklist,
 	};
 
@@ -82,6 +80,9 @@ const CustomerHomeLaunchpad = ( {
 			siteSlug,
 			tracksData,
 			extraActions: defaultExtraActions,
+			eventHandlers: {
+				onSiteLaunched,
+			},
 		} );
 	};
 

--- a/client/my-sites/customer-home/cards/launchpad/pre-launch.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/pre-launch.tsx
@@ -34,13 +34,13 @@ const LaunchpadPreLaunch = (): JSX.Element => {
 		}
 	};
 
-	const siteLaunched = () => {
+	const onSiteLaunched = () => {
 		setCelebrateLaunchModalIsOpenWrapper( true );
 	};
 
 	return (
 		<>
-			<CustomerHomeLaunchpad checklistSlug={ checklistSlug } extraActions={ { siteLaunched } } />
+			<CustomerHomeLaunchpad checklistSlug={ checklistSlug } onSiteLaunched={ onSiteLaunched } />
 			{ celebrateLaunchModalIsOpen && (
 				<CelebrateLaunchModal
 					setModalIsOpen={ setCelebrateLaunchModalIsOpenWrapper }

--- a/packages/launchpad/src/action-components/share-site-modal/index.tsx
+++ b/packages/launchpad/src/action-components/share-site-modal/index.tsx
@@ -17,14 +17,15 @@ interface ShareSiteModalProps {
 const ShareSiteModal = ( { setModalIsOpen, site }: ShareSiteModalProps ) => {
 	const translate = useTranslate();
 	const queryClient = useQueryClient();
+	const siteSlug = site?.slug || ( site?.URL && new URL( site.URL ).host );
 
 	const [ clipboardCopied, setClipboardCopied ] = useState( false );
 	const clipboardTextEl = useRef( null );
 
 	const copyHandler = async () => {
-		navigator.clipboard.writeText( `https://${ site?.slug }` );
-		if ( site?.slug ) {
-			await updateLaunchpadSettings( site.slug, {
+		navigator.clipboard.writeText( `https://${ siteSlug }` );
+		if ( siteSlug ) {
+			await updateLaunchpadSettings( siteSlug, {
 				checklist_statuses: { share_site: true },
 			} );
 		}
@@ -51,7 +52,7 @@ const ShareSiteModal = ( { setModalIsOpen, site }: ShareSiteModalProps ) => {
 						<div className="share-site-modal__modal-site">
 							<div className="share-site-modal__modal-domain">
 								<p className="share-site-modal__modal-domain-text" ref={ clipboardTextEl }>
-									{ site?.slug }
+									{ siteSlug }
 								</p>
 
 								<Popover

--- a/packages/launchpad/src/action-components/share-site-modal/index.tsx
+++ b/packages/launchpad/src/action-components/share-site-modal/index.tsx
@@ -79,7 +79,11 @@ const ShareSiteModal = ( { setModalIsOpen, site }: ShareSiteModalProps ) => {
 								</Popover>
 							</div>
 
-							<Button onClick={ copyHandler } className="share-site-modal__modal-view-site">
+							<Button
+								onClick={ copyHandler }
+								className="share-site-modal__modal-view-site"
+								disabled={ ! siteSlug }
+							>
 								<Icon icon={ link } size={ 22 } />
 								<span className="share-site-modal__modal-view-site-text">
 									{ translate( 'Copy' ) }

--- a/packages/launchpad/src/action-components/share-site-modal/index.tsx
+++ b/packages/launchpad/src/action-components/share-site-modal/index.tsx
@@ -17,7 +17,21 @@ interface ShareSiteModalProps {
 const ShareSiteModal = ( { setModalIsOpen, site }: ShareSiteModalProps ) => {
 	const translate = useTranslate();
 	const queryClient = useQueryClient();
-	const siteSlug = site?.slug || ( site?.URL && new URL( site.URL ).host );
+	const getSiteSlug = ( site: SiteDetails | null ): string | null => {
+		if ( ! site ) {
+			return null;
+		}
+
+		if ( site.slug ) {
+			return site.slug;
+		}
+
+		if ( site.URL ) {
+			return new URL( site.URL ).host;
+		}
+		return null;
+	};
+	const siteSlug = getSiteSlug( site );
 
 	const [ clipboardCopied, setClipboardCopied ] = useState( false );
 	const clipboardTextEl = useRef( null );

--- a/packages/launchpad/src/action-components/share-site-modal/style.scss
+++ b/packages/launchpad/src/action-components/share-site-modal/style.scss
@@ -132,7 +132,7 @@
 		color: #101517;
 	}
 
-	.share-site-modal__modal-view-site:hover {
+	.share-site-modal__modal-view-site:hover:not(:disabled) {
 		text-decoration: underline;
 	}
 }

--- a/packages/launchpad/src/default-wired-launchpad.tsx
+++ b/packages/launchpad/src/default-wired-launchpad.tsx
@@ -14,12 +14,14 @@ type DefaultWiredLaunchpadProps = {
 	siteSlug: string | null;
 	checklistSlug: string;
 	launchpadContext: string;
+	onSiteLaunched?: () => void;
 };
 
 const DefaultWiredLaunchpad = ( {
 	siteSlug,
 	checklistSlug,
 	launchpadContext,
+	onSiteLaunched,
 }: DefaultWiredLaunchpadProps ) => {
 	const {
 		data: { checklist },
@@ -71,6 +73,9 @@ const DefaultWiredLaunchpad = ( {
 			tracksData,
 			extraActions: {
 				setActiveChecklist,
+			},
+			eventHandlers: {
+				onSiteLaunched,
 			},
 		} );
 	};

--- a/packages/launchpad/src/default-wired-launchpad.tsx
+++ b/packages/launchpad/src/default-wired-launchpad.tsx
@@ -2,7 +2,7 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import {
 	LaunchpadNavigator,
 	Site,
-	SiteSelect,
+	type SiteSelect,
 	sortLaunchpadTasksByCompletionStatus,
 	useLaunchpad,
 } from '@automattic/data-stores';

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -19,10 +19,12 @@ export const setUpActionsForTasks = ( {
 	tasks,
 	tracksData,
 	extraActions,
+	eventHandlers,
 	uiContext = 'calypso',
 }: LaunchpadTaskActionsProps ): Task[] => {
 	const { recordTracksEvent, checklistSlug, tasklistCompleted, launchpadContext } = tracksData;
 	const { setShareSiteModalIsOpen, siteLaunched, setActiveChecklist } = extraActions;
+	const { onSiteLaunched } = eventHandlers || {};
 
 	//Record click events for tasks
 	const recordTaskClickTracksEvent = ( task: Task ) => {
@@ -125,7 +127,13 @@ export const setUpActionsForTasks = ( {
 							apiVersion: '1.1',
 							method: 'post',
 						} );
-						siteLaunched?.();
+						// TODO: Remove this check once we migrate the siteLaunched event
+						// to the new event handler
+						if ( onSiteLaunched ) {
+							onSiteLaunched();
+						} else {
+							siteLaunched?.();
+						}
 					};
 					useCalypsoPath = false;
 					break;

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -23,7 +23,7 @@ export const setUpActionsForTasks = ( {
 	uiContext = 'calypso',
 }: LaunchpadTaskActionsProps ): Task[] => {
 	const { recordTracksEvent, checklistSlug, tasklistCompleted, launchpadContext } = tracksData;
-	const { setShareSiteModalIsOpen, siteLaunched, setActiveChecklist } = extraActions;
+	const { setShareSiteModalIsOpen, setActiveChecklist } = extraActions;
 	const { onSiteLaunched } = eventHandlers || {};
 
 	//Record click events for tasks
@@ -127,13 +127,7 @@ export const setUpActionsForTasks = ( {
 							apiVersion: '1.1',
 							method: 'post',
 						} );
-						// TODO: Remove this check once we migrate the siteLaunched event
-						// to the new event handler
-						if ( onSiteLaunched ) {
-							onSiteLaunched();
-						} else {
-							siteLaunched?.();
-						}
+						onSiteLaunched?.();
 					};
 					useCalypsoPath = false;
 					break;

--- a/packages/launchpad/src/types.ts
+++ b/packages/launchpad/src/types.ts
@@ -62,10 +62,15 @@ export interface PermittedActions {
 	setActiveChecklist: ( siteSlug: string, activeChecklistSlug: string ) => void;
 }
 
+export type EventHandlers = {
+	onSiteLaunched?: () => void;
+};
+
 export interface LaunchpadTaskActionsProps {
 	siteSlug: string | null;
 	tasks: Task[];
 	tracksData: LaunchpadTracksData;
 	extraActions: PermittedActions;
 	uiContext?: 'calypso';
+	eventHandlers?: EventHandlers;
 }

--- a/packages/launchpad/src/types.ts
+++ b/packages/launchpad/src/types.ts
@@ -58,7 +58,6 @@ export interface LaunchpadResponse {
 
 export interface PermittedActions {
 	setShareSiteModalIsOpen?: ( isOpen: boolean ) => void;
-	siteLaunched?: () => void;
 	setActiveChecklist: ( siteSlug: string, activeChecklistSlug: string ) => void;
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/82888

## Proposed Changes

* This PR adds the Share Site Modal component to the Default Wired Launchpad component, which allows us to complete the "Share your site" task from the Navigator.
* I also had to adapt the Share Site Modal component to use the Site information from the data store. Currently, I still left the support for the data used on the Customer Home, which uses the `site.slug` instead of the site.URL.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso Live link below or apply this PR to your local environment
* On a site with the Build intent, navigate to `/home/:siteSlug?flags=launchpad/navigator`
* Make sure the behavior for the "Share your site" task remains unchanged on the Launchpad
* Click on the progress ring in the master bar to show the Launchpad Navigator modal.
* Click on the "Share your site" task and make sure it shows up the "Share Site Modal" component.
* Click on the `copy` button to make sure it works.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?