### PR TITLE
Stats: Update date picker logic to use URL params

### DIFF
--- a/client/my-sites/stats/stats-date-control/index.tsx
+++ b/client/my-sites/stats/stats-date-control/index.tsx
@@ -38,12 +38,6 @@ const shortcutList = [
 		offset: 0,
 		range: 365,
 	},
-	{
-		id: 'all-time',
-		label: 'All Time',
-		offset: 0,
-		range: 400, // TODO: Don't hard code this value.
-	},
 ];
 
 const StatsDateControl = ( {

--- a/client/my-sites/stats/stats-date-control/index.tsx
+++ b/client/my-sites/stats/stats-date-control/index.tsx
@@ -4,7 +4,7 @@ import qs from 'qs';
 import React from 'react';
 import IntervalDropdown from '../stats-interval-dropdown';
 import DateControlPicker from './stats-date-control-picker';
-import { StatsDateControlProps } from './types';
+import { StatsDateControlProps, DateControlPickerShortcut } from './types';
 import './style.scss';
 
 const COMPONENT_CLASS_NAME = 'stats-date-control';
@@ -26,19 +26,19 @@ const shortcutList = [
 		id: 'last-7-days',
 		label: 'Last 7 Days',
 		offset: 0,
-		range: 7,
+		range: 6,
 	},
 	{
 		id: 'last-30-days',
 		label: 'Last 30 Days',
 		offset: 0,
-		range: 30,
+		range: 29,
 	},
 	{
 		id: 'last-year',
 		label: 'Last Year',
 		offset: 0,
-		range: 365,
+		range: 364, // ranges are zero based!
 	},
 ];
 
@@ -78,10 +78,25 @@ const StatsDateControl = ( {
 		page( href );
 	};
 
+	// Handler for shortcut selection.
+	const onShortcutHandler = ( shortcut: DateControlPickerShortcut ) => {
+		// Generate new dates.
+		const anchor = moment().subtract( shortcut.offset, 'days' );
+		const endDate = anchor.format( 'YYYY-MM-DD' );
+		const startDate = anchor.subtract( shortcut.range, 'days' ).format( 'YYYY-MM-DD' );
+
+		const href = generateNewLink( 'day', startDate, endDate );
+		page( href );
+	};
+
 	return (
 		<div className={ COMPONENT_CLASS_NAME }>
 			<IntervalDropdown period={ period } pathTemplate={ pathTemplate } />
-			<DateControlPicker shortcutList={ shortcutList } onApply={ onApplyButtonHandler } />
+			<DateControlPicker
+				shortcutList={ shortcutList }
+				onShortcut={ onShortcutHandler }
+				onApply={ onApplyButtonHandler }
+			/>
 		</div>
 	);
 };

--- a/client/my-sites/stats/stats-date-control/index.tsx
+++ b/client/my-sites/stats/stats-date-control/index.tsx
@@ -49,7 +49,6 @@ const StatsDateControl = ( {
 	pathTemplate,
 	onChangeChartQuantity,
 }: StatsDateControlProps ) => {
-
 	// Shared link generation helper.
 	const generateNewLink = ( period: string, startDate: string, endDate: string ) => {
 		const newRangeQuery = qs.stringify(
@@ -82,12 +81,7 @@ const StatsDateControl = ( {
 	return (
 		<div className={ COMPONENT_CLASS_NAME }>
 			<IntervalDropdown period={ period } pathTemplate={ pathTemplate } />
-			<DateControlPicker
-				slug={ slug }
-				queryParams={ queryParams }
-				shortcutList={ shortcutList }
-				handleApply={ onApplyButtonHandler }
-			/>
+			<DateControlPicker shortcutList={ shortcutList } handleApply={ onApplyButtonHandler } />
 		</div>
 	);
 };

--- a/client/my-sites/stats/stats-date-control/index.tsx
+++ b/client/my-sites/stats/stats-date-control/index.tsx
@@ -66,6 +66,22 @@ const StatsDateControl = ( {
 		return `${ url }${ newRangeQuery }`;
 	};
 
+	const bestPeriodForDays = ( days: number ): string => {
+		// 30 bars, one day is one bar
+		if ( days <= 30 ) {
+			return 'day';
+		}
+		// 25 bars, 7 days one bar
+		if ( days <= 7 * 25 ) {
+			return 'week';
+		}
+		// 25 bars, 30 days one bar
+		if ( days <= 30 * 25 ) {
+			return 'month';
+		}
+		return 'year';
+	};
+
 	// Previous Apply button handling.
 	const handleApply = ( startDate: string, endDate: string ) => {
 		// calculate offset between start and end to influcence the number of points for the chart
@@ -79,7 +95,9 @@ const StatsDateControl = ( {
 
 	// New Apply button handling.
 	const onApplyButtonHandler = ( startDate: string, endDate: string ) => {
-		const href = generateNewLink( 'day', startDate, endDate );
+		const rangeInDays = Math.abs( moment( endDate ).diff( moment( startDate ), 'days' ) );
+		const period = bestPeriodForDays( rangeInDays );
+		const href = generateNewLink( period, startDate, endDate );
 		page( href );
 	};
 

--- a/client/my-sites/stats/stats-date-control/index.tsx
+++ b/client/my-sites/stats/stats-date-control/index.tsx
@@ -47,6 +47,7 @@ const StatsDateControl = ( {
 	pathTemplate,
 	onChangeChartQuantity,
 }: StatsDateControlProps ) => {
+	// Previous Apply button handling.
 	const handleApply = ( startDate: string, endDate: string ) => {
 		// calculate offset between start and end to influcence the number of points for the chart
 		// TODO: take period into account
@@ -57,6 +58,12 @@ const StatsDateControl = ( {
 		onChangeChartQuantity( offset + 1 );
 	};
 
+	// New Apply button handling.
+	const onApplyButtonHandler = ( startDate: string, endDate: string ) => {
+		console.log( 'new handler called' );
+		// do something...
+	};
+
 	return (
 		<div className={ COMPONENT_CLASS_NAME }>
 			<IntervalDropdown period={ period } pathTemplate={ pathTemplate } />
@@ -64,7 +71,7 @@ const StatsDateControl = ( {
 				slug={ slug }
 				queryParams={ queryParams }
 				shortcutList={ shortcutList }
-				handleApply={ handleApply }
+				handleApply={ onApplyButtonHandler }
 			/>
 		</div>
 	);

--- a/client/my-sites/stats/stats-date-control/index.tsx
+++ b/client/my-sites/stats/stats-date-control/index.tsx
@@ -1,4 +1,6 @@
 import moment from 'moment';
+import page from 'page';
+import qs from 'qs';
 import React from 'react';
 import IntervalDropdown from '../stats-interval-dropdown';
 import DateControlPicker from './stats-date-control-picker';
@@ -47,6 +49,19 @@ const StatsDateControl = ( {
 	pathTemplate,
 	onChangeChartQuantity,
 }: StatsDateControlProps ) => {
+
+	// Shared link generation helper.
+	const generateNewLink = ( period: string, startDate: string, endDate: string ) => {
+		const newRangeQuery = qs.stringify(
+			Object.assign( {}, queryParams, { chartStart: startDate, chartEnd: endDate } ),
+			{
+				addQueryPrefix: true,
+			}
+		);
+		const url = `/stats/${ period }/${ slug }`;
+		return `${ url }${ newRangeQuery }`;
+	};
+
 	// Previous Apply button handling.
 	const handleApply = ( startDate: string, endDate: string ) => {
 		// calculate offset between start and end to influcence the number of points for the chart
@@ -60,8 +75,8 @@ const StatsDateControl = ( {
 
 	// New Apply button handling.
 	const onApplyButtonHandler = ( startDate: string, endDate: string ) => {
-		console.log( 'new handler called' );
-		// do something...
+		const href = generateNewLink( 'day', startDate, endDate );
+		page( href );
 	};
 
 	return (

--- a/client/my-sites/stats/stats-date-control/index.tsx
+++ b/client/my-sites/stats/stats-date-control/index.tsx
@@ -47,13 +47,7 @@ const shortcutList = [
 	},
 ];
 
-const StatsDateControl = ( {
-	slug,
-	queryParams,
-	period,
-	pathTemplate,
-	onChangeChartQuantity,
-}: StatsDateControlProps ) => {
+const StatsDateControl = ( { slug, queryParams, period, pathTemplate }: StatsDateControlProps ) => {
 	// Shared link generation helper.
 	const generateNewLink = ( period: string, startDate: string, endDate: string ) => {
 		const newRangeQuery = qs.stringify(
@@ -80,17 +74,6 @@ const StatsDateControl = ( {
 			return 'month';
 		}
 		return 'year';
-	};
-
-	// Previous Apply button handling.
-	const handleApply = ( startDate: string, endDate: string ) => {
-		// calculate offset between start and end to influcence the number of points for the chart
-		// TODO: take period into account
-		const offset = Math.abs( moment( endDate ).diff( moment( startDate ), 'days' ) );
-
-		// TODO: add period update if the offet is too big to accomodate the chart
-
-		onChangeChartQuantity( offset + 1 );
 	};
 
 	// New Apply button handling.

--- a/client/my-sites/stats/stats-date-control/index.tsx
+++ b/client/my-sites/stats/stats-date-control/index.tsx
@@ -60,6 +60,7 @@ const StatsDateControl = ( { slug, queryParams, period, pathTemplate }: StatsDat
 		return `${ url }${ newRangeQuery }`;
 	};
 
+	// Determine period based on number of days in date range.
 	const bestPeriodForDays = ( days: number ): string => {
 		// 30 bars, one day is one bar
 		if ( days <= 30 ) {
@@ -76,12 +77,13 @@ const StatsDateControl = ( { slug, queryParams, period, pathTemplate }: StatsDat
 		return 'year';
 	};
 
-	// New Apply button handling.
+	// Handler for Apply button.
 	const onApplyButtonHandler = ( startDate: string, endDate: string ) => {
+		// Determine period based on date range.
 		const rangeInDays = Math.abs( moment( endDate ).diff( moment( startDate ), 'days' ) );
 		const period = bestPeriodForDays( rangeInDays );
-		const href = generateNewLink( period, startDate, endDate );
-		page( href );
+		// Update chart via routing.
+		page( generateNewLink( period, startDate, endDate ) );
 	};
 
 	// Handler for shortcut selection.
@@ -90,9 +92,8 @@ const StatsDateControl = ( { slug, queryParams, period, pathTemplate }: StatsDat
 		const anchor = moment().subtract( shortcut.offset, 'days' );
 		const endDate = anchor.format( 'YYYY-MM-DD' );
 		const startDate = anchor.subtract( shortcut.range, 'days' ).format( 'YYYY-MM-DD' );
-
-		const href = generateNewLink( shortcut.period, startDate, endDate );
-		page( href );
+		// Update chart via routing.
+		page( generateNewLink( shortcut.period, startDate, endDate ) );
 	};
 
 	return (

--- a/client/my-sites/stats/stats-date-control/index.tsx
+++ b/client/my-sites/stats/stats-date-control/index.tsx
@@ -48,6 +48,10 @@ const shortcutList = [
 ];
 
 const StatsDateControl = ( { slug, queryParams, period, pathTemplate }: StatsDateControlProps ) => {
+	// ToDo: Consider removing period from shortcuts.
+	// We could use the bestPeriodForDays() helper and keep the shortcuts
+	// consistent with the custom ranges.
+
 	// Shared link generation helper.
 	const generateNewLink = ( period: string, startDate: string, endDate: string ) => {
 		const newRangeQuery = qs.stringify(

--- a/client/my-sites/stats/stats-date-control/index.tsx
+++ b/client/my-sites/stats/stats-date-control/index.tsx
@@ -81,7 +81,7 @@ const StatsDateControl = ( {
 	return (
 		<div className={ COMPONENT_CLASS_NAME }>
 			<IntervalDropdown period={ period } pathTemplate={ pathTemplate } />
-			<DateControlPicker shortcutList={ shortcutList } handleApply={ onApplyButtonHandler } />
+			<DateControlPicker shortcutList={ shortcutList } onApply={ onApplyButtonHandler } />
 		</div>
 	);
 };

--- a/client/my-sites/stats/stats-date-control/index.tsx
+++ b/client/my-sites/stats/stats-date-control/index.tsx
@@ -7,6 +7,45 @@ import './style.scss';
 
 const COMPONENT_CLASS_NAME = 'stats-date-control';
 
+const shortcutList = [
+	{
+		id: 'today',
+		label: 'Today',
+		offset: 0,
+		range: 0,
+	},
+	{
+		id: 'yesterday',
+		label: 'Yesterday',
+		offset: 1,
+		range: 0,
+	},
+	{
+		id: 'last-7-days',
+		label: 'Last 7 Days',
+		offset: 0,
+		range: 7,
+	},
+	{
+		id: 'last-30-days',
+		label: 'Last 30 Days',
+		offset: 0,
+		range: 30,
+	},
+	{
+		id: 'last-year',
+		label: 'Last Year',
+		offset: 0,
+		range: 365,
+	},
+	{
+		id: 'all-time',
+		label: 'All Time',
+		offset: 0,
+		range: 400, // TODO: Don't hard code this value.
+	},
+];
+
 const StatsDateControl = ( {
 	slug,
 	queryParams,
@@ -14,45 +53,6 @@ const StatsDateControl = ( {
 	pathTemplate,
 	onChangeChartQuantity,
 }: StatsDateControlProps ) => {
-	const shortcutList = [
-		{
-			id: 'today',
-			label: 'Today',
-			offset: 0,
-			range: 0,
-		},
-		{
-			id: 'yesterday',
-			label: 'Yesterday',
-			offset: 1,
-			range: 0,
-		},
-		{
-			id: 'last-7-days',
-			label: 'Last 7 Days',
-			offset: 0,
-			range: 7,
-		},
-		{
-			id: 'last-30-days',
-			label: 'Last 30 Days',
-			offset: 0,
-			range: 30,
-		},
-		{
-			id: 'last-year',
-			label: 'Last Year',
-			offset: 0,
-			range: 365,
-		},
-		{
-			id: 'all-time',
-			label: 'All Time',
-			offset: 0,
-			range: 400, // TODO: Don't hard code this value.
-		},
-	];
-
 	const handleApply = ( startDate: string, endDate: string ) => {
 		// calculate offset between start and end to influcence the number of points for the chart
 		// TODO: take period into account

--- a/client/my-sites/stats/stats-date-control/index.tsx
+++ b/client/my-sites/stats/stats-date-control/index.tsx
@@ -15,30 +15,35 @@ const shortcutList = [
 		label: 'Today',
 		offset: 0,
 		range: 0,
+		period: 'day',
 	},
 	{
 		id: 'yesterday',
 		label: 'Yesterday',
 		offset: 1,
 		range: 0,
+		period: 'day',
 	},
 	{
 		id: 'last-7-days',
 		label: 'Last 7 Days',
 		offset: 0,
 		range: 6,
+		period: 'day',
 	},
 	{
 		id: 'last-30-days',
 		label: 'Last 30 Days',
 		offset: 0,
 		range: 29,
+		period: 'day',
 	},
 	{
 		id: 'last-year',
 		label: 'Last Year',
 		offset: 0,
 		range: 364, // ranges are zero based!
+		period: 'month',
 	},
 ];
 
@@ -85,7 +90,7 @@ const StatsDateControl = ( {
 		const endDate = anchor.format( 'YYYY-MM-DD' );
 		const startDate = anchor.subtract( shortcut.range, 'days' ).format( 'YYYY-MM-DD' );
 
-		const href = generateNewLink( 'day', startDate, endDate );
+		const href = generateNewLink( shortcut.period, startDate, endDate );
 		page( href );
 	};
 

--- a/client/my-sites/stats/stats-date-control/stats-date-control-picker-date.tsx
+++ b/client/my-sites/stats/stats-date-control/stats-date-control-picker-date.tsx
@@ -17,7 +17,7 @@ const DateControlPickerDate = ( {
 		<div className="date-control-picker-date">
 			<div className="stats-date-control-picker-dates__inputs">
 				<TextControl value={ startDate } onChange={ onStartChange } />
-				<TextControl type="date" value={ endDate } onChange={ onEndChange } />
+				<TextControl value={ endDate } onChange={ onEndChange } />
 			</div>
 			<div className="stats-date-control-picker-dates__buttons">
 				<Button onClick={ onCancel }>Cancel</Button>

--- a/client/my-sites/stats/stats-date-control/stats-date-control-picker-date.tsx
+++ b/client/my-sites/stats/stats-date-control/stats-date-control-picker-date.tsx
@@ -16,8 +16,8 @@ const DateControlPickerDate = ( {
 	return (
 		<div className="date-control-picker-date">
 			<div className="stats-date-control-picker-dates__inputs">
-				<TextControl value={ startDate } onChange={ onStartChange } />
-				<TextControl value={ endDate } onChange={ onEndChange } />
+				<TextControl type="date" value={ startDate } onChange={ onStartChange } />
+				<TextControl type="date" value={ endDate } onChange={ onEndChange } />
 			</div>
 			<div className="stats-date-control-picker-dates__buttons">
 				<Button onClick={ onCancel }>Cancel</Button>

--- a/client/my-sites/stats/stats-date-control/stats-date-control-picker-date.tsx
+++ b/client/my-sites/stats/stats-date-control/stats-date-control-picker-date.tsx
@@ -16,7 +16,7 @@ const DateControlPickerDate = ( {
 	return (
 		<div className="date-control-picker-date">
 			<div className="stats-date-control-picker-dates__inputs">
-				<TextControl type="date" value={ startDate } onChange={ onStartChange } />
+				<TextControl value={ startDate } onChange={ onStartChange } />
 				<TextControl type="date" value={ endDate } onChange={ onEndChange } />
 			</div>
 			<div className="stats-date-control-picker-dates__buttons">

--- a/client/my-sites/stats/stats-date-control/stats-date-control-picker.tsx
+++ b/client/my-sites/stats/stats-date-control/stats-date-control-picker.tsx
@@ -52,21 +52,6 @@ const DateControlPicker = ( {
 		page( href );
 	};
 
-	const handleOnApply2 = () => {
-		const nextDay = inputStartDate;
-		const nextDayQuery = qs.stringify( Object.assign( {}, queryParams, { startDate: nextDay } ), {
-			addQueryPrefix: true,
-		} );
-		const period = 'day'; // TODO: make this dynamic
-		const url = `/stats/${ period }/${ slug }`;
-		const href = `${ url }${ nextDayQuery }`;
-
-		// expose the values externally
-		handleApply( inputStartDate, inputEndDate );
-
-		page( href );
-	};
-
 	const handleOnCancel = () => {
 		togglePopoverOpened( false );
 	};

--- a/client/my-sites/stats/stats-date-control/stats-date-control-picker.tsx
+++ b/client/my-sites/stats/stats-date-control/stats-date-control-picker.tsx
@@ -48,6 +48,7 @@ const DateControlPicker = ( {
 
 	const handleOnApply = () => {
 		togglePopoverOpened( false );
+		handleApply( inputStartDate, inputEndDate );
 		const href = generateNewLink( 'day', inputStartDate, inputEndDate );
 		page( href );
 	};

--- a/client/my-sites/stats/stats-date-control/stats-date-control-picker.tsx
+++ b/client/my-sites/stats/stats-date-control/stats-date-control-picker.tsx
@@ -8,7 +8,7 @@ import DateControlPickerShortcuts from './stats-date-control-picker-shortcuts';
 import { DateControlPickerProps, DateControlPickerShortcut } from './types';
 import './style.scss';
 
-const DateControlPicker = ( { shortcutList, handleApply }: DateControlPickerProps ) => {
+const DateControlPicker = ( { shortcutList, onApply }: DateControlPickerProps ) => {
 	// TODO: remove placeholder values
 	const [ inputStartDate, setInputStartDate ] = useState(
 		moment().subtract( 6, 'days' ).format( 'YYYY-MM-DD' )
@@ -30,7 +30,7 @@ const DateControlPicker = ( { shortcutList, handleApply }: DateControlPickerProp
 
 	const handleOnApply = () => {
 		togglePopoverOpened( false );
-		handleApply( inputStartDate, inputEndDate );
+		onApply( inputStartDate, inputEndDate );
 	};
 
 	const handleOnCancel = () => {

--- a/client/my-sites/stats/stats-date-control/stats-date-control-picker.tsx
+++ b/client/my-sites/stats/stats-date-control/stats-date-control-picker.tsx
@@ -8,12 +8,7 @@ import DateControlPickerShortcuts from './stats-date-control-picker-shortcuts';
 import { DateControlPickerProps, DateControlPickerShortcut } from './types';
 import './style.scss';
 
-const DateControlPicker = ( {
-	slug,
-	queryParams,
-	shortcutList,
-	handleApply,
-}: DateControlPickerProps ) => {
+const DateControlPicker = ( { shortcutList, handleApply }: DateControlPickerProps ) => {
 	// TODO: remove placeholder values
 	const [ inputStartDate, setInputStartDate ] = useState(
 		moment().subtract( 6, 'days' ).format( 'YYYY-MM-DD' )

--- a/client/my-sites/stats/stats-date-control/stats-date-control-picker.tsx
+++ b/client/my-sites/stats/stats-date-control/stats-date-control-picker.tsx
@@ -17,10 +17,10 @@ const DateControlPicker = ( {
 	handleApply,
 }: DateControlPickerProps ) => {
 	// TODO: remove placeholder values
-	const [ inputStartDate, setInputStartDate ] = useState( new Date().toISOString().slice( 0, 10 ) );
-	const [ inputEndDate, setInputEndDate ] = useState(
-		new Date( new Date().setMonth( new Date().getMonth() - 3 ) ).toISOString().slice( 0, 10 )
+	const [ inputStartDate, setInputStartDate ] = useState(
+		moment().subtract( 6, 'days' ).format( 'YYYY-MM-DD' )
 	);
+	const [ inputEndDate, setInputEndDate ] = useState( moment().format( 'YYYY-MM-DD' ) );
 	const [ currentShortcut, setCurrentShortcut ] = useState( 'today' );
 	const infoReferenceElement = useRef( null );
 	const [ popoverOpened, togglePopoverOpened ] = useState( false );

--- a/client/my-sites/stats/stats-date-control/stats-date-control-picker.tsx
+++ b/client/my-sites/stats/stats-date-control/stats-date-control-picker.tsx
@@ -8,7 +8,7 @@ import DateControlPickerShortcuts from './stats-date-control-picker-shortcuts';
 import { DateControlPickerProps, DateControlPickerShortcut } from './types';
 import './style.scss';
 
-const DateControlPicker = ( { shortcutList, onApply }: DateControlPickerProps ) => {
+const DateControlPicker = ( { shortcutList, onShortcut, onApply }: DateControlPickerProps ) => {
 	// TODO: remove placeholder values
 	const [ inputStartDate, setInputStartDate ] = useState(
 		moment().subtract( 6, 'days' ).format( 'YYYY-MM-DD' )
@@ -38,6 +38,14 @@ const DateControlPicker = ( { shortcutList, onApply }: DateControlPickerProps ) 
 	};
 
 	const handleShortcutSelected = ( shortcut: DateControlPickerShortcut ) => {
+		// Push logic to caller.
+		togglePopoverOpened( false );
+		onShortcut( shortcut );
+
+		// TODO: Remove following logic once the values properly
+		// trickle down from the caller. Currently sets the selected
+		// shortcut and updates the button label.
+
 		// Shared date math.
 		const calcNewDateWithOffset = ( date: Date, offset: number ): Date => {
 			// We do our date math based on 24 hour increments.
@@ -51,13 +59,13 @@ const DateControlPicker = ( { shortcutList, onApply }: DateControlPickerProps ) 
 			return date.toISOString().split( 'T' )[ 0 ];
 		};
 
-		// Calc new start date based on offset value from shortcut.
-		const newStartDate = calcNewDateWithOffset( new Date(), shortcut.offset );
-		setInputStartDate( formattedDate( newStartDate ) );
-
-		// Calc new end date based on start date plus range as specified in shortcut.
-		const newEndDate = calcNewDateWithOffset( newStartDate, shortcut.range );
+		// Calc new end date based on offset value from shortcut.
+		const newEndDate = calcNewDateWithOffset( new Date(), shortcut.offset );
 		setInputEndDate( formattedDate( newEndDate ) );
+
+		// Calc new start date based on end date plus range as specified in shortcut.
+		const newStartDate = calcNewDateWithOffset( newEndDate, shortcut.range );
+		setInputStartDate( formattedDate( newStartDate ) );
 
 		setCurrentShortcut( shortcut.id || '' );
 	};

--- a/client/my-sites/stats/stats-date-control/stats-date-control-picker.tsx
+++ b/client/my-sites/stats/stats-date-control/stats-date-control-picker.tsx
@@ -35,7 +35,24 @@ const DateControlPicker = ( {
 		setInputEndDate( value );
 	};
 
+	const generateNewLink = ( period: string, startDate: string, endDate: string ) => {
+		const newRangeQuery = qs.stringify(
+			Object.assign( {}, queryParams, { chartStart: startDate, chartEnd: endDate } ),
+			{
+				addQueryPrefix: true,
+			}
+		);
+		const url = `/stats/${ period }/${ slug }`;
+		return `${ url }${ newRangeQuery }`;
+	};
+
 	const handleOnApply = () => {
+		togglePopoverOpened( false );
+		const href = generateNewLink( 'day', inputStartDate, inputEndDate );
+		page( href );
+	};
+
+	const handleOnApply2 = () => {
 		const nextDay = inputStartDate;
 		const nextDayQuery = qs.stringify( Object.assign( {}, queryParams, { startDate: nextDay } ), {
 			addQueryPrefix: true,

--- a/client/my-sites/stats/stats-date-control/stats-date-control-picker.tsx
+++ b/client/my-sites/stats/stats-date-control/stats-date-control-picker.tsx
@@ -2,8 +2,6 @@ import { Popover } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { Icon, calendar } from '@wordpress/icons';
 import moment from 'moment';
-import page from 'page';
-import qs from 'qs';
 import React, { useState, useRef } from 'react';
 import DateControlPickerDate from './stats-date-control-picker-date';
 import DateControlPickerShortcuts from './stats-date-control-picker-shortcuts';
@@ -35,22 +33,9 @@ const DateControlPicker = ( {
 		setInputEndDate( value );
 	};
 
-	const generateNewLink = ( period: string, startDate: string, endDate: string ) => {
-		const newRangeQuery = qs.stringify(
-			Object.assign( {}, queryParams, { chartStart: startDate, chartEnd: endDate } ),
-			{
-				addQueryPrefix: true,
-			}
-		);
-		const url = `/stats/${ period }/${ slug }`;
-		return `${ url }${ newRangeQuery }`;
-	};
-
 	const handleOnApply = () => {
 		togglePopoverOpened( false );
 		handleApply( inputStartDate, inputEndDate );
-		const href = generateNewLink( 'day', inputStartDate, inputEndDate );
-		page( href );
 	};
 
 	const handleOnCancel = () => {

--- a/client/my-sites/stats/stats-date-control/types.d.ts
+++ b/client/my-sites/stats/stats-date-control/types.d.ts
@@ -23,6 +23,7 @@ interface DateControlPickerShortcut {
 	label: string;
 	offset: number;
 	range: number;
+	period: string;
 }
 
 interface DateControlPickerDateProps {

--- a/client/my-sites/stats/stats-date-control/types.d.ts
+++ b/client/my-sites/stats/stats-date-control/types.d.ts
@@ -8,6 +8,7 @@ interface StatsDateControlProps {
 
 interface DateControlPickerProps {
 	shortcutList: DateControlPickerShortcut[];
+	onShortcut: ( shortcut: DateControlPickerShortcut ) => void;
 	onApply: ( startDate: string, endDate: string ) => void;
 }
 
@@ -18,7 +19,7 @@ interface DateControlPickerShortcutsProps {
 }
 
 interface DateControlPickerShortcut {
-	id?: string;
+	id: string;
 	label: string;
 	offset: number;
 	range: number;

--- a/client/my-sites/stats/stats-date-control/types.d.ts
+++ b/client/my-sites/stats/stats-date-control/types.d.ts
@@ -8,7 +8,7 @@ interface StatsDateControlProps {
 
 interface DateControlPickerProps {
 	shortcutList: DateControlPickerShortcut[];
-	handleApply: ( startDate: string, endDate: string ) => void;
+	onApply: ( startDate: string, endDate: string ) => void;
 }
 
 interface DateControlPickerShortcutsProps {

--- a/client/my-sites/stats/stats-date-control/types.d.ts
+++ b/client/my-sites/stats/stats-date-control/types.d.ts
@@ -7,8 +7,6 @@ interface StatsDateControlProps {
 }
 
 interface DateControlPickerProps {
-	slug: string;
-	queryParams: string;
 	shortcutList: DateControlPickerShortcut[];
 	handleApply: ( startDate: string, endDate: string ) => void;
 }

--- a/client/my-sites/stats/stats-date-control/types.d.ts
+++ b/client/my-sites/stats/stats-date-control/types.d.ts
@@ -3,7 +3,6 @@ interface StatsDateControlProps {
 	queryParams: string;
 	period: 'day' | 'week' | 'month' | 'year';
 	pathTemplate: string;
-	onChangeChartQuantity: ( customQuantity: number ) => void;
 }
 
 interface DateControlPickerProps {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #83071 & #82221 & #83039.

## Proposed Changes

Updates the logic in the date picker. Shortcuts and input fields now update the chart via routing and URL params. Includes period computation from #83072. Thanks @grzegorz-cp!

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Test Initial State
1. Open the Live branch.
2. Navigate to **Stats → Traffic** page.
3. Confirm existing interval and navigation controls work.
4. Enable new date controls: `?flags=stats/date-control`
5. Confirm chart shows 7 days of data and button label shows corresponding dates.

### Test Shortcuts
1. Open the date picker and test various shortcuts.
2. Confirm the popover auto-close on selection.
3. Confirm the date labels update on selection
4. Confirm the chart updates to show the corresponding range.
5. Confirm selecting the "Last Year" shortcut sets the period to "month" in the URL.

### Test Input Fields
1. Open the date picker and test input fields.
2. Confirm the button label updates as the dates change. (needs updated logic)
3. Confirm entering a new range and hitting **Cancel** does not update the chart. (button label will show wrong dates)
4. Confirm entering a valid date range and hitting **Apply** updates things correctly.
5. Confirm that the period is updated to something reasonable if the date range is large.

Note: The date labels will get out of sync in step 3 as the labels are not driven by the URL params yet. They'll be correct again when updating the range and clicking **Apply**.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?