### PR TITLE
Jetpack Atomic E2E: Use day of month in atomic variation instead of 2 hour window for better retry stability

### DIFF
--- a/packages/calypso-e2e/src/env-variables.ts
+++ b/packages/calypso-e2e/src/env-variables.ts
@@ -248,12 +248,12 @@ function getAtomicVariationInMixedRun() {
 		'ecomm-plan',
 	];
 	// The goal here is controlled randomness to include multiple variations within a single run.
-	// By using the current two hour time window and the test file name hash, we can get a
-	// lot of variation throughout the day while also ensuring the same variation is used on a failed retry.
-	const currentTwoHourWindow = new Date().getHours() % 12;
+	// By using the current day of the month and the test file name hash, we can get a
+	// lot of variation throughout the week while also ensuring the same variation is used on a failed retry.
+	const currentDayOfMonth = new Date().getDate();
 	const currentTestFileName = global.testFileName || '';
 	const fileHash = hashTestFileName( currentTestFileName );
-	const variationIndex = ( currentTwoHourWindow + fileHash ) % allVariations.length;
+	const variationIndex = ( currentDayOfMonth + fileHash ) % allVariations.length;
 	return allVariations[ variationIndex ];
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

I was waffling about doing this earlier, but I now think this is the right tradeoff. In short, we now seed the mixing of the atomic variation with the day of the month vs the two hour window. We had a failed retry recently because the test ran over the two-hour window change. 

In this case, this means the mixing of tests will look the same on each given day, but will then switch up on each different day of the month. I think this still allows us to have our controlled randomness, but with much better stability. This means you have a full day to debug and retry a test and you can still use the TeamCity configuration to do so! And we'll see way fewer "wrong retries", where we retry a test in a different environment

## Testing Instructions

- [ ] Run the atomic build smoke build twice. The tests should be the same

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?