### PR TITLE
Add tips panel to comments moderation

### DIFF
--- a/client/my-sites/comments/comment-tips.jsx
+++ b/client/my-sites/comments/comment-tips.jsx
@@ -1,14 +1,30 @@
+import { Button, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import ActionPanel from 'calypso/components/action-panel';
 import ActionPanelBody from 'calypso/components/action-panel/body';
 import ActionPanelFigure from 'calypso/components/action-panel/figure';
 import ActionPanelTitle from 'calypso/components/action-panel/title';
+import { useDispatch } from 'calypso/state';
+import { setPreference } from 'calypso/state/preferences/actions';
+
+export const COMMENTS_TIPS_DISMISSED_PREFERENCE = 'dismissible-comments-moderation-tips-test';
 
 const CommentTips = () => {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const dismissTips = () => dispatch( setPreference( COMMENTS_TIPS_DISMISSED_PREFERENCE, true ) );
 
 	return (
 		<ActionPanel className="comments-tips__action-panel">
+			<Button
+				className="comments-tips__dismiss-button"
+				onClick={ dismissTips }
+				borderless
+				title={ translate( 'Dismiss tips' ) }
+			>
+				<Gridicon icon="cross" size="24px" />
+			</Button>
 			<ActionPanelBody>
 				<ActionPanelFigure align="left">
 					<img

--- a/client/my-sites/comments/comment-tips.jsx
+++ b/client/my-sites/comments/comment-tips.jsx
@@ -1,5 +1,7 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
 import ActionPanel from 'calypso/components/action-panel';
 import ActionPanelBody from 'calypso/components/action-panel/body';
 import ActionPanelFigure from 'calypso/components/action-panel/figure';
@@ -13,7 +15,14 @@ const CommentTips = () => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const dismissTips = () => dispatch( savePreference( COMMENTS_TIPS_DISMISSED_PREFERENCE, true ) );
+	const dismissTips = () => {
+		dispatch( savePreference( COMMENTS_TIPS_DISMISSED_PREFERENCE, true ) );
+		recordTracksEvent( 'calypso_comments_moderation_tips_dismissed' );
+	};
+
+	useEffect( () => {
+		recordTracksEvent( 'calypso_comments_moderation_tips_viewed' );
+	}, [] );
 
 	return (
 		<ActionPanel className="comments-tips__action-panel">

--- a/client/my-sites/comments/comment-tips.jsx
+++ b/client/my-sites/comments/comment-tips.jsx
@@ -5,15 +5,15 @@ import ActionPanelBody from 'calypso/components/action-panel/body';
 import ActionPanelFigure from 'calypso/components/action-panel/figure';
 import ActionPanelTitle from 'calypso/components/action-panel/title';
 import { useDispatch } from 'calypso/state';
-import { setPreference } from 'calypso/state/preferences/actions';
+import { savePreference } from 'calypso/state/preferences/actions';
 
-export const COMMENTS_TIPS_DISMISSED_PREFERENCE = 'dismissible-comments-moderation-tips-test';
+export const COMMENTS_TIPS_DISMISSED_PREFERENCE = 'dismissible-comments-moderation-tips';
 
 const CommentTips = () => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const dismissTips = () => dispatch( setPreference( COMMENTS_TIPS_DISMISSED_PREFERENCE, true ) );
+	const dismissTips = () => dispatch( savePreference( COMMENTS_TIPS_DISMISSED_PREFERENCE, true ) );
 
 	return (
 		<ActionPanel className="comments-tips__action-panel">

--- a/client/my-sites/comments/comment-tips.jsx
+++ b/client/my-sites/comments/comment-tips.jsx
@@ -1,0 +1,44 @@
+import { useTranslate } from 'i18n-calypso';
+import ActionPanel from 'calypso/components/action-panel';
+import ActionPanelBody from 'calypso/components/action-panel/body';
+import ActionPanelFigure from 'calypso/components/action-panel/figure';
+import ActionPanelTitle from 'calypso/components/action-panel/title';
+
+const CommentTips = () => {
+	const translate = useTranslate();
+
+	return (
+		<ActionPanel>
+			<ActionPanelBody>
+				<ActionPanelFigure align="left">
+					<img
+						src="/calypso/images/wordpress/logo-stars.svg"
+						width="170"
+						height="143"
+						alt="WordPress logo"
+					/>
+				</ActionPanelFigure>
+				<ActionPanelTitle>{ translate( 'A few helpful tips' ) }</ActionPanelTitle>
+				<ul>
+					<li>
+						{ translate(
+							'Comments are the best part of blogging, but you decide which comments get published.'
+						) }
+					</li>
+					<li>
+						{ translate(
+							'Spammers and odd folks will want to be on your post so look at their links and if it seems scammy, don’t hesitate to delete or spam the comment.'
+						) }
+					</li>
+					<li>
+						{ translate(
+							'When real people show up, approve the comment and reply to them! Engage them, this is your community.'
+						) }
+					</li>
+				</ul>
+			</ActionPanelBody>
+		</ActionPanel>
+	);
+};
+
+export default CommentTips;

--- a/client/my-sites/comments/comment-tips.jsx
+++ b/client/my-sites/comments/comment-tips.jsx
@@ -8,7 +8,7 @@ const CommentTips = () => {
 	const translate = useTranslate();
 
 	return (
-		<ActionPanel>
+		<ActionPanel className="comments-tips__action-panel">
 			<ActionPanelBody>
 				<ActionPanelFigure align="left">
 					<img

--- a/client/my-sites/comments/main.jsx
+++ b/client/my-sites/comments/main.jsx
@@ -12,13 +12,13 @@ import ScreenOptionsTab from 'calypso/components/screen-options-tab';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { preventWidows } from 'calypso/lib/formatting';
 import { withJetpackConnectionProblem } from 'calypso/state/jetpack-connection-health/selectors/is-jetpack-connection-problem.js';
+import { getPreference } from 'calypso/state/preferences/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getSiteId } from 'calypso/state/sites/selectors';
 import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import CommentList from './comment-list';
-import CommentTips from './comment-tips';
+import CommentTips, { COMMENTS_TIPS_DISMISSED_PREFERENCE } from './comment-tips';
 import { NEWEST_FIRST } from './constants';
-
 import './style.scss';
 
 export class CommentsManagement extends Component {
@@ -59,6 +59,7 @@ export class CommentsManagement extends Component {
 			siteFragment,
 			status,
 			translate,
+			hideModerationTips,
 		} = this.props;
 		const { order } = this.state;
 
@@ -100,7 +101,7 @@ export class CommentsManagement extends Component {
 				) }
 				{ showCommentList && (
 					<>
-						<CommentTips />
+						{ ! hideModerationTips && <CommentTips /> }
 						<CommentList
 							key={ `${ siteId }-${ status }` }
 							changePage={ changePage }
@@ -131,6 +132,7 @@ const mapStateToProps = ( state, { siteFragment } ) => {
 		siteId,
 		showCommentList,
 		showPermissionError,
+		hideModerationTips: getPreference( state, COMMENTS_TIPS_DISMISSED_PREFERENCE ),
 	};
 };
 

--- a/client/my-sites/comments/main.jsx
+++ b/client/my-sites/comments/main.jsx
@@ -16,6 +16,7 @@ import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getSiteId } from 'calypso/state/sites/selectors';
 import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import CommentList from './comment-list';
+import CommentTips from './comment-tips';
 import { NEWEST_FIRST } from './constants';
 
 import './style.scss';
@@ -98,17 +99,20 @@ export class CommentsManagement extends Component {
 					/>
 				) }
 				{ showCommentList && (
-					<CommentList
-						key={ `${ siteId }-${ status }` }
-						changePage={ changePage }
-						order={ order }
-						page={ page }
-						postId={ postId }
-						setOrder={ this.setOrder }
-						siteId={ siteId }
-						siteFragment={ siteFragment }
-						status={ status }
-					/>
+					<>
+						<CommentTips />
+						<CommentList
+							key={ `${ siteId }-${ status }` }
+							changePage={ changePage }
+							order={ order }
+							page={ page }
+							postId={ postId }
+							setOrder={ this.setOrder }
+							siteId={ siteId }
+							siteFragment={ siteFragment }
+							status={ status }
+						/>
+					</>
 				) }
 			</Main>
 		);

--- a/client/my-sites/comments/main.jsx
+++ b/client/my-sites/comments/main.jsx
@@ -19,6 +19,7 @@ import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import CommentList from './comment-list';
 import CommentTips, { COMMENTS_TIPS_DISMISSED_PREFERENCE } from './comment-tips';
 import { NEWEST_FIRST } from './constants';
+
 import './style.scss';
 
 export class CommentsManagement extends Component {

--- a/client/my-sites/comments/style.scss
+++ b/client/my-sites/comments/style.scss
@@ -152,11 +152,25 @@
 }
 
 .comments-tips__action-panel {
+	position: relative;
 	.action-panel__figure {
 		margin-bottom: 0;
+		width: auto;
 	}
 	ul {
 		color: var(--color-neutral-70);
 		line-height: 24px;
+	}
+	.comments-tips__dismiss-button {
+		position: absolute;
+		top: 0;
+		right: 0;
+		padding: 8px;
+		margin: 8px 12px 8px 8px;
+
+		.gridicon {
+			height: 24px;
+			width: 24px;
+		}
 	}
 }

--- a/client/my-sites/comments/style.scss
+++ b/client/my-sites/comments/style.scss
@@ -150,3 +150,13 @@
 		opacity: 1;
 	}
 }
+
+.comments-tips__action-panel {
+	.action-panel__figure {
+		margin-bottom: 0;
+	}
+	ul {
+		color: var(--color-neutral-70);
+		line-height: 24px;
+	}
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # pe7F0s-1kj-p2

## Proposed Changes

* Adds a tips banner at the top of the comments moderation page in calypso.
* The banner is dismissible at the user level of calypso preferences and saved under `dismissible-comments-moderation-tips`
* Adds tracking events for `calypso_comments_moderation_tips_viewed` and `calypso_comments_moderation_tips_dismissed`

<img width="1055" alt="Screenshot 2023-10-18 at 1 17 20 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/2468630e-913b-4cda-8651-b3274a34ee0c">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch, navigate to "comments" section in the nav sidebar. (ensure you are not on wp-admin classic view).
* Verify the new banner is visible, and sends the `calypso_comments_moderation_tips_viewed` tracking event.
* Dismiss the banner via the "X" in the top right. Verify this dismisses the banner and sends the `calypso_comments_moderation_tips_dismissed` tracking event.
* Navigate to another site in site selection, reload calypso/refresh the browser.
* navigate back to comments, verify the banner is not present.
* To undismiss the banner in testing, you can run `wp user-attributes undismiss_a_banner --user_id=<userId> --banner=dismissible-comments-moderation-tips`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?