### PR TITLE
Update BlazePress e2e to use new image upload DOM

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/blaze-campaign-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/blaze-campaign-page.ts
@@ -43,9 +43,13 @@ export class BlazeCampaignPage {
 	 * @param {TestFile} path TestFile object.
 	 */
 	async uploadImage( path: TestFile ) {
+		const fileChooserPromiser = this.page.waitForEvent( 'filechooser' );
 		await this.page
-			.getByLabel( 'Click or drag an image here to upload.' )
-			.setInputFiles( path.fullpath );
+			.getByRole( 'region', { name: 'Appearance' } )
+			.getByRole( 'button', { name: 'Upload' } )
+			.click();
+		const fileChooser = await fileChooserPromiser;
+		await fileChooser.setFiles( path.fullpath );
 
 		await this.page.getByRole( 'region', { name: 'Appearance' } ).locator( 'img' ).waitFor();
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Updating to the BlazePress e2e to match the new image upload DOM.

See: p1697551097289669-slack-C02DQP0FP
Using the [FileChooser API](https://playwright.dev/docs/api/class-filechooser) as it works a bit more cleanly here

## Testing Instructions

PR tests should pass again

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?