### PR TITLE
Reader Nudge: Add "First Posts" nudge card

### DIFF
--- a/client/my-sites/customer-home/cards/constants.js
+++ b/client/my-sites/customer-home/cards/constants.js
@@ -16,6 +16,7 @@ export const FEATURE_QUICK_START = 'home-feature-quick-start';
 export const FEATURE_STATS = 'home-feature-stats';
 export const FEATURE_SUPPORT = 'home-feature-support';
 export const FEATURE_SITE_PREVIEW = 'home-feature-site-preview';
+export const NOTICE_READER_FIRST_POSTS = 'home-reader-first-posts';
 export const NOTICE_SITE_LAUNCH_SELLER_UPSELL = 'home-site-launch-seller-upsell';
 export const NOTICE_CELEBRATE_SITE_CREATION = 'home-notice-celebrate-site-creation';
 export const NOTICE_CELEBRATE_SITE_LAUNCH = 'home-notice-celebrate-site-launch';

--- a/client/my-sites/customer-home/cards/notices/reader-first-posts/index.jsx
+++ b/client/my-sites/customer-home/cards/notices/reader-first-posts/index.jsx
@@ -1,6 +1,6 @@
 import { Card, Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { NOTICE_READER_FIRST_POSTS } from 'calypso/my-sites/customer-home/cards/constants';
+//import { NOTICE_READER_FIRST_POSTS } from 'calypso/my-sites/customer-home/cards/constants';
 
 const ReaderFirstPosts = () => {
 	const translate = useTranslate();

--- a/client/my-sites/customer-home/cards/notices/reader-first-posts/index.jsx
+++ b/client/my-sites/customer-home/cards/notices/reader-first-posts/index.jsx
@@ -1,15 +1,24 @@
 import { Card, Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import page from 'page';
+//import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 //import { NOTICE_READER_FIRST_POSTS } from 'calypso/my-sites/customer-home/cards/constants';
 
 const ReaderFirstPosts = () => {
 	const translate = useTranslate();
-	// @TODO: Add Tracks events.
+
+	const clickButton = () => {
+		// @TODO: Add Tracks events.
+		//recordTracksEvent( 'calypso_home_reader_first_posts_nudge_click' );
+
+		page.redirect( '/discover?selectedTab=first-posts' );
+	};
+
 	return (
 		<Card className="reader-first-posts__nudge">
 			<h2>{ translate( 'Looking for inspiration?' ) }</h2>
 			<p>{ translate( 'See what other brand new sites are writing about.' ) }</p>
-			<Button className="reader-first-posts__button" href="/discover?selectedTab=firstposts">
+			<Button primary onClick={ () => clickButton() } className="reader-first-posts__button">
 				{ translate( 'Take a look' ) }
 			</Button>
 		</Card>

--- a/client/my-sites/customer-home/cards/notices/reader-first-posts/index.jsx
+++ b/client/my-sites/customer-home/cards/notices/reader-first-posts/index.jsx
@@ -1,0 +1,19 @@
+import { Card, Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { NOTICE_READER_FIRST_POSTS } from 'calypso/my-sites/customer-home/cards/constants';
+
+const ReaderFirstPosts = () => {
+	const translate = useTranslate();
+	// @TODO: Add Tracks events.
+	return (
+		<Card className="reader-first-posts__nudge">
+			<h2>{ translate( 'Looking for inspiration?' ) }</h2>
+			<p>{ translate( 'See what other brand new sites are writing about.' ) }</p>
+			<Button className="reader-first-posts__button" href="/discover?selectedTab=firstposts">
+				{ translate( 'Take a look' ) }
+			</Button>
+		</Card>
+	);
+};
+
+export default ReaderFirstPosts;

--- a/client/my-sites/customer-home/cards/notices/reader-first-posts/index.jsx
+++ b/client/my-sites/customer-home/cards/notices/reader-first-posts/index.jsx
@@ -11,7 +11,7 @@ const ReaderFirstPosts = () => {
 		// @TODO: Add Tracks events.
 		//recordTracksEvent( 'calypso_home_reader_first_posts_nudge_click' );
 
-		page.redirect( '/discover?selectedTab=first-posts' );
+		page.redirect( '/discover?selectedTab=firstposts' );
 	};
 
 	return (

--- a/client/my-sites/customer-home/locations/secondary/index.jsx
+++ b/client/my-sites/customer-home/locations/secondary/index.jsx
@@ -11,6 +11,7 @@ import {
 	LAUNCHPAD_INTENT_FREE_NEWSLETTER,
 	LAUNCHPAD_INTENT_PAID_NEWSLETTER,
 	LAUNCHPAD_PRE_LAUNCH,
+	NOTICE_READER_FIRST_POSTS,
 } from 'calypso/my-sites/customer-home/cards/constants';
 import DomainUpsell from 'calypso/my-sites/customer-home/cards/features/domain-upsell';
 import HelpSearch from 'calypso/my-sites/customer-home/cards/features/help-search';
@@ -22,6 +23,7 @@ import {
 } from 'calypso/my-sites/customer-home/cards/launchpad/intent-newsletter';
 import LaunchpadIntentWrite from 'calypso/my-sites/customer-home/cards/launchpad/intent-write';
 import LaunchpadPreLaunch from 'calypso/my-sites/customer-home/cards/launchpad/pre-launch';
+import ReaderFirstPosts from 'calypso/my-sites/customer-home/cards/notices/reader-first-posts';
 import LearnGrow from './learn-grow';
 
 const cardComponents = {
@@ -30,6 +32,7 @@ const cardComponents = {
 	[ SECTION_LEARN_GROW ]: LearnGrow,
 	[ SECTION_BLOGGING_PROMPT ]: BloggingPrompt,
 	[ FEATURE_SUPPORT ]: HelpSearch,
+	[ NOTICE_READER_FIRST_POSTS ]: ReaderFirstPosts,
 	[ LAUNCHPAD_INTENT_BUILD ]: LaunchpadIntentBuild,
 	[ LAUNCHPAD_INTENT_WRITE ]: LaunchpadIntentWrite,
 	[ LAUNCHPAD_INTENT_FREE_NEWSLETTER ]: LaunchpadIntentFreeNewsletter,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #83105

## Proposed Changes

* Add a basic card with some copy to act as the "First Posts" nudge in Customer Home for launched sites.
* Design will need to be polished, and we need to add Tracks events, but those can happen in a future PR.
* Once we're clear on the copy, we should string freeze this ASAP.

<img width="1062" alt="Screenshot 2023-10-17 at 11 22 11 AM" src="https://github.com/Automattic/wp-calypso/assets/2124984/83538b2a-d15a-4395-9a9c-328f6a922561">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR
* Apply D125476-code to your sandbox and sandbox the API
* Visit `/home/siteSlug` on a launched site.
* You should see something like the following:

<img width="1062" alt="Screenshot 2023-10-17 at 11 22 11 AM" src="https://github.com/Automattic/wp-calypso/assets/2124984/b19386c7-e1f7-40fe-84ee-114d71b55d62">

* Click on the "Take me there" button and ensure it brings you to `/discover?selectedTab=first-posts`
* Test on a site that hasn't launched yet; you should not see the card.
* Un-sandbox the API and test on a site that has launched; you should not see the card, and there should be no errors in the console.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?