### PR TITLE
Jetpack Cloud: Add sidebar navigation items for Purchases view

### DIFF
--- a/client/jetpack-cloud/sections/sidebar-navigation/lib/constants.ts
+++ b/client/jetpack-cloud/sections/sidebar-navigation/lib/constants.ts
@@ -1,8 +1,12 @@
 export const JETPACK_MANAGE_DASHBOARD_LINK = '/dashboard';
 export const JETPACK_MANAGE_PLUGINS_LINK = '/plugins/manage';
-export const JETPACK_MANAGE_LICENCES_LINK = '/partner-portal/licenses';
-export const JETPACK_MANAGE_BILLING_LINK = '/partner-portal/billing';
-
 export const JETPACK_CLOUD_ACTIVITY_LOG_LINK = '/activity-log';
 export const JETPACK_CLOUD_SEARCH_LINK = '/jetpack-search';
 export const JETPACK_CLOUD_SOCIAL_LINK = '/jetpack-social';
+export const JETPACK_MANAGE_PARTNER_PORTAL_LINK = '/partner-portal';
+export const JETPACK_MANAGE_LICENCES_LINK = `${ JETPACK_MANAGE_PARTNER_PORTAL_LINK }/licenses`;
+export const JETPACK_MANAGE_BILLING_LINK = `${ JETPACK_MANAGE_PARTNER_PORTAL_LINK }/billing`;
+export const JETPACK_MANAGE_COMPANY_DETAILS_LINK = `${ JETPACK_MANAGE_PARTNER_PORTAL_LINK }/company-details`;
+export const JETPACK_MANAGE_INVOICES_LINK = `${ JETPACK_MANAGE_PARTNER_PORTAL_LINK }/invoices`;
+export const JETPACK_MANAGE_PAYMENT_METHODS_LINK = `${ JETPACK_MANAGE_PARTNER_PORTAL_LINK }/payment-methods`;
+export const JETPACK_MANAGE_PRICES_LINK = `${ JETPACK_MANAGE_PARTNER_PORTAL_LINK }/prices`;

--- a/client/jetpack-cloud/sections/sidebar-navigation/purchases.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/purchases.tsx
@@ -2,51 +2,64 @@ import { chevronLeft, formatListBulletsRTL, payment, receipt, store, tag } from 
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import NewSidebar from 'calypso/jetpack-cloud/components/sidebar';
+import { itemLinkMatches } from 'calypso/my-sites/sidebar/utils';
+
+const PARTNER_PORTAL_ROOT_PATH = '/partner-portal';
+
+const onClickMenuItem = ( path: string ) => {
+	page.redirect( path );
+};
+
+const isSelected = ( link: string ) => {
+	const pathname = window.location.pathname;
+	return itemLinkMatches( link, pathname );
+};
+
+type ItemProps = {
+	icon: JSX.Element;
+	link: string;
+	title: string;
+};
+const createItem = ( { icon, link, title }: ItemProps ) => ( {
+	icon,
+	path: PARTNER_PORTAL_ROOT_PATH,
+	link,
+	title,
+	onClickMenuItem,
+	isSelected: isSelected( link ),
+} );
 
 const PurchasesSidebar = () => {
 	const translate = useTranslate();
 
-	const onClickMenuItem = ( path: string ) => {
-		page.redirect( path );
-	};
-
 	const menuItems = [
-		{
+		createItem( {
 			icon: store,
-			path: '/partner-portal',
-			link: '/partner-portal/billing',
+			link: `${ PARTNER_PORTAL_ROOT_PATH }/billing`,
 			title: translate( 'Billing' ),
-			onClickMenuItem: onClickMenuItem,
-		},
-		{
+		} ),
+		createItem( {
 			icon: payment,
-			path: '/partner-portal',
-			link: '/partner-portal/payment-methods',
+			link: `${ PARTNER_PORTAL_ROOT_PATH }/payment-methods`,
 			title: translate( 'Payment Methods' ),
-			onClickMenuItem: onClickMenuItem,
-		},
-		{
+		} ),
+		createItem( {
 			icon: receipt,
-			path: '/partner-portal',
-			link: '/partner-portal/invoices',
+			link: `${ PARTNER_PORTAL_ROOT_PATH }/invoices`,
 			title: translate( 'Invoices' ),
-			onClickMenuItem: onClickMenuItem,
-		},
-		{
+		} ),
+		createItem( {
 			icon: tag,
-			path: '/partner-portal',
-			link: '/partner-portal/prices',
+			link: `${ PARTNER_PORTAL_ROOT_PATH }/prices`,
 			title: translate( 'Prices' ),
-			onClickMenuItem: onClickMenuItem,
-		},
-		{
+		} ),
+		createItem( {
 			icon: formatListBulletsRTL,
-			path: '/partner-portal',
-			link: '/partner-portal/company-details',
+			link: `${ PARTNER_PORTAL_ROOT_PATH }/company-details`,
 			title: translate( 'Company Details' ),
-			onClickMenuItem: onClickMenuItem,
-		},
+		} ),
 	];
+
 	return (
 		<NewSidebar
 			isJetpackManage

--- a/client/jetpack-cloud/sections/sidebar-navigation/purchases.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/purchases.tsx
@@ -1,32 +1,23 @@
 import { chevronLeft, formatListBulletsRTL, payment, receipt, store, tag } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import page from 'page';
 import NewSidebar from 'calypso/jetpack-cloud/components/sidebar';
-import { itemLinkMatches } from 'calypso/my-sites/sidebar/utils';
+import {
+	JETPACK_MANAGE_BILLING_LINK,
+	JETPACK_MANAGE_COMPANY_DETAILS_LINK,
+	JETPACK_MANAGE_DASHBOARD_LINK,
+	JETPACK_MANAGE_INVOICES_LINK,
+	JETPACK_MANAGE_PARTNER_PORTAL_LINK,
+	JETPACK_MANAGE_PAYMENT_METHODS_LINK,
+	JETPACK_MANAGE_PRICES_LINK,
+} from './lib/constants';
+import { isMenuItemSelected, redirectPage } from './lib/sidebar';
+import { MenuItemProps } from './types';
 
-const PARTNER_PORTAL_ROOT_PATH = '/partner-portal';
-
-const onClickMenuItem = ( path: string ) => {
-	page.redirect( path );
-};
-
-const isSelected = ( link: string ) => {
-	const pathname = window.location.pathname;
-	return itemLinkMatches( link, pathname );
-};
-
-type ItemProps = {
-	icon: JSX.Element;
-	link: string;
-	title: string;
-};
-const createItem = ( { icon, link, title }: ItemProps ) => ( {
-	icon,
-	path: PARTNER_PORTAL_ROOT_PATH,
-	link,
-	title,
-	onClickMenuItem,
-	isSelected: isSelected( link ),
+const createItem = ( props: Omit< MenuItemProps, 'path' > ) => ( {
+	...props,
+	path: JETPACK_MANAGE_PARTNER_PORTAL_LINK,
+	onClickMenuItem: redirectPage,
+	isSelected: isMenuItemSelected( props.link ),
 } );
 
 const PurchasesSidebar = () => {
@@ -35,27 +26,27 @@ const PurchasesSidebar = () => {
 	const menuItems = [
 		createItem( {
 			icon: store,
-			link: `${ PARTNER_PORTAL_ROOT_PATH }/billing`,
+			link: JETPACK_MANAGE_BILLING_LINK,
 			title: translate( 'Billing' ),
 		} ),
 		createItem( {
 			icon: payment,
-			link: `${ PARTNER_PORTAL_ROOT_PATH }/payment-methods`,
+			link: JETPACK_MANAGE_PAYMENT_METHODS_LINK,
 			title: translate( 'Payment Methods' ),
 		} ),
 		createItem( {
 			icon: receipt,
-			link: `${ PARTNER_PORTAL_ROOT_PATH }/invoices`,
+			link: JETPACK_MANAGE_INVOICES_LINK,
 			title: translate( 'Invoices' ),
 		} ),
 		createItem( {
 			icon: tag,
-			link: `${ PARTNER_PORTAL_ROOT_PATH }/prices`,
+			link: JETPACK_MANAGE_PRICES_LINK,
 			title: translate( 'Prices' ),
 		} ),
 		createItem( {
 			icon: formatListBulletsRTL,
-			link: `${ PARTNER_PORTAL_ROOT_PATH }/company-details`,
+			link: JETPACK_MANAGE_COMPANY_DETAILS_LINK,
 			title: translate( 'Company Details' ),
 		} ),
 	];
@@ -63,13 +54,13 @@ const PurchasesSidebar = () => {
 	return (
 		<NewSidebar
 			isJetpackManage
-			path="/partner-portal"
+			path={ JETPACK_MANAGE_PARTNER_PORTAL_LINK }
 			menuItems={ menuItems }
 			description={ translate( 'Manage all your billing related settings from one place.' ) }
 			backButtonProps={ {
 				label: translate( 'Purchases' ),
 				icon: chevronLeft,
-				onClick: () => onClickMenuItem( '/dashboard' ),
+				onClick: () => redirectPage( JETPACK_MANAGE_DASHBOARD_LINK ),
 			} }
 		/>
 	);

--- a/client/jetpack-cloud/sections/sidebar-navigation/purchases.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/purchases.tsx
@@ -1,11 +1,65 @@
+import { chevronLeft, formatListBulletsRTL, payment, receipt, store, tag } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import page from 'page';
 import NewSidebar from 'calypso/jetpack-cloud/components/sidebar';
 
-// This sidebar is what Jetpack Manage customers will see when they select the
-// Purchases item from the top-level navigation sidebar. It'll display options
-// like Licenses, Invoices, Billing, etc.
-// FIXME: Add menu items
 const PurchasesSidebar = () => {
-	return <NewSidebar path="/partner-portal" menuItems={ [] } />;
+	const translate = useTranslate();
+
+	const onClickMenuItem = ( path: string ) => {
+		page.redirect( path );
+	};
+
+	const menuItems = [
+		{
+			icon: store,
+			path: '/partner-portal',
+			link: '/partner-portal/billing',
+			title: translate( 'Billing' ),
+			onClickMenuItem: onClickMenuItem,
+		},
+		{
+			icon: payment,
+			path: '/partner-portal',
+			link: '/partner-portal/payment-methods',
+			title: translate( 'Payment Methods' ),
+			onClickMenuItem: onClickMenuItem,
+		},
+		{
+			icon: receipt,
+			path: '/partner-portal',
+			link: '/partner-portal/invoices',
+			title: translate( 'Invoices' ),
+			onClickMenuItem: onClickMenuItem,
+		},
+		{
+			icon: tag,
+			path: '/partner-portal',
+			link: '/partner-portal/prices',
+			title: translate( 'Prices' ),
+			onClickMenuItem: onClickMenuItem,
+		},
+		{
+			icon: formatListBulletsRTL,
+			path: '/partner-portal',
+			link: '/partner-portal/company-details',
+			title: translate( 'Company Details' ),
+			onClickMenuItem: onClickMenuItem,
+		},
+	];
+	return (
+		<NewSidebar
+			isJetpackManage
+			path="/partner-portal"
+			menuItems={ menuItems }
+			description={ translate( 'Manage all your billing related settings from one place.' ) }
+			backButtonProps={ {
+				label: translate( 'Purchases' ),
+				icon: chevronLeft,
+				onClick: () => onClickMenuItem( '/dashboard' ),
+			} }
+		/>
+	);
 };
 
 export default PurchasesSidebar;


### PR DESCRIPTION
This pull request adds menu navigation items for the Purchases view in Jetpack Cloud.

Depends on #83073, https://github.com/Automattic/jetpack-genesis/issues/57.
Resolves https://github.com/Automattic/jetpack-genesis/issues/61.

## Proposed Changes

* Add a collection of new menu items in `client/jetpack-cloud/sections/sidebar-navigation/purchases.tsx`, to be passed to `NewSidbar` as the value of the `menuItems` property.
* Import icons for each new menu item, matching designs (see: `Ra0o7IPph3bCS2xUCnAusZ-fi-4354%3A9506`).

## Testing Instructions

1. With this pull request loaded in your Jetpack Cloud test environment, visit `/dashboard?flags=jetpack/new-navigation`.
2. Click the **Purchases** item in the sidebar navigation panel.
3. Verify you're sent to the **Billing** page.
4. Look over each icon in the sidebar, ensuring the icon and its label match designs (see: `Ra0o7IPph3bCS2xUCnAusZ-fi-4354%3A9506`).
5. Click each link, ensuring you're sent to the appropriate page and the navigation item is highlighted afterward.
6. Verify that the text and icon for all menu items look and behave appropriately even as the viewport is resized.

### Mobile

<img width="457" alt="image" src="https://github.com/Automattic/wp-calypso/assets/670067/7944f43c-1e68-4cf1-8354-d2961e5ffb18">

### Desktop

<img width="1111" alt="image" src="https://github.com/Automattic/wp-calypso/assets/670067/cfb1600e-47d1-45f0-904a-532ff867ea6d">