### PR TITLE
Happy Blocks: Update universal-header for Learn

### DIFF
--- a/apps/happy-blocks/block-library/universal-header/index.php
+++ b/apps/happy-blocks/block-library/universal-header/index.php
@@ -22,7 +22,7 @@ if ( isset( $args['website'] ) ) {
 }
 
 ?>
-<div id="lpc-header-nav" class="lpc lpc-header-nav <?php esc_attr( $website_clasname ); ?>">
+<div id="lpc-header-nav" class="lpc lpc-header-nav <?php echo esc_attr( $website_clasname ); ?>">
 	<div class="x-root lpc-header-nav-wrapper">
 		<div class="lpc-header-nav-container">
 			<!-- Nav bar starts here. -->
@@ -65,6 +65,13 @@ if ( isset( $args['website'] ) ) {
 								<button class="x-nav-link x-link" data-dropdown-trigger="resources" aria-haspopup="true"
 									aria-expanded="false">
 									<?php esc_html_e( 'Resources', 'happy-blocks' ); ?> <span class="x-nav-link-chevron"
+										aria-hidden="true"></span>
+								</button>
+							</li>
+							<li class="x-nav-item x-nav-item--wide" role="menuitem">
+								<button class="x-nav-link x-link" data-dropdown-trigger="learn" aria-haspopup="true"
+									aria-expanded="false">
+									<?php esc_html_e( 'Learn', 'happy-blocks' ); ?> <span class="x-nav-link-chevron"
 										aria-hidden="true"></span>
 								</button>
 							</li>
@@ -240,13 +247,6 @@ if ( isset( $args['website'] ) ) {
 					<ul role="menu">
 						<li>
 							<a role="menuitem" class="x-dropdown-link x-link"
-								href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/support/' ) ); ?>"
-								tabindex="-1">
-								<?php echo esc_html( fixme__( 'WordPress.com Support', __( 'Support', 'happy-blocks' ) ) ); ?>
-							</a>
-						</li>
-						<li>
-							<a role="menuitem" class="x-dropdown-link x-link"
 								href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/blog/' ) ); ?>"
 								tabindex="-1">
 								<?php esc_html_e( 'News', 'happy-blocks' ); ?>
@@ -294,21 +294,46 @@ if ( isset( $args['website'] ) ) {
 							<?php esc_html_e( 'Blog Search', 'happy-blocks' ); ?>
 							</a>
 						</li>
-						<?php if ( time() >= strtotime( '2021-02-17' ) ) : ?>
+					</ul>
+				</div>
+				<div class="x-dropdown-content" data-dropdown-name="learn" role="menu"
+					aria-label="<?php esc_attr_e( 'Learn', 'happy-blocks' ); ?>" aria-hidden="true">
+					<ul role="menu">
 						<li>
 							<a role="menuitem" class="x-dropdown-link x-link"
-								href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/webinars/' ) ); ?>"
+								href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/learn/' ) ); ?>"
 								tabindex="-1">
-							<?php esc_html_e( 'Daily Webinars', 'happy-blocks' ); ?>
+								<?php esc_html_e( 'Learn WordPress.com', 'happy-blocks' ); ?>
 							</a>
 						</li>
 						<li>
 							<a role="menuitem" class="x-dropdown-link x-link"
-								href="<?php echo esc_url( '//wordpress.com/learn/' ); ?>" tabindex="-1">
-							<?php esc_html_e( 'Learn WordPress', 'happy-blocks' ); ?>
+								href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/learn/webinars/' ) ); ?>"
+								tabindex="-1">
+								<?php esc_html_e( 'Webinars', 'happy-blocks' ); ?>
 							</a>
 						</li>
-						<?php endif; ?>
+						<li>
+							<a role="menuitem" class="x-dropdown-link x-link"
+								href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/learn/courses/' ) ); ?>"
+								tabindex="-1">
+								<?php esc_html_e( 'Courses', 'happy-blocks' ); ?>
+							</a>
+						</li>
+						<li>
+							<a role="menuitem" class="x-dropdown-link x-link"
+								href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/forums/' ) ); ?>"
+								tabindex="-1">
+								<?php esc_html_e( 'Community Forum', 'happy-blocks' ); ?>
+							</a>
+						</li>
+						<li>
+							<a role="menuitem" class="x-dropdown-link x-link"
+								href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/support/' ) ); ?>"
+								tabindex="-1">
+								<?php esc_html_e( 'Support Guides', 'happy-blocks' ); ?>
+							</a>
+						</li>
 					</ul>
 				</div>
 			</div>
@@ -490,13 +515,6 @@ if ( isset( $args['website'] ) ) {
 						<ul class="x-menu-grid" role="menu">
 							<li class="x-menu-grid-item">
 								<a role="menuitem" class="x-menu-link x-link"
-									href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/support/' ) ); ?>"
-									tabindex="-1">
-									<?php echo esc_html( fixme__( 'WordPress.com Support', __( 'Support', 'happy-blocks' ) ) ); ?>
-								</a>
-							</li>
-							<li class="x-menu-grid-item">
-								<a role="menuitem" class="x-menu-link x-link"
 									href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/blog/' ) ); ?>"
 									tabindex="-1">
 									<?php esc_html_e( 'News', 'happy-blocks' ); ?>
@@ -544,21 +562,48 @@ if ( isset( $args['website'] ) ) {
 								<?php esc_html_e( 'Blog Search', 'happy-blocks' ); ?>
 								</a>
 							</li>
-							<?php if ( time() >= strtotime( '2021-02-17' ) ) : ?>
+						</ul>
+					</div>
+					<div class="x-menu-list">
+						<div class="x-menu-list-title">
+							<?php esc_html_e( 'Learn', 'happy-blocks' ); ?>
+						</div>
+						<ul class="x-menu-grid" role="menu">
 							<li class="x-menu-grid-item">
 								<a role="menuitem" class="x-menu-link x-link"
-									href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/webinars/' ) ); ?>"
+									href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/learn/' ) ); ?>"
 									tabindex="-1">
-								<?php esc_html_e( 'Daily Webinars', 'happy-blocks' ); ?>
+									<?php esc_html_e( 'Learn WordPress.com', 'happy-blocks' ); ?>
 								</a>
 							</li>
 							<li class="x-menu-grid-item">
 								<a role="menuitem" class="x-menu-link x-link"
-									href="<?php echo esc_url( '//wordpress.com/learn/' ); ?>" tabindex="-1">
-								<?php esc_html_e( 'Learn WordPress', 'happy-blocks' ); ?>
+									href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/learn/webinars/' ) ); ?>"
+									tabindex="-1">
+									<?php esc_html_e( 'Webinars', 'happy-blocks' ); ?>
 								</a>
 							</li>
-							<?php endif; ?>
+							<li class="x-menu-grid-item">
+								<a role="menuitem" class="x-menu-link x-link"
+									href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/learn/courses/' ) ); ?>"
+									tabindex="-1">
+									<?php esc_html_e( 'Courses', 'happy-blocks' ); ?>
+								</a>
+							</li>
+							<li class="x-menu-grid-item">
+								<a role="menuitem" class="x-menu-link x-link"
+									href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/forums/' ) ); ?>"
+									tabindex="-1">
+									<?php esc_html_e( 'Community Forum', 'happy-blocks' ); ?>
+								</a>
+							</li>
+							<li class="x-menu-grid-item">
+								<a role="menuitem" class="x-menu-link x-link"
+									href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/support/' ) ); ?>"
+									tabindex="-1">
+									<?php esc_html_e( 'Support Guides', 'happy-blocks' ); ?>
+								</a>
+							</li>
 						</ul>
 					</div>
 				</div>


### PR DESCRIPTION
We updated the wpcom Navbar for Learn in a new folder, `universal-header-v2`, used by Learn. 
There is no more need for this separation, as Support theme is the only remaining one to use `universal-header` from happy-blocks, so this PR updates the old version to be equal to v2.

After merging this and changing Support to point to this "v1", we will remove v2.

## Testing
1. Checkout and `yarn dev --sync" after `cd apps/happy-blocks/``
2. Apply https://github.com/Automattic/wpsupport3/pull/682 to support
3. Test that the wpcom navbar has not changed

Correct navbar:
![image](https://github.com/Automattic/wp-calypso/assets/52076348/0ac5a339-c611-4c15-a0b7-c6e6a765c194)
