### PR TITLE
Theme Collections: Minor UI Fixes

### DIFF
--- a/client/components/theme-collection/index.tsx
+++ b/client/components/theme-collection/index.tsx
@@ -64,14 +64,13 @@ export default function ThemeCollection( {
 							nextEl: '.theme-collection__carousel-nav-button--next',
 							prevEl: '.theme-collection__carousel-nav-button--previous',
 						},
-						threshold: 5,
 						slideToClickedSlide: false,
 						rewind: true,
 						slidesPerView: 1.2,
 						breakpoints: {
 							// deprecated Calypso breakpoints used in the Theme Showcase
 							'660': {
-								slidesPerView: 2.2,
+								slidesPerView: 2.3,
 							},
 							// break-xlarge in Gutenberg breakpoints
 							'1080': {

--- a/client/components/theme-collection/index.tsx
+++ b/client/components/theme-collection/index.tsx
@@ -67,14 +67,17 @@ export default function ThemeCollection( {
 						slideToClickedSlide: false,
 						rewind: true,
 						slidesPerView: 1.2,
+						spaceBetween: -16,
 						breakpoints: {
 							// deprecated Calypso breakpoints used in the Theme Showcase
 							'660': {
-								slidesPerView: 2.3,
+								slidesPerView: 2.2,
+								spaceBetween: -32,
 							},
 							// break-xlarge in Gutenberg breakpoints
 							'1080': {
 								slidesPerView: 3,
+								spaceBetween: -16,
 							},
 						},
 						modules: [ Navigation, Keyboard, Mousewheel ],

--- a/client/components/theme-collection/index.tsx
+++ b/client/components/theme-collection/index.tsx
@@ -65,11 +65,12 @@ export default function ThemeCollection( {
 							prevEl: '.theme-collection__carousel-nav-button--previous',
 						},
 						threshold: 5,
-						slideToClickedSlide: true,
+						slideToClickedSlide: false,
+						rewind: true,
 						slidesPerView: 1.2,
 						breakpoints: {
-							// break-small in Gutenberg breakpoints
-							'600': {
+							// deprecated Calypso breakpoints used in the Theme Showcase
+							'660': {
 								slidesPerView: 2.2,
 							},
 							// break-xlarge in Gutenberg breakpoints
@@ -77,7 +78,6 @@ export default function ThemeCollection( {
 								slidesPerView: 3,
 							},
 						},
-						spaceBetween: 32,
 						modules: [ Navigation, Keyboard, Mousewheel ],
 					} );
 					setSwiperLoaded( true );

--- a/client/components/theme-collection/style.scss
+++ b/client/components/theme-collection/style.scss
@@ -1,3 +1,4 @@
+@import "@automattic/typography/styles/variables";
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
@@ -45,21 +46,23 @@
 
 .theme-collection__title {
 	line-height: 1;
-	font-size: 1.25rem;
-	font-weight: 400;
+	font-size: $font-body;
+	font-weight: 600;
 	color: var(--gray-gray-100, #101517);
 
 	@include break-small {
-		font-size: 1.75rem;
+		font-size: rem(24px);
+		font-weight: 400;
 	}
 }
 
 .theme-collection__description * {
 	color: var(--gray-gray-70, #3c434a);
+	font-size: $font-body-small;
 	margin-bottom: 0;
 
 	@include break-small {
-		font-size: 1rem;
+		font-size: $font-body;
 	}
 }
 
@@ -83,7 +86,7 @@
 	align-items: center;
 
 	.theme-collection__see-all {
-		font-size: 1rem;
+		font-size: $font-body-small;
 		font-style: normal;
 		font-weight: 400;
 		line-height: 20px;
@@ -100,8 +103,11 @@
 		@include break-small {
 			text-decoration: none;
 			align-items: inherit;
-			font-size: 0.875rem;
 			margin-right: 24px;
+
+			&:hover {
+				text-decoration: underline;
+			}
 		}
 	}
 

--- a/client/components/theme-collection/style.scss
+++ b/client/components/theme-collection/style.scss
@@ -115,7 +115,7 @@
 			display: flex;
 			justify-content: center;
 			margin: 0 8px;
-			transition: opacity 0.3s linear;
+			transition: filter 0.1s linear;
 			pointer-events: all;
 		}
 
@@ -125,10 +125,6 @@
 
 		&:hover {
 			filter: brightness(0.9);
-		}
-
-		&.swiper-button-disabled {
-			pointer-events: none;
 		}
 	}
 }

--- a/client/components/theme-collection/style.scss
+++ b/client/components/theme-collection/style.scss
@@ -5,12 +5,6 @@
 .theme-collection__container {
 	margin-top: 48px;
 
-	// Ensure the bottom is well padded.
-	// @see https://github.com/Automattic/wp-calypso/blob/af56132740bb9890a99a9caf55fdd4b8b38a4d50/client/layout/style.scss#L124-L132
-	@include breakpoint-deprecated( ">1400px" ) {
-		padding-bottom: 88px;
-	}
-
 	.theme-collection__list-wrapper.swiper-wrapper {
 		overflow-y: clip;
 	}

--- a/client/components/theme-collection/style.scss
+++ b/client/components/theme-collection/style.scss
@@ -5,6 +5,12 @@
 .theme-collection__container {
 	margin-top: 48px;
 
+	// Ensure the bottom is well padded.
+	// @see https://github.com/Automattic/wp-calypso/blob/af56132740bb9890a99a9caf55fdd4b8b38a4d50/client/layout/style.scss#L124-L132
+	@include breakpoint-deprecated( ">1400px" ) {
+		padding-bottom: 88px;
+	}
+
 	.theme-collection__list-wrapper.swiper-wrapper {
 		overflow-y: clip;
 	}

--- a/client/components/theme-collection/style.scss
+++ b/client/components/theme-collection/style.scss
@@ -3,15 +3,7 @@
 @import "@wordpress/base-styles/mixins";
 
 .theme-collection__container {
-	padding-bottom: 32px;
-
-	&:last-child {
-		padding-bottom: 0;
-
-		@include break-xlarge {
-			padding-bottom: 32px;
-		}
-	}
+	margin-top: 48px;
 
 	.theme-collection__list-wrapper.swiper-wrapper {
 		overflow-y: clip;

--- a/client/components/theme-collection/style.scss
+++ b/client/components/theme-collection/style.scss
@@ -61,7 +61,13 @@
 .theme-collection__list-item.swiper-slide {
 	.card.theme-card {
 		margin: 0;
-		padding: 0 16px;
+		padding-left: 16px;
+		padding-right: 16px;
+
+		@include breakpoint-deprecated( ">660px" ) {
+			padding-left: 32px;
+			padding-right: 32px;
+		}
 	}
 }
 

--- a/client/components/theme-collection/style.scss
+++ b/client/components/theme-collection/style.scss
@@ -4,10 +4,6 @@
 .theme-collection__container {
 	padding-bottom: 32px;
 
-	@include break-xlarge {
-		margin: 0 48px;
-	}
-
 	&:last-child {
 		padding-bottom: 0;
 
@@ -16,16 +12,8 @@
 		}
 	}
 
-	.theme-collection__list-wrapper {
-		padding-right: 32px;
-
-		@include break-xlarge {
-			padding-right: 0;
-		}
-
-		&.swiper-wrapper {
-			overflow-y: clip;
-		}
+	.theme-collection__list-wrapper.swiper-wrapper {
+		overflow-y: clip;
 	}
 
 	.theme-card__info-options {
@@ -78,7 +66,7 @@
 .theme-collection__list-item.swiper-slide {
 	.card.theme-card {
 		margin: 0;
-		padding: 0;
+		padding: 0 16px;
 	}
 }
 

--- a/client/my-sites/themes/collections/style.scss
+++ b/client/my-sites/themes/collections/style.scss
@@ -11,10 +11,12 @@
 			margin-right: -32px;
 		}
 
-		// Ensure the bottom is well padded.
-		// @see https://github.com/Automattic/wp-calypso/blob/af56132740bb9890a99a9caf55fdd4b8b38a4d50/client/layout/style.scss#L124-L132
-		@include breakpoint-deprecated( ">1400px" ) {
-			padding-bottom: 88px;
+		&:last-child {
+			// Ensure the bottom is well padded.
+			// @see https://github.com/Automattic/wp-calypso/blob/af56132740bb9890a99a9caf55fdd4b8b38a4d50/client/layout/style.scss#L124-L132
+			@include breakpoint-deprecated( ">1400px" ) {
+				padding-bottom: 88px;
+			}
 		}
 	}
 

--- a/client/my-sites/themes/collections/style.scss
+++ b/client/my-sites/themes/collections/style.scss
@@ -3,28 +3,33 @@
 
 .themes__showcase {
 	.theme-collection__container {
-		margin: 0 -16px;
+		margin-left: -16px;
+		margin-right: -16px;
 
 		@include breakpoint-deprecated( ">660px" ) {
-			margin: 0 -32px;
+			margin-left: -32px;
+			margin-right: -32px;
 		}
 	}
 
 	.theme-collection__meta {
-		margin: 0 16px;
+		margin-left: 16px;
+		margin-right: 16px;
 
 		@include breakpoint-deprecated( ">660px" ) {
-			margin: 0 32px;
+			margin-left: 32px;
+			margin-right: 32px;
 		}
 	}
 
 	.theme-collection__list-item.swiper-slide .card.theme-card {
 		@include breakpoint-deprecated( ">660px" ) {
-			padding: 0 0 0 32px;
+			padding-left: 32px;
 		}
 
 		@include break-xlarge {
-			padding: 0 32px;
+			padding-left: 32px;
+			padding-right: 32px;
 		}
 	}
 }

--- a/client/my-sites/themes/collections/style.scss
+++ b/client/my-sites/themes/collections/style.scss
@@ -27,15 +27,4 @@
 			margin-right: 32px;
 		}
 	}
-
-	.theme-collection__list-item.swiper-slide .card.theme-card {
-		@include breakpoint-deprecated( ">660px" ) {
-			padding-left: 32px;
-		}
-
-		@include break-xlarge {
-			padding-left: 32px;
-			padding-right: 32px;
-		}
-	}
 }

--- a/client/my-sites/themes/collections/style.scss
+++ b/client/my-sites/themes/collections/style.scss
@@ -1,0 +1,30 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.themes__showcase {
+	.theme-collection__container {
+		margin: 0 -16px;
+
+		@include breakpoint-deprecated( ">660px" ) {
+			margin: 0 -32px;
+		}
+	}
+
+	.theme-collection__meta {
+		margin: 0 16px;
+
+		@include breakpoint-deprecated( ">660px" ) {
+			margin: 0 32px;
+		}
+	}
+
+	.theme-collection__list-item.swiper-slide .card.theme-card {
+		@include breakpoint-deprecated( ">660px" ) {
+			padding: 0 0 0 32px;
+		}
+
+		@include break-xlarge {
+			padding: 0 32px;
+		}
+	}
+}

--- a/client/my-sites/themes/collections/style.scss
+++ b/client/my-sites/themes/collections/style.scss
@@ -10,6 +10,12 @@
 			margin-left: -32px;
 			margin-right: -32px;
 		}
+
+		// Ensure the bottom is well padded.
+		// @see https://github.com/Automattic/wp-calypso/blob/af56132740bb9890a99a9caf55fdd4b8b38a4d50/client/layout/style.scss#L124-L132
+		@include breakpoint-deprecated( ">1400px" ) {
+			padding-bottom: 88px;
+		}
 	}
 
 	.theme-collection__meta {

--- a/client/my-sites/themes/collections/theme-collections-layout.tsx
+++ b/client/my-sites/themes/collections/theme-collections-layout.tsx
@@ -1,6 +1,7 @@
 import { memo } from 'react';
 import { THEME_COLLECTIONS } from 'calypso/my-sites/themes/collections/collection-definitions';
 import ShowcaseThemeCollection from 'calypso/my-sites/themes/collections/showcase-theme-collection';
+import './style.scss';
 
 type OnSeeAll = {
 	tier?: string;

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -1,3 +1,4 @@
+@import "@automattic/typography/styles/variables";
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
@@ -280,7 +281,8 @@
 		}
 
 		.collection-header__title {
-			font-size: 2.75rem;
+			font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
+			font-size: rem(44px);
 			font-style: normal;
 			font-weight: 400;
 			line-height: 52px;
@@ -289,7 +291,7 @@
 
 		.collection-header__description {
 			font-family: "SF Pro Text", serif;
-			font-size: 1rem;
+			font-size: $font-body;
 			font-style: normal;
 			font-weight: 400;
 			line-height: 24px;


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/wp-calypso/pull/82987

This PR contains various smaller UI fixes on the `ThemeCollection` component and its implementation within the Logged-out Theme Showcase.

* Ensure the slides enter and leave the viewport from the edge of the screen rather than from an arbitrary boundary (typically aligned with the content container).
  * To achieve this, I've ensured the carousel overrules the content container padding and spans the entire screen width, applying the padding to the heading and slides instead.
  * The margins logic has been moved to a Showcase-specific stylesheet, so that the Collection component remains unconcerned from specific implementation details.
  * This also fixes a stray horizontal scrollbar appearing on small screens (check the Mobile/Before screenshot).
* Adjusted the font sizes to align with the latest Figma iteration (Desktop's first milestone and Mobile i3).
* Increased the spacing between collections from 32px to 48px. Also, always aligned them to the general horizontal margins (16px or 32px, depending on the screen size).
* Fixed the "See all" behaviour (as discussed privately): always underlined on mobile; only underlined on hover on large screens.
* Added a `rewind` property to the carousel, so that it's possible to loop between first and last slide, instead of having to swipe one by one.


Note for @rcrdortiz: I understand the larger horizontal margins on desktop (48px of the carousel + 32px of Showcase padding vs the current 32px) was intentional in https://github.com/Automattic/wp-calypso/pull/82987.
I agree that the larger spacing looks better, but I also think that we should keep the margins consistent across the whole view.
I'm sure the larger margin will work perfectly with the revised category list (from the Search Experience project), so we can resize once we get there.
How do you feel about it?

### Screenshots

| Width | Before | After |
|--------|--------|--------|
| >1080px | <img width="1490" alt="Screenshot 2023-10-17 at 18 09 04" src="https://github.com/Automattic/wp-calypso/assets/2070010/9c94fd2a-a2d5-4d20-abb4-5d1d10f49189"> | <img width="1490" alt="Screenshot 2023-10-17 at 18 10 04" src="https://github.com/Automattic/wp-calypso/assets/2070010/22634c16-c0a6-4190-b0f5-089640fc8f98"> |
| >660px | <img width="991" alt="Screenshot 2023-10-17 at 18 12 06" src="https://github.com/Automattic/wp-calypso/assets/2070010/ff1d812e-c3cb-4723-9a84-e36457ae9bb2"> | <img width="991" alt="Screenshot 2023-10-17 at 18 12 03" src="https://github.com/Automattic/wp-calypso/assets/2070010/5b0d9ff0-b96d-4510-9d0f-710768c56493"> |
| Mobile | <img width="529" alt="Screenshot 2023-10-17 at 18 11 24" src="https://github.com/Automattic/wp-calypso/assets/2070010/fbe5cb61-6bdd-49ac-9ae5-c5789fef2acf"> | <img width="529" alt="Screenshot 2023-10-17 at 18 10 59" src="https://github.com/Automattic/wp-calypso/assets/2070010/ee245851-a50d-4158-a3b1-7f4127088bc3"> | 

### Testing Instructions

1. Navigate to `/themes?flags=themes/discovery-lots`.
2. Play around with the screen width to check the collections always look and feel ok.
3. Ensure:
   - There is no horizontal scroll on mobile screens.
   - On large screens, the "See all" link is only underlined on hover; on mobile, it's always underlined.
4. Check that all the changes proposed in the PR work as described.