### PR TITLE
[Experiment] LoTS Discovery: Internal Navigation

### DIFF
--- a/client/my-sites/themes/collections/theme-collections-layout.tsx
+++ b/client/my-sites/themes/collections/theme-collections-layout.tsx
@@ -6,23 +6,23 @@ export interface ThemeCollectionsLayoutProps {
 	getActionLabel: ( themeId: string ) => string;
 	getOptions: ( themeId: string ) => void;
 	getScreenshotUrl: ( themeId: string ) => string;
-	onTierSelect: ( tier: string ) => void;
+	onSeeAll: ( filters: object ) => void;
 }
 
 function ThemeCollectionsLayout( props: ThemeCollectionsLayoutProps ) {
-	const { onTierSelect } = props;
+	const { onSeeAll, ...rest } = props;
 
 	return (
 		<>
 			<ShowcaseThemeCollection
 				{ ...THEME_COLLECTIONS.premium }
-				{ ...props }
-				onSeeAll={ () => onTierSelect( 'premium' ) }
+				{ ...rest }
+				onSeeAll={ () => onSeeAll( { tier: 'premium' } ) }
 			/>
 			<ShowcaseThemeCollection
 				{ ...THEME_COLLECTIONS.partner }
-				{ ...props }
-				onSeeAll={ () => onTierSelect( 'marketplace' ) }
+				{ ...rest }
+				onSeeAll={ () => onSeeAll( { tier: 'marketplace' } ) }
 			/>
 		</>
 	);

--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -70,11 +70,15 @@ export function localizeThemesPath( path, locale, isLoggedOut = true ) {
 	return path;
 }
 
-export function addOptionsToGetUrl( options, { tabFilter, styleVariationSlug } ) {
+export function addOptionsToGetUrl(
+	options,
+	{ tabFilter, styleVariationSlug, isCollectionView, tier }
+) {
 	return mapValues( options, ( option ) =>
 		Object.assign( {}, option, {
 			...( option.getUrl && {
-				getUrl: ( t ) => option.getUrl( t, { tabFilter, styleVariationSlug } ),
+				getUrl: ( t ) =>
+					option.getUrl( t, { tabFilter, styleVariationSlug, isCollectionView, tier } ),
 			} ),
 		} )
 	);

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -186,7 +186,7 @@ class ThemesSelection extends Component {
 	getOptions = ( themeId, styleVariation, context ) => {
 		let options = this.props.getOptions( themeId, styleVariation );
 
-		const { tabFilter } = this.props;
+		const { tabFilter, tier, isCollectionView } = this.props;
 		const wrappedActivateAction = ( action ) => {
 			return ( t ) => {
 				this.props.setThemePreviewOptions( themeId, null, null, { styleVariation, tabFilter } );
@@ -233,6 +233,8 @@ class ThemesSelection extends Component {
 		if ( options ) {
 			options = addOptionsToGetUrl( options, {
 				tabFilter,
+				tier,
+				isCollectionView,
 				styleVariationSlug: styleVariation?.slug,
 			} );
 			if ( options.activate ) {

--- a/client/state/themes/selectors/get-theme-details-url.js
+++ b/client/state/themes/selectors/get-theme-details-url.js
@@ -17,7 +17,7 @@ export function getThemeDetailsUrl( state, themeId, siteId, options = {} ) {
 	}
 
 	const sitePart = siteId ? `/${ getSiteSlug( state, siteId ) }` : '';
-	const { tabFilter, styleVariationSlug } = options;
+	const { isCollectionView, tabFilter, tier, styleVariationSlug } = options;
 	const searchParams = {};
 	if ( tabFilter ) {
 		searchParams.tab_filter = tabFilter;
@@ -25,6 +25,14 @@ export function getThemeDetailsUrl( state, themeId, siteId, options = {} ) {
 
 	if ( styleVariationSlug ) {
 		searchParams.style_variation = styleVariationSlug;
+	}
+
+	if ( isCollectionView ) {
+		const collectionParams = [
+			...( tier && [ `tier:${ tier }` ] ),
+			...( tabFilter && [ `filter:${ tabFilter }` ] ),
+		].join( '|' );
+		searchParams.collection_view = collectionParams;
 	}
 
 	return addQueryArgs( `/theme/${ themeId }${ sitePart }`, searchParams );


### PR DESCRIPTION
Kind of an alternative approach to #83044.

Since we are currently not interested in indexing Collection views, it might be a good idea to keep them in internal navigation instead of changing URLs, potentially letting Google index duplicated content.

This is a proof of concept, not particularly clean and elegant. These are the key bits:

- Having `ThemesSelection` use the internal state instead of the query params is (wait for it) _trivial_.
  - It's basically all about merging the (new) `filter` and `tier` in state with `themeProps` that are passed to `ThemesSelection`.
- The back navigation is even more _trivial_.
  - Just reset the state and call it a day.
  - As you might see, I haven't done any UI work beside adding the Back button for testing purpose. That's not the point of this PoC, and we can just easily reuse lots of #83044 for that.
- On the other hand, navigating back from a theme details page is absolutely mental.
  - I started drilling query params all over the place, but had to leave for the night.
  - I really hated what I was doing.
  - And it wasn't really working (for some reason, the params are appended to the `/theme` URL only for the More->Info button, but not for the actual theme card... 🤔 
  - Also, my plan of adding `?collection_view=tier:foo|filter:bar` does not scale really well if we want custom collections. I don't have a better idea, but I think this needs to be solved regardless of what kind of approach we take in the end 🤔 