### PR TITLE
Remove lodash pick() from reader/stats.js

### DIFF
--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -1,6 +1,5 @@
 import { localeRegexString } from '@automattic/i18n-utils';
 import debugFactory from 'debug';
-import { pick } from 'lodash';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import { bumpStat, bumpStatWithPageView } from 'calypso/lib/analytics/mc';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -190,11 +189,10 @@ export function recordTrackForPost( eventName, post = {}, additionalProps = {}, 
 	recordTrack( eventName, { ...getTracksPropertiesForPost( post ), ...additionalProps }, options );
 	if ( post.railcar && allowedTracksRailcarEventNames.has( eventName ) ) {
 		// check for overrides for the railcar
-		recordTracksRailcarInteract(
-			eventName,
-			post.railcar,
-			pick( additionalProps, [ 'ui_position', 'ui_algo' ] )
-		);
+		recordTracksRailcarInteract( eventName, post.railcar, {
+			ui_algo: additionalProps?.ui_algo,
+			ui_position: additionalProps?.ui_position,
+		} );
 	} else if ( process.env.NODE_ENV !== 'production' && post.railcar ) {
 		// eslint-disable-next-line no-console
 		console.warn( 'Consider allowing reader track', eventName );
@@ -212,11 +210,10 @@ export function getTracksPropertiesForPost( post = {} ) {
 }
 
 export function recordRailcar( eventName, railcar, eventProperties ) {
-	recordTracksRailcarInteract(
-		eventName,
-		railcar,
-		pick( eventProperties, [ 'ui_position', 'ui_algo' ] )
-	);
+	recordTracksRailcarInteract( eventName, railcar, {
+		ui_algo: eventProperties?.ui_algo,
+		ui_position: eventProperties?.ui_position,
+	} );
 }
 
 export function recordTrackWithRailcar( eventName, railcar, eventProperties ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* This PR refactors the code in `client/reader/stats.js` to avoid using the `pick()` function from lodash. This should hopefully reduce the bundle size slightly.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
