### PR TITLE
Reader Nudges: Add tracking to First Posts nudge

### DIFF
--- a/client/my-sites/customer-home/cards/notices/reader-first-posts/index.jsx
+++ b/client/my-sites/customer-home/cards/notices/reader-first-posts/index.jsx
@@ -1,21 +1,29 @@
 import { Card, Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
-//import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-//import { NOTICE_READER_FIRST_POSTS } from 'calypso/my-sites/customer-home/cards/constants';
+import TrackComponentView from 'calypso/lib/analytics/track-component-view';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { NOTICE_READER_FIRST_POSTS } from 'calypso/my-sites/customer-home/cards/constants';
 
 const ReaderFirstPosts = () => {
 	const translate = useTranslate();
 
 	const clickButton = () => {
-		// @TODO: Add Tracks events.
-		//recordTracksEvent( 'calypso_home_reader_first_posts_nudge_click' );
+		recordTracksEvent( 'calypso_my_home_reader_first_posts_nudge_click', {
+			id: NOTICE_READER_FIRST_POSTS,
+		} );
 
 		page.redirect( '/discover?selectedTab=firstposts' );
 	};
 
 	return (
 		<Card className="reader-first-posts__nudge">
+			<TrackComponentView
+				eventName="calypso_my_home_reader_first_posts_nudge_view"
+				eventProperties={ {
+					id: NOTICE_READER_FIRST_POSTS,
+				} }
+			/>
 			<h2>{ translate( 'Looking for inspiration?' ) }</h2>
 			<p>{ translate( 'See what other brand new sites are writing about.' ) }</p>
 			<Button primary onClick={ () => clickButton() } className="reader-first-posts__button">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #83106, #83105

## Proposed Changes

* This builds on #83106 and adds Tracks data to the card on view and click.

<img width="999" alt="Screenshot 2023-10-17 at 4 25 40 PM" src="https://github.com/Automattic/wp-calypso/assets/2124984/ba130296-28ae-48e9-b0af-97ee8a4563e2">

<img width="981" alt="Screenshot 2023-10-17 at 4 25 56 PM" src="https://github.com/Automattic/wp-calypso/assets/2124984/c071901c-e5f9-464a-914e-a33ac33a0e35">

* Also fixes the link to the First Posts tab in the Reader by using the correct query param. :) 


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR
* Navigate to `/home/siteSlug` on a recently launched site
* Open the console and log calypso:analytics events to localStorage (or use Tracks Vigilante): `localStorage.debug="calypso:analytics*"`; add this to the console then refresh the page.
* You should see the above Tracks events upon viewing the new card (`calypso_my_home_reader_first_posts_nudge_view`) as well as clicking on the primary action button (`calypso_my_home_reader_first_posts_nudge_click`) with the property `id: 'home-reader-first-posts'`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?