### PR TITLE
Domains: Include renewal price for premium domains

### DIFF
--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -139,11 +139,13 @@ class DomainProductPrice extends Component {
 	}
 
 	renderSalePrice() {
-		const { price, salePrice, translate } = this.props;
+		const { price, salePrice, renewPrice, translate } = this.props;
 
 		const className = classnames( 'domain-product-price', 'is-free-domain', 'is-sale-domain', {
 			'domain-product-price__domain-step-signup-flow': this.props.showStrikedOutPrice,
 		} );
+
+		const isRenewCostDifferent = price !== renewPrice;
 
 		return (
 			<div className={ className }>
@@ -160,12 +162,21 @@ class DomainProductPrice extends Component {
 						comment: '%(cost)s is the annual renewal price of a domain currently on sale',
 					} ) }
 				</div>
+				{ isRenewCostDifferent && (
+					<div className="domain-product-price__renewal-price">
+						{ translate( 'Renews for %(cost)s {{small}}/year{{/small}}', {
+							args: { cost: renewPrice },
+							components: { small: <small /> },
+							comment: '%(cost)s is the annual renewal price of the domain',
+						} ) }
+					</div>
+				) }
 			</div>
 		);
 	}
 
 	renderPrice() {
-		const { salePrice, showStrikedOutPrice, price, translate } = this.props;
+		const { salePrice, showStrikedOutPrice, price, renewPrice, translate } = this.props;
 		if ( salePrice ) {
 			return this.renderSalePrice();
 		}
@@ -175,6 +186,7 @@ class DomainProductPrice extends Component {
 			'domain-product-price__domain-step-signup-flow': showStrikedOutPrice,
 		} );
 		const productPriceClassName = showStrikedOutPrice ? '' : 'domain-product-price__price';
+		const isRenewCostDifferent = price !== renewPrice;
 
 		return (
 			<div className={ className }>
@@ -184,6 +196,15 @@ class DomainProductPrice extends Component {
 						components: { small: <small /> },
 					} ) }
 				</span>
+				{ isRenewCostDifferent && (
+					<div className="domain-product-price__renewal-price">
+						{ translate( 'Renews for %(cost)s {{small}}/year{{/small}}', {
+							args: { cost: renewPrice },
+							components: { small: <small /> },
+							comment: '%(cost)s is the annual renewal price of the domain',
+						} ) }
+					</div>
+				) }
 			</div>
 		);
 	}

--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -62,6 +62,23 @@ class DomainProductPrice extends Component {
 		return this.renderReskinDomainPrice();
 	}
 
+	renderRenewalPrice() {
+		const { price, renewPrice, translate } = this.props;
+		const isRenewCostDifferent = price !== renewPrice;
+
+		if ( isRenewCostDifferent ) {
+			return (
+				<div className="domain-product-price__renewal-price">
+					{ translate( 'Renews for %(cost)s {{small}}/year{{/small}}', {
+						args: { cost: renewPrice },
+						components: { small: <small /> },
+						comment: '%(cost)s is the annual renewal price of the domain',
+					} ) }
+				</div>
+			);
+		}
+	}
+
 	renderReskinFreeWithPlanText() {
 		const { isMappingProduct, translate, isCurrentPlan100YearPlan } = this.props;
 
@@ -139,13 +156,11 @@ class DomainProductPrice extends Component {
 	}
 
 	renderSalePrice() {
-		const { price, salePrice, renewPrice, translate } = this.props;
+		const { price, salePrice, translate } = this.props;
 
 		const className = classnames( 'domain-product-price', 'is-free-domain', 'is-sale-domain', {
 			'domain-product-price__domain-step-signup-flow': this.props.showStrikedOutPrice,
 		} );
-
-		const isRenewCostDifferent = price !== renewPrice;
 
 		return (
 			<div className={ className }>
@@ -162,21 +177,13 @@ class DomainProductPrice extends Component {
 						comment: '%(cost)s is the annual renewal price of a domain currently on sale',
 					} ) }
 				</div>
-				{ isRenewCostDifferent && (
-					<div className="domain-product-price__renewal-price">
-						{ translate( 'Renews for %(cost)s {{small}}/year{{/small}}', {
-							args: { cost: renewPrice },
-							components: { small: <small /> },
-							comment: '%(cost)s is the annual renewal price of the domain',
-						} ) }
-					</div>
-				) }
+				{ this.renderRenewalPrice() }
 			</div>
 		);
 	}
 
 	renderPrice() {
-		const { salePrice, showStrikedOutPrice, price, renewPrice, translate } = this.props;
+		const { salePrice, showStrikedOutPrice, price, translate } = this.props;
 		if ( salePrice ) {
 			return this.renderSalePrice();
 		}
@@ -186,7 +193,6 @@ class DomainProductPrice extends Component {
 			'domain-product-price__domain-step-signup-flow': showStrikedOutPrice,
 		} );
 		const productPriceClassName = showStrikedOutPrice ? '' : 'domain-product-price__price';
-		const isRenewCostDifferent = price !== renewPrice;
 
 		return (
 			<div className={ className }>
@@ -196,15 +202,7 @@ class DomainProductPrice extends Component {
 						components: { small: <small /> },
 					} ) }
 				</span>
-				{ isRenewCostDifferent && (
-					<div className="domain-product-price__renewal-price">
-						{ translate( 'Renews for %(cost)s {{small}}/year{{/small}}', {
-							args: { cost: renewPrice },
-							components: { small: <small /> },
-							comment: '%(cost)s is the annual renewal price of the domain',
-						} ) }
-					</div>
-				) }
+				{ this.renderRenewalPrice() }
 			</div>
 		);
 	}

--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -153,7 +153,7 @@ class DomainProductPrice extends Component {
 						components: { small: <small /> },
 					} ) }
 				</div>
-				<div className="domain-product-price__renewal-price">
+				<div className="domain-product-price__regular-price">
 					{ translate( '%(cost)s {{small}}/year{{/small}}', {
 						args: { cost: price },
 						components: { small: <small /> },

--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -15,6 +15,7 @@ class DomainProductPrice extends Component {
 	static propTypes = {
 		isLoading: PropTypes.bool,
 		price: PropTypes.string,
+		renewPrice: PropTypes.string,
 		freeWithPlan: PropTypes.bool,
 		requiresPlan: PropTypes.bool,
 		domainsWithPlansOnly: PropTypes.bool.isRequired,

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -85,13 +85,20 @@
 		margin: auto 0;
 	}
 
+	.domain-product-price__renewal-price {
+		line-height: 1.7;
+		font-size: $font-body-small;
+		color: var(--color-text-subtle);
+	}
+
 	&.is-free-domain,
 	&.is-sale-domain {
 		line-height: 1.7;
 		margin-top: 2px;
 
 		.domain-product-price__price,
-		.domain-product-price__regular-price {
+		.domain-product-price__regular-price,
+		.domain-product-price__renewal-price {
 			font-size: $font-body-small;
 			color: var(--color-text-subtle);
 		}
@@ -99,6 +106,12 @@
 		.domain-product-price__regular-price {
 			text-decoration: line-through;
 
+			small {
+				font-size: $font-body-small;
+			}
+		}
+
+		.domain-product-price__renewal-price {
 			small {
 				font-size: $font-body-small;
 			}

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -81,7 +81,7 @@
 	}
 
 	.domain-product-price__price,
-	.domain-product-price__renewal-price {
+	.domain-product-price__regular-price {
 		margin: auto 0;
 	}
 
@@ -91,12 +91,12 @@
 		margin-top: 2px;
 
 		.domain-product-price__price,
-		.domain-product-price__renewal-price {
+		.domain-product-price__regular-price {
 			font-size: $font-body-small;
 			color: var(--color-text-subtle);
 		}
 
-		.domain-product-price__renewal-price {
+		.domain-product-price__regular-price {
 			text-decoration: line-through;
 
 			small {

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -66,6 +66,7 @@ class DomainRegistrationSuggestion extends Component {
 		pendingCheckSuggestion: PropTypes.object,
 		unavailableDomains: PropTypes.array,
 		productCost: PropTypes.string,
+		renewCost: PropTypes.string,
 		productSaleCost: PropTypes.string,
 		isReskinned: PropTypes.bool,
 		domainAndPlanUpsellFlow: PropTypes.bool,
@@ -409,6 +410,7 @@ class DomainRegistrationSuggestion extends Component {
 			isFeatured,
 			suggestion: { domain_name: domain },
 			productCost,
+			renewCost,
 			productSaleCost,
 			premiumDomain,
 			showStrikedOutPrice,
@@ -428,6 +430,7 @@ class DomainRegistrationSuggestion extends Component {
 				premiumDomain={ premiumDomain }
 				priceRule={ this.getPriceRule() }
 				price={ productCost }
+				renewPrice={ renewCost }
 				salePrice={ productSaleCost }
 				domain={ domain }
 				domainsWithPlansOnly={ domainsWithPlansOnly }
@@ -455,9 +458,11 @@ const mapStateToProps = ( state, props ) => {
 
 	let productCost;
 	let productSaleCost;
+	let renewCost;
 
 	if ( isPremium ) {
 		productCost = props.premiumDomain?.cost;
+		renewCost = props.premiumDomain?.renew_cost;
 		if ( props.premiumDomain?.sale_cost ) {
 			productSaleCost = formatCurrency( props.premiumDomain?.sale_cost, currentUserCurrencyCode, {
 				stripZeros,
@@ -465,6 +470,8 @@ const mapStateToProps = ( state, props ) => {
 		}
 	} else {
 		productCost = getDomainPrice( productSlug, productsList, currentUserCurrencyCode, stripZeros );
+		// Renew cost is the same as the product cost for non-premium domains
+		renewCost = productCost;
 		productSaleCost = getDomainSalePrice(
 			productSlug,
 			productsList,
@@ -477,6 +484,7 @@ const mapStateToProps = ( state, props ) => {
 		showHstsNotice: isHstsRequired( productSlug, productsList ),
 		showDotGayNotice: isDotGayNoticeRequired( productSlug, productsList ),
 		productCost,
+		renewCost,
 		productSaleCost,
 		flowName,
 		currentUser: getCurrentUser( state ),

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -15,6 +15,7 @@ class DomainSuggestion extends Component {
 		premiumDomain: PropTypes.object,
 		priceRule: PropTypes.string,
 		price: PropTypes.string,
+		renewPrice: PropTypes.string,
 		domain: PropTypes.string,
 		hidePrice: PropTypes.bool,
 		showChevron: PropTypes.bool,
@@ -29,6 +30,7 @@ class DomainSuggestion extends Component {
 			hidePrice,
 			premiumDomain,
 			price,
+			renewPrice,
 			priceRule,
 			salePrice,
 			isSignupStep,
@@ -47,6 +49,7 @@ class DomainSuggestion extends Component {
 		return (
 			<DomainProductPrice
 				price={ price }
+				renewPrice={ renewPrice }
 				salePrice={ salePrice }
 				rule={ priceRule }
 				isSignupStep={ isSignupStep }

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -931,6 +931,7 @@ class RegisterDomainStep extends Component {
 				is_premium: data.is_premium,
 				cost: data.cost,
 				sale_cost: data.sale_cost,
+				renew_cost: data.renew_cost,
 				is_price_limit_exceeded: data.is_price_limit_exceeded,
 			} ) )
 			.catch( ( error ) => ( {

--- a/packages/wpcom-checkout/src/introductory-offer.ts
+++ b/packages/wpcom-checkout/src/introductory-offer.ts
@@ -1,4 +1,4 @@
-import { isDomainRegistration } from '@automattic/calypso-products/dist/esm';
+import { isDomainRegistration } from '@automattic/calypso-products';
 import { formatCurrency } from '@automattic/format-currency';
 import i18n from 'i18n-calypso';
 import type { ResponseCartProduct } from '@automattic/shopping-cart';

--- a/packages/wpcom-checkout/src/introductory-offer.ts
+++ b/packages/wpcom-checkout/src/introductory-offer.ts
@@ -1,3 +1,5 @@
+import { isDomainRegistration } from '@automattic/calypso-products/dist/esm';
+import { formatCurrency } from '@automattic/format-currency';
 import i18n from 'i18n-calypso';
 import type { ResponseCartProduct } from '@automattic/shopping-cart';
 
@@ -122,7 +124,7 @@ export function getItemIntroductoryOfferDisplay(
 	}
 
 	const isFreeTrial = product.item_subtotal_integer === 0;
-	const text = getIntroductoryOfferIntervalDisplay(
+	let text = getIntroductoryOfferIntervalDisplay(
 		translate,
 		product.introductory_offer_terms.interval_unit,
 		product.introductory_offer_terms.interval_count,
@@ -130,6 +132,22 @@ export function getItemIntroductoryOfferDisplay(
 		'checkout',
 		product.introductory_offer_terms.transition_after_renewal_count
 	);
+
+	if (
+		isDomainRegistration( product ) &&
+		product.item_original_cost_integer < product.item_subtotal_integer
+	) {
+		text = String(
+			translate( 'Renews for %(renewalPrice)s/year', {
+				args: {
+					renewalPrice: formatCurrency( product.item_original_cost_integer, product.currency, {
+						isSmallestUnit: true,
+						stripZeros: true,
+					} ),
+				},
+			} )
+		);
+	}
 
 	return { enabled: true, text };
 }


### PR DESCRIPTION
## Proposed Changes
Some premium domain names might have a renewal price that differs from the initial registration price. This renewal price must be displayed so the user knows when buying the domain. This PR adds these changes.

## Testing Instructions
- Go to `/domains/manage`;
- Search for a `.art` premium domain;
- For the suggestions component:
  - Confirm that you're able to see the renewal price differing from the registration price, same as in the screenshots;
  - Hack the backend to include a sale for the domains, and ensure the renewal price still gets displayed separately.
  - Ensure that all other domain components are unchanged and work the same as before.
- For the checkout and masterbar cart components:
  - Confirm that you're able to see the renewal price differing from the registration price, same as in the screenshots;

## Preview

#### Premium domain on sale 
![image](https://github.com/Automattic/wp-calypso/assets/18705930/50b5af7c-d3ae-4536-9706-bf5484cf41f6)

#### Regular premium domain
![image](https://github.com/Automattic/wp-calypso/assets/18705930/b8aac1ef-d66d-475c-b9d6-76b7f62a919d)

#### Checkout summary
![image](https://github.com/Automattic/wp-calypso/assets/18705930/9f540e64-cac7-4131-852f-f3f6c74005c0)

#### Masterbar cart
![image](https://github.com/Automattic/wp-calypso/assets/18705930/2f8683ad-8d7e-411d-b613-6cff74e9782a)

#### Domain-only flow (`/start/domain/domain-only`)
![image](https://github.com/Automattic/wp-calypso/assets/18705930/06b652f3-8746-4923-bf71-33e24e2adbd2)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?