### PR TITLE
Launchpad: Use the Wordpress Button component on the Launchpad

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/videopress.scss
+++ b/client/landing/stepper/declarative-flow/internals/videopress.scss
@@ -303,6 +303,7 @@ body.is-videopress-tv-purchase-stepper {
 		.checklist-item__task.completed.enabled:hover .checklist-item__text,
 		.checklist-item__task.completed.enabled:hover .checklist-item__checkmark,
 		.button.checklist-item__task-content:hover:not([disabled]),
+		.components-button.checklist-item__task-content:focus:not([disabled]),
 		.button.checklist-item__task-content:focus:not([disabled]) {
 			color: $videopress-theme-yellow;
 			fill: $videopress-theme-yellow;

--- a/packages/launchpad/package.json
+++ b/packages/launchpad/package.json
@@ -32,6 +32,7 @@
 		"@automattic/components": "workspace:^",
 		"@automattic/data-stores": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
+		"@wordpress/components": "^25.9.1",
 		"classnames": "^2.3.1",
 		"tslib": "^2.3.0",
 		"utility-types": "^3.10.0",

--- a/packages/launchpad/src/checklist-item/index.tsx
+++ b/packages/launchpad/src/checklist-item/index.tsx
@@ -1,4 +1,5 @@
-import { Badge, Button, Gridicon } from '@automattic/components';
+import { Badge, Gridicon } from '@automattic/components';
+import { Button } from '@wordpress/components';
 import classnames from 'classnames';
 import { translate, useRtl } from 'i18n-calypso';
 import { Task } from '../types';
@@ -28,6 +29,13 @@ const ChecklistItem = ( { task, isPrimaryAction }: { task: Task; isPrimaryAction
 	// when clicking on the task list items.
 	const buttonHref = task.useCalypsoPath && task.calypso_path ? task.calypso_path : undefined;
 
+	// The Button component does not accept the `disabled` and `href` props together.
+	// This code will only add href property if the disabled variable is false.
+	const buttonProps = {
+		disabled,
+		...( disabled ? {} : { href: buttonHref } ),
+	};
+
 	return (
 		<li
 			className={ classnames( 'checklist-item__task', {
@@ -40,20 +48,18 @@ const ChecklistItem = ( { task, isPrimaryAction }: { task: Task; isPrimaryAction
 			{ isPrimaryAction ? (
 				<Button
 					className="checklist-item__checklist-primary-button"
-					disabled={ disabled }
 					data-task={ id }
-					href={ buttonHref }
 					onClick={ handlePrimaryAction }
+					{ ...buttonProps }
 				>
 					{ title }
 				</Button>
 			) : (
 				<Button
 					className="checklist-item__task-content"
-					disabled={ disabled }
 					data-task={ id }
-					href={ buttonHref }
 					onClick={ actionDispatch }
+					{ ...buttonProps }
 				>
 					{ completed && (
 						// show checkmark for completed tasks regardless if they are disabled or kept active

--- a/packages/launchpad/src/checklist-item/style.scss
+++ b/packages/launchpad/src/checklist-item/style.scss
@@ -3,7 +3,7 @@
 @import "@automattic/typography/styles/variables";
 
 .checklist-item__task-content {
-	align-items: flex-start;
+	align-items: center;
 	background-color: transparent;
 	border-bottom: 1px solid var(--studio-gray-5);
 	border-left: none;
@@ -15,9 +15,42 @@
 	width: 100%;
 	margin: 0;
 	color: var(--color-neutral-100);
+	height: auto;
+	cursor: pointer;
+	font-family: $sans;
+	font-size: $font-body-small;
+	line-height: 22px;
+	outline: 0;
+	overflow: hidden;
+	text-decoration: none;
+
+	&:visited {
+		color: var(--color-neutral-100);
+	}
+
+	&:disabled {
+		opacity: 1;
+		color: var(--color-neutral-20);
+	}
 
 	&.is-placeholder {
 		padding: 16px 0 16px 0;
+	}
+
+	&.components-button:focus {
+		box-shadow: none;
+		outline: none;
+	}
+
+	.badge {
+		margin-left: auto;
+		background-color: var(--studio-blue-5);
+		color: var(--studio-blue-80);
+		font-size: $font-body-extra-small;
+	}
+
+	.checklist-item__chevron {
+		width: auto;
 	}
 }
 
@@ -38,18 +71,11 @@
 	}
 }
 
-.button.checklist-item__task-content:hover:not([disabled]),
-.button.checklist-item__task-content:focus:not([disabled]) {
+.components-button.checklist-item__task-content:hover:not([disabled]),
+.components-button.checklist-item__task-content:focus:not([disabled]) {
 	fill: var(--studio-blue-50);
 	color: var(--studio-blue-50);
 	border-bottom: 1px solid var(--studio-gray-5);
-}
-
-.checklist-item__task-content .badge {
-	margin-left: auto;
-	background-color: var(--studio-blue-5);
-	color: var(--studio-blue-80);
-	font-size: $font-body-extra-small;
 }
 
 .checklist-item__task-content[disabled],
@@ -68,11 +94,13 @@
 }
 
 .checklist-item__checkmark-container {
-	margin-right: 8px;
+	margin-right: 7px;
 	width: 20px;
+	display: flex;
+	margin-left: 1px;
+	margin-bottom: -2px;
 
 	.checklist-item__checkmark {
-		top: 2px;
 		vertical-align: text-bottom;
 	}
 }
@@ -199,6 +227,11 @@
 	background-color: var(--color-primary);
 	border-color: var(--color-primary);
 	color: var(--color-text-inverted);
+	justify-content: center;
+	font-size: $font-body-small;
+	height: auto;
+	line-height: 22px;
+	border: 1px solid var(--color-neutral-10);
 
 	&:hover:not([disabled]) {
 		background-color: var(--color-primary-60);
@@ -210,5 +243,12 @@
 		background-color: var(--color-primary-10);
 		border-color: var(--color-primary-10);
 		color: var(--color-text-inverted);
+	}
+
+	&.components-button:disabled {
+		opacity: 1;
+		&:hover {
+			color: var(--color-text-inverted);
+		}
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1108,6 +1108,7 @@ __metadata:
     "@automattic/components": "workspace:^"
     "@automattic/data-stores": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"
+    "@wordpress/components": ^25.9.1
     classnames: ^2.3.1
     postcss: ^8.4.5
     react: ^18.2.0


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #83046

## Proposed Changes

* Switches the Button component from `@automattic/components` package to `@wordpress/components` package. We are doing this to prevent adding the `.button` class from the `@automattic/components` Button component, which conflicts in wp-admin.
* I had to create a constant and then spread it to the Worpdress Button component because the `disabled` and `href` properties can't be added together. See: https://github.com/WordPress/gutenberg/blob/a99f3264efa305b018aeb34785706b023f1acf2c/packages/components/src/button/types.ts#L13-L15

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso Live link below or apply this PR to your local environment
* Create a new site with the Build intent
* Go through the onboarding flow until you reach the fullscreen Launchpad
* Go through the tasks and make sure it remains with the correct behavior
* Launch your site and go to the Customer Home page
* Go through the tasks on the post-launch Launchpad and make sure the actions and the disabled state continue to work as previously. You can check the disabled state on the "Verify your email" task, which is disabled if your account is already verified.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?