### PR TITLE
Headers: Replace FormattedHeader in `client/my-sites/people` with NavigationHeader

### DIFF
--- a/client/components/navigation-header/style.scss
+++ b/client/components/navigation-header/style.scss
@@ -4,7 +4,6 @@
 .navigation-header {
 	box-sizing: border-box;
 	width: 100%;
-	background-color: var(--studio-white);
 	padding: 16px 16px 0 16px;
 	margin: 0;
 

--- a/client/components/navigation-header/style.scss
+++ b/client/components/navigation-header/style.scss
@@ -4,13 +4,12 @@
 .navigation-header {
 	box-sizing: border-box;
 	width: 100%;
-	padding: 16px 16px 0 16px;
-	margin: 0;
-
+	padding: 16px;
+	margin-bottom: 32px;
 	@include break-small {
-		margin-bottom: 24px;
-		margin-top: 0;
-		padding: 0;
+
+		padding: 0 0 24px 0;
+		margin-bottom: 16px;
 	}
 
 	.breadcrumbs-back {

--- a/client/my-sites/domains/style.scss
+++ b/client/my-sites/domains/style.scss
@@ -52,9 +52,3 @@ body.is-section-domains.is-domain-plan-package-flow {
 		max-width: $break-medium;
 	}
 }
-
-@media screen and (max-width: $break-small) {
-	.is-section-domains .navigation-header {
-		margin-bottom: 10px;
-	}
-}

--- a/client/my-sites/people/edit-team-member-form/index.jsx
+++ b/client/my-sites/people/edit-team-member-form/index.jsx
@@ -4,9 +4,9 @@ import { localize } from 'i18n-calypso';
 import page from 'page';
 import { useEffect } from 'react';
 import { connect } from 'react-redux';
-import FormattedHeader from 'calypso/components/formatted-header';
 import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import useUserQuery from 'calypso/data/users/use-user-query';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { useProtectForm } from 'calypso/lib/protect-form';
@@ -61,13 +61,10 @@ export const EditTeamMemberForm = ( {
 		<Main className="edit-team-member-form">
 			<PageViewTracker path="people/edit/:site/:user" title="People > View Team Member" />
 			{ isEnabled( 'user-management-revamp' ) && (
-				<FormattedHeader
-					brandFont
-					className="people__page-heading"
-					headerText={ translate( 'Users' ) }
-					subHeaderText={ translate( 'People who have subscribed to your site and team members.' ) }
-					align="left"
-					hasScreenOptions
+				<NavigationHeader
+					navigationItems={ [] }
+					title={ translate( 'Users' ) }
+					subtitle={ translate( 'People who have subscribed to your site and team members.' ) }
 				/>
 			) }
 			<HeaderCake onClick={ goBack } isCompact>

--- a/client/my-sites/people/main.jsx
+++ b/client/my-sites/people/main.jsx
@@ -3,9 +3,9 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import titlecase from 'to-title-case';
 import EmptyContent from 'calypso/components/empty-content';
-import FormattedHeader from 'calypso/components/formatted-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import ScreenOptionsTab from 'calypso/components/screen-options-tab';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import P2TeamBanner from 'calypso/my-sites/people/p2-team-banner';
@@ -172,13 +172,10 @@ class People extends Component {
 					path={ `/people/${ filter }/:site` }
 					title={ `People > ${ titlecase( filter ) }` }
 				/>
-				<FormattedHeader
-					brandFont
-					className="people__page-heading"
-					headerText={ this.renderHeaderText() }
-					subHeaderText={ this.renderSubheaderText() }
-					align="left"
-					hasScreenOptions
+				<NavigationHeader
+					navigationItems={ [] }
+					title={ this.renderHeaderText() }
+					subtitle={ this.renderSubheaderText() }
 				/>
 				<div>
 					<PeopleSectionNav

--- a/client/my-sites/people/people-invite-details/index.jsx
+++ b/client/my-sites/people/people-invite-details/index.jsx
@@ -8,10 +8,10 @@ import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import QuerySiteInvites from 'calypso/components/data/query-site-invites';
 import EmptyContent from 'calypso/components/empty-content';
-import FormattedHeader from 'calypso/components/formatted-header';
 import HeaderCake from 'calypso/components/header-cake';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import PeopleListItem from 'calypso/my-sites/people/people-list-item';
 import { deleteInvite } from 'calypso/state/invites/actions';
@@ -169,15 +169,10 @@ export class PeopleInviteDetails extends PureComponent {
 				{ siteId && <QuerySiteInvites siteId={ siteId } /> }
 
 				{ isEnabled( 'user-management-revamp' ) && (
-					<FormattedHeader
-						brandFont
-						className="people__page-heading"
-						headerText={ translate( 'Users' ) }
-						subHeaderText={ translate(
-							'People who have subscribed to your site and team members.'
-						) }
-						align="left"
-						hasScreenOptions
+					<NavigationHeader
+						navigationItems={ [] }
+						title={ translate( 'Users' ) }
+						subtitle={ translate( 'People who have subscribed to your site and team members.' ) }
 					/>
 				) }
 

--- a/client/my-sites/people/people-invites-pending/index.tsx
+++ b/client/my-sites/people/people-invites-pending/index.tsx
@@ -3,10 +3,10 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import EmptyContent from 'calypso/components/empty-content';
-import FormattedHeader from 'calypso/components/formatted-header';
 import HeaderCake from 'calypso/components/header-cake';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import TeamInvites from 'calypso/my-sites/people/team-invites';
 import { useSelector } from 'calypso/state';
@@ -33,11 +33,10 @@ export default function PeopleInvitesPending( props: Props ) {
 				path="/people/pending-invites/:site"
 				title="People > Pending Invite People"
 			/>
-			<FormattedHeader
-				brandFont
-				className="people__page-heading"
-				headerText={ translate( 'Users' ) }
-				subHeaderText={ translate(
+			<NavigationHeader
+				navigationItems={ [] }
+				title={ translate( 'Users' ) }
+				subtitle={ translate(
 					'Invite subscribers and team members to your site and manage their access settings. {{learnMore}}Learn more{{/learnMore}}.',
 					{
 						components: {
@@ -50,8 +49,6 @@ export default function PeopleInvitesPending( props: Props ) {
 						},
 					}
 				) }
-				align="left"
-				hasScreenOptions
 			/>
 			<HeaderCake onClick={ goBack }>{ translate( 'Pending invites' ) }</HeaderCake>
 			<TeamInvites />

--- a/client/my-sites/people/people-invites/index.jsx
+++ b/client/my-sites/people/people-invites/index.jsx
@@ -6,9 +6,9 @@ import { PureComponent, Fragment } from 'react';
 import { connect } from 'react-redux';
 import QuerySiteInvites from 'calypso/components/data/query-site-invites';
 import EmptyContent from 'calypso/components/empty-content';
-import FormattedHeader from 'calypso/components/formatted-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import PeopleListItem from 'calypso/my-sites/people/people-list-item';
 import PeopleListSectionHeader from 'calypso/my-sites/people/people-list-section-header';
@@ -81,11 +81,10 @@ class PeopleInvites extends PureComponent {
 			<Main className="people-invites">
 				<PageViewTracker path="/people/invites/:site" title="People > Invites" />
 				{ siteId && <QuerySiteInvites siteId={ siteId } /> }
-				<FormattedHeader
-					brandFont
-					className="people-invites__page-heading"
-					headerText={ translate( 'Users' ) }
-					subHeaderText={ translate(
+				<NavigationHeader
+					navigationItems={ [] }
+					title={ translate( 'Users' ) }
+					subtitle={ translate(
 						'View and Manage the invites to your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 						{
 							components: {
@@ -95,7 +94,6 @@ class PeopleInvites extends PureComponent {
 							},
 						}
 					) }
-					align="left"
 				/>
 				<PeopleSectionNav
 					filter="invites"

--- a/client/my-sites/people/subscriber-details/index.tsx
+++ b/client/my-sites/people/subscriber-details/index.tsx
@@ -3,10 +3,10 @@ import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { useEffect, useState } from 'react';
 import EmptyContent from 'calypso/components/empty-content';
-import FormattedHeader from 'calypso/components/formatted-header';
 import HeaderCake from 'calypso/components/header-cake';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import useFollowerQuery from 'calypso/data/followers/use-follower-query';
 import useRemoveFollowerMutation from 'calypso/data/followers/use-remove-follower-mutation';
 import accept from 'calypso/lib/accept';
@@ -120,13 +120,10 @@ export default function SubscriberDetails( props: Props ) {
 		<Main className="people-member-details">
 			<PageViewTracker path="/people/subscribers/:site/:id" title="People > User Details" />
 
-			<FormattedHeader
-				brandFont
-				className="people__page-heading"
-				headerText={ translate( 'Users' ) }
-				subHeaderText={ translate( 'People who have subscribed to your site and team members.' ) }
-				align="left"
-				hasScreenOptions
+			<NavigationHeader
+				navigationItems={ [] }
+				title={ translate( 'Users' ) }
+				subtitle={ translate( 'People who have subscribed to your site and team members.' ) }
 			/>
 
 			<HeaderCake isCompact onClick={ onBackClick }>

--- a/client/my-sites/people/subscribers-team/index.tsx
+++ b/client/my-sites/people/subscribers-team/index.tsx
@@ -1,9 +1,9 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
-import FormattedHeader from 'calypso/components/formatted-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { JetpackConnectionHealthBanner } from 'calypso/components/jetpack/connection-health';
 import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import ScreenOptionsTab from 'calypso/components/screen-options-tab';
 import SectionNav from 'calypso/components/section-nav';
 import useFollowersQuery from 'calypso/data/followers/use-followers-query';
@@ -59,11 +59,10 @@ function SubscribersTeam( props: Props ) {
 			{ isJetpack && isPossibleJetpackConnectionProblem && site?.ID && (
 				<JetpackConnectionHealthBanner siteId={ site.ID } />
 			) }
-			<FormattedHeader
-				brandFont
-				className="people__page-heading"
-				headerText={ translate( 'Users' ) }
-				subHeaderText={ translate(
+			<NavigationHeader
+				navigationItems={ [] }
+				title={ translate( 'Users' ) }
+				subtitle={ translate(
 					'Invite team members to your site and manage their access settings. {{learnMore}}Learn more{{/learnMore}}.',
 					{
 						components: {
@@ -76,8 +75,6 @@ function SubscribersTeam( props: Props ) {
 						},
 					}
 				) }
-				align="left"
-				hasScreenOptions
 			/>
 			<div>
 				<SectionNav>

--- a/client/my-sites/people/viewer-details/index.tsx
+++ b/client/my-sites/people/viewer-details/index.tsx
@@ -4,10 +4,10 @@ import page from 'page';
 import { useEffect, useState } from 'react';
 import QuerySiteInvites from 'calypso/components/data/query-site-invites';
 import EmptyContent from 'calypso/components/empty-content';
-import FormattedHeader from 'calypso/components/formatted-header';
 import HeaderCake from 'calypso/components/header-cake';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import useRemoveViewer from 'calypso/data/viewers/use-remove-viewer-mutation';
 import useViewerQuery from 'calypso/data/viewers/use-viewer-query';
 import accept from 'calypso/lib/accept';
@@ -119,13 +119,10 @@ export default function ViewerDetails( props: Props ) {
 			<PageViewTracker path="/people/viewers/:site/:id" title="People > User Details" />
 			{ site?.ID && <QuerySiteInvites siteId={ site?.ID } /> }
 
-			<FormattedHeader
-				brandFont
-				className="people__page-heading"
-				headerText={ translate( 'Users' ) }
-				subHeaderText={ translate( 'People who have subscribed to your site and team members.' ) }
-				align="left"
-				hasScreenOptions
+			<NavigationHeader
+				navigationItems={ [] }
+				title={ translate( 'Users' ) }
+				subtitle={ translate( 'People who have subscribed to your site and team members.' ) }
 			/>
 
 			<HeaderCake isCompact onClick={ onBackClick }>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4221

## Proposed Changes

* This PR removes the CSS background color from the `<NavigationHeader>` component, making it transparent.
* This PR also replaces all occurrences of `<FormattedHeader>` in `client/my-sites/people` with `<NavigationHeader>` 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Load this PR and check the following URLS to ensure the header still works correctly.

* http://calypso.localhost:3000/people/team/ [site] 
* http://calypso.localhost:3000/people/edit/ [site] / [username]
* http://calypso.localhost:3000/people/viewers/ [site] / [id] <- The subscriber ID doesn't have to exist to access this page. You can use a random string.
* http://calypso.localhost:3000/people/invites/ [site] 
* http://calypso.localhost:3000/people/invites/ [site] / [inviteId] <- The invite ID doesn't have to exist to access this page. You can use a random string.
* http://calypso.localhost:3000/people/pending-invites/ [site]
* http://calypso.localhost:3000/people/team/ [site] ?flags=-user-management-revamp <- Note the flag removal. This is an old version of the page.
* http://calypso.localhost:3000/people/subscribers/ [site] / [id] <- The subscriber ID doesn't have to exist to access this page. You can use a random string.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?