### PR TITLE
Launchpad: Use the Wordpress Button component on the Navigator

### DIFF
--- a/packages/launchpad-navigator/package.json
+++ b/packages/launchpad-navigator/package.json
@@ -33,6 +33,7 @@
 		"@automattic/data-stores": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/launchpad": "workspace:^",
+		"@wordpress/components": "^25.7.0",
 		"classnames": "^2.3.1",
 		"i18n-calypso": "workspace:^",
 		"tslib": "^2.3.0",

--- a/packages/launchpad-navigator/package.json
+++ b/packages/launchpad-navigator/package.json
@@ -33,7 +33,7 @@
 		"@automattic/data-stores": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/launchpad": "workspace:^",
-		"@wordpress/components": "^25.7.0",
+		"@wordpress/components": "^25.9.1",
 		"classnames": "^2.3.1",
 		"i18n-calypso": "workspace:^",
 		"tslib": "^2.3.0",

--- a/packages/launchpad-navigator/package.json
+++ b/packages/launchpad-navigator/package.json
@@ -33,6 +33,7 @@
 		"@automattic/data-stores": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/launchpad": "workspace:^",
+		"@wordpress/components": "^25.9.1",
 		"classnames": "^2.3.1",
 		"i18n-calypso": "workspace:^",
 		"tslib": "^2.3.0",

--- a/packages/launchpad-navigator/package.json
+++ b/packages/launchpad-navigator/package.json
@@ -33,7 +33,6 @@
 		"@automattic/data-stores": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/launchpad": "workspace:^",
-		"@wordpress/components": "^25.9.1",
 		"classnames": "^2.3.1",
 		"i18n-calypso": "workspace:^",
 		"tslib": "^2.3.0",

--- a/packages/launchpad-navigator/src/floating-navigator/index.tsx
+++ b/packages/launchpad-navigator/src/floating-navigator/index.tsx
@@ -31,7 +31,6 @@ const FloatingNavigator = ( { siteSlug, toggleLaunchpadIsVisible }: FloatingNavi
 				<h2>{ translate( 'Next steps for your site' ) }</h2>
 				<Button
 					aria-label={ translate( 'Close task list modal' ) }
-					// borderless
 					className="launchpad-navigator__floating-navigator-close-button"
 					onClick={ () => setLaunchpadIsVisible( false ) }
 				>

--- a/packages/launchpad-navigator/src/floating-navigator/index.tsx
+++ b/packages/launchpad-navigator/src/floating-navigator/index.tsx
@@ -1,6 +1,7 @@
-import { Card, Button, Gridicon } from '@automattic/components';
+import { Card, Gridicon } from '@automattic/components';
 import { LaunchpadNavigator } from '@automattic/data-stores';
 import { DefaultWiredLaunchpad } from '@automattic/launchpad';
+import { Button } from '@wordpress/components';
 import { select } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 
@@ -30,7 +31,7 @@ const FloatingNavigator = ( { siteSlug, toggleLaunchpadIsVisible }: FloatingNavi
 				<h2>{ translate( 'Next steps for your site' ) }</h2>
 				<Button
 					aria-label={ translate( 'Close task list modal' ) }
-					borderless
+					// borderless
 					className="launchpad-navigator__floating-navigator-close-button"
 					onClick={ () => setLaunchpadIsVisible( false ) }
 				>
@@ -43,7 +44,9 @@ const FloatingNavigator = ( { siteSlug, toggleLaunchpadIsVisible }: FloatingNavi
 				launchpadContext={ launchpadContext }
 			/>
 			<div className="launchpad-navigator__floating-navigator-actions">
-				<Button disabled>{ translate( 'Older tasks' ) }</Button>
+				<Button disabled variant="secondary">
+					{ translate( 'Older tasks' ) }
+				</Button>
 			</div>
 		</Card>
 	);

--- a/packages/launchpad-navigator/src/floating-navigator/style.scss
+++ b/packages/launchpad-navigator/src/floating-navigator/style.scss
@@ -34,4 +34,11 @@
 		display: flex;
 		margin-top: 1em;
 	}
+
+	.launchpad-navigator__floating-navigator-close-button {
+		&:focus {
+			outline: none;
+			box-shadow: none;
+		}
+	}
 }

--- a/packages/launchpad-navigator/src/floating-navigator/style.scss
+++ b/packages/launchpad-navigator/src/floating-navigator/style.scss
@@ -33,9 +33,16 @@
 	.launchpad-navigator__floating-navigator-actions {
 		display: flex;
 		margin-top: 1em;
+		.components-button {
+			padding: 8px 14px;
+			font-size: $font-body-small;
+			line-height: 24px;
+			height: auto;
+		}
 	}
 
 	.launchpad-navigator__floating-navigator-close-button {
+		padding: 4px 0;
 		&:focus {
 			outline: none;
 			box-shadow: none;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1077,6 +1077,7 @@ __metadata:
     "@automattic/data-stores": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"
     "@automattic/launchpad": "workspace:^"
+    "@wordpress/components": ^25.9.1
     classnames: ^2.3.1
     i18n-calypso: "workspace:^"
     postcss: ^8.4.5


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #83046

## Proposed Changes

* Switches the Button component from `@automattic/components` package to `@wordpress/components` package. We are doing this to prevent adding the `.button` class from the @automattic/components Button component, which conflicts in wp-admin.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso Live link below or apply this PR to your local environment
* On a site with the Build intent, navigate to `/home/:siteSlug?flags=launchpad/navigator`
* Click on the progress ring on the master bar and ensure the Navigator is shown
* Make sure the "Older Tasks" button is disabled and looks like expected
* Use the `X` button to close the modal, and make sure it looks like expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?