### PR TITLE
ActivityLog: Add message when filters return empty results in Jetpack Cloud

### DIFF
--- a/client/components/activity-card-list/index.jsx
+++ b/client/components/activity-card-list/index.jsx
@@ -9,6 +9,7 @@ import QueryJetpackCredentialsStatus from 'calypso/components/data/query-jetpack
 import QueryRewindCapabilities from 'calypso/components/data/query-rewind-capabilities';
 import QueryRewindPolicies from 'calypso/components/data/query-rewind-policies';
 import QueryRewindState from 'calypso/components/data/query-rewind-state';
+import EmptyContent from 'calypso/components/empty-content';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import Pagination from 'calypso/components/pagination';
 import { withApplySiteOffset } from 'calypso/components/site-offset';
@@ -148,6 +149,7 @@ class ActivityCardList extends Component {
 			userLocale,
 			availableActions,
 			onClickClone,
+			siteSlug,
 		} = this.props;
 
 		const today = ( applySiteOffset ?? moment )();
@@ -163,6 +165,19 @@ class ActivityCardList extends Component {
 				: 'activity-card-list__secondary-card';
 
 		const dateFormat = userLocale === 'en' ? 'MMM Do' : 'LL';
+
+		if ( pageLogs.length === 0 ) {
+			return (
+				<>
+					<EmptyContent
+						title={ translate( 'No matching events found.' ) }
+						line={ translate( 'Try adjusting your date range or activity type filters' ) }
+						action={ translate( 'Remove all filters' ) }
+						actionURL={ '/activity-log/' + siteSlug }
+					/>
+				</>
+			);
+		}
 
 		return pageLogs.map( ( { date, logs: dateLogs, hasMore }, index ) => (
 			<div key={ `activity-card-list__date-group-${ index }` }>

--- a/client/my-sites/activity/filterbar/text-selector.tsx
+++ b/client/my-sites/activity/filterbar/text-selector.tsx
@@ -1,8 +1,8 @@
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { TextControl } from '@wordpress/components';
-import { useState } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
-import React, { FunctionComponent, useEffect } from 'react';
+import React, { FunctionComponent } from 'react';
 import { useDispatch } from 'react-redux';
 import { updateFilter } from 'calypso/state/activity-log/actions';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';

--- a/client/my-sites/activity/filterbar/text-selector.tsx
+++ b/client/my-sites/activity/filterbar/text-selector.tsx
@@ -2,7 +2,7 @@ import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { TextControl } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { updateFilter } from 'calypso/state/activity-log/actions';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
@@ -20,6 +20,14 @@ const TextSelector: FunctionComponent< Props > = ( { siteId, filter } ) => {
 	const isMobile = useMobileBreakpoint();
 
 	const [ searchQuery, setSearchQuery ] = useState( filter.textSearch || '' );
+
+	useEffect( () => {
+		// If the filter is cleared, clear the search query
+		if ( ! filter.textSearch ) {
+			setSearchQuery( '' );
+		}
+	}, [ filter.textSearch ] );
+
 	const dispatch = useDispatch() as CalypsoDispatch;
 	const onKeyDown = ( event: React.KeyboardEvent< HTMLInputElement > ) => {
 		const { value } = event.currentTarget;


### PR DESCRIPTION
Related to https://github.com/Automattic/jetpack-roadmap/issues/671

## Proposed Changes

* Add message when filters return empty results in Jetpack Cloud, similar to how it behaves in Calypso Blue

| Before | After |
|---|---|
| ![image](https://github.com/Automattic/wp-calypso/assets/1488641/e1eaccb1-8cb9-4157-bfd0-e7ead9294ad3) | ![image](https://github.com/Automattic/wp-calypso/assets/1488641/109965a7-bb90-4521-af9a-7269e099b131) |

## Testing Instructions
* Spin up a Jetpack Cloud live branch and visit the Activity Log
* Try searching for something that doesn't exist, so you can force the Activity Log search to return an empty result
* Validate it displays the `No matching events found` message, similar to the `After` screenshot shared above.
* Click on `Remove all filters` and ensure the URL removes the query arguments, all filters are gone and it displays the default results (the same you saw when you loaded the page the first time). 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?