### PR TITLE
correct how the backup retention disclaimer shows on the jetpack pricing page

### DIFF
--- a/client/components/jetpack/jetpack-product-info/hooks/use-included-product-description-map.tsx
+++ b/client/components/jetpack/jetpack-product-info/hooks/use-included-product-description-map.tsx
@@ -28,7 +28,7 @@ export const useIncludedProductDescriptionMap = ( productSlug: string ) => {
 
 	return useMemo( (): Record< string, ProductDescription > => {
 		const backupDescription = translate(
-			'Real-time backups as you edit. {{span}}30-day{{/span}} activity log archive. Unlimited one-click restores.',
+			'Real-time backups as you edit. {{span}}30-day{{/span}} activity log archive *. Unlimited one-click restores.',
 			{
 				components: {
 					span: <span />,
@@ -36,7 +36,7 @@ export const useIncludedProductDescriptionMap = ( productSlug: string ) => {
 			}
 		);
 		const backupT2Description = translate(
-			'Real-time backups as you edit. {{span}}1-year{{/span}} activity log archive. Unlimited one-click restores.',
+			'Real-time backups as you edit. {{span}}1-year{{/span}} activity log archive *. Unlimited one-click restores.',
 			{
 				components: {
 					span: <span />,

--- a/client/components/jetpack/jetpack-product-info/hooks/use-included-product-description-map.tsx
+++ b/client/components/jetpack/jetpack-product-info/hooks/use-included-product-description-map.tsx
@@ -28,7 +28,7 @@ export const useIncludedProductDescriptionMap = ( productSlug: string ) => {
 
 	return useMemo( (): Record< string, ProductDescription > => {
 		const backupDescription = translate(
-			'Real-time backups as you edit. {{span}}30-day{{/span}} activity log archive *. Unlimited one-click restores.',
+			'Real-time backups as you edit. {{span}}30-day{{/span}} activity log archive*. Unlimited one-click restores.',
 			{
 				components: {
 					span: <span />,
@@ -36,7 +36,7 @@ export const useIncludedProductDescriptionMap = ( productSlug: string ) => {
 			}
 		);
 		const backupT2Description = translate(
-			'Real-time backups as you edit. {{span}}1-year{{/span}} activity log archive *. Unlimited one-click restores.',
+			'Real-time backups as you edit. {{span}}1-year{{/span}} activity log archive*. Unlimited one-click restores.',
 			{
 				components: {
 					span: <span />,

--- a/client/my-sites/plans/jetpack-plans/slug-to-selector-product.ts
+++ b/client/my-sites/plans/jetpack-plans/slug-to-selector-product.ts
@@ -104,21 +104,8 @@ function slugToItem( slug: string ): Plan | Product | SelectorProduct | null | u
 }
 
 function getDisclaimerLink() {
-	const backupStorageFaqId = 'backup-storage-limits-faq';
-
-	const urlParams = new URLSearchParams( window.location.search );
-	const calypsoEnv = urlParams.get( 'calypso_env' );
-	// Check to see if FAQ is on the current page
-	// This is so we can anchor link to it instead of opening a new window if it is on the page already
-	const backupStorageFaq = document.getElementById( backupStorageFaqId );
-
-	if ( backupStorageFaq ) {
-		return `#${ backupStorageFaqId }`;
-	}
-
-	return calypsoEnv === 'development'
-		? `http://jetpack.cloud.localhost:3000/pricing#${ backupStorageFaqId }`
-		: `https://cloud.jetpack.com/pricing#${ backupStorageFaqId }`;
+	const backupStorageFaqId = 'backup-storage-limits-lightbox-faq';
+	return `#${ backupStorageFaqId }`;
 }
 
 function getFeaturedProductDescription( item: Product ) {

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -443,6 +443,8 @@ import {
 	FEATURE_AI_ASSISTED_PRODUCT_DESCRIPTION,
 	TYPE_HOSTING_TRIAL,
 	GROUP_P2,
+	FEATURE_JETPACK_30_DAY_ARCHIVE_ACTIVITY_LOG,
+	FEATURE_JETPACK_1_YEAR_ARCHIVE_ACTIVITY_LOG,
 } from './constants';
 import type {
 	BillingTerm,
@@ -2238,6 +2240,7 @@ const getPlanJetpackSecurityT1Details = (): IncompleteJetpackPlan => ( {
 		FEATURE_JETPACK_REAL_TIME_MALWARE_SCANNING,
 		FEATURE_ANTISPAM_V2,
 		FEATURE_WAF,
+		FEATURE_JETPACK_30_DAY_ARCHIVE_ACTIVITY_LOG,
 	],
 	getIncludedFeatures: () => [
 		FEATURE_JETPACK_BACKUP_T1_BI_YEARLY,
@@ -2276,6 +2279,13 @@ const getPlanJetpackSecurityT1Details = (): IncompleteJetpackPlan => ( {
 const getPlanJetpackSecurityT2Details = (): IncompleteJetpackPlan => ( {
 	...getPlanJetpackSecurityT1Details(),
 	type: TYPE_SECURITY_T2,
+	getPlanCardFeatures: () => [
+		FEATURE_PLAN_SECURITY_DAILY,
+		FEATURE_PRODUCT_BACKUP_REALTIME_V2,
+		FEATURE_PRODUCT_SCAN_REALTIME_V2,
+		FEATURE_WAF,
+		FEATURE_JETPACK_1_YEAR_ARCHIVE_ACTIVITY_LOG,
+	],
 	getIncludedFeatures: () => [
 		FEATURE_JETPACK_BACKUP_T2_YEARLY,
 		FEATURE_JETPACK_BACKUP_T2_MONTHLY,
@@ -2333,6 +2343,7 @@ const getPlanJetpackCompleteDetails = (): IncompleteJetpackPlan => ( {
 		FEATURE_JETPACK_PRODUCT_VIDEOPRESS,
 		FEATURE_PRODUCT_SEARCH_V2,
 		FEATURE_CRM_V2,
+		FEATURE_JETPACK_1_YEAR_ARCHIVE_ACTIVITY_LOG,
 	],
 	getIncludedFeatures: () =>
 		compact( [

--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -582,9 +582,7 @@ export const getJetpackProductDisclaimers = (
 
 	/* Checks if any slugs of featues on the current Product match a set of slugs provided to this function. This determines whether or not to show the disclaimer based on whether the features the disclaimer is for is present */
 	const doesProductHaveCompatibleSlug = ( slugsToCheckFor: string[] ) => {
-		const combinedFeatureSlugs = featureSlugs.concat( slugsToCheckFor );
-
-		return new Set( combinedFeatureSlugs ).size !== combinedFeatureSlugs.length;
+		return slugsToCheckFor.some( ( slug ) => featureSlugs.includes( slug ) );
 	};
 
 	const getLink = () => {
@@ -620,6 +618,9 @@ export const getJetpackProductDisclaimers = (
 		[ PLAN_JETPACK_SECURITY_T1_MONTHLY ]: backupDisclaimer,
 		[ PLAN_JETPACK_SECURITY_T2_YEARLY ]: backupDisclaimer,
 		[ PLAN_JETPACK_SECURITY_T2_MONTHLY ]: backupDisclaimer,
+		[ PLAN_JETPACK_COMPLETE_BI_YEARLY ]: backupDisclaimer,
+		[ PLAN_JETPACK_COMPLETE ]: backupDisclaimer,
+		[ PLAN_JETPACK_COMPLETE_MONTHLY ]: backupDisclaimer,
 		[ PRODUCT_JETPACK_MONITOR_YEARLY ]: monitorDisclaimer,
 		[ PRODUCT_JETPACK_MONITOR_MONTHLY ]: monitorDisclaimer,
 	};
@@ -1006,8 +1007,8 @@ export const getJetpackProductsWhatIsIncluded = (): Record< string, Array< Trans
 		}
 	);
 
-	const backupIncludesInfoT1Log = translate( '30-day activity log archive' );
-	const backupIncludesInfoT2Log = translate( '{{strong}}1 year{{/strong}} activity log archive', {
+	const backupIncludesInfoT1Log = translate( '30-day activity log archive *' );
+	const backupIncludesInfoT2Log = translate( '{{strong}}1 year{{/strong}} activity log archive *', {
 		components: {
 			strong: <strong />,
 		},
@@ -1520,7 +1521,7 @@ export const getJetpackProductsFAQs = (
 
 	const backupFAQs: Array< FAQ > = [
 		{
-			id: 'backup-storage-limits',
+			id: 'backup-storage-limits-lightbox',
 			question: translate( 'How do backup storage limits work?' ),
 			answer: translate(
 				'If your backup storage limit is reached, older backups will be deleted and, depending on your site’s size, the backup retention period (archive) might be reduced to %(monthlyDays)d days. This will affect how far back you can see backups in your activity log. Existing backups can still be restored, but new updates won’t be backed up until you upgrade or free up storage.',


### PR DESCRIPTION
## Proposed Changes

* This diff updates the backup retention disclaimer on the Jetpack pricing page to show correctly on Backup, Security and Complete detail modals.

## Testing Instructions

* Locally or using the Calypso live link, navigate to the /pricing page in Jetpack Cloud.
* Click on "More about Security" in the Security product card.
* Note that the mention of the activity log associated with the backup product should now have an asterik
![Screenshot 2023-10-17 at 6 02 12 PM](https://github.com/Automattic/wp-calypso/assets/18016357/a7b04df8-7c8a-4541-ad60-8b5fdd2af062)
* The corresponding disclaimer should show at the bottom of the modal
![Screenshot 2023-10-17 at 6 01 36 PM](https://github.com/Automattic/wp-calypso/assets/18016357/f45214b4-d239-4f0c-b2be-7d18e1779a3f)
* Clicking on "Learn More" should open the collapsed FAQ item within the modal
![Screenshot 2023-10-17 at 6 01 42 PM](https://github.com/Automattic/wp-calypso/assets/18016357/686dabca-e1c2-4e0a-b2c3-74aaf3402065)

*Repeat the same test for "More about Complete" and "More about VaultPress Backup" on the Complete and Backup product cards. Confirm that the disclaimer is present and toggles the correct FAQ item.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?