### PR TITLE
Purchase Management: Add subscription end date to purchase meta

### DIFF
--- a/client/me/purchases/manage-purchase/purchase-meta-end-date.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-end-date.tsx
@@ -1,0 +1,22 @@
+import { useTranslate } from 'i18n-calypso';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import type { Purchase } from 'calypso/lib/purchases/types';
+
+function PurchaseMetaEndDate( { purchase }: { purchase: Purchase } ) {
+	const translate = useTranslate();
+	const moment = useLocalizedMoment();
+	const dateSpan = <span className="manage-purchase__detail-date-span" />;
+
+	const subsEndDateText = translate( 'Paid through {{dateSpan}}%(expireDate)s{{/dateSpan}}', {
+		args: {
+			expireDate: moment( purchase.expiryDate ).format( 'LL' ),
+		},
+		components: {
+			dateSpan,
+		},
+	} );
+
+	return <span>{ subsEndDateText }</span>;
+}
+
+export default PurchaseMetaEndDate;

--- a/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
@@ -6,8 +6,10 @@ import {
 	isJetpackProduct,
 	JETPACK_LEGACY_PLANS,
 } from '@automattic/calypso-products';
+import { localizeUrl } from '@automattic/i18n-utils';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import {
 	hasPaymentMethod,
@@ -152,6 +154,14 @@ function PurchaseMetaExpiration( {
 					} ) }
 				>
 					{ subsBillingText }
+					<InlineSupportLink
+						showText={ false }
+						supportPostId={ 267092 }
+						iconSize={ 16 }
+						supportLink={ localizeUrl(
+							'https://wordpress.com/support/manage-purchases/automatic-renewal/#when-renewal-occurs'
+						) }
+					/>
 				</span>
 				{ ! isAutorenewalEnabled &&
 					! hideAutoRenew &&

--- a/client/me/purchases/manage-purchase/purchase-meta.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.tsx
@@ -29,6 +29,7 @@ import { getByPurchaseId } from 'calypso/state/purchases/selectors';
 import { getSite, isRequestingSites } from 'calypso/state/sites/selectors';
 import { managePurchase } from '../paths';
 import { isAkismetTemporarySitePurchase, isTemporarySitePurchase } from '../utils';
+import PurchaseMetaEndDate from './purchase-meta-end-date';
 import PurchaseMetaExpiration from './purchase-meta-expiration';
 import PurchaseMetaIntroductoryOfferDetail from './purchase-meta-introductory-offer-detail';
 import PurchaseMetaOwner from './purchase-meta-owner';
@@ -90,6 +91,12 @@ export default function PurchaseMeta( {
 					<span className="manage-purchase__detail">
 						<PurchaseMetaPrice purchase={ purchase } />
 						<PurchaseMetaIntroductoryOfferDetail purchase={ purchase } />
+					</span>
+				</li>
+				<li>
+					<em className="manage-purchase__detail-label"> Subscription End Date </em>
+					<span className="manage-purchase__detail">
+						<PurchaseMetaEndDate purchase={ purchase } />
 					</span>
 				</li>
 				<PurchaseMetaExpiration

--- a/client/me/purchases/manage-purchase/purchase-meta.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.tsx
@@ -93,12 +93,14 @@ export default function PurchaseMeta( {
 						<PurchaseMetaIntroductoryOfferDetail purchase={ purchase } />
 					</span>
 				</li>
-				<li>
-					<em className="manage-purchase__detail-label"> Subscription End Date </em>
-					<span className="manage-purchase__detail">
-						<PurchaseMetaEndDate purchase={ purchase } />
-					</span>
-				</li>
+				{ purchase.expiryDate && (
+					<li>
+						<em className="manage-purchase__detail-label"> Subscription End Date </em>
+						<span className="manage-purchase__detail">
+							<PurchaseMetaEndDate purchase={ purchase } />
+						</span>
+					</li>
+				) }
 				<PurchaseMetaExpiration
 					purchase={ purchase }
 					site={ site ?? undefined }

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -347,6 +347,10 @@
 	&.is-expiring .manage-purchase__detail-date-span {
 		color: var(--studio-pink-50);
 	}
+
+	& .inline-support-link {
+		display: inline;
+	}
 }
 
 .manage-purchase__detail .user__name {


### PR DESCRIPTION
There has been https://github.com/Automattic/wp-calypso/issues/81947 around adding a column for the subscription end date to our existing purchase management page.

Related to #81947 

## Proposed Changes

- This PR adds a new purchase meta column and prints out the subscription's expiry date to notify customers that they have "Paid through _x date_".

Examples (ignore icon spacing, this will be fixed later):

**Auto renewal ON**

![image](https://github.com/Automattic/wp-calypso/assets/16580129/8f7b77ab-9b91-41b6-96be-3229e8d4f15e)

**Auto renewal OFF**

![image](https://github.com/Automattic/wp-calypso/assets/16580129/3215a831-fc34-49e6-9803-4c1c1986e2bc)


## Testing Instructions

* Go to `/me/purchases` and click through a variety of purchases
* These changes should only show for subscriptions and domains (i.e purchases with an expiration)
* You'll want to check that the `subscription end date` and `subscription renewal` columns make sense and aid in the clarity of the subscription terms for our customers
* Test the `?` icon in the `subscription renewal` column, make sure it properly loads the help center and shows the "When Renewal Occurs" section of the automatic renewal docs. (Note, I believe there is a slight styling bug in the way we display anchor points in the help center preview. You'll notice that the content loads a few pixels further down the page than the anchored header, so it may not be seen unless you scroll up)

One thing to look out for is any subscription that does not have an expiration date. Most (if not all) cases should be handled, but if you see one like the following image then you'll want to report that:

![image](https://github.com/Automattic/wp-calypso/assets/16580129/0f3ac208-954b-4372-9b99-7257d6c8435a)

Note the 'Paid through Invalid date'.
