### PR TITLE
Stats: use date input as temporary datepicker

### DIFF
--- a/client/my-sites/stats/stats-date-control/stats-date-control-date-input.tsx
+++ b/client/my-sites/stats/stats-date-control/stats-date-control-date-input.tsx
@@ -2,7 +2,7 @@ import moment from 'moment';
 import React from 'react';
 
 interface Props {
-	id?: string;
+	id: string;
 	value: string;
 	onChange?: ( value: string ) => void;
 	max?: string;

--- a/client/my-sites/stats/stats-date-control/stats-date-control-date-input.tsx
+++ b/client/my-sites/stats/stats-date-control/stats-date-control-date-input.tsx
@@ -1,0 +1,27 @@
+import moment from 'moment';
+import React from 'react';
+
+interface Props {
+	id?: string;
+	value: string;
+	onChange?: ( value: string ) => void;
+	max?: string;
+}
+
+const DateInput: React.FC< Props > = ( { value, onChange, id } ) => {
+	const handleChange = ( event: React.ChangeEvent< HTMLInputElement > ) => {
+		onChange && onChange( event.target.value );
+	};
+
+	return (
+		<input
+			id={ id }
+			type="date"
+			value={ value }
+			onChange={ handleChange }
+			max={ moment().format( 'YYYY-MM-DD' ) }
+		/>
+	);
+};
+
+export default DateInput;

--- a/client/my-sites/stats/stats-date-control/stats-date-control-date-input.tsx
+++ b/client/my-sites/stats/stats-date-control/stats-date-control-date-input.tsx
@@ -8,20 +8,17 @@ interface Props {
 	max?: string;
 }
 
-const DateInput: React.FC< Props > = ( { value, onChange, id } ) => {
+const DateInput: React.FC< Props > = ( {
+	value,
+	onChange,
+	id,
+	max = moment().format( 'YYYY-MM-DD' ),
+} ) => {
 	const handleChange = ( event: React.ChangeEvent< HTMLInputElement > ) => {
 		onChange && onChange( event.target.value );
 	};
 
-	return (
-		<input
-			id={ id }
-			type="date"
-			value={ value }
-			onChange={ handleChange }
-			max={ moment().format( 'YYYY-MM-DD' ) }
-		/>
-	);
+	return <input id={ id } type="date" value={ value } onChange={ handleChange } max={ max } />;
 };
 
 export default DateInput;

--- a/client/my-sites/stats/stats-date-control/stats-date-control-picker-date.tsx
+++ b/client/my-sites/stats/stats-date-control/stats-date-control-picker-date.tsx
@@ -1,5 +1,6 @@
-import { TextControl, Button } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+import DateInput from './stats-date-control-date-input';
 import { DateControlPickerDateProps } from './types';
 
 const DateControlPickerDate = ( {
@@ -21,11 +22,11 @@ const DateControlPickerDate = ( {
 			<div className="stats-date-control-picker-dates__inputs">
 				<div className="stats-date-control-picker-dates__inputs-input-group">
 					<label htmlFor="startDate">From</label>
-					<TextControl id="startDate" value={ startDate } onChange={ onStartChange } />
+					<DateInput id="startDate" value={ startDate } onChange={ onStartChange } />
 				</div>
 				<div className="stats-date-control-picker-dates__inputs-input-group">
 					<label htmlFor="endDate">To</label>
-					<TextControl id="endDate" value={ endDate } onChange={ onEndChange } />
+					<DateInput id="endDate" value={ endDate } onChange={ onEndChange } />
 				</div>
 			</div>
 			<div className="stats-date-control-picker-dates__buttons">

--- a/client/my-sites/stats/stats-date-control/style.scss
+++ b/client/my-sites/stats/stats-date-control/style.scss
@@ -55,10 +55,6 @@
 	flex-direction: row-reverse;
 }
 
-.date-control-picker-date .stats-date-control-picker-dates__inputs .stats-date-control-picker-dates__inputs-input-group .components-base-control .components-base-control__field input.components-text-control__input {
-	max-width: 120px;
-}
-
 .stats-date-control-picker {
 
 	> .components-button {
@@ -86,7 +82,7 @@
 	display: flex; // to position "From" and "To" groups side by side
 	gap: 16px; // spacing between the "From" input and the "To" input
 
-	input[type="text"] {
+	input[type="date"] {
 		font-family: $font-sf-pro-text;
 		font-size: 14px; // stylelint-disable-line declaration-property-unit-allowed-list
 		font-style: normal;
@@ -97,7 +93,7 @@
 		background: var(--black-white-white, #fff);
 		padding: 10px 16px;
 		width: auto;
-		max-width: 95%; // this is to ensure it doesn't overflow its container
+		max-width: 120px;
 		box-sizing: content-box; // this ensures padding isn't included in the total width
 	}
 }


### PR DESCRIPTION
## Proposed Changes

Use date input for date validation and date picker.

## Testing Instructions

* Open Calypso Live Branch `/stats/week/:siteSlug?flags=stats/date-control`
* Open date picker pop up
* Ensure the two inputs support date pick up and the format is your localized date format
* Ensure the max date to select is today (not all browser support this tho)

<img width="1231" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/d8439cf5-96df-4e5e-bb01-0984e4244fe9">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?