### PR TITLE
Stats Chart: set max bar width and arrange empty space

### DIFF
--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -98,6 +98,7 @@ class StatModuleChartTabs extends Component {
 			'is-chart-tabs',
 			{
 				'is-loading': isActiveTabLoading,
+				'has-more-than-three-bars': this.props.chartData.length >= 3,
 			},
 		];
 

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -98,7 +98,7 @@ class StatModuleChartTabs extends Component {
 			'is-chart-tabs',
 			{
 				'is-loading': isActiveTabLoading,
-				'has-more-than-three-bars': this.props.chartData.length >= 3,
+				'has-less-than-three-bars': this.props.chartData.length < 3,
 			},
 		];
 

--- a/client/my-sites/stats/stats-chart-tabs/style.scss
+++ b/client/my-sites/stats/stats-chart-tabs/style.scss
@@ -230,10 +230,10 @@ ul.module-tabs {
 
 .is-chart-tabs {
 	.chart__bars {
-		justify-content: space-around;
-	}
-	&.has-more-than-three-bars .chart__bars {
 		justify-content: space-between;
+	}
+	&.has-less-than-three-bars .chart__bars {
+		justify-content: space-around;
 	}
 	.chart__bar {
 		max-width: 156px;

--- a/client/my-sites/stats/stats-chart-tabs/style.scss
+++ b/client/my-sites/stats/stats-chart-tabs/style.scss
@@ -227,3 +227,16 @@ ul.module-tabs {
 		}
 	}
 }
+
+.is-chart-tabs {
+	.chart__bars {
+		justify-content: space-around;
+	}
+	&.has-more-than-three-bars .chart__bars {
+		justify-content: space-between;
+	}
+	.chart__bar {
+		max-width: 156px;
+	}
+
+}


### PR DESCRIPTION
## Proposed Changes

Set max bar with to `156px` as per design. Use `space-around` when there are less than three bars, 

## Testing Instructions

* Open Calypso Live Branch `/stats/day/:siteSlug?flags=stats%2Fdate-control`
* Choose Today / Yesterday and two days
* The space is distributed as `space-around` and the max width of the bars are 156px
* Choose Last 7 days
*  The space is distributed as `space-between`

<img width="1339" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/1ad90788-a753-457c-ab30-fb1d5945d28e">

<img width="1314" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/56092aea-1daf-409b-812d-f23617df0aae">

<img width="1284" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/fef200f9-0cdd-4c2a-93d2-2af1e50af637">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?