### PR TITLE
Stats: Date Picker - add date range heading

### DIFF
--- a/client/my-sites/stats/stats-date-control/stats-date-control-picker-date.tsx
+++ b/client/my-sites/stats/stats-date-control/stats-date-control-picker-date.tsx
@@ -18,6 +18,11 @@ const DateControlPickerDate = ( {
 
 	return (
 		<div className="date-control-picker-date">
+			<p className="date-control-picker-date__heading">
+				Date Range
+				<span> (dd/mm/yyyy)</span>
+				{ /* TODO: should date range example be localized? */ }
+			</p>
 			<div className="stats-date-control-picker-dates__inputs">
 				<div className="stats-date-control-picker-dates__inputs-input-group">
 					<label htmlFor="startDate">From</label>

--- a/client/my-sites/stats/stats-date-control/stats-date-control-picker-date.tsx
+++ b/client/my-sites/stats/stats-date-control/stats-date-control-picker-date.tsx
@@ -21,7 +21,7 @@ const DateControlPickerDate = ( {
 		<div className="date-control-picker-date">
 			<h2 className="date-control-picker-date__heading">
 				{ translate( 'Date Range' ) }
-				<span> { translate( '(dd/mm/yyyy)' ) }</span>
+				<span>(dd/mm/yyyy)</span>
 			</h2>
 			<div className="stats-date-control-picker-dates__inputs">
 				<div className="stats-date-control-picker-dates__inputs-input-group">

--- a/client/my-sites/stats/stats-date-control/stats-date-control-picker-date.tsx
+++ b/client/my-sites/stats/stats-date-control/stats-date-control-picker-date.tsx
@@ -11,11 +11,6 @@ const DateControlPickerDate = ( {
 	onCancel,
 }: DateControlPickerDateProps ) => {
 	const translate = useTranslate();
-	// TODO: Rename component?
-	// Feels a bit confusing now. Should have a better idea
-	// of appropriate names once hierarchy is finalized.
-
-	const translate = useTranslate();
 
 	return (
 		<div className="date-control-picker-date">

--- a/client/my-sites/stats/stats-date-control/stats-date-control-picker-date.tsx
+++ b/client/my-sites/stats/stats-date-control/stats-date-control-picker-date.tsx
@@ -16,7 +16,7 @@ const DateControlPickerDate = ( {
 		<div className="date-control-picker-date">
 			<h2 className="date-control-picker-date__heading">
 				{ translate( 'Date Range' ) }
-				<span>(dd/mm/yyyy)</span>
+				<span> (dd/mm/yyyy)</span>
 			</h2>
 			<div className="stats-date-control-picker-dates__inputs">
 				<div className="stats-date-control-picker-dates__inputs-input-group">

--- a/client/my-sites/stats/stats-date-control/stats-date-control-picker-date.tsx
+++ b/client/my-sites/stats/stats-date-control/stats-date-control-picker-date.tsx
@@ -10,6 +10,7 @@ const DateControlPickerDate = ( {
 	onApply,
 	onCancel,
 }: DateControlPickerDateProps ) => {
+	const translate = useTranslate();
 	// TODO: Rename component?
 	// Feels a bit confusing now. Should have a better idea
 	// of appropriate names once hierarchy is finalized.
@@ -18,11 +19,10 @@ const DateControlPickerDate = ( {
 
 	return (
 		<div className="date-control-picker-date">
-			<p className="date-control-picker-date__heading">
-				Date Range
-				<span> (dd/mm/yyyy)</span>
-				{ /* TODO: should date range example be localized? */ }
-			</p>
+			<h2 className="date-control-picker-date__heading">
+				{ translate( 'Date Range' ) }
+				<span> { translate( '(dd/mm/yyyy)' ) }</span>
+			</h2>
 			<div className="stats-date-control-picker-dates__inputs">
 				<div className="stats-date-control-picker-dates__inputs-input-group">
 					<label htmlFor="startDate">From</label>

--- a/client/my-sites/stats/stats-date-control/style.scss
+++ b/client/my-sites/stats/stats-date-control/style.scss
@@ -112,3 +112,21 @@
 }
 
 // TODO: Add final colors to shortcuts.
+.stats-date-control-picker__popover-content .date-control-picker-date .date-control-picker-date__heading {
+	color: var(--gray-gray-80, #2c3338);
+	font-family: $font-sf-pro-text;
+	font-size: 14px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+	font-style: normal;
+	font-weight: 500;
+	line-height: 24px;
+	letter-spacing: -0.28px;
+
+	span {
+		color: var(--gray-gray-50, #646970);
+		font-size: 12px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		line-height: 18px;
+		letter-spacing: -0.24px;
+	}
+
+}
+

--- a/client/my-sites/stats/stats-date-control/style.scss
+++ b/client/my-sites/stats/stats-date-control/style.scss
@@ -111,7 +111,6 @@
 	justify-content: flex-end;
 }
 
-// TODO: Add final colors to shortcuts.
 .stats-date-control-picker__popover-content .date-control-picker-date .date-control-picker-date__heading {
 	color: var(--gray-gray-80, #2c3338);
 	font-family: $font-sf-pro-text;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #82702

## Proposed Changes

* This small PR adds a styled date range selector heading to go above the input fields

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
--> 
* Load the Calypso live branch 
* Navigate to `/stats/day/{site URL}`
* Confirm that everything remains unchanged without the feature flag applied
* Append `?flags=stats/date-control` to the end of the URL
* Confirm there is a `Date Range (dd/mm/yyyy)` heading visible, and that styling matches image below:

 ![image](https://github.com/Automattic/wp-calypso/assets/30754158/f6f9595c-520a-4bf1-94d7-c5649b235483) 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?