### PR TITLE
Stats: Translate shortcut and button labels in date range picker

### DIFF
--- a/client/my-sites/stats/stats-date-control/index.tsx
+++ b/client/my-sites/stats/stats-date-control/index.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from 'i18n-calypso';
 import moment from 'moment';
 import page from 'page';
 import qs from 'qs';
@@ -8,48 +9,50 @@ import './style.scss';
 
 const COMPONENT_CLASS_NAME = 'stats-date-control';
 
-const shortcutList = [
-	{
-		id: 'today',
-		label: 'Today',
-		offset: 0,
-		range: 0,
-		period: 'day',
-	},
-	{
-		id: 'yesterday',
-		label: 'Yesterday',
-		offset: 1,
-		range: 0,
-		period: 'day',
-	},
-	{
-		id: 'last-7-days',
-		label: 'Last 7 Days',
-		offset: 0,
-		range: 6,
-		period: 'day',
-	},
-	{
-		id: 'last-30-days',
-		label: 'Last 30 Days',
-		offset: 0,
-		range: 29,
-		period: 'day',
-	},
-	{
-		id: 'last-year',
-		label: 'Last Year',
-		offset: 0,
-		range: 364, // ranges are zero based!
-		period: 'month',
-	},
-];
-
 const StatsDateControl = ( { slug, queryParams }: StatsDateControlProps ) => {
 	// ToDo: Consider removing period from shortcuts.
 	// We could use the bestPeriodForDays() helper and keep the shortcuts
 	// consistent with the custom ranges.
+
+	const translate = useTranslate();
+
+	const shortcutList = [
+		{
+			id: 'today',
+			label: translate( 'Today' ),
+			offset: 0,
+			range: 0,
+			period: 'day',
+		},
+		{
+			id: 'yesterday',
+			label: translate( 'Yesterday' ),
+			offset: 1,
+			range: 0,
+			period: 'day',
+		},
+		{
+			id: 'last-7-days',
+			label: translate( 'Last 7 Days' ),
+			offset: 0,
+			range: 6,
+			period: 'day',
+		},
+		{
+			id: 'last-30-days',
+			label: translate( 'Last 30 Days' ),
+			offset: 0,
+			range: 29,
+			period: 'day',
+		},
+		{
+			id: 'last-year',
+			label: translate( 'Last Year' ),
+			offset: 0,
+			range: 364, // ranges are zero based!
+			period: 'month',
+		},
+	];
 
 	// Shared link generation helper.
 	const generateNewLink = ( period: string, startDate: string, endDate: string ) => {

--- a/client/my-sites/stats/stats-date-control/stats-date-control-picker-date.tsx
+++ b/client/my-sites/stats/stats-date-control/stats-date-control-picker-date.tsx
@@ -1,5 +1,5 @@
 import { TextControl, Button } from '@wordpress/components';
-import React from 'react';
+import { useTranslate } from 'i18n-calypso';
 import { DateControlPickerDateProps } from './types';
 
 const DateControlPickerDate = ( {
@@ -13,6 +13,9 @@ const DateControlPickerDate = ( {
 	// TODO: Rename component?
 	// Feels a bit confusing now. Should have a better idea
 	// of appropriate names once hierarchy is finalized.
+
+	const translate = useTranslate();
+
 	return (
 		<div className="date-control-picker-date">
 			<div className="stats-date-control-picker-dates__inputs">
@@ -20,9 +23,9 @@ const DateControlPickerDate = ( {
 				<TextControl value={ endDate } onChange={ onEndChange } />
 			</div>
 			<div className="stats-date-control-picker-dates__buttons">
-				<Button onClick={ onCancel }>Cancel</Button>
+				<Button onClick={ onCancel }>{ translate( 'Cancel' ) }</Button>
 				<Button variant="primary" onClick={ onApply }>
-					Apply
+					{ translate( 'Apply' ) }
 				</Button>
 			</div>
 		</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #83072.

## Proposed Changes

Wraps shortcut and button labels in calls to `translate()`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Load the Live preview site.
2. Visit the **Stats → Traffic** page.
3. Enable the date range picker: `?flags=stats/date-control`
4. Confirm the shortcuts and buttons show up correctly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?