### PR TITLE
Stats: Push date range down to date controls

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -329,6 +329,7 @@ class StatsSite extends Component {
 								onChangeLegend={ this.onChangeLegend }
 								isWithNewDateControl={ isDateControlEnabled }
 								slug={ slug }
+								dateRange={ customChartRange }
 							>
 								{ ' ' }
 								<DatePicker

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -238,8 +238,8 @@ class StatsSite extends Component {
 			} else {
 				customChartRange = { chartEnd: moment().format( 'YYYY-MM-DD' ) };
 			}
-			// Sort out quantity for chart. Default to 7 days.
-			let daysInRange = 7;
+			// Sort out quantity for chart. Default to 30 days.
+			let daysInRange = 30;
 			const chartStart = this.getValidDateOrNullFromInput( context.query?.chartStart );
 			const isSameOrBefore = moment( chartStart ).isSameOrBefore( moment( chartEnd ) );
 			if ( chartStart && isSameOrBefore ) {

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -245,8 +245,14 @@ class StatsSite extends Component {
 			if ( chartStart && isSameOrBefore ) {
 				// Add one to calculation to include the start date.
 				daysInRange = moment( chartEnd ).diff( moment( chartStart ), 'days' ) + 1;
+				customChartRange.chartStart = chartStart;
+			} else {
+				customChartRange.chartStart = moment()
+					.subtract( daysInRange, 'days' )
+					.format( 'YYYY-MM-DD' );
 			}
 			this.state.customChartQuantity = quantityForDaysAndPeriod( daysInRange, period );
+			customChartRange.daysInRange = daysInRange;
 		}
 
 		const query = memoizedQuery( period, endOf.format( 'YYYY-MM-DD' ) );

--- a/client/my-sites/stats/stats-date-control/index.tsx
+++ b/client/my-sites/stats/stats-date-control/index.tsx
@@ -102,9 +102,16 @@ const StatsDateControl = ( { slug, queryParams }: StatsDateControlProps ) => {
 		page( generateNewLink( shortcut.period, startDate, endDate ) );
 	};
 
+	const getButtonLable = () => {
+		// ToDo: Add logic for button label.
+		// Custom range or shortcut label.
+		return 'All your dates...';
+	};
+
 	return (
 		<div className={ COMPONENT_CLASS_NAME }>
 			<DateControlPicker
+				buttonLabel={ getButtonLable() }
 				shortcutList={ shortcutList }
 				onShortcut={ onShortcutHandler }
 				onApply={ onApplyButtonHandler }

--- a/client/my-sites/stats/stats-date-control/index.tsx
+++ b/client/my-sites/stats/stats-date-control/index.tsx
@@ -105,8 +105,9 @@ const StatsDateControl = ( { slug, queryParams, dateRange }: StatsDateControlPro
 	const getButtonLable = () => {
 		// ToDo: Add logic for button label.
 		// Custom range or shortcut label.
-		const newLabel = `${ dateRange.chartStart } - ${ dateRange.chartEnd }`;
-		return newLabel;
+		const startDate = moment( dateRange.chartStart ).format( 'MMMM Do, YYYY' );
+		const endDate = moment( dateRange.chartEnd ).format( 'MMMM Do, YYYY' );
+		return `${ startDate } - ${ endDate }`;
 	};
 
 	return (

--- a/client/my-sites/stats/stats-date-control/index.tsx
+++ b/client/my-sites/stats/stats-date-control/index.tsx
@@ -139,6 +139,7 @@ const StatsDateControl = ( { slug, queryParams, dateRange }: StatsDateControlPro
 		<div className={ COMPONENT_CLASS_NAME }>
 			<DateControlPicker
 				buttonLabel={ getButtonLable() }
+				dateRange={ dateRange }
 				shortcutList={ shortcutList }
 				onShortcut={ onShortcutHandler }
 				onApply={ onApplyButtonHandler }

--- a/client/my-sites/stats/stats-date-control/index.tsx
+++ b/client/my-sites/stats/stats-date-control/index.tsx
@@ -9,7 +9,7 @@ import './style.scss';
 
 const COMPONENT_CLASS_NAME = 'stats-date-control';
 
-const StatsDateControl = ( { slug, queryParams }: StatsDateControlProps ) => {
+const StatsDateControl = ( { slug, queryParams, dateRange }: StatsDateControlProps ) => {
 	// ToDo: Consider removing period from shortcuts.
 	// We could use the bestPeriodForDays() helper and keep the shortcuts
 	// consistent with the custom ranges.
@@ -105,7 +105,8 @@ const StatsDateControl = ( { slug, queryParams }: StatsDateControlProps ) => {
 	const getButtonLable = () => {
 		// ToDo: Add logic for button label.
 		// Custom range or shortcut label.
-		return 'All your dates...';
+		const newLabel = `${ dateRange.chartStart } - ${ dateRange.chartEnd }`;
+		return newLabel;
 	};
 
 	return (

--- a/client/my-sites/stats/stats-date-control/index.tsx
+++ b/client/my-sites/stats/stats-date-control/index.tsx
@@ -102,32 +102,37 @@ const StatsDateControl = ( { slug, queryParams, dateRange }: StatsDateControlPro
 		page( generateNewLink( shortcut.period, startDate, endDate ) );
 	};
 
-	const getLabelForRange = () => {
+	const getShortcutForRange = () => {
 		const today = moment().format( 'YYYY-MM-DD' );
+		// Today
 		if ( today === dateRange.chartEnd && dateRange.daysInRange === 1 ) {
-			return 'Today';
+			return shortcutList[ 0 ];
 		}
+		// Last 7 days
 		if ( today === dateRange.chartEnd && dateRange.daysInRange === 7 ) {
-			return 'Last 7 days';
+			return shortcutList[ 2 ];
 		}
+		// Last 30 days
 		if ( today === dateRange.chartEnd && dateRange.daysInRange === 30 ) {
-			return 'Last 30 days';
+			return shortcutList[ 3 ];
 		}
+		// Last year
 		if ( today === dateRange.chartEnd && dateRange.daysInRange === 365 ) {
-			return 'Last year';
+			return shortcutList[ 4 ];
 		}
 		const yesterday = moment().subtract( 1, 'days' ).format( 'YYYY-MM-DD' );
+		// Yesterday
 		if ( yesterday === dateRange.chartEnd && dateRange.daysInRange === 1 ) {
-			return 'Yesterday';
+			return shortcutList[ 1 ];
 		}
 		return null;
 	};
 
-	const getButtonLable = () => {
+	const getButtonLabel = () => {
 		// Test for a shortcut match.
-		const label = getLabelForRange();
-		if ( label !== null ) {
-			return label;
+		const shortcut = getShortcutForRange();
+		if ( shortcut !== null ) {
+			return shortcut.label;
 		}
 		// Generate a full date range for the label.
 		const startDate = moment( dateRange.chartStart ).format( 'MMMM Do, YYYY' );
@@ -138,9 +143,10 @@ const StatsDateControl = ( { slug, queryParams, dateRange }: StatsDateControlPro
 	return (
 		<div className={ COMPONENT_CLASS_NAME }>
 			<DateControlPicker
-				buttonLabel={ getButtonLable() }
+				buttonLabel={ getButtonLabel() }
 				dateRange={ dateRange }
 				shortcutList={ shortcutList }
+				selectedShortcut={ getShortcutForRange()?.id }
 				onShortcut={ onShortcutHandler }
 				onApply={ onApplyButtonHandler }
 			/>

--- a/client/my-sites/stats/stats-date-control/index.tsx
+++ b/client/my-sites/stats/stats-date-control/index.tsx
@@ -102,9 +102,34 @@ const StatsDateControl = ( { slug, queryParams, dateRange }: StatsDateControlPro
 		page( generateNewLink( shortcut.period, startDate, endDate ) );
 	};
 
+	const getLabelForRange = () => {
+		const today = moment().format( 'YYYY-MM-DD' );
+		if ( today === dateRange.chartEnd && dateRange.daysInRange === 1 ) {
+			return 'Today';
+		}
+		if ( today === dateRange.chartEnd && dateRange.daysInRange === 7 ) {
+			return 'Last 7 days';
+		}
+		if ( today === dateRange.chartEnd && dateRange.daysInRange === 30 ) {
+			return 'Last 30 days';
+		}
+		if ( today === dateRange.chartEnd && dateRange.daysInRange === 365 ) {
+			return 'Last year';
+		}
+		const yesterday = moment().subtract( 1, 'days' ).format( 'YYYY-MM-DD' );
+		if ( yesterday === dateRange.chartEnd && dateRange.daysInRange === 1 ) {
+			return 'Yesterday';
+		}
+		return null;
+	};
+
 	const getButtonLable = () => {
-		// ToDo: Add logic for button label.
-		// Custom range or shortcut label.
+		// Test for a shortcut match.
+		const label = getLabelForRange();
+		if ( label !== null ) {
+			return label;
+		}
+		// Generate a full date range for the label.
 		const startDate = moment( dateRange.chartStart ).format( 'MMMM Do, YYYY' );
 		const endDate = moment( dateRange.chartEnd ).format( 'MMMM Do, YYYY' );
 		return `${ startDate } - ${ endDate }`;

--- a/client/my-sites/stats/stats-date-control/stats-date-control-picker.tsx
+++ b/client/my-sites/stats/stats-date-control/stats-date-control-picker.tsx
@@ -8,7 +8,12 @@ import DateControlPickerShortcuts from './stats-date-control-picker-shortcuts';
 import { DateControlPickerProps, DateControlPickerShortcut } from './types';
 import './style.scss';
 
-const DateControlPicker = ( { shortcutList, onShortcut, onApply }: DateControlPickerProps ) => {
+const DateControlPicker = ( {
+	buttonLabel,
+	shortcutList,
+	onShortcut,
+	onApply,
+}: DateControlPickerProps ) => {
 	// TODO: remove placeholder values
 	const [ inputStartDate, setInputStartDate ] = useState(
 		moment().subtract( 6, 'days' ).format( 'YYYY-MM-DD' )
@@ -70,14 +75,10 @@ const DateControlPicker = ( { shortcutList, onShortcut, onApply }: DateControlPi
 		setCurrentShortcut( shortcut.id || '' );
 	};
 
-	const formatDate = ( date: string ) => {
-		return moment( date ).format( 'MMM D, YYYY' );
-	};
-
 	return (
 		<div className="stats-date-control-picker">
 			<Button onClick={ () => togglePopoverOpened( ! popoverOpened ) } ref={ infoReferenceElement }>
-				{ `${ formatDate( inputStartDate ) } - ${ formatDate( inputEndDate ) }` }
+				{ buttonLabel }
 				<Icon className="gridicon" icon={ calendar } />
 			</Button>
 			<Popover

--- a/client/my-sites/stats/stats-date-control/stats-date-control-picker.tsx
+++ b/client/my-sites/stats/stats-date-control/stats-date-control-picker.tsx
@@ -12,17 +12,17 @@ const DateControlPicker = ( {
 	buttonLabel,
 	dateRange,
 	shortcutList,
+	selectedShortcut,
 	onShortcut,
 	onApply,
 }: DateControlPickerProps ) => {
-	// TODO: remove placeholder values
+	// Pull dates from provided range.
 	const [ inputStartDate, setInputStartDate ] = useState(
 		moment( dateRange.chartStart ).format( 'YYYY-MM-DD' )
 	);
 	const [ inputEndDate, setInputEndDate ] = useState(
 		moment( dateRange.chartEnd ).format( 'YYYY-MM-DD' )
 	);
-	const [ currentShortcut, setCurrentShortcut ] = useState( 'today' );
 	const infoReferenceElement = useRef( null );
 	const [ popoverOpened, togglePopoverOpened ] = useState( false );
 
@@ -74,8 +74,6 @@ const DateControlPicker = ( {
 		// Calc new start date based on end date plus range as specified in shortcut.
 		const newStartDate = calcNewDateWithOffset( newEndDate, shortcut.range );
 		setInputStartDate( formattedDate( newStartDate ) );
-
-		setCurrentShortcut( shortcut.id || '' );
 	};
 
 	return (
@@ -100,7 +98,7 @@ const DateControlPicker = ( {
 					/>
 					<DateControlPickerShortcuts
 						shortcutList={ shortcutList }
-						currentShortcut={ currentShortcut }
+						currentShortcut={ selectedShortcut }
 						onClick={ handleShortcutSelected }
 					/>
 				</div>

--- a/client/my-sites/stats/stats-date-control/stats-date-control-picker.tsx
+++ b/client/my-sites/stats/stats-date-control/stats-date-control-picker.tsx
@@ -10,15 +10,18 @@ import './style.scss';
 
 const DateControlPicker = ( {
 	buttonLabel,
+	dateRange,
 	shortcutList,
 	onShortcut,
 	onApply,
 }: DateControlPickerProps ) => {
 	// TODO: remove placeholder values
 	const [ inputStartDate, setInputStartDate ] = useState(
-		moment().subtract( 6, 'days' ).format( 'YYYY-MM-DD' )
+		moment( dateRange.chartStart ).format( 'YYYY-MM-DD' )
 	);
-	const [ inputEndDate, setInputEndDate ] = useState( moment().format( 'YYYY-MM-DD' ) );
+	const [ inputEndDate, setInputEndDate ] = useState(
+		moment( dateRange.chartEnd ).format( 'YYYY-MM-DD' )
+	);
 	const [ currentShortcut, setCurrentShortcut ] = useState( 'today' );
 	const infoReferenceElement = useRef( null );
 	const [ popoverOpened, togglePopoverOpened ] = useState( false );

--- a/client/my-sites/stats/stats-date-control/types.d.ts
+++ b/client/my-sites/stats/stats-date-control/types.d.ts
@@ -6,6 +6,7 @@ interface StatsDateControlProps {
 }
 
 interface DateControlPickerProps {
+	buttonLabel: string;
 	shortcutList: DateControlPickerShortcut[];
 	onShortcut: ( shortcut: DateControlPickerShortcut ) => void;
 	onApply: ( startDate: string, endDate: string ) => void;

--- a/client/my-sites/stats/stats-date-control/types.d.ts
+++ b/client/my-sites/stats/stats-date-control/types.d.ts
@@ -10,13 +10,14 @@ interface DateControlPickerProps {
 	buttonLabel: string;
 	dateRange: any;
 	shortcutList: DateControlPickerShortcut[];
+	selectedShortcut: string | undefined;
 	onShortcut: ( shortcut: DateControlPickerShortcut ) => void;
 	onApply: ( startDate: string, endDate: string ) => void;
 }
 
 interface DateControlPickerShortcutsProps {
 	shortcutList: DateControlPickerShortcut[];
-	currentShortcut: string;
+	currentShortcut: string | undefined;
 	onClick: ( shortcut: DateControlPickerShortcut ) => void;
 }
 

--- a/client/my-sites/stats/stats-date-control/types.d.ts
+++ b/client/my-sites/stats/stats-date-control/types.d.ts
@@ -3,6 +3,7 @@ interface StatsDateControlProps {
 	queryParams: string;
 	period: 'day' | 'week' | 'month' | 'year';
 	pathTemplate: string;
+	dateRange: any;
 }
 
 interface DateControlPickerProps {

--- a/client/my-sites/stats/stats-date-control/types.d.ts
+++ b/client/my-sites/stats/stats-date-control/types.d.ts
@@ -8,6 +8,7 @@ interface StatsDateControlProps {
 
 interface DateControlPickerProps {
 	buttonLabel: string;
+	dateRange: any;
 	shortcutList: DateControlPickerShortcut[];
 	onShortcut: ( shortcut: DateControlPickerShortcut ) => void;
 	onApply: ( startDate: string, endDate: string ) => void;

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -121,6 +121,7 @@ class StatsPeriodNavigation extends PureComponent {
 			pathTemplate,
 			onChangeChartQuantity,
 			isWithNewDateControl,
+			dateRange,
 		} = this.props;
 
 		const isToday = moment( date ).isSame( moment(), period );
@@ -140,6 +141,7 @@ class StatsPeriodNavigation extends PureComponent {
 							period={ period }
 							pathTemplate={ pathTemplate }
 							onChangeChartQuantity={ onChangeChartQuantity }
+							dateRange={ dateRange }
 						/>
 						<div className="stats-period-navigation__period-control">
 							{ this.props.activeTab && (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #83133 & #83139.

## Proposed Changes

Captures the date range (instead of just the chartEnd value) and pushes it down to the various date picker controls.

- The date range comes from the URL params. Defaults to 30 days if none provided.
- Button label is set based on provided range.
- Button label uses shortcut name if appropriate.
- Text inputs are set based on range.
- Selected shortcut is based on range (or none).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open Live branch.
2. Navigate to **Stats → Traffic**.
3. Enable new date controls: `?flags=stats/date-control`
4. Confirm range is 30 days.
5. Confirm button shows "Last 30 days".
6. Open picker and confirm both input fields and shortcut are set correctly.
7. Test various shortcuts work. Button label, selected shortcut, and input fields should stay in sync.
8. Manually update input range to something custom and Apply.
9. Confirm button label shows full date range.
10. Manually update input range back to dates matching a shortcut and Apply.
11. Confirm button label shows shortcut label again.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?