### PR TITLE
Jetpack Manage: Add dashboard menu items to the new sidebar

### DIFF
--- a/client/jetpack-cloud/sections/sidebar-navigation/jetpack-manage.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/jetpack-manage.tsx
@@ -1,61 +1,55 @@
 import { plugins, key, currencyDollar, category } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import page from 'page';
 import NewSidebar from 'calypso/jetpack-cloud/components/sidebar';
-import { itemLinkMatches } from 'calypso/my-sites/sidebar/utils';
 import {
 	JETPACK_MANAGE_DASHBOARD_LINK,
 	JETPACK_MANAGE_PLUGINS_LINK,
 	JETPACK_MANAGE_LICENCES_LINK,
 	JETPACK_MANAGE_BILLING_LINK,
 } from './lib/constants';
+import { redirectPage, isMenuItemSelected } from './lib/sidebar';
+import type { MenuItemProps } from './types';
 
 const JetpackManageSidebar = () => {
 	const translate = useTranslate();
 
 	const onClickMenuItem = ( path: string ) => {
-		page.redirect( path );
+		// TODO: Track event when user clicks on a menu item
+		redirectPage( path );
 	};
 
-	const isSelected = ( link: string ) => {
-		const pathname = window.location.pathname;
-		return itemLinkMatches( link, pathname );
-	};
+	const createItem = ( props: MenuItemProps ) => ( {
+		...props,
+		onClickMenuItem,
+		isSelected: isMenuItemSelected( props.link ),
+	} );
 
 	const menuItems = [
-		{
+		createItem( {
 			icon: category,
 			path: '/',
 			link: JETPACK_MANAGE_DASHBOARD_LINK,
 			title: translate( 'Sites Management' ),
-			onClickMenuItem: onClickMenuItem,
-			isSelected: isSelected( JETPACK_MANAGE_DASHBOARD_LINK ),
-		},
-		{
+		} ),
+		createItem( {
 			icon: plugins,
 			path: '/',
 			link: JETPACK_MANAGE_PLUGINS_LINK,
 			title: translate( 'Plugin Management' ),
-			onClickMenuItem: onClickMenuItem,
-			isSelected: isSelected( JETPACK_MANAGE_PLUGINS_LINK ),
-		},
-		{
+		} ),
+		createItem( {
 			icon: key,
 			path: '/',
 			link: JETPACK_MANAGE_LICENCES_LINK,
 			title: translate( 'Licenses' ),
-			onClickMenuItem: onClickMenuItem,
-			isSelected: isSelected( JETPACK_MANAGE_LICENCES_LINK ),
-		},
-		{
+		} ),
+		createItem( {
 			icon: currencyDollar,
 			path: '/partner-portal/',
 			link: JETPACK_MANAGE_BILLING_LINK,
 			title: translate( 'Purchases' ),
-			onClickMenuItem: onClickMenuItem,
 			withChevron: true,
-			isSelected: isSelected( JETPACK_MANAGE_BILLING_LINK ),
-		},
+		} ),
 	];
 	return <NewSidebar isJetpackManage path="/" menuItems={ menuItems } />;
 };

--- a/client/jetpack-cloud/sections/sidebar-navigation/jetpack-manage.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/jetpack-manage.tsx
@@ -1,12 +1,63 @@
+import { plugins, key, currencyDollar, category } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import page from 'page';
 import NewSidebar from 'calypso/jetpack-cloud/components/sidebar';
+import { itemLinkMatches } from 'calypso/my-sites/sidebar/utils';
+import {
+	JETPACK_MANAGE_DASHBOARD_LINK,
+	JETPACK_MANAGE_PLUGINS_LINK,
+	JETPACK_MANAGE_LICENCES_LINK,
+	JETPACK_MANAGE_BILLING_LINK,
+} from './lib/constants';
 
-// This sidebar is what Jetpack Manage customers will see by default as they
-// navigate around Jetpack Cloud with no specific site selected.
-// It'll display menu options like Sites Management, Plugin Management,
-// and Purchases.
-// FIXME: Add menu items
 const JetpackManageSidebar = () => {
-	return <NewSidebar isJetpackManage path="/" menuItems={ [] } />;
+	const translate = useTranslate();
+
+	const onClickMenuItem = ( path: string ) => {
+		page.redirect( path );
+	};
+
+	const isSelected = ( link: string ) => {
+		const pathname = window.location.pathname;
+		return itemLinkMatches( link, pathname );
+	};
+
+	const menuItems = [
+		{
+			icon: category,
+			path: '/',
+			link: JETPACK_MANAGE_DASHBOARD_LINK,
+			title: translate( 'Sites Management' ),
+			onClickMenuItem: onClickMenuItem,
+			isSelected: isSelected( JETPACK_MANAGE_DASHBOARD_LINK ),
+		},
+		{
+			icon: plugins,
+			path: '/',
+			link: JETPACK_MANAGE_PLUGINS_LINK,
+			title: translate( 'Plugin Management' ),
+			onClickMenuItem: onClickMenuItem,
+			isSelected: isSelected( JETPACK_MANAGE_PLUGINS_LINK ),
+		},
+		{
+			icon: key,
+			path: '/',
+			link: JETPACK_MANAGE_LICENCES_LINK,
+			title: translate( 'Licenses' ),
+			onClickMenuItem: onClickMenuItem,
+			isSelected: isSelected( JETPACK_MANAGE_LICENCES_LINK ),
+		},
+		{
+			icon: currencyDollar,
+			path: '/partner-portal/',
+			link: JETPACK_MANAGE_BILLING_LINK,
+			title: translate( 'Purchases' ),
+			onClickMenuItem: onClickMenuItem,
+			withChevron: true,
+			isSelected: isSelected( JETPACK_MANAGE_BILLING_LINK ),
+		},
+	];
+	return <NewSidebar isJetpackManage path="/" menuItems={ menuItems } />;
 };
 
 export default JetpackManageSidebar;

--- a/client/jetpack-cloud/sections/sidebar-navigation/lib/constants.ts
+++ b/client/jetpack-cloud/sections/sidebar-navigation/lib/constants.ts
@@ -1,0 +1,4 @@
+export const JETPACK_MANAGE_DASHBOARD_LINK = '/dashboard';
+export const JETPACK_MANAGE_PLUGINS_LINK = '/plugins/manage';
+export const JETPACK_MANAGE_LICENCES_LINK = '/partner-portal/licenses';
+export const JETPACK_MANAGE_BILLING_LINK = '/partner-portal/billing';

--- a/client/jetpack-cloud/sections/sidebar-navigation/lib/sidebar.ts
+++ b/client/jetpack-cloud/sections/sidebar-navigation/lib/sidebar.ts
@@ -1,0 +1,20 @@
+import page from 'page';
+import { itemLinkMatches } from 'calypso/my-sites/sidebar/utils';
+
+/**
+ * Determines whether a menu item should be selected based on the current URL path.
+ * @param link The link to compare against the current URL path.
+ * @returns A boolean value indicating whether the link matches the current URL path.
+ */
+export const isMenuItemSelected = ( link: string ) => {
+	const pathname = window.location.pathname;
+	return itemLinkMatches( link, pathname );
+};
+
+/**
+ * Redirects to the specified path.
+ * @param path The path to redirect to.
+ */
+export const redirectPage = ( path: string ) => {
+	page.redirect( path );
+};

--- a/client/jetpack-cloud/sections/sidebar-navigation/types.ts
+++ b/client/jetpack-cloud/sections/sidebar-navigation/types.ts
@@ -1,0 +1,8 @@
+export type MenuItemProps = {
+	icon: JSX.Element;
+	link: string;
+	path: string;
+	title: string;
+	withChevron?: boolean;
+	isExternalLink?: boolean;
+};


### PR DESCRIPTION

Resolves https://github.com/Automattic/jetpack-genesis/issues/59

## Proposed Changes

This PR adds the menu items to the dashboard in Jetpack Manage.

### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Open the Jetpack Cloud live link
2. Visit the /dashboard and append the URL with ?flags=jetpack/new-navigation
3. Verify that you can now see the menu items and that Sites Management is highlighted below. Please note none of the other links will work as of now. This will be fixed in follow-up PRs. Also, note the `key` might have to changed and this can be done later

<img width="274" alt="Screenshot 2023-10-18 at 12 26 29 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/d9d2068f-f2d0-4141-ae95-607d3d97e4a8">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?