### PR TITLE
Fix the missing popover color

### DIFF
--- a/packages/components/src/popover/index.stories.jsx
+++ b/packages/components/src/popover/index.stories.jsx
@@ -1,0 +1,32 @@
+import { useEffect, useRef, useState } from 'react';
+import Popover from '.';
+
+export default { title: 'packages/components/Popover' };
+
+const Container = ( props ) => {
+	const [ currentRef, setCurrentRef ] = useState( undefined );
+	const ref = useRef( undefined );
+	useEffect( () => {
+		setCurrentRef( ref.current );
+	}, [] );
+	return (
+		<>
+			<div ref={ ref } style={ { display: 'inline-block', border: '1px solid gray' } }>
+				Target Element
+			</div>
+			<Popover
+				className="theme-card__tooltip"
+				context={ currentRef }
+				isVisible={ true }
+				showDelay={ 0 }
+				{ ...props }
+			>
+				I am the description.
+			</Popover>
+		</>
+	);
+};
+
+export const Basic = () => {
+	return <Container />;
+};

--- a/packages/design-picker/src/components/theme-card/index.stories.tsx
+++ b/packages/design-picker/src/components/theme-card/index.stories.tsx
@@ -1,4 +1,4 @@
-import { Story, Meta } from '@storybook/react';
+import { StoryFn, Meta } from '@storybook/react';
 import { ComponentProps } from 'react';
 import ThemeCard from './index';
 
@@ -12,7 +12,7 @@ export default {
 	},
 } as Meta;
 
-type ThemeCardStory = Story< ComponentProps< typeof ThemeCard > >;
+type ThemeCardStory = StoryFn< ComponentProps< typeof ThemeCard > >;
 const Template: ThemeCardStory = ( args ) => <ThemeCard { ...args } />;
 
 const Image = () => (
@@ -24,6 +24,9 @@ const Image = () => (
 const defaultArgs = {
 	name: 'Stewart',
 	image: <Image></Image>,
+	isShowDescriptionOnImageHover: true,
+	description:
+		'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
 };
 
 export const NotActive: ThemeCardStory = Template.bind( {} );

--- a/packages/design-picker/src/components/theme-card/style.scss
+++ b/packages/design-picker/src/components/theme-card/style.scss
@@ -156,18 +156,22 @@ $theme-card-info-margin-top: 16px;
 }
 
 .theme-card__tooltip {
-	&.is-top,
-	&.is-top-left,
-	&.is-top-right {
-		.popover__arrow {
-			border-top-color: var(--color-neutral-60);
-			bottom: 4px;
-
-			&::before {
-				display: none;
+	@mixin popover__arrow( $side ) {
+		&.is-#{$side},
+		&.is-#{$side}-left,
+		&.is-#{$side}-right {
+			.popover__arrow {
+				// Reset the original style.
+				border-color: transparent;
+				&::before {
+					// Change the color according to ThemeCard's needs.
+					border-#{$side}-color: var(--color-neutral-60);
+				}
 			}
 		}
 	}
+	@include popover__arrow( top );
+	@include popover__arrow( bottom );
 
 	ul {
 		list-style: none;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/81825

## Proposed Changes

This PR fixes the missing popover color on the Theme Showcase page. The original issue is https://github.com/Automattic/wp-calypso/issues/81825, and this PR does NOT fix the translation problem. 

The `Popover` component does not provide the color. See this independent storybook component 👇

<img width="168" alt="Screenshot 2023-10-18 at 16 22 47" src="https://github.com/Automattic/wp-calypso/assets/5287479/31190367-fae4-4b59-b5eb-b4c587645a8d">

So, we need to override the color according to our needs. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the Theme Showcase page
* Mouseover on any of the Theme Card
* See the popover (tooltip) arrow with the color 

before

https://github.com/Automattic/wp-calypso/assets/5287479/361fa4d3-559e-4f81-8d5f-b6acdd4d82ba

after

https://github.com/Automattic/wp-calypso/assets/5287479/7356c6f3-b67e-44b5-ad68-3e8f4c3c137a

Storybook (`yarn storybook:start`) 

https://github.com/Automattic/wp-calypso/assets/5287479/85f03d71-899e-42d9-90cc-0bb4aded2a66


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?