### PR TITLE
chore: remove override of custom TeamCity version.

### DIFF
--- a/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
+++ b/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
@@ -93,7 +93,6 @@ open class E2EBuildType(
 		params {
 			param("env.NODE_CONFIG_ENV", "test")
 			param("env.PLAYWRIGHT_BROWSERS_PATH", "0")
-			param("env.TEAMCITY_VERSION", "2021")
 			param("env.HEADLESS", "true")
 			param("env.LOCALE", "en")
 			param("env.DEBUG", "")

--- a/.teamcity/_self/lib/utils/E2EBuildLibrary.kt
+++ b/.teamcity/_self/lib/utils/E2EBuildLibrary.kt
@@ -51,7 +51,6 @@ fun BuildSteps.collectE2eResults(): ScriptBuildStep {
 fun ParametrizedWithType.defaultE2eParams() {
     param("env.NODE_CONFIG_ENV", "test")
     param("env.PLAYWRIGHT_BROWSERS_PATH", "0")
-    param("env.TEAMCITY_VERSION", "2021")
     param("env.HEADLESS", "true")
     param("env.LOCALE", "en")
 	param("env.DEBUG", "")
@@ -96,7 +95,7 @@ fun defaultE2eArtifactRules(): String = """
 fun BuildSteps.runE2eTestsWithRetry(
 	testGroup: String,
 	additionalEnvVars: Map<String, String> = mapOf(),
-	stepName: String = "Run tests" 
+	stepName: String = "Run tests"
 ): ScriptBuildStep {
 	val envVarExport = additionalEnvVars.map { ( key, value ) -> "export $key='$value'" }.joinToString( separator = "\n" )
 
@@ -105,7 +104,7 @@ fun BuildSteps.runE2eTestsWithRetry(
         scriptContent = """
             # Configure bash shell.
             set -x
-            
+
             # Export additional environment variables.
             $envVarExport
 

--- a/.teamcity/_self/projects/MarTech.kt
+++ b/.teamcity/_self/projects/MarTech.kt
@@ -42,7 +42,6 @@ object ToSAcceptanceTracking: BuildType ({
 	params {
 		param("env.NODE_CONFIG_ENV", "test")
 		param("env.PLAYWRIGHT_BROWSERS_PATH", "0")
-		param("env.TEAMCITY_VERSION", "2021")
 		param("env.HEADLESS", "true")
 		param("env.LOCALE", "en")
 	}

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -806,7 +806,6 @@ object PreReleaseE2ETests : BuildType({
 	params {
 		param("env.NODE_CONFIG_ENV", "test")
 		param("env.PLAYWRIGHT_BROWSERS_PATH", "0")
-		param("env.TEAMCITY_VERSION", "2021")
 		param("env.HEADLESS", "true")
 		param("env.LOCALE", "en")
 		param("env.VIEWPORT_NAME", "desktop")


### PR DESCRIPTION
## Proposed Changes

This PR removes the override of custom TeamCity version from various configurations.

I don't know if this actually has an effect, but we're already using [TeamCity 2023.5](https://github.com/Automattic/wp-calypso/blob/trunk/.teamcity/settings.kts#L45) which introduces a lot of enhancements.

Context: I would like to experiment with [Slack service messages](https://www.jetbrains.com/help/teamcity/service-messages.html#Sending+Custom+Email+Messages) (introduced in 2023.5).

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)
  - [x] Pre-Release E2E
  - [x] Unit Tests

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?