### PR TITLE
Jetpack Manage: Add Managed sites page sidebar menu using the new navigation.

### DIFF
--- a/client/components/jetpack/sidebar/menu-items/jetpack-icons.jsx
+++ b/client/components/jetpack/sidebar/menu-items/jetpack-icons.jsx
@@ -2,7 +2,7 @@ import classnames from 'classnames';
 import PropTypes from 'prop-types';
 
 export default function JetpackIcons( props ) {
-	const { className, icon } = props;
+	const { className, icon, size = 28 } = props;
 
 	const classes = classnames( 'sidebar__menu-icon', className );
 
@@ -38,8 +38,8 @@ export default function JetpackIcons( props ) {
 		<svg
 			className={ classes }
 			viewBox="0 0 24 24"
-			width="28"
-			height="28"
+			width={ size }
+			height={ size }
 			fill="none"
 			xmlns="http://www.w3.org/2000/svg"
 		>
@@ -51,4 +51,5 @@ export default function JetpackIcons( props ) {
 JetpackIcons.propTypes = {
 	className: PropTypes.string,
 	icon: PropTypes.string,
+	size: PropTypes.number,
 };

--- a/client/jetpack-cloud/components/sidebar/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/index.tsx
@@ -34,6 +34,7 @@ type Props = {
 		withChevron?: boolean;
 		isExternalLink?: boolean;
 		isSelected: boolean;
+		trackEventName?: string;
 	}[];
 	description?: string;
 	backButtonProps?: {
@@ -70,7 +71,16 @@ const JetpackCloudSidebar = ( {
 						backButtonProps={ backButtonProps }
 					>
 						{ menuItems.map( ( item ) => (
-							<SidebarNavigatorMenuItem key={ item.link } { ...item } />
+							<SidebarNavigatorMenuItem
+								key={ item.link }
+								{ ...item }
+								onClickMenuItem={ ( path ) => {
+									if ( item.trackEventName ) {
+										recordTracksEvent( item.trackEventName );
+									}
+									item.onClickMenuItem( path );
+								} }
+							/>
 						) ) }
 					</SidebarNavigatorMenu>
 				</SidebarNavigator>

--- a/client/jetpack-cloud/components/sidebar/style.scss
+++ b/client/jetpack-cloud/components/sidebar/style.scss
@@ -12,6 +12,10 @@
 			color: var(--studio-green-50);
 		}
 	}
+
+	.sidebar__menu-icon {
+		margin: 0;
+	}
 }
 
 .jetpack-cloud-sidebar__header {

--- a/client/jetpack-cloud/sections/sidebar-navigation/jetpack-manage.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/jetpack-manage.tsx
@@ -13,14 +13,9 @@ import type { MenuItemProps } from './types';
 const JetpackManageSidebar = () => {
 	const translate = useTranslate();
 
-	const onClickMenuItem = ( path: string ) => {
-		// TODO: Track event when user clicks on a menu item
-		redirectPage( path );
-	};
-
 	const createItem = ( props: MenuItemProps ) => ( {
 		...props,
-		onClickMenuItem,
+		onClickMenuItem: redirectPage,
 		isSelected: isMenuItemSelected( props.link ),
 	} );
 

--- a/client/jetpack-cloud/sections/sidebar-navigation/lib/constants.ts
+++ b/client/jetpack-cloud/sections/sidebar-navigation/lib/constants.ts
@@ -2,3 +2,7 @@ export const JETPACK_MANAGE_DASHBOARD_LINK = '/dashboard';
 export const JETPACK_MANAGE_PLUGINS_LINK = '/plugins/manage';
 export const JETPACK_MANAGE_LICENCES_LINK = '/partner-portal/licenses';
 export const JETPACK_MANAGE_BILLING_LINK = '/partner-portal/billing';
+
+export const JETPACK_CLOUD_ACTIVITY_LOG_LINK = '/activity-log';
+export const JETPACK_CLOUD_SEARCH_LINK = '/jetpack-search';
+export const JETPACK_CLOUD_SOCIAL_LINK = '/jetpack-social';

--- a/client/jetpack-cloud/sections/sidebar-navigation/lib/sidebar.ts
+++ b/client/jetpack-cloud/sections/sidebar-navigation/lib/sidebar.ts
@@ -16,5 +16,5 @@ export const isMenuItemSelected = ( link: string ) => {
  * @param path The path to redirect to.
  */
 export const redirectPage = ( path: string ) => {
-	page.redirect( path );
+	page( path );
 };

--- a/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
@@ -2,7 +2,6 @@ import config from '@automattic/calypso-config';
 import { WPCOM_FEATURES_BACKUPS, WPCOM_FEATURES_SCAN } from '@automattic/calypso-products';
 import { chevronLeft, cloud, cog, currencyDollar, plugins, search, shield } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import page from 'page';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import QueryScanState from 'calypso/components/data/query-jetpack-scan';
@@ -24,10 +23,7 @@ import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-
-const onClickMenuItem = ( url: string ) => {
-	page.redirect( url );
-};
+import { redirectPage } from './lib/sidebar';
 
 const useMenuItems = ( {
 	siteId,
@@ -69,7 +65,7 @@ const useMenuItems = ( {
 					path: '/',
 					link: `/activity-log/${ siteSlug }`,
 					title: translate( 'Activity Log' ),
-					onClickMenuItem: onClickMenuItem,
+					onClickMenuItem: redirectPage,
 					trackEventName: 'calypso_jetpack_sidebar_activity_clicked',
 					enabled: isAdmin,
 					isSelected: itemLinkMatches( path, `/activity-log/${ siteSlug }` ),
@@ -79,7 +75,7 @@ const useMenuItems = ( {
 					path: '/',
 					link: pluginsPath( siteSlug ),
 					title: translate( 'Plugins' ),
-					onClickMenuItem: onClickMenuItem,
+					onClickMenuItem: redirectPage,
 					trackEventName: 'calypso_jetpack_sidebar_plugins_clicked',
 					enabled: isPluginManagementEnabled && isAgency,
 					isSelected: itemLinkMatches( path, pluginsPath( siteSlug ) ),
@@ -89,7 +85,7 @@ const useMenuItems = ( {
 					path: '/',
 					link: backupPath( siteSlug ),
 					title: translate( 'Backup' ),
-					onClickMenuItem: onClickMenuItem,
+					onClickMenuItem: redirectPage,
 					trackEventName: 'calypso_jetpack_sidebar_backup_clicked',
 					enabled: isAdmin && ! isWPForTeamsSite,
 					isSelected: itemLinkMatches( path, backupPath( siteSlug ) ),
@@ -99,7 +95,7 @@ const useMenuItems = ( {
 					path: '/',
 					link: scanPath( siteSlug ),
 					title: translate( 'Scan' ),
-					onClickMenuItem: onClickMenuItem,
+					onClickMenuItem: redirectPage,
 					trackEventName: 'calypso_jetpack_sidebar_scan_clicked',
 					enabled: isAdmin && ! isWPCOM && ! isWPForTeamsSite,
 					isSelected: itemLinkMatches( path, scanPath( siteSlug ) ),
@@ -109,7 +105,7 @@ const useMenuItems = ( {
 					path: '/',
 					link: `/jetpack-search/${ siteSlug }`,
 					title: translate( 'Search' ),
-					onClickMenuItem: onClickMenuItem,
+					onClickMenuItem: redirectPage,
 					trackEventName: 'calypso_jetpack_sidebar_search_clicked',
 					enabled: isAdmin,
 					isSelected: itemLinkMatches( path, `/jetpack-search/${ siteSlug }` ),
@@ -119,7 +115,7 @@ const useMenuItems = ( {
 					path: '/',
 					link: `/jetpack-social/${ siteSlug }`,
 					title: translate( 'Social' ),
-					onClickMenuItem: onClickMenuItem,
+					onClickMenuItem: redirectPage,
 					trackEventName: 'calypso_jetpack_sidebar_social_clicked',
 					enabled: isAdmin && isSectionNameEnabled( 'jetpack-social' ) && ! isWPForTeamsSite,
 					isSelected: itemLinkMatches( path, `/jetpack-social/${ siteSlug }` ),
@@ -129,7 +125,7 @@ const useMenuItems = ( {
 					path: '/',
 					link: settingsPath( siteSlug ),
 					title: translate( 'Settings' ),
-					onClickMenuItem: onClickMenuItem,
+					onClickMenuItem: redirectPage,
 					trackEventName: 'calypso_jetpack_sidebar_settings_clicked',
 					enabled: shouldShowSettings,
 					isSelected: itemLinkMatches( path, settingsPath( siteSlug ) ),
@@ -139,7 +135,7 @@ const useMenuItems = ( {
 					path: '/',
 					link: purchasesPath( siteSlug ),
 					title: translate( 'Purchases' ),
-					onClickMenuItem: onClickMenuItem,
+					onClickMenuItem: redirectPage,
 					trackEventName: 'calypso_jetpack_sidebar_purchases_clicked',
 					enabled: shouldShowPurchases,
 					isSelected: itemLinkMatches( path, purchasesPath( siteSlug ) ),
@@ -178,7 +174,7 @@ const ManageSelectedSiteSidebar = ( { path }: { path: string } ) => {
 						? {
 								label: translate( 'Site Settings' ),
 								icon: chevronLeft,
-								onClick: () => onClickMenuItem( '/dashboard' ),
+								onClick: () => redirectPage( '/dashboard' ),
 						  }
 						: undefined
 				}

--- a/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
@@ -16,6 +16,7 @@ import {
 	backupPath,
 	scanPath,
 } from 'calypso/lib/jetpack/paths';
+import { itemLinkMatches } from 'calypso/my-sites/sidebar/utils';
 import { isSectionNameEnabled } from 'calypso/sections-filter';
 import { isAgencyUser } from 'calypso/state/partner-portal/partner/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
@@ -24,7 +25,7 @@ import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
-const ManageSelectedSiteSidebar = () => {
+const ManageSelectedSiteSidebar = ( { path }: { path: string } ) => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
 	const isAgency = useSelector( isAgencyUser );
@@ -50,8 +51,8 @@ const ManageSelectedSiteSidebar = () => {
 
 	const isPluginManagementEnabled = config.isEnabled( 'jetpack/plugin-management' );
 
-	const onClickMenuItem = ( path: string ) => {
-		page.redirect( path );
+	const onClickMenuItem = ( url: string ) => {
+		page.redirect( url );
 	};
 
 	const menuItems = useMemo(
@@ -65,6 +66,7 @@ const ManageSelectedSiteSidebar = () => {
 					onClickMenuItem: onClickMenuItem,
 					trackEventName: 'calypso_jetpack_sidebar_activity_clicked',
 					enabled: isAdmin,
+					isSelected: itemLinkMatches( path, `/activity-log/${ siteSlug }` ),
 				},
 				{
 					icon: cloud,
@@ -74,6 +76,7 @@ const ManageSelectedSiteSidebar = () => {
 					onClickMenuItem: onClickMenuItem,
 					trackEventName: 'calypso_jetpack_sidebar_backup_clicked',
 					enabled: isAdmin && ! isWPForTeamsSite,
+					isSelected: itemLinkMatches( path, backupPath( siteSlug ) ),
 				},
 				{
 					icon: shield,
@@ -83,6 +86,7 @@ const ManageSelectedSiteSidebar = () => {
 					onClickMenuItem: onClickMenuItem,
 					trackEventName: 'calypso_jetpack_sidebar_scan_clicked',
 					enabled: isAdmin && ! isWPCOM && ! isWPForTeamsSite,
+					isSelected: itemLinkMatches( path, scanPath( siteSlug ) ),
 				},
 				{
 					icon: search,
@@ -92,6 +96,7 @@ const ManageSelectedSiteSidebar = () => {
 					onClickMenuItem: onClickMenuItem,
 					trackEventName: 'calypso_jetpack_sidebar_search_clicked',
 					enabled: isAdmin,
+					isSelected: itemLinkMatches( path, `/jetpack-search/${ siteSlug }` ),
 				},
 				{
 					icon: <JetpackIcons icon="activity-log" size={ 24 } />,
@@ -101,6 +106,7 @@ const ManageSelectedSiteSidebar = () => {
 					onClickMenuItem: onClickMenuItem,
 					trackEventName: 'calypso_jetpack_sidebar_social_clicked',
 					enabled: isAdmin && isSectionNameEnabled( 'jetpack-social' ) && ! isWPForTeamsSite,
+					isSelected: itemLinkMatches( path, `/jetpack-social/${ siteSlug }` ),
 				},
 				{
 					icon: plugins,
@@ -110,6 +116,7 @@ const ManageSelectedSiteSidebar = () => {
 					onClickMenuItem: onClickMenuItem,
 					trackEventName: 'calypso_jetpack_sidebar_plugins_clicked',
 					enabled: isPluginManagementEnabled && isAgency,
+					isSelected: itemLinkMatches( path, pluginsPath( siteSlug ) ),
 				},
 				{
 					icon: cog,
@@ -119,6 +126,7 @@ const ManageSelectedSiteSidebar = () => {
 					onClickMenuItem: onClickMenuItem,
 					trackEventName: 'calypso_jetpack_sidebar_settings_clicked',
 					enabled: shouldShowSettings,
+					isSelected: itemLinkMatches( path, settingsPath( siteSlug ) ),
 				},
 				{
 					icon: currencyDollar,
@@ -128,6 +136,7 @@ const ManageSelectedSiteSidebar = () => {
 					onClickMenuItem: onClickMenuItem,
 					trackEventName: 'calypso_jetpack_sidebar_purchases_clicked',
 					enabled: shouldShowPurchases,
+					isSelected: itemLinkMatches( path, purchasesPath( siteSlug ) ),
 				},
 			].filter( ( { enabled } ) => enabled ),
 		[
@@ -136,6 +145,7 @@ const ManageSelectedSiteSidebar = () => {
 			isPluginManagementEnabled,
 			isWPCOM,
 			isWPForTeamsSite,
+			path,
 			shouldShowPurchases,
 			shouldShowSettings,
 			siteSlug,

--- a/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import { WPCOM_FEATURES_BACKUPS, WPCOM_FEATURES_SCAN } from '@automattic/calypso-products';
-import { Icon, chevronLeft, plugins } from '@wordpress/icons';
+import { chevronLeft, cloud, cog, currencyDollar, plugins, search, shield } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { useMemo } from 'react';
@@ -58,7 +58,7 @@ const ManageSelectedSiteSidebar = () => {
 		() =>
 			[
 				{
-					icon: <JetpackIcons icon="activity-log" />,
+					icon: <JetpackIcons icon="activity-log" size={ 24 } />,
 					path: '/',
 					link: `/activity-log/${ siteSlug }`,
 					title: translate( 'Activity Log' ),
@@ -67,7 +67,7 @@ const ManageSelectedSiteSidebar = () => {
 					enabled: isAdmin,
 				},
 				{
-					icon: <JetpackIcons icon="backup" />,
+					icon: cloud,
 					path: '/',
 					link: backupPath( siteSlug ),
 					title: translate( 'VaultPress Backup' ),
@@ -76,7 +76,7 @@ const ManageSelectedSiteSidebar = () => {
 					enabled: isAdmin && ! isWPForTeamsSite,
 				},
 				{
-					icon: <JetpackIcons icon="scan" />,
+					icon: shield,
 					path: '/',
 					link: scanPath( siteSlug ),
 					title: translate( 'Scan' ),
@@ -85,7 +85,7 @@ const ManageSelectedSiteSidebar = () => {
 					enabled: isAdmin && ! isWPCOM && ! isWPForTeamsSite,
 				},
 				{
-					icon: <JetpackIcons icon="search" />,
+					icon: search,
 					path: '/',
 					link: `/jetpack-search/${ siteSlug }`,
 					title: translate( 'Search' ),
@@ -94,7 +94,7 @@ const ManageSelectedSiteSidebar = () => {
 					enabled: isAdmin,
 				},
 				{
-					icon: <JetpackIcons icon="social" />,
+					icon: <JetpackIcons icon="activity-log" size={ 24 } />,
 					path: '/',
 					link: `/jetpack-social/${ siteSlug }`,
 					title: translate( 'Social' ),
@@ -103,7 +103,7 @@ const ManageSelectedSiteSidebar = () => {
 					enabled: isAdmin && isSectionNameEnabled( 'jetpack-social' ) && ! isWPForTeamsSite,
 				},
 				{
-					icon: <Icon className="sidebar__menu-icon" size={ 28 } icon={ plugins } />,
+					icon: plugins,
 					path: '/',
 					link: pluginsPath( siteSlug ),
 					title: translate( 'Plugins' ),
@@ -112,7 +112,7 @@ const ManageSelectedSiteSidebar = () => {
 					enabled: isPluginManagementEnabled && isAgency,
 				},
 				{
-					icon: <JetpackIcons icon="settings" />,
+					icon: cog,
 					path: '/',
 					link: settingsPath( siteSlug ),
 					title: translate( 'Settings' ),
@@ -121,7 +121,7 @@ const ManageSelectedSiteSidebar = () => {
 					enabled: shouldShowSettings,
 				},
 				{
-					icon: <JetpackIcons icon="money" />,
+					icon: currencyDollar,
 					path: '/',
 					link: purchasesPath( siteSlug ),
 					title: translate( 'Purchases' ),

--- a/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
@@ -120,7 +120,7 @@ const useMenuItems = ( {
 					title: translate( 'Search' ),
 					onClickMenuItem: redirectPage,
 					trackEventName: 'calypso_jetpack_sidebar_search_clicked',
-					enabled: isAdmin,
+					enabled: true,
 					isSelected: itemLinkMatches( path, `${ JETPACK_CLOUD_SEARCH_LINK }/${ siteSlug }` ),
 				},
 				{

--- a/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
@@ -1,6 +1,14 @@
 import config from '@automattic/calypso-config';
 import { WPCOM_FEATURES_BACKUPS, WPCOM_FEATURES_SCAN } from '@automattic/calypso-products';
-import { chevronLeft, cloud, cog, currencyDollar, plugins, search, shield } from '@wordpress/icons';
+import {
+	chevronLeft,
+	cloud,
+	settings,
+	currencyDollar,
+	plugins,
+	search,
+	shield,
+} from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
@@ -23,6 +31,11 @@ import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import {
+	JETPACK_CLOUD_ACTIVITY_LOG_LINK,
+	JETPACK_CLOUD_SEARCH_LINK,
+	JETPACK_CLOUD_SOCIAL_LINK,
+} from './lib/constants';
 import { redirectPage } from './lib/sidebar';
 
 const useMenuItems = ( {
@@ -63,12 +76,12 @@ const useMenuItems = ( {
 				{
 					icon: <JetpackIcons icon="activity-log" size={ 24 } />,
 					path: '/',
-					link: `/activity-log/${ siteSlug }`,
+					link: `${ JETPACK_CLOUD_ACTIVITY_LOG_LINK }/${ siteSlug }`,
 					title: translate( 'Activity Log' ),
 					onClickMenuItem: redirectPage,
 					trackEventName: 'calypso_jetpack_sidebar_activity_clicked',
 					enabled: isAdmin,
-					isSelected: itemLinkMatches( path, `/activity-log/${ siteSlug }` ),
+					isSelected: itemLinkMatches( path, `${ JETPACK_CLOUD_ACTIVITY_LOG_LINK }/${ siteSlug }` ),
 				},
 				{
 					icon: plugins,
@@ -103,25 +116,25 @@ const useMenuItems = ( {
 				{
 					icon: search,
 					path: '/',
-					link: `/jetpack-search/${ siteSlug }`,
+					link: `${ JETPACK_CLOUD_SEARCH_LINK }/${ siteSlug }`,
 					title: translate( 'Search' ),
 					onClickMenuItem: redirectPage,
 					trackEventName: 'calypso_jetpack_sidebar_search_clicked',
 					enabled: isAdmin,
-					isSelected: itemLinkMatches( path, `/jetpack-search/${ siteSlug }` ),
+					isSelected: itemLinkMatches( path, `${ JETPACK_CLOUD_SEARCH_LINK }/${ siteSlug }` ),
 				},
 				{
-					icon: <JetpackIcons icon="activity-log" size={ 24 } />,
+					icon: <JetpackIcons icon="social" size={ 24 } />,
 					path: '/',
-					link: `/jetpack-social/${ siteSlug }`,
+					link: `${ JETPACK_CLOUD_SOCIAL_LINK }/${ siteSlug }`,
 					title: translate( 'Social' ),
 					onClickMenuItem: redirectPage,
 					trackEventName: 'calypso_jetpack_sidebar_social_clicked',
 					enabled: isAdmin && isSectionNameEnabled( 'jetpack-social' ) && ! isWPForTeamsSite,
-					isSelected: itemLinkMatches( path, `/jetpack-social/${ siteSlug }` ),
+					isSelected: itemLinkMatches( path, `${ JETPACK_CLOUD_SOCIAL_LINK }/${ siteSlug }` ),
 				},
 				{
-					icon: cog,
+					icon: settings,
 					path: '/',
 					link: settingsPath( siteSlug ),
 					title: translate( 'Settings' ),

--- a/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
@@ -1,8 +1,167 @@
+import config from '@automattic/calypso-config';
+import { WPCOM_FEATURES_BACKUPS, WPCOM_FEATURES_SCAN } from '@automattic/calypso-products';
+import { Icon, chevronLeft, plugins } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import page from 'page';
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import QueryScanState from 'calypso/components/data/query-jetpack-scan';
+import QuerySiteFeatures from 'calypso/components/data/query-site-features';
+import JetpackIcons from 'calypso/components/jetpack/sidebar/menu-items/jetpack-icons';
 import NewSidebar from 'calypso/jetpack-cloud/components/sidebar';
+import {
+	settingsPath,
+	purchasesPath,
+	pluginsPath,
+	backupPath,
+	scanPath,
+} from 'calypso/lib/jetpack/paths';
+import { isSectionNameEnabled } from 'calypso/sections-filter';
+import { isAgencyUser } from 'calypso/state/partner-portal/partner/selectors';
+import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
+import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
+import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
-// This sidebar is what people will see when they pick a site from the site
-// selector. It'll display menu options like Activity Log, Backup, Social, etc.
-// FIXME: Add menu items and the right path
-const ManageSelectedSiteSidebar = () => <NewSidebar path="/" menuItems={ [] } />;
+const ManageSelectedSiteSidebar = () => {
+	const translate = useTranslate();
+	const siteId = useSelector( getSelectedSiteId );
+	const isAgency = useSelector( isAgencyUser );
+	const siteSlug = useSelector( getSelectedSiteSlug );
+	const hasBackups = useSelector( ( state ) =>
+		siteHasFeature( state, siteId, WPCOM_FEATURES_BACKUPS )
+	);
+	const hasScan = useSelector( ( state ) => siteHasFeature( state, siteId, WPCOM_FEATURES_SCAN ) );
+
+	const isAdmin = useSelector( ( state ) => canCurrentUser( state, siteId, 'manage_options' ) );
+
+	const isWPCOM = useSelector( ( state ) => getIsSiteWPCOM( state, siteId ) );
+
+	const isWPForTeamsSite = useSelector( ( state ) => isSiteWPForTeams( state, siteId ) );
+
+	const shouldShowSettings =
+		useSelector( ( state ) => canCurrentUser( state, siteId, 'manage_options' ) ) &&
+		( hasBackups || hasScan );
+
+	const shouldShowPurchases =
+		useSelector( ( state ) => canCurrentUser( state, siteId, 'own_site' ) ) &&
+		isSectionNameEnabled( 'site-purchases' );
+
+	const isPluginManagementEnabled = config.isEnabled( 'jetpack/plugin-management' );
+
+	const onClickMenuItem = ( path: string ) => {
+		page.redirect( path );
+	};
+
+	const menuItems = useMemo(
+		() =>
+			[
+				{
+					icon: <JetpackIcons icon="activity-log" />,
+					path: '/',
+					link: `/activity-log/${ siteSlug }`,
+					title: translate( 'Activity Log' ),
+					onClickMenuItem: onClickMenuItem,
+					trackEventName: 'calypso_jetpack_sidebar_activity_clicked',
+					enabled: isAdmin,
+				},
+				{
+					icon: <JetpackIcons icon="backup" />,
+					path: '/',
+					link: backupPath( siteSlug ),
+					title: translate( 'VaultPress Backup' ),
+					onClickMenuItem: onClickMenuItem,
+					trackEventName: 'calypso_jetpack_sidebar_backup_clicked',
+					enabled: isAdmin && ! isWPForTeamsSite,
+				},
+				{
+					icon: <JetpackIcons icon="scan" />,
+					path: '/',
+					link: scanPath( siteSlug ),
+					title: translate( 'Scan' ),
+					onClickMenuItem: onClickMenuItem,
+					trackEventName: 'calypso_jetpack_sidebar_scan_clicked',
+					enabled: isAdmin && ! isWPCOM && ! isWPForTeamsSite,
+				},
+				{
+					icon: <JetpackIcons icon="search" />,
+					path: '/',
+					link: `/jetpack-search/${ siteSlug }`,
+					title: translate( 'Search' ),
+					onClickMenuItem: onClickMenuItem,
+					trackEventName: 'calypso_jetpack_sidebar_search_clicked',
+					enabled: isAdmin,
+				},
+				{
+					icon: <JetpackIcons icon="social" />,
+					path: '/',
+					link: `/jetpack-social/${ siteSlug }`,
+					title: translate( 'Social' ),
+					onClickMenuItem: onClickMenuItem,
+					trackEventName: 'calypso_jetpack_sidebar_social_clicked',
+					enabled: isAdmin && isSectionNameEnabled( 'jetpack-social' ) && ! isWPForTeamsSite,
+				},
+				{
+					icon: <Icon className="sidebar__menu-icon" size={ 28 } icon={ plugins } />,
+					path: '/',
+					link: pluginsPath( siteSlug ),
+					title: translate( 'Plugins' ),
+					onClickMenuItem: onClickMenuItem,
+					trackEventName: 'calypso_jetpack_sidebar_plugins_clicked',
+					enabled: isPluginManagementEnabled && isAgency,
+				},
+				{
+					icon: <JetpackIcons icon="settings" />,
+					path: '/',
+					link: settingsPath( siteSlug ),
+					title: translate( 'Settings' ),
+					onClickMenuItem: onClickMenuItem,
+					trackEventName: 'calypso_jetpack_sidebar_settings_clicked',
+					enabled: shouldShowSettings,
+				},
+				{
+					icon: <JetpackIcons icon="money" />,
+					path: '/',
+					link: purchasesPath( siteSlug ),
+					title: translate( 'Purchases' ),
+					onClickMenuItem: onClickMenuItem,
+					trackEventName: 'calypso_jetpack_sidebar_purchases_clicked',
+					enabled: shouldShowPurchases,
+				},
+			].filter( ( { enabled } ) => enabled ),
+		[
+			isAdmin,
+			isAgency,
+			isPluginManagementEnabled,
+			isWPCOM,
+			isWPForTeamsSite,
+			shouldShowPurchases,
+			shouldShowSettings,
+			siteSlug,
+			translate,
+		]
+	);
+
+	return (
+		<>
+			<QuerySiteFeatures siteIds={ [ siteId ] } />
+			{ siteId && <QueryScanState siteId={ siteId } /> }
+			<NewSidebar
+				path="/"
+				menuItems={ menuItems }
+				backButtonProps={
+					isAgency
+						? {
+								label: translate( 'Site Management' ),
+								icon: chevronLeft,
+								onClick: () => onClickMenuItem( '/dashboard' ),
+						  }
+						: undefined
+				}
+			/>
+		</>
+	);
+};
 
 export default ManageSelectedSiteSidebar;

--- a/client/lib/jetpack/paths.ts
+++ b/client/lib/jetpack/paths.ts
@@ -2,13 +2,13 @@ import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { addQueryArgs } from 'calypso/lib/url';
 
 const backupBasePath = () => '/backup';
-export const backupPath = ( siteSlug?: string, query = {} ): string => {
+export const backupPath = ( siteSlug?: string | null, query = {} ): string => {
 	const path = siteSlug ? `${ backupBasePath() }/${ siteSlug }` : backupBasePath();
 	return addQueryArgs( query, path );
 };
 
 const scanBasePath = () => '/scan';
-export const scanPath = ( siteSlug?: string ): string =>
+export const scanPath = ( siteSlug?: string | null ): string =>
 	siteSlug ? `${ scanBasePath() }/${ siteSlug }` : scanBasePath();
 
 const settingsBasePath = () => ( isJetpackCloud() ? '/settings' : '/settings/jetpack' );
@@ -42,7 +42,7 @@ export const agencySignupBasePath = () => '/agency/signup';
 
 const pluginsBasePath = '/plugins/manage';
 
-export const pluginsPath = ( siteSlug?: string, query = {} ): string => {
+export const pluginsPath = ( siteSlug?: string | null, query = {} ): string => {
 	const path = siteSlug ? `${ pluginsBasePath }/${ siteSlug }` : pluginsBasePath;
 	return addQueryArgs( query, path );
 };

--- a/client/state/selectors/can-current-user.js
+++ b/client/state/selectors/can-current-user.js
@@ -4,8 +4,8 @@
  * - `false` if the user does not have the capability, or if specifying an invalid capability;
  * - `null` if the capability cannot be determined (the site is not currently known)
  * @see https://codex.wordpress.org/Function_Reference/current_user_can
- * @param  {Object}   state      Global state tree
- * @param  {number|undefined}   siteId     Site ID
+ * @param  {Object|unknown}   state      Global state tree
+ * @param  {number|undefined|null}   siteId     Site ID
  * @param  {string}   capability Capability label
  * @returns {boolean}            Whether current user has capability
  */

--- a/client/state/selectors/is-site-wpforteams.js
+++ b/client/state/selectors/is-site-wpforteams.js
@@ -1,8 +1,8 @@
 import { get } from 'lodash';
 /**
  * Returns true if site is a WP for Teams site, false if not and null if unknown
- * @param  {Object}   state  Global state tree
- * @param  {number}   siteId Site ID
+ * @param  {Object|unknown}   state  Global state tree
+ * @param  {number|null}   siteId Site ID
  * @returns {?boolean}        Whether site is a WP for Teams site
  */
 export default function isSiteWPForTeams( state, siteId ) {


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack-genesis/issues/60
Depends on #83085

## Proposed Changes

* Add Sidebar menu items in the Single site page.
<img width="278" alt="Screen Shot 2023-10-18 at 6 50 30 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/f7c86027-ada0-4edd-ba60-3f1ca258b836">

## Testing Instructions

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

* Use the Jetpack cloud live link and go to a single site page (e,g. /activity-log/<SITE>?flags=jetpack/new-navigation)
* Confirm that the menu items are rendering correctly. Please test if the items match what was in production.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?