### PR TITLE
Headers: Update font & details on navigation-header

### DIFF
--- a/client/components/navigation-header/style.scss
+++ b/client/components/navigation-header/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
 
 .navigation-header {
 	box-sizing: border-box;
@@ -8,8 +9,8 @@
 	margin-bottom: 32px;
 	@include break-small {
 
-		padding: 0 0 24px 0;
-		margin-bottom: 16px;
+		padding: 0;
+		margin-bottom: 24px;
 	}
 
 	.breadcrumbs-back {
@@ -32,15 +33,21 @@
 	}
 
 	.formatted-header__title {
-		font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
-		font-size: $font-title-medium;
+		font-family: "SF Pro Display", $sans;
+		font-size: $font-title-small;
 		font-weight: 500;
 		margin-bottom: 4px;
-		min-height: 33px;
+		line-height: 26px;
 	}
 	.formatted-header__subtitle {
-		min-height: 20px;
+		color: var(--color-neutral-60);
 		margin: 0;
+		line-height: 20px;
+		letter-spacing: -0.15px;
+	}
+
+	.button {
+		line-height: 20px;
 	}
 }
 


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/4219
Follow up of https://github.com/Automattic/wp-calypso/pull/83066

## Proposed Changes

Updated some details on the new navigation header CSS.

Slack discussion: p1697614230622259-slack-CKZHG0QCR
| Before | After |
| --- | --- |
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/201d7ad7-9ede-4802-9760-1fee2fb92a0c) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/e8247715-7792-4ec9-ba01-5c82dc72c7f7) |
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/5cff6714-64e5-4970-8fad-fe9ab97bf04d) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/84c80dc7-7537-4434-a178-8ebf7faa5980) |
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/2637cb0c-dcec-4600-8c77-197265eeb9d1) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/b32dabaa-27d0-456f-8503-bb1d5ba19bc7) |

## Testing Instructions

* Check details against Figma: eqlepL7MHifK8Bgr1OWqLr-fi-9382%3A26649
* Check on `/home`
* Check on `/themes`
* Check on `/people`