### PR TITLE
Design first flow: Skip design setup if there's a preselected free theme with style variation

### DIFF
--- a/client/landing/stepper/declarative-flow/design-first.ts
+++ b/client/landing/stepper/declarative-flow/design-first.ts
@@ -105,6 +105,10 @@ const designFirst: Flow = {
 						} );
 
 						if ( providedDependencies?.hasSetPreselectedTheme ) {
+							await updateLaunchpadSettings( siteSlug, {
+								checklist_statuses: { design_completed: true },
+							} );
+
 							return navigate( `launchpad?siteSlug=${ siteSlug }` );
 						}
 

--- a/client/landing/stepper/declarative-flow/design-first.ts
+++ b/client/landing/stepper/declarative-flow/design-first.ts
@@ -104,7 +104,7 @@ const designFirst: Flow = {
 							launchpad_screen: 'full',
 						} );
 
-						if ( providedDependencies?.shouldSkipDesignSetup ) {
+						if ( providedDependencies?.hasSetPreselectedTheme ) {
 							return navigate( 'launchpad' );
 						}
 

--- a/client/landing/stepper/declarative-flow/design-first.ts
+++ b/client/landing/stepper/declarative-flow/design-first.ts
@@ -105,7 +105,7 @@ const designFirst: Flow = {
 						} );
 
 						if ( providedDependencies?.hasSetPreselectedTheme ) {
-							await updateLaunchpadSettings( siteSlug, {
+							updateLaunchpadSettings( siteSlug as string, {
 								checklist_statuses: { design_completed: true },
 							} );
 

--- a/client/landing/stepper/declarative-flow/design-first.ts
+++ b/client/landing/stepper/declarative-flow/design-first.ts
@@ -104,6 +104,10 @@ const designFirst: Flow = {
 							launchpad_screen: 'full',
 						} );
 
+						if ( providedDependencies?.shouldSkipDesignSetup ) {
+							return navigate( 'launchpad' );
+						}
+
 						return window.location.assign(
 							addQueryArgs( `/setup/update-design/designSetup`, {
 								siteSlug: siteSlug,

--- a/client/landing/stepper/declarative-flow/design-first.ts
+++ b/client/landing/stepper/declarative-flow/design-first.ts
@@ -105,7 +105,7 @@ const designFirst: Flow = {
 						} );
 
 						if ( providedDependencies?.hasSetPreselectedTheme ) {
-							return navigate( 'launchpad' );
+							return navigate( `launchpad?siteSlug=${ siteSlug }` );
 						}
 
 						return window.location.assign(

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -19,6 +19,7 @@ import {
 	isNewsletterFlow,
 	isBlogOnboardingFlow,
 	isOnboardingPMFlow,
+	setThemeOnSite,
 } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
@@ -101,9 +102,11 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, da
 		theme = DEFAULT_NEWSLETTER_THEME;
 	}
 
+	let preselectedThemeSlug = '';
+	let preselectedThemeStyleVariation = '';
+
 	// Maybe set the theme for the user instead of taking them to the update-design flow.
 	// See: https://github.com/Automattic/wp-calypso/issues/83077
-	let preselectedThemeSlug = '';
 	if ( isDesignFirstFlow( flow ) ) {
 		const themeSlug = getQueryArg( window.location.href, 'theme' );
 		const themeType = getQueryArg( window.location.href, 'theme_type' );
@@ -112,6 +115,7 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, da
 		// Only do this for preselected free themes with style variation.
 		if ( !! themeSlug && themeType === FREE_THEME && !! styleVariation ) {
 			preselectedThemeSlug = `pub/${ themeSlug }`;
+			preselectedThemeStyleVariation = styleVariation;
 		}
 	}
 
@@ -167,7 +171,7 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, da
 			flow,
 			true,
 			isPaidDomainItem,
-			preselectedThemeSlug || theme,
+			theme,
 			siteVisibility,
 			urlData?.meta.title ?? selectedSiteTitle,
 			// We removed the color option during newsletter onboarding.
@@ -180,6 +184,10 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, da
 			domainCartItem,
 			sourceSlug
 		);
+
+		if ( preselectedThemeSlug && site?.siteSlug ) {
+			await setThemeOnSite( site.siteSlug, preselectedThemeSlug, preselectedThemeStyleVariation );
+		}
 
 		if ( planCartItem?.product_slug === PLAN_HOSTING_TRIAL_MONTHLY && site ) {
 			await addHostingTrial( { siteId: site.siteId, planSlug: PLAN_HOSTING_TRIAL_MONTHLY } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -8,6 +8,7 @@ import {
 	addProductsToCart,
 	createSiteWithCart,
 	isCopySiteFlow,
+	isDesignFirstFlow,
 	isFreeFlow,
 	isLinkInBioFlow,
 	isMigrationFlow,
@@ -20,6 +21,7 @@ import {
 } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
+import { getQueryArg } from '@wordpress/url';
 import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import { LoadingBar } from 'calypso/components/loading-bar';
@@ -97,6 +99,21 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, da
 	} else if ( isNewsletterFlow( flow ) ) {
 		theme = DEFAULT_NEWSLETTER_THEME;
 	}
+
+	// Maybe set the theme for the user instead of taking them to the update-design flow.
+	// See: https://github.com/Automattic/wp-calypso/issues/83077
+	let preselectedThemeSlug = '';
+	if ( isDesignFirstFlow( flow ) ) {
+		const themeSlug = getQueryArg( window.location.href, 'theme' );
+		const themeType = getQueryArg( window.location.href, 'theme_type' );
+		const styleVariation = getQueryArg( window.location.href, 'style_variation' );
+
+		// Only do this for preselected free themes with style variation.
+		if ( !! themeSlug && themeType === 'free' && !! styleVariation ) {
+			preselectedThemeSlug = `pub/${ themeSlug }`;
+		}
+	}
+
 	const isPaidDomainItem = Boolean( domainCartItem?.product_slug );
 
 	const progress = useSelect(
@@ -149,7 +166,7 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, da
 			flow,
 			true,
 			isPaidDomainItem,
-			theme,
+			preselectedThemeSlug || theme,
 			siteVisibility,
 			urlData?.meta.title ?? selectedSiteTitle,
 			// We removed the color option during newsletter onboarding.
@@ -190,6 +207,7 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, da
 			siteId: site?.siteId,
 			siteSlug: site?.siteSlug,
 			goToCheckout: Boolean( planCartItem ),
+			shouldSkipDesignSetup: Boolean( preselectedThemeSlug ),
 		};
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -115,7 +115,7 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, da
 		// Only do this for preselected free themes with style variation.
 		if ( !! themeSlug && themeType === FREE_THEME && !! styleVariation ) {
 			preselectedThemeSlug = `pub/${ themeSlug }`;
-			preselectedThemeStyleVariation = styleVariation;
+			preselectedThemeStyleVariation = styleVariation as string;
 		}
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -1,5 +1,6 @@
 import { PLAN_HOSTING_TRIAL_MONTHLY } from '@automattic/calypso-products';
 import { Site } from '@automattic/data-stores';
+import { FREE_THEME } from '@automattic/design-picker';
 import {
 	ECOMMERCE_FLOW,
 	StepContainer,
@@ -109,7 +110,7 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, da
 		const styleVariation = getQueryArg( window.location.href, 'style_variation' );
 
 		// Only do this for preselected free themes with style variation.
-		if ( !! themeSlug && themeType === 'free' && !! styleVariation ) {
+		if ( !! themeSlug && themeType === FREE_THEME && !! styleVariation ) {
 			preselectedThemeSlug = `pub/${ themeSlug }`;
 		}
 	}
@@ -207,7 +208,7 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, da
 			siteId: site?.siteId,
 			siteSlug: site?.siteSlug,
 			goToCheckout: Boolean( planCartItem ),
-			shouldSkipDesignSetup: Boolean( preselectedThemeSlug ),
+			hasSetPreselectedTheme: Boolean( preselectedThemeSlug ),
 		};
 	}
 

--- a/client/my-sites/themes/theme-preview.jsx
+++ b/client/my-sites/themes/theme-preview.jsx
@@ -81,7 +81,7 @@ class ThemePreview extends Component {
 		};
 	};
 
-	appendStyleVariationOptionToUrl = ( url ) => {
+	appendStyleVariationOptionToUrl = ( url, key = 'slug' ) => {
 		const styleVariationOption = this.getStyleVariationOption();
 		if ( ! styleVariationOption ) {
 			return url;
@@ -89,7 +89,7 @@ class ThemePreview extends Component {
 
 		const [ base, query ] = url.split( '?' );
 		const params = new URLSearchParams( query );
-		params.set( 'style_variation', styleVariationOption.title );
+		params.set( 'style_variation', styleVariationOption[ key ] );
 
 		return `${ base }?${ params.toString() }`;
 	};
@@ -182,7 +182,10 @@ class ThemePreview extends Component {
 			return;
 		}
 
-		const buttonHref = primaryOption.getUrl ? primaryOption.getUrl( this.props.themeId ) : null;
+		const { themeId } = this.props;
+		const buttonHref = primaryOption.getUrl
+			? this.appendStyleVariationOptionToUrl( primaryOption.getUrl( themeId ) )
+			: null;
 
 		return (
 			<Button primary onClick={ this.onPrimaryButtonClick } href={ buttonHref }>
@@ -197,7 +200,10 @@ class ThemePreview extends Component {
 			return;
 		}
 
-		const buttonHref = secondaryButton.getUrl ? secondaryButton.getUrl( this.props.themeId ) : null;
+		const { themeId } = this.props;
+		const buttonHref = secondaryButton.getUrl
+			? this.appendStyleVariationOptionToUrl( secondaryButton.getUrl( themeId ) )
+			: null;
 
 		return (
 			<Button onClick={ this.onSecondaryButtonClick } href={ buttonHref }>
@@ -238,7 +244,8 @@ class ThemePreview extends Component {
 						showSEO={ false }
 						onClose={ this.props.hideThemePreview }
 						previewUrl={ this.appendStyleVariationOptionToUrl(
-							demoUrl + '?demo=true&iframe=true&theme_preview=true'
+							demoUrl + '?demo=true&iframe=true&theme_preview=true',
+							'title'
 						) }
 						externalUrl={ demoUrl }
 						belowToolbar={ this.props.belowToolbar }

--- a/packages/onboarding/src/cart/index.tsx
+++ b/packages/onboarding/src/cart/index.tsx
@@ -282,7 +282,11 @@ export async function addProductsToCart(
 	}
 }
 
-export async function setThemeOnSite( siteSlug: string, themeSlugWithRepo: string ) {
+export async function setThemeOnSite(
+	siteSlug: string,
+	themeSlugWithRepo: string,
+	themeStyleVariation: string
+) {
 	if ( isEmpty( themeSlugWithRepo ) ) {
 		return;
 	}
@@ -296,6 +300,7 @@ export async function setThemeOnSite( siteSlug: string, themeSlugWithRepo: strin
 			apiVersion: '1.1',
 			body: {
 				theme,
+				...( themeStyleVariation && { style_variation_slug: themeStyleVariation } ),
 			},
 		} );
 	} catch ( error ) {

--- a/packages/onboarding/src/cart/index.tsx
+++ b/packages/onboarding/src/cart/index.tsx
@@ -285,7 +285,7 @@ export async function addProductsToCart(
 export async function setThemeOnSite(
 	siteSlug: string,
 	themeSlugWithRepo: string,
-	themeStyleVariation: string
+	themeStyleVariation?: string
 ) {
 	if ( isEmpty( themeSlugWithRepo ) ) {
 		return;

--- a/packages/onboarding/src/index.ts
+++ b/packages/onboarding/src/index.ts
@@ -12,6 +12,7 @@ export {
 	addPlanToCart,
 	addProductsToCart,
 	replaceProductsInCart,
+	setThemeOnSite,
 } from './cart';
 export { setupSiteAfterCreation, base64ImageToBlob } from './setup-tailored-site-after-creation';
 export { uploadAndSetSiteLogo } from './upload-and-set-site-logo';


### PR DESCRIPTION
## Proposed Changes

This PR updates the design-first flow so that the design picker step is bypassed when the user has preselected a free theme with style variation. As a result, the user will land directly in the Launchpad.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the logged-out theme showcase.
* Select the category Blog (required).
* Find a free theme and select one of its style variations.
* Select the Pick this Design option.
* Ensure that after the account screen, the user lands directly on the Launchpad instead of the Design Picker.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?