### PR TITLE
Design Picker: cleanup unused fields

### DIFF
--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -133,15 +133,10 @@ export interface Design {
 export interface DesignOptions {
 	styleVariation?: StyleVariation;
 	globalStyles?: GlobalStyles;
-	pageTemplate?: string;
-	trimContent?: boolean;
-	posts_source_site_id?: number;
-	keepHomepage?: boolean;
 }
 
 export interface DesignPreviewOptions {
 	language?: string;
-	vertical_id?: string;
 	site_title?: string;
 	site_tagline?: string;
 	viewport_height?: number;

--- a/packages/design-picker/src/utils/__tests__/designs.test.ts
+++ b/packages/design-picker/src/utils/__tests__/designs.test.ts
@@ -23,7 +23,7 @@ describe( 'Design Picker designs utils', () => {
 
 		it( 'should return the block-previews/site endpoint with the correct query params', () => {
 			expect( getDesignPreviewUrl( design, {} ) ).toEqual(
-				`https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fzoologist&pattern_ids=12%2C34&viewport_height=${ DEFAULT_VIEWPORT_HEIGHT }&source_site=patternboilerplates.wordpress.com&site_title=Zoologist`
+				`https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fzoologist&pattern_ids=12%2C34&viewport_height=${ DEFAULT_VIEWPORT_HEIGHT }&site_title=Zoologist`
 			);
 		} );
 
@@ -33,7 +33,7 @@ describe( 'Design Picker designs utils', () => {
 			} );
 
 			expect( getDesignPreviewUrl( customizedDesign, {} ) ).toEqual(
-				`https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fzoologist&pattern_ids=12%2C34&header_pattern_ids=56%2C78&viewport_height=${ DEFAULT_VIEWPORT_HEIGHT }&source_site=patternboilerplates.wordpress.com&site_title=Zoologist`
+				`https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fzoologist&pattern_ids=12%2C34&header_pattern_ids=56%2C78&viewport_height=${ DEFAULT_VIEWPORT_HEIGHT }&site_title=Zoologist`
 			);
 		} );
 
@@ -43,20 +43,19 @@ describe( 'Design Picker designs utils', () => {
 			} );
 
 			expect( getDesignPreviewUrl( customizedDesign, {} ) ).toEqual(
-				`https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fzoologist&pattern_ids=12%2C34&footer_pattern_ids=56%2C78&viewport_height=${ DEFAULT_VIEWPORT_HEIGHT }&source_site=patternboilerplates.wordpress.com&site_title=Zoologist`
+				`https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fzoologist&pattern_ids=12%2C34&footer_pattern_ids=56%2C78&viewport_height=${ DEFAULT_VIEWPORT_HEIGHT }&site_title=Zoologist`
 			);
 		} );
 
 		it( 'should append the preview options to the query params', () => {
 			const options: DesignPreviewOptions = {
 				language: 'id',
-				vertical_id: '3',
 				site_title: 'Design Title',
 				viewport_height: 700,
 			};
 
 			expect( getDesignPreviewUrl( design, options ) ).toEqual(
-				`https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fzoologist&pattern_ids=12%2C34&vertical_id=3&language=id&viewport_height=700&source_site=patternboilerplates.wordpress.com&site_title=Design%20Title`
+				`https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fzoologist&pattern_ids=12%2C34&language=id&viewport_height=700&site_title=Design%20Title`
 			);
 		} );
 
@@ -68,7 +67,7 @@ describe( 'Design Picker designs utils', () => {
 			};
 
 			expect( getDesignPreviewUrl( design, options ) ).toEqual(
-				`https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fzoologist&pattern_ids=12%2C34&viewport_height=${ DEFAULT_VIEWPORT_HEIGHT }&source_site=patternboilerplates.wordpress.com&site_title=Mock%28Design%29%28Title%29`
+				`https://public-api.wordpress.com/wpcom/v2/block-previews/site?stylesheet=pub%2Fzoologist&pattern_ids=12%2C34&viewport_height=${ DEFAULT_VIEWPORT_HEIGHT }&site_title=Mock%28Design%29%28Title%29`
 			);
 		} );
 	} );

--- a/packages/design-picker/src/utils/designs.ts
+++ b/packages/design-picker/src/utils/designs.ts
@@ -27,12 +27,10 @@ export const getDesignPreviewUrl = (
 		footer_pattern_ids: recipe?.footer_pattern_ids
 			? recipe?.footer_pattern_ids.join( ',' )
 			: undefined,
-		vertical_id: options.vertical_id,
 		language: options.language,
 		viewport_height: ! options.disable_viewport_height
 			? options.viewport_height || DEFAULT_VIEWPORT_HEIGHT
 			: undefined,
-		source_site: 'patternboilerplates.wordpress.com',
 		...( options.use_screenshot_overrides && {
 			use_screenshot_overrides: options.use_screenshot_overrides,
 		} ),


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/wp-calypso/issues/82225

## Proposed Changes

Removed the following unused query args to the `/block-previews/site` endpoint:

- `vertical_id`, `source_site` (leftover from verticalization)

Removed the following unused params from `DesignOptions`:

- `trimContent`, `keepHomepage`: leftover from Headstart
- `pageTemplate`, `posts_source_site_id`: leftover from Assembler before we moved to the `assemble-site` endpoint

## Testing Instructions

Test that the Design Picker step is still working as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?