### PR TITLE
Importer: Refactor pre-migration component

### DIFF
--- a/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
@@ -157,10 +157,10 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 	 * Decide the render state based on the current component state
 	 */
 	useEffect( () => {
-		if ( ! isTargetSitePlanCompatible ) {
-			setRenderState( 'upgrade-plan' );
-		} else if ( requiresPluginUpdate ) {
+		if ( requiresPluginUpdate ) {
 			setRenderState( 'update-plugin' );
+		} else if ( ! isTargetSitePlanCompatible ) {
+			setRenderState( 'upgrade-plan' );
 		} else if ( showCredentials ) {
 			setRenderState( 'credentials' );
 		} else if ( isFetchingCredentials || isFetchingMigrationData ) {

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
@@ -165,7 +165,7 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 			setRenderState( 'credentials' );
 		} else if ( isFetchingCredentials || isFetchingMigrationData ) {
 			setRenderState( 'loading' );
-		} else if ( ! sourceSite || ( sourceSite && sourceSite.ID !== sourceSiteId ) ) {
+		} else if ( ! sourceSiteId ) {
 			setRenderState( 'not-authorized' );
 		} else {
 			setRenderState( 'ready' );
@@ -173,7 +173,6 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 	}, [
 		isFetchingCredentials,
 		isFetchingMigrationData,
-		sourceSite,
 		sourceSiteId,
 		requiresPluginUpdate,
 		showCredentials,

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
@@ -171,11 +171,11 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 			setRenderState( 'ready' );
 		}
 	}, [
+		sourceSiteId,
+		showCredentials,
+		requiresPluginUpdate,
 		isFetchingCredentials,
 		isFetchingMigrationData,
-		sourceSiteId,
-		requiresPluginUpdate,
-		showCredentials,
 		isTargetSitePlanCompatible,
 	] );
 

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
@@ -59,7 +59,6 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 
 	const [ renderState, setRenderState ] = useState< PreMigrationState >( 'loading' );
 	const [ showCredentials, setShowCredentials ] = useState( false );
-	const [ hasLoaded, setHasLoaded ] = useState( false );
 	const [ continueImport, setContinueImport ] = useState( false );
 
 	const {
@@ -111,7 +110,7 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 		},
 	} );
 
-	const { hasCredentials, isRequesting: isRequestingCredentials } =
+	const { hasCredentials, isRequesting: isFetchingCredentials } =
 		useSiteCredentialsInfo( sourceSiteId );
 
 	const onUpgradeAndMigrateClick = () => {
@@ -149,7 +148,7 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 			setRenderState( 'credentials' );
 		} else if ( ! isTargetSitePlanCompatible ) {
 			setRenderState( 'upgrade-plan' );
-		} else if ( ! hasLoaded || isRequestingCredentials ) {
+		} else if ( isFetchingCredentials || isFetchingMigrationData ) {
 			setRenderState( 'loading' );
 		} else if ( ! sourceSite || ( sourceSite && sourceSite.ID !== sourceSiteId ) ) {
 			setRenderState( 'not-authorized' );
@@ -157,8 +156,8 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 			setRenderState( 'ready' );
 		}
 	}, [
-		hasLoaded,
-		isRequestingCredentials,
+		isFetchingCredentials,
+		isFetchingMigrationData,
 		sourceSite,
 		sourceSiteId,
 		requiresPluginUpdate,

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
@@ -96,14 +96,6 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 		isRequestingSitePlans( state, targetSite.ID )
 	);
 
-	useEffect( () => {
-		if ( queryTargetSitePlanStatus === 'fetching' && ! isRequestingTargetSitePlans ) {
-			setQueryTargetSitePlanStatus( 'fetched' );
-			setContinueImport( true );
-			fetchMigrationEnabledStatus();
-		}
-	}, [ queryTargetSitePlanStatus, isRequestingTargetSitePlans, fetchMigrationEnabledStatus ] );
-
 	const { isLoading: isAddingTrial } = useAddHostingTrialMutation( {
 		onSuccess: () => {
 			setQueryTargetSitePlanStatus( 'fetching' );
@@ -135,6 +127,18 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 		}
 		dispatch( getCredentials( sourceSiteId ) );
 	}, [ isTargetSitePlanCompatible, sourceSiteId, dispatch ] );
+
+	/**
+	 * Recognize when the plan upgrade is done
+	 * and fetch the migration enabled status
+	 */
+	useEffect( () => {
+		if ( queryTargetSitePlanStatus === 'fetching' && ! isRequestingTargetSitePlans ) {
+			setQueryTargetSitePlanStatus( 'fetched' );
+			setContinueImport( true );
+			fetchMigrationEnabledStatus();
+		}
+	}, [ queryTargetSitePlanStatus, isRequestingTargetSitePlans, fetchMigrationEnabledStatus ] );
 
 	/**
 	 * Start (continue) the import after:

--- a/client/data/site-migration/use-migration-enabled.ts
+++ b/client/data/site-migration/use-migration-enabled.ts
@@ -5,7 +5,6 @@ import type { SiteId, URL } from 'calypso/types';
 
 /**
  * Fetches migration enabled information for a specific target site and source site.
- *
  * @param targetSiteId - The ID of the target site.
  * @param sourceSite - The ID or URL of the source site.
  * @param enabled - Optional flag to enable/disable the query. Default is true.
@@ -34,6 +33,7 @@ export const useMigrationEnabledInfoQuery = (
 		},
 		enabled: !! ( enabled && targetSiteId && sourceSite ),
 		retry: false,
+		refetchOnWindowFocus: false,
 		select( data ) {
 			return {
 				...data,

--- a/client/data/site-migration/use-source-migration-status-query.ts
+++ b/client/data/site-migration/use-source-migration-status-query.ts
@@ -24,6 +24,7 @@ export const useSourceMigrationStatusQuery = (
 		},
 		enabled: !! sourceIdOrSlug,
 		retry: false,
+		refetchOnWindowFocus: false,
 		onError: ( error: MigrationStatusError ) => {
 			onErrorCallback && onErrorCallback( error );
 		},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/82758

## Proposed Changes

* Refactored pre-migration component
* Got rid of `hasLoaded` flag and relied on the in-progress flags for defining the loading state
* Grouped effects and described each of them for easier future maintenance
* Turned off the onWindowFocus re-fetch

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/import-focused?siteSlug={SLUG}`
* Pass through the flow with different combination
* JP connected and without JP connection
* Simple or Atomic target site
* Upgrade plan transition between `simple` to `atomic`
* Check if everything works as it is now in production

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?