### PR TITLE
Headers: Replace FormattedHeader in /me with NavigationHeader (Part 1 of 2)

### DIFF
--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -11,7 +11,6 @@ import CSSTransition from 'react-transition-group/CSSTransition';
 import TransitionGroup from 'react-transition-group/TransitionGroup';
 import ColorSchemePicker from 'calypso/blocks/color-scheme-picker';
 import QueryUserSettings from 'calypso/components/data/query-user-settings';
-import FormattedHeader from 'calypso/components/formatted-header';
 import FormButton from 'calypso/components/forms/form-button';
 import FormButtonsBar from 'calypso/components/forms/form-buttons-bar';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
@@ -26,6 +25,7 @@ import InlineSupportLink from 'calypso/components/inline-support-link';
 import LanguagePicker from 'calypso/components/language-picker';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import Notice from 'calypso/components/notice';
 import SectionHeader from 'calypso/components/section-header';
 import SitesDropdown from 'calypso/components/sites-dropdown';
@@ -61,6 +61,7 @@ import { isFetchingUserSettings } from 'calypso/state/user-settings/selectors';
 import { saveUnsavedUserSettings } from 'calypso/state/user-settings/thunks';
 import AccountSettingsCloseLink from './close-link';
 import ToggleSitesAsLandingPage from './toggle-sites-as-landing-page';
+
 import './style.scss';
 
 export const noticeId = 'me-settings-notice';
@@ -365,7 +366,6 @@ class Account extends Component {
 	/**
 	 * We handle the username (user_login) change manually through an onChange handler
 	 * so that we can also run a debounced validation on the username.
-	 *
 	 * @param {Object} event Event from onChange of user_login input
 	 */
 	handleUsernameChange = ( event ) => {
@@ -870,11 +870,10 @@ class Account extends Component {
 				<QueryUserSettings />
 				<PageViewTracker path="/me/account" title="Me > Account Settings" />
 				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
-				<FormattedHeader
-					brandFont
-					headerText={ translate( 'Account settings' ) }
-					align="left"
-					subHeaderText={ translate(
+				<NavigationHeader
+					navigationItems={ [] }
+					title={ translate( 'Account settings' ) }
+					subtitle={ translate(
 						'Adjust your account information and interface settings. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 						{
 							components: {

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -43,7 +43,9 @@ class Help extends PureComponent {
 	getHelpfulArticles = () => {
 		const helpfulResults = [
 			{
-				link: 'https://wordpress.com/support/do-i-need-a-website-a-blog-or-a-website-with-a-blog/',
+				link: localizeUrl(
+					'https://wordpress.com/support/do-i-need-a-website-a-blog-or-a-website-with-a-blog/'
+				),
 				title: this.props.translate( 'Do I Need a Website, a Blog, or a Website with a Blog?' ),
 				description: this.props.translate(
 					'If you’re building a brand new site, you might be wondering if you need a website, a blog, or a website with a blog. At WordPress.com, you can create all of these options easily, right in your dashboard.'
@@ -51,7 +53,7 @@ class Help extends PureComponent {
 				image: helpWebsite,
 			},
 			{
-				link: 'https://wordpress.com/support/business-plan/',
+				link: localizeUrl( 'https://wordpress.com/support/business-plan/' ),
 				title: this.props.translate( 'Uploading custom plugins and themes' ),
 				description: this.props.translate(
 					'Learn more about installing a custom theme or plugin using the Business plan.'
@@ -59,7 +61,7 @@ class Help extends PureComponent {
 				image: helpPlugins,
 			},
 			{
-				link: 'https://wordpress.com/support/domains/',
+				link: localizeUrl( 'https://wordpress.com/support/domains/' ),
 				title: this.props.translate( 'All About Domains' ),
 				description: this.props.translate(
 					'Set up your domain whether it’s registered with WordPress.com or elsewhere.'
@@ -67,7 +69,7 @@ class Help extends PureComponent {
 				image: helpDomains,
 			},
 			{
-				link: 'https://wordpress.com/support/start/',
+				link: localizeUrl( 'https://wordpress.com/support/start/' ),
 				title: this.props.translate( 'Get Started' ),
 				description: this.props.translate(
 					'No matter what kind of site you want to build, our five-step checklists will get you set up and ready to publish.'
@@ -75,7 +77,7 @@ class Help extends PureComponent {
 				image: helpGetStarted,
 			},
 			{
-				link: 'https://wordpress.com/support/settings/privacy-settings/',
+				link: localizeUrl( 'https://wordpress.com/support/settings/privacy-settings/' ),
 				title: this.props.translate( 'Privacy Settings' ),
 				description: this.props.translate(
 					'Limit your site’s visibility or make it completely private.'
@@ -83,7 +85,7 @@ class Help extends PureComponent {
 				image: helpPrivacy,
 			},
 			{
-				link: 'https://wordpress.com/support/manage-purchases/',
+				link: localizeUrl( 'https://wordpress.com/support/manage-purchases/' ),
 				title: this.props.translate( 'Managing Purchases, Renewals, and Cancellations' ),
 				description: this.props.translate(
 					'Have a question or need to change something about a purchase you have made? Learn how.'

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -12,8 +12,8 @@ import helpPlugins from 'calypso/assets/images/illustrations/help-plugins.svg';
 import helpPrivacy from 'calypso/assets/images/illustrations/help-privacy.svg';
 import helpWebsite from 'calypso/assets/images/illustrations/help-website.svg';
 import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
-import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
@@ -228,15 +228,14 @@ class Help extends PureComponent {
 			<Main className="help" wideLayout>
 				<PageViewTracker path="/help" title="Help" />
 
-				<div className="help__heading">
-					<FormattedHeader
-						brandFont
-						headerText={ translate( 'Support' ) }
-						subHeaderText={ translate( 'Get help with your WordPress.com site' ) }
-						align="left"
-					/>
+				<NavigationHeader
+					navigationItems={ [] }
+					title={ translate( 'Support' ) }
+					subtitle={ translate( 'Get help with your WordPress.com site' ) }
+				>
 					<HelpContactUsHeader />
-				</div>
+				</NavigationHeader>
+
 				<HelpSearch onSearch={ this.setIsSearching } />
 				{ ! this.state.isSearching && (
 					<div className="help__inner-wrapper">

--- a/client/me/memberships/subscription.jsx
+++ b/client/me/memberships/subscription.jsx
@@ -7,11 +7,11 @@ import { useEffect } from 'react';
 import { connect, useDispatch } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryMembershipsSubscriptions from 'calypso/components/data/query-memberships-subscriptions';
-import FormattedHeader from 'calypso/components/formatted-header';
 import HeaderCake from 'calypso/components/header-cake';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import Main from 'calypso/components/main';
 import MaterialIcon from 'calypso/components/material-icon';
+import NavigationHeader from 'calypso/components/navigation-header';
 import Notice from 'calypso/components/notice';
 import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
 import titles from 'calypso/me/purchases/titles';
@@ -77,7 +77,7 @@ function Subscription( { translate, subscription, moment, stoppingStatus } ) {
 				title={ isProduct ? translate( 'Product Details' ) : translate( 'Subscription Details' ) }
 			/>
 			<QueryMembershipsSubscriptions />
-			<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
+			<NavigationHeader navigationItems={ [] } title={ titles.sectionTitle } />
 			<HeaderCake backHref={ purchasesRoot }>
 				{ isProduct ? translate( 'Product Details' ) : translate( 'Subscription Details' ) }
 			</HeaderCake>

--- a/client/me/privacy/main.jsx
+++ b/client/me/privacy/main.jsx
@@ -9,10 +9,10 @@ import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryUserSettings from 'calypso/components/data/query-user-settings';
 import ExternalLink from 'calypso/components/external-link';
-import FormattedHeader from 'calypso/components/formatted-header';
 import FormButton from 'calypso/components/forms/form-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import SectionHeader from 'calypso/components/section-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { protectForm } from 'calypso/lib/protect-form';
@@ -70,7 +70,7 @@ class Privacy extends Component {
 				<PageViewTracker path="/me/privacy" title="Me > Privacy" />
 				<DocumentHead title={ translate( 'Privacy Settings' ) } />
 				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
-				<FormattedHeader brandFont headerText={ translate( 'Privacy' ) } align="left" />
+				<NavigationHeader navigationItems={ [] } title={ translate( 'Privacy' ) } />
 
 				<SectionHeader label={ translate( 'Usage information' ) } />
 				<Card className="privacy__settings">

--- a/client/me/profile/index.jsx
+++ b/client/me/profile/index.jsx
@@ -6,7 +6,6 @@ import { flowRight as compose } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import EditGravatar from 'calypso/blocks/edit-gravatar';
-import FormattedHeader from 'calypso/components/formatted-header';
 import FormButton from 'calypso/components/forms/form-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
@@ -14,6 +13,7 @@ import FormTextInput from 'calypso/components/forms/form-text-input';
 import FormTextarea from 'calypso/components/forms/form-textarea';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import SectionHeader from 'calypso/components/section-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { protectForm } from 'calypso/lib/protect-form';
@@ -26,6 +26,7 @@ import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { isFetchingUserSettings } from 'calypso/state/user-settings/selectors';
 import { getIAmDeveloperCopy } from './get-i-am-a-developer-copy';
 import UpdatedGravatarString from './updated-gravatar-string';
+
 import './style.scss';
 
 class Profile extends Component {
@@ -52,10 +53,10 @@ class Profile extends Component {
 			<Main className="profile">
 				<PageViewTracker path="/me" title="Me > My Profile" />
 				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
-				<FormattedHeader
-					brandFont
-					headerText={ this.props.translate( 'My Profile' ) }
-					subHeaderText={ this.props.translate(
+				<NavigationHeader
+					navigationItems={ [] }
+					title={ this.props.translate( 'My Profile' ) }
+					subtitle={ this.props.translate(
 						'Set your name, bio, and other public-facing information. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 						{
 							components: {
@@ -65,7 +66,6 @@ class Profile extends Component {
 							},
 						}
 					) }
-					align="left"
 				/>
 
 				<SectionHeader label={ this.props.translate( 'Profile' ) } />

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -8,6 +8,7 @@ import NoSitesMessage from 'calypso/components/empty-content/no-sites-message';
 import FormattedHeader from 'calypso/components/formatted-header';
 import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { useGeoLocationQuery } from 'calypso/data/geo/use-geolocation-query';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -115,7 +116,8 @@ export function confirmCancelDomain( context, next ) {
 		return (
 			<PurchasesWrapper title={ titles.confirmCancelDomain }>
 				<Main wideLayout className="purchases__cancel-domain confirm-cancel-domain">
-					<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
+					<NavigationHeader navigationItems={ [] } title={ titles.sectionTitle } />
+
 					<ConfirmCancelDomain
 						purchaseId={ parseInt( context.params.purchaseId, 10 ) }
 						siteSlug={ context.params.site }

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -216,7 +216,7 @@ export function managePurchaseByOwnership( context, next ) {
 		return (
 			<PurchasesWrapper title={ titles.managePurchase }>
 				<Main wideLayout className={ classes }>
-					<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
+					<NavigationHeader navigationItems={ [] } title={ titles.sectionTitle } />
 					<PageViewTracker
 						path="/me/purchases/:ownershipId"
 						title="Purchases > Manage Purchase by Ownership"

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -171,7 +171,7 @@ export function vatDetails( context, next ) {
 				<Main wideLayout className={ classes }>
 					<PageViewTracker path={ vatDetailsPath } title="Purchases > VAT Details" />
 
-					<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
+					<NavigationHeader navigationItems={ [] } title={ titles.sectionTitle } />
 					<HeaderCake onClick={ goToBillingHistory }>{ title }</HeaderCake>
 
 					<VatInfoPage siteSlug={ context.params.site } />

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -245,7 +245,7 @@ export function changePaymentMethod( context, next ) {
 		return (
 			<PurchasesWrapper title={ titles.changePaymentMethod }>
 				<Main wideLayout className="purchases__edit-payment-method">
-					<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
+					<NavigationHeader navigationItems={ [] } title={ titles.sectionTitle } />
 					<CheckoutErrorBoundary
 						errorMessage={ translate( 'Sorry, there was an error loading this page.' ) }
 						onError={ logPurchasesError }

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -191,7 +191,7 @@ export function managePurchase( context, next ) {
 		return (
 			<PurchasesWrapper title={ titles.managePurchase }>
 				<Main wideLayout className={ classes }>
-					<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
+					<NavigationHeader navigationItems={ [] } title={ titles.sectionTitle } />
 					<PageViewTracker
 						path="/me/purchases/:site/:purchaseId"
 						title="Purchases > Manage Purchase"

--- a/client/me/purchases/payment-methods/main.tsx
+++ b/client/me/purchases/payment-methods/main.tsx
@@ -1,8 +1,8 @@
 import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
-import FormattedHeader from 'calypso/components/formatted-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import PaymentMethodList from 'calypso/me/purchases/payment-methods/payment-method-list';
 import PurchasesNavigation from 'calypso/me/purchases/purchases-navigation';
@@ -18,10 +18,10 @@ function PaymentMethods() {
 		<Main wideLayout className="payment-methods__main">
 			<DocumentHead title={ titles.paymentMethods } />
 			<PageViewTracker path="/me/purchases/payment-methods" title="Me > Payment Methods" />
-			<FormattedHeader
-				brandFont
-				headerText={ titles.sectionTitle }
-				subHeaderText={ translate(
+			<NavigationHeader
+				navigationItems={ [] }
+				title={ titles.sectionTitle }
+				subtitle={ translate(
 					'Add or delete payment methods for your account. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 					{
 						components: {
@@ -31,8 +31,8 @@ function PaymentMethods() {
 						},
 					}
 				) }
-				align="left"
 			/>
+
 			<PurchasesNavigation section="paymentMethods" />
 			<PaymentMethodList addPaymentMethodUrl={ getAddNewPaymentMethodPath() } />
 		</Main>

--- a/client/me/security/main.jsx
+++ b/client/me/security/main.jsx
@@ -5,9 +5,9 @@ import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
-import FormattedHeader from 'calypso/components/formatted-header';
 import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 import AccountPassword from 'calypso/me/account-password';
@@ -42,7 +42,7 @@ class Security extends Component {
 				<PageViewTracker path={ path } title="Me > Password" />
 				<DocumentHead title={ translate( 'Password' ) } />
 
-				<FormattedHeader brandFont headerText={ translate( 'Security' ) } align="left" />
+				<NavigationHeader navigationItems={ [] } title={ translate( 'Security' ) } />
 
 				{ ! useCheckupMenu && <SecuritySectionNav path={ path } /> }
 				{ useCheckupMenu && (

--- a/client/me/site-blocks/main.jsx
+++ b/client/me/site-blocks/main.jsx
@@ -6,9 +6,9 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QuerySiteBlocks from 'calypso/components/data/query-site-blocks';
-import FormattedHeader from 'calypso/components/formatted-header';
 import InfiniteList from 'calypso/components/infinite-list';
 import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { requestSiteBlocks } from 'calypso/state/reader/site-blocks/actions';
 import {
@@ -56,7 +56,7 @@ class SiteBlockList extends Component {
 				<QuerySiteBlocks />
 				<PageViewTracker path="/me/site-blocks" title="Me > Blocked Sites" />
 				<DocumentHead title={ translate( 'Blocked Sites' ) } />
-				<FormattedHeader brandFont headerText={ translate( 'Blocked Sites' ) } align="left" />
+				<NavigationHeader navigationItems={ [] } title={ translate( 'Blocked Sites' ) } />
 
 				<Card className="site-blocks__intro">
 					<p>

--- a/client/me/social-login/index.jsx
+++ b/client/me/social-login/index.jsx
@@ -5,9 +5,9 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
-import FormattedHeader from 'calypso/components/formatted-header';
 import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import Notice from 'calypso/components/notice';
 import AppleIcon from 'calypso/components/social-icons/apple';
 import GoogleIcon from 'calypso/components/social-icons/google';
@@ -77,7 +77,7 @@ class SocialLogin extends Component {
 				<PageViewTracker path="/me/security/social-login" title="Me > Social Login" />
 				<DocumentHead title={ title } />
 
-				<FormattedHeader brandFont headerText={ translate( 'Security' ) } align="left" />
+				<NavigationHeader navigationItems={ [] } title={ translate( 'Security' ) } />
 
 				{ ! useCheckupMenu && <SecuritySectionNav path={ path } /> }
 				{ useCheckupMenu && (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4221

## Proposed Changes

* This is 1 of 2 PRs that replaces occurrences of `<FormattedHeader>` in client/me/ with `<NavigationHeader>`

I'm breaking up refactoring client/me/ into 2 PRs to keep the PR and review size manageable. 2nd PR is here: https://github.com/Automattic/wp-calypso/pull/83248

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

View the code to ensure it looks correct, and view the pages below to visually confirm. Some pages are difficult to get to, in those cases, we can rely on reviewing the code only.

* http://calypso.localhost:3000/me
* http://calypso.localhost:3000/me/account
* http://calypso.localhost:3000/help
  * We added `localizeUrl()` to the links under "Most Helpful Articles" to make the linter happy. Make sure they still work.
* http://calypso.localhost:3000/me/privacy
* http://calypso.localhost:3000/me/purchases/payment-methods
* http://calypso.localhost:3000/me/purchases/memberships <- You need an active membership to get to this page. :/
* http://calypso.localhost:3000/me/site-blocks
* http://calypso.localhost:3000/me/security/social-login
* http://calypso.localhost:3000/me/purchases/:site/:purchaseId/confirm-cancel-domain <- You can get to this page even if the domain has already been canceled, but you need a real purchaseId.
* http://calypso.localhost:3000/me/purchases/vat-details
* http://calypso.localhost:3000/me/purchases/:site/:purchaseId
* http://calypso.localhost:3000/me/purchases/:ownershipId <- I'm not sure how to get here or how to get an ownershipId. Eyeballing the code looks correct is probably sufficient.
* http://calypso.localhost:3000/me/purchases/:site/:purchaseId/payment-method/change/:methodId <- If you ever had a payment method (besides credits) on file for a purchase, there is an option to "Change payment method" on the purchase details page. Click that button to get here.
* http://calypso.localhost:3000/me/security/password

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?