### PR TITLE
Earn: Filter launchpad on frontend for atomic

### DIFF
--- a/client/my-sites/earn/launchpad/index.tsx
+++ b/client/my-sites/earn/launchpad/index.tsx
@@ -2,8 +2,10 @@ import { CircularProgressBar } from '@automattic/components';
 import { Launchpad, Task } from '@automattic/launchpad';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'calypso/state';
-import { getConnectUrlForSiteId } from 'calypso/state/memberships/settings/selectors';
+import { getProductsForSiteId } from 'calypso/state/memberships/product-list/selectors';
+import { getConnectedAccountIdForSiteId } from 'calypso/state/memberships/settings/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { Product } from '../types';
 
 type EarnLaunchpadProps = {
 	numberOfSteps: number;
@@ -12,11 +14,10 @@ type EarnLaunchpadProps = {
 
 const EarnLaunchpad = ( { numberOfSteps, completedSteps }: EarnLaunchpadProps ) => {
 	const translate = useTranslate();
-
 	const site = useSelector( ( state ) => getSelectedSite( state ) );
-
-	const stripeConnectUrl = useSelector( ( state ) =>
-		getConnectUrlForSiteId( state, site?.ID ?? 0 )
+	const products: Product[] = useSelector( ( state ) => getProductsForSiteId( state, site?.ID ) );
+	const connectedAccountId = useSelector( ( state ) =>
+		getConnectedAccountIdForSiteId( state, site?.ID )
 	);
 
 	const taskFilter = ( tasks: Task[] ): Task[] => {
@@ -29,18 +30,12 @@ const EarnLaunchpad = ( { numberOfSteps, completedSteps }: EarnLaunchpadProps ) 
 				case 'stripe_connected':
 					return {
 						...task,
-						actionDispatch: () => {
-							window.location.assign( stripeConnectUrl );
-						},
+						is_complete: !! connectedAccountId,
 					};
 				case 'paid_offer_created':
 					return {
 						...task,
-						actionDispatch: () => {
-							window.location.assign(
-								`/earn/payments-plans/${ site?.slug }?launchpad=add-product#add-newsletter-payment-plan`
-							);
-						},
+						is_complete: !! ( products && products.length > 0 ),
 					};
 				default:
 					return task;

--- a/client/my-sites/earn/launchpad/index.tsx
+++ b/client/my-sites/earn/launchpad/index.tsx
@@ -9,7 +9,6 @@ import {
 	getConnectedAccountIdForSiteId,
 } from 'calypso/state/memberships/settings/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import { Product } from '../types';
 
 type EarnLaunchpadProps = {
 	numberOfSteps: number;
@@ -19,13 +18,12 @@ type EarnLaunchpadProps = {
 const EarnLaunchpad = ( { numberOfSteps, completedSteps }: EarnLaunchpadProps ) => {
 	const translate = useTranslate();
 	const site = useSelector( ( state ) => getSelectedSite( state ) );
-	const products: Product[] = useSelector( ( state ) => getProductsForSiteId( state, site?.ID ) );
-	const connectedAccountId = useSelector( ( state ) =>
-		getConnectedAccountIdForSiteId( state, site?.ID )
-	);
-	const stripeConnectUrl = useSelector( ( state ) =>
-		getConnectUrlForSiteId( state, site?.ID ?? 0 )
-	);
+
+	const { products, connectedAccountId, stripeConnectUrl } = useSelector( ( state ) => ( {
+		products: getProductsForSiteId( state, site?.ID ),
+		connectedAccountId: getConnectedAccountIdForSiteId( state, site?.ID ),
+		stripeConnectUrl: getConnectUrlForSiteId( state, site?.ID ?? 0 ),
+	} ) );
 
 	const taskFilter = ( tasks: Task[] ): Task[] => {
 		if ( ! tasks ) {

--- a/client/my-sites/earn/launchpad/index.tsx
+++ b/client/my-sites/earn/launchpad/index.tsx
@@ -1,7 +1,8 @@
 import { CircularProgressBar } from '@automattic/components';
-import { DefaultWiredLaunchpad } from '@automattic/launchpad';
+import { Launchpad, Task } from '@automattic/launchpad';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'calypso/state';
+import { getConnectUrlForSiteId } from 'calypso/state/memberships/settings/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 type EarnLaunchpadProps = {
@@ -13,6 +14,39 @@ const EarnLaunchpad = ( { numberOfSteps, completedSteps }: EarnLaunchpadProps ) 
 	const translate = useTranslate();
 
 	const site = useSelector( ( state ) => getSelectedSite( state ) );
+
+	const stripeConnectUrl = useSelector( ( state ) =>
+		getConnectUrlForSiteId( state, site?.ID ?? 0 )
+	);
+
+	const taskFilter = ( tasks: Task[] ): Task[] => {
+		if ( ! tasks ) {
+			return [];
+		}
+
+		return tasks.map( ( task ) => {
+			switch ( task.id ) {
+				case 'stripe_connected':
+					return {
+						...task,
+						actionDispatch: () => {
+							window.location.assign( stripeConnectUrl );
+						},
+					};
+				case 'paid_offer_created':
+					return {
+						...task,
+						actionDispatch: () => {
+							window.location.assign(
+								`/earn/payments-plans/${ site?.slug }?launchpad=add-product#add-newsletter-payment-plan`
+							);
+						},
+					};
+				default:
+					return task;
+			}
+		} );
+	};
 
 	return (
 		<div className="earn__launchpad">
@@ -32,11 +66,7 @@ const EarnLaunchpad = ( { numberOfSteps, completedSteps }: EarnLaunchpadProps ) 
 					{ translate( 'Let your fans support your art, writing, or project directly.' ) }
 				</p>
 			</div>
-			<DefaultWiredLaunchpad
-				siteSlug={ site?.slug ?? null }
-				checklistSlug="earn"
-				launchpadContext="earn"
-			/>
+			<Launchpad siteSlug={ site?.slug ?? null } checklistSlug="earn" taskFilter={ taskFilter } />
 		</div>
 	);
 };


### PR DESCRIPTION
## Proposed Changes

* Adds a frontend task filter for launchpad to ensure task completion status and links both work on atomic. 
* The alternative to this was to add an extra api request on the backend from jetpack-mu-wpcom to the memberships wpcom endpoint to retrieve memberships data, which is needed for task completion. But the earn page code is already pinging the memberships endpoint, and it seems less than ideal to hit the same endpoint twice (from jetpack and jetpack-mu-wpcom) on the same page, when the data is already available in calypso. 
* If we're going to keep this, we could remove the backend code that gets membership settings and sets completion status on the backend (see three methods starting), and simply rely on the frontend code. See https://github.com/Automattic/jetpack/pull/33200/files#diff-3e92c2cff4e2dd4ec2e0ef889cac1c73a78275f711d0cd9b4e419b7753de513eR891

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1) Test simple sites
   - Go to https://wordpress.com/earn/YOURDOMAIN
   - Confirm launchpad tasks have the correct status.
   - Confirm task links work as expected
   - Try connecting/disconnecting Stripe or creating/deleting plans to confirm status to confirm statuses update as expected.

1) Test on an atomic sites
   - Go to https://wordpress.com/earn/YOURATOMICDOMAIN
   - Confirm launchpad tasks have the correct status.
   - Confirm task links work as expected
   - Try connecting/disconnecting Stripe or creating/deleting plans to confirm status to confirm statuses update as expected.
  