### PR TITLE
Launchpad: Remove duplicated eventHandlers property

### DIFF
--- a/packages/launchpad/src/default-wired-launchpad.tsx
+++ b/packages/launchpad/src/default-wired-launchpad.tsx
@@ -91,9 +91,6 @@ const DefaultWiredLaunchpad = ( {
 			eventHandlers: {
 				onSiteLaunched,
 			},
-			eventHandlers: {
-				onSiteLaunched,
-			},
 		} );
 	};
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Somehow, the `eventHandlers` property got duplicated, which caused the `yarn start` to stop working with the following error:
```
# This file contains the result of Yarn building a package (wp-calypso@workspace:.)
# Script name: postinstall

packages/launchpad/src/default-wired-launchpad.tsx(94,4): error TS1117: An object literal cannot have multiple properties with the same name.
```
* This PR simply removes the duplicated `eventHandlers` property.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch locally
* Run 
```
yarn && yarn start
```
* Make sure the local calypso server is started

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?