### PR TITLE
Theme Discovery: Add Recommended Collection

### DIFF
--- a/client/my-sites/themes/collections/collection-definitions.tsx
+++ b/client/my-sites/themes/collections/collection-definitions.tsx
@@ -1,6 +1,20 @@
 import { translate } from 'i18n-calypso';
 
 export const THEME_COLLECTIONS = {
+	recommended: {
+		query: {
+			collection: 'recommended',
+			filter: '',
+			number: 10,
+			page: 1,
+			search: '',
+			tier: '',
+		},
+		title: translate( 'Recommended Themes' ),
+		collectionSlug: 'recommended',
+		description: <p>Lorem ipsum dolor sit amet</p>,
+		seeAllLink: '/themes',
+	},
 	premium: {
 		query: {
 			collection: 'recommended',

--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -29,6 +29,7 @@ export function getProps( context ) {
 		analyticsPageTitle,
 		analyticsPath,
 		search: context.query.s,
+		isCollectionView: context.query.v === 'collection',
 		pathName: context.pathname,
 		trackScrollPage: boundTrackScrollPage,
 	};

--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -29,7 +29,6 @@ export function getProps( context ) {
 		analyticsPageTitle,
 		analyticsPath,
 		search: context.query.s,
-		isCollectionView: context.query.v === 'collection',
 		pathName: context.pathname,
 		trackScrollPage: boundTrackScrollPage,
 	};

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -354,12 +354,9 @@ class ThemeShowcase extends Component {
 	};
 
 	getCollectionViewHeader = () => {
-		const key = ( this.props.tier ?? '' ) + ( this.props.filter ?? '' );
+		const keyParts = [ this.props.tier, this.props.filter ];
+		const key = keyParts.filter( ( part ) => !! part ).join( '-' ) || 'recommended';
 		const { title, description } = THEME_COLLECTIONS[ key ];
-
-		if ( ! title || ! description || ( !! this.props.filter && !! this.props.tier ) ) {
-			return;
-		}
 
 		return (
 			<div className="collection-header">

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -508,7 +508,7 @@ class ThemeShowcase extends Component {
 		} );
 
 		page( url );
-		this.scrollToSearchInput();
+		window.scrollTo( { top: 0 } );
 	};
 
 	render() {

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -76,14 +76,12 @@ class ThemeShowcase extends Component {
 
 		this.subjectFilters = this.getSubjectFilters( props );
 		this.subjectTermTable = getSubjectsFromTermTable( props.filterToTermTable );
-		this.isDiscoveryEnabled = this.props.isLoggedIn
-			? config.isEnabled( 'themes/discovery-lits' )
-			: config.isEnabled( 'themes/discovery-lots' );
 	}
 
 	static propTypes = {
 		tier: PropTypes.oneOf( [ '', 'free', 'premium', 'marketplace' ] ),
 		search: PropTypes.string,
+		isCollectionView: PropTypes.bool,
 		pathName: PropTypes.string,
 		// Connected props
 		options: PropTypes.objectOf( optionShape ),
@@ -458,7 +456,11 @@ class ThemeShowcase extends Component {
 	renderThemes = ( themeProps ) => {
 		const tabKey = this.getSelectedTabFilter().key;
 
-		const showCollections = this.props.tier === '' && this.isDiscoveryEnabled;
+		const showCollections =
+			this.props.tier === '' &&
+			( this.props.isLoggedIn
+				? config.isEnabled( 'themes/discovery-lits' )
+				: config.isEnabled( 'themes/discovery-lots' ) );
 
 		switch ( tabKey ) {
 			case staticFilters.MYTHEMES?.key:
@@ -581,46 +583,48 @@ class ThemeShowcase extends Component {
 					{ isSiteWooExpressOrEcomFreeTrial && (
 						<div className="themes__showcase">{ this.renderBanner() }</div>
 					) }
-					<div className="themes__controls">
-						<div className="theme__search">
-							<div className="theme__search-input">
-								{ isSearchV2 ? (
-									<SearchThemesV2
-										query={ featureStringFilter + search }
-										onSearch={ this.doSearch }
-									/>
-								) : (
-									<SearchThemes
-										query={ filterString + search }
-										onSearch={ this.doSearch }
-										recordTracksEvent={ this.recordSearchThemesTracksEvent }
-									/>
+					{ ! isCollectionView && (
+						<div className="themes__controls">
+							<div className="theme__search">
+								<div className="theme__search-input">
+									{ isSearchV2 ? (
+										<SearchThemesV2
+											query={ featureStringFilter + search }
+											onSearch={ this.doSearch }
+										/>
+									) : (
+										<SearchThemes
+											query={ filterString + search }
+											onSearch={ this.doSearch }
+											recordTracksEvent={ this.recordSearchThemesTracksEvent }
+										/>
+									) }
+								</div>
+								{ tabFilters && premiumThemesEnabled && ! isMultisite && (
+									<SelectDropdown
+										className="section-nav-tabs__dropdown"
+										onSelect={ this.onTierSelectFilter }
+										selectedText={ translate( 'View: %s', {
+											args: getOptionLabel( tiers, tier ) || '',
+										} ) }
+										options={ tiers }
+										initialSelected={ tier }
+									></SelectDropdown>
 								) }
 							</div>
-							{ tabFilters && premiumThemesEnabled && ! isMultisite && (
-								<SelectDropdown
-									className="section-nav-tabs__dropdown"
-									onSelect={ this.onTierSelectFilter }
-									selectedText={ translate( 'View: %s', {
-										args: getOptionLabel( tiers, tier ) || '',
-									} ) }
-									options={ tiers }
-									initialSelected={ tier }
-								></SelectDropdown>
+							{ tabFilters && ! isSiteWooExpressOrEcomFreeTrial && (
+								<ThemesToolbarGroup
+									items={ Object.values( tabFilters ) }
+									selectedKey={ this.getSelectedTabFilter().key }
+									onSelect={ ( key ) =>
+										this.onFilterClick(
+											Object.values( tabFilters ).find( ( tabFilter ) => tabFilter.key === key )
+										)
+									}
+								/>
 							) }
 						</div>
-						{ tabFilters && ! isSiteWooExpressOrEcomFreeTrial && (
-							<ThemesToolbarGroup
-								items={ Object.values( tabFilters ) }
-								selectedKey={ this.getSelectedTabFilter().key }
-								onSelect={ ( key ) =>
-									this.onFilterClick(
-										Object.values( tabFilters ).find( ( tabFilter ) => tabFilter.key === key )
-									)
-								}
-							/>
-						) }
-					</div>
+					) }
 					<div className="themes__showcase">
 						{ isCollectionView && this.getCollectionViewHeader() }
 						{ ! isSiteWooExpressOrEcomFreeTrial && this.renderBanner() }

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -76,12 +76,14 @@ class ThemeShowcase extends Component {
 
 		this.subjectFilters = this.getSubjectFilters( props );
 		this.subjectTermTable = getSubjectsFromTermTable( props.filterToTermTable );
+		this.isDiscoveryEnabled = this.props.isLoggedIn
+			? config.isEnabled( 'themes/discovery-lits' )
+			: config.isEnabled( 'themes/discovery-lots' );
 	}
 
 	static propTypes = {
 		tier: PropTypes.oneOf( [ '', 'free', 'premium', 'marketplace' ] ),
 		search: PropTypes.string,
-		isCollectionView: PropTypes.bool,
 		pathName: PropTypes.string,
 		// Connected props
 		options: PropTypes.objectOf( optionShape ),
@@ -452,11 +454,7 @@ class ThemeShowcase extends Component {
 	renderThemes = ( themeProps ) => {
 		const tabKey = this.getSelectedTabFilter().key;
 
-		const showCollections =
-			this.props.tier === '' &&
-			( this.props.isLoggedIn
-				? config.isEnabled( 'themes/discovery-lits' )
-				: config.isEnabled( 'themes/discovery-lots' ) );
+		const showCollections = this.props.tier === '' && this.isDiscoveryEnabled;
 
 		switch ( tabKey ) {
 			case staticFilters.MYTHEMES?.key:
@@ -524,7 +522,6 @@ class ThemeShowcase extends Component {
 			isMultisite,
 			premiumThemesEnabled,
 			isSiteWooExpressOrEcomFreeTrial,
-			isCollectionView,
 		} = this.props;
 		const tier = this.props.tier || 'all';
 		const canonicalUrl = 'https://wordpress.com' + pathName;
@@ -579,48 +576,46 @@ class ThemeShowcase extends Component {
 					{ isSiteWooExpressOrEcomFreeTrial && (
 						<div className="themes__showcase">{ this.renderBanner() }</div>
 					) }
-					{ ! isCollectionView && (
-						<div className="themes__controls">
-							<div className="theme__search">
-								<div className="theme__search-input">
-									{ isSearchV2 ? (
-										<SearchThemesV2
-											query={ featureStringFilter + search }
-											onSearch={ this.doSearch }
-										/>
-									) : (
-										<SearchThemes
-											query={ filterString + search }
-											onSearch={ this.doSearch }
-											recordTracksEvent={ this.recordSearchThemesTracksEvent }
-										/>
-									) }
-								</div>
-								{ tabFilters && premiumThemesEnabled && ! isMultisite && (
-									<SelectDropdown
-										className="section-nav-tabs__dropdown"
-										onSelect={ this.onTierSelectFilter }
-										selectedText={ translate( 'View: %s', {
-											args: getOptionLabel( tiers, tier ) || '',
-										} ) }
-										options={ tiers }
-										initialSelected={ tier }
-									></SelectDropdown>
+					<div className="themes__controls">
+						<div className="theme__search">
+							<div className="theme__search-input">
+								{ isSearchV2 ? (
+									<SearchThemesV2
+										query={ featureStringFilter + search }
+										onSearch={ this.doSearch }
+									/>
+								) : (
+									<SearchThemes
+										query={ filterString + search }
+										onSearch={ this.doSearch }
+										recordTracksEvent={ this.recordSearchThemesTracksEvent }
+									/>
 								) }
 							</div>
-							{ tabFilters && ! isSiteWooExpressOrEcomFreeTrial && (
-								<ThemesToolbarGroup
-									items={ Object.values( tabFilters ) }
-									selectedKey={ this.getSelectedTabFilter().key }
-									onSelect={ ( key ) =>
-										this.onFilterClick(
-											Object.values( tabFilters ).find( ( tabFilter ) => tabFilter.key === key )
-										)
-									}
-								/>
+							{ tabFilters && premiumThemesEnabled && ! isMultisite && (
+								<SelectDropdown
+									className="section-nav-tabs__dropdown"
+									onSelect={ this.onTierSelectFilter }
+									selectedText={ translate( 'View: %s', {
+										args: getOptionLabel( tiers, tier ) || '',
+									} ) }
+									options={ tiers }
+									initialSelected={ tier }
+								></SelectDropdown>
 							) }
 						</div>
-					) }
+						{ tabFilters && ! isSiteWooExpressOrEcomFreeTrial && (
+							<ThemesToolbarGroup
+								items={ Object.values( tabFilters ) }
+								selectedKey={ this.getSelectedTabFilter().key }
+								onSelect={ ( key ) =>
+									this.onFilterClick(
+										Object.values( tabFilters ).find( ( tabFilter ) => tabFilter.key === key )
+									)
+								}
+							/>
+						) }
+					</div>
 					<div className="themes__showcase">
 						{ isCollectionView && this.getCollectionViewHeader() }
 						{ ! isSiteWooExpressOrEcomFreeTrial && this.renderBanner() }

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -463,7 +463,7 @@ class ThemeShowcase extends Component {
 			case staticFilters.MYTHEMES?.key:
 				return <ThemesSelection { ...themeProps } />;
 			case staticFilters.RECOMMENDED.key:
-				if ( showCollections ) {
+				if ( showCollections && ! this.props.isCollectionView ) {
 					return (
 						<ThemeCollectionsLayout
 							getOptions={ this.getThemeOptions }

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -359,6 +359,10 @@ class ThemeShowcase extends Component {
 		const key = ( this.props.tier ?? '' ) + ( this.props.filter ?? '' );
 		const { title, description } = THEME_COLLECTIONS[ key ];
 
+		if ( ! title || ! description || ( !! this.props.filter && !! this.props.tier ) ) {
+			return;
+		}
+
 		return (
 			<div className="collection-header">
 				<Button
@@ -522,6 +526,7 @@ class ThemeShowcase extends Component {
 			isMultisite,
 			premiumThemesEnabled,
 			isSiteWooExpressOrEcomFreeTrial,
+			isCollectionView,
 		} = this.props;
 		const tier = this.props.tier || 'all';
 		const canonicalUrl = 'https://wordpress.com' + pathName;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Now we have a carousel in the Discovery view that contains all the Recommended themes.

Related to:
- https://github.com/Automattic/dotcom-forge/issues/4242

Builds on:
- https://github.com/Automattic/wp-calypso/pull/83166

## Proposed Changes

* Leveraged the existing `v=collection` argument so that we can have a collection view over `/themes`.
* We'll show the recommend collection view instead of the discovery screen when needed.
* Fixed an issue on `onCollectionSeeAll` that caused scrolling to the search input which doesn't exist in the collection view. We now scroll to the top of the page instead.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso container.
* Go to `/themes?flags=themes/discovery-lots`
* You should see the recommended carousel.
* If you click on see more you should see the recommended collection view instead of the Discovery view.
* If you open/preview a theme and go back you should be in the recommended collection view.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?