### PR TITLE
Specify correct orderBy parameter for the Recommended tab

### DIFF
--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -229,6 +229,8 @@ const streamApis = {
 				tag_recs_per_card: 5,
 				site_recs_per_card: 5,
 				age_based_decay: 0.5,
+				// Default order is by date (latest) unless we're on the recommended tab which shows popular instead.
+				orderBy: streamKeySuffix( streamKey ).includes( 'recommended' ) ? 'popular' : 'date',
 			} ),
 		apiNamespace: 'wpcom/v2',
 	},

--- a/client/state/data-layer/wpcom/read/streams/test/index.js
+++ b/client/state/data-layer/wpcom/read/streams/test/index.js
@@ -86,6 +86,7 @@ describe( 'streams', () => {
 							site_recs_per_card: 5,
 							tags: [],
 							age_based_decay: 0.5,
+							orderBy: 'popular',
 						},
 					},
 				},


### PR DESCRIPTION
The "Recommended" tab should show posts ordered by popularity.  Previously, we ordered "Recommended" by date so it showed the same posts as "Latest".

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #83064

## Proposed Changes

The "Recommended" tab should show posts ordered by popularity.  Previously, we ordered "Recommended" by date so it showed the same posts as "Latest".

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


* Apply D125808-code to your sandbox and sandbox the public-api.
* Checkout this branch locally or use the calypso.live link.
* Go to `/discover`. Make note of the posts that are displayed under the "Recommended" tab.
* Click on "Latest" and verify that you see a different set of posts.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
