### PR TITLE
Disable old calypso app builds

### DIFF
--- a/.teamcity/_self/lib/wpcom/WPComPluginBuild.kt
+++ b/.teamcity/_self/lib/wpcom/WPComPluginBuild.kt
@@ -57,42 +57,8 @@ open class WPComPluginBuild(
 			executionTimeoutMin = 6
 		}
 
-		triggers {
-			vcs {
-				branchFilter = """
-					+:*
-					-:pull*
-				""".trimIndent()
-				triggerRules = """
-					-:test/e2e/**
-					-:docs/**.md
-					-:comment=stress test:**
-					-:packages/calypso-e2e/**
-				""".trimIndent()
-			}
-		}
-
 		features {
 			perfmon {
-			}
-			pullRequests {
-				vcsRootExtId = "${Settings.WpCalypso.id}"
-				provider = github {
-					authType = token {
-						token = "credentialsJSON:57e22787-e451-48ed-9fea-b9bf30775b36"
-					}
-					filterAuthorRole = PullRequests.GitHubRoleFilter.EVERYBODY
-				}
-			}
-
-			commitStatusPublisher {
-				vcsRootExtId = "${Settings.WpCalypso.id}"
-				publisher = github {
-					githubUrl = "https://api.github.com"
-					authType = personalToken {
-						token = "credentialsJSON:57e22787-e451-48ed-9fea-b9bf30775b36"
-					}
-				}
 			}
 		}
 

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -71,7 +71,7 @@ object WPComPlugins : Project({
 object CalypsoApps: BuildType({
 	id("calypso_WPComPlugins_Build_Plugins")
 	uuid = "8453b8fe-226f-4e91-b5cc-8bdad15e0814"
-	name = "CalypsoApps"
+	name = "Build Calypso Apps"
 	description = "Builds all Calypso apps and saves release artifacts for each. This replaces the separate build configurations for each app."
 
 	// Incremented to 4 to make sure ETK updates continue to work:


### PR DESCRIPTION
This PR removes the VCS integration for the legacy calypso apps builds. Ultimately, the builds will be removed in #82897, but I want to simply disable them first in case we need to revert anything. (If we delete them, TeamCity could remove their history, which we aren't quite ready to do yet.)

This should be good to go if CI passes.

See original PR: #81571