### PR TITLE
Update media disc usage and menu header

### DIFF
--- a/client/blocks/plan-storage/bar.jsx
+++ b/client/blocks/plan-storage/bar.jsx
@@ -29,8 +29,9 @@ export class PlanStorageBar extends Component {
 		}
 
 		const percent = Math.min(
-			Math.round( ( mediaStorage.storage_used_bytes / mediaStorage.max_storage_bytes ) * 1000 ) /
-				10,
+			Math.round(
+				( ( mediaStorage.storage_used_bytes / mediaStorage.max_storage_bytes ) * 1000 ) / 10
+			),
 			100
 		);
 
@@ -39,7 +40,7 @@ export class PlanStorageBar extends Component {
 			'is-warn': percent > WARN_PERCENT && percent <= ALERT_PERCENT,
 		} );
 
-		const max = filesize( mediaStorage.max_storage_bytes );
+		const max = filesize( Math.round( mediaStorage.max_storage_bytes ) );
 
 		return (
 			<div className={ classes }>

--- a/client/blocks/plan-storage/bar.jsx
+++ b/client/blocks/plan-storage/bar.jsx
@@ -40,7 +40,7 @@ export class PlanStorageBar extends Component {
 			'is-warn': percent > WARN_PERCENT && percent <= ALERT_PERCENT,
 		} );
 
-		const max = filesize( Math.round( mediaStorage.max_storage_bytes ) );
+		const max = filesize( mediaStorage.max_storage_bytes, { round: 0 } );
 
 		return (
 			<div className={ classes }>

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -7,9 +7,9 @@ import ImageEditor from 'calypso/blocks/image-editor';
 import VideoEditor from 'calypso/blocks/video-editor';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryMedia from 'calypso/components/data/query-media';
-import FormattedHeader from 'calypso/components/formatted-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { JetpackConnectionHealthBanner } from 'calypso/components/jetpack/connection-health';
+import NavigationHeader from 'calypso/components/navigation-header';
 import Notice from 'calypso/components/notice';
 import ScreenOptionsTab from 'calypso/components/screen-options-tab';
 import { withEditMedia } from 'calypso/data/media/use-edit-media-mutation';
@@ -224,7 +224,6 @@ class Media extends Component {
 	 * Start the process to delete media items.
 	 * `callback` is an optional parameter which will execute once the confirm dialog is accepted.
 	 * It's used especially when the item is attempting to be removed using the item detail dialog.
-	 *
 	 * @param  {Function} [callback] - callback function
 	 */
 	deleteMedia( callback ) {
@@ -373,11 +372,9 @@ class Media extends Component {
 					<JetpackConnectionHealthBanner siteId={ siteId } />
 				) }
 				<DocumentHead title={ translate( 'Media' ) } />
-				<FormattedHeader
-					brandFont
-					className="media__page-heading"
-					headerText={ translate( 'Media' ) }
-					subHeaderText={ translate(
+				<NavigationHeader
+					title={ translate( 'Media' ) }
+					subtitle={ translate(
 						'Manage all the media on your site, including images, video, and more. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 						{
 							components: {
@@ -385,9 +382,10 @@ class Media extends Component {
 							},
 						}
 					) }
-					align="left"
-					hasScreenOptions
-				/>
+				>
+					<ScreenOptionsTab wpAdminPath="upload.php?preferred-view=classic" />
+				</NavigationHeader>
+
 				{ this.props.selectedSite.is_private && this.props.selectedSite.is_wpcom_atomic && (
 					<Notice
 						showDismiss={ false }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 4225-gh-Automattic/dotcom-forge

## Proposed Changes

* Updated media disc usage to use round numbers
* Upgraded media Header to the new one as part of project p9Jlb4-8ec-p2

| Before | After |
|--------|--------|
| <img width="713" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/fc1e628b-bbe8-4010-8171-88f9a0e83e78"> |<img width="719" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/6892726a-a7f3-4c30-b323-8a13aab5e814"> | 



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Instructions here: p1697653585264959-slack-CKZHG0QCR

* Ensure we rounded the storage numbers
* Ensure Media header is working as expected


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?