### PR TITLE
Jetpack Cloud: Update page headers to match new designs

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Button, Count } from '@automattic/components';
 import { isWithinBreakpoint } from '@automattic/viewport';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
@@ -125,7 +126,8 @@ export default function SitesOverview() {
 		}
 	}, [ refetch, jetpackSiteDisconnected ] );
 
-	const pageTitle = translate( 'Dashboard' );
+	const isNewNavigation = isEnabled( 'jetpack/new-navigation' );
+	const pageTitle = isNewNavigation ? translate( 'Sites Management' ) : translate( 'Dashboard' );
 
 	const basePath = '/dashboard';
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -1,6 +1,13 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
+.is-jetpack-new-navigation {
+	.sites-overview__page-title {
+		margin-block-end: 8px;
+		font-weight: 600;
+	}
+}
+
 .sites-overview__large-screen {
 	.site-search-filter-container__search .search.is-open .search__open-icon {
 		width: 60px;

--- a/client/jetpack-cloud/sections/partner-portal/layout/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/layout/style.scss
@@ -1,3 +1,9 @@
+.is-jetpack-new-navigation {
+	.partner-portal-layout__header h1 {
+		font-weight: 600;
+	}
+}
+
 .main.partner-portal-layout {
 	padding-inline: 0;
 

--- a/client/jetpack-cloud/sections/plugin-management/plugins-overview/index.tsx
+++ b/client/jetpack-cloud/sections/plugin-management/plugins-overview/index.tsx
@@ -45,9 +45,13 @@ export default function PluginsOverview( { filter, search, site, pluginSlug, pat
 	}
 
 	if ( hasFetched ) {
+		const isNewNavigation = isEnabled( 'jetpack/new-navigation' );
+		const sectionTitle = isNewNavigation
+			? translate( 'Plugin Management' )
+			: translate( 'Plugins' );
 		return (
 			<div className="plugins-overview__container">
-				<SidebarNavigation sectionTitle={ translate( 'Plugins' ) } />
+				<SidebarNavigation sectionTitle={ sectionTitle } />
 				{ pluginSlug ? (
 					<PluginDetails isJetpackCloud siteUrl={ site } pluginSlug={ pluginSlug } path={ path } />
 				) : (

--- a/client/jetpack-cloud/sections/plugin-management/plugins-overview/index.tsx
+++ b/client/jetpack-cloud/sections/plugin-management/plugins-overview/index.tsx
@@ -1,5 +1,7 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
+import { useQueryJetpackPartnerPortalPartner } from 'calypso/components/data/query-jetpack-partner-portal-partner';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import SelectPartnerKey from 'calypso/jetpack-cloud/sections/partner-portal/primary/select-partner-key';
@@ -39,6 +41,8 @@ export default function PluginsOverview( { filter, search, site, pluginSlug, pat
 			dispatch( setSelectedSiteId( null ) );
 		}
 	}, [ dispatch, site ] );
+
+	useQueryJetpackPartnerPortalPartner();
 
 	if ( hasFetched && ! hasActiveKey ) {
 		return <SelectPartnerKey />;

--- a/client/jetpack-cloud/sections/plugin-management/plugins-overview/style.scss
+++ b/client/jetpack-cloud/sections/plugin-management/plugins-overview/style.scss
@@ -1,6 +1,13 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
+.is-jetpack-new-navigation {
+	.plugins__page-title {
+		font-weight: 600;
+		margin-block-end: 8px;
+	}
+}
+
 .plugins-overview__container {
 	display: flex;
 	flex-direction: column;

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import {
 	WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS,
 	WPCOM_FEATURES_MANAGE_PLUGINS,
@@ -451,9 +452,15 @@ export class PluginsMain extends Component {
 
 		const { isJetpackCloud, selectedSite } = this.props;
 
-		const pageTitle = isJetpackCloud
-			? this.props.translate( 'Plugins', { textOnly: true } )
-			: this.props.translate( 'Installed Plugins', { textOnly: true } );
+		const isNewNavigation = isEnabled( 'jetpack/new-navigation' );
+		let pageTitle;
+		if ( isJetpackCloud ) {
+			pageTitle = isNewNavigation
+				? this.props.translate( 'Plugin Management', { textOnly: true } )
+				: this.props.translate( 'Plugins', { textOnly: true } );
+		} else {
+			pageTitle = this.props.translate( 'Installed Plugins', { textOnly: true } );
+		}
 
 		const { title, count } = this.getSelectedText();
 


### PR DESCRIPTION
This pull request makes some small cosmetic changes when `jetpack/new-navigation` is enabled, so that page headers more closely resemble design mock-ups (see: `Ra0o7IPph3bCS2xUCnAusZ-fi`).

Resolves https://github.com/Automattic/jetpack-genesis/issues/64.

## Proposed Changes

When the `jetpack/new-navigation` feature flag is enabled:

* Change title of Dashboard to 'Sites Management'
* Change title of Plugins to 'Plugin Management'
* Add make page titles bold and give them 8px of bottom margin

## Known issues

* Some new sidebar navigation items may not work correctly, especially if you haven't previously selected a site before looking at various pages intended for use with the "All Sites" view. This issue is unrelated to this PR and will be fixed later.

## Testing Instructions

* Visit Jetpack Cloud in your testing environment and select a site (e.g., view its Activity Log page). **This is to work around the point mentioned in *Known issues*, above.**
* Visit the Sites Management/Dashboard page, adding `?flags=jetpack/new-navigation` to enable the new sidebar navigation feature flag.
* Visit other Jetpack Manage pages, ensuring the page title header is always bolded and there is 8px of margin between the header and description (if one exists).

## Reference screenshots (before / after)

### Sites Management

<img height="200" src="https://github.com/Automattic/wp-calypso/assets/670067/9b8882cf-dfe5-40d3-bcb1-7ddda3debec2" /> <img height="200" src="https://github.com/Automattic/wp-calypso/assets/670067/6dc342a1-c83f-48cf-9b8b-cd05882a1534" />

### Plugins Management

<img height="200" src="https://github.com/Automattic/wp-calypso/assets/670067/d0275d44-db96-4ca3-a9c2-e500f8815f9a" /> <img height="200" src="https://github.com/Automattic/wp-calypso/assets/670067/06526600-ba71-4b75-8891-baca2196d9d5" />

### Prices

<img height="200" src="https://github.com/Automattic/wp-calypso/assets/670067/ad93b0a8-d1a3-4b61-b2ff-3b0973e2edc4" /> <img height="200" src="https://github.com/Automattic/wp-calypso/assets/670067/a8b7d7f2-db03-4fa8-b5c8-863e454708f4" />

### Billing

<img height="200" src="https://github.com/Automattic/wp-calypso/assets/670067/b4bd6635-13f1-4436-aa4e-aff72b8692c5" /> <img height="200" src="https://github.com/Automattic/wp-calypso/assets/670067/1549ad68-9bc9-4fe7-983a-aff5a7cb043b" />

### Company Details

<img height="200" src="https://github.com/Automattic/wp-calypso/assets/670067/4ded2199-67fe-4f15-a5b7-0a8bad055d60" /> <img height="200" src="https://github.com/Automattic/wp-calypso/assets/670067/bcda6d33-fa21-4c22-bf5c-8348118ef4bd" />