### PR TITLE
Marketplace ProgressBar: Memoize steps to avoid unnecessary re-rendering

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-thank-you-steps.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-thank-you-steps.tsx
@@ -44,12 +44,23 @@ export function useThankYouSteps( {
 		[ translate ]
 	);
 
-	const steps = multipleProductTypes
-		? defaultSteps
-		: [
-				...( pluginSlugs.length > 0 ? pluginsProgressbarSteps : [] ),
-				...( themeSlugs.length > 0 ? themesProgressbarSteps : [] ),
-		  ];
+	const steps = useMemo(
+		() =>
+			multipleProductTypes
+				? defaultSteps
+				: [
+						...( pluginSlugs.length > 0 ? pluginsProgressbarSteps : [] ),
+						...( themeSlugs.length > 0 ? themesProgressbarSteps : [] ),
+				  ],
+		[
+			defaultSteps,
+			multipleProductTypes,
+			pluginSlugs.length,
+			pluginsProgressbarSteps,
+			themeSlugs.length,
+			themesProgressbarSteps,
+		]
+	);
 
 	return { steps, additionalSteps };
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/83188

## Proposed Changes

Wrap `steps` into a `useMemo` hook to avoid unnecessary re-rendering.

## Testing Instructions
* With a non-atomic site
* Go to the Design Picker page with a Marketplace theme selected /setup/update-design/designSetup?siteSlug=:site&theme=:theme_slug. Theme slugs such as makoney and olsen-fse can be used.
* Click on Unlock Theme
* Complete the purchase
* Check if the progressbar is actually progressing
* Test the same in production, the progressbar shouldn't be progressing

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
