### PR TITLE
Checkout: Reload cart when transaction fails

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -219,6 +219,7 @@ export default function CheckoutMain( {
 	const {
 		applyCoupon,
 		replaceProductInCart,
+		reloadFromServer: reloadCart,
 		isLoading: isLoadingCart,
 		isPendingUpdate: isCartPendingUpdate,
 		responseCart,
@@ -447,6 +448,7 @@ export default function CheckoutMain( {
 			includeGSuiteDetails,
 			reduxDispatch,
 			responseCart,
+			reloadCart,
 			siteId: updatedSiteId,
 			siteSlug: updatedSiteSlug,
 			stripeConfiguration,
@@ -462,6 +464,7 @@ export default function CheckoutMain( {
 			includeGSuiteDetails,
 			reduxDispatch,
 			responseCart,
+			reloadCart,
 			updatedSiteId,
 			stripe,
 			stripeConfiguration,

--- a/client/my-sites/checkout/src/lib/existing-card-processor.ts
+++ b/client/my-sites/checkout/src/lib/existing-card-processor.ts
@@ -48,6 +48,7 @@ export default async function existingCardProcessor(
 		contactDetails,
 		reduxDispatch,
 		responseCart,
+		reloadCart,
 	} = dataForProcessor;
 	if ( ! stripe ) {
 		throw new Error( 'Stripe is required to submit an existing card payment' );
@@ -146,6 +147,9 @@ export default async function existingCardProcessor(
 			);
 
 			handle3DSInFlightError( error, paymentIntentId );
+
+			// Refresh the cart in case things have changed during the transaction.
+			reloadCart();
 
 			// Errors here are "expected" errors, meaning that they (hopefully) come
 			// from the endpoint and not from some bug in the frontend code.

--- a/client/my-sites/checkout/src/lib/free-purchase-processor.ts
+++ b/client/my-sites/checkout/src/lib/free-purchase-processor.ts
@@ -26,6 +26,7 @@ export default async function freePurchaseProcessor(
 ): Promise< PaymentProcessorResponse > {
 	const {
 		responseCart,
+		reloadCart,
 		includeDomainDetails,
 		includeGSuiteDetails,
 		contactDetails,
@@ -62,7 +63,12 @@ export default async function freePurchaseProcessor(
 
 	return submitWpcomTransaction( formattedTransactionData, transactionOptions )
 		.then( makeSuccessResponse )
-		.catch( ( error ) => makeErrorResponse( error.message ) );
+		.catch( ( error ) => {
+			// Refresh the cart in case things have changed during the transaction.
+			reloadCart();
+
+			return makeErrorResponse( error.message );
+		} );
 }
 
 function prepareFreePurchaseTransaction(

--- a/client/my-sites/checkout/src/lib/generic-redirect-processor.ts
+++ b/client/my-sites/checkout/src/lib/generic-redirect-processor.ts
@@ -29,6 +29,7 @@ export default async function genericRedirectProcessor(
 		includeGSuiteDetails,
 		reduxDispatch,
 		responseCart,
+		reloadCart,
 		contactDetails,
 		fromSiteSlug,
 	} = transactionOptions;
@@ -81,7 +82,12 @@ export default async function genericRedirectProcessor(
 			}
 			return makeRedirectResponse( response?.redirect_url );
 		} )
-		.catch( ( error ) => makeErrorResponse( error.message ) );
+		.catch( ( error ) => {
+			// Refresh the cart in case things have changed during the transaction.
+			reloadCart();
+
+			return makeErrorResponse( error.message );
+		} );
 }
 
 function isValidTransactionData( submitData: unknown ): submitData is RedirectTransactionRequest {

--- a/client/my-sites/checkout/src/lib/multi-partner-card-processor.ts
+++ b/client/my-sites/checkout/src/lib/multi-partner-card-processor.ts
@@ -79,6 +79,7 @@ async function stripeCardProcessor(
 		includeDomainDetails,
 		includeGSuiteDetails,
 		responseCart,
+		reloadCart,
 		siteId,
 		contactDetails,
 		reduxDispatch,
@@ -180,6 +181,9 @@ async function stripeCardProcessor(
 			} );
 
 			handle3DSInFlightError( error, paymentIntentId );
+
+			// Refresh the cart in case things have changed during the transaction.
+			reloadCart();
 
 			// Errors here are "expected" errors, meaning that they (hopefully) come
 			// from the endpoint and not from some bug in the frontend code.

--- a/client/my-sites/checkout/src/lib/paypal-express-processor.ts
+++ b/client/my-sites/checkout/src/lib/paypal-express-processor.ts
@@ -26,6 +26,7 @@ export default async function payPalProcessor(
 		includeDomainDetails,
 		includeGSuiteDetails,
 		responseCart,
+		reloadCart,
 		siteId,
 		siteSlug,
 		contactDetails,
@@ -72,7 +73,12 @@ export default async function payPalProcessor(
 			}
 			return makeRedirectResponse( response.redirect_url );
 		} )
-		.catch( ( error ) => makeErrorResponse( error.message ) );
+		.catch( ( error ) => {
+			// Refresh the cart in case things have changed during the transaction.
+			reloadCart();
+
+			return makeErrorResponse( error.message );
+		} );
 }
 
 /**

--- a/client/my-sites/checkout/src/lib/we-chat-processor.ts
+++ b/client/my-sites/checkout/src/lib/we-chat-processor.ts
@@ -34,6 +34,7 @@ export default async function weChatProcessor(
 		includeGSuiteDetails,
 		reduxDispatch,
 		responseCart,
+		reloadCart,
 		contactDetails,
 	} = options;
 	const paymentMethodId = 'wechat';
@@ -84,7 +85,12 @@ export default async function weChatProcessor(
 			}
 			return makeManualResponse( response );
 		} )
-		.catch( ( error ) => makeErrorResponse( error.message ) );
+		.catch( ( error ) => {
+			// Refresh the cart in case things have changed during the transaction.
+			reloadCart();
+
+			return makeErrorResponse( error.message );
+		} );
 }
 
 function isValidTransactionData( submitData: unknown ): submitData is WeChatTransactionRequest {

--- a/client/my-sites/checkout/src/lib/web-pay-processor.ts
+++ b/client/my-sites/checkout/src/lib/web-pay-processor.ts
@@ -40,8 +40,14 @@ export default async function webPayProcessor(
 		recordTransactionBeginAnalytics( { paymentMethodId: webPaymentType } )
 	);
 
-	const { includeDomainDetails, includeGSuiteDetails, responseCart, siteId, contactDetails } =
-		transactionOptions;
+	const {
+		includeDomainDetails,
+		includeGSuiteDetails,
+		responseCart,
+		reloadCart,
+		siteId,
+		contactDetails,
+	} = transactionOptions;
 
 	debug( 'formatting web-pay transaction', submitData );
 	const formattedTransactionData = createTransactionEndpointRequestPayload( {
@@ -99,6 +105,9 @@ export default async function webPayProcessor(
 			} );
 
 			handle3DSInFlightError( error, paymentIntentId );
+
+			// Refresh the cart in case things have changed during the transaction.
+			reloadCart();
 
 			// Errors here are "expected" errors, meaning that they (hopefully) come
 			// from the endpoint and not from some bug in the frontend code.

--- a/client/my-sites/checkout/src/test/existing-card-processor.ts
+++ b/client/my-sites/checkout/src/test/existing-card-processor.ts
@@ -31,6 +31,7 @@ describe( 'existingCardProcessor', () => {
 		...processorOptions,
 		stripe,
 		responseCart: cart,
+		reloadCart: () => Promise.resolve( cart ),
 	};
 
 	const basicExpectedStripeRequest = {
@@ -72,7 +73,7 @@ describe( 'existingCardProcessor', () => {
 
 	it( 'throws an error if there is no storedDetailsId passed', async () => {
 		const submitData = {};
-		await expect( existingCardProcessor( submitData, options ) ).rejects.toThrowError(
+		await expect( existingCardProcessor( submitData, options ) ).rejects.toThrow(
 			/requires saved card information and none was provided/
 		);
 	} );
@@ -82,7 +83,7 @@ describe( 'existingCardProcessor', () => {
 			storedDetailsId: 'stored-details-id',
 			name: 'test name',
 		};
-		await expect( existingCardProcessor( submitData, options ) ).rejects.toThrowError(
+		await expect( existingCardProcessor( submitData, options ) ).rejects.toThrow(
 			/requires a Stripe token and none was provided/
 		);
 	} );
@@ -93,7 +94,7 @@ describe( 'existingCardProcessor', () => {
 			name: 'test name',
 			paymentMethodToken: 'stripe-token',
 		};
-		await expect( existingCardProcessor( submitData, options ) ).rejects.toThrowError(
+		await expect( existingCardProcessor( submitData, options ) ).rejects.toThrow(
 			/requires a processor id and none was provided/
 		);
 	} );

--- a/client/my-sites/checkout/src/test/existing-card-processor.ts
+++ b/client/my-sites/checkout/src/test/existing-card-processor.ts
@@ -27,11 +27,12 @@ describe( 'existingCardProcessor', () => {
 	const stripe = {
 		confirmCardPayment: mockConfirmCardPayment as Stripe[ 'confirmCardPayment' ],
 	} as Stripe;
+	const reloadCart = jest.fn();
 	const options: PaymentProcessorOptions = {
 		...processorOptions,
 		stripe,
 		responseCart: cart,
-		reloadCart: () => Promise.resolve( cart ),
+		reloadCart,
 	};
 
 	const basicExpectedStripeRequest = {
@@ -69,6 +70,10 @@ describe( 'existingCardProcessor', () => {
 
 	beforeEach( () => {
 		mockLogStashEndpoint();
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
 	} );
 
 	it( 'throws an error if there is no storedDetailsId passed', async () => {
@@ -170,6 +175,30 @@ describe( 'existingCardProcessor', () => {
 				},
 			} )
 		).resolves.toStrictEqual( expected );
+	} );
+
+	it( 'reloads the cart if the transaction fails', async () => {
+		mockTransactionsEndpoint( () => [
+			400,
+			{
+				error: 'test_error',
+				message: 'test error',
+			},
+		] );
+		const submitData = {
+			storedDetailsId: 'stored-details-id',
+			name: 'test name',
+			paymentMethodToken: 'stripe-token',
+			paymentPartnerProcessorId: 'stripe_ie',
+		};
+		await existingCardProcessor( submitData, {
+			...options,
+			contactDetails: {
+				countryCode,
+				postalCode,
+			},
+		} );
+		expect( reloadCart ).toHaveBeenCalled();
 	} );
 
 	it( 'sends the correct data to the endpoint with a site and one product', async () => {

--- a/client/my-sites/checkout/src/test/generic-redirect-processor.ts
+++ b/client/my-sites/checkout/src/test/generic-redirect-processor.ts
@@ -1,5 +1,6 @@
 import { getEmptyResponseCart, getEmptyResponseCartProduct } from '@automattic/shopping-cart';
 import genericRedirectProcessor from '../lib/generic-redirect-processor';
+import { PaymentProcessorOptions } from '../types/payment-processors';
 import {
 	mockTransactionsEndpoint,
 	mockTransactionsRedirectResponse,
@@ -18,9 +19,10 @@ describe( 'genericRedirectProcessor', () => {
 		is_domain_registration: true,
 	};
 	const cart = { ...getEmptyResponseCart(), products: [ product ] };
-	const options = {
+	const options: PaymentProcessorOptions = {
 		...processorOptions,
 		responseCart: cart,
+		reloadCart: () => Promise.resolve( cart ),
 	};
 
 	const basicExpectedStripeRequest = {

--- a/client/my-sites/checkout/src/test/generic-redirect-processor.ts
+++ b/client/my-sites/checkout/src/test/generic-redirect-processor.ts
@@ -19,10 +19,11 @@ describe( 'genericRedirectProcessor', () => {
 		is_domain_registration: true,
 	};
 	const cart = { ...getEmptyResponseCart(), products: [ product ] };
+	const reloadCart = jest.fn();
 	const options: PaymentProcessorOptions = {
 		...processorOptions,
 		responseCart: cart,
-		reloadCart: () => Promise.resolve( cart ),
+		reloadCart,
 	};
 
 	const basicExpectedStripeRequest = {
@@ -60,6 +61,10 @@ describe( 'genericRedirectProcessor', () => {
 		},
 	};
 
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
 	it( 'sends the correct data to the endpoint with no site and one product', async () => {
 		const transactionsEndpoint = mockTransactionsEndpoint( mockTransactionsRedirectResponse );
 		const submitData = {
@@ -77,6 +82,28 @@ describe( 'genericRedirectProcessor', () => {
 			} )
 		).resolves.toStrictEqual( expected );
 		expect( transactionsEndpoint ).toHaveBeenCalledWith( basicExpectedStripeRequest );
+	} );
+
+	it( 'reloads the cart if the transaction fails', async () => {
+		mockTransactionsEndpoint( () => [
+			200,
+			{
+				error: 'test_error',
+				message: 'test error',
+			},
+		] );
+		const submitData = {
+			name: 'test name',
+			email: 'test@example.com',
+		};
+		await genericRedirectProcessor( 'bancontact', submitData, {
+			...options,
+			contactDetails: {
+				countryCode,
+				postalCode,
+			},
+		} );
+		expect( reloadCart ).toHaveBeenCalled();
 	} );
 
 	it( 'returns a generic error response if the transaction fails with a 200 response', async () => {

--- a/client/my-sites/checkout/src/test/multi-partner-card-processor.tsx
+++ b/client/my-sites/checkout/src/test/multi-partner-card-processor.tsx
@@ -189,6 +189,7 @@ describe( 'multiPartnerCardProcessor', () => {
 		stripe,
 		stripeConfiguration,
 		responseCart: cart,
+		reloadCart: () => Promise.resolve( cart ),
 	};
 
 	beforeEach( () => {
@@ -197,14 +198,14 @@ describe( 'multiPartnerCardProcessor', () => {
 
 	it( 'throws an error if there is no paymentPartner', async () => {
 		const submitData = {};
-		await expect( multiPartnerCardProcessor( submitData, options ) ).rejects.toThrowError(
+		await expect( multiPartnerCardProcessor( submitData, options ) ).rejects.toThrow(
 			/paymentPartner/
 		);
 	} );
 
 	it( 'throws an error if there is an unknown paymentPartner', async () => {
 		const submitData = { paymentPartner: 'unknown' };
-		await expect( multiPartnerCardProcessor( submitData, options ) ).rejects.toThrowError(
+		await expect( multiPartnerCardProcessor( submitData, options ) ).rejects.toThrow(
 			/Unrecognized card payment partner/
 		);
 	} );
@@ -212,7 +213,7 @@ describe( 'multiPartnerCardProcessor', () => {
 	describe( 'for a stripe paymentPartner', () => {
 		it( 'throws an error if there is no stripe object', async () => {
 			const submitData = { paymentPartner: 'stripe' };
-			await expect( multiPartnerCardProcessor( submitData, options ) ).rejects.toThrowError(
+			await expect( multiPartnerCardProcessor( submitData, options ) ).rejects.toThrow(
 				/requires stripe and none was provided/
 			);
 		} );
@@ -222,7 +223,7 @@ describe( 'multiPartnerCardProcessor', () => {
 				paymentPartner: 'stripe',
 				stripe,
 			};
-			await expect( multiPartnerCardProcessor( submitData, options ) ).rejects.toThrowError(
+			await expect( multiPartnerCardProcessor( submitData, options ) ).rejects.toThrow(
 				/requires stripeConfiguration and none was provided/
 			);
 		} );
@@ -233,7 +234,7 @@ describe( 'multiPartnerCardProcessor', () => {
 				stripe,
 				stripeConfiguration,
 			};
-			await expect( multiPartnerCardProcessor( submitData, options ) ).rejects.toThrowError(
+			await expect( multiPartnerCardProcessor( submitData, options ) ).rejects.toThrow(
 				/requires credit card field and none was provided/
 			);
 		} );

--- a/client/my-sites/checkout/src/test/multi-partner-card-processor.tsx
+++ b/client/my-sites/checkout/src/test/multi-partner-card-processor.tsx
@@ -184,16 +184,22 @@ describe( 'multiPartnerCardProcessor', () => {
 		createPaymentMethod: createMockStripeToken,
 	} as Stripe;
 
+	const reloadCart = jest.fn();
+
 	const options: PaymentProcessorOptions = {
 		...processorOptions,
 		stripe,
 		stripeConfiguration,
 		responseCart: cart,
-		reloadCart: () => Promise.resolve( cart ),
+		reloadCart,
 	};
 
 	beforeEach( () => {
 		mockLogStashEndpoint();
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
 	} );
 
 	it( 'throws an error if there is no paymentPartner', async () => {
@@ -416,6 +422,31 @@ describe( 'multiPartnerCardProcessor', () => {
 					coupon: '',
 				},
 			} );
+		} );
+
+		it( 'reloads the cart if the transaction fails', async () => {
+			mockTransactionsEndpoint( () => [
+				400,
+				{
+					error: 'test_error',
+					message: 'test error',
+				},
+			] );
+			const submitData = {
+				paymentPartner: 'stripe',
+				stripe,
+				stripeConfiguration,
+				name: 'test name',
+				cardNumberElement: mockCardNumberElement,
+			};
+			await multiPartnerCardProcessor( submitData, {
+				...options,
+				contactDetails: {
+					countryCode,
+					postalCode,
+				},
+			} );
+			expect( reloadCart ).toHaveBeenCalled();
 		} );
 
 		it( 'returns an explicit error response if the transaction fails with a non-200 error', async () => {

--- a/client/my-sites/checkout/src/test/paypal-express-processor.ts
+++ b/client/my-sites/checkout/src/test/paypal-express-processor.ts
@@ -4,6 +4,7 @@
 
 import { getEmptyResponseCart, getEmptyResponseCartProduct } from '@automattic/shopping-cart';
 import payPalExpressProcessor from '../lib/paypal-express-processor';
+import { PaymentProcessorOptions } from '../types/payment-processors';
 import {
 	mockPayPalEndpoint,
 	mockPayPalRedirectResponse,
@@ -28,9 +29,10 @@ describe( 'payPalExpressProcessor', () => {
 		is_domain_registration: true,
 	};
 	const cart = { ...getEmptyResponseCart(), products: [ product ] };
-	const options = {
+	const options: PaymentProcessorOptions = {
 		...processorOptions,
 		responseCart: cart,
+		reloadCart: () => Promise.resolve( cart ),
 	};
 
 	const basicExpectedRequest = {

--- a/client/my-sites/checkout/src/test/paypal-express-processor.ts
+++ b/client/my-sites/checkout/src/test/paypal-express-processor.ts
@@ -29,10 +29,11 @@ describe( 'payPalExpressProcessor', () => {
 		is_domain_registration: true,
 	};
 	const cart = { ...getEmptyResponseCart(), products: [ product ] };
+	const reloadCart = jest.fn();
 	const options: PaymentProcessorOptions = {
 		...processorOptions,
 		responseCart: cart,
-		reloadCart: () => Promise.resolve( cart ),
+		reloadCart,
 	};
 
 	const basicExpectedRequest = {
@@ -61,6 +62,10 @@ describe( 'payPalExpressProcessor', () => {
 
 	beforeEach( () => {
 		setMockLocation( 'https://example.com/' );
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
 	} );
 
 	it( 'sends the correct data to the endpoint with no site and one product', async () => {
@@ -96,6 +101,24 @@ describe( 'payPalExpressProcessor', () => {
 				},
 			} )
 		).resolves.toStrictEqual( expected );
+	} );
+
+	it( 'reloads the cart if the transaction fails', async () => {
+		mockPayPalEndpoint( () => [
+			400,
+			{
+				error: 'test_error',
+				message: 'test error',
+			},
+		] );
+		await payPalExpressProcessor( {
+			...options,
+			contactDetails: {
+				countryCode,
+				postalCode,
+			},
+		} );
+		expect( reloadCart ).toHaveBeenCalled();
 	} );
 
 	it( 'sends the correct data to the endpoint with a site and one product', async () => {

--- a/client/my-sites/checkout/src/test/we-chat-processor.ts
+++ b/client/my-sites/checkout/src/test/we-chat-processor.ts
@@ -4,6 +4,7 @@
 
 import { getEmptyResponseCart, getEmptyResponseCartProduct } from '@automattic/shopping-cart';
 import weChatProcessor from '../lib/we-chat-processor';
+import { PaymentProcessorOptions } from '../types/payment-processors';
 import {
 	mockTransactionsEndpoint,
 	mockTransactionsRedirectResponse,
@@ -22,9 +23,10 @@ describe( 'weChatProcessor', () => {
 		is_domain_registration: true,
 	};
 	const cart = { ...getEmptyResponseCart(), products: [ product ] };
-	const options = {
+	const options: PaymentProcessorOptions = {
 		...processorOptions,
 		responseCart: cart,
+		reloadCart: () => Promise.resolve( cart ),
 	};
 
 	const basicExpectedStripeRequest = {

--- a/client/my-sites/checkout/src/test/web-pay-processor.ts
+++ b/client/my-sites/checkout/src/test/web-pay-processor.ts
@@ -1,5 +1,6 @@
 import { getEmptyResponseCart, getEmptyResponseCartProduct } from '@automattic/shopping-cart';
 import webPayProcessor from '../lib/web-pay-processor';
+import { PaymentProcessorOptions } from '../types/payment-processors';
 import {
 	mockTransactionsEndpoint,
 	mockTransactionsSuccessResponse,
@@ -20,9 +21,10 @@ describe( 'webPayProcessor', () => {
 		is_domain_registration: true,
 	};
 	const cart = { ...getEmptyResponseCart(), products: [ product ] };
-	const options = {
+	const options: PaymentProcessorOptions = {
 		...processorOptions,
 		responseCart: cart,
+		reloadCart: () => Promise.resolve( cart ),
 	};
 
 	const stripe = {};
@@ -65,14 +67,14 @@ describe( 'webPayProcessor', () => {
 
 	it( 'throws an error if there is no stripe object', async () => {
 		const submitData = { paymentPartner: 'stripe' };
-		await expect( webPayProcessor( 'apple-pay', submitData, options ) ).rejects.toThrowError(
+		await expect( webPayProcessor( 'apple-pay', submitData, options ) ).rejects.toThrow(
 			/requires stripe and none was provided/
 		);
 	} );
 
 	it( 'throws an error if there is no stripeConfiguration object', async () => {
 		const submitData = { paymentPartner: 'stripe', stripe };
-		await expect( webPayProcessor( 'apple-pay', submitData, options ) ).rejects.toThrowError(
+		await expect( webPayProcessor( 'apple-pay', submitData, options ) ).rejects.toThrow(
 			/requires stripeConfiguration and none was provided/
 		);
 	} );

--- a/client/my-sites/checkout/src/types/payment-processors.ts
+++ b/client/my-sites/checkout/src/types/payment-processors.ts
@@ -1,6 +1,6 @@
 import type { GetThankYouUrl } from '../hooks/use-get-thank-you-url';
 import type { StripeConfiguration } from '@automattic/calypso-stripe';
-import type { ResponseCart } from '@automattic/shopping-cart';
+import type { ReloadCartFromServer, ResponseCart } from '@automattic/shopping-cart';
 import type { ManagedContactDetails } from '@automattic/wpcom-checkout';
 import type { Stripe } from '@stripe/stripe-js';
 import type { CalypsoDispatch } from 'calypso/state/types';
@@ -13,6 +13,7 @@ export interface PaymentProcessorOptions {
 	stripeConfiguration: StripeConfiguration | null;
 	reduxDispatch: CalypsoDispatch;
 	responseCart: ResponseCart;
+	reloadCart: ReloadCartFromServer;
 	getThankYouUrl: GetThankYouUrl;
 	siteSlug: string | undefined;
 	siteId: number | undefined;

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/index.tsx
@@ -73,7 +73,7 @@ export default function PurchaseModalWrapper( props: PurchaseModalProps ) {
 	const { stripe, stripeConfiguration } = useStripe();
 	const reduxDispatch = useDispatch();
 	const cartKey = useCartKey();
-	const { responseCart } = useShoppingCart( cartKey );
+	const { responseCart, reloadFromServer: reloadCart } = useShoppingCart( cartKey );
 	const selectedSite = useSelector( getSelectedSite );
 
 	const contactDetailsType = getContactDetailsType( props.cart );
@@ -88,6 +88,7 @@ export default function PurchaseModalWrapper( props: PurchaseModalProps ) {
 			includeGSuiteDetails,
 			reduxDispatch,
 			responseCart,
+			reloadCart,
 			siteSlug: selectedSite?.slug ?? '',
 			siteId: selectedSite?.ID,
 			stripe,
@@ -106,6 +107,7 @@ export default function PurchaseModalWrapper( props: PurchaseModalProps ) {
 			reduxDispatch,
 			selectedSite,
 			responseCart,
+			reloadCart,
 		]
 	);
 


### PR DESCRIPTION
## Proposed Changes

When paying in checkout, it's possible for the transactions endpoint to fail with an error. Rarely this happens after the transaction has actually completed (the user has been charged) but before the product has been provisioned. In this case the user should be notified that something is wrong, but that flow is a little broken (see https://github.com/Automattic/payments-shilling/issues/2053). If it does happen and the user is returned to checkout with an error, the cart will probably already have been emptied on the server to prevent the user attempting the purchase again, but right now the user is unlikely to notice that the cart has been cleared because it does not check the server for updates. This will probably lead the user to make a duplicate purchase as they attempt to figure out what went wrong.

In this PR we modify every payment processor function used by checkout so that if it fails it will refresh the cart from the server.

This is part of https://github.com/Automattic/payments-shilling/issues/2053

## Testing Instructions

Automated tests are included.

Testing this manually is tricky because the failure case is hard to reproduce. However, here's how to do it:

1. Undo the changes from D123619-code.
2. Using Store Admin, find an Akismet subscription that is inactive ("Removed") or remove an active subscription.
3. Next you'll need to be logged-in to calypso for the user with that subscription.
4. Construct a checkout URL to renew that subscription. For example, https://wordpress.com/checkout/akismet/ak_plus_yearly_2/renew/1061222 for the user `paytontest171` (you will need to be using the test tables for this subscription). 
5. Visit the checkout URL and complete checkout (NOTE that you will be charged!). You should be returned to checkout with an error message.
6. Verify that the shopping cart shows as empty.