### PR TITLE
Stats: recover legend in chart

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -352,7 +352,7 @@ class StatsSite extends Component {
 							chartTab={ this.props.chartTab }
 							customQuantity={ this.state.customChartQuantity }
 							customRange={ customChartRange }
-							hideLegend={ true }
+							hideLegend={ isDateControlEnabled }
 						/>
 					</>
 


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/83189

## Proposed Changes

Only hide the legend when new date picker is enabled.

However, we might need to change the E2E tests, because we are releasing the feature today @dpasque .

## Testing Instructions

* Open Calypso Live
* Open Traffic page
* Ensure you see the Legend

![image](https://github.com/Automattic/wp-calypso/assets/1425433/c55e0255-8acd-4b57-a3a6-cecff6be05fa)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?