### PR TITLE
Minor calypso app improvements

### DIFF
--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -21,15 +21,6 @@ object WPComPlugins : Project({
 	// Default params for WPcom Plugins.
 	params {
 		param("docker_image", "registry.a8c.com/calypso/ci-wpcom:latest")
-		param("build.prefix", "1")
-		checkbox(
-			name = "skip_release_diff",
-			value = "false",
-			label = "Skip release diff",
-			description = "Skips the diff against the previous successful build, uploading the artifact as the latest successful build.",
-			checked = "true",
-			unchecked = "false"
-		)
 	}
 
 	buildType(CalypsoApps)
@@ -55,7 +46,7 @@ object WPComPlugins : Project({
 					"notifications-release-build",
 					"odyssey-stats-release-build",
 					"blaze-dashboard-release-build",
-					"etk-release-build",
+					"editing-toolkit-release-build",
 					"wpcom-block-editor-release-build",
 					"o2-blocks-release-build",
 					"happy-blocks-release-build",
@@ -74,8 +65,19 @@ object CalypsoApps: BuildType({
 	name = "Build Calypso Apps"
 	description = "Builds all Calypso apps and saves release artifacts for each. This replaces the separate build configurations for each app."
 
-	// Incremented to 4 to make sure ETK updates continue to work:
-	params { param("build.prefix", "4") }
+	params {
+		// Incremented to 4 to make sure ETK updates continue to work:
+		param("build.prefix", "4")
+		checkbox(
+			name = "skip_release_diff",
+			value = "false",
+			label = "Skip release diff",
+			description = "Skips the diff against the previous successful build, uploading the artifact as the latest successful build.",
+			checked = "true",
+			unchecked = "false"
+		)
+	}
+
 	buildNumberPattern = "%build.prefix%.%build.counter%"
 	features {
 		perfmon {
@@ -408,20 +410,16 @@ private object GutenbergUploadSourceMapsToSentry: BuildType() {
 
 			uploadPluginSourceMaps(
 				slug = "editing-toolkit",
-				buildId = "calypso_WPComPlugins_EditorToolKit",
-				buildTag = "etk-release-build",
 				wpcomURL = "~/wp-content/plugins/editing-toolkit-plugin/prod/"
 			)
 
 			uploadPluginSourceMaps(
 				slug = "wpcom-block-editor",
-				buildId = "calypso_WPComPlugins_WpcomBlockEditor",
 				wpcomURL = "~/wpcom-block-editor"
 			)
 
 			uploadPluginSourceMaps(
 				slug = "notifications",
-				buildId = "calypso_WPComPlugins_Notifications",
 				wpcomURL = "~/notifications"
 			)
 		}
@@ -432,7 +430,6 @@ private object GutenbergUploadSourceMapsToSentry: BuildType() {
 // to Sentry.
 fun BuildSteps.uploadPluginSourceMaps(
 	slug: String,
-	buildId: String,
 	wpcomURL: String,
 	buildTag: String = "$slug-release-build",
 ): ScriptBuildStep {
@@ -442,7 +439,7 @@ fun BuildSteps.uploadPluginSourceMaps(
 			rm -rf code code.zip
 
 			# Downloads the latest release build for the plugin.
-			wget "%teamcity.serverUrl%/repository/download/$buildId/$buildTag.tcbuildtag/$slug.zip?guest=1&branch=trunk" -O ./code.zip
+			wget "%teamcity.serverUrl%/repository/download/calypso_WPComPlugins_Build_Plugins/$buildTag.tcbuildtag/$slug.zip?guest=1&branch=trunk" -O ./code.zip
 
 			unzip -q ./code.zip -d ./code
 			cd code

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -69,6 +69,14 @@ object CalypsoApps: BuildType({
 	params {
 		// Incremented to 4 to make sure ETK updates continue to work:
 		param("build.prefix", "4")
+		checkbox(
+			name = "skip_release_diff",
+			value = "false",
+			label = "Skip release diff",
+			description = "Skips the diff against the previous successful build, uploading the artifact as the latest successful build.",
+			checked = "true",
+			unchecked = "false"
+		)
 	}
 
 	buildNumberPattern = "%build.prefix%.%build.counter%"

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -21,6 +21,7 @@ object WPComPlugins : Project({
 	// Default params for WPcom Plugins.
 	params {
 		param("docker_image", "registry.a8c.com/calypso/ci-wpcom:latest")
+		param("build.prefix", "1")
 	}
 
 	buildType(CalypsoApps)
@@ -68,14 +69,6 @@ object CalypsoApps: BuildType({
 	params {
 		// Incremented to 4 to make sure ETK updates continue to work:
 		param("build.prefix", "4")
-		checkbox(
-			name = "skip_release_diff",
-			value = "false",
-			label = "Skip release diff",
-			description = "Skips the diff against the previous successful build, uploading the artifact as the latest successful build.",
-			checked = "true",
-			unchecked = "false"
-		)
 	}
 
 	buildNumberPattern = "%build.prefix%.%build.counter%"

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -413,7 +413,7 @@ function load_wpcom_documentation_links() {
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_wpcom_documentation_links' );
 
 /**
- * Add support links to block description
+ * Add support links to block description.
  */
 function load_block_description_links() {
 	require_once __DIR__ . '/wpcom-block-description-links/class-wpcom-block-description-links.php';

--- a/bin/process-calypso-app-artifacts.mjs
+++ b/bin/process-calypso-app-artifacts.mjs
@@ -124,7 +124,10 @@ async function addGitHubComment( _changedApps ) {
 	const docsMsg = '_For info about this notification, see here: PCYsg-OT6-p2_';
 	const changedAppsMsg = notifyApps.map( ( { slug } ) => `* ${ slug }` ).join( '\n' );
 	// Note: extra escaping is necessary because the message is passed to bash.
-	const testMsg = `To test WordPress.com changes, run \`install-plugin.sh \\$pluginSlug ${ process.env.git_branch }\` on your sandbox.`;
+	const testMsg =
+		'To test WordPress.com changes, run \\`install-plugin.sh \\$pluginSlug ' +
+		process.env.git_branch +
+		'\\` on your sandbox.';
 
 	const appMsg = `${ header }\n\n${ docsMsg }\n\n${ changedAppsMsg }\n\n${ testMsg }`;
 

--- a/bin/process-calypso-app-artifacts.mjs
+++ b/bin/process-calypso-app-artifacts.mjs
@@ -123,7 +123,8 @@ async function addGitHubComment( _changedApps ) {
 	const header = '**This PR modifies the release build for the following Calypso Apps:**';
 	const docsMsg = '_For info about this notification, see here: PCYsg-OT6-p2_';
 	const changedAppsMsg = notifyApps.map( ( { slug } ) => `* ${ slug }` ).join( '\n' );
-	const testMsg = `To test WordPress.com changes, run "install-plugin.sh $pluginSlug ${ process.env.git_branch }" on your sandbox.`;
+	// Note: extra escaping is necessary because the message is passed to bash.
+	const testMsg = `To test WordPress.com changes, run \`install-plugin.sh \\$pluginSlug ${ process.env.git_branch }\` on your sandbox.`;
 
 	const appMsg = `${ header }\n\n${ docsMsg }\n\n${ changedAppsMsg }\n\n${ testMsg }`;
 


### PR DESCRIPTION
I'm moving some changes here from #82897 so that I can land them sooner:

- Move a build param closer to where it's used, instead of applying it to all builds.
- Update artifact name for ETK in artifact retention settings
- Update source map uploader to point at the new build
- Fix missing information in calypso apps message (`$pluginSlug` was getting processed raw by bash, instead of getting inserted into the message)