### PR TITLE
Theme Discovery: Update Copy and Fix UI

### DIFF
--- a/client/components/theme-collection/index.tsx
+++ b/client/components/theme-collection/index.tsx
@@ -78,7 +78,7 @@ export default function ThemeCollection( {
 							// break-xlarge in Gutenberg breakpoints
 							'1080': {
 								slidesPerView: 3,
-								spaceBetween: -16,
+								spaceBetween: -48,
 							},
 						},
 						modules: [ Navigation, Keyboard, Mousewheel ],

--- a/client/components/theme-collection/index.tsx
+++ b/client/components/theme-collection/index.tsx
@@ -2,8 +2,9 @@ import { Button } from '@wordpress/components';
 import { chevronLeft, chevronRight, Icon } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { PropsWithChildren, ReactElement, useEffect, useRef, useState } from 'react';
-import './style.scss';
 import { Swiper as SwiperType } from 'swiper/types';
+import { preventWidows } from 'calypso/lib/formatting';
+import './style.scss';
 
 interface ThemeCollectionProps {
 	collectionSlug: string;
@@ -97,7 +98,7 @@ export default function ThemeCollection( {
 			<div className="theme-collection__meta">
 				<div className="theme-collection__headings">
 					<h2 className="theme-collection__title">{ title }</h2>
-					<div className="theme-collection__description">{ description }</div>
+					<div className="theme-collection__description">{ preventWidows( description ) }</div>
 				</div>
 				<div className="theme-collection__carousel-controls">
 					<Button className="theme-collection__see-all" onClick={ onSeeAll }>

--- a/client/components/theme-collection/index.tsx
+++ b/client/components/theme-collection/index.tsx
@@ -9,7 +9,7 @@ import './style.scss';
 interface ThemeCollectionProps {
 	collectionSlug: string;
 	title: string;
-	description: ReactElement;
+	description: ReactElement | null;
 	onSeeAll: () => void;
 }
 

--- a/client/components/theme-collection/style.scss
+++ b/client/components/theme-collection/style.scss
@@ -98,16 +98,13 @@
 		font-size: $font-body-small;
 		font-style: normal;
 		font-weight: 400;
+		height: auto;
 		line-height: 1.4;
 		letter-spacing: -0.15px;
 		padding: 0;
 		margin-right: 0;
 		align-items: flex-end;
 		text-decoration: underline;
-
-		&:focus {
-			box-shadow: none;
-		}
 
 		@include break-small {
 			text-decoration: none;

--- a/client/components/theme-collection/style.scss
+++ b/client/components/theme-collection/style.scss
@@ -29,6 +29,7 @@
 }
 
 .theme-collection__headings {
+	align-self: flex-end;
 	flex-basis: 80%;
 
 	@include break-small {

--- a/client/components/theme-collection/style.scss
+++ b/client/components/theme-collection/style.scss
@@ -74,6 +74,10 @@
 			padding-left: 32px;
 			padding-right: 32px;
 		}
+		@include break-xlarge {
+			padding-left: 48px;
+			padding-right: 48px;
+		}
 	}
 }
 

--- a/client/components/theme-collection/style.scss
+++ b/client/components/theme-collection/style.scss
@@ -38,13 +38,12 @@
 
 .theme-collection__title {
 	color: var(--studio-gray-100);
-	font-size: $font-body;
-	font-weight: 600;
-	line-height: 1.5;
+	font-size: $font-body-large;
+	font-weight: 400;
+	line-height: 1.4;
 
 	@include break-small {
 		font-size: rem(28px);
-		font-weight: 400;
 		line-height: 1.2;
 	}
 }

--- a/client/components/theme-collection/style.scss
+++ b/client/components/theme-collection/style.scss
@@ -32,25 +32,27 @@
 	flex-basis: 80%;
 
 	@include break-small {
-		flex-basis: 45%;
+		flex-basis: 60%;
 	}
 }
 
 .theme-collection__title {
-	line-height: 1;
+	color: var(--studio-gray-100);
 	font-size: $font-body;
 	font-weight: 600;
-	color: var(--gray-gray-100, #101517);
+	line-height: 1.5;
 
 	@include break-small {
 		font-size: rem(24px);
 		font-weight: 400;
+		line-height: 1.2;
 	}
 }
 
 .theme-collection__description {
-	color: var(--gray-gray-70, #3c434a);
+	color: var(--studio-gray-60);
 	font-size: $font-body-small;
+	line-height: 1.4;
 
 	& > * {
 		margin-bottom: 0;
@@ -58,6 +60,7 @@
 
 	@include break-small {
 		font-size: $font-body;
+		line-height: 1.5;
 	}
 }
 
@@ -75,7 +78,7 @@
 }
 
 .theme-collection__list-wrapper {
-	margin-top: 1em;
+	margin-top: 24px;
 }
 
 .theme-collection__carousel-controls {
@@ -87,10 +90,11 @@
 	align-items: center;
 
 	.theme-collection__see-all {
+		color: var(--studio-gray-100);
 		font-size: $font-body-small;
 		font-style: normal;
 		font-weight: 400;
-		line-height: 20px;
+		line-height: 1.4;
 		letter-spacing: -0.15px;
 		padding: 0;
 		margin-right: 0;
@@ -119,7 +123,8 @@
 			padding: 0;
 			width: 32px;
 			height: 32px;
-			background: #eee;
+			background: var(--studio-white);
+			border: 1px solid var(--studio-gray-5);
 			border-radius: 50%;
 			display: flex;
 			justify-content: center;

--- a/client/components/theme-collection/style.scss
+++ b/client/components/theme-collection/style.scss
@@ -43,7 +43,7 @@
 	line-height: 1.5;
 
 	@include break-small {
-		font-size: rem(24px);
+		font-size: rem(28px);
 		font-weight: 400;
 		line-height: 1.2;
 	}

--- a/client/components/theme-collection/style.scss
+++ b/client/components/theme-collection/style.scss
@@ -123,13 +123,13 @@
 			padding: 0;
 			width: 32px;
 			height: 32px;
-			background: var(--studio-white);
+			background-color: var(--studio-white);
 			border: 1px solid var(--studio-gray-5);
 			border-radius: 50%;
 			display: flex;
 			justify-content: center;
 			margin: 0 8px;
-			transition: filter 0.1s linear;
+			transition: background-color 0.1s linear;
 			pointer-events: all;
 		}
 
@@ -138,7 +138,7 @@
 		}
 
 		&:hover {
-			filter: brightness(0.9);
+			background-color: var(--studio-gray-0);
 		}
 	}
 }

--- a/client/components/theme-collection/style.scss
+++ b/client/components/theme-collection/style.scss
@@ -48,7 +48,7 @@
 	}
 }
 
-.theme-collection__description * {
+.theme-collection__description {
 	color: var(--gray-gray-70, #3c434a);
 	font-size: $font-body-small;
 	margin-bottom: 0;

--- a/client/components/theme-collection/style.scss
+++ b/client/components/theme-collection/style.scss
@@ -51,7 +51,10 @@
 .theme-collection__description {
 	color: var(--gray-gray-70, #3c434a);
 	font-size: $font-body-small;
-	margin-bottom: 0;
+
+	& > * {
+		margin-bottom: 0;
+	}
 
 	@include break-small {
 		font-size: $font-body;

--- a/client/my-sites/themes/collections/collection-definitions.tsx
+++ b/client/my-sites/themes/collections/collection-definitions.tsx
@@ -12,7 +12,8 @@ export const THEME_COLLECTIONS = {
 			search: '',
 			tier: '',
 		},
-		title: translate( 'Featured Themes' ),
+		title: translate( 'Featured' ),
+		fullTitle: translate( 'Featured Themes' ),
 		collectionSlug: 'recommended',
 		description: (
 			<p>{ translate( 'An expert-curated list of themes to get the most out of your site.' ) }</p>
@@ -28,7 +29,8 @@ export const THEME_COLLECTIONS = {
 			search: '',
 			tier: 'premium',
 		},
-		title: translate( 'Premium Themes' ),
+		title: translate( 'Premium' ),
+		fullTitle: translate( 'Premium Themes' ),
 		collectionSlug: 'premium-themes',
 		description: (
 			<p>
@@ -48,7 +50,8 @@ export const THEME_COLLECTIONS = {
 			search: '',
 			tier: 'marketplace',
 		},
-		title: translate( 'Partner Themes' ),
+		title: translate( 'Partner' ),
+		fullTitle: translate( 'Partner Themes' ),
 		collectionSlug: 'partner-themes',
 		description: (
 			<p>
@@ -78,7 +81,8 @@ export const THEME_COLLECTIONS = {
 			search: '',
 			tier: '',
 		},
-		title: translate( 'Writers and Bloggers Themes' ),
+		title: translate( 'Writers and Bloggers' ),
+		fullTitle: translate( 'Writers and Bloggers Themes' ),
 		collectionSlug: 'blog-themes',
 		description: null,
 		seeAllLink: '/themes/filter/blog',
@@ -92,7 +96,8 @@ export const THEME_COLLECTIONS = {
 			search: '',
 			tier: '',
 		},
-		title: translate( 'Portfolio Themes' ),
+		title: translate( 'Portfolio' ),
+		fullTitle: translate( 'Portfolio Themes' ),
 		collectionSlug: 'portfolio-themes',
 		description: null,
 		seeAllLink: '/themes/filter/portfolio',
@@ -106,7 +111,8 @@ export const THEME_COLLECTIONS = {
 			search: '',
 			tier: '',
 		},
-		title: translate( 'Business Themes' ),
+		title: translate( 'Business' ),
+		fullTitle: translate( 'Business Themes' ),
 		collectionSlug: 'business-themes',
 		description: (
 			<p>
@@ -126,7 +132,8 @@ export const THEME_COLLECTIONS = {
 			search: '',
 			tier: '',
 		},
-		title: translate( 'Art and Design Themes' ),
+		title: translate( 'Art and Design' ),
+		fullTitle: translate( 'Art and Design Themes' ),
 		collectionSlug: 'art-design-themes',
 		description: null,
 		seeAllLink: '/themes/filter/art-design',

--- a/client/my-sites/themes/collections/collection-definitions.tsx
+++ b/client/my-sites/themes/collections/collection-definitions.tsx
@@ -1,4 +1,6 @@
+import { localizeUrl } from '@automattic/i18n-utils';
 import { translate } from 'i18n-calypso';
+import ExternalLink from 'calypso/components/external-link';
 
 export const THEME_COLLECTIONS = {
 	recommended: {
@@ -49,7 +51,21 @@ export const THEME_COLLECTIONS = {
 		title: translate( 'Partner Themes' ),
 		collectionSlug: 'partner-themes',
 		description: (
-			<p>{ translate( 'Professional themes designed and developed by our partners.' ) }</p>
+			<p>
+				{ translate(
+					'Professional themes designed and developed by our partners. {{link}}Learn more{{/link}}.',
+					{
+						components: {
+							link: (
+								<ExternalLink
+									href={ localizeUrl( 'https://wordpress.com/support/partner-themes/' ) }
+									target="_blank"
+								/>
+							),
+						},
+					}
+				) }
+			</p>
 		),
 		seeAllLink: '/themes/marketplace',
 	},

--- a/client/my-sites/themes/collections/collection-definitions.tsx
+++ b/client/my-sites/themes/collections/collection-definitions.tsx
@@ -10,9 +10,11 @@ export const THEME_COLLECTIONS = {
 			search: '',
 			tier: '',
 		},
-		title: translate( 'Recommended Themes' ),
+		title: translate( 'Featured Themes' ),
 		collectionSlug: 'recommended',
-		description: <p>Lorem ipsum dolor sit amet</p>,
+		description: (
+			<p>{ translate( 'An expert-curated list of themes to get the most out of your site.' ) }</p>
+		),
 		seeAllLink: '/themes',
 	},
 	premium: {
@@ -26,7 +28,13 @@ export const THEME_COLLECTIONS = {
 		},
 		title: translate( 'Premium Themes' ),
 		collectionSlug: 'premium-themes',
-		description: <p>Lorem ipsum dolor sit amet</p>,
+		description: (
+			<p>
+				{ translate(
+					'Get Premium and unlock a bundle of exclusive themes to take your website even further.'
+				) }
+			</p>
+		),
 		seeAllLink: '/themes/premium',
 	},
 	marketplace: {
@@ -40,7 +48,9 @@ export const THEME_COLLECTIONS = {
 		},
 		title: translate( 'Partner Themes' ),
 		collectionSlug: 'partner-themes',
-		description: <p>Lorem ipsum dolor sit amet</p>,
+		description: (
+			<p>{ translate( 'Professional themes designed and developed by our partners.' ) }</p>
+		),
 		seeAllLink: '/themes/marketplace',
 	},
 	blog: {
@@ -52,9 +62,9 @@ export const THEME_COLLECTIONS = {
 			search: '',
 			tier: '',
 		},
-		title: translate( 'Blog Themes' ),
+		title: translate( 'Writers and Bloggers Themes' ),
 		collectionSlug: 'blog-themes',
-		description: <p>Lorem ipsum dolor sit amet</p>,
+		description: null,
 		seeAllLink: '/themes/filter/blog',
 	},
 	portfolio: {
@@ -68,7 +78,7 @@ export const THEME_COLLECTIONS = {
 		},
 		title: translate( 'Portfolio Themes' ),
 		collectionSlug: 'portfolio-themes',
-		description: <p>Lorem ipsum dolor sit amet</p>,
+		description: null,
 		seeAllLink: '/themes/filter/portfolio',
 	},
 	business: {
@@ -82,7 +92,13 @@ export const THEME_COLLECTIONS = {
 		},
 		title: translate( 'Business Themes' ),
 		collectionSlug: 'business-themes',
-		description: <p>Lorem ipsum dolor sit amet</p>,
+		description: (
+			<p>
+				{ translate(
+					'Professionally designed to take your business to the next level — no matter its size or kind.'
+				) }
+			</p>
+		),
 		seeAllLink: '/themes/filter/business',
 	},
 	'art-design': {
@@ -96,7 +112,7 @@ export const THEME_COLLECTIONS = {
 		},
 		title: translate( 'Art and Design Themes' ),
 		collectionSlug: 'art-design-themes',
-		description: <p>Lorem ipsum dolor sit amet</p>,
+		description: null,
 		seeAllLink: '/themes/filter/art-design',
 	},
 };

--- a/client/my-sites/themes/collections/showcase-theme-collection.tsx
+++ b/client/my-sites/themes/collections/showcase-theme-collection.tsx
@@ -12,7 +12,7 @@ import {
 interface ShowcaseThemeCollectionProps extends ThemeCollectionsLayoutProps {
 	collectionSlug: string;
 	title: string;
-	description: ReactElement;
+	description: ReactElement | null;
 	query: ThemesQuery;
 	onSeeAll: () => void;
 }

--- a/client/my-sites/themes/collections/style.scss
+++ b/client/my-sites/themes/collections/style.scss
@@ -60,7 +60,7 @@
 	.theme-collection-view-header__back {
 		color: var(--studio-blue-50);
 		font-size: 1rem;
-		font-family: "SF Pro Text", serif;
+		font-family: "SF Pro Text", $sans;
 		font-style: normal;
 		font-weight: 400;
 		letter-spacing: -0.32px;
@@ -71,7 +71,7 @@
 
 	.theme-collection-view-header__title {
 		color: var(--studio-blue-50);
-		font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
+		font-family: $brand-serif;
 		font-size: rem(44px);
 		font-style: normal;
 		font-weight: 400;
@@ -81,7 +81,7 @@
 
 	.theme-collection-view-header__description {
 		color: var(--studio-gray-80);
-		font-family: "SF Pro Text", serif;
+		font-family: "SF Pro Text", $sans;
 		font-size: $font-body-large;
 		font-style: normal;
 		font-weight: 400;

--- a/client/my-sites/themes/collections/style.scss
+++ b/client/my-sites/themes/collections/style.scss
@@ -10,6 +10,10 @@
 			margin-left: -32px;
 			margin-right: -32px;
 		}
+		@include break-xlarge {
+			margin-left: -48px;
+			margin-right: -48px;
+		}
 
 		&:last-child {
 			// Ensure the bottom is well padded.
@@ -31,6 +35,10 @@
 		@include breakpoint-deprecated( ">660px" ) {
 			margin-left: 32px;
 			margin-right: 32px;
+		}
+		@include break-xlarge {
+			margin-left: 48px;
+			margin-right: 48px;
 		}
 	}
 }

--- a/client/my-sites/themes/collections/style.scss
+++ b/client/my-sites/themes/collections/style.scss
@@ -42,3 +42,51 @@
 		}
 	}
 }
+
+.theme-showcase.is-collection-view {
+	.theme-collection-view-header {
+		background-color: #e5f4ff;
+		padding: 32px 16px;
+
+		@include breakpoint-deprecated( ">660px" ) {
+			padding: 48px 32px;
+		}
+		@include break-xlarge {
+			margin-bottom: 48px;
+			padding: 48px;
+		}
+	}
+
+	.theme-collection-view-header__back {
+		color: var(--studio-blue-50);
+		font-size: 1rem;
+		font-family: "SF Pro Text", serif;
+		font-style: normal;
+		font-weight: 400;
+		letter-spacing: -0.32px;
+		line-height: 1.5;
+		padding-left: 0;
+		text-decoration: none;
+	}
+
+	.theme-collection-view-header__title {
+		color: var(--studio-blue-50);
+		font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
+		font-size: rem(44px);
+		font-style: normal;
+		font-weight: 400;
+		line-height: 1.15;
+		margin-bottom: 16px;
+	}
+
+	.theme-collection-view-header__description {
+		color: var(--studio-gray-80);
+		font-family: "SF Pro Text", serif;
+		font-size: $font-body-large;
+		font-style: normal;
+		font-weight: 400;
+		line-height: 1.6;
+		margin-bottom: 0;
+		max-width: 680px;
+	}
+}

--- a/client/my-sites/themes/collections/theme-collection-view-header.jsx
+++ b/client/my-sites/themes/collections/theme-collection-view-header.jsx
@@ -1,0 +1,31 @@
+import { Button } from '@wordpress/components';
+import { chevronLeft } from '@wordpress/icons';
+import { translate } from 'i18n-calypso';
+import page from 'page';
+import { preventWidows } from 'calypso/lib/formatting';
+import { THEME_COLLECTIONS } from 'calypso/my-sites/themes/collections/collection-definitions';
+
+export default function ThemeCollectionViewHeader( { backUrl, filter, tier } ) {
+	const keyParts = [ tier, filter ];
+	const key = keyParts.filter( ( part ) => !! part ).join( '-' ) || 'recommended';
+	const { fullTitle, description } = THEME_COLLECTIONS[ key ];
+
+	return (
+		<div className="theme-collection-view-header">
+			<Button
+				className="theme-collection-view-header__back"
+				icon={ chevronLeft }
+				onClick={ () => page( backUrl ) }
+				variant="link"
+			>
+				{ translate( 'Back' ) }
+			</Button>
+			{ fullTitle && <h2 className="theme-collection-view-header__title">{ fullTitle }</h2> }
+			{ description && (
+				<div className="theme-collection-view-header__description">
+					{ preventWidows( description ) }
+				</div>
+			) }
+		</div>
+	);
+}

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -1,8 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { FEATURE_INSTALL_THEMES } from '@automattic/calypso-products';
-import { Button } from '@wordpress/components';
-import { chevronLeft, Icon } from '@wordpress/icons';
 import classNames from 'classnames';
 import { localize, translate } from 'i18n-calypso';
 import { compact, pickBy } from 'lodash';
@@ -20,9 +18,8 @@ import SelectDropdown from 'calypso/components/select-dropdown';
 import { getOptionLabel } from 'calypso/landing/subscriptions/helpers';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { buildRelativeSearchUrl } from 'calypso/lib/build-url';
-import { preventWidows } from 'calypso/lib/formatting';
 import ActivationModal from 'calypso/my-sites/themes/activation-modal';
-import { THEME_COLLECTIONS } from 'calypso/my-sites/themes/collections/collection-definitions';
+import ThemeCollectionViewHeader from 'calypso/my-sites/themes/collections/theme-collection-view-header';
 import ThemeCollectionsLayout from 'calypso/my-sites/themes/collections/theme-collections-layout';
 import ThanksModal from 'calypso/my-sites/themes/thanks-modal';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -365,37 +362,6 @@ class ThemeShowcase extends Component {
 		this.scrollToSearchInput();
 	};
 
-	getCollectionViewHeader = () => {
-		const keyParts = [ this.props.tier, this.props.filter ];
-		const key = keyParts.filter( ( part ) => !! part ).join( '-' ) || 'recommended';
-		const { fullTitle, description } = THEME_COLLECTIONS[ key ];
-
-		return (
-			<div className="collection-header">
-				<Button
-					className="collection-header__back"
-					onClick={ () =>
-						page(
-							this.constructUrl( {
-								isCollectionView: false,
-								tier: '',
-								filter: '',
-								category: staticFilters.RECOMMENDED.key,
-							} )
-						)
-					}
-				>
-					<Icon icon={ chevronLeft } />
-					{ translate( 'Back' ) }
-				</Button>
-				{ fullTitle && <h2 className="collection-header__title">{ fullTitle }</h2> }
-				{ description && (
-					<div className="collection-header__description">{ preventWidows( description ) }</div>
-				) }
-			</div>
-		);
-	};
-
 	allThemes = ( { themeProps } ) => {
 		const { filter, isCollectionView, isJetpackSite, tier, children } = this.props;
 		if ( isJetpackSite ) {
@@ -644,8 +610,19 @@ class ThemeShowcase extends Component {
 							) }
 						</div>
 					) }
+					{ isCollectionView && (
+						<ThemeCollectionViewHeader
+							backUrl={ this.constructUrl( {
+								isCollectionView: false,
+								tier: '',
+								filter: '',
+								category: staticFilters.RECOMMENDED.key,
+							} ) }
+							filter={ this.props.filter }
+							tier={ this.props.tier }
+						/>
+					) }
 					<div className="themes__showcase">
-						{ isCollectionView && this.getCollectionViewHeader() }
 						{ ! isSiteWooExpressOrEcomFreeTrial && this.renderBanner() }
 						{ this.renderThemes( themeProps ) }
 					</div>

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -396,14 +396,20 @@ class ThemeShowcase extends Component {
 	};
 
 	allThemes = ( { themeProps } ) => {
-		const { isJetpackSite, children } = this.props;
+		const { filter, isCollectionView, isJetpackSite, tier, children } = this.props;
 		if ( isJetpackSite ) {
 			return children;
 		}
 
+		// In Collection View of pricing tiers (e.g. Partner themes), prevent requesting only recommended themes.
+		const themesSelectionProps = {
+			...themeProps,
+			...( isCollectionView && tier && ! filter && { tabFilter: '' } ),
+		};
+
 		return (
 			<div className="theme-showcase__all-themes">
-				<ThemesSelection { ...themeProps } />
+				<ThemesSelection { ...themesSelectionProps } />
 			</div>
 		);
 	};

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -367,7 +367,7 @@ class ThemeShowcase extends Component {
 	getCollectionViewHeader = () => {
 		const keyParts = [ this.props.tier, this.props.filter ];
 		const key = keyParts.filter( ( part ) => !! part ).join( '-' ) || 'recommended';
-		const { title, description } = THEME_COLLECTIONS[ key ];
+		const { fullTitle, description } = THEME_COLLECTIONS[ key ];
 
 		return (
 			<div className="collection-header">
@@ -387,7 +387,7 @@ class ThemeShowcase extends Component {
 					<Icon icon={ chevronLeft } />
 					{ translate( 'Back' ) }
 				</Button>
-				{ title && <h2 className="collection-header__title">{ title }</h2> }
+				{ fullTitle && <h2 className="collection-header__title">{ fullTitle }</h2> }
 				{ description && (
 					<div className="collection-header__description">{ preventWidows( description ) }</div>
 				) }

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -3,6 +3,7 @@ import config from '@automattic/calypso-config';
 import { FEATURE_INSTALL_THEMES } from '@automattic/calypso-products';
 import { Button } from '@wordpress/components';
 import { chevronLeft, Icon } from '@wordpress/icons';
+import classNames from 'classnames';
 import { localize, translate } from 'i18n-calypso';
 import { compact, pickBy } from 'lodash';
 import page from 'page';
@@ -575,8 +576,14 @@ class ThemeShowcase extends Component {
 		const tabFilters = this.getTabFilters();
 		const tiers = this.getTiers();
 
+		const classnames = classNames( 'theme-showcase', {
+			'is-discovery-view':
+				this.props.tier === '' && this.isThemeDiscoveryEnabled() && ! isCollectionView,
+			'is-collection-view': isCollectionView,
+		} );
+
 		return (
-			<div className="theme-showcase">
+			<div className={ classnames }>
 				<PageViewTracker
 					path={ this.props.analyticsPath }
 					title={ this.props.analyticsPageTitle }

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -19,6 +19,7 @@ import SelectDropdown from 'calypso/components/select-dropdown';
 import { getOptionLabel } from 'calypso/landing/subscriptions/helpers';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { buildRelativeSearchUrl } from 'calypso/lib/build-url';
+import { preventWidows } from 'calypso/lib/formatting';
 import ActivationModal from 'calypso/my-sites/themes/activation-modal';
 import { THEME_COLLECTIONS } from 'calypso/my-sites/themes/collections/collection-definitions';
 import ThemeCollectionsLayout from 'calypso/my-sites/themes/collections/theme-collections-layout';
@@ -387,7 +388,9 @@ class ThemeShowcase extends Component {
 					{ translate( 'Back' ) }
 				</Button>
 				{ title && <h2 className="collection-header__title">{ title }</h2> }
-				{ description && <div className="collection-header__description">{ description }</div> }
+				{ description && (
+					<div className="collection-header__description">{ preventWidows( description ) }</div>
+				) }
 			</div>
 		);
 	};

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -140,7 +140,7 @@ class ThemeShowcase extends Component {
 
 	isThemeDiscoveryEnabled = () =>
 		( this.props.isLoggedIn && config.isEnabled( 'themes/discovery-lits' ) ) ||
-		config.isEnabled( 'themes/discovery-lots' );
+		( ! this.props.isLoggedIn && config.isEnabled( 'themes/discovery-lots' ) );
 
 	isStaticFilter = ( tabFilter ) => {
 		return Object.values( staticFilters ).some(

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -7,7 +7,7 @@ import { localize, translate } from 'i18n-calypso';
 import { compact, pickBy } from 'lodash';
 import page from 'page';
 import PropTypes from 'prop-types';
-import React, { createRef, Component } from 'react';
+import { createRef, Component } from 'react';
 import { connect } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
 import QueryProductsList from 'calypso/components/data/query-products-list';
@@ -138,6 +138,10 @@ class ThemeShowcase extends Component {
 		this.props.setBackPath( this.constructUrl() );
 	}
 
+	isThemeDiscoveryEnabled = () =>
+		( this.props.isLoggedIn && config.isEnabled( 'themes/discovery-lits' ) ) ||
+		config.isEnabled( 'themes/discovery-lots' );
+
 	isStaticFilter = ( tabFilter ) => {
 		return Object.values( staticFilters ).some(
 			( staticFilter ) => tabFilter.key === staticFilter.key
@@ -160,11 +164,17 @@ class ThemeShowcase extends Component {
 			( this.props.isJetpackSite && ! this.props.isAtomicSite ) ||
 			( this.props.isAtomicSite && this.props.siteCanInstallThemes );
 
+		const recommendedFilter = {
+			...staticFilters.RECOMMENDED,
+			...( this.props.tier === '' &&
+				this.isThemeDiscoveryEnabled() && { text: this.props.translate( 'Discover' ) } ),
+		};
+
 		return {
 			...( shouldShowMyThemesFilter && {
 				MYTHEMES: staticFilters.MYTHEMES,
 			} ),
-			RECOMMENDED: staticFilters.RECOMMENDED,
+			RECOMMENDED: recommendedFilter,
 			ALL: staticFilters.ALL,
 			...this.subjectFilters,
 		};
@@ -453,11 +463,7 @@ class ThemeShowcase extends Component {
 	renderThemes = ( themeProps ) => {
 		const tabKey = this.getSelectedTabFilter().key;
 
-		const showCollections =
-			this.props.tier === '' &&
-			( this.props.isLoggedIn
-				? config.isEnabled( 'themes/discovery-lits' )
-				: config.isEnabled( 'themes/discovery-lots' ) );
+		const showCollections = this.props.tier === '' && this.isThemeDiscoveryEnabled();
 
 		switch ( tabKey ) {
 			case staticFilters.MYTHEMES?.key:

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -35,6 +35,10 @@
 		@include breakpoint-deprecated( ">660px" ) {
 			padding: 64px 32px 16px;
 		}
+		@include break-xlarge {
+			padding-left: 48px;
+			padding-right: 48px;
+		}
 
 		h1 {
 			color: var(--studio-blue-50);
@@ -66,6 +70,9 @@
 
 			@include breakpoint-deprecated( ">660px" ) {
 				padding: 0 32px;
+			}
+			@include break-xlarge {
+				padding: 0 48px;
 			}
 		}
 	}

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -270,47 +270,6 @@
 
 	.themes__showcase {
 		margin-top: 32px;
-
-		.collection-header {
-			margin: 48px auto;
-		}
-
-		.collection-header__back {
-			padding-left: 0;
-			font-size: 1rem;
-			font-family: "SF Pro Text", serif;
-			font-style: normal;
-			font-weight: 400;
-			line-height: 24px;
-			letter-spacing: -0.32px;
-
-			&.components-button {
-				&:focus {
-					box-shadow: none;
-				}
-			}
-		}
-
-		.collection-header__title {
-			color: var(--studio-gray-100);
-			font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
-			font-size: rem(56px);
-			font-style: normal;
-			font-weight: 400;
-			line-height: 1;
-			letter-spacing: 0.2px;
-			margin-bottom: 16px;
-		}
-
-		.collection-header__description {
-			color: var(--studio-gray-80);
-			font-family: "SF Pro Text", serif;
-			font-size: $font-body-large;
-			font-style: normal;
-			font-weight: 400;
-			line-height: 1.4;
-			letter-spacing: 0.444px;
-		}
 	}
 
 	.themes__selection .themes-list {

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -262,10 +262,9 @@
 	}
 
 	.themes__showcase {
-		margin-top: 32px;
 
 		.collection-header {
-			margin-bottom: 1.5em;
+			margin: 48px auto;
 		}
 
 		.collection-header__back {
@@ -285,21 +284,24 @@
 		}
 
 		.collection-header__title {
+			color: var(--studio-gray-100);
 			font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
-			font-size: rem(44px);
+			font-size: rem(56px);
 			font-style: normal;
 			font-weight: 400;
-			line-height: 52px;
+			line-height: 1;
 			letter-spacing: 0.2px;
+			margin-bottom: 16px;
 		}
 
 		.collection-header__description {
+			color: var(--studio-gray-80);
 			font-family: "SF Pro Text", serif;
-			font-size: $font-body;
+			font-size: $font-body-large;
 			font-style: normal;
 			font-weight: 400;
-			line-height: 24px;
-			letter-spacing: -0.32px;
+			line-height: 1.4;
+			letter-spacing: 0.444px;
 		}
 	}
 

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -264,6 +264,10 @@
 	.themes__showcase {
 		margin-top: 32px;
 
+		.collection-header {
+			margin-bottom: 1.5em;
+		}
+
 		.collection-header__back {
 			padding-left: 0;
 			font-size: 1rem;

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -262,6 +262,7 @@
 	}
 
 	.themes__showcase {
+		margin-top: 32px;
 
 		.collection-header {
 			margin: 48px auto;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/3941

## Proposed Changes

* Rename "Recommended" as "Discover" when appropriate in the context of Theme Discovery.
* Use the actual copy for all the collections.
* Address Discovery view feedbacks (font sizes, line heights, colors, margins, nav buttons).
* Address Collection view feedbacks (font sizes, line heights, margins).
* Prevent widows on collection descriptions.
* Remove repetitive "Themes" in collection titles in Discovery view.
* In Collection view of pricing tiers (e.g. Partner themes), request all themes, not just the curated ones.

| View | Before | After |
|--------|--------|--------|
| Discovery | <img width="1153" alt="Screenshot 2023-10-19 at 19 33 21" src="https://github.com/Automattic/wp-calypso/assets/2070010/8f2ed872-c65c-4319-8506-1aec13ba320b"> | <img width="1153" alt="Screenshot 2023-10-19 at 19 32 35" src="https://github.com/Automattic/wp-calypso/assets/2070010/3fe3695d-7c04-4707-b62d-1a2736910f9c"> |
| Collection | <img width="1153" alt="Screenshot 2023-10-19 at 19 33 26" src="https://github.com/Automattic/wp-calypso/assets/2070010/b0b1cacc-184c-4e6e-96d9-8279989cc435"> | <img width="1153" alt="Screenshot 2023-10-19 at 19 32 39" src="https://github.com/Automattic/wp-calypso/assets/2070010/410115e7-1f30-4a6a-bf7d-75bb8880d3a6"> | 

### Some Noteworthy Notes

- The previously-called "Blog Themes" collection is now "Writers and Bloggers Themes". Is it proper English?
- The current behaviour of the "Discover" category is wonky, but I can't think of a better one while we work on the Search Experience project.
  - It is labelled `Discover` only when the pricing tier is "All" — that's the only case it shows the Discovery view.
  - It is labelled `Recommended` when the pricing tier is selected — in those cases, it does not show the Discovery view.

### Still Missing

- Fix the LoTS grid logic to show up to 3 themes per row (and generally speaking, the same amount of themes as in a carousel at the same screen width).
- Figure out how to loop instead of rewind.
- Update theme card style (non blocking for release).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pick the Calypso Live link and append `?flags=themes/discovery-lots`.
* Enjoy!

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?