### PR TITLE
Stats: Date Control - left align heading

### DIFF
--- a/client/my-sites/stats/stats-date-control/style.scss
+++ b/client/my-sites/stats/stats-date-control/style.scss
@@ -121,6 +121,7 @@
 	font-weight: 500;
 	line-height: 24px;
 	letter-spacing: -0.28px;
+	text-align: left;
 
 	span {
 		color: var(--gray-gray-50, #646970);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* This tiny PR is a followup to https://github.com/Automattic/wp-calypso/pull/83201 to fix a commit that was missed. It just left aligns the heading. 

## Testing Instructions

* Load the Calypso live branch 
* Navigate to `/stats/day/{site URL}`
* Confirm that everything remains unchanged without the feature flag applied
* Append `?flags=stats/date-control` to the end of the URL
* Confirm that you see the left aligned heading as per example below:

| Before  | After  |
| ------------- | ------------- |
| ![image](https://github.com/Automattic/wp-calypso/assets/30754158/b0ea4911-fcc4-410f-ba91-e9b69bfe75bb) | ![image](https://github.com/Automattic/wp-calypso/assets/30754158/63dd0641-174d-44b8-bfb5-033c479dfc9f) |



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?