### PR TITLE
Marketplace Congrats: Add page title

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -1,6 +1,8 @@
 import { ConfettiAnimation } from '@automattic/components';
 import { ThemeProvider, Global, css } from '@emotion/react';
+import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
+import DocumentHead from 'calypso/components/data/document-head';
 import { ThankYou } from 'calypso/components/thank-you';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import MarketplaceProgressBar from 'calypso/my-sites/marketplace/components/progressbar';
@@ -33,6 +35,7 @@ const MarketplaceThankYou = ( {
 	isOnboardingFlow: boolean;
 } ) => {
 	const dispatch = useDispatch();
+	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
 	const isRequestingPlugins = useSelector( ( state ) =>
 		siteId ? isRequesting( state, siteId ) : false
@@ -123,6 +126,7 @@ const MarketplaceThankYou = ( {
 
 	return (
 		<ThemeProvider theme={ theme }>
+			<DocumentHead title={ translate( 'Next steps' ) } />
 			<PageViewTracker path="/marketplace/thank-you/:site" title="Marketplace > Thank you" />
 			{ /* Using Global to override Global masterbar height */ }
 			<Global


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/83194

## Proposed Changes

Add a page title; currently, it uses the title previously set.

![CleanShot 2023-10-18 at 14 56 16@2x](https://github.com/Automattic/wp-calypso/assets/5039531/a96c6ba4-3a24-43a1-9024-89d7b33311c9)

## Testing Instructions
* Go to the Congrats page with an already purchased plugin or theme. Ex: `/checkout/thank-you/:site?plugins=:plugin_id`
* Check if the page title is set as shown above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
