### PR TITLE
with theme flow: Reorder user login to be at the end

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -103,7 +103,7 @@ export function generateFlows( {
 		},
 		{
 			name: 'with-theme',
-			steps: [ userSocialStep, 'domains-theme-preselected', 'plans-theme-preselected' ],
+			steps: [ 'domains-theme-preselected', 'plans-theme-preselected', userSocialStep ],
 			destination: getWithThemeDestination,
 			description: 'Preselect a theme to activate/buy from an external source',
 			lastModified: '2023-10-11',


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/83207

## Proposed Changes

Reorder user login to be at the end of the `with-theme` flow.


## Testing Instructions
* From a incognito window 
* Go to `/themes`
* Select a Partner theme as `SolarOne`
* Click to `Pick this design`
* You should select domain and plan
* Only them you should be presented with the login step.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
