### PR TITLE
Onboarding: Change modal text for Videomaker trial

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/videopress-onboarding-intent-modal-portfolio.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/videopress-onboarding-intent-modal-portfolio.tsx
@@ -46,7 +46,7 @@ const VideoPressOnboardingIntentModalPortfolio: React.FC< IntroModalContentProps
 		if ( planProductObject ) {
 			// eslint-disable-next-line @wordpress/valid-sprintf
 			getStartedText = config.isEnabled( 'videomaker-trial' )
-				? translate( 'Start free trial' )
+				? translate( 'Start a free trial' )
 				: sprintf(
 						/* translators: Price displayed on VideoPress intro page. %s is monthly price. */
 						translate( 'Get started - from %s/month' ),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/videopress-onboarding-intent-modal-portfolio.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/videopress-onboarding-intent-modal-portfolio.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { useLocale } from '@automattic/i18n-utils';
 import { useSelect } from '@wordpress/data';
 import { sprintf } from '@wordpress/i18n';
@@ -21,6 +22,14 @@ const VideoPressOnboardingIntentModalPortfolio: React.FC< IntroModalContentProps
 	);
 
 	let getStartedText: string | ReactElement = translate( 'Get started' );
+	let learnMoreText: string | React.ReactNode = translate(
+		'{{a}}Or learn more about VideoPress{{/a}}',
+		{
+			components: {
+				a: <a href="https://videopress.com/" target="_blank" rel="external noreferrer noopener" />,
+			},
+		}
+	);
 
 	let defaultSupportedPlan = supportedPlans.find( ( plan ) => {
 		return plan.periodAgnosticSlug === 'premium';
@@ -36,11 +45,31 @@ const VideoPressOnboardingIntentModalPortfolio: React.FC< IntroModalContentProps
 
 		if ( planProductObject ) {
 			// eslint-disable-next-line @wordpress/valid-sprintf
-			getStartedText = sprintf(
-				/* translators: Price displayed on VideoPress intro page. %s is monthly price. */
-				translate( 'Get started - from %s/month' ),
-				planProductObject.price
-			);
+			getStartedText = config.isEnabled( 'videomaker-trial' )
+				? translate( 'Start free trial' )
+				: sprintf(
+						/* translators: Price displayed on VideoPress intro page. %s is monthly price. */
+						translate( 'Get started - from %s/month' ),
+						planProductObject.price
+				  );
+
+			if ( config.isEnabled( 'videomaker-trial' ) ) {
+				learnMoreText = translate(
+					'After trial, plans start as low as %(price)s/month. {{a}}Learn more about VideoPress{{/a}}',
+					{
+						args: { price: planProductObject.price },
+						components: {
+							a: (
+								<a
+									href="https://videopress.com/"
+									target="_blank"
+									rel="external noreferrer noopener"
+								/>
+							),
+						},
+					}
+				);
+			}
 		}
 	}
 
@@ -78,6 +107,7 @@ const VideoPressOnboardingIntentModalPortfolio: React.FC< IntroModalContentProps
 				text: getStartedText,
 				onClick: onSubmit,
 			} }
+			learnMoreText={ learnMoreText }
 		/>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/videopress-onboarding-intent-modal-portfolio.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/videopress-onboarding-intent-modal-portfolio.tsx
@@ -55,6 +55,7 @@ const VideoPressOnboardingIntentModalPortfolio: React.FC< IntroModalContentProps
 
 			if ( config.isEnabled( 'videomaker-trial' ) ) {
 				learnMoreText = translate(
+					/* translators: Displayed on VideoPress signup flow intro page. %(price)s is monthly price. */
 					'After trial, plans start as low as %(price)s/month. {{a}}Learn more about VideoPress{{/a}}',
 					{
 						args: { price: planProductObject.price },

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/videopress-onboarding-intent-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/videopress-onboarding-intent-modal.tsx
@@ -1,9 +1,8 @@
-import config from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { Icon, arrowRight } from '@wordpress/icons';
 import emailValidator from 'email-validator';
 import { useTranslate } from 'i18n-calypso';
-import React, { ChangeEvent, ReactElement, useEffect, useState } from 'react';
+import React, { ChangeEvent, useEffect, useState } from 'react';
 import '../intro/videopress-intro-modal-styles.scss';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import CheckmarkIcon from '../intro/icons/checkmark-icon';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/videopress-onboarding-intent-modal.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videopress-onboarding-intent/videopress-onboarding-intent-modal.tsx
@@ -1,8 +1,9 @@
+import config from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { Icon, arrowRight } from '@wordpress/icons';
 import emailValidator from 'email-validator';
 import { useTranslate } from 'i18n-calypso';
-import React, { ChangeEvent, useEffect, useState } from 'react';
+import React, { ChangeEvent, ReactElement, useEffect, useState } from 'react';
 import '../intro/videopress-intro-modal-styles.scss';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import CheckmarkIcon from '../intro/icons/checkmark-icon';
@@ -18,6 +19,7 @@ export interface VideoPressOnboardingIntentModalContentProps extends IntroModalC
 		href?: string;
 		onClick?: () => void;
 	};
+	learnMoreText?: string | React.ReactNode;
 	isComingSoon?: boolean;
 	intent?: string;
 	surveyTitle?: string;
@@ -32,6 +34,7 @@ const VideoPressOnboardingIntentModal: React.FC< VideoPressOnboardingIntentModal
 	intent,
 	featuresList,
 	actionButton,
+	learnMoreText,
 	isComingSoon,
 	surveyTitle,
 	surveyUrl,
@@ -143,19 +146,7 @@ const VideoPressOnboardingIntentModal: React.FC< VideoPressOnboardingIntentModal
 							>
 								{ actionButton.text }
 							</Button>
-							<div className="learn-more">
-								{ translate( '{{a}}Or learn more about VideoPress.{{/a}}', {
-									components: {
-										a: (
-											<a
-												href="https://videopress.com/"
-												target="_blank"
-												rel="external noreferrer noopener"
-											/>
-										),
-									},
-								} ) }
-							</div>
+							<div className="learn-more">{ learnMoreText }</div>
 						</>
 					) }
 					{ isComingSoon && (


### PR DESCRIPTION
This PR updates the labels on the onboarding flow modal when using the new Videomaker trial flag:

<img width="1373" alt="Screenshot 2023-10-18 at 4 12 07 PM" src="https://github.com/Automattic/wp-calypso/assets/789137/65c609b4-3863-4804-8919-eacb915d6734">

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Testing locally, visit `/setup/videopress`, and click on the `Showcase your work` option.
* You should see the new `Start free trial` text and the pricing info below the button.
* Close the modal and choose some other options to ensure the modal still works with other content.
* Edit `development.json`, set `videomaker-trial` to `false`.
* `yarn && yarn start`, revisit `/setup/videopress` and verify you see the prod onboarding flow and modals.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
