### PR TITLE
Fix URL in Sentry source map uploader

### DIFF
--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -440,7 +440,7 @@ fun BuildSteps.uploadPluginSourceMaps(
 			rm -rf code code.zip
 
 			# Downloads the latest release build for the plugin.
-			wget "%teamcity.serverUrl%/repository/download/calypso_WPComPlugins_Build_Plugins/$buildTag.tcbuildtag/$slug.zip?guest=1&branch=trunk" -O ./code.zip
+			wget "%teamcity.serverUrl%/repository/download/calypso_calypso_WPComPlugins_Build_Plugins/$buildTag.tcbuildtag/$slug.zip?guest=1&branch=trunk" -O ./code.zip
 
 			unzip -q ./code.zip -d ./code
 			cd code

--- a/apps/notifications/webpack.config.js
+++ b/apps/notifications/webpack.config.js
@@ -40,12 +40,21 @@ function getWebpackConfig(
 		'output-path': outputPath,
 	} );
 
+	// While this used to be the output of "git describe", we don't really use
+	// tags enough to justify it. Now, the short sha will be good enough. The commit
+	// sha from process.env is set by TeamCity, and tracks GitHub. (rev-parse often
+	// does not.)
+	const gitDescribe = (
+		process.env.commit_sha ??
+		spawnSync( 'git', [ 'rev-parse', 'HEAD' ], {
+			encoding: 'utf8',
+		} ).stdout.replace( '\n', '' )
+	).slice( 0, 11 );
+
 	const pageMeta = {
 		nodePlatform: process.platform,
 		nodeVersion: process.version,
-		gitDescribe: spawnSync( 'git', [ 'describe', '--always', '--dirty', '--long' ], {
-			encoding: 'utf8',
-		} ).stdout.replace( '\n', '' ),
+		gitDescribe,
 	};
 
 	return {

--- a/packages/calypso-apps-builder/index.js
+++ b/packages/calypso-apps-builder/index.js
@@ -189,14 +189,13 @@ function git( cmd ) {
 async function copyMetaFiles( archiveDir ) {
 	const buildNumber = process.env.build_number;
 
-	const cacheBuster = git( 'describe --always --dirty --long' );
 	// Use commit hash from the environment if available. In TeamCity, that reflects
 	// the GitHub data -- the local data may be different.
 	const commitHash = process.env.commit_sha ?? git( 'rev-parse HEAD' );
 
 	const buildMeta = {
 		build_number: buildNumber ?? 'dev',
-		cache_buster: cacheBuster,
+		cache_buster: commitHash,
 		commit_hash: commitHash,
 		commit_url: `https://github.com/Automattic/wp-calypso/commit/${ commitHash }`,
 	};

--- a/packages/calypso-apps-builder/index.js
+++ b/packages/calypso-apps-builder/index.js
@@ -192,10 +192,12 @@ async function copyMetaFiles( archiveDir ) {
 	// Use commit hash from the environment if available. In TeamCity, that reflects
 	// the GitHub data -- the local data may be different.
 	const commitHash = process.env.commit_sha ?? git( 'rev-parse HEAD' );
+	// Calypso repo short sha is currently at 11 characters.
+	const cacheBuster = commitHash.slice( 0, 11 );
 
 	const buildMeta = {
 		build_number: buildNumber ?? 'dev',
-		cache_buster: commitHash,
+		cache_buster: cacheBuster,
 		commit_hash: commitHash,
 		commit_url: `https://github.com/Automattic/wp-calypso/commit/${ commitHash }`,
 	};


### PR DESCRIPTION
## Proposed Changes
After #83199, I broke the source map uploader because the URL is wrong. The new URL is correct, and I tested it :)

Additionally, I'm changing the cache buster for calypso apps to the commit hash. Previously, this used `git describe`, which was originally used for the first build of notifications maybe 5-6 years ago. That output includes the "tag" plus the number of commits since the tag plus the commit sha. 

This isn't really helpful because we don't use tags in a meaningful way. In fact, the tag is `intentional_failure` for some reason.

I think we might as well just use the short sha for the cache buster, since the longer string isn't any more helpful.

At the same time, we have to update notifications. For legacy reasons, it includes a `git-describe` meta tag, and our normalization logic needs this to match the cache buster. For the same reasoning as above, I think the short sha is fine here.