### PR TITLE
Checkout: Do not consider a receipt as success while order is loading on pending page

### DIFF
--- a/client/my-sites/checkout/src/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-complete-callback.tsx
@@ -30,7 +30,6 @@ import { recordCompositeCheckoutErrorDuringAnalytics } from '../lib/analytics';
 import normalizeTransactionResponse from '../lib/normalize-transaction-response';
 import { absoluteRedirectThroughPending, redirectThroughPending } from '../lib/pending-page';
 import { translateCheckoutPaymentMethodToWpcomPaymentMethod } from '../lib/translate-payment-method-names';
-import type { FailedResponse } from '../lib/normalize-transaction-response';
 import type {
 	PaymentEventCallback,
 	PaymentEventCallbackArguments,
@@ -293,7 +292,7 @@ async function recordPaymentCompleteAnalytics( {
 	sitePlanSlug,
 }: {
 	paymentMethodId: string | null;
-	transactionResult: WPCOMTransactionEndpointResponse | FailedResponse | undefined;
+	transactionResult: WPCOMTransactionEndpointResponse | undefined;
 	redirectUrl: string;
 	responseCart: ResponseCart;
 	checkoutFlow?: string;

--- a/client/my-sites/checkout/src/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-complete-callback.tsx
@@ -195,7 +195,8 @@ export default function useCreatePaymentCompleteCallback( {
 				receiptId &&
 				transactionResult &&
 				'purchases' in transactionResult &&
-				transactionResult.purchases
+				transactionResult.purchases &&
+				transactionResult.success
 			) {
 				debug( 'fetching receipt' );
 				reduxDispatch( fetchReceiptCompleted( receiptId, transactionResult ) );

--- a/client/my-sites/checkout/src/hooks/use-purchase-order.tsx
+++ b/client/my-sites/checkout/src/hooks/use-purchase-order.tsx
@@ -1,0 +1,149 @@
+import { useQuery } from '@tanstack/react-query';
+import { useDebugValue } from 'react';
+import wp from 'calypso/lib/wp';
+import {
+	ERROR,
+	PROCESSING,
+	ASYNC_PENDING,
+	FAILURE,
+	SUCCESS,
+	UNKNOWN,
+} from 'calypso/state/order-transactions/constants';
+import type { OrderTransaction } from 'calypso/state/selectors/get-order-transaction';
+
+async function fetchPurchaseOrder( orderId: number | undefined ): Promise< RawOrder | undefined > {
+	if ( ! orderId ) {
+		return undefined;
+	}
+	return wp.req.get( `/me/transactions/order/${ orderId }`, {
+		apiVersion: '1.1',
+	} );
+}
+
+type PurchaseOrderStatus = 'error' | 'processing' | 'async-pending' | 'payment-failure' | 'success';
+type OrderTransactionStatus =
+	| typeof ERROR
+	| typeof PROCESSING
+	| typeof ASYNC_PENDING
+	| typeof FAILURE
+	| typeof SUCCESS
+	| typeof UNKNOWN;
+
+interface RawOrder {
+	order_id: number;
+	user_id: number;
+	receipt_id: number | undefined;
+	processing_status: PurchaseOrderStatus;
+}
+
+function transformPurchaseOrderStatusToOrderTransactionStatus(
+	rawStatus: PurchaseOrderStatus
+): OrderTransactionStatus {
+	switch ( rawStatus ) {
+		case 'error':
+			return ERROR;
+		case 'processing':
+			return PROCESSING;
+		case 'async-pending':
+			return ASYNC_PENDING;
+		case 'payment-failure':
+			return FAILURE;
+		case 'success':
+			return SUCCESS;
+		default:
+			return UNKNOWN;
+	}
+}
+
+/**
+ * Convert data from the endpoint into the data format previously used by the
+ * order data-layer.
+ *
+ * TODO: in the future it would be nice to get rid of OrderTransaction entirely
+ * and replace it with RawOrder everywhere, but for now this will reduce the
+ * refactoring needs as we migrate to this hook.
+ */
+function transformRawOrderToOrderTransaction( rawOrder: RawOrder ): OrderTransaction {
+	const processingStatus = transformPurchaseOrderStatusToOrderTransactionStatus(
+		rawOrder.processing_status
+	);
+	if ( processingStatus === SUCCESS && rawOrder.receipt_id ) {
+		return {
+			orderId: rawOrder.order_id,
+			userId: rawOrder.user_id,
+			receiptId: rawOrder.receipt_id,
+			processingStatus,
+		};
+	}
+	if ( processingStatus === ERROR ) {
+		return {
+			orderId: rawOrder.order_id,
+			userId: rawOrder.user_id,
+			processingStatus,
+		};
+	}
+	if ( processingStatus === PROCESSING ) {
+		return {
+			orderId: rawOrder.order_id,
+			userId: rawOrder.user_id,
+			processingStatus,
+		};
+	}
+	if ( processingStatus === ASYNC_PENDING ) {
+		return {
+			orderId: rawOrder.order_id,
+			userId: rawOrder.user_id,
+			processingStatus,
+		};
+	}
+	if ( processingStatus === FAILURE ) {
+		return {
+			orderId: rawOrder.order_id,
+			userId: rawOrder.user_id,
+			processingStatus,
+		};
+	}
+	return {
+		orderId: rawOrder.order_id,
+		userId: rawOrder.user_id,
+		processingStatus: UNKNOWN,
+	};
+}
+
+function isOrderComplete( order: undefined | OrderTransaction ): boolean {
+	if ( ! order ) {
+		return false;
+	}
+	if ( order.processingStatus === PROCESSING ) {
+		return false;
+	}
+	return true;
+}
+
+/**
+ * Fetch the current status of an in-progress order.
+ */
+export default function usePurchaseOrder(
+	orderId: number | undefined,
+	pollInterval: number
+): {
+	isLoading: boolean;
+	order: OrderTransaction | undefined;
+} {
+	const shouldFetch = Boolean( orderId );
+	const queryKey = [ 'purchase-order', orderId ];
+
+	const { data: order, isLoading } = useQuery< OrderTransaction | undefined, Error >( {
+		queryKey,
+		queryFn: async () => {
+			const rawOrder = await fetchPurchaseOrder( orderId );
+			return rawOrder ? transformRawOrderToOrderTransaction( rawOrder ) : undefined;
+		},
+		enabled: shouldFetch,
+		refetchInterval: ( data ) => ( isOrderComplete( data ) ? false : pollInterval ),
+	} );
+
+	const output = { isLoading: shouldFetch ? isLoading : false, order };
+	useDebugValue( output );
+	return output;
+}

--- a/client/my-sites/checkout/src/lib/pending-page.ts
+++ b/client/my-sites/checkout/src/lib/pending-page.ts
@@ -1,5 +1,5 @@
 import page from '@automattic/calypso-router';
-import { SUCCESS, ERROR, FAILURE, UNKNOWN } from 'calypso/state/order-transactions/constants';
+import { SUCCESS, ERROR, FAILURE } from 'calypso/state/order-transactions/constants';
 import type { OrderTransaction } from 'calypso/state/selectors/get-order-transaction';
 
 export interface PendingPageRedirectOptions {
@@ -24,6 +24,7 @@ export interface RedirectInstructions {
 }
 
 export interface RedirectForTransactionStatusArgs {
+	isLoadingOrder: boolean;
 	error?: Error | null;
 	transaction?: OrderTransaction | null;
 	orderId?: number;
@@ -339,6 +340,7 @@ function getDefaultSuccessUrl(
  * response. These flags can be used to notify the user.
  */
 export function getRedirectFromPendingPage( {
+	isLoadingOrder,
 	error,
 	transaction,
 	orderId,
@@ -349,7 +351,6 @@ export function getRedirectFromPendingPage( {
 	fromSiteSlug,
 }: RedirectForTransactionStatusArgs ): RedirectInstructions | undefined {
 	const checkoutUrl = siteSlug ? `/checkout/${ siteSlug }` : '/checkout/no-site';
-	const planRoute = siteSlug ? `/plans/my-plan/${ siteSlug }` : '/pricing';
 	const errorUrl = `/checkout/failed-purchases`;
 
 	// If SaaS Product Redirect URL was passed then just return as redirect instruction so that
@@ -360,9 +361,10 @@ export function getRedirectFromPendingPage( {
 		};
 	}
 
-	// If there is a receipt ID, then the order must already be complete. In
-	// that case, we can redirect immediately.
-	if ( receiptId ) {
+	// If there is a receipt ID and the order is not loading and does not exist
+	// (eg: for free purchases which do not use Orders), then the order must
+	// already be complete. In that case, we can redirect immediately.
+	if ( receiptId && ! isLoadingOrder && ! transaction ) {
 		return {
 			url: filterAllowedRedirect(
 				interpolateReceiptId(
@@ -381,60 +383,48 @@ export function getRedirectFromPendingPage( {
 	// existing behavior and send the user to a generic thank-you page,
 	// assuming that the purchase was successful. This goes to the URL path
 	// `/checkout/thank-you/:site/:receiptId` but without a real receiptId.
-	if ( ! orderId && ! transaction ) {
+	if ( ! orderId && ! transaction && ! receiptId ) {
 		return {
 			url: getDefaultSuccessUrl( siteSlug, undefined ),
 		};
 	}
 
-	if ( transaction ) {
-		const { processingStatus } = transaction;
-
+	if ( transaction?.processingStatus === SUCCESS ) {
 		// If the order is complete, we can redirect to the final page.
-		if ( SUCCESS === processingStatus ) {
-			const { receiptId: transactionReceiptId } = transaction;
+		const { receiptId: transactionReceiptId } = transaction;
 
-			return {
-				url: filterAllowedRedirect(
-					interpolateReceiptId(
-						redirectTo ?? getDefaultSuccessUrl( siteSlug, transactionReceiptId ),
-						transactionReceiptId
-					),
-					siteSlug || fromSiteSlug,
-					getDefaultSuccessUrl( siteSlug, transactionReceiptId )
+		return {
+			url: filterAllowedRedirect(
+				interpolateReceiptId(
+					redirectTo ?? getDefaultSuccessUrl( siteSlug, transactionReceiptId ),
+					transactionReceiptId
 				),
-			};
-		}
-
-		// If the processing status indicates that there was something wrong,
-		// it could be because the user has cancelled the payment, or because
-		// the payment failed after being authorized. Redirect users back to
-		// the checkout page so they can try again on a failure or to a
-		// dedicated error page on an error.
-		if ( ERROR === processingStatus ) {
-			return {
-				url: errorUrl,
-				isError: true,
-			};
-		}
-		if ( FAILURE === processingStatus ) {
-			return {
-				url: checkoutUrl,
-				isError: true,
-			};
-		}
-
-		// The API has responded a status string that we don't expect somehow.
-		// Redirect users back to the plan page so that they won't be stuck here.
-		if ( UNKNOWN === processingStatus ) {
-			return {
-				url: planRoute,
-				isUnknown: true,
-			};
-		}
+				siteSlug || fromSiteSlug,
+				getDefaultSuccessUrl( siteSlug, transactionReceiptId )
+			),
+		};
 	}
 
-	// A HTTP error occured; we will send the user back to checkout.
+	// If the processing status indicates that there was something wrong,
+	// it could be because the user has cancelled the payment, or because
+	// the payment failed after being authorized. Redirect users back to
+	// the checkout page so they can try again on a failure or to a
+	// dedicated error page on an error.
+	if ( transaction?.processingStatus === ERROR ) {
+		return {
+			url: errorUrl,
+			isError: true,
+		};
+	}
+	if ( transaction?.processingStatus === FAILURE ) {
+		return {
+			url: checkoutUrl,
+			isError: true,
+		};
+	}
+
+	// A HTTP or other unknown error occured; we will send the user back to
+	// checkout.
 	if ( error ) {
 		return {
 			url: checkoutUrl,

--- a/client/my-sites/checkout/src/test/pending-page.ts
+++ b/client/my-sites/checkout/src/test/pending-page.ts
@@ -322,6 +322,31 @@ describe( 'getRedirectFromPendingPage', () => {
 		expect( actual ).toEqual( { url: url } );
 	} );
 
+	it( 'returns a failure url if the transaction has an error and there is a receipt', () => {
+		const actual = getRedirectFromPendingPage( {
+			isLoadingOrder: false,
+			receiptId: 12345,
+			redirectTo: '/home',
+			siteSlug: 'example.com',
+			transaction: {
+				orderId: 1,
+				userId: 1,
+				processingStatus: ERROR,
+			},
+		} );
+		expect( actual ).toEqual( { url: '/checkout/failed-purchases', isError: true } );
+	} );
+
+	it( 'returns nothing if the transaction is loading and there is a receipt', () => {
+		const actual = getRedirectFromPendingPage( {
+			isLoadingOrder: true,
+			receiptId: 12345,
+			redirectTo: '/home',
+			siteSlug: 'example.com',
+		} );
+		expect( actual ).toBeUndefined();
+	} );
+
 	it( 'returns a failure url if the transaction has an error', () => {
 		const actual = getRedirectFromPendingPage( {
 			isLoadingOrder: false,

--- a/client/my-sites/checkout/src/test/pending-page.ts
+++ b/client/my-sites/checkout/src/test/pending-page.ts
@@ -174,12 +174,17 @@ describe( 'redirectThroughPending', () => {
 
 describe( 'getRedirectFromPendingPage', () => {
 	it( 'returns a simple relative url if there is also a receipt', () => {
-		const actual = getRedirectFromPendingPage( { redirectTo: '/home', receiptId: 12345 } );
+		const actual = getRedirectFromPendingPage( {
+			isLoadingOrder: false,
+			redirectTo: '/home',
+			receiptId: 12345,
+		} );
 		expect( actual ).toEqual( { url: '/home' } );
 	} );
 
 	it( 'returns a receipt interpolated relative url if there is also a receipt', () => {
 		const actual = getRedirectFromPendingPage( {
+			isLoadingOrder: false,
 			redirectTo: '/home/:receiptId',
 			receiptId: 12345,
 		} );
@@ -188,6 +193,7 @@ describe( 'getRedirectFromPendingPage', () => {
 
 	it( 'returns a simple absolute url if it is allowed and there is also a receipt', () => {
 		const actual = getRedirectFromPendingPage( {
+			isLoadingOrder: false,
 			redirectTo: 'https://wordpress.com/home',
 			receiptId: 12345,
 		} );
@@ -196,6 +202,7 @@ describe( 'getRedirectFromPendingPage', () => {
 
 	it( 'returns a simple absolute url if it matches the siteSlug and there is also a receipt', () => {
 		const actual = getRedirectFromPendingPage( {
+			isLoadingOrder: false,
 			redirectTo: 'https://example.com/home',
 			receiptId: 12345,
 			siteSlug: 'example.com',
@@ -205,6 +212,7 @@ describe( 'getRedirectFromPendingPage', () => {
 
 	it( 'returns a simple absolute url if it matches the `fromSiteSlug` and there is no `siteSlug` and there is also a receipt', () => {
 		const actual = getRedirectFromPendingPage( {
+			isLoadingOrder: false,
 			redirectTo: 'https://example.com/wp-admin/pamin.php?page=jetpack&connect_url_redirect',
 			receiptId: 12345,
 			fromSiteSlug: 'example.com',
@@ -216,6 +224,7 @@ describe( 'getRedirectFromPendingPage', () => {
 
 	it( 'returns a receipt interpolated absolute url if it is allowed and there is also a receipt', () => {
 		const actual = getRedirectFromPendingPage( {
+			isLoadingOrder: false,
 			redirectTo: 'https://wordpress.com/home/:receiptId',
 			receiptId: 12345,
 		} );
@@ -224,6 +233,7 @@ describe( 'getRedirectFromPendingPage', () => {
 
 	it( 'returns a generic no-site url for an absolute url if it is not allowed and there is also a receipt', () => {
 		const actual = getRedirectFromPendingPage( {
+			isLoadingOrder: false,
 			redirectTo: 'https://example.com/home',
 			receiptId: 12345,
 		} );
@@ -232,6 +242,7 @@ describe( 'getRedirectFromPendingPage', () => {
 
 	it( 'returns a generic url with a site for an absolute url if it is not allowed and there is also a receipt and a site', () => {
 		const actual = getRedirectFromPendingPage( {
+			isLoadingOrder: false,
 			redirectTo: 'https://example.com/home',
 			receiptId: 12345,
 			siteSlug: 'foo.bar',
@@ -241,6 +252,7 @@ describe( 'getRedirectFromPendingPage', () => {
 
 	it( 'returns a no-site generic url if there is no receipt and no order and no site', () => {
 		const actual = getRedirectFromPendingPage( {
+			isLoadingOrder: false,
 			redirectTo: '/home',
 		} );
 		expect( actual ).toEqual( { url: '/checkout/thank-you/no-site/unknown-receipt' } );
@@ -248,6 +260,7 @@ describe( 'getRedirectFromPendingPage', () => {
 
 	it( 'returns a generic url with a site if there is no receipt and no order and a site', () => {
 		const actual = getRedirectFromPendingPage( {
+			isLoadingOrder: false,
 			redirectTo: '/home',
 			siteSlug: 'example.com',
 		} );
@@ -256,6 +269,7 @@ describe( 'getRedirectFromPendingPage', () => {
 
 	it( 'returns a simple success url if the transaction is successful', () => {
 		const actual = getRedirectFromPendingPage( {
+			isLoadingOrder: false,
 			redirectTo: '/home',
 			siteSlug: 'example.com',
 			transaction: {
@@ -270,6 +284,7 @@ describe( 'getRedirectFromPendingPage', () => {
 
 	it( 'returns a success url with interpolated receipt if the transaction is successful', () => {
 		const actual = getRedirectFromPendingPage( {
+			isLoadingOrder: false,
 			redirectTo: '/home/:receiptId',
 			siteSlug: 'example.com',
 			transaction: {
@@ -284,6 +299,7 @@ describe( 'getRedirectFromPendingPage', () => {
 
 	it( 'returns a generic url if the transaction is successful and the url is not allowed', () => {
 		const actual = getRedirectFromPendingPage( {
+			isLoadingOrder: false,
 			redirectTo: 'https://foo.bar/home/:receiptId',
 			siteSlug: 'example.com',
 			transaction: {
@@ -300,6 +316,7 @@ describe( 'getRedirectFromPendingPage', () => {
 		const url = 'https://vendor-app-url.com/thank-you-page/?intent-id=234234';
 
 		const actual = getRedirectFromPendingPage( {
+			isLoadingOrder: false,
 			saasRedirectUrl: url,
 		} );
 		expect( actual ).toEqual( { url: url } );
@@ -307,6 +324,7 @@ describe( 'getRedirectFromPendingPage', () => {
 
 	it( 'returns a failure url if the transaction has an error', () => {
 		const actual = getRedirectFromPendingPage( {
+			isLoadingOrder: false,
 			redirectTo: '/home',
 			siteSlug: 'example.com',
 			transaction: {
@@ -320,6 +338,7 @@ describe( 'getRedirectFromPendingPage', () => {
 
 	it( 'returns a checkout url if the transaction fails', () => {
 		const actual = getRedirectFromPendingPage( {
+			isLoadingOrder: false,
 			redirectTo: '/home',
 			siteSlug: 'example.com',
 			transaction: {
@@ -333,6 +352,7 @@ describe( 'getRedirectFromPendingPage', () => {
 
 	it( 'returns a failure url if the transaction has an error and there is no site', () => {
 		const actual = getRedirectFromPendingPage( {
+			isLoadingOrder: false,
 			redirectTo: '/home',
 			transaction: {
 				orderId: 1,
@@ -345,6 +365,7 @@ describe( 'getRedirectFromPendingPage', () => {
 
 	it( 'returns a checkout url if the transaction fails and there is no site', () => {
 		const actual = getRedirectFromPendingPage( {
+			isLoadingOrder: false,
 			redirectTo: '/home',
 			transaction: {
 				orderId: 1,
@@ -357,6 +378,7 @@ describe( 'getRedirectFromPendingPage', () => {
 
 	it( 'returns a checkout url if there was an HTTP error', () => {
 		const actual = getRedirectFromPendingPage( {
+			isLoadingOrder: false,
 			redirectTo: '/home',
 			siteSlug: 'example.com',
 			error: new Error( 'test error' ),
@@ -365,8 +387,9 @@ describe( 'getRedirectFromPendingPage', () => {
 		expect( actual ).toEqual( { url: '/checkout/example.com', isError: true } );
 	} );
 
-	it( 'returns a plans url if the transaction is unknown', () => {
+	it( 'returns a checkout url if the transaction is unknown', () => {
 		const actual = getRedirectFromPendingPage( {
+			isLoadingOrder: false,
 			redirectTo: '/home',
 			siteSlug: 'example.com',
 			transaction: {
@@ -375,11 +398,12 @@ describe( 'getRedirectFromPendingPage', () => {
 				processingStatus: UNKNOWN,
 			},
 		} );
-		expect( actual ).toEqual( { url: '/plans/my-plan/example.com', isUnknown: true } );
+		expect( actual ).toEqual( { url: '/checkout/example.com', isUnknown: true } );
 	} );
 
-	it( 'returns a pricing url if the transaction is unknown and there is no site', () => {
+	it( 'returns a checkout url if the transaction is unknown and there is no site', () => {
 		const actual = getRedirectFromPendingPage( {
+			isLoadingOrder: false,
 			redirectTo: '/home',
 			transaction: {
 				orderId: 1,
@@ -387,11 +411,12 @@ describe( 'getRedirectFromPendingPage', () => {
 				processingStatus: UNKNOWN,
 			},
 		} );
-		expect( actual ).toEqual( { url: '/pricing', isUnknown: true } );
+		expect( actual ).toEqual( { url: '/checkout/no-site', isUnknown: true } );
 	} );
 
 	it( 'returns nothing if the transaction is not complete', () => {
 		const actual = getRedirectFromPendingPage( {
+			isLoadingOrder: false,
 			redirectTo: '/home',
 			transaction: {
 				orderId: 1,

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -5,10 +5,10 @@ type PurchaseSiteId = number;
 
 export type WPCOMTransactionEndpointResponseSuccess = {
 	success: true;
-	purchases: Record< PurchaseSiteId, Purchase[] > | [];
-	failed_purchases: Record< PurchaseSiteId, FailedPurchase[] > | [];
+	purchases: Record< PurchaseSiteId, Purchase[] >;
+	failed_purchases: Record< PurchaseSiteId, FailedPurchase[] >;
 	receipt_id: number;
-	order_id: number;
+	order_id: number | '';
 	redirect_url?: string;
 	is_gift_purchase: boolean;
 	display_price: string;
@@ -19,10 +19,10 @@ export type WPCOMTransactionEndpointResponseSuccess = {
 
 export type WPCOMTransactionEndpointResponseFailed = {
 	success: false;
-	purchases: Record< PurchaseSiteId, Purchase[] > | [];
-	failed_purchases: Record< PurchaseSiteId, FailedPurchase[] > | [];
+	purchases: Record< PurchaseSiteId, Purchase[] >;
+	failed_purchases: Record< PurchaseSiteId, FailedPurchase[] >;
 	receipt_id: number;
-	order_id: number;
+	order_id: number | '';
 	redirect_url?: string;
 	is_gift_purchase: boolean;
 	display_price: string;
@@ -33,7 +33,7 @@ export type WPCOMTransactionEndpointResponseFailed = {
 
 export type WPCOMTransactionEndpointResponseRedirect = {
 	message: { payment_intent_client_secret: string } | '';
-	order_id: number;
+	order_id: number | '';
 	redirect_url: string;
 };
 

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -17,6 +17,20 @@ export type WPCOMTransactionEndpointResponseSuccess = {
 	currency: string;
 };
 
+export type WPCOMTransactionEndpointResponseFailed = {
+	success: false;
+	purchases: Record< PurchaseSiteId, Purchase[] > | [];
+	failed_purchases: Record< PurchaseSiteId, FailedPurchase[] > | [];
+	receipt_id: number;
+	order_id: number;
+	redirect_url?: string;
+	is_gift_purchase: boolean;
+	display_price: string;
+	price_integer: number;
+	price_float: number;
+	currency: string;
+};
+
 export type WPCOMTransactionEndpointResponseRedirect = {
 	message: { payment_intent_client_secret: string } | '';
 	order_id: number;
@@ -25,6 +39,7 @@ export type WPCOMTransactionEndpointResponseRedirect = {
 
 export type WPCOMTransactionEndpointResponse =
 	| WPCOMTransactionEndpointResponseSuccess
+	| WPCOMTransactionEndpointResponseFailed
 	| WPCOMTransactionEndpointResponseRedirect;
 
 export interface TaxVendorInfo {


### PR DESCRIPTION
There are certain ways in which the transaction process can fail for checkout AFTER the user has been charged. When that happens, there is still a receipt generated for the charge, but the purchase order is marked as an error and it's likely that provisioning the product has failed.

After a transaction completes, users are redirected to the checkout "pending" page, which displays a loading screen. That page polls the purchase order endpoint for a finished order. If the order is successful, it sends the user to the post-checkout page. If the order has failed, it sends the user back to checkout. If the order has an error, as in the situation above, it sends the user to a special page which explains the situation.

However, free purchases do not currently use orders at all. Because of that, we also sometimes pass a receipt ID to the pending page. If the receipt is present, the page considers this proof that the order was successful and sends the user along, regardless of the order status. For purchases which failed but did generate a receipt, this tells the user their purchase was successful even when it was not.

## Proposed Changes

In this PR, we modify the pending page so that it will wait for the order to be loaded, even if there is a receipt available. If the order has loaded AND no order was found (ie: a free purchase), only then do we consider the purchase a success. Otherwise, we use the order status to determine the outcome.

This means that free purchases which fail in this way will still suffer from the confusing behavior but that's not as big an issue since they do not need to be refunded for their purchase, which is the main purpose of the error flow. After https://github.com/Automattic/payments-shilling/issues/2007 is merged, this will no longer be an issue.

## Testing Instructions

- First, apply D123620-code and the additional changes listed in that diff's testing instructions.
- Follow that diff's testing instructions and verify that you end up on the failed purchase page.
- Next, just try making a full-credits purchase of a product on this branch.
- Verify that you end up on a success page and do not get stuck on the pending page.