### PR TITLE
Update: Site search by suffixing with a dot

### DIFF
--- a/client/components/site-selector/sites-list.tsx
+++ b/client/components/site-selector/sites-list.tsx
@@ -9,6 +9,7 @@ import {
 	SitesSortingPreferenceProps,
 	withSitesSortingPreference,
 } from 'calypso/state/sites/hooks/with-sites-sorting';
+import { addDotSuffix } from 'calypso/utils';
 
 // Why isn't `title` part of SiteDetails, though?
 type SiteDetailsWithTitle = SiteDetails & { title: string };
@@ -44,7 +45,7 @@ const SitesList = ( {
 	const { __ } = useI18n();
 	return (
 		<SiteSelectorSitesList
-			filtering={ { search: searchTerm } }
+			filtering={ { search: addDotSuffix( searchTerm ) } }
 			sites={ originalSites }
 			sorting={ sitesSorting }
 		>

--- a/client/me/notification-settings/blogs-settings/index.jsx
+++ b/client/me/notification-settings/blogs-settings/index.jsx
@@ -11,6 +11,7 @@ import NoSitesMessage from 'calypso/components/empty-content/no-sites-message';
 import InfiniteList from 'calypso/components/infinite-list';
 import getSites from 'calypso/state/selectors/get-sites';
 import { isRequestingSites } from 'calypso/state/sites/selectors';
+import { addDotSuffix } from 'calypso/utils';
 import Blog from './blog';
 import Placeholder from './placeholder';
 
@@ -115,7 +116,7 @@ class BlogsSettings extends Component {
 					/>
 				) }
 				<FilteredInfiniteList
-					searchTerm={ this.state.searchTerm }
+					searchTerm={ addDotSuffix( this.state.searchTerm ) }
 					items={ sites }
 					renderItem={ renderBlog }
 				/>

--- a/client/sites-dashboard/components/sites-content-controls.tsx
+++ b/client/sites-dashboard/components/sites-content-controls.tsx
@@ -6,6 +6,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import page from 'page';
 import { ComponentPropsWithoutRef, useEffect, useRef } from 'react';
 import SelectDropdown from 'calypso/components/select-dropdown';
+import { addDotSuffix } from 'calypso/utils';
 import { MEDIA_QUERIES } from '../utils';
 import { SitesDisplayModeSwitcher } from './sites-display-mode-switcher';
 import { SitesSearch } from './sites-search';
@@ -130,7 +131,10 @@ export const SitesContentControls = ( {
 		<FilterBar>
 			<SitesSearch
 				searchIcon={ <SearchIcon /> }
-				onSearch={ ( term ) => onQueryParamChange( { search: term?.trim(), page: undefined } ) }
+				onSearch={ ( term ) => {
+					term = term?.trim();
+					onQueryParamChange( { search: addDotSuffix( term ), page: undefined } );
+				} }
 				isReskinned
 				placeholder={ __( 'Search by name or domain…' ) }
 				disableAutocorrect={ true }

--- a/client/utils.ts
+++ b/client/utils.ts
@@ -51,3 +51,16 @@ export function isEligibleForProductSampling( userId: number, percentage: number
 
 	return userSegment < percentage;
 }
+
+/**
+ * Adds a dot suffix to a string if it doesn't already have one.
+ * @param str string
+ * @returns string
+ */
+export function addDotSuffix( str: string ) {
+	if ( str.endsWith( '.' ) ) {
+		return str;
+	}
+
+	return str + '.';
+}


### PR DESCRIPTION
This PR improves the site search by suffixing the query with a dot. 

In my case I have sites that are something like. 
example5566.wordpress.com
example1234.wordpress.com
example.wordpress.com

Without this "fix" when I search for `example` the fuzzy search doesn not favour  (order) the example.wordpress.com site higher. It returns the list based on the order that I created the sites or something else. ( I don't really know) 

With this fix that I see the site `example.wordpress.com` to return at the top of this list since we are now looking for the term `example.` and that is the exact match. 

## Proposed Changes

* This PR fixes the 

## Testing Instructions
1. Perform the search in the sidebar ( site selector) , notice the improved search results.
2. Perform the search in /sites, notice the improved search results. 
3. Perform the search in /me/notifications, notice the improved search results. 
*

## Pre-merge Checklist
- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?