### PR TITLE
ActivityLog: Improve post published date placement

### DIFF
--- a/client/components/activity-card/index.tsx
+++ b/client/components/activity-card/index.tsx
@@ -1,11 +1,13 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { Card, Gridicon } from '@automattic/components';
 import classnames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
 import { useMemo, useState } from 'react';
 import * as React from 'react';
 import ActivityActor from 'calypso/components/activity-card/activity-actor';
 import ActivityDescription from 'calypso/components/activity-card/activity-description';
 import QueryRewindState from 'calypso/components/data/query-rewind-state';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { applySiteOffset } from 'calypso/lib/site/timezone';
 import { useSelector } from 'calypso/state';
 import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
@@ -64,6 +66,25 @@ const ActivityCard: React.FC< OwnProps > = ( {
 
 	const showStreamsContent = showContent && activity.streams;
 
+	const moment = useLocalizedMoment();
+	const translate = useTranslate();
+
+	const renderPublishedDate = () => {
+		const published = activity?.activityDescription?.[ 0 ]?.published;
+
+		if ( published ) {
+			const publishedFormattedDate = moment( published ).format( 'll' );
+			return (
+				<span className="activity-card__activity-post-published-date">
+					{ ' · ' }
+					{ translate( 'Published:' ) } { publishedFormattedDate }
+				</span>
+			);
+		}
+
+		return null;
+	};
+
 	return (
 		<div
 			className={ classnames( className, 'activity-card', {
@@ -97,7 +118,10 @@ const ActivityCard: React.FC< OwnProps > = ( {
 					<MediaPreview activity={ activity } />
 					<ActivityDescription activity={ activity } />
 				</div>
-				<div className="activity-card__activity-title">{ activity.activityTitle }</div>
+				<div className="activity-card__activity-title">
+					{ activity.activityTitle }
+					{ renderPublishedDate() }
+				</div>
 
 				{ ! summarize && (
 					<Toolbar

--- a/client/components/activity-card/style.scss
+++ b/client/components/activity-card/style.scss
@@ -28,8 +28,7 @@
 
 	.activity-card__actor-info,
 	.activity-card__actor-role,
-	.activity-card__activity-title,
-	.note-formatted-block__post-publish-date {
+	.activity-card__activity-title {
 		font-size: 0.75rem;
 		color: rgb(100, 105, 112);
 	}

--- a/client/components/notes-formatted-block/blocks.jsx
+++ b/client/components/notes-formatted-block/blocks.jsx
@@ -1,4 +1,3 @@
-import { useTranslate } from 'i18n-calypso';
 import { startsWith } from 'lodash';
 import { useSelector } from 'react-redux';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
@@ -47,13 +46,7 @@ export const FilePath = ( { children } ) => (
 	</div>
 );
 
-export const Post = ( { content, children, meta } ) => {
-	const moment = useLocalizedMoment();
-	const siteId = useSelector( getSelectedSiteId );
-	const timezone = useSelector( ( state ) => getSiteTimezoneValue( state, siteId ) );
-	const gmtOffset = useSelector( ( state ) => getSiteGmtOffset( state, siteId ) );
-	const translate = useTranslate();
-
+export const Post = ( { content, children } ) => {
 	let titleContent = children;
 
 	// Don't render links to WordPress.com inside Jetpack Cloud
@@ -67,29 +60,7 @@ export const Post = ( { content, children, meta } ) => {
 		}
 	}
 
-	let publishedContent = null;
-	if ( meta.published ) {
-		const formattedPublishedDate = applySiteOffset( moment( meta.published ), {
-			timezone,
-			gmtOffset,
-		} ).format( 'MMM D, YYYY' );
-
-		publishedContent = (
-			<>
-				<br />
-				<span className="note-formatted-block__post-publish-date">
-					{ translate( 'Published:' ) } { formattedPublishedDate }
-				</span>
-			</>
-		);
-	}
-
-	return (
-		<>
-			{ titleContent }
-			{ publishedContent }
-		</>
-	);
+	return titleContent;
 };
 
 export const Comment = ( { content, children } ) => {

--- a/client/components/notes-formatted-block/test/blocks.js
+++ b/client/components/notes-formatted-block/test/blocks.js
@@ -174,27 +174,6 @@ describe( 'Post block', () => {
 
 		expect( unlinkedPost ).toHaveTextContent( text );
 	} );
-
-	test( 'if the post has a published date, shows the published date span', () => {
-		isJetpackCloud.mockImplementation( () => true );
-
-		const content = {
-			siteId: 1,
-			postId: 10,
-			isTrashed: false,
-		};
-
-		const meta = {
-			published: 1695394395000,
-		};
-
-		const text = 'another post';
-		render( <Blocks.Post content={ content } children={ text } meta={ meta } /> );
-
-		const publishSpan = screen.getByText( /Published:/i );
-
-		expect( publishSpan ).toBeTruthy();
-	} );
 } );
 
 describe( 'Comment block', () => {

--- a/client/my-sites/activity/activity-log-item/index.jsx
+++ b/client/my-sites/activity/activity-log-item/index.jsx
@@ -139,6 +139,7 @@ class ActivityLogItem extends Component {
 		const {
 			activity: {
 				activityTitle,
+				activityDescription,
 				actorAvatarUrl,
 				actorName,
 				actorRole,
@@ -146,9 +147,27 @@ class ActivityLogItem extends Component {
 				activityMedia,
 				isBreakpointActive: isDesktop,
 			},
+			moment,
+			translate,
 		} = this.props;
 
 		const rewindAction = this.renderRewindAction();
+
+		const renderPublishedDate = () => {
+			const published = activityDescription?.[ 0 ]?.published;
+
+			if ( published ) {
+				const publishedFormattedDate = moment( published ).format( 'll' );
+				return (
+					<span className="activity-card__activity-post-published-date">
+						{ ' · ' }
+						{ translate( 'Published:' ) } { publishedFormattedDate }
+					</span>
+				);
+			}
+
+			return null;
+		};
 
 		return (
 			<div className="activity-log-item__card-header">
@@ -174,7 +193,10 @@ class ActivityLogItem extends Component {
 								rewindIsActive={ this.props.rewindIsActive }
 							/>
 						</div>
-						<div className="activity-log-item__description-summary">{ activityTitle }</div>
+						<div className="activity-log-item__description-summary">
+							{ activityTitle }
+							{ renderPublishedDate() }
+						</div>
 					</div>
 					{ rewindAction && (
 						<div className="activity-log-item__description-actions">{ rewindAction }</div>

--- a/client/my-sites/activity/activity-log-item/style.scss
+++ b/client/my-sites/activity/activity-log-item/style.scss
@@ -300,8 +300,7 @@
 }
 
 .activity-log-item__actor-role,
-.activity-log-item__description-summary,
-.note-formatted-block__post-publish-date {
+.activity-log-item__description-summary {
 	font-size: $font-body-extra-small;
 	color: var(--color-text-subtle);
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-roadmap/issues/648

## Proposed Changes

* Improve placement of `Published:` field in Activity Log that is currently visible for events related to posts that are already published. https://github.com/Automattic/wp-calypso/pull/82207 for context

| Before | After |
|---|---|
| ![image](https://github.com/Automattic/wp-calypso/assets/1488641/3ccc2112-d70e-40f3-8ad7-417a376b2983) | ![image](https://github.com/Automattic/wp-calypso/assets/1488641/1b65e2b7-f0f5-4c69-b44f-7454f3c4f092) |
| ![image](https://github.com/Automattic/wp-calypso/assets/1488641/020b9e3c-0145-4cbb-a217-035177f1ae34) | ![image](https://github.com/Automattic/wp-calypso/assets/1488641/52cd44f2-953b-4da5-aa82-810a960172be) |

## Testing Instructions
Similar to #82207
* Spin up Calypso Blue and Jetpack Cloud live branches
* Visit a site's activity log which has some published posts
* Ensure the published posts have an `Published: ` present on the Activity Card
* Posts that have yet to be published should show nothing for this.
* Posts of other types, such as updated/modified for an already published post should also show the original publish date.
* If there are modified / update events prior to the publish date, it is expected that those will show nothing, as the Activity Log isn't retroactive.
* These cases should be true in both WordPress.com and Jetpack Cloud

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?