### PR TITLE
Fix wpcom subdomain suggestion mismatch

### DIFF
--- a/client/jetpack-app/plans/main.tsx
+++ b/client/jetpack-app/plans/main.tsx
@@ -12,7 +12,6 @@ import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getPlanSlug } from 'calypso/state/plans/selectors';
 import type { Plan } from '@automattic/calypso-products';
-import type { DomainSuggestion } from '@automattic/data-stores';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import type { AppState } from 'calypso/types';
 
@@ -99,7 +98,7 @@ const JetpackAppPlans: React.FC< JetpackAppPlansProps > = ( { paidDomainName, or
 		window.location.href = addQueryArgs( originalUrl, args );
 	};
 
-	const setSiteUrlAsFreeDomainSuggestion = ( freeDomainSuggestion: DomainSuggestion ) => {
+	const setSiteUrlAsFreeDomainSuggestion = ( freeDomainSuggestion: { domain_name: string } ) => {
 		freeDomainSuggestionNameRef.current = freeDomainSuggestion.domain_name;
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -33,7 +33,7 @@ import { getIntervalType } from 'calypso/signup/steps/plans/util';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getPlanSlug } from 'calypso/state/plans/selectors';
 import { ONBOARD_STORE } from '../../../../stores';
-import type { OnboardSelect, DomainSuggestion } from '@automattic/data-stores';
+import type { OnboardSelect } from '@automattic/data-stores';
 import type { PlansIntent } from 'calypso/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans';
 import './style.scss';
 
@@ -131,7 +131,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 		setDomainCartItem( null );
 	};
 
-	const setSiteUrlAsFreeDomainSuggestion = ( freeDomainSuggestion: DomainSuggestion ) => {
+	const setSiteUrlAsFreeDomainSuggestion = ( freeDomainSuggestion: { domain_name: string } ) => {
 		setDomain( freeDomainSuggestion );
 	};
 

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/free-plan-free-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/free-plan-free-domain-dialog.tsx
@@ -83,7 +83,7 @@ function LazyDisplayText( {
  * 2 - Select the free plan
  */
 export function FreePlanFreeDomainDialog( {
-	wpcomFreeDomainSuggestion,
+	generatedWPComSubdomain,
 	onFreePlanSelected,
 	onPlanSelected,
 	suggestedPlanSlug,
@@ -135,8 +135,8 @@ export function FreePlanFreeDomainDialog( {
 									strong: <strong></strong>,
 									subdomain: (
 										<LazyDisplayText
-											displayText={ wpcomFreeDomainSuggestion?.result?.domain_name }
-											isLoading={ wpcomFreeDomainSuggestion?.isLoading }
+											displayText={ generatedWPComSubdomain?.result?.domain_name }
+											isLoading={ generatedWPComSubdomain?.isLoading }
 										/>
 									),
 								},
@@ -221,7 +221,7 @@ export function FreePlanFreeDomainDialog( {
 			<ButtonRow>
 				<StyledButton
 					className="free-plan-free-domain-dialog__plan-button is-upsell-modal-personal-plan"
-					disabled={ wpcomFreeDomainSuggestion.isLoading || ! wpcomFreeDomainSuggestion.result }
+					disabled={ generatedWPComSubdomain.isLoading || ! generatedWPComSubdomain.result }
 					primary
 					maxwidth="260px"
 					onClick={ () => {
@@ -238,7 +238,7 @@ export function FreePlanFreeDomainDialog( {
 
 				<StyledButton
 					className="free-plan-free-domain-dialog__plan-button is-upsell-modal-free-plan"
-					disabled={ wpcomFreeDomainSuggestion.isLoading || ! wpcomFreeDomainSuggestion.result }
+					disabled={ generatedWPComSubdomain.isLoading || ! generatedWPComSubdomain.result }
 					onClick={ () => {
 						onFreePlanSelected();
 					} }

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/free-plan-paid-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/free-plan-paid-domain-dialog.tsx
@@ -18,7 +18,7 @@ import { DomainPlanDialogProps, MODAL_VIEW_EVENT_NAME } from '.';
 
 export function FreePlanPaidDomainDialog( {
 	paidDomainName,
-	wpcomFreeDomainSuggestion,
+	generatedWPComSubdomain,
 	suggestedPlanSlug,
 	onFreePlanSelected,
 	onPlanSelected,
@@ -78,18 +78,18 @@ export function FreePlanPaidDomainDialog( {
 				</RowWithBorder>
 				<Row>
 					<DomainName>
-						{ wpcomFreeDomainSuggestion.isLoading && <LoadingPlaceHolder /> }
-						{ wpcomFreeDomainSuggestion.result &&
+						{ generatedWPComSubdomain.isLoading && <LoadingPlaceHolder /> }
+						{ generatedWPComSubdomain.result &&
 							translate( '%(paidDomainName)s redirects to %(wpcomFreeDomain)s', {
 								args: {
 									paidDomainName,
-									wpcomFreeDomain: wpcomFreeDomainSuggestion.result.domain_name,
+									wpcomFreeDomain: generatedWPComSubdomain.result.domain_name,
 								},
 								comment: '%(wpcomFreeDomain)s is a WordPress.com subdomain, e.g. foo.wordpress.com',
 							} ) }
 					</DomainName>
 					<StyledButton
-						disabled={ wpcomFreeDomainSuggestion.isLoading || ! wpcomFreeDomainSuggestion.result }
+						disabled={ generatedWPComSubdomain.isLoading || ! generatedWPComSubdomain.result }
 						busy={ isBusy }
 						onClick={ handleFreePlanClick }
 					>

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/hooks/use-modal-resolution-callback.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/hooks/use-modal-resolution-callback.tsx
@@ -10,6 +10,7 @@ import {
 type Props = {
 	isCustomDomainAllowedOnFreePlan: DataResponse< boolean >;
 	isPlanUpsellEnabledOnFreeDomain: DataResponse< boolean >;
+	flowName?: string | null;
 };
 
 /**
@@ -18,6 +19,7 @@ type Props = {
 export function useModalResolutionCallback( {
 	isCustomDomainAllowedOnFreePlan,
 	isPlanUpsellEnabledOnFreeDomain,
+	flowName,
 }: Props ) {
 	return useCallback(
 		( currentSelectedPlan?: string | null ): ModalType | null => {
@@ -30,14 +32,12 @@ export function useModalResolutionCallback( {
 					return FREE_PLAN_PAID_DOMAIN_DIALOG;
 				}
 
-				/**
-				 * Either this or the above modal to be removed
-				 * after experiment 21394-explat-experiment is over
-				 */
-				return PAID_PLAN_IS_REQUIRED_DIALOG;
+				if ( flowName === 'onboarding' || flowName === 'onboarding-pm' ) {
+					return PAID_PLAN_IS_REQUIRED_DIALOG;
+				}
 			}
 			return null;
 		},
-		[ isCustomDomainAllowedOnFreePlan.result, isPlanUpsellEnabledOnFreeDomain?.result ]
+		[ flowName, isCustomDomainAllowedOnFreePlan.result, isPlanUpsellEnabledOnFreeDomain.result ]
 	);
 }

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/index.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/index.tsx
@@ -1,11 +1,9 @@
 import { PLAN_PERSONAL, PlanSlug } from '@automattic/calypso-products';
 import { Dialog } from '@automattic/components';
-import { DomainSuggestions } from '@automattic/data-stores';
 import { Global, css } from '@emotion/react';
 import { FreePlanFreeDomainDialog } from './free-plan-free-domain-dialog';
 import { FreePlanPaidDomainDialog } from './free-plan-paid-domain-dialog';
 import PaidPlanIsRequiredDialog from './paid-plan-is-required-dialog';
-import type { DomainSuggestion } from '@automattic/data-stores';
 import type { DataResponse } from 'calypso/my-sites/plans-grid/types';
 
 export const PAID_PLAN_IS_REQUIRED_DIALOG = 'PAID_PLAN_IS_REQUIRED_DIALOG';
@@ -20,7 +18,7 @@ export type ModalType =
 	| typeof MODAL_LOADER;
 
 export type DomainPlanDialogProps = {
-	wpcomFreeDomainSuggestion: DataResponse< DomainSuggestion >;
+	generatedWPComSubdomain: DataResponse< { domain_name: string } >;
 	suggestedPlanSlug: PlanSlug;
 	onFreePlanSelected: ( isDomainRetained?: boolean ) => void;
 	onPlanSelected: () => void;
@@ -30,7 +28,7 @@ type ModalContainerProps = {
 	isModalOpen: boolean;
 	paidDomainName?: string;
 	modalType?: ModalType | null;
-	wpcomFreeDomainSuggestion: DataResponse< DomainSuggestions.DomainSuggestion >;
+	generatedWPComSubdomain: DataResponse< { domain_name: string } >;
 	onClose: () => void;
 	onFreePlanSelected: ( isDomainRetained?: boolean ) => void;
 	onPlanSelected: ( planSlug: string ) => void;
@@ -42,7 +40,7 @@ export const MODAL_VIEW_EVENT_NAME = 'calypso_plan_upsell_modal_view';
 function DisplayedModal( {
 	paidDomainName,
 	modalType,
-	wpcomFreeDomainSuggestion,
+	generatedWPComSubdomain,
 	onFreePlanSelected,
 	onPlanSelected,
 }: Omit< ModalContainerProps, 'selectedPlan' > ) {
@@ -51,7 +49,7 @@ function DisplayedModal( {
 			return (
 				<FreePlanPaidDomainDialog
 					paidDomainName={ paidDomainName as string }
-					wpcomFreeDomainSuggestion={ wpcomFreeDomainSuggestion }
+					generatedWPComSubdomain={ generatedWPComSubdomain }
 					suggestedPlanSlug={ PLAN_PERSONAL }
 					onFreePlanSelected={ onFreePlanSelected }
 					onPlanSelected={ () => {
@@ -63,7 +61,7 @@ function DisplayedModal( {
 			return (
 				<FreePlanFreeDomainDialog
 					suggestedPlanSlug={ PLAN_PERSONAL }
-					wpcomFreeDomainSuggestion={ wpcomFreeDomainSuggestion }
+					generatedWPComSubdomain={ generatedWPComSubdomain }
 					onFreePlanSelected={ onFreePlanSelected }
 					onPlanSelected={ () => {
 						onPlanSelected( PLAN_PERSONAL );
@@ -75,7 +73,7 @@ function DisplayedModal( {
 				<PaidPlanIsRequiredDialog
 					paidDomainName={ paidDomainName as string }
 					suggestedPlanSlug={ PLAN_PERSONAL }
-					wpcomFreeDomainSuggestion={ wpcomFreeDomainSuggestion }
+					generatedWPComSubdomain={ generatedWPComSubdomain }
 					onFreePlanSelected={ onFreePlanSelected }
 					onPlanSelected={ () => {
 						onPlanSelected( PLAN_PERSONAL );

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-is-required-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-is-required-dialog.tsx
@@ -17,7 +17,7 @@ import { DomainPlanDialogProps, MODAL_VIEW_EVENT_NAME } from '.';
 
 export default function PaidPlanIsRequiredDialog( {
 	paidDomainName,
-	wpcomFreeDomainSuggestion,
+	generatedWPComSubdomain,
 	suggestedPlanSlug,
 	onFreePlanSelected,
 	onPlanSelected,
@@ -62,13 +62,13 @@ export default function PaidPlanIsRequiredDialog( {
 				</RowWithBorder>
 				<Row>
 					<DomainName>
-						{ wpcomFreeDomainSuggestion.isLoading && <LoadingPlaceHolder /> }
-						{ wpcomFreeDomainSuggestion.result && (
-							<div>{ wpcomFreeDomainSuggestion.result.domain_name }</div>
+						{ generatedWPComSubdomain.isLoading && <LoadingPlaceHolder /> }
+						{ generatedWPComSubdomain.result && (
+							<div>{ generatedWPComSubdomain.result.domain_name }</div>
 						) }
 					</DomainName>
 					<StyledButton
-						disabled={ wpcomFreeDomainSuggestion.isLoading || ! wpcomFreeDomainSuggestion.result }
+						disabled={ generatedWPComSubdomain.isLoading || ! generatedWPComSubdomain.result }
 						busy={ isBusy }
 						onClick={ handleFreeDomainClick }
 					>

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/test/plan-upsell-modal.test.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/test/plan-upsell-modal.test.tsx
@@ -33,6 +33,7 @@ function MockPlansFeaturesMain( {
 	const resolveModal = useModalResolutionCallback( {
 		isCustomDomainAllowedOnFreePlan,
 		isPlanUpsellEnabledOnFreeDomain,
+		flowName,
 	} );
 	return <div data-testid="modal-render">{ resolveModal( selectedPlan ) }</div>;
 }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -276,6 +276,7 @@ const PlansFeaturesMain = ( {
 	const resolveModal = useModalResolutionCallback( {
 		isCustomDomainAllowedOnFreePlan,
 		isPlanUpsellEnabledOnFreeDomain,
+		flowName,
 	} );
 
 	const toggleShowPlansComparisonGrid = () => {

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -77,7 +77,6 @@ import usePlanIntentFromSiteMeta from './hooks/use-plan-intent-from-site-meta';
 import usePlanUpgradeabilityCheck from './hooks/use-plan-upgradeability-check';
 import useGetFreeSubdomainSuggestion from './hooks/use-suggested-free-domain-from-paid-domain';
 import type { IntervalType } from './types';
-import type { DomainSuggestion } from '@automattic/data-stores';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import type {
 	GridPlan,
@@ -133,7 +132,7 @@ export interface PlansFeaturesMainProps {
 	signupFlowUserName?: string;
 	flowName?: string | null;
 	removePaidDomain?: () => void;
-	setSiteUrlAsFreeDomainSuggestion?: ( freeDomainSuggestion: DomainSuggestion ) => void;
+	setSiteUrlAsFreeDomainSuggestion?: ( freeDomainSuggestion: { domain_name: string } ) => void;
 	intervalType?: IntervalType;
 	planTypeSelector?: 'customer' | 'interval';
 	withDiscount?: string;
@@ -293,12 +292,12 @@ const PlansFeaturesMain = ( {
 			paidDomainName || siteTitle || signupFlowUserName || currentUserName
 		);
 
-	const resolvedSubdomainName: DataResponse< string > = useMemo( () => {
+	const resolvedSubdomainName: DataResponse< { domain_name: string } > = useMemo( () => {
 		return {
 			isLoading: signupFlowSubdomain ? false : wpcomFreeDomainSuggestion.isLoading,
 			result: signupFlowSubdomain
-				? signupFlowSubdomain
-				: wpcomFreeDomainSuggestion.result?.domain_name,
+				? { domain_name: signupFlowSubdomain }
+				: wpcomFreeDomainSuggestion.result,
 		};
 	}, [ signupFlowSubdomain, wpcomFreeDomainSuggestion ] );
 
@@ -502,7 +501,7 @@ const PlansFeaturesMain = ( {
 			actionOverrides = {
 				loggedInFreePlan: {
 					status:
-						isPlanUpsellEnabledOnFreeDomain.isLoading || wpcomFreeDomainSuggestion.isLoading
+						isPlanUpsellEnabledOnFreeDomain.isLoading || resolvedSubdomainName.isLoading
 							? 'blocked'
 							: 'enabled',
 				},
@@ -513,7 +512,7 @@ const PlansFeaturesMain = ( {
 			actionOverrides = {
 				loggedInFreePlan: {
 					status:
-						isPlanUpsellEnabledOnFreeDomain.isLoading || wpcomFreeDomainSuggestion.isLoading
+						isPlanUpsellEnabledOnFreeDomain.isLoading || resolvedSubdomainName.isLoading
 							? 'blocked'
 							: 'enabled',
 					callback: () => {
@@ -537,7 +536,7 @@ const PlansFeaturesMain = ( {
 		isInSignup,
 		sitePlanSlug,
 		isPlanUpsellEnabledOnFreeDomain.isLoading,
-		wpcomFreeDomainSuggestion.isLoading,
+		resolvedSubdomainName.isLoading,
 		translate,
 		domainFromHomeUpsellFlow,
 		siteSlug,
@@ -649,7 +648,7 @@ const PlansFeaturesMain = ( {
 				isModalOpen={ isModalOpen }
 				paidDomainName={ paidDomainName }
 				modalType={ resolveModal( lastClickedPlan ) }
-				wpcomFreeDomainSuggestion={ wpcomFreeDomainSuggestion }
+				generatedWPComSubdomain={ resolvedSubdomainName }
 				onClose={ () => setIsModalOpen( false ) }
 				onFreePlanSelected={ ( isDomainRetained ) => {
 					if ( ! isDomainRetained ) {
@@ -657,13 +656,14 @@ const PlansFeaturesMain = ( {
 					}
 					// Since this domain will not be available after it is selected, invalidate the cache.
 					invalidateDomainSuggestionCache();
-					wpcomFreeDomainSuggestion.result &&
-						setSiteUrlAsFreeDomainSuggestion?.( wpcomFreeDomainSuggestion.result );
+					if ( resolvedSubdomainName.result?.domain_name ) {
+						setSiteUrlAsFreeDomainSuggestion?.( resolvedSubdomainName.result );
+					}
 					onUpgradeClick?.( null );
 				} }
 				onPlanSelected={ ( planSlug ) => {
-					if ( ! signupFlowSubdomain && wpcomFreeDomainSuggestion.result ) {
-						setSiteUrlAsFreeDomainSuggestion?.( wpcomFreeDomainSuggestion.result );
+					if ( resolvedSubdomainName.result?.domain_name ) {
+						setSiteUrlAsFreeDomainSuggestion?.( resolvedSubdomainName.result );
 					}
 					invalidateDomainSuggestionCache();
 					const cartItemForPlan = getCartItemForPlan( planSlug );
@@ -734,7 +734,7 @@ const PlansFeaturesMain = ( {
 								gridPlans={ gridPlansForFeaturesGrid }
 								gridPlanForSpotlight={ gridPlanForSpotlight }
 								paidDomainName={ paidDomainName }
-								wpcomFreeDomainSuggestion={ wpcomFreeDomainSuggestion }
+								generatedWPComSubdomain={ resolvedSubdomainName }
 								isCustomDomainAllowedOnFreePlan={ isCustomDomainAllowedOnFreePlan }
 								isInSignup={ isInSignup }
 								isLaunchPage={ isLaunchPage }
@@ -780,7 +780,7 @@ const PlansFeaturesMain = ( {
 											gridPlans={ gridPlansForComparisonGrid }
 											gridPlanForSpotlight={ gridPlanForSpotlight }
 											paidDomainName={ paidDomainName }
-											wpcomFreeDomainSuggestion={ wpcomFreeDomainSuggestion }
+											generatedWPComSubdomain={ resolvedSubdomainName }
 											isCustomDomainAllowedOnFreePlan={ isCustomDomainAllowedOnFreePlan }
 											isInSignup={ isInSignup }
 											isLaunchPage={ isLaunchPage }

--- a/client/my-sites/plans-grid/components/features-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/features-grid/index.tsx
@@ -508,7 +508,7 @@ class FeaturesGrid extends Component< FeaturesGridType > {
 			translate,
 			hideUnavailableFeatures,
 			selectedFeature,
-			wpcomFreeDomainSuggestion,
+			generatedWPComSubdomain,
 			isCustomDomainAllowedOnFreePlan,
 		} = this.props;
 		const plansWithFeatures = renderedGridPlans.filter(
@@ -521,7 +521,7 @@ class FeaturesGrid extends Component< FeaturesGridType > {
 			<PlanFeaturesContainer
 				plansWithFeatures={ plansWithFeatures }
 				paidDomainName={ paidDomainName }
-				wpcomFreeDomainSuggestion={ wpcomFreeDomainSuggestion }
+				generatedWPComSubdomain={ generatedWPComSubdomain }
 				translate={ translate }
 				hideUnavailableFeatures={ hideUnavailableFeatures }
 				selectedFeature={ selectedFeature }

--- a/client/my-sites/plans-grid/components/features.tsx
+++ b/client/my-sites/plans-grid/components/features.tsx
@@ -7,7 +7,6 @@ import { LoadingPlaceHolder } from '../../plans-features-main/components/loading
 import { PlanFeaturesItem } from './item';
 import { Plans2023Tooltip } from './plans-2023-tooltip';
 import type { TransformedFeatureObject } from '../types';
-import type { DomainSuggestion } from '@automattic/data-stores';
 import type { DataResponse } from 'calypso/my-sites/plans-grid/types';
 
 const SubdomainSuggestion = styled.div`
@@ -25,12 +24,11 @@ const SubdomainSuggestion = styled.div`
 
 const FreePlanCustomDomainFeature: React.FC< {
 	paidDomainName: string;
-	wpcomFreeDomainSuggestion: DataResponse< DomainSuggestion >;
+	generatedWPComSubdomain: DataResponse< { domain_name: string } >;
 	isCustomDomainAllowedOnFreePlan: DataResponse< boolean >;
-} > = ( { paidDomainName, wpcomFreeDomainSuggestion, isCustomDomainAllowedOnFreePlan } ) => {
+} > = ( { paidDomainName, generatedWPComSubdomain, isCustomDomainAllowedOnFreePlan } ) => {
 	const translate = useTranslate();
-	const isLoading =
-		wpcomFreeDomainSuggestion.isLoading || isCustomDomainAllowedOnFreePlan.isLoading;
+	const isLoading = generatedWPComSubdomain.isLoading || isCustomDomainAllowedOnFreePlan.isLoading;
 	return (
 		<SubdomainSuggestion>
 			{ isLoading && <LoadingPlaceHolder /> }
@@ -45,7 +43,7 @@ const FreePlanCustomDomainFeature: React.FC< {
 				) : (
 					<>
 						<div className="is-domain-name">{ paidDomainName }</div>
-						<div>{ wpcomFreeDomainSuggestion.result?.domain_name }</div>
+						<div>{ generatedWPComSubdomain.result?.domain_name }</div>
 					</>
 				) ) }
 		</SubdomainSuggestion>
@@ -56,7 +54,7 @@ const PlanFeatures2023GridFeatures: React.FC< {
 	features: Array< TransformedFeatureObject >;
 	planSlug: string;
 	paidDomainName?: string;
-	wpcomFreeDomainSuggestion: DataResponse< DomainSuggestion >;
+	generatedWPComSubdomain: DataResponse< { domain_name: string } >;
 	hideUnavailableFeatures?: boolean;
 	selectedFeature?: string;
 	isCustomDomainAllowedOnFreePlan: DataResponse< boolean >;
@@ -66,7 +64,7 @@ const PlanFeatures2023GridFeatures: React.FC< {
 	features,
 	planSlug,
 	paidDomainName,
-	wpcomFreeDomainSuggestion,
+	generatedWPComSubdomain,
 	hideUnavailableFeatures,
 	selectedFeature,
 	isCustomDomainAllowedOnFreePlan,
@@ -127,7 +125,7 @@ const PlanFeatures2023GridFeatures: React.FC< {
 											<FreePlanCustomDomainFeature
 												key={ key }
 												paidDomainName={ paidDomainName as string }
-												wpcomFreeDomainSuggestion={ wpcomFreeDomainSuggestion }
+												generatedWPComSubdomain={ generatedWPComSubdomain }
 												isCustomDomainAllowedOnFreePlan={ isCustomDomainAllowedOnFreePlan }
 											/>
 										</Plans2023Tooltip>

--- a/client/my-sites/plans-grid/components/plan-features-container.tsx
+++ b/client/my-sites/plans-grid/components/plan-features-container.tsx
@@ -7,12 +7,11 @@ import PlanFeatures2023GridFeatures from './features';
 import PlanDivOrTdContainer from './plan-div-td-container';
 import { Plans2023Tooltip } from './plans-2023-tooltip';
 import type { GridPlan } from '../hooks/npm-ready/data-store/use-grid-plans';
-import type { DomainSuggestion } from '@automattic/data-stores';
 
 const PlanFeaturesContainer: React.FC< {
 	plansWithFeatures: GridPlan[];
 	paidDomainName?: string;
-	wpcomFreeDomainSuggestion: DataResponse< DomainSuggestion >; // used to show a wpcom free domain in the Free plan column when a paid domain is picked.
+	generatedWPComSubdomain: DataResponse< { domain_name: string } >; // used to show a wpcom free domain in the Free plan column when a paid domain is picked.
 	translate: LocalizeProps[ 'translate' ];
 	hideUnavailableFeatures?: boolean; // used to hide features that are not available, instead of strike-through as explained in #76206
 	selectedFeature?: string;
@@ -21,7 +20,7 @@ const PlanFeaturesContainer: React.FC< {
 } > = ( {
 	plansWithFeatures,
 	paidDomainName,
-	wpcomFreeDomainSuggestion,
+	generatedWPComSubdomain,
 	translate,
 	hideUnavailableFeatures,
 	selectedFeature,
@@ -46,7 +45,7 @@ const PlanFeaturesContainer: React.FC< {
 						features={ wpcomFeatures }
 						planSlug={ planSlug }
 						paidDomainName={ paidDomainName }
-						wpcomFreeDomainSuggestion={ wpcomFreeDomainSuggestion }
+						generatedWPComSubdomain={ generatedWPComSubdomain }
 						hideUnavailableFeatures={ hideUnavailableFeatures }
 						selectedFeature={ selectedFeature }
 						isCustomDomainAllowedOnFreePlan={ isCustomDomainAllowedOnFreePlan }
@@ -75,7 +74,7 @@ const PlanFeaturesContainer: React.FC< {
 						features={ jetpackFeatures }
 						planSlug={ planSlug }
 						paidDomainName={ paidDomainName }
-						wpcomFreeDomainSuggestion={ wpcomFreeDomainSuggestion }
+						generatedWPComSubdomain={ generatedWPComSubdomain }
 						hideUnavailableFeatures={ hideUnavailableFeatures }
 						isCustomDomainAllowedOnFreePlan={ isCustomDomainAllowedOnFreePlan }
 						setActiveTooltipId={ setActiveTooltipId }

--- a/client/my-sites/plans-grid/index.tsx
+++ b/client/my-sites/plans-grid/index.tsx
@@ -14,7 +14,6 @@ import type {
 } from './hooks/npm-ready/data-store/use-grid-plans';
 import type { DataResponse, PlanActionOverrides } from './types';
 import type { FeatureList, WPComStorageAddOnSlug } from '@automattic/calypso-products';
-import type { DomainSuggestion } from '@automattic/data-stores';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import './style.scss';
 
@@ -42,7 +41,7 @@ export interface PlansGridProps {
 	onStorageAddOnClick?: ( addOnSlug: WPComStorageAddOnSlug ) => void;
 	flowName?: string | null;
 	paidDomainName?: string;
-	wpcomFreeDomainSuggestion: DataResponse< DomainSuggestion >; // used to show a wpcom free domain in the Free plan column when a paid domain is picked.
+	generatedWPComSubdomain: DataResponse< { domain_name: string } >; // used to show a wpcom free domain in the Free plan column when a paid domain is picked.
 	intervalType: string;
 	currentSitePlanSlug?: string | null;
 	hideUnavailableFeatures?: boolean; // used to hide features that are not available, instead of strike-through as explained in #76206

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -154,12 +154,16 @@ export class PlansStep extends Component {
 		const { signupDependencies } = this.props;
 		const { siteUrl, domainItem, siteTitle, username } = signupDependencies;
 		const paidDomainName = domainItem?.meta;
+		let freeWPComSubdomain;
+		if ( typeof siteUrl === 'string' && siteUrl.includes( '.wordpress.com' ) ) {
+			freeWPComSubdomain = siteUrl;
+		}
 		return (
 			<div>
 				{ errorDisplay }
 				<PlansFeaturesMain
 					paidDomainName={ paidDomainName }
-					freeSubdomain={ ! domainItem ? siteUrl : undefined }
+					freeSubdomain={ freeWPComSubdomain }
 					siteTitle={ siteTitle }
 					signupFlowUserName={ username }
 					siteId={ selectedSite?.ID }
@@ -343,7 +347,6 @@ PlansStep.propTypes = {
 /**
  * Checks if the domainItem picked in the domain step is a top level .blog domain -
  * we only want to make Blogger plan available if it is.
- *
  * @param {Object} domainItem domainItem object stored in the "choose domain" step
  * @returns {boolean} is .blog domain registration
  */


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Fixes a subdomain mismatch that occurs by reusing the wpcom subdomain if provided by the domain step

https://github.com/Automattic/wp-calypso/blob/511c9a198eb6472dc95fdae5c1a5b34943fe5679/client/signup/steps/plans/index.jsx#L154-L166

* Above changes fixes the breaking E2E test that caused the revert of the modal refactor
    * Original: https://github.com/Automattic/wp-calypso/pull/81644
    * Revert: https://github.com/Automattic/wp-calypso/pull/83173
    * Second Attempt: https://github.com/Automattic/wp-calypso/pull/83175
        * (This PR is branched off from it)   
    * Basically since we were not reusing the domain suggestion provided by the domain step, it breaks assumptions of using the same domain name inside the E2E test.
    * This change makes sure that whenever the domains step provides a WPCOM subdomain suggestion, we us it, instead of using a brand new generated subdomain

* There was a bug that was introduced above, where the `Paid plan is required` was not limited to the onboarding flows, which was fixed.

https://github.com/Automattic/wp-calypso/blob/5a232294cef4fcc47b6f864c6bd76c277477ad98/client/my-sites/plans-features-main/components/plan-upsell-modal/hooks/use-modal-resolution-callback.tsx#L34-L37

* Also Refactors the subdomain suggestion with a more descriptive name and more focussed restrictive type

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Confidence Check tests in #81644
* Specially focus on the consistency of subdomain, or selected domains across Modals and Plans Grid
* Deeply focus on the siteUrl used after clicking the modal CTAs (Paid plan or Free)
* Make sure pre release tests are working

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?