### PR TITLE
Stats: Adding localised moment

### DIFF
--- a/client/my-sites/stats/stats-date-control/index.tsx
+++ b/client/my-sites/stats/stats-date-control/index.tsx
@@ -1,8 +1,8 @@
 import { useTranslate } from 'i18n-calypso';
-import moment from 'moment';
 import page from 'page';
 import qs from 'qs';
 import React from 'react';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import DateControlPicker from './stats-date-control-picker';
 import { StatsDateControlProps, DateControlPickerShortcut } from './types';
 import './style.scss';
@@ -15,6 +15,7 @@ const StatsDateControl = ( { slug, queryParams, dateRange }: StatsDateControlPro
 	// consistent with the custom ranges.
 
 	const translate = useTranslate();
+	const moment = useLocalizedMoment();
 
 	const shortcutList = [
 		{

--- a/client/my-sites/stats/stats-date-control/stats-date-control-picker.tsx
+++ b/client/my-sites/stats/stats-date-control/stats-date-control-picker.tsx
@@ -1,8 +1,8 @@
 import { Popover } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { Icon, calendar } from '@wordpress/icons';
-import moment from 'moment';
 import React, { useState, useRef } from 'react';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import DateControlPickerDate from './stats-date-control-picker-date';
 import DateControlPickerShortcuts from './stats-date-control-picker-shortcuts';
 import { DateControlPickerProps, DateControlPickerShortcut } from './types';
@@ -16,6 +16,7 @@ const DateControlPicker = ( {
 	onShortcut,
 	onApply,
 }: DateControlPickerProps ) => {
+	const moment = useLocalizedMoment();
 	// Pull dates from provided range.
 	const [ inputStartDate, setInputStartDate ] = useState(
 		moment( dateRange.chartStart ).format( 'YYYY-MM-DD' )


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #82316

## Proposed Changes

* wrapping moment with localised moment js to maintain user's date format

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* open live branch and apply the feature flag `stats/date-control`
* change your system settings and WordPress language to US English
* verify that the date format in the new date picker text field respects `mm/dd/yyyy` format
* change your system settings and WordPress language to a non-US English language and format e.g. UK English
* verify that the date format in the new date picker text field respects `dd/mm/yyyy` format

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?