### PR TITLE
Fix reader css issue on cards with title and image only in /read feed

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -103,6 +103,7 @@
 				color: var(--color-text-inverted);
 				display: inline;
 				font-size: $font-body-extra-small;
+				line-height: 20px;
 			}
 
 			.reader-post-actions {
@@ -206,7 +207,7 @@
 	}
 
 	&:not(.is-compact) {
-		.reader-post-card__title {
+		.reader-post-card__post-details .reader-post-card__title {
 			margin-top: 24px;
 		}
 		.reader-excerpt__content {


### PR DESCRIPTION
Fixes a couple of CSS issues on the /read feed that affect cards with image and title only.

Original report p1697603387083669-slack-C03NLNTPZ2T

Before: 
<img width="602" alt="Screen Shot 2023-10-19 at 1 56 47 pm" src="https://github.com/Automattic/wp-calypso/assets/22446385/47bd0cfe-926d-498c-8e6a-8a368babc447">

After:
<img width="611" alt="Screen Shot 2023-10-19 at 1 57 52 pm" src="https://github.com/Automattic/wp-calypso/assets/22446385/25b0afd1-d972-4d65-a947-4bbf86da4659">

Also fix line height so that letters below the line aren't cut off.

<img width="355" alt="Screen Shot 2023-10-19 at 10 18 05 am" src="https://github.com/Automattic/wp-calypso/assets/22446385/a82e7942-0c37-4365-9b30-55113c6a0472">

### Testing instructions
Follow puppydogkisses.com or create a test site with posts containing only a title and featured image (no text content)
go to the /read feed and view posts.
CSS issue should be fixed.
