### PR TITLE
Stats: Refactoring to use translations

### DIFF
--- a/client/my-sites/stats/stats-interval-dropdown/index.jsx
+++ b/client/my-sites/stats/stats-interval-dropdown/index.jsx
@@ -1,15 +1,51 @@
 import { Button, Dropdown } from '@wordpress/components';
 import { check, Icon, chevronDown } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import qs from 'qs';
 import './style.scss';
 
+const StatsIntervalDropdownListing = ( { selected, onSelection, intervals } ) => {
+	const isSelectedItem = ( interval ) => {
+		return interval === selected;
+	};
+
+	const clickHandler = ( interval ) => {
+		onSelection( interval );
+	};
+
+	return (
+		<div className="stats-interval-dropdown-listing">
+			<ul className="stats-interval-dropdown-listing__list">
+				{ Object.keys( intervals ).map( ( intervalKey ) => {
+					const intervalLabel = intervals[ intervalKey ];
+
+					return (
+						<li className="stats-interval-dropdown-listing__interval" key={ intervalKey }>
+							<Button
+								onClick={ () => {
+									clickHandler( intervalKey );
+								} }
+							>
+								{ intervalLabel }
+								{ isSelectedItem( intervalKey ) && <Icon icon={ check } /> }
+							</Button>
+						</li>
+					);
+				} ) }
+			</ul>
+		</div>
+	);
+};
+
 const IntervalDropdown = ( { slug, period, queryParams } ) => {
+	const translate = useTranslate();
+
 	const intervalLabels = {
-		day: 'Days',
-		week: 'Weeks',
-		month: 'Months',
-		year: 'Years',
+		day: translate( 'Days' ),
+		week: translate( 'Weeks' ),
+		month: translate( 'Months' ),
+		year: translate( 'Years' ),
 	};
 
 	// New interval listing that preserves date range.
@@ -42,40 +78,15 @@ const IntervalDropdown = ( { slug, period, queryParams } ) => {
 			) }
 			renderContent={ () => (
 				<div className="stats-interval-dropdown__container">
-					<StatsIntervalDropdownListing selected={ period } onSelection={ onSelectionHandler } />
+					<StatsIntervalDropdownListing
+						selected={ period }
+						onSelection={ onSelectionHandler }
+						intervals={ intervalLabels }
+					/>
 				</div>
 			) }
 		/>
 	);
 };
-
-function StatsIntervalDropdownListing( props ) {
-	const intervals = [ 'day', 'week', 'month', 'year' ];
-	const labels = [ 'Days', 'Weeks', 'Months', 'Years' ];
-	function isSelectedItem( interval ) {
-		return interval === props.selected;
-	}
-	function clickHandler( interval ) {
-		props.onSelection( interval );
-	}
-	return (
-		<div className="stats-interval-dropdown-listing">
-			<ul className="stats-interval-dropdown-listing__list">
-				{ intervals.map( ( interval, idx ) => (
-					<li className="stats-interval-dropdown-listing__interval" key={ interval }>
-						<Button
-							onClick={ () => {
-								clickHandler( interval );
-							} }
-						>
-							{ labels[ idx ] }
-							{ isSelectedItem( interval ) && <Icon icon={ check } /> }
-						</Button>
-					</li>
-				) ) }
-			</ul>
-		</div>
-	);
-}
 
 export default IntervalDropdown;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #82313

## Proposed Changes

* refactoring new interval control to use translated values

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* open live branch and apply the feature flag `stats/date-control`
* change your WordPress language to English
* verify labels in the interval dropdown
* change your WordPress language to non-English
* verify that the labels are translated
* click and change intervals - verify that the URL and the chart changes accordingly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?