### PR TITLE
Stats: Fixing alignment for small screens

### DIFF
--- a/client/my-sites/stats/stats-period-navigation/style.scss
+++ b/client/my-sites/stats/stats-period-navigation/style.scss
@@ -26,6 +26,7 @@
 	.stats-period-navigation__date-control {
 		display: flex;
 		flex-flow: column nowrap;
+		margin-left: auto;
 
 		.stats-period-navigation__period-control {
 			display: flex;
@@ -48,4 +49,5 @@
 .stats-period-navigation.stats-period-navigation__is-with-new-date-control {
 	padding: 0;
 	align-items: flex-start;
+	row-gap: 8px;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #82082

## Proposed Changes

* push wrapped section to the right side for smaller screens

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* open live branch and apply the feature flag `stats/date-control`
* reduce screen size so the new date control wraps to another line
* verify that the layout makes sense and the control is on the right side

Alignment after the update:
<img width="775" alt="SCR-20231019-okke" src="https://github.com/Automattic/wp-calypso/assets/112354940/41a2ada7-2827-4884-bdce-3ae15532ab5d">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?