### PR TITLE
Theme showcase: simplify activation modal UX & copy

### DIFF
--- a/client/my-sites/themes/activation-modal.jsx
+++ b/client/my-sites/themes/activation-modal.jsx
@@ -112,7 +112,7 @@ export class ActivationModal extends Component {
 					</h1>
 					<p className="activation-modal__description">
 						{ translate(
-							'You’re about to change your active theme from {{strong}}%(activeThemeName)s{{/strong}} to {{strong}}%(newThemeName)s{{/strong}}.{{br}}{{/br}}{{br}}{{/br}}This will replace your homepage. Your old content remains on the site and can be recovered later. {{a}}Learn more{{/a}}.',
+							'You’re about to change your active theme from {{strong}}%(activeThemeName)s{{/strong}} to {{strong}}%(newThemeName)s{{/strong}}.{{br}}{{/br}}{{br}}{{/br}}This will replace your homepage, but your content will remain accessible. {{a}}Learn more{{/a}}.',
 							{
 								args: {
 									activeThemeName: activeTheme.name,

--- a/client/my-sites/themes/activation-modal.jsx
+++ b/client/my-sites/themes/activation-modal.jsx
@@ -112,7 +112,7 @@ export class ActivationModal extends Component {
 					</h1>
 					<p className="activation-modal__description">
 						{ translate(
-							'You’re about to change your active theme from {{strong}}%(activeThemeName)s{{/strong}} to {{strong}}%(newThemeName)s{{/strong}}.{{br}}{{/br}}{{br}}{{/br}}This will replace your homepage. Don’t worry, your old content can still be accessed. {{a}}Learn more{{/a}}.',
+							'You’re about to change your active theme from {{strong}}%(activeThemeName)s{{/strong}} to {{strong}}%(newThemeName)s{{/strong}}.{{br}}{{/br}}{{br}}{{/br}}This will replace your homepage. Your old content remains on the site and can be recovered later. {{a}}Learn more{{/a}}.',
 							{
 								args: {
 									activeThemeName: activeTheme.name,

--- a/client/my-sites/themes/activation-modal.jsx
+++ b/client/my-sites/themes/activation-modal.jsx
@@ -1,7 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Dialog, Gridicon, Button, ScreenReaderText } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { CheckboxControl } from '@wordpress/components';
 import { translate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -19,6 +18,7 @@ import {
 	isThemeActive,
 	shouldShowActivationModal,
 	getThemeIdToActivate,
+	getActiveTheme,
 } from 'calypso/state/themes/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
@@ -27,65 +27,50 @@ import './activation-modal.scss';
 export class ActivationModal extends Component {
 	static propTypes = {
 		source: PropTypes.oneOf( [ 'details', 'list', 'upload' ] ).isRequired,
-		theme: PropTypes.shape( {
-			author: PropTypes.string,
-			author_uri: PropTypes.string,
+		newTheme: PropTypes.shape( {
 			id: PropTypes.string,
+			name: PropTypes.string,
+		} ),
+		activeTheme: PropTypes.shape( {
 			name: PropTypes.string,
 		} ),
 		isActivating: PropTypes.bool.isRequired,
 		siteId: PropTypes.number,
 		isVisible: PropTypes.bool,
 		onClose: PropTypes.func,
-		installingThemeId: PropTypes.string,
+		newThemeId: PropTypes.string,
 	};
-
-	constructor( props ) {
-		super( props );
-		this.state = {
-			hasConfirmed: false,
-		};
-	}
 
 	closeModalHandler =
 		( action = 'dismiss' ) =>
 		() => {
-			const { installingThemeId, siteId, source } = this.props;
+			const { newThemeId, siteId, source } = this.props;
 			if ( 'activeTheme' === action ) {
-				this.props.acceptActivationModal( installingThemeId );
+				this.props.acceptActivationModal( newThemeId );
 
 				/**
 				 * We don't want to keep the current homepage since it's "broken" for now.
 				 * Update this when we find a way to improve the theme switch experience as a whole.
-				 *
 				 * @see pbxlJb-3Uv-p2
 				 */
 				const keepCurrentHomepage = false;
 
 				recordTracksEvent( 'calypso_theme_autoloading_homepage_modal_activate_click', {
-					theme: installingThemeId,
+					theme: newThemeId,
 					keep_current_homepage: keepCurrentHomepage,
 				} );
-				return this.props.activateTheme(
-					installingThemeId,
-					siteId,
-					source,
-					false,
-					keepCurrentHomepage
-				);
+				return this.props.activateTheme( newThemeId, siteId, source, false, keepCurrentHomepage );
 			} else if ( 'dismiss' === action ) {
 				recordTracksEvent( 'calypso_theme_autoloading_homepage_modal_dismiss', {
 					action: 'escape',
-					theme: installingThemeId,
+					theme: newThemeId,
 				} );
 				return this.props.dismissActivationModal();
 			}
 		};
 
 	render() {
-		const { theme, isActivating, isCurrentTheme, isVisible = false } = this.props;
-
-		const { hasConfirmed } = this.state;
+		const { newTheme, activeTheme, isActivating, isCurrentTheme, isVisible = false } = this.props;
 
 		// Nothing to do when it's the current theme.
 		if ( isCurrentTheme ) {
@@ -97,11 +82,9 @@ export class ActivationModal extends Component {
 			return null;
 		}
 
-		if ( ! theme ) {
+		if ( ! newTheme || ! activeTheme ) {
 			return null;
 		}
-
-		const { name: themeName, id: themeId } = this.props.theme;
 
 		return (
 			<Dialog
@@ -111,7 +94,7 @@ export class ActivationModal extends Component {
 			>
 				<TrackComponentView
 					eventName="calypso_theme_autoloading_homepage_modal_view"
-					eventProperties={ { theme: themeId } }
+					eventProperties={ { theme: newTheme.id } }
 				/>
 				<Button
 					className="themes__activation-modal-close-icon"
@@ -124,13 +107,17 @@ export class ActivationModal extends Component {
 				<div className="themes__theme-preview-wrapper">
 					<h1 className="activation-modal__heading">
 						{ translate( 'Activate %(themeName)s', {
-							args: { themeName },
+							args: { themeName: newTheme.name },
 						} ) }
 					</h1>
 					<p className="activation-modal__description">
 						{ translate(
-							'After activation, this layout will replace your existing homepage. But you can still access your old content. {{a}}Learn more{{/a}}.',
+							'You’re about to change your active theme from {{strong}}%(activeThemeName)s{{/strong}} to {{strong}}%(newThemeName)s{{/strong}}.{{br}}{{/br}}{{br}}{{/br}}This will replace your homepage. Don’t worry, your old content can still be accessed. {{a}}Learn more{{/a}}.',
 							{
+								args: {
+									activeThemeName: activeTheme.name,
+									newThemeName: newTheme.name,
+								},
 								components: {
 									a: (
 										<a
@@ -139,26 +126,16 @@ export class ActivationModal extends Component {
 											rel="noopener noreferrer"
 										/>
 									),
+									br: <br />,
+									strong: <strong />,
 								},
 							}
 						) }
 					</p>
-					<CheckboxControl
-						className="activation-modal__checkbox"
-						label={ translate(
-							'I understand that this layout will replace my existing homepage.'
-						) }
-						checked={ hasConfirmed }
-						onChange={ () => this.setState( { hasConfirmed: ! hasConfirmed } ) }
-					/>
 					<div className="activation-modal__actions">
-						<Button
-							primary
-							onClick={ this.closeModalHandler( 'activeTheme' ) }
-							disabled={ ! hasConfirmed }
-						>
+						<Button primary onClick={ this.closeModalHandler( 'activeTheme' ) }>
 							{ translate( 'Activate %(themeName)s', {
-								args: { themeName },
+								args: { themeName: newTheme.name },
 							} ) }
 						</Button>
 					</div>
@@ -171,16 +148,18 @@ export class ActivationModal extends Component {
 export default connect(
 	( state ) => {
 		const siteId = getSelectedSiteId( state );
-		const installingThemeId = getThemeIdToActivate( state );
+		const newThemeId = getThemeIdToActivate( state );
+		const activeThemeId = getActiveTheme( state, siteId );
 
 		return {
 			siteId,
 			siteDomain: getSiteDomain( state, siteId ),
-			installingThemeId,
-			theme: installingThemeId && getCanonicalTheme( state, siteId, installingThemeId ),
+			newThemeId,
+			newTheme: newThemeId && getCanonicalTheme( state, siteId, newThemeId ),
+			activeTheme: activeThemeId && getCanonicalTheme( state, siteId, activeThemeId ),
 			isActivating: !! isActivatingTheme( state, siteId ),
-			isCurrentTheme: isThemeActive( state, installingThemeId, siteId ),
-			isVisible: shouldShowActivationModal( state, installingThemeId ),
+			isCurrentTheme: isThemeActive( state, newThemeId, siteId ),
+			isVisible: shouldShowActivationModal( state, newThemeId ),
 		};
 	},
 	{

--- a/client/my-sites/themes/activation-modal.jsx
+++ b/client/my-sites/themes/activation-modal.jsx
@@ -121,7 +121,9 @@ export class ActivationModal extends Component {
 								components: {
 									a: (
 										<a
-											href={ localizeUrl( 'https://wordpress.com/support/themes/changing-themes' ) }
+											href={ localizeUrl(
+												'https://wordpress.com/support/themes/changing-themes/#what-happens-to-your-old-content'
+											) }
 											target="_blank"
 											rel="noopener noreferrer"
 										/>

--- a/client/my-sites/themes/activation-modal.scss
+++ b/client/my-sites/themes/activation-modal.scss
@@ -13,7 +13,7 @@
 		font-size: $font-title-large;
 		line-height: 1.1;
 		width: 100%;
-		margin-bottom: 16px;
+		margin-bottom: 32px;
 	}
 }
 
@@ -31,7 +31,8 @@
 }
 
 .activation-modal__description {
-	margin-bottom: 56px;
+	margin-bottom: 36px;
+	text-wrap: pretty;
 }
 
 .activation-modal__checkbox {


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/wp-calypso/issues/83152

## Proposed Changes

When activating a theme, we now:

1. remove the checkbox (reducing the number of clicks)
2. mention the old (existing) theme name
3. make the copy less scary

|Before|After|
|-|-|
|<img width="638" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/5d998f57-d416-45ee-a322-f6a2e4850080">|<img width="637" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/8f68ee16-9608-40d3-b470-edfb952882e2">|

## Testing Instructions

1. Go to `/themes`
2. Activate a theme
3. Make sure the modal shows up as expected above
4. Make sure the theme can actually be activated after confirming the modal

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?