### PR TITLE
Defer domainCart dependency check

### DIFF
--- a/client/lib/signup/flow-controller.ts
+++ b/client/lib/signup/flow-controller.ts
@@ -296,7 +296,6 @@ export default class SignupFlowController {
 	/**
 	 * Returns a list of non-excluded steps in the flow which enable the branch steps. Otherwise, return a list
 	 * of all steps
-	 *
 	 * @returns {Array} a list of dependency names
 	 */
 	_getFlowSteps() {
@@ -314,7 +313,6 @@ export default class SignupFlowController {
 
 	/**
 	 * Returns a list of the dependencies provided in the flow configuration.
-	 *
 	 * @returns {Array} a list of dependency names
 	 */
 	_getFlowProvidesDependencies() {
@@ -342,10 +340,12 @@ export default class SignupFlowController {
 		}
 
 		if ( completedSteps.length === currentSteps.length && undefined !== this._onComplete ) {
-			this._assertFlowProvidedRequiredDependencies();
 			// deferred to ensure that the onComplete function is called after the stores have
 			// emitted their final change events.
-			defer( () => this._onComplete( dependencies, this._destination( dependencies ) ) );
+			defer( () => {
+				this._assertFlowProvidedRequiredDependencies();
+				this._onComplete( dependencies, this._destination( dependencies ) );
+			} );
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/4150 (maybe?)

## Proposed Changes

* We have a consistent but intermittent bug during the plans step of the onboarding flow. We haven't been able to reproduce it yet so this PR is an attempt at a fix.
* In this PR I'm suspecting there might be a timing issue where we assert step dependency validity before the step store has been fully updated.

## Testing Instructions

* Ensure step dependency still fires and throws up an error as before (does it stop the flow or just throw a notice?) - I couldn't confirm this still works (something up with my local build after a revert), will check again tomorrow.
* Ensure /start flows can still submit steps
