### PR TITLE
Global Styles: Show premium badge when grouped together

### DIFF
--- a/packages/global-styles/src/components/global-styles-variations/index.tsx
+++ b/packages/global-styles/src/components/global-styles-variations/index.tsx
@@ -147,17 +147,13 @@ const GlobalStylesVariations = ( {
 				>
 					<div className="global-styles-variations__header">
 						<h2>
-							{ ! splitDefaultVariation ? (
-								<>
-									<span>{ headerText }</span>
-									{ ! splitDefaultVariation && <PremiumBadge
-										shouldHideTooltip
-										shouldCompactWithAnimation
-										labelText={ translate( 'Included in your plan' ) }
-									/>
-								</>
-							) : (
-								headerText
+							<span>{ headerText }</span>
+							{ ! splitDefaultVariation && (
+								<PremiumBadge
+									shouldHideTooltip
+									shouldCompactWithAnimation
+									labelText={ translate( 'Included in your plan' ) }
+								/>
 							) }
 						</h2>
 						{ ! splitDefaultVariation && (

--- a/packages/global-styles/src/components/global-styles-variations/index.tsx
+++ b/packages/global-styles/src/components/global-styles-variations/index.tsx
@@ -150,7 +150,7 @@ const GlobalStylesVariations = ( {
 							{ ! splitDefaultVariation ? (
 								<>
 									<span>{ headerText }</span>
-									<PremiumBadge
+									{ ! splitDefaultVariation && <PremiumBadge
 										shouldHideTooltip
 										shouldCompactWithAnimation
 										labelText={ translate( 'Included in your plan' ) }

--- a/packages/global-styles/src/components/global-styles-variations/index.tsx
+++ b/packages/global-styles/src/components/global-styles-variations/index.tsx
@@ -146,7 +146,20 @@ const GlobalStylesVariations = ( {
 					} ) }
 				>
 					<div className="global-styles-variations__header">
-						<h2>{ headerText }</h2>
+						<h2>
+							{ ! splitDefaultVariation ? (
+								<>
+									<span>{ headerText }</span>
+									<PremiumBadge
+										shouldHideTooltip
+										shouldCompactWithAnimation
+										labelText={ translate( 'Included in your plan' ) }
+									/>
+								</>
+							) : (
+								headerText
+							) }
+						</h2>
 						{ ! splitDefaultVariation && (
 							<div>
 								<p>{ translate( 'You can change your style at any time.' ) }</p>


### PR DESCRIPTION
## Proposed Changes

See pbxlJb-4Ku-p2. One of the suggestions from https://github.com/Automattic/wp-calypso/pull/82705 is to show the premium badge when global styles are grouped together. We can safely assume that currently, global styles are grouped together when the site plan is Premium or above. Thus, the text of the premium badge will say "Included in your plan".

Theme detail page
| Before | After | 
| --- | --- |
| ![Screenshot 2023-10-19 at 1 48 07 PM](https://github.com/Automattic/wp-calypso/assets/797888/c39748c4-f23c-4538-ace4-a698a8a6e641) |  ![Screenshot 2023-10-19 at 1 43 21 PM](https://github.com/Automattic/wp-calypso/assets/797888/67f05a9f-995a-43cd-932b-eb0c678278b9) |

Design picker preview
| Before | After |
| --- | --- |
| ![Screenshot 2023-10-19 at 1 48 37 PM](https://github.com/Automattic/wp-calypso/assets/797888/52597270-dd39-4bf5-91a9-f68aca16124d) |  ![Screenshot 2023-10-19 at 1 46 05 PM](https://github.com/Automattic/wp-calypso/assets/797888/e76c3186-1cc4-4f05-9ce2-3b7e328ba91c) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use a site with premium plan or above...
* Head to the Theme Showcase and select any theme with style variations.
* Ensure that the global styles are grouped together, with the premium badge.
* Head to the Design Picker and select any theme with style variations.
* Ensure that the global styles are grouped together, with the premium badge.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?