### PR TITLE
Live Preview: Fix the broken z-index of the introduction modal

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/live-preview-modal/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/live-preview-modal/style.scss
@@ -5,7 +5,7 @@
 
 .dialog__content.live-preview-modal {
 	position: relative;
-	padding: 48px 48px 28px;
+	padding: 48px 32px 28px;
 	max-width: 720px;
 	box-sizing: border-box;
 	text-wrap: pretty;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/live-preview-modal/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/live-preview-modal/style.scss
@@ -5,10 +5,14 @@
 
 .dialog__content.live-preview-modal {
 	position: relative;
-	padding: 48px 32px 28px;
 	max-width: 720px;
 	box-sizing: border-box;
 	text-wrap: pretty;
+	padding: 48px 48px 28px;
+
+	@media ( max-width: $break-mobile ) {
+		padding: 48px 32px 28px;
+	}
 
 	h1 {
 		@extend .wp-brand-font;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/live-preview-modal/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/live-preview-modal/style.scss
@@ -48,5 +48,6 @@
 	background-color: rgba(0, 0, 0, 0.7);
 	// Dialog sets `z-index: z-index("root", ".dialog__backdrop")`,
 	// but this modal is used outside of Calypso, so we need to set it manually.
-	z-index: 9999;
+	// We can refactor to use Modal from `@wordpress/components` instead of Dialog.
+	z-index: 100000;
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/live-preview-modal/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/live-preview-modal/style.scss
@@ -15,6 +15,7 @@
 		font-size: $font-title-large;
 		margin-top: 0;
 		margin-bottom: 32px;
+		line-height: 1.2;
 	}
 
 	p {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/live-preview-modal/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/live-preview-modal/style.scss
@@ -45,4 +45,7 @@
 
 .dialog__backdrop.live-preview-modal__overlay {
 	background-color: rgba(0, 0, 0, 0.7);
+	// Dialog sets `z-index: z-index("root", ".dialog__backdrop")`,
+	// but this modal is used outside of Calypso, so we need to set it manually.
+	z-index: 9999;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Originally raised in: p7DVsv-iTp-p2#comment-48006
Related to: https://github.com/Automattic/wp-calypso/pull/82666

## Proposed Changes

This PR fixes the broken z-index of the introduction modal in Live Preview (Preview & Customize).

| before | after |
|--------|--------|
| <img width="386" alt="Screenshot 2023-10-19 at 15 35 43" src="https://github.com/Automattic/wp-calypso/assets/5287479/42d17d88-47d1-488f-bf4f-d99ce27426ee"> | <img width="384" alt="Screenshot 2023-10-19 at 15 32 33" src="https://github.com/Automattic/wp-calypso/assets/5287479/13a0db1f-2afe-4b44-b846-b3cdc754d479"> | 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Patch this change to your sandbox: `install-plugin.sh editing-toolkit fix/live-preview-modal-sp`.
1. Sandbox YOUR SITE.
1. Simulate the mobile device in your Chrome DevTools.
1. Now go to Appearance -> Themes.
1. Choose a Free theme and click "Preview & Customize".
1. Verify that the modal is shown in front of every element.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?