### PR TITLE
Jetpack Manage: update the plugin management navigation menu 

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/controller.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/controller.tsx
@@ -25,6 +25,7 @@ import {
 	LicenseSortDirection,
 	LicenseSortField,
 } from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import NewJetpackManageSidebar from 'calypso/jetpack-cloud/sections/sidebar-navigation/jetpack-manage';
 import NewPurchasesSidebar from 'calypso/jetpack-cloud/sections/sidebar-navigation/purchases';
 import { addQueryArgs } from 'calypso/lib/route';
 import {
@@ -85,7 +86,11 @@ export function licensesContext( context: PageJS.Context, next: () => void ): vo
 	);
 
 	context.header = <Header />;
-	setSidebar( context );
+	if ( isEnabled( 'jetpack/new-navigation' ) ) {
+		context.secondary = <NewJetpackManageSidebar />;
+	} else {
+		context.secondary = <PartnerPortalSidebar path={ context.path } />;
+	}
 	context.primary = (
 		<Licenses
 			filter={ filter }

--- a/client/jetpack-cloud/sections/partner-portal/controller.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/controller.tsx
@@ -38,8 +38,10 @@ import Header from './header';
 import WPCOMAtomicHosting from './primary/wpcom-atomic-hosting';
 import type PageJS from 'page';
 
+const isNewNavigationEnabled = isEnabled( 'jetpack/new-navigation' );
+
 const setSidebar = ( context: PageJS.Context ): void => {
-	if ( isEnabled( 'jetpack/new-navigation' ) ) {
+	if ( isNewNavigationEnabled ) {
 		context.secondary = <NewPurchasesSidebar />;
 	} else {
 		context.secondary = <PartnerPortalSidebar path={ context.path } />;
@@ -171,7 +173,7 @@ export function pricesContext( context: PageJS.Context, next: () => void ): void
 }
 
 export function landingPageContext() {
-	page.redirect( '/partner-portal/licenses' );
+	page.redirect( isNewNavigationEnabled ? '/partner-portal/billing' : '/partner-portal/licenses' );
 	return;
 }
 

--- a/client/jetpack-cloud/sections/plugin-management/controller.tsx
+++ b/client/jetpack-cloud/sections/plugin-management/controller.tsx
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import page from 'page';
+import NewJetpackManageSidebar from 'calypso/jetpack-cloud/sections/sidebar-navigation/jetpack-manage';
 import { isAgencyUser } from 'calypso/state/partner-portal/partner/selectors';
 import Header from '../agency-dashboard/header';
 import DashboardSidebar from '../agency-dashboard/sidebar';
@@ -17,6 +18,14 @@ const redirectIfHasNoAccess = ( context: PageJS.Context ) => {
 	}
 };
 
+const setSidebar = ( context: PageJS.Context ): void => {
+	if ( config.isEnabled( 'jetpack/new-navigation' ) ) {
+		context.secondary = <NewJetpackManageSidebar />;
+	} else {
+		context.secondary = <DashboardSidebar path={ context.path } />;
+	}
+};
+
 export function pluginManagementContext( context: PageJS.Context, next: VoidFunction ): void {
 	redirectIfHasNoAccess( context );
 	const { filter = 'all', site } = context.params;
@@ -24,7 +33,7 @@ export function pluginManagementContext( context: PageJS.Context, next: VoidFunc
 	context.header = <Header />;
 	// Set secondary context only on multi-site view
 	if ( ! site ) {
-		context.secondary = <DashboardSidebar path={ context.path } />;
+		setSidebar( context );
 	}
 	context.primary = (
 		<PluginsOverview
@@ -42,7 +51,7 @@ export function pluginDetailsContext( context: PageJS.Context, next: VoidFunctio
 	context.header = <Header />;
 	// Set secondary context only on multi-site view
 	if ( ! site ) {
-		context.secondary = <DashboardSidebar path={ context.path } />;
+		setSidebar( context );
 	}
 	context.primary = <PluginsOverview pluginSlug={ plugin } site={ site } path={ context.path } />;
 	next();


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/62

## Proposed Changes

This PR 

- Updates the plugin management navigation menu.
- Redirect to the billing page as default for `/partner-portal/` if new navigation is enabled
- Load the Jetpack Manage navigation menu for the Licenses page

## Testing Instructions

- Switch to the `add/update-plugin-management-menu` branch > Set `jetpack/new-navigation` to true in `config/jetpack-cloud-development.json` file > Start the server
- Go to `client/jetpack-cloud/sections/sidebar-navigation/purchases.tsx` and make the below changes

```
import { store, chevronLeft } from '@wordpress/icons';
import { useTranslate } from 'i18n-calypso';
import page from 'page';
import NewSidebar from 'calypso/jetpack-cloud/components/sidebar';

const PurchasesSidebar = () => {
	const translate = useTranslate();

	const onClickMenuItem = ( path: string ) => {
		page.redirect( path );
	};

	const menuItems = [
		{
			icon: store,
			path: '/partner-portal',
			link: '/partner-portal/billing',
			title: translate( 'Billing' ),
			onClickMenuItem: onClickMenuItem,
                          isSelected: true
		},
	];
	return (
		<NewSidebar
			isJetpackManage
			path="/partner-portal"
			menuItems={ menuItems }
			description={ translate( 'Manage all your billing related settings from one place.' ) }
			backButtonProps={ {
				label: translate( 'Purchases' ),
				icon: chevronLeft,
				onClick: () => onClickMenuItem( '/dashboard' ),
			} }
		/>
	);
};

export default PurchasesSidebar;
```
- Click on `Plugin Management` and verify that the new navigation menu is visible > Verify the same for plugin details page > Refresh the page and verify the menu item is highlighted correctly.

<img width="1919" alt="Screenshot 2023-10-19 at 1 02 40 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/78431c53-54aa-45a2-80a5-dc4378b1c5e0">

- Now click on the `Purchases` menu item and verify that you are redirected to the billing page. 
- Now click on the `Licenses` menu item and the navigation menu is visible as shown below:

<img width="1920" alt="Screenshot 2023-10-19 at 1 05 02 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/92ea8028-d070-4432-ae71-85a5d195a8eb">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?