### PR TITLE
FoldableCard to packages (Step 3): Update references to use new package component

### DIFF
--- a/client/components/domains/accordion/index.tsx
+++ b/client/components/domains/accordion/index.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
+import { FoldableCard } from '@automattic/components';
 import { Icon, chevronDown, chevronUp } from '@wordpress/icons';
 import classNames from 'classnames';
-import FoldableCard from 'calypso/components/foldable-card';
 import type { AccordionProps } from './types';
 import './style.scss';
 

--- a/client/components/domains/connect-domain-step/connect-domain-step-suggested-start.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-suggested-start.jsx
@@ -1,4 +1,4 @@
-import { Button } from '@automattic/components';
+import { Button, FoldableCard } from '@automattic/components';
 import { createElement, createInterpolateElement } from '@wordpress/element';
 import { Icon, chevronDown, chevronUp, info } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
@@ -11,7 +11,6 @@ import {
 	stepsHeading,
 	stepSlug,
 } from 'calypso/components/domains/connect-domain-step/constants';
-import FoldableCard from 'calypso/components/foldable-card';
 import MaterialIcon from 'calypso/components/material-icon';
 import { isSubdomain } from 'calypso/lib/domains';
 import { domainManagementDns } from 'calypso/my-sites/domains/paths';

--- a/client/components/jetpack/jetpack-product-info/section.tsx
+++ b/client/components/jetpack/jetpack-product-info/section.tsx
@@ -1,6 +1,6 @@
+import { FoldableCard } from '@automattic/components';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { FunctionComponent, ReactNode, useLayoutEffect, useRef, useState } from 'react';
-import FoldableCard from 'calypso/components/foldable-card';
 
 // `title` is required, except if the section is always expanded
 type Props = (

--- a/client/components/jetpack/log-item/index.tsx
+++ b/client/components/jetpack/log-item/index.tsx
@@ -1,7 +1,7 @@
+import { FoldableCard } from '@automattic/components';
 import classnames from 'classnames';
 import { PureComponent, ReactNode } from 'react';
 import CardHeading from 'calypso/components/card-heading';
-import FoldableCard from 'calypso/components/foldable-card';
 import type { TranslateResult } from 'i18n-calypso';
 import './style.scss';
 

--- a/client/components/jetpack/scan-threats/index.tsx
+++ b/client/components/jetpack/scan-threats/index.tsx
@@ -1,7 +1,6 @@
-import { Button, Card } from '@automattic/components';
+import { Button, Card, FoldableCard } from '@automattic/components';
 import { numberFormat, translate } from 'i18n-calypso';
 import * as React from 'react';
-import FoldableCard from 'calypso/components/foldable-card';
 import InfoPopover from 'calypso/components/info-popover';
 import FixAllThreatsDialog from 'calypso/components/jetpack/fix-all-threats-dialog';
 import SecurityIcon from 'calypso/components/jetpack/security-icon';

--- a/client/jetpack-cloud/sections/settings/main.jsx
+++ b/client/jetpack-cloud/sections/settings/main.jsx
@@ -1,4 +1,4 @@
-import { Card } from '@automattic/components';
+import { Card, FoldableCard } from '@automattic/components';
 import { localize, useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
@@ -9,7 +9,6 @@ import QueryJetpackScan from 'calypso/components/data/query-jetpack-scan';
 import QueryRewindState from 'calypso/components/data/query-rewind-state';
 import QuerySiteCredentials from 'calypso/components/data/query-site-credentials';
 import ExternalLink from 'calypso/components/external-link';
-import FoldableCard from 'calypso/components/foldable-card';
 import ServerCredentialsForm from 'calypso/components/jetpack/server-credentials-form';
 import Main from 'calypso/components/main';
 import SidebarNavigation from 'calypso/components/sidebar-navigation';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/hundred-year-plan-step-wrapper/index.tsx
@@ -1,5 +1,5 @@
 import { PLAN_100_YEARS, getPlan } from '@automattic/calypso-products';
-import { Gridicon, WordPressLogo } from '@automattic/components';
+import { Gridicon, WordPressLogo, FoldableCard } from '@automattic/components';
 import { ProductsList } from '@automattic/data-stores';
 import { formatCurrency } from '@automattic/format-currency';
 import { StepContainer } from '@automattic/onboarding';
@@ -9,7 +9,6 @@ import { Button } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { useState, type ReactElement, PropsWithChildren } from 'react';
-import FoldableCard from 'calypso/components/foldable-card';
 import { VideoPreload } from 'calypso/components/hundred-year-loader-view';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { usePresalesChat } from 'calypso/lib/presales-chat';

--- a/client/me/concierge/shared/available-time-card.js
+++ b/client/me/concierge/shared/available-time-card.js
@@ -7,7 +7,7 @@
 
 import 'moment-timezone'; // monkey patches the existing moment.js
 import config from '@automattic/calypso-config';
-import { Button, Gridicon } from '@automattic/components';
+import { Button, Gridicon, FoldableCard } from '@automattic/components';
 import { getLanguage } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
 import { isEmpty } from 'lodash';
@@ -15,7 +15,6 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import day from 'calypso/assets/images/quick-start/day.svg';
 import night from 'calypso/assets/images/quick-start/night.svg';
-import FoldableCard from 'calypso/components/foldable-card';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';

--- a/client/me/connected-application-item/index.jsx
+++ b/client/me/connected-application-item/index.jsx
@@ -1,9 +1,8 @@
-import { Button } from '@automattic/components';
+import { Button, FoldableCard } from '@automattic/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import FoldableCard from 'calypso/components/foldable-card';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import safeProtocolUrl from 'calypso/lib/safe-protocol-url';
 import ConnectedApplicationIcon from 'calypso/me/connected-application-icon';

--- a/client/my-sites/activity/activity-log-item/aggregated.jsx
+++ b/client/my-sites/activity/activity-log-item/aggregated.jsx
@@ -1,11 +1,10 @@
-import { Button } from '@automattic/components';
+import { Button, FoldableCard } from '@automattic/components';
 import { withDesktopBreakpoint } from '@automattic/viewport-react';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { omit, flowRight as compose } from 'lodash';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
-import FoldableCard from 'calypso/components/foldable-card';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { applySiteOffset } from 'calypso/lib/site/timezone';

--- a/client/my-sites/activity/activity-log-item/index.jsx
+++ b/client/my-sites/activity/activity-log-item/index.jsx
@@ -1,4 +1,4 @@
-import { Button, Gridicon } from '@automattic/components';
+import { Button, Gridicon, FoldableCard } from '@automattic/components';
 import { withDesktopBreakpoint } from '@automattic/viewport-react';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -6,7 +6,6 @@ import { flowRight as compose } from 'lodash';
 import PropTypes from 'prop-types';
 import { Fragment, Component } from 'react';
 import { connect } from 'react-redux';
-import FoldableCard from 'calypso/components/foldable-card';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import { settingsPath } from 'calypso/lib/jetpack/paths';
 import scrollTo from 'calypso/lib/scroll-to';
@@ -305,7 +304,6 @@ class ActivityLogItem extends Component {
 
 	/**
 	 * Displays a button to take users to enter credentials.
-	 *
 	 * @returns {Object} Get button to fix credentials.
 	 */
 	renderFixCredsAction = () => {

--- a/client/my-sites/activity/activity-log/threat-alert.jsx
+++ b/client/my-sites/activity/activity-log/threat-alert.jsx
@@ -1,11 +1,10 @@
-import { Button, Card, Spinner } from '@automattic/components';
+import { Button, Card, Spinner, FoldableCard } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import DiffViewer from 'calypso/components/diff-viewer';
-import FoldableCard from 'calypso/components/foldable-card';
 import InfoPopover from 'calypso/components/info-popover';
 import MarkedLines from 'calypso/components/marked-lines';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';

--- a/client/my-sites/customer-home/cards/actions/quick-links-for-hosted-sites/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links-for-hosted-sites/index.jsx
@@ -1,10 +1,9 @@
 import { getAllFeaturesForPlan } from '@automattic/calypso-products/';
-import { JetpackLogo } from '@automattic/components';
+import { JetpackLogo, FoldableCard } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { useDispatch, useSelector, connect } from 'react-redux';
 import { useDebouncedCallback } from 'use-debounce';
-import FoldableCard from 'calypso/components/foldable-card';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference } from 'calypso/state/preferences/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';

--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -1,12 +1,11 @@
 import { getAllFeaturesForPlan } from '@automattic/calypso-products/';
-import { JetpackLogo } from '@automattic/components';
+import { JetpackLogo, FoldableCard } from '@automattic/components';
 import i18n, { getLocaleSlug, useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { connect, useSelector } from 'react-redux';
 import { useDebouncedCallback } from 'use-debounce';
 import fiverrIcon from 'calypso/assets/images/customer-home/fiverr-logo-grey.svg';
 import blazeIcon from 'calypso/assets/images/icons/blaze-icon.svg';
-import FoldableCard from 'calypso/components/foldable-card';
 import withIsFSEActive from 'calypso/data/themes/with-is-fse-active';
 import { canCurrentUserAddEmail } from 'calypso/lib/domains';
 import { hasPaidEmailWithUs } from 'calypso/lib/emails';

--- a/client/my-sites/customer-home/cards/actions/wp-for-teams-quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/wp-for-teams-quick-links/index.jsx
@@ -1,8 +1,8 @@
+import { FoldableCard } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { connect } from 'react-redux';
 import { useDebouncedCallback } from 'use-debounce';
-import FoldableCard from 'calypso/components/foldable-card';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference } from 'calypso/state/preferences/selectors';

--- a/client/my-sites/domains/domain-management/email-setup/index.jsx
+++ b/client/my-sites/domains/domain-management/email-setup/index.jsx
@@ -1,8 +1,8 @@
+import { FoldableCard } from '@automattic/components';
 import { Icon, chevronDown, chevronUp } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
-import FoldableCard from 'calypso/components/foldable-card';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';

--- a/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
+++ b/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
@@ -1,10 +1,9 @@
-import { Dialog, FormInputValidation } from '@automattic/components';
+import { Dialog, FormInputValidation, FoldableCard } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import { ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useTranslate } from 'i18n-calypso';
 import { ChangeEvent, useState, useEffect, useMemo } from 'react';
-import FoldableCard from 'calypso/components/foldable-card';
 import CountedTextArea from 'calypso/components/forms/counted-textarea';
 import FormCurrencyInput from 'calypso/components/forms/form-currency-input';
 import FormFieldset from 'calypso/components/forms/form-fieldset';

--- a/client/my-sites/exporter/export-card/index.jsx
+++ b/client/my-sites/exporter/export-card/index.jsx
@@ -1,8 +1,8 @@
+import { FoldableCard } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { flowRight } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import FoldableCard from 'calypso/components/foldable-card';
 import SpinnerButton from 'calypso/components/spinner-button';
 import { Interval, EVERY_SECOND } from 'calypso/lib/interval';
 import { withAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';

--- a/client/my-sites/exporter/export-media-card/index.js
+++ b/client/my-sites/exporter/export-media-card/index.js
@@ -1,9 +1,8 @@
-import { Button } from '@automattic/components';
+import { Button, FoldableCard } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { Fragment } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import QueryMediaExport from 'calypso/components/data/query-media-export';
-import FoldableCard from 'calypso/components/foldable-card';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import useMediaStorageQuery from 'calypso/data/media-storage/use-media-storage-query';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';

--- a/client/my-sites/marketing/connections/service-placeholder.jsx
+++ b/client/my-sites/marketing/connections/service-placeholder.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/heading-has-content */
 import { Button, Gridicon, FoldableCard } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';

--- a/client/my-sites/marketing/connections/service-placeholder.jsx
+++ b/client/my-sites/marketing/connections/service-placeholder.jsx
@@ -1,8 +1,7 @@
-import { Button, Gridicon } from '@automattic/components';
+import { Button, Gridicon, FoldableCard } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
-import FoldableCard from 'calypso/components/foldable-card';
 
 class SharingServicePlaceholder extends Component {
 	static propTypes = {

--- a/client/my-sites/marketing/connections/service.jsx
+++ b/client/my-sites/marketing/connections/service.jsx
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import { FEATURE_SOCIAL_MASTODON_CONNECTION } from '@automattic/calypso-products';
-import { Badge } from '@automattic/components';
+import { Badge, FoldableCard } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import requestExternalAccess from '@automattic/request-external-access';
 import classnames from 'classnames';
@@ -10,7 +10,6 @@ import PropTypes from 'prop-types';
 import { Component, cloneElement } from 'react';
 import { connect } from 'react-redux';
 import ExternalLink from 'calypso/components/external-link';
-import FoldableCard from 'calypso/components/foldable-card';
 import Notice from 'calypso/components/notice';
 import SocialLogo from 'calypso/components/social-logo';
 import { recordGoogleEvent, recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -55,7 +54,6 @@ import ServiceTip from './service-tip';
 
 /**
  * Check if the connection is broken or requires reauth.
- *
  * @param {Object} connection Publicize connection.
  * @returns {boolean} True if connection is broken or requires reauthentication.
  */
@@ -152,14 +150,12 @@ export class SharingService extends Component {
 
 	/**
 	 * Handle external access provided by the user.
-	 *
 	 * @param {number} keyringConnectionId Keyring connection ID.
 	 */
 	externalAccessProvided = ( keyringConnectionId ) => {}; // eslint-disable-line no-unused-vars
 
 	/**
 	 * Establishes a new connection.
-	 *
 	 * @param {Object} service             Service to connect to.
 	 * @param {number} keyringConnectionId Keyring conneciton ID.
 	 * @param {number} externalUserId      Optional. User ID for the service. Default: 0.
@@ -229,7 +225,6 @@ export class SharingService extends Component {
 
 	/**
 	 * Create or update the connection
-	 *
 	 * @param {number} keyringConnectionId Keyring conneciton ID.
 	 * @param {number} externalUserId      Optional. User ID for the service. Default: 0.
 	 */
@@ -273,7 +268,6 @@ export class SharingService extends Component {
 
 	/**
 	 * Sets a connection to be site-wide or not.
-	 *
 	 * @param  {Object}   connection Connection to update.
 	 * @param  {boolean}  shared     Whether the connection can be used by other users.
 	 * @returns {Function}            Action thunk
@@ -283,7 +277,6 @@ export class SharingService extends Component {
 
 	/**
 	 * Lets users re-authenticate their Keyring connections if lost.
-	 *
 	 * @param {Array} connections Optional. Broken connections.
 	 *                            Default: All broken connections for this service.
 	 */
@@ -326,7 +319,6 @@ export class SharingService extends Component {
 
 	/**
 	 * Fetch connections
-	 *
 	 * @param {Object} connection Connection to update.
 	 * @returns {Function} Action thunk
 	 */
@@ -335,7 +327,6 @@ export class SharingService extends Component {
 
 	/**
 	 * Checks whether any connection can be removed.
-	 *
 	 * @returns {boolean} true if there's any removable; otherwise, false.
 	 */
 	canRemoveConnection = () => {
@@ -344,7 +335,6 @@ export class SharingService extends Component {
 
 	/**
 	 * Deletes the passed connections.
-	 *
 	 * @param {Array} connections Optional. Connections to be deleted.
 	 *                            Default: All connections for this service.
 	 */
@@ -401,7 +391,6 @@ export class SharingService extends Component {
 
 	/**
 	 * Get current connections
-	 *
 	 * @param  {Array} overrides Optional. If it is passed, just return the argument
 	 *                           instead of the default connections.
 	 * @returns {Array} connections
@@ -413,7 +402,6 @@ export class SharingService extends Component {
 	/**
 	 * Given a service name and optional site ID, returns the current status of the
 	 * service's connection.
-	 *
 	 * @param {string} service The name of the service to check
 	 * @returns {string} Connection status.
 	 */
@@ -453,7 +441,6 @@ export class SharingService extends Component {
 	/**
 	 * Given a service name and optional site ID, returns whether the Keyring
 	 * authorization attempt succeeded in creating new Keyring account options.
-	 *
 	 * @param {Array} externalAccounts Props to check on if a keyring connection succeeded.
 	 * @returns {boolean} Whether the Keyring authorization attempt succeeded
 	 */
@@ -705,7 +692,6 @@ export class SharingService extends Component {
 
 /**
  * Connect a SharingService component to a Redux store.
- *
  * @param  {Component} sharingService     A SharingService component
  * @param  {Function}  mapStateToProps    Optional. A function to pick props from the state.
  *                                        It should return a plain object, which will be merged into the component's props.

--- a/client/my-sites/plans-grid/components/features-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/features-grid/index.tsx
@@ -17,11 +17,11 @@ import {
 	SalesforceLogo,
 	SlackLogo,
 	TimeLogo,
+	FoldableCard,
 } from '@automattic/components';
 import classNames from 'classnames';
 import { LocalizeProps } from 'i18n-calypso';
 import { Component } from 'react';
-import FoldableCard from 'calypso/components/foldable-card';
 import { isStorageUpgradeableForPlan } from '../../lib/is-storage-upgradeable-for-plan';
 import { getStorageStringFromFeature } from '../../util';
 import PlanFeatures2023GridActions from '../actions';

--- a/client/my-sites/plugins/plugin-details-sidebar-usp/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar-usp/index.jsx
@@ -1,8 +1,8 @@
+import { FoldableCard } from '@automattic/components';
 import { useBreakpoint } from '@automattic/viewport-react';
 import styled from '@emotion/styled';
 import { Fragment } from 'react';
 import ExternalLink from 'calypso/components/external-link';
-import FoldableCard from 'calypso/components/foldable-card';
 
 const Container = styled( FoldableCard )`
 	display: flex;

--- a/client/my-sites/site-settings/date-time-format/index.jsx
+++ b/client/my-sites/site-settings/date-time-format/index.jsx
@@ -1,8 +1,8 @@
+import { FoldableCard } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { capitalize, includes } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
-import FoldableCard from 'calypso/components/foldable-card';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import DateFormatOption from './date-format-option';
 import { getDefaultDateFormats, getDefaultTimeFormats } from './default-formats';

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-configured/index.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-configured/index.jsx
@@ -1,11 +1,10 @@
 import { WPCOM_FEATURES_REAL_TIME_BACKUPS } from '@automattic/calypso-products';
-import { CompactCard, Button, Gridicon } from '@automattic/components';
+import { CompactCard, Button, Gridicon, FoldableCard } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { find } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
-import FoldableCard from 'calypso/components/foldable-card';
 import RewindCredentialsForm from 'calypso/components/rewind-credentials-form';
 import { deleteCredentials } from 'calypso/state/jetpack/credentials/actions';
 import getRewindState from 'calypso/state/selectors/get-rewind-state';

--- a/client/my-sites/site-settings/jetpack-site-stats.jsx
+++ b/client/my-sites/site-settings/jetpack-site-stats.jsx
@@ -1,4 +1,4 @@
-import { CompactCard } from '@automattic/components';
+import { CompactCard, FoldableCard } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
 import { localize } from 'i18n-calypso';
 import { includes } from 'lodash';
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import QueryJetpackConnection from 'calypso/components/data/query-jetpack-connection';
-import FoldableCard from 'calypso/components/foldable-card';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLegend from 'calypso/components/forms/form-legend';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';

--- a/client/my-sites/site-settings/protect.jsx
+++ b/client/my-sites/site-settings/protect.jsx
@@ -1,11 +1,10 @@
-import { Button } from '@automattic/components';
+import { Button, FoldableCard } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { includes, some } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import QueryJetpackConnection from 'calypso/components/data/query-jetpack-connection';
-import FoldableCard from 'calypso/components/foldable-card';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';

--- a/client/my-sites/site-settings/spam-filtering-settings.jsx
+++ b/client/my-sites/site-settings/spam-filtering-settings.jsx
@@ -4,14 +4,13 @@ import {
 	WPCOM_FEATURES_ANTISPAM,
 	isJetpackAntiSpam,
 } from '@automattic/calypso-products';
-import { FormInputValidation, Gridicon } from '@automattic/components';
+import { FormInputValidation, Gridicon, FoldableCard } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { includes, isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import ExternalLink from 'calypso/components/external-link';
-import FoldableCard from 'calypso/components/foldable-card';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1,5 +1,5 @@
 import { PLAN_PERSONAL, isFreeWordPressComDomain } from '@automattic/calypso-products';
-import { Button } from '@automattic/components';
+import { Button, FoldableCard } from '@automattic/components';
 import { formatCurrency } from '@automattic/format-currency';
 import { VIDEOPRESS_FLOW, isWithThemeFlow, isHostingSignupFlow } from '@automattic/onboarding';
 import { isTailoredSignupFlow } from '@automattic/onboarding/src';
@@ -20,7 +20,6 @@ import RegisterDomainStep from 'calypso/components/domains/register-domain-step'
 import { recordUseYourDomainButtonClick } from 'calypso/components/domains/register-domain-step/analytics';
 import ReskinSideExplainer from 'calypso/components/domains/reskin-side-explainer';
 import UseMyDomain from 'calypso/components/domains/use-my-domain';
-import FoldableCard from 'calypso/components/foldable-card';
 import Notice from 'calypso/components/notice';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/78992
Branched from https://github.com/Automattic/wp-calypso/pull/83232

We should wait for https://github.com/Automattic/wp-calypso/pull/83232 to sit in production for several days before merging this PR. It will allow us to see if there were any problems with our migration.

## Proposed Changes

- Repoints any references to `FoldableCard` from Calypso components to `@automattic/components`
- This is a change that touches many files. We effectively made this change in the background with https://github.com/Automattic/wp-calypso/pull/83232, so all `FoldableCard` components are running the new/relocated code already. This PR repoints the reference from the wrapper to the "real" code, so I don't expect this to cause any issues.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Make sure tests pass.
- Do a spot-check of `FoldableCard` instances to ensure they still look/work as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
