### PR TITLE
FoldableCard to packages (Step 4): Remove FoldableCard component shim

### DIFF
--- a/client/components/foldable-card/index.jsx
+++ b/client/components/foldable-card/index.jsx
@@ -1,7 +1,0 @@
-import { FoldableCard } from '@automattic/components';
-
-// We're in the process of migrating to @automattic/components. Because of this, we're using this wrapper
-// component to point references to the old FoldableCard component to the new one in @automattic/components.
-// This allows us to transition in smaller pieces and without risking updates to the old Calypso component in the interim.
-
-export default FoldableCard;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/78992
Branched from https://github.com/Automattic/wp-calypso/pull/83235

## Proposed Changes

Following up on https://github.com/Automattic/wp-calypso/pull/83235, there are no more `client/components/foldable-card` references in Calypso. All instances of the FoldableCard component are now imported from @automattic/components.

Because of this, we remove the unused client/components/foldable-card directory and contents.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Smoke test instances of the count component (see https://github.com/Automattic/wp-calypso/pull/83232)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?