### PR TITLE
Theme Discovery: Add the Assembler CTA and Randomize the Collections

### DIFF
--- a/client/components/themes-list/get-site-assembler-url.js
+++ b/client/components/themes-list/get-site-assembler-url.js
@@ -1,0 +1,22 @@
+import { WITH_THEME_ASSEMBLER_FLOW } from '@automattic/onboarding';
+
+export default function getSiteAssemblerUrl( {
+	isLoggedIn,
+	selectedSite,
+	shouldGoToAssemblerStep,
+	siteEditorUrl,
+} ) {
+	if ( isLoggedIn && selectedSite && ! shouldGoToAssemblerStep ) {
+		return siteEditorUrl;
+	}
+
+	// Redirect people to create a site first if they don't log in or they have no sites.
+	const basePathname = isLoggedIn && selectedSite ? '/setup' : '/start';
+	const params = new URLSearchParams( { ref: 'calypshowcase' } );
+
+	if ( selectedSite?.slug ) {
+		params.set( 'siteSlug', selectedSite.slug );
+	}
+
+	return `${ basePathname }/${ WITH_THEME_ASSEMBLER_FLOW }?${ params }`;
+}

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -5,7 +5,6 @@ import {
 	usePatternAssemblerCtaData,
 	isAssemblerSupported,
 } from '@automattic/design-picker';
-import { WITH_THEME_ASSEMBLER_FLOW } from '@automattic/onboarding';
 import { Icon, addTemplate, brush, cloudUpload } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
 import { isEmpty, times } from 'lodash';
@@ -23,6 +22,7 @@ import { upsellCardDisplayed as upsellCardDisplayedAction } from 'calypso/state/
 import { DEFAULT_THEME_QUERY } from 'calypso/state/themes/constants';
 import { getThemesBookmark } from 'calypso/state/themes/themes-ui/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+import getSiteAssemblerUrl from './get-site-assembler-url';
 
 import './style.scss';
 
@@ -41,27 +41,6 @@ const getGridColumns = ( gridContainerRef, minColumnWidth, margin ) => {
 	// in a division by zero. In that case, we just assume that there's only one column.
 	const columnsPerRow = Math.floor( availableWidth / ( minColumnWidth + margin ) ) || 1;
 	return columnsPerRow;
-};
-
-const getSiteAssemblerUrl = ( {
-	isLoggedIn,
-	selectedSite,
-	shouldGoToAssemblerStep,
-	siteEditorUrl,
-} ) => {
-	if ( isLoggedIn && selectedSite && ! shouldGoToAssemblerStep ) {
-		return siteEditorUrl;
-	}
-
-	// Redirect people to create a site first if they don't log in or they have no sites.
-	const basePathname = isLoggedIn && selectedSite ? '/setup' : '/start';
-	const params = new URLSearchParams( { ref: 'calypshowcase' } );
-
-	if ( selectedSite?.slug ) {
-		params.set( 'siteSlug', selectedSite.slug );
-	}
-
-	return `${ basePathname }/${ WITH_THEME_ASSEMBLER_FLOW }?${ params }`;
 };
 
 export const ThemesList = ( { tabFilter, ...props } ) => {

--- a/client/my-sites/themes/collections/style.scss
+++ b/client/my-sites/themes/collections/style.scss
@@ -18,6 +18,10 @@
 				padding-bottom: 88px;
 			}
 		}
+
+		& + .pattern-assembler-cta-wrapper {
+			margin-top: 48px;
+		}
 	}
 
 	.theme-collection__meta {

--- a/client/my-sites/themes/collections/theme-collections-layout.tsx
+++ b/client/my-sites/themes/collections/theme-collections-layout.tsx
@@ -1,6 +1,13 @@
+import { PatternAssemblerCta, isAssemblerSupported } from '@automattic/design-picker';
 import { memo } from 'react';
+import { useSelector } from 'react-redux';
+import getSiteAssemblerUrl from 'calypso/components/themes-list/get-site-assembler-url';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { THEME_COLLECTIONS } from 'calypso/my-sites/themes/collections/collection-definitions';
 import ShowcaseThemeCollection from 'calypso/my-sites/themes/collections/showcase-theme-collection';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import getSiteEditorUrl from 'calypso/state/selectors/get-site-editor-url';
+import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import './style.scss';
 
 type OnSeeAll = {
@@ -15,10 +22,40 @@ export interface ThemeCollectionsLayoutProps {
 	onSeeAll: ( object: OnSeeAll ) => void;
 }
 
+function ThemeCollectionsPatternAssemblerCta() {
+	const selectedSiteId = useSelector( getSelectedSiteId );
+	const selectedSite = useSelector( getSelectedSite );
+	const isLoggedIn = useSelector( isUserLoggedIn );
+	const siteEditorUrl = useSelector( ( state: object ) =>
+		getSiteEditorUrl( state, selectedSiteId, {
+			canvas: 'edit',
+			assembler: '1',
+		} )
+	);
+	const onClick = () => {
+		const shouldGoToAssemblerStep = isAssemblerSupported();
+
+		recordTracksEvent( 'calypso_themeshowcase_pattern_assembler_cta_click', {
+			goes_to_assembler_step: shouldGoToAssemblerStep,
+		} );
+
+		const destinationUrl = getSiteAssemblerUrl( {
+			isLoggedIn,
+			selectedSite,
+			shouldGoToAssemblerStep,
+			siteEditorUrl,
+		} );
+		window.location.assign( destinationUrl );
+	};
+	return <PatternAssemblerCta onButtonClick={ onClick } />;
+}
+
 function ThemeCollectionsLayout( props: ThemeCollectionsLayoutProps ) {
 	const { onSeeAll } = props;
 
-	const collections = Object.values( THEME_COLLECTIONS ).map( ( collection ) => {
+	const collections = Object.values( THEME_COLLECTIONS ).sort( () => Math.random() - 0.5 );
+
+	const showcaseThemeCollections = collections.map( ( collection ) => {
 		const { filter, tier } = collection.query;
 		return (
 			<ShowcaseThemeCollection
@@ -30,7 +67,13 @@ function ThemeCollectionsLayout( props: ThemeCollectionsLayoutProps ) {
 		);
 	} );
 
-	return <>{ collections }</>;
+	showcaseThemeCollections.splice(
+		3,
+		0,
+		<ThemeCollectionsPatternAssemblerCta key="showcase-theme-collections-pattern-assembler-cta" />
+	);
+
+	return showcaseThemeCollections;
 }
 
 export default memo( ThemeCollectionsLayout );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/3941

## Proposed Changes

* Extract the `getSiteAssemblerUrl` for convenience (cc @Automattic/lego).
* Add the Assembler CTA after the third collection in the Theme Discovery context.
* Randomize the collections.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso Live link in a logged-out tab.
* Append `/themes?flags=themes/discovery-lots`.
* Ensure the collections are in random order.
* Ensure the Assembler CTA ("Design your own") appears after the third collection, and works as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?