### PR TITLE
Gravatar: Fix the bg color of the login page

### DIFF
--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -613,6 +613,7 @@ $image-height: 47px;
 	}
 
 	.login__form {
+		background-color: inherit;
 		padding: 0;
 	}
 
@@ -691,7 +692,8 @@ $image-height: 47px;
 		color: inherit;
 	}
 
-	.login__social {
+	.login__social,
+	.social-buttons__button.button {
 		background-color: inherit;
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 106062-Automattic/gravatar

## Proposed Changes

* To fix the bg color of Gravatar's passwordless login page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this PR
* Run `yarn` and then `yarn start`
* The following bg color of the elements should be fixed: from `#fdfdfd` to `#fff`:

| Before | After |
| - | - |
| <img width="570" alt="截圖 2023-10-19 晚上9 30 35" src="https://github.com/Automattic/wp-calypso/assets/21308003/a44ff767-3d4d-4420-aed8-0ef5f8cd7941"> | <img width="568" alt="截圖 2023-10-19 晚上9 30 06" src="https://github.com/Automattic/wp-calypso/assets/21308003/456527cb-47cc-4e46-9690-01156cb8a5b7"> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
