### PR TITLE
GF Signup: Remove the free upsell modal from onboaring flow and add a few conditional safeguards

### DIFF
--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/hooks/use-modal-resolution-callback.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/hooks/use-modal-resolution-callback.tsx
@@ -11,6 +11,7 @@ type Props = {
 	isCustomDomainAllowedOnFreePlan: DataResponse< boolean >;
 	isPlanUpsellEnabledOnFreeDomain: DataResponse< boolean >;
 	flowName?: string | null;
+	paidDomain?: string | null;
 };
 
 /**
@@ -20,6 +21,7 @@ export function useModalResolutionCallback( {
 	isCustomDomainAllowedOnFreePlan,
 	isPlanUpsellEnabledOnFreeDomain,
 	flowName,
+	paidDomain,
 }: Props ) {
 	return useCallback(
 		( currentSelectedPlan?: string | null ): ModalType | null => {
@@ -32,12 +34,17 @@ export function useModalResolutionCallback( {
 					return FREE_PLAN_PAID_DOMAIN_DIALOG;
 				}
 
-				if ( flowName === 'onboarding' || flowName === 'onboarding-pm' ) {
+				if ( paidDomain && ( flowName === 'onboarding' || flowName === 'onboarding-pm' ) ) {
 					return PAID_PLAN_IS_REQUIRED_DIALOG;
 				}
 			}
 			return null;
 		},
-		[ flowName, isCustomDomainAllowedOnFreePlan.result, isPlanUpsellEnabledOnFreeDomain.result ]
+		[
+			flowName,
+			isCustomDomainAllowedOnFreePlan.result,
+			isPlanUpsellEnabledOnFreeDomain.result,
+			paidDomain,
+		]
 	);
 }

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/hooks/use-modal-resolution-callback.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/hooks/use-modal-resolution-callback.tsx
@@ -11,7 +11,7 @@ type Props = {
 	isCustomDomainAllowedOnFreePlan: DataResponse< boolean >;
 	isPlanUpsellEnabledOnFreeDomain: DataResponse< boolean >;
 	flowName?: string | null;
-	paidDomain?: string | null;
+	paidDomainName?: string | null;
 };
 
 /**
@@ -21,7 +21,7 @@ export function useModalResolutionCallback( {
 	isCustomDomainAllowedOnFreePlan,
 	isPlanUpsellEnabledOnFreeDomain,
 	flowName,
-	paidDomain,
+	paidDomainName,
 }: Props ) {
 	return useCallback(
 		( currentSelectedPlan?: string | null ): ModalType | null => {
@@ -34,7 +34,7 @@ export function useModalResolutionCallback( {
 					return FREE_PLAN_PAID_DOMAIN_DIALOG;
 				}
 
-				if ( paidDomain && ( flowName === 'onboarding' || flowName === 'onboarding-pm' ) ) {
+				if ( paidDomainName && ( flowName === 'onboarding' || flowName === 'onboarding-pm' ) ) {
 					return PAID_PLAN_IS_REQUIRED_DIALOG;
 				}
 			}
@@ -44,7 +44,7 @@ export function useModalResolutionCallback( {
 			flowName,
 			isCustomDomainAllowedOnFreePlan.result,
 			isPlanUpsellEnabledOnFreeDomain.result,
-			paidDomain,
+			paidDomainName,
 		]
 	);
 }

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/test/plan-upsell-modal.test.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/test/plan-upsell-modal.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import { PLAN_FREE, PLAN_PERSONAL } from '@automattic/calypso-products';
-import { screen } from '@testing-library/react';
+import { screen, renderHook } from '@testing-library/react';
 import useIsFreeDomainFreePlanUpsellEnabled from 'calypso/my-sites/plans-features-main/hooks/use-is-free-domain-free-plan-upsell-enabled';
 import useIsFreePlanCustomDomainUpsellEnabled from 'calypso/my-sites/plans-features-main/hooks/use-is-free-plan-custom-domain-upsell-enabled';
 import {
@@ -16,115 +16,131 @@ import { useModalResolutionCallback } from '../hooks/use-modal-resolution-callba
 function MockPlansFeaturesMain( {
 	flowName,
 	selectedPlan,
-	paidSubdomain,
+	paidDomain,
 }: {
 	flowName: string;
 	selectedPlan: string;
-	paidSubdomain: string;
+	paidDomain?: string | null;
 } ) {
 	const isCustomDomainAllowedOnFreePlan = useIsFreePlanCustomDomainUpsellEnabled(
 		flowName,
-		paidSubdomain
+		paidDomain
 	);
 	const isPlanUpsellEnabledOnFreeDomain = useIsFreeDomainFreePlanUpsellEnabled(
 		flowName,
-		paidSubdomain
+		paidDomain
 	);
 	const resolveModal = useModalResolutionCallback( {
 		isCustomDomainAllowedOnFreePlan,
 		isPlanUpsellEnabledOnFreeDomain,
 		flowName,
+		paidDomain,
 	} );
 	return <div data-testid="modal-render">{ resolveModal( selectedPlan ) }</div>;
 }
 
 describe( 'PlanUpsellModal tests', () => {
-	test( 'A paid domain on the onboarding-pm flow should show the FREE_PLAN_PAID_DOMAIN_DIALOG', () => {
-		renderWithProvider(
-			<MockPlansFeaturesMain
-				flowName="onboarding-pm"
-				selectedPlan={ PLAN_FREE }
-				paidSubdomain="yourgroovydomain.com"
-			/>
-		);
-		expect( screen.getByTestId( 'modal-render' ) ).toHaveTextContent(
-			FREE_PLAN_PAID_DOMAIN_DIALOG
-		);
+	describe( 'Mocked PlansFeaturesMain tests', () => {
+		test( 'A paid domain on the onboarding-pm flow should show the FREE_PLAN_PAID_DOMAIN_DIALOG', () => {
+			renderWithProvider(
+				<MockPlansFeaturesMain
+					flowName="onboarding-pm"
+					selectedPlan={ PLAN_FREE }
+					paidDomain="yourgroovydomain.com"
+				/>
+			);
+			expect( screen.getByTestId( 'modal-render' ) ).toHaveTextContent(
+				FREE_PLAN_PAID_DOMAIN_DIALOG
+			);
+		} );
+
+		test( 'A free domain on the onboarding-pm flow should show the FREE_PLAN_FREE_DOMAIN_DIALOG', () => {
+			renderWithProvider(
+				<MockPlansFeaturesMain flowName="onboarding-pm" selectedPlan={ PLAN_FREE } />
+			);
+			expect( screen.getByTestId( 'modal-render' ) ).toHaveTextContent(
+				FREE_PLAN_FREE_DOMAIN_DIALOG
+			);
+		} );
+
+		test( 'A free domain on the onboarding flow should NOT show any Dialog', () => {
+			renderWithProvider(
+				<MockPlansFeaturesMain flowName="onboarding" selectedPlan={ PLAN_FREE } />
+			);
+			expect( screen.queryByText( /DIALOG/i ) ).toBeNull();
+		} );
+
+		test( 'A paid domain on the onboarding flow should show the PAID_PLAN_IS_REQUIRED_DIALOG', () => {
+			renderWithProvider(
+				<MockPlansFeaturesMain
+					flowName="onboarding"
+					selectedPlan={ PLAN_FREE }
+					paidDomain="yourgroovydomain.com"
+				/>
+			);
+			expect( screen.getByTestId( 'modal-render' ) ).toHaveTextContent(
+				PAID_PLAN_IS_REQUIRED_DIALOG
+			);
+		} );
+
+		test( 'Paid plan selections should not show any modals', () => {
+			/**
+			 * Flow onboarding paid domain
+			 */
+			const { queryByText: queryByText1 } = renderWithProvider(
+				<MockPlansFeaturesMain
+					flowName="onboarding"
+					selectedPlan={ PLAN_PERSONAL }
+					paidDomain="yourgroovydomain.com"
+				/>
+			);
+
+			expect( queryByText1( /DIALOG/i ) ).toBeNull();
+
+			/**
+			 * Flow onboarding-pm paid domain
+			 */
+			const { queryByText: queryByText2 } = renderWithProvider(
+				<MockPlansFeaturesMain
+					flowName="onboarding-pm"
+					selectedPlan={ PLAN_PERSONAL }
+					paidDomain="yourgroovydomain.com"
+				/>
+			);
+
+			expect( queryByText2( /DIALOG/i ) ).toBeNull();
+
+			/**
+			 * Flow onboarding free domain
+			 */
+			const { queryByText: queryByText3 } = renderWithProvider(
+				<MockPlansFeaturesMain flowName="onboarding" selectedPlan={ PLAN_PERSONAL } />
+			);
+
+			expect( queryByText3( /DIALOG/i ) ).toBeNull();
+
+			/**
+			 * Flow onboarding-pm free domain
+			 */
+			const { queryByText: queryByText4 } = renderWithProvider(
+				<MockPlansFeaturesMain flowName="onboarding-pm" selectedPlan={ PLAN_PERSONAL } />
+			);
+
+			expect( queryByText4( /DIALOG/i ) ).toBeNull();
+		} );
 	} );
-	test( 'A free domain on the onboarding-pm flow should show the FREE_PLAN_FREE_DOMAIN_DIALOG', () => {
-		renderWithProvider(
-			<MockPlansFeaturesMain flowName="onboarding-pm" selectedPlan={ PLAN_FREE } />
-		);
-		expect( screen.getByTestId( 'modal-render' ) ).toHaveTextContent(
-			FREE_PLAN_FREE_DOMAIN_DIALOG
-		);
-	} );
 
-	test( 'A free domain on the onboarding flow should show the FREE_PLAN_FREE_DOMAIN_DIALOG', () => {
-		renderWithProvider(
-			<MockPlansFeaturesMain flowName="onboarding" selectedPlan={ PLAN_FREE } />
-		);
-		expect( screen.getByTestId( 'modal-render' ) ).toHaveTextContent(
-			FREE_PLAN_FREE_DOMAIN_DIALOG
-		);
-	} );
-
-	test( 'A paid domain on the onboarding flow should show the PAID_PLAN_IS_REQUIRED_DIALOG', () => {
-		renderWithProvider(
-			<MockPlansFeaturesMain
-				flowName="onboarding"
-				selectedPlan={ PLAN_FREE }
-				paidSubdomain="yourgroovydomain.com"
-			/>
-		);
-		expect( screen.getByTestId( 'modal-render' ) ).toHaveTextContent(
-			PAID_PLAN_IS_REQUIRED_DIALOG
-		);
-	} );
-
-	test( 'Paid plan selections should not show any modals', () => {
-		/**
-		 * Flow onboarding paid domain
-		 */
-		const { queryByText: queryByText1 } = renderWithProvider(
-			<MockPlansFeaturesMain
-				flowName="onboarding"
-				selectedPlan={ PLAN_PERSONAL }
-				paidSubdomain="yourgroovydomain.com"
-			/>
-		);
-
-		expect( queryByText1( /DIALOG/i ) ).toBeNull();
-
-		/**
-		 * Flow onboarding-pm paid domain
-		 */
-		const { queryByText: queryByText2 } = renderWithProvider(
-			<MockPlansFeaturesMain
-				flowName="onboarding-pm"
-				selectedPlan={ PLAN_PERSONAL }
-				paidSubdomain="yourgroovydomain.com"
-			/>
-		);
-
-		expect( queryByText2( /DIALOG/i ) ).toBeNull();
-
-		/**
-		 * Flow onboarding free domain
-		 */
-		const { queryByText: queryByText3 } = renderWithProvider(
-			<MockPlansFeaturesMain flowName="onboarding" selectedPlan={ PLAN_PERSONAL } />
-		);
-
-		expect( queryByText3( /DIALOG/i ) ).toBeNull();
-
-		/**
-		 * Flow onboarding-pm free domain
-		 */
-		const { queryByText: queryByText4 } = renderWithProvider(
-			<MockPlansFeaturesMain flowName="onboarding-pm" selectedPlan={ PLAN_PERSONAL } />
-		);
-
-		expect( queryByText4( /DIALOG/i ) ).toBeNull();
+	describe( 'useModalResolutionCallback hook related tests', () => {
+		test( 'Free plan and free domain selection should not show any modals on the onboarding flow when all other modals are hidden', () => {
+			const { result } = renderHook( () =>
+				useModalResolutionCallback( {
+					isCustomDomainAllowedOnFreePlan: { result: false, isLoading: false },
+					isPlanUpsellEnabledOnFreeDomain: { result: false, isLoading: false },
+					flowName: 'Onboarding',
+					paidDomain: null,
+				} )
+			);
+			expect( result.current( PLAN_FREE ) ).toBeNull();
+		} );
 	} );
 } );

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/test/plan-upsell-modal.test.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/test/plan-upsell-modal.test.tsx
@@ -16,25 +16,25 @@ import { useModalResolutionCallback } from '../hooks/use-modal-resolution-callba
 function MockPlansFeaturesMain( {
 	flowName,
 	selectedPlan,
-	paidDomain,
+	paidDomainName,
 }: {
 	flowName: string;
 	selectedPlan: string;
-	paidDomain?: string | null;
+	paidDomainName?: string | null;
 } ) {
 	const isCustomDomainAllowedOnFreePlan = useIsFreePlanCustomDomainUpsellEnabled(
 		flowName,
-		paidDomain
+		paidDomainName
 	);
 	const isPlanUpsellEnabledOnFreeDomain = useIsFreeDomainFreePlanUpsellEnabled(
 		flowName,
-		paidDomain
+		paidDomainName
 	);
 	const resolveModal = useModalResolutionCallback( {
 		isCustomDomainAllowedOnFreePlan,
 		isPlanUpsellEnabledOnFreeDomain,
 		flowName,
-		paidDomain,
+		paidDomainName,
 	} );
 	return <div data-testid="modal-render">{ resolveModal( selectedPlan ) }</div>;
 }
@@ -46,7 +46,7 @@ describe( 'PlanUpsellModal tests', () => {
 				<MockPlansFeaturesMain
 					flowName="onboarding-pm"
 					selectedPlan={ PLAN_FREE }
-					paidDomain="yourgroovydomain.com"
+					paidDomainName="yourgroovydomain.com"
 				/>
 			);
 			expect( screen.getByTestId( 'modal-render' ) ).toHaveTextContent(
@@ -75,7 +75,7 @@ describe( 'PlanUpsellModal tests', () => {
 				<MockPlansFeaturesMain
 					flowName="onboarding"
 					selectedPlan={ PLAN_FREE }
-					paidDomain="yourgroovydomain.com"
+					paidDomainName="yourgroovydomain.com"
 				/>
 			);
 			expect( screen.getByTestId( 'modal-render' ) ).toHaveTextContent(
@@ -91,7 +91,7 @@ describe( 'PlanUpsellModal tests', () => {
 				<MockPlansFeaturesMain
 					flowName="onboarding"
 					selectedPlan={ PLAN_PERSONAL }
-					paidDomain="yourgroovydomain.com"
+					paidDomainName="yourgroovydomain.com"
 				/>
 			);
 
@@ -104,7 +104,7 @@ describe( 'PlanUpsellModal tests', () => {
 				<MockPlansFeaturesMain
 					flowName="onboarding-pm"
 					selectedPlan={ PLAN_PERSONAL }
-					paidDomain="yourgroovydomain.com"
+					paidDomainName="yourgroovydomain.com"
 				/>
 			);
 
@@ -137,7 +137,7 @@ describe( 'PlanUpsellModal tests', () => {
 					isCustomDomainAllowedOnFreePlan: { result: false, isLoading: false },
 					isPlanUpsellEnabledOnFreeDomain: { result: false, isLoading: false },
 					flowName: 'Onboarding',
-					paidDomain: null,
+					paidDomainName: null,
 				} )
 			);
 			expect( result.current( PLAN_FREE ) ).toBeNull();

--- a/client/my-sites/plans-features-main/hooks/use-is-free-domain-free-plan-upsell-enabled.ts
+++ b/client/my-sites/plans-features-main/hooks/use-is-free-domain-free-plan-upsell-enabled.ts
@@ -4,7 +4,7 @@ const useIsFreeDomainFreePlanUpsellEnabled = (
 	flowName?: string | null,
 	paidDomainName?: string | null
 ): DataResponse< boolean > => {
-	if ( ! paidDomainName && ( flowName === 'onboarding' || flowName === 'onboarding-pm' ) ) {
+	if ( ! paidDomainName && flowName === 'onboarding-pm' ) {
 		return {
 			isLoading: false,
 			result: true,

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -277,6 +277,7 @@ const PlansFeaturesMain = ( {
 		isCustomDomainAllowedOnFreePlan,
 		isPlanUpsellEnabledOnFreeDomain,
 		flowName,
+		paidDomainName,
 	} );
 
 	const toggleShowPlansComparisonGrid = () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Hides the free domain, free plan modal on the onboarding flow: 
     * https://github.com/Automattic/wp-calypso/pull/83245/files#diff-e5aa5e0751c704a348e3becc036bebfc3f48829b6f3408faa377ed89dbb0ad03R6-R8
* Guard against future bug by forcing `is paid domain required` modal to ensure a paid domain is available.
    * https://github.com/Automattic/wp-calypso/pull/83245/files#diff-68408c7090122731dbaa000f767f57b1c483b58b2898efc775ab9ae0e454e841R37-R39  
* Updated and added a new tests for above changes 
* Fixes typo in variable name from `paidSubdomain`  -> `paidDomain`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure tests are not failing
* On the onboarding flow a free domain and free plan should not show a modal
* On the onboarding flow a paid domain and free plan should show a modal
* On the onboarding-pm flow a paid domain and free domain should both show a modal on a free plan
* Check https://github.com/Automattic/wp-calypso/pull/81644 for detailed test cases

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?