### PR TITLE
Updates the i18n-utils package changelog

### DIFF
--- a/packages/i18n-utils/CHANGELOG.md
+++ b/packages/i18n-utils/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.3.0
+
+- Makes the `locale` argument optional on the `addLocaleToPathLocaleInFront` function and omits the locale in the path in case it is default. [https://github.com/Automattic/wp-calypso/pull/80533](#80533)
+- Adds functions to override the language in the path [https://github.com/Automattic/wp-calypso/pull/80302](#80302)
+- Add '/plans' url to mapping and add the locales allow list [https://github.com/Automattic/wp-calypso/pull/79570](#79570)
+- Updates the `getLanguage` regex to string so it can be combined with other regexes [https://github.com/Automattic/wp-calypso/pull/78656](#78656)
+- Add `/setup` localization mapping [https://github.com/Automattic/wp-calypso/pull/77313](#77313)
+- The locale should no longer be added to the host, and we should use it on the path instead. [https://github.com/Automattic/wp-calypso/pull/76767](#76767)
+
 ## 1.2.0
 
 Add support for preserving trailing slash variation in `localizeUrl`


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?