### PR TITLE
Headers: Replace FormattedHeader in /me with NavigationHeader (Part 2 or 2)

### DIFF
--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -14,8 +14,8 @@ import ActionPanelFigureListItem from 'calypso/components/action-panel/figure-li
 import ActionPanelFooter from 'calypso/components/action-panel/footer';
 import ActionPanelLink from 'calypso/components/action-panel/link';
 import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
-import FormattedHeader from 'calypso/components/formatted-header';
 import HeaderCake from 'calypso/components/header-cake';
+import NavigationHeader from 'calypso/components/navigation-header';
 import { redirectToLogout } from 'calypso/state/current-user/actions';
 import { hasLoadedUserPurchasesFromServer } from 'calypso/state/purchases/selectors';
 import getAccountClosureSites from 'calypso/state/selectors/get-account-closure-sites';
@@ -78,7 +78,7 @@ class AccountSettingsClose extends Component {
 		return (
 			<div className={ containerClasses } role="main">
 				<QueryUserPurchases />
-				<FormattedHeader brandFont headerText={ translate( 'Account Settings' ) } align="left" />
+				<NavigationHeader navigationItems={ [] } title={ translate( 'Account Settings' ) } />
 
 				<HeaderCake onClick={ this.goBack }>
 					<h1>{ translate( 'Close account' ) }</h1>

--- a/client/me/connected-applications/index.jsx
+++ b/client/me/connected-applications/index.jsx
@@ -7,9 +7,9 @@ import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryConnectedApplications from 'calypso/components/data/query-connected-applications';
 import EmptyContent from 'calypso/components/empty-content';
-import FormattedHeader from 'calypso/components/formatted-header';
 import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 import ConnectedAppItem from 'calypso/me/connected-application-item';
@@ -114,7 +114,7 @@ class ConnectedApplications extends PureComponent {
 				/>
 				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
 
-				<FormattedHeader brandFont headerText={ translate( 'Security' ) } align="left" />
+				<NavigationHeader navigationItems={ [] } title={ translate( 'Security' ) } />
 
 				<DocumentHead title={ translate( 'Connected Applications' ) } />
 

--- a/client/me/notification-settings/comment-settings/index.jsx
+++ b/client/me/notification-settings/comment-settings/index.jsx
@@ -2,9 +2,9 @@ import { Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import FormattedHeader from 'calypso/components/formatted-header';
 import FormSectionHeading from 'calypso/components/forms/form-section-heading';
 import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 import SettingsForm from 'calypso/me/notification-settings/settings-form';
@@ -51,11 +51,7 @@ class NotificationCommentsSettings extends Component {
 				/>
 				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
 
-				<FormattedHeader
-					brandFont
-					headerText={ translate( 'Notification Settings' ) }
-					align="left"
-				/>
+				<NavigationHeader navigationItems={ [] } title={ translate( 'Notification Settings' ) } />
 
 				<Navigation path={ path } />
 

--- a/client/me/notification-settings/main.jsx
+++ b/client/me/notification-settings/main.jsx
@@ -5,8 +5,8 @@ import { find } from 'lodash';
 import page from 'page';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 import ReauthRequired from 'calypso/me/reauth-required';
@@ -66,10 +66,9 @@ class NotificationSettings extends Component {
 						{ this.props.translate( 'Manage all subscriptions' ) }
 					</Button>
 				) }
-				<FormattedHeader
-					brandFont
-					headerText={ this.props.translate( 'Notification Settings' ) }
-					align="left"
+				<NavigationHeader
+					navigationItems={ [] }
+					title={ this.props.translate( 'Notification Settings' ) }
 				/>
 
 				<Navigation path={ this.props.path } />

--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -3,7 +3,6 @@ import { localize } from 'i18n-calypso';
 import { flowRight as compose } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import FormattedHeader from 'calypso/components/formatted-header';
 import FormButton from 'calypso/components/forms/form-button';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
@@ -14,6 +13,7 @@ import FormSelect from 'calypso/components/forms/form-select';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { protectForm } from 'calypso/lib/protect-form';
 import twoStepAuthorization from 'calypso/lib/two-step-authorization';
@@ -63,10 +63,9 @@ class NotificationSubscriptions extends Component {
 				/>
 				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
 
-				<FormattedHeader
-					brandFont
-					headerText={ this.props.translate( 'Notification Settings' ) }
-					align="left"
+				<NavigationHeader
+					navigationItems={ [] }
+					title={ this.props.translate( 'Notification Settings' ) }
 				/>
 
 				<Navigation path={ this.props.path } />

--- a/client/me/notification-settings/wpcom-settings/index.jsx
+++ b/client/me/notification-settings/wpcom-settings/index.jsx
@@ -3,9 +3,9 @@ import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import FormattedHeader from 'calypso/components/formatted-header';
 import FormSectionHeading from 'calypso/components/forms/form-section-heading';
 import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 import ReauthRequired from 'calypso/me/reauth-required';
@@ -197,10 +197,9 @@ class WPCOMNotifications extends Component {
 					title="Me > Notifications > Updates from WordPress.com"
 				/>
 				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
-				<FormattedHeader
-					brandFont
-					headerText={ this.props.translate( 'Notification Settings' ) }
-					align="left"
+				<NavigationHeader
+					navigationItems={ [] }
+					title={ this.props.translate( 'Notification Settings' ) }
 				/>
 
 				<Navigation path={ this.props.path } />

--- a/client/me/purchases/add-new-payment-method/index.tsx
+++ b/client/me/purchases/add-new-payment-method/index.tsx
@@ -4,11 +4,11 @@ import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { useMemo, useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
-import FormattedHeader from 'calypso/components/formatted-header';
 import HeaderCake from 'calypso/components/header-cake';
 import Layout from 'calypso/components/layout';
 import Column from 'calypso/components/layout/column';
 import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { getStripeConfiguration } from 'calypso/lib/store-transactions';
 import PaymentMethodLoader from 'calypso/me/purchases/components/payment-method-loader';
@@ -61,7 +61,8 @@ function AddNewPaymentMethod() {
 			<PageViewTracker path="/me/purchases/add-payment-method" title={ title } />
 			<DocumentHead title={ title } />
 
-			<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
+			<NavigationHeader navigationItems={ [] } title={ titles.sectionTitle } />
+
 			<HeaderCake onClick={ goToPaymentMethods }>{ addPaymentMethodTitle }</HeaderCake>
 
 			<Layout>

--- a/client/me/purchases/billing-history/main.tsx
+++ b/client/me/purchases/billing-history/main.tsx
@@ -3,9 +3,9 @@ import { CompactCard, Card } from '@automattic/components';
 import i18n, { getLocaleSlug, useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryBillingTransactions from 'calypso/components/data/query-billing-transactions';
-import FormattedHeader from 'calypso/components/formatted-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import { useGeoLocationQuery } from 'calypso/data/geo/use-geolocation-query';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import BillingHistoryList from 'calypso/me/purchases/billing-history/billing-history-list';
@@ -60,10 +60,10 @@ function BillingHistory() {
 		<Main wideLayout className="billing-history">
 			<DocumentHead title={ titles.billingHistory } />
 			<PageViewTracker path="/me/purchases/billing" title="Me > Billing History" />
-			<FormattedHeader
-				brandFont
-				headerText={ titles.sectionTitle }
-				subHeaderText={ translate(
+			<NavigationHeader
+				navigationItems={ [] }
+				title={ titles.sectionTitle }
+				subtitle={ translate(
 					'View, print, and email your receipts. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 					{
 						components: {
@@ -71,7 +71,6 @@ function BillingHistory() {
 						},
 					}
 				) }
-				align="left"
 			/>
 			<QueryBillingTransactions transactionType="past" />
 			<PurchasesNavigation section="billingHistory" />

--- a/client/me/purchases/billing-history/receipt.tsx
+++ b/client/me/purchases/billing-history/receipt.tsx
@@ -8,11 +8,11 @@ import { Component, useState, useCallback } from 'react';
 import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryBillingTransaction from 'calypso/components/data/query-billing-transaction';
-import FormattedHeader from 'calypso/components/formatted-header';
 import FormLabel from 'calypso/components/forms/form-label';
 import HeaderCake from 'calypso/components/header-cake';
 import { withLocalizedMoment, useLocalizedMoment } from 'calypso/components/localized-moment';
 import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import TextareaAutosize from 'calypso/components/textarea-autosize';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { PARTNER_PAYPAL_EXPRESS } from 'calypso/lib/checkout/payment-methods';
@@ -94,7 +94,8 @@ class BillingReceipt extends Component< BillingReceiptProps & BillingReceiptConn
 					title="Me > Billing History > Receipt"
 				/>
 
-				<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
+				<NavigationHeader navigationItems={ [] } title={ titles.sectionTitle } />
+
 				<QueryBillingTransaction transactionId={ transactionId } />
 
 				<ReceiptTitle backHref={ billingHistory } />

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -5,7 +5,6 @@ import page from 'page';
 import { Fragment, useCallback } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import NoSitesMessage from 'calypso/components/empty-content/no-sites-message';
-import FormattedHeader from 'calypso/components/formatted-header';
 import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
@@ -91,7 +90,8 @@ export function cancelPurchase( context, next ) {
 		return (
 			<PurchasesWrapper title={ titles.cancelPurchase }>
 				<Main wideLayout className="purchases__cancel">
-					<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
+					<NavigationHeader navigationItems={ [] } title={ titles.sectionTitle } />
+
 					<CancelPurchase
 						purchaseId={ parseInt( context.params.purchaseId, 10 ) }
 						siteSlug={ context.params.site }

--- a/client/me/purchases/purchases-list/index.jsx
+++ b/client/me/purchases/purchases-list/index.jsx
@@ -9,9 +9,9 @@ import QueryMembershipsSubscriptions from 'calypso/components/data/query-members
 import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import EmptyContent from 'calypso/components/empty-content';
 import NoSitesMessage from 'calypso/components/empty-content/no-sites-message';
-import FormattedHeader from 'calypso/components/formatted-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { getPurchasesBySite, getSubscriptionsBySite } from 'calypso/lib/purchases';
 import { PurchaseListConciergeBanner } from 'calypso/me/purchases/purchases-list/purchase-list-concierge-banner';
@@ -100,7 +100,7 @@ class PurchasesList extends Component {
 				return (
 					<Main wideLayout className="purchases-list">
 						<PageViewTracker path="/me/purchases" title="Purchases > No Sites" />
-						<FormattedHeader brandFont headerText={ titles.sectionTitle } align="left" />
+						<NavigationHeader navigationItems={ [] } title={ titles.sectionTitle } />
 						<PurchasesNavigation section="activeUpgrades" />
 						<NoSitesMessage />
 					</Main>
@@ -132,10 +132,10 @@ class PurchasesList extends Component {
 				<QueryMembershipsSubscriptions />
 				<PageViewTracker path="/me/purchases" title="Purchases" />
 
-				<FormattedHeader
-					brandFont
-					headerText={ titles.sectionTitle }
-					subHeaderText={ translate(
+				<NavigationHeader
+					navigationItems={ [] }
+					title={ titles.sectionTitle }
+					subtitle={ translate(
 						'View, manage, or cancel your plan and other purchases. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 						{
 							components: {
@@ -143,7 +143,6 @@ class PurchasesList extends Component {
 							},
 						}
 					) }
-					align="left"
 				/>
 				<PurchasesNavigation section="activeUpgrades" />
 				{ content }

--- a/client/me/security-account-email/index.tsx
+++ b/client/me/security-account-email/index.tsx
@@ -2,9 +2,9 @@ import { Button, Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
-import FormattedHeader from 'calypso/components/formatted-header';
 import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { useProtectForm } from 'calypso/lib/protect-form';
 import twoStepAuthorization from 'calypso/lib/two-step-authorization';
@@ -72,7 +72,7 @@ const SecurityAccountEmail = ( { path }: { path: string } ) => {
 
 			<DocumentHead title={ translate( 'Account Email' ) } />
 
-			<FormattedHeader brandFont headerText={ translate( 'Security' ) } align="left" />
+			<NavigationHeader navigationItems={ [] } title={ translate( 'Security' ) } />
 
 			<HeaderCake backText={ translate( 'Back' ) } backHref="/me/security">
 				{ translate( 'Account Email' ) }

--- a/client/me/security-account-recovery/index.jsx
+++ b/client/me/security-account-recovery/index.jsx
@@ -4,9 +4,9 @@ import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryAccountRecoverySettings from 'calypso/components/data/query-account-recovery-settings';
-import FormattedHeader from 'calypso/components/formatted-header';
 import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 import ReauthRequired from 'calypso/me/reauth-required';
@@ -46,7 +46,7 @@ const SecurityAccountRecovery = ( props ) => (
 		<PageViewTracker path="/me/security/account-recovery" title="Me > Account Recovery" />
 		<QueryAccountRecoverySettings />
 
-		<FormattedHeader brandFont headerText={ props.translate( 'Security' ) } align="left" />
+		<NavigationHeader navigationItems={ [] } title={ props.translate( 'Security' ) } />
 
 		{ ! config.isEnabled( 'security/security-checkup' ) && (
 			<SecuritySectionNav path={ props.path } />

--- a/client/me/security-checkup/index.jsx
+++ b/client/me/security-checkup/index.jsx
@@ -4,8 +4,8 @@ import { Component } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryAccountRecoverySettings from 'calypso/components/data/query-account-recovery-settings';
 import QueryUserSettings from 'calypso/components/data/query-user-settings';
-import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import SectionHeader from 'calypso/components/section-header';
 import VerticalNav from 'calypso/components/vertical-nav';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -42,7 +42,7 @@ class SecurityCheckupComponent extends Component {
 
 				<DocumentHead title={ translate( 'Security' ) } />
 
-				<FormattedHeader brandFont headerText={ translate( 'Security' ) } align="left" />
+				<NavigationHeader navigationItems={ [] } title={ translate( 'Security' ) } />
 
 				<SectionHeader label={ translate( 'Security Checklist' ) } />
 

--- a/client/me/security-ssh-key/security-ssh-key.tsx
+++ b/client/me/security-ssh-key/security-ssh-key.tsx
@@ -7,9 +7,9 @@ import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
-import FormattedHeader from 'calypso/components/formatted-header';
 import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 import ReauthRequired from 'calypso/me/reauth-required';
@@ -170,7 +170,7 @@ export const SecuritySSHKey = ( { queryParams }: SecuritySSHKeyProps ) => {
 			<PageViewTracker path="/me/security/ssh-key" title="Me > SSH Key" />
 			<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
 
-			<FormattedHeader brandFont headerText={ __( 'Security' ) } align="left" />
+			<NavigationHeader navigationItems={ [] } title={ __( 'Security' ) } />
 
 			<HeaderCake
 				backText={ redirectToHosting ? __( 'Back to Hosting Configuration' ) : __( 'Back' ) }

--- a/client/me/two-step/index.jsx
+++ b/client/me/two-step/index.jsx
@@ -6,9 +6,9 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryUserSettings from 'calypso/components/data/query-user-settings';
-import FormattedHeader from 'calypso/components/formatted-header';
 import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 import AppPasswords from 'calypso/me/application-passwords';
@@ -102,7 +102,7 @@ class TwoStep extends Component {
 
 				<DocumentHead title={ translate( 'Two-Step Authentication' ) } />
 
-				<FormattedHeader brandFont headerText={ translate( 'Security' ) } align="left" />
+				<NavigationHeader navigationItems={ [] } title={ translate( 'Security' ) } />
 
 				{ ! useCheckupMenu && <SecuritySectionNav path={ path } /> }
 				{ useCheckupMenu && (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4221

## Proposed Changes

* This is 2 of 2 PRs that replace occurrences of `<FormattedHeader>` in client/me/ with `<NavigationHeader>`

I broke up refactoring client/me/ into 2 PRs to keep the PR and review size manageable. The first PR is here: https://github.com/Automattic/wp-calypso/pull/83178

## Testing Instructions

View the code to ensure it looks correct, and view the pages below to visually confirm. Some pages are difficult to get to, in those cases, we can rely on reviewing the code only.

 * http://calypso.localhost:3000/me/notifications
 * http://calypso.localhost:3000/me/security
 * http://calypso.localhost:3000/me/security/connected-applications
 * http://calypso.localhost:3000/me/security/ssh-key
 * http://calypso.localhost:3000/me/security/two-step
 * http://calypso.localhost:3000/me/security/account-email
 * http://calypso.localhost:3000/me/security/account-recovery
 * http://calypso.localhost:3000/me/purchases/add-payment-method
 * http://calypso.localhost:3000/me/purchases/billing/[receiptId] <- You can get here by looking at an old purchase and "viewing receipt"
 * http://calypso.localhost:3000/me/purchases <- More than 0 purchase
 * http://calypso.localhost:3000/me/purchases <- 0 purchases
 * http://calypso.localhost:3000/me/purchases/billing
 * http://calypso.localhost:3000/me/notifications/updates
 * http://calypso.localhost:3000/me/notifications/comments
 * http://calypso.localhost:3000/me/notifications/subscriptions
 * http://calypso.localhost:3000/me/purchases/[siteSlug]/[purchaseId]/cancel <- "Cancel plan" in purchase details
 * http://calypso.localhost:3000/me/account/close



<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?