### PR TITLE
Update newsletter e2e tests for new email subscribe flow

### DIFF
--- a/test/e2e/specs/users/newsletter__subscribe-remove.ts
+++ b/test/e2e/specs/users/newsletter__subscribe-remove.ts
@@ -82,7 +82,18 @@ skipDescribeIf( envVariables.ATOMIC_VARIATION === 'private' )(
 				const confirmationURL = emailClient.getLinkFromMessageByKey( message, 'Confirm now' );
 				expect( confirmationURL ).not.toBe( null );
 
-				await page.goto( confirmationURL as string );
+				// Now, when you subscribe from a post, it uses a magic link login and redirects you to the post you subscribed from.
+				// All of this takes a good bit longer due to some behinds-the-scenes stuff, so we need a longer timeout.
+				// We also should make sure we have a fresh page so we know for sure when the redirect happens to the original post.
+				const pageForConfirming = await browser.newPage();
+				const waitForRedirectToOriginalPost = pageForConfirming.waitForURL(
+					( url ) => url.href.includes( newPostDetails.URL ),
+					{
+						timeout: 45 * 1000,
+					}
+				);
+				await pageForConfirming.goto( confirmationURL as string );
+				await waitForRedirectToOriginalPost;
 			} );
 		} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Context: p1697728294123419-slack-C034JEXD1RD

There's a new flow for email subscriptions! In short, we now send magic login links and make shell accounts, and then do some extra redirecting. This updates our newsletter/subscribe tests for that.

## Testing Instructions

- [x] Jetpack tests should pass on CI For this branch

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?