### PR TITLE
Headers: Replace FormattedHeader in /settings with NavigationHeader 

### DIFF
--- a/client/blocks/disconnect-jetpack/style.scss
+++ b/client/blocks/disconnect-jetpack/style.scss
@@ -1,6 +1,4 @@
 .disconnect-jetpack__block {
-	text-align: center;
-	max-width: 400px;
 	color: var(--color-neutral-50);
 
 	.disconnect-jetpack__header {

--- a/client/my-sites/site-settings/disconnect-site/confirm.jsx
+++ b/client/my-sites/site-settings/disconnect-site/confirm.jsx
@@ -4,9 +4,9 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import DisconnectJetpack from 'calypso/blocks/disconnect-jetpack';
 import DocumentHead from 'calypso/components/data/document-head';
-import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
 import enrichedSurveyData from 'calypso/components/marketing-survey/cancel-purchase-form/enriched-survey-data';
+import NavigationHeader from 'calypso/components/navigation-header';
 import NavigationLink from 'calypso/components/wizard/navigation-link';
 import { submitSurvey } from 'calypso/lib/purchases/actions';
 import redirectNonJetpack from 'calypso/my-sites/site-settings/redirect-non-jetpack';
@@ -71,12 +71,14 @@ class ConfirmDisconnection extends Component {
 		return (
 			<Main className="disconnect-site__confirm">
 				<DocumentHead title={ translate( 'Site Settings' ) } />
-				<FormattedHeader
-					headerText={ translate( 'Confirm Disconnection' ) }
-					subHeaderText={ translate(
+				<NavigationHeader
+					navigationItems={ [] }
+					title={ translate( 'Confirm Disconnection' ) }
+					subtitle={ translate(
 						'Confirm that you want to disconnect your site from WordPress.com.'
 					) }
 				/>
+
 				<DisconnectJetpack
 					disconnectHref={ disconnectHref ?? '/stats' }
 					isBroken={ false }

--- a/client/my-sites/site-settings/disconnect-site/down-flow.jsx
+++ b/client/my-sites/site-settings/disconnect-site/down-flow.jsx
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import NavigationLink from 'calypso/components/wizard/navigation-link';
 import { addQueryArgs } from 'calypso/lib/url';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -15,15 +16,13 @@ function DownFlow( { confirmHref, backHref, site, recordTracksEvent: tracks } ) 
 	return (
 		<Main className="disconnect-site__down-flow">
 			<DocumentHead title={ translate( 'Site Settings' ) } />
-			<FormattedHeader
-				headerText={ translate(
-					'Your site, {{strong}}%(siteName)s{{/strong}}, cannot be accessed',
-					{
-						args: { siteName: site.name },
-						components: { strong: <strong /> },
-					}
-				) }
-				subHeaderText={ translate(
+			<NavigationHeader
+				navigationItems={ [] }
+				title={ translate( 'Your site, {{strong}}%(siteName)s{{/strong}}, cannot be accessed', {
+					args: { siteName: site.name },
+					components: { strong: <strong /> },
+				} ) }
+				subtitle={ translate(
 					'Jetpack wasn’t able to connect to {{strong}}%(siteSlug)s{{/strong}}.{{br/}}Let’s figure out why — there are a few things to try.',
 					{
 						args: { siteSlug: site.slug },
@@ -34,6 +33,7 @@ function DownFlow( { confirmHref, backHref, site, recordTracksEvent: tracks } ) 
 					}
 				) }
 			/>
+
 			<div className="disconnect-site__actions">
 				<CompactCard
 					onClick={ () => tracks( 'calypso_jetpack_site_indicator_disconnect_confirm' ) }

--- a/client/my-sites/site-settings/disconnect-site/survey-flow.jsx
+++ b/client/my-sites/site-settings/disconnect-site/survey-flow.jsx
@@ -1,7 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
-import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import NavigationLink from 'calypso/components/wizard/navigation-link';
 import DisconnectSurvey from './disconnect-survey';
 import Troubleshoot from './troubleshoot';
@@ -12,9 +12,10 @@ export default function SurveyFlow( { confirmHref, backHref } ) {
 	return (
 		<Main className="disconnect-site__site-settings">
 			<DocumentHead title={ translate( 'Site Settings' ) } />
-			<FormattedHeader
-				headerText={ translate( 'Disable Jetpack' ) }
-				subHeaderText={ translate( "Please let us know why you're disabling Jetpack." ) }
+			<NavigationHeader
+				navigationItems={ [] }
+				title={ translate( 'Disable Jetpack' ) }
+				subtitle={ translate( "Please let us know why you're disabling Jetpack." ) }
 			/>
 			<DisconnectSurvey confirmHref={ confirmHref } />
 			<div className="disconnect-site__navigation-links">

--- a/client/my-sites/site-settings/main.jsx
+++ b/client/my-sites/site-settings/main.jsx
@@ -5,9 +5,9 @@ import JetpackBackupCredsBanner from 'calypso/blocks/jetpack-backup-creds-banner
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
-import FormattedHeader from 'calypso/components/formatted-header';
 import { JetpackConnectionHealthBanner } from 'calypso/components/jetpack/connection-health';
 import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import ScreenOptionsTab from 'calypso/components/screen-options-tab';
 import { withJetpackConnectionProblem } from 'calypso/state/jetpack-connection-health/selectors/is-jetpack-connection-problem.js';
 import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
@@ -35,16 +35,14 @@ const SiteSettingsComponent = ( {
 			<QuerySitePurchases siteId={ siteId } />
 			<JetpackDevModeNotice />
 			<JetpackBackupCredsBanner event="settings-backup-credentials" />
-			<FormattedHeader
-				brandFont
-				className="site-settings__page-heading"
-				headerText={ translate( 'General Settings' ) }
-				subHeaderText={ translate(
+			<NavigationHeader
+				navigationItems={ [] }
+				title={ translate( 'General Settings' ) }
+				subtitle={ translate(
 					'Manage your site settings, including language, time zone, site visibility, and more.'
 				) }
-				align="left"
-				hasScreenOptions
 			/>
+
 			<SiteSettingsNavigation section="general" />
 			<GeneralSettings />
 		</Main>

--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -9,7 +9,6 @@ import TermTreeSelector from 'calypso/blocks/term-tree-selector';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryTerms from 'calypso/components/data/query-terms';
-import FormattedHeader from 'calypso/components/formatted-header';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormSelect from 'calypso/components/forms/form-select';
@@ -18,6 +17,7 @@ import FormInput from 'calypso/components/forms/form-text-input';
 import FormTextarea from 'calypso/components/forms/form-textarea';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import Notice from 'calypso/components/notice';
 import { decodeEntities } from 'calypso/lib/formatting';
 import scrollTo from 'calypso/lib/scroll-to';
@@ -184,10 +184,10 @@ class PodcastingDetails extends Component {
 		return (
 			<Main>
 				<DocumentHead title={ translate( 'Podcasting' ) } />
-				<FormattedHeader
-					brandFont
-					headerText={ translate( 'Podcasting' ) }
-					subHeaderText={ translate(
+				<NavigationHeader
+					navigationItems={ [] }
+					title={ translate( 'Podcasting' ) }
+					subtitle={ translate(
 						'Publish a podcast feed to Apple Podcasts and other podcasting services. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 						{
 							components: {
@@ -195,7 +195,6 @@ class PodcastingDetails extends Component {
 							},
 						}
 					) }
-					align="left"
 				/>
 
 				<form id="site-settings" onSubmit={ handleSubmitForm }>

--- a/client/my-sites/site-settings/settings-discussion/main.jsx
+++ b/client/my-sites/site-settings/settings-discussion/main.jsx
@@ -1,9 +1,9 @@
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
-import FormattedHeader from 'calypso/components/formatted-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import ScreenOptionsTab from 'calypso/components/screen-options-tab';
 import { FediverseSettingsSection } from 'calypso/my-sites/site-settings/fediverse-settings';
 import DiscussionForm from 'calypso/my-sites/site-settings/form-discussion';
@@ -16,11 +16,10 @@ const SiteSettingsDiscussion = ( { site, translate } ) => (
 		<ScreenOptionsTab wpAdminPath="options-discussion.php" />
 		<DocumentHead title={ translate( 'Discussion Settings' ) } />
 		<JetpackDevModeNotice />
-		<FormattedHeader
-			brandFont
-			className="settings-discussion__page-heading"
-			headerText={ translate( 'Discussion Settings' ) }
-			subHeaderText={ translate(
+		<NavigationHeader
+			navigationItems={ [] }
+			title={ translate( 'Discussion Settings' ) }
+			subtitle={ translate(
 				'Control how people interact with your site through comments. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 				{
 					components: {
@@ -28,9 +27,8 @@ const SiteSettingsDiscussion = ( { site, translate } ) => (
 					},
 				}
 			) }
-			align="left"
-			hasScreenOptions
 		/>
+
 		<SiteSettingsNavigation site={ site } section="discussion" />
 		<FediverseSettingsSection />
 		<DiscussionForm />

--- a/client/my-sites/site-settings/settings-jetpack/main.jsx
+++ b/client/my-sites/site-settings/settings-jetpack/main.jsx
@@ -9,8 +9,8 @@ import DocumentHead from 'calypso/components/data/document-head';
 import QueryRewindState from 'calypso/components/data/query-rewind-state';
 import QuerySiteFeatures from 'calypso/components/data/query-site-features';
 import EmptyContent from 'calypso/components/empty-content';
-import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import HasRetentionCapabilitiesSwitch from 'calypso/jetpack-cloud/sections/settings/has-retention-capabilities-switch';
 import AdvancedCredentialsLoadingPlaceholder from 'calypso/jetpack-cloud/sections/settings/loading';
 import JetpackDevModeNotice from 'calypso/my-sites/site-settings/jetpack-dev-mode-notice';
@@ -57,12 +57,8 @@ const SiteSettingsJetpack = ( {
 			<QuerySiteFeatures siteIds={ [ siteId ] } />
 			<DocumentHead title={ translate( 'Jetpack Settings' ) } />
 			<JetpackDevModeNotice />
-			<FormattedHeader
-				brandFont
-				className="settings-jetpack__page-heading"
-				headerText={ translate( 'Jetpack Settings' ) }
-				align="left"
-			/>
+			<NavigationHeader navigationItems={ [] } title={ translate( 'Jetpack Settings' ) } />
+
 			<SiteSettingsNavigation site={ site } section="jetpack" />
 			{ config.isEnabled( 'jetpack/backup-retention-settings' ) ? (
 				// @TODO: Maybe we should move HasRetentionCapabilitiesSwitch to BackupRetentionManagement

--- a/client/my-sites/site-settings/settings-newsletter/main.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/main.tsx
@@ -4,8 +4,8 @@ import { useEffect } from 'react';
 import SubscriptionsModuleBanner from 'calypso/blocks/subscriptions-module-banner';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
-import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import scrollToAnchor from 'calypso/lib/scroll-to-anchor';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import { useSelector } from 'calypso/state';
@@ -201,7 +201,7 @@ const NewsletterSettings = () => {
 	return (
 		<Main>
 			<DocumentHead title={ translate( 'Newsletter Settings' ) } />
-			<FormattedHeader brandFont headerText={ translate( 'Newsletter Settings' ) } align="left" />
+			<NavigationHeader navigationItems={ [] } title={ translate( 'Newsletter Settings' ) } />
 			<SubscriptionsModuleBanner />
 			<NewsletterSettingsForm />
 		</Main>

--- a/client/my-sites/site-settings/settings-performance/main.jsx
+++ b/client/my-sites/site-settings/settings-performance/main.jsx
@@ -8,9 +8,9 @@ import { connect } from 'react-redux';
 import EligibilityWarnings from 'calypso/blocks/eligibility-warnings';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
-import FormattedHeader from 'calypso/components/formatted-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import Cloudflare from 'calypso/my-sites/site-settings/cloudflare';
 import JetpackDevModeNotice from 'calypso/my-sites/site-settings/jetpack-dev-mode-notice';
 import MediaSettingsPerformance from 'calypso/my-sites/site-settings/media-settings-performance';
@@ -56,11 +56,10 @@ class SiteSettingsPerformance extends Component {
 			<Main className="settings-performance site-settings site-settings__performance-settings">
 				<DocumentHead title={ translate( 'Performance Settings' ) } />
 				<JetpackDevModeNotice />
-				<FormattedHeader
-					brandFont
-					className="settings-performance__page-heading"
-					headerText={ translate( 'Performance Settings' ) }
-					subHeaderText={ translate(
+				<NavigationHeader
+					navigationItems={ [] }
+					title={ translate( 'Performance Settings' ) }
+					subtitle={ translate(
 						"Explore settings to improve your site's performance. {{learnMoreLink}}Learn more{{/learnMoreLink}}.",
 						{
 							components: {
@@ -74,8 +73,8 @@ class SiteSettingsPerformance extends Component {
 							},
 						}
 					) }
-					align="left"
 				/>
+
 				<SiteSettingsNavigation site={ site } section="performance" />
 
 				<Search

--- a/client/my-sites/site-settings/settings-reading/main.tsx
+++ b/client/my-sites/site-settings/settings-reading/main.tsx
@@ -2,9 +2,9 @@ import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
-import FormattedHeader from 'calypso/components/formatted-header';
 import { JetpackConnectionHealthBanner } from 'calypso/components/jetpack/connection-health';
 import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import ScreenOptionsTab from 'calypso/components/screen-options-tab';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import { useSelector } from 'calypso/state';
@@ -202,7 +202,7 @@ const ReadingSettings = () => {
 				<JetpackConnectionHealthBanner siteId={ siteId } />
 			) }
 			<DocumentHead title={ translate( 'Reading Settings' ) } />
-			<FormattedHeader brandFont headerText={ translate( 'Reading Settings' ) } align="left" />
+			<NavigationHeader navigationItems={ [] } title={ translate( 'Reading Settings' ) } />
 			<ReadingSettingsForm />
 		</Main>
 	);

--- a/client/my-sites/site-settings/settings-security/main.jsx
+++ b/client/my-sites/site-settings/settings-security/main.jsx
@@ -6,8 +6,8 @@ import DocumentHead from 'calypso/components/data/document-head';
 import QueryRewindState from 'calypso/components/data/query-rewind-state';
 import QuerySiteFeatures from 'calypso/components/data/query-site-features';
 import EmptyContent from 'calypso/components/empty-content';
-import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import JetpackMonitor from 'calypso/my-sites/site-settings/form-jetpack-monitor';
 import FormSecurity from 'calypso/my-sites/site-settings/form-security';
 import JetpackCredentials from 'calypso/my-sites/site-settings/jetpack-credentials';
@@ -56,12 +56,10 @@ export const SiteSettingsSecurity = ( {
 			<QuerySiteFeatures siteIds={ [ siteId ] } />
 			<DocumentHead title={ translate( 'Security Settings' ) } />
 			<JetpackDevModeNotice />
-			<FormattedHeader
-				brandFont
-				className="settings-security__page-heading"
-				headerText={ translate( 'Security Settings' ) }
-				subHeaderText={ translate( "Manage your site's security settings." ) }
-				align="left"
+			<NavigationHeader
+				navigationItems={ [] }
+				title={ translate( 'Security Settings' ) }
+				subtitle={ translate( "Manage your site's security settings." ) }
 			/>
 			<SiteSettingsNavigation site={ site } section="security" />
 			{ showCredentials && <JetpackCredentials /> }

--- a/client/my-sites/site-settings/settings-writing/main.jsx
+++ b/client/my-sites/site-settings/settings-writing/main.jsx
@@ -1,8 +1,8 @@
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
-import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import ScreenOptionsTab from 'calypso/components/screen-options-tab';
 import WritingForm from 'calypso/my-sites/site-settings/form-writing';
 import JetpackDevModeNotice from 'calypso/my-sites/site-settings/jetpack-dev-mode-notice';
@@ -14,14 +14,12 @@ const SiteSettingsWriting = ( { site, translate } ) => (
 		<ScreenOptionsTab wpAdminPath="options-writing.php" />
 		<DocumentHead title={ translate( 'Writing Settings' ) } />
 		<JetpackDevModeNotice />
-		<FormattedHeader
-			brandFont
-			className="settings-writing__page-heading"
-			headerText={ translate( 'Writing Settings' ) }
-			subHeaderText={ translate( "Manage settings related to your site's content." ) }
-			align="left"
-			hasScreenOptions
+		<NavigationHeader
+			navigationItems={ [] }
+			title={ translate( 'Writing Settings' ) }
+			subtitle={ translate( "Manage settings related to your site's content." ) }
 		/>
+
 		<SiteSettingsNavigation site={ site } section="writing" />
 		<WritingForm />
 	</Main>

--- a/client/my-sites/site-settings/site-owner-transfer/site-transfer-card.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/site-transfer-card.tsx
@@ -1,10 +1,10 @@
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import ActionPanel from 'calypso/components/action-panel';
-import FormattedHeader from 'calypso/components/formatted-header';
 import HeaderCake from 'calypso/components/header-cake';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 
 const ActionPanelStyled = styled( ActionPanel )( {
@@ -28,10 +28,10 @@ export function SiteTransferCard( {
 	const translate = useTranslate();
 	return (
 		<Main>
-			<FormattedHeader
-				brandFont
-				headerText={ translate( 'Site Transfer' ) }
-				subHeaderText={ translate(
+			<NavigationHeader
+				navigationItems={ [] }
+				title={ translate( 'Site Transfer' ) }
+				subtitle={ translate(
 					'Transfer your site to another WordPress.com user. {{a}}Learn more.{{/a}}',
 					{
 						components: {
@@ -39,8 +39,8 @@ export function SiteTransferCard( {
 						},
 					}
 				) }
-				align="left"
 			/>
+
 			<PageViewTracker
 				path="/settings/start-site-transfer/:site"
 				title="Settings > Start Site Transfer"

--- a/client/my-sites/site-settings/taxonomies/index.jsx
+++ b/client/my-sites/site-settings/taxonomies/index.jsx
@@ -4,9 +4,9 @@ import { get } from 'lodash';
 import { connect } from 'react-redux';
 import TaxonomyManager from 'calypso/blocks/taxonomy-manager';
 import DocumentHead from 'calypso/components/data/document-head';
-import FormattedHeader from 'calypso/components/formatted-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import ScreenOptionsTab from 'calypso/components/screen-options-tab';
 import { getPostTypeTaxonomy } from 'calypso/state/post-types/taxonomies/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -22,10 +22,10 @@ const Taxonomies = ( { translate, labels, postType, taxonomy } ) => {
 			<DocumentHead
 				title={ translate( 'Manage %(taxonomy)s', { args: { taxonomy: labels.name } } ) }
 			/>
-			<FormattedHeader
-				brandFont
-				headerText={ labels.name }
-				subHeaderText={ translate(
+			<NavigationHeader
+				navigationItems={ [] }
+				title={ labels.name }
+				subtitle={ translate(
 					'Create, edit, and manage the %(taxonomy)s on your site. {{learnMoreLink/}}',
 					{
 						args: { taxonomy: taxonomyName },
@@ -40,8 +40,6 @@ const Taxonomies = ( { translate, labels, postType, taxonomy } ) => {
 						},
 					}
 				) }
-				align="left"
-				hasScreenOptions
 			/>
 			<TaxonomyManager taxonomy={ taxonomy } postType={ postType } />
 		</Main>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


Related to https://github.com/Automattic/dotcom-forge/issues/4221

## Proposed Changes

* This PR replaces occurrences of <FormattedHeader> in client/my-sites/site-settings/ with <NavigationHeader>

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

View the code to ensure it looks correct, and view the pages below to visually confirm. Some pages are difficult to get to, in those cases, we can rely on reviewing the code only.

* http://calypso.localhost:3000/settings/security/[siteSlug] <- Visible on Atomic Business sites
* http://calypso.localhost:3000/settings/disconnect-site/[jetpackSiteSlug]
* http://calypso.localhost:3000/settings/disconnect-site/[jetpackSiteSlug]?type=down
* http://calypso.localhost:3000/settings/disconnect-site/confirm/[jetpackSiteSlug] <- I modified `client/blocks/disconnect-jetpack/style.scss` a bit so the content would look good with the new header.
* http://calypso.localhost:3000/settings/general/[siteSlug]
* http://calypso.localhost:3000/settings/discussion/[siteSlug]
* http://calypso.localhost:3000/settings/jetpack/[jetpackSiteSlug]
* http://calypso.localhost:3000/settings/writing/[siteSlug]
* http://calypso.localhost:3000/settings/newsletter/[siteSlug]
* http://calypso.localhost:3000/settings/reading/[siteSlug]
* http://calypso.localhost:3000/settings/podcasting/[siteSlug]
* http://calypso.localhost:3000/settings/performance/[siteSlug]
* http://calypso.localhost:3000/settings/start-site-transfer/[siteSlug]
* http://calypso.localhost:3000/settings/taxonomies/post_tag/[siteSlug]

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?