### PR TITLE
Earn: Consolidate Launchpad logic in hook

### DIFF
--- a/client/my-sites/earn/hooks/use-earn-launchpad-tasks.ts
+++ b/client/my-sites/earn/hooks/use-earn-launchpad-tasks.ts
@@ -1,0 +1,69 @@
+import { useLaunchpad } from '@automattic/data-stores';
+import { Task } from '@automattic/launchpad';
+import { useSelector } from 'calypso/state';
+import { getProductsForSiteId } from 'calypso/state/memberships/product-list/selectors';
+import {
+	getConnectUrlForSiteId,
+	getConnectedAccountIdForSiteId,
+} from 'calypso/state/memberships/settings/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+
+export const useEarnLaunchpadTasks = () => {
+	const checklistSlug = 'earn';
+	const site = useSelector( ( state ) => getSelectedSite( state ) );
+
+	const { products, connectedAccountId, stripeConnectUrl } = useSelector( ( state ) => ( {
+		products: getProductsForSiteId( state, site?.ID ),
+		connectedAccountId: getConnectedAccountIdForSiteId( state, site?.ID ),
+		stripeConnectUrl: getConnectUrlForSiteId( state, site?.ID ?? 0 ),
+	} ) );
+
+	const {
+		data: { checklist },
+	} = useLaunchpad( site?.slug ?? null, checklistSlug );
+
+	const taskFilter = ( tasks: Task[] | null | undefined ): Task[] => {
+		if ( ! tasks ) {
+			return [];
+		}
+
+		return tasks.map( ( task ) => {
+			switch ( task.id ) {
+				case 'stripe_connected':
+					return {
+						...task,
+						completed: Boolean( connectedAccountId ),
+						actionDispatch: () => {
+							window.location.assign( stripeConnectUrl );
+						},
+					};
+				case 'paid_offer_created':
+					return {
+						...task,
+						completed: Boolean( products && products.length > 0 ),
+						actionDispatch: () => {
+							window.location.assign(
+								`/earn/payments-plans/${ site?.slug }?launchpad=add-product#add-newsletter-payment-plan`
+							);
+						},
+					};
+				default:
+					return task;
+			}
+		} );
+	};
+
+	const enhancedChecklist = taskFilter( checklist );
+	const numberOfSteps = enhancedChecklist?.length || 0;
+	const completedSteps = ( enhancedChecklist?.filter( ( task ) => task.completed ) || [] ).length;
+	const tasklistCompleted = completedSteps >= numberOfSteps;
+	const shouldLoad = ! tasklistCompleted && numberOfSteps > 0;
+
+	return {
+		checklistSlug,
+		taskFilter,
+		numberOfSteps,
+		completedSteps,
+		shouldLoad,
+	};
+};


### PR DESCRIPTION
## Proposed Changes

* Fixes Launchpad showing on atomic even when tasks are completed. This was due to fact that we were still trying to check task completion based on task status returned from backend, which doesn't work on atomic.
* I've consolidated all the launchpad logic in a hook, and the return values are now used in both the conditional on Earn > Home, and in the Launchpad component. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1) Test simple sites
   - Go to https://wordpress.com/earn/YOURDOMAIN
   - Confirm launchpad tasks have the correct status.
   - Confirm task links work as expected
   - Try connecting/disconnecting Stripe or creating/deleting plans to confirm status to confirm statuses update as expected.

1) Test on an atomic sites
   - Go to https://wordpress.com/earn/YOURATOMICDOMAIN
   - Confirm launchpad tasks have the correct status.
   - Confirm task links work as expected
   - Try connecting/disconnecting Stripe or creating/deleting plans to confirm status to confirm statuses update as expected.
  

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?