### PR TITLE
(ETK/ErrorReporting) Activate the Error Reporting module in WP frontend for logged-in users

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php
@@ -144,13 +144,14 @@ function enqueue_script() {
  * decide what tool to activate.
  */
 function setup_error_reporting() {
-	add_action( 'admin_print_scripts', __NAMESPACE__ . '\head_error_handler', 0 );
+	add_action( 'wp_print_scripts', __NAMESPACE__ . '\head_error_handler', 0 );
 	add_filter( 'script_loader_tag', __NAMESPACE__ . '\add_crossorigin_to_script_els', 99, 2 );
 	// We load as last as possible for perf reasons. The head handler will
 	// capture errors until the main handler is loaded.
-	add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\enqueue_script', 99 );
+	add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_script', 99 );
 }
 
-if ( is_site_eligible_for_error_reporting() ) {
+// Only set up error reporting if a user is logged in and the site is eligible for error reporting
+if ( is_user_logged_in() && is_site_eligible_for_error_reporting() ) {
 	setup_error_reporting();
 }

--- a/apps/notifications/src/standalone/index.js
+++ b/apps/notifications/src/standalone/index.js
@@ -138,4 +138,23 @@ const init = ( wpcom ) => {
 	);
 };
 
-createClient().then( init );
+function setupErrorRethrowingToParentFrame() {
+	const rethrowErrorInParent = ( { error } ) => {
+		if ( ! error ) {
+			return;
+		}
+
+		const errorData = {
+			type: error.constructor.name,
+			message: error.message,
+			trace: error.stack,
+			url: document.location.href,
+		};
+
+		sendMessage( { action: 'rethrowUnhandledException', data: errorData } );
+	};
+
+	window.addEventListener( 'error', rethrowErrorInParent );
+}
+
+createClient().then( setupErrorRethrowingToParentFrame ).then( init );


### PR DESCRIPTION
## Proposed Changes

Calypso counterpart to: D126125-code.

Follow-up to https://github.com/Automattic/wp-calypso/pull/78081. See https://github.com/Automattic/wp-calypso/pull/78081#issuecomment-1590170243 for more context.

This PR aims to activate the Error Reporting module (which also activates Sentry for 10% of WPCOM sites) in the frontend, but only for logged-in users. This is done in order to have the relevant error reporting SDK activated in this context, and then, as per this comment, we will:

> Add logic in the notifications standalone app to capture errors and forward them through the iframe proxy to the parent frame, so that the Sentry instance in the WPAdmin context (exposed by the ETK) can pick it up. It will be recorded in the gutenberg-wp-admin Sentry project. 

## Testing Instructions

More specific steps will be added later.

1. Check that the error reporting is loading in the frontend for logged-in users
2. Check that error reporting is not loading in the frontend if user is not logged-in
3. Check that error reporting is still working as expected in the WPAdmin context
4. Test error reporting from within the standalone notifications iframe

To test, follow the instructions in this PR: https://github.com/Automattic/wp-calypso/pull/62632. 

It doesn't matter if the error reporting client is Sentry or homebrew, but you can also adjust the logic here to always load Sentry for your test site: https://github.com/Automattic/wp-calypso/blob/trunk/apps/editing-toolkit/editing-toolkit-plugin/error-reporting/index.php#L86