### PR TITLE
Fix e2e Test for removing modal mechanic on the onboarding flow

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts
@@ -46,7 +46,10 @@ export class SignupPickPlanPage {
 		}
 
 		if ( name === 'Free' ) {
-			if ( this.selectedDomain?.includes( 'wordpress.com' ) ) {
+			if (
+				this.selectedDomain?.includes( 'wordpress.com' ) &&
+				this.page.url().includes( 'onboarding-pm' )
+			) {
 				/** Shows a modal */
 				await this.plansPage.selectPlan( name );
 				actions = [

--- a/packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts
@@ -10,18 +10,15 @@ import type { SiteDetails, NewSiteResponse } from '../../../types/rest-api-clien
 export class SignupPickPlanPage {
 	private page: Page;
 	private plansPage: PlansPage;
-	private selectedDomain?: string;
 
 	/**
 	 * Constructs an instance of the component.
 	 *
 	 * @param {Page} page The underlying page.
-	 * @param {string} selectedDomain The selected domain in the previous step.
 	 */
-	constructor( page: Page, selectedDomain?: string ) {
+	constructor( page: Page ) {
 		this.page = page;
 		this.plansPage = new PlansPage( page );
-		this.selectedDomain = selectedDomain;
 	}
 
 	/**
@@ -37,14 +34,14 @@ export class SignupPickPlanPage {
 		] );
 
 		let url: RegExp;
-		let actions: Array< Promise< any > > = [];
 		if ( name !== 'Free' ) {
 			// Non-free plans should redirect to the Checkout cart.
 			url = new RegExp( '.*checkout.*' );
 		} else {
 			url = new RegExp( '.*setup/site-setup.*' );
 		}
-		actions = [
+
+		const actions = [
 			this.page.waitForResponse( /.*sites\/new\?.*/ ),
 			this.page.waitForURL( url, { timeout: 30 * 1000 } ),
 			this.plansPage.selectPlan( name ),

--- a/packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts
@@ -44,27 +44,11 @@ export class SignupPickPlanPage {
 		} else {
 			url = new RegExp( '.*setup/site-setup.*' );
 		}
-
-		if ( name === 'Free' ) {
-			if (
-				this.selectedDomain?.includes( 'wordpress.com' ) &&
-				this.page.url().includes( 'onboarding-pm' )
-			) {
-				/** Shows a modal */
-				await this.plansPage.selectPlan( name );
-				actions = [
-					this.page.waitForResponse( /.*sites\/new\?.*/ ),
-					this.page.waitForURL( url, { timeout: 30 * 1000 } ),
-					this.plansPage.selectModalUpsellPlan( name ),
-				];
-			}
-		} else if ( actions.length === 0 ) {
-			actions = [
-				this.page.waitForResponse( /.*sites\/new\?.*/ ),
-				this.page.waitForURL( url, { timeout: 30 * 1000 } ),
-				this.plansPage.selectPlan( name ),
-			];
-		}
+		actions = [
+			this.page.waitForResponse( /.*sites\/new\?.*/ ),
+			this.page.waitForURL( url, { timeout: 30 * 1000 } ),
+			this.plansPage.selectPlan( name ),
+		];
 
 		const [ response ] = await Promise.all( actions );
 

--- a/test/e2e/specs/onboarding/onboarding__site-assembler.ts
+++ b/test/e2e/specs/onboarding/onboarding__site-assembler.ts
@@ -42,7 +42,7 @@ describe( 'Onboarding: Site Assembler', () => {
 		} );
 
 		it( `Select WordPress.com Free plan`, async function () {
-			const signupPickPlanPage = new SignupPickPlanPage( page, selectedFreeDomain );
+			const signupPickPlanPage = new SignupPickPlanPage( page );
 			newSiteDetails = await signupPickPlanPage.selectPlan( 'Free' );
 		} );
 	} );

--- a/test/e2e/specs/onboarding/onboarding__write.ts
+++ b/test/e2e/specs/onboarding/onboarding__write.ts
@@ -59,7 +59,7 @@ describe( DataHelper.createSuiteTitle( 'Onboarding: Write Focus' ), function () 
 		} );
 
 		it( `Select WordPress.com Free plan`, async function () {
-			const signupPickPlanPage = new SignupPickPlanPage( page, selectedFreeDomain );
+			const signupPickPlanPage = new SignupPickPlanPage( page );
 			newSiteDetails = await signupPickPlanPage.selectPlan( 'Free' );
 		} );
 	} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Modal upsell on free plan mechanic is only being applied to the onboarding-pm flow
* Change done to the basic onboarding flow is reverted,  so the E2E change needs to be reverted as well
     * Initial addition to basic onboarding: https://github.com/Automattic/wp-calypso/pull/83175
     * Removal of modal from basic onboarding: https://github.com/Automattic/wp-calypso/pull/83245

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?