### PR TITLE
Revert "GF Signup: Remove the free upsell modal from onboaring flow and add a few conditional safeguards"

### DIFF
--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/hooks/use-modal-resolution-callback.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/hooks/use-modal-resolution-callback.tsx
@@ -11,7 +11,6 @@ type Props = {
 	isCustomDomainAllowedOnFreePlan: DataResponse< boolean >;
 	isPlanUpsellEnabledOnFreeDomain: DataResponse< boolean >;
 	flowName?: string | null;
-	paidDomainName?: string | null;
 };
 
 /**
@@ -21,7 +20,6 @@ export function useModalResolutionCallback( {
 	isCustomDomainAllowedOnFreePlan,
 	isPlanUpsellEnabledOnFreeDomain,
 	flowName,
-	paidDomainName,
 }: Props ) {
 	return useCallback(
 		( currentSelectedPlan?: string | null ): ModalType | null => {
@@ -34,17 +32,12 @@ export function useModalResolutionCallback( {
 					return FREE_PLAN_PAID_DOMAIN_DIALOG;
 				}
 
-				if ( paidDomainName && ( flowName === 'onboarding' || flowName === 'onboarding-pm' ) ) {
+				if ( flowName === 'onboarding' || flowName === 'onboarding-pm' ) {
 					return PAID_PLAN_IS_REQUIRED_DIALOG;
 				}
 			}
 			return null;
 		},
-		[
-			flowName,
-			isCustomDomainAllowedOnFreePlan.result,
-			isPlanUpsellEnabledOnFreeDomain.result,
-			paidDomainName,
-		]
+		[ flowName, isCustomDomainAllowedOnFreePlan.result, isPlanUpsellEnabledOnFreeDomain.result ]
 	);
 }

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/test/plan-upsell-modal.test.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/test/plan-upsell-modal.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import { PLAN_FREE, PLAN_PERSONAL } from '@automattic/calypso-products';
-import { screen, renderHook } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import useIsFreeDomainFreePlanUpsellEnabled from 'calypso/my-sites/plans-features-main/hooks/use-is-free-domain-free-plan-upsell-enabled';
 import useIsFreePlanCustomDomainUpsellEnabled from 'calypso/my-sites/plans-features-main/hooks/use-is-free-plan-custom-domain-upsell-enabled';
 import {
@@ -16,131 +16,115 @@ import { useModalResolutionCallback } from '../hooks/use-modal-resolution-callba
 function MockPlansFeaturesMain( {
 	flowName,
 	selectedPlan,
-	paidDomainName,
+	paidSubdomain,
 }: {
 	flowName: string;
 	selectedPlan: string;
-	paidDomainName?: string | null;
+	paidSubdomain: string;
 } ) {
 	const isCustomDomainAllowedOnFreePlan = useIsFreePlanCustomDomainUpsellEnabled(
 		flowName,
-		paidDomainName
+		paidSubdomain
 	);
 	const isPlanUpsellEnabledOnFreeDomain = useIsFreeDomainFreePlanUpsellEnabled(
 		flowName,
-		paidDomainName
+		paidSubdomain
 	);
 	const resolveModal = useModalResolutionCallback( {
 		isCustomDomainAllowedOnFreePlan,
 		isPlanUpsellEnabledOnFreeDomain,
 		flowName,
-		paidDomainName,
 	} );
 	return <div data-testid="modal-render">{ resolveModal( selectedPlan ) }</div>;
 }
 
 describe( 'PlanUpsellModal tests', () => {
-	describe( 'Mocked PlansFeaturesMain tests', () => {
-		test( 'A paid domain on the onboarding-pm flow should show the FREE_PLAN_PAID_DOMAIN_DIALOG', () => {
-			renderWithProvider(
-				<MockPlansFeaturesMain
-					flowName="onboarding-pm"
-					selectedPlan={ PLAN_FREE }
-					paidDomainName="yourgroovydomain.com"
-				/>
-			);
-			expect( screen.getByTestId( 'modal-render' ) ).toHaveTextContent(
-				FREE_PLAN_PAID_DOMAIN_DIALOG
-			);
-		} );
-
-		test( 'A free domain on the onboarding-pm flow should show the FREE_PLAN_FREE_DOMAIN_DIALOG', () => {
-			renderWithProvider(
-				<MockPlansFeaturesMain flowName="onboarding-pm" selectedPlan={ PLAN_FREE } />
-			);
-			expect( screen.getByTestId( 'modal-render' ) ).toHaveTextContent(
-				FREE_PLAN_FREE_DOMAIN_DIALOG
-			);
-		} );
-
-		test( 'A free domain on the onboarding flow should NOT show any Dialog', () => {
-			renderWithProvider(
-				<MockPlansFeaturesMain flowName="onboarding" selectedPlan={ PLAN_FREE } />
-			);
-			expect( screen.queryByText( /DIALOG/i ) ).toBeNull();
-		} );
-
-		test( 'A paid domain on the onboarding flow should show the PAID_PLAN_IS_REQUIRED_DIALOG', () => {
-			renderWithProvider(
-				<MockPlansFeaturesMain
-					flowName="onboarding"
-					selectedPlan={ PLAN_FREE }
-					paidDomainName="yourgroovydomain.com"
-				/>
-			);
-			expect( screen.getByTestId( 'modal-render' ) ).toHaveTextContent(
-				PAID_PLAN_IS_REQUIRED_DIALOG
-			);
-		} );
-
-		test( 'Paid plan selections should not show any modals', () => {
-			/**
-			 * Flow onboarding paid domain
-			 */
-			const { queryByText: queryByText1 } = renderWithProvider(
-				<MockPlansFeaturesMain
-					flowName="onboarding"
-					selectedPlan={ PLAN_PERSONAL }
-					paidDomainName="yourgroovydomain.com"
-				/>
-			);
-
-			expect( queryByText1( /DIALOG/i ) ).toBeNull();
-
-			/**
-			 * Flow onboarding-pm paid domain
-			 */
-			const { queryByText: queryByText2 } = renderWithProvider(
-				<MockPlansFeaturesMain
-					flowName="onboarding-pm"
-					selectedPlan={ PLAN_PERSONAL }
-					paidDomainName="yourgroovydomain.com"
-				/>
-			);
-
-			expect( queryByText2( /DIALOG/i ) ).toBeNull();
-
-			/**
-			 * Flow onboarding free domain
-			 */
-			const { queryByText: queryByText3 } = renderWithProvider(
-				<MockPlansFeaturesMain flowName="onboarding" selectedPlan={ PLAN_PERSONAL } />
-			);
-
-			expect( queryByText3( /DIALOG/i ) ).toBeNull();
-
-			/**
-			 * Flow onboarding-pm free domain
-			 */
-			const { queryByText: queryByText4 } = renderWithProvider(
-				<MockPlansFeaturesMain flowName="onboarding-pm" selectedPlan={ PLAN_PERSONAL } />
-			);
-
-			expect( queryByText4( /DIALOG/i ) ).toBeNull();
-		} );
+	test( 'A paid domain on the onboarding-pm flow should show the FREE_PLAN_PAID_DOMAIN_DIALOG', () => {
+		renderWithProvider(
+			<MockPlansFeaturesMain
+				flowName="onboarding-pm"
+				selectedPlan={ PLAN_FREE }
+				paidSubdomain="yourgroovydomain.com"
+			/>
+		);
+		expect( screen.getByTestId( 'modal-render' ) ).toHaveTextContent(
+			FREE_PLAN_PAID_DOMAIN_DIALOG
+		);
+	} );
+	test( 'A free domain on the onboarding-pm flow should show the FREE_PLAN_FREE_DOMAIN_DIALOG', () => {
+		renderWithProvider(
+			<MockPlansFeaturesMain flowName="onboarding-pm" selectedPlan={ PLAN_FREE } />
+		);
+		expect( screen.getByTestId( 'modal-render' ) ).toHaveTextContent(
+			FREE_PLAN_FREE_DOMAIN_DIALOG
+		);
 	} );
 
-	describe( 'useModalResolutionCallback hook related tests', () => {
-		test( 'Free plan and free domain selection should not show any modals on the onboarding flow when all other modals are hidden', () => {
-			const { result } = renderHook( () =>
-				useModalResolutionCallback( {
-					isCustomDomainAllowedOnFreePlan: { result: false, isLoading: false },
-					isPlanUpsellEnabledOnFreeDomain: { result: false, isLoading: false },
-					flowName: 'Onboarding',
-					paidDomainName: null,
-				} )
-			);
-			expect( result.current( PLAN_FREE ) ).toBeNull();
-		} );
+	test( 'A free domain on the onboarding flow should show the FREE_PLAN_FREE_DOMAIN_DIALOG', () => {
+		renderWithProvider(
+			<MockPlansFeaturesMain flowName="onboarding" selectedPlan={ PLAN_FREE } />
+		);
+		expect( screen.getByTestId( 'modal-render' ) ).toHaveTextContent(
+			FREE_PLAN_FREE_DOMAIN_DIALOG
+		);
+	} );
+
+	test( 'A paid domain on the onboarding flow should show the PAID_PLAN_IS_REQUIRED_DIALOG', () => {
+		renderWithProvider(
+			<MockPlansFeaturesMain
+				flowName="onboarding"
+				selectedPlan={ PLAN_FREE }
+				paidSubdomain="yourgroovydomain.com"
+			/>
+		);
+		expect( screen.getByTestId( 'modal-render' ) ).toHaveTextContent(
+			PAID_PLAN_IS_REQUIRED_DIALOG
+		);
+	} );
+
+	test( 'Paid plan selections should not show any modals', () => {
+		/**
+		 * Flow onboarding paid domain
+		 */
+		const { queryByText: queryByText1 } = renderWithProvider(
+			<MockPlansFeaturesMain
+				flowName="onboarding"
+				selectedPlan={ PLAN_PERSONAL }
+				paidSubdomain="yourgroovydomain.com"
+			/>
+		);
+
+		expect( queryByText1( /DIALOG/i ) ).toBeNull();
+
+		/**
+		 * Flow onboarding-pm paid domain
+		 */
+		const { queryByText: queryByText2 } = renderWithProvider(
+			<MockPlansFeaturesMain
+				flowName="onboarding-pm"
+				selectedPlan={ PLAN_PERSONAL }
+				paidSubdomain="yourgroovydomain.com"
+			/>
+		);
+
+		expect( queryByText2( /DIALOG/i ) ).toBeNull();
+
+		/**
+		 * Flow onboarding free domain
+		 */
+		const { queryByText: queryByText3 } = renderWithProvider(
+			<MockPlansFeaturesMain flowName="onboarding" selectedPlan={ PLAN_PERSONAL } />
+		);
+
+		expect( queryByText3( /DIALOG/i ) ).toBeNull();
+
+		/**
+		 * Flow onboarding-pm free domain
+		 */
+		const { queryByText: queryByText4 } = renderWithProvider(
+			<MockPlansFeaturesMain flowName="onboarding-pm" selectedPlan={ PLAN_PERSONAL } />
+		);
+
+		expect( queryByText4( /DIALOG/i ) ).toBeNull();
 	} );
 } );

--- a/client/my-sites/plans-features-main/hooks/use-is-free-domain-free-plan-upsell-enabled.ts
+++ b/client/my-sites/plans-features-main/hooks/use-is-free-domain-free-plan-upsell-enabled.ts
@@ -4,7 +4,7 @@ const useIsFreeDomainFreePlanUpsellEnabled = (
 	flowName?: string | null,
 	paidDomainName?: string | null
 ): DataResponse< boolean > => {
-	if ( ! paidDomainName && flowName === 'onboarding-pm' ) {
+	if ( ! paidDomainName && ( flowName === 'onboarding' || flowName === 'onboarding-pm' ) ) {
 		return {
 			isLoading: false,
 			result: true,

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -277,7 +277,6 @@ const PlansFeaturesMain = ( {
 		isCustomDomainAllowedOnFreePlan,
 		isPlanUpsellEnabledOnFreeDomain,
 		flowName,
-		paidDomainName,
 	} );
 
 	const toggleShowPlansComparisonGrid = () => {


### PR DESCRIPTION
Reverts Automattic/wp-calypso#83245
Broken pre release tests.