### PR TITLE
Free hosting trial: allow site launch

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -54,7 +54,6 @@ import { launchSite } from 'calypso/state/sites/launch/actions';
 import {
 	isSiteOnECommerceTrial as getIsSiteOnECommerceTrial,
 	isSiteOnMigrationTrial as getIsSiteOnMigrationTrial,
-	isTrialSite,
 } from 'calypso/state/sites/plans/selectors';
 import {
 	getSiteOption,
@@ -1078,7 +1077,8 @@ const connectComponent = connect( ( state ) => {
 		hasSitePreviewLink: siteHasFeature( state, siteId, WPCOM_FEATURES_SITE_PREVIEW_LINKS ),
 		isSiteOnECommerceTrial: getIsSiteOnECommerceTrial( state, siteId ),
 		isSiteOnMigrationTrial: getIsSiteOnMigrationTrial( state, siteId ),
-		isLaunchable: ! isTrialSite( state, siteId ),
+		isLaunchable:
+			! getIsSiteOnECommerceTrial( state, siteId ) && ! getIsSiteOnMigrationTrial( state, siteId ),
 	};
 }, mapDispatchToProps );
 

--- a/client/state/sites/launch/actions.js
+++ b/client/state/sites/launch/actions.js
@@ -4,6 +4,7 @@ import 'calypso/state/data-layer/wpcom/sites/launch';
 import isUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSiteSlug, isCurrentPlanPaid, getSiteOption } from 'calypso/state/sites/selectors';
+import { isSiteOnHostingTrial } from '../plans/selectors';
 
 export const launchSite = ( siteId ) => ( {
 	type: SITE_LAUNCH,
@@ -32,7 +33,7 @@ export const launchSiteOrRedirectToLaunchSignupFlow =
 			isCurrentPlanPaid( getState(), siteId ) &&
 			getDomainsBySiteId( getState(), siteId ).length > 1;
 
-		if ( isPaidWithDomain || isAnchorPodcast ) {
+		if ( isPaidWithDomain || isAnchorPodcast || isSiteOnHostingTrial( getState(), siteId ) ) {
 			dispatch( launchSite( siteId ) );
 			return;
 		}


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/4272.

## Proposed Changes

Let's allow a hosting trial site to be launched to the public.

The `/sites` action actually launches the `/start/launch-site` flow. I did not went that route because it upsells a domain for the user but they won't be able to use it (https://github.com/Automattic/dotcom-forge/issues/4215) unless they upgrade their site to Business, which they might not want to yet.

If they skip the domain purchase step, they are shown the plans grid, which again might not the best action right now since they might not be convinced of the upgrade.

I have no strong feelings about letting the user go through the flow, though. Let me know if that's the path we want to go.

Worth noting that the "Launch site" card in `/settings/general/%s` do not redirect to `/start/launch-site/%s` unless there is a domain associated with the site already.

This _might_ be a bug and the desirable outcome is to launch the launch site flow because [the code checks](https://github.com/Automattic/wp-calypso/blob/trunk/client/my-sites/site-settings/form-general.jsx#L654) whether a site has more than one domain, which will always be true because Atomic sites have `.wordpress.com` and `.wpcomstaging.com` domains associated with it 🤔  cc @niranjan-uma-shankar

## Testing Instructions

The first thing you need to do is to apply D126043-code to your sandbox.

### Launch by completing the "Launch site" checklist task

![image](https://github.com/Automattic/wp-calypso/assets/26530524/1ecd3840-fa48-4879-b626-f5d6475a018b)

Create a trial site in `/setup/new-hosted-site` and click the "Launch site" checklist task. Verify that the site is live by accessing it in incognito mode.

### Launch through Settings > General

![image](https://github.com/Automattic/wp-calypso/assets/26530524/473aac9d-4b67-4139-8bd4-11152496b705)

Create a trial site in `/setup/new-hosted-site` and go to `Settings > General`. Scroll down and check that the "Launch site" card has the CTA enabled. Click it and verify that the site is live by accessing it in incognito mode.

### Launch by clicking the "Launch site" /sites action

![image](https://github.com/Automattic/wp-calypso/assets/26530524/56ad0c26-77f9-4370-a80d-152aee800713)

Create a trial site in `/setup/new-hosted-site` and go to `/sites`. Find the newly created trial site and click the "Launch site" ellipsis menu action. Verify that the site is live by accessing it in incognito mode.