### PR TITLE
Earn: Support links open in modal

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -50,6 +50,10 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/domains/',
 		post_id: 1988,
 	},
+	donations: {
+		link: 'https://wordpress.com/support/wordpress-editor/blocks/donations/',
+		post_id: 171110,
+	},
 	earn: {
 		link: 'https://wordpress.com/support/monetize-your-site/',
 		post_id: 120172,
@@ -158,6 +162,10 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/paid-newsletters/',
 		post_id: 168381,
 	},
+	payment_button_block: {
+		link: 'https://wordpress.com/support/wordpress-editor/blocks/payments/#payment-button-block',
+		post_id: 169123,
+	},
 	payment_method_all_subscriptions: {
 		link: 'https://wordpress.com/support/payment/#using-a-payment-method-for-all-subscriptions',
 		post_id: 76237,
@@ -169,6 +177,10 @@ const contextLinks = {
 	payment_methods_manage: {
 		link: 'https://wordpress.com/support/payment/#manage-payment-methods',
 		post_id: 76237,
+	},
+	paypal: {
+		link: 'https://wordpress.com/support/wordpress-editor/blocks/pay-with-paypal/',
+		post_id: 168671,
 	},
 	performance: {
 		link: 'https://wordpress.com/support/settings/performance-settings/',
@@ -189,6 +201,10 @@ const contextLinks = {
 	posts: {
 		link: 'https://wordpress.com/support/posts/',
 		post_id: 84,
+	},
+	premium_content_block: {
+		link: 'https://wordpress.com/support/wordpress-editor/blocks/premium-content-block/',
+		post_id: 243475,
 	},
 	privacy: {
 		link: 'https://wordpress.com/support/settings/privacy-settings/',

--- a/client/my-sites/earn/components/earn-support-button.tsx
+++ b/client/my-sites/earn/components/earn-support-button.tsx
@@ -1,0 +1,13 @@
+import InlineSupportLink from 'calypso/components/inline-support-link';
+
+type EarnSupportButtonProps = {
+	supportContext: string;
+};
+
+const EarnSupportButton = ( { supportContext }: EarnSupportButtonProps ) => (
+	<div className="action-panel__cta">
+		<InlineSupportLink supportContext={ supportContext } showIcon={ false } className="button" />
+	</div>
+);
+
+export default EarnSupportButton;

--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -16,6 +16,7 @@ import ClipboardButtonInput from 'calypso/components/clipboard-button-input';
 import QueryMembershipsEarnings from 'calypso/components/data/query-memberships-earnings';
 import QueryMembershipsSettings from 'calypso/components/data/query-memberships-settings';
 import EmptyContent from 'calypso/components/empty-content';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import PromoSection, {
 	Props as PromoSectionProps,
 	PromoSectionCardProps,
@@ -152,6 +153,11 @@ const Home = () => {
 		const cta = hasSimplePayments
 			? {
 					text: translate( 'Learn more' ),
+					component: (
+						<div className="action-panel__cta">
+							<InlineSupportLink supportContext="paypal" showIcon={ false } className="button" />
+						</div>
+					),
 					action: () => {
 						trackCtaButton( 'simple-payments' );
 						window.location.href = localizeUrl(
@@ -197,14 +203,21 @@ const Home = () => {
 	const getRecurringPaymentsCard = (): PromoSectionCardProps => {
 		const cta = {
 			text: translate( 'Learn more' ),
+			...( hasConnectedAccount && {
+				component: (
+					<div className="action-panel__cta">
+						<InlineSupportLink
+							supportContext="payment_button_block"
+							showIcon={ false }
+							className="button"
+						/>
+					</div>
+				),
+			} ),
 			action: () => {
 				trackCtaButton( 'recurring-payments' );
-				const learnMoreLink = ! hasConnectedAccount
-					? 'https://wordpress.com/payments-donations/'
-					: 'https://wordpress.com/support/wordpress-editor/blocks/payments/#payment-button-block';
-
 				if ( window && window.location ) {
-					window.location.href = localizeUrl( learnMoreLink );
+					window.location.href = localizeUrl( 'https://wordpress.com/payments-donations/' );
 				}
 			},
 		};
@@ -238,14 +251,17 @@ const Home = () => {
 	const getDonationsCard = (): PromoSectionCardProps => {
 		const cta = {
 			text: translate( 'Learn more' ),
+			...( hasConnectedAccount && {
+				component: (
+					<div className="action-panel__cta">
+						<InlineSupportLink supportContext="donations" showIcon={ false } className="button" />
+					</div>
+				),
+			} ),
 			action: () => {
 				trackCtaButton( 'donations' );
-				const learnMoreLink = ! hasConnectedAccount
-					? 'https://wordpress.com/payments-donations/'
-					: 'https://wordpress.com/support/wordpress-editor/blocks/donations/';
-
 				if ( window && window.location ) {
-					window.location.href = localizeUrl( learnMoreLink );
+					window.location.href = localizeUrl( 'https://wordpress.com/payments-donations/' );
 				}
 			},
 		};
@@ -284,6 +300,15 @@ const Home = () => {
 		}
 		const cta = {
 			text: translate( 'Learn more' ),
+			component: (
+				<div className="action-panel__cta">
+					<InlineSupportLink
+						supportContext="premium_content_block"
+						showIcon={ false }
+						className="button"
+					/>
+				</div>
+			),
 			action: () => {
 				trackLearnLink( 'premium-content' );
 				if ( window && window.location ) {
@@ -321,6 +346,15 @@ const Home = () => {
 		}
 		const cta = {
 			text: translate( 'Learn more' ),
+			component: (
+				<div className="action-panel__cta">
+					<InlineSupportLink
+						supportContext="paid-newsletters"
+						showIcon={ false }
+						className="button"
+					/>
+				</div>
+			),
 			action: () => {
 				trackCtaButton( 'learn-paid-newsletters' );
 				if ( window && window.location ) {

--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -16,7 +16,6 @@ import ClipboardButtonInput from 'calypso/components/clipboard-button-input';
 import QueryMembershipsEarnings from 'calypso/components/data/query-memberships-earnings';
 import QueryMembershipsSettings from 'calypso/components/data/query-memberships-settings';
 import EmptyContent from 'calypso/components/empty-content';
-import InlineSupportLink from 'calypso/components/inline-support-link';
 import PromoSection, {
 	Props as PromoSectionProps,
 	PromoSectionCardProps,
@@ -35,6 +34,7 @@ import { getSitePlanSlug } from 'calypso/state/sites/plans/selectors';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { isRequestingWordAdsApprovalForSite } from 'calypso/state/wordads/approve/selectors';
+import EarnSupportButton from './components/earn-support-button';
 import StatsSection from './components/stats';
 import EarnLaunchpad from './launchpad';
 
@@ -153,11 +153,7 @@ const Home = () => {
 		const cta = hasSimplePayments
 			? {
 					text: translate( 'Learn more' ),
-					component: (
-						<div className="action-panel__cta">
-							<InlineSupportLink supportContext="paypal" showIcon={ false } className="button" />
-						</div>
-					),
+					component: <EarnSupportButton supportContext="paypal" />,
 					action: () => {
 						trackCtaButton( 'simple-payments' );
 						window.location.href = localizeUrl(
@@ -204,15 +200,7 @@ const Home = () => {
 		const cta = {
 			text: translate( 'Learn more' ),
 			...( hasConnectedAccount && {
-				component: (
-					<div className="action-panel__cta">
-						<InlineSupportLink
-							supportContext="payment_button_block"
-							showIcon={ false }
-							className="button"
-						/>
-					</div>
-				),
+				component: <EarnSupportButton supportContext="payment_button_block" />,
 			} ),
 			action: () => {
 				trackCtaButton( 'recurring-payments' );
@@ -252,11 +240,7 @@ const Home = () => {
 		const cta = {
 			text: translate( 'Learn more' ),
 			...( hasConnectedAccount && {
-				component: (
-					<div className="action-panel__cta">
-						<InlineSupportLink supportContext="donations" showIcon={ false } className="button" />
-					</div>
-				),
+				component: <EarnSupportButton supportContext="donations" />,
 			} ),
 			action: () => {
 				trackCtaButton( 'donations' );
@@ -300,15 +284,7 @@ const Home = () => {
 		}
 		const cta = {
 			text: translate( 'Learn more' ),
-			component: (
-				<div className="action-panel__cta">
-					<InlineSupportLink
-						supportContext="premium_content_block"
-						showIcon={ false }
-						className="button"
-					/>
-				</div>
-			),
+			component: <EarnSupportButton supportContext="premium_content_block" />,
 			action: () => {
 				trackLearnLink( 'premium-content' );
 				if ( window && window.location ) {
@@ -346,15 +322,7 @@ const Home = () => {
 		}
 		const cta = {
 			text: translate( 'Learn more' ),
-			component: (
-				<div className="action-panel__cta">
-					<InlineSupportLink
-						supportContext="paid-newsletters"
-						showIcon={ false }
-						className="button"
-					/>
-				</div>
-			),
+			component: <EarnSupportButton supportContext="paid-newsletters" />,
 			action: () => {
 				trackCtaButton( 'learn-paid-newsletters' );
 				if ( window && window.location ) {

--- a/client/my-sites/earn/style.scss
+++ b/client/my-sites/earn/style.scss
@@ -81,6 +81,9 @@ See https://dequeuniversity.com/rules/axe/4.6/link-in-text-block?application=Axe
 .earn .formatted-header__subtitle a {
 	text-decoration: underline;
 }
+.earn .promo-card a.button {
+	text-decoration: none;
+}
 
 .earn__notes {
 	clear: both;


### PR DESCRIPTION
## Proposed Changes

* Updates Earn promo card support links to open in modal rather than take user out of Earn to WordPress.com support site.

<img width="1162" alt="earn-support-modal" src="https://github.com/Automattic/wp-calypso/assets/21228350/de4440e8-b0b3-4581-8ab2-9789fadb6acc">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Go to http://calypso.localhost:3000/earn/YOURDOMAIN, click the 'Learn More' button on each promo card, and confirm it opens a side modal, and does not redirect to the support website. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?