### PR TITLE
Headers: Replace /plugins /woocommerce header component with NavigationHeader

### DIFF
--- a/client/components/breadcrumb/index.tsx
+++ b/client/components/breadcrumb/index.tsx
@@ -57,7 +57,7 @@ const StyledItem = styled.div`
 `;
 
 const StyledGridicon = styled( Gridicon )`
-	margin: 0 12px;
+	margin: 0 16px;
 	color: var( --color-neutral-10 );
 `;
 

--- a/client/components/navigation-header/index.tsx
+++ b/client/components/navigation-header/index.tsx
@@ -45,7 +45,7 @@ const NavigationHeader = React.forwardRef< HTMLElement, Props >( ( props, ref ) 
 		id,
 		className,
 		children,
-		navigationItems,
+		navigationItems = [],
 		mobileItem,
 		compactBreadcrumb,
 		title,
@@ -62,12 +62,14 @@ const NavigationHeader = React.forwardRef< HTMLElement, Props >( ( props, ref ) 
 						compact={ compactBreadcrumb }
 						hideWhenOnlyOneLevel
 					/>
-					<FormattedHeader
-						align="left"
-						headerText={ title }
-						subHeaderText={ subtitle }
-						screenReader={ screenReader }
-					/>
+					{ navigationItems.length < 2 && (
+						<FormattedHeader
+							align="left"
+							headerText={ title }
+							subHeaderText={ subtitle }
+							screenReader={ screenReader }
+						/>
+					) }
 					<ActionsContainer>{ children }</ActionsContainer>
 				</div>
 			</Container>

--- a/client/components/navigation-header/index.tsx
+++ b/client/components/navigation-header/index.tsx
@@ -55,13 +55,13 @@ const NavigationHeader = React.forwardRef< HTMLElement, Props >( ( props, ref ) 
 	return (
 		<header id={ id } className={ 'navigation-header ' + className } ref={ ref }>
 			<Container>
-				<Breadcrumb
-					items={ navigationItems }
-					mobileItem={ mobileItem }
-					compact={ compactBreadcrumb }
-					hideWhenOnlyOneLevel
-				/>
 				<div className="navigation-header__main">
+					<Breadcrumb
+						items={ navigationItems }
+						mobileItem={ mobileItem }
+						compact={ compactBreadcrumb }
+						hideWhenOnlyOneLevel
+					/>
 					<FormattedHeader
 						align="left"
 						headerText={ title }

--- a/client/components/navigation-header/style.scss
+++ b/client/components/navigation-header/style.scss
@@ -13,12 +13,20 @@
 		margin-bottom: 24px;
 	}
 
-	.breadcrumbs-back {
-		margin-top: 24px;
-	}
-
 	.breadcrumbs {
-		margin-top: 24px;
+		li {
+			color: var(--studio-gray-60, #50575e);
+			font-family: "SF Pro Text", $sans;
+			font-size: $font-body-small;
+			font-style: normal;
+			font-weight: 400;
+			line-height: 20px;
+			letter-spacing: -0.15px;
+			&:last-of-type:not(:first-of-type) {
+				color: var(--studio-gray-100, #101517);
+				font-weight: 400;
+			}
+		}
 	}
 }
 
@@ -48,6 +56,7 @@
 
 	.button {
 		line-height: 20px;
+		display: flex;
 	}
 }
 

--- a/client/components/navigation-header/style.scss
+++ b/client/components/navigation-header/style.scss
@@ -35,6 +35,7 @@
 	justify-content: space-between;
 	align-items: center;
 	box-sizing: border-box;
+	min-height: 50px;
 
 	> .formatted-header {
 		flex: 1;

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -18,7 +18,7 @@ import QueryJetpackSitesFeatures from 'calypso/components/data/query-jetpack-sit
 import QueryPlugins from 'calypso/components/data/query-plugins';
 import QuerySiteFeatures from 'calypso/components/data/query-site-features';
 import EmptyContent from 'calypso/components/empty-content';
-import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
+import NavigationHeader from 'calypso/components/navigation-header';
 import Search from 'calypso/components/search';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
@@ -139,9 +139,6 @@ export class PluginsMain extends Component {
 			{
 				label: this.props.translate( 'Plugins' ),
 				href: `/plugins/${ selectedSiteSlug || '' }`,
-				helpBubble: this.props.translate(
-					'Add new functionality and integrations to your site with plugins.'
-				),
 			},
 			{
 				label: this.props.translate( 'Installed Plugins' ),
@@ -484,11 +481,27 @@ export class PluginsMain extends Component {
 				) }
 				{ this.renderPageViewTracking() }
 				{ ! isJetpackCloud && (
-					<FixedNavigationHeader
-						className="plugin__header"
-						compactBreadcrumb={ false }
-						navigationItems={ this.props.breadcrumbs }
-					/>
+					<NavigationHeader
+						navigationItems={ [] }
+						title={ pageTitle }
+						subtitle={
+							this.props.selectedSite
+								? this.props.translate( 'Manage all plugins installed on %(selectedSite)s', {
+										args: {
+											selectedSite: this.props.selectedSite.domain,
+										},
+								  } )
+								: this.props.translate( 'Manage plugins installed on all sites' )
+						}
+					>
+						{ ! isJetpackCloud && (
+							<>
+								{ this.renderAddPluginButton() }
+								{ this.renderUploadPluginButton() }
+								<UpdatePlugins isWpCom plugins={ currentPlugins } />
+							</>
+						) }
+					</NavigationHeader>
 				) }
 				<div
 					className={ classNames( 'plugins__top-container', {
@@ -496,28 +509,6 @@ export class PluginsMain extends Component {
 					} ) }
 				>
 					<div className="plugins__content-wrapper">
-						<div className="plugins__page-title-container">
-							<div className="plugins__header-left-content">
-								<h2 className="plugins__page-title">{ pageTitle }</h2>
-								<div className="plugins__page-subtitle">
-									{ this.props.selectedSite
-										? this.props.translate( 'Manage all plugins installed on %(selectedSite)s', {
-												args: {
-													selectedSite: this.props.selectedSite.domain,
-												},
-										  } )
-										: this.props.translate( 'Manage plugins installed on all sites' ) }
-								</div>
-							</div>
-							{ ! isJetpackCloud && (
-								<div className="plugins__header-right-content">
-									{ this.renderAddPluginButton() }
-									{ this.renderUploadPluginButton() }
-									<UpdatePlugins isWpCom plugins={ currentPlugins } />
-								</div>
-							) }
-						</div>
-
 						<div className="plugins__main plugins__main-updated">
 							<div className="plugins__main-header">
 								<SectionNav

--- a/client/my-sites/plugins/plans/index.tsx
+++ b/client/my-sites/plugins/plans/index.tsx
@@ -4,10 +4,10 @@ import { useEffect } from 'react';
 import ActionCard from 'calypso/components/action-card';
 import ActionPanelLink from 'calypso/components/action-panel/link';
 import DocumentHead from 'calypso/components/data/document-head';
-import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 import FormattedHeader from 'calypso/components/formatted-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import MainComponent from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import PromoSection, { Props as PromoSectionProps } from 'calypso/components/promo-section';
 import { Gridicon } from 'calypso/devdocs/design/playground-scope';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -33,14 +33,6 @@ const Plans = ( { intervalType }: { intervalType: 'yearly' | 'monthly' } ) => {
 					label: translate( 'Plugins' ),
 					href: `/plugins/${ selectedSite?.slug || '' }`,
 					id: 'plugins',
-					helpBubble: translate(
-						'Add new functionality and integrations to your site with plugins. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-						{
-							components: {
-								learnMoreLink: <InlineSupportLink supportContext="plugins" showIcon={ false } />,
-							},
-						}
-					),
 				} )
 			);
 		}
@@ -84,7 +76,25 @@ const Plans = ( { intervalType }: { intervalType: 'yearly' | 'monthly' } ) => {
 		<MainComponent className="plugin-plans-main" wideLayout>
 			<PageViewTracker path="/plugins/plans/:interval/:site" title="Plugins > Plan Upgrade" />
 			<DocumentHead title={ translate( 'Plugins > Plan Upgrade' ) } />
-			<FixedNavigationHeader navigationItems={ breadcrumbs } />
+			<NavigationHeader
+				navigationItems={ breadcrumbs }
+				title={ breadcrumbs.length < 2 ? translate( 'Plugins' ) : '' }
+				subtitle={
+					breadcrumbs.length < 2
+						? translate(
+								'Add new functionality and integrations to your site with plugins. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+								{
+									components: {
+										learnMoreLink: (
+											<InlineSupportLink supportContext="plugins" showIcon={ false } />
+										),
+									},
+								}
+						  )
+						: ''
+				}
+			/>
+
 			<FormattedHeader
 				className="plugin-plans-header"
 				headerText={ `Your current plan doesn't support plugins` }

--- a/client/my-sites/plugins/plans/index.tsx
+++ b/client/my-sites/plugins/plans/index.tsx
@@ -78,21 +78,15 @@ const Plans = ( { intervalType }: { intervalType: 'yearly' | 'monthly' } ) => {
 			<DocumentHead title={ translate( 'Plugins > Plan Upgrade' ) } />
 			<NavigationHeader
 				navigationItems={ breadcrumbs }
-				title={ breadcrumbs.length < 2 ? translate( 'Plugins' ) : '' }
-				subtitle={
-					breadcrumbs.length < 2
-						? translate(
-								'Add new functionality and integrations to your site with plugins. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-								{
-									components: {
-										learnMoreLink: (
-											<InlineSupportLink supportContext="plugins" showIcon={ false } />
-										),
-									},
-								}
-						  )
-						: ''
-				}
+				title={ translate( 'Plugins' ) }
+				subtitle={ translate(
+					'Add new functionality and integrations to your site with plugins. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+					{
+						components: {
+							learnMoreLink: <InlineSupportLink supportContext="plugins" showIcon={ false } />,
+						},
+					}
+				) }
 			/>
 
 			<FormattedHeader

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -12,9 +12,8 @@ import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySiteFeatures from 'calypso/components/data/query-site-features';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import EmptyContent from 'calypso/components/empty-content';
-import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
-import InlineSupportLink from 'calypso/components/inline-support-link';
 import MainComponent from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import { useESPlugin } from 'calypso/data/marketplace/use-es-query';
@@ -230,14 +229,6 @@ function PluginDetails( props ) {
 					label: translate( 'Plugins' ),
 					href: localizePath( `/plugins/${ selectedSite?.slug || '' }` ),
 					id: 'plugins',
-					helpBubble: translate(
-						'Add new functionality and integrations to your site with plugins. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-						{
-							components: {
-								learnMoreLink: <InlineSupportLink supportContext="plugins" showIcon={ false } />,
-							},
-						}
-					),
 				} )
 			);
 		}
@@ -339,7 +330,7 @@ function PluginDetails( props ) {
 	} );
 
 	return (
-		<MainComponent wideLayout>
+		<MainComponent className="is-plugin-details" wideLayout isLoggedOut={ ! isLoggedIn }>
 			<DocumentHead title={ getPageTitle() } />
 			<PageViewTracker
 				path={ analyticsPath }
@@ -351,7 +342,7 @@ function PluginDetails( props ) {
 			<QuerySiteFeatures siteIds={ selectedOrAllSites.map( ( site ) => site.ID ) } />
 			<QueryProductsList persist={ ! wporgPluginNotFound } />
 			<QuerySitePurchases siteId={ selectedSite?.ID } />
-			<FixedNavigationHeader compactBreadcrumb={ ! isWide } navigationItems={ breadcrumbs } />
+			<NavigationHeader compactBreadcrumb={ ! isWide } navigationItems={ breadcrumbs } />
 			<PluginNotices
 				pluginId={ fullPlugin.id }
 				sites={ sitesWithPlugins }

--- a/client/my-sites/plugins/plugin-upload/index.jsx
+++ b/client/my-sites/plugins/plugin-upload/index.jsx
@@ -10,6 +10,7 @@ import QueryEligibility from 'calypso/components/data/query-atat-eligibility';
 import EmptyContent from 'calypso/components/empty-content';
 import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { initiateAutomatedTransferWithPluginZip } from 'calypso/state/automated-transfer/actions';
 import {
@@ -100,6 +101,7 @@ class PluginUpload extends Component {
 			<Main>
 				<PageViewTracker path="/plugins/upload/:site" title="Plugins > Upload" />
 				<QueryEligibility siteId={ siteId } />
+				<NavigationHeader navigationItems={ [] } title={ translate( 'Plugins' ) } />
 				<HeaderCake onClick={ this.back }>{ translate( 'Install plugin' ) }</HeaderCake>
 				{ isJetpackMultisite && this.renderNotAvailableForMultisite() }
 				{ showEligibility && (

--- a/client/my-sites/plugins/plugins-navigation-header/index.jsx
+++ b/client/my-sites/plugins/plugins-navigation-header/index.jsx
@@ -169,19 +169,15 @@ const PluginsNavigationHeader = ( { navigationHeaderRef, categoryName, category,
 			navigationItems={ breadcrumbs }
 			compactBreadcrumb={ isMobile }
 			ref={ navigationHeaderRef }
-			title={ breadcrumbs.length < 2 ? translate( 'Plugins' ) : '' }
-			subtitle={
-				breadcrumbs.length < 2
-					? translate(
-							'Add new functionality and integrations to your site with plugins. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-							{
-								components: {
-									learnMoreLink: <InlineSupportLink supportContext="plugins" showIcon={ false } />,
-								},
-							}
-					  )
-					: ''
-			}
+			title={ translate( 'Plugins' ) }
+			subtitle={ translate(
+				'Add new functionality and integrations to your site with plugins. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+				{
+					components: {
+						learnMoreLink: <InlineSupportLink supportContext="plugins" showIcon={ false } />,
+					},
+				}
+			) }
 		>
 			<ManageButton
 				shouldShowManageButton={ shouldShowManageButton }

--- a/client/my-sites/plugins/plugins-navigation-header/index.jsx
+++ b/client/my-sites/plugins/plugins-navigation-header/index.jsx
@@ -8,8 +8,8 @@ import { Icon, upload } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
+import NavigationHeader from 'calypso/components/navigation-header';
 import { useLocalizedPlugins, useServerEffect } from 'calypso/my-sites/plugins/utils';
 import { recordTracksEvent, recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { appendBreadcrumb, resetBreadcrumbs } from 'calypso/state/breadcrumb/actions';
@@ -113,14 +113,6 @@ const PluginsNavigationHeader = ( { navigationHeaderRef, categoryName, category,
 			label: translate( 'Plugins' ),
 			href: localizePath( `/plugins/${ selectedSite?.slug || '' }` ),
 			id: 'plugins',
-			helpBubble: translate(
-				'Add new functionality and integrations to your site with plugins. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-				{
-					components: {
-						learnMoreLink: <InlineSupportLink supportContext="plugins" showIcon={ false } />,
-					},
-				}
-			),
 		};
 
 		if ( breadcrumbs?.length === 0 || ( ! category && ! search ) ) {
@@ -173,27 +165,38 @@ const PluginsNavigationHeader = ( { navigationHeaderRef, categoryName, category,
 	}, [ selectedSite?.slug, search, category, categoryName, dispatch, localizePath ] );
 
 	return (
-		<FixedNavigationHeader
+		<NavigationHeader
 			navigationItems={ breadcrumbs }
 			compactBreadcrumb={ isMobile }
 			ref={ navigationHeaderRef }
+			title={ breadcrumbs.length < 2 ? translate( 'Plugins' ) : '' }
+			subtitle={
+				breadcrumbs.length < 2
+					? translate(
+							'Add new functionality and integrations to your site with plugins. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+							{
+								components: {
+									learnMoreLink: <InlineSupportLink supportContext="plugins" showIcon={ false } />,
+								},
+							}
+					  )
+					: ''
+			}
 		>
-			<div className="plugins-browser__main-buttons">
-				<ManageButton
-					shouldShowManageButton={ shouldShowManageButton }
-					siteAdminUrl={ siteAdminUrl }
-					siteSlug={ selectedSite?.slug }
-					jetpackNonAtomic={ jetpackNonAtomic }
-					hasManagePlugins={ hasManagePlugins }
-				/>
+			<ManageButton
+				shouldShowManageButton={ shouldShowManageButton }
+				siteAdminUrl={ siteAdminUrl }
+				siteSlug={ selectedSite?.slug }
+				jetpackNonAtomic={ jetpackNonAtomic }
+				hasManagePlugins={ hasManagePlugins }
+			/>
 
-				<UploadPluginButton
-					isMobile={ isMobile }
-					siteSlug={ selectedSite?.slug }
-					hasUploadPlugins={ !! selectedSite }
-				/>
-			</div>
-		</FixedNavigationHeader>
+			<UploadPluginButton
+				isMobile={ isMobile }
+				siteSlug={ selectedSite?.slug }
+				hasUploadPlugins={ !! selectedSite }
+			/>
+		</NavigationHeader>
 	);
 };
 

--- a/client/my-sites/plugins/search-box-header/style.scss
+++ b/client/my-sites/plugins/search-box-header/style.scss
@@ -87,7 +87,6 @@
 		font-weight: 400;
 		line-height: 40px;
 		color: var(--studio-blue-90);
-		padding-top: 40px;
 	}
 	.search-box-header__sticky-ref {
 		padding-bottom: 48px;

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -436,22 +436,19 @@ body.is-section-plugins #primary {
 	}
 }
 .plugins__top-container {
-	margin: 0 -32px;
-	padding: 8px 48px 0;
 	@include breakpoint-deprecated( ">660px" ) {
-		padding: 16px 48px 0;
 		border-bottom: 1px solid var(--color-primary-5);
 	}
 	@include break-large() {
-		padding: 6px 48px 0;
+		padding: 6px 32px 0;
 	}
 }
 
 .plugins__top-container-wp {
-	padding-top: 4rem;
+	padding: 0 16px;
 	border-bottom: none;
-	@include break-large {
-		padding-top: 3rem;
+	@media (min-width: $break-small) {
+		padding: 0;
 	}
 }
 
@@ -465,11 +462,11 @@ body.is-section-plugins #primary {
 .plugins__main-content {
 	// We need these negative margin values because we want to make the container full-width,
 	// but our element is inside a limited-width parent.
-	margin: 0 -32px;
-	padding: 0 48px;
+	margin: 0;
+	padding: 0 16px;
 	flex: 1 1 100%;
-	@include breakpoint-deprecated( ">660px" ) {
-		padding: 16px 48px;
+	@media (min-width: $break-small) {
+		padding: 16px 0;
 		background: rgba(255, 255, 255, 0.5);
 		margin-bottom: -32px;
 	}

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -4,14 +4,25 @@
 @import "./woocommerce-box.scss";
 
 .is-section-plugins .main {
-	padding-top: 24px; // Compensate for the fixed header.
 
-	@media ( max-width: 782px ) {
-		padding-top: 45px;
+	&.is-logged-out:not(.is-plugin-details) {
+		.navigation-header {
+			visibility: hidden;
+			position: absolute;
+			top: 0;
+		}
+	}
+	&.is-logged-out.is-plugin-details {
+		.navigation-header {
+			margin-top: -47px;
+		}
 	}
 
-	@media ( max-width: 660px ) {
-		padding-top: 60px;
+	.navigation-header {
+		@media (max-width: $break-small) {
+			padding-bottom: 16px;
+			margin-bottom: 0;
+		}
 	}
 
 	.upsell-nudge {

--- a/client/my-sites/woocommerce/landing-page.tsx
+++ b/client/my-sites/woocommerce/landing-page.tsx
@@ -189,7 +189,7 @@ const LandingPage: React.FunctionComponent< Props > = ( { siteId } ) => {
 
 	return (
 		<div className="landing-page">
-			<NavigationHeader navigationItems={ [] } title="WooCommerce" ref={ headerRef }>
+			<NavigationHeader navigationItems={ [] } title={ __( 'WooCommerce' ) } ref={ headerRef }>
 				{ isAboveElement && (
 					<Button onClick={ finalCTAHandler } primary disabled={ isTransferringBlocked }>
 						{ displayData.action }

--- a/client/my-sites/woocommerce/landing-page.tsx
+++ b/client/my-sites/woocommerce/landing-page.tsx
@@ -6,9 +6,9 @@ import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs } from '@wordpress/url';
 import page from 'page';
 import EmptyContent from 'calypso/components/empty-content';
-import FixedNavigationHeader from 'calypso/components/fixed-navigation-header';
 import FormattedHeader from 'calypso/components/formatted-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
+import NavigationHeader from 'calypso/components/navigation-header';
 import PromoSection, { Props as PromoSectionProps } from 'calypso/components/promo-section';
 import WarningCard from 'calypso/components/warning-card';
 import { useSendEmailVerification } from 'calypso/landing/stepper/hooks/use-send-email-verification';
@@ -39,7 +39,6 @@ interface DisplayData {
 
 const LandingPage: React.FunctionComponent< Props > = ( { siteId } ) => {
 	const { __ } = useI18n();
-	const navigationItems = [ { label: 'WooCommerce' } ];
 	const currentIntent = useSelector( ( state ) => getSiteOption( state, siteId, 'site_intent' ) );
 
 	const dispatch = useDispatch();
@@ -190,13 +189,13 @@ const LandingPage: React.FunctionComponent< Props > = ( { siteId } ) => {
 
 	return (
 		<div className="landing-page">
-			<FixedNavigationHeader navigationItems={ navigationItems } ref={ headerRef }>
+			<NavigationHeader navigationItems={ [] } title="WooCommerce" ref={ headerRef }>
 				{ isAboveElement && (
 					<Button onClick={ finalCTAHandler } primary disabled={ isTransferringBlocked }>
 						{ displayData.action }
 					</Button>
 				) }
-			</FixedNavigationHeader>
+			</NavigationHeader>
 			{ renderWarningNotice() }
 			<EmptyContent
 				title={ displayData.title }

--- a/client/my-sites/woocommerce/style.scss
+++ b/client/my-sites/woocommerce/style.scss
@@ -11,15 +11,16 @@ body.is-section-woocommerce-installation.theme-default.color-scheme {
 
 .woocommerce {
 	.main {
-		padding-top: 72px;
-
-		@include breakpoint-deprecated( ">660px" ) {
-			padding-top: 35px;
-		}
-
 		@media ( max-width: 660px ) {
 			padding-left: 15px;
 			padding-right: 15px;
+		}
+	}
+
+	.navigation-header {
+		@media (max-width: $break-small) {
+			padding-bottom: 16px;
+			margin-bottom: 0;
 		}
 	}
 

--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -18,7 +18,7 @@ const selectors = {
 	browseFirstCategory: 'button:has-text("Search Engine Optimization")',
 	categoryButton: ( section: string ) =>
 		`button:has-text("${ section }"),a:has-text("${ section }")`,
-	breadcrumb: ( section: string ) => `.fixed-navigation-header__header a:text("${ section }") `,
+	breadcrumb: ( section: string ) => `.navigation-header__main a:text("${ section }") `,
 	pricingToggle: ':text("Monthly Price"), :text("Annual Price")',
 	monthlyPricingSelect: 'a[data-bold-text^="Monthly price"]',
 	annualPricingSelect: 'a[data-bold-text^="Annual price"]',


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/4220

## Proposed Changes

Replaces header with NavigationHeader.
We also updated NavigationHeader breadcrumbs to match Figma: eqlepL7MHifK8Bgr1OWqLr-fi-9617%3A45816

## To-do
- [ ] Update e2e tests

## Testing Instructions

### Test the new header on this pages:
#### Logged-in
- http://calypso.localhost:3000/woocommerce-installation/test1233213.blog
- http://calypso.localhost:3000/plugins/browse/seo/test123.blog
- http://calypso.localhost:3000/plugins/test123.blog
- http://calypso.localhost:3000/plugins/wordpress-seo-premium/test123.blog
- http://calypso.localhost:3000/plugins/plans/wordpress-seo-premium/annually/test123.blog
- http://calypso.localhost:3000/plugins/plans/sensei-pro/monthly/test123.blog
- http://calypso.localhost:3000/plugins/upload/test123.blog

#### Logged-out
- http://calypso.localhost:3000/plugins/browse/seo
- http://calypso.localhost:3000/plugins
- http://calypso.localhost:3000/plugins/wordpress-seo-premium

#### Also check other pages if nothing is broken