### PR TITLE
Site-specific domains page: add custom domain upsell

### DIFF
--- a/client/my-sites/domains/domain-management/list/options-domain-button.jsx
+++ b/client/my-sites/domains/domain-management/list/options-domain-button.jsx
@@ -130,12 +130,16 @@ class AddDomainButton extends Component {
 	}
 
 	render() {
-		const { specificSiteActions, ellipsisButton, borderless } = this.props;
+		const { specificSiteActions, ellipsisButton, disabled, borderless } = this.props;
 		const classes = classNames( 'options-domain-button', ellipsisButton && 'ellipsis' );
 
 		if ( ellipsisButton ) {
 			return (
-				<EllipsisMenu popoverClassName="options-domain-button__popover" position="bottom">
+				<EllipsisMenu
+					disabled={ disabled }
+					popoverClassName="options-domain-button__popover"
+					position="bottom"
+				>
 					{ this.renderOptions() }
 				</EllipsisMenu>
 			);
@@ -149,6 +153,7 @@ class AddDomainButton extends Component {
 					onClick={ this.toggleAddMenu }
 					ref={ this.addDomainButtonRef }
 					borderless={ borderless }
+					disabled={ disabled }
 				>
 					{ this.renderLabel() }
 				</Button>


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/4215.

## Proposed Changes

Let's not let a user manage domains if they are on a plan that do not allow custom domains (free, trials.)

![image](https://github.com/Automattic/wp-calypso/assets/26530524/d99bd04c-a619-40bb-b09c-f03b6f2b2ea0)

## Testing Instructions

Apply D126065-code to your sandbox and proxy yourself to it.

Open the `/domains/manage/%s` page on a site that is on the free plan, or a free trial plan, and verify that the CTA is disabled and the upsell banner points to `/plans/%s`.