### PR TITLE
Stats: Show localized date format to the Date Picker

### DIFF
--- a/client/my-sites/stats/stats-date-control/stats-date-control-picker-date.tsx
+++ b/client/my-sites/stats/stats-date-control/stats-date-control-picker-date.tsx
@@ -3,6 +3,11 @@ import { useTranslate } from 'i18n-calypso';
 import DateInput from './stats-date-control-date-input';
 import { DateControlPickerDateProps } from './types';
 
+const getLocaleDateFormat = () => {
+	const date = new Date( 2001, 11, 25 ).toLocaleDateString().substring( 0, 10 );
+	return date.replace( '2001', 'yyyy' ).replace( '12', 'mm' ).replace( '25', 'dd' );
+};
+
 const DateControlPickerDate = ( {
 	startDate = '',
 	endDate = '',
@@ -17,7 +22,7 @@ const DateControlPickerDate = ( {
 		<div className="date-control-picker-date">
 			<h2 className="date-control-picker-date__heading">
 				{ translate( 'Date Range' ) }
-				<span> (dd/mm/yyyy)</span>
+				<span> ({ getLocaleDateFormat() }) </span>
 			</h2>
 			<div className="stats-date-control-picker-dates__inputs">
 				<div className="stats-date-control-picker-dates__inputs-input-group">


### PR DESCRIPTION
Related to #83148

## Proposed Changes

A 'hacky' solution to show date format that matches user's locale.

## Testing Instructions

* Open Calypso Live Branch `/stats/day/:siteSlug?flags=stats%2Fdate-control`
* Open date dropdown
* Ensure the date format matches the date input

<img width="617" alt="Screenshot 2023-10-20 at 11 34 29 AM" src="https://github.com/Automattic/wp-calypso/assets/1425433/5cbc69f6-deae-451c-b29a-78d05a11634d">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?