### PR TITLE
Stats: release date picker to the Traffic page

### DIFF
--- a/client/my-sites/stats/stats-interval-dropdown/index.jsx
+++ b/client/my-sites/stats/stats-interval-dropdown/index.jsx
@@ -16,13 +16,15 @@ const StatsIntervalDropdownListing = ( { selected, onSelection, intervals } ) =>
 
 	return (
 		<div className="stats-interval-dropdown-listing">
-			<ul className="stats-interval-dropdown-listing__list">
+			<ul className="stats-interval-dropdown-listing__list" role="radiogroup">
 				{ Object.keys( intervals ).map( ( intervalKey ) => {
 					const intervalLabel = intervals[ intervalKey ];
 
 					return (
 						<li className="stats-interval-dropdown-listing__interval" key={ intervalKey }>
 							<Button
+								role="radio"
+								aria-checked={ isSelectedItem( intervalKey ) }
 								onClick={ () => {
 									clickHandler( intervalKey );
 								} }

--- a/client/my-sites/stats/stats-interval-dropdown/index.jsx
+++ b/client/my-sites/stats/stats-interval-dropdown/index.jsx
@@ -21,7 +21,11 @@ const StatsIntervalDropdownListing = ( { selected, onSelection, intervals } ) =>
 					const intervalLabel = intervals[ intervalKey ];
 
 					return (
-						<li className="stats-interval-dropdown-listing__interval" key={ intervalKey }>
+						<li
+							className="stats-interval-dropdown-listing__interval"
+							key={ intervalKey }
+							role="none"
+						>
 							<Button
 								role="radio"
 								aria-checked={ isSelectedItem( intervalKey ) }

--- a/config/development.json
+++ b/config/development.json
@@ -182,7 +182,7 @@
 		"site-indicator": true,
 		"site-profiler": true,
 		"ssr/prefetch-timebox": false,
-		"stats/date-control": false,
+		"stats/date-control": true,
 		"stats/new-video-summary": true,
 		"stats/subscribers-chart-section": false,
 		"stats/paid-wpcom-stats": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -123,7 +123,7 @@
 		"stats/new-video-summary": false,
 		"stats/subscribers-chart-section": false,
 		"stats/paid-wpcom-stats": true,
-		"stats/date-control": false,
+		"stats/date-control": true,
 		"stats/type-detection": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,

--- a/config/production.json
+++ b/config/production.json
@@ -151,7 +151,7 @@
 		"stats/new-video-summary": false,
 		"stats/subscribers-chart-section": false,
 		"stats/paid-wpcom-stats": true,
-		"stats/date-control": false,
+		"stats/date-control": true,
 		"stats/type-detection": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -147,7 +147,7 @@
 		"stats/subscribers-chart-section": false,
 		"stats/paid-wpcom-stats": true,
 		"stats/type-detection": true,
-		"stats/date-control": false,
+		"stats/date-control": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"subscriber-csv-upload": true,

--- a/config/test.json
+++ b/config/test.json
@@ -105,7 +105,7 @@
 		"stats/new-video-summary": false,
 		"stats/subscribers-chart-section": false,
 		"stats/paid-wpcom-stats": true,
-		"stats/date-control": false,
+		"stats/date-control": true,
 		"stats/type-detection": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -156,7 +156,7 @@
 		"stats/new-video-summary": false,
 		"stats/subscribers-chart-section": false,
 		"stats/paid-wpcom-stats": true,
-		"stats/date-control": false,
+		"stats/date-control": true,
 		"stats/type-detection": true,
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,

--- a/packages/calypso-e2e/src/lib/pages/stats-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/stats-page.ts
@@ -96,11 +96,6 @@ export class StatsPage {
 	 * @param {StatsPeriod} period Stats period to show.
 	 */
 	async selectStatsPeriod( period: StatsPeriod ) {
-		const expandDropdownButton = this.anchor.locator(
-			'.stats-interval-dropdown .components-button'
-		);
-		await expandDropdownButton.click();
-
 		const target = this.anchor.getByRole( 'radiogroup' ).getByRole( 'radio', { name: period } );
 		await target.click();
 

--- a/packages/calypso-e2e/src/lib/pages/stats-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/stats-page.ts
@@ -96,7 +96,11 @@ export class StatsPage {
 	 * @param {StatsPeriod} period Stats period to show.
 	 */
 	async selectStatsPeriod( period: StatsPeriod ) {
+		const expandDropdownButton = this.anchor.locator( '.stats-interval-dropdown' );
+		await expandDropdownButton.click();
+
 		const target = this.anchor.getByRole( 'radiogroup' ).getByRole( 'radio', { name: period } );
+		await target.waitFor();
 		await target.click();
 
 		if ( ! ( await target.isChecked() ) ) {

--- a/packages/calypso-e2e/src/lib/pages/stats-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/stats-page.ts
@@ -110,6 +110,29 @@ export class StatsPage {
 	}
 
 	/**
+	 * For new Interval Dropdown
+	 * Selects the period to show for the stats, including the graph.
+	 *
+	 * @param {StatsPeriod} period Stats period to show.
+	 */
+	async selectStatsPeriodFromDropdown( period: StatsPeriod ) {
+		const expandDropdownButton = this.anchor
+			.locator( '.stats-interval-dropdown' )
+			.getByRole( 'button' )
+			.first();
+		await expandDropdownButton.click();
+
+		const target = this.page
+			.locator( '.components-popover' )
+			.getByRole( 'radio', { name: period } );
+		await target.click();
+
+		if ( ! ( await target.isChecked() ) ) {
+			throw new Error( `Failed to select the Stats Period ${ period }` );
+		}
+	}
+
+	/**
 	 * Changes the stats view to specific activities.
 	 *
 	 * @param {ActivityTypes} activityType Type of activity to show.

--- a/packages/calypso-e2e/src/lib/pages/stats-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/stats-page.ts
@@ -96,11 +96,12 @@ export class StatsPage {
 	 * @param {StatsPeriod} period Stats period to show.
 	 */
 	async selectStatsPeriod( period: StatsPeriod ) {
-		const expandDropdownButton = this.anchor.locator( '.stats-interval-dropdown' );
+		const expandDropdownButton = this.anchor.locator(
+			'.stats-interval-dropdown .components-button'
+		);
 		await expandDropdownButton.click();
 
 		const target = this.anchor.getByRole( 'radiogroup' ).getByRole( 'radio', { name: period } );
-		await target.waitFor();
 		await target.click();
 
 		if ( ! ( await target.isChecked() ) ) {

--- a/test/e2e/specs/stats/stats.ts
+++ b/test/e2e/specs/stats/stats.ts
@@ -67,7 +67,7 @@ describe( DataHelper.createSuiteTitle( 'Stats' ), function () {
 		} );
 
 		it( 'Select "Months" stats period', async function () {
-			await statsPage.selectStatsPeriod( 'Months' );
+			await statsPage.selectStatsPeriodFromDropdown( 'Months' );
 		} );
 
 		it( 'Filter traffic activity to Likes', async function () {


### PR DESCRIPTION
## Proposed Changes

Release the new date picker to the Traffic page.

## Testing Instructions

* Open Calypso Live Branch `/stats/day/:siteSlug`
* Have a click around for the date picker
* Ensure there's no obvious caveats 

<img width="1316" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/649120ea-9272-4d42-a539-8d8de0ef67da">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?