### PR TITLE
Free hosting trial: add trial countdown banner to the Hosting Configuration page

### DIFF
--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -42,6 +42,7 @@ import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { requestSite } from 'calypso/state/sites/actions';
 import {
 	isSiteOnECommerceTrial,
+	isSiteOnHostingTrial,
 	isSiteOnMigrationTrial,
 } from 'calypso/state/sites/plans/selectors';
 import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
@@ -219,6 +220,7 @@ class Hosting extends Component {
 			isBasicHostingDisabled,
 			isECommerceTrial,
 			isMigrationTrial,
+			isHostingTrial,
 			isSiteAtomic,
 			isTransferring,
 			isWpcomStagingSite,
@@ -361,6 +363,8 @@ class Hosting extends Component {
 				! isWpcomStagingSite );
 		const banner = shouldShowUpgradeBanner ? getUpgradeBanner() : getAtomicActivationNotice();
 
+		const isBusinessTrial = isMigrationTrial || isHostingTrial;
+
 		return (
 			<Main wideLayout className="hosting">
 				{ ! isLoadingSftpData && <ScrollToAnchorOnMount offset={ HEADING_OFFSET } /> }
@@ -374,8 +378,8 @@ class Hosting extends Component {
 					) }
 					align="left"
 				/>
-				{ ! isMigrationTrial && banner }
-				{ isMigrationTrial && (
+				{ ! isBusinessTrial && banner }
+				{ isBusinessTrial && (
 					<TrialBanner
 						callToAction={
 							<Button primary href={ `/plans/${ siteSlug }` }>
@@ -407,6 +411,7 @@ export default connect(
 			isJetpack: isJetpackSite( state, siteId ),
 			isECommerceTrial: isSiteOnECommerceTrial( state, siteId ),
 			isMigrationTrial: isSiteOnMigrationTrial( state, siteId ),
+			isHostingTrial: isSiteOnHostingTrial( state, siteId ),
 			transferState: getAutomatedTransferStatus( state, siteId ),
 			isTransferring: isAutomatedTransferActive( state, siteId ),
 			isAdvancedHostingDisabled: ! hasSftpFeature || ! isSiteAtomic,

--- a/client/my-sites/plans/trials/trial-banner/use-banner-subtitle.ts
+++ b/client/my-sites/plans/trials/trial-banner/use-banner-subtitle.ts
@@ -1,4 +1,8 @@
-import { PLAN_MIGRATION_TRIAL_MONTHLY, PlanSlug } from '@automattic/calypso-products';
+import {
+	PLAN_HOSTING_TRIAL_MONTHLY,
+	PLAN_MIGRATION_TRIAL_MONTHLY,
+	PlanSlug,
+} from '@automattic/calypso-products';
 import { Plans } from '@automattic/data-stores';
 import { useLocale } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
@@ -61,6 +65,25 @@ export default function useBannerSubtitle(
 					subtitle = translate(
 						'Your free trial will end in %(daysLeft)d day. Upgrade to a plan by %(expirationdate)s to unlock new features and launch your migrated website.',
 						'Your free trial will end in %(daysLeft)d days. Upgrade to a plan by %(expirationdate)s to unlock new features and launch your migrated website.',
+						{
+							count: trialDaysLeftToDisplay,
+							args: {
+								daysLeft: trialDaysLeftToDisplay,
+								expirationdate: readableExpirationDate as string,
+							},
+						}
+					);
+				}
+				break;
+			case PLAN_HOSTING_TRIAL_MONTHLY:
+				if ( trialExpired ) {
+					subtitle = translate(
+						'Your free trial has expired. Upgrade to a plan to continue using advanced features.'
+					);
+				} else {
+					subtitle = translate(
+						'Your free trial will end in %(daysLeft)d day. Upgrade to a plan by %(expirationdate)s to continue using advanced features.',
+						'Your free trial will end in %(daysLeft)d days. Upgrade to a plan by %(expirationdate)s to continue using advanced features.',
 						{
 							count: trialDaysLeftToDisplay,
 							args: {


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/4056.

## Proposed Changes

Title.

![image](https://github.com/Automattic/wp-calypso/assets/26530524/d1b71598-e6dd-4e22-a8f9-3884ea91d9ff)

## Testing Instructions

Browse `/hosting-config/%s` in a site that has an ongoing trial and check that the countdown displays how many days are left.

Browse `/hosting-config/%s` in a site that is no longer in the trial period and verify that the countdown is over and the trial expired message shows up.