### PR TITLE
Assembler - Force opacity animation on patterns in the large preview

### DIFF
--- a/packages/block-renderer/src/components/block-renderer-container.scss
+++ b/packages/block-renderer/src/components/block-renderer-container.scss
@@ -15,6 +15,7 @@
 		iframe {
 			max-width: initial;
 			border: none;
+			// Overwrites the inlined transition: all 0.3s ease 0s; from Gutenberg
 			transition: opacity 0.15s ease-in-out !important;
 		}
 	}

--- a/packages/block-renderer/src/components/block-renderer-container.scss
+++ b/packages/block-renderer/src/components/block-renderer-container.scss
@@ -15,7 +15,7 @@
 		iframe {
 			max-width: initial;
 			border: none;
-			transition: opacity 0.15s ease-in-out;
+			transition: opacity 0.15s ease-in-out !important;
 		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1697744149253339-slack-CRWCHQGUB

## Proposed Changes

* Force opacity animation on patterns in the large preview using `!important` to overwrite inline styles.

<img width="329" alt="Screenshot 2566-10-20 at 11 35 59" src="https://github.com/Automattic/wp-calypso/assets/1881481/0cabafa1-cda9-4470-9f8b-b17c3c691b31">

We could also overwrite or filter that `transition` as in https://github.com/Automattic/wp-calypso/blob/6453515a0e85ef1e43f382d16560d29843a46982/packages/block-renderer/src/components/block-renderer-container.tsx#L67

Let me know if the JS solution would be better for this case. I would appreciate guidance in that case.


|BEFORE|AFTER|
|--|--|
|<video src="https://github.com/Automattic/wp-calypso/assets/1881481/bdb9efa6-daaf-4f61-9099-c2b9bc3a68ae">|<video src="https://github.com/Automattic/wp-calypso/assets/1881481/1df9f340-87bd-49af-96bc-127e99ea8ab0">|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access the assembler `/setup/with-theme-assembler/patternAssembler?siteSlug={ SITE }`
* Click "Sections > Gallery" and add the Slideshow pattern
* Verify it loads using an opacity animation

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?