### PR TITLE
Revert "Woo Express" copy on login pages

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -391,7 +391,7 @@ class Login extends Component {
 						<p className="login__header-subtitle">
 							{ this.showContinueAsUser()
 								? translate(
-										"All Woo Express stores are powered by WordPress.com!{{br/}}First, select the account you'd like to use.",
+										"All Woo stores are powered by WordPress.com!{{br/}}First, select the account you'd like to use.",
 										{
 											components: {
 												br: <br />,
@@ -399,7 +399,7 @@ class Login extends Component {
 										}
 								  )
 								: translate(
-										"All Woo Express stores are powered by WordPress.com!{{br/}}Please, log in to continue. Don't have an account? {{signupLink}}Sign up{{/signupLink}}",
+										"All Woo stores are powered by WordPress.com!{{br/}}Please, log in to continue. Don't have an account? {{signupLink}}Sign up{{/signupLink}}",
 										{
 											components: {
 												signupLink: <a href={ this.getSignupUrl() } />,

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -205,7 +205,7 @@ export class UserStep extends Component {
 						  );
 			} else if ( isWooOAuth2Client( oauth2Client ) && ! wccomFrom ) {
 				subHeaderText = translate(
-					'All Woo Express stores are powered by WordPress.com.{{br/}}Please create an account to continue. Already registered? {{a}}Log in{{/a}}',
+					'All Woo stores are powered by WordPress.com.{{br/}}Please create an account to continue. Already registered? {{a}}Log in{{/a}}',
 					{
 						components: {
 							a: <a href={ loginUrl } />,


### PR DESCRIPTION
…d signup flows"

This reverts commit 1f7f48bd83e43a659f10da40fa7ce22d54b2530a.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

There has been some discussion about moving forward with better conditional copy on the login page(s). In order to prevent customer confusion in the short term, I'm suggesting reverting this simple text change.

## Proposed Changes

* Removes instances of "Woo Express" on login pages, so it simply says "Woo" (this was the original state)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this branch and build Calypso locally
* Log out of WooCommerce.com, then click the Log In link in the top right.
* Change the URL in your browser from https://wordpress.com to your local Calypso URL (typically http://calypso.localhost:3000)
* Note the verbiage change below the page header: "All Woo stores are powered by WordPress.com"
* Proceed to login, then note you will be redirected to WordPress.com again. Change the URL in your browser once again to point to your local Calypso install.
* You should see the "Select an account" screen with the same verbiage change: "All Woo stores are powered by WordPress.com"
* Lastly, open an incognito/private tab and visit WooCommerce.com then click on the Get Started button up top to get to the NUX flow.
* Click "Skip this step" and then hit the Continue button on the "Tell us a bit about your store" screen, then click the Try Woo Express for free button on the following screen.
* You're once again redirected to WordPress.com; switch the URL to your local Calypso to verify this screen also mentions "All Woo stores" instead of "All Woo Express stores"

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?