### PR TITLE
Theme Details: Show site selection list  (fixing that it doesn't show up)

### DIFF
--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -79,7 +79,7 @@ body.is-focus-sites {
 
 	.is-section-theme & {
 		.sites.main {
-			padding-top: 79px;
+			padding-top: calc(79px - var(--masterbar-height));
 		}
 	}
 

--- a/client/my-sites/theme/index.web.js
+++ b/client/my-sites/theme/index.web.js
@@ -3,8 +3,6 @@ import { translate } from 'i18n-calypso';
 import { makeLayout, redirectWithoutLocaleParamIfLoggedIn } from 'calypso/controller';
 import {
 	selectSiteIfLoggedInWithSites,
-	hideNavigationIfLoggedInWithNoSites,
-	addNavigationIfLoggedIn,
 	redirectToLoginIfSiteRequested,
 } from 'calypso/my-sites/controller';
 import { getTheme } from 'calypso/state/themes/selectors';
@@ -32,8 +30,6 @@ export default function ( router ) {
 		`/${ langParam }/theme/:slug/:section(setup|support)?/:site_id?`,
 		redirectWithoutLocaleParamIfLoggedIn,
 		redirectToLoginIfSiteRequested,
-		hideNavigationIfLoggedInWithNoSites,
-		addNavigationIfLoggedIn,
 		setTitleIfThemeExisted,
 		selectSiteIfLoggedInWithSites,
 		fetchThemeDetailsData,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1697774704609349/1697772599.529069-slack-CRWCHQGUB

## Proposed Changes

* This PR focuses on displaying the site selection when people land on the Theme Details page without the specific site in the URL.

| Case | Screenshot |
| - | - | 
| Logged-out | <img width="300" src="https://github.com/Automattic/wp-calypso/assets/13596067/f8a792c6-b844-4055-b185-53cffb873c1c" /> |
| With no sites | <img width="300" src="https://github.com/Automattic/wp-calypso/assets/13596067/2ef9c74b-a53d-4aa3-822d-2deae2467a0b" /> |
| With sites but not specified | <img width="300" src="https://github.com/Automattic/wp-calypso/assets/13596067/85e2eed3-a2f0-4fe3-a3f4-54a41fd4ac14" /> | 
| With specific site | <img width="300" src="https://github.com/Automattic/wp-calypso/assets/13596067/2fdc91ba-7d02-42fd-b855-3d24687e992b" /> |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /theme/peirao with the following situation, and ensure the Theme Details page looks good
  * Logged-out
  * The user with no site
  * The user with sites but not specified, and then select a site
* Go to /theme/peirao/<your_site>, and ensure the Theme Details page looks good

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?