### PR TITLE
Plans page for Jetpack App: Ensure "paid plan required" modal is shown

### DIFF
--- a/client/jetpack-app/plans/main.tsx
+++ b/client/jetpack-app/plans/main.tsx
@@ -118,7 +118,6 @@ const JetpackAppPlans: React.FC< JetpackAppPlansProps > = ( { paidDomainName, or
 						hidePlanTypeSelector
 						hidePlansFeatureComparison
 						setSiteUrlAsFreeDomainSuggestion={ setSiteUrlAsFreeDomainSuggestion }
-						flowName="onboarding-jetpack-app"
 					/>
 				</>
 			) : (

--- a/client/jetpack-app/plans/main.tsx
+++ b/client/jetpack-app/plans/main.tsx
@@ -118,6 +118,7 @@ const JetpackAppPlans: React.FC< JetpackAppPlansProps > = ( { paidDomainName, or
 						hidePlanTypeSelector
 						hidePlansFeatureComparison
 						setSiteUrlAsFreeDomainSuggestion={ setSiteUrlAsFreeDomainSuggestion }
+						flowName="onboarding-jetpack-app"
 					/>
 				</>
 			) : (

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/hooks/use-modal-resolution-callback.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/hooks/use-modal-resolution-callback.tsx
@@ -12,6 +12,7 @@ type Props = {
 	isPlanUpsellEnabledOnFreeDomain: DataResponse< boolean >;
 	flowName?: string | null;
 	paidDomainName?: string | null;
+	intent?: string | null;
 };
 
 /**
@@ -22,6 +23,7 @@ export function useModalResolutionCallback( {
 	isPlanUpsellEnabledOnFreeDomain,
 	flowName,
 	paidDomainName,
+	intent,
 }: Props ) {
 	return useCallback(
 		( currentSelectedPlan?: string | null ): ModalType | null => {
@@ -34,7 +36,12 @@ export function useModalResolutionCallback( {
 					return FREE_PLAN_PAID_DOMAIN_DIALOG;
 				}
 
-				if ( paidDomainName && ( flowName === 'onboarding' || flowName === 'onboarding-pm' ) ) {
+				if (
+					paidDomainName &&
+					( flowName === 'onboarding' ||
+						flowName === 'onboarding-pm' ||
+						intent === 'plans-jetpack-app-site-creation' )
+				) {
 					return PAID_PLAN_IS_REQUIRED_DIALOG;
 				}
 			}
@@ -45,6 +52,7 @@ export function useModalResolutionCallback( {
 			isCustomDomainAllowedOnFreePlan.result,
 			isPlanUpsellEnabledOnFreeDomain.result,
 			paidDomainName,
+			intent,
 		]
 	);
 }

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/hooks/use-modal-resolution-callback.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/hooks/use-modal-resolution-callback.tsx
@@ -34,7 +34,12 @@ export function useModalResolutionCallback( {
 					return FREE_PLAN_PAID_DOMAIN_DIALOG;
 				}
 
-				if ( paidDomainName && ( flowName === 'onboarding' || flowName === 'onboarding-pm' ) ) {
+				if (
+					paidDomainName &&
+					( flowName === 'onboarding' ||
+						flowName === 'onboarding-pm' ||
+						flowName === 'onboarding-jetpack-app' )
+				) {
 					return PAID_PLAN_IS_REQUIRED_DIALOG;
 				}
 			}

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/hooks/use-modal-resolution-callback.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/hooks/use-modal-resolution-callback.tsx
@@ -34,12 +34,7 @@ export function useModalResolutionCallback( {
 					return FREE_PLAN_PAID_DOMAIN_DIALOG;
 				}
 
-				if (
-					paidDomainName &&
-					( flowName === 'onboarding' ||
-						flowName === 'onboarding-pm' ||
-						flowName === 'onboarding-jetpack-app' )
-				) {
+				if ( paidDomainName && ( flowName === 'onboarding' || flowName === 'onboarding-pm' ) ) {
 					return PAID_PLAN_IS_REQUIRED_DIALOG;
 				}
 			}

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/test/plan-upsell-modal.test.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/test/plan-upsell-modal.test.tsx
@@ -17,10 +17,12 @@ function MockPlansFeaturesMain( {
 	flowName,
 	selectedPlan,
 	paidDomainName,
+	intent,
 }: {
 	flowName: string;
 	selectedPlan: string;
 	paidDomainName?: string | null;
+	intent?: string | null;
 } ) {
 	const isCustomDomainAllowedOnFreePlan = useIsFreePlanCustomDomainUpsellEnabled(
 		flowName,
@@ -35,6 +37,7 @@ function MockPlansFeaturesMain( {
 		isPlanUpsellEnabledOnFreeDomain,
 		flowName,
 		paidDomainName,
+		intent,
 	} );
 	return <div data-testid="modal-render">{ resolveModal( selectedPlan ) }</div>;
 }
@@ -128,6 +131,29 @@ describe( 'PlanUpsellModal tests', () => {
 
 			expect( queryByText4( /DIALOG/i ) ).toBeNull();
 		} );
+
+		test( 'A paid domain with Jetpack App intent should show the PAID_PLAN_IS_REQUIRED_DIALOG', () => {
+			renderWithProvider(
+				<MockPlansFeaturesMain
+					selectedPlan={ PLAN_FREE }
+					paidDomainName="yourgroovydomain.com"
+					intent="plans-jetpack-app-site-creation"
+				/>
+			);
+			expect( screen.getByTestId( 'modal-render' ) ).toHaveTextContent(
+				PAID_PLAN_IS_REQUIRED_DIALOG
+			);
+		} );
+
+		test( 'A free domain with Jetpack App intent should NOT show any Dialog', () => {
+			renderWithProvider(
+				<MockPlansFeaturesMain
+					selectedPlan={ PLAN_FREE }
+					intent="plans-jetpack-app-site-creation"
+				/>
+			);
+			expect( screen.queryByText( /DIALOG/i ) ).toBeNull();
+		} );
 	} );
 
 	describe( 'useModalResolutionCallback hook related tests', () => {
@@ -138,6 +164,7 @@ describe( 'PlanUpsellModal tests', () => {
 					isPlanUpsellEnabledOnFreeDomain: { result: false, isLoading: false },
 					flowName: 'Onboarding',
 					paidDomainName: null,
+					intent: null,
 				} )
 			);
 			expect( result.current( PLAN_FREE ) ).toBeNull();

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -278,6 +278,7 @@ const PlansFeaturesMain = ( {
 		isPlanUpsellEnabledOnFreeDomain,
 		flowName,
 		paidDomainName,
+		intent: intentFromProps,
 	} );
 
 	const toggleShowPlansComparisonGrid = () => {


### PR DESCRIPTION
"Paid plan required" modal doesn't appear on `jetpack-app/plans` flow anymore. It's caused by an added requirement during recent refactorings to specify an "onboarding" flow for this modal to appear:

> There was a bug that was introduced above, where the Paid plan is required was not limited to the onboarding flows, which was fixed.
> -- https://github.com/Automattic/wp-calypso/pull/83215

Previous implementation relied on assumption that `paidDomainName` parameter is enough to trigger this pop-up.

## Proposed Changes

* Add `onboarding-jetpack-app` flow to modal presentation condition
* Pass it to plans component

## Testing Instructions

Before testing, set wp-iphone or wp-android user agents.

### paid_domain_name + free plan selection
1. Pass `paid_domain_name` parameter (.com/jetpack-app/plans?paid_domain_name=greatdomain.com)
2. Select Free Plan
3. Confirm modal is opened

### no parameters + free plan selection
1. Open plans page without any parameters (.com/jetpack-app/plans)
2. Select Free Plan
3. Confirm tapping on Free plan opens redirection URL with a free plan slug (.com/jetpack-app/plans?plan_slug=free_plan)


https://github.com/Automattic/wp-calypso/assets/4062343/6a737d5a-aa82-487a-ae19-980def2835e7

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?