### PR TITLE
Jetpack Manage: Add onboarding for the new navigation component.

### DIFF
--- a/client/jetpack-cloud/components/guided-tour/index.tsx
+++ b/client/jetpack-cloud/components/guided-tour/index.tsx
@@ -71,17 +71,14 @@ const GuidedTour = ( { tours, preferenceName }: Props ) => {
 
 	const targetElement = useAsyncElement( target, 3000 );
 
-	// Show the popover after a short delay to allow the popover to be positioned correctly
 	useEffect( () => {
 		if ( targetElement && ! isDismissed && hasFetched ) {
-			setTimeout( () => {
-				setIsVisible( true );
-				dispatch(
-					recordTracksEvent( 'calypso_jetpack_cloud_start_tour', {
-						tour: preferenceName,
-					} )
-				);
-			}, 100 );
+			setIsVisible( true );
+			dispatch(
+				recordTracksEvent( 'calypso_jetpack_cloud_start_tour', {
+					tour: preferenceName,
+				} )
+			);
 		}
 	}, [ dispatch, isDismissed, preferenceName, targetElement, hasFetched ] );
 

--- a/client/jetpack-cloud/components/guided-tour/index.tsx
+++ b/client/jetpack-cloud/components/guided-tour/index.tsx
@@ -1,4 +1,5 @@
 import { Popover, Button } from '@automattic/components';
+import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'calypso/state';
@@ -25,6 +26,7 @@ export interface Tour {
 }
 
 interface Props {
+	className?: string;
 	tours: Tour[];
 	preferenceName: string;
 }
@@ -55,7 +57,7 @@ const useAsyncElement = ( target: string, maxDuration: number ): HTMLElement | n
 	return asyncElement;
 };
 
-const GuidedTour = ( { tours, preferenceName }: Props ) => {
+const GuidedTour = ( { className, tours, preferenceName }: Props ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
@@ -108,8 +110,8 @@ const GuidedTour = ( { tours, preferenceName }: Props ) => {
 	return (
 		<Popover
 			isVisible={ isVisible }
+			className={ classNames( className, 'guided-tour__popover' ) }
 			context={ targetElement }
-			className="guided-tour__popover"
 			position={ popoverPosition }
 		>
 			<h2 className="guided-tour__popover-heading">{ title }</h2>

--- a/client/jetpack-cloud/components/guided-tour/index.tsx
+++ b/client/jetpack-cloud/components/guided-tour/index.tsx
@@ -10,9 +10,18 @@ import { preferencesLastFetchedTimestamp } from 'calypso/state/preferences/selec
 import './style.scss';
 
 export interface Tour {
-	targetId: string;
+	target: string;
 	title: string;
 	description: string;
+	popoverPosition?:
+		| 'top'
+		| 'top right'
+		| 'right'
+		| 'bottom right'
+		| 'bottom'
+		| 'bottom left'
+		| 'left'
+		| 'top left';
 }
 
 interface Props {
@@ -33,15 +42,15 @@ const GuidedTour = ( { tours, preferenceName }: Props ) => {
 
 	const isDismissed = preference?.dismiss;
 
-	const { title, description, targetId } = tours[ currentStep ];
+	const { title, description, target, popoverPosition } = tours[ currentStep ];
 
 	// Set the target element for the popover
 	useEffect( () => {
-		if ( targetId ) {
-			const element = document.querySelector( `#${ targetId }` ) as HTMLElement | null;
+		if ( target ) {
+			const element = document.querySelector( target ) as HTMLElement | null;
 			setTargetElement( element );
 		}
-	}, [ targetId ] );
+	}, [ target ] );
 
 	// Show the popover after a short delay to allow the popover to be positioned correctly
 	useEffect( () => {
@@ -81,7 +90,12 @@ const GuidedTour = ( { tours, preferenceName }: Props ) => {
 	const lastTourLabel = tours.length === 1 ? translate( 'Got it' ) : translate( 'Done' );
 
 	return (
-		<Popover isVisible={ isVisible } context={ targetElement } className="guided-tour__popover">
+		<Popover
+			isVisible={ isVisible }
+			context={ targetElement }
+			className="guided-tour__popover"
+			position={ popoverPosition }
+		>
 			<h2 className="guided-tour__popover-heading">{ title }</h2>
 			<p className="guided-tour__popover-description">{ description }</p>
 			<div className="guided-tour__popover-footer">

--- a/client/jetpack-cloud/components/guided-tour/index.tsx
+++ b/client/jetpack-cloud/components/guided-tour/index.tsx
@@ -33,12 +33,17 @@ interface Props {
 
 // This hook will return the async element matching the target selector.
 // After timeout has passed, it will return null.
-const useAsyncElement = ( target: string, maxDuration: number ): HTMLElement | null => {
+//
+// @param target - The selector to match the element against
+// @param timeoutDuration - The maximum duration (in milliseconds) to wait for the element
+//
+// @returns The element matching the target selector, or null if the timeout has passed
+const useAsyncElement = ( target: string, timeoutDuration: number ): HTMLElement | null => {
 	const [ asyncElement, setAsyncElement ] = useState< HTMLElement | null >( null );
 
 	useEffect( () => {
 		// Set timeout to ensure we don't wait too long for the element
-		const endTime = Date.now() + maxDuration;
+		const endTime = Date.now() + timeoutDuration;
 
 		const getAsyncElement = ( endTime: number ) => {
 			const element = document.querySelector( target ) as HTMLElement | null;
@@ -52,7 +57,7 @@ const useAsyncElement = ( target: string, maxDuration: number ): HTMLElement | n
 		};
 
 		getAsyncElement( endTime );
-	}, [ target, maxDuration ] );
+	}, [ target, timeoutDuration ] );
 
 	return asyncElement;
 };

--- a/client/jetpack-cloud/components/guided-tour/index.tsx
+++ b/client/jetpack-cloud/components/guided-tour/index.tsx
@@ -29,6 +29,20 @@ interface Props {
 	preferenceName: string;
 }
 
+// Helper function to get an element, returning a promise that resolves when the element is rendered.
+const getElementAsync = ( target: string ): Promise< HTMLElement > =>
+	new Promise( ( resolve ) => {
+		const getElement = () => {
+			const element = document.querySelector( target ) as HTMLElement | null;
+			if ( element ) {
+				resolve( element );
+			} else {
+				requestAnimationFrame( getElement );
+			}
+		};
+		getElement();
+	} );
+
 const GuidedTour = ( { tours, preferenceName }: Props ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -47,8 +61,7 @@ const GuidedTour = ( { tours, preferenceName }: Props ) => {
 	// Set the target element for the popover
 	useEffect( () => {
 		if ( target ) {
-			const element = document.querySelector( target ) as HTMLElement | null;
-			setTargetElement( element );
+			getElementAsync( target ).then( ( element ) => setTargetElement( element ) );
 		}
 	}, [ target ] );
 

--- a/client/jetpack-cloud/components/sidebar/style.scss
+++ b/client/jetpack-cloud/components/sidebar/style.scss
@@ -67,11 +67,9 @@
 }
 
 .jetpack-cloud-sidebar__guided-tour {
-	&--is-large-screen {
-		display: none;
+	display: none;
 
-		@include break-medium {
-			display: block;
-		}
+	@include break-medium {
+		display: block;
 	}
 }

--- a/client/jetpack-cloud/components/sidebar/style.scss
+++ b/client/jetpack-cloud/components/sidebar/style.scss
@@ -1,3 +1,7 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+
 // This file is meant to house style rules that all implementations of the base
 // sidebar will implement by default.
 
@@ -59,5 +63,15 @@
 		// TODO: Value taken directly from designs;
 		// confirm this weight is correct and refactor as necessary
 		font-weight: 500;
+	}
+}
+
+.jetpack-cloud-sidebar__guided-tour {
+	&--is-large-screen {
+		display: none;
+
+		@include break-medium {
+			display: block;
+		}
 	}
 }

--- a/client/jetpack-cloud/sections/sidebar-navigation/jetpack-manage.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/jetpack-manage.tsx
@@ -1,6 +1,7 @@
 import { plugins, currencyDollar, category } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import JetpackIcons from 'calypso/components/jetpack/sidebar/menu-items/jetpack-icons';
+import GuidedTour from 'calypso/jetpack-cloud/components/guided-tour';
 import NewSidebar from 'calypso/jetpack-cloud/components/sidebar';
 import {
 	JETPACK_MANAGE_DASHBOARD_LINK,
@@ -10,6 +11,8 @@ import {
 } from './lib/constants';
 import { redirectPage, isMenuItemSelected } from './lib/sidebar';
 import type { MenuItemProps } from './types';
+
+const BILLING_MENU_ITEM_ID = 'partner-portal-billing-menu-item';
 
 const JetpackManageSidebar = () => {
 	const translate = useTranslate();
@@ -50,6 +53,7 @@ const JetpackManageSidebar = () => {
 			},
 		} ),
 		createItem( {
+			id: BILLING_MENU_ITEM_ID,
 			icon: currencyDollar,
 			path: '/partner-portal/',
 			link: JETPACK_MANAGE_BILLING_LINK,
@@ -60,7 +64,39 @@ const JetpackManageSidebar = () => {
 			withChevron: true,
 		} ),
 	];
-	return <NewSidebar isJetpackManage path="/" menuItems={ menuItems } />;
+	return (
+		<>
+			<NewSidebar isJetpackManage path="/" menuItems={ menuItems } />
+
+			<GuidedTour
+				preferenceName="jetpack-manage-sidebar-v2-dashboard-tour"
+				tours={ [
+					{
+						target: '.jetpack-cloud-sidebar__all-sites-icon',
+						title: translate( 'Switch Sites Easily' ),
+						description: translate(
+							'You can navigate through your individual site views from here.'
+						),
+					},
+					{
+						target: '.jetpack-cloud-sidebar__profile-dropdown-button-icon',
+						title: translate( 'Access Profile & Help Docs' ),
+						description: translate(
+							'Here you can logout from your account or view our help documentation.'
+						),
+					},
+					{
+						target: `#${ BILLING_MENU_ITEM_ID } svg`,
+						popoverPosition: 'bottom left',
+						title: translate( 'Manage Purchases' ),
+						description: translate(
+							'Here you can view your billing info, payment methods, invoices and more.'
+						),
+					},
+				] }
+			/>
+		</>
+	);
 };
 
 export default JetpackManageSidebar;

--- a/client/jetpack-cloud/sections/sidebar-navigation/jetpack-manage.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/jetpack-manage.tsx
@@ -69,6 +69,7 @@ const JetpackManageSidebar = () => {
 			<NewSidebar isJetpackManage path="/" menuItems={ menuItems } />
 
 			<GuidedTour
+				className="jetpack-cloud-sidebar__guided-tour--is-large-screen"
 				preferenceName="jetpack-manage-sidebar-v2-dashboard-tour"
 				tours={ [
 					{

--- a/client/jetpack-cloud/sections/sidebar-navigation/jetpack-manage.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/jetpack-manage.tsx
@@ -69,7 +69,7 @@ const JetpackManageSidebar = () => {
 			<NewSidebar isJetpackManage path="/" menuItems={ menuItems } />
 
 			<GuidedTour
-				className="jetpack-cloud-sidebar__guided-tour--is-large-screen"
+				className="jetpack-cloud-sidebar__guided-tour"
 				preferenceName="jetpack-manage-sidebar-v2-dashboard-tour"
 				tours={ [
 					{

--- a/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
@@ -15,6 +15,7 @@ import { useSelector } from 'react-redux';
 import QueryScanState from 'calypso/components/data/query-jetpack-scan';
 import QuerySiteFeatures from 'calypso/components/data/query-site-features';
 import JetpackIcons from 'calypso/components/jetpack/sidebar/menu-items/jetpack-icons';
+import GuidedTour from 'calypso/jetpack-cloud/components/guided-tour';
 import NewSidebar from 'calypso/jetpack-cloud/components/sidebar';
 import {
 	settingsPath,
@@ -201,6 +202,26 @@ const ManageSelectedSiteSidebar = ( { path }: { path: string } ) => {
 						  }
 						: undefined
 				}
+			/>
+
+			<GuidedTour
+				preferenceName="jetpack-cloud-sidebar-v2-managed-selected-site-tour"
+				tours={ [
+					isAgency
+						? {
+								target: '.components-navigator-back-button svg',
+								popoverPosition: 'bottom left',
+								title: translate( 'Back to Sites Management' ),
+								description: translate(
+									'Click here when you want to return to managing all of your sites.'
+								),
+						  }
+						: {
+								target: '.jetpack-cloud-sidebar__header .site-icon',
+								title: translate( 'Switch Sites Easily' ),
+								description: translate( 'Here you can navigate between your different sites.' ),
+						  },
+				] }
 			/>
 		</>
 	);

--- a/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
@@ -205,7 +205,7 @@ const ManageSelectedSiteSidebar = ( { path }: { path: string } ) => {
 			/>
 
 			<GuidedTour
-				className="jetpack-cloud-sidebar__guided-tour--is-large-screen"
+				className="jetpack-cloud-sidebar__guided-tour"
 				preferenceName="jetpack-cloud-sidebar-v2-managed-selected-site-tour"
 				tours={ [
 					isAgency

--- a/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
@@ -205,6 +205,7 @@ const ManageSelectedSiteSidebar = ( { path }: { path: string } ) => {
 			/>
 
 			<GuidedTour
+				className="jetpack-cloud-sidebar__guided-tour--is-large-screen"
 				preferenceName="jetpack-cloud-sidebar-v2-managed-selected-site-tour"
 				tours={ [
 					isAgency

--- a/client/jetpack-cloud/sections/sidebar-navigation/types.ts
+++ b/client/jetpack-cloud/sections/sidebar-navigation/types.ts
@@ -1,4 +1,5 @@
 export type MenuItemProps = {
+	id?: string;
 	icon: JSX.Element;
 	link: string;
 	path: string;

--- a/client/layout/sidebar-v2/navigator/navigator-menu-item.tsx
+++ b/client/layout/sidebar-v2/navigator/navigator-menu-item.tsx
@@ -12,6 +12,7 @@ import './style.scss';
 const ICON_SIZE = 24;
 
 interface Props {
+	id?: string;
 	icon: JSX.Element;
 	path: string;
 	link: string;
@@ -23,6 +24,7 @@ interface Props {
 }
 
 export const SidebarNavigatorMenuItem = ( {
+	id,
 	icon,
 	path,
 	link,
@@ -39,6 +41,7 @@ export const SidebarNavigatorMenuItem = ( {
 					'is-active': isSelected,
 				} ) }
 				onClick={ () => onClickMenuItem( link ) }
+				id={ id }
 			>
 				<HStack justify="flex-start">
 					{ icon && <Icon style={ { fill: 'currentcolor' } } icon={ icon } size={ ICON_SIZE } /> }


### PR DESCRIPTION
This PR adds the onboarding of the new navigation component. The implementation uses the `GuidedTour` component to show popovers to targeted areas in the UI.

Closes https://github.com/Automattic/jetpack-genesis/issues/69

## Proposed Changes

* Update the `GuidedTour` component to support a generic selector instead of just limiting the selector to IDs. This is because sometimes our target component is a child of a component we don't control.
* To allow us to target specific menu items with our `GuidedTour` component, this PR adds the id prop as a unique identifier.
* Adds guided sidebar tour on both the Site Management and Single site page.

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**
* Use the Jetpack Cloud live link and go to `/dashboard?flags=jetpack/new-navigation`
* Confirm that the first step tooltip appears pointing to the Site selector. The Step consists of three steps, refer to the images below.
<img width="293" alt="Screen Shot 2023-10-20 at 4 04 02 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/1a029eed-d570-48d3-b315-85d39a293c13">
<img width="399" alt="Screen Shot 2023-10-20 at 4 05 06 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/5e6354e8-1f15-4057-84e7-80ae06a50b1a">
<img width="277" alt="Screen Shot 2023-10-20 at 4 05 11 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/ab4d484d-1626-45aa-a75a-5f204c7260a0">

* Next, go to the Single site view (e.g., `/activity-log/<SITE>?flags=jetpack/new-navigation`)
* For the Agency account, confirm that the tour is rendered.
<img width="277" alt="Screen Shot 2023-10-20 at 4 08 44 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/0c1d752e-360c-4e08-9c05-636afbfc3a3e">

* For Non-Agency accounts, confirm that the tour is rendered. (You can create a separate JP account or set your agency account to non-agency in the Partner Portal MC.)
<img width="270" alt="Screen Shot 2023-10-20 at 4 09 20 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/811d8c94-832b-4b75-8b77-eba808830073">

### Reset Preferences
The Guided tour can only be completed once. If you wish to test again, please reset the following preferences using the Staging dev tool:
<img width="778" alt="Screen Shot 2023-10-20 at 4 11 16 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/46c5c3d9-4307-4776-9475-af9a6f2d677d">


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?