### PR TITLE
Migration flow: Adding isNewSite check for confirm modal

### DIFF
--- a/client/blocks/importer/wordpress/import-everything/pre-migration/credentials-form.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/credentials-form.tsx
@@ -17,6 +17,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { updateCredentials } from 'calypso/state/jetpack/credentials/actions';
 import getJetpackCredentialsUpdateError from 'calypso/state/selectors/get-jetpack-credentials-update-error';
 import getJetpackCredentialsUpdateStatus from 'calypso/state/selectors/get-jetpack-credentials-update-status';
+import { isNewSite } from 'calypso/state/sites/selectors';
 import ConfirmModal from './confirm-modal';
 import type { CredentialsProtocol, CredentialsStatus, StartImportTrackingProps } from './types';
 
@@ -45,6 +46,7 @@ export const CredentialsForm: React.FunctionComponent< Props > = ( props ) => {
 	const formSubmissionStatus: CredentialsStatus = useSelector( ( state ) =>
 		getJetpackCredentialsUpdateStatus( state, sourceSite.ID )
 	);
+	const isNewlyCreatedSite = useSelector( ( state: object ) => isNewSite( state, targetSite.ID ) );
 
 	const isFormSubmissionPending = formSubmissionStatus === 'pending';
 	const formHasErrors = formErrors && Object.keys( formErrors ).length > 0;
@@ -156,6 +158,13 @@ export const CredentialsForm: React.FunctionComponent< Props > = ( props ) => {
 		updateError &&
 			dispatch( recordTracksEvent( 'calypso_site_migration_credentials_update_error' ) );
 	}, [ updateError ] );
+
+	// If it's a newly created site, we don't need to show the confirm modal
+	useEffect( () => {
+		if ( isNewlyCreatedSite ) {
+			setMigrationConfirmed( true );
+		}
+	}, [ isNewlyCreatedSite, setMigrationConfirmed ] );
 
 	return (
 		<>

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
@@ -237,6 +237,7 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 				<MigrationReady
 					sourceSiteSlug={ sourceSiteSlug }
 					sourceSiteHasCredentials={ hasCredentials }
+					targetSiteId={ targetSite.ID }
 					targetSiteSlug={ targetSite.slug }
 					migrationTrackingProps={ migrationTrackingProps }
 					startImport={ startImport }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #80999

## Proposed Changes

This PR adds a check on the destination site to see if it's a newly created site. We use the existing `isNewSite` selector to identify if a site is newly created(created in less than 30 minutes).  If a site is newly created, we won't show the confirm modal before the `Start migration` button. 

Note: The site picker will stay as it is because there's a "create a new site" CTA on the screen. We consider the rest of the sites from the site picker to be existing old sites. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using an existing site first, navigate to `calypso.localhost:3000/setup/import-focused/import?siteSlug=${target_site_slug}`
* Go through the migration flow and try to start a migration, you will see the confirm modal shows up as it is in production. 
* Try to create a new site, navigate to `calypso.localhost:3000/setup/import-focused/import?siteSlug=${target_site_slug}`
* You can purchase a plan or start a trial, and try to start the migration.
* You shouldn't see the confirm modal show up when clicking "Start Migration" button.
* Try out credential forms as well and make sure the behavior is the same.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?