### PR TITLE
Logged-out reader: Some changes to embed it on NaNoWriMo LP

### DIFF
--- a/client/blocks/comments/form.jsx
+++ b/client/blocks/comments/form.jsx
@@ -10,6 +10,7 @@ import Gravatar from 'calypso/components/gravatar';
 import { navigate } from 'calypso/lib/navigate';
 import { createAccountUrl } from 'calypso/lib/paths';
 import { ProtectFormGuard } from 'calypso/lib/protect-form';
+import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-embed-page';
 import { recordAction, recordGaEvent, recordTrackForPost } from 'calypso/reader/stats';
 import { writeComment, deleteComment, replyComment } from 'calypso/state/comments/actions';
 import { getCurrentUser, isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -64,6 +65,12 @@ class PostCommentForm extends Component {
 	handleTextChange = ( event ) => {
 		if ( ! this.props.isLoggedIn ) {
 			const { pathname } = getUrlParts( window.location.href );
+			if ( isReaderTagEmbedPage( window.location ) ) {
+				return window.open(
+					createAccountUrl( { redirectTo: pathname, ref: 'reader-lp' } ),
+					'_blank'
+				);
+			}
 			return navigate( createAccountUrl( { redirectTo: pathname, ref: 'reader-lp' } ) );
 		}
 		// Update the comment text in the container's state

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -12,6 +12,7 @@ import TimeSince from 'calypso/components/time-since';
 import { decodeEntities } from 'calypso/lib/formatting';
 import { navigate } from 'calypso/lib/navigate';
 import { createAccountUrl } from 'calypso/lib/paths';
+import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-embed-page';
 import withDimensions from 'calypso/lib/with-dimensions';
 import { getStreamUrl } from 'calypso/reader/route';
 import { recordAction, recordGaEvent, recordPermalinkClick } from 'calypso/reader/stats';
@@ -108,6 +109,12 @@ class PostComment extends PureComponent {
 	handleReply = () => {
 		if ( ! this.props.isLoggedIn ) {
 			const { pathname } = getUrlParts( window.location.href );
+			if ( isReaderTagEmbedPage( window.location ) ) {
+				return window.open(
+					createAccountUrl( { redirectTo: pathname, ref: 'reader-lp' } ),
+					'_blank'
+				);
+			}
 			return navigate( createAccountUrl( { redirectTo: pathname, ref: 'reader-lp' } ) );
 		}
 		this.props.onReplyClick( this.props.commentId );

--- a/client/blocks/like-button/button.jsx
+++ b/client/blocks/like-button/button.jsx
@@ -7,6 +7,7 @@ import { createElement, PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { navigate } from 'calypso/lib/navigate';
 import { createAccountUrl } from 'calypso/lib/paths';
+import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-embed-page';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import LikeIcons from './icons';
 import './style.scss';
@@ -50,6 +51,13 @@ class LikeButton extends PureComponent {
 	toggleLiked( event ) {
 		if ( ! this.props.isLoggedIn ) {
 			const { pathname } = getUrlParts( window.location.href );
+			if ( isReaderTagEmbedPage( window.location ) ) {
+				return window.open(
+					createAccountUrl( { redirectTo: pathname, ref: 'reader-lp' } ),
+					'_blank'
+				);
+			}
+
 			return navigate( createAccountUrl( { redirectTo: pathname, ref: 'reader-lp' } ) );
 		}
 		if ( event ) {

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -27,6 +27,7 @@ import OfflineStatus from 'calypso/layout/offline-status';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { isWpMobileApp, isWcMobileApp } from 'calypso/lib/mobile-app';
 import { isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
+import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-embed-page';
 import { getMessagePathForJITM } from 'calypso/lib/route';
 import UserVerificationChecker from 'calypso/lib/user/verification-checker';
 import { OdieAssistantProvider } from 'calypso/odie/context';
@@ -363,7 +364,10 @@ export default withCurrentRoute(
 			[ 'jetpack-connect', 'login' ].includes( sectionName ) &&
 			isWooCommerceCoreProfilerFlow( state );
 		const noMasterbarForRoute =
-			isJetpackLogin || currentRoute === '/me/account/closed' || isDomainAndPlanPackageFlow;
+			isJetpackLogin ||
+			currentRoute === '/me/account/closed' ||
+			isDomainAndPlanPackageFlow ||
+			isReaderTagEmbedPage( window.location );
 		const noMasterbarForSection =
 			! isWooCoreProfilerFlow && [ 'signup', 'jetpack-connect' ].includes( sectionName );
 		const masterbarIsHidden =

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -86,6 +86,12 @@ const LayoutLoggedOut = ( {
 	const isReaderSearchPage =
 		sectionName === 'reader' && pathNameWithoutLocale.startsWith( '/read/search' );
 
+	const urlParams = new URLSearchParams( window.location.search );
+	const isReaderParedDownSearchPage =
+		sectionName === 'reader' &&
+		pathNameWithoutLocale.startsWith( '/read/search' ) &&
+		urlParams.get( 'type' ) === 'basic';
+
 	// It's used to add a class name for the login and magic login of Gravatar powered clients only (not for F2A pages)
 	const isGravPoweredLoginPage =
 		isGravPoweredClient &&
@@ -143,7 +149,12 @@ const LayoutLoggedOut = ( {
 
 			masterbar = <OauthClientMasterbar oauth2Client={ oauth2Client } />;
 		}
-	} else if ( config.isEnabled( 'jetpack-cloud' ) || isWpMobileApp() || isJetpackThankYou ) {
+	} else if (
+		config.isEnabled( 'jetpack-cloud' ) ||
+		isWpMobileApp() ||
+		isJetpackThankYou ||
+		isReaderParedDownSearchPage
+	) {
 		masterbar = null;
 	} else if (
 		[ 'plugins', 'themes', 'theme', 'reader', 'subscriptions', 'site-profiler' ].includes(
@@ -220,16 +231,17 @@ const LayoutLoggedOut = ( {
 				</>
 			) }
 
-			{ [ 'themes', 'theme', 'reader' ].includes( sectionName ) && (
-				<UniversalNavbarFooter
-					onLanguageChange={ ( e ) => {
-						navigate( `/${ e.target.value + pathNameWithoutLocale }` );
-						window.location.reload();
-					} }
-					currentRoute={ currentRoute }
-					isLoggedIn={ isLoggedIn }
-				/>
-			) }
+			{ [ 'themes', 'theme', 'reader' ].includes( sectionName ) &&
+				! isReaderParedDownSearchPage && (
+					<UniversalNavbarFooter
+						onLanguageChange={ ( e ) => {
+							navigate( `/${ e.target.value + pathNameWithoutLocale }` );
+							window.location.reload();
+						} }
+						currentRoute={ currentRoute }
+						isLoggedIn={ isLoggedIn }
+					/>
+				) }
 		</div>
 	);
 };

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -24,6 +24,7 @@ import {
 	isWPJobManagerOAuth2Client,
 	isGravPoweredOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
+import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-embed-page';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getRedirectToOriginal } from 'calypso/state/login/selectors';
 import { isPartnerSignupQuery } from 'calypso/state/login/utils';
@@ -79,18 +80,13 @@ const LayoutLoggedOut = ( {
 		sectionName === 'checkout' && currentRoute.startsWith( '/checkout/jetpack/thank-you' );
 
 	const isReaderTagPage = sectionName === 'reader' && pathNameWithoutLocale.startsWith( '/tag/' );
+	const isReaderTagEmbed = isReaderTagPage && isReaderTagEmbedPage( window.location );
 
 	const isReaderDiscoverPage =
 		sectionName === 'reader' && pathNameWithoutLocale.startsWith( '/discover' );
 
 	const isReaderSearchPage =
 		sectionName === 'reader' && pathNameWithoutLocale.startsWith( '/read/search' );
-
-	const urlParams = new URLSearchParams( window.location.search );
-	const isReaderParedDownSearchPage =
-		sectionName === 'reader' &&
-		pathNameWithoutLocale.startsWith( '/read/search' ) &&
-		urlParams.get( 'type' ) === 'basic';
 
 	// It's used to add a class name for the login and magic login of Gravatar powered clients only (not for F2A pages)
 	const isGravPoweredLoginPage =
@@ -153,7 +149,7 @@ const LayoutLoggedOut = ( {
 		config.isEnabled( 'jetpack-cloud' ) ||
 		isWpMobileApp() ||
 		isJetpackThankYou ||
-		isReaderParedDownSearchPage
+		isReaderTagEmbed
 	) {
 		masterbar = null;
 	} else if (
@@ -231,17 +227,16 @@ const LayoutLoggedOut = ( {
 				</>
 			) }
 
-			{ [ 'themes', 'theme', 'reader' ].includes( sectionName ) &&
-				! isReaderParedDownSearchPage && (
-					<UniversalNavbarFooter
-						onLanguageChange={ ( e ) => {
-							navigate( `/${ e.target.value + pathNameWithoutLocale }` );
-							window.location.reload();
-						} }
-						currentRoute={ currentRoute }
-						isLoggedIn={ isLoggedIn }
-					/>
-				) }
+			{ [ 'themes', 'theme', 'reader' ].includes( sectionName ) && ! isReaderTagEmbed && (
+				<UniversalNavbarFooter
+					onLanguageChange={ ( e ) => {
+						navigate( `/${ e.target.value + pathNameWithoutLocale }` );
+						window.location.reload();
+					} }
+					currentRoute={ currentRoute }
+					isLoggedIn={ isLoggedIn }
+				/>
+			) }
 		</div>
 	);
 };

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -80,7 +80,6 @@ const LayoutLoggedOut = ( {
 		sectionName === 'checkout' && currentRoute.startsWith( '/checkout/jetpack/thank-you' );
 
 	const isReaderTagPage = sectionName === 'reader' && pathNameWithoutLocale.startsWith( '/tag/' );
-	const isReaderTagEmbed = isReaderTagPage && isReaderTagEmbedPage( window.location );
 
 	const isReaderDiscoverPage =
 		sectionName === 'reader' && pathNameWithoutLocale.startsWith( '/discover' );
@@ -149,7 +148,7 @@ const LayoutLoggedOut = ( {
 		config.isEnabled( 'jetpack-cloud' ) ||
 		isWpMobileApp() ||
 		isJetpackThankYou ||
-		isReaderTagEmbed
+		isReaderTagEmbedPage
 	) {
 		masterbar = null;
 	} else if (
@@ -227,7 +226,7 @@ const LayoutLoggedOut = ( {
 				</>
 			) }
 
-			{ [ 'themes', 'theme', 'reader' ].includes( sectionName ) && ! isReaderTagEmbed && (
+			{ [ 'themes', 'theme', 'reader' ].includes( sectionName ) && ! isReaderTagEmbedPage && (
 				<UniversalNavbarFooter
 					onLanguageChange={ ( e ) => {
 						navigate( `/${ e.target.value + pathNameWithoutLocale }` );

--- a/client/lib/reader/is-reader-embed-page.js
+++ b/client/lib/reader/is-reader-embed-page.js
@@ -1,0 +1,5 @@
+export default function isReaderTagEmbedPage( url ) {
+	const urlObject = new URL( url );
+	const urlParams = new URLSearchParams( url.search );
+	return urlObject.pathname.includes( '/tag/' ) && urlParams.get( 'type' ) === 'embed';
+}

--- a/client/reader/tag-stream/index.js
+++ b/client/reader/tag-stream/index.js
@@ -10,6 +10,7 @@ import {
 	render as clientRender,
 } from 'calypso/controller';
 import { setLocaleMiddleware } from 'calypso/controller/shared';
+import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-embed-page';
 import { sidebar, updateLastRoute } from 'calypso/reader/controller';
 import { tagListing } from './controller';
 
@@ -34,6 +35,19 @@ export default function () {
 	page( '/tag/*', redirectHashtaggedTags );
 
 	page( `/${ anyLangParam }/tag/:tag`, redirectInvalidLanguage );
+
+	if ( isReaderTagEmbedPage( window.location ) ) {
+		page(
+			[ '/tag/:tag', `/${ langParam }/tag/:tag` ],
+			setLocaleMiddleware(),
+			redirectToSignup,
+			updateLastRoute,
+			tagListing,
+			makeLayout,
+			clientRender
+		);
+		return;
+	}
 
 	page(
 		[ '/tag/:tag', `/${ langParam }/tag/:tag` ],

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -8,6 +8,7 @@ import QueryReaderFollowedTags from 'calypso/components/data/query-reader-follow
 import QueryReaderTag from 'calypso/components/data/query-reader-tag';
 import { navigate } from 'calypso/lib/navigate';
 import { createAccountUrl } from 'calypso/lib/paths';
+import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-embed-page';
 import ReaderMain from 'calypso/reader/components/reader-main';
 import HeaderBack from 'calypso/reader/header-back';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
@@ -147,6 +148,12 @@ class TagStream extends Component {
 				/>
 			</>
 		);
+		const sidebarProps = ! isReaderTagEmbedPage( window.location ) && {
+			streamSidebar: () => (
+				<ReaderTagSidebar tag={ this.props.decodedTagSlug } showFollow={ false } />
+			),
+			sidebarTabTitle: this.props.translate( 'Related' ),
+		};
 
 		return (
 			<Stream
@@ -159,10 +166,7 @@ class TagStream extends Component {
 				streamHeader={ tagHeader }
 				showSiteNameOnCards={ false }
 				useCompactCards={ true }
-				streamSidebar={ () => (
-					<ReaderTagSidebar tag={ this.props.decodedTagSlug } showFollow={ false } />
-				) }
-				sidebarTabTitle={ this.props.translate( 'Related' ) }
+				{ ...sidebarProps }
 			>
 				<QueryReaderFollowedTags />
 				<QueryReaderTag tag={ this.props.decodedTagSlug } />


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Context - pe8liG-hD-p2 and pdhack-NI-p2
## Proposed Changes

* This renders a pared down version of the Reader tag page than can be used as an embed in landing pages.
* The requirement for this pared down Reader comes from having to embed the tag page on the NaNoWriMo landing page - please check pe8liG-hD#comment-494 which gives more context on why the changes in this PR are relevant.

**How is the pared down Reader rendered?**

When the Reader tag page is accessed with the query param `type=embed`. e.g. `wordpress.com/tag/nanowrimo?sort=date&type=embed`.

**What changes are included in this PR?**

For the embed version:
* Remove masterbar and sidebar in both logged-in and logged-out views.
* In the logged-out view, clicking on "Like", "Reply", or typing a comment in the comment form should open the signup page in a new tab. Otherwise, the embed will open the signup page within the embed, inside of in the parent window. 
* Render the logged-out Reader version even if the user is logged-in.

**Logged-out**

<img width="1425" alt="Screenshot 2023-10-20 at 4 03 45 PM" src="https://github.com/Automattic/wp-calypso/assets/1269602/2b1bcbbc-9551-48dc-a69b-df6f74bd0c7f">

**Logged-in**
<img width="1417" alt="Screenshot 2023-10-20 at 4 06 12 PM" src="https://github.com/Automattic/wp-calypso/assets/1269602/6ab28a8f-399f-4c37-9d1f-87b5b4142ef8">



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `tag/nanowrimo?sort=date&type=embed` while logged-out and verify that you don't see the sidebar, masterbar, and footer. Only the posts should be visible. 



* While logged-out, clicking on "Like", "Reply", or typing in the comment form should open the signup page in a new tab. 
* Visit `tag/nanowrimo?sort=date&type=embed` while logged-in to WP.com, and verify that you see the logged-out Reader view, with masterbar, sidebar and footer removed. 
