### PR TITLE
Design Preview: Fix infinite re-rendering

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/hooks/use-recipe.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/hooks/use-recipe.ts
@@ -5,7 +5,7 @@ import {
 } from '@automattic/design-picker';
 import { useColorPaletteVariations, useFontPairingVariations } from '@automattic/global-styles';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { ONBOARD_STORE } from '../../../../../stores';
 import type { GlobalStyles, OnboardSelect, StarterDesigns } from '@automattic/data-stores';
@@ -66,6 +66,8 @@ const useRecipe = (
 		} ),
 		[]
 	);
+
+	const isInitializedRef = useRef( false );
 
 	const { stylesheet = '' } = selectedDesign?.recipe || {};
 
@@ -178,7 +180,7 @@ const useRecipe = (
 
 	// Initialize the preselected design and style variations.
 	useEffect( () => {
-		if ( ! allDesigns || ! preselectedTheme ) {
+		if ( ! allDesigns || ! preselectedTheme || isInitializedRef.current ) {
 			return;
 		}
 
@@ -202,6 +204,7 @@ const useRecipe = (
 
 		setSelectedDesign( requestedDesign );
 		setIsPreviewingDesign( true );
+		isInitializedRef.current = true;
 	}, [
 		preselectedTheme,
 		preselectedStyle,

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -8,7 +8,6 @@ import { ECOMMERCE_FLOW, ecommerceFlowRecurTypes } from '@automattic/onboarding'
 import { QueryClientProvider } from '@tanstack/react-query';
 import { useDispatch } from '@wordpress/data';
 import defaultCalypsoI18n from 'i18n-calypso';
-import { useEffect } from 'react';
 import ReactDom from 'react-dom';
 import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';
@@ -52,22 +51,26 @@ function determineFlow() {
 /**
  * TODO: this is no longer a switch and should be removed
  */
-const FlowSwitch: React.FC< { flow: Flow } > = ( { flow } ) => {
+const FlowSwitch: React.FC< { user: UserStore.CurrentUser | undefined; flow: Flow } > = ( {
+	user,
+	flow,
+} ) => {
+	const { receiveCurrentUser } = useDispatch( USER_STORE );
 	const { setEcommerceFlowRecurType } = useDispatch( ONBOARD_STORE );
-	const recurType = useQuery().get( 'recur' ) ?? '';
 
-	useEffect( () => {
-		if ( flow.name !== ECOMMERCE_FLOW ) {
-			return;
-		}
+	const recurType = useQuery().get( 'recur' );
 
-		const isValidRecurType = Object.values( ecommerceFlowRecurTypes ).includes( recurType );
+	if ( flow.name === ECOMMERCE_FLOW ) {
+		const isValidRecurType =
+			recurType && Object.values( ecommerceFlowRecurTypes ).includes( recurType );
 		if ( isValidRecurType ) {
 			setEcommerceFlowRecurType( recurType );
 		} else {
 			setEcommerceFlowRecurType( ecommerceFlowRecurTypes.YEARLY );
 		}
-	}, [ flow.name, recurType ] );
+	}
+
+	user && receiveCurrentUser( user as UserStore.CurrentUser );
 
 	return <FlowRenderer flow={ flow } />;
 };
@@ -116,7 +119,7 @@ window.AppBoot = async () => {
 				<QueryClientProvider client={ queryClient }>
 					<WindowLocaleEffectManager />
 					<BrowserRouter basename="setup">
-						<FlowSwitch flow={ flow } />
+						<FlowSwitch user={ user as UserStore.CurrentUser } flow={ flow } />
 						{ config.isEnabled( 'cookie-banner' ) && (
 							<AsyncLoad require="calypso/blocks/cookie-banner" placeholder={ null } />
 						) }

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -1,11 +1,12 @@
 import '@automattic/calypso-polyfills';
 import accessibleFocus from '@automattic/accessible-focus';
 import { initializeAnalytics } from '@automattic/calypso-analytics';
+import { CurrentUser } from '@automattic/calypso-analytics/dist/types/utils/current-user';
 import config from '@automattic/calypso-config';
-import { User as UserStore, UserActions } from '@automattic/data-stores';
+import { User as UserStore } from '@automattic/data-stores';
 import { ECOMMERCE_FLOW, ecommerceFlowRecurTypes } from '@automattic/onboarding';
 import { QueryClientProvider } from '@tanstack/react-query';
-import { dispatch, useDispatch } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import defaultCalypsoI18n from 'i18n-calypso';
 import { useEffect } from 'react';
 import ReactDom from 'react-dom';
@@ -38,15 +39,7 @@ import type { Flow } from './declarative-flow/internals/types';
 declare const window: AppWindow;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function setupUser( reduxStore: any, user: UserStore.CurrentUser | false ) {
-	if ( ! user ) {
-		return;
-	}
-
-	// initialize Stepper User store
-	( dispatch( USER_STORE ) as UserActions ).receiveCurrentUser( user );
-
-	// initialize Calypso User Store
+function initializeCalypsoUserStore( reduxStore: any, user: CurrentUser ) {
 	reduxStore.dispatch( setCurrentUser( user ) );
 }
 
@@ -99,8 +92,8 @@ window.AppBoot = async () => {
 	// Add accessible-focus listener.
 	accessibleFocus();
 
-	const user = ( await initializeCurrentUser() ) as UserStore.CurrentUser | false;
-	const userId = user ? user.ID : undefined;
+	const user = ( await initializeCurrentUser() ) as unknown;
+	const userId = ( user as CurrentUser ).ID;
 
 	const queryClient = await createQueryClient( userId );
 
@@ -108,7 +101,8 @@ window.AppBoot = async () => {
 	const reduxStore = createReduxStore( initialState, initialReducer );
 	setStore( reduxStore, getStateFromCache( userId ) );
 	setupLocale( user, reduxStore );
-	setupUser( reduxStore, user );
+
+	user && initializeCalypsoUserStore( reduxStore, user as CurrentUser );
 	initializeAnalytics( user, getSuperProps( reduxStore ) );
 
 	setupErrorLogger( reduxStore );

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -7,6 +7,7 @@ import { ECOMMERCE_FLOW, ecommerceFlowRecurTypes } from '@automattic/onboarding'
 import { QueryClientProvider } from '@tanstack/react-query';
 import { dispatch, useDispatch } from '@wordpress/data';
 import defaultCalypsoI18n from 'i18n-calypso';
+import { useEffect } from 'react';
 import ReactDom from 'react-dom';
 import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';
@@ -58,26 +59,22 @@ function determineFlow() {
 /**
  * TODO: this is no longer a switch and should be removed
  */
-const FlowSwitch: React.FC< { user: UserStore.CurrentUser | undefined; flow: Flow } > = ( {
-	user,
-	flow,
-} ) => {
-	const { receiveCurrentUser } = useDispatch( USER_STORE );
+const FlowSwitch: React.FC< { flow: Flow } > = ( { flow } ) => {
 	const { setEcommerceFlowRecurType } = useDispatch( ONBOARD_STORE );
+	const recurType = useQuery().get( 'recur' ) ?? '';
 
-	const recurType = useQuery().get( 'recur' );
+	useEffect( () => {
+		if ( flow.name !== ECOMMERCE_FLOW ) {
+			return;
+		}
 
-	if ( flow.name === ECOMMERCE_FLOW ) {
-		const isValidRecurType =
-			recurType && Object.values( ecommerceFlowRecurTypes ).includes( recurType );
+		const isValidRecurType = Object.values( ecommerceFlowRecurTypes ).includes( recurType );
 		if ( isValidRecurType ) {
 			setEcommerceFlowRecurType( recurType );
 		} else {
 			setEcommerceFlowRecurType( ecommerceFlowRecurTypes.YEARLY );
 		}
-	}
-
-	user && receiveCurrentUser( user as UserStore.CurrentUser );
+	}, [ flow.name, recurType ] );
 
 	return <FlowRenderer flow={ flow } />;
 };
@@ -125,7 +122,7 @@ window.AppBoot = async () => {
 				<QueryClientProvider client={ queryClient }>
 					<WindowLocaleEffectManager />
 					<BrowserRouter basename="setup">
-						<FlowSwitch user={ user as UserStore.CurrentUser } flow={ flow } />
+						<FlowSwitch flow={ flow } />
 						{ config.isEnabled( 'cookie-banner' ) && (
 							<AsyncLoad require="calypso/blocks/cookie-banner" placeholder={ null } />
 						) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1697776363743409-slack-CRWCHQGUB

## Proposed Changes

* Avoid calling the `receiveCurrentUser` action on every render
* Avoid initializing the preselected design and style variations multiple times because the deps change, e.g. `pickUnlistedDesign`. The `pickUnlistedDesign` function is always the new one on every render

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /setup/site-setup/designSetup?theme=fewer&siteSlug=your_site
* Ensure the page won't re-rendering forever
* Ensure the back button works as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?