### PR TITLE
My home preview: hide cookie banner and remove clicks

### DIFF
--- a/client/my-sites/customer-home/cards/features/site-preview/index.tsx
+++ b/client/my-sites/customer-home/cards/features/site-preview/index.tsx
@@ -70,7 +70,7 @@ const SitePreview = ( { isFSEActive }: SitePreviewProps ): JSX.Element => {
 		canvas: 'edit',
 	} );
 
-	const iframeSrcKeepHomepage = `//${ wpcomDomain.domain }/?hide_banners=true&preview_overlay=true`;
+	const iframeSrcKeepHomepage = `//${ wpcomDomain.domain }/?hide_banners=true&preview_overlay=true&preview=true`;
 
 	return (
 		<div className="home-site-preview">

--- a/client/my-sites/customer-home/cards/features/site-preview/style.scss
+++ b/client/my-sites/customer-home/cards/features/site-preview/style.scss
@@ -30,6 +30,7 @@
 		.home-site-preview__thumbnail {
 			display: block;
 			height: 235px;
+			pointer-events: none;
 			width: 100%;
 			iframe {
 				// The idea is to zoom-out the iframe to get most of the content


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->



## Proposed Changes

* Append `preview=true` to iframe URL to stop cookie banner from showing. The preview param might stop other things showing up as well.
* Stop mouse events to the iframe to avoid clicks/hovers

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* At my home, preview a site where you haven't dismissed the cookie banner. Incognito mode should help.

### Before

<img width="389" alt="Screenshot 2023-10-20 at 12 02 37" src="https://github.com/Automattic/wp-calypso/assets/87168/130fc91e-f045-4657-8704-a9bb597594f6">

https://github.com/Automattic/wp-calypso/assets/87168/8dd5ff88-61f1-4816-9816-51393ce24360


### After

<img width="336" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/7274e228-58e0-41a0-81fd-a9aeb1cddec8">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?