### PR TITLE
Jetpack Manage: add event tracking for new navigation changes

### DIFF
--- a/client/jetpack-cloud/components/sidebar/header/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/header/index.tsx
@@ -4,6 +4,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import AllSites from 'calypso/blocks/all-sites';
 import Site from 'calypso/blocks/site';
 import { SidebarV2Header as SidebarHeader } from 'calypso/layout/sidebar-v2';
+import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import { setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import JetpackLogo from './jetpack-logo.svg';
@@ -29,7 +30,14 @@ const Header = ( { forceAllSitesView = false }: Props ) => {
 
 	const onSelectSite = useCallback( () => {
 		dispatch( setLayoutFocus( 'sites' ) );
-	}, [ dispatch ] );
+		dispatch(
+			forceAllSitesView
+				? recordTracksEvent( 'calypso_jetpack_sidebar_switch_site_all_click' )
+				: recordTracksEvent( 'calypso_jetpack_sidebar_switch_site_single_click', {
+						site_id: selectedSiteId,
+				  } )
+		);
+	}, [ dispatch, forceAllSitesView, selectedSiteId ] );
 
 	return (
 		<SidebarHeader className="jetpack-cloud-sidebar__header">

--- a/client/jetpack-cloud/components/sidebar/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/index.tsx
@@ -1,4 +1,3 @@
-import { recordTracksEvent } from '@automattic/calypso-analytics';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import JetpackIcons from 'calypso/components/jetpack/sidebar/menu-items/jetpack-icons';
@@ -10,7 +9,8 @@ import Sidebar, {
 	SidebarNavigatorMenu,
 	SidebarNavigatorMenuItem,
 } from 'calypso/layout/sidebar-v2';
-import { useSelector } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getJetpackAdminUrl from 'calypso/state/sites/selectors/get-jetpack-admin-url';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import SidebarHeader from './header';
@@ -55,6 +55,7 @@ const JetpackCloudSidebar = ( {
 	);
 
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 
 	return (
 		<Sidebar className={ classNames( 'jetpack-cloud-sidebar', className ) }>
@@ -73,7 +74,7 @@ const JetpackCloudSidebar = ( {
 								{ ...item }
 								onClickMenuItem={ ( path ) => {
 									if ( item.trackEventName ) {
-										recordTracksEvent( item.trackEventName, item.trackEventProps );
+										dispatch( recordTracksEvent( item.trackEventName, item.trackEventProps ) );
 									}
 									item.onClickMenuItem( path );
 								} }
@@ -91,7 +92,7 @@ const JetpackCloudSidebar = ( {
 						path={ jetpackAdminUrl }
 						icon={ <JetpackIcons icon="wordpress" /> }
 						onClickMenuItem={ ( link ) => {
-							recordTracksEvent( 'calypso_jetpack_sidebar_wp_admin_link_click' );
+							dispatch( recordTracksEvent( 'calypso_jetpack_sidebar_wp_admin_link_click' ) );
 							window.open( link, '_blank' );
 						} }
 						isExternalLink

--- a/client/jetpack-cloud/components/sidebar/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/index.tsx
@@ -17,10 +17,6 @@ import SidebarHeader from './header';
 
 import './style.scss';
 
-// This is meant to be the "base" sidebar component. All context-specific sidebars
-// (Sites Management, Plugin Management, Purchases, non-Manage functionality)
-// would use it to construct the right experience for that context.
-
 type Props = {
 	className?: string;
 	isJetpackManage?: boolean;
@@ -35,6 +31,7 @@ type Props = {
 		isExternalLink?: boolean;
 		isSelected: boolean;
 		trackEventName?: string;
+		trackEventProps?: { [ key: string ]: string };
 	}[];
 	description?: string;
 	backButtonProps?: {
@@ -76,7 +73,7 @@ const JetpackCloudSidebar = ( {
 								{ ...item }
 								onClickMenuItem={ ( path ) => {
 									if ( item.trackEventName ) {
-										recordTracksEvent( item.trackEventName );
+										recordTracksEvent( item.trackEventName, item.trackEventProps );
 									}
 									item.onClickMenuItem( path );
 								} }

--- a/client/jetpack-cloud/sections/sidebar-navigation/jetpack-manage.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/jetpack-manage.tsx
@@ -16,6 +16,7 @@ const JetpackManageSidebar = () => {
 	const createItem = ( props: MenuItemProps ) => ( {
 		...props,
 		onClickMenuItem: redirectPage,
+		trackEventName: 'calypso_jetpack_sidebar_menu_click',
 		isSelected: isMenuItemSelected( props.link ),
 	} );
 
@@ -25,24 +26,36 @@ const JetpackManageSidebar = () => {
 			path: '/',
 			link: JETPACK_MANAGE_DASHBOARD_LINK,
 			title: translate( 'Sites Management' ),
+			trackEventProps: {
+				menu_item: 'Jetpack Cloud / Dashboard',
+			},
 		} ),
 		createItem( {
 			icon: plugins,
 			path: '/',
 			link: JETPACK_MANAGE_PLUGINS_LINK,
 			title: translate( 'Plugin Management' ),
+			trackEventProps: {
+				menu_item: 'Jetpack Cloud / Plugins',
+			},
 		} ),
 		createItem( {
 			icon: key,
 			path: '/',
 			link: JETPACK_MANAGE_LICENCES_LINK,
 			title: translate( 'Licenses' ),
+			trackEventProps: {
+				menu_item: 'Jetpack Cloud / Partner Portal / Licenses',
+			},
 		} ),
 		createItem( {
 			icon: currencyDollar,
 			path: '/partner-portal/',
 			link: JETPACK_MANAGE_BILLING_LINK,
 			title: translate( 'Purchases' ),
+			trackEventProps: {
+				menu_item: 'Jetpack Cloud / Partner Portal',
+			},
 			withChevron: true,
 		} ),
 	];

--- a/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
@@ -1,4 +1,3 @@
-import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { WPCOM_FEATURES_BACKUPS, WPCOM_FEATURES_SCAN } from '@automattic/calypso-products';
 import {
@@ -26,6 +25,8 @@ import {
 } from 'calypso/lib/jetpack/paths';
 import { itemLinkMatches } from 'calypso/my-sites/sidebar/utils';
 import { isSectionNameEnabled } from 'calypso/sections-filter';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { isAgencyUser } from 'calypso/state/partner-portal/partner/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
@@ -49,6 +50,7 @@ const useMenuItems = ( {
 	isAgency: boolean;
 } ) => {
 	const translate = useTranslate();
+
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const hasBackups = useSelector( ( state ) =>
 		siteHasFeature( state, siteId, WPCOM_FEATURES_BACKUPS )
@@ -172,6 +174,8 @@ const useMenuItems = ( {
 
 const ManageSelectedSiteSidebar = ( { path }: { path: string } ) => {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
+
 	const siteId = useSelector( getSelectedSiteId );
 	const isAgency = useSelector( isAgencyUser );
 	const menuItems = useMenuItems( { siteId, isAgency, path } );
@@ -189,7 +193,9 @@ const ManageSelectedSiteSidebar = ( { path }: { path: string } ) => {
 								label: translate( 'Site Settings' ),
 								icon: chevronLeft,
 								onClick: () => {
-									recordTracksEvent( 'calypso_jetpack_sidebar_site_settings_back_button_click' );
+									dispatch(
+										recordTracksEvent( 'calypso_jetpack_sidebar_site_settings_back_button_click' )
+									);
 									redirectPage( '/dashboard' );
 								},
 						  }

--- a/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { WPCOM_FEATURES_BACKUPS, WPCOM_FEATURES_SCAN } from '@automattic/calypso-products';
 import {
@@ -187,7 +188,10 @@ const ManageSelectedSiteSidebar = ( { path }: { path: string } ) => {
 						? {
 								label: translate( 'Site Settings' ),
 								icon: chevronLeft,
-								onClick: () => redirectPage( '/dashboard' ),
+								onClick: () => {
+									recordTracksEvent( 'calypso_jetpack_sidebar_site_settings_back_button_click' );
+									redirectPage( '/dashboard' );
+								},
 						  }
 						: undefined
 				}

--- a/client/jetpack-cloud/sections/sidebar-navigation/purchases.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/purchases.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { chevronLeft, formatListBulletsRTL, payment, receipt, store, tag } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import NewSidebar from 'calypso/jetpack-cloud/components/sidebar';
@@ -60,7 +61,10 @@ const PurchasesSidebar = () => {
 			backButtonProps={ {
 				label: translate( 'Purchases' ),
 				icon: chevronLeft,
-				onClick: () => redirectPage( JETPACK_MANAGE_DASHBOARD_LINK ),
+				onClick: () => {
+					recordTracksEvent( 'calypso_jetpack_sidebar_new_purchases_back_button_click' );
+					redirectPage( JETPACK_MANAGE_DASHBOARD_LINK );
+				},
 			} }
 		/>
 	);

--- a/client/jetpack-cloud/sections/sidebar-navigation/purchases.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/purchases.tsx
@@ -18,6 +18,7 @@ const createItem = ( props: Omit< MenuItemProps, 'path' > ) => ( {
 	...props,
 	path: JETPACK_MANAGE_PARTNER_PORTAL_LINK,
 	onClickMenuItem: redirectPage,
+	trackEventName: 'calypso_jetpack_sidebar_menu_click',
 	isSelected: isMenuItemSelected( props.link ),
 } );
 
@@ -29,26 +30,41 @@ const PurchasesSidebar = () => {
 			icon: store,
 			link: JETPACK_MANAGE_BILLING_LINK,
 			title: translate( 'Billing' ),
+			trackEventProps: {
+				menu_item: 'Jetpack Cloud / Partner Portal / Billing',
+			},
 		} ),
 		createItem( {
 			icon: payment,
 			link: JETPACK_MANAGE_PAYMENT_METHODS_LINK,
 			title: translate( 'Payment Methods' ),
+			trackEventProps: {
+				menu_item: 'Jetpack Cloud / Partner Portal / Payment Methods',
+			},
 		} ),
 		createItem( {
 			icon: receipt,
 			link: JETPACK_MANAGE_INVOICES_LINK,
 			title: translate( 'Invoices' ),
+			trackEventProps: {
+				menu_item: 'Jetpack Cloud / Partner Portal / Invoices',
+			},
 		} ),
 		createItem( {
 			icon: tag,
 			link: JETPACK_MANAGE_PRICES_LINK,
 			title: translate( 'Prices' ),
+			trackEventProps: {
+				menu_item: 'Jetpack Cloud / Partner Portal / Prices',
+			},
 		} ),
 		createItem( {
 			icon: formatListBulletsRTL,
 			link: JETPACK_MANAGE_COMPANY_DETAILS_LINK,
 			title: translate( 'Company Details' ),
+			trackEventProps: {
+				menu_item: 'Jetpack Cloud / Partner Portal / Company Details',
+			},
 		} ),
 	];
 

--- a/client/jetpack-cloud/sections/sidebar-navigation/purchases.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/purchases.tsx
@@ -1,7 +1,8 @@
-import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { chevronLeft, formatListBulletsRTL, payment, receipt, store, tag } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import NewSidebar from 'calypso/jetpack-cloud/components/sidebar';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
 	JETPACK_MANAGE_BILLING_LINK,
 	JETPACK_MANAGE_COMPANY_DETAILS_LINK,
@@ -24,6 +25,7 @@ const createItem = ( props: Omit< MenuItemProps, 'path' > ) => ( {
 
 const PurchasesSidebar = () => {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 
 	const menuItems = [
 		createItem( {
@@ -78,7 +80,9 @@ const PurchasesSidebar = () => {
 				label: translate( 'Purchases' ),
 				icon: chevronLeft,
 				onClick: () => {
-					recordTracksEvent( 'calypso_jetpack_sidebar_new_purchases_back_button_click' );
+					dispatch(
+						recordTracksEvent( 'calypso_jetpack_sidebar_new_purchases_back_button_click' )
+					);
 					redirectPage( JETPACK_MANAGE_DASHBOARD_LINK );
 				},
 			} }

--- a/client/jetpack-cloud/sections/sidebar-navigation/types.ts
+++ b/client/jetpack-cloud/sections/sidebar-navigation/types.ts
@@ -5,4 +5,5 @@ export type MenuItemProps = {
 	title: string;
 	withChevron?: boolean;
 	isExternalLink?: boolean;
+	trackEventProps?: { [ key: string ]: string };
 };


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/68

## Proposed Changes

This PR adds track events to the new navigation changes in Jetpack Cloud. I tried using the same event names for all expect the profile dropdown and newly added menu items or features.

### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Open the Jetpack Cloud live link
2. Visit the /dashboard & append the URL with `?flags=jetpack/new-navigation`
3. Open the dev tool, go to the network tab, and apply the filters - `jetpack-cloud-development` as search and select `Img` filters.

<img width="739" alt="Screenshot 2023-01-19 at 12 43 57 PM" src="https://user-images.githubusercontent.com/10586875/213378720-624de9b6-dc14-489e-a9a2-d7f04cfa478c.png">

4. Perform the below actions and verify that the API call to track the event is made with the right action names.

------

<img width="437" alt="Screenshot 2023-10-20 at 3 04 19 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/13d9b8d8-3d15-49ee-bf0d-a5401c8b9dad">

#### 1) Click the All Sites label to switch the site

Event name:  `calypso_jetpack_sidebar_switch_site_all_click` 

#### 2) Click the menu item: Sites Management

Event name: `calypso_jetpack_sidebar_menu_click`
Extra props: `menu_item: Jetpack Cloud / Dashboard`

#### 3) Click the menu item: Plugin Management

Event name: `calypso_jetpack_sidebar_menu_click`
Extra props: `menu_item: Jetpack Cloud / Plugins`

#### 4) Click the menu item: Licenses

Event name: `calypso_jetpack_sidebar_menu_click`
Extra props: `menu_item: Jetpack Cloud / Partner Portal / Licenses`

#### 5) Click the menu item: Purchases

Event name: `calypso_jetpack_sidebar_menu_click`
Extra props: `menu_item: Jetpack Cloud / Partner Portal`

#### 6) Click the profile dropdown

Event name: `calypso_jetpack_sidebar_profile_toggle` & `calypso_jetpack_sidebar_profile_close` for only close

#### 7) Click the profile dropdown menu item: Get Help

Event name: `calypso_jetpack_sidebar_gethelp`

#### 8) Click the profile dropdown menu item: Sign out

Event name: `calypso_jetpack_sidebar_signout`

------

<img width="281" alt="Screenshot 2023-10-20 at 3 04 28 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/5914823b-8b12-428d-9265-aeaf173a6a44">

#### 9) Click the back button before the **Purchases** heading

Event name:  `calypso_jetpack_sidebar_new_purchases_back_button_click`

#### 10) Click the menu item: Billing

Event name: `calypso_jetpack_sidebar_menu_click`
Extra props: `menu_item: Jetpack Cloud / Partner Portal / Billing`

#### 11) Click the menu item: Payment Methods

Event name: `calypso_jetpack_sidebar_menu_click`
Extra props: `menu_item: Jetpack Cloud / Partner Portal / Payment Methods`

#### 12) Click the menu item: Invoices

Event name: `calypso_jetpack_sidebar_menu_click`
Extra props: `menu_item: Jetpack Cloud / Partner Portal / Invoices`

#### 13) Click the menu item: Prices

Event name: `calypso_jetpack_sidebar_menu_click`
Extra props: `menu_item: Jetpack Cloud / Partner Portal / Prices`

#### 14) Click the menu item: Company Details

Event name: `calypso_jetpack_sidebar_menu_click`
Extra props: `menu_item: Jetpack Cloud / Partner Portal / Company Details`

------

<img width="281" alt="Screenshot 2023-10-20 at 3 04 39 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/7a179eef-d08a-4531-8709-cccd4d170552">

#### 15) Click the Site name label to switch the site

Event name:  `calypso_jetpack_sidebar_switch_site_single_click`
Extra props: `site_id: <site_id>`

#### 16) Click the back button before the **Site Settings** heading

Event name:  `calypso_jetpack_sidebar_site_settings_back_button_click`

#### 17) Click the menu item: Activity Log

Event name: `calypso_jetpack_sidebar_activity_clicked`

#### 18) Click the menu item: Plugins

Event name: `calypso_jetpack_sidebar_plugins_clicked`

#### 19) Click the menu item: Backup

Event name: `calypso_jetpack_sidebar_backup_clicked`

#### 20) Click the menu item: Scan

Event name: `calypso_jetpack_sidebar_scan_clicked`

#### 21) Click the menu item: Search

Event name: `calypso_jetpack_sidebar_search_clicked`

#### 22) Click the menu item: Social

Event name: `calypso_jetpack_sidebar_social_clicked`

#### 23) Click the menu item: Settings

Event name: `calypso_jetpack_sidebar_settings_clicked`

#### 24) Click the menu item: Purchases

Event name: `calypso_jetpack_sidebar_purchases_clicked`

#### 25)Click the menu item: WP Admin

Event name: `calypso_jetpack_sidebar_wp_admin_link_click`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?