### PR TITLE
Theme Discovery: Randomize Collections only once per SSR

### DIFF
--- a/client/my-sites/themes/collections/theme-collections-layout.tsx
+++ b/client/my-sites/themes/collections/theme-collections-layout.tsx
@@ -22,6 +22,8 @@ export interface ThemeCollectionsLayoutProps {
 	onSeeAll: ( object: OnSeeAll ) => void;
 }
 
+const collections = Object.values( THEME_COLLECTIONS ).sort( () => Math.random() - 0.5 );
+
 function ThemeCollectionsPatternAssemblerCta() {
 	const selectedSiteId = useSelector( getSelectedSiteId );
 	const selectedSite = useSelector( getSelectedSite );
@@ -52,8 +54,6 @@ function ThemeCollectionsPatternAssemblerCta() {
 
 function ThemeCollectionsLayout( props: ThemeCollectionsLayoutProps ) {
 	const { onSeeAll } = props;
-
-	const collections = Object.values( THEME_COLLECTIONS ).sort( () => Math.random() - 0.5 );
 
 	const showcaseThemeCollections = collections.map( ( collection ) => {
 		const { filter, tier } = collection.query;


### PR DESCRIPTION
We're randomizing the list of collections every time we load the discovery page, this is a bit misleading since if we open a carousel and press the back button we get a completely different Discover view.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* We now only randomize the collection list once per render.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso live link
* Go to the LoTS and add `?flags=themes/discovery-lots` 
* When you click on the `see more` link and then navigate back you should see different collections are still in the same order.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?