### PR TITLE
Newsletter settings: track changes to custom messages

### DIFF
--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -151,7 +151,7 @@ const wrapSettingsForm = ( getFormSettings ) => ( SettingsForm ) => {
 
 		// Some Utils
 		handleSubmitForm = ( event ) => {
-			const { dirtyFields, fields, trackTracksEvent, path } = this.props;
+			const { dirtyFields, fields, settings, trackTracksEvent, path } = this.props;
 
 			if ( event && ! event.isDefaultPrevented() && event.nativeEvent ) {
 				event.preventDefault();
@@ -190,6 +190,22 @@ const wrapSettingsForm = ( getFormSettings ) => ( SettingsForm ) => {
 							value: fields.wpcom_newsletter_categories_enabled,
 							path,
 						} );
+						break;
+					case 'subscription_options':
+						if ( fields.subscription_options.welcome !== settings.subscription_options.welcome ) {
+							trackTracksEvent( 'calypso_settings_subscription_options_welcome_updated', {
+								path,
+							} );
+						}
+
+						if (
+							fields.subscription_options.comment_follow !==
+							settings.subscription_options.comment_follow
+						) {
+							trackTracksEvent( 'calypso_settings_subscription_options_comment_follow_updated', {
+								path,
+							} );
+						}
 						break;
 				}
 			} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Adds tracking to custom messages saved via Newsletter settings. 


## Proposed Changes

* Adds tracking to custom messages saved via Newsletter settings by comparing old/new value. `dirtyFields` contains only info that `subscription_options` changed, but messages which are inside the option aren't tracked separately.

Alternatively I could've updated `updateDirtyFields` but felt more involved for little gain, especially since we're moving these messages out to editor in future.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go Newsletter settings
* Make changes to textfields under "Messages"
* Save, see tracks events
* Now refresh and don't edit, save, and see no Tracks events
* You can use `localStorage.debug="calypso:analytics"` in console (and refresh) to see Tracks events fire

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
