### PR TITLE
Subscriber modal setting: add tracks events

### DIFF
--- a/client/my-sites/site-settings/settings-newsletter/SubscribeModalSetting.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/SubscribeModalSetting.tsx
@@ -4,6 +4,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import { useActiveThemeQuery } from 'calypso/data/themes/use-active-theme-query';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import getSiteEditorUrl from 'calypso/state/selectors/get-site-editor-url';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 export const SUBSCRIBE_MODAL_OPTION = 'sm_enabled';
@@ -35,6 +36,10 @@ export const SubscribeModalSetting = ( {
 		  } )
 		: false;
 
+	const onEditClick = () => {
+		recordTracksEvent( 'calypso_settings_subscriber_modal_edit_click' );
+	};
+
 	return (
 		<>
 			<ToggleControl
@@ -50,7 +55,7 @@ export const SubscribeModalSetting = ( {
 				{ subscribeModalEditorUrl && (
 					<>
 						{ ' ' }
-						<ExternalLink href={ subscribeModalEditorUrl }>
+						<ExternalLink href={ subscribeModalEditorUrl } onClick={ onEditClick }>
 							{ translate( 'Preview and edit the popup' ) }
 						</ExternalLink>
 					</>

--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -191,6 +191,12 @@ const wrapSettingsForm = ( getFormSettings ) => ( SettingsForm ) => {
 							path,
 						} );
 						break;
+					case 'sm_enabled':
+						trackTracksEvent( 'calypso_settings_subscription_modal_updated', {
+							value: fields.sm_enabled,
+							path,
+						} );
+						break;
 				}
 			} );
 			if ( path === '/settings/reading/:site' ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->



## Proposed Changes

* Add tracks events to Subscriber modal toggle

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Observe tracks events, e.g. by hitting `localStorage.debug="calypso:analytics"` in the console and refresh.
* Go to Settings -> Newsletter
* Click toggle on, save, and toggle off, and save again
* Click edit link
* You should have 3 events logged:

<img width="555" alt="Screenshot 2023-10-20 at 14 09 16" src="https://github.com/Automattic/wp-calypso/assets/87168/c2d284d1-1298-4c4b-9a81-b61174611cc0">
<img width="589" alt="Screenshot 2023-10-20 at 14 09 19" src="https://github.com/Automattic/wp-calypso/assets/87168/85be8afc-e1e0-4c80-99ba-7d74782b78c5">
<img width="558" alt="Screenshot 2023-10-20 at 14 09 33" src="https://github.com/Automattic/wp-calypso/assets/87168/fa1c2388-b5d1-4659-8230-d2be3be5bce4">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?