### PR TITLE
Allow post-processing of tasks from DefaultWiredLaunchpad

### DIFF
--- a/client/my-sites/earn/hooks/use-earn-launchpad-tasks.ts
+++ b/client/my-sites/earn/hooks/use-earn-launchpad-tasks.ts
@@ -2,50 +2,40 @@ import { useLaunchpad } from '@automattic/data-stores';
 import { Task } from '@automattic/launchpad';
 import { useSelector } from 'calypso/state';
 import { getProductsForSiteId } from 'calypso/state/memberships/product-list/selectors';
-import {
-	getConnectUrlForSiteId,
-	getConnectedAccountIdForSiteId,
-} from 'calypso/state/memberships/settings/selectors';
+import { getConnectedAccountIdForSiteId } from 'calypso/state/memberships/settings/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 export const useEarnLaunchpadTasks = () => {
 	const checklistSlug = 'earn';
 	const site = useSelector( ( state ) => getSelectedSite( state ) );
 
-	const { products, connectedAccountId, stripeConnectUrl } = useSelector( ( state ) => ( {
+	const { products, connectedAccountId } = useSelector( ( state ) => ( {
 		products: getProductsForSiteId( state, site?.ID ),
 		connectedAccountId: getConnectedAccountIdForSiteId( state, site?.ID ),
-		stripeConnectUrl: getConnectUrlForSiteId( state, site?.ID ?? 0 ),
 	} ) );
 
 	const {
 		data: { checklist },
 	} = useLaunchpad( site?.slug ?? null, checklistSlug );
 
-	const taskFilter = ( tasks: Task[] | null | undefined ): Task[] => {
+	const taskFilter = ( tasks: Task[] ): Task[] => {
 		if ( ! tasks ) {
 			return [];
 		}
 
+		// Override the `completed` value for tasks where the back end site may
+		// not have the correct values available.
 		return tasks.map( ( task ) => {
 			switch ( task.id ) {
 				case 'stripe_connected':
 					return {
 						...task,
 						completed: Boolean( connectedAccountId ),
-						actionDispatch: () => {
-							window.location.assign( stripeConnectUrl );
-						},
 					};
 				case 'paid_offer_created':
 					return {
 						...task,
 						completed: Boolean( products && products.length > 0 ),
-						actionDispatch: () => {
-							window.location.assign(
-								`/earn/payments-plans/${ site?.slug }?launchpad=add-product#add-newsletter-payment-plan`
-							);
-						},
 					};
 				default:
 					return task;
@@ -53,9 +43,9 @@ export const useEarnLaunchpadTasks = () => {
 		} );
 	};
 
-	const enhancedChecklist = taskFilter( checklist );
-	const numberOfSteps = enhancedChecklist?.length || 0;
-	const completedSteps = ( enhancedChecklist?.filter( ( task ) => task.completed ) || [] ).length;
+	const enhancedChecklist = checklist ? taskFilter( checklist ) : [];
+	const numberOfSteps = enhancedChecklist.length;
+	const completedSteps = enhancedChecklist.filter( ( task ) => task.completed ).length;
 	const tasklistCompleted = completedSteps >= numberOfSteps;
 	const shouldLoad = ! tasklistCompleted && numberOfSteps > 0;
 

--- a/client/my-sites/earn/launchpad/index.tsx
+++ b/client/my-sites/earn/launchpad/index.tsx
@@ -1,5 +1,5 @@
 import { CircularProgressBar } from '@automattic/components';
-import { Launchpad, Task } from '@automattic/launchpad';
+import { DefaultWiredLaunchpad, type Task } from '@automattic/launchpad';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'calypso/state';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
@@ -7,7 +7,7 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
 type EarnLaunchpadProps = {
 	launchpad: {
 		checklistSlug: string;
-		taskFilter: ( tasks: Task[] | null | undefined ) => Task[];
+		taskFilter: ( tasks: Task[] ) => Task[];
 		numberOfSteps: number;
 		completedSteps: number;
 		shouldLoad: boolean;
@@ -37,10 +37,11 @@ const EarnLaunchpad = ( { launchpad }: EarnLaunchpadProps ) => {
 					{ translate( 'Let your fans support your art, writing, or project directly.' ) }
 				</p>
 			</div>
-			<Launchpad
+			<DefaultWiredLaunchpad
 				siteSlug={ site?.slug ?? null }
 				checklistSlug={ checklistSlug }
-				taskFilter={ taskFilter }
+				onPostFilterTasks={ taskFilter }
+				launchpadContext="earn"
 			/>
 		</div>
 	);

--- a/packages/launchpad/src/default-wired-launchpad.tsx
+++ b/packages/launchpad/src/default-wired-launchpad.tsx
@@ -20,6 +20,7 @@ type DefaultWiredLaunchpadProps = {
 	checklistSlug: string;
 	launchpadContext: string;
 	onSiteLaunched?: () => void;
+	onPostFilterTasks?: ( tasks: Task[] ) => Task[];
 };
 
 const DefaultWiredLaunchpad = ( {
@@ -27,6 +28,7 @@ const DefaultWiredLaunchpad = ( {
 	checklistSlug,
 	launchpadContext,
 	onSiteLaunched,
+	onPostFilterTasks,
 }: DefaultWiredLaunchpadProps ) => {
 	const {
 		data: { checklist },
@@ -80,7 +82,7 @@ const DefaultWiredLaunchpad = ( {
 	] );
 
 	const taskFilter = ( tasks: Task[] ) => {
-		return setUpActionsForTasks( {
+		const baseTasks = setUpActionsForTasks( {
 			tasks,
 			siteSlug,
 			tracksData,
@@ -92,6 +94,12 @@ const DefaultWiredLaunchpad = ( {
 				onSiteLaunched,
 			},
 		} );
+
+		if ( onPostFilterTasks ) {
+			return onPostFilterTasks( baseTasks );
+		}
+
+		return baseTasks;
 	};
 
 	const launchpadOptions = {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
* https://github.com/Automattic/wp-calypso/pull/83254
* https://github.com/Automattic/wp-calypso/pull/82643

## Proposed Changes

This PR takes on two changes:
* The PR adds a new `onPostFilterTasks` argument to `DefaultWiredLaunchpad` to make it possible for callers to wire in additional processing of tasks before they are rendered in the launchpad
* The PR updates the Earn launchpad to use the `DefaultWiredLaunchpad` instead of the lower-level `Launchpad` component, and to leverage the new `onPostFilterTasks` option to wire in completion status for the Earn-related tasks as we don't have that data available on the back end for Atomic sites.
  - An important side effect of this change is that the Earn task list now gets all the default Tracks events "for free", where those were previously missing due to the completely custom `taskFilter`.
  - We also get better navigation UX for the "Set up an offer..." task, which is tied to using a link instead of a JS-driven `window.location.assign()` call -- see https://github.com/Automattic/wp-calypso/pull/82643 for more details

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

@Automattic/zap, please feel free to expand on these testing instructions -- I am not fully aware of all the edge cases that #83254 was meant to address.

* Run this branch locally or via Calypso.live
* Ensure that you are able to see Tracks events -- this may be easiest using https://github.com/Automattic/tracks-chrome-extension
* Navigate to _Tools_ -> _Earn_ for a site where you haven't completed the Earn task list
* Verify that you see the Earn task list shown when you load the page
* Verify that you see a `calypso_launchpad_tasklist_viewed` event, with the `context` and `checklist_slug` event properties set to `earn`
* Verify that you see two `calypso_launchpad_task_view` events, with the appropriate `task_id` values, as well as the correct `is_complete` values and the `context` and `checklist_slug` properties set to `earn.
* Click on both of the tasks to verify that we generate the appropriate `calypso_launchpad_task_clicked` event for each click. When clicking on the "Set up an offer..." task, verify that you don't see a full-page load

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?