### PR TITLE
Update Join Conversation dialog

### DIFF
--- a/client/blocks/reader-join-conversation/dialog.jsx
+++ b/client/blocks/reader-join-conversation/dialog.jsx
@@ -6,12 +6,10 @@ import useLoginWindow from 'calypso/data/reader/use-login-window';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import './style.scss';
 
-const ReaderJoinConversationDialog = ( { onClose, isVisible } ) => {
+const ReaderJoinConversationDialog = ( { onClose, isVisible, onLoginSuccess } ) => {
 	const translate = useTranslate();
 
-	const { login, createAccount } = useLoginWindow( {
-		onLoginSuccess: () => window.location.reload(),
-	} );
+	const { login, createAccount } = useLoginWindow( { onLoginSuccess: onLoginSuccess } );
 
 	const onLoginClick = () => {
 		recordTracksEvent( 'calypso_reader_dialog_login_clicked' );
@@ -26,7 +24,6 @@ const ReaderJoinConversationDialog = ( { onClose, isVisible } ) => {
 	return (
 		<Dialog
 			additionalClassNames="reader-join-conversation-dialog"
-			isBackdropVisible={ true }
 			isVisible={ isVisible }
 			onClose={ onClose }
 			showCloseIcon={ true }
@@ -44,7 +41,6 @@ const ReaderJoinConversationDialog = ( { onClose, isVisible } ) => {
 				>
 					{ translate( 'Create a new account' ) }
 				</Button>
-				<br />
 				<Button isLink onClick={ onLoginClick } className="reader-join-conversation-dialog__login">
 					{ translate( 'Log in' ) }
 				</Button>

--- a/client/blocks/reader-join-conversation/docs/example.jsx
+++ b/client/blocks/reader-join-conversation/docs/example.jsx
@@ -1,16 +1,21 @@
 import { Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import ReaderJoinConversationDialog from 'calypso/blocks/reader-join-conversation/dialog';
 
 const ReaderJoinConversationDialogExample = () => {
+	const translate = useTranslate();
 	const [ isVisible, setIsVisible ] = useState( false );
 
 	return (
 		<div className="docs__design-assets-group">
-			<Button onClick={ () => setIsVisible( true ) }>Show Reader Join Conversation Dialog</Button>
+			<Button onClick={ () => setIsVisible( true ) }>
+				{ translate( 'Show Reader Join Conversation Dialog' ) }
+			</Button>
 			<ReaderJoinConversationDialog
 				onClose={ () => setIsVisible( false ) }
 				isVisible={ isVisible }
+				onLoginSuccess={ () => window.location.reload() }
 			/>
 		</div>
 	);

--- a/client/data/reader/use-login-window.ts
+++ b/client/data/reader/use-login-window.ts
@@ -39,7 +39,7 @@ export default function useLoginWindow( {
 		);
 	}
 
-	const loginURL = addQueryArgs( { redirect_to: redirectTo }, `https://wordpress.com/log-in` );
+	const loginURL = addQueryArgs( { redirect_to: redirectTo }, 'https://wordpress.com/log-in' );
 	const createAccountURL = `https://wordpress.com${ createAccountUrl( {
 		redirectTo: redirectTo,
 		ref: 'reader-lw',

--- a/client/data/reader/use-login-window.ts
+++ b/client/data/reader/use-login-window.ts
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import { createAccountUrl } from 'calypso/lib/paths';
+import { addQueryArgs } from 'calypso/lib/url';
 
 interface UseLoginWindowProps {
 	onLoginSuccess: () => void;
@@ -17,18 +18,32 @@ export default function useLoginWindow( {
 	const environment = config( 'env_id' );
 	let domain = 'wordpress.com';
 	let redirectTo = encodeURIComponent(
-		`https://${ domain }/public.api/connect/?action=verify&service=wordpress`
+		addQueryArgs(
+			{
+				action: 'verify',
+				service: 'wordpress',
+			},
+			`https://${ domain }/public.api/connect/`
+		)
 	);
+
+	// When in development, we need to redirect to a sandboxed domain to allow us to test changes to /public.api/connect/
 	if ( environment === 'development' ) {
 		domain = 'wpcalypso.wordpress.com';
 		redirectTo = encodeURIComponent(
-			`https://${ domain }/public.api/connect/?action=verify&service=wordpress&domain=${ domain }&origin=${ new URL(
-				window.location.href
-			)?.hostname }`
+			addQueryArgs(
+				{
+					action: 'verify',
+					service: 'wordpress',
+					domain: domain,
+					origin: new URL( window.location.href )?.hostname,
+				},
+				`https://${ domain }/public.api/connect/`
+			)
 		);
 	}
 
-	const loginURL = `https://wordpress.com/log-in?redirect_to=${ redirectTo }`;
+	const loginURL = addQueryArgs( { redirect_to: redirectTo }, `https://wordpress.com/log-in` );
 	const createAccountURL = `https://wordpress.com${ createAccountUrl( {
 		redirectTo: redirectTo,
 		ref: 'reader-lw',

--- a/client/data/reader/use-login-window.ts
+++ b/client/data/reader/use-login-window.ts
@@ -17,29 +17,25 @@ export default function useLoginWindow( {
 	const isBrowser: boolean = typeof window !== 'undefined';
 	const environment = config( 'env_id' );
 	let domain = 'wordpress.com';
-	let redirectTo = encodeURIComponent(
-		addQueryArgs(
-			{
-				action: 'verify',
-				service: 'wordpress',
-			},
-			`https://${ domain }/public.api/connect/`
-		)
+	let redirectTo = addQueryArgs(
+		{
+			action: 'verify',
+			service: 'wordpress',
+		},
+		`https://${ domain }/public.api/connect/`
 	);
 
 	// When in development, we need to redirect to a sandboxed domain to allow us to test changes to /public.api/connect/
 	if ( environment === 'development' ) {
 		domain = 'wpcalypso.wordpress.com';
-		redirectTo = encodeURIComponent(
-			addQueryArgs(
-				{
-					action: 'verify',
-					service: 'wordpress',
-					domain: domain,
-					origin: new URL( window.location.href )?.hostname,
-				},
-				`https://${ domain }/public.api/connect/`
-			)
+		redirectTo = addQueryArgs(
+			{
+				action: 'verify',
+				service: 'wordpress',
+				domain: domain,
+				origin: new URL( window.location.href )?.hostname,
+			},
+			`https://${ domain }/public.api/connect/`
 		);
 	}
 


### PR DESCRIPTION
This tidies up a few issues raised after merge in https://github.com/Automattic/wp-calypso/pull/83100

Fixes;

- [x] Remove redundant dialog props
- [x] Pass in `onLoginSuccess` prop 
- [x] Remove redundant/extra markup from dialog
- [x] Translate string in example
- [x] Update to use `addQueryArgs` in `useLoginWindow` when possible

I tried to update styles to use vars where possible but I couldn't find any I could use. Going to skip this task.

### Testing

* Sandbox the domains public-api.wordpress.com and wpcalypso.wordpress.com
* Requires patch code-D124724 - this handles the postMessage to inform popup window of login event - without this, the page will not refresh after login is complete
* Test out the join conversation dialog component from http://calypso.localhost:3000/devdocs/blocks/reader-join-conversation-dialog
* The page should refresh and you should be logged into WordPress.
