### PR TITLE
Add blogging prompt links to sidebar

### DIFF
--- a/client/reader/stream/reader-tag-sidebar/index.jsx
+++ b/client/reader/stream/reader-tag-sidebar/index.jsx
@@ -19,18 +19,23 @@ import { getReaderTagBySlug } from 'calypso/state/reader/tags/selectors';
 import { registerLastActionRequiresLogin } from 'calypso/state/reader-ui/actions';
 import '../style.scss';
 
+import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
+
+import '../style.scss';
+
 const ReaderTagSidebar = ( {
 	tag,
 	showFollow,
 	registerLastActionRequiresLogin: registerLastActionRequiresLoginProp,
 } ) => {
+	const primarySiteId = useSelector( ( state ) => getPrimarySiteId( state ) );
 	const translate = useTranslate();
 	const relatedMetaByTag = useRelatedMetaByTag( tag );
 	const tagStats = useTagStats( tag );
 	const dispatch = useDispatch();
 	const isFollowing = useSelector( ( state ) => getReaderTagBySlug( state, tag )?.isFollowing );
 	const isLoggedIn = useSelector( ( state ) => isUserLoggedIn( state ) );
-	const { data: prompts } = useBloggingPrompts( 1, 10 );
+	const { data: prompts } = useBloggingPrompts( primarySiteId, 10 );
 
 	if ( relatedMetaByTag === undefined ) {
 		return null;

--- a/client/reader/stream/reader-tag-sidebar/index.jsx
+++ b/client/reader/stream/reader-tag-sidebar/index.jsx
@@ -38,7 +38,7 @@ const ReaderTagSidebar = ( {
 		return null;
 	}
 
-	const showRecentPrompts = tag.indexOf( 'dailyprompt' === 0 ) || tag.indexOf( 'bloganuary' );
+	const showRecentPrompts = tag.indexOf( 'dailyprompt' === 0 ) || tag.indexOf( 'bloganuary' ) === 0;
 
 	const handleRecentPromptClick = ( prompt ) => {
 		recordAction( 'clicked_reader_sidebar_recent_prompt' );

--- a/client/reader/stream/reader-tag-sidebar/index.jsx
+++ b/client/reader/stream/reader-tag-sidebar/index.jsx
@@ -17,10 +17,7 @@ import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions'
 import { requestFollowTag, requestUnfollowTag } from 'calypso/state/reader/tags/items/actions';
 import { getReaderTagBySlug } from 'calypso/state/reader/tags/selectors';
 import { registerLastActionRequiresLogin } from 'calypso/state/reader-ui/actions';
-import '../style.scss';
-
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
-
 import '../style.scss';
 
 const ReaderTagSidebar = ( {

--- a/client/reader/stream/reader-tag-sidebar/index.jsx
+++ b/client/reader/stream/reader-tag-sidebar/index.jsx
@@ -1,6 +1,7 @@
 import { Button } from '@automattic/components';
 import { addLocaleToPathLocaleInFront } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
+import moment from 'moment';
 import { connect, useDispatch, useSelector } from 'react-redux';
 import FollowButton from 'calypso/blocks/follow-button/button';
 import TagLink from 'calypso/blocks/reader-post-card/tag-link';
@@ -32,7 +33,9 @@ const ReaderTagSidebar = ( {
 	const dispatch = useDispatch();
 	const isFollowing = useSelector( ( state ) => getReaderTagBySlug( state, tag )?.isFollowing );
 	const isLoggedIn = useSelector( ( state ) => isUserLoggedIn( state ) );
-	const { data: prompts } = useBloggingPrompts( primarySiteId, 10 );
+
+	const today = moment().subtract( 10, 'd' ).format( '--MM-DD' );
+	const { data: prompts } = useBloggingPrompts( primarySiteId, today, 10 );
 
 	if ( relatedMetaByTag === undefined ) {
 		return null;

--- a/client/reader/stream/reader-tag-sidebar/index.jsx
+++ b/client/reader/stream/reader-tag-sidebar/index.jsx
@@ -38,7 +38,7 @@ const ReaderTagSidebar = ( {
 		return null;
 	}
 
-	const showRecentPrompts = tag.indexOf( 'dailyprompt' === 0 ) || tag.indexOf( 'bloganuary' ) === 0;
+	const showRecentPrompts = tag.indexOf( 'dailyprompt' ) === 0 || tag.indexOf( 'bloganuary' ) === 0;
 
 	const handleRecentPromptClick = ( prompt ) => {
 		recordAction( 'clicked_reader_sidebar_recent_prompt' );

--- a/client/reader/stream/reader-tag-sidebar/index.jsx
+++ b/client/reader/stream/reader-tag-sidebar/index.jsx
@@ -38,7 +38,7 @@ const ReaderTagSidebar = ( {
 		return null;
 	}
 
-	const showRecentPrompts = 'dailyprompt' === tag || 'bloganuary' === tag;
+	const showRecentPrompts = tag.indexOf( 'dailyprompt' === 0 ) || tag.indexOf( 'bloganuary' );
 
 	const handleRecentPromptClick = ( prompt ) => {
 		recordAction( 'clicked_reader_sidebar_recent_prompt' );

--- a/client/reader/stream/reader-tag-sidebar/index.jsx
+++ b/client/reader/stream/reader-tag-sidebar/index.jsx
@@ -4,6 +4,7 @@ import { useTranslate } from 'i18n-calypso';
 import { connect, useDispatch, useSelector } from 'react-redux';
 import FollowButton from 'calypso/blocks/follow-button/button';
 import TagLink from 'calypso/blocks/reader-post-card/tag-link';
+import { useBloggingPrompts } from 'calypso/data/blogging-prompt/use-blogging-prompts';
 import { useRelatedMetaByTag } from 'calypso/data/reader/use-related-meta-by-tag';
 import { useTagStats } from 'calypso/data/reader/use-tag-stats';
 import formatNumberCompact from 'calypso/lib/format-number-compact';
@@ -29,10 +30,23 @@ const ReaderTagSidebar = ( {
 	const dispatch = useDispatch();
 	const isFollowing = useSelector( ( state ) => getReaderTagBySlug( state, tag )?.isFollowing );
 	const isLoggedIn = useSelector( ( state ) => isUserLoggedIn( state ) );
+	const { data: prompts } = useBloggingPrompts( 1, 10 );
 
 	if ( relatedMetaByTag === undefined ) {
 		return null;
 	}
+
+	const showRecentPrompts = 'dailyprompt' === tag || 'bloganuary' === tag;
+
+	const handleRecentPromptClick = ( prompt ) => {
+		recordAction( 'clicked_reader_sidebar_recent_prompt' );
+		recordGaEvent( 'Clicked Reader Sidebar Recent Blogging Prompt' );
+		dispatch(
+			recordReaderTracksEvent( 'calypso_reader_sidebar_recent_prompt_clicked', {
+				prompt_id: prompt.id,
+			} )
+		);
+	};
 
 	const handleTagSidebarClick = () => {
 		recordAction( 'clicked_reader_sidebar_tag' );
@@ -143,6 +157,25 @@ const ReaderTagSidebar = ( {
 					<Button primary onClick={ trackSignupClick }>
 						{ translate( 'Join the WordPress.com community' ) }
 					</Button>
+				</div>
+			) }
+			{ showRecentPrompts && prompts && (
+				<div className="reader-tag-sidebar__recent-prompts">
+					<h2>{ translate( 'Recent Prompts' ) }</h2>
+					{ prompts.map( ( prompt ) => (
+						<div key={ 'prompt-link-' + prompt.id }>
+							<a
+								className="reader-tag-sidebar__recent-prompt-link"
+								href={ '/tag/dailyprompt-' + encodeURIComponent( prompt.id ) }
+								onClick={ () => {
+									handleRecentPromptClick( prompt );
+								} }
+							>
+								{ ' ' }
+								{ prompt.text }{ ' ' }
+							</a>
+						</div>
+					) ) }
 				</div>
 			) }
 		</>

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -745,7 +745,7 @@
 			text-decoration: underline;
 			font-weight: 500;
 			color: var(--color-neutral-100);
-			margin-bottom: 8px;
+			margin-bottom: 12px;
 		}
 	}
 	.reader-tag-sidebar-stats {

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -734,6 +734,20 @@
 		color: var(--color-neutral-100);
 	}
 
+	.reader-tag-sidebar__recent-prompts {
+		h2 {
+			font-size: $font-body;
+			margin-bottom: 14px;
+		}
+		.reader-tag-sidebar__recent-prompt-link {
+			display: block;
+			font-size: $font-body-small;
+			text-decoration: underline;
+			font-weight: 500;
+			color: var(--color-neutral-100);
+			margin-bottom: 8px;
+		}
+	}
 	.reader-tag-sidebar-stats {
 		display: flex;
 		flex-direction: row;


### PR DESCRIPTION
Part of pe7F0s-1iI-p2 but also applies to blogging prompts.
This adds links to other blogging prompts to the sidebar when you are viewing `dailyprompt` or also `bloganuary` tag (which will be added shortly to be used with the bloganuary promotion)
<img width="1292" alt="Screen Shot 2023-10-20 at 10 25 46 pm" src="https://github.com/Automattic/wp-calypso/assets/22446385/e01a31c4-4c49-4b49-99fd-2c4f68105090">


### Testing instructions 

go to /tag/dailyprompt
You should see a list of recent prompts in the sidebar
Click one
An event should be logged to tracks `calypso_reader_sidebar_recent_prompt_clicked` which includes the prompt id.
You should be taken to the tag page for the prompt