### PR TITLE
Importers: Fix importer flickering issue

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer-blogger/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer-blogger/index.tsx
@@ -3,9 +3,9 @@ import { Step } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { withImporterWrapper } from '../importer';
 import './style.scss';
 
-const ImporterBlogger: Step = function ( props ) {
-	const Importer = withImporterWrapper( BloggerImporter );
+const Importer = withImporterWrapper( BloggerImporter );
 
+const ImporterBlogger: Step = function ( props ) {
 	return <Importer importer="blogger" { ...props } />;
 };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer-medium/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer-medium/index.tsx
@@ -4,6 +4,7 @@ import { withImporterWrapper } from '../importer';
 import './style.scss';
 
 const Importer = withImporterWrapper( MediumImporter );
+
 const ImporterMedium: Step = function ( props ) {
 	return <Importer importer="medium" { ...props } />;
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer-squarespace/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer-squarespace/index.tsx
@@ -3,9 +3,9 @@ import { Step } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { withImporterWrapper } from '../importer';
 import './style.scss';
 
-const ImporterSquarespace: Step = function ( props ) {
-	const Importer = withImporterWrapper( SquarespaceImporter );
+const Importer = withImporterWrapper( SquarespaceImporter );
 
+const ImporterSquarespace: Step = function ( props ) {
 	return <Importer importer="squarespace" { ...props } />;
 };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer-wix/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer-wix/index.tsx
@@ -3,10 +3,10 @@ import { Step } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { withImporterWrapper } from '../importer';
 import './style.scss';
 
-const ImporterWix: Step = function ( props ) {
-	const Importer = withImporterWrapper( WixImporter );
+const Importer = withImporterWrapper( WixImporter );
 
-	return <Importer importer="wix" { ...props } />;
+const ImporterWix: Step = function ( props ) {
+	return <Importer importer="wix" { ...props } navigation={ props.navigation } />;
 };
 
 export default ImporterWix;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Discovered during work on: https://github.com/Automattic/wp-calypso/issues/82919

## Proposed Changes

* Fixed importer flickering issue
Before this commit, on each rerender, the HOC component has been initiated again, causing a loop of allSites fetches.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/import-focused?siteSlug={SLUG}`
* Enter any Wix, Blogger, or Squarespace URL
* Run the import
* Check if everything works smoothly

**Flickering example:**
![screen-flickering](https://github.com/Automattic/wp-calypso/assets/1241413/cedf4186-aca9-4a59-a16e-f9709abbdfc7)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?