### PR TITLE
Reader/Discover: remove tags from discover stream key

### DIFF
--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -2,7 +2,7 @@ import config from '@automattic/calypso-config';
 import warn from '@wordpress/warning';
 import i18n from 'i18n-calypso';
 import { random, map, includes, get } from 'lodash';
-import { getTagsFromStreamKey } from 'calypso/reader/discover/helper';
+import { buildDiscoverStreamKey, getTagsFromStreamKey } from 'calypso/reader/discover/helper';
 import { keyForPost } from 'calypso/reader/post-key';
 import XPostHelper from 'calypso/reader/xpost-helper';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -447,7 +447,11 @@ export function handlePage( action, data ) {
 				receiveRecommendedSites( { seed: 'discover-new-sites', sites: streamNewSites } )
 			);
 		}
-		actions.push( receivePage( { streamKey, query, streamItems, pageHandle, gap } ) );
+		let newStreamKey = streamKey;
+		if ( streamKey === 'discover:recommended' && data.user_interests ) {
+			newStreamKey = buildDiscoverStreamKey( 'recommended', data.user_interests );
+		}
+		actions.push( receivePage( { streamKey: newStreamKey, query, streamItems, pageHandle, gap } ) );
 	}
 
 	return actions;

--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -447,6 +447,12 @@ export function handlePage( action, data ) {
 				receiveRecommendedSites( { seed: 'discover-new-sites', sites: streamNewSites } )
 			);
 		}
+
+		// The first request when going to wordpress.com/discover does not include tags in the streamKey
+		// because it is still waiting for the user's interests to be fetched.
+		// Given that the user interests will be retrieved in the response from /read/streams/discover we
+		// use that values to generate a correct streamKey and prevent doing a new request when the user
+		// interests are finally fetched. More context here: paYKcK-3zo-p2#comment-2528.
 		let newStreamKey = streamKey;
 		if ( streamKey === 'discover:recommended' && data.user_interests ) {
 			newStreamKey = buildDiscoverStreamKey( 'recommended', data.user_interests );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

This PR removes user tags from stream cache key. It assumes that user tags are being use by default when calling `wpcom/v2/read/streams/discover`.
This way we can make two small user experience tweaks:
* Less time to see the Reader cards
* Removes flickering

Context: paYKcK-3zo-p2 
## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR on your local env or go to the Calypso.live link below
* Apply this diff on your sandbox (and sandbox `public-api`) if not merged: D126132-code
* Open a new browser tab and open network tools
* Filter for `discover` to see the requests made to the discover endpoint 
<img width="475" alt="image" src="https://github.com/Automattic/wp-calypso/assets/375980/67243abb-f5d3-48c9-bb0e-7509c9699506">

* Navigate to `calypso.localhost:3000/discover`
* Verify that only 2 requests are made to discover
* Verify that the cards start rendering after the first request is done

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?