### PR TITLE
Free hosting trial: lift domain and support request limitations

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/hosting-trial-acknowledge.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/hosting-trial-acknowledge.tsx
@@ -76,7 +76,7 @@ const HostingTrialAcknowledgeInternal = ( { onStartTrialClick }: CallToActionPro
 				{ planName: plan?.getTitle() }
 			) }
 			callToAction={ <CallToAction onStartTrialClick={ onStartTrialClick } /> }
-			trialLimitations={ [ __( 'Limited email sending capabilities' ), __( '3GB of storage' ) ] }
+			trialLimitations={ [ __( 'Lower priority email sending' ), __( '3GB of storage' ) ] }
 		/>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/hosting-trial-acknowledge.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/hosting-trial-acknowledge.tsx
@@ -76,12 +76,7 @@ const HostingTrialAcknowledgeInternal = ( { onStartTrialClick }: CallToActionPro
 				{ planName: plan?.getTitle() }
 			) }
 			callToAction={ <CallToAction onStartTrialClick={ onStartTrialClick } /> }
-			trialLimitations={ [
-				__( 'Limited email sending capabilities' ),
-				__( '3GB of storage' ),
-				__( 'no domain mapping' ),
-				__( '3 support requests' ),
-			] }
+			trialLimitations={ [ __( 'Limited email sending capabilities' ), __( '3GB of storage' ) ] }
 		/>
 	);
 };


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/4261.

## Proposed Changes

Title.

![image](https://github.com/Automattic/wp-calypso/assets/26530524/03665ad9-bd9a-48a8-8683-206858baa5aa)


## Testing Instructions

Open `/setup/new-hosted-site`, choose the trial offer and verify that the domain and support request limitations are not there anymore.