### PR TITLE
Headers: Add top margin on /plugins

### DIFF
--- a/client/my-sites/plugins/search-box-header/style.scss
+++ b/client/my-sites/plugins/search-box-header/style.scss
@@ -87,6 +87,7 @@
 		font-weight: 400;
 		line-height: 40px;
 		color: var(--studio-blue-90);
+		margin-top: 24px;
 	}
 	.search-box-header__sticky-ref {
 		padding-bottom: 48px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4290

## Proposed Changes

Add separation between header and searchbox header title.

| Before | After |
| --- | --- |
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/e8f38f94-dd2e-427b-acd2-aa456c2fe609) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/fc9aa737-3901-45f4-b583-deb9cf567843) |

## Testing Instructions

* Go to /plugins and check the margins.

