### PR TITLE
Partner Program: Changing page title on existing agency signup page

### DIFF
--- a/client/jetpack-cloud/sections/agency-signup/agency-signup-form/index.tsx
+++ b/client/jetpack-cloud/sections/agency-signup/agency-signup-form/index.tsx
@@ -97,7 +97,7 @@ export default function AgencySignupForm() {
 			</svg>
 
 			<CardHeading className="agency-signup-form__heading">
-				{ translate( 'Sign up as an Agency' ) }
+				{ translate( 'Sign up for Jetpack Manage' ) }
 			</CardHeading>
 
 			<h2 className="agency-signup-form__subheading">

--- a/client/jetpack-cloud/sections/agency-signup/primary/agency-signup/index.tsx
+++ b/client/jetpack-cloud/sections/agency-signup/primary/agency-signup/index.tsx
@@ -9,7 +9,7 @@ export default function AgencySignup() {
 
 	return (
 		<Main className="agency-signup">
-			<DocumentHead title={ translate( 'Sign up as an Agency' ) } />
+			<DocumentHead title={ translate( 'Sign up for Jetpack Manage' ) } />
 			<SidebarNavigation />
 
 			<AgencySignupForm />


### PR DESCRIPTION
Related to https://github.com/Automattic/jetpack-manage/issues/43

## Proposed Changes

* This PR changes the meta title and page title from `Sign up as an Agency` to `Sign up for Jetpack Manage` on the existing agency signup form in Calypso:

![Screenshot 2023-10-20 at 16 19](https://github.com/Automattic/wp-calypso/assets/16754605/2c284dce-f4c4-4738-8267-4e9cff431172)


## Testing Instructions

* Visit the agency sign up form whilst in staging and using a new WPcom user - http://jetpack.cloud.localhost:3000/agency/signup - and verify the titles have changed to match the screenshot above.

