### PR TITLE
Marketplace Progress bar: Rename 'Activating theme' step

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
@@ -74,7 +74,7 @@ export function useThemesThankYouData(
 						translate( 'Activating the theme feature' ), // Transferring to Atomic
 						translate( 'Setting up theme installation' ), // Transferring to Atomic
 						translate( 'Installing theme' ), // Transferring to Atomic
-						translate( 'Activating theme' ),
+						translate( 'Getting the theme ready' ),
 				  ],
 		// We intentionally don't set `isJetpack` as dependency to keep the same steps after the Atomic transfer.
 		// eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/83205
Related to #83206

## Proposed Changes

Rename `"Activating theme"` step to `"Getting the theme ready"` as the theme is not activated at this step anymore.

![CleanShot 2023-10-18 at 15 44 02@2x](https://github.com/Automattic/wp-calypso/assets/5039531/dbd21f25-3687-4e98-b567-85d50dbe4c75)


## Testing Instructions
* With a non-atomic site
* Go to the Design Picker page with a Marketplace theme selected /setup/update-design/designSetup?siteSlug=:site&theme=:theme_slug. Theme slugs such as makoney and olsen-fse can be used.
* Click on Unlock Theme
* Complete the purchase
* Check the `'Activating theme'` step is not shown anymore