### PR TITLE
Remove underline and shift to lighter colour for Launchpad skip link

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -20,6 +20,10 @@
 		.step-container__skip-wrapper .step-container__navigation-link.has-underline {
 			color: var(--studio-gray-70);
 			text-decoration: none;
+
+			&:hover {
+				text-decoration: underline;
+			}
 		}
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -16,6 +16,11 @@
 		margin: 0;
 		max-width: none;
 		min-height: 100vh;
+
+		.step-container__skip-wrapper .step-container__navigation-link.has-underline {
+			color: var(--studio-gray-70);
+			text-decoration: none;
+		}
 	}
 
 	.step-container__buttons {

--- a/client/landing/stepper/declarative-flow/internals/videopress.scss
+++ b/client/landing/stepper/declarative-flow/internals/videopress.scss
@@ -268,6 +268,10 @@ body.is-videopress-tv-purchase-stepper {
 			}
 		}
 
+		.step-container__skip-wrapper .step-container__navigation-link.has-underline {
+			color: $videopress-theme-grey;
+		}
+
 		.launchpad__checklist-item-chevron,
 		.checklist-item__chevron {
 			align-self: center;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* This PR makes some small changes to the "Skip for now" link that we show on the fullscreen Launchpad to make it less prominent. The specific changes are as follows:
  - The text colour for the default launchpad is changed from black / #000000 to #3c434a (aka `--studio-gray-70`)
  - The text colour for the VideoPress launchpad is changed from white / #ffffff to #a7aaad / `$videopress-theme-grey`
  - The underline for the link is removed by default, but is added back on hover (and all other hover features remain in place)

## Screenshots

### Before

#### Fullscreen Launchpad

<img width="1727" alt="Screenshot 2023-10-20 at 17 37 57" src="https://github.com/Automattic/wp-calypso/assets/3376401/b3711c32-c368-4f0f-92a9-469b74bb0b00">

#### VideoPress launchpad

<img width="1727" alt="Screenshot 2023-10-20 at 17 48 58" src="https://github.com/Automattic/wp-calypso/assets/3376401/80dee60f-955c-4480-ae90-f5c91abc7507">

### After

#### Fullscreen Launchpad

<img width="1727" alt="Screenshot 2023-10-20 at 17 38 40" src="https://github.com/Automattic/wp-calypso/assets/3376401/7d7b6e20-e033-49a4-a6eb-6ecfbc4242e8">

#### VideoPress Launchpad

<img width="1727" alt="Screenshot 2023-10-20 at 17 48 30" src="https://github.com/Automattic/wp-calypso/assets/3376401/071e5ca7-dab8-4423-80a1-ba6e13d8059c">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch locally or via Calypso.live
* Use an existing site that is still showing the fullscreen Launchpad, or create a new one
* Verify that you see the new styles in the fullscreen Launchpad
* Use an existing site created via the VideoPress signup flow, or create a new one via `/setup/videopress`
* Verify that you see the new styles

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?