### PR TITLE
Take 2: Some changes to adapt the Reader to be embeddable on LPs

### DIFF
--- a/client/blocks/comments/form.jsx
+++ b/client/blocks/comments/form.jsx
@@ -10,6 +10,7 @@ import Gravatar from 'calypso/components/gravatar';
 import { navigate } from 'calypso/lib/navigate';
 import { createAccountUrl } from 'calypso/lib/paths';
 import { ProtectFormGuard } from 'calypso/lib/protect-form';
+import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-tag-embed-page';
 import { recordAction, recordGaEvent, recordTrackForPost } from 'calypso/reader/stats';
 import { writeComment, deleteComment, replyComment } from 'calypso/state/comments/actions';
 import { getCurrentUser, isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -64,6 +65,12 @@ class PostCommentForm extends Component {
 	handleTextChange = ( event ) => {
 		if ( ! this.props.isLoggedIn ) {
 			const { pathname } = getUrlParts( window.location.href );
+			if ( isReaderTagEmbedPage( window.location ) ) {
+				return window.open(
+					createAccountUrl( { redirectTo: pathname, ref: 'reader-lp' } ),
+					'_blank'
+				);
+			}
 			return navigate( createAccountUrl( { redirectTo: pathname, ref: 'reader-lp' } ) );
 		}
 		// Update the comment text in the container's state

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -12,6 +12,7 @@ import TimeSince from 'calypso/components/time-since';
 import { decodeEntities } from 'calypso/lib/formatting';
 import { navigate } from 'calypso/lib/navigate';
 import { createAccountUrl } from 'calypso/lib/paths';
+import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-tag-embed-page';
 import withDimensions from 'calypso/lib/with-dimensions';
 import { getStreamUrl } from 'calypso/reader/route';
 import { recordAction, recordGaEvent, recordPermalinkClick } from 'calypso/reader/stats';
@@ -108,6 +109,12 @@ class PostComment extends PureComponent {
 	handleReply = () => {
 		if ( ! this.props.isLoggedIn ) {
 			const { pathname } = getUrlParts( window.location.href );
+			if ( isReaderTagEmbedPage( window.location ) ) {
+				return window.open(
+					createAccountUrl( { redirectTo: pathname, ref: 'reader-lp' } ),
+					'_blank'
+				);
+			}
 			return navigate( createAccountUrl( { redirectTo: pathname, ref: 'reader-lp' } ) );
 		}
 		this.props.onReplyClick( this.props.commentId );

--- a/client/blocks/like-button/button.jsx
+++ b/client/blocks/like-button/button.jsx
@@ -7,6 +7,7 @@ import { createElement, PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { navigate } from 'calypso/lib/navigate';
 import { createAccountUrl } from 'calypso/lib/paths';
+import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-tag-embed-page';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import LikeIcons from './icons';
 import './style.scss';
@@ -50,6 +51,12 @@ class LikeButton extends PureComponent {
 	toggleLiked( event ) {
 		if ( ! this.props.isLoggedIn ) {
 			const { pathname } = getUrlParts( window.location.href );
+			if ( isReaderTagEmbedPage( window.location ) ) {
+				return window.open(
+					createAccountUrl( { redirectTo: pathname, ref: 'reader-lp' } ),
+					'_blank'
+				);
+			}
 			return navigate( createAccountUrl( { redirectTo: pathname, ref: 'reader-lp' } ) );
 		}
 		if ( event ) {

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -27,6 +27,7 @@ import OfflineStatus from 'calypso/layout/offline-status';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { isWpMobileApp, isWcMobileApp } from 'calypso/lib/mobile-app';
 import { isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
+import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-tag-embed-page';
 import { getMessagePathForJITM } from 'calypso/lib/route';
 import UserVerificationChecker from 'calypso/lib/user/verification-checker';
 import { OdieAssistantProvider } from 'calypso/odie/context';
@@ -363,7 +364,10 @@ export default withCurrentRoute(
 			[ 'jetpack-connect', 'login' ].includes( sectionName ) &&
 			isWooCommerceCoreProfilerFlow( state );
 		const noMasterbarForRoute =
-			isJetpackLogin || currentRoute === '/me/account/closed' || isDomainAndPlanPackageFlow;
+			isJetpackLogin ||
+			currentRoute === '/me/account/closed' ||
+			isDomainAndPlanPackageFlow ||
+			isReaderTagEmbedPage( window?.location );
 		const noMasterbarForSection =
 			! isWooCoreProfilerFlow && [ 'signup', 'jetpack-connect' ].includes( sectionName );
 		const masterbarIsHidden =

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -24,6 +24,7 @@ import {
 	isWPJobManagerOAuth2Client,
 	isGravPoweredOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
+import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-tag-embed-page';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getRedirectToOriginal } from 'calypso/state/login/selectors';
 import { isPartnerSignupQuery } from 'calypso/state/login/utils';
@@ -143,7 +144,12 @@ const LayoutLoggedOut = ( {
 
 			masterbar = <OauthClientMasterbar oauth2Client={ oauth2Client } />;
 		}
-	} else if ( config.isEnabled( 'jetpack-cloud' ) || isWpMobileApp() || isJetpackThankYou ) {
+	} else if (
+		config.isEnabled( 'jetpack-cloud' ) ||
+		isWpMobileApp() ||
+		isJetpackThankYou ||
+		isReaderTagEmbedPage( window?.location )
+	) {
 		masterbar = null;
 	} else if (
 		[ 'plugins', 'themes', 'theme', 'reader', 'subscriptions', 'site-profiler' ].includes(
@@ -220,16 +226,17 @@ const LayoutLoggedOut = ( {
 				</>
 			) }
 
-			{ [ 'themes', 'theme', 'reader' ].includes( sectionName ) && (
-				<UniversalNavbarFooter
-					onLanguageChange={ ( e ) => {
-						navigate( `/${ e.target.value + pathNameWithoutLocale }` );
-						window.location.reload();
-					} }
-					currentRoute={ currentRoute }
-					isLoggedIn={ isLoggedIn }
-				/>
-			) }
+			{ [ 'themes', 'theme', 'reader' ].includes( sectionName ) &&
+				! isReaderTagEmbedPage( window?.location ) && (
+					<UniversalNavbarFooter
+						onLanguageChange={ ( e ) => {
+							navigate( `/${ e.target.value + pathNameWithoutLocale }` );
+							window.location.reload();
+						} }
+						currentRoute={ currentRoute }
+						isLoggedIn={ isLoggedIn }
+					/>
+				) }
 		</div>
 	);
 };

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -80,6 +80,7 @@ const LayoutLoggedOut = ( {
 		sectionName === 'checkout' && currentRoute.startsWith( '/checkout/jetpack/thank-you' );
 
 	const isReaderTagPage = sectionName === 'reader' && pathNameWithoutLocale.startsWith( '/tag/' );
+	const isReaderTagEmbed = typeof window !== 'undefined' && isReaderTagEmbedPage( window.location );
 
 	const isReaderDiscoverPage =
 		sectionName === 'reader' && pathNameWithoutLocale.startsWith( '/discover' );
@@ -148,7 +149,7 @@ const LayoutLoggedOut = ( {
 		config.isEnabled( 'jetpack-cloud' ) ||
 		isWpMobileApp() ||
 		isJetpackThankYou ||
-		isReaderTagEmbedPage( window?.location )
+		isReaderTagEmbed
 	) {
 		masterbar = null;
 	} else if (
@@ -226,17 +227,16 @@ const LayoutLoggedOut = ( {
 				</>
 			) }
 
-			{ [ 'themes', 'theme', 'reader' ].includes( sectionName ) &&
-				! isReaderTagEmbedPage( window?.location ) && (
-					<UniversalNavbarFooter
-						onLanguageChange={ ( e ) => {
-							navigate( `/${ e.target.value + pathNameWithoutLocale }` );
-							window.location.reload();
-						} }
-						currentRoute={ currentRoute }
-						isLoggedIn={ isLoggedIn }
-					/>
-				) }
+			{ [ 'themes', 'theme', 'reader' ].includes( sectionName ) && ! isReaderTagEmbed && (
+				<UniversalNavbarFooter
+					onLanguageChange={ ( e ) => {
+						navigate( `/${ e.target.value + pathNameWithoutLocale }` );
+						window.location.reload();
+					} }
+					currentRoute={ currentRoute }
+					isLoggedIn={ isLoggedIn }
+				/>
+			) }
 		</div>
 	);
 };

--- a/client/lib/reader/is-reader-tag-embed-page.js
+++ b/client/lib/reader/is-reader-tag-embed-page.js
@@ -1,0 +1,5 @@
+export default function isReaderTagEmbedPage( url ) {
+	const urlObject = new URL( url );
+	const urlParams = new URLSearchParams( url.search );
+	return urlObject.pathname.includes( '/tag/' ) && urlParams.get( 'type' ) === 'embed';
+}

--- a/client/reader/tag-stream/index.js
+++ b/client/reader/tag-stream/index.js
@@ -10,6 +10,7 @@ import {
 	render as clientRender,
 } from 'calypso/controller';
 import { setLocaleMiddleware } from 'calypso/controller/shared';
+import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-tag-embed-page';
 import { sidebar, updateLastRoute } from 'calypso/reader/controller';
 import { tagListing } from './controller';
 
@@ -34,6 +35,19 @@ export default function () {
 	page( '/tag/*', redirectHashtaggedTags );
 
 	page( `/${ anyLangParam }/tag/:tag`, redirectInvalidLanguage );
+
+	if ( isReaderTagEmbedPage( window.location ) ) {
+		page(
+			[ '/tag/:tag', `/${ langParam }/tag/:tag` ],
+			setLocaleMiddleware(),
+			redirectToSignup,
+			updateLastRoute,
+			tagListing,
+			makeLayout,
+			clientRender
+		);
+		return;
+	}
 
 	page(
 		[ '/tag/:tag', `/${ langParam }/tag/:tag` ],

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -8,6 +8,7 @@ import QueryReaderFollowedTags from 'calypso/components/data/query-reader-follow
 import QueryReaderTag from 'calypso/components/data/query-reader-tag';
 import { navigate } from 'calypso/lib/navigate';
 import { createAccountUrl } from 'calypso/lib/paths';
+import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-tag-embed-page';
 import ReaderMain from 'calypso/reader/components/reader-main';
 import HeaderBack from 'calypso/reader/header-back';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
@@ -147,6 +148,12 @@ class TagStream extends Component {
 				/>
 			</>
 		);
+		const sidebarProps = ! isReaderTagEmbedPage( window.location ) && {
+			streamSidebar: () => (
+				<ReaderTagSidebar tag={ this.props.decodedTagSlug } showFollow={ false } />
+			),
+			sidebarTabTitle: this.props.translate( 'Related' ),
+		};
 
 		return (
 			<Stream
@@ -159,10 +166,7 @@ class TagStream extends Component {
 				streamHeader={ tagHeader }
 				showSiteNameOnCards={ false }
 				useCompactCards={ true }
-				streamSidebar={ () => (
-					<ReaderTagSidebar tag={ this.props.decodedTagSlug } showFollow={ false } />
-				) }
-				sidebarTabTitle={ this.props.translate( 'Related' ) }
+				{ ...sidebarProps }
 			>
 				<QueryReaderFollowedTags />
 				<QueryReaderTag tag={ this.props.decodedTagSlug } />


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Take 2 of https://github.com/Automattic/wp-calypso/pull/83285 which had to be reverted due to the masterbar disappearing on the logged out /themes and /plugins page. See see p1697814444190859-slack-C02FMH4G8.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Same as https://github.com/Automattic/wp-calypso/pull/83285
* Additionally, also confirm that the masterbar and footer are visible in the logged-out `/themes` and `/plugins` pages.

