### PR TITLE
Plans 2023: Remove unused p2 plans logic in plans-features component

### DIFF
--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -1,6 +1,5 @@
 import {
 	isMonthly,
-	PLAN_P2_FREE,
 	getPlanClass,
 	planLevelsMatch,
 	PLAN_ECOMMERCE_TRIAL_MONTHLY,
@@ -64,7 +63,7 @@ const PlanFeaturesActionsButton = ( {
 		onUpgradeClick();
 	};
 
-	if ( current && ! isInSignup && planType !== PLAN_P2_FREE ) {
+	if ( current && ! isInSignup ) {
 		return (
 			<Button className={ classes } href={ manageHref } disabled={ ! manageHref }>
 				{ canPurchase ? translate( 'Manage plan' ) : translate( 'View plan' ) }

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -9,8 +9,6 @@ import {
 	GROUP_WPCOM,
 	TERM_ANNUALLY,
 	TERM_BIENNIALLY,
-	PLAN_P2_FREE,
-	PLAN_P2_PLUS,
 } from '@automattic/calypso-products';
 import { ProductIcon } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
@@ -36,12 +34,7 @@ const PLANS_LIST = getPlans();
 
 export class PlanFeaturesHeader extends Component {
 	render() {
-		const { isInSignup, plansWithScroll, planType, isInVerticalScrollingPlansExperiment } =
-			this.props;
-
-		if ( planType === PLAN_P2_FREE ) {
-			return this.renderPlansHeaderP2Free();
-		}
+		const { isInSignup, plansWithScroll, isInVerticalScrollingPlansExperiment } = this.props;
 
 		// Do not use the signup-specific header, unify plans for the plansWithScroll test
 		if ( plansWithScroll ) {
@@ -76,18 +69,14 @@ export class PlanFeaturesHeader extends Component {
 			translate,
 		} = this.props;
 
-		const headerClasses = classNames( 'plan-features__header', getPlanClass( planType ), {
-			'is-p2-plus': planType === PLAN_P2_PLUS,
-		} );
+		const headerClasses = classNames( 'plan-features__header', getPlanClass( planType ) );
 		const isCurrent = this.isPlanCurrent();
 
 		return (
 			<header className={ headerClasses }>
-				{ planType !== PLAN_P2_PLUS && (
-					<div className="plan-features__header-figure">
-						<ProductIcon slug={ planType } />
-					</div>
-				) }
+				<div className="plan-features__header-figure">
+					<ProductIcon slug={ planType } />
+				</div>
 				<div className="plan-features__header-text">
 					<h4 className="plan-features__header-title">{ title }</h4>
 					{ this.getPlanFeaturesPrices() }
@@ -152,25 +141,6 @@ export class PlanFeaturesHeader extends Component {
 					{ this.getIntervalDiscount() }
 				</div>
 			</span>
-		);
-	}
-
-	renderPlansHeaderP2Free() {
-		const { planType, isInSignup, translate } = this.props;
-
-		const headerClasses = classNames( 'plan-features__header', getPlanClass( planType ), {
-			'is-p2-free': true,
-		} );
-		const isCurrent = this.isPlanCurrent();
-
-		return (
-			<header className={ headerClasses }>
-				<div className="plan-features__header-text">
-					<h4 className="plan-features__header-title">P2</h4>
-					<h4 className="plan-features__header-title-free">{ translate( 'Free' ) }</h4>
-				</div>
-				{ ! isInSignup && isCurrent && <PlanPill>{ translate( 'Your Plan' ) }</PlanPill> }
-			</header>
 		);
 	}
 

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -311,18 +311,6 @@ $plan-features-sidebar-width: 272px;
 		padding: 12px 12px 0;
 	}
 
-	&.is-p2-free,
-	&.is-p2-plus {
-		padding-left: 12px;
-		@include breakpoint-deprecated( ">1040px" ) {
-			padding-left: 24px;
-		}
-	}
-
-	&.is-p2-plus {
-		border-bottom-color: var(--p2-color-link);
-	}
-
 	.plans-features-main__group.is-wpcom & {
 		&.is-blogger-plan {
 			border-bottom: solid 2px var(--color-plan-blogger);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/77652 and https://github.com/Automattic/wp-calypso/pull/82786

## Proposed Changes

* We replaced the outdated p2 workspaces `/plans` page with the 2023 pricing page `PlansFeaturesMain` component in https://github.com/Automattic/wp-calypso/pull/82786
* In doing so, we now have unused logic in the legacy `PlansFeatures` component. We remove them in this PR.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new p2 site by visiting calypso.localhost:3000/start/p2 and following onboarding instructions
* Note the site slug that's created for your new p2 workspace
* Navigate directly to calypso.localhost:3000/plans/{P2_WORKSPACE_SITE_SLUG}
* Verify that the P2+ plan can still be purchased
* Verify that the "Your plan" badge highlights the correct plan
* Verify that, when the current plan is the p2 free plan, that the "Manage add-ons" button redirects to the /add-ons page in Calypso admin
* Verify that everything behaves as expected in the mobile view
* Verify that a stepper, signup, and wooexpress pricing grid pages still render as expected. See PCYsg-RDT-p2e for more detailed instructions

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?