### PR TITLE
Add-ons: Make isAddOn property optional

### DIFF
--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -618,7 +618,6 @@ const getPlanFreeDetails = (): IncompleteWPcomPlan => ( {
 		return [
 			{
 				slug: FEATURE_1GB_STORAGE,
-				isAddOn: false,
 			},
 		];
 	},
@@ -858,7 +857,6 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 		return [
 			{
 				slug: FEATURE_6GB_STORAGE,
-				isAddOn: false,
 			},
 		];
 	},
@@ -1278,7 +1276,6 @@ const getPlanWooExpressMediumDetails = (): IncompleteWPcomPlan => ( {
 		return [
 			{
 				slug: FEATURE_200GB_STORAGE,
-				isAddOn: false,
 			},
 		];
 	},
@@ -1314,7 +1311,6 @@ const getPlanWooExpressSmallDetails = (): IncompleteWPcomPlan => ( {
 		return [
 			{
 				slug: FEATURE_50GB_STORAGE,
-				isAddOn: false,
 			},
 		];
 	},
@@ -1489,7 +1485,6 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 		return [
 			{
 				slug: FEATURE_13GB_STORAGE,
-				isAddOn: false,
 			},
 		];
 	},
@@ -3456,7 +3451,6 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 			return [
 				{
 					slug: FEATURE_P2_13GB_STORAGE,
-					isAddOn: false,
 				},
 			];
 		},
@@ -3515,7 +3509,6 @@ PLANS_LIST[ PLAN_P2_FREE ] = {
 		return [
 			{
 				slug: FEATURE_P2_3GB_STORAGE,
-				isAddOn: false,
 			},
 		];
 	},

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -220,7 +220,7 @@ export type StorageOption = {
 	slug: string;
 	// Determines if the storage option is an add-on that can be purchased. There are a mixture of patterns
 	// to identify add-ons for now, and we're temporarily adding one more
-	isAddOn: boolean;
+	isAddOn?: boolean;
 };
 
 export type Plan = BillingTerm & {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/79041#discussion_r1284207446 and https://github.com/Automattic/martech/issues/2023

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?