### PR TITLE
Fediverse: add onboarding flow

### DIFF
--- a/client/landing/stepper/declarative-flow/fediverse.ts
+++ b/client/landing/stepper/declarative-flow/fediverse.ts
@@ -1,0 +1,272 @@
+import {
+	updateLaunchpadSettings,
+	type OnboardSelect,
+	type UserSelect,
+} from '@automattic/data-stores';
+import { isAssemblerDesign } from '@automattic/design-picker';
+import { useLocale } from '@automattic/i18n-utils';
+import { useFlowProgress, FEDIVERSE_FLOW } from '@automattic/onboarding';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { addQueryArgs } from '@wordpress/url';
+import { translate } from 'i18n-calypso';
+import { useEffect } from 'react';
+import { getLocaleFromQueryParam, getLocaleFromPathname } from 'calypso/boot/locale';
+import wpcom from 'calypso/lib/wp';
+import {
+	setSignupCompleteSlug,
+	persistSignupDestination,
+	setSignupCompleteFlowName,
+} from 'calypso/signup/storageUtils';
+import { useSiteIdParam } from '../hooks/use-site-id-param';
+import { useSiteSlug } from '../hooks/use-site-slug';
+import { USER_STORE, ONBOARD_STORE } from '../stores';
+import { getLoginUrl } from '../utils/path';
+import { recordSubmitStep } from './internals/analytics/record-submit-step';
+import DesignSetup from './internals/steps-repository/design-setup';
+import ErrorStep from './internals/steps-repository/error-step';
+import FreeSetup from './internals/steps-repository/free-setup';
+import LaunchPad from './internals/steps-repository/launchpad';
+import PatternAssembler from './internals/steps-repository/pattern-assembler/lazy';
+import Processing from './internals/steps-repository/processing-step';
+import { ProcessingResult } from './internals/steps-repository/processing-step/constants';
+import SiteCreationStep from './internals/steps-repository/site-creation-step';
+import {
+	AssertConditionResult,
+	AssertConditionState,
+	Flow,
+	ProvidedDependencies,
+} from './internals/types';
+
+const fediverse: Flow = {
+	name: FEDIVERSE_FLOW,
+	get title() {
+		return translate( 'Enter the fediverse' );
+	},
+	useSteps() {
+		const { resetOnboardStore } = useDispatch( ONBOARD_STORE );
+
+		useEffect( () => {
+			resetOnboardStore();
+		}, [] );
+
+		return [
+			{ slug: 'freeSetup', component: FreeSetup },
+			{ slug: 'siteCreationStep', component: SiteCreationStep },
+			{ slug: 'processing', component: Processing },
+			{ slug: 'launchpad', component: LaunchPad },
+			{ slug: 'designSetup', component: DesignSetup },
+			{ slug: 'patternAssembler', component: PatternAssembler },
+			{ slug: 'error', component: ErrorStep },
+		];
+	},
+
+	useStepNavigation( _currentStep, navigate ) {
+		const flowName = this.name;
+		const { setStepProgress, setPendingAction } = useDispatch( ONBOARD_STORE );
+		const flowProgress = useFlowProgress( { stepName: _currentStep, flowName } );
+		setStepProgress( flowProgress );
+		const siteId = useSiteIdParam();
+		const siteSlug = useSiteSlug();
+		const selectedDesign = useSelect(
+			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedDesign(),
+			[]
+		);
+
+		// trigger guides on step movement, we don't care about failures or response
+		wpcom.req.post(
+			'guides/trigger',
+			{
+				apiNamespace: 'wpcom/v2/',
+			},
+			{
+				flow: flowName,
+				step: _currentStep,
+			}
+		);
+
+		const exitFlow = ( to: string ) => {
+			setPendingAction( () => {
+				return new Promise( () => {
+					window.location.assign( to );
+				} );
+			} );
+
+			return navigate( 'processing' );
+		};
+
+		const submit = ( providedDependencies: ProvidedDependencies = {}, ...results: string[] ) => {
+			recordSubmitStep( providedDependencies, '', flowName, _currentStep );
+
+			switch ( _currentStep ) {
+				case 'freeSetup':
+					return navigate( 'siteCreationStep' );
+
+				case 'siteCreationStep':
+					return navigate( 'processing' );
+
+				case 'processing':
+					if ( results.some( ( result ) => result === ProcessingResult.FAILURE ) ) {
+						return navigate( 'error' );
+					}
+
+					if ( providedDependencies?.goToHome && providedDependencies?.siteSlug ) {
+						return window.location.replace(
+							addQueryArgs( `/home/${ siteId ?? providedDependencies?.siteSlug }`, {
+								celebrateLaunch: true,
+								launchpadComplete: true,
+							} )
+						);
+					}
+
+					if ( isAssemblerDesign( selectedDesign ) ) {
+						const params = new URLSearchParams( {
+							canvas: 'edit',
+							assembler: '1',
+						} );
+
+						return exitFlow( `/site-editor/${ siteSlug }?${ params }` );
+					}
+
+					if ( selectedDesign ) {
+						return navigate( `launchpad?siteSlug=${ siteSlug }` );
+					}
+
+					return navigate( `designSetup?siteSlug=${ providedDependencies?.siteSlug }` );
+
+				case 'designSetup':
+					if ( providedDependencies?.goToCheckout ) {
+						const destination = `/setup/${ flowName }/launchpad?siteSlug=${ providedDependencies.siteSlug }`;
+						persistSignupDestination( destination );
+						setSignupCompleteSlug( providedDependencies?.siteSlug );
+						setSignupCompleteFlowName( flowName );
+						const returnUrl = encodeURIComponent(
+							`/setup/${ flowName }/launchpad?siteSlug=${ providedDependencies?.siteSlug }`
+						);
+
+						return window.location.assign(
+							`/checkout/${ encodeURIComponent(
+								( providedDependencies?.siteSlug as string ) ?? ''
+							) }?redirect_to=${ returnUrl }&signup=1`
+						);
+					}
+
+					if ( providedDependencies?.shouldGoToAssembler ) {
+						return navigate( 'patternAssembler' );
+					}
+
+					return navigate( `processing?siteSlug=${ siteSlug }` );
+
+				case 'patternAssembler': {
+					return navigate( `processing?siteSlug=${ siteSlug }` );
+				}
+
+				case 'launchpad': {
+					return navigate( 'processing' );
+				}
+			}
+			return providedDependencies;
+		};
+
+		const goBack = () => {
+			switch ( _currentStep ) {
+				case 'patternAssembler':
+					return navigate( 'designSetup' );
+			}
+		};
+
+		const goNext = async () => {
+			switch ( _currentStep ) {
+				case 'launchpad':
+					if ( siteSlug ) {
+						await updateLaunchpadSettings( siteSlug, { launchpad_screen: 'skipped' } );
+					}
+					return window.location.assign( `/home/${ siteId ?? siteSlug }` );
+
+				default:
+					return navigate( 'freeSetup' );
+			}
+		};
+
+		const goToStep = ( step: string ) => {
+			navigate( step );
+		};
+
+		return { goNext, goBack, goToStep, submit };
+	},
+
+	useAssertConditions(): AssertConditionResult {
+		const userIsLoggedIn = useSelect(
+			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
+			[]
+		);
+		let result: AssertConditionResult = { state: AssertConditionState.SUCCESS };
+
+		const queryParams = new URLSearchParams( window.location.search );
+		const flowName = this.name;
+
+		// There is a race condition where useLocale is reporting english,
+		// despite there being a locale in the URL so we need to look it up manually.
+		// We also need to support both query param and path suffix localized urls
+		// depending on where the user is coming from.
+		const useLocaleSlug = useLocale();
+		// Query param support can be removed after dotcom-forge/issues/2960 and 2961 are closed.
+		const queryLocaleSlug = getLocaleFromQueryParam();
+		const pathLocaleSlug = getLocaleFromPathname();
+		const locale = queryLocaleSlug || pathLocaleSlug || useLocaleSlug;
+
+		const flags = queryParams.get( 'flags' );
+		const siteSlug = queryParams.get( 'siteSlug' );
+
+		const getStartUrl = () => {
+			let hasFlowParams = false;
+			const flowParams = new URLSearchParams();
+
+			if ( siteSlug ) {
+				flowParams.set( 'siteSlug', siteSlug );
+				hasFlowParams = true;
+			}
+
+			if ( locale && locale !== 'en' ) {
+				flowParams.set( 'locale', locale );
+				hasFlowParams = true;
+			}
+
+			const redirectTarget =
+				window?.location?.pathname +
+				( hasFlowParams ? encodeURIComponent( '?' + flowParams.toString() ) : '' );
+
+			const logInUrl = getLoginUrl( {
+				variationName: flowName,
+				redirectTo: redirectTarget,
+				locale,
+			} );
+
+			return logInUrl + ( flags ? `&flags=${ flags }` : '' );
+		};
+
+		// Despite sending a CHECKING state, this function gets called again with the
+		// /setup/blog/blogger-intent route which has no locale in the path so we need to
+		// redirect off of the first render.
+		// This effects both /setup/blog/<locale> starting points and /setup/blog/blogger-intent/<locale> urls.
+		// The double call also hapens on urls without locale.
+		useEffect( () => {
+			if ( ! userIsLoggedIn ) {
+				const logInUrl = getStartUrl();
+				window.location.assign( logInUrl );
+			}
+		}, [] );
+
+		if ( ! userIsLoggedIn ) {
+			const logInUrl = getStartUrl();
+			window.location.assign( logInUrl );
+			result = {
+				state: AssertConditionState.FAILURE,
+				message: 'free-flow requires a logged in user',
+			};
+		}
+
+		return result;
+	},
+};
+
+export default fediverse;

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -13,6 +13,7 @@ import {
 	VIDEOPRESS_TV_FLOW,
 	VIDEOPRESS_TV_PURCHASE_FLOW,
 	GOOGLE_TRANSFER,
+	FEDIVERSE_FLOW,
 } from '@automattic/onboarding';
 import type { Flow } from '../declarative-flow/internals/types';
 
@@ -122,6 +123,7 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 
 	'domain-user-transfer': () =>
 		import( /* webpackChunkName: "domain-user-transfer-flow" */ './domain-user-transfer' ),
+	[ FEDIVERSE_FLOW ]: () => import( /* webpackChunkName: "fediverse-flow" */ './fediverse' ),
 };
 
 const videoPressTvFlows: Record< string, () => Promise< { default: Flow } > > = config.isEnabled(

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -35,6 +35,7 @@ export const DOMAIN_TRANSFER = 'domain-transfer';
 export const GOOGLE_TRANSFER = 'google-transfer';
 export const ONBOARDING_PM_FLOW = 'onboarding-media';
 export const HUNDRED_YEAR_PLAN_FLOW = 'hundred-year-plan';
+export const FEDIVERSE_FLOW = 'fediverse';
 
 export const isOnboardingPMFlow = ( flowName: string | null | undefined ) => {
 	return Boolean( flowName && flowName === ONBOARDING_PM_FLOW );


### PR DESCRIPTION
This is just a stub, for now, based on the `free` flow.

See peLCyI-bF-p2

## Proposed Changes

* Add a `/setup/fediverse` onboarding flow

## Testing Instructions

* n/a: not even close to ready

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?