### PR TITLE
Add: App Promo to discover sidebar

### DIFF
--- a/client/reader/stream/reader-tag-sidebar/index.jsx
+++ b/client/reader/stream/reader-tag-sidebar/index.jsx
@@ -134,10 +134,12 @@ const ReaderTagSidebar = ( {
 				{ translate( 'See all tags' ) }
 			</a>
 			<AppPromo
-				title={ translate( 'Download the Jetpack App for the best mobile reading experience' ) }
+				title={ translate( 'Get the Jetpack App ' ) }
 				campaign="calypso-reader-tag"
 				hasQRCode={ true }
-				subheader={ translate( 'Comes with darkmode, offline reading and custom styles' ) }
+				subheader={ translate(
+					'For the ultimate on-the-go reading experience. Scan the QR Code below to get started.'
+				) }
 				hasGetAppButton={ false }
 				iconSize={ 40 }
 			/>

--- a/client/reader/stream/reader-tag-sidebar/index.jsx
+++ b/client/reader/stream/reader-tag-sidebar/index.jsx
@@ -133,7 +133,14 @@ const ReaderTagSidebar = ( {
 			>
 				{ translate( 'See all tags' ) }
 			</a>
-			<AppPromo />
+			<AppPromo
+				title={ translate( 'Download the Jetpack App for the best mobile reading experience' ) }
+				campaign="calypso-reader-tag"
+				hasQRCode={ true }
+				subheader={ translate( 'Comes with darkmode, offline reading and custom styles' ) }
+				hasGetAppButton={ false }
+				iconSize={ 40 }
+			/>
 			{ relatedSitesLinks && (
 				<div className="reader-tag-sidebar-related-sites">
 					<h2>{ translate( 'Related Sites' ) }</h2>

--- a/client/reader/stream/reader-tag-sidebar/index.jsx
+++ b/client/reader/stream/reader-tag-sidebar/index.jsx
@@ -2,6 +2,7 @@ import { Button } from '@automattic/components';
 import { addLocaleToPathLocaleInFront } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { connect, useDispatch, useSelector } from 'react-redux';
+import AppPromo from 'calypso/blocks/app-promo';
 import FollowButton from 'calypso/blocks/follow-button/button';
 import TagLink from 'calypso/blocks/reader-post-card/tag-link';
 import { useRelatedMetaByTag } from 'calypso/data/reader/use-related-meta-by-tag';
@@ -132,6 +133,7 @@ const ReaderTagSidebar = ( {
 			>
 				{ translate( 'See all tags' ) }
 			</a>
+			<AppPromo />
 			{ relatedSitesLinks && (
 				<div className="reader-tag-sidebar-related-sites">
 					<h2>{ translate( 'Related Sites' ) }</h2>

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -800,6 +800,18 @@
 	.reader-feed-header__seen-button {
 		margin-bottom: 24px;
 	}
+
+	.app-promo {
+		background-color: transparent;
+
+		.get-apps__card-text {
+			display: none;
+		}
+
+		.app-promo__qr-code {
+			margin: 20px 0 0;
+		}
+	}
 }
 
 // Posts and Sites tabbed headers

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -803,6 +803,8 @@
 
 	.app-promo {
 		background-color: transparent;
+		border-radius: 10px; /* stylelint-disable-line scales/radii */
+		padding: 16px 16px 24px;
 
 		.get-apps__card-text {
 			display: none;
@@ -810,6 +812,10 @@
 
 		.app-promo__qr-code {
 			margin: 20px 0 0;
+		}
+
+		.card-heading {
+			margin-bottom: 16px;
 		}
 	}
 }


### PR DESCRIPTION
This PR ads a banner to the discover tab that tells users about the Jetpack app. 

Logged out Discover Tab.

Before:

<img width="400" alt="Screenshot 2023-11-03 at 11 17 58 AM" src="https://github.com/Automattic/wp-calypso/assets/115071/4f73f4f7-4b5f-402f-93c9-a4173d09b6d9">

After:
<img width="400" alt="Screenshot 2023-11-03 at 11 16 56 AM" src="https://github.com/Automattic/wp-calypso/assets/115071/87ecce27-ac6a-43cc-bd4d-b9b45a34b229" />


Logged in Discover Tab.
Before:
<img width="400" alt="Screenshot 2023-11-03 at 11 17 23 AM" src="https://github.com/Automattic/wp-calypso/assets/115071/05792838-2a1f-404f-83b6-0467d3bae612">


After:

<img width="400" alt="Screenshot 2023-11-03 at 11 18 49 AM" src="https://github.com/Automattic/wp-calypso/assets/115071/c6707c4b-f88e-4d0b-8650-c6eb48399585">


## Testing Instructions

* When logged out and logged in visit /discover?selectedTab=dailyprompt
* And notice the App Promo for the jetpack app.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?