### PR TITLE
ETK Performance: defer loading the Help Center

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
@@ -90,10 +90,9 @@ class Help_Center {
 			plugins_url( 'dist/help-center.min.js', __FILE__ ),
 			is_array( $script_dependencies ) ? $script_dependencies : array(),
 			$this->version,
-			array(
-				'strategy' => 'defer',
-			)
+			true
 		);
+		wp_script_add_data( 'help-center-script', 'strategy', 'defer' );
 
 		wp_enqueue_style(
 			'help-center-style',

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/class-help-center.php
@@ -90,7 +90,9 @@ class Help_Center {
 			plugins_url( 'dist/help-center.min.js', __FILE__ ),
 			is_array( $script_dependencies ) ? $script_dependencies : array(),
 			$this->version,
-			true
+			array(
+				'strategy' => 'defer',
+			)
 		);
 
 		wp_enqueue_style(


### PR DESCRIPTION
Context: pdDR7T-12w-p2


### Testing steps
1. Checkout this branch.
2. in apps/editing-toolkit, run `yarn dev --sync`.
3. Go to the editor of a sandboxed simple site, make sure the Help Center works great.
