### PR TITLE
fix: restored wccom-from query parameter

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -387,26 +387,8 @@ class Login extends Component {
 			if ( isWoo ) {
 				if ( isPartnerSignup ) {
 					headerText = translate( 'Log in to your account' );
-				} else if ( wccomFrom ) {
-					preHeader = (
-						<Fragment>
-							{ 'cart' === wccomFrom ? (
-								<WooCommerceConnectCartHeader />
-							) : (
-								<div className="login__woocommerce-wrapper">
-									<div className={ classNames( 'login__woocommerce-logo' ) }>
-										<svg width={ 200 } viewBox="0 0 1270 170">
-											<AsyncLoad
-												require="calypso/components/jetpack-header/woocommerce"
-												darkColorScheme={ false }
-												placeholder={ null }
-											/>
-										</svg>
-									</div>
-								</div>
-							) }
-						</Fragment>
-					);
+				} else if ( wccomFrom === 'cart' ) {
+					preHeader = <WooCommerceConnectCartHeader />;
 					headerText = translate( 'Log in with a WordPress.com account' );
 					postHeader = (
 						<p className="login__header-subtitle">
@@ -428,26 +410,26 @@ class Login extends Component {
 					);
 				} else {
 					headerText = <h3>{ translate( "Let's get started" ) }</h3>;
+					const poweredByWpCom =
+						wccomFrom === 'nux'
+							? translate( 'All Woo Express stores are powered by WordPress.com!' )
+							: translate( 'All Woo stores are powered by WordPress.com!' );
+					const accountSelectionOrLoginToContinue = this.showContinueAsUser()
+						? translate( "First, select the account you'd like to use." )
+						: translate(
+								"Please, log in to continue. Don't have an account? {{signupLink}}Sign up{{/signupLink}}",
+								{
+									components: {
+										signupLink: <a href={ this.getSignupUrl() } />,
+										br: <br />,
+									},
+								}
+						  );
 					postHeader = (
 						<p className="login__header-subtitle">
-							{ this.showContinueAsUser()
-								? translate(
-										"All Woo stores are powered by WordPress.com!{{br/}}First, select the account you'd like to use.",
-										{
-											components: {
-												br: <br />,
-											},
-										}
-								  )
-								: translate(
-										"All Woo stores are powered by WordPress.com!{{br/}}Please, log in to continue. Don't have an account? {{signupLink}}Sign up{{/signupLink}}",
-										{
-											components: {
-												signupLink: <a href={ this.getSignupUrl() } />,
-												br: <br />,
-											},
-										}
-								  ) }
+							{ poweredByWpCom }
+							<br />
+							{ accountSelectionOrLoginToContinue }
 						</p>
 					);
 				}

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -375,9 +375,9 @@ export class LoginForm extends Component {
 	};
 
 	getLoginButtonText = () => {
-		const { translate, isWoo, wccomFrom, isWooCoreProfilerFlow } = this.props;
+		const { translate, isWoo, isWooCoreProfilerFlow } = this.props;
 		if ( this.isPasswordView() || this.isFullView() ) {
-			if ( isWoo && ! wccomFrom && ! isWooCoreProfilerFlow ) {
+			if ( isWoo && ! isWooCoreProfilerFlow ) {
 				return translate( 'Get started' );
 			}
 
@@ -650,7 +650,6 @@ export class LoginForm extends Component {
 			isJetpackWooCommerceFlow,
 			isP2Login,
 			isJetpackWooDnaFlow,
-			wccomFrom,
 			currentQuery,
 			showSocialLoginFormOnly,
 			isWoo,
@@ -725,10 +724,6 @@ export class LoginForm extends Component {
 				showSocialLogin: !! accountType, // Only show the social buttons after the user entered an email.
 				socialToS,
 			} );
-		}
-
-		if ( isWoo && wccomFrom ) {
-			return this.renderWooCommerce( { socialToS } );
 		}
 
 		return (

--- a/client/blocks/login/two-factor-authentication/security-key-form.scss
+++ b/client/blocks/login/two-factor-authentication/security-key-form.scss
@@ -12,15 +12,19 @@
 		padding: 0;
 
 		button.is-primary {
-			width: 404px !important;
+			max-width: 404px !important;
 		}
+
 		.two-factor-authentication__actions {
 			padding: 40px 0 40px 0;
-			width: 404px;
+			width: 100%;
+			max-width: 404px;
+
 			button {
-				width: 100% !important;
+				max-width: 100% !important;
 			}
 		}
+
 		.two-factor-authentication__verification-code-form {
 			margin-bottom: 40px;
 		}

--- a/client/blocks/login/two-factor-authentication/verification-code-form.scss
+++ b/client/blocks/login/two-factor-authentication/verification-code-form.scss
@@ -8,10 +8,19 @@
 	width: 100%;
 }
 
-.woo .two-factor-authentication__verification-code-form {
-	margin-bottom: 52px;
-	padding: 16px 0 0;
+.woo .two-factor-authentication__verification-code-form-wrapper {
+	padding: 4px 0 0;
 	text-align: center;
+
+	.security-key-form__help-text {
+		margin-bottom: 40px;
+	}
+
+	.two-factor-authentication__verification-code-form {
+		border: 0;
+		padding: 0 0 10px;
+		margin-bottom: 40px;
+	}
 
 	@media screen and ( max-width: 660px ) {
 		text-align: left;
@@ -37,11 +46,13 @@
 	}
 
 	.form-fieldset {
-		margin: 40px 0 -8px;
+		margin: 40px auto 16px;
+		max-width: 404px;
 	}
 
 	.form-button {
-		margin: 24px 0 0;
+		margin: 0;
+		max-width: 404px;
 	}
 
 	.form-fieldset,
@@ -50,6 +61,26 @@
 			margin-left: 0;
 			margin-right: 0;
 			width: 100%;
+		}
+	}
+
+	.auth-form__separator {
+		max-width: 404px;
+		margin-left: auto;
+		margin-right: auto;
+	}
+
+	.two-factor-authentication__actions.card {
+		padding: 36px 0 40px;
+
+		.button {
+			border: 1px solid #c3c4c7;
+			color: var(--color-gray-100);
+			font-weight: 500;
+			line-height: 20px;
+			box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+			width: 100%;
+			max-width: 404px;
 		}
 	}
 }

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -1125,11 +1125,7 @@ class SignupForm extends Component {
 			);
 		}
 
-		if (
-			this.props.isJetpackWooCommerceFlow ||
-			this.props.isJetpackWooDnaFlow ||
-			( this.props.isWoo && this.props.wccomFrom )
-		) {
+		if ( this.props.isJetpackWooCommerceFlow || this.props.isJetpackWooDnaFlow ) {
 			return (
 				<div className={ classNames( 'signup-form__woocommerce', this.props.className ) }>
 					<LoggedOutForm onSubmit={ this.handleWooCommerceSubmit } noValidate={ true }>

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -55,7 +55,6 @@ class Document extends Component {
 			feedbackURL,
 			inlineScriptNonce,
 			isSupportSession,
-			isWCComConnect,
 			isWooDna,
 			requestFrom,
 			useTranslationChunks,
@@ -167,7 +166,6 @@ class Document extends Component {
 									[ 'is-section-' + sectionName ]: sectionName,
 									'is-jetpack-woocommerce-flow': isJetpackWooCommerceFlow,
 									'is-jetpack-woo-dna-flow': isJetpackWooDnaFlow,
-									'is-wccom-oauth-flow': isWCComConnect,
 								} ) }
 							>
 								<div className="layout__content">

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -26,7 +26,6 @@ import WooCoreProfilerMasterbar from 'calypso/layout/masterbar/woo-core-profiler
 import OfflineStatus from 'calypso/layout/offline-status';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { isWpMobileApp, isWcMobileApp } from 'calypso/lib/mobile-app';
-import { isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
 import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-tag-embed-page';
 import { getMessagePathForJITM } from 'calypso/lib/route';
 import UserVerificationChecker from 'calypso/lib/user/verification-checker';
@@ -247,7 +246,6 @@ class Layout extends Component {
 			'is-jetpack-mobile-flow': this.props.isJetpackMobileFlow,
 			'is-jetpack-woocommerce-flow': this.props.isJetpackWooCommerceFlow,
 			'is-jetpack-woo-dna-flow': this.props.isJetpackWooDnaFlow,
-			'is-wccom-oauth-flow': isWooOAuth2Client( this.props.oauth2Client ) && this.props.wccomFrom,
 			'is-woocommerce-core-profiler-flow': this.props.isWooCoreProfilerFlow,
 			woo: this.props.isWooCoreProfilerFlow,
 		} );

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -55,7 +55,6 @@ const LayoutLoggedOut = ( {
 	isGravatar,
 	isWPJobManager,
 	isGravPoweredClient,
-	wccomFrom,
 	masterbarIsHidden,
 	oauth2Client,
 	primary,
@@ -130,7 +129,6 @@ const LayoutLoggedOut = ( {
 		'is-popup': isPopup,
 		'is-jetpack-woocommerce-flow': isJetpackWooCommerceFlow,
 		'is-jetpack-woo-dna-flow': isJetpackWooDnaFlow,
-		'is-wccom-oauth-flow': isWooOAuth2Client( oauth2Client ) && wccomFrom,
 		'is-p2-login': isP2Login,
 		'is-gravatar': isGravatar,
 		'is-wp-job-manager': isWPJobManager,
@@ -156,11 +154,7 @@ const LayoutLoggedOut = ( {
 			masterbar = (
 				<MasterbarLogin goBackUrl={ localizeUrl( 'https://wordpress.com/partners/', locale ) } />
 			);
-		} else if (
-			( isWooOAuth2Client( oauth2Client ) && wccomFrom ) ||
-			isGravatar ||
-			isGravPoweredClient
-		) {
+		} else if ( isGravatar || isGravPoweredClient ) {
 			masterbar = null;
 		} else {
 			classes.dops = true;

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -508,12 +508,22 @@
 		display: none;
 	}
 
+	.signup-form .auth-form__separator {
+		width: 100%;
+	}
+
 	.auth-form__separator + .auth-form__social.card {
 		clip-path: unset; // unset the rule applied in ./client/blocks/authentication/form-divider/style.scss
 		border-top: 1px solid #e6e6e6;
 		max-width: 100%;
 	}
 
+	.auth-form__separator {
+		&::before,
+		&::after {
+			content: none;
+		}
+	}
 	.auth-form__social,
 	.two-factor-authentication__actions {
 		background: initial;

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -712,7 +712,8 @@
 
 	.auth-form__social {
 		max-width: 100%;
-		padding: 44px 0 14px;
+		padding: 40px 0 14px;
+		border-top: 0;
 		display: flex;
 		flex-direction: column;
 		align-items: center;

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -421,7 +421,8 @@
 		min-height: 238px;
 
 		~ .auth-form__separator {
-			margin: -10px 0;
+			margin: -10px auto;
+			max-width: 472px;
 		}
 
 		~ .card.auth-form__social.is-login {
@@ -517,39 +518,25 @@
 		display: none;
 	}
 
-	.auth-form__separator {
-		&::before,
-		&::after {
-			content: none;
-		}
+	.auth-form__separator::before,
+	.auth-form__separator::after {
+		border-block-start: $woo-form-divider-border;
 	}
 
 	.auth-form__separator + .auth-form__social.card {
 		clip-path: unset; // unset the rule applied in ./client/blocks/authentication/form-divider/style.scss
-		border-top: 1px solid #e6e6e6;
 		max-width: 100%;
 	}
 
 	.auth-form__social,
 	.two-factor-authentication__actions {
 		background: initial;
-		border-top: $woo-form-divider-border;
 		padding-top: 40px;
 		padding-bottom: 40px;
 		text-align: center;
 
 		@media screen and ( max-width: 660px ) {
 			padding-top: 28px;
-		}
-	}
-
-	.two-factor-authentication__actions.card {
-		.button {
-			border: 1px solid #c3c4c7;
-			color: var(--color-gray-100);
-			font-weight: 500;
-			line-height: 20px;
-			box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
 		}
 	}
 
@@ -598,11 +585,10 @@
 			&::after {
 				position: absolute;
 				border-inline-start: 0;
-				border-block-start: 1px solid #eaeaeb;
+				border-block-start: $woo-form-divider-border;
 				inset-block-start: 50%;
 				inset-inline-start: 0;
 				width: 42%;
-				content: none;
 			}
 
 			&::after {
@@ -726,7 +712,6 @@
 
 	.auth-form__social {
 		max-width: 100%;
-		border-top: 1px solid #e6e6e6;
 		padding: 44px 0 14px;
 		display: flex;
 		flex-direction: column;
@@ -934,10 +919,6 @@
 				font-size: rem(11px);
 				color: $gray-900;
 			}
-		}
-
-		.two-factor-authentication__actions.card {
-			padding-top: 36px;
 		}
 
 		div.login__two-factor-footer {

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -508,6 +508,12 @@
 		display: none;
 	}
 
+	.auth-form__separator + .auth-form__social.card {
+		clip-path: unset; // unset the rule applied in ./client/blocks/authentication/form-divider/style.scss
+		border-top: 1px solid #e6e6e6;
+		max-width: 100%;
+	}
+
 	.auth-form__social,
 	.two-factor-authentication__actions {
 		background: initial;
@@ -568,6 +574,10 @@
 			margin-left: 0;
 			margin-right: 0;
 
+			@media ( min-width: 782px ) {
+				width: 100%;
+			}
+
 			&::before,
 			&::after {
 				position: absolute;
@@ -576,6 +586,7 @@
 				inset-block-start: 50%;
 				inset-inline-start: 0;
 				width: 42%;
+				content: none;
 			}
 
 			&::after {
@@ -590,6 +601,11 @@
 			background: #fff;
 			padding: 0 27px !important;
 		}
+	}
+
+	.auth-form__separator .auth-form__separator-text {
+		padding: 0 27px;
+		background: #fff;
 	}
 
 	.wp-login__footer--oauth {
@@ -958,6 +974,10 @@
 
 		.signup-form {
 			padding-top: 24px;
+		}
+
+		button.social-buttons__button.button {
+			width: 100%;
 		}
 
 		// Log in link on signup page

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -418,6 +418,15 @@
 		max-width: 472px;
 		margin: 54px auto 0;
 		height: unset;
+		min-height: 238px;
+
+		~ .auth-form__separator {
+			margin: -10px 0;
+		}
+
+		~ .card.auth-form__social.is-login {
+			max-width: 472px;
+		}
 
 		.continue-as-user__gravatar-link {
 			pointer-events: auto;
@@ -508,8 +517,11 @@
 		display: none;
 	}
 
-	.signup-form .auth-form__separator {
-		width: 100%;
+	.auth-form__separator {
+		&::before,
+		&::after {
+			content: none;
+		}
 	}
 
 	.auth-form__separator + .auth-form__social.card {
@@ -518,12 +530,6 @@
 		max-width: 100%;
 	}
 
-	.auth-form__separator {
-		&::before,
-		&::after {
-			content: none;
-		}
-	}
 	.auth-form__social,
 	.two-factor-authentication__actions {
 		background: initial;

--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -174,12 +174,7 @@ export const isReactLostPasswordScreenEnabled = () => {
 	);
 };
 
-export const canDoMagicLogin = (
-	twoFactorAuthType,
-	oauth2Client,
-	wccomFrom,
-	isJetpackWooCommerceFlow
-) => {
+export const canDoMagicLogin = ( twoFactorAuthType, oauth2Client, isJetpackWooCommerceFlow ) => {
 	if ( ! config.isEnabled( `login/magic-login` ) || twoFactorAuthType ) {
 		return false;
 	}
@@ -189,7 +184,7 @@ export const canDoMagicLogin = (
 		return false;
 	}
 
-	if ( isWooOAuth2Client( oauth2Client ) && wccomFrom ) {
+	if ( isWooOAuth2Client( oauth2Client ) ) {
 		return false;
 	}
 

--- a/client/login/wp-login/login-buttons.tsx
+++ b/client/login/wp-login/login-buttons.tsx
@@ -28,7 +28,7 @@ const LoginButtons = ( {
 }: LoginButtonsProps ) => {
 	const translate = useTranslate();
 
-	const { query, wccomFrom, isJetpackWooCommerceFlow, currentRoute } = useSelector( ( state ) => {
+	const { query, isJetpackWooCommerceFlow, currentRoute } = useSelector( ( state ) => {
 		const query = getCurrentQueryArguments( state );
 
 		return {
@@ -41,9 +41,7 @@ const LoginButtons = ( {
 	const dispatch = useDispatch();
 
 	const getMagicLoginPageLink = () => {
-		if (
-			! canDoMagicLogin( twoFactorAuthType, oauth2Client, wccomFrom, isJetpackWooCommerceFlow )
-		) {
+		if ( ! canDoMagicLogin( twoFactorAuthType, oauth2Client, isJetpackWooCommerceFlow ) ) {
 			return null;
 		}
 

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -24,7 +24,6 @@ import { STEPPER_SECTION_DEFINITION } from 'calypso/landing/stepper/section';
 import { SUBSCRIPTIONS_SECTION_DEFINITION } from 'calypso/landing/subscriptions/section';
 import { shouldSeeCookieBanner } from 'calypso/lib/analytics/utils';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
-import { isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { login } from 'calypso/lib/paths';
 import loginRouter, { LOGIN_SECTION_DEFINITION } from 'calypso/login';
 import sections from 'calypso/sections';
@@ -98,7 +97,7 @@ function setupLoggedInContext( req, res, next ) {
 	next();
 }
 
-function getDefaultContext( request, response, entrypoint = 'entry-main', sectionName ) {
+function getDefaultContext( request, response, entrypoint = 'entry-main' ) {
 	performanceMark( request.context, 'getDefaultContext' );
 
 	const geoIPCountryCode = request.headers[ 'x-geoip-country-code' ];
@@ -147,12 +146,6 @@ function getDefaultContext( request, response, entrypoint = 'entry-main', sectio
 	const devEnvironments = [ 'development', 'jetpack-cloud-development' ];
 	const isDebug = devEnvironments.includes( calypsoEnv ) || request.query.debug !== undefined;
 
-	const oauthClientId = request.query.oauth2_client_id || request.query.client_id;
-	const isWCComConnect =
-		( 'login' === sectionName || 'signup' === sectionName ) &&
-		request.query[ 'wccom-from' ] &&
-		isWooOAuth2Client( { id: parseInt( oauthClientId ) } );
-
 	const reactQueryDevtoolsHelper = config.isEnabled( 'dev/react-query-devtools' );
 	const authHelper = config.isEnabled( 'dev/auth-helper' );
 	const accountSettingsHelper = config.isEnabled( 'dev/account-settings-helper' );
@@ -177,7 +170,6 @@ function getDefaultContext( request, response, entrypoint = 'entry-main', sectio
 		env: calypsoEnv,
 		sanitize: sanitize,
 		requestFrom: request.query.from,
-		isWCComConnect,
 		isWooDna: wooDnaConfig( request.query ).isWooDnaFlow(),
 		badge: false,
 		lang: config( 'i18n_default_locale_slug' ),

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -219,7 +219,7 @@ export class UserStep extends Component {
 						break;
 					default:
 						subHeaderText = translate(
-							'All Woo stores are powered by WordPress.com.{{br/}}Please create an account to continue. Already registered? {{a}}Log in{{/a}}',
+							'All Woo stores are powered by WordPress.com!{{br/}}Please create an account to continue. Already registered? {{a}}Log in{{/a}}',
 							{
 								components: {
 									a: <a href={ loginUrl } />,
@@ -232,7 +232,7 @@ export class UserStep extends Component {
 				}
 			} else if ( isWooOAuth2Client( oauth2Client ) && ! wccomFrom ) {
 				subHeaderText = translate(
-					'All Woo stores are powered by WordPress.com.{{br/}}Please create an account to continue. Already registered? {{a}}Log in{{/a}}',
+					'All Woo stores are powered by WordPress.com!{{br/}}Please create an account to continue. Already registered? {{a}}Log in{{/a}}',
 					{
 						components: {
 							a: <a href={ loginUrl } />,
@@ -705,16 +705,16 @@ export class UserStep extends Component {
 }
 
 const ConnectedUser = connect(
-	( state ) => ( {
-        const oauth2RedirectUrl = new URL( getCurrentQueryArguments( state ).oauth2_redirect );
-        return {
-            oauth2Client: getCurrentOAuth2Client( state ),
-		    suggestedUsername: getSuggestedUsername( state ),
+	( state ) => {
+		const oauth2RedirectUrl = new URL( getCurrentQueryArguments( state ).oauth2_redirect );
+		return {
+			oauth2Client: getCurrentOAuth2Client( state ),
+			suggestedUsername: getSuggestedUsername( state ),
 			wccomFrom: oauth2RedirectUrl.searchParams.get( 'wccom-from' ),
-		    from: get( getCurrentQueryArguments( state ), 'from' ),
-		    userLoggedIn: isUserLoggedIn( state ),
-        }
-	} ),
+			from: get( getCurrentQueryArguments( state ), 'from' ),
+			userLoggedIn: isUserLoggedIn( state ),
+		};
+	},
 	{
 		errorNotice,
 		recordTracksEvent,

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -198,14 +198,38 @@ export class UserStep extends Component {
 
 		if ( [ 'wpcc', 'crowdsignal' ].includes( flowName ) && oauth2Client ) {
 			if ( isWooOAuth2Client( oauth2Client ) && wccomFrom ) {
-				subHeaderText =
-					'cart' === wccomFrom
-						? translate(
-								"You'll need an account to complete your purchase and manage your subscription"
-						  )
-						: translate(
-								"You'll need an account to connect your store and manage your extensions"
-						  );
+				switch ( wccomFrom ) {
+					case 'cart':
+						subHeaderText = translate(
+							"You'll need an account to complete your purchase and manage your subscription"
+						);
+						break;
+					case 'nux':
+						subHeaderText = translate(
+							'All Woo Express stores are powered by WordPress.com.{{br/}}Please create an account to continue. Already registered? {{a}}Log in{{/a}}',
+							{
+								components: {
+									a: <a href={ loginUrl } />,
+									br: <br />,
+								},
+								comment:
+									'Link displayed on the Signup page to users having account to log in WooCommerce via WordPress.com',
+							}
+						);
+						break;
+					default:
+						subHeaderText = translate(
+							'All Woo stores are powered by WordPress.com.{{br/}}Please create an account to continue. Already registered? {{a}}Log in{{/a}}',
+							{
+								components: {
+									a: <a href={ loginUrl } />,
+									br: <br />,
+								},
+								comment:
+									'Link displayed on the Signup page to users having account to log in WooCommerce via WordPress.com',
+							}
+						);
+				}
 			} else if ( isWooOAuth2Client( oauth2Client ) && ! wccomFrom ) {
 				subHeaderText = translate(
 					'All Woo stores are powered by WordPress.com.{{br/}}Please create an account to continue. Already registered? {{a}}Log in{{/a}}',
@@ -682,11 +706,14 @@ export class UserStep extends Component {
 
 const ConnectedUser = connect(
 	( state ) => ( {
-		oauth2Client: getCurrentOAuth2Client( state ),
-		suggestedUsername: getSuggestedUsername( state ),
-		wccomFrom: get( getCurrentQueryArguments( state ), 'wccom-from' ),
-		from: get( getCurrentQueryArguments( state ), 'from' ),
-		userLoggedIn: isUserLoggedIn( state ),
+        const oauth2RedirectUrl = new URL( getCurrentQueryArguments( state ).oauth2_redirect );
+        return {
+            oauth2Client: getCurrentOAuth2Client( state ),
+		    suggestedUsername: getSuggestedUsername( state ),
+			wccomFrom: oauth2RedirectUrl.searchParams.get( 'wccom-from' ),
+		    from: get( getCurrentQueryArguments( state ), 'from' ),
+		    userLoggedIn: isUserLoggedIn( state ),
+        }
 	} ),
 	{
 		errorNotice,

--- a/client/state/login/utils.js
+++ b/client/state/login/utils.js
@@ -192,12 +192,16 @@ export function isPartnerSignupQuery( currentQuery ) {
 
 	// Handles login through /log-in/?redirect_to=...
 	if ( typeof currentQuery?.redirect_to === 'string' ) {
-		return /woocommerce\.com\/partner-signup/.test( currentQuery.redirect_to );
+		return /woocommerce\.(?:com|test)\/partner-signup/.test(
+			decodeURIComponent( currentQuery.redirect_to )
+		);
 	}
 
 	// Handles user creation through /start/wpcc?oauth2_redirect=...
 	if ( typeof currentQuery?.oauth2_redirect === 'string' ) {
-		return /woocommerce\.com\/partner-signup/.test( currentQuery.oauth2_redirect );
+		return /woocommerce\.(?:com|test)\/partner-signup/.test(
+			decodeURIComponent( currentQuery.oauth2_redirect )
+		);
 	}
 
 	return false;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #https://github.com/Automattic/woocommerce.com/pull/18470

This PR must not be merged before the above, as it will cause the NUX login flow to be broken without the correct wccom-from parameter handling

## Proposed Changes

* The handling of the `wccom-from` query parameter in the Woo OAuth flow has been broken for some time, as it seems that the selector was expecting it to be a top level query parameter. In actuality, the query parameter was being inserted within the `redirect_to` URL's query parameter
* This PR fixes the selector, and in the process, has the consequence of uncovering some branches that have been `false` ever since the `wccom-from` parameter was broken. As far as I can tell, these branches are obsolete and I simply deleted them. 

- ** It is possible that I'm mistaken, and that there are existing login flows that insert the `wccom-from` parameter at the top level. Please sound out if you are aware **

- While investigating the code I also noticed that the non-woo branded partner login page (https://github.com/Automattic/wp-calypso/pull/64362) seems to have been broken by URL encoding at some point, so I fixed it (cc: @lsl)
- I also tested with the new WC Core Profiler login, which supersedes the previous login (https://github.com/Automattic/wp-calypso/pull/35193). As a result of this, I deleted the code paths that relate to that design, as they were being activated due to `wccom-from` detection being fixed

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. If you're able to run the [woocommerce-start-dev-env environment](https://github.com/woocommerce/woocommerce-start-dev-env), use that. Otherwise you'll have to settle for modifying the login page to calypso.localhost instead.
1. Check out https://github.com/Automattic/wp-calypso/pull/83340 and run that too
3. Check out this branch go to `woocommerce.test/start` 
4. Go through the NUX while logged out
5. When you click on the WooExpress CTA you should be brought to the login page on WordPress.com
6. If you not using the start-dev-env, change `wordpress.com` to `calypso.localhost:3000`
7. Observe that you see `All Woo Express stores are powered by WordPress.com!` instead of `All Woo stores are powered by WordPress.com!`

![image](https://github.com/Automattic/woocommerce.com/assets/27843274/ff8d3e97-9a56-40f1-a16d-e12eeeb0f51e)

- Also observe that if you go straight to "Login" from the woocommerce.test home page, you should see the `All Woo stores are powered by WordPress.com!` text copy
- Please also test around the other login flows with this wp-calypso PR, as I'm not too confident if I broke any other login flow. As far as I can tell, the wccom-from parameter has been null for awhile for the oauth login flow, so enabling it broke some things. I'm not sure if the non-oauth2 flow is still in use anywhere.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?