### PR TITLE
Fix brand colors on connection screen

### DIFF
--- a/client/my-sites/marketing/style.scss
+++ b/client/my-sites/marketing/style.scss
@@ -10,42 +10,36 @@
 	}
 
 	&.facebook {
-		h2,
 		.sharing-service__logo {
 			color: var(--color-facebook);
 		}
 	}
 
 	&.twitter {
-		h2,
 		.sharing-service__logo {
 			color: var(--color-twitter);
 		}
 	}
 
 	&.google_plus {
-		h2,
 		.sharing-service__logo {
 			color: var(--color-google-plus);
 		}
 	}
 
 	&.linkedin {
-		h2,
 		.sharing-service__logo {
 			color: var(--color-linkedin);
 		}
 	}
 
 	&.tumblr {
-		h2,
 		.sharing-service__logo {
 			color: var(--color-tumblr);
 		}
 	}
 
 	&.instagram-basic-display {
-		h2,
 		.sharing-service__logo {
 			color: var(--color-instagram);
 		}
@@ -58,9 +52,18 @@
 	}
 
 	&.mastodon {
-		h2,
 		.sharing-service__logo {
 			color: var(--color-mastodon);
+		}
+	}
+	&.nextdoor {
+		.sharing-service__logo {
+			color: var(--color-nextdoor);
+			// This is to fix the logo being too big
+			// Other icons seems to have 8px of padding
+			// so, we'll decrease the width (40px) by 2 and add 6px of padding
+			width: 38px;
+			padding-inline: 6px;
 		}
 	}
 
@@ -292,10 +295,6 @@
 @mixin sharing-service( $name, $color ) {
 	.sharing-service.#{ $name } .sharing-service__icon {
 		background: $color;
-	}
-
-	.sharing-service.#{ $name } .sharing-service__name {
-		color: $color;
 	}
 
 	.sharing-connection__account-avatar.is-fallback.#{ $name } {


### PR DESCRIPTION
## Proposed Changes

* Fix Nextdoor icons size which was bigger than other icons
* Fix Nextdoor icon color to use the brand color
* Make the service name for all the services to be the same (black)

## Testing Instructions

* Apply D125526-code to your sandbox
* Point `public-api.wordpress.com` to your sandbox
* Add the blog sticker to your site:
`add_blog_sticker( 'jetpack-social-nextdoor-connection', null, null, <YOUR_SITE_ID> );` 
* Goto `/marketing/connections/:site` in Calypso Blue
* Confirm that you see the Nextdoor connection
* Confirm that the Nextdoor icon is of the same size as others
* Confirm that Nextdoor icon has the brand color - `#8ed500`
* Confirm that all the serives names are in black instead of the respective brand color


| Before | After |
|--------|--------|
| <img width="415" alt="Screenshot 2023-10-23 at 10 41 44 AM" src="https://github.com/Automattic/wp-calypso/assets/18226415/cbfed4d1-5ba1-49de-a157-514f81b56b64"> | <img width="427" alt="Screenshot 2023-10-23 at 10 22 19 AM" src="https://github.com/Automattic/wp-calypso/assets/18226415/69094e0f-1b22-4317-b12c-36c724067d94"> |
 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?