### PR TITLE
My home: add "add your own domain" link under preview

### DIFF
--- a/client/my-sites/customer-home/cards/features/site-preview/index.tsx
+++ b/client/my-sites/customer-home/cards/features/site-preview/index.tsx
@@ -95,6 +95,14 @@ const SitePreview = ( { isFSEActive }: SitePreviewProps ): JSX.Element => {
 					<SiteUrl href={ selectedSite.URL } title={ selectedSite.URL }>
 						<Truncated>{ selectedSite.slug }</Truncated>
 					</SiteUrl>
+					<a
+						onClick={ () => {
+							recordTracksEvent( 'calypso_customer_home_site_preview_get_domain_clicked' );
+						} }
+						href={ `/domains/add/${ selectedSite.slug }` }
+					>
+						{ __( 'Add your own domain' ) }
+					</a>
 				</div>
 				<SitePreviewEllipsisMenu />
 			</div>

--- a/client/my-sites/customer-home/cards/features/site-preview/style.scss
+++ b/client/my-sites/customer-home/cards/features/site-preview/style.scss
@@ -66,6 +66,7 @@
 			flex-direction: column;
 			gap: 4px;
 			max-width: calc(100% - 24px);
+			font-size: $font-body-small;
 
 			.home-site-preview__info-title {
 				color: var(--color-neutral-80);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

![image](https://github.com/Automattic/wp-calypso/assets/87168/3971689d-0263-46f7-a63c-8df9cd597c76)

TODO:

Show some other action, or hide link altogether, when they have a paid domain.

## Proposed Changes

* Adds a link to add your own domain under site preview and domain.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?