### PR TITLE
Design Picker: show full theme description when sidebar fits

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -228,7 +228,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 
 	const selectedDesignHasStyleVariations = ( selectedDesign?.style_variations || [] ).length > 0;
 	const { data: selectedDesignDetails } = useStarterDesignBySlug( selectedDesign?.slug || '', {
-		enabled: isPreviewingDesign && selectedDesignHasStyleVariations,
+		enabled: isPreviewingDesign,
 		select: ( design: Design ) => {
 			if ( disableCheckoutImmediately && design?.style_variations ) {
 				design.style_variations = [];
@@ -827,7 +827,8 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 					}
 					title={ headerDesignTitle }
 					selectedDesignTitle={ designTitle }
-					description={ selectedDesign.description }
+					shortDescription={ selectedDesign.description }
+					description={ selectedDesignDetails?.description }
 					variations={
 						selectedDesignHasStyleVariations ? selectedDesignDetails?.style_variations : []
 					}

--- a/packages/design-preview/src/components/sidebar.tsx
+++ b/packages/design-preview/src/components/sidebar.tsx
@@ -1,6 +1,5 @@
-import { Button } from '@automattic/components';
 import { NavigatorScreens, useNavigatorButtons } from '@automattic/onboarding';
-import { useMemo, useState } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useTranslate } from 'i18n-calypso';
 import type { Category } from '@automattic/design-picker/src/types';
@@ -52,8 +51,6 @@ const Sidebar: React.FC< SidebarProps > = ( {
 	onNavigatorPathChange,
 } ) => {
 	const translate = useTranslate();
-	const [ isShowFullDescription, setIsShowFullDescription ] = useState( false );
-	const isShowDescriptionToggle = shortDescription && description !== shortDescription;
 	const navigatorButtons = useNavigatorButtons( screens );
 
 	const decodedDescription = useMemo(
@@ -93,23 +90,7 @@ const Sidebar: React.FC< SidebarProps > = ( {
 						) }
 						{ ( decodedDescription || decodedShortDescription ) && (
 							<div className="design-preview__sidebar-description">
-								<p>
-									{ isShowDescriptionToggle ? (
-										<>
-											{ isShowFullDescription ? decodedDescription : decodedShortDescription }
-											<Button
-												borderless
-												onClick={ () => setIsShowFullDescription( ! isShowFullDescription ) }
-											>
-												{ isShowFullDescription
-													? translate( 'Read less' )
-													: translate( 'Read more' ) }
-											</Button>
-										</>
-									) : (
-										decodedDescription ?? decodedShortDescription
-									) }
-								</p>
+								<p>{ screens.length !== 1 ? decodedDescription : decodedShortDescription }</p>
 							</div>
 						) }
 					</div>


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/wp-calypso/issues/82679

## Proposed Changes

In the following scenarios:

- Theme does not style variations, colors, and fonts
- Themes support colors and fonts but not style variations

then the sidebar in the design preview will look "empty".

In this case, this PR proposes to show the full theme description to fill the empty space.

|Before|After|
|-|-|
|<img width="974" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/6069b03a-12a9-48c4-a761-2166bcad805a">|<img width="974" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/ed529306-c3b8-4204-852c-0a2a3085de4d">|
|<img width="976" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/25b362d8-1103-4c76-8501-33e0cbff4daf">|<img width="974" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/31db282f-6188-47f8-b2d7-bb6cbbfbd2f6">|


## Testing Instructions

1. Go to `/setup/site-setup/designSetup?siteSlug=<siteSlug>`
2. Click a theme from both scenarios, verify that long description (if available) is shown.
   * Theme does not style variations, colors, and fonts:
      - all Partner themes
   * Themes support colors and fonts but not style variations:
      - all themes without style variations,
         * except the ones in the [denylist](https://github.com/Automattic/wp-calypso/blob/1d92258075029817415f5c9bd43d2150fbc60ed2/packages/design-preview/src/constants.ts#L1): 
3. Click a theme from outside the above scenarios, verify only the first sentence is shown.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?