### PR TITLE
ETK Performance: Defer loading the global styles plugins

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/global-styles/class-global-styles.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/global-styles/class-global-styles.php
@@ -298,10 +298,9 @@ class Global_Styles {
 			$src,
 			$deps,
 			filemtime( plugin_dir_path( __FILE__ ) . 'dist/customizer-fonts.min.js' ),
-			array(
-				'strategy' => 'defer',
-			)
+			true
 		);
+		wp_script_add_data( $handle, 'strategy', 'defer' );
 
 		$current_user       = wp_get_current_user();
 		$tracks_events_data = array();
@@ -420,10 +419,9 @@ class Global_Styles {
 			plugins_url( 'dist/global-styles.min.js', __FILE__ ),
 			$dependencies,
 			$version,
-			array(
-				'strategy' => 'defer',
-			)
+			true
 		);
+		wp_script_add_data( 'jetpack-global-styles-editor-script', 'strategy', 'defer' );
 		wp_set_script_translations( 'jetpack-global-styles-editor-script', 'full-site-editing' );
 		wp_localize_script(
 			'jetpack-global-styles-editor-script',

--- a/apps/editing-toolkit/editing-toolkit-plugin/global-styles/class-global-styles.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/global-styles/class-global-styles.php
@@ -298,7 +298,9 @@ class Global_Styles {
 			$src,
 			$deps,
 			filemtime( plugin_dir_path( __FILE__ ) . 'dist/customizer-fonts.min.js' ),
-			true
+			array(
+				'strategy' => 'defer',
+			)
 		);
 
 		$current_user       = wp_get_current_user();
@@ -418,7 +420,9 @@ class Global_Styles {
 			plugins_url( 'dist/global-styles.min.js', __FILE__ ),
 			$dependencies,
 			$version,
-			true
+			array(
+				'strategy' => 'defer',
+			)
 		);
 		wp_set_script_translations( 'jetpack-global-styles-editor-script', 'full-site-editing' );
 		wp_localize_script(

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -158,7 +158,9 @@ function wpcom_global_styles_enqueue_block_editor_assets() {
 		plugins_url( 'dist/wpcom-global-styles.min.js', __FILE__ ),
 		$dependencies,
 		$version,
-		true
+		array(
+			'strategy' => 'defer',
+		)
 	);
 	wp_set_script_translations( 'wpcom-global-styles-editor', 'full-site-editing' );
 
@@ -211,7 +213,9 @@ function wpcom_global_styles_enqueue_assets() {
 		plugins_url( 'dist/wpcom-global-styles-view.min.js', __FILE__ ),
 		$dependencies,
 		$version,
-		true
+		array(
+			'strategy' => 'defer',
+		)
 	);
 	wp_enqueue_style(
 		'wpcom-global-styles',

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -158,10 +158,9 @@ function wpcom_global_styles_enqueue_block_editor_assets() {
 		plugins_url( 'dist/wpcom-global-styles.min.js', __FILE__ ),
 		$dependencies,
 		$version,
-		array(
-			'strategy' => 'defer',
-		)
+		true
 	);
+	wp_script_add_data( 'wpcom-global-styles-editor', 'strategy', 'defer' );
 	wp_set_script_translations( 'wpcom-global-styles-editor', 'full-site-editing' );
 
 	$reset_global_styles_support_url = 'https://wordpress.com/support/using-styles/#reset-all-styles';
@@ -213,10 +212,9 @@ function wpcom_global_styles_enqueue_assets() {
 		plugins_url( 'dist/wpcom-global-styles-view.min.js', __FILE__ ),
 		$dependencies,
 		$version,
-		array(
-			'strategy' => 'defer',
-		)
+		true
 	);
+	wp_script_add_data( 'wpcom-global-styles', 'strategy', 'defer' );
 	wp_enqueue_style(
 		'wpcom-global-styles',
 		plugins_url( 'dist/wpcom-global-styles-view.css', __FILE__ ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pdDR7T-12w-p2

## Proposed Changes

* Defer loading the global styles plugins
  * jetpack-global-styles-editor-script
  * wpcom-global-styles
  * wpcom-global-styles-editor

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Checkout this branch.
2. in apps/editing-toolkit, run `yarn dev --sync`.
3. Go to the editor of a sandboxed simple site, and make sure the global styles related feature works as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?