### PR TITLE
ETK Performance: Defer loading the starter page templates plugins

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
@@ -85,7 +85,9 @@ class Starter_Page_Templates {
 			plugins_url( 'dist/starter-page-templates.min.js', __FILE__ ),
 			array( 'wp-plugins', 'wp-edit-post', 'wp-element' ),
 			filemtime( plugin_dir_path( __FILE__ ) . 'dist/starter-page-templates.min.js' ),
-			true
+			array(
+				'strategy' => 'defer',
+			)
 		);
 	}
 
@@ -164,7 +166,9 @@ class Starter_Page_Templates {
 			null,
 			array(),
 			'1.O',
-			true
+			array(
+				'strategy' => 'defer',
+			)
 		);
 		wp_add_inline_script(
 			'starter-page-templates-error',

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
@@ -85,10 +85,9 @@ class Starter_Page_Templates {
 			plugins_url( 'dist/starter-page-templates.min.js', __FILE__ ),
 			array( 'wp-plugins', 'wp-edit-post', 'wp-element' ),
 			filemtime( plugin_dir_path( __FILE__ ) . 'dist/starter-page-templates.min.js' ),
-			array(
-				'strategy' => 'defer',
-			)
+			true
 		);
+		wp_script_add_data( 'starter-page-templates', 'strategy', 'defer' );
 	}
 
 	/**
@@ -166,10 +165,9 @@ class Starter_Page_Templates {
 			null,
 			array(),
 			'1.O',
-			array(
-				'strategy' => 'defer',
-			)
+			true
 		);
+		wp_script_add_data( 'starter-page-templates-error', 'strategy', 'defer' );
 		wp_add_inline_script(
 			'starter-page-templates-error',
 			sprintf(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pdDR7T-12w-p2

## Proposed Changes

* Defer loading the starter page templates plugins
  * starter-page-templates
  * starter-page-templates-error

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Checkout this branch.
2. in apps/editing-toolkit, run `yarn dev --sync`.
3. Create a new page on your sandboxed simple site
4. Make sure the starter page templates works as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?