### PR TITLE
Gutenframe: Only try to select the PostLockedModal in appropriate conditions

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -146,39 +146,40 @@ function handlePostLocked( calypsoPort ) {
 	const unsubscribe = subscribe( () => {
 		const isLocked = select( 'core/editor' ).isPostLocked();
 		const isLockTakeover = select( 'core/editor' ).isPostLockTakeover();
-		const lockedDialogButtons = document.querySelectorAll(
-			'div.editor-post-locked-modal__buttons > a'
-		);
 
-		const isPostTakeoverDialog = isLocked && ! isLockTakeover && lockedDialogButtons.length === 3;
-
-		if ( isPostTakeoverDialog ) {
-			//signal the parent frame to navigate to All Posts
-			lockedDialogButtons[ 0 ].addEventListener(
-				'click',
-				( event ) => {
-					event.preventDefault();
-					calypsoPort.postMessage( { action: 'goToAllPosts' } );
-				},
-				false
+		if ( isLocked && ! isLockTakeover ) {
+			const lockedDialogButtons = document.querySelectorAll(
+				'div.editor-post-locked-modal__buttons > a'
 			);
 
-			//overrides the all posts link just in case the user treats the link... as a link.
-			if ( calypsoifyGutenberg && calypsoifyGutenberg.closeUrl ) {
-				lockedDialogButtons[ 0 ].setAttribute( 'target', '_parent' );
-				lockedDialogButtons[ 0 ].setAttribute( 'href', calypsoifyGutenberg.closeUrl );
+			if ( lockedDialogButtons.length === 3 ) {
+				//signal the parent frame to navigate to All Posts
+				lockedDialogButtons[ 0 ].addEventListener(
+					'click',
+					( event ) => {
+						event.preventDefault();
+						calypsoPort.postMessage( { action: 'goToAllPosts' } );
+					},
+					false
+				);
+
+				//overrides the all posts link just in case the user treats the link... as a link.
+				if ( calypsoifyGutenberg && calypsoifyGutenberg.closeUrl ) {
+					lockedDialogButtons[ 0 ].setAttribute( 'target', '_parent' );
+					lockedDialogButtons[ 0 ].setAttribute( 'href', calypsoifyGutenberg.closeUrl );
+				}
+
+				//changes the Take Over link url to add the frame-nonce
+				lockedDialogButtons[ 2 ].setAttribute(
+					'href',
+					addQueryArgs( lockedDialogButtons[ 2 ].getAttribute( 'href' ), {
+						calypsoify: 1,
+						'frame-nonce': getQueryArg( window.location.href, 'frame-nonce' ),
+					} )
+				);
+
+				unsubscribe();
 			}
-
-			//changes the Take Over link url to add the frame-nonce
-			lockedDialogButtons[ 2 ].setAttribute(
-				'href',
-				addQueryArgs( lockedDialogButtons[ 2 ].getAttribute( 'href' ), {
-					calypsoify: 1,
-					'frame-nonce': getQueryArg( window.location.href, 'frame-nonce' ),
-				} )
-			);
-
-			unsubscribe();
 		}
 	} );
 }
@@ -192,28 +193,29 @@ function handlePostLockTakeover( calypsoPort ) {
 	const unsubscribe = subscribe( () => {
 		const isLocked = select( 'core/editor' ).isPostLocked();
 		const isLockTakeover = select( 'core/editor' ).isPostLockTakeover();
-		const allPostsButton = document.querySelector( 'div.editor-post-locked-modal__buttons > a' );
 
-		const isPostTakeoverDialog = isLocked && isLockTakeover && allPostsButton;
+		if ( isLocked && isLockTakeover ) {
+			const allPostsButton = document.querySelector( 'div.editor-post-locked-modal__buttons > a' );
 
-		if ( isPostTakeoverDialog ) {
-			//handle All Posts button click event
-			allPostsButton.addEventListener(
-				'click',
-				( event ) => {
-					event.preventDefault();
-					calypsoPort.postMessage( { action: 'goToAllPosts' } );
-				},
-				false
-			);
+			if ( allPostsButton ) {
+				//handle All Posts button click event
+				allPostsButton.addEventListener(
+					'click',
+					( event ) => {
+						event.preventDefault();
+						calypsoPort.postMessage( { action: 'goToAllPosts' } );
+					},
+					false
+				);
 
-			//overrides the all posts link just in case the user treats the link... as a link.
-			if ( calypsoifyGutenberg && calypsoifyGutenberg.closeUrl ) {
-				allPostsButton.setAttribute( 'target', '_parent' );
-				allPostsButton.setAttribute( 'href', calypsoifyGutenberg.closeUrl );
+				//overrides the all posts link just in case the user treats the link... as a link.
+				if ( calypsoifyGutenberg && calypsoifyGutenberg.closeUrl ) {
+					allPostsButton.setAttribute( 'target', '_parent' );
+					allPostsButton.setAttribute( 'href', calypsoifyGutenberg.closeUrl );
+				}
+
+				unsubscribe();
 			}
-
-			unsubscribe();
 		}
 	} );
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Reported on Slack: p1697833272217969-slack-C04DZ8M0GHW

## Proposed Changes

* Stop always querying the DOM for the `PostLockedModal`'s button, and only do it when the modal is supposed to be displayed.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Note: using "Hide whitespace" would make the code easier to review, since most lines have simply been moved into a deeper nesting level.

* Enter the `wpcom-block-editor` folder.
* Start the dev env with `yarn dev --sync`.
* Sandbox `widgets.wp.com`.
* Sandbox a site with two separate test users.
* Log in to the site with both users (e.g. in two different browser profiles), and edit the same post.
  * Ensure you are editing the post in Calypso; the URL should be like `https://wordpress.com/post/{ SITE_FRAGMENT }/{ POST_ID }`.
* I'm unsure how to trigger the Post Lock modal, but at some point after typing on sides, it will show up automatically. 🤷 

<img width="506" alt="Screenshot 2023-10-24 at 11 43 13" src="https://github.com/Automattic/wp-calypso/assets/2070010/b9956b58-1bec-4053-9035-86df9d432071">

* Ensure the two `document.querySelector( 'div.editor-post-locked-modal__buttons > a' )` are only executed when the pre-conditions are cleared, and not every time the whole state updates.
  * To test this, it's just easier to scatter `console.log` throughout the code.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?