### PR TITLE
Import onboarding: Skip ready preview step for the WordPress importer

### DIFF
--- a/client/blocks/import/capture/index.tsx
+++ b/client/blocks/import/capture/index.tsx
@@ -84,10 +84,6 @@ const CaptureStep: React.FunctionComponent< StepProps > = ( {
 	recordTracksEvent,
 	disableImportListStep,
 } ) => {
-	/**
-	 ↓ Methods
-	 */
-
 	const currentUser = useSelect(
 		( select ) => ( select( USER_STORE ) as UserSelect ).getCurrentUser(),
 		[]
@@ -96,11 +92,22 @@ const CaptureStep: React.FunctionComponent< StepProps > = ( {
 	const runProcess = ( url: string ): void => {
 		// Analyze the URL and when we receive the urlData, decide where to go next.
 		analyzeUrl( url ).then( ( response: UrlData ) => {
-			let stepSectionName = response.platform === 'unknown' ? 'not' : 'preview';
+			let stepSectionName;
 
-			if ( response.platform === 'wordpress' && response.platform_data?.is_wpcom ) {
-				stepSectionName = 'wpcom';
+			switch ( response.platform ) {
+				case 'unknown':
+					stepSectionName = 'not';
+					break;
+
+				case 'wordpress':
+					stepSectionName = response.platform_data?.is_wpcom ? 'wpcom' : 'preview';
+					break;
+
+				default:
+					stepSectionName = 'preview';
+					break;
 			}
+
 			goToStep( 'ready', stepSectionName );
 		} );
 	};

--- a/client/blocks/import/capture/index.tsx
+++ b/client/blocks/import/capture/index.tsx
@@ -1,19 +1,17 @@
-import { useSelect } from '@wordpress/data';
 import { localize, translate } from 'i18n-calypso';
 import React, { useEffect, useRef } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 import illustrationImg from 'calypso/assets/images/onboarding/import-1.svg';
 import FormattedHeader from 'calypso/components/formatted-header';
-import { USER_STORE } from 'calypso/landing/stepper/stores';
 import { triggerMigrationStartingEvent } from 'calypso/my-sites/migrate/helpers';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { analyzeUrl, resetError } from 'calypso/state/imports/url-analyzer/actions';
 import { isAnalyzing, getAnalyzerError } from 'calypso/state/imports/url-analyzer/selectors';
 import ScanningStep from '../scanning';
 import { GoToStep, UrlData } from '../types';
 import CaptureInput from './capture-input';
 import type { OnInputEnter, OnInputChange } from './types';
-import type { UserSelect } from '@automattic/data-stores';
 import type { FunctionComponent } from 'react';
 
 import './style.scss';
@@ -76,6 +74,7 @@ const trackEventParams = {
 };
 
 const CaptureStep: React.FunctionComponent< StepProps > = ( {
+	currentUser,
 	goToStep,
 	analyzeUrl,
 	resetError,
@@ -84,10 +83,6 @@ const CaptureStep: React.FunctionComponent< StepProps > = ( {
 	recordTracksEvent,
 	disableImportListStep,
 } ) => {
-	const currentUser = useSelect(
-		( select ) => ( select( USER_STORE ) as UserSelect ).getCurrentUser(),
-		[]
-	);
 	const isStartingPointEventTriggeredRef = useRef( false );
 	const runProcess = ( url: string ): void => {
 		// Analyze the URL and when we receive the urlData, decide where to go next.
@@ -173,6 +168,7 @@ const CaptureStep: React.FunctionComponent< StepProps > = ( {
 
 const connector = connect(
 	( state ) => ( {
+		currentUser: getCurrentUser( state || {} ),
 		isAnalyzing: isAnalyzing( state ),
 		analyzerError: getAnalyzerError( state ),
 	} ),

--- a/client/blocks/import/capture/index.tsx
+++ b/client/blocks/import/capture/index.tsx
@@ -16,8 +16,6 @@ import type { FunctionComponent } from 'react';
 
 import './style.scss';
 
-/* eslint-disable wpcalypso/jsx-classname-namespace */
-
 interface Props {
 	translate: typeof translate;
 	onInputEnter: OnInputEnter;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready-preview/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready-preview/index.tsx
@@ -34,9 +34,15 @@ const ImportReadyPreview: Step = function ImportStep( props ) {
 		! urlData && goToHomeStep();
 	}, [ urlData, navigation ] );
 
-	// redirect directly to importer page if it comes from move to wpcom plugin
+	// redirect directly to importer page
 	useEffect( () => {
-		urlData && isMigrateFromWp && goToImporterPage();
+		if ( ! urlData ) {
+			return;
+		}
+
+		if ( isMigrateFromWp || urlData.platform === 'wordpress' ) {
+			goToImporterPage();
+		}
 	}, [ urlData, isMigrateFromWp ] );
 
 	/**

--- a/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
@@ -95,6 +95,13 @@ export class StartImportFlow {
 	}
 
 	/**
+	 * Validates that we've landed on the import (migration) ready page.
+	 */
+	async validateImportReadyPage(): Promise< void > {
+		await this.page.waitForSelector( selectors.startBuildingHeader( 'You are ready to migrate' ) );
+	}
+
+	/**
 	 * Validates that we've landed on the building page.
 	 *
 	 * @param {string} reason The reason shown in main header.

--- a/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
@@ -97,8 +97,8 @@ export class StartImportFlow {
 	/**
 	 * Validates that we've landed on the import (migration) ready page.
 	 */
-	async validateImportReadyPage(): Promise< void > {
-		await this.page.waitForSelector( selectors.startBuildingHeader( 'You are ready to migrate' ) );
+	async validateUpgradePlanPage(): Promise< void > {
+		await this.page.waitForSelector( selectors.startBuildingHeader( 'Upgrade your plan' ) );
 	}
 
 	/**

--- a/test/e2e/specs/importer/importer__site-setup.ts
+++ b/test/e2e/specs/importer/importer__site-setup.ts
@@ -39,8 +39,6 @@ describe( DataHelper.createSuiteTitle( 'Importer: Site Setup' ), () => {
 
 		it( 'Start a WordPress import', async () => {
 			await startImportFlow.enterURL( 'make.wordpress.org' );
-			await startImportFlow.validateImportPage();
-			await startImportFlow.clickButton( 'Import your content' );
 			await Promise.any( [
 				startImportFlow.clickPremigrationOptionButton(),
 				Promise.all( [

--- a/test/e2e/specs/importer/importer__site-setup.ts
+++ b/test/e2e/specs/importer/importer__site-setup.ts
@@ -120,7 +120,7 @@ describe( DataHelper.createSuiteTitle( 'Importer: Site Setup' ), () => {
 
 		it( 'Go to Import page', async () => {
 			await startImportFlow.enterURL( 'make.wordpress.org' );
-			await startImportFlow.validateImportReadyPage();
+			await startImportFlow.validateUpgradePlanPage();
 		} );
 
 		// Back one page

--- a/test/e2e/specs/importer/importer__site-setup.ts
+++ b/test/e2e/specs/importer/importer__site-setup.ts
@@ -120,7 +120,7 @@ describe( DataHelper.createSuiteTitle( 'Importer: Site Setup' ), () => {
 
 		it( 'Go to Import page', async () => {
 			await startImportFlow.enterURL( 'make.wordpress.org' );
-			await startImportFlow.validateImportPage();
+			await startImportFlow.validateImportReadyPage();
 		} );
 
 		// Back one page


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/82919

## Proposed Changes

- Skipped `Ready Preview` step for the WordPress importer flow

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/import-focused?siteSlug={TARGET_SITE_SLUG}`
* Enter any self hosted WordPress URL (eg. jurassic ninja)
* Submit form
* Check if the `Ready Preview` step is skipped 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?