### PR TITLE
Reader Nudges: Update First Posts nudge style for consistency

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -41,7 +41,7 @@
 		],
 		"scales/radii": [
 			{
-				"scale": [ 2, 4 ],
+				"scale": [ 2, 3, 4 ],
 				"units": [ "px" ]
 			}
 		],

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -41,7 +41,7 @@
 		],
 		"scales/radii": [
 			{
-				"scale": [ 2, 3, 4 ],
+				"scale": [ 2, 4 ],
 				"units": [ "px" ]
 			}
 		],

--- a/client/my-sites/customer-home/cards/notices/reader-first-posts/index.jsx
+++ b/client/my-sites/customer-home/cards/notices/reader-first-posts/index.jsx
@@ -1,6 +1,5 @@
 import { Card, Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import page from 'page';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { NOTICE_READER_FIRST_POSTS } from 'calypso/my-sites/customer-home/cards/constants';
@@ -14,8 +13,6 @@ const ReaderFirstPosts = () => {
 		recordTracksEvent( 'calypso_my_home_reader_first_posts_nudge_click', {
 			id: NOTICE_READER_FIRST_POSTS,
 		} );
-
-		page.redirect( '/discover?selectedTab=firstposts' );
 	};
 
 	return (
@@ -33,7 +30,12 @@ const ReaderFirstPosts = () => {
 				</p>
 			</div>
 			<div className="reader-first-posts__actions">
-				<Button primary onClick={ () => clickButton() } className="reader-first-posts__button">
+				<Button
+					primary
+					onClick={ () => clickButton() }
+					className="reader-first-posts__button"
+					href="/discover?selectedTab=firstposts"
+				>
 					{ translate( 'Take a look' ) }
 				</Button>
 			</div>

--- a/client/my-sites/customer-home/cards/notices/reader-first-posts/style.scss
+++ b/client/my-sites/customer-home/cards/notices/reader-first-posts/style.scss
@@ -1,5 +1,5 @@
 .reader-first-posts__nudge {
-	border-radius: 3px;
+	border-radius: 3px; /* stylelint-disable-line scales/radii */
 	display: flex;
 	align-items: center;
 	justify-content: space-between;

--- a/client/my-sites/customer-home/cards/notices/reader-first-posts/style.scss
+++ b/client/my-sites/customer-home/cards/notices/reader-first-posts/style.scss
@@ -1,4 +1,5 @@
 .reader-first-posts__nudge {
+	border-radius: 3px;
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
@@ -11,7 +12,7 @@
 	}
 	.reader-first-posts__title {
 		font-size: $font-title-small;
-		font-weight: bold;
+		font-weight: 500;
 		margin-bottom: 5px;
 	}
 	.reader-first-posts__actions {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #83105#issuecomment-1774841096

## Proposed Changes

* Updates styles for the First Posts nudge to add 3px border radius to the card and 500 weight font to the title for consistency with other cards.
* ~~Also adds 3px as an "allowed" border radius to stylelint scales.~~ Reverting this for now, will ignore in this diff and update on its own in a future PR. Too messy; we've already scattered "ignore this lint rule" across a bunch of stylesheets and they'll fail code quality tests as a result of this change. 🙃 #83365 to address this.
* Switch to `href` prop rather than onClick for the Button link. 
* Ensure you still see Tracks events on view and click.

**Before**

<img width="673" alt="Screenshot 2023-10-23 at 10 14 47 AM" src="https://github.com/Automattic/wp-calypso/assets/2124984/adf889e7-4e8f-412f-af44-eb64098d9e1d">

**After**

<img width="649" alt="Screenshot 2023-10-23 at 10 09 11 AM" src="https://github.com/Automattic/wp-calypso/assets/2124984/74a9721e-631b-4182-a823-0c6cb6126326">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR
* Navigate to `/home` on a newly launched site, logged in as an Automattician
* You should see the nudge below the task list and above the domains prompt
* Click on the call to action; make sure it still takes you to `/discover?selectedTab=firstposts`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?