### PR TITLE
Ensure data labels are string types in stats lists

### DIFF
--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -92,7 +92,7 @@ export function buildExportArray( data, parent = null ) {
 	if ( ! data || ! data.label || ! data.value ) {
 		return [];
 	}
-	const label = parent ? parent + ' > ' + data.label : data.label;
+	const label = parent ? parent + ' > ' + String( data.label ) : String( data.label );
 	// eslint-disable-next-line
 	const escapedLabel = label.replace( /\"/, '""' );
 	let exportData = [ [ '"' + escapedLabel + '"', data.value ] ];


### PR DESCRIPTION
Fixes p1698068745164569-slack-C04U5A26MJB

## Proposed Changes

A small bugfix to the way the CSV export is constructed in Calypso. The function to escape the label ran `.replace` on the value of the label. However, no check was done if `data.label` was indeed a string.

A screenshot of the value that caused the error:

![CleanShot 2023-10-23 at 16 11 44@2x](https://github.com/Automattic/wp-calypso/assets/528287/8c997c20-78ad-4c12-9efe-c150a8434647)

Notice that 95 is an integer, and not a string.

## Testing Instructions

Either code review, or try to reproduce the case from Sentry (can be found in) p1698068745164569-slack-C04U5A26MJB 

- Log in as the user in the ticket
- Navigate to Stats > Search terms
- Play around with the pills (Change from Yearly to All time a few times)
- Ensure you don't get a white screen

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?