### PR TITLE
Checkout: show pricing grid features

### DIFF
--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -18,10 +18,6 @@ import {
 	isAkismetProduct,
 	planHasFeature,
 	WPCOM_FEATURES_ATOMIC,
-	isPersonal,
-	isPremium,
-	isBusiness,
-	isEcommerce,
 	isWooExpressPlan,
 } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
@@ -38,7 +34,6 @@ import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import * as React from 'react';
 import { hasFreeCouponTransfersOnly } from 'calypso/lib/cart-values/cart-items';
-import { useExperiment } from 'calypso/lib/explat';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
@@ -55,10 +50,6 @@ import type { TranslateResult } from 'i18n-calypso';
 
 // This will make converting to TS less noisy. The order of components can be reorganized later
 /* eslint-disable @typescript-eslint/no-use-before-define */
-
-function isPlanEligibleForCheckoutFeatureListExperiment( plan: ResponseCartProduct ) {
-	return isPersonal( plan ) || isPremium( plan ) || isBusiness( plan ) || isEcommerce( plan );
-}
 
 export default function WPCheckoutOrderSummary( {
 	siteId,
@@ -89,13 +80,6 @@ export default function WPCheckoutOrderSummary( {
 	const plan = responseCart.products.find( ( product ) => isPlan( product ) );
 	const hasMonthlyPlanInCart = Boolean( plan && isMonthly( plan?.product_slug ) );
 
-	const [ isLoadingExperimentAssignment ] = useExperiment(
-		'calypso_checkout_feature_list_copy_v2',
-		{
-			isEligible: plan && isPlanEligibleForCheckoutFeatureListExperiment( plan ),
-		}
-	);
-
 	return (
 		<CheckoutSummaryCard
 			className={ isCartUpdating ? 'is-loading' : '' }
@@ -107,7 +91,7 @@ export default function WPCheckoutOrderSummary( {
 						? translate( 'WordPress.com Gift Subscription' )
 						: translate( 'Included with your purchase' ) }
 				</CheckoutSummaryFeaturesTitle>
-				{ isCartUpdating || isLoadingExperimentAssignment ? (
+				{ isCartUpdating ? (
 					<LoadingCheckoutSummaryFeaturesList />
 				) : (
 					<CheckoutSummaryFeaturesWrapper siteId={ siteId } nextDomainIsFree={ nextDomainIsFree } />
@@ -621,10 +605,7 @@ function CheckoutSummaryPlanFeatures( props: {
 		( product ) => product.extra.purchaseType === 'renewal'
 	);
 
-	const [ , experimentAssignment ] = useExperiment( 'calypso_checkout_feature_list_copy_v2', {
-		isEligible: planInCart && isPlanEligibleForCheckoutFeatureListExperiment( planInCart ),
-	} );
-	const showPricingGridFeatures = 'treatment' === experimentAssignment?.variationName;
+	const showPricingGridFeatures = ! hasRenewalInCart;
 
 	const planFeatures = getPlanFeatures(
 		planInCart,

--- a/client/my-sites/checkout/src/lib/get-plan-features.ts
+++ b/client/my-sites/checkout/src/lib/get-plan-features.ts
@@ -9,9 +9,9 @@ import {
 	isWpComPremiumPlan,
 	isStarterPlan,
 	is100YearPlan,
-	FEATURE_FREE_DOMAIN,
 	Feature,
 	applyTestFiltersToPlansList,
+	FEATURE_CUSTOM_DOMAIN,
 } from '@automattic/calypso-products';
 import { isValueTruthy } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
@@ -42,17 +42,21 @@ export default function getPlanFeatures(
 			return [];
 		}
 
-		const featureList: Feature[] = planObject?.getCheckoutFeatures?.() || [];
+		const features: Feature[] = planObject?.getCheckoutFeatures?.() || [];
 		const annualPlanOnlyFeatures = planObject?.getAnnualPlansOnlyFeatures?.() || [];
 
-		return (
-			featureList
-				// Exclude annual plan only features if the current plan is a monthly plan
-				?.filter( ( feature ) => ! isMonthlyPlan || ! annualPlanOnlyFeatures.includes( feature ) )
-				// Show the free domain feature if `showFreeDomainFeature` is true
-				?.filter( ( feature ) => feature !== FEATURE_FREE_DOMAIN || showFreeDomainFeature )
-				?.map( ( feature ) => String( FEATURES_LIST[ feature ].getTitle() ) )
-		);
+		const featureList = features
+			// Exclude annual plan only features if the current plan is a monthly plan
+			.filter( ( feature ) => ! isMonthlyPlan || ! annualPlanOnlyFeatures.includes( feature ) )
+			// Show the free domain feature if `showFreeDomainFeature` is true
+			.filter( ( feature ) => feature !== FEATURE_CUSTOM_DOMAIN || showFreeDomainFeature )
+			.map( ( feature ) => String( FEATURES_LIST[ feature ].getTitle() ) );
+
+		// If the new feature list is available, return it.
+		// Else fallback to the previous list of features.
+		if ( featureList.length ) {
+			return featureList;
+		}
 	}
 
 	const emailSupport = String( translate( 'Customer support via email' ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/growth-foundations/issues/237

## Proposed Changes

This PR contains a few related changes.
1. Ship the treatment version of this experiment (pbxNRc-33H-p2), but only for non-renewal (new purchases) checkouts only. If pricing grid features are not defined for a particular product, we fallback to the list of features shown earlier.
2. This also solves the bug reported here (pNPgK-6HR-p2) by replacing the incorrect reference to `FEATURE_FREE_DOMAIN` with `FEATURE_CUSTOM_DOMAIN`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
#### New Purchases

* Go to `/plans/<site slug>` for a site on the free plan.
* Click on upgrade for each of the plans and confirm that the checkout page shows an updated feature list that matches the screenshots in #81313.

-----

#### Manual Renewals

* Go to `/plans/<site slug>` for a site on any paid plan.
* Click on "Manage Plan" -> "Renew Now". 
* Confirm that you see the same text as on production.
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?