### PR TITLE
Revert "Logging domainCart dependency error instead of throwing it on production"

### DIFF
--- a/client/lib/signup/flow-controller.ts
+++ b/client/lib/signup/flow-controller.ts
@@ -1,6 +1,4 @@
-import config from '@automattic/calypso-config';
 import debugModule from 'debug';
-import { translate } from 'i18n-calypso';
 import {
 	defer,
 	difference,
@@ -18,7 +16,6 @@ import {
 import page from 'page';
 import { Store, Unsubscribe as ReduxUnsubscribe } from 'redux';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { logToLogstash } from 'calypso/lib/logstash';
 import wpcom from 'calypso/lib/wp';
 import flows from 'calypso/signup/config/flows';
 import untypedSteps from 'calypso/signup/config/steps';
@@ -279,35 +276,15 @@ export default class SignupFlowController {
 			);
 
 			if ( dependenciesNotProvided.length > 0 ) {
-				const errorMessage =
+				throw new Error(
 					'The dependencies [' +
-					dependenciesNotProvided +
-					'] were listed as provided by the ' +
-					step.stepName +
-					' step but were not provided by it [ current flow: ' +
-					this._flowName +
-					' ].';
-
-				logToLogstash( {
-					feature: 'calypso_client',
-					message: errorMessage,
-					severity: config( 'env_id' ) === 'production' ? 'error' : 'debug',
-					blog_id: this._flow.providesDependenciesInQuery?.includes( 'siteId' ),
-					properties: {
-						env: config( 'env_id' ),
-						type: 'calypso_dependency_check_error',
-					},
-				} );
-
-				if ( config( 'env_id' ) === 'production' ) {
-					throw new Error(
-						translate(
-							'We’re sorry, something went wrong. Please try again in a few minutes or contact our support channel'
-						)
-					);
-				} else {
-					throw new Error( errorMessage );
-				}
+						dependenciesNotProvided +
+						'] were listed as provided by the ' +
+						step.stepName +
+						' step but were not provided by it [ current flow: ' +
+						this._flowName +
+						' ].'
+				);
 			}
 		} );
 	}
@@ -319,6 +296,7 @@ export default class SignupFlowController {
 	/**
 	 * Returns a list of non-excluded steps in the flow which enable the branch steps. Otherwise, return a list
 	 * of all steps
+	 *
 	 * @returns {Array} a list of dependency names
 	 */
 	_getFlowSteps() {
@@ -336,6 +314,7 @@ export default class SignupFlowController {
 
 	/**
 	 * Returns a list of the dependencies provided in the flow configuration.
+	 *
 	 * @returns {Array} a list of dependency names
 	 */
 	_getFlowProvidesDependencies() {

--- a/client/lib/signup/test/flow-controller.js
+++ b/client/lib/signup/test/flow-controller.js
@@ -17,11 +17,6 @@ jest.mock( 'calypso/signup/config/flows-pure', () =>
 );
 jest.mock( 'calypso/signup/config/steps', () => require( './mocks/signup/config/steps' ) );
 jest.mock( 'calypso/signup/config/steps-pure', () => require( './mocks/signup/config/steps' ) );
-jest.mock( 'calypso/lib/logstash', () => {
-	return {
-		logToLogstash: jest.fn(),
-	};
-} );
 
 function createSignupStore( initialState ) {
 	return createStore(


### PR DESCRIPTION
Reverts Automattic/wp-calypso#83266