### PR TITLE
Launchpad: The Navigator Modal should close when navigating to other pages

### DIFF
--- a/packages/launchpad-navigator/src/floating-navigator/index.tsx
+++ b/packages/launchpad-navigator/src/floating-navigator/index.tsx
@@ -1,5 +1,5 @@
 import { LaunchpadNavigator } from '@automattic/data-stores';
-import { DefaultWiredLaunchpad } from '@automattic/launchpad';
+import { DefaultWiredLaunchpad, type EventHandlers, type Task } from '@automattic/launchpad';
 import { Modal } from '@wordpress/components';
 import { select } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
@@ -24,6 +24,12 @@ const FloatingNavigator = ( { siteSlug, toggleLaunchpadIsVisible }: FloatingNavi
 
 	const setLaunchpadIsVisible = toggleLaunchpadIsVisible || ( () => {} );
 
+	const onTaskClick: EventHandlers[ 'onTaskClick' ] = ( task: Task ) => {
+		if ( task.calypso_path !== undefined ) {
+			setLaunchpadIsVisible( false );
+		}
+	};
+
 	return (
 		<Modal
 			title={ translate( 'Next steps for your site' ) }
@@ -34,6 +40,7 @@ const FloatingNavigator = ( { siteSlug, toggleLaunchpadIsVisible }: FloatingNavi
 				siteSlug={ siteSlug }
 				checklistSlug={ checklistSlug }
 				launchpadContext={ launchpadContext }
+				onTaskClick={ onTaskClick }
 			/>
 		</Modal>
 	);

--- a/packages/launchpad-navigator/src/floating-navigator/index.tsx
+++ b/packages/launchpad-navigator/src/floating-navigator/index.tsx
@@ -25,7 +25,7 @@ const FloatingNavigator = ( { siteSlug, toggleLaunchpadIsVisible }: FloatingNavi
 	const setLaunchpadIsVisible = toggleLaunchpadIsVisible || ( () => {} );
 
 	const onTaskClick: EventHandlers[ 'onTaskClick' ] = ( task: Task ) => {
-		if ( task.calypso_path !== undefined ) {
+		if ( task.useCalypsoPath && task.calypso_path !== undefined ) {
 			setLaunchpadIsVisible( false );
 		}
 	};

--- a/packages/launchpad/src/default-wired-launchpad.tsx
+++ b/packages/launchpad/src/default-wired-launchpad.tsx
@@ -11,7 +11,7 @@ import { useEffect, useState } from 'react';
 import { ShareSiteModal } from './action-components';
 import Launchpad from './launchpad';
 import { setUpActionsForTasks } from './setup-actions';
-import type { Task } from './types';
+import type { EventHandlers, Task } from './types';
 
 export const SITE_STORE = Site.register( { client_id: '', client_secret: '' } );
 
@@ -20,6 +20,7 @@ type DefaultWiredLaunchpadProps = {
 	checklistSlug: string;
 	launchpadContext: string;
 	onSiteLaunched?: () => void;
+	onTaskClick?: EventHandlers[ 'onTaskClick' ];
 	onPostFilterTasks?: ( tasks: Task[] ) => Task[];
 };
 
@@ -28,6 +29,7 @@ const DefaultWiredLaunchpad = ( {
 	checklistSlug,
 	launchpadContext,
 	onSiteLaunched,
+	onTaskClick,
 	onPostFilterTasks,
 }: DefaultWiredLaunchpadProps ) => {
 	const {
@@ -92,6 +94,7 @@ const DefaultWiredLaunchpad = ( {
 			},
 			eventHandlers: {
 				onSiteLaunched,
+				onTaskClick,
 			},
 		} );
 

--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -25,7 +25,7 @@ export const setUpActionsForTasks = ( {
 }: LaunchpadTaskActionsProps ): Task[] => {
 	const { recordTracksEvent, checklistSlug, tasklistCompleted, launchpadContext } = tracksData;
 	const { setShareSiteModalIsOpen, setActiveChecklist } = extraActions;
-	const { onSiteLaunched } = eventHandlers || {};
+	const { onSiteLaunched, onTaskClick } = eventHandlers || {};
 
 	//Record click events for tasks
 	const recordTaskClickTracksEvent = ( task: Task ) => {
@@ -154,6 +154,7 @@ export const setUpActionsForTasks = ( {
 			if ( siteSlug && setActiveChecklist ) {
 				setActiveChecklist( siteSlug, checklistSlug );
 			}
+			onTaskClick?.( task );
 			action?.();
 		};
 

--- a/packages/launchpad/src/types.ts
+++ b/packages/launchpad/src/types.ts
@@ -63,6 +63,7 @@ export interface PermittedActions {
 
 export type EventHandlers = {
 	onSiteLaunched?: () => void;
+	onTaskClick?: ( task: Task ) => void;
 };
 
 export interface LaunchpadTaskActionsProps {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* We must close the Navigator modal when we click on a task so it doesn't stick on the screen when users are redirected to another page.
* I also prevented the new `onTaskClick` event from being fired if the task doesn't redirect the user to another page.
* I will handle the actions outside the Navigator in a follow up PR.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso Live link below or apply this patch to your local environment
* On a site with the Build intent, navigate to `/home/:siteSlug?flags=launchpad/navigator`
* Open the navigator by clicking on the progress ring on the Master bar
* Click on the "Share your site" task to ensure it shows the modal and keeps the navigator open.
* Click on a task that redirects the user to another page, like the "Customize your domain" task.
* Make sure the Navigator modal is closed upon redirecting.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?