### PR TITLE
ETK Performance: defer loading the domain upsell callout

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-domain-upsell-callout/class-wpcom-domain-upsell-callout.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-domain-upsell-callout/class-wpcom-domain-upsell-callout.php
@@ -57,6 +57,7 @@ class WPCOM_Domain_Upsell_Callout {
 			$version,
 			true
 		);
+		wp_script_add_data( 'wpcom-domain-upsell-callout-script', 'strategy', 'defer' );
 
 		wp_set_script_translations( 'wpcom-domain-upsell-callout-script', 'full-site-editing' );
 


### PR DESCRIPTION
Context: pdDR7T-12w-p2

## Proposed Changes

Defer loading the Domain Upsell callout script
- wpcom-domain-upsell-callout

## Testing Instructions

1. Checkout this branch.
2. in apps/editing-toolkit, run `yarn dev --sync`.
3. Sandbox a site with a yearly plan and no custom domain
5. Go to the editor, make sure the Domain Callout is showing

<img width="3452" alt="image" src="https://github.com/Automattic/wp-calypso/assets/402286/bcd2d79a-c567-44b3-8c2c-d77b32da3b78">