### PR TITLE
Earn: Update Earn to Monetize

### DIFF
--- a/client/my-sites/earn/main.tsx
+++ b/client/my-sites/earn/main.tsx
@@ -220,11 +220,11 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 				title={ `${ adsProgramName } ${ capitalize( section ) }` }
 			/>
 			<DocumentHead
-				title={ layoutTitles[ section as keyof typeof layoutTitles ] ?? translate( 'Earn' ) }
+				title={ layoutTitles[ section as keyof typeof layoutTitles ] ?? translate( 'Monetize' ) }
 			/>
 			<NavigationHeader
 				navigationItems={ [] }
-				title={ translate( 'Earn' ) }
+				title={ translate( 'Monetize' ) }
 				subtitle={ translate(
 					'Explore tools to earn money with your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 					{

--- a/client/my-sites/sidebar/static-data/fallback-menu.js
+++ b/client/my-sites/sidebar/static-data/fallback-menu.js
@@ -499,7 +499,7 @@ export default function buildFallbackResponse( {
 				{
 					parent: 'tools.php',
 					slug: 'tools-earn',
-					title: translate( 'Earn' ),
+					title: translate( 'Monetize' ),
 					type: 'menu-item',
 					url: `/earn/${ siteDomain }`,
 				},

--- a/client/my-sites/sidebar/static-data/jetpack-fallback-menu.js
+++ b/client/my-sites/sidebar/static-data/jetpack-fallback-menu.js
@@ -174,7 +174,7 @@ export default function jetpackMenu( { siteDomain, hasUnifiedImporter } ) {
 				{
 					parent: 'tools.php',
 					slug: 'tools-earn',
-					title: translate( 'Earn' ),
+					title: translate( 'Monetize' ),
 					type: 'submenu-item',
 					url: `/earn/${ siteDomain }`,
 				},

--- a/packages/calypso-e2e/src/lib/pages/wp-admin/jetpack-dashboard-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/wp-admin/jetpack-dashboard-page.ts
@@ -9,7 +9,7 @@ export type SettingsTabs =
 	| 'Discussion'
 	| 'Traffic'
 	| 'Newsletter'
-	| 'Earn';
+	| 'Monetize';
 // Discriminated union type.
 type JetpackTabs =
 	| { view: 'Dashboard'; tab: DashboardTabs }

--- a/test/e2e/specs/jetpack/jetpack__dashboard-smoke.ts
+++ b/test/e2e/specs/jetpack/jetpack__dashboard-smoke.ts
@@ -84,10 +84,10 @@ skipDescribeIf( envVariables.TEST_ON_ATOMIC !== true )(
 			skipItIf( envVariables.ATOMIC_VARIATION === 'private' )(
 				'Click on Earn tab in the Settings view',
 				async function () {
-					await jetpackDashboardPage.clickTab( { view: 'Settings', tab: 'Earn' } );
+					await jetpackDashboardPage.clickTab( { view: 'Settings', tab: 'Monetize' } );
 
 					await page
-						.getByRole( 'heading', { name: 'Earn', level: 1 } )
+						.getByRole( 'heading', { name: 'Monetize', level: 1 } )
 						.waitFor( { state: 'attached' } );
 				}
 			);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack/pull/33741

## Proposed Changes

* Updates page title of the Earn page from 'Earn' to 'Monetize'.
* Updates associated e2e tests.
* A related backend Jetpack PR updates the name of the dashboard menu item from Earn to Monetize. 

<img width="1456" alt="monetize" src="https://github.com/Automattic/wp-calypso/assets/21228350/34d48ab4-5304-4ef1-8f5b-1df9a761bc2d">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Go http://calypso.localhost:3000/earn/YOURSIMPLESITEDOMAIN and confirm the page title and document title are updated to Monetize. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?