### PR TITLE
Fix domain badge vertical alignment

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -270,8 +270,8 @@ class DomainRegistrationSuggestion extends Component {
 			<div className={ titleWrapperClassName }>
 				<h3 className="domain-registration-suggestion__title">
 					{ title } { ( showHstsNotice || showDotGayNotice ) && this.renderInfoBubble() }
-					{ this.renderBadges() }
 				</h3>
+				{ this.renderBadges() }
 			</div>
 		);
 	}

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -270,8 +270,8 @@ class DomainRegistrationSuggestion extends Component {
 			<div className={ titleWrapperClassName }>
 				<h3 className="domain-registration-suggestion__title">
 					{ title } { ( showHstsNotice || showDotGayNotice ) && this.renderInfoBubble() }
+					{ this.renderBadges() }
 				</h3>
-				{ this.renderBadges() }
 			</div>
 		);
 	}

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -332,9 +332,7 @@ body.is-section-signup.is-white-signup {
 		}
 
 		@include break-wide {
-			align-self: baseline;
-			margin-left: 12px;
-			margin-bottom: 0;
+			margin: auto 0 auto 12px;
 			flex: 1;
 		}
 	}

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -327,7 +327,6 @@ body.is-section-signup.is-white-signup {
 		}
 
 		@include break-wide {
-			margin-left: 12px;
 			margin-bottom: 0;
 			flex: 1;
 		}
@@ -382,6 +381,7 @@ body.is-section-signup.is-white-signup {
 
 		.domain-registration-suggestion__title {
 			font-size: 0.875rem;
+			margin-right: 12px;
 
 			@include break-mobile {
 				font-size: 1rem;

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -173,6 +173,7 @@
 	display: flex;
 	flex-direction: column-reverse;
 	flex-wrap: nowrap;
+	align-items: flex-start;
 
 	@include break-mobile {
 		flex-direction: row;
@@ -196,11 +197,6 @@
 		width: auto;
 		max-width: 100%;
 		padding-right: 0.2em;
-		display: flex;
-	}
-
-	.badge {
-		align-self: center;
 	}
 
 	.domain-registration-suggestion__hsts-tooltip {
@@ -309,7 +305,6 @@
 
 	@include break-mobile {
 		margin: 0 0 0 4px;
-		align-self: center;
 	}
 }
 
@@ -321,8 +316,8 @@ body.is-section-signup.is-white-signup {
 
 	.domain-registration-suggestion__badges {
 		margin-left: 0;
-		margin-top: 0;
-		margin-bottom: 10px;
+		margin-top: 2px;
+		margin-bottom: 0;
 
 		.badge {
 			border-radius: 4px;
@@ -332,7 +327,6 @@ body.is-section-signup.is-white-signup {
 		}
 
 		@include break-wide {
-			align-self: baseline;
 			margin-left: 12px;
 			margin-bottom: 0;
 			flex: 1;

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -332,7 +332,9 @@ body.is-section-signup.is-white-signup {
 		}
 
 		@include break-wide {
-			margin: auto 0 auto 12px;
+			align-self: baseline;
+			margin-left: 12px;
+			margin-bottom: 0;
 			flex: 1;
 		}
 	}

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -317,7 +317,7 @@ body.is-section-signup.is-white-signup {
 	.domain-registration-suggestion__badges {
 		margin-left: 0;
 		margin-top: 2px;
-		margin-bottom: 0;
+		margin-bottom: 10px;
 
 		.badge {
 			border-radius: 4px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1698096553075489-slack-C05CT832K2T

## Proposed Changes

* Adjusts the badge alignment in the domain step so it's vertically aligned with the domain name.

Before | After
--|--
<img width="829" alt="Screenshot 2023-10-23 at 5 28 20 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/138f019f-9767-4cf7-85e7-7d74cf6e6095"> | <img width="921" alt="Screenshot 2023-10-23 at 5 28 45 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/03fddbb6-550d-4a12-b4ed-1d098c0e2e1a">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /start to view the domain step in the `onboarding` flow and check the badge alignment
* Go to /domains to view the domain step in the "domain only" flow and check the badge alignment
* Check some other flows to make sure they look ok
* Check using different browsers

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?