### PR TITLE
Purchase Management: Add tooltip to renewal field to denote expiration date

### DIFF
--- a/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
@@ -142,7 +142,7 @@ function PurchaseMetaExpiration( {
 				return false;
 			}
 
-			if ( purchase.renewDate !== purchase.expiryDate ) {
+			if ( purchase.renewDate !== purchase.expiryDate && purchase.canDisableAutoRenew ) {
 				return true;
 			}
 

--- a/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
@@ -153,19 +153,21 @@ function PurchaseMetaExpiration( {
 					} ) }
 				>
 					{ subsBillingText }
-					<InfoPopover position="bottom right">
-						{ translate(
-							'Your subscription is paid through {{dateSpan}}%(expireDate)s{{/dateSpan}}, but will be renewed prior to that date.',
-							{
-								args: {
-									expireDate: moment( purchase.expiryDate ).format( 'LL' ),
-								},
-								components: {
-									dateSpan,
-								},
-							}
-						) }
-					</InfoPopover>
+					{ purchase.renewDate.length !== 0 && (
+						<InfoPopover position="bottom right">
+							{ translate(
+								'Your subscription is paid through {{dateSpan}}%(expireDate)s{{/dateSpan}}, but will be renewed prior to that date.',
+								{
+									args: {
+										expireDate: moment( purchase.expiryDate ).format( 'LL' ),
+									},
+									components: {
+										dateSpan,
+									},
+								}
+							) }
+						</InfoPopover>
+					) }
 				</span>
 				{ ! isAutorenewalEnabled &&
 					! hideAutoRenew &&

--- a/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
@@ -9,6 +9,7 @@ import {
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import InfoPopover from 'calypso/components/info-popover';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import {
 	hasPaymentMethod,
@@ -156,13 +157,16 @@ function PurchaseMetaExpiration( {
 					{ purchase.renewDate.length !== 0 && (
 						<InfoPopover position="bottom right">
 							{ translate(
-								'Your subscription is paid through {{dateSpan}}%(expireDate)s{{/dateSpan}}, but will be renewed prior to that date.',
+								'Your subscription is paid through {{dateSpan}}%(expireDate)s{{/dateSpan}}, but will be renewed prior to that date. {{inlineSupportLink}}Learn more{{/inlineSupportLink}}',
 								{
 									args: {
 										expireDate: moment( purchase.expiryDate ).format( 'LL' ),
 									},
 									components: {
 										dateSpan,
+										inlineSupportLink: (
+											<InlineSupportLink supportContext="autorenewal" showIcon={ false } />
+										),
 									},
 								}
 							) }

--- a/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
@@ -8,6 +8,7 @@ import {
 } from '@automattic/calypso-products';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
+import InfoPopover from 'calypso/components/info-popover';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import {
 	hasPaymentMethod,
@@ -152,6 +153,19 @@ function PurchaseMetaExpiration( {
 					} ) }
 				>
 					{ subsBillingText }
+					<InfoPopover position="bottom right">
+						{ translate(
+							'Your subscription is paid through {{dateSpan}}%(expireDate)s{{/dateSpan}}, but will be renewed prior to that date.',
+							{
+								args: {
+									expireDate: moment( purchase.expiryDate ).format( 'LL' ),
+								},
+								components: {
+									dateSpan,
+								},
+							}
+						) }
+					</InfoPopover>
 				</span>
 				{ ! isAutorenewalEnabled &&
 					! hideAutoRenew &&

--- a/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
@@ -142,7 +142,10 @@ function PurchaseMetaExpiration( {
 				return false;
 			}
 
-			if ( purchase.renewDate !== purchase.expiryDate && purchase.canDisableAutoRenew ) {
+			if (
+				purchase.renewDate !== purchase.expiryDate &&
+				( purchase.expiryStatus === 'active' || purchase.expiryStatus === 'auto-renewing' )
+			) {
 				return true;
 			}
 

--- a/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
@@ -137,6 +137,17 @@ function PurchaseMetaExpiration( {
 				},
 			} );
 		}
+		const shouldShowTooltip = () => {
+			if ( ! purchase.expiryDate || ! purchase.renewDate ) {
+				return false;
+			}
+
+			if ( purchase.renewDate !== purchase.expiryDate ) {
+				return true;
+			}
+
+			return false;
+		};
 
 		return (
 			<li className="manage-purchase__meta-expiration">
@@ -154,7 +165,7 @@ function PurchaseMetaExpiration( {
 					} ) }
 				>
 					{ subsBillingText }
-					{ purchase.renewDate.length !== 0 && (
+					{ shouldShowTooltip() && (
 						<InfoPopover position="bottom right">
 							{ translate(
 								'Your subscription is paid through {{dateSpan}}%(expireDate)s{{/dateSpan}}, but will be renewed prior to that date. {{inlineSupportLink}}Learn more{{/inlineSupportLink}}',

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -302,6 +302,11 @@
 		text-align: left;
 	}
 
+	& > button.info-popover {
+		position: relative;
+		top: 3px;
+	}
+
 	.components-toggle-control {
 		display: inline-block;
 


### PR DESCRIPTION
This is an alternative approach to resolve the issue noted here https://github.com/Automattic/wp-calypso/pull/83136.

Couple note: 
- Not sure we really need to mess with the styling of the icon, since the positioning tends to be off depending on the width of the column, RTL, etc. The component itself really should handle the styling without extra intervention, so maybe it is an issue better handled by the components team.
- I left out the 'Learn more' link since we have a variety of products that have separate documentation. This would be a 'nice to have' feature but isn't required to solve the original issue.

Related to #83136

## Proposed Changes

* This PR adds a tooltip to the Subscription Renewal column that details the expiration date of subscription, whereas the renewal column details the renewal date which is often days to weeks before the expiration of the product.

## Testing Instructions

* Check a handful of purchases to ensure the tooltip loads only when autorenewal is turned on
* For instance, if autorenew is OFF, then there is no reason to show the tooltip since the Subscription Renewal column will display the expiration date

