### PR TITLE
Update margin on the domain step

### DIFF
--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -347,7 +347,9 @@ body.is-section-signup.is-white-signup {
 		flex-direction: column;
 		box-shadow: none;
 
-		@include break-mobile {
+		margin: 0;
+
+		@include break-small {
 			margin: 0 20px;
 			flex-direction: row;
 		}

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -266,7 +266,7 @@ body.is-section-signup.is-white-signup .featured-domain-suggestions {
 	margin: 0;
 	border-top: 1px solid rgba(220, 220, 222, 0.64);
 
-	@include break-mobile {
+	@include break-small {
 		margin: 0 20px;
 		border-top: none;
 	}

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -350,11 +350,11 @@ body.is-section-signup.is-white-signup {
 			}
 
 			@include break-large {
-				margin: 0 20px 0 40px;
+				margin: 0 0 0 40px;
 				padding: 40px 0;
 			}
 
-			@include break-wide {
+			@include break-huge {
 				margin: 0 0 0 60px;
 			}
 

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -952,14 +952,6 @@ body.is-section-signup.is-white-signup .layout:not(.dops):not(.is-wccom-oauth-fl
 	.signup__step.is-emails,
 	.signup__step.is-mailbox,
 	.is-domain-only {
-		@include break-large {
-			margin: 0 0 0 20px;
-		}
-
-		@include break-wide {
-			padding-inline-start: 20px;
-		}
-
 		.is-wide-layout {
 			max-width: 1280px;
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1698096553075489-slack-C05CT832K2T

## Proposed Changes

* Updates the margin on the domain step so it's centered better on the page.

Before | After
--|--
<img width="1475" alt="Screenshot 2023-10-23 at 5 49 06 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/3f196b3f-01f5-4bb0-8dfd-c8828093c11f"> | <img width="1476" alt="Screenshot 2023-10-23 at 5 48 42 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/9956663e-8f2a-499b-b9cb-48559c9347ad">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


- Go to /start to view the domain step in the onboarding flow and check the margins
- Go to /domains to view the domain step in the "domain only" flow and check the margins
- Check some other flows to make sure they look ok
- Check using different browsers
- Check that margin and page looks ok with a RTL language


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?