### PR TITLE
Components: Add isPrimary to Promo Card buttons

### DIFF
--- a/client/components/promo-section/promo-card/cta.tsx
+++ b/client/components/promo-section/promo-card/cta.tsx
@@ -17,6 +17,7 @@ interface CtaAction {
 export interface CtaButton {
 	text: string | TranslateResult;
 	action: URL | ClickCallback | CtaAction;
+	isPrimary?: boolean;
 	component?: JSX.Element;
 	disabled?: boolean;
 	busy?: boolean;
@@ -54,7 +55,7 @@ function buttonProps( button: CtaButton, isPrimary: boolean ) {
 	}
 
 	return {
-		className: 'promo-card__cta-button',
+		className: `promo-card__cta-button ${ button.isPrimary && 'is-primary' }`,
 		primary: isPrimary,
 		disabled: button.disabled ? true : false,
 		busy: button.busy ? true : false,

--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -154,6 +154,7 @@ const Home = () => {
 			  }
 			: {
 					text: translate( 'Unlock this feature' ),
+					isPrimary: true,
 					action: () => {
 						trackUpgrade( 'plans', 'simple-payments' );
 						page(
@@ -398,6 +399,7 @@ const Home = () => {
 				  }
 				: {
 						text: translate( 'Unlock this feature' ),
+						isPrimary: true,
 						action: () => {
 							trackUpgrade( 'plans', 'ads' );
 							page(


### PR DESCRIPTION
## Proposed Changes

* Allow is-primary class to be added to PromoCard cta buttons on the Earn page. Updates the PromoCardCta component, and then uses the new prop on the earn page. 
* Note: The PromoCard component itself also has an isPrimary prop, but this causes more extensive changes to the whole card, not jut button color.

**Before**
<img width="1059" alt="isprimary-before" src="https://github.com/Automattic/wp-calypso/assets/21228350/c64cee4e-aa15-4bb0-a173-7cf1bf3aea15">

**After**
<img width="1061" alt="isprimary-after" src="https://github.com/Automattic/wp-calypso/assets/21228350/8671438f-d3e5-4db6-bf60-3d4b2579edb5">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1) Test with a simple site on a free plan, ideally where you haven't enabled ads yet.
2) Go to http://calypso.localhost:3000/earn/YOURSLUG, and confirm that the 'Unlock this feature' buttons are pink. 
3) Confirm buttons continue to behave as expected. 
4) Bonus: Find other screens that use the PromoSection components and confirm those continue to look and work as expected. Example: https://wordpress.com/backup/YOURDOMAIN



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?