### PR TITLE
Launchpad: Remove the Other Tasks button

### DIFF
--- a/packages/launchpad-navigator/src/floating-navigator/index.tsx
+++ b/packages/launchpad-navigator/src/floating-navigator/index.tsx
@@ -42,11 +42,6 @@ const FloatingNavigator = ( { siteSlug, toggleLaunchpadIsVisible }: FloatingNavi
 				checklistSlug={ checklistSlug }
 				launchpadContext={ launchpadContext }
 			/>
-			<div className="launchpad-navigator__floating-navigator-actions">
-				<Button disabled variant="secondary">
-					{ translate( 'Older tasks' ) }
-				</Button>
-			</div>
 		</Card>
 	);
 };

--- a/packages/launchpad-navigator/src/floating-navigator/style.scss
+++ b/packages/launchpad-navigator/src/floating-navigator/style.scss
@@ -30,17 +30,6 @@
 		}
 	}
 
-	.launchpad-navigator__floating-navigator-actions {
-		display: flex;
-		margin-top: 1em;
-		.components-button {
-			padding: 8px 14px;
-			font-size: $font-body-small;
-			line-height: 24px;
-			height: auto;
-		}
-	}
-
 	.launchpad-navigator__floating-navigator-close-button {
 		padding: 4px 0;
 		&:focus {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Removes the "Other Tasks" button from the Launchpad Navigator modal.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso Live link below or apply this PR to your local environment
* On a site with the Build intent, navigate to `/home/:siteSlug?flags=launchpad/navigator`
* Click on the progress ring on the master bar and ensure the Navigator is shown
* Make sure the "Other Tasks" button

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?