### PR TITLE
Launchpad: Reduces the Navigator top padding

### DIFF
--- a/packages/launchpad-navigator/src/floating-navigator/style.scss
+++ b/packages/launchpad-navigator/src/floating-navigator/style.scss
@@ -10,7 +10,7 @@
 	cursor: default;
 	transition: max-height 0.5s;
 	min-width: 25em;
-	padding-top: 7px;
+	padding-top: 16px;
 
 	.launchpad-navigator__floating-navigator-header {
 		display: flex;
@@ -21,7 +21,6 @@
 			font-family: $font-sf-pro-display;
 			font-size: $font-title-small;
 			font-weight: 500;
-			line-height: 50px;
 		}
 
 		.button.is-borderless .gridicon {

--- a/packages/launchpad-navigator/src/floating-navigator/style.scss
+++ b/packages/launchpad-navigator/src/floating-navigator/style.scss
@@ -10,6 +10,7 @@
 	cursor: default;
 	transition: max-height 0.5s;
 	min-width: 25em;
+	padding-top: 7px;
 
 	.launchpad-navigator__floating-navigator-header {
 		display: flex;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* The padding seems uneven because the title has too much spacing. I reduced the top padding so the spacing matches the sides.

**Before/After**

<img width="363" alt="Screen Shot 2023-10-24 at 00 20 30" src="https://github.com/Automattic/wp-calypso/assets/1234758/36ac29b5-f036-470e-b88d-0802f0d730f8">
<img width="365" alt="Screen Shot 2023-10-24 at 00 20 22" src="https://github.com/Automattic/wp-calypso/assets/1234758/af74d64b-7b28-403e-be18-67e71e244f2b">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso Live link below or apply this PR to your local environment
* On a site with the Build intent, navigate to `/home/:siteSlug?flags=launchpad/navigator`
* Click on the progress ring on the master bar
* Make sure the spacing on the top is the same as the sides

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?