### PR TITLE
Fix styles for add a domain button

### DIFF
--- a/client/my-sites/domains/domain-management/list/options-domain-button.jsx
+++ b/client/my-sites/domains/domain-management/list/options-domain-button.jsx
@@ -2,6 +2,7 @@
 
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button } from '@automattic/components';
+import { isMobile } from '@automattic/viewport';
 import { Icon, plus, search } from '@wordpress/icons';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -124,7 +125,7 @@ class AddDomainButton extends Component {
 		return (
 			<>
 				<Icon icon={ plus } className="options-domain-button__add gridicon" viewBox="2 2 20 20" />
-				<span className="options-domain-button__desktop">{ label }</span>
+				{ ! isMobile() && <span className="options-domain-button__desktop">{ label }</span> }
 			</>
 		);
 	}

--- a/client/my-sites/domains/domain-management/list/options-domain-button.scss
+++ b/client/my-sites/domains/domain-management/list/options-domain-button.scss
@@ -4,6 +4,12 @@
 button {
 	&.options-domain-button {
 		padding: 8px;
+		align-items: center;
+
+		.gridicon {
+			top: 0;
+			margin-top: 0;
+		}
 
 		&__popover {
 			margin-top: 5px;
@@ -13,15 +19,6 @@ button {
 			padding: 7px 15px;
 			font-size: $font-body-small;
 			line-height: 1;
-
-			.gridicon {
-				top: 5px;
-				margin-top: -8px;
-			}
-
-			& > .gridicon {
-				margin-left: 5px;
-			}
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/83393

## Proposed Changes

* Adjust the button styles to be centered vertically

![desktop](https://github.com/Automattic/wp-calypso/assets/6586048/e395e587-b2c3-4fc9-a55d-af93b0ba23dc)
![mobile](https://github.com/Automattic/wp-calypso/assets/6586048/54a0bfc5-8fcd-4797-ac8b-0fadb9b8cce3)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/domains/manage`
* Check the style of the Add a domain button for all screen sizes (will require a reload for changing from mobile to desktop breakpoint 480px)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?