### PR TITLE
Subscriber Stats: release subscriber growth graph

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -184,7 +184,7 @@
 		"ssr/prefetch-timebox": false,
 		"stats/date-control": true,
 		"stats/new-video-summary": true,
-		"stats/subscribers-chart-section": false,
+		"stats/subscribers-chart-section": true,
 		"stats/paid-wpcom-stats": true,
 		"stats/type-detection": true,
 		"stepper-woocommerce-poc": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -121,7 +121,7 @@
 		"site-profiler": true,
 		"ssr/prefetch-timebox": true,
 		"stats/new-video-summary": false,
-		"stats/subscribers-chart-section": false,
+		"stats/subscribers-chart-section": true,
 		"stats/paid-wpcom-stats": true,
 		"stats/date-control": true,
 		"stats/type-detection": true,

--- a/config/production.json
+++ b/config/production.json
@@ -149,7 +149,7 @@
 		"ssr/prefetch-timebox": true,
 		"ssr/sample-log-cache-misses": true,
 		"stats/new-video-summary": false,
-		"stats/subscribers-chart-section": false,
+		"stats/subscribers-chart-section": true,
 		"stats/paid-wpcom-stats": true,
 		"stats/date-control": true,
 		"stats/type-detection": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -144,7 +144,7 @@
 		"site-profiler": true,
 		"ssr/prefetch-timebox": true,
 		"stats/new-video-summary": false,
-		"stats/subscribers-chart-section": false,
+		"stats/subscribers-chart-section": true,
 		"stats/paid-wpcom-stats": true,
 		"stats/type-detection": true,
 		"stats/date-control": true,

--- a/config/test.json
+++ b/config/test.json
@@ -103,7 +103,7 @@
 		"site-profiler": true,
 		"ssr/prefetch-timebox": true,
 		"stats/new-video-summary": false,
-		"stats/subscribers-chart-section": false,
+		"stats/subscribers-chart-section": true,
 		"stats/paid-wpcom-stats": true,
 		"stats/date-control": true,
 		"stats/type-detection": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -154,7 +154,7 @@
 		"site-profiler": true,
 		"ssr/prefetch-timebox": true,
 		"stats/new-video-summary": false,
-		"stats/subscribers-chart-section": false,
+		"stats/subscribers-chart-section": true,
 		"stats/paid-wpcom-stats": true,
 		"stats/date-control": true,
 		"stats/type-detection": true,


### PR DESCRIPTION
## Proposed Changes

Release Subscriber growth chart.

## Testing Instructions

* Open Calypso Live Branch on `/stats/subscribers/day/:siteSlug`
* Ensure the chart work okay
* Ensure the most recent number matches `Total Subscribers` in `All-time stats` section

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?