### PR TITLE
Plugin Management: Fix the padding issue & page heading & subtitle not showing for the Plugins page

### DIFF
--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -505,10 +505,26 @@ export class PluginsMain extends Component {
 				) }
 				<div
 					className={ classNames( 'plugins__top-container', {
-						'plugins__top-container-wp': ! isJetpackCloud,
+						'plugins__top-container-jc': isJetpackCloud,
 					} ) }
 				>
 					<div className="plugins__content-wrapper">
+						{ isJetpackCloud && (
+							<div className="plugins__page-title-container">
+								<div className="plugins__header-left-content">
+									<h2 className="plugins__page-title">{ pageTitle }</h2>
+									<div className="plugins__page-subtitle">
+										{ this.props.selectedSite
+											? this.props.translate( 'Manage all plugins installed on %(selectedSite)s', {
+													args: {
+														selectedSite: this.props.selectedSite.domain,
+													},
+											  } )
+											: this.props.translate( 'Manage plugins installed on all sites' ) }
+									</div>
+								</div>
+							</div>
+						) }
 						<div className="plugins__main plugins__main-updated">
 							<div className="plugins__main-header">
 								<SectionNav

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -540,7 +540,11 @@ export class PluginsMain extends Component {
 						</div>
 					</div>
 				</div>
-				<div className="plugins__main-content">
+				<div
+					className={ classNames( 'plugins__main-content', {
+						'plugins__main-content-jc': isJetpackCloud,
+					} ) }
+				>
 					<div className="plugins__content-wrapper">
 						{
 							// Hide the search box only when the request to fetch plugins fail, and there are no sites.

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -436,19 +436,23 @@ body.is-section-plugins #primary {
 	}
 }
 .plugins__top-container {
-	@include breakpoint-deprecated( ">660px" ) {
-		border-bottom: 1px solid var(--color-primary-5);
-	}
-	@include break-large() {
-		padding: 6px 32px 0;
+	padding: 0 16px;
+
+	@media (min-width: $break-small) {
+		padding: 0;
 	}
 }
 
-.plugins__top-container-wp {
-	padding: 0 16px;
-	border-bottom: none;
-	@media (min-width: $break-small) {
-		padding: 0;
+.plugins__top-container-jc {
+	margin: 0 -32px;
+	padding: 4px 48px 0;
+
+	@include breakpoint-deprecated( ">660px" ) {
+		border-bottom: 1px solid var(--color-primary-5);
+	}
+
+	@include break-large() {
+		padding: 6px 48px 0;
 	}
 }
 

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -464,8 +464,6 @@ body.is-section-plugins #primary {
 	}
 }
 .plugins__main-content {
-	// We need these negative margin values because we want to make the container full-width,
-	// but our element is inside a limited-width parent.
 	margin: 0;
 	padding: 0 16px;
 	flex: 1 1 100%;
@@ -475,6 +473,19 @@ body.is-section-plugins #primary {
 		margin-bottom: -32px;
 	}
 }
+
+.plugins__main-content-jc {
+	// We need these negative margin values because we want to make the container full-width,
+	// but our element is inside a limited-width parent.
+	margin: 0 -32px;
+	padding: 0 48px;
+
+	@include breakpoint-deprecated( ">660px" ) {
+		padding: 16px 48px;
+		margin-bottom: -32px;
+	}
+}
+
 .plugins__search {
 	height: 52px;
 	box-shadow: 0 0 0 1px var(--color-neutral-5);


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-manage/issues/60

## Proposed Changes

This PR fixes:

- Page heading & subheading for the Plugins page not being shown in Jetpack Cloud.
- Some padding issues with the main container

### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Open the Jetpack Cloud live link
2. Click the Plugins menu item
3. Verify that you can now see the page heading & subheading. Verify that same for the single site view(Switch site > Click on Plugins).
4. Also, visit the Calyso live link > Select a site > Click on the Plugins > Click the Installed Plugins button on the top right > Verify it looks the same as production.

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="1025" alt="Screenshot 2023-10-24 at 12 14 39 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/5ec1945e-b553-44a0-8761-d1c3c5d21c98">
</td>
<td>
<img width="1025" alt="Screenshot 2023-10-24 at 12 14 42 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/29ec9caf-88e2-4b2f-9b0f-ed23149393be">
</td>
</tr>
<tr>
<td>
<img width="1728" alt="Screenshot 2023-10-24 at 12 38 27 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/cd5a27b7-2fe5-4439-86ac-db12d2abe8b2">
</td>
<td>
<img width="1728" alt="Screenshot 2023-10-24 at 12 47 00 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/69da7d8d-818a-421e-8456-c60d75a31a20">
</td>
</tr>
</table>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?