### PR TITLE
Staging Sites: Remove yolo/staging-sites-i3 flag as feature was launched

### DIFF
--- a/client/my-sites/hosting/staging-site-card/card-content/manage-staging-site-card-content.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/manage-staging-site-card-content.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Button, Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
@@ -103,7 +102,6 @@ export const ManageStagingSiteCardContent = ( {
 }: CardContentProps ) => {
 	{
 		const translate = useTranslate();
-		const isStagingSitesI3Enabled = isEnabled( 'yolo/staging-sites-i3' );
 		const productionSiteUrl = useSelector( ( state ) => getSiteUrl( state, siteId ) );
 
 		const ConfirmationDeleteButton = () => {
@@ -172,24 +170,20 @@ export const ManageStagingSiteCardContent = ( {
 						<ConfirmationDeleteButton />
 					</ActionButtons>
 				</BorderedContainer>
-				{ isStagingSitesI3Enabled ? (
-					<>
-						<SyncActionsContainer>
-							<SiteSyncCard
-								type="production"
-								onPush={ onPushClick }
-								onPull={ onPullClick }
-								disabled={ isButtonDisabled }
-								productionSiteId={ siteId }
-								siteUrls={ {
-									production: productionSiteUrl,
-									staging: stagingSite.url,
-								} }
-								error={ error }
-							/>
-						</SyncActionsContainer>
-					</>
-				) : null }
+				<SyncActionsContainer>
+					<SiteSyncCard
+						type="production"
+						onPush={ onPushClick }
+						onPull={ onPullClick }
+						disabled={ isButtonDisabled }
+						productionSiteId={ siteId }
+						siteUrls={ {
+							production: productionSiteUrl,
+							staging: stagingSite.url,
+						} }
+						error={ error }
+					/>
+				</SyncActionsContainer>
 			</>
 		);
 	}

--- a/client/my-sites/hosting/staging-site-card/staging-site-production-card.tsx
+++ b/client/my-sites/hosting/staging-site-card/staging-site-production-card.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Button, Card, Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
@@ -62,7 +61,6 @@ function StagingSiteProductionCard( { disabled, siteId, translate }: CardProps )
 	const dispatch = useDispatch();
 	const [ loadingError, setLoadingError ] = useState( null );
 	const [ syncError, setSyncError ] = useState< string | null >( null );
-	const isStagingSitesI3Enabled = isEnabled( 'yolo/staging-sites-i3' );
 	const stagingSiteUrl = useSelector( ( state ) => getSiteUrl( state, siteId ) );
 
 	const { data: productionSite, isLoading } = useProductionSiteDetail( siteId, {
@@ -143,22 +141,20 @@ function StagingSiteProductionCard( { disabled, siteId, translate }: CardProps )
 						<span>{ __( 'Switch to production site' ) }</span>
 					</Button>
 				</ActionButtons>
-				{ isStagingSitesI3Enabled && (
-					<SyncActionsContainer>
-						<SiteSyncCard
-							type="staging"
-							productionSiteId={ productionSite.id }
-							siteUrls={ {
-								production: productionSite.url,
-								staging: stagingSiteUrl,
-							} }
-							onPush={ pullFromStaging }
-							onPull={ pushToStaging }
-							error={ syncError }
-							disabled={ disabled || isSyncInProgress }
-						/>
-					</SyncActionsContainer>
-				) }
+				<SyncActionsContainer>
+					<SiteSyncCard
+						type="staging"
+						productionSiteId={ productionSite.id }
+						siteUrls={ {
+							production: productionSite.url,
+							staging: stagingSiteUrl,
+						} }
+						onPush={ pullFromStaging }
+						onPull={ pushToStaging }
+						error={ syncError }
+						disabled={ disabled || isSyncInProgress }
+					/>
+				</SyncActionsContainer>
 			</>
 		);
 	};

--- a/config/development.json
+++ b/config/development.json
@@ -220,7 +220,6 @@
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": false,
 		"yolo/hosting-metrics-i1": true,
-		"yolo/staging-sites-i3": true,
 		"yolo/wp-admin-site-default": true
 	}
 }

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -157,7 +157,6 @@
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,
 		"yolo/hosting-metrics-i1": false,
-		"yolo/staging-sites-i3": true,
 		"yolo/wp-admin-site-default": true
 	},
 	"siftscience_key": "a4f69f6759",

--- a/config/production.json
+++ b/config/production.json
@@ -186,7 +186,6 @@
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,
 		"yolo/hosting-metrics-i1": true,
-		"yolo/staging-sites-i3": true,
 		"yolo/wp-admin-site-default": false
 	},
 	"siftscience_key": "a4f69f6759",

--- a/config/stage.json
+++ b/config/stage.json
@@ -180,7 +180,6 @@
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,
 		"yolo/hosting-metrics-i1": true,
-		"yolo/staging-sites-i3": true,
 		"yolo/wp-admin-site-default": false
 	},
 	"siftscience_key": "e00e878351",

--- a/config/test.json
+++ b/config/test.json
@@ -118,7 +118,6 @@
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": false,
 		"yolo/hosting-metrics-i1": true,
-		"yolo/staging-sites-i3": true,
 		"yolo/wp-admin-site-default": true
 	}
 }

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -190,7 +190,6 @@
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,
 		"yolo/hosting-metrics-i1": true,
-		"yolo/staging-sites-i3": true,
 		"yolo/wp-admin-site-default": true
 	},
 	"siftscience_key": "e00e878351",


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/3699

## Proposed Changes

In this PR, I propose to remove the feature flag we used during Staging Sites i3 project development.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check if staging sites synchronization UI is displayed and works on both staging and production site

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?