### PR TITLE
Patterns - Track usage of patterns created by users in wpcom_pattern_inserted

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -360,6 +360,7 @@ const maybeTrackPatternInsertion = ( actionData, additionalData ) => {
 			blocks_replaced,
 			insert_method,
 			search_term,
+			is_user_created: patternName?.startsWith( 'core/block/' ),
 			...context,
 		} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #82909

## Proposed Changes

* Add prop `is_user_created` to tracks event `wpcom_pattern_inserted`

This PR uses the pattern name (slug) to identify patterns created by users. Read more in pcD9cT-5Sg-p2#comment-5634

https://github.com/Automattic/wp-calypso/assets/1881481/709321d7-a5e3-4592-8c5d-69f42a017ecf


### Follow-up task
Register the new event prop with a description in Tracks.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Sandbox your site
* Patch this change to your sandbox with: `install-plugin.sh wpcom-block-editor fix/add-pattern-tracks-event-prop`
* Access the site editor `{ SITE }/wp-admin/site-editor.php?categoryType=pattern&path=%2Fpatterns`
* Create a pattern
  * Click "Patterns" and then the `+` icon to "Create a pattern"
<img width="521" alt="Screenshot 2566-10-24 at 15 35 28" src="https://github.com/Automattic/wp-calypso/assets/1881481/6ab13f17-2a21-429a-ac46-7d4c2de2ae60">

  * Add any content to the pattern and "Save" it 
* Add your pattern to the canvas from the inserter
* Verify the event has the new prop using the extension Tracks Vigilante
<img width="787" alt="Screenshot 2566-10-24 at 15 53 05" src="https://github.com/Automattic/wp-calypso/assets/1881481/f0884b92-b8bb-4f83-8a7c-2ab554031b64">

* Revert changes in your sandbox with `install-plugin.sh wpcom-block-editor --revert`




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?