### PR TITLE
Fix the optimistic updates for subscription details

### DIFF
--- a/packages/data-stores/src/reader/helpers/optimistic-update.ts
+++ b/packages/data-stores/src/reader/helpers/optimistic-update.ts
@@ -27,6 +27,10 @@ const alterSiteSubscriptionDetails = async (
 	const previousData: PreviousData[] = [];
 
 	keys.push(
+		buildQueryKey( [ 'read', 'site-subscription-details', String( blogId ), '' ], isLoggedIn, id )
+	);
+
+	keys.push(
 		buildQueryKey(
 			[ 'read', 'site-subscription-details', String( blogId ), String( subscriptionId ) ],
 			isLoggedIn,
@@ -58,4 +62,20 @@ const alterSiteSubscriptionDetails = async (
 	return previousData;
 };
 
-export { alterSiteSubscriptionDetails };
+const invalidateSiteSubscriptionDetails = (
+	queryClient: QueryClient,
+	{ blogId, subscriptionId, isLoggedIn, id }: SiteSubScriptionDetailsParameters
+) => {
+	queryClient.invalidateQueries( [ 'read', 'site-subscriptions' ] );
+	queryClient.invalidateQueries(
+		buildQueryKey( [ 'read', 'site-subscription-details', blogId ], isLoggedIn, id )
+	);
+	queryClient.invalidateQueries(
+		buildQueryKey( [ 'read', 'site-subscription-details', blogId, '' ], isLoggedIn, id )
+	);
+	queryClient.invalidateQueries(
+		buildQueryKey( [ 'read', 'site-subscription-details', '', subscriptionId ], isLoggedIn, id )
+	);
+};
+
+export { alterSiteSubscriptionDetails, invalidateSiteSubscriptionDetails };

--- a/packages/data-stores/src/reader/helpers/optimistic-update.ts
+++ b/packages/data-stores/src/reader/helpers/optimistic-update.ts
@@ -1,0 +1,61 @@
+import { QueryClient } from '@tanstack/react-query';
+import { SiteSubscriptionDetails } from '../types';
+import { buildQueryKey } from './index';
+
+type SiteSubScriptionDetailsParameters = {
+	blogId: string;
+	subscriptionId: string;
+	isLoggedIn: boolean;
+	id?: number;
+};
+
+type CacheKey = ( string | number | boolean | undefined )[];
+
+type PreviousData = {
+	key: CacheKey;
+	data: SiteSubscriptionDetails;
+};
+
+type UpdateFn = ( previousData: SiteSubscriptionDetails ) => SiteSubscriptionDetails;
+
+const alterSiteSubscriptionDetails = async (
+	queryClient: QueryClient,
+	{ blogId, subscriptionId, isLoggedIn, id }: SiteSubScriptionDetailsParameters,
+	updater: UpdateFn
+) => {
+	const keys: CacheKey[] = [];
+	const previousData: PreviousData[] = [];
+
+	keys.push(
+		buildQueryKey(
+			[ 'read', 'site-subscription-details', String( blogId ), String( subscriptionId ) ],
+			isLoggedIn,
+			id
+		)
+	);
+
+	keys.push(
+		buildQueryKey(
+			[ 'read', 'site-subscription-details', '', String( subscriptionId ) ],
+			isLoggedIn,
+			id
+		)
+	);
+
+	keys.push( [ 'read', 'subscriptions', subscriptionId, isLoggedIn, id ] );
+
+	for ( const key of keys ) {
+		await queryClient.cancelQueries( key );
+
+		const previousDataForKey = queryClient.getQueryData< SiteSubscriptionDetails >( key );
+		if ( previousDataForKey ) {
+			previousData.push( { key, data: previousDataForKey } );
+			const updatedData = updater( previousDataForKey as SiteSubscriptionDetails );
+			queryClient.setQueryData( key, updatedData );
+		}
+	}
+
+	return previousData;
+};
+
+export { alterSiteSubscriptionDetails };

--- a/packages/data-stores/src/reader/mutations/use-site-delivery-frequency-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-delivery-frequency-mutation.ts
@@ -1,7 +1,10 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { EmailDeliveryFrequency } from '../constants';
 import { callApi, applyCallbackToPages, buildQueryKey } from '../helpers';
-import { alterSiteSubscriptionDetails } from '../helpers/optimistic-update';
+import {
+	alterSiteSubscriptionDetails,
+	invalidateSiteSubscriptionDetails,
+} from '../helpers/optimistic-update';
 import { useIsLoggedIn } from '../hooks';
 import type {
 	PagedQueryResult,
@@ -129,18 +132,12 @@ const useSiteDeliveryFrequencyMutation = () => {
 			}
 		},
 		onSettled: ( _data, _err, { blog_id, subscriptionId } ) => {
-			// pass in a more minimal key, everything to the right will be invalidated
-			queryClient.invalidateQueries( [ 'read', 'site-subscriptions' ] );
-			queryClient.invalidateQueries(
-				buildQueryKey( [ 'read', 'site-subscription-details', String( blog_id ) ], isLoggedIn, id )
-			);
-			queryClient.invalidateQueries(
-				buildQueryKey(
-					[ 'read', 'site-subscription-details', '', String( subscriptionId ) ],
-					isLoggedIn,
-					id
-				)
-			);
+			invalidateSiteSubscriptionDetails( queryClient, {
+				blogId: String( blog_id ),
+				subscriptionId: String( subscriptionId ),
+				isLoggedIn,
+				id,
+			} );
 			queryClient.invalidateQueries( [ 'read', 'subscriptions', subscriptionId, isLoggedIn, id ] );
 		},
 	} );

--- a/packages/data-stores/src/reader/mutations/use-site-email-me-new-comments-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-email-me-new-comments-mutation.ts
@@ -1,6 +1,9 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { buildQueryKey, callApi } from '../helpers';
-import { alterSiteSubscriptionDetails } from '../helpers/optimistic-update';
+import {
+	alterSiteSubscriptionDetails,
+	invalidateSiteSubscriptionDetails,
+} from '../helpers/optimistic-update';
 import { useIsLoggedIn } from '../hooks';
 import type { SiteSubscriptionsPages, SiteSubscriptionDetails } from '../types';
 
@@ -120,18 +123,13 @@ const useSiteEmailMeNewCommentsMutation = () => {
 				}
 			}
 		},
-		onSettled: ( _data, _err, { subscriptionId } ) => {
-			queryClient.invalidateQueries( [ 'read', 'site-subscriptions' ] );
-			queryClient.invalidateQueries(
-				buildQueryKey( [ 'read', 'site-subscription-details' ], isLoggedIn, id )
-			);
-			queryClient.invalidateQueries(
-				buildQueryKey(
-					[ 'read', 'site-subscription-details', '', String( subscriptionId ) ],
-					isLoggedIn,
-					id
-				)
-			);
+		onSettled: ( _data, _err, { blog_id, subscriptionId } ) => {
+			invalidateSiteSubscriptionDetails( queryClient, {
+				blogId: String( blog_id ),
+				subscriptionId: String( subscriptionId ),
+				isLoggedIn,
+				id,
+			} );
 			queryClient.invalidateQueries( [ 'read', 'subscriptions', subscriptionId, isLoggedIn, id ] );
 		},
 	} );

--- a/packages/data-stores/src/reader/mutations/use-site-email-me-new-comments-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-email-me-new-comments-mutation.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { buildQueryKey, callApi } from '../helpers';
+import { alterSiteSubscriptionDetails } from '../helpers/optimistic-update';
 import { useIsLoggedIn } from '../hooks';
 import type { SiteSubscriptionsPages, SiteSubscriptionDetails } from '../types';
 
@@ -51,21 +52,8 @@ const useSiteEmailMeNewCommentsMutation = () => {
 				isLoggedIn,
 				id
 			);
-			const siteSubscriptionDetailsByBlogIdQueryKey = buildQueryKey(
-				[ 'read', 'site-subscription-details', String( blog_id ) ],
-				isLoggedIn,
-				id
-			);
-			const siteSubscriptionDetailsQueryKey = [
-				'read',
-				'subscriptions',
-				subscriptionId,
-				isLoggedIn,
-				id,
-			];
 
 			await queryClient.cancelQueries( siteSubscriptionsQueryKey );
-			await queryClient.cancelQueries( siteSubscriptionDetailsQueryKey );
 
 			const previousSiteSubscriptions =
 				queryClient.getQueryData< SiteSubscriptionsPages >( siteSubscriptionsQueryKey );
@@ -96,72 +84,53 @@ const useSiteEmailMeNewCommentsMutation = () => {
 				} );
 			}
 
-			const previousSiteSubscriptionDetailsByBlogId =
-				queryClient.getQueryData< SiteSubscriptionDetails >(
-					siteSubscriptionDetailsByBlogIdQueryKey
-				);
-			if ( previousSiteSubscriptionDetailsByBlogId ) {
-				queryClient.setQueryData( siteSubscriptionDetailsByBlogIdQueryKey, {
-					...previousSiteSubscriptionDetailsByBlogId,
-					delivery_methods: {
-						...previousSiteSubscriptionDetailsByBlogId.delivery_methods,
-						email: {
-							...previousSiteSubscriptionDetailsByBlogId.delivery_methods?.email,
-							send_comments: send_comments,
+			const previousSiteSubscriptionDetails = await alterSiteSubscriptionDetails(
+				queryClient,
+				{ blogId: String( blog_id ), subscriptionId: String( subscriptionId ), isLoggedIn, id },
+				( previousData ) => {
+					return {
+						...previousData,
+						delivery_methods: {
+							...previousData.delivery_methods,
+							email: {
+								...previousData.delivery_methods?.email,
+								send_comments: send_comments,
+							},
 						},
-					},
-				} );
-			}
-
-			const previousSiteSubscriptionDetails = queryClient.getQueryData< SiteSubscriptionDetails >(
-				siteSubscriptionDetailsQueryKey
+					} as SiteSubscriptionDetails;
+				}
 			);
-			if ( previousSiteSubscriptionDetails ) {
-				queryClient.setQueryData( siteSubscriptionDetailsQueryKey, {
-					...previousSiteSubscriptionDetails,
-					delivery_methods: {
-						...previousSiteSubscriptionDetails.delivery_methods,
-						email: {
-							...previousSiteSubscriptionDetails.delivery_methods?.email,
-							send_comments: send_comments,
-						},
-					},
-				} );
-			}
+
 			return {
 				previousSiteSubscriptions,
-				previousSiteSubscriptionDetailsByBlogId,
 				previousSiteSubscriptionDetails,
 			};
 		},
-		onError: ( _err, { blog_id, subscriptionId }, context ) => {
+		onError: ( _err, _, context ) => {
 			if ( context?.previousSiteSubscriptions ) {
 				queryClient.setQueryData(
 					buildQueryKey( [ 'read', 'site-subscriptions' ], isLoggedIn, id ),
 					context.previousSiteSubscriptions
 				);
 			}
-			if ( context?.previousSiteSubscriptionDetailsByBlogId ) {
-				queryClient.setQueryData(
-					buildQueryKey(
-						[ 'read', 'site-subscription-details', String( blog_id ) ],
-						isLoggedIn,
-						id
-					),
-					context.previousSiteSubscriptionDetailsByBlogId
-				);
-			}
+
 			if ( context?.previousSiteSubscriptionDetails ) {
-				queryClient.setQueryData(
-					[ 'read', 'subscriptions', subscriptionId, isLoggedIn, id ],
-					context.previousSiteSubscriptionDetails
-				);
+				for ( const { key, data } of context.previousSiteSubscriptionDetails ) {
+					queryClient.setQueryData( key, data );
+				}
 			}
 		},
 		onSettled: ( _data, _err, { subscriptionId } ) => {
 			queryClient.invalidateQueries( [ 'read', 'site-subscriptions' ] );
 			queryClient.invalidateQueries(
 				buildQueryKey( [ 'read', 'site-subscription-details' ], isLoggedIn, id )
+			);
+			queryClient.invalidateQueries(
+				buildQueryKey(
+					[ 'read', 'site-subscription-details', '', String( subscriptionId ) ],
+					isLoggedIn,
+					id
+				)
 			);
 			queryClient.invalidateQueries( [ 'read', 'subscriptions', subscriptionId, isLoggedIn, id ] );
 		},

--- a/packages/data-stores/src/reader/mutations/use-site-email-me-new-posts-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-email-me-new-posts-mutation.ts
@@ -1,6 +1,9 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { buildQueryKey, callApi } from '../helpers';
-import { alterSiteSubscriptionDetails } from '../helpers/optimistic-update';
+import {
+	alterSiteSubscriptionDetails,
+	invalidateSiteSubscriptionDetails,
+} from '../helpers/optimistic-update';
 import { useIsLoggedIn } from '../hooks';
 import type { SiteSubscriptionsPages, SiteSubscriptionDetails } from '../types';
 
@@ -124,17 +127,12 @@ const useSiteEmailMeNewPostsMutation = () => {
 			}
 		},
 		onSettled: ( _data, _err, { blog_id, subscriptionId } ) => {
-			queryClient.invalidateQueries( [ 'read', 'site-subscriptions' ] );
-			queryClient.invalidateQueries(
-				buildQueryKey( [ 'read', 'site-subscription-details', String( blog_id ) ], isLoggedIn, id )
-			);
-			queryClient.invalidateQueries(
-				buildQueryKey(
-					[ 'read', 'site-subscription-details', '', String( subscriptionId ) ],
-					isLoggedIn,
-					id
-				)
-			);
+			invalidateSiteSubscriptionDetails( queryClient, {
+				blogId: String( blog_id ),
+				subscriptionId: String( subscriptionId ),
+				isLoggedIn,
+				id,
+			} );
 			queryClient.invalidateQueries( [ 'read', 'subscriptions', subscriptionId, isLoggedIn, id ] );
 		},
 	} );

--- a/packages/data-stores/src/reader/mutations/use-site-email-me-new-posts-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-email-me-new-posts-mutation.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { buildQueryKey, callApi } from '../helpers';
+import { alterSiteSubscriptionDetails } from '../helpers/optimistic-update';
 import { useIsLoggedIn } from '../hooks';
 import type { SiteSubscriptionsPages, SiteSubscriptionDetails } from '../types';
 
@@ -51,22 +52,8 @@ const useSiteEmailMeNewPostsMutation = () => {
 				isLoggedIn,
 				id
 			);
-			const siteSubscriptionDetailsByBlogIdQueryKey = buildQueryKey(
-				[ 'read', 'site-subscription-details', String( blog_id ) ],
-				isLoggedIn,
-				id
-			);
-			const siteSubscriptionDetailsCacheKey = [
-				'read',
-				'subscriptions',
-				subscriptionId,
-				isLoggedIn,
-				id,
-			];
 
 			await queryClient.cancelQueries( siteSubscriptionsQueryKey );
-			await queryClient.cancelQueries( siteSubscriptionDetailsByBlogIdQueryKey );
-			await queryClient.cancelQueries( siteSubscriptionDetailsCacheKey );
 
 			const previousSiteSubscriptions =
 				queryClient.getQueryData< SiteSubscriptionsPages >( siteSubscriptionsQueryKey );
@@ -96,46 +83,34 @@ const useSiteEmailMeNewPostsMutation = () => {
 				} );
 			}
 
-			const previousSiteSubscriptionDetails = queryClient.getQueryData< SiteSubscriptionDetails >(
-				siteSubscriptionDetailsCacheKey
+			const previousSiteSubscriptionDetails = await alterSiteSubscriptionDetails(
+				queryClient,
+				{
+					blogId: String( blog_id ),
+					subscriptionId: String( subscriptionId ),
+					isLoggedIn,
+					id,
+				},
+				( siteSubscriptionDetails ) => {
+					return {
+						...siteSubscriptionDetails,
+						delivery_methods: {
+							...siteSubscriptionDetails.delivery_methods,
+							email: {
+								...siteSubscriptionDetails.delivery_methods?.email,
+								send_posts: send_posts,
+							},
+						},
+					} as SiteSubscriptionDetails;
+				}
 			);
-			if ( previousSiteSubscriptionDetails ) {
-				queryClient.setQueryData( siteSubscriptionDetailsCacheKey, {
-					...previousSiteSubscriptionDetails,
-					delivery_methods: {
-						...previousSiteSubscriptionDetails.delivery_methods,
-						email: {
-							...previousSiteSubscriptionDetails.delivery_methods?.email,
-							send_posts: send_posts,
-						},
-					},
-				} );
-			}
-
-			const previousSiteSubscriptionDetailsByBlogId =
-				queryClient.getQueryData< SiteSubscriptionDetails >(
-					siteSubscriptionDetailsByBlogIdQueryKey
-				);
-			if ( previousSiteSubscriptionDetailsByBlogId ) {
-				queryClient.setQueryData( siteSubscriptionDetailsByBlogIdQueryKey, {
-					...previousSiteSubscriptionDetailsByBlogId,
-					delivery_methods: {
-						...previousSiteSubscriptionDetailsByBlogId.delivery_methods,
-						email: {
-							...previousSiteSubscriptionDetailsByBlogId.delivery_methods?.email,
-							send_posts: send_posts,
-						},
-					},
-				} );
-			}
 
 			return {
 				previousSiteSubscriptions,
 				previousSiteSubscriptionDetails,
-				previousSiteSubscriptionDetailsByBlogId,
 			};
 		},
-		onError: ( _err, { blog_id, subscriptionId }, context ) => {
+		onError: ( _err, _, context ) => {
 			if ( context?.previousSiteSubscriptions ) {
 				queryClient.setQueryData(
 					buildQueryKey( [ 'read', 'site-subscriptions' ], isLoggedIn, id ),
@@ -143,26 +118,22 @@ const useSiteEmailMeNewPostsMutation = () => {
 				);
 			}
 			if ( context?.previousSiteSubscriptionDetails ) {
-				queryClient.setQueryData(
-					[ 'read', 'subscriptions', subscriptionId, isLoggedIn, id ],
-					context.previousSiteSubscriptionDetails
-				);
-			}
-			if ( context?.previousSiteSubscriptionDetailsByBlogId ) {
-				queryClient.setQueryData(
-					buildQueryKey(
-						[ 'read', 'site-subscription-details', String( blog_id ) ],
-						isLoggedIn,
-						id
-					),
-					context.previousSiteSubscriptionDetails
-				);
+				for ( const { key, data } of context.previousSiteSubscriptionDetails ) {
+					queryClient.setQueryData( key, data );
+				}
 			}
 		},
 		onSettled: ( _data, _err, { blog_id, subscriptionId } ) => {
 			queryClient.invalidateQueries( [ 'read', 'site-subscriptions' ] );
 			queryClient.invalidateQueries(
 				buildQueryKey( [ 'read', 'site-subscription-details', String( blog_id ) ], isLoggedIn, id )
+			);
+			queryClient.invalidateQueries(
+				buildQueryKey(
+					[ 'read', 'site-subscription-details', '', String( subscriptionId ) ],
+					isLoggedIn,
+					id
+				)
 			);
 			queryClient.invalidateQueries( [ 'read', 'subscriptions', subscriptionId, isLoggedIn, id ] );
 		},

--- a/packages/data-stores/src/reader/mutations/use-site-notify-me-of-new-posts-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-notify-me-of-new-posts-mutation.ts
@@ -1,6 +1,9 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { buildQueryKey, callApi } from '../helpers';
-import { alterSiteSubscriptionDetails } from '../helpers/optimistic-update';
+import {
+	alterSiteSubscriptionDetails,
+	invalidateSiteSubscriptionDetails,
+} from '../helpers/optimistic-update';
 import { useIsLoggedIn } from '../hooks';
 import type { SiteSubscriptionsPages, SiteSubscriptionDetails } from '../types';
 
@@ -126,17 +129,12 @@ const useSiteNotifyMeOfNewPostsMutation = () => {
 			}
 		},
 		onSettled: ( _data, _err, { blog_id, subscriptionId } ) => {
-			queryClient.invalidateQueries( [ 'read', 'site-subscriptions' ] );
-			queryClient.invalidateQueries(
-				buildQueryKey( [ 'read', 'site-subscription-details', String( blog_id ) ], isLoggedIn, id )
-			);
-			queryClient.invalidateQueries(
-				buildQueryKey(
-					[ 'read', 'site-subscription-details', '', String( subscriptionId ) ],
-					isLoggedIn,
-					id
-				)
-			);
+			invalidateSiteSubscriptionDetails( queryClient, {
+				blogId: String( blog_id ),
+				subscriptionId: String( subscriptionId ),
+				isLoggedIn,
+				id,
+			} );
 			queryClient.invalidateQueries( [ 'read', 'subscriptions', subscriptionId, isLoggedIn, id ] );
 		},
 	} );

--- a/packages/data-stores/src/reader/queries/use-site-subscription-details-query.ts
+++ b/packages/data-stores/src/reader/queries/use-site-subscription-details-query.ts
@@ -6,6 +6,7 @@ import type { SiteSubscriptionDetailsResponse } from '../types';
 const useSiteSubscriptionDetailsQuery = ( blogId = '', subscriptionId = '' ) => {
 	const { id, isLoggedIn } = useIsLoggedIn();
 	const enabled = useIsQueryEnabled();
+
 	return useQuery( {
 		queryKey: buildQueryKey(
 			[ 'read', 'site-subscription-details', blogId, subscriptionId ],


### PR DESCRIPTION
Related to  p1698096546101449-slack-C025Q5RK2


## Proposed Changes

The optimistic update for SiteSubscriptionDetails was failing because there are now two cache keys that can be used: one with a blogId & one with a subscriptionId:

- `['read', 'site-subscription-details', '', 'subscriptionId' ] `
-` ['read', 'site-subscription-details', 'blogId', 'subscriptionId' ]`

This PR introduces a `optimistic-update` helper file, which now contains a `alterSiteSubscriptionDetails` function. This function updates all cache keys with the new data.

## Testing Instructions

- Apply this PR
- Go to Reader & view some subscription details
- Change the settings (Notify me of new posts, Email me new posts, ...) and make sure the UI updates when clicking any
- Do the same in the popover of the Manage Subscriptions view
- Finally, do the same in the Subscription Portal

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?