### PR TITLE
Ensure My Home card headers are all using the same font size and weight

### DIFF
--- a/client/my-sites/customer-home/cards/education/educational-content/style.scss
+++ b/client/my-sites/customer-home/cards/education/educational-content/style.scss
@@ -12,8 +12,8 @@
 	}
 
 	h2 {
-		font-weight: 600;
-		font-size: $font-body;
+		font-weight: 500;
+		font-size: $font-title-small;
 		margin-bottom: 8px;
 	}
 

--- a/client/my-sites/customer-home/cards/education/educational-content/style.scss
+++ b/client/my-sites/customer-home/cards/education/educational-content/style.scss
@@ -13,7 +13,7 @@
 
 	h2 {
 		font-weight: 500;
-		font-size: $font-title-small;
+		font-size: $font-body-large;
 		margin-bottom: 8px;
 	}
 

--- a/client/my-sites/customer-home/cards/launchpad/style.scss
+++ b/client/my-sites/customer-home/cards/launchpad/style.scss
@@ -22,7 +22,7 @@
 
 		.customer-home-launchpad__title {
 			flex: 1;
-			font-size: $font-title-small;
+			font-size: $font-body-large;
 			font-weight: 500;
 			font-family: $font-sf-pro-display;
 		}

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -191,8 +191,12 @@ body.is-section-home.theme-default.color-scheme {
 .customer-home__main .card-heading,
 .customer-home__main .foldable-card__header {
 	margin-top: 0;
-	font-size: $font-title-small;
+	font-size: $font-body-large;
 	font-weight: 500;
+}
+
+.customer-home__main .blogging-prompt .blogging-prompt__card .blogging-prompt__prompt-text {
+	font-size: $font-body-large;
 }
 
 .customer-home__card-subheader {

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -191,8 +191,8 @@ body.is-section-home.theme-default.color-scheme {
 .customer-home__main .card-heading,
 .customer-home__main .foldable-card__header {
 	margin-top: 0;
-	font-size: $font-body;
-	font-weight: 600;
+	font-size: $font-title-small;
+	font-weight: 500;
 }
 
 .customer-home__card-subheader {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* This PR updates the card headers in Customer Home so they are all using a font size of `$font-body-large` (which is defined as `rem( 18px )`) and a font weight of 500.

## Screenshots

### Without launchpad (i.e. with full-width banner)

#### Before

https://github.com/Automattic/wp-calypso/assets/3376401/72cb207f-5679-46f7-a4f3-80d1e9f2fee2

#### After

https://github.com/Automattic/wp-calypso/assets/3376401/704068c4-2bed-4758-bd6c-9f46cd860107

### With launchpad

#### Before

https://github.com/Automattic/wp-calypso/assets/3376401/340071bd-0114-4e3c-9605-5839b71157ba

#### After (with domain upsell card)

https://github.com/Automattic/wp-calypso/assets/3376401/030d680d-490e-4bea-b3c2-cbd7758a0088

#### After (without domain upsell card)

https://github.com/Automattic/wp-calypso/assets/3376401/7c9f330c-f3a7-4d1b-ae80-f78af3ff7292

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch locally or via Calypso.live
* Visit Customer Home and verify that the various card titles have consistent font sizes and weights

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [N/A] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?