### PR TITLE
Assembler: Add the Pages screen to the navigator

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
@@ -15,6 +15,7 @@ export const NAVIGATOR_PATHS = {
 	ACTIVATION: '/activation',
 	CONFIRMATION: '/confirmation',
 	UPSELL: '/upsell',
+	PAGES: '/pages',
 };
 
 export const INITIAL_PATH = NAVIGATOR_PATHS.MAIN_HEADER;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -44,6 +44,7 @@ import ScreenColorPalettes from './screen-color-palettes';
 import ScreenConfirmation from './screen-confirmation';
 import ScreenFontPairings from './screen-font-pairings';
 import ScreenMain from './screen-main';
+import ScreenPages from './screen-pages';
 import ScreenPatternListPanel from './screen-pattern-list-panel';
 import ScreenSections from './screen-sections';
 import ScreenStyles from './screen-styles';
@@ -548,6 +549,10 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 						hasColor={ !! colorVariation }
 						hasFont={ !! fontVariation }
 					/>
+				</NavigatorScreen>
+
+				<NavigatorScreen path={ NAVIGATOR_PATHS.PAGES } partialMatch>
+					<ScreenPages onContinueClick={ onContinue } recordTracksEvent={ recordTracksEvent } />
 				</NavigatorScreen>
 
 				<NavigatorScreen path={ NAVIGATOR_PATHS.ACTIVATION } className="screen-activation">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-pages.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-pages.tsx
@@ -1,0 +1,63 @@
+import { NavigatorHeader } from '@automattic/onboarding';
+import { Button } from '@wordpress/components';
+import { useEffect, useState } from 'react';
+import { PATTERN_ASSEMBLER_EVENTS } from './events';
+import { useScreen } from './hooks';
+import NavigatorTitle from './navigator-title';
+
+interface Props {
+	onContinueClick: () => void;
+	recordTracksEvent: ( name: string, eventProperties?: any ) => void;
+}
+
+const ScreenPages = ( { onContinueClick, recordTracksEvent }: Props ) => {
+	const [ disabled, setDisabled ] = useState( true );
+	const { title, description, continueLabel } = useScreen( 'pages' );
+
+	const handleContinueClick = () => {
+		if ( ! disabled ) {
+			onContinueClick();
+		}
+	};
+
+	// Use the mousedown event to prevent either the button focusing or text selection
+	const handleMouseDown = ( event: React.MouseEvent ) => {
+		if ( disabled ) {
+			event.preventDefault();
+			recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.CONTINUE_MISCLICK );
+		}
+	};
+
+	// Set a delay to enable the Continue button since the user might mis-click easily when they go back from another screen
+	useEffect( () => {
+		const timeoutId = window.setTimeout( () => setDisabled( false ), 300 );
+		return () => {
+			window.clearTimeout( timeoutId );
+		};
+	}, [] );
+
+	return (
+		<>
+			<NavigatorHeader
+				title={ <NavigatorTitle title={ title } /> }
+				description={ description }
+				hideBack
+			/>
+			<div className="screen-container__body"></div>
+			<div className="screen-container__footer">
+				<Button
+					className="pattern-assembler__button"
+					variant="primary"
+					disabled={ disabled }
+					__experimentalIsFocusable
+					onMouseDown={ handleMouseDown }
+					onClick={ () => handleContinueClick() }
+				>
+					{ continueLabel }
+				</Button>
+			</div>
+		</>
+	);
+};
+
+export default ScreenPages;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/types.ts
@@ -34,7 +34,14 @@ export type PanelObject = {
 	selectedPatterns?: Pattern[];
 };
 
-export type ScreenName = 'main' | 'sections' | 'styles' | 'confirmation' | 'activation' | 'upsell';
+export type ScreenName =
+	| 'main'
+	| 'sections'
+	| 'styles'
+	| 'confirmation'
+	| 'activation'
+	| 'upsell'
+	| 'pages';
 
 export type Tag = {
 	slug: string;

--- a/config/development.json
+++ b/config/development.json
@@ -136,6 +136,7 @@
 		"onboarding/import-redirect-to-themes": true,
 		"p2/p2-plus": true,
 		"page/export": true,
+		"pattern-assembler/add-pages": false,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -81,6 +81,7 @@
 		"my-sites/add-ons": true,
 		"network-connection": true,
 		"p2/p2-plus": true,
+		"pattern-assembler/add-pages": false,
 		"plans/hosting-trial": false,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,

--- a/config/production.json
+++ b/config/production.json
@@ -103,6 +103,7 @@
 		"onboarding/import-from-wordpress": true,
 		"onboarding/import-redirect-to-themes": true,
 		"p2/p2-plus": true,
+		"pattern-assembler/add-pages": false,
 		"plans/hosting-trial": false,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -100,6 +100,7 @@
 		"onboarding/import-redirect-to-themes": true,
 		"p2/p2-plus": true,
 		"page/export": true,
+		"pattern-assembler/add-pages": false,
 		"plans/hosting-trial": false,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -109,6 +109,7 @@
 		"onboarding/import-light": false,
 		"onboarding/import-redirect-to-themes": true,
 		"p2/p2-plus": true,
+		"pattern-assembler/add-pages": false,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,


### PR DESCRIPTION
## Proposed Change

This PR introduces the Pages screen to the Assembler navigator. The Pages screen is behind the feature flag `pattern-assembler/add-pages` which is disabled in ALL environments.

![Screenshot 2023-10-25 at 5 59 29 PM](https://github.com/Automattic/wp-calypso/assets/797888/b31e415e-d912-48d6-a1db-bacbf442fe9b)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Assembler, and add the URL param `&flags=pattern-assembler/add-pages`.
* Select any pattern and click on Select Styles.
* Select any styles and click on Save and Continue.
* Ensure that the next step is the Pages screen.
* In the Pages screen, click on Save and Continue.
* Ensure that you are now either in the Confirmation or Activation screen, if no premium styles have been selected.
* Otherwise, you will be taken to the Upsell screen, and then the Confirmation or Activation screen.

Please test that the Assembler navigation flow works as before when the feature flag is not enabled.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?