### PR TITLE
Happy Blocks: Support content footer - change link

### DIFF
--- a/apps/happy-blocks/block-library/support-content-links/index.php
+++ b/apps/happy-blocks/block-library/support-content-links/index.php
@@ -23,7 +23,7 @@
 	</p>
 	<p>
 		<?php esc_html_e( 'New to WordPress.com? ', 'happy-blocks' ); ?>
-		<a href="<?php echo esc_url( 'https://wordpress.com/support/start/' ); ?>" target="_blank" rel="noreferrer noopener">
+		<a href="<?php echo esc_url( 'https://wordpress.com/plans/' ); ?>" target="_blank" rel="noreferrer noopener">
 			<?php esc_html_e( 'Find your perfect-fit plan here.', 'happy-blocks' ); ?>
 		</a>
 	</p>


### PR DESCRIPTION
We switched the link from `[wordpress.com/support/start](https://wordpress.com/support/start/)` to `[wordpress.com/plans](https://wordpress.com/plans/)`

p9Jlb4-96s-p2#comment-9422

Fixes https://github.com/Automattic/wpsupport3/issues/684