### PR TITLE
Subscription Management: Manage notification settings should go to `/me/notifications/subscriptions`.

### DIFF
--- a/client/me/notification-settings/blogs-settings/style.scss
+++ b/client/me/notification-settings/blogs-settings/style.scss
@@ -123,8 +123,3 @@
 		height: 22px;
 	}
 }
-
-.notification-settings .notification-settings__back-button.has-icon.has-text {
-	padding: 0;
-	margin-bottom: 24px;
-}

--- a/client/me/notification-settings/comment-settings/index.jsx
+++ b/client/me/notification-settings/comment-settings/index.jsx
@@ -15,6 +15,7 @@ import {
 	hasUnsavedNotificationSettingsChanges,
 } from 'calypso/state/notification-settings/selectors';
 import Navigation from '../navigation';
+import SubscriptionManagementBackButton from '../subscription-management-back-button';
 
 import './style.scss';
 
@@ -50,6 +51,8 @@ class NotificationCommentsSettings extends Component {
 					title="Me > Notifications > Comments on other sites"
 				/>
 				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
+
+				<SubscriptionManagementBackButton />
 
 				<NavigationHeader navigationItems={ [] } title={ translate( 'Notification Settings' ) } />
 

--- a/client/me/notification-settings/main.jsx
+++ b/client/me/notification-settings/main.jsx
@@ -1,8 +1,5 @@
-import { Gridicon } from '@automattic/components';
-import { Button } from '@wordpress/components';
 import { localize } from 'i18n-calypso';
 import { find } from 'lodash';
-import page from 'page';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import Main from 'calypso/components/main';
@@ -18,6 +15,7 @@ import {
 import BlogsSettings from './blogs-settings';
 import Navigation from './navigation';
 import PushNotificationSettings from './push-notification-settings';
+import SubscriptionManagementBackButton from './subscription-management-back-button';
 
 class NotificationSettings extends Component {
 	componentDidMount() {
@@ -57,15 +55,7 @@ class NotificationSettings extends Component {
 				<PageViewTracker path="/me/notifications" title="Me > Notifications" />
 				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
 
-				{ page.current.includes( 'referrer=management' ) && (
-					<Button
-						className="notification-settings__back-button"
-						onClick={ () => page( '/read/subscriptions' ) }
-						icon={ <Gridicon icon="chevron-left" size={ 12 } /> }
-					>
-						{ this.props.translate( 'Manage all subscriptions' ) }
-					</Button>
-				) }
+				<SubscriptionManagementBackButton />
 				<NavigationHeader
 					navigationItems={ [] }
 					title={ this.props.translate( 'Notification Settings' ) }

--- a/client/me/notification-settings/navigation.jsx
+++ b/client/me/notification-settings/navigation.jsx
@@ -1,4 +1,5 @@
 import { localize } from 'i18n-calypso';
+import page from 'page';
 import { Component } from 'react';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
@@ -34,8 +35,15 @@ class NotificationSettingsNavigation extends Component {
 	};
 
 	navItem = ( path ) => {
+		const pathWithOptionalReferrer =
+			path + ( page.current.includes( 'referrer=management' ) ? '?referrer=management' : '' );
+
 		return (
-			<NavItem path={ path } key={ path } selected={ this.props.path === path }>
+			<NavItem
+				path={ pathWithOptionalReferrer }
+				key={ path }
+				selected={ this.props.path === pathWithOptionalReferrer }
+			>
 				{ this.itemLabels()[ path ] }
 			</NavItem>
 		);

--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -21,6 +21,7 @@ import withFormBase from 'calypso/me/form-base/with-form-base';
 import Navigation from 'calypso/me/notification-settings/navigation';
 import ReauthRequired from 'calypso/me/reauth-required';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
+import SubscriptionManagementBackButton from '../subscription-management-back-button';
 
 class NotificationSubscriptions extends Component {
 	handleClickEvent( action ) {
@@ -62,6 +63,8 @@ class NotificationSubscriptions extends Component {
 					title="Me > Notifications > Subscriptions Delivery"
 				/>
 				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
+
+				<SubscriptionManagementBackButton />
 
 				<NavigationHeader
 					navigationItems={ [] }

--- a/client/me/notification-settings/subscription-management-back-button/index.jsx
+++ b/client/me/notification-settings/subscription-management-back-button/index.jsx
@@ -1,0 +1,25 @@
+import { Gridicon } from '@automattic/components';
+import { Button } from '@wordpress/components';
+import { localize } from 'i18n-calypso';
+import page from 'page';
+import { Component } from 'react';
+import { connect } from 'react-redux';
+import './style.scss';
+
+class SubscriptionManagementBackButton extends Component {
+	render() {
+		return (
+			page.current.includes( 'referrer=management' ) && (
+				<Button
+					className="subscription-management-back-button"
+					onClick={ () => page( '/read/subscriptions' ) }
+					icon={ <Gridicon icon="chevron-left" size={ 12 } /> }
+				>
+					{ this.props.translate( 'Manage all subscriptions' ) }
+				</Button>
+			)
+		);
+	}
+}
+
+export default connect()( localize( SubscriptionManagementBackButton ) );

--- a/client/me/notification-settings/subscription-management-back-button/style.scss
+++ b/client/me/notification-settings/subscription-management-back-button/style.scss
@@ -1,0 +1,4 @@
+.subscription-management-back-button.has-icon.has-text {
+	padding: 0;
+	margin-bottom: 24px;
+}

--- a/client/me/notification-settings/wpcom-settings/index.jsx
+++ b/client/me/notification-settings/wpcom-settings/index.jsx
@@ -21,6 +21,7 @@ import {
 import hasJetpackSites from 'calypso/state/selectors/has-jetpack-sites';
 import Navigation from '../navigation';
 import ActionButtons from '../settings-form/actions';
+import SubscriptionManagementBackButton from '../subscription-management-back-button';
 import EmailCategory from './email-category';
 
 import './style.scss';
@@ -197,6 +198,9 @@ class WPCOMNotifications extends Component {
 					title="Me > Notifications > Updates from WordPress.com"
 				/>
 				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
+
+				<SubscriptionManagementBackButton />
+
 				<NavigationHeader
 					navigationItems={ [] }
 					title={ this.props.translate( 'Notification Settings' ) }

--- a/client/reader/site-subscriptions-manager/subscriptions-manager-wrapper.tsx
+++ b/client/reader/site-subscriptions-manager/subscriptions-manager-wrapper.tsx
@@ -81,7 +81,7 @@ const SubscriptionsManagerWrapper = ( {
 								<Button
 									className="site-subscriptions-manager__manage-notifications-button"
 									variant="link"
-									href="/me/notifications?referrer=management"
+									href="/me/notifications/subscriptions?referrer=management"
 								>
 									{ translate( 'Manage notification settings' ) }
 								</Button>


### PR DESCRIPTION
## Proposed Changes

* On subscription management page, the "Manage notification settings" link will now go to `/me/notifications/subscriptions` instead of `/me/notifications`.
* On every page of `/me/notifications/*`, the "< Manage all subscriptions" back button will always persist if the url param `?referrer=management` exists.

Context: p1697463356791249/1697458260.859359-slack-C9EJ7KSGH

## Testing Instructions

1. Go to `/read/subscriptions`.
2. Click on "Manage notification settings".
   - You should land in `/me/notifications/subscriptions?referrer=management`.
3. Click on every tab "Notifications", "Comments", "Updates", "Reader Subscriptions"
   - The "< Manage all subscriptions" back button should be displayed all the time.
   - The tab menu should have right active state.
4. Click on the "< Manage all subscriptions" button.
   - You should land in `/read/subscriptions`.
5. Ensure no regressions with the non-referrer version by going to `/me/notifications` and click on every tab.


https://github.com/Automattic/wp-calypso/assets/1287077/be32e5c5-772e-4660-81a9-5a40e3873af3



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?