### PR TITLE
Subscribers Page: Hide total count heading and filter bar when site has no subscribers.

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
@@ -25,21 +25,26 @@ const SubscriberListContainer = ( {
 
 	return (
 		<section className="subscriber-list-container">
-			<div className="subscriber-list-container__header">
-				<span className="subscriber-list-container__title">
-					{ translate( 'Total', {
-						context: 'Total number of subscribers',
-					} ) }
-				</span>{ ' ' }
-				<span
-					className={ `subscriber-list-container__subscriber-count ${
-						isLoading ? 'loading-placeholder' : ''
-					}` }
-				>
-					{ numberFormat( total, 0 ) }
-				</span>
-			</div>
-			<SubscriberListActionsBar />
+			{ ! isLoading && Boolean( grandTotal ) && (
+				<>
+					<div className="subscriber-list-container__header">
+						<span className="subscriber-list-container__title">
+							{ translate( 'Total', {
+								context: 'Total number of subscribers',
+							} ) }
+						</span>{ ' ' }
+						<span
+							className={ `subscriber-list-container__subscriber-count ${
+								isLoading ? 'loading-placeholder' : ''
+							}` }
+						>
+							{ numberFormat( total, 0 ) }
+						</span>
+					</div>
+
+					<SubscriberListActionsBar />
+				</>
+			) }
 			{ isLoading &&
 				new Array( 10 ).fill( null ).map( ( _, index ) => (
 					<div key={ index } data-ignored={ _ }>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/79476 (fixes partly)
Related Slack thread: p1697737903410349-slack-C02NQ4HMJKV

## Proposed Changes

* Hides total count heading and filter bar when site has no subscribers.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to subscribers page on a site with no subscribers, e.g. `/subscribers/site_with_no_subscribers.wordpress.com`.
* You should not see the total count and filter bar.

| Before | After |
| --- | --- |
| <img width="1765" alt="2023-10-24_14-08-25" src="https://github.com/Automattic/wp-calypso/assets/1287077/30892f86-5642-4a8e-b08e-2e0d3d9960c0"> | <img width="1765" alt="2023-10-24_14-08-46" src="https://github.com/Automattic/wp-calypso/assets/1287077/48e83805-285e-4df6-abe3-fe00ba73ca01"> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?