### PR TITLE
Jetpack Manage: Fix the issue with the Atomic site provisioning notice reappearing after dismissing.

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -42,6 +42,8 @@ import type { Site } from '../sites-overview/types';
 
 import './style.scss';
 
+const QUERY_PARAM_PROVISIONING = 'provisioning';
+
 export default function SitesOverview() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -246,8 +248,19 @@ export default function SitesOverview() {
 	const [ hasDismissedProvisioningNotice, setHasDismissedProvisioningNotice ] =
 		useState< boolean >( false );
 	const isProvisioningSite =
-		'true' === getQueryArg( window.location.href, 'provisioning' ) ||
+		'true' === getQueryArg( window.location.href, QUERY_PARAM_PROVISIONING ) ||
 		( ! isLoadingProvisioningBlogIds && Number( provisioningBlogIds?.length ) > 0 );
+
+	const onDismissProvisioningNotice = () => {
+		setHasDismissedProvisioningNotice( true );
+
+		// Delete query param 'provisioning' from the URL.
+		window.history.replaceState(
+			null,
+			'',
+			removeQueryArgs( window.location.href, QUERY_PARAM_PROVISIONING )
+		);
+	};
 
 	return (
 		<div className="sites-overview">
@@ -259,10 +272,7 @@ export default function SitesOverview() {
 						<DashboardBanners />
 
 						{ isProvisioningSite && ! hasDismissedProvisioningNotice && (
-							<Notice
-								status="is-info"
-								onDismissClick={ () => setHasDismissedProvisioningNotice( true ) }
-							>
+							<Notice status="is-info" onDismissClick={ onDismissProvisioningNotice }>
 								{ translate(
 									"We're setting up your new WordPress.com site and will notify you once it's ready, which should only take a few minutes."
 								) }


### PR DESCRIPTION
This PR fixes an issue with the Atomic site provisioning notice reappearing after dismissing and refreshing the page. The issue happens since **'provisioning'** query param is not removed when dismissing the notice. This query param is used to determine when to show the notice, and we need to remove this when dismissing the notice.

<img width="1557" alt="Screen Shot 2023-10-24 at 8 10 15 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/3dec3d52-eefc-4ce5-8d05-6700a9e45cb5">

Closes https://github.com/Automattic/jetpack-manage/issues/37

## Proposed Changes

* Update the dismiss handler on the Provisioning notice to remove the 'provisioning' query param in the URL.

## Testing Instructions
Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

* Use the live link and go to `/dashboard?provisioning=true`
* Dismiss the Provisioning notice and confirm the URL is also updated.
* Refresh the page and confirm the notice will not reappear again.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
