### PR TITLE
Add support for hiding the launchpad modal when navigating away

### DIFF
--- a/client/layout/masterbar/masterbar-launchpad-navigator.tsx
+++ b/client/layout/masterbar/masterbar-launchpad-navigator.tsx
@@ -1,6 +1,7 @@
 import { FloatingNavigator, LaunchpadNavigatorIcon } from '@automattic/launchpad-navigator';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
+import page from 'page';
 import { useState } from 'react';
 import { useSelector } from 'react-redux';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -29,6 +30,7 @@ const MasterbarLaunchpadNavigator = () => {
 			{ launchpadIsVisible && (
 				<div className="masterbar__launchpad-navigator">
 					<FloatingNavigator
+						pageExitCallback={ page.exit }
 						siteSlug={ siteSlug }
 						toggleLaunchpadIsVisible={ setLaunchpadIsVisible }
 					/>

--- a/packages/launchpad-navigator/src/floating-navigator/index.tsx
+++ b/packages/launchpad-navigator/src/floating-navigator/index.tsx
@@ -4,20 +4,41 @@ import { DefaultWiredLaunchpad } from '@automattic/launchpad';
 import { Button } from '@wordpress/components';
 import { select } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
 
 import './style.scss';
 
 type ToggleLaunchpadIsVisible = ( shouldBeVisible: boolean ) => void;
 
 export type FloatingNavigatorProps = {
+	pageExitCallback?: (
+		path: string,
+		handler: ( context: object, next: () => void ) => void
+	) => void;
 	siteSlug: string | null;
 	toggleLaunchpadIsVisible?: ToggleLaunchpadIsVisible;
 };
 
-const FloatingNavigator = ( { siteSlug, toggleLaunchpadIsVisible }: FloatingNavigatorProps ) => {
+let _is_page_exit_registered = false;
+
+const FloatingNavigator = ( {
+	pageExitCallback,
+	siteSlug,
+	toggleLaunchpadIsVisible,
+}: FloatingNavigatorProps ) => {
 	const launchpadContext = 'launchpad-navigator';
 	const translate = useTranslate();
 	const checklistSlug = select( LaunchpadNavigator.store ).getActiveChecklistSlug() || null;
+
+	useEffect( () => {
+		if ( pageExitCallback && ! _is_page_exit_registered && toggleLaunchpadIsVisible ) {
+			pageExitCallback( '*', ( context, next ) => {
+				toggleLaunchpadIsVisible( false );
+				next();
+			} );
+			_is_page_exit_registered = true;
+		}
+	}, [ pageExitCallback, toggleLaunchpadIsVisible ] );
 
 	if ( ! checklistSlug ) {
 		return null;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* This PR explores adding some logic to make it possible for Calypso to trigger changes to the Launchpad Navigator modal visibility when users navigate between pages. The implementation depends on `page.exit` from the `page` module being supplied as a prop to `FloatingNavigator`, and then adds some one-time code that sets up a middleware that hides the Launchpad Navigator whenever a page navigation occurs via `page`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch locally or via `calypso.live`.
* Navigate to Customer Home for a site that has an active task list
* Add `?flags=launchpad/navigator` to the URL -- copy the full URL as you're going to need to return to this page multiple times!
* We now need to test that various ways of navigating away from the page correctly hide the modal:
  - Open the launchpad navigator, and click on a task in the task list that navigates to a new page in Calypso.
     * Verify that the modal is hidden before you get to the next page
  - Navigate back to the original URL with the `flags` URL argument and open the Launchpad Navigator modal
  - Click on an item in the left nav that takes you to a new page in Calypso.
     * Verify that the modal is hidden before you get to the next page
  - Navigate back to the original URL with the `flags` URL argument and open the Launchpad Navigator modal 
  - Click on an item in the left nav that takes you to a page in wp-admin (e.g. _Jetpack_ -> _Search_ | _Akismet Anti-Spam_)
    * Click on your browser Back button to try and pick up the previous state
    * Verify that the modal is no longer shown
  - Navigate back to the original URL with the `flags` URL argument and open the Launchpad Navigator modal
    * Click on a task that shows a modal (currently only "Share your site" qualifies)
    * Verify that the modal is shown and that the Launchpad Navigator remains visible

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?