### PR TITLE
Reskin blogging prompt and add api parameter

### DIFF
--- a/client/components/blogging-prompt-card/index.jsx
+++ b/client/components/blogging-prompt-card/index.jsx
@@ -1,10 +1,10 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Card, Button, Gridicon } from '@automattic/components';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector, useDispatch } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
+import isBloganuary from 'calypso/data/blogging-prompt/is-bloganuary';
 import { useBloggingPrompts } from 'calypso/data/blogging-prompt/use-blogging-prompts';
 import useSkipCurrentViewMutation from 'calypso/data/home/use-skip-current-view-mutation';
 import { SECTION_BLOGGING_PROMPT } from 'calypso/my-sites/customer-home/cards/constants';
@@ -24,7 +24,6 @@ const BloggingPromptCard = ( { siteId, viewContext, showMenu, index } ) => {
 	const maxNumberOfPrompts = 10;
 	const { data: prompts } = useBloggingPrompts( siteId, maxNumberOfPrompts );
 	const { skipCard } = useSkipCurrentViewMutation( siteId );
-	const isBloganuary = isEnabled( 'bloganuary' );
 
 	if ( prompts === undefined ) {
 		return null;
@@ -76,7 +75,7 @@ const BloggingPromptCard = ( { siteId, viewContext, showMenu, index } ) => {
 					<LightbulbIcon />
 					{ /*`key` is necessary due to behavior of preventWidows function in CardHeading component.*/ }
 					<span className="blogging-prompt__heading-text" key="blogging-prompt__heading-text">
-						{ isBloganuary
+						{ isBloganuary()
 							? translate( 'Bloganuary writing prompt' )
 							: translate( 'Daily writing prompt' ) }
 					</span>

--- a/client/components/blogging-prompt-card/index.jsx
+++ b/client/components/blogging-prompt-card/index.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Card, Button, Gridicon } from '@automattic/components';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -23,6 +24,7 @@ const BloggingPromptCard = ( { siteId, viewContext, showMenu, index } ) => {
 	const maxNumberOfPrompts = 10;
 	const { data: prompts } = useBloggingPrompts( siteId, maxNumberOfPrompts );
 	const { skipCard } = useSkipCurrentViewMutation( siteId );
+	const isBloganuary = isEnabled( 'bloganuary' );
 
 	if ( prompts === undefined ) {
 		return null;
@@ -74,7 +76,9 @@ const BloggingPromptCard = ( { siteId, viewContext, showMenu, index } ) => {
 					<LightbulbIcon />
 					{ /*`key` is necessary due to behavior of preventWidows function in CardHeading component.*/ }
 					<span className="blogging-prompt__heading-text" key="blogging-prompt__heading-text">
-						{ translate( 'Daily writing prompt' ) }
+						{ isBloganuary
+							? translate( 'Bloganuary writing prompt' )
+							: translate( 'Daily writing prompt' ) }
 					</span>
 					{ showMenu && renderMenu() }
 				</CardHeading>

--- a/client/components/blogging-prompt-card/prompts-navigation.jsx
+++ b/client/components/blogging-prompt-card/prompts-navigation.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Button, Gridicon } from '@automattic/components';
 import { addQueryArgs } from '@wordpress/url';
 import classnames from 'classnames';
@@ -16,6 +17,7 @@ const PromptsNavigation = ( { siteId, prompts, tracksPrefix, index } ) => {
 	const editorUrl = useSelector( ( state ) => getEditorUrl( state, siteId ) );
 	const backIcon = 'arrow-left';
 	const forwardIcon = 'arrow-right';
+	const isBloganuary = isEnabled( 'bloganuary' );
 
 	const initialIndex = index ? index % prompts.length : 0;
 	const [ promptIndex, setPromptIndex ] = useState( initialIndex );
@@ -89,6 +91,15 @@ const PromptsNavigation = ( { siteId, prompts, tracksPrefix, index } ) => {
 		);
 	};
 
+	const trackBloganuaryMoreInfoClick = () => {
+		dispatch(
+			recordTracksEvent( tracksPrefix + 'bloganuary_more_info_click', {
+				site_id: siteId,
+				prompt_id: getPrompt()?.id,
+			} )
+		);
+	};
+
 	const renderPromptNavigation = () => {
 		const buttonClasses = classnames( 'navigation-link' );
 
@@ -126,11 +137,12 @@ const PromptsNavigation = ( { siteId, prompts, tracksPrefix, index } ) => {
 			</div>
 		);
 
+		const promptLink =
+			'/tag/dailyprompt' + ( prompt && prompt.id ? '-' + encodeURIComponent( prompt.id ) : '' );
+
 		const viewAllResponses = (
 			<a
-				href={
-					'/tag/dailyprompt' + ( prompt && prompt.id ? '-' + encodeURIComponent( prompt.id ) : '' )
-				}
+				href={ promptLink }
 				className="blogging-prompt__prompt-responses-link"
 				onClick={ trackClickViewAllResponses }
 			>
@@ -158,6 +170,17 @@ const PromptsNavigation = ( { siteId, prompts, tracksPrefix, index } ) => {
 		return (
 			<div className="blogging-prompt__prompt-answers">
 				{ renderResponses() }
+				{ isBloganuary && (
+					<a
+						href="https://wordpress.com/bloganuary"
+						className="blogging-prompt__bloganuary-link"
+						target="_blank"
+						rel="noopener noreferrer"
+						onClick={ trackBloganuaryMoreInfoClick }
+					>
+						{ translate( 'Learn more' ) }
+					</a>
+				) }
 				<Button href={ getNewPostLink() } onClick={ handleBloggingPromptClick }>
 					{ translate( 'Post Answer', {
 						comment:

--- a/client/components/blogging-prompt-card/prompts-navigation.jsx
+++ b/client/components/blogging-prompt-card/prompts-navigation.jsx
@@ -1,10 +1,10 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Button, Gridicon } from '@automattic/components';
 import { addQueryArgs } from '@wordpress/url';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import isBloganuary from 'calypso/data/blogging-prompt/is-bloganuary';
 import { navigate } from 'calypso/lib/navigate';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getEditorUrl from 'calypso/state/selectors/get-editor-url';
@@ -17,7 +17,6 @@ const PromptsNavigation = ( { siteId, prompts, tracksPrefix, index } ) => {
 	const editorUrl = useSelector( ( state ) => getEditorUrl( state, siteId ) );
 	const backIcon = 'arrow-left';
 	const forwardIcon = 'arrow-right';
-	const isBloganuary = isEnabled( 'bloganuary' );
 
 	const initialIndex = index ? index % prompts.length : 0;
 	const [ promptIndex, setPromptIndex ] = useState( initialIndex );
@@ -170,7 +169,7 @@ const PromptsNavigation = ( { siteId, prompts, tracksPrefix, index } ) => {
 		return (
 			<div className="blogging-prompt__prompt-answers">
 				{ renderResponses() }
-				{ isBloganuary && (
+				{ isBloganuary() && (
 					<a
 						href="https://wordpress.com/bloganuary"
 						className="blogging-prompt__bloganuary-link"

--- a/client/components/blogging-prompt-card/style.scss
+++ b/client/components/blogging-prompt-card/style.scss
@@ -91,6 +91,15 @@
 				text-decoration-line: none;
 			}
 		}
+		.blogging-prompt__bloganuary-link {
+			color: var(--studio-gray-80);
+			font-size: $font-body-small;
+			text-decoration-line: underline;
+			margin-right: 8px;
+			&:hover {
+				text-decoration-line: none;
+			}
+		}
 		.blogging-prompt__prompt-no-response {
 			align-items: center;
 			display: flex;

--- a/client/data/blogging-prompt/is-bloganuary.ts
+++ b/client/data/blogging-prompt/is-bloganuary.ts
@@ -1,0 +1,10 @@
+import { isEnabled } from '@automattic/calypso-config';
+
+/**
+ * In future this will be automatically enabled in January. For now it just checks a feature flag.
+ *
+ * @returns true if bloganuary mode is active
+ */
+export default function isBloganuary() {
+	return isEnabled( 'bloganuary' );
+}

--- a/client/data/blogging-prompt/use-blogging-prompts.ts
+++ b/client/data/blogging-prompt/use-blogging-prompts.ts
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { useQuery, UseQueryResult } from '@tanstack/react-query';
 import moment from 'moment';
 import wp from 'calypso/lib/wp';
@@ -27,12 +28,12 @@ export const useBloggingPrompts = (
 	page: number
 ): UseQueryResult< BloggingPrompt[] | null > => {
 	const today = moment().format( 'YYYY-MM-DD' );
-
+	const isBloganuary = isEnabled( 'bloganuary' );
 	return useQuery( {
-		queryKey: [ 'blogging-prompts', today + '-' + page ],
+		queryKey: [ 'blogging-prompts', today + '-' + page, isBloganuary ],
 		queryFn: () =>
 			wp.req.get( {
-				path: `/sites/${ siteId }/blogging-prompts?number=${ page }&from=${ today }`,
+				path: `/sites/${ siteId }/blogging-prompts?number=${ page }&from=${ today }&is_bloganuary=${ isBloganuary }`,
 				apiNamespace: 'wpcom/v2',
 			} ),
 		enabled: !! siteId,

--- a/config/development.json
+++ b/config/development.json
@@ -31,6 +31,7 @@
 	"features": {
 		"ad-tracking": false,
 		"akismet/siteless-checkout": true,
+		"bloganuary": true,
 		"calypso/ai-assembler": true,
 		"calypso/help-center": true,
 		"calypsoify/plugins": true,


### PR DESCRIPTION
Starts on pe7F0s-1iI-p2

We don't have a design for the my-home card for bloganuary card, but to make a start on it, I've added some default content. I've used a feature flag so it can be tested.

The design will be changed later.

<img width="690" alt="Screen Shot 2023-10-24 at 11 04 02 pm" src="https://github.com/Automattic/wp-calypso/assets/22446385/24436f9a-a354-47aa-ac1d-1e5ad57cac44">


### Test instructions 

Apply D126376-code

Add `?flags=+bloganuary` to the url.
Go to my-home page for a site with `site_intent=write`.
In the card we should see only prompts from January and should see some modifications to the UI.