### PR TITLE
Subscriber management: add tracks events to growth section

### DIFF
--- a/client/my-sites/subscribers/components/grow-your-audience/grow-your-audience.tsx
+++ b/client/my-sites/subscribers/components/grow-your-audience/grow-your-audience.tsx
@@ -3,6 +3,7 @@ import { Card, CardBody, Icon } from '@wordpress/components';
 import { chartBar, people, trendingUp } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { SectionContainer } from 'calypso/components/section';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector } from 'calypso/state';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { getEarnPageUrl } from '../../helpers';
@@ -12,11 +13,23 @@ type GrowYourAudienceCardProps = {
 	icon: JSX.Element;
 	text: string;
 	title: string;
+	tracksEventCta: string;
 	url: string;
 };
 
-const GrowYourAudienceCard = ( { icon, text, title, url }: GrowYourAudienceCardProps ) => {
+const GrowYourAudienceCard = ( {
+	icon,
+	text,
+	title,
+	tracksEventCta,
+	url,
+}: GrowYourAudienceCardProps ) => {
 	const translate = useTranslate();
+
+	const onClick = () =>
+		recordTracksEvent( 'calypso_subscriber_management_growth_cta_click', {
+			cta: tracksEventCta,
+		} );
 
 	return (
 		<Card className="grow-your-audience__card" size="small">
@@ -26,7 +39,13 @@ const GrowYourAudienceCard = ( { icon, text, title, url }: GrowYourAudienceCardP
 					{ title }
 				</h3>
 				<p className="grow-your-audience__card-text">{ text }</p>
-				<a className="grow-your-audience__card-link" href={ url } target="_blank" rel="noreferrer">
+				<a
+					className="grow-your-audience__card-link"
+					href={ url }
+					onClick={ onClick }
+					target="_blank"
+					rel="noreferrer"
+				>
 					{ translate( 'Learn more' ) }
 				</a>
 			</CardBody>
@@ -49,6 +68,7 @@ const GrowYourAudience = () => {
 						'Using a subscriber block is the first step to growing your audience.'
 					) }
 					title={ translate( 'Every visitor is a potential subscriber' ) }
+					tracksEventCta="subscribe-block"
 					url={ localizeUrl(
 						'https://wordpress.com/support/wordpress-editor/blocks/subscribe-block/'
 					) }
@@ -60,6 +80,7 @@ const GrowYourAudience = () => {
 						'Create fresh content, publish regularly, and understand your audience with site stats.'
 					) }
 					title={ translate( 'Keep your readers engaged' ) }
+					tracksEventCta="go-content-strategy"
 					url="https://wordpress.com/go/content-blogging/how-to-start-a-successful-blog-that-earns-links-traffic-and-revenue/#creating-a-blog-content-strategy" // eslint-disable-line wpcalypso/i18n-unlocalized-url
 				/>
 
@@ -69,6 +90,7 @@ const GrowYourAudience = () => {
 						'Allow your readers to support your work with paid subscriptions, gated content, or tips.'
 					) }
 					title={ translate( 'Start earning' ) }
+					tracksEventCta="earn"
 					url={ getEarnPageUrl( selectedSiteSlug ) }
 				/>
 			</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Add tracks click event to Growth section at subscriber management

<img width="1252" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/fd236cbf-1ec9-45f2-bc13-bf9aea96b19d">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Observe tracks events, e.g. by hitting localStorage.debug="calypso:analytics" in the console and refresh.
* Open Users -> Subscribers (you need to have some subscribers so that you see growth section)
* Click each CTA
* Confirm you see events witgh right `cta` prop
   
   <img width="555" alt="Screenshot 2023-10-24 at 16 10 21" src="https://github.com/Automattic/wp-calypso/assets/87168/8ae9576c-66ae-4d18-bcaf-fafaa7256e60">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?