### PR TITLE
Subscriber management: link to stats instead of subscriber block docs

### DIFF
--- a/client/my-sites/subscribers/components/grow-your-audience/grow-your-audience.tsx
+++ b/client/my-sites/subscribers/components/grow-your-audience/grow-your-audience.tsx
@@ -25,27 +25,35 @@ const GrowYourAudienceCard = ( {
 	icon,
 	text,
 	title,
+	tracksEventCta,
 	url,
-}: GrowYourAudienceCardProps ) => (
-	<Card className="grow-your-audience__card" size="small">
-		<CardBody className="grow-your-audience__card-body">
-			<h3 className="grow-your-audience__card-title">
-				<Icon className="grow-your-audience__card-icon" icon={ icon } size={ 20 } />
-				{ title }
-			</h3>
-			<p className="grow-your-audience__card-text">{ text }</p>
-			{ externalUrl ? (
-				<ExternalLink className="grow-your-audience__card-link" href={ url }>
-					{ ctaLabel }
-				</ExternalLink>
-			) : (
-				<a className="grow-your-audience__card-link" href={ url }>
-					{ ctaLabel }
-				</a>
-			) }
-		</CardBody>
-	</Card>
-);
+}: GrowYourAudienceCardProps ) => {
+	const onClick = () =>
+		recordTracksEvent( 'calypso_subscriber_management_growth_cta_click', {
+			cta: tracksEventCta,
+		} );
+
+	return (
+		<Card className="grow-your-audience__card" size="small">
+			<CardBody className="grow-your-audience__card-body">
+				<h3 className="grow-your-audience__card-title">
+					<Icon className="grow-your-audience__card-icon" icon={ icon } size={ 20 } />
+					{ title }
+				</h3>
+				<p className="grow-your-audience__card-text">{ text }</p>
+				{ externalUrl ? (
+					<ExternalLink className="grow-your-audience__card-link" href={ url } onClick={ onClick }>
+						{ ctaLabel }
+					</ExternalLink>
+				) : (
+					<a className="grow-your-audience__card-link" href={ url } onClick={ onClick }>
+						{ ctaLabel }
+					</a>
+				) }
+			</CardBody>
+		</Card>
+	);
+};
 
 const GrowYourAudience = () => {
 	const locale = useLocale();
@@ -72,6 +80,7 @@ const GrowYourAudience = () => {
 							'Take a look at your stats and refine your content strategy for better engagement.'
 						) }
 						title={ translate( 'Explore your stats' ) }
+						tracksEventCta="stats"
 						ctaLabel={ translate( 'Check stats' ) }
 						url={ `/stats/subscribers/${ selectedSiteSlug }` }
 					/>
@@ -82,6 +91,7 @@ const GrowYourAudience = () => {
 							'Using a subscriber block is the first step to growing your audience.'
 						) }
 						title={ translate( 'Every visitor is a potential subscriber' ) }
+						tracksEventCta="subscribe-block"
 						ctaLabel={ translate( 'Learn more' ) }
 						externalUrl
 						url={ localizeUrl(
@@ -96,6 +106,7 @@ const GrowYourAudience = () => {
 						'Allow your readers to support your work with paid subscriptions, gated content, or tips.'
 					) }
 					title={ translate( 'Start earning' ) }
+					tracksEventCta="earn"
 					ctaLabel={ translate( 'Learn more' ) }
 					url={ `/earn/${ selectedSiteSlug ?? '' }` }
 				/>
@@ -106,6 +117,7 @@ const GrowYourAudience = () => {
 						'Create fresh content, publish regularly, and understand your audience with site stats.'
 					) }
 					title={ translate( 'Keep your readers engaged' ) }
+					tracksEventCta="go-content-strategy"
 					ctaLabel={ translate( 'Learn more' ) }
 					externalUrl
 					url="https://wordpress.com/go/content-blogging/how-to-start-a-successful-blog-that-earns-links-traffic-and-revenue/#creating-a-blog-content-strategy" // eslint-disable-line wpcalypso/i18n-unlocalized-url

--- a/client/my-sites/subscribers/components/grow-your-audience/grow-your-audience.tsx
+++ b/client/my-sites/subscribers/components/grow-your-audience/grow-your-audience.tsx
@@ -1,4 +1,6 @@
+import { englishLocales, useLocale, localizeUrl } from '@automattic/i18n-utils';
 import { Card, CardBody, Icon, ExternalLink } from '@wordpress/components';
+import { hasTranslation } from '@wordpress/i18n';
 import { chartBar, people, trendingUp } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { SectionContainer } from 'calypso/components/section';
@@ -46,23 +48,47 @@ const GrowYourAudienceCard = ( {
 );
 
 const GrowYourAudience = () => {
+	const locale = useLocale();
 	const translate = useTranslate();
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
+
+	const statsCardTranslated =
+		englishLocales.includes( locale ) ||
+		( hasTranslation( 'Explore your stats' ) &&
+			hasTranslation(
+				'Take a look at your stats and refine your content strategy for better engagement.'
+			) &&
+			hasTranslation( 'Check stats' ) );
 
 	return (
 		<SectionContainer className="grow-your-audience">
 			<h2 className="grow-your-audience__title">{ translate( 'Grow your audience' ) }</h2>
 
 			<div className="grow-your-audience__cards">
-				<GrowYourAudienceCard
-					icon={ chartBar }
-					text={ translate(
-						'Take a look at your stats and refine your content strategy for better engagement.'
-					) }
-					title={ translate( 'Explore your stats' ) }
-					ctaLabel={ translate( 'Check stats' ) }
-					url={ `/stats/subscribers/${ selectedSiteSlug }` }
-				/>
+				{ statsCardTranslated ? (
+					<GrowYourAudienceCard
+						icon={ chartBar }
+						text={ translate(
+							'Take a look at your stats and refine your content strategy for better engagement.'
+						) }
+						title={ translate( 'Explore your stats' ) }
+						ctaLabel={ translate( 'Check stats' ) }
+						url={ `/stats/subscribers/${ selectedSiteSlug }` }
+					/>
+				) : (
+					<GrowYourAudienceCard
+						icon={ chartBar }
+						text={ translate(
+							'Using a subscriber block is the first step to growing your audience.'
+						) }
+						title={ translate( 'Every visitor is a potential subscriber' ) }
+						ctaLabel={ translate( 'Learn more' ) }
+						externalUrl
+						url={ localizeUrl(
+							'https://wordpress.com/support/wordpress-editor/blocks/subscribe-block/'
+						) }
+					/>
+				) }
 
 				<GrowYourAudienceCard
 					icon={ trendingUp }

--- a/client/my-sites/subscribers/components/grow-your-audience/grow-your-audience.tsx
+++ b/client/my-sites/subscribers/components/grow-your-audience/grow-your-audience.tsx
@@ -1,4 +1,4 @@
-import { Card, CardBody, Icon } from '@wordpress/components';
+import { Card, CardBody, Icon, ExternalLink } from '@wordpress/components';
 import { chartBar, people, trendingUp } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { SectionContainer } from 'calypso/components/section';
@@ -10,6 +10,7 @@ import './style.scss';
 
 type GrowYourAudienceCardProps = {
 	ctaLabel: string;
+	externalUrl?: boolean;
 	icon: JSX.Element;
 	text: string;
 	title: string;
@@ -19,6 +20,7 @@ type GrowYourAudienceCardProps = {
 
 const GrowYourAudienceCard = ( {
 	ctaLabel,
+	externalUrl,
 	icon,
 	text,
 	title,
@@ -31,9 +33,15 @@ const GrowYourAudienceCard = ( {
 				{ title }
 			</h3>
 			<p className="grow-your-audience__card-text">{ text }</p>
-			<a className="grow-your-audience__card-link" href={ url } target="_blank" rel="noreferrer">
-				{ ctaLabel }
-			</a>
+			{ externalUrl ? (
+				<ExternalLink className="grow-your-audience__card-link" href={ url }>
+					{ ctaLabel }
+				</ExternalLink>
+			) : (
+				<a className="grow-your-audience__card-link" href={ url }>
+					{ ctaLabel }
+				</a>
+			) }
 		</CardBody>
 	</Card>
 );
@@ -64,6 +72,7 @@ const GrowYourAudience = () => {
 					) }
 					title={ translate( 'Keep your readers engaged' ) }
 					ctaLabel={ translate( 'Learn more' ) }
+					externalUrl
 					url="https://wordpress.com/go/content-blogging/how-to-start-a-successful-blog-that-earns-links-traffic-and-revenue/#creating-a-blog-content-strategy" // eslint-disable-line wpcalypso/i18n-unlocalized-url
 				/>
 

--- a/client/my-sites/subscribers/components/grow-your-audience/grow-your-audience.tsx
+++ b/client/my-sites/subscribers/components/grow-your-audience/grow-your-audience.tsx
@@ -1,4 +1,3 @@
-import { localizeUrl } from '@automattic/i18n-utils';
 import { Card, CardBody, Icon } from '@wordpress/components';
 import { chartBar, people, trendingUp } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
@@ -10,6 +9,7 @@ import { getEarnPageUrl } from '../../helpers';
 import './style.scss';
 
 type GrowYourAudienceCardProps = {
+	ctaLabel: string;
 	icon: JSX.Element;
 	text: string;
 	title: string;
@@ -18,40 +18,25 @@ type GrowYourAudienceCardProps = {
 };
 
 const GrowYourAudienceCard = ( {
+	ctaLabel,
 	icon,
 	text,
 	title,
-	tracksEventCta,
 	url,
-}: GrowYourAudienceCardProps ) => {
-	const translate = useTranslate();
-
-	const onClick = () =>
-		recordTracksEvent( 'calypso_subscriber_management_growth_cta_click', {
-			cta: tracksEventCta,
-		} );
-
-	return (
-		<Card className="grow-your-audience__card" size="small">
-			<CardBody className="grow-your-audience__card-body">
-				<h3 className="grow-your-audience__card-title">
-					<Icon className="grow-your-audience__card-icon" icon={ icon } size={ 20 } />
-					{ title }
-				</h3>
-				<p className="grow-your-audience__card-text">{ text }</p>
-				<a
-					className="grow-your-audience__card-link"
-					href={ url }
-					onClick={ onClick }
-					target="_blank"
-					rel="noreferrer"
-				>
-					{ translate( 'Learn more' ) }
-				</a>
-			</CardBody>
-		</Card>
-	);
-};
+}: GrowYourAudienceCardProps ) => (
+	<Card className="grow-your-audience__card" size="small">
+		<CardBody className="grow-your-audience__card-body">
+			<h3 className="grow-your-audience__card-title">
+				<Icon className="grow-your-audience__card-icon" icon={ icon } size={ 20 } />
+				{ title }
+			</h3>
+			<p className="grow-your-audience__card-text">{ text }</p>
+			<a className="grow-your-audience__card-link" href={ url } target="_blank" rel="noreferrer">
+				{ ctaLabel }
+			</a>
+		</CardBody>
+	</Card>
+);
 
 const GrowYourAudience = () => {
 	const translate = useTranslate();
@@ -65,13 +50,11 @@ const GrowYourAudience = () => {
 				<GrowYourAudienceCard
 					icon={ chartBar }
 					text={ translate(
-						'Using a subscriber block is the first step to growing your audience.'
+						'Take a look at your stats and refine your content strategy for better engagement.'
 					) }
-					title={ translate( 'Every visitor is a potential subscriber' ) }
-					tracksEventCta="subscribe-block"
-					url={ localizeUrl(
-						'https://wordpress.com/support/wordpress-editor/blocks/subscribe-block/'
-					) }
+					title={ translate( 'Explore your stats' ) }
+					ctaLabel={ translate( 'Check stats' ) }
+					url={ `/stats/subscribers/${ selectedSiteSlug }` }
 				/>
 
 				<GrowYourAudienceCard
@@ -80,7 +63,7 @@ const GrowYourAudience = () => {
 						'Create fresh content, publish regularly, and understand your audience with site stats.'
 					) }
 					title={ translate( 'Keep your readers engaged' ) }
-					tracksEventCta="go-content-strategy"
+					ctaLabel={ translate( 'Learn more' ) }
 					url="https://wordpress.com/go/content-blogging/how-to-start-a-successful-blog-that-earns-links-traffic-and-revenue/#creating-a-blog-content-strategy" // eslint-disable-line wpcalypso/i18n-unlocalized-url
 				/>
 
@@ -90,7 +73,7 @@ const GrowYourAudience = () => {
 						'Allow your readers to support your work with paid subscriptions, gated content, or tips.'
 					) }
 					title={ translate( 'Start earning' ) }
-					tracksEventCta="earn"
+					ctaLabel={ translate( 'Learn more' ) }
 					url={ getEarnPageUrl( selectedSiteSlug ) }
 				/>
 			</div>

--- a/client/my-sites/subscribers/components/grow-your-audience/grow-your-audience.tsx
+++ b/client/my-sites/subscribers/components/grow-your-audience/grow-your-audience.tsx
@@ -5,7 +5,6 @@ import { SectionContainer } from 'calypso/components/section';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector } from 'calypso/state';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-import { getEarnPageUrl } from '../../helpers';
 import './style.scss';
 
 type GrowYourAudienceCardProps = {
@@ -66,6 +65,16 @@ const GrowYourAudience = () => {
 				/>
 
 				<GrowYourAudienceCard
+					icon={ trendingUp }
+					text={ translate(
+						'Allow your readers to support your work with paid subscriptions, gated content, or tips.'
+					) }
+					title={ translate( 'Start earning' ) }
+					ctaLabel={ translate( 'Learn more' ) }
+					url={ `/earn/${ selectedSiteSlug ?? '' }` }
+				/>
+
+				<GrowYourAudienceCard
 					icon={ people }
 					text={ translate(
 						'Create fresh content, publish regularly, and understand your audience with site stats.'
@@ -74,16 +83,6 @@ const GrowYourAudience = () => {
 					ctaLabel={ translate( 'Learn more' ) }
 					externalUrl
 					url="https://wordpress.com/go/content-blogging/how-to-start-a-successful-blog-that-earns-links-traffic-and-revenue/#creating-a-blog-content-strategy" // eslint-disable-line wpcalypso/i18n-unlocalized-url
-				/>
-
-				<GrowYourAudienceCard
-					icon={ trendingUp }
-					text={ translate(
-						'Allow your readers to support your work with paid subscriptions, gated content, or tips.'
-					) }
-					title={ translate( 'Start earning' ) }
-					ctaLabel={ translate( 'Learn more' ) }
-					url={ getEarnPageUrl( selectedSiteSlug ) }
 				/>
 			</div>
 		</SectionContainer>

--- a/client/my-sites/subscribers/helpers/index.ts
+++ b/client/my-sites/subscribers/helpers/index.ts
@@ -1,11 +1,6 @@
 import { SubscriberListArgs } from '../types';
 
-const URL_PREFIX = 'https://wordpress.com';
-
-const getEarnPageUrl = ( siteSlug: string | null ) => `${ URL_PREFIX }/earn/${ siteSlug ?? '' }`;
-
-const getEarnPaymentsPageUrl = ( siteSlug: string | null ) =>
-	`${ URL_PREFIX }/earn/payments/${ siteSlug ?? '' }`;
+const getEarnPaymentsPageUrl = ( siteSlug: string | null ) => `/earn/payments/${ siteSlug ?? '' }`;
 
 const getSubscribersCacheKey = (
 	siteId: number | undefined | null,
@@ -93,7 +88,6 @@ const sanitizeInt = ( intString: string ) => {
 const getSubscriberDetailsType = ( userId: number | undefined ) => ( userId ? 'wpcom' : 'email' );
 
 export {
-	getEarnPageUrl,
 	getEarnPaymentsPageUrl,
 	getSubscriberDetailsCacheKey,
 	getSubscriberDetailsUrl,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

* Adds link to subscriber stats, removes "subscriber block" link. The subscriber block link is at empty state of this page still, when it should be most useful.
* Swaps order of "earn" and "go" cards
* Adds "external link" indicator to go article link
* Removes helper for earn links to simplify.

Note that old card shows for non-English locales until those strings have been translated.


**Before**
![image](https://github.com/Automattic/wp-calypso/assets/87168/a5e83cb6-c823-49b3-a47a-8a14f1e9827a)

**After**

<img width="1188" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/d4a5b2f0-8d1d-400e-a06c-2290fd72e065">


I'll want to merge adding tracks events first (https://github.com/Automattic/wp-calypso/pull/83422) wait a couple days for data, rebase, and then merge this.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Users → Subscribers
* Your site should have subscribers, or you won't see growth section
* See card at growth section, links should work.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?