### PR TITLE
Headers: Add ScreenOptionsTab as an option in NavigationHeader

### DIFF
--- a/client/components/navigation-header/index.tsx
+++ b/client/components/navigation-header/index.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import React, { ReactNode } from 'react';
 import Breadcrumb, { Item as TBreadcrumbItem } from 'calypso/components/breadcrumb';
+import ScreenOptionsTab from 'calypso/components/screen-options-tab';
 import FormattedHeader from '../formatted-header';
 
 import './style.scss';
@@ -38,6 +39,7 @@ interface Props {
 	title?: string | ReactNode;
 	subtitle?: string | ReactNode;
 	screenReader?: string | ReactNode;
+	screenOptionsTab?: string;
 }
 
 const NavigationHeader = React.forwardRef< HTMLElement, Props >( ( props, ref ) => {
@@ -51,6 +53,7 @@ const NavigationHeader = React.forwardRef< HTMLElement, Props >( ( props, ref ) 
 		title,
 		subtitle,
 		screenReader,
+		screenOptionsTab,
 	} = props;
 	return (
 		<header id={ id } className={ 'navigation-header ' + className } ref={ ref }>
@@ -71,6 +74,7 @@ const NavigationHeader = React.forwardRef< HTMLElement, Props >( ( props, ref ) 
 						/>
 					) }
 					<ActionsContainer>{ children }</ActionsContainer>
+					{ screenOptionsTab && <ScreenOptionsTab wpAdminPath={ screenOptionsTab } /> }
 				</div>
 			</Container>
 		</header>

--- a/client/my-sites/comments/main.jsx
+++ b/client/my-sites/comments/main.jsx
@@ -8,7 +8,6 @@ import InlineSupportLink from 'calypso/components/inline-support-link';
 import { JetpackConnectionHealthBanner } from 'calypso/components/jetpack/connection-health';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
-import ScreenOptionsTab from 'calypso/components/screen-options-tab';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { preventWidows } from 'calypso/lib/formatting';
 import { withJetpackConnectionProblem } from 'calypso/state/jetpack-connection-health/selectors/is-jetpack-connection-problem.js';
@@ -63,7 +62,6 @@ export class CommentsManagement extends Component {
 
 		return (
 			<Main className="comments" wideLayout>
-				<ScreenOptionsTab wpAdminPath="edit-comments.php" />
 				<PageViewTracker path={ analyticsPath } title="Comments" />
 				{ isJetpack && isPossibleJetpackConnectionProblem && (
 					<JetpackConnectionHealthBanner siteId={ siteId } />
@@ -71,6 +69,7 @@ export class CommentsManagement extends Component {
 				<DocumentHead title={ translate( 'Comments' ) } />
 				{ ! showPermissionError && (
 					<NavigationHeader
+						screenOptionsTab="edit-comments.php"
 						navigationItems={ [] }
 						title={ translate( 'Comments' ) }
 						subtitle={ translate(

--- a/client/my-sites/importer/section-import.jsx
+++ b/client/my-sites/importer/section-import.jsx
@@ -12,7 +12,6 @@ import EmptyContent from 'calypso/components/empty-content';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
-import ScreenOptionsTab from 'calypso/components/screen-options-tab';
 import SectionHeader from 'calypso/components/section-header';
 import { getImporterByKey, getImporters } from 'calypso/lib/importer/importer-config';
 import { EVERY_FIVE_SECONDS, Interval } from 'calypso/lib/interval';
@@ -337,9 +336,9 @@ class SectionImport extends Component {
 
 		return (
 			<Main>
-				<ScreenOptionsTab wpAdminPath="import.php" />
 				<DocumentHead title={ translate( 'Import Content' ) } />
 				<NavigationHeader
+					screenOptionsTab="import.php"
 					navigationItems={ [] }
 					title={ translate( 'Import Content' ) }
 					subtitle={ translate(

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -11,7 +11,6 @@ import InlineSupportLink from 'calypso/components/inline-support-link';
 import { JetpackConnectionHealthBanner } from 'calypso/components/jetpack/connection-health';
 import NavigationHeader from 'calypso/components/navigation-header';
 import Notice from 'calypso/components/notice';
-import ScreenOptionsTab from 'calypso/components/screen-options-tab';
 import { withEditMedia } from 'calypso/data/media/use-edit-media-mutation';
 import { withDeleteMedia } from 'calypso/data/media/with-delete-media';
 import accept from 'calypso/lib/accept';
@@ -365,7 +364,6 @@ class Media extends Component {
 
 		return (
 			<div ref={ this.containerRef } className="main main-column media" role="main">
-				<ScreenOptionsTab wpAdminPath="upload.php" />
 				{ mediaId && site && site.ID && <QueryMedia siteId={ site.ID } mediaId={ mediaId } /> }
 				<PageViewTracker path={ this.getAnalyticsPath() } title="Media" />
 				{ isJetpack && isPossibleJetpackConnectionProblem && (
@@ -373,6 +371,7 @@ class Media extends Component {
 				) }
 				<DocumentHead title={ translate( 'Media' ) } />
 				<NavigationHeader
+					screenOptionsTab="upload.php?preferred-view=classic"
 					title={ translate( 'Media' ) }
 					subtitle={ translate(
 						'Manage all the media on your site, including images, video, and more. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
@@ -382,9 +381,7 @@ class Media extends Component {
 							},
 						}
 					) }
-				>
-					<ScreenOptionsTab wpAdminPath="upload.php?preferred-view=classic" />
-				</NavigationHeader>
+				/>
 
 				{ this.props.selectedSite.is_private && this.props.selectedSite.is_wpcom_atomic && (
 					<Notice

--- a/client/my-sites/pages/main.jsx
+++ b/client/my-sites/pages/main.jsx
@@ -10,7 +10,6 @@ import InlineSupportLink from 'calypso/components/inline-support-link';
 import { JetpackConnectionHealthBanner } from 'calypso/components/jetpack/connection-health';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
-import ScreenOptionsTab from 'calypso/components/screen-options-tab';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { Experiment } from 'calypso/lib/explat';
 import { mapPostStatus } from 'calypso/lib/route';
@@ -95,7 +94,6 @@ class PagesMain extends Component {
 
 		return (
 			<Main wideLayout classname="pages">
-				<ScreenOptionsTab wpAdminPath="edit.php?post_type=page" />
 				<PageViewTracker path={ this.getAnalyticsPath() } title={ this.getAnalyticsTitle() } />
 				{ isJetpack && isPossibleJetpackConnectionProblem && (
 					<JetpackConnectionHealthBanner siteId={ siteId } />
@@ -103,6 +101,7 @@ class PagesMain extends Component {
 				<DocumentHead title={ translate( 'Pages' ) } />
 				<SitePreview />
 				<NavigationHeader
+					screenOptionsTab="edit.php?post_type=page"
 					navigationItems={ [] }
 					title={ translate( 'Pages' ) }
 					subtitle={ translate(

--- a/client/my-sites/people/main.jsx
+++ b/client/my-sites/people/main.jsx
@@ -6,7 +6,6 @@ import EmptyContent from 'calypso/components/empty-content';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
-import ScreenOptionsTab from 'calypso/components/screen-options-tab';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import P2TeamBanner from 'calypso/my-sites/people/p2-team-banner';
 import PeopleSectionNav from 'calypso/my-sites/people/people-section-nav';
@@ -167,12 +166,12 @@ class People extends Component {
 
 		return (
 			<Main>
-				<ScreenOptionsTab wpAdminPath="users.php" />
 				<PageViewTracker
 					path={ `/people/${ filter }/:site` }
 					title={ `People > ${ titlecase( filter ) }` }
 				/>
 				<NavigationHeader
+					screenOptionsTab="users.php"
 					navigationItems={ [] }
 					title={ this.renderHeaderText() }
 					subtitle={ this.renderSubheaderText() }

--- a/client/my-sites/people/subscribers-team/index.tsx
+++ b/client/my-sites/people/subscribers-team/index.tsx
@@ -4,7 +4,6 @@ import InlineSupportLink from 'calypso/components/inline-support-link';
 import { JetpackConnectionHealthBanner } from 'calypso/components/jetpack/connection-health';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
-import ScreenOptionsTab from 'calypso/components/screen-options-tab';
 import SectionNav from 'calypso/components/section-nav';
 import useFollowersQuery from 'calypso/data/followers/use-followers-query';
 import useUsersQuery from 'calypso/data/users/use-users-query';
@@ -55,11 +54,11 @@ function SubscribersTeam( props: Props ) {
 
 	return (
 		<Main>
-			<ScreenOptionsTab wpAdminPath="users.php" />
 			{ isJetpack && isPossibleJetpackConnectionProblem && site?.ID && (
 				<JetpackConnectionHealthBanner siteId={ site.ID } />
 			) }
 			<NavigationHeader
+				screenOptionsTab="users.php"
 				navigationItems={ [] }
 				title={ translate( 'Users' ) }
 				subtitle={ translate(

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -9,7 +9,6 @@ import InlineSupportLink from 'calypso/components/inline-support-link';
 import { JetpackConnectionHealthBanner } from 'calypso/components/jetpack/connection-health';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
-import ScreenOptionsTab from 'calypso/components/screen-options-tab';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { mapPostStatus } from 'calypso/lib/route';
 import PostTypeFilter from 'calypso/my-sites/post-type-filter';
@@ -96,10 +95,10 @@ class PostsMain extends Component {
 						messagePath="wp:edit-post:admin_notices"
 					/>
 				) }
-				<ScreenOptionsTab wpAdminPath="edit.php" />
 				<PageViewTracker path={ this.getAnalyticsPath() } title={ this.getAnalyticsTitle() } />
 				<DocumentHead title={ translate( 'Posts' ) } />
 				<NavigationHeader
+					screenOptionsTab="edit.php"
 					navigationItems={ [] }
 					title={ translate( 'Posts' ) }
 					subtitle={ translate(

--- a/client/my-sites/site-settings/main.jsx
+++ b/client/my-sites/site-settings/main.jsx
@@ -8,7 +8,6 @@ import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import { JetpackConnectionHealthBanner } from 'calypso/components/jetpack/connection-health';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
-import ScreenOptionsTab from 'calypso/components/screen-options-tab';
 import { withJetpackConnectionProblem } from 'calypso/state/jetpack-connection-health/selectors/is-jetpack-connection-problem.js';
 import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -26,7 +25,6 @@ const SiteSettingsComponent = ( {
 } ) => {
 	return (
 		<Main className="site-settings">
-			<ScreenOptionsTab wpAdminPath="options-general.php" />
 			{ isJetpack && isPossibleJetpackConnectionProblem && (
 				<JetpackConnectionHealthBanner siteId={ siteId } />
 			) }
@@ -36,6 +34,7 @@ const SiteSettingsComponent = ( {
 			<JetpackDevModeNotice />
 			<JetpackBackupCredsBanner event="settings-backup-credentials" />
 			<NavigationHeader
+				screenOptionsTab="options-general.php"
 				navigationItems={ [] }
 				title={ translate( 'General Settings' ) }
 				subtitle={ translate(

--- a/client/my-sites/site-settings/settings-discussion/main.jsx
+++ b/client/my-sites/site-settings/settings-discussion/main.jsx
@@ -4,7 +4,6 @@ import DocumentHead from 'calypso/components/data/document-head';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
-import ScreenOptionsTab from 'calypso/components/screen-options-tab';
 import { FediverseSettingsSection } from 'calypso/my-sites/site-settings/fediverse-settings';
 import DiscussionForm from 'calypso/my-sites/site-settings/form-discussion';
 import JetpackDevModeNotice from 'calypso/my-sites/site-settings/jetpack-dev-mode-notice';
@@ -13,10 +12,10 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 const SiteSettingsDiscussion = ( { site, translate } ) => (
 	<Main className="settings-discussion site-settings">
-		<ScreenOptionsTab wpAdminPath="options-discussion.php" />
 		<DocumentHead title={ translate( 'Discussion Settings' ) } />
 		<JetpackDevModeNotice />
 		<NavigationHeader
+			screenOptionsTab="options-discussion.php"
 			navigationItems={ [] }
 			title={ translate( 'Discussion Settings' ) }
 			subtitle={ translate(

--- a/client/my-sites/site-settings/settings-reading/main.tsx
+++ b/client/my-sites/site-settings/settings-reading/main.tsx
@@ -5,7 +5,6 @@ import DocumentHead from 'calypso/components/data/document-head';
 import { JetpackConnectionHealthBanner } from 'calypso/components/jetpack/connection-health';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
-import ScreenOptionsTab from 'calypso/components/screen-options-tab';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import { useSelector } from 'calypso/state';
 import { useIsJetpackConnectionProblem } from 'calypso/state/jetpack-connection-health/selectors/is-jetpack-connection-problem.js';
@@ -198,12 +197,15 @@ const ReadingSettings = () => {
 
 	return (
 		<Main className="site-settings site-settings__reading-settings">
-			<ScreenOptionsTab wpAdminPath="options-reading.php" />
 			{ isJetpack && isPossibleJetpackConnectionProblem && siteId && (
 				<JetpackConnectionHealthBanner siteId={ siteId } />
 			) }
 			<DocumentHead title={ translate( 'Reading Settings' ) } />
-			<NavigationHeader navigationItems={ [] } title={ translate( 'Reading Settings' ) } />
+			<NavigationHeader
+				screenOptionsTab="options-reading.php"
+				navigationItems={ [] }
+				title={ translate( 'Reading Settings' ) }
+			/>
 			<ReadingSettingsForm />
 		</Main>
 	);

--- a/client/my-sites/site-settings/settings-writing/main.jsx
+++ b/client/my-sites/site-settings/settings-writing/main.jsx
@@ -3,7 +3,6 @@ import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
-import ScreenOptionsTab from 'calypso/components/screen-options-tab';
 import WritingForm from 'calypso/my-sites/site-settings/form-writing';
 import JetpackDevModeNotice from 'calypso/my-sites/site-settings/jetpack-dev-mode-notice';
 import SiteSettingsNavigation from 'calypso/my-sites/site-settings/navigation';
@@ -11,10 +10,10 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 const SiteSettingsWriting = ( { site, translate } ) => (
 	<Main className="settings-writing site-settings">
-		<ScreenOptionsTab wpAdminPath="options-writing.php" />
 		<DocumentHead title={ translate( 'Writing Settings' ) } />
 		<JetpackDevModeNotice />
 		<NavigationHeader
+			screenOptionsTab="options-writing.php"
 			navigationItems={ [] }
 			title={ translate( 'Writing Settings' ) }
 			subtitle={ translate( "Manage settings related to your site's content." ) }

--- a/client/my-sites/site-settings/taxonomies/index.jsx
+++ b/client/my-sites/site-settings/taxonomies/index.jsx
@@ -7,7 +7,6 @@ import DocumentHead from 'calypso/components/data/document-head';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
-import ScreenOptionsTab from 'calypso/components/screen-options-tab';
 import { getPostTypeTaxonomy } from 'calypso/state/post-types/taxonomies/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 
@@ -18,11 +17,11 @@ const Taxonomies = ( { translate, labels, postType, taxonomy } ) => {
 
 	return (
 		<Main wideLayout className={ classnames( 'taxonomies', taxonomy ) }>
-			<ScreenOptionsTab wpAdminPath={ `edit-tags.php?taxonomy=${ taxonomy }` } />
 			<DocumentHead
 				title={ translate( 'Manage %(taxonomy)s', { args: { taxonomy: labels.name } } ) }
 			/>
 			<NavigationHeader
+				screenOptionsTab={ `edit-tags.php?taxonomy=${ taxonomy }` }
 				navigationItems={ [] }
 				title={ labels.name }
 				subtitle={ translate(

--- a/client/my-sites/themes/theme-showcase-header.jsx
+++ b/client/my-sites/themes/theme-showcase-header.jsx
@@ -3,7 +3,6 @@ import { useSelector } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import NavigationHeader from 'calypso/components/navigation-header';
-import ScreenOptionsTab from 'calypso/components/screen-options-tab';
 import { preventWidows } from 'calypso/lib/formatting';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -76,6 +75,7 @@ export default function ThemeShowcaseHeader( {
 			<DocumentHead title={ documentHeadTitle } meta={ metas } />
 			{ isLoggedIn ? (
 				<NavigationHeader
+					screenOptionsTab="themes.php"
 					compactBreadcrumb={ false }
 					navigationItems={ [] }
 					mobileItem={ null }
@@ -92,7 +92,6 @@ export default function ThemeShowcaseHeader( {
 					{ selectedSiteId && (
 						<>
 							<InstallThemeButton />
-							<ScreenOptionsTab wpAdminPath="themes.php" />
 						</>
 					) }
 				</NavigationHeader>


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/4229

## Proposed Changes

As some of the pages (like `/themes`) use the `ScreenOptionsTab` component, we added the `screenOptionsTab` option to the `NavigationHeader`
We also updated the pages that uses `NavigationHeader` & `screenOptionsTab` component to use the NavigationHeader's screenOptionsTab option instead.

| Closed | Opened |
| --- | --- |
| <img width="396" alt="image" src="https://github.com/Automattic/wp-calypso/assets/402286/80e372c1-da4a-40c4-8f16-d11623693eb8"> | <img width="291" alt="image" src="https://github.com/Automattic/wp-calypso/assets/402286/defa8187-9fcf-423a-a76a-c4d5a63dcdce"> |

## Testing Instructions

Check the view options on the top-right of the screen and the classic view link in the following paths:
- http://calypso.localhost:3000/media/:site-slug
- http://calypso.localhost:3000/posts/:site-slug
- http://calypso.localhost:3000/pages/:site-slug
- http://calypso.localhost:3000/import/:site-slug
- http://calypso.localhost:3000/comments/all/:site-slug
- http://calypso.localhost:3000/people/team/:site-slug
- http://calypso.localhost:3000/settings/general/:site-slug
- http://calypso.localhost:3000/settings/writing/:site-slug
- http://calypso.localhost:3000/settings/reading/:site-slug
- http://calypso.localhost:3000/settings/discussion/:site-slug
