### PR TITLE
Happy Blocks: Missing url localization for support content footer

### DIFF
--- a/apps/happy-blocks/block-library/support-content-links/index.php
+++ b/apps/happy-blocks/block-library/support-content-links/index.php
@@ -23,7 +23,7 @@
 	</p>
 	<p>
 		<?php esc_html_e( 'New to WordPress.com? ', 'happy-blocks' ); ?>
-		<a href="<?php echo esc_url( 'https://wordpress.com/plans/' ); ?>" target="_blank" rel="noreferrer noopener">
+		<a href="<?php echo esc_url( localized_wpcom_url( 'https://wordpress.com/plans/' ) ); ?>" target="_blank" rel="noreferrer noopener">
 			<?php esc_html_e( 'Find your perfect-fit plan here.', 'happy-blocks' ); ?>
 		</a>
 	</p>


### PR DESCRIPTION
We changed a link in https://github.com/Automattic/wp-calypso/pull/83413, for the support content footer.

This PR simply adds localization to that URL.