### PR TITLE
Fix domain badge styling for domains/add

### DIFF
--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -39,11 +39,10 @@
 	}
 
 	.badge {
-		margin-left: 0;
 		border-radius: 4px;
 		font-size: 0.75rem;
 		font-weight: 500;
-		margin-right: 4px;
+		margin: 2px 4px 0 0;
 
 		&.badge--warning {
 			background-color: var(--color-warning-10);
@@ -218,7 +217,6 @@
 	word-break: break-all;
 
 	@include breakpoint-deprecated( ">480px" ) {
-		align-self: center;
 		padding-right: 2em;
 	}
 }
@@ -316,7 +314,6 @@ body.is-section-signup.is-white-signup {
 
 	.domain-registration-suggestion__badges {
 		margin-left: 0;
-		margin-top: 2px;
 		margin-bottom: 10px;
 
 		.badge {


### PR DESCRIPTION
Related to p1698160608748919/1698096553.075489-slack-C05CT832K2T

## Proposed Changes

* Fix badge alignment on domains/add

Before:
<img width="1017" alt="Screen Shot 2023-10-24 at 11 12 20 AM" src="https://github.com/Automattic/wp-calypso/assets/1689238/6c17f829-7f9d-4a41-915d-63ff5315f7d0">

After:
<img width="1039" alt="Screen Shot 2023-10-24 at 1 20 46 PM" src="https://github.com/Automattic/wp-calypso/assets/1689238/4feb08cd-f72f-40da-8b26-1851e36fa174">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /domains/add/{site}
* Search for a domain
* Verify that the Sale badges are vertically aligned with the suggested domains.
* Check the badge position in the `/start/domain/domain-only` and `start/domains` flows.
* Check that the badges are also aligned on mobile.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?