### PR TITLE
Newsletter "tier" type

### DIFF
--- a/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
+++ b/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
@@ -234,18 +234,25 @@ const RecurringPaymentsPlanAddEditModal = ( {
 		title: productDetails.title + __( '(yearly)', 'jetpack' ),
 	} );
 
-	const getCurrentProductDetails = (): Product => ( {
-		currency: currentCurrency,
-		price: currentPrice,
-		title: editedProductName,
-		interval: editedSchedule,
-		buyer_can_change_amount: editedPayWhatYouWant,
-		multiple_per_user: editedMultiplePerUser,
-		type: editedPostIsTier ? TIER_TYPE : null,
-		welcome_email_content: editedCustomConfirmationMessage,
-		subscribe_as_site_subscriber: editedPostPaidNewsletter,
-		is_editable: true,
-	} );
+	const getCurrentProductDetails = (): Product => {
+		const product: Product = {
+			currency: currentCurrency,
+			price: currentPrice,
+			title: editedProductName,
+			interval: editedSchedule,
+			buyer_can_change_amount: editedPayWhatYouWant,
+			multiple_per_user: editedMultiplePerUser,
+			welcome_email_content: editedCustomConfirmationMessage,
+			subscribe_as_site_subscriber: editedPostPaidNewsletter,
+			is_editable: true,
+		};
+
+		if ( editedPostIsTier ) {
+			product.type = TIER_TYPE;
+		}
+
+		return product;
+	};
 
 	const onClose = ( reason: string | undefined ) => {
 		if ( reason === 'submit' && ( ! product || ! product.ID ) ) {

--- a/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
+++ b/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
@@ -135,7 +135,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 	);
 
 	const [ editedPostIsTier, setEditedPostIsTier ] = useState(
-		product?.type === TIER_TYPE ?? false
+		( product?.type === TIER_TYPE || product?.subscribe_as_site_subscriber ) ?? false
 	);
 
 	const [ editedSchedule, setEditedSchedule ] = useState(

--- a/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
+++ b/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
@@ -241,6 +241,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 		interval: editedSchedule,
 		buyer_can_change_amount: editedPayWhatYouWant,
 		multiple_per_user: editedMultiplePerUser,
+		type: editedPostIsTier ? TIER_TYPE : null,
 		welcome_email_content: editedCustomConfirmationMessage,
 		subscribe_as_site_subscriber: editedPostPaidNewsletter,
 		is_editable: true,

--- a/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
+++ b/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
@@ -18,6 +18,7 @@ import {
 	PLAN_YEARLY_FREQUENCY,
 	PLAN_MONTHLY_FREQUENCY,
 	PLAN_ONE_TIME_FREQUENCY,
+	TIER_TYPE,
 } from 'calypso/my-sites/earn/memberships/constants';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -132,6 +133,11 @@ const RecurringPaymentsPlanAddEditModal = ( {
 	const [ editedPostPaidNewsletter, setEditedPostPaidNewsletter ] = useState(
 		product?.subscribe_as_site_subscriber ?? false
 	);
+
+	const [ editedPostIsTier, setEditedPostIsTier ] = useState(
+		product?.type === TIER_TYPE ?? false
+	);
+
 	const [ editedSchedule, setEditedSchedule ] = useState(
 		product?.renewal_schedule ?? PLAN_MONTHLY_FREQUENCY
 	);
@@ -244,11 +250,12 @@ const RecurringPaymentsPlanAddEditModal = ( {
 		if ( reason === 'submit' && ( ! product || ! product.ID ) ) {
 			const productDetails: Product = getCurrentProductDetails();
 
-			if ( editedPostPaidNewsletter ) {
+			if ( editedPostPaidNewsletter || editedPostIsTier ) {
 				const annualProductDetails = {
 					...productDetails,
 					interval: PLAN_YEARLY_FREQUENCY,
 					price: currentAnnualPrice,
+					type: TIER_TYPE,
 				};
 				dispatch(
 					requestAddTier(
@@ -274,7 +281,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 			const productDetails = getCurrentProductDetails();
 			productDetails.ID = product.ID;
 
-			if ( ! editedPostPaidNewsletter ) {
+			if ( ! ( editedPostPaidNewsletter || editedPostIsTier ) ) {
 				dispatch(
 					requestUpdateProduct(
 						siteId ?? selectedSiteId,
@@ -350,7 +357,10 @@ const RecurringPaymentsPlanAddEditModal = ( {
 				</FormFieldset>
 				<FormFieldset className="memberships__dialog-sections-type">
 					<ToggleControl
-						onChange={ ( newValue ) => setEditedPostPaidNewsletter( newValue ) }
+						onChange={ ( newValue ) => {
+							setEditedPostPaidNewsletter( newValue );
+							setEditedPostIsTier( newValue );
+						} }
 						checked={ editedPostPaidNewsletter }
 						disabled={ !! product.ID }
 						label={ translate( 'Paid newsletter tier' ) }

--- a/client/my-sites/earn/memberships/constants.ts
+++ b/client/my-sites/earn/memberships/constants.ts
@@ -7,3 +7,5 @@ export const PLAN_MONTHLY_FREQUENCY = '1 month';
 export const PLAN_YEARLY_FREQUENCY = '1 year';
 
 export const PLAN_ONE_TIME_FREQUENCY = 'one-time';
+
+export const TIER_TYPE = 'tier';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/gold/issues/192

## Proposed Changes

* Apply D126468-code

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?