### PR TITLE
Login page: Add magic-login link if wrong password

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -629,6 +629,24 @@ export class LoginForm extends Component {
 
 		const magicLoginPageLinkWithEmail = addQueryArgs( { email_address: emailAddress }, loginLink );
 
+		if (
+			hasTranslation(
+				'It seems you entered an incorrect password. Want to get a {{magicLoginLink}}login link{{/magicLoginLink}} via email?'
+			) ||
+			englishLocales.includes( this.props.locale )
+		) {
+			return this.props.translate(
+				'It seems you entered an incorrect password. Want to get a {{magicLoginLink}}login link{{/magicLoginLink}} via email?',
+				{
+					components: {
+						magicLoginLink: (
+							<a href={ magicLoginPageLinkWithEmail } onClick={ this.handleMagicLoginClick } />
+						),
+					},
+				}
+			);
+		}
+
 		return this.props.translate(
 			'Would you like to {{magicLoginLink}}receive a login link{{/magicLoginLink}}?',
 			{
@@ -828,10 +846,7 @@ export class LoginForm extends Component {
 							/>
 
 							{ requestError && requestError.field === 'password' && (
-								<FormInputValidation isError text={ requestError.message }>
-									{ ' ' }
-									{ this.renderMagicLoginLink() }
-								</FormInputValidation>
+								<FormInputValidation isError text={ this.renderMagicLoginLink() } />
 							) }
 						</div>
 					</div>

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -630,7 +630,7 @@ export class LoginForm extends Component {
 		const magicLoginPageLinkWithEmail = addQueryArgs( { email_address: emailAddress }, loginLink );
 
 		return this.props.translate(
-			' Would you like to {{magicLoginLink}}receive a login link{{/magicLoginLink}}?',
+			'Would you like to {{magicLoginLink}}receive a login link{{/magicLoginLink}}?',
 			{
 				components: {
 					magicLoginLink: (

--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -168,3 +168,48 @@ export const isReactLostPasswordScreenEnabled = () => {
 		cookies.enable_react_password_screen === 'yes'
 	);
 };
+
+export const canDoMagicLogin = (
+	twoFactorAuthType,
+	oauth2Client,
+	wccomFrom,
+	isJetpackWooCommerceFlow
+) => {
+	if ( ! config.isEnabled( `login/magic-login` ) || twoFactorAuthType ) {
+		return false;
+	}
+
+	// jetpack cloud cannot have users being sent to WordPress.com
+	if ( isJetpackCloudOAuth2Client( oauth2Client ) ) {
+		return false;
+	}
+
+	if ( isWooOAuth2Client( oauth2Client ) && wccomFrom ) {
+		return false;
+	}
+
+	if ( isJetpackWooCommerceFlow ) {
+		return false;
+	}
+
+	return true;
+};
+
+export const getLoginLinkPageUrl = ( locale = 'en', currentRoute, signupUrl, oauth2ClientId ) => {
+	// The email address from the URL (if present) is added to the login
+	// parameters in this.handleMagicLoginLinkClick(). But it's left out
+	// here deliberately, to ensure that if someone copies this link to
+	// paste somewhere else, their email address isn't included in it.
+	const loginParameters = {
+		locale: locale,
+		twoFactorAuthType: 'link',
+		signupUrl: signupUrl,
+		oauth2ClientId,
+	};
+
+	if ( currentRoute === '/log-in/jetpack' ) {
+		loginParameters.twoFactorAuthType = 'jetpack/link';
+	}
+
+	return login( loginParameters );
+};

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -11,12 +11,13 @@ import { connect } from 'react-redux';
 import ExternalLink from 'calypso/components/external-link';
 import LoggedOutFormBackLink from 'calypso/components/logged-out-form/back-link';
 import { isDomainConnectAuthorizePath } from 'calypso/lib/domains/utils';
-import { getSignupUrl, pathWithLeadingSlash } from 'calypso/lib/login';
 import {
-	isCrowdsignalOAuth2Client,
-	isJetpackCloudOAuth2Client,
-	isWooOAuth2Client,
-} from 'calypso/lib/oauth2-clients';
+	getSignupUrl,
+	pathWithLeadingSlash,
+	canDoMagicLogin,
+	getLoginLinkPageUrl,
+} from 'calypso/lib/login';
+import { isCrowdsignalOAuth2Client, isJetpackCloudOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { login, lostPassword } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/url';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -88,7 +89,9 @@ export class LoginLinks extends Component {
 	handleMagicLoginLinkClick = ( event ) => {
 		event.preventDefault();
 
-		this.props.recordTracksEvent( 'calypso_login_magic_login_request_click' );
+		this.props.recordTracksEvent( 'calypso_login_magic_login_request_click', {
+			origin: 'login-links',
+		} );
 		this.props.resetMagicLoginRequestForm();
 
 		// Add typed email address as a query param
@@ -107,25 +110,6 @@ export class LoginLinks extends Component {
 
 	recordSignUpLinkClick = () => {
 		this.props.recordTracksEvent( 'calypso_login_sign_up_link_click', { origin: 'login-links' } );
-	};
-
-	getLoginLinkPageUrl = () => {
-		// The email address from the URL (if present) is added to the login
-		// parameters in this.handleMagicLoginLinkClick(). But it's left out
-		// here deliberately, to ensure that if someone copies this link to
-		// paste somewhere else, their email address isn't included in it.
-		const loginParameters = {
-			locale: this.props.locale,
-			twoFactorAuthType: 'link',
-			signupUrl: this.props.query?.signup_url,
-			oauth2ClientId: this.props.oauth2ClientId,
-		};
-
-		if ( this.props.currentRoute === '/log-in/jetpack' ) {
-			loginParameters.twoFactorAuthType = 'jetpack/link';
-		}
-
-		return login( loginParameters );
 	};
 
 	getLoginLinkText = () => {
@@ -224,7 +208,14 @@ export class LoginLinks extends Component {
 	}
 
 	renderMagicLoginLink() {
-		if ( ! config.isEnabled( 'login/magic-login' ) || this.props.twoFactorAuthType ) {
+		if (
+			! canDoMagicLogin(
+				this.props.twoFactorAuthType,
+				this.props.oauth2Client,
+				this.props.wccomFrom,
+				this.props.isJetpackWooCommerceFlow
+			)
+		) {
 			return null;
 		}
 
@@ -232,18 +223,12 @@ export class LoginLinks extends Component {
 			return null;
 		}
 
-		// jetpack cloud cannot have users being sent to WordPress.com
-		if ( isJetpackCloudOAuth2Client( this.props.oauth2Client ) ) {
-			return null;
-		}
-
-		// @todo Implement a muriel version of the email login links for the WooCommerce onboarding flows
-		if ( isWooOAuth2Client( this.props.oauth2Client ) && this.props.wccomFrom ) {
-			return null;
-		}
-		if ( this.props.isJetpackWooCommerceFlow ) {
-			return null;
-		}
+		const loginLink = getLoginLinkPageUrl(
+			this.props.locale,
+			this.props.currentRoute,
+			this.props.query?.signup_url,
+			this.props.oauth2ClientId
+		);
 
 		return (
 			<a
@@ -254,7 +239,7 @@ export class LoginLinks extends Component {
 				// A simpler solution would have been to add rel=external or
 				// rel=download, but it would have been semantically wrong.
 				ref={ this.loginLinkRef }
-				href={ this.getLoginLinkPageUrl() }
+				href={ loginLink }
 				key="magic-login-link"
 				data-e2e-link="magic-login-link"
 			>


### PR DESCRIPTION
During Login, we now offer a magic-login page link if the user uses a wrong password.

<img width="502" alt="image" src="https://github.com/Automattic/wp-calypso/assets/52076348/7f7bedd6-86ae-48e8-a292-b2960329ad7e">

## Testing
1. Live link and visit `/log-in`
2. Enter a valid email and a wrong password. You should see the new link.
3. Click and you should go to `/log-in/link?email_address=[YOUR EMAIL]`