### PR TITLE
Domains: Fix domain search filter bottom margin

### DIFF
--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -215,7 +215,7 @@ body.is-section-signup.is-white-signup {
 		}
 	}
 	.search-filters__buttons {
-		margin: 0 20px 48px;
+		margin: 0 20px 0;
 		padding: 0;
 		box-shadow: none;
 


### PR DESCRIPTION
Related to p1698161061401589/1698096553.075489-slack-C05CT832K2T

## Proposed Changes

* Reduce bottom margin on buttons in the Domains search filter.

Before | After
------- | -----
<img width="359" alt="Screen Shot 2023-10-24 at 11 23 07 AM" src="https://github.com/Automattic/wp-calypso/assets/1689238/8ddf0e55-f4e0-4e0c-b2d2-002e7da365ce"> | <img width="352" alt="Screen Shot 2023-10-24 at 1 43 56 PM" src="https://github.com/Automattic/wp-calypso/assets/1689238/68bfac24-d359-4568-bd3a-806bc46bb265">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to each of the domains flows: /start/domains, /start/domain/domain-only, /domains/add
* Click to filter the search
* Check that the filter modal has equal top and bottom padding

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?