### PR TITLE
Fixes the Promote post campaign geo target information

### DIFF
--- a/client/data/promote-post/types.ts
+++ b/client/data/promote-post/types.ts
@@ -5,15 +5,14 @@ export enum CampaignStatus {
 	'finished',
 }
 
-export const AudienceListKeys = {
-	topics: 'topics',
-	countries: 'countries',
-	devices: 'devices',
-	OSs: 'OSs',
-};
-
 export type AudienceList = {
-	[ key in keyof typeof AudienceListKeys ]: string;
+	devices: string;
+	cities: string;
+	states: string;
+	regions: string;
+	countries: string;
+	topics: string;
+	languages: string;
 };
 
 export type Campaign = {

--- a/client/data/promote-post/use-promote-post-campaigns-query.ts
+++ b/client/data/promote-post/use-promote-post-campaigns-query.ts
@@ -1,13 +1,9 @@
 import { useQuery } from '@tanstack/react-query';
 import { requestDSPHandleErrors } from 'calypso/lib/promote-post';
+import { AudienceList } from './types';
 
 export type CampaignResponse = {
-	audience_list: {
-		devices: string;
-		countries: string;
-		topics: string;
-		languages: string;
-	};
+	audience_list: AudienceList;
 	content_config: {
 		clickUrl: string;
 		title: string;

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -36,6 +36,7 @@ import {
 	getCampaignStatus,
 	getCampaignStatusBadgeColor,
 } from '../../utils';
+import TargetLocations from './target-locations';
 
 interface Props {
 	isLoading?: boolean;
@@ -126,10 +127,11 @@ export default function CampaignItemDetails( props: Props ) {
 	} );
 
 	// Target block
-	const devicesList = audience_list ? audience_list[ 'devices' ] : '';
-	const countriesList = audience_list ? audience_list[ 'countries' ] : '';
-	const topicsList = audience_list ? audience_list[ 'topics' ] : '';
-	const languagesList = audience_list ? audience_list[ 'languages' ] : '';
+	const {
+		devices: devicesList,
+		topics: topicsList,
+		languages: languagesList,
+	} = audience_list || {};
 
 	// Formatted labels
 	const ctrFormatted = clickthrough_rate ? `${ clickthrough_rate.toFixed( 2 ) }%` : '-';
@@ -141,7 +143,6 @@ export default function CampaignItemDetails( props: Props ) {
 	const campaignTitleFormatted = title || __( 'Untitled' );
 	const campaignCreatedFormatted = moment.utc( created_at ).format( 'MMMM DD, YYYY' );
 	const devicesListFormatted = devicesList ? `${ devicesList }` : __( 'All' );
-	const countriesListFormatted = countriesList ? `${ countriesList }` : __( 'Everywhere' );
 	const languagesListFormatted = languagesList
 		? `${ languagesList }`
 		: translate( 'All languages' );
@@ -519,8 +520,12 @@ export default function CampaignItemDetails( props: Props ) {
 										<span className="campaign-item-details__label">
 											{ translate( 'Location' ) }
 										</span>
-										<span className="campaign-item-details__details">
-											{ ! isLoading ? countriesListFormatted : <FlexibleSkeleton /> }
+										<span className="campaign-item-details__details campaign-item-details__locations">
+											{ ! isLoading ? (
+												<TargetLocations audienceList={ audience_list } />
+											) : (
+												<FlexibleSkeleton />
+											) }
 										</span>
 										<span className="campaign-item-details__label">
 											{ translate( 'Languages' ) }

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
@@ -312,6 +312,16 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 				margin-bottom: 24px;
 			}
 
+			.campaign-item-details__locations {
+				display: flex;
+				flex-direction: column;
+
+				i {
+					font-weight: 500;
+					font-style: normal;
+				}
+			}
+
 			.campaign-item-details__label .amount {
 				color: $studio-gray-60;
 				font-weight: 400;

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/target-locations.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/target-locations.tsx
@@ -1,0 +1,72 @@
+import { useTranslate } from 'i18n-calypso';
+import { FC } from 'react';
+import { AudienceList } from 'calypso/data/promote-post/types';
+
+interface Props {
+	audienceList?: AudienceList;
+}
+
+const TargetLocations: FC< Props > = ( { audienceList } ) => {
+	const translate = useTranslate();
+	const isUsingNewGeoLocationData = !! audienceList && 'cities' in audienceList; // We didn't sent this field in the previous model
+
+	const { cities: citiesList, states: statesList, regions, countries } = audienceList || {};
+
+	let regionsList = isUsingNewGeoLocationData ? regions : countries; // Old campaigns used Continents, instead of countries/regions. I will put those under regions now.
+	const countriesList = isUsingNewGeoLocationData ? countries : '';
+
+	if ( ! citiesList && ! statesList && ! regionsList && ! countriesList ) {
+		regionsList = translate( 'Everywhere' );
+	}
+
+	return (
+		<>
+			{ citiesList && (
+				<span>
+					{
+						/* translators: %s: list of cities (i.e. New York, Florida City) */
+						translate( '{{i}}Cities:{{/i}} %(citiesList)s', {
+							args: { citiesList },
+							components: { i: <i /> },
+						} )
+					}
+				</span>
+			) }
+			{ statesList && (
+				<span>
+					{
+						/* translators: %s: list of states (i.e. New York, Florida) */
+						translate( '{{i}}States:{{/i}} %(statesList)s', {
+							args: { statesList },
+							components: { i: <i /> },
+						} )
+					}
+				</span>
+			) }
+			{ countriesList && (
+				<span>
+					{
+						/* translators: %s: list of countries (i.e. United States, Germany) */
+						translate( '{{i}}Countries:{{/i}} %(countriesList)s', {
+							args: { countriesList },
+							components: { i: <i /> },
+						} )
+					}
+				</span>
+			) }
+			{ regionsList && (
+				<span>
+					{
+						/* translators: %s: list of regions (i.e. Scotland, Toscana) */
+						translate( '{{i}}Regions:{{/i}} %(regionsList)s', {
+							args: { regionsList },
+							components: { i: <i /> },
+						} )
+					}
+				</span>
+			) }
+		</>
+	);
+};
+
+export default TargetLocations;


### PR DESCRIPTION
## Proposed Changes

The Blaze campaign details page is showing incorrect information in the Location field. This happens because the DSP now handles two different formats. This PR aims to fix that problem and be compatible with old and new campaigns.

This is how the page will look (the campaign is using all of the possible location types)
![Screenshot 2023-10-24 at 15 52 32](https://github.com/Automattic/wp-calypso/assets/1258162/45319496-5d82-43be-9d9a-0f9aeb4a9438)

## Testing Instructions

* Open the live preview and go to Tools->Advertising
* Click on the campaigns tab, and then in one of your campaigns
* Verify that the Location field shows the correct information
Old campaigns should show the value under the prefix `Regions` (before we only allowed the user to select continents)
New campaigns can have multiple types of locations (cities, states, countries and regions). 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?