### PR TITLE
Jetpack Cloud: Update site selector appearance and behavior

### DIFF
--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -254,7 +254,7 @@ class Site extends Component {
 }
 
 function mapStateToProps( state, ownProps ) {
-	const siteId = ownProps.siteId || ownProps.site.ID;
+	const siteId = ownProps.siteId || ownProps.site?.ID;
 	const site = siteId ? getSite( state, siteId ) : ownProps.site;
 
 	return {

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -283,7 +283,8 @@ export class SiteSelector extends Component {
 			( site === ALL_SITES && selectedSite === null ) ||
 			selectedSite === site.ID ||
 			selectedSite === site.domain ||
-			selectedSite === site.slug
+			selectedSite === site.slug ||
+			selectedSite?.ID === site.ID
 		);
 	};
 

--- a/client/jetpack-cloud/components/sidebar/header/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/header/index.tsx
@@ -61,7 +61,7 @@ const Header = ( { forceAllSitesView = false }: Props ) => {
 	const translate = useTranslate();
 	const selectedSiteId = useSelector( getSelectedSiteId );
 
-	const toggleSiteSelector2 = useToggleSiteSelector( { forceAllSitesView, selectedSiteId } );
+	const toggleSiteSelector = useToggleSiteSelector( { forceAllSitesView, selectedSiteId } );
 
 	return (
 		<SidebarHeader className="jetpack-cloud-sidebar__header">
@@ -71,13 +71,13 @@ const Header = ( { forceAllSitesView = false }: Props ) => {
 					showCount={ false }
 					icon={ <AllSitesIcon /> }
 					title={ translate( 'All Sites' ) }
-					onSelect={ toggleSiteSelector2 }
+					onSelect={ toggleSiteSelector }
 				/>
 			) : (
 				<Site
 					className="jetpack-cloud-sidebar__selected-site"
 					siteId={ selectedSiteId }
-					onSelect={ toggleSiteSelector2 }
+					onSelect={ toggleSiteSelector }
 				/>
 			) }
 			<ProfileDropdown />

--- a/client/jetpack-cloud/components/sidebar/header/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/header/index.tsx
@@ -1,5 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import AllSites from 'calypso/blocks/all-sites';
 import Site from 'calypso/blocks/site';
@@ -23,13 +23,24 @@ const AllSitesIcon = () => (
 	/>
 );
 
-const Header = ( { forceAllSitesView = false }: Props ) => {
-	const dispatch = useDispatch();
-	const translate = useTranslate();
-	const selectedSiteId = useSelector( getSelectedSiteId );
+// NOTE: This hook is a little hacky, to get around the "outside click"
+// close behavior that happens inside `<SiteSelector />`. Instead of
+// using the `getCurrentLayoutFocus` selector, we use internal state to
+// derive whether or not the site selector should be visible.
+const useToggleSiteSelector = ( {
+	forceAllSitesView,
+	selectedSiteId,
+}: {
+	forceAllSitesView: boolean;
+	selectedSiteId: number | null;
+} ) => {
+	const SITES_FOCUS = 'sites';
+	const SIDEBAR_FOCUS = 'sidebar';
 
-	const onSelectSite = useCallback( () => {
-		dispatch( setLayoutFocus( 'sites' ) );
+	const [ isVisible, setVisible ] = useState( false );
+	const dispatch = useDispatch();
+
+	return useCallback( () => {
 		dispatch(
 			forceAllSitesView
 				? recordTracksEvent( 'calypso_jetpack_sidebar_switch_site_all_click' )
@@ -37,7 +48,20 @@ const Header = ( { forceAllSitesView = false }: Props ) => {
 						site_id: selectedSiteId,
 				  } )
 		);
-	}, [ dispatch, forceAllSitesView, selectedSiteId ] );
+
+		// If the site selector is currently visible, make it not visible,
+		// and vice versa
+		const nextFocus = isVisible ? SIDEBAR_FOCUS : SITES_FOCUS;
+		setVisible( ( val ) => ! val );
+		dispatch( setLayoutFocus( nextFocus ) );
+	}, [ dispatch, forceAllSitesView, isVisible, selectedSiteId ] );
+};
+
+const Header = ( { forceAllSitesView = false }: Props ) => {
+	const translate = useTranslate();
+	const selectedSiteId = useSelector( getSelectedSiteId );
+
+	const toggleSiteSelector2 = useToggleSiteSelector( { forceAllSitesView, selectedSiteId } );
 
 	return (
 		<SidebarHeader className="jetpack-cloud-sidebar__header">
@@ -47,13 +71,13 @@ const Header = ( { forceAllSitesView = false }: Props ) => {
 					showCount={ false }
 					icon={ <AllSitesIcon /> }
 					title={ translate( 'All Sites' ) }
-					onSelect={ onSelectSite }
+					onSelect={ toggleSiteSelector2 }
 				/>
 			) : (
 				<Site
 					className="jetpack-cloud-sidebar__selected-site"
 					siteId={ selectedSiteId }
-					onSelect={ onSelectSite }
+					onSelect={ toggleSiteSelector2 }
 				/>
 			) }
 			<ProfileDropdown />

--- a/client/jetpack-cloud/components/sidebar/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/index.tsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
+import { useQueryJetpackPartnerPortalPartner } from 'calypso/components/data/query-jetpack-partner-portal-partner';
 import JetpackIcons from 'calypso/components/jetpack/sidebar/menu-items/jetpack-icons';
 import SiteSelector from 'calypso/components/site-selector';
 import Sidebar, {
@@ -11,6 +12,7 @@ import Sidebar, {
 } from 'calypso/layout/sidebar-v2';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { hasActivePartnerKey } from 'calypso/state/partner-portal/partner/selectors';
 import getJetpackAdminUrl from 'calypso/state/sites/selectors/get-jetpack-admin-url';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import SidebarHeader from './header';
@@ -53,6 +55,9 @@ const JetpackCloudSidebar = ( {
 	const jetpackAdminUrl = useSelector( ( state ) =>
 		siteId ? getJetpackAdminUrl( state, siteId ) : null
 	);
+
+	useQueryJetpackPartnerPortalPartner();
+	const canAccessJetpackManage = useSelector( hasActivePartnerKey );
 
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -103,7 +108,7 @@ const JetpackCloudSidebar = ( {
 
 			<SiteSelector
 				showAddNewSite
-				showAllSites={ isJetpackManage }
+				showAllSites={ canAccessJetpackManage }
 				isJetpackAgencyDashboard={ isJetpackManage }
 				className="jetpack-cloud-sidebar__site-selector"
 				allSitesPath="/dashboard"

--- a/client/jetpack-cloud/components/sidebar/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/index.tsx
@@ -1,6 +1,5 @@
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useQueryJetpackPartnerPortalPartner } from 'calypso/components/data/query-jetpack-partner-portal-partner';
 import JetpackIcons from 'calypso/components/jetpack/sidebar/menu-items/jetpack-icons';
 import SiteSelector from 'calypso/components/site-selector';
 import Sidebar, {
@@ -12,7 +11,7 @@ import Sidebar, {
 } from 'calypso/layout/sidebar-v2';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { hasActivePartnerKey } from 'calypso/state/partner-portal/partner/selectors';
+import { hasJetpackPartnerAccess } from 'calypso/state/partner-portal/partner/selectors';
 import getJetpackAdminUrl from 'calypso/state/sites/selectors/get-jetpack-admin-url';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import SidebarHeader from './header';
@@ -56,8 +55,7 @@ const JetpackCloudSidebar = ( {
 		siteId ? getJetpackAdminUrl( state, siteId ) : null
 	);
 
-	useQueryJetpackPartnerPortalPartner();
-	const canAccessJetpackManage = useSelector( hasActivePartnerKey );
+	const canAccessJetpackManage = useSelector( hasJetpackPartnerAccess );
 
 	const translate = useTranslate();
 	const dispatch = useDispatch();

--- a/client/jetpack-cloud/sections/agency-dashboard/controller.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/controller.tsx
@@ -2,6 +2,7 @@ import config from '@automattic/calypso-config';
 import page from 'page';
 import NewJetpackManageSidebar from 'calypso/jetpack-cloud/sections/sidebar-navigation/jetpack-manage';
 import { isAgencyUser } from 'calypso/state/partner-portal/partner/selectors';
+import { setAllSitesSelected } from 'calypso/state/ui/actions';
 import DashboardOverview from './dashboard-overview';
 import Header from './header';
 import DashboardSidebar from './sidebar';
@@ -40,5 +41,9 @@ export function agencyDashboardContext( context: PageJS.Context, next: VoidFunct
 			sort={ sort }
 		/>
 	);
+
+	// By definition, Sites Management does not select any one specific site
+	context.store.dispatch( setAllSitesSelected() );
+
 	next();
 }

--- a/client/jetpack-cloud/sections/partner-portal/controller.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/controller.tsx
@@ -35,6 +35,7 @@ import {
 } from 'calypso/state/partner-portal/partner/selectors';
 import { ToSConsent } from 'calypso/state/partner-portal/types';
 import getSites from 'calypso/state/selectors/get-sites';
+import { setAllSitesSelected } from 'calypso/state/ui/actions/set-sites';
 import Header from './header';
 import WPCOMAtomicHosting from './primary/wpcom-atomic-hosting';
 import type PageJS from 'page';
@@ -48,6 +49,12 @@ const setSidebar = ( context: PageJS.Context ): void => {
 		context.secondary = <PartnerPortalSidebar path={ context.path } />;
 	}
 };
+
+export function allSitesContext( context: PageJS.Context, next: () => void ): void {
+	// Many (if not all) Partner Portal pages do not select any one specific site
+	context.store.dispatch( setAllSitesSelected() );
+	next();
+}
 
 export function partnerContext( context: PageJS.Context, next: () => void ): void {
 	context.header = <Header />;

--- a/client/jetpack-cloud/sections/partner-portal/index.ts
+++ b/client/jetpack-cloud/sections/partner-portal/index.ts
@@ -6,13 +6,20 @@ import './style.scss';
 
 export default function () {
 	// Load the partner for the current user.
-	page( `/partner-portal/partner`, controller.partnerContext, makeLayout, clientRender );
+	page(
+		`/partner-portal/partner`,
+		controller.partnerContext,
+		controller.allSitesContext,
+		makeLayout,
+		clientRender
+	);
 
 	// Display the ToS, if necessary.
 	page(
 		`/partner-portal/terms-of-service`,
 		controller.requireAccessContext,
 		controller.termsOfServiceContext,
+		controller.allSitesContext,
 		makeLayout,
 		clientRender
 	);
@@ -23,6 +30,7 @@ export default function () {
 		controller.requireAccessContext,
 		controller.requireTermsOfServiceConsentContext,
 		controller.partnerKeyContext,
+		controller.allSitesContext,
 		makeLayout,
 		clientRender
 	);
@@ -34,6 +42,7 @@ export default function () {
 		controller.requireTermsOfServiceConsentContext,
 		controller.requireSelectedPartnerKeyContext,
 		controller.licensesContext,
+		controller.allSitesContext,
 		makeLayout,
 		clientRender
 	);
@@ -48,6 +57,7 @@ export default function () {
 		controller.requireTermsOfServiceConsentContext,
 		controller.requireSelectedPartnerKeyContext,
 		controller.issueLicenseContext,
+		controller.allSitesContext,
 		makeLayout,
 		clientRender
 	);
@@ -60,6 +70,7 @@ export default function () {
 		controller.requireSelectedPartnerKeyContext,
 		controller.requireValidPaymentMethod,
 		controller.assignLicenseContext,
+		controller.allSitesContext,
 		makeLayout,
 		clientRender
 	);
@@ -72,6 +83,7 @@ export default function () {
 		controller.requireSelectedPartnerKeyContext,
 		controller.requireValidPaymentMethod,
 		controller.downloadProductsContext,
+		controller.allSitesContext,
 		makeLayout,
 		clientRender
 	);
@@ -83,6 +95,7 @@ export default function () {
 		controller.requireTermsOfServiceConsentContext,
 		controller.requireSelectedPartnerKeyContext,
 		controller.paymentMethodListContext,
+		controller.allSitesContext,
 		makeLayout,
 		clientRender
 	);
@@ -93,6 +106,7 @@ export default function () {
 		controller.requireTermsOfServiceConsentContext,
 		controller.requireSelectedPartnerKeyContext,
 		controller.paymentMethodAddContext,
+		controller.allSitesContext,
 		makeLayout,
 		clientRender
 	);
@@ -103,6 +117,7 @@ export default function () {
 		controller.requireTermsOfServiceConsentContext,
 		controller.requireSelectedPartnerKeyContext,
 		controller.invoicesDashboardContext,
+		controller.allSitesContext,
 		makeLayout,
 		clientRender
 	);
@@ -113,6 +128,7 @@ export default function () {
 		controller.requireTermsOfServiceConsentContext,
 		controller.requireSelectedPartnerKeyContext,
 		controller.companyDetailsDashboardContext,
+		controller.allSitesContext,
 		makeLayout,
 		clientRender
 	);
@@ -124,6 +140,7 @@ export default function () {
 		controller.requireTermsOfServiceConsentContext,
 		controller.requireSelectedPartnerKeyContext,
 		controller.pricesContext,
+		controller.allSitesContext,
 		makeLayout,
 		clientRender
 	);
@@ -135,6 +152,7 @@ export default function () {
 		controller.requireTermsOfServiceConsentContext,
 		controller.requireSelectedPartnerKeyContext,
 		controller.billingDashboardContext,
+		controller.allSitesContext,
 		makeLayout,
 		clientRender
 	);
@@ -146,6 +164,7 @@ export default function () {
 		controller.requireTermsOfServiceConsentContext,
 		controller.requireSelectedPartnerKeyContext,
 		controller.landingPageContext,
+		controller.allSitesContext,
 		makeLayout,
 		clientRender
 	);
@@ -158,6 +177,7 @@ export default function () {
 			controller.requireTermsOfServiceConsentContext,
 			controller.requireSelectedPartnerKeyContext,
 			controller.wpcomAtomicHostingContext,
+			controller.allSitesContext,
 			makeLayout,
 			clientRender
 		);

--- a/client/jetpack-cloud/style.scss
+++ b/client/jetpack-cloud/style.scss
@@ -53,7 +53,7 @@
 	.site-selector {
 		top: 80px;
 
-		&__sites {
+		.site-selector__sites {
 			border-top: initial;
 		}
 

--- a/client/jetpack-cloud/style.scss
+++ b/client/jetpack-cloud/style.scss
@@ -73,6 +73,7 @@
 
 			margin: 4px 4px 0 4px;
 
+			&.is-selected,
 			&:hover {
 				border-radius: 4px;
 			}

--- a/client/jetpack-cloud/style.scss
+++ b/client/jetpack-cloud/style.scss
@@ -49,6 +49,19 @@
 	.my-sites__navigation {
 		height: 100%;
 	}
+
+	.site-selector {
+		top: 80px;
+
+		.site {
+			margin: 4px 4px 4px 0;
+
+			&:hover {
+				--color-sidebar-menu-hover-background: #e3f0e4;
+				border-radius: 4px;
+			}
+		}
+	}
 }
 
 .button {

--- a/client/jetpack-cloud/style.scss
+++ b/client/jetpack-cloud/style.scss
@@ -68,7 +68,6 @@
 
 		.all-sites,
 		.site {
-			--color-sidebar-menu-hover-background: #e3f0e4;
 			--color-sidebar-menu-selected-background: #e3f0e4;
 
 			margin: 4px 4px 0 4px;

--- a/client/jetpack-cloud/style.scss
+++ b/client/jetpack-cloud/style.scss
@@ -53,11 +53,27 @@
 	.site-selector {
 		top: 80px;
 
+		&__sites {
+			border-top: initial;
+		}
+
+		.all-sites {
+			border-bottom: initial;
+
+			// Remove the long-content fade if All Sites is selected
+			.all-sites__title::after {
+				display: none;
+			}
+		}
+
+		.all-sites,
 		.site {
-			margin: 4px 4px 4px 0;
+			--color-sidebar-menu-hover-background: #e3f0e4;
+			--color-sidebar-menu-selected-background: #e3f0e4;
+
+			margin: 4px 4px 0 4px;
 
 			&:hover {
-				--color-sidebar-menu-hover-background: #e3f0e4;
 				border-radius: 4px;
 			}
 		}


### PR DESCRIPTION
This pull request updates the look of the new navigation sidebar to more closely resemble designs (in terms of color, borders, etc; see: `Ra0o7IPph3bCS2xUCnAusZ-fi-4355%3A47612`). It also adds a way for customers who have an active partner key to _return_ to All Sites view if they leave it to manage a single site.

## Proposed Changes

* Move the site selector downward on the page, to show the selected site at the top.
* Change the colors and borders of site selector items, so that selected items are green, there are no borders between items, and items have a border radius of 4px.
* Create a small custom hook to work around some external behavior in the Site Selector itself, so that clicking on the selected site at the top of the screen works properly.
* Show "All Sites" when in single site mode, for customers who have access to the Jetpack Manage interface (i.e., they have an active partner key).

## Testing Instructions

* In your Jetpack Cloud testing environment, apply this PR and load the Sites Management page. Make sure to add `?flags=jetpack/new-navigation` to your browser's query string so you can see the new navigation sidebar.
* Test opening and closing the Site Selector in the sidebar by repeatedly clicking the currently selected site. The selector should appear and disappear with each click.
* Select any site in your list to be sent to the single-site management view. Verify you're able to return to the Sites Management page by re-opening the site selector in the same way, and selecting All Sites.
* Inspect the appearance of the Site Selector and compare it with existing designs (see: `Ra0o7IPph3bCS2xUCnAusZ-fi-4355%3A47612`). Pay special attention to border radii, colors when hovering over a site, and margins between the site selector and its containing elements.

## Reference captures

### Mobile

https://github.com/Automattic/wp-calypso/assets/670067/41568bbb-b952-4eb0-92f5-f98c955631f0

### Desktop

https://github.com/Automattic/wp-calypso/assets/670067/9575ef55-2d1a-457d-bf7f-a670a4c5aab5