### PR TITLE
Plans 2023: Remove ExternalLinkWithTracking dependency

### DIFF
--- a/client/my-sites/plans-grid/components/actions.tsx
+++ b/client/my-sites/plans-grid/components/actions.tsx
@@ -18,9 +18,9 @@ import { isMobile } from '@automattic/viewport';
 import styled from '@emotion/styled';
 import { useSelect } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
+import { addQueryArgs } from '@wordpress/url';
 import classNames from 'classnames';
 import { localize, TranslateResult, useTranslate } from 'i18n-calypso';
-import ExternalLinkWithTracking from 'calypso/components/external-link/with-tracking';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useManageTooltipToggle } from 'calypso/my-sites/plans-grid/hooks/use-manage-tooltip-toggle';
 import { useSelector } from 'calypso/state';
@@ -479,32 +479,41 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 	);
 
 	if ( isWpcomEnterpriseGridPlan ) {
-		const vipLandingPageUrlWithoutUtmCampaign =
-			'https://wpvip.com/wordpress-vip-agile-content-platform?utm_source=WordPresscom&utm_medium=automattic_referral';
+		const vipLandingPageUrlWithUtmCampaign = addQueryArgs(
+			'https://wpvip.com/wordpress-vip-agile-content-platform',
+			{
+				utm_source: 'WordPresscom',
+				utm_medium: 'automattic_referral',
+				utm_campaign: 'calypso_signup',
+			}
+		);
 
 		return (
-			<ExternalLinkWithTracking
-				href={ `${ vipLandingPageUrlWithoutUtmCampaign }&utm_campaign=calypso_signup` }
+			<Button
+				className={ classNames( classes ) }
+				onClick={ () =>
+					recordTracksEvent( 'calypso_plan_step_enterprise_click', { flow: flowName } )
+				}
+				href={ vipLandingPageUrlWithUtmCampaign }
 				target="_blank"
-				tracksEventName="calypso_plan_step_enterprise_click"
-				tracksEventProps={ { flow: flowName } }
 			>
-				<Button className={ classNames( classes ) }>{ translate( 'Learn more' ) }</Button>
-			</ExternalLinkWithTracking>
+				{ translate( 'Learn more' ) }
+			</Button>
 		);
 	}
 
 	if ( isWooExpressPlusPlan ) {
 		return (
-			<ExternalLinkWithTracking
+			<Button
 				className={ classNames( classes ) }
+				onClick={ () =>
+					recordTracksEvent( 'calypso_plan_step_woo_express_plus_click', { flow: flowName } )
+				}
 				href="https://woocommerce.com/get-in-touch/"
 				target="_blank"
-				tracksEventName="calypso_plan_step_woo_express_plus_click"
-				tracksEventProps={ { flow: flowName } }
 			>
 				{ translate( 'Get in touch' ) }
-			</ExternalLinkWithTracking>
+			</Button>
 		);
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/79007

## Proposed Changes

* Removes `ExternalLinkWithTracking` and replaces it with calls to `recordTracksEvent` (tracked in https://github.com/Automattic/wp-calypso/issues/79006)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/plans` and ensure Enterprise plan CTA button renders as before
* Ensure clicking on it redirects to the correct VIP landing page (as before)
* Ensure (in Network tab) the event `calypso_plan_step_enterprise_click` is sent for tracking with the `flow` attribute

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?