### PR TITLE
Onboarding with Theme: Add intervalType property

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -108,7 +108,7 @@ export function generateFlows( {
 			description: 'Preselect a theme to activate/buy from an external source',
 			lastModified: '2023-10-11',
 			showRecaptcha: true,
-			providesDependenciesInQuery: [ 'theme' ],
+			providesDependenciesInQuery: [ 'theme', 'intervalType' ],
 			optionalDependenciesInQuery: [ 'theme_type', 'style_variation' ],
 			hideProgressIndicator: true,
 		},

--- a/client/state/themes/selectors/get-theme-signup-url.js
+++ b/client/state/themes/selectors/get-theme-signup-url.js
@@ -1,4 +1,4 @@
-import { FREE_THEME } from '@automattic/design-picker';
+import { FREE_THEME, MARKETPLACE_THEME } from '@automattic/design-picker';
 import { DESIGN_FIRST_FLOW } from '@automattic/onboarding';
 import { addQueryArgs } from '@wordpress/url';
 import { getThemeType, isThemePremium } from 'calypso/state/themes/selectors';
@@ -24,6 +24,7 @@ export function getThemeSignupUrl( state, themeId, options = {} ) {
 		theme: themeId,
 		theme_type: themeType,
 		style_variation: styleVariationSlug,
+		intervalType: themeType === MARKETPLACE_THEME ? 'monthly' : 'yearly',
 	};
 
 	// If the selected free theme belongs to the blog category, redirect users to the blog tailored flow

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -1511,7 +1511,7 @@ describe( 'themes selectors', () => {
 			);
 
 			expect( signupUrl ).toEqual(
-				'/start/with-theme?ref=calypshowcase&theme=twentysixteen&theme_type=free'
+				'/start/with-theme?ref=calypshowcase&theme=twentysixteen&theme_type=free&intervalType=yearly'
 			);
 		} );
 
@@ -1537,6 +1537,7 @@ describe( 'themes selectors', () => {
 				theme: 'mood',
 				premium: 'true',
 				theme_type: 'premium',
+				intervalType: 'yearly',
 			} );
 		} );
 	} );


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/83255

## Proposed Changes

Add the `intervalType` property to the `with-theme` flow and have the monthly option pre-selected for plans when selecting a Partner Theme.

## Testing Instructions

* From an incognito window, go to `/themes`
* Select a partner theme
*  Click on `Pick this design`
* Check the URL to see if it has the `intervalType=monthly`
* After the domain step, check if the plans has the monthly option selected
* Select a plan and on the checkout page verify the monthly options are selected for plan and theme

![CleanShot 2023-10-24 at 16 25 48@2x](https://github.com/Automattic/wp-calypso/assets/5039531/31286193-891c-4d7e-be82-40eb09eaada7)

* From an incognito window, go to `/themes`
* Select a free or premium theme
* The flow should keep working as before

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
