### PR TITLE
Fix 2FA security key form UI issues

### DIFF
--- a/client/blocks/login/two-factor-authentication/security-key-form.jsx
+++ b/client/blocks/login/two-factor-authentication/security-key-form.jsx
@@ -1,4 +1,5 @@
 import { Card, Spinner } from '@automattic/components';
+import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -46,7 +47,9 @@ class SecurityKeyForm extends Component {
 
 		return (
 			<form
-				className="two-factor-authentication__verification-code-form-wrapper"
+				className={ classNames( 'two-factor-authentication__verification-code-form-wrapper', {
+					isWoo: isWoo,
+				} ) }
 				onSubmit={ this.initiateSecurityKeyAuthentication }
 			>
 				<Card compact className="two-factor-authentication__verification-code-form">

--- a/client/blocks/login/two-factor-authentication/security-key-form.jsx
+++ b/client/blocks/login/two-factor-authentication/security-key-form.jsx
@@ -8,6 +8,7 @@ import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/stat
 import { formUpdate, loginUserWithSecurityKey } from 'calypso/state/login/actions';
 import TwoFactorActions from './two-factor-actions';
 import './verification-code-form.scss';
+import './security-key-form.scss';
 
 class SecurityKeyForm extends Component {
 	static propTypes = {

--- a/client/blocks/login/two-factor-authentication/security-key-form.scss
+++ b/client/blocks/login/two-factor-authentication/security-key-form.scss
@@ -1,0 +1,16 @@
+.two-factor-authentication__verification-code-form-wrapper {
+	padding: 0;
+	button.is-primary {
+		width: 404px !important;
+	}
+	.two-factor-authentication__actions {
+		padding: 40px 0 40px 0;
+		width: 404px;
+		button {
+			width: 100% !important;
+		}
+	}
+	.two-factor-authentication__verification-code-form {
+		margin-bottom: 40px;
+	}
+}

--- a/client/blocks/login/two-factor-authentication/security-key-form.scss
+++ b/client/blocks/login/two-factor-authentication/security-key-form.scss
@@ -1,16 +1,29 @@
 .two-factor-authentication__verification-code-form-wrapper {
-	padding: 0;
-	button.is-primary {
-		width: 404px !important;
-	}
 	.two-factor-authentication__actions {
-		padding: 40px 0 40px 0;
-		width: 404px;
+		padding: 24px;
 		button {
-			width: 100% !important;
+			display: block;
+			margin-left: auto;
+			margin-right: auto;
 		}
 	}
-	.two-factor-authentication__verification-code-form {
-		margin-bottom: 40px;
+
+	&.isWoo {
+		padding: 0;
+
+		button.is-primary {
+			width: 404px !important;
+		}
+		.two-factor-authentication__actions {
+			padding: 40px 0 40px 0;
+			width: 404px;
+			button {
+				width: 100% !important;
+			}
+		}
+		.two-factor-authentication__verification-code-form {
+			margin-bottom: 40px;
+		}
 	}
 }
+


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #78614 

## Proposed Changes

* Added a new scss file to target the security code form
* Updated CSS to align buttons correctly.

Because the other login pages use 617px, I chose not to update the security form to 615px in order to maintain consistency.

## Testing Instructions

For whatever reasons, I wasn't able to register a security key in my account settings when I use my local calypso env. The security key registered for WPCOM doesn't seem to work locally either.

I had to modify the code to make the security code form to render.

1. Checkout this branch locally.
2. Run `yarn start` to start the server.
3. Open `client/blocks/login/two-factor-content.jsx`
4. Remove `if ( twoFactorAuthType === 'webauthn' && isBrowserSupported ) {` if statement to render `SecurityKeyForm` forcefully. 
5. Visit http://calypso.localhost:3000/log-in/authenticator?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3Da5274524352825b45bdbaed4f70e128d5312be03587854fff05ce581fe608a34%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.com%252Fwc-api%252Fwpcom-signin%253Fnext%253D%25252Fstart%25252F%252523%25252Finstallation%26blog_id%3D0%26wpcom_connect%3D1%26wccom-from%26calypso_env%3Dproduction%26jetpack-code%26jetpack-user-id%3D0%26action%3Doauth2-login%26from-calypso%3D1&client_id=50916
6. Login and confirm the security key form renders correctly.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?