### PR TITLE
Assembler: Fix the action bar stuck

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-action-bar.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-action-bar.scss
@@ -30,6 +30,7 @@
 
 	.pattern-action-bar__action {
 		height: 40px;
+		white-space: nowrap;
 
 		&.has-icon {
 			min-width: 40px;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -218,11 +218,18 @@ const PatternLargePreview = ( {
 			}
 		};
 
+		// When the value of the `hasSelectedPattern` changes, it will append/remove the
+		// frame to the DOM. Hence, we need to check the value to bind the event again
+		// after the frame is removed and then appended to the DOM.
+		if ( ! hasSelectedPattern ) {
+			return;
+		}
+
 		frameRef.current?.addEventListener( 'mouseleave', handleMouseLeave );
 		return () => {
 			frameRef.current?.removeEventListener( 'mouseleave', handleMouseLeave );
 		};
-	}, [ frameRef, setActiveElement ] );
+	}, [ frameRef, hasSelectedPattern, setActiveElement ] );
 
 	return (
 		<DeviceSwitcher

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -101,7 +101,10 @@ const PatternLargePreview = ( {
 		};
 
 		const handleMouseLeave = ( event: React.MouseEvent< HTMLElement > ) => {
-			if ( ! frameRef.current?.contains( event.relatedTarget as Node ) ) {
+			const hasNextActiveElement =
+				event.relatedTarget instanceof Node &&
+				! frameRef.current?.contains( event.relatedTarget as Node );
+			if ( ! hasNextActiveElement ) {
 				setActiveElement( null );
 			}
 		};
@@ -213,7 +216,7 @@ const PatternLargePreview = ( {
 	useEffect( () => {
 		const handleMouseLeave = ( event: MouseEvent ) => {
 			const relatedTarget = event.relatedTarget as HTMLElement | null;
-			if ( ! relatedTarget?.closest( '.pattern-assembler__pattern-action-bar' ) ) {
+			if ( ! relatedTarget?.closest?.( '.pattern-assembler__pattern-action-bar' ) ) {
 				setActiveElement( null );
 			}
 		};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/83034

## Proposed Changes

* The action bar might be stuck there when you hover off the pattern. The reason is the `device-switcher__frame` element is removed & appended to the DOM whenever the value of the `hasSelectedPattern` changes. And it leads to the `mouseleave` event on the `device-switcher__frame` element cannot be triggered anymore.
* Here is the real case on production (chrome only) but I cannot reproduce it on my local env
  * When you land on the Assembler with the selected pattern at the beginning (e.g.: refresh the page), the `hasSelectedPattern` is false initially, and we bind the `mouseleave` event to the `device-switcher__frame` element. However, the value becomes true immediately so the `mouseleave` event doesn't work as that element will be removed from the DOM and then appended again.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the Assembler
* Select a pattern, remove it, and select it again
* Hover on that pattern and ensure you see the action bar
* Hover off that pattern and ensure the action bar will be gone instead of sticking there

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?