### PR TITLE
Update/nav mobile

### DIFF
--- a/client/components/navigation-header/index.tsx
+++ b/client/components/navigation-header/index.tsx
@@ -20,12 +20,6 @@ const Container = styled.div`
 	}
 `;
 
-const ActionsContainer = styled.div`
-	display: flex;
-	align-items: center;
-	gap: 16px;
-`;
-
 interface Props {
 	id?: string;
 	className?: string;
@@ -80,7 +74,7 @@ const NavigationHeader = React.forwardRef< HTMLElement, Props >( ( props, ref ) 
 							screenReader={ screenReader }
 						/>
 					) }
-					<ActionsContainer>{ children }</ActionsContainer>
+					<div className="navigation-header__actions">{ children }</div>
 				</div>
 			</Container>
 		</header>

--- a/client/components/navigation-header/index.tsx
+++ b/client/components/navigation-header/index.tsx
@@ -66,6 +66,7 @@ const NavigationHeader = React.forwardRef< HTMLElement, Props >( ( props, ref ) 
 							align="left"
 							headerText={ title }
 							subHeaderText={ subtitle }
+							tooltipText={ subtitle }
 							screenReader={ screenReader }
 						/>
 					) }

--- a/client/components/navigation-header/index.tsx
+++ b/client/components/navigation-header/index.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import classnames from 'classnames';
 import React, { ReactNode } from 'react';
 import Breadcrumb, { Item as TBreadcrumbItem } from 'calypso/components/breadcrumb';
 import ScreenOptionsTab from 'calypso/components/screen-options-tab';
@@ -52,9 +53,18 @@ const NavigationHeader = React.forwardRef< HTMLElement, Props >( ( props, ref ) 
 		screenOptionsTab,
 	} = props;
 	return (
-		<header id={ id } className={ 'navigation-header ' + className } ref={ ref }>
+		<header
+			id={ id }
+			className={ classnames(
+				className,
+				'navigation-header',
+				screenOptionsTab && children ? 'navigation-header__screen-options-tab' : ''
+			) }
+			ref={ ref }
+		>
 			<Container>
 				<div className="navigation-header__main">
+					{ screenOptionsTab && <ScreenOptionsTab wpAdminPath={ screenOptionsTab } /> }
 					<Breadcrumb
 						items={ navigationItems }
 						mobileItem={ mobileItem }
@@ -71,7 +81,6 @@ const NavigationHeader = React.forwardRef< HTMLElement, Props >( ( props, ref ) 
 						/>
 					) }
 					<ActionsContainer>{ children }</ActionsContainer>
-					{ screenOptionsTab && <ScreenOptionsTab wpAdminPath={ screenOptionsTab } /> }
 				</div>
 			</Container>
 		</header>

--- a/client/components/navigation-header/index.tsx
+++ b/client/components/navigation-header/index.tsx
@@ -7,10 +7,6 @@ import FormattedHeader from '../formatted-header';
 import './style.scss';
 
 const Container = styled.div`
-	@media ( max-width: 660px ) {
-		min-height: 60px;
-	}
-
 	.main.is-wide-layout & {
 		max-width: 1040px;
 		margin: auto;

--- a/client/components/navigation-header/style.scss
+++ b/client/components/navigation-header/style.scss
@@ -88,8 +88,18 @@
 			display: none;
 		}
 	}
+
+	.navigation-header__actions {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		@media ( min-width: $break-small ) {
+			gap: 16px;
+		}
+	}
 }
 
 #primary header.navigation-header header.formatted-header {
 	margin: 0;
 }
+

--- a/client/components/navigation-header/style.scss
+++ b/client/components/navigation-header/style.scss
@@ -74,10 +74,10 @@
 		line-height: 20px;
 		letter-spacing: -0.15px;
 
-		display: inline-block;
 		// Hide subtitle text on small screens
-		@media ( max-width: $break-small ) {
-			display: none;
+		display: none;
+		@media ( min-width: $break-small ) {
+			display: inline-block;
 		}
 	}
 

--- a/client/components/navigation-header/style.scss
+++ b/client/components/navigation-header/style.scss
@@ -8,9 +8,8 @@
 	padding: 16px;
 	margin-bottom: 32px;
 	@include break-small {
-
-		padding: 0;
-		margin-bottom: 24px;
+		padding: 0 0 24px 0;
+		margin-bottom: 16px;
 	}
 
 	.breadcrumbs {
@@ -35,7 +34,6 @@
 	justify-content: space-between;
 	align-items: center;
 	box-sizing: border-box;
-	min-height: 50px;
 
 	@media ( max-width: 660px ) {
 		min-height: 60px;

--- a/client/components/navigation-header/style.scss
+++ b/client/components/navigation-header/style.scss
@@ -74,10 +74,10 @@
 		line-height: 20px;
 		letter-spacing: -0.15px;
 
+		display: inline-block;
 		// Hide subtitle text on small screens
-		display: none;
-		@media ( min-width: $break-small ) {
-			display: inline-block;
+		@media ( max-width: $break-small ) {
+			display: none;
 		}
 	}
 

--- a/client/components/navigation-header/style.scss
+++ b/client/components/navigation-header/style.scss
@@ -27,6 +27,17 @@
 			}
 		}
 	}
+
+	// Add extra space when there is a classic/non classic option tab at the top on mobile that collides with cta's
+	&.navigation-header__screen-options-tab {
+		padding-top: 38px; // 30 for screen options tab + 8 gap
+	}
+	@include break-small {
+		&.navigation-header__screen-options-tab {
+			// There are existing workarounds for desktop layouts, revert back to 16 here
+			padding-top: 16px;
+		}
+	}
 }
 
 .navigation-header__main {

--- a/client/components/navigation-header/style.scss
+++ b/client/components/navigation-header/style.scss
@@ -81,6 +81,11 @@
 		}
 	}
 
+	.button {
+		display: flex;
+		line-height: 20px;
+	}
+
 	.info-popover {
 		// Show subtitle text on small screens under help icon
 		display: inline-block;

--- a/client/components/navigation-header/style.scss
+++ b/client/components/navigation-header/style.scss
@@ -43,7 +43,7 @@
 .navigation-header__main {
 	display: flex;
 	justify-content: space-between;
-	align-items: center;
+	align-items: flex-start;
 	box-sizing: border-box;
 
 	@media ( max-width: 660px ) {

--- a/client/components/navigation-header/style.scss
+++ b/client/components/navigation-header/style.scss
@@ -6,7 +6,7 @@
 	box-sizing: border-box;
 	width: 100%;
 	padding: 16px;
-	margin-bottom: 32px;
+	margin-bottom: 0;
 	@include break-small {
 		padding: 0 0 24px 0;
 		margin-bottom: 16px;

--- a/client/components/navigation-header/style.scss
+++ b/client/components/navigation-header/style.scss
@@ -43,7 +43,7 @@
 .navigation-header__main {
 	display: flex;
 	justify-content: space-between;
-	align-items: flex-start;
+	align-items: center;
 	box-sizing: border-box;
 
 	@media ( max-width: 660px ) {

--- a/client/components/navigation-header/style.scss
+++ b/client/components/navigation-header/style.scss
@@ -56,16 +56,26 @@
 		line-height: 26px;
 		margin-bottom: 0;
 	}
+
 	.formatted-header__subtitle {
 		color: var(--color-neutral-60);
 		margin: 0;
 		line-height: 20px;
 		letter-spacing: -0.15px;
+
+		// Hide subtitle text on small screens
+		display: none;
+		@media ( min-width: $break-small ) {
+			display: inline-block;
+		}
 	}
 
-	.button {
-		line-height: 20px;
-		display: flex;
+	.info-popover {
+		// Show subtitle text on small screens under help icon
+		display: inline-block;
+		@media ( min-width: $break-small ) {
+			display: none;
+		}
 	}
 }
 

--- a/client/components/navigation-header/style.scss
+++ b/client/components/navigation-header/style.scss
@@ -92,10 +92,7 @@
 	.navigation-header__actions {
 		display: flex;
 		align-items: center;
-		gap: 8px;
-		@media ( min-width: $break-small ) {
-			gap: 16px;
-		}
+		gap: 16px;
 	}
 }
 

--- a/client/landing/subscriptions/components/add-sites-button/styles.scss
+++ b/client/landing/subscriptions/components/add-sites-button/styles.scss
@@ -1,7 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 
 .subscriptions-add-sites__button {
-	margin-top: 12px;
 
 	.subscriptions-add-sites__button-icon {
 		display: none;

--- a/client/landing/subscriptions/components/subscriptions-ellipsis-menu/styles.scss
+++ b/client/landing/subscriptions/components/subscriptions-ellipsis-menu/styles.scss
@@ -65,6 +65,8 @@ $rotateOnOpenDeg: 90deg;
 
 .subscriptions-ellipsis-menu {
 	height: 24px;
+	display: flex;
+	align-items: center;
 
 	&__toggle {
 		cursor: pointer;

--- a/client/landing/subscriptions/components/subscriptions-ellipsis-menu/styles.scss
+++ b/client/landing/subscriptions/components/subscriptions-ellipsis-menu/styles.scss
@@ -64,9 +64,6 @@
 $rotateOnOpenDeg: 90deg;
 
 .subscriptions-ellipsis-menu {
-	height: 24px;
-	display: flex;
-	align-items: center;
 
 	&__toggle {
 		cursor: pointer;

--- a/client/my-sites/subscribers/components/shared/popover-style.scss
+++ b/client/my-sites/subscribers/components/shared/popover-style.scss
@@ -1,5 +1,5 @@
 .subscriber-popover__container {
-	height: 32px;
+	height: 24px;
 }
 
 .subscriber-popover__toggle {

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -59,7 +59,7 @@ const SubscribersHeader = ( { selectedSiteId }: SubscribersHeaderProps ) => {
 				onClick={ () => setShowAddSubscribersModal( true ) }
 			>
 				<Gridicon icon="plus" size={ 24 } />
-				{ translate( 'Add subscribers' ) }
+				<span className="add-subscribers-button-text">{ translate( 'Add subscribers' ) }</span>
 			</Button>
 			<SubscribersHeaderPopover siteId={ selectedSiteId } />
 		</NavigationHeader>

--- a/client/my-sites/subscribers/style.scss
+++ b/client/my-sites/subscribers/style.scss
@@ -3,15 +3,29 @@
 @import "@wordpress/base-styles/breakpoints";
 
 .subscribers.main {
-	padding: 0 32px;
-
 	.subscribers__section {
 		margin-bottom: 64px;
 	}
 
 	.add-subscribers-button {
-		display: flex;
-		gap: 10px;
+		.gridicon {
+			margin-right: 0;
+		}
+
+		.add-subscribers-button-text {
+			margin-left: 4px;
+			display: none;
+		}
+
+		@media ( min-width: $break-small ) {
+			.add-subscribers-button-text {
+				display: inline;
+			}
+		}
+	}
+
+	@media ( min-width: $break-mobile ) {
+		padding: 0 32px;
 	}
 }
 

--- a/client/my-sites/subscribers/style.scss
+++ b/client/my-sites/subscribers/style.scss
@@ -33,7 +33,6 @@
 			padding: 16px 0;
 		}
 	}
-
 }
 
 .subscribers__header {

--- a/client/my-sites/subscribers/style.scss
+++ b/client/my-sites/subscribers/style.scss
@@ -23,10 +23,17 @@
 			}
 		}
 	}
+	padding: 0 32px;
 
-	@media ( min-width: $break-mobile ) {
-		padding: 0 32px;
+	@media ( max-width: $break-small ) {
+		padding: 0 16px;
 	}
+	.navigation-header {
+		@media ( max-width: $break-small ) {
+			padding: 16px 0;
+		}
+	}
+
 }
 
 .subscribers__header {
@@ -34,6 +41,7 @@
 	margin-bottom: 30px;
 	font-size: $font-title-small;
 	line-height: 26px;
+
 
 	.subscribers__title {
 		font-weight: 500;

--- a/client/reader/site-subscriptions-manager/style.scss
+++ b/client/reader/site-subscriptions-manager/style.scss
@@ -6,10 +6,11 @@
 
 .site-subscriptions-manager {
 	&.main {
-		max-width: none;
+		max-width: 1168px;
 		min-height: 100vh;
-		margin: 0;
-		padding: 0;
+		margin: 0 auto;
+		padding: 0 32px;
+
 		@media (max-width: $break-small) {
 			padding: 0 16px;
 

--- a/client/reader/site-subscriptions-manager/style.scss
+++ b/client/reader/site-subscriptions-manager/style.scss
@@ -1,3 +1,4 @@
+@import "@wordpress/base-styles/breakpoints";
 @import "@automattic/typography/styles/variables";
 @import "@automattic/color-studio/dist/color-variables";
 @import "client/landing/subscriptions/styles/search-component";
@@ -5,10 +6,17 @@
 
 .site-subscriptions-manager {
 	&.main {
-		max-width: 1168px;
+		max-width: none;
 		min-height: 100vh;
-		margin: 0 auto;
-		padding: 0 32px;
+		margin: 0;
+		padding: 0;
+		@media (max-width: $break-small) {
+			padding: 0 16px;
+
+			.navigation-header {
+				padding: 16px 0;
+			}
+		}
 
 		@extend %search-component-subscriptions-style;
 	}


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/4279

## Proposed Changes

- Move subtitle under tooltip on small screens
- Compact button on subscribers screen for mobile
- Remove header minheight and set margin matching figma
- Fix spacing for screen-options-tab after removing minheights
- Remove content gap on mobile - looked like too much space on most screens e.g. posts

Todo: 
- [x] Button icon padding on /subscribers 
- [x] Gap between button and ellipsis on /read/subscriptions
- [x] /read/subscriptions should be full width on mobile (looks like padding or margin needs to be cleared)
- [x] Jetpack stats breakpoint issue https://github.com/Automattic/dotcom-forge/issues/4329

## Testing Instructions

* http://calypso.localhost:3000/subscribers/
* /read/subscriptions
* /plugins
* /themes
* /home
* /posts
* /domains

Most of these changes happen at mobile and small breakpoints, desktop should be unaffected.

