### PR TITLE
Jetpack Manage: new navigation UI enhancements | part 2

### DIFF
--- a/client/jetpack-cloud/components/sidebar/header/style.scss
+++ b/client/jetpack-cloud/components/sidebar/header/style.scss
@@ -58,7 +58,7 @@ html.accessible-focus .jetpack-cloud-sidebar__profile-dropdown-button:focus {
 }
 
 .jetpack-cloud-sidebar__profile-dropdown-menu-item {
-	padding: 8px;
+	padding: 1px 8px;
 	border-radius: 4px;
 
 	&:hover,

--- a/client/jetpack-cloud/components/sidebar/style.scss
+++ b/client/jetpack-cloud/components/sidebar/style.scss
@@ -12,12 +12,13 @@
 
 
 	.split-button {
+		display: flex;
+
 		a {
-			width: 70%;
+			flex-grow: 1;
 		}
 
 		button.split-button__toggle {
-			width: 30%;
 			border-top-left-radius: 0;
 			border-bottom-left-radius: 0;
 		}

--- a/client/jetpack-cloud/components/sidebar/style.scss
+++ b/client/jetpack-cloud/components/sidebar/style.scss
@@ -10,6 +10,20 @@
 		background-color: var(--color-sidebar-background);
 	}
 
+
+	.split-button {
+		a {
+			width: 70%;
+		}
+
+		button.split-button__toggle {
+			width: 30%;
+			border-top-left-radius: 0;
+			border-bottom-left-radius: 0;
+		}
+	}
+
+
 	.sidebar-v2__menu-item {
 		svg {
 			color: #6f6f6f;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -12,8 +12,8 @@
 	}
 
 	.sites-overview__container {
-		// The -44px is to undo the padding of .layout__content (32px) and .sites-overview_container (6px + 6px)
-		min-height: calc(100vh - 44px);
+		// The -76px is to undo the padding of layout.has-no-masterbar (32px), .layout__content (32px) and .sites-overview_container (6px + 6px)
+		min-height: calc(100vh - 76px);
 	}
 }
 

--- a/client/jetpack-cloud/sections/plugin-management/plugins-overview/style.scss
+++ b/client/jetpack-cloud/sections/plugin-management/plugins-overview/style.scss
@@ -8,8 +8,8 @@
 	}
 
 	.plugins-overview__container {
-		// The -32px is to undo the padding of .layout__content (32px)
-		min-height: calc(100vh - 32px);
+		// The -64px is to undo the padding of layout.has-no-masterbar (32px) & .layout__content (32px)
+		min-height: calc(100vh - 64px);
 	}
 }
 

--- a/client/layout/sidebar-v2/navigator/style.scss
+++ b/client/layout/sidebar-v2/navigator/style.scss
@@ -8,6 +8,7 @@
 	padding: 0;
 
 	.components-navigator-back-button {
+		padding-block-start: 0;
 		margin-block-end: 8px;
 		color: var(--studio-gray-90);
 		font-size: rem(16px);


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/74

## Proposed Changes

This PR does the below UI enhancements:

- Fix unnecessary scrolling on the Plugin Management page.
- Fix unnecessary scrolling on the Sites Management page
- Reduce profile dropdown item padding
- Make the sidebar footer button full-width


### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Open the Jetpack Cloud live link
2. Visit the /dashboard & append the URL with `?flags=jetpack/new-navigation`
3. Visit the Sites Management page and verify that there is no unnecessary scroll
4. Visit the Plugin Management page and verify that there is no unnecessary scroll
5. Click the profile dropdown and verify the padding looks good.

<img width="299" alt="Screenshot 2023-10-25 at 12 39 57 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/d2403847-eab4-4520-b1bd-4a35c3ea9529">

6. Click the site switcher and verify that the `Add new site` button has full-width

<img width="279" alt="Screenshot 2023-10-25 at 12 39 45 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/e55d390f-2007-4e1e-98c7-f08d9da9f829">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?