### PR TITLE
Headers: Fix /stats padding

### DIFF
--- a/client/my-sites/stats/modernized-layout-styles.scss
+++ b/client/my-sites/stats/modernized-layout-styles.scss
@@ -35,8 +35,8 @@ $sidebar-appearance-break-point: 783px;
 		padding: 0 max(calc(50% - #{math.div($stats-sections-max-width, 2)}), 32px);
 
 		@media ( max-width: $custom-mobile-breakpoint ) {
-			padding-left: 0 !important;
-			padding-right: 0 !important;
+			padding-left: 0;
+			padding-right: 0;
 		}
 	}
 
@@ -48,11 +48,13 @@ $sidebar-appearance-break-point: 783px;
 	&.has-fixed-nav {
 		padding-top: 44px;
 	}
-
 	.navigation-header {
-		padding-left: max(calc(50% - #{math.div($stats-sections-max-width, 2)}), 32px);
-		padding-right: max(calc(50% - #{math.div($stats-sections-max-width, 2)}), 32px);
+		@media ( min-width: $custom-mobile-breakpoint ) {
+			padding-left: max(calc(50% - #{math.div($stats-sections-max-width, 2)}), 32px);
+			padding-right: max(calc(50% - #{math.div($stats-sections-max-width, 2)}), 32px);
+		}
 	}
+
 }
 
 .is-section-stats,

--- a/client/my-sites/stats/modernized-layout-styles.scss
+++ b/client/my-sites/stats/modernized-layout-styles.scss
@@ -2,6 +2,7 @@
 
 @use "sass:math";
 @import "@automattic/components/src/highlight-cards/variables.scss";
+@import "@wordpress/base-styles/breakpoints";
 
 $stats-background-color: #fdfdfd;
 $stats-sections-max-width: 1224px;
@@ -34,7 +35,7 @@ $sidebar-appearance-break-point: 783px;
 	> * {
 		padding: 0 max(calc(50% - #{math.div($stats-sections-max-width, 2)}), 32px);
 
-		@media ( max-width: $custom-mobile-breakpoint ) {
+		@media ( max-width: $break-small ) {
 			padding-left: 0;
 			padding-right: 0;
 		}
@@ -49,12 +50,20 @@ $sidebar-appearance-break-point: 783px;
 		padding-top: 44px;
 	}
 	.navigation-header {
-		@media ( min-width: $custom-mobile-breakpoint ) {
+		@media ( max-width: $break-small ) {
+			margin-bottom: 0;
+		}
+		@media ( min-width: $break-small ) {
 			padding-left: max(calc(50% - #{math.div($stats-sections-max-width, 2)}), 32px);
 			padding-right: max(calc(50% - #{math.div($stats-sections-max-width, 2)}), 32px);
 		}
 	}
-
+	.navigation-header__main {
+		@media ( min-width: $break-small ) and ( max-width: $custom-mobile-breakpoint ) {
+			padding-left: 0.825em;
+			padding-right: 0.825em;
+		}
+	}
 }
 
 .is-section-stats,

--- a/client/my-sites/stats/modernized-layout-styles.scss
+++ b/client/my-sites/stats/modernized-layout-styles.scss
@@ -35,14 +35,23 @@ $sidebar-appearance-break-point: 783px;
 		padding: 0 max(calc(50% - #{math.div($stats-sections-max-width, 2)}), 32px);
 
 		@media ( max-width: $custom-mobile-breakpoint ) {
-			padding-left: 0;
-			padding-right: 0;
+			padding-left: 0 !important;
+			padding-right: 0 !important;
 		}
 	}
 
 	> .stats-banner-wrapper .jetpack-backup-creds-banner {
 		// .jetpack-backup-creds-banner has a bottom margin of 16px. This overrides it since we want it to be 32px
 		margin-bottom: 32px;
+	}
+
+	&.has-fixed-nav {
+		padding-top: 44px;
+	}
+
+	.navigation-header {
+		padding-left: max(calc(50% - #{math.div($stats-sections-max-width, 2)}), 32px);
+		padding-right: max(calc(50% - #{math.div($stats-sections-max-width, 2)}), 32px);
 	}
 }
 


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/4329

## Proposed Changes

Fix /stats header padding when changing pages.

| Before | After |
| --- | --- |
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/b2fc0e1a-05f7-44b0-8555-27c9c7ec0ac4) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/00e50a58-1766-452a-9f5b-d7f18c84346d) |

## Testing Instructions

* Go to `/stats` with screen width between 600px and 1500px.
* Check header left padding