### PR TITLE
Processing Screen: Change copy for BBE flows

### DIFF
--- a/client/signup/reskinned-processing-screen/index.jsx
+++ b/client/signup/reskinned-processing-screen/index.jsx
@@ -11,8 +11,6 @@ import './style.scss';
 // Default estimated time to perform "loading"
 const DURATION_IN_MS = 6000;
 
-const flowsWithDesignPicker = [ 'setup-site', 'do-it-for-me', 'do-it-for-me-store' ];
-
 const useSteps = ( { flowName, hasPaidDomain, isDestinationSetupSiteFlow } ) => {
 	const { __ } = useI18n();
 	let steps = [];
@@ -38,6 +36,32 @@ const useSteps = ( { flowName, hasPaidDomain, isDestinationSetupSiteFlow } ) => 
 		case HOSTING_LP_FLOW:
 			steps = [ { title: __( 'Creating your account' ) } ];
 			break;
+		case 'setup-site':
+			// Custom durations give a more believable loading effect while setting up
+			// the site with headstart. Which can take quite a long time.
+			steps = [
+				{ title: __( 'Laying the foundations' ), duration: 7000 },
+				{ title: __( 'Turning on the lights' ), duration: 3000 },
+				{ title: __( 'Making it beautiful' ), duration: 4000 },
+				{ title: __( 'Personalizing your site' ), duration: 7000 },
+				{ title: __( 'Sprinkling some magic' ), duration: 4000 },
+				{ title: __( 'Securing your data' ), duration: 9000 },
+				{ title: __( 'Enabling encryption' ), duration: 3000 },
+				{ title: __( 'Optimizing your content' ), duration: 6000 },
+				{ title: __( 'Applying a shiny top coat' ), duration: 4000 },
+				{ title: __( 'Closing the loop' ) },
+			];
+			break;
+		case 'do-it-for-me':
+		case 'do-it-for-me-store':
+			steps = [
+				{ title: __( 'Saving your selections' ), duration: 7000 },
+				{ title: __( 'Turning on the lights' ), duration: 3000 },
+				{ title: __( 'Planning the next chess move' ), duration: 4000 },
+				{ title: __( 'Making you cookies' ), duration: 9000 },
+				{ title: __( 'Closing the loop' ) },
+			];
+			break;
 		default:
 			steps = [
 				! isDestinationSetupSiteFlow && { title: __( 'Building your site' ) },
@@ -47,23 +71,6 @@ const useSteps = ( { flowName, hasPaidDomain, isDestinationSetupSiteFlow } ) => 
 				{ title: __( 'Making you cookies' ) },
 				{ title: __( 'Planning the next chess move' ) },
 			];
-	}
-
-	if ( flowsWithDesignPicker.includes( flowName ) ) {
-		// Custom durations give a more believable loading effect while setting up
-		// the site with headstart. Which can take quite a long time.
-		steps = [
-			{ title: __( 'Laying the foundations' ), duration: 7000 },
-			{ title: __( 'Turning on the lights' ), duration: 3000 },
-			{ title: __( 'Making it beautiful' ), duration: 4000 },
-			{ title: __( 'Personalizing your site' ), duration: 7000 },
-			{ title: __( 'Sprinkling some magic' ), duration: 4000 },
-			{ title: __( 'Securing your data' ), duration: 9000 },
-			{ title: __( 'Enabling encryption' ), duration: 3000 },
-			{ title: __( 'Optimizing your content' ), duration: 6000 },
-			{ title: __( 'Applying a shiny top coat' ), duration: 4000 },
-			{ title: __( 'Closing the loop' ) },
-		];
 	}
 
 	return useRef( steps.filter( Boolean ) );
@@ -78,7 +85,8 @@ export default function ReskinnedProcessingScreen( props ) {
 	const { isDestinationSetupSiteFlow, flowName } = props;
 	const totalSteps = steps.current.length;
 	const shouldShowNewSpinner =
-		isDestinationSetupSiteFlow || flowsWithDesignPicker.includes( flowName );
+		isDestinationSetupSiteFlow ||
+		[ 'setup-site', 'do-it-for-me', 'do-it-for-me-store' ].includes( flowName );
 
 	const [ currentStep, setCurrentStep ] = useState( 0 );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/martech/issues/2131

## Proposed Changes

* Updates the copy of the processing screen text for BBE.


https://github.com/Automattic/wp-calypso/assets/5436027/ae2960a5-4f02-49da-a5bd-7257cccc62c8



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/do-it-for-me` and proceed through the flow steps.
* Confirm that the loading screen displays the new copy.

----

* To view the complete loading screen, patch this line:
https://github.com/Automattic/wp-calypso/blob/b5096906e6974d5d36cde8250987673a306275e2/client/signup/main.jsx#L150
and set `shouldShowLoadingScreen` to true.
* Now go to `/start/do-it-for-me`. The processing screen should be visible.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?