### PR TITLE
Assembler - Update query to fetch page patterns

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
@@ -49,7 +49,7 @@ export const PATTERN_CATEGORIES = [
 	//'media', -- Not exist
 	'newsletter',
 	//'podcast', -- Hidden
-	//'portfolio', -- Hidden
+	'portfolio', // For page patterns only
 	//'quotes', -- Not exist
 	'services',
 	'store',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-dotcom-patterns.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-dotcom-patterns.ts
@@ -15,8 +15,7 @@ const useDotcomPatterns = (
 				method: 'GET',
 				apiVersion: '1.1',
 				query: new URLSearchParams( {
-					tags: 'assembler',
-					pattern_meta: 'is_web',
+					tags: 'assembler,assembler_priority',
 					categories: PATTERN_CATEGORIES.join( ',' ),
 				} ).toString(),
 			} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-patterns-map-by-category.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-patterns-map-by-category.ts
@@ -1,16 +1,16 @@
 import { useMemo } from 'react';
 import { PATTERN_CATEGORIES } from '../constants';
-import { isPriorityPattern } from '../utils';
-import type { Pattern, Category } from '../types';
+import { isPriorityPattern, isPagePattern } from '../utils';
+import type { Pattern } from '../types';
 
-const usePatternsMapByCategory = ( patterns: Pattern[], categories: Category[] ) => {
+const usePatternsMapByCategory = ( patterns: Pattern[] ) => {
 	return useMemo( () => {
 		const categoriesMap: Record< string, Pattern[] > = {};
 
 		patterns.reverse().forEach( ( pattern ) => {
 			Object.keys( pattern.categories ).forEach( ( category ) => {
-				if ( ! PATTERN_CATEGORIES.includes( category ) ) {
-					// Only show allowed categories
+				if ( ! PATTERN_CATEGORIES.includes( category ) || isPagePattern( pattern ) ) {
+					// Only show patterns (not pages) in allowed categories
 					return;
 				}
 				if ( ! categoriesMap[ category ] ) {
@@ -24,7 +24,7 @@ const usePatternsMapByCategory = ( patterns: Pattern[], categories: Category[] )
 			} );
 		} );
 		return categoriesMap;
-	}, [ patterns, categories ] );
+	}, [ patterns ] );
 };
 
 export default usePatternsMapByCategory;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -97,7 +97,7 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 		() => dotcomPatterns.map( ( pattern ) => encodePatternId( pattern.ID ) ),
 		[ dotcomPatterns ]
 	);
-	const patternsMapByCategory = usePatternsMapByCategory( dotcomPatterns, categories );
+	const patternsMapByCategory = usePatternsMapByCategory( dotcomPatterns );
 	const {
 		header,
 		footer,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
@@ -30,3 +30,5 @@ export const injectCategoryToPattern = (
 
 export const isPriorityPattern = ( { tags: { assembler_priority } }: Pattern ) =>
 	!! assembler_priority;
+
+export const isPagePattern = ( { tags: { assembler_page } }: Pattern ) => !! assembler_page;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #83449

## Proposed Changes

* Query:
  * Include the tag `assembler_priority` to fetch the page patterns (5) for this first iteration.
    * Read more in https://github.com/Automattic/wp-calypso/issues/83449.
  * Include the category `portfolio`
    * Only for page patterns because there aren't any `portfolio` patterns tagged as `assembler`.
  * Remove the tag `is_web`
    * Because isn't required as there aren't any `is_mobile` patterns tagged as `assembler`.
* Others
  * Only show patterns (not pages) in allowed categories
  * Add the util `isPagePattern()`
  * Clean unused code

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the assembler and confirm that the categories and patterns are the same as in production. 


https://github.com/Automattic/wp-calypso/assets/1881481/0a95c466-9e3f-49f1-bc44-922a73a067dd



Notes:
  * The query still doesn't return the new page patterns because they have not been published yet.
  * After the new page patterns are published, they won't appear in the list 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?