### PR TITLE
Staging Sites: Tweak synchronization option language

### DIFF
--- a/client/my-sites/hosting/staging-site-card/card-content/staging-sync-card.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/staging-sync-card.tsx
@@ -33,7 +33,7 @@ function useIsPermanentSyncError( error: string | null | undefined ) {
 const synchronizationOptions: CheckboxOptionItem[] = [
 	{
 		name: 'sqls',
-		label: 'Site Database (SQL)',
+		label: 'Site database (SQL)',
 		subTitle: translate(
 			'Overwrite the database, including any posts, pages, products, or orders.'
 		),
@@ -42,42 +42,35 @@ const synchronizationOptions: CheckboxOptionItem[] = [
 	},
 	{
 		name: 'themes',
-		label: translate( 'Themes' ),
-		subTitle: translate( 'All files and directories in the themes directory.' ),
+		label: translate( 'Theme files and directories' ),
 		checked: false,
 		isDangerous: false,
 	},
 	{
 		name: 'plugins',
-		label: translate( 'Plugins' ),
-		subTitle: translate( 'All files and directories in the plugins directory.' ),
+		label: translate( 'Plugin files and directories' ),
 		checked: false,
 		isDangerous: false,
 	},
 	{
 		name: 'uploads',
-		label: translate( 'Media Uploads' ),
+		label: translate( 'Media uploads' ),
 		subTitle: translate(
-			'All files and directories in the uploads directory. You must also select ‘Site database‘ if it is necessary for the files to appear as media uploads in WordPress.'
+			'You must also select ‘Site database’ for the files to appear in the Media Library.'
 		),
 		checked: false,
 		isDangerous: false,
 	},
 	{
 		name: 'contents',
-		label: translate( 'wp-content Directory' ),
-		subTitle: translate(
-			'All files and directories in the wp-content directory other than themes, plugins, and uploads.'
-		),
+		label: translate( 'Additional wp-content files and directories' ),
+		subTitle: translate( 'Anything other than themes, plugins, and uploads.' ),
 		checked: false,
 		isDangerous: false,
 	},
 	{
 		name: 'roots',
-		label: translate( 'Web Root' ),
-		subTitle: translate(
-			'All files and directories in the WordPress root other than wp-content, including any non WordPress files.'
-		),
+		label: translate( 'Additional web root files and directories' ),
 		checked: false,
 		isDangerous: false,
 	},
@@ -196,7 +189,7 @@ const StagingToProductionSync = ( {
 		<>
 			{ showSyncPanel && (
 				<>
-					<OptionsTreeTitle>{ translate( 'Synchronize the following:' ) }</OptionsTreeTitle>
+					<OptionsTreeTitle>{ translate( 'Synchronize this data:' ) }</OptionsTreeTitle>
 					<SyncOptionsPanel
 						reset={ ! isSyncInProgress }
 						items={ synchronizationOptions }

--- a/client/my-sites/hosting/staging-site-card/card-content/staging-sync-card.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/staging-sync-card.tsx
@@ -63,8 +63,8 @@ const synchronizationOptions: CheckboxOptionItem[] = [
 	},
 	{
 		name: 'contents',
-		label: translate( 'Additional wp-content files and directories' ),
-		subTitle: translate( 'Anything other than themes, plugins, and uploads.' ),
+		label: translate( 'wp-content files and directories' ),
+		subTitle: translate( 'Apart from themes, plugins, and uploads.' ),
 		checked: false,
 		isDangerous: false,
 	},

--- a/client/my-sites/hosting/staging-site-card/sync-options-panel.tsx
+++ b/client/my-sites/hosting/staging-site-card/sync-options-panel.tsx
@@ -23,7 +23,7 @@ const DangerousItemsTitle = styled.p( {
 
 const ToggleControlWithHelpMargin = styled( ToggleControl )( {
 	'.components-base-control__help': {
-		marginLeft: '4em',
+		marginLeft: '44px',
 		marginTop: 0,
 	},
 	label: {
@@ -45,7 +45,7 @@ const ToggleWithLabelFontSize = styled( ToggleControl )( {
 } );
 
 const ItemSubtitle = styled.span( {
-	fontSize: '12px',
+	fontSize: '14px',
 	color: 'var(--color-text-subtle) (#646970)',
 	fontStyle: 'italic',
 } );


### PR DESCRIPTION
See https://github.com/Automattic/dotcom-forge/issues/4223#issuecomment-1772553021

## Proposed Changes

Tweaks the language used in the synchronization options.

### After

<img width="762" alt="CleanShot 2023-10-25 at 11 27 06@2x" src="https://github.com/Automattic/wp-calypso/assets/36432/6e00abd1-4fb2-400b-8687-f48d375ff9d1">


### Before

<img width="760" alt="CleanShot 2023-10-25 at 05 18 23@2x" src="https://github.com/Automattic/wp-calypso/assets/36432/391e86ce-5058-4a57-825f-f5ff48a9aeaa">

## Testing Instructions

1. Navigate to Hosting Configuration and view the new settings.