### PR TITLE
Jetpack Manage: Add chevron down icon on All sites and Single site views (sidebar)

### DIFF
--- a/client/blocks/all-sites/index.jsx
+++ b/client/blocks/all-sites/index.jsx
@@ -1,6 +1,7 @@
 import config from '@automattic/calypso-config';
-import { Count, Gridicon } from '@automattic/components';
+import { Count } from '@automattic/components';
 import styled from '@emotion/styled';
+import { Icon, chevronDown } from '@wordpress/icons';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -38,7 +39,7 @@ class AllSites extends Component {
 		isHighlighted: false,
 		showCount: true,
 		showIcon: false,
-		showChevronIcon: false,
+		showChevronDownIcon: false,
 		domain: '',
 	};
 
@@ -49,7 +50,7 @@ class AllSites extends Component {
 		isHighlighted: PropTypes.bool,
 		showCount: PropTypes.bool,
 		showIcon: PropTypes.bool,
-		showChevronIcon: PropTypes.bool,
+		showChevronDownIcon: PropTypes.bool,
 		count: PropTypes.number,
 		icon: PropTypes.node,
 		title: PropTypes.string,
@@ -83,7 +84,7 @@ class AllSites extends Component {
 			isSelected,
 			showCount,
 			showIcon,
-			showChevronIcon,
+			showChevronDownIcon,
 		} = this.props;
 
 		// Note: Update CSS selectors in SiteSelector.scrollToHighlightedSite() if the class names change.
@@ -107,12 +108,8 @@ class AllSites extends Component {
 					<div className="all-sites__info site__info">
 						<span className="all-sites__title site__title">
 							{ title || translate( 'All My Sites' ) }
-							{ showChevronIcon && (
-								<Gridicon
-									className="all-sites__title-chevron-icon"
-									icon="chevron-down"
-									size={ 18 }
-								/>
+							{ showChevronDownIcon && (
+								<Icon icon={ chevronDown } className="all-sites__title-chevron-icon" size={ 24 } />
 							) }
 						</span>
 						{ domain && <span className="all-sites__domain site__domain">{ domain }</span> }

--- a/client/blocks/all-sites/index.jsx
+++ b/client/blocks/all-sites/index.jsx
@@ -1,5 +1,5 @@
 import config from '@automattic/calypso-config';
-import { Count } from '@automattic/components';
+import { Count, Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -38,6 +38,7 @@ class AllSites extends Component {
 		isHighlighted: false,
 		showCount: true,
 		showIcon: false,
+		showChevronIcon: false,
 		domain: '',
 	};
 
@@ -48,6 +49,7 @@ class AllSites extends Component {
 		isHighlighted: PropTypes.bool,
 		showCount: PropTypes.bool,
 		showIcon: PropTypes.bool,
+		showChevronIcon: PropTypes.bool,
 		count: PropTypes.number,
 		icon: PropTypes.node,
 		title: PropTypes.string,
@@ -72,8 +74,17 @@ class AllSites extends Component {
 	}
 
 	render() {
-		const { title, href, domain, translate, isHighlighted, isSelected, showCount, showIcon } =
-			this.props;
+		const {
+			title,
+			href,
+			domain,
+			translate,
+			isHighlighted,
+			isSelected,
+			showCount,
+			showIcon,
+			showChevronIcon,
+		} = this.props;
 
 		// Note: Update CSS selectors in SiteSelector.scrollToHighlightedSite() if the class names change.
 		const allSitesClass = classNames( {
@@ -96,6 +107,13 @@ class AllSites extends Component {
 					<div className="all-sites__info site__info">
 						<span className="all-sites__title site__title">
 							{ title || translate( 'All My Sites' ) }
+							{ showChevronIcon && (
+								<Gridicon
+									className="all-sites__title-chevron-icon"
+									icon="chevron-down"
+									size={ 18 }
+								/>
+							) }
 						</span>
 						{ domain && <span className="all-sites__domain site__domain">{ domain }</span> }
 					</div>

--- a/client/blocks/all-sites/style.scss
+++ b/client/blocks/all-sites/style.scss
@@ -6,6 +6,13 @@
 	padding: 0;
 	position: relative;
 
+	.all-sites__title {
+		display: flex;
+		.all-sites__title-chevron-icon {
+			margin-inline-start: 12px;
+		}
+	}
+
 	.all-sites__content {
 		padding: 13px 4px 13px 16px;
 		cursor: pointer;

--- a/client/blocks/all-sites/style.scss
+++ b/client/blocks/all-sites/style.scss
@@ -8,6 +8,8 @@
 
 	.all-sites__title {
 		display: flex;
+		align-items: center;
+
 		.all-sites__title-chevron-icon {
 			margin-inline-start: 12px;
 		}

--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -49,6 +49,7 @@ class Site extends Component {
 		homeLink: false,
 		// if homeLink is enabled
 		showHomeIcon: true,
+		showChevronIcon: false,
 		compact: false,
 
 		isP2Hub: false,
@@ -72,6 +73,7 @@ class Site extends Component {
 		siteId: PropTypes.number,
 		homeLink: PropTypes.bool,
 		showHomeIcon: PropTypes.bool,
+		showChevronIcon: PropTypes.bool,
 		compact: PropTypes.bool,
 		isP2Hub: PropTypes.bool,
 		isSiteP2: PropTypes.bool,
@@ -194,7 +196,16 @@ class Site extends Component {
 						size={ this.props.compact ? 24 : this.props.isReskinned ? 50 : 32 }
 					/>
 					<div className="site__info">
-						<div className="site__title">{ site.title }</div>
+						{ ! this.props.showChevronIcon ? (
+							<div className="site__title">{ site.title }</div>
+						) : (
+							<div className="site__title-with-chevron-icon">
+								<span className="site__title">{ site.title }</span>
+								<span className="site__title-chevron-icon">
+									<Gridicon icon="chevron-right" size={ 18 } />
+								</span>
+							</div>
+						) }
 						{ ! this.props.isReskinned && this.renderSiteDomain() }
 						{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
 						{ this.props.isSiteP2 && ! this.props.isP2Hub && (

--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -1,6 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { Gridicon } from '@automattic/components';
-import { layout } from '@wordpress/icons';
+import { Icon, chevronDown, layout } from '@wordpress/icons';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import page from 'page';
@@ -49,7 +49,7 @@ class Site extends Component {
 		homeLink: false,
 		// if homeLink is enabled
 		showHomeIcon: true,
-		showChevronIcon: false,
+		showChevronDownIcon: false,
 		compact: false,
 
 		isP2Hub: false,
@@ -73,7 +73,7 @@ class Site extends Component {
 		siteId: PropTypes.number,
 		homeLink: PropTypes.bool,
 		showHomeIcon: PropTypes.bool,
-		showChevronIcon: PropTypes.bool,
+		showChevronDownIcon: PropTypes.bool,
 		compact: PropTypes.bool,
 		isP2Hub: PropTypes.bool,
 		isSiteP2: PropTypes.bool,
@@ -196,13 +196,13 @@ class Site extends Component {
 						size={ this.props.compact ? 24 : this.props.isReskinned ? 50 : 32 }
 					/>
 					<div className="site__info">
-						{ ! this.props.showChevronIcon ? (
+						{ ! this.props.showChevronDownIcon ? (
 							<div className="site__title">{ site.title }</div>
 						) : (
 							<div className="site__title-with-chevron-icon">
 								<span className="site__title">{ site.title }</span>
 								<span className="site__title-chevron-icon">
-									<Gridicon icon="chevron-right" size={ 18 } />
+									<Icon icon={ chevronDown } size={ 24 } />
 								</span>
 							</div>
 						) }

--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -141,6 +141,19 @@
 	margin-top: 2px;
 }
 
+.site__title-with-chevron-icon {
+	display: flex;
+
+	.site__title {
+		position: relative;
+		flex: 1;
+	}
+	.site__title-chevron-icon {
+		color: var(--color-text);
+		margin-inline-start: 12px;
+	}
+}
+
 .site__title,
 .site__domain {
 	overflow: hidden;

--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -143,11 +143,12 @@
 
 .site__title-with-chevron-icon {
 	display: flex;
+	align-items: center;
 
 	.site__title {
 		position: relative;
-		flex: 1;
 	}
+
 	.site__title-chevron-icon {
 		color: var(--color-text);
 		margin-inline-start: 12px;

--- a/client/jetpack-cloud/components/sidebar/header/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/header/index.tsx
@@ -44,6 +44,7 @@ const Header = ( { forceAllSitesView = false }: Props ) => {
 			{ forceAllSitesView ? (
 				<AllSites
 					showIcon
+					showChevronIcon
 					showCount={ false }
 					icon={ <AllSitesIcon /> }
 					title={ translate( 'All Sites' ) }
@@ -51,6 +52,7 @@ const Header = ( { forceAllSitesView = false }: Props ) => {
 				/>
 			) : (
 				<Site
+					showChevronIcon
 					className="jetpack-cloud-sidebar__selected-site"
 					siteId={ selectedSiteId }
 					onSelect={ onSelectSite }

--- a/client/jetpack-cloud/components/sidebar/header/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/header/index.tsx
@@ -44,7 +44,7 @@ const Header = ( { forceAllSitesView = false }: Props ) => {
 			{ forceAllSitesView ? (
 				<AllSites
 					showIcon
-					showChevronIcon
+					showChevronDownIcon
 					showCount={ false }
 					icon={ <AllSitesIcon /> }
 					title={ translate( 'All Sites' ) }
@@ -52,7 +52,7 @@ const Header = ( { forceAllSitesView = false }: Props ) => {
 				/>
 			) : (
 				<Site
-					showChevronIcon
+					showChevronDownIcon
 					className="jetpack-cloud-sidebar__selected-site"
 					siteId={ selectedSiteId }
 					onSelect={ onSelectSite }


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/63

## Proposed Changes

This PR adds chevron down icons next to the "All sites" title (in All Sites view) and next to the Site name (in Single Site view).

As the component that renders the title is reused in many places, and there are some UX improvements like text fading out when overflows (e.g., a long site name), I decided to take a more defensive approach to ensure that this won't break the UX experience of any existing flow.

The additional CSS styles (on a single view) were needed as I wanted to preserve the existing fade-out effect for long texts, which turned out not to work as expected, but this will be fixed in a follow-up PR. Reported here: p1698124334920639-slack-C04H4NY6STW.

**Screenshot**

Before | After
--|--
![image](https://github.com/Automattic/wp-calypso/assets/1749918/ef8fb082-01e7-4f5f-a6b0-28002ce881ea)|![image](https://github.com/Automattic/wp-calypso/assets/1749918/e1be9dbe-fd15-47a3-85b6-f3807ca03e38)


## Testing Instructions
- Open the Jetpack Cloud Live link below and visit `/dashboard`
- Verify that chevron down icon is displayed next to the "All Sites" in the sidebar
- Visit single site view, e.g., `/backup/:site`
- Verify that chevron down icon is displayed next to the site name in the sidebar
- Verify that sites with long names are displayed correctly
- Open the Calypso live links below and verify no regression is caused by this PR
- Verify that everything looks good on different screen sizes

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?