### PR TITLE
Added redirection when the token from the email is expired for non-wpcom users

### DIFF
--- a/client/components/empty-content/index.jsx
+++ b/client/components/empty-content/index.jsx
@@ -38,6 +38,10 @@ class EmptyContent extends Component {
 	};
 
 	primaryAction() {
+		if ( ! this.props.action ) {
+			return null;
+		}
+
 		if ( typeof this.props.action !== 'string' ) {
 			return this.props.action;
 		}

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -160,14 +160,22 @@ export function magicLoginUse( context, next ) {
 
 	const previousQuery = context.state || {};
 
-	const { client_id, email, redirect_to, token } = previousQuery;
+	const { client_id, email, redirect_to, token, transition: isTransition } = previousQuery;
+
+	const transition = isTransition === 'true';
 
 	const flow = redirect_to?.includes( 'jetpack/connect' ) ? 'jetpack' : null;
 
 	const PrimaryComponent = getHandleEmailedLinkFormComponent( flow );
 
 	context.primary = (
-		<PrimaryComponent clientId={ client_id } emailAddress={ email } token={ token } />
+		<PrimaryComponent
+			clientId={ client_id }
+			emailAddress={ email }
+			token={ token }
+			redirectTo={ redirect_to }
+			transition={ transition }
+		/>
 	);
 
 	next();

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -161,7 +161,8 @@ export function magicLoginUse( context, next ) {
 	const previousQuery = context.state || {};
 
 	const { client_id, email, redirect_to, token, transition: isTransition } = previousQuery;
-
+	const params = new URLSearchParams( new URL( redirect_to ).search );
+	const activate = params.get( 'activate' );
 	const transition = isTransition === 'true';
 
 	const flow = redirect_to?.includes( 'jetpack/connect' ) ? 'jetpack' : null;
@@ -175,6 +176,7 @@ export function magicLoginUse( context, next ) {
 			token={ token }
 			redirectTo={ redirect_to }
 			transition={ transition }
+			activate={ activate }
 		/>
 	);
 

--- a/client/login/magic-login/emailed-login-link-expired.jsx
+++ b/client/login/magic-login/emailed-login-link-expired.jsx
@@ -28,7 +28,7 @@ const getEmailType = ( redirectTo ) => {
 		return EmailType.ManageSubscription;
 	}
 
-	if ( redirectTo && redirectTo.includes( 'redirect_to_blog_post_id' ) ) {
+	if ( redirectTo && redirectTo.includes( 'activate=' ) ) {
 		return EmailType.ConfirmSubscription;
 	}
 
@@ -93,26 +93,34 @@ class EmailedLoginLinkExpired extends Component {
 	};
 
 	resendEmail = ( emailType ) => {
+		if ( emailType === EmailType.ConfirmSubscription ) {
+			this.handleResponse(
+				resendSubscriptionConfirmationEmail(
+					this.state.emailAddress,
+					this.state.postId,
+					this.state.activate
+				)
+			);
+		}
+		if ( emailType === EmailType.ManageSubscription ) {
+			this.handleResponse(
+				resendSubscriptionManagementEmail( this.state.emailAddress, this.state.token )
+			);
+		}
+	};
+
+	handleResponse( promise ) {
 		const { translate } = this.props;
 		const errorMessages = getResendEmailErrorMessages( translate );
 
-		if ( emailType === EmailType.ConfirmSubscription ) {
-			resendSubscriptionConfirmationEmail(
-				this.state.emailAddress,
-				this.state.postId,
-				this.state.activate
-			)
-				.then( () => {
-					this.setCheckEmailText();
-				} )
-				.catch( ( error ) => {
-					this.props.errorNotice( errorMessages[ error.code ] );
-				} );
-		}
-		if ( emailType === EmailType.ManageSubscription ) {
-			resendSubscriptionManagementEmail();
-		}
-	};
+		promise
+			.then( () => {
+				this.setCheckEmailText();
+			} )
+			.catch( ( error ) => {
+				this.props.errorNotice( errorMessages[ error.code ] );
+			} );
+	}
 
 	setLoggingExpiredText = () => {
 		const { translate } = this.props;

--- a/client/login/magic-login/handle-emailed-link-form.jsx
+++ b/client/login/magic-login/handle-emailed-link-form.jsx
@@ -44,6 +44,7 @@ class HandleEmailedLinkForm extends Component {
 		token: PropTypes.string.isRequired,
 		redirectTo: PropTypes.string,
 		transition: PropTypes.bool,
+		activate: PropTypes.string,
 
 		// Connected props
 		authError: PropTypes.oneOfType( [ PropTypes.string, PropTypes.number ] ),
@@ -151,16 +152,26 @@ class HandleEmailedLinkForm extends Component {
 			translate,
 			initialQuery,
 			oauth2Client,
+			redirectTo,
+			transition,
+			token,
+			activate,
 		} = this.props;
 		const isWooDna = wooDnaConfig( initialQuery ).isWooDnaFlow();
 		const isGravPoweredClient = isGravPoweredOAuth2Client( oauth2Client );
 
 		if ( isExpired ) {
+			const postId = new URLSearchParams( redirectTo ).get( 'redirect_to_blog_post_id' );
+
 			return (
 				<EmailedLoginLinkExpired
 					isGravPoweredClient={ isGravPoweredClient }
-					redirectTo={ this.props.redirectTo }
-					transition={ this.props.transition }
+					redirectTo={ redirectTo }
+					transition={ transition }
+					token={ token }
+					emailAddress={ emailAddress }
+					postId={ postId }
+					activate={ activate }
 				/>
 			);
 		}

--- a/client/login/magic-login/handle-emailed-link-form.jsx
+++ b/client/login/magic-login/handle-emailed-link-form.jsx
@@ -42,6 +42,8 @@ class HandleEmailedLinkForm extends Component {
 		clientId: PropTypes.string,
 		emailAddress: PropTypes.string.isRequired,
 		token: PropTypes.string.isRequired,
+		redirectTo: PropTypes.string,
+		transition: PropTypes.bool,
 
 		// Connected props
 		authError: PropTypes.oneOfType( [ PropTypes.string, PropTypes.number ] ),
@@ -154,7 +156,13 @@ class HandleEmailedLinkForm extends Component {
 		const isGravPoweredClient = isGravPoweredOAuth2Client( oauth2Client );
 
 		if ( isExpired ) {
-			return <EmailedLoginLinkExpired isGravPoweredClient={ isGravPoweredClient } />;
+			return (
+				<EmailedLoginLinkExpired
+					isGravPoweredClient={ isGravPoweredClient }
+					redirectTo={ this.props.redirectTo }
+					transition={ this.props.transition }
+				/>
+			);
 		}
 
 		let buttonLabel;

--- a/client/login/magic-login/handle-emailed-link-form.jsx
+++ b/client/login/magic-login/handle-emailed-link-form.jsx
@@ -160,7 +160,7 @@ class HandleEmailedLinkForm extends Component {
 		const isWooDna = wooDnaConfig( initialQuery ).isWooDnaFlow();
 		const isGravPoweredClient = isGravPoweredOAuth2Client( oauth2Client );
 
-		if ( isExpired ) {
+		if ( isExpired && ! isFetching ) {
 			const postId = new URLSearchParams( redirectTo ).get( 'redirect_to_blog_post_id' );
 
 			return (
@@ -255,16 +255,18 @@ class HandleEmailedLinkForm extends Component {
 		}
 
 		return (
-			<EmptyContent
-				action={ action }
-				className={ classNames( 'magic-login__handle-link', {
-					'magic-login__is-fetching-auth': isFetching,
-				} ) }
-				illustration={ illustration }
-				illustrationWidth={ 500 }
-				line={ line }
-				title={ title }
-			/>
+			! isFetching && (
+				<EmptyContent
+					action={ action }
+					className={ classNames( 'magic-login__handle-link', {
+						'magic-login__is-fetching-auth': isFetching,
+					} ) }
+					illustration={ illustration }
+					illustrationWidth={ 500 }
+					line={ line }
+					title={ title }
+				/>
+			)
 		);
 	}
 }

--- a/client/login/magic-login/resend-email.jsx
+++ b/client/login/magic-login/resend-email.jsx
@@ -1,0 +1,42 @@
+import wpcomRequest from 'wpcom-proxy-request';
+
+export function resendSubscriptionConfirmationEmail( emailAddress, postId, key ) {
+	return wpcomRequest( {
+		path: '/subscribers/emails/resend/subscription-confirmation',
+		apiVersion: 'v2',
+		apiNamespace: 'wpcom/v2',
+		body: {
+			email_address: emailAddress,
+			post_id: postId,
+			key,
+		},
+		method: 'POST',
+	} );
+}
+
+export function resendSubscriptionManagementEmail( emailAddress, token ) {
+	return wpcomRequest( {
+		path: '/subscribers/emails/resend/subscription-management',
+		apiVersion: 'v2',
+		apiNamespace: 'wpcom/v2',
+		body: {
+			email_address: emailAddress,
+			token,
+		},
+		method: 'POST',
+	} );
+}
+
+export const getResendEmailErrorMessages = ( translate ) => {
+	return {
+		subscriber_not_found: translate( 'There is no subscriber with this email address.' ),
+		subscription_not_found: translate( 'There is no subscription with this email address.' ),
+		invalid_token: translate( 'The token is not valid for the provided email address.' ),
+		rest_invalid_param: translate(
+			'One of the parameters is not valid. Please checkc your inbox for a more recent email.'
+		),
+		rest_missing_callback_param: translate(
+			'One of the parameters is missing. Please check your inbox for a more recent email.'
+		),
+	};
+};


### PR DESCRIPTION
## Proposed Changes

When the non-WPCom user clicks on Confirm Subscription and Manage Subscriptions, and the token is expired, we need to show a different screen than the "Loggin link expired". Additionally, when the user clicks on the "try again" button, a different endpoint should be called (one for re-sending the email with the magic signup link).

## Testing Instructions

### Subscription Confirmation email

1. Apply this PR and start the application.
2. Go to a blog and subscribe with an email that doesn't have a WPCom account associated.
3. Go to your inbox and copy the link of the "Confirm now" button.
4. Check the link. There is a redirect_to parameter. Copy that URL. It should have this format: `wordpress.com/log-in/link/use?token=xxxxxx&email=xxxxx&client_id=xxxxx&redirect_to=xxxxxx&transition=true` (yes, it has another redirect_to inside).
5. Change `wordpress.com` for `calypso.localhost:3000` in that URL.
6. Go to the file `client/state/login/magic-login/actions.js` and change the line 77 from `token,` to `token: 'xxx'`. This way we are going to simulate the token is expired.
7. Open an incognito window and paste the URL you modified in the 5th step.
8. You should see the token expired screen:
<img width="878" alt="Screenshot 2023-10-26 at 17 48 03" src="https://github.com/Automattic/wp-calypso/assets/3832570/b87d77a9-0a4a-49b0-9ce6-c26cc900617b">
9. Click on the `Try again` button.
10. Check your inbox. You should have a new link with a refreshed token. Copy the link.
11. Paste the link into an incognito window, and it should confirm the subscription correctly (you would want to check the subscriber's page of that blog and see if your email is there now).


### Subscription Manager email

1. Apply this PR and start the application.
2. Go to `https://wordpress.com/email-subscriptions`. Write your non-wpcom user email and press enter.
3. Go to your inbox and copy the link of the "Manage Subscriptions" button.
4. Check the link. There is a redirect_to parameter. Copy that URL. It should have this format: `https://wordpress.com/log-in/link/use?token=xxxx&email=xxxx&client_id=xxxxx&redirect_to=xxxxxx&transition=true` (yes, this one has another redirect_to inside too).
5. Change `wordpress.com` for `calypso.localhost:3000` in that URL.
6. Go to the file `client/state/login/magic-login/actions.js` and change the line 77 from `token,` to `token: 'xxx'`. This way we are going to simulate the token is expired.
7. Open an incognito window and paste the URL you modified in the 5th step.
8. You should see the token expired screen:
<img width="844" alt="Screenshot 2023-10-26 at 20 37 02" src="https://github.com/Automattic/wp-calypso/assets/3832570/33cf402c-bf2b-49cb-af98-ae4bcf2fb58a">
9. Click on the `Try again` button.
10. Check your inbox. You should have a new link with a refreshed token. Copy the link.
11. Paste the link into an incognito window, and it should take you to your subscriptions screen.

### **Regression test**

1. Go to `calypso.localhost:3000` in an incognito window in the browser.
2. Click `Log in to WordPress.com`.
3. Click `Email me a login link`.
4. Insert there the email of a WPCom account and click `Get link`.
5. Go to your inbox, copy the link in the action button on the email, and change `wordpress.com` to `calypso.localhost:3000` in that link.
6. Paste the link in an incognito window. It should proceed as normal.


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?