### PR TITLE
Plans Grid Refactor: Remove is reskinned parameter from plan grid related code

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -81,7 +81,6 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 	const translate = useTranslate();
 	const isDesktop = useDesktopBreakpoint();
 	const stepName = 'plans';
-	const isReskinned = true;
 	const customerType = 'personal';
 	const isInVerticalScrollingPlansExperiment = true;
 	const headerText = __( 'Choose a plan' );
@@ -153,7 +152,6 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 					customerType={ customerType }
 					plansWithScroll={ isDesktop }
 					flowName={ flowName }
-					isReskinned={ isReskinned }
 					hidePlansFeatureComparison={ hidePlansFeatureComparison }
 					intent={ plansIntent }
 					removePaidDomain={ removePaidDomain }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -174,7 +174,6 @@ export interface PlansFeaturesMainProps {
 	hideEnterprisePlan?: boolean;
 	isStepperUpgradeFlow?: boolean;
 	isLaunchPage?: boolean | null;
-	isReskinned?: boolean;
 	isPlansInsideStepper?: boolean;
 	showBiennialToggle?: boolean;
 	hideUnavailableFeatures?: boolean; // used to hide features that are not available, instead of strike-through as explained in #76206
@@ -226,7 +225,6 @@ const PlansFeaturesMain = ( {
 	hideEcommercePlan,
 	hideEnterprisePlan,
 	intent: intentFromProps, // do not set a default value for this prop here
-	isReskinned,
 	showBiennialToggle,
 	customerType = 'personal',
 	planTypeSelector = 'interval',
@@ -793,7 +791,6 @@ const PlansFeaturesMain = ( {
 									selectedFeature={ selectedFeature }
 									selectedPlan={ selectedPlan }
 									siteId={ siteId }
-									isReskinned={ isReskinned }
 									intervalType={ intervalType }
 									hideUnavailableFeatures={ hideUnavailableFeatures }
 									currentSitePlanSlug={ sitePlanSlug }
@@ -857,7 +854,6 @@ const PlansFeaturesMain = ( {
 												selectedFeature={ selectedFeature }
 												selectedPlan={ selectedPlan }
 												siteId={ siteId }
-												isReskinned={ isReskinned }
 												intervalType={ intervalType }
 												hideUnavailableFeatures={ hideUnavailableFeatures }
 												currentSitePlanSlug={ sitePlanSlug }

--- a/client/my-sites/plans-grid/components/features-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/features-grid/index.tsx
@@ -237,25 +237,16 @@ class FeaturesGrid extends Component< FeaturesGridType > {
 	}
 
 	renderPlanPrice( renderedGridPlans: GridPlan[], options?: PlanRowOptions ) {
-		const {
-			isReskinned,
-			isLargeCurrency,
-			translate,
-			isPlanUpgradeCreditEligible,
-			currentSitePlanSlug,
-			siteId,
-		} = this.props;
+		const { isLargeCurrency, translate, isPlanUpgradeCreditEligible, currentSitePlanSlug, siteId } =
+			this.props;
 		return renderedGridPlans.map( ( { planSlug } ) => {
 			const isWooExpressPlus = isWooExpressPlusPlan( planSlug );
-			const classes = classNames( 'plan-features-2023-grid__table-item', {
-				'has-border-top': ! isReskinned,
-			} );
 
 			return (
 				<PlanDivOrTdContainer
 					scope="col"
 					key={ planSlug }
-					className={ classes }
+					className="plan-features-2023-grid__table-item plan-price"
 					isTableCell={ options?.isTableCell }
 				>
 					<PlanFeatures2023GridHeaderPrice

--- a/client/my-sites/plugins/plans/index.tsx
+++ b/client/my-sites/plugins/plans/index.tsx
@@ -103,7 +103,6 @@ const Plans = ( { intervalType }: { intervalType: 'yearly' | 'monthly' } ) => {
 					intervalType={ intervalType }
 					selectedPlan={ PLAN_BUSINESS }
 					intent="plans-plugins"
-					isReskinned
 				/>
 			</div>
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
Fixes #78569
- Related to: https://github.com/Automattic/wp-calypso/issues/82335
- Builds on top of : https://github.com/Automattic/wp-calypso/pull/83443
- This is part of a chain of branches, Please Follow order shown here for order in which to review  https://github.com/Automattic/wp-calypso/issues/82335#issuecomment-1781940845
## Proposed Changes
* Removes the unnecessary isReskinned flag, the change should not effect any styling of the grids since the reskinned flag was not use in the new layout.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure all tests run without errors.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?