### PR TITLE
Fix "manage patterns"editor menu item to work when iframed

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -647,10 +647,11 @@ async function openLinksInParentFrame( calypsoPort ) {
 	const body = document.querySelector( '.interface-interface-skeleton__body' );
 	sidebarsObserver.observe( body, { childList: true } );
 
+	// Observes the popover slot for the "Manage reusable blocks" link which can be found
+	// in the reusable block's more menu or in the block-editor menu
 	const popoverSlotObserver = new window.MutationObserver( ( mutations ) => {
-		const isComponentsPopover = ( node ) => node.classList.contains( 'components-popover' );
-
 		const replaceWithManageReusableBlocksHref = ( anchorElem ) => {
+			// We should leave the URL alone so it goes to the fancy site-editor view, not a regular old post listing
 			anchorElem.href = manageReusableBlocksUrl;
 			anchorElem.target = '_top';
 		};
@@ -664,11 +665,13 @@ async function openLinksInParentFrame( calypsoPort ) {
 					continue;
 				}
 
-				if ( isComponentsPopover( node ) ) {
-					const manageReusableBlocksAnchorElem = node.querySelector(
-						'a[href$="edit.php?post_type=wp_block"]'
+				const popoverSlot = node.querySelector( '.components-popover' );
+
+				if ( popoverSlot ) {
+					const manageReusableBlocksAnchorElem = popoverSlot.querySelector(
+						'a[href$="site-editor.php?path=%2Fpatterns"]'
 					);
-					const manageNavigationMenusAnchorElem = node.querySelector(
+					const manageNavigationMenusAnchorElem = popoverSlot.querySelector(
 						'a[href$="edit.php?post_type=wp_navigation"]'
 					);
 
@@ -692,7 +695,7 @@ async function openLinksInParentFrame( calypsoPort ) {
 			}
 		}
 	} );
-	const popoverSlotElem = document.querySelector( '.interface-interface-skeleton ~ .popover-slot' );
+	const popoverSlotElem = document.querySelector( 'body' );
 	popoverSlotElem && popoverSlotObserver.observe( popoverSlotElem, { childList: true } );
 
 	// Sidebar might already be open before this script is executed.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #83472 

## Proposed Changes

Clicking "Manage pattern" link in the block-editor menu shows a firefox error, this fixes that. It does not fix the individual pattern block menus (see #83472) - those menu items are added after the initial menu component is created.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


 1. Ensure you use the calypso rather than classic view to manage posts
 2. Go to the post editor
 3. Click the three-dot/meatball menu at the top right
 4. Click Manage patterns
 5. It should send you to the manage patterns interface without any scary iframe warnings.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?