### PR TITLE
Checkout: update free purchase label for Akismet Free carts

### DIFF
--- a/client/my-sites/checkout/src/payment-methods/free-purchase.tsx
+++ b/client/my-sites/checkout/src/payment-methods/free-purchase.tsx
@@ -80,6 +80,8 @@ function WordPressFreePurchaseLabel() {
 	const isCartAllOneTimePurchases = responseCart.products.every(
 		( product ) => product.is_one_time_purchase
 	);
+	// Don't show additional free payment methods if all products in the cart prevent them.
+	// Currently only Akismet Free explicitly prevents them.
 	const isCartAllProductsThatPreventAdditionalFreeMethods = responseCart.products.every(
 		( product ) => product.product_slug === PRODUCT_AKISMET_FREE
 	);

--- a/client/my-sites/checkout/src/payment-methods/free-purchase.tsx
+++ b/client/my-sites/checkout/src/payment-methods/free-purchase.tsx
@@ -1,3 +1,4 @@
+import { PRODUCT_AKISMET_FREE } from '@automattic/calypso-products';
 import { Button, useFormStatus, FormStatus } from '@automattic/composite-checkout';
 import formatCurrency from '@automattic/format-currency';
 import { useShoppingCart } from '@automattic/shopping-cart';
@@ -79,8 +80,15 @@ function WordPressFreePurchaseLabel() {
 	const isCartAllOneTimePurchases = responseCart.products.every(
 		( product ) => product.is_one_time_purchase
 	);
+	const isCartAllProductsThatPreventAdditionalFreeMethods = responseCart.products.every(
+		( product ) => product.product_slug === PRODUCT_AKISMET_FREE
+	);
 
-	if ( ! isCartAllOneTimePurchases && ! doesCartHaveRenewalWithPaymentMethod ) {
+	if (
+		! isCartAllOneTimePurchases &&
+		! doesCartHaveRenewalWithPaymentMethod &&
+		! isCartAllProductsThatPreventAdditionalFreeMethods
+	) {
 		return (
 			<>
 				<div>{ __( 'Assign a payment method later' ) }</div>


### PR DESCRIPTION
Some products (e.g. Akismet Free) are intentionally free, recurring (not one-time), and not meant to be upgraded. As such, there's no need to show the free Checkout payment methods. This PR updates the free payment method to say "Free Purchase" instead of "Assign Payment Method Later" for Akismet Free carts.

Backend: ~~D126607-code~~
Fixes: https://github.com/Automattic/payments-shilling/issues/2109

**To test:**
- for a user without any Akismet purchases or a new user, visit calypso.localhost:3000/checkout/akismet/ak_free_yearly
- verify that only the free payment method is shown in the payment method step and that its label reads "Free Purchase"