### PR TITLE
FHT: Redirect to start of the flow when user already had a free trial

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/hosting-trial-acknowledge.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/hosting-trial-acknowledge.tsx
@@ -5,9 +5,8 @@ import {
 	PLAN_BUSINESS,
 	getPlan,
 } from '@automattic/calypso-products';
-import { NextButton, SubTitle, Title } from '@automattic/onboarding';
+import { NextButton, SubTitle } from '@automattic/onboarding';
 import { Button, Spinner } from '@wordpress/components';
-import { createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { getFeatureByKey } from 'calypso/lib/plans/features-list';
@@ -22,12 +21,11 @@ const FEATURES_NOT_INCLUDED_IN_FREE_TRIAL = [
 	FEATURE_PAYMENT_TRANSACTION_FEES_2,
 ];
 
-interface Props {
-	goBack?: () => void;
+interface CallToActionProps {
 	onStartTrialClick(): void;
 }
 
-const CallToAction = ( { onStartTrialClick }: Props ) => {
+const CallToAction = ( { onStartTrialClick }: CallToActionProps ) => {
 	const { __ } = useI18n();
 	const { isVerified, hasUser, isSending, email, resendEmail } = useVerifyEmail();
 	const startTrial = () => {
@@ -49,7 +47,7 @@ const CallToAction = ( { onStartTrialClick }: Props ) => {
 	);
 };
 
-const HostingTrialAcknowledgeInternal = ( { onStartTrialClick, goBack }: Props ) => {
+const HostingTrialAcknowledgeInternal = ( { onStartTrialClick }: CallToActionProps ) => {
 	const { __ } = useI18n();
 	const plan = getPlan( PLAN_BUSINESS );
 	const isEligible = useSelector( isUserEligibleForFreeHostingTrial );
@@ -57,20 +55,7 @@ const HostingTrialAcknowledgeInternal = ( { onStartTrialClick, goBack }: Props )
 		plan && 'getPlanCompareFeatures' in plan ? plan.getPlanCompareFeatures?.() ?? [] : [];
 
 	if ( ! isEligible ) {
-		return (
-			<div className="trial-plan--container">
-				<Title>{ __( 'You already enrolled in a trial' ) }</Title>
-				<SubTitle>
-					{ createInterpolateElement(
-						__(
-							"You've already enjoyed a free trial and are not eligible for another.<br />Upgrade now to keep enjoying the benefits of a Business plan."
-						),
-						{ br: <br /> }
-					) }
-				</SubTitle>
-				<NextButton onClick={ goBack }>{ __( 'Upgrade now' ) }</NextButton>
-			</div>
-		);
+		return window.location.assign( '/setup/new-hosted-site' );
 	}
 
 	return (
@@ -142,10 +127,5 @@ function EmailVerification( {
 }
 
 export const HostingTrialAcknowledge: Step = ( { navigation } ) => {
-	return (
-		<HostingTrialAcknowledgeInternal
-			onStartTrialClick={ () => navigation.submit?.() }
-			goBack={ navigation.goBack }
-		/>
-	);
+	return <HostingTrialAcknowledgeInternal onStartTrialClick={ () => navigation.submit?.() } />;
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/hosting-trial-acknowledge.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/hosting-trial-acknowledge.tsx
@@ -63,7 +63,7 @@ const HostingTrialAcknowledgeInternal = ( { onStartTrialClick, goBack }: Props )
 				<SubTitle>
 					{ createInterpolateElement(
 						__(
-							"You've already enrolled in a free trial and is not eligible for a new one.<br />Upgrade now to continue enjoying the benefits of a Business plan."
+							"You've already enjoyed a free trial and are not eligible for another.<br />Upgrade now to keep enjoying the benefits of a Business plan."
 						),
 						{ br: <br /> }
 					) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/hosting-trial-acknowledge.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/hosting-trial-acknowledge.tsx
@@ -9,6 +9,7 @@ import { NextButton, SubTitle } from '@automattic/onboarding';
 import { Button, Spinner } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
+import { useEffect } from 'react';
 import { getFeatureByKey } from 'calypso/lib/plans/features-list';
 import { useSelector } from 'calypso/state';
 import { isUserEligibleForFreeHostingTrial } from 'calypso/state/selectors/is-user-eligible-for-free-hosting-trial';
@@ -54,8 +55,14 @@ const HostingTrialAcknowledgeInternal = ( { onStartTrialClick }: CallToActionPro
 	const planFeatures =
 		plan && 'getPlanCompareFeatures' in plan ? plan.getPlanCompareFeatures?.() ?? [] : [];
 
+	useEffect( () => {
+		if ( ! isEligible ) {
+			window.location.assign( '/setup/new-hosted-site' );
+		}
+	}, [ isEligible ] );
+
 	if ( ! isEligible ) {
-		return window.location.assign( '/setup/new-hosted-site' );
+		return null;
 	}
 
 	return (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/hosting-trial-acknowledge.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/hosting-trial-acknowledge.tsx
@@ -9,10 +9,7 @@ import { NextButton, SubTitle } from '@automattic/onboarding';
 import { Button, Spinner } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
-import { useEffect } from 'react';
 import { getFeatureByKey } from 'calypso/lib/plans/features-list';
-import { useSelector } from 'calypso/state';
-import { isUserEligibleForFreeHostingTrial } from 'calypso/state/selectors/is-user-eligible-for-free-hosting-trial';
 import { TrialPlan } from './trial-plan';
 import { useVerifyEmail } from './use-verify-email';
 import type { Step } from '../../types';
@@ -52,19 +49,8 @@ const CallToAction = ( { onStartTrialClick }: CallToActionProps ) => {
 const HostingTrialAcknowledgeInternal = ( { onStartTrialClick }: CallToActionProps ) => {
 	const { __ } = useI18n();
 	const plan = getPlan( PLAN_BUSINESS );
-	const isEligible = useSelector( isUserEligibleForFreeHostingTrial );
 	const planFeatures =
 		plan && 'getPlanCompareFeatures' in plan ? plan.getPlanCompareFeatures?.() ?? [] : [];
-
-	useEffect( () => {
-		if ( ! isEligible ) {
-			window.location.assign( '/setup/new-hosted-site' );
-		}
-	}, [ isEligible ] );
-
-	if ( ! isEligible ) {
-		return null;
-	}
 
 	return (
 		<TrialPlan

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/hosting-trial-acknowledge.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/hosting-trial-acknowledge.tsx
@@ -15,6 +15,7 @@ import { useSelector } from 'calypso/state';
 import { isUserEligibleForFreeHostingTrial } from 'calypso/state/selectors/is-user-eligible-for-free-hosting-trial';
 import { TrialPlan } from './trial-plan';
 import { useVerifyEmail } from './use-verify-email';
+import type { Step } from '../../types';
 
 const FEATURES_NOT_INCLUDED_IN_FREE_TRIAL = [
 	FEATURE_CUSTOM_DOMAIN,

--- a/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
@@ -8,6 +8,8 @@ import {
 	persistSignupDestination,
 	setSignupCompleteFlowName,
 } from 'calypso/signup/storageUtils';
+import { useSelector } from 'calypso/state';
+import { isUserEligibleForFreeHostingTrial } from 'calypso/state/selectors/is-user-eligible-for-free-hosting-trial';
 import { useSiteSetupFlowProgress } from '../hooks/use-site-setup-flow-progress';
 import { ONBOARD_STORE, USER_STORE } from '../stores';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
@@ -155,7 +157,7 @@ const hosting: Flow = {
 	},
 	useSideEffect( currentStepSlug ) {
 		const { resetOnboardStore } = useDispatch( ONBOARD_STORE );
-
+		const isEligible = useSelector( isUserEligibleForFreeHostingTrial );
 		const userIsLoggedIn = useSelect(
 			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
 			[]
@@ -165,7 +167,11 @@ const hosting: Flow = {
 			if ( ! userIsLoggedIn ) {
 				window.location.assign( '/start/hosting' );
 			}
-		}, [ userIsLoggedIn ] );
+
+			if ( currentStepSlug === 'trialAcknowledge' && ! isEligible ) {
+				window.location.assign( '/setup/new-hosted-site' );
+			}
+		}, [ userIsLoggedIn, isEligible, currentStepSlug ] );
 
 		useEffect(
 			() => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
Users can go to `/trialAcknowledge` and click the `Start trial` button even though they had already completed a trial.
This PR redirects to start of flow to prevent creating an empty site with trial button
Related to #

## Proposed Changes

* Redirect to start of the flow if user not eligible

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enroll in a hosting trial or use an account that had already enrolled
* go to `/new-hosted-site/trialAcknowledge`
* Verify you are redirected to start of the flow.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?