### PR TITLE
Reader: Add tracking to individual posts as user scrolls

### DIFF
--- a/client/reader/stream/post-lifecycle.jsx
+++ b/client/reader/stream/post-lifecycle.jsx
@@ -40,11 +40,6 @@ const useTrackPostView = ( postObj ) => {
 			}
 
 			const intersectionHandler = ( entries ) => {
-				// Only fire once per category
-				if ( ! wrapperDiv ) {
-					return;
-				}
-
 				const [ entry ] = entries;
 				if ( ! entry.isIntersecting ) {
 					return;

--- a/client/reader/stream/post-lifecycle.jsx
+++ b/client/reader/stream/post-lifecycle.jsx
@@ -26,7 +26,7 @@ import CrossPost from './x-post';
  * @param postObj Object The post data.
  * @returns A callback ref that MUST be used on a div element for tracking.
  */
-const useTrackPostView = ( postObj ) => {
+const useTrackPostView = ( postObj, stream ) => {
 	const observerRef = useRef();
 
 	// Use a callback as the ref so we get called for both mount and unmount events
@@ -49,6 +49,7 @@ const useTrackPostView = ( postObj ) => {
 					feed_id: postObj?.feed_ID,
 					site_id: postObj?.blogId,
 					post_id: postObj?.postId,
+					ui_algo: stream,
 				} );
 			};
 
@@ -70,7 +71,7 @@ const useTrackPostView = ( postObj ) => {
  * @returns A React component that renders a post and tracks when the post is displayed.
  */
 const TrackedPost = ( { ...props } ) => {
-	const trackingDivRef = useTrackPostView( props.postKey );
+	const trackingDivRef = useTrackPostView( props.postKey, props.streamKey );
 
 	return <Post postRef={ trackingDivRef } { ...props } />;
 };

--- a/client/reader/stream/post-lifecycle.jsx
+++ b/client/reader/stream/post-lifecycle.jsx
@@ -24,6 +24,7 @@ import CrossPost from './x-post';
  * The hook ensures that we generate post display Tracks events when the user views
  * the underlying `div` element.
  * @param postObj Object The post data.
+ * @param recordTracksEvent Function The function to call to record a Tracks event with standardized Reader props.
  * @returns A callback ref that MUST be used on a div element for tracking.
  */
 const useTrackPostView = ( postObj, recordTracksEvent ) => {

--- a/client/reader/stream/post.jsx
+++ b/client/reader/stream/post.jsx
@@ -55,8 +55,10 @@ class ReaderPostCardAdapter extends Component {
 				fixedHeaderHeight={ this.props.fixedHeaderHeight }
 				streamKey={ this.props.streamKey }
 			>
-				{ feedId && <QueryReaderFeed feedId={ feedId } /> }
-				{ ! isExternal && siteId && <QueryReaderSite siteId={ +siteId } /> }
+				<div ref={ this.props.postRef }>
+					{ feedId && <QueryReaderFeed feedId={ feedId } /> }
+					{ ! isExternal && siteId && <QueryReaderSite siteId={ +siteId } /> }
+				</div>
 			</ReaderPostCard>
 		);
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #83358

## Proposed Changes

* Use a callback with the Intersection Observer API to fire a Tracks event each time a post scrolls into view.
* Wrap the `Post` in a function component so we can make use of hooks.
* Wrap the content of each post in a DIV with the tracking `ref`
* Fire the Tracks event `calypso_reader_post_display` each time the post is more than 60% shown in the viewport with multiple Reader-specific props, including the `ui_algo` (stream context), post ID, feed ID, and blog ID.

~~This is working, but there's some strange behavior that causes a ton of warnings to crop up in the console about selectors returning different results with the same parameters causing unnecessary rerenders.~~

I checked `trunk` and you get the same warnings on several different pages in Calypso, including the Reader, so I don't think those are related to this PR:

<img width="831" alt="Screenshot 2023-10-26 at 9 29 12 AM" src="https://github.com/Automattic/wp-calypso/assets/2124984/c81f8f59-4de3-4378-ab0c-b4622e331817">

It might be worth investigating as part of improving Reader's performance going forward, though.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR
* Navigate to `/discover` 
* Open the console and show Tracks events by adding `localStorage.debug="calypso:analytics*"`, hitting enter, and refreshing the page; alternatively, use Tracks Vigilante.
* As you scroll down the page you should see new events firing called `calypso_reader_post_display` with props `feed_id`, `site_id`, and `post_id`.
* When a post is approximately 60% within the viewport, the event should fire.

<img width="633" alt="Screenshot 2023-10-30 at 1 33 32 PM" src="https://github.com/Automattic/wp-calypso/assets/2124984/224d14a5-7a3e-4f7b-b6e0-76d93f3b540c">

## Pre-merge Checklist


<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?