### PR TITLE
JP Manage: 46 - add partner opt-in checkbox

### DIFF
--- a/client/jetpack-cloud/sections/agency-signup/agency-signup-form/index.tsx
+++ b/client/jetpack-cloud/sections/agency-signup/agency-signup-form/index.tsx
@@ -55,6 +55,7 @@ export default function AgencySignupForm() {
 					contact_person: payload.contactPerson,
 					company_website: payload.companyWebsite,
 					company_type: payload.companyType,
+					partner_program_opt_in: payload.partnerProgramOptIn,
 					city: payload.city,
 					line1: payload.line1,
 					line2: payload.line2,

--- a/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
@@ -1,6 +1,7 @@
 import { Button, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState, useMemo, ChangeEvent, useEffect } from 'react';
+import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormRadio from 'calypso/components/forms/form-radio';
@@ -68,12 +69,20 @@ export default function CompanyDetailsForm( {
 	const [ contactPerson, setContactPerson ] = useState( initialValues.contactPerson ?? '' );
 	const [ companyWebsite, setCompanyWebsite ] = useState( initialValues.companyWebsite ?? '' );
 	const [ companyType, setCompanyType ] = useState( initialValues.companyType ?? '' );
+	const [ partnerProgramOptIn, setPartnerProgramOptIn ] = useState( false );
+
+	const [ showPartnerProgramOptIn, setShowPartnerProgramOptIn ] = useState( false );
 
 	const country = getCountry( countryValue, countryOptions );
 	const stateOptions = stateOptionsMap[ country ];
 
 	const handleCompanyTypeChange = ( event: ChangeEvent< HTMLInputElement > ) => {
 		setCompanyType( event.target.value );
+
+		const isEligibleForPartnerProgram = companyTypesEligibleForPartnerProgram.includes(
+			event.target.value
+		);
+		setShowPartnerProgramOptIn( isEligibleForPartnerProgram );
 	};
 	useEffect( () => {
 		// Reset the value of state since our options have changed.
@@ -190,6 +199,23 @@ export default function CompanyDetailsForm( {
 						className={ undefined }
 					/>
 				</FormFieldset>
+				{ showPartnerProgramOptIn && (
+					<FormFieldset>
+						<FormLabel htmlFor="partnerProgramOptIn">
+							{ translate( 'Jetpack Agency & Pro Partner program' ) }
+						</FormLabel>
+						<FormInputCheckbox
+							id="partnerProgramOptIn"
+							name="partnerProgramOptIn"
+							checked={ partnerProgramOptIn }
+							disabled={ isLoading }
+							onChange={ ( event: ChangeEvent< HTMLInputElement > ) =>
+								setPartnerProgramOptIn( event.target.checked )
+							}
+						/>
+						<span>{ translate( 'Sign up for the Jetpack Agency & Pro Partner program' ) }</span>
+					</FormFieldset>
+				) }
 				<FormFieldset>
 					<FormLabel>{ translate( 'Country' ) }</FormLabel>
 					{ showCountryFields && (

--- a/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
@@ -38,6 +38,7 @@ interface Props {
 		contactPerson?: string;
 		companyWebsite?: string;
 		companyType?: string;
+		partnerProgramOptIn?: boolean;
 		city?: string;
 		line1?: string;
 		line2?: string;
@@ -103,6 +104,7 @@ export default function CompanyDetailsForm( {
 			contactPerson,
 			companyWebsite,
 			companyType,
+			partnerProgramOptIn,
 			city,
 			line1,
 			line2,
@@ -116,6 +118,7 @@ export default function CompanyDetailsForm( {
 			contactPerson,
 			companyWebsite,
 			companyType,
+			partnerProgramOptIn,
 			city,
 			line1,
 			line2,

--- a/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
@@ -26,6 +26,8 @@ function getCountry( country: string, options: CountryOption[] ): string {
 	return options[ 0 ].value;
 }
 
+const companyTypesEligibleForPartnerProgram = [ 'agency', 'freelancer' ];
+
 interface Props {
 	includeTermsOfService?: boolean;
 	isLoading: boolean;

--- a/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
@@ -78,11 +78,10 @@ export default function CompanyDetailsForm( {
 	const stateOptions = stateOptionsMap[ country ];
 
 	const handleCompanyTypeChange = ( event: ChangeEvent< HTMLInputElement > ) => {
-		setCompanyType( event.target.value );
+		const selectedType = event.target.value;
+		setCompanyType( selectedType );
 
-		const isEligibleForPartnerProgram = companyTypesEligibleForPartnerProgram.includes(
-			event.target.value
-		);
+		const isEligibleForPartnerProgram = companyTypesEligibleForPartnerProgram.includes( selectedType );
 		setShowPartnerProgramOptIn( isEligibleForPartnerProgram );
 	};
 

--- a/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
@@ -84,6 +84,14 @@ export default function CompanyDetailsForm( {
 		);
 		setShowPartnerProgramOptIn( isEligibleForPartnerProgram );
 	};
+
+	useEffect( () => {
+		// reset opt-in setting if ineligible company is selected
+		if ( ! companyTypesEligibleForPartnerProgram.includes( companyType ) ) {
+			setPartnerProgramOptIn( false );
+		}
+	}, [ companyType ] );
+
 	useEffect( () => {
 		// Reset the value of state since our options have changed.
 		setAddressState( stateOptions?.length ? stateOptions[ 0 ].value : '' );

--- a/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
@@ -81,7 +81,8 @@ export default function CompanyDetailsForm( {
 		const selectedType = event.target.value;
 		setCompanyType( selectedType );
 
-		const isEligibleForPartnerProgram = companyTypesEligibleForPartnerProgram.includes( selectedType );
+		const isEligibleForPartnerProgram =
+			companyTypesEligibleForPartnerProgram.includes( selectedType );
 		setShowPartnerProgramOptIn( isEligibleForPartnerProgram );
 	};
 

--- a/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
@@ -70,6 +70,9 @@ export default function CompanyDetailsForm( {
 	const country = getCountry( countryValue, countryOptions );
 	const stateOptions = stateOptionsMap[ country ];
 
+	const handleCompanyTypeChange = ( event: ChangeEvent< HTMLInputElement > ) => {
+		setCompanyType( event.target.value );
+	};
 	useEffect( () => {
 		// Reset the value of state since our options have changed.
 		setAddressState( stateOptions?.length ? stateOptions[ 0 ].value : '' );
@@ -164,9 +167,7 @@ export default function CompanyDetailsForm( {
 						label={ translate( 'Agency' ) }
 						value="agency"
 						checked={ companyType === 'agency' }
-						onChange={ ( event: ChangeEvent< HTMLInputElement > ) =>
-							setCompanyType( event.target.value )
-						}
+						onChange={ handleCompanyTypeChange }
 						disabled={ isLoading }
 						className={ undefined }
 					/>
@@ -174,9 +175,7 @@ export default function CompanyDetailsForm( {
 						label={ translate( 'Freelancer/Pro' ) }
 						value="freelancer"
 						checked={ companyType === 'freelancer' }
-						onChange={ ( event: ChangeEvent< HTMLInputElement > ) =>
-							setCompanyType( event.target.value )
-						}
+						onChange={ handleCompanyTypeChange }
 						disabled={ isLoading }
 						className={ undefined }
 					/>
@@ -184,9 +183,7 @@ export default function CompanyDetailsForm( {
 						label={ translate( 'A business with multiple sites' ) }
 						value="business"
 						checked={ companyType === 'business' }
-						onChange={ ( event: ChangeEvent< HTMLInputElement > ) =>
-							setCompanyType( event.target.value )
-						}
+						onChange={ handleCompanyTypeChange }
 						disabled={ isLoading }
 						className={ undefined }
 					/>

--- a/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
@@ -157,7 +157,9 @@ export default function CompanyDetailsForm( {
 					/>
 				</FormFieldset>
 				<FormFieldset>
-					<FormLabel>{ translate( 'Which answer below best describes your company:' ) }</FormLabel>
+					<FormLabel>
+						{ translate( 'Choose which of the below options best describes your company:' ) }
+					</FormLabel>
 					<FormRadio
 						label={ translate( 'Agency' ) }
 						value="agency"

--- a/client/state/partner-portal/partner/hooks/use-create-partner-mutation.ts
+++ b/client/state/partner-portal/partner/hooks/use-create-partner-mutation.ts
@@ -11,6 +11,7 @@ function createPartner( details: PartnerDetailsPayload ): Promise< APIPartner > 
 			contact_person: details.contactPerson,
 			company_website: details.companyWebsite,
 			company_type: details.companyType,
+			partner_program_opt_in: details.partnerProgramOptIn,
 			city: details.city,
 			line1: details.line1,
 			line2: details.line2,

--- a/client/state/partner-portal/types.ts
+++ b/client/state/partner-portal/types.ts
@@ -159,6 +159,7 @@ export interface CompanyDetailsPayload {
 }
 
 export interface PartnerDetailsPayload extends CompanyDetailsPayload {
+	partnerProgramOptIn: boolean;
 	companyType: string;
 	tos?: 'consented';
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves Automattic/jetpack-manage#46

## Proposed Changes

This adds a partner program opt-in checkbox to `<CompanyDetailsForm>`, and passes the boolean value to tracks and to the REST API.

I also changed the previous field's wording from this (which implied a question):

`Which answer below best describes your company:`

to this:

`Choose which of the below options best describes your company:`

Note that I'm not sure if tracking is done correctly, as I never saw anything in Tracks (in `trunk` or this branch).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the `add/jp-manage/46-partner_opt-in_checkbox` branch.
2. In a private browser window, go here: http://jetpack.cloud.localhost:3000/agency/signup
3. Log in with a non-partner (probably new) WordPress.com account.
4. Try the different company types:
    * "Agency" and "Freelancer/Pro" will show the partner program opt-in checkbox.
    * "A business with multiple sites" will hide the checkbox and reset the opt-in state to false.
    ![image](https://github.com/Automattic/wp-calypso/assets/32492176/74cc62d6-8643-4d10-b2d4-d18a1169c081)
5. Pull up the browser's network inspector.
6. Submit the form and verify the `partner_program_opt_in` param is properly sent.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
