### PR TITLE
Multi-domain: Show paid plan required modal when free subdomain selected last

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -691,21 +691,25 @@ export class RenderDomainsStep extends Component {
 		const { step } = this.props;
 		const { lastDomainSearched } = step.domainForm ?? {};
 
+		const domainCart = getDomainRegistrations( this.props.cart );
 		const { suggestion } = step;
-		const isPurchasingItem = suggestion && Boolean( suggestion.product_slug );
+		const isPurchasingItem =
+			( suggestion && Boolean( suggestion.product_slug ) ) || domainCart?.length > 0;
 		const siteUrl =
 			suggestion &&
 			( isPurchasingItem
 				? suggestion.domain_name
 				: suggestion.domain_name.replace( '.wordpress.com', '' ) );
 
-		const domainItem = isPurchasingItem
-			? domainRegistration( {
-					domain: suggestion.domain_name,
-					productSlug: suggestion.product_slug,
-			  } )
-			: undefined;
-		const domainCart = getDomainRegistrations( this.props.cart );
+		let domainItem;
+
+		if ( isPurchasingItem ) {
+			const selectedDomain = domainCart.length > 0 ? domainCart[ 0 ] : suggestion;
+			domainItem = domainRegistration( {
+				domain: selectedDomain.domain_name || selectedDomain.meta,
+				productSlug: selectedDomain.product_slug,
+			} );
+		}
 
 		this.props.submitSignupStep(
 			Object.assign(

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -706,8 +706,8 @@ export class RenderDomainsStep extends Component {
 		if ( isPurchasingItem ) {
 			const selectedDomain = domainCart?.length > 0 ? domainCart[ 0 ] : suggestion;
 			domainItem = domainRegistration( {
-				domain: selectedDomain.domain_name || selectedDomain.meta,
-				productSlug: selectedDomain.product_slug,
+				domain: selectedDomain?.domain_name || selectedDomain?.meta,
+				productSlug: selectedDomain?.product_slug,
 			} );
 		}
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -704,7 +704,7 @@ export class RenderDomainsStep extends Component {
 		let domainItem;
 
 		if ( isPurchasingItem ) {
-			const selectedDomain = domainCart.length > 0 ? domainCart[ 0 ] : suggestion;
+			const selectedDomain = domainCart?.length > 0 ? domainCart[ 0 ] : suggestion;
 			domainItem = domainRegistration( {
 				domain: selectedDomain.domain_name || selectedDomain.meta,
 				productSlug: selectedDomain.product_slug,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4342

## Proposed Changes

* For multi-domain selection, if the last domain selected is the free subdomain, properly present the `PAID_PLAN_IS_REQUIRED_DIALOG` modal on the Plans page.

Before | After
--|--
<video src="https://github.com/Automattic/wp-calypso/assets/140841/fd21ee39-aec1-47b6-9d36-bf24d00da90a" /> | <video src="https://github.com/Automattic/wp-calypso/assets/140841/63575cad-85f5-4449-ba26-f0e0261bb83e" />


### What's going on here

The `PAID_PLAN_IS_REQUIRED_DIALOG` modal checks if `paidDomainName` is set [here](https://github.com/Automattic/wp-calypso/blob/458e40aca5af8e0c3635a4ab64404d8224c5659e/client/my-sites/plans-features-main/components/plan-upsell-modal/hooks/use-modal-resolution-callback.tsx#L40), and `paidDomainName` is set [here](https://github.com/Automattic/wp-calypso/blob/bab747458579f57ff24ddd78076f35ca5b27d281/client/signup/steps/plans/index.jsx#L130) on the Plans step. `domainItem` is set on `goToNext` in the file updated in this PR.

The issue is `domainItem` was built when only one domain name could be selected, so it relied on the last domain "suggestion". If the last domain "suggestion" is the free site, `domainItem` is `undefined` therefor `paidDomainName` is undefined, and the `PAID_PLAN_IS_REQUIRED_DIALOG` modal does not show.

To fix this, this PR checks if there are `domainCart` items. If so, we use the first one for the `domainItem`. If there are not, we use `suggestion`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load this PR locally
* Regression test by testing the `onboarding` flow and confirm it still works as intended when selecting a paid domain or free subdomain. Check that the "required paid plan" modal appears if you select the free plan on the Plans page.
* Test on multi-domain by setting `shouldUseMultipleDomainsInCart` to return true [here](https://github.com/Automattic/wp-calypso/blob/1f590eb6aff46add65ed1a911c6451504673b48b/client/signup/steps/domains/utils.js#L44).
* Try selecting multiple domains and finally select the free subdomain. You should see the "required paid plan" modal when selecting the free plan on the Plans page.
* You should also continue to see the "required paid plan" modal when you select paid domains but do not select the free subdomain.
* If you only select the free subdomain, you should NOT see the "required paid plan" modal.
* Test around this issue.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?