### PR TITLE
Launchpad: Fix the Navigator task ordering

### DIFF
--- a/client/my-sites/customer-home/cards/launchpad/index.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/index.tsx
@@ -1,7 +1,7 @@
 import { Button, CircularProgressBar, Gridicon } from '@automattic/components';
 import {
 	updateLaunchpadSettings,
-	useLaunchpad,
+	useSortedLaunchpadTasks,
 	sortLaunchpadTasksByCompletionStatus,
 	LaunchpadNavigator,
 } from '@automattic/data-stores';
@@ -38,7 +38,7 @@ const CustomerHomeLaunchpad = ( {
 	const useLaunchpadOptions = { onSuccess: sortLaunchpadTasksByCompletionStatus };
 	const {
 		data: { checklist, is_dismissed: initialIsChecklistDismissed },
-	} = useLaunchpad( siteSlug, checklistSlug, useLaunchpadOptions );
+	} = useSortedLaunchpadTasks( siteSlug, checklistSlug );
 
 	useEffect( () => {
 		setIsDismissed( initialIsChecklistDismissed );

--- a/packages/data-stores/src/queries/use-launchpad.ts
+++ b/packages/data-stores/src/queries/use-launchpad.ts
@@ -119,6 +119,16 @@ export const useLaunchpad = (
 	} );
 };
 
+export const useSortedLaunchpadTasks = (
+	siteSlug: string | null,
+	checklist_slug?: string | 0 | null | undefined
+) => {
+	const launchpadOptions = {
+		onSuccess: sortLaunchpadTasksByCompletionStatus,
+	};
+	return useLaunchpad( siteSlug, checklist_slug, launchpadOptions );
+};
+
 export const updateLaunchpadSettings = (
 	siteSlug: string | number,
 	settings: LaunchpadUpdateSettings = {}

--- a/packages/launchpad-navigator/src/icon/index.tsx
+++ b/packages/launchpad-navigator/src/icon/index.tsx
@@ -1,9 +1,5 @@
 import { CircularProgressBar } from '@automattic/components';
-import {
-	LaunchpadNavigator,
-	sortLaunchpadTasksByCompletionStatus,
-	useLaunchpad,
-} from '@automattic/data-stores';
+import { LaunchpadNavigator, useSortedLaunchpadTasks } from '@automattic/data-stores';
 import { select } from '@wordpress/data';
 import type { Task } from '@automattic/launchpad';
 
@@ -17,13 +13,9 @@ const LaunchpadNavigatorIcon = ( { siteSlug }: LaunchpadNavigatorIconProps ) => 
 	const currentNavigatorChecklistSlug =
 		select( LaunchpadNavigator.store ).getActiveChecklistSlug() || null;
 
-	const launchpadOptions = {
-		onSuccess: sortLaunchpadTasksByCompletionStatus,
-	};
-
 	const {
 		data: { checklist },
-	} = useLaunchpad( siteSlug, currentNavigatorChecklistSlug, launchpadOptions );
+	} = useSortedLaunchpadTasks( siteSlug, currentNavigatorChecklistSlug );
 
 	const numberOfSteps = checklist?.length || 0;
 	const completedSteps = ( checklist?.filter( ( task: Task ) => task.completed ) || [] ).length;

--- a/packages/launchpad-navigator/src/icon/index.tsx
+++ b/packages/launchpad-navigator/src/icon/index.tsx
@@ -1,5 +1,9 @@
 import { CircularProgressBar } from '@automattic/components';
-import { LaunchpadNavigator, useLaunchpad } from '@automattic/data-stores';
+import {
+	LaunchpadNavigator,
+	sortLaunchpadTasksByCompletionStatus,
+	useLaunchpad,
+} from '@automattic/data-stores';
 import { select } from '@wordpress/data';
 import type { Task } from '@automattic/launchpad';
 
@@ -13,9 +17,13 @@ const LaunchpadNavigatorIcon = ( { siteSlug }: LaunchpadNavigatorIconProps ) => 
 	const currentNavigatorChecklistSlug =
 		select( LaunchpadNavigator.store ).getActiveChecklistSlug() || null;
 
+	const launchpadOptions = {
+		onSuccess: sortLaunchpadTasksByCompletionStatus,
+	};
+
 	const {
 		data: { checklist },
-	} = useLaunchpad( siteSlug, currentNavigatorChecklistSlug );
+	} = useLaunchpad( siteSlug, currentNavigatorChecklistSlug, launchpadOptions );
 
 	const numberOfSteps = checklist?.length || 0;
 	const completedSteps = ( checklist?.filter( ( task: Task ) => task.completed ) || [] ).length;

--- a/packages/launchpad/src/default-wired-launchpad.tsx
+++ b/packages/launchpad/src/default-wired-launchpad.tsx
@@ -4,7 +4,7 @@ import {
 	Site,
 	type SiteSelect,
 	sortLaunchpadTasksByCompletionStatus,
-	useLaunchpad,
+	useSortedLaunchpadTasks,
 } from '@automattic/data-stores';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useState } from 'react';
@@ -32,7 +32,7 @@ const DefaultWiredLaunchpad = ( {
 }: DefaultWiredLaunchpadProps ) => {
 	const {
 		data: { checklist },
-	} = useLaunchpad( siteSlug, checklistSlug );
+	} = useSortedLaunchpadTasks( siteSlug, checklistSlug );
 
 	const { setActiveChecklist } = useDispatch( LaunchpadNavigator.store );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* In rare instances, the ordering would not work correctly because one of the places we used the useLaunchpad hook was not ordering the response.

https://github.com/Automattic/wp-calypso/blob/de377de0e9742bd43a3e7ac14ee24bfc352fe3c2/packages/launchpad-navigator/src/icon/index.tsx#L16-L18

* We discussed and decided to add a new hook called `useSortedLaunchpadTasks` instead of adding the `launchpadOptions` in all the places we needed. This new hook wraps around the `useLaunchpad` hook and adds the `onSuccess` option by default.
* Once https://github.com/Automattic/wp-calypso/pull/83466 is merged, we will remove the usage of the `sortLaunchpadTasksByCompletionStatus` callback on the Customer Home component!

Note: If the Navigator modal doesn't show up, ensure you first interact(click on it) with a task in the Launchpad. Clicking on a task will make the checklist active. This bug will be addressed on @daledupreez changes: https://github.com/Automattic/wp-calypso/pull/83477#pullrequestreview-1699345199

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso Live link below or apply this PR to your local environment
* On a site with the `build` intent, navigate to `/home/:siteSlug?flags=launchpad/navigator`
* Open the navigator and ensure the completed tasks stay at the top.
* Refresh the page and click on the navigator, opening and closing a few times
* Repeat the steps a few times to ensure the ordering is solid.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?