### PR TITLE
Remove the 255 character restriction for TXT record rdata

### DIFF
--- a/client/my-sites/domains/domain-management/dns/txt-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/txt-record.jsx
@@ -3,13 +3,11 @@ import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
-import ExternalLink from 'calypso/components/external-link';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-with-affixes';
 import FormTextarea from 'calypso/components/forms/form-textarea';
-import { DNS_TXT_RECORD_CHAR_LIMIT } from 'calypso/lib/url/support';
 
 class TxtRecord extends Component {
 	static propTypes = {
@@ -24,17 +22,6 @@ class TxtRecord extends Component {
 
 		if ( value?.length === 0 ) {
 			return translate( 'TXT records may not be empty' );
-		} else if ( value?.length > 255 ) {
-			return translate(
-				'TXT records may not exceed 255 characters. {{supportLink}}Learn more{{/supportLink}}.',
-				{
-					components: {
-						supportLink: (
-							<ExternalLink href={ DNS_TXT_RECORD_CHAR_LIMIT } target="_blank" icon={ false } />
-						),
-					},
-				}
-			);
 		}
 
 		return null;

--- a/client/my-sites/domains/domain-management/dns/txt-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/txt-record.jsx
@@ -3,11 +3,13 @@ import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
+import ExternalLink from 'calypso/components/external-link';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-with-affixes';
 import FormTextarea from 'calypso/components/forms/form-textarea';
+import { DNS_TXT_RECORD_CHAR_LIMIT } from 'calypso/lib/url/support';
 
 class TxtRecord extends Component {
 	static propTypes = {
@@ -22,6 +24,17 @@ class TxtRecord extends Component {
 
 		if ( value?.length === 0 ) {
 			return translate( 'TXT records may not be empty' );
+		} else if ( value?.length > 65536 ) {
+			return translate(
+				'TXT records may not exceed 65536 characters. {{supportLink}}Learn more{{/supportLink}}.',
+				{
+					components: {
+						supportLink: (
+							<ExternalLink href={ DNS_TXT_RECORD_CHAR_LIMIT } target="_blank" icon={ false } />
+						),
+					},
+				}
+			);
 		}
 
 		return null;

--- a/client/my-sites/domains/domain-management/dns/txt-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/txt-record.jsx
@@ -24,9 +24,9 @@ class TxtRecord extends Component {
 
 		if ( value?.length === 0 ) {
 			return translate( 'TXT records may not be empty' );
-		} else if ( value?.length > 65536 ) {
+		} else if ( value?.length > 65535 ) {
 			return translate(
-				'TXT records may not exceed 65536 characters. {{supportLink}}Learn more{{/supportLink}}.',
+				'TXT records may not exceed 65535 characters. {{supportLink}}Learn more{{/supportLink}}.',
 				{
 					components: {
 						supportLink: (

--- a/client/state/domains/dns/utils.js
+++ b/client/state/domains/dns/utils.js
@@ -82,7 +82,7 @@ function isValidData( data, type ) {
 		case 'MX':
 			return isValidDomain( data );
 		case 'TXT':
-			return data.length > 0 && data.length < 256;
+			return data.length > 0;
 	}
 }
 

--- a/client/state/domains/dns/utils.js
+++ b/client/state/domains/dns/utils.js
@@ -82,7 +82,7 @@ function isValidData( data, type ) {
 		case 'MX':
 			return isValidDomain( data );
 		case 'TXT':
-			return data.length > 0;
+			return data.length > 0 && data.length < 65536;
 	}
 }
 


### PR DESCRIPTION
Because of some back-end updates, we can now support TXT records longer than 255 characters.  This PR just removes this restriction.

## Testing Instructions

Attempt to set a TXT record with the data field having more than 255 characters.  Make sure this works properly and shows up in a dig query like this:

```
a8ctest.com.		2790	IN	TXT	"123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345" "zyxwvutsrqponmlkjihgfedcba"
```