### PR TITLE
Add Ons: Migrate use add on checkout link hook to data stores package

### DIFF
--- a/client/my-sites/add-ons/hooks/use-add-ons.ts
+++ b/client/my-sites/add-ons/hooks/use-add-ons.ts
@@ -9,6 +9,7 @@ import {
 	PRODUCT_1GB_SPACE,
 	WPCOM_FEATURES_AI_ASSISTANT,
 } from '@automattic/calypso-products';
+import { useAddOnCheckoutLink } from '@automattic/data-stores';
 import { createSelector } from '@automattic/state-utils';
 import { useMemo } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
@@ -24,6 +25,7 @@ import getBillingTransactionFilters from 'calypso/state/selectors/get-billing-tr
 import getFeaturesBySiteId from 'calypso/state/selectors/get-site-features';
 import { usePastBillingTransactions } from 'calypso/state/sites/hooks/use-billing-history';
 import { getSiteOption } from 'calypso/state/sites/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { AppState } from 'calypso/types';
 import { STORAGE_LIMIT } from '../constants';
 import customDesignIcon from '../icons/custom-design';
@@ -32,11 +34,10 @@ import jetpackStatsIcon from '../icons/jetpack-stats';
 import spaceUpgradeIcon from '../icons/space-upgrade';
 import unlimitedThemesIcon from '../icons/unlimited-themes';
 import isStorageAddonEnabled from '../is-storage-addon-enabled';
-import useAddOnCheckoutLink from './use-add-on-checkout-link';
 import useAddOnDisplayCost from './use-add-on-display-cost';
 import useAddOnFeatureSlugs from './use-add-on-feature-slugs';
 import useAddOnPrices from './use-add-on-prices';
-import type { AddOnMeta } from '@automattic/data-stores';
+import type { AddOnMeta, SiteDetails } from '@automattic/data-stores';
 
 const useSpaceUpgradesPurchased = ( {
 	isInSignup,
@@ -69,7 +70,7 @@ const useSpaceUpgradesPurchased = ( {
 	}, [ billingTransactions, filter, isInSignup, siteId, isLoading ] );
 };
 
-const useActiveAddOnsDefs = () => {
+const useActiveAddOnsDefs = ( selectedSite: SiteDetails ) => {
 	const translate = useTranslate();
 	const checkoutLink = useAddOnCheckoutLink();
 
@@ -144,7 +145,7 @@ const useActiveAddOnsDefs = () => {
 				),
 				featured: false,
 				purchased: false,
-				checkoutLink: checkoutLink( PRODUCT_1GB_SPACE, 50 ),
+				checkoutLink: checkoutLink( selectedSite, PRODUCT_1GB_SPACE, 50 ),
 			},
 			{
 				productSlug: PRODUCT_1GB_SPACE,
@@ -159,7 +160,7 @@ const useActiveAddOnsDefs = () => {
 				),
 				featured: false,
 				purchased: false,
-				checkoutLink: checkoutLink( PRODUCT_1GB_SPACE, 100 ),
+				checkoutLink: checkoutLink( selectedSite, PRODUCT_1GB_SPACE, 100 ),
 			},
 			{
 				productSlug: PRODUCT_JETPACK_STATS_PWYW_YEARLY,
@@ -359,7 +360,8 @@ const useAddOns = ( siteId?: number, isInSignup = false ): ( AddOnMeta | null )[
 	// if upgrade is not bought - only show it if available storage and if it's larger than previously bought upgrade
 	const { data: mediaStorage } = useMediaStorageQuery( siteId );
 	const { isLoading, spaceUpgradesPurchased } = useSpaceUpgradesPurchased( { isInSignup, siteId } );
-	const activeAddOns = useActiveAddOnsDefs();
+	const selectedSite = useSelector( getSelectedSite );
+	const activeAddOns = useActiveAddOnsDefs( selectedSite );
 
 	return useSelector( ( state ): ( AddOnMeta | null )[] => {
 		return getAddOnsTransformed(

--- a/client/my-sites/add-ons/hooks/use-add-ons.ts
+++ b/client/my-sites/add-ons/hooks/use-add-ons.ts
@@ -70,7 +70,7 @@ const useSpaceUpgradesPurchased = ( {
 	}, [ billingTransactions, filter, isInSignup, siteId, isLoading ] );
 };
 
-const useActiveAddOnsDefs = ( selectedSite: SiteDetails ) => {
+const useActiveAddOnsDefs = ( selectedSite: SiteDetails | null ) => {
 	const translate = useTranslate();
 	const checkoutLink = useAddOnCheckoutLink();
 
@@ -145,7 +145,7 @@ const useActiveAddOnsDefs = ( selectedSite: SiteDetails ) => {
 				),
 				featured: false,
 				purchased: false,
-				checkoutLink: checkoutLink( selectedSite, PRODUCT_1GB_SPACE, 50 ),
+				checkoutLink: checkoutLink( selectedSite?.slug ?? null, PRODUCT_1GB_SPACE, 50 ),
 			},
 			{
 				productSlug: PRODUCT_1GB_SPACE,
@@ -160,7 +160,7 @@ const useActiveAddOnsDefs = ( selectedSite: SiteDetails ) => {
 				),
 				featured: false,
 				purchased: false,
-				checkoutLink: checkoutLink( selectedSite, PRODUCT_1GB_SPACE, 100 ),
+				checkoutLink: checkoutLink( selectedSite?.slug ?? null, PRODUCT_1GB_SPACE, 100 ),
 			},
 			{
 				productSlug: PRODUCT_JETPACK_STATS_PWYW_YEARLY,
@@ -360,7 +360,7 @@ const useAddOns = ( siteId?: number, isInSignup = false ): ( AddOnMeta | null )[
 	// if upgrade is not bought - only show it if available storage and if it's larger than previously bought upgrade
 	const { data: mediaStorage } = useMediaStorageQuery( siteId );
 	const { isLoading, spaceUpgradesPurchased } = useSpaceUpgradesPurchased( { isInSignup, siteId } );
-	const selectedSite = useSelector( getSelectedSite );
+	const selectedSite = useSelector( getSelectedSite ) ?? null;
 	const activeAddOns = useActiveAddOnsDefs( selectedSite );
 
 	return useSelector( ( state ): ( AddOnMeta | null )[] => {

--- a/client/my-sites/add-ons/main.tsx
+++ b/client/my-sites/add-ons/main.tsx
@@ -1,3 +1,4 @@
+import { useAddOnCheckoutLink } from '@automattic/data-stores';
 import { css, Global } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
@@ -13,7 +14,6 @@ import { useSelector } from 'calypso/state';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import AddOnsGrid from './components/add-ons-grid';
-import useAddOnCheckoutLink from './hooks/use-add-on-checkout-link';
 import useAddOnPurchaseStatus from './hooks/use-add-on-purchase-status';
 import useAddOns from './hooks/use-add-ons';
 import type { ReactElement } from 'react';
@@ -96,7 +96,7 @@ interface Props {
 
 const AddOnsMain: React.FunctionComponent< Props > = () => {
 	const translate = useTranslate();
-	const selectedSite = useSelector( getSelectedSite );
+	const selectedSite = useSelector( getSelectedSite ) ?? null;
 	const addOns = useAddOns( selectedSite?.ID );
 	const filteredAddOns = addOns.filter( ( addOn ) => ! addOn?.exceedsSiteStorageLimits );
 
@@ -115,7 +115,7 @@ const AddOnsMain: React.FunctionComponent< Props > = () => {
 	}
 
 	const handleActionPrimary = ( addOnSlug: string, quantity?: number ) => {
-		page.redirect( `${ checkoutLink( addOnSlug, quantity ) }` );
+		page.redirect( `${ checkoutLink( selectedSite, addOnSlug, quantity ) }` );
 	};
 
 	const handleActionSelected = () => {

--- a/client/my-sites/add-ons/main.tsx
+++ b/client/my-sites/add-ons/main.tsx
@@ -115,7 +115,7 @@ const AddOnsMain: React.FunctionComponent< Props > = () => {
 	}
 
 	const handleActionPrimary = ( addOnSlug: string, quantity?: number ) => {
-		page.redirect( `${ checkoutLink( selectedSite, addOnSlug, quantity ) }` );
+		page.redirect( `${ checkoutLink( selectedSite?.slug ?? null, addOnSlug, quantity ) }` );
 	};
 
 	const handleActionSelected = () => {

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -339,6 +339,7 @@ const PlansFeaturesMain = ( {
 			const cartItemForStorageAddOn = cartItems?.find(
 				( items ) => items.product_slug === PRODUCT_1GB_SPACE
 			);
+
 			if ( cartItemForStorageAddOn?.extra ) {
 				recordTracksEvent( 'calypso_signup_storage_add_on_upgrade_click', {
 					add_on_slug: cartItemForStorageAddOn.extra.feature_slug,

--- a/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
+++ b/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
@@ -25,7 +25,6 @@ import {
 	isEcommercePlan,
 	TYPE_P2_PLUS,
 } from '@automattic/calypso-products';
-import useAddOnCheckoutLink from 'calypso/my-sites/add-ons/hooks/use-add-on-checkout-link';
 import { isSamePlan } from '../../../lib/is-same-plan';
 import useHighlightLabels from './use-highlight-labels';
 import usePlansFromTypes from './use-plans-from-types';
@@ -324,7 +323,6 @@ const useGridPlans = ( {
 		planSlugs: availablePlanSlugs,
 		storageAddOns,
 	} );
-	const checkoutLink = useAddOnCheckoutLink();
 
 	// Null return would indicate that we are still loading the data. No grid without grid plans.
 	if ( ! pricingMeta || ! pricedAPIPlans ) {
@@ -362,20 +360,8 @@ const useGridPlans = ( {
 						product_slug: planSlug,
 				  };
 
-		let storageAddOnsForPlan = null;
-
-		if ( isBusinessPlan( planSlug ) || isEcommercePlan( planSlug ) ) {
-			storageAddOnsForPlan =
-				storageAddOns &&
-				storageAddOns?.map( ( addOn ) => {
-					return (
-						addOn && {
-							...addOn,
-							checkoutUrl: checkoutLink( addOn.productSlug, addOn.quantity ),
-						}
-					);
-				} );
-		}
+		const storageAddOnsForPlan =
+			isBusinessPlan( planSlug ) || isEcommercePlan( planSlug ) ? storageAddOns : null;
 
 		return {
 			planSlug,

--- a/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
+++ b/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
@@ -25,6 +25,7 @@ import {
 	isEcommercePlan,
 	TYPE_P2_PLUS,
 } from '@automattic/calypso-products';
+import useAddOnCheckoutLink from 'calypso/my-sites/add-ons/hooks/use-add-on-checkout-link';
 import { isSamePlan } from '../../../lib/is-same-plan';
 import useHighlightLabels from './use-highlight-labels';
 import usePlansFromTypes from './use-plans-from-types';
@@ -323,6 +324,7 @@ const useGridPlans = ( {
 		planSlugs: availablePlanSlugs,
 		storageAddOns,
 	} );
+	const checkoutLink = useAddOnCheckoutLink();
 
 	// Null return would indicate that we are still loading the data. No grid without grid plans.
 	if ( ! pricingMeta || ! pricedAPIPlans ) {
@@ -360,8 +362,20 @@ const useGridPlans = ( {
 						product_slug: planSlug,
 				  };
 
-		const storageAddOnsForPlan =
-			isBusinessPlan( planSlug ) || isEcommercePlan( planSlug ) ? storageAddOns : null;
+		let storageAddOnsForPlan = null;
+
+		if ( isBusinessPlan( planSlug ) || isEcommercePlan( planSlug ) ) {
+			storageAddOnsForPlan =
+				storageAddOns &&
+				storageAddOns?.map( ( addOn ) => {
+					return (
+						addOn && {
+							...addOn,
+							checkoutUrl: checkoutLink( addOn.productSlug, addOn.quantity ),
+						}
+					);
+				} );
+		}
 
 		return {
 			planSlug,

--- a/packages/data-stores/package.json
+++ b/packages/data-stores/package.json
@@ -39,6 +39,7 @@
 		"@wordpress/data-controls": "^3.13.0",
 		"@wordpress/deprecated": "^3.44.0",
 		"@wordpress/url": "^3.45.0",
+		"@wordpress/element": "^5.21.0",
 		"fast-json-stable-stringify": "^2.1.0",
 		"i18n-calypso": "workspace:^",
 		"qs": "^6.9.1",

--- a/packages/data-stores/src/add-ons/use-add-on-checkout-link.ts
+++ b/packages/data-stores/src/add-ons/use-add-on-checkout-link.ts
@@ -1,6 +1,5 @@
 import { useCallback } from '@wordpress/element';
-import { useSelector } from 'react-redux';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
+import type { SiteDetails } from '@automattic/data-stores';
 
 /**
  * Returns a function that will return a formatted checkout link for the given add-on and quantity.
@@ -9,25 +8,26 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
  * @returns {Function} A function returnig a formatted checkout link for the given add-on and quantity
  */
 
-const useAddOnCheckoutLink = (): ( ( addOnSlug: string, quantity?: number ) => string ) => {
-	const selectedSite = useSelector( getSelectedSite );
+export const useAddOnCheckoutLink = (): ( (
+	siteDetails: SiteDetails | null,
+	addOnSlug: string,
+	quantity?: number
+) => string ) => {
 	const checkoutLinkCallback = useCallback(
-		( addOnSlug: string, quantity?: number ): string => {
+		( siteDetails: SiteDetails, addOnSlug: string, quantity?: number ): string => {
 			// If no site is provided, return the checkout link with the add-on (will render site-selector).
-			if ( ! selectedSite ) {
+			if ( ! siteDetails ) {
 				return `/checkout/${ addOnSlug }`;
 			}
 
-			const checkoutLinkFormat = `/checkout/${ selectedSite?.slug }/${ addOnSlug }`;
+			const checkoutLinkFormat = `/checkout/${ siteDetails?.slug }/${ addOnSlug }`;
 
 			if ( quantity ) {
 				return checkoutLinkFormat + `:-q-${ quantity }`;
 			}
 			return checkoutLinkFormat;
 		},
-		[ selectedSite ]
+		[]
 	);
 	return checkoutLinkCallback;
 };
-
-export default useAddOnCheckoutLink;

--- a/packages/data-stores/src/add-ons/use-add-on-checkout-link.ts
+++ b/packages/data-stores/src/add-ons/use-add-on-checkout-link.ts
@@ -1,5 +1,5 @@
 import { useCallback } from '@wordpress/element';
-import type { SiteDetails } from '@automattic/data-stores';
+import type { SiteDetails } from '../site/types';
 
 /**
  * Returns a function that will return a formatted checkout link for the given add-on and quantity.

--- a/packages/data-stores/src/add-ons/use-add-on-checkout-link.ts
+++ b/packages/data-stores/src/add-ons/use-add-on-checkout-link.ts
@@ -9,18 +9,22 @@ import type { SiteDetails } from '../site/types';
  */
 
 export const useAddOnCheckoutLink = (): ( (
-	siteDetails: SiteDetails | null,
+	selectedSiteSlug: SiteDetails[ 'slug' ] | null,
 	addOnSlug: string,
 	quantity?: number
 ) => string ) => {
 	const checkoutLinkCallback = useCallback(
-		( siteDetails: SiteDetails | null, addOnSlug: string, quantity?: number ): string => {
+		(
+			selectedSiteSlug: SiteDetails[ 'slug' ] | null,
+			addOnSlug: string,
+			quantity?: number
+		): string => {
 			// If no site is provided, return the checkout link with the add-on (will render site-selector).
-			if ( ! siteDetails ) {
+			if ( ! selectedSiteSlug ) {
 				return `/checkout/${ addOnSlug }`;
 			}
 
-			const checkoutLinkFormat = `/checkout/${ siteDetails?.slug }/${ addOnSlug }`;
+			const checkoutLinkFormat = `/checkout/${ selectedSiteSlug }/${ addOnSlug }`;
 
 			if ( quantity ) {
 				return checkoutLinkFormat + `:-q-${ quantity }`;

--- a/packages/data-stores/src/add-ons/use-add-on-checkout-link.ts
+++ b/packages/data-stores/src/add-ons/use-add-on-checkout-link.ts
@@ -14,7 +14,7 @@ export const useAddOnCheckoutLink = (): ( (
 	quantity?: number
 ) => string ) => {
 	const checkoutLinkCallback = useCallback(
-		( siteDetails: SiteDetails, addOnSlug: string, quantity?: number ): string => {
+		( siteDetails: SiteDetails | null, addOnSlug: string, quantity?: number ): string => {
 			// If no site is provided, return the checkout link with the add-on (will render site-selector).
 			if ( ! siteDetails ) {
 				return `/checkout/${ addOnSlug }`;

--- a/packages/data-stores/src/index.ts
+++ b/packages/data-stores/src/index.ts
@@ -24,6 +24,7 @@ export * from './plans/types';
 export * from './theme';
 export * from './user/types';
 export * from './wpcom-plans-ui/types';
+export * from './add-ons/use-add-on-checkout-link';
 export * from './queries/use-launchpad';
 export * from './queries/use-all-domains-query';
 export * from './queries/use-site-domains-query';

--- a/yarn.lock
+++ b/yarn.lock
@@ -621,6 +621,7 @@ __metadata:
     "@wordpress/api-fetch": ^6.41.0
     "@wordpress/data-controls": ^3.13.0
     "@wordpress/deprecated": ^3.44.0
+    "@wordpress/element": ^5.21.0
     "@wordpress/url": ^3.45.0
     fast-json-stable-stringify: ^2.1.0
     i18n-calypso: "workspace:^"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/2023 and https://github.com/Automattic/wp-calypso/pull/83005#discussion_r1370992420

This PR kicks off the migration of the add-ons data layer into an npm package. We're doing so to align with the 2023 plans pricing page refactor, which aims to migrate the plans-grid into a reusable package ( which will be shared in environments inside _and_ outside Calypso )

## Proposed Changes

* Migrates the useAddOnCheckoutLink hook into the `data-stores` npm package

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**/add-ons**
* Create a site through `/start`
* Navigate to `/add-ons/{SITE_SLUG}`
* Click on the "Buy add-on" button for either the 50GB or 100GB storage add-on
* Verify that the correct storage add-on is added to the checkout cart

![Screenshot 2023-10-25 at 3 25 28 PM](https://github.com/Automattic/wp-calypso/assets/5414230/a51c73da-0f60-4273-9805-197ea7d44965)

**/plans**
* Create a site through `/start`
* Upgrade site to a business plan and navigate to `/plans/{SITE_SLUG}`
* In the spotlight business plan card, select either the 50GB or 100GB storage add-on
* Click on the "Upgrade" button
* Verify that the correct storage add-on is added to the checkout cart

<img width="1489" alt="Screenshot 2023-10-25 at 3 24 22 PM" src="https://github.com/Automattic/wp-calypso/assets/5414230/7daa250f-ecdb-40c6-a315-c99d78e4e1e9">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?