### PR TITLE
Add support for ALIAS records

### DIFF
--- a/client/my-sites/domains/domain-management/dns/alias-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/alias-record.jsx
@@ -1,0 +1,62 @@
+import { FormInputValidation } from '@automattic/components';
+import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import { Component } from 'react';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+
+class AliasRecord extends Component {
+	static propTypes = {
+		fieldValues: PropTypes.object.isRequired,
+		onChange: PropTypes.func.isRequired,
+		selectedDomainName: PropTypes.string.isRequired,
+		show: PropTypes.bool.isRequired,
+	};
+
+	render() {
+		const { fieldValues, isValid, onChange, show, translate } = this.props;
+		const classes = classnames( { 'is-hidden': ! show } );
+		const isDataValid = isValid( 'data' );
+		const isTTLValid = isValid( 'ttl' );
+
+		return (
+			<div className={ classes }>
+				<FormFieldset>
+					<FormLabel>{ translate( 'Alias Of (Points To)' ) }</FormLabel>
+					<FormTextInput
+						name="data"
+						isError={ ! isDataValid }
+						onChange={ onChange }
+						value={ fieldValues.data }
+						placeholder={ translate( 'e.g. %(example)s', { args: { example: 'example.com' } } ) }
+					/>
+					{ ! isDataValid && (
+						<FormInputValidation text={ translate( 'Invalid Target Host' ) } isError />
+					) }
+				</FormFieldset>
+
+				<FormFieldset>
+					<FormLabel>TTL (time to live)</FormLabel>
+					<FormTextInput
+						name="ttl"
+						isError={ ! isTTLValid }
+						onChange={ onChange }
+						value={ fieldValues.ttl }
+						defaultValue={ 3600 }
+						placeholder={ 3600 }
+					/>
+					{ ! isTTLValid && (
+						<FormInputValidation
+							text={ translate( 'Invalid TTL value - Use a value between 300 and 86400' ) }
+							isError
+						/>
+					) }
+				</FormFieldset>
+			</div>
+		);
+	}
+}
+
+export default localize( AliasRecord );

--- a/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
@@ -17,6 +17,7 @@ import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import ARecord from './a-record';
+import AliasRecord from './alias-record';
 import CnameRecord from './cname-record';
 import MxRecord from './mx-record';
 import SrvRecord from './srv-record';
@@ -49,6 +50,18 @@ class DnsAddNew extends React.Component {
 				),
 				initialFields: {
 					name: '',
+					ttl: 3600,
+					data: '',
+				},
+			},
+			{
+				component: AliasRecord,
+				types: [ 'ALIAS' ],
+				description: translate(
+					'ALIAS (domain alias) records are typically used to direct one domain (e.g. example.com) to another domain (e.g. example.net).'
+				),
+				initialFields: {
+					name: '@',
 					ttl: 3600,
 					data: '',
 				},

--- a/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
@@ -58,7 +58,7 @@ class DnsAddNew extends React.Component {
 				component: AliasRecord,
 				types: [ 'ALIAS' ],
 				description: translate(
-					'ALIAS (domain alias) records are typically used to direct one domain (e.g. example.com) to another domain (e.g. example.net).'
+					'An ALIAS record is a non-standard DNS record that is used to direct your domain to the target domain. The IP address of the target is resolved on the DNS server.'
 				),
 				initialFields: {
 					name: '@',

--- a/client/state/domains/dns/utils.js
+++ b/client/state/domains/dns/utils.js
@@ -78,6 +78,7 @@ function isValidData( data, type ) {
 			return data.match( /^(\d{1,3}\.){3}\d{1,3}$/ );
 		case 'AAAA':
 			return data.match( /^[a-f0-9:]+$/i );
+		case 'ALIAS':
 		case 'CNAME':
 		case 'MX':
 			return isValidDomain( data );
@@ -123,7 +124,7 @@ function isRootDomain( name, domainName ) {
 }
 
 function canBeRootDomain( type ) {
-	return [ 'A', 'AAAA', 'MX', 'SRV', 'TXT' ].includes( type );
+	return [ 'A', 'AAAA', 'ALIAS', 'MX', 'SRV', 'TXT' ].includes( type );
 }
 
 function getFieldWithDot( field ) {


### PR DESCRIPTION
We can now add support for ALIAS records.

## Testing Instructions

Add an ALIAS record.  Use `dig` to check that the correct A records are returned for the domain.

The description of the alias record is shown in the DNS editor screen:
<img width="780" alt="DNS_Records_‹_A8C_Test_Site_—_WordPress_com" src="https://github.com/Automattic/wp-calypso/assets/1379730/df42846e-9e08-4e95-815a-dab07c9a7e87">

