### PR TITLE
Subscription Management: Add subscription not found Tracks event

### DIFF
--- a/client/blocks/reader-site-subscription/context.tsx
+++ b/client/blocks/reader-site-subscription/context.tsx
@@ -16,6 +16,8 @@ export type SiteSubscriptionContextProps = {
 	data?: Reader.SiteSubscriptionDetails< string >;
 	isLoading: boolean;
 	error?: Reader.ErrorResponse | unknown;
+	blogId?: string;
+	subscriptionId?: string;
 };
 
 export const SiteSubscriptionContext = createContext< SiteSubscriptionContextProps | undefined >(

--- a/client/blocks/reader-site-subscription/index.tsx
+++ b/client/blocks/reader-site-subscription/index.tsx
@@ -9,7 +9,7 @@ import { useDispatch } from 'react-redux';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
 import WordPressLogo from 'calypso/components/wordpress-logo';
 import { Notice, NoticeType } from 'calypso/landing/subscriptions/components/notice';
-import { successNotice } from 'calypso/state/notices/actions';
+import { infoNotice } from 'calypso/state/notices/actions';
 import { Path, useSiteSubscription } from './context';
 import SiteSubscriptionDetails from './details';
 import './styles.scss';
@@ -35,10 +35,9 @@ const useHandleSubscriptionNotFoundError = ( transition?: boolean ) => {
 
 		if ( transition ) {
 			dispatch(
-				successNotice(
-					translate( "We're updating your subscriptions. It should be ready shortly." ),
-					{ duration: 5000 }
-				)
+				infoNotice( translate( "We're updating your subscriptions. It should be ready shortly." ), {
+					duration: 5000,
+				} )
 			);
 
 			page.show( '/read/subscriptions/' );

--- a/client/blocks/reader-site-subscription/index.tsx
+++ b/client/blocks/reader-site-subscription/index.tsx
@@ -37,6 +37,8 @@ const useHandleSubscriptionNotFoundError = ( transition?: boolean ) => {
 			dispatch(
 				infoNotice( translate( "We're updating your subscriptions. It should be ready shortly." ), {
 					duration: 5000,
+					displayOnNextPage: true,
+					isPersistent: true,
 				} )
 			);
 

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -343,6 +343,7 @@ export async function siteSubscription( context, next ) {
 			require="calypso/reader/site-subscription"
 			subscriptionId={ context.params.subscription_id }
 			blogId={ context.params.blog_id }
+			transition={ context.query.transition === 'true' }
 		/>
 	);
 	return next();

--- a/client/reader/site-subscription/index.tsx
+++ b/client/reader/site-subscription/index.tsx
@@ -1,5 +1,11 @@
 import SiteSubscription, { SiteSubscriptionProps } from './site-subscription';
 
-export default ( { blogId, subscriptionId }: SiteSubscriptionProps ) => {
-	return <SiteSubscription blogId={ blogId } subscriptionId={ subscriptionId } />;
+export default ( { blogId, subscriptionId, transition }: SiteSubscriptionProps ) => {
+	return (
+		<SiteSubscription
+			blogId={ blogId }
+			subscriptionId={ subscriptionId }
+			transition={ transition }
+		/>
+	);
 };

--- a/client/reader/site-subscription/site-subscription-provider.tsx
+++ b/client/reader/site-subscription/site-subscription-provider.tsx
@@ -41,8 +41,10 @@ const SiteSubscriptionProvider: React.FC< SiteSubscriptionProviderProps > = ( {
 			data: subscriptionData,
 			isLoading,
 			error: error || subscriptionError,
+			blogId,
+			subscriptionId,
 		} ),
-		[ error, isLoading, subscriptionData, subscriptionError ]
+		[ blogId, error, isLoading, subscriptionData, subscriptionError, subscriptionId ]
 	);
 
 	return (

--- a/client/reader/site-subscription/site-subscription.tsx
+++ b/client/reader/site-subscription/site-subscription.tsx
@@ -9,14 +9,15 @@ import SiteSubscriptionProvider from './site-subscription-provider';
 export type SiteSubscriptionProps = {
 	blogId?: string;
 	subscriptionId?: string;
+	transition?: boolean;
 };
 
-const SiteSubscription = ( { blogId, subscriptionId }: SiteSubscriptionProps ) => {
+const SiteSubscription = ( { blogId, subscriptionId, transition }: SiteSubscriptionProps ) => {
 	return (
 		<SubscriptionManagerContextProvider portal={ SubscriptionsPortal.Reader }>
 			<SiteSubscriptionProvider blogId={ blogId } subscriptionId={ subscriptionId }>
 				<Main className="site-subscriptions-manager">
-					<ReaderSiteSubscription />
+					<ReaderSiteSubscription transition={ transition } />
 				</Main>
 			</SiteSubscriptionProvider>
 		</SubscriptionManagerContextProvider>


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/83491

## Proposed Changes

* Adds subscription not found Tracks event
  * If the subscription was found, no event is tracked
  * If the error comes after the third attempt, the error is tracked and the user sees the not found page
  * If the URL has `transition=true`, the user is redirected to the subscriptions page and sees a notice

## Testing Instructions

Apply this PR to your local and test with the following URLs:
* http://calypso.localhost:3000/read/subscriptions/{invalid-id}
  * Error tracked; Not found page;
* http://calypso.localhost:3000/read/subscriptions/{invalid-id}?transition=true
  * Error tracked; Redirect to list; Info notice;
* http://calypso.localhost:3000/read/site/subscription/{invalid-id}
  * Error tracked; Not found page;
* http://calypso.localhost:3000/read/site/subscription/{invalid-id}?transition=true
  * Error tracked; Redirect to list; Info notice;

And for the regression tests, the following URLs should work as usual:
* http://calypso.localhost:3000/read/subscriptions/{valid-subscription-id}
* http://calypso.localhost:3000/read/subscriptions/{valid-subscription-id}?transition=true
* http://calypso.localhost:3000/read/site/subscription/{valid-blog-id}
* http://calypso.localhost:3000/read/site/subscription/{valid-blog-id}?transition=true

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?