### PR TITLE
wp-admin Site Default: Ensure 'Default style' is checked by default

### DIFF
--- a/client/my-sites/hosting/site-admin-interface-card/index.js
+++ b/client/my-sites/hosting/site-admin-interface-card/index.js
@@ -116,7 +116,7 @@ const SiteAdminInterfaceCard = ( { siteId, adminInterface } ) => {
 
 export default connect( ( state ) => {
 	const siteId = getSelectedSiteId( state );
-	const adminInterface = getSiteOption( state, siteId, 'wpcom_admin_interface' ) ?? 'calypso';
+	const adminInterface = getSiteOption( state, siteId, 'wpcom_admin_interface' ) || 'calypso';
 
 	return { siteId, adminInterface };
 } )( localize( SiteAdminInterfaceCard ) );


### PR DESCRIPTION
See p1698232335763369-slack-C04GESRBWKW

## Proposed Changes

Ensures 'Default style' is checked by default. `getSiteOption( state, siteId, 'wpcom_admin_interface' )` returns an empty string when undefined, so the Logical OR operator is more appropriate than the Nullish Coalescing operator.

<img width="748" alt="CleanShot 2023-10-25 at 16 08 39@2x" src="https://github.com/Automattic/wp-calypso/assets/36432/c75bc3fd-f143-473d-9e85-23946af4c944">

## Testing Instructions

1. Create a new Business site and take it Atomic.
2. Navigate to Hosting Configuration.
3. Verify the 'Default style' radio option is checked by default.