### PR TITLE
Subscribers Page: Add Tracks events to the Empty Subscribers launchpad

### DIFF
--- a/client/my-sites/subscribers/components/empty-list-view/empty-list-view.tsx
+++ b/client/my-sites/subscribers/components/empty-list-view/empty-list-view.tsx
@@ -1,34 +1,49 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { Card, CardBody, Icon } from '@wordpress/components';
 import { chartBar, chevronRight, people, trendingUp } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import './style.scss';
+import { useEffect } from 'react';
 
 type EmptyListCTALinkProps = {
 	icon: JSX.Element;
 	text: string;
 	url: string;
+	eventName: string;
 };
 
-const EmptyListCTALink = ( { icon, text, url }: EmptyListCTALinkProps ) => (
-	<Card
-		className="empty-list-view__cta-link"
-		size="small"
-		as="a"
-		href={ url }
-		rel="noreferrer"
-		target="_blank"
-	>
-		<CardBody className="empty-list-view__card-body">
-			<Icon className="empty-list-view__cta-link-icon" icon={ icon } size={ 20 } />
-			<span className="empty-list-view__cta-link-text">{ text }</span>
-			<Icon className="empty-list-view__cta-link-icon" icon={ chevronRight } size={ 20 } />
-		</CardBody>
-	</Card>
-);
+const EmptyListCTALink = ( { icon, text, url, eventName }: EmptyListCTALinkProps ) => {
+	const handleClick = () => {
+		recordTracksEvent( eventName );
+	};
+
+	return (
+		<Card
+			className="empty-list-view__cta-link"
+			size="small"
+			as="a"
+			href={ url }
+			rel="noreferrer"
+			target="_blank"
+			onClick={ handleClick }
+		>
+			<CardBody className="empty-list-view__card-body">
+				<Icon className="empty-list-view__cta-link-icon" icon={ icon } size={ 20 } />
+				<span className="empty-list-view__cta-link-text">{ text }</span>
+				<Icon className="empty-list-view__cta-link-icon" icon={ chevronRight } size={ 20 } />
+			</CardBody>
+		</Card>
+	);
+};
 
 const EmptyListView = () => {
 	const translate = useTranslate();
+
+	// Record an event when the empty view is rendered
+	useEffect( () => {
+		recordTracksEvent( 'calypso_subscribers_empty_view_displayed' );
+	}, [] );
 
 	return (
 		<div className="empty-list-view">
@@ -44,6 +59,7 @@ const EmptyListView = () => {
 				url={ localizeUrl(
 					'https://wordpress.com/support/wordpress-editor/blocks/subscribe-block/'
 				) }
+				eventName="calypso_subscribers_empty_view_subscribe_block_clicked"
 			/>
 			<EmptyListCTALink
 				icon={ people }
@@ -51,11 +67,13 @@ const EmptyListView = () => {
 				url={ localizeUrl(
 					'https://wordpress.com/support/launch-a-newsletter/import-subscribers-to-a-newsletter/'
 				) }
+				eventName="calypso_subscribers_empty_view_import_subscribers_clicked"
 			/>
 			<EmptyListCTALink
 				icon={ trendingUp }
 				text={ translate( 'Grow your audience' ) }
 				url={ localizeUrl( 'https://wordpress.com/support/category/grow-your-audience/' ) }
+				eventName="calypso_subscribers_empty_view_grow_your_audience_clicked"
 			/>
 		</div>
 	);


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/83493

## Proposed Changes

* Adds Tracks events to the Empty Subscribers launchpad:
  * calypso_subscribers_empty_view_displayed
  * calypso_subscribers_empty_view_subscribe_block_clicked
  * calypso_subscribers_empty_view_import_subscribers_clicked
  * calypso_subscribers_empty_view_grow_your_audience_clicked

## Testing Instructions

* Apply this PR to your local
* Use a site with no subscribers
* Go to http://calypso.localhost:3000/subscribers/{site-slug}
* Open the Network requests to check if the events are tracked
* `calypso_subscribers_empty_view_displayed` should be tracked once when the page is rendered
* Click on each CTA and check if the related events are tracked
* Go to Tracks to search for the events

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?