### PR TITLE
Jetpack Manage: Fix incorrect sidebar onboarding string.

### DIFF
--- a/client/jetpack-cloud/sections/sidebar-navigation/jetpack-manage.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/jetpack-manage.tsx
@@ -83,7 +83,7 @@ const JetpackManageSidebar = () => {
 						target: '.jetpack-cloud-sidebar__profile-dropdown-button-icon',
 						title: translate( 'Access Profile & Help Docs' ),
 						description: translate(
-							'Here you can logout from your account or view our help documentation.'
+							'Here you can log out from your account or view our help documentation.'
 						),
 					},
 					{


### PR DESCRIPTION
## Proposed Changes

* Fix incorrect 'logout' to 'log out' in the onboarding string.
<img width="413" alt="Screen Shot 2023-10-26 at 10 33 26 AM" src="https://github.com/Automattic/wp-calypso/assets/56598660/8ccb8580-6b30-4b05-a6b2-59e51db1088b">

## Testing Instructions
Prerequisites

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

* Use the Jetpack Cloud live link and go to `/dashboard`
* Go to step 2 of the sidebar navigation and confirm the string **'Here you can log out from your account or view our help documentation.'** is displayed. (If you aren't seeing the onboarding tooltip, make sure you reset your preferences).


## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?