### PR TITLE
Jetpack Manage: Wrap navigation menu and items with ul and li elements.

### DIFF
--- a/client/jetpack-cloud/components/sidebar/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/index.tsx
@@ -85,19 +85,21 @@ const JetpackCloudSidebar = ( {
 			</SidebarMain>
 
 			{ ! isJetpackManage && jetpackAdminUrl && (
-				<SidebarFooter>
-					<SidebarNavigatorMenuItem
-						title={ translate( 'WP Admin' ) }
-						link={ jetpackAdminUrl }
-						path={ jetpackAdminUrl }
-						icon={ <JetpackIcons icon="wordpress" /> }
-						onClickMenuItem={ ( link ) => {
-							dispatch( recordTracksEvent( 'calypso_jetpack_sidebar_wp_admin_link_click' ) );
-							window.open( link, '_blank' );
-						} }
-						isExternalLink
-						isSelected={ false }
-					/>
+				<SidebarFooter className="jetpack-cloud-sidebar__footer">
+					<ul>
+						<SidebarNavigatorMenuItem
+							title={ translate( 'WP Admin' ) }
+							link={ jetpackAdminUrl }
+							path={ jetpackAdminUrl }
+							icon={ <JetpackIcons icon="wordpress" /> }
+							onClickMenuItem={ ( link ) => {
+								dispatch( recordTracksEvent( 'calypso_jetpack_sidebar_wp_admin_link_click' ) );
+								window.open( link, '_blank' );
+							} }
+							isExternalLink
+							isSelected={ false }
+						/>
+					</ul>
 				</SidebarFooter>
 			) }
 

--- a/client/jetpack-cloud/components/sidebar/style.scss
+++ b/client/jetpack-cloud/components/sidebar/style.scss
@@ -88,3 +88,8 @@
 		display: block;
 	}
 }
+
+.jetpack-cloud-sidebar__footer ul {
+	list-style: none;
+	margin: 0;
+}

--- a/client/layout/sidebar-v2/footer.tsx
+++ b/client/layout/sidebar-v2/footer.tsx
@@ -1,7 +1,10 @@
+import classNames from 'classnames';
+
 type Props = {
+	className?: string;
 	children: React.ReactNode;
 };
 
-export const SidebarV2Footer = ( { children }: Props ) => {
-	return <div className="sidebar-v2__footer">{ children }</div>;
+export const SidebarV2Footer = ( { className, children }: Props ) => {
+	return <div className={ classNames( 'sidebar-v2__footer', className ) }>{ children }</div>;
 };

--- a/client/layout/sidebar-v2/navigator/navigator-menu-item.tsx
+++ b/client/layout/sidebar-v2/navigator/navigator-menu-item.tsx
@@ -56,8 +56,10 @@ export const SidebarNavigatorMenuItem = ( {
 	};
 
 	return (
-		<NavigatorButton as={ SidebarItem } path={ path }>
-			{ title }
-		</NavigatorButton>
+		<li>
+			<NavigatorButton as={ SidebarItem } path={ path }>
+				{ title }
+			</NavigatorButton>
+		</li>
 	);
 };

--- a/client/layout/sidebar-v2/navigator/navigator-menu.tsx
+++ b/client/layout/sidebar-v2/navigator/navigator-menu.tsx
@@ -25,19 +25,23 @@ export const SidebarNavigatorMenu = ( { description, backButtonProps, path, chil
 			<Card>
 				<CardBody className="sidebar-v2__navigator-sub-menu">
 					<VStack spacing={ 0 } justify="flex-start">
-						{ backButtonProps && (
-							<NavigatorToParentButton
-								icon={ backButtonProps.icon }
-								onClick={ backButtonProps.onClick }
-								text={ backButtonProps.label }
-							/>
-						) }
-						<div>
-							{ description && (
-								<div className="sidebar-v2__navigator-group-description">{ description }</div>
+						<ul>
+							{ backButtonProps && (
+								<li>
+									<NavigatorToParentButton
+										icon={ backButtonProps.icon }
+										onClick={ backButtonProps.onClick }
+										text={ backButtonProps.label }
+									/>
+								</li>
 							) }
-							{ children }
-						</div>
+							<div>
+								{ description && (
+									<div className="sidebar-v2__navigator-group-description">{ description }</div>
+								) }
+								{ children }
+							</div>
+						</ul>
 					</VStack>
 				</CardBody>
 			</Card>

--- a/client/layout/sidebar-v2/navigator/style.scss
+++ b/client/layout/sidebar-v2/navigator/style.scss
@@ -28,6 +28,11 @@
 	padding: 0 12px;
 }
 
+.sidebar-v2__navigator-sub-menu ul {
+	list-style: none;
+	margin: 0;
+}
+
 .sidebar-v2__menu-item.components-item {
 	font-size: rem(13px);
 


### PR DESCRIPTION
As recommended by [W3C's WIA standard](https://www.w3.org/WAI/tutorials/menus/structure/). We need to wrap our menus with **ul** and **li**. 

## Proposed Changes

* This PR fixes the semantic markup of our new navigation menu to follow the recommended structure.

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

* Use the Jetpack Cloud live link and go to `/dashboard`
* Confirm that the sidebar menu works as expected and the paddings and margins do not change with the new update. Make sure you inspect the element and confirm that the navigation menu is wrapped with **ul** and **li**.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
