### PR TITLE
Jetpack Manage: Change Sidebar back button labels.

### DIFF
--- a/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
@@ -191,7 +191,7 @@ const ManageSelectedSiteSidebar = ( { path }: { path: string } ) => {
 				backButtonProps={
 					isAgency
 						? {
-								label: translate( 'Site Settings' ),
+								label: translate( 'All sites' ),
 								icon: chevronLeft,
 								onClick: () => {
 									dispatch(

--- a/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
@@ -191,7 +191,7 @@ const ManageSelectedSiteSidebar = ( { path }: { path: string } ) => {
 				backButtonProps={
 					isAgency
 						? {
-								label: translate( 'All sites' ),
+								label: translate( 'Sites' ),
 								icon: chevronLeft,
 								onClick: () => {
 									dispatch(

--- a/client/jetpack-cloud/sections/sidebar-navigation/purchases.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/purchases.tsx
@@ -77,7 +77,7 @@ const PurchasesSidebar = () => {
 			menuItems={ menuItems }
 			description={ translate( 'Manage all your billing related settings from one place.' ) }
 			backButtonProps={ {
-				label: translate( 'Sites Management' ),
+				label: translate( 'Sites' ),
 				icon: chevronLeft,
 				onClick: () => {
 					dispatch(

--- a/client/jetpack-cloud/sections/sidebar-navigation/purchases.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/purchases.tsx
@@ -77,7 +77,7 @@ const PurchasesSidebar = () => {
 			menuItems={ menuItems }
 			description={ translate( 'Manage all your billing related settings from one place.' ) }
 			backButtonProps={ {
-				label: translate( 'Purchases' ),
+				label: translate( 'Site Management' ),
 				icon: chevronLeft,
 				onClick: () => {
 					dispatch(

--- a/client/jetpack-cloud/sections/sidebar-navigation/purchases.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/purchases.tsx
@@ -77,7 +77,7 @@ const PurchasesSidebar = () => {
 			menuItems={ menuItems }
 			description={ translate( 'Manage all your billing related settings from one place.' ) }
 			backButtonProps={ {
-				label: translate( 'Site Management' ),
+				label: translate( 'Sites Management' ),
 				icon: chevronLeft,
 				onClick: () => {
 					dispatch(


### PR DESCRIPTION
To better emphasize where the back button goes. This PR updates the labeling. 

<img width="266" alt="Screen Shot 2023-10-30 at 1 57 23 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/b7169b16-cf7b-4a39-989f-04a7f822fc04">
<img width="264" alt="Screen Shot 2023-10-30 at 1 57 30 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/10d7644f-8396-4565-9471-934948c3e554">


Closes https://github.com/Automattic/jetpack-genesis/issues/75

## Proposed Changes

* Change **'Site settings'** to **'Sites'** label.
* Change **'Purchases'** to **'Sites'** label.

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

* Use the Jetpack Cloud live link and go to `/partner-portal/billing`
* Confirm that the sidebar back button label shows **'Sites'**.
* go to `/activity-log/<SITE>`
* Confirm that the sidebar back button label shows **'Sites'**.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?