### PR TITLE
Jetpack Manage: Fix sidebar menu inconsistent styling and cut-off issue.

### DIFF
--- a/client/layout/sidebar-v2/navigator/style.scss
+++ b/client/layout/sidebar-v2/navigator/style.scss
@@ -36,7 +36,8 @@
 .sidebar-v2__menu-item.components-item {
 	font-size: rem(13px);
 
-	&.is-active {
+	&.is-active,
+	&:hover {
 		border-radius: 4px;
 	}
 

--- a/client/layout/sidebar-v2/navigator/style.scss
+++ b/client/layout/sidebar-v2/navigator/style.scss
@@ -31,19 +31,18 @@
 
 .sidebar-v2__menu-item.components-item {
 	font-size: rem(13px);
+
+	&:hover:not(.is-active) {
+		background: var(--studio-gray-0);
+		color: initial;
+	}
 }
 
 .sidebar-v2__navigator-sub-menu .components-navigator-back-button,
 .sidebar-v2__menu-item.components-item {
 	border-radius: 4px;
-
 	&:focus {
 		box-shadow: 0 0 0 1px var(--studio-gray-10);
-	}
-
-	&:hover:not(.is-active) {
-		background: var(--studio-gray-0);
-		color: initial;
 	}
 }
 

--- a/client/layout/sidebar-v2/navigator/style.scss
+++ b/client/layout/sidebar-v2/navigator/style.scss
@@ -5,19 +5,15 @@
 }
 
 .sidebar-v2__navigator-sub-menu.components-card-body {
-	padding: 0;
+	// Container cuts off content if we do not add 1px padding.
+	padding: 1px;
 
 	.components-navigator-back-button {
-		padding-block-start: 0;
 		margin-block-end: 8px;
 		color: var(--studio-gray-90);
 		font-size: rem(16px);
 		font-weight: 600;
 		justify-content: start;
-
-		&:focus {
-			box-shadow: none;
-		}
 	}
 }
 
@@ -35,10 +31,14 @@
 
 .sidebar-v2__menu-item.components-item {
 	font-size: rem(13px);
+}
 
-	&.is-active,
-	&:hover {
-		border-radius: 4px;
+.sidebar-v2__navigator-sub-menu .components-navigator-back-button,
+.sidebar-v2__menu-item.components-item {
+	border-radius: 4px;
+
+	&:focus {
+		box-shadow: 0 0 0 1px var(--studio-gray-10);
 	}
 
 	&:hover:not(.is-active) {

--- a/client/layout/sidebar-v2/style.scss
+++ b/client/layout/sidebar-v2/style.scss
@@ -20,6 +20,10 @@
 	flex-grow: 1;
 	overflow-y: auto;
 	height: 0;  // To support scrollable in the main content area, we set height to 0.
+
+	// Navigator container has some issue displaying edges without adding 1px padding.
+	// This is to offset the 1px padding and achieved the sidebar 16px padding.
+	margin: -1px;
 }
 
 .sidebar-v2__footer {


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack-genesis/issues/77
Closes https://github.com/Automattic/jetpack-genesis/issues/78

## Proposed Changes

* Fix inconsistency with the back button and navigation menu items by unifying the hover and focus styling.
* Add some paddings to fix the issue with the navigator menu container cutting off edges.

## Testing Instructions
Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

* Use the Jetpack Cloud live link and go to /partner-portal/billing
* Confirm that when focusing and hovering the back button and menu items, nothing is cut off, and they have consistent border and background colors.

https://github.com/Automattic/wp-calypso/assets/56598660/b65be1cc-7d2b-4994-acf7-38e2ee68f20f



## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?