### PR TITLE
Jetpack E2E: instead of typing into the editor directly, trigger the block inserter.

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/paragraph-block.ts
+++ b/packages/calypso-e2e/src/lib/blocks/paragraph-block.ts
@@ -23,8 +23,12 @@ export class ParagraphBlock {
 	 *
 	 * @param {string} text Text to be entered into the paragraph.
 	 */
-	async enterParagraph( text: string ): Promise< void > {
-		await this.block.fill( text );
+	async enterParagraph( text: string, { type }: { type?: boolean } = {} ): Promise< void > {
+		if ( type ) {
+			await this.block.type( text );
+		} else {
+			await this.block.fill( text );
+		}
 	}
 
 	/**

--- a/test/e2e/specs/editor/editor__post-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__post-basic-flow.ts
@@ -8,6 +8,7 @@ import {
 	EditorPage,
 	PublishedPostPage,
 	TestAccount,
+	ParagraphBlock,
 	envVariables,
 	getTestAccountByFeature,
 	envToFeatureKey,
@@ -54,8 +55,14 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 			await editorPage.enterTitle( title );
 		} );
 
-		it( 'Enter post text', async function () {
-			await editorPage.enterText( quote );
+		it( 'Enter post content', async function () {
+			const blockHandle = await editorPage.addBlockFromSidebar(
+				ParagraphBlock.blockName,
+				ParagraphBlock.blockEditorSelector,
+				{ noSearch: true }
+			);
+			const paragraphBlock = new ParagraphBlock( blockHandle );
+			await paragraphBlock.enterParagraph( quote );
 		} );
 	} );
 
@@ -89,6 +96,8 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 	describe( 'Jetpack features', function () {
 		it( 'Open Jetpack settings', async function () {
 			// @TODO https://github.com/Automattic/wp-calypso/pull/82301
+			// Works around the scenario where the Jetpack icon isn't pinned on the
+			// editor toolbar.
 			await editorPage.openEditorOptionsMenu();
 			const page = await editorPage.getEditorParent();
 

--- a/test/e2e/specs/editor/editor__post-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__post-basic-flow.ts
@@ -62,7 +62,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 				{ noSearch: true }
 			);
 			const paragraphBlock = new ParagraphBlock( blockHandle );
-			await paragraphBlock.enterParagraph( quote );
+			await paragraphBlock.enterParagraph( quote, { type: true } );
 		} );
 	} );
 
@@ -215,7 +215,9 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 		it( 'Post content is found in published post', async function () {
 			publishedPostPage = new PublishedPostPage( newPage );
 			await publishedPostPage.validateTitle( title );
-			await publishedPostPage.validateTextInPost( quote );
+			for ( const part in quote.split( '\n' ) ) {
+				await publishedPostPage.validateTextInPost( part );
+			}
 		} );
 
 		it( 'Post metadata is found in published post', async function () {


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/83503, https://github.com/Automattic/wp-calypso/issues/83507 which triggered an escalation.

## Proposed Changes

This PR revises an existing editor spec to trigger the block inserter.

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Calypso E2E (desktop)
  - [x] Jetpack E2E Simple (mobile)
  - [x] Jetpack E2E Simple (desktop)
  - [x] Jetpack E2E AT Smoke (desktop)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?