### PR TITLE
Assembler: Improve the props of the zoom-out event

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -53,6 +53,7 @@ const PatternLargePreview = ( {
 	const [ viewportHeight, setViewportHeight ] = useState< number | undefined >( 0 );
 	const [ device, setDevice ] = useState< string >( 'computer' );
 	const [ zoomOutScale, setZoomOutScale ] = useState( 1 );
+	const zoomOutScaleRef = useRef( zoomOutScale );
 	const [ backgroundColor ] = useGlobalStyle( 'color.background' );
 	const patternLargePreviewStyle = useMemo(
 		() =>
@@ -63,15 +64,13 @@ const PatternLargePreview = ( {
 		[ zoomOutScale, backgroundColor ]
 	);
 
-	const [ debouncedRecordZoomOutScaleChange ] = useDebouncedCallback(
-		( from: number, to: number ) => {
-			recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.LARGE_PREVIEW_ZOOM_OUT_SCALE_CHANGE, {
-				from_scale: from,
-				to_scale: to,
-			} );
-		},
-		1000
-	);
+	const [ debouncedRecordZoomOutScaleChange ] = useDebouncedCallback( ( value: number ) => {
+		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.LARGE_PREVIEW_ZOOM_OUT_SCALE_CHANGE, {
+			from_scale: zoomOutScaleRef.current,
+			to_scale: value,
+		} );
+		zoomOutScaleRef.current = value;
+	}, 300 );
 
 	const [ activeElement, setActiveElement ] = useState< HTMLElement | null >( null );
 
@@ -181,7 +180,7 @@ const PatternLargePreview = ( {
 	const handleZoomOutScale = ( value: number ) => {
 		setZoomOutScale( value );
 		if ( zoomOutScale !== value ) {
-			debouncedRecordZoomOutScaleChange( zoomOutScale, value );
+			debouncedRecordZoomOutScaleChange( value );
 		}
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -63,11 +63,15 @@ const PatternLargePreview = ( {
 		[ zoomOutScale, backgroundColor ]
 	);
 
-	const [ debouncedRecordZoomOutScaleChange ] = useDebouncedCallback( ( value: number ) => {
-		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.LARGE_PREVIEW_ZOOM_OUT_SCALE_CHANGE, {
-			zoom_out_scale: value,
-		} );
-	}, 1000 );
+	const [ debouncedRecordZoomOutScaleChange ] = useDebouncedCallback(
+		( from: number, to: number ) => {
+			recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.LARGE_PREVIEW_ZOOM_OUT_SCALE_CHANGE, {
+				from_scale: from,
+				to_scale: to,
+			} );
+		},
+		1000
+	);
 
 	const [ activeElement, setActiveElement ] = useState< HTMLElement | null >( null );
 
@@ -177,7 +181,7 @@ const PatternLargePreview = ( {
 	const handleZoomOutScale = ( value: number ) => {
 		setZoomOutScale( value );
 		if ( zoomOutScale !== value ) {
-			debouncedRecordZoomOutScaleChange( value );
+			debouncedRecordZoomOutScaleChange( zoomOutScale, value );
 		}
 	};
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Improve the properties of the `calypso_signup_pattern_assembler_large_preview_zoom_out_scale_change` event so we can know the current value and the next value!

![image](https://github.com/Automattic/wp-calypso/assets/13596067/2ef078af-f719-4337-91e7-977e840ab85d)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /setup?siteSlug=your_site
* Continue to Design Picker
* Select "Design your own"
* On the Assembler
  * Select a pattern
  * Scroll the zoom-out slider
  * Verify the event has both `from_scale` and `to_scale` props

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?