### PR TITLE
Add email to login URL if email_exists error

### DIFF
--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -105,6 +105,13 @@ class PasswordlessSignupForm extends Component {
 		this.submitTracksEvent( false, { action_message: error.message, error_code: error.error } );
 
 		if ( [ 'already_taken', 'already_active', 'email_exists' ].includes( error.error ) ) {
+			if ( error.error === 'email_exists' ) {
+				this.props.saveSignupStep( {
+					stepName: this.props.stepName,
+					formError: error.error,
+				} );
+			}
+
 			const email = typeof this.state.email === 'string' ? this.state.email.trim() : '';
 			const response = await wpcom.req.get(
 				`/users/${ encodeURIComponent( email ) }/auth-options`
@@ -198,18 +205,6 @@ class PasswordlessSignupForm extends Component {
 		} );
 	};
 
-	goToLogin = () => {
-		page(
-			addQueryArgs(
-				{
-					email_address: this.state.email,
-					use_email_from_url: true,
-				},
-				this.props.logInUrl
-			)
-		);
-	};
-
 	submitStep = ( data ) => {
 		const { flowName, stepName, goToNextStep, submitCreateAccountStep } = this.props;
 		submitCreateAccountStep(
@@ -227,11 +222,20 @@ class PasswordlessSignupForm extends Component {
 		goToNextStep();
 	};
 
-	onInputChange = ( { target: { value } } ) =>
+	onInputChange = ( { target: { value } } ) => {
+		// Clear the form error if the user changes their email address.
+		if ( this.props.step?.formError === 'email_exists' ) {
+			this.props.saveSignupStep( {
+				stepName: this.props.stepName,
+				formError: null,
+			} );
+		}
+
 		this.setState( {
 			email: value,
 			errorMessages: null,
 		} );
+	};
 
 	renderNotice() {
 		return (

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -105,13 +105,6 @@ class PasswordlessSignupForm extends Component {
 		this.submitTracksEvent( false, { action_message: error.message, error_code: error.error } );
 
 		if ( [ 'already_taken', 'already_active', 'email_exists' ].includes( error.error ) ) {
-			if ( error.error === 'email_exists' ) {
-				this.props.saveSignupStep( {
-					stepName: this.props.stepName,
-					formError: error.error,
-				} );
-			}
-
 			const email = typeof this.state.email === 'string' ? this.state.email.trim() : '';
 			const response = await wpcom.req.get(
 				`/users/${ encodeURIComponent( email ) }/auth-options`
@@ -223,14 +216,6 @@ class PasswordlessSignupForm extends Component {
 	};
 
 	onInputChange = ( { target: { value } } ) => {
-		// Clear the form error if the user changes their email address.
-		if ( this.props.step?.formError === 'email_exists' ) {
-			this.props.saveSignupStep( {
-				stepName: this.props.stepName,
-				formError: null,
-			} );
-		}
-
 		this.setState( {
 			email: value,
 			errorMessages: null,

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -215,12 +215,11 @@ class PasswordlessSignupForm extends Component {
 		goToNextStep();
 	};
 
-	onInputChange = ( { target: { value } } ) => {
+	onInputChange = ( { target: { value } } ) =>
 		this.setState( {
 			email: value,
 			errorMessages: null,
 		} );
-	};
 
 	renderNotice() {
 		return (

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -166,6 +166,7 @@ export class UserStep extends Component {
 
 	getLoginUrl() {
 		const { oauth2Client, wccomFrom, isReskinned, sectionName, from, locale } = this.props;
+		const populateEmail = this.props?.step?.formError === 'email_exists';
 
 		return login( {
 			isJetpack: 'jetpack-connect' === sectionName,
@@ -176,6 +177,7 @@ export class UserStep extends Component {
 			wccomFrom,
 			isWhiteLogin: isReskinned,
 			signupUrl: window.location.pathname + window.location.search,
+			emailAddress: populateEmail ? this.props?.step?.form?.email : null,
 		} );
 	}
 

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -166,7 +166,6 @@ export class UserStep extends Component {
 
 	getLoginUrl() {
 		const { oauth2Client, wccomFrom, isReskinned, sectionName, from, locale } = this.props;
-		const populateEmail = this.props?.step?.formError === 'email_exists';
 
 		return login( {
 			isJetpack: 'jetpack-connect' === sectionName,
@@ -177,7 +176,7 @@ export class UserStep extends Component {
 			wccomFrom,
 			isWhiteLogin: isReskinned,
 			signupUrl: window.location.pathname + window.location.search,
-			emailAddress: populateEmail ? this.props?.step?.form?.email : null,
+			emailAddress: this.props?.step?.form?.email,
 		} );
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/83264

## Proposed Changes

* Add `email_address` to login URL for existing email error (link # 2 in screenshot below)

![image](https://github.com/Automattic/wp-calypso/assets/10482592/20fcf1b1-010f-4141-8684-b3fde2e3c934)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch or use live link
* Navigate to `/start/user-social`
* Click `Continue with email` option, enter an email for an existing account then click `Continue`. You should see the following error message (`An account with this email address already exists. Log in now to finish signing up.`
* Verify both login links (open in new tab for easier testing) in the screenshot above navigate to the login screen with the email field populated
* Close the tabs, navigate back to the `start/user-social` tab, change the email input field, then verify the header login link navigates to the login screen without the email field populated.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/83264