### PR TITLE
FHT: Assign hosting flow users to an experiment cohort experiment

### DIFF
--- a/client/my-sites/plans-features-main/hooks/use-free-hosting-trial-assignment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-free-hosting-trial-assignment.ts
@@ -1,0 +1,28 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { useExperiment } from 'calypso/lib/explat';
+
+export function useFreeHostingTrialAssignment(): {
+	isLoadingHostingTrialExperiment: boolean;
+	isAssignedToHostingTrialExperiment: boolean;
+} {
+	const [ isLoadingHostingTrialExperiment, experimentAssignment ] = useExperiment(
+		'wpcom_hosting_business_plan_free_trial',
+		{
+			isEligible: ! isEnabled( 'plans/hosting-trial' ),
+		}
+	);
+
+	if ( isEnabled( 'plans/hosting-trial' ) ) {
+		return {
+			isLoadingHostingTrialExperiment: false,
+
+			// The plans/hosting-trial flag forces the user to be treated as if they're in the treatment group.
+			isAssignedToHostingTrialExperiment: true,
+		};
+	}
+
+	return {
+		isLoadingHostingTrialExperiment,
+		isAssignedToHostingTrialExperiment: experimentAssignment?.variationName === 'treatment',
+	};
+}

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -72,6 +72,7 @@ import usePricedAPIPlans from './hooks/data-store/use-priced-api-plans';
 import usePricingMetaForGridPlans from './hooks/data-store/use-pricing-meta-for-grid-plans';
 import useCurrentPlanManageHref from './hooks/use-current-plan-manage-href';
 import useFilterPlansForPlanFeatures from './hooks/use-filter-plans-for-plan-features';
+import { useFreeHostingTrialAssignment } from './hooks/use-free-hosting-trial-assignment';
 import useIsFreeDomainFreePlanUpsellEnabled from './hooks/use-is-free-domain-free-plan-upsell-enabled';
 import useObservableForOdie from './hooks/use-observable-for-odie';
 import usePlanBillingPeriod from './hooks/use-plan-billing-period';
@@ -382,6 +383,8 @@ const PlansFeaturesMain = ( {
 		? 'plans-default-wpcom'
 		: intentFromProps || intentFromSiteMeta.intent || 'plans-default-wpcom';
 
+	const { isLoadingHostingTrialExperiment, isAssignedToHostingTrialExperiment } =
+		useFreeHostingTrialAssignment();
 	const eligibleForFreeHostingTrial = useSelector( isUserEligibleForFreeHostingTrial );
 
 	const gridPlans = useGridPlans( {
@@ -396,7 +399,7 @@ const PlansFeaturesMain = ( {
 		sitePlanSlug,
 		hideEnterprisePlan,
 		usePlanUpgradeabilityCheck,
-		eligibleForFreeHostingTrial,
+		eligibleForFreeHostingTrial: isAssignedToHostingTrialExperiment && eligibleForFreeHostingTrial,
 		showLegacyStorageFeature,
 		isSubdomainNotGenerated: ! resolvedSubdomainName.result,
 		storageAddOns,
@@ -728,109 +731,116 @@ const PlansFeaturesMain = ( {
 					</FreePlanSubHeader>
 				) ) }
 			{ isDisplayingPlansNeededForFeature() && <SecondaryFormattedHeader siteSlug={ siteSlug } /> }
-			{ ( isLoadingGridPlans || resolvedSubdomainName.isLoading ) && <Spinner size={ 30 } /> }
-			{ ! isLoadingGridPlans && ! resolvedSubdomainName.isLoading && (
-				<>
-					{ ! hidePlanSelector && <PlanTypeSelector { ...planTypeSelectorProps } /> }
-					<div
-						className={ classNames(
-							'plans-features-main__group',
-							'is-wpcom',
-							'is-2023-pricing-grid',
-							{
-								'is-scrollable': plansWithScroll,
-							}
-						) }
-						data-e2e-plans="wpcom"
-					>
-						<div className="plans-wrapper">
-							<FeaturesGrid
-								gridPlans={ gridPlansForFeaturesGrid }
-								gridPlanForSpotlight={ gridPlanForSpotlight }
-								paidDomainName={ paidDomainName }
-								generatedWPComSubdomain={ resolvedSubdomainName }
-								isCustomDomainAllowedOnFreePlan={ isCustomDomainAllowedOnFreePlan }
-								isInSignup={ isInSignup }
-								isLaunchPage={ isLaunchPage }
-								onUpgradeClick={ handleUpgradeClick }
-								flowName={ flowName }
-								selectedFeature={ selectedFeature }
-								selectedPlan={ selectedPlan }
-								siteId={ siteId }
-								isReskinned={ isReskinned }
-								intervalType={ intervalType }
-								hideUnavailableFeatures={ hideUnavailableFeatures }
-								currentSitePlanSlug={ sitePlanSlug }
-								planActionOverrides={ planActionOverrides }
-								intent={ intent }
-								showLegacyStorageFeature={ showLegacyStorageFeature }
-								showUpgradeableStorage={ showUpgradeableStorage }
-								stickyRowOffset={ masterbarHeight }
-								usePricingMetaForGridPlans={ usePricingMetaForGridPlans }
-								allFeaturesList={ FEATURES_LIST }
-								onStorageAddOnClick={ handleStorageAddOnClick }
-								currentPlanManageHref={ currentPlanManageHref }
-								canUserManageCurrentPlan={ canUserManageCurrentPlan }
-								showRefundPeriod={ isAnyHostingFlow( flowName ) }
-							/>
-							{ ! hidePlansFeatureComparison && (
-								<>
-									<ComparisonGridToggle
-										onClick={ toggleShowPlansComparisonGrid }
-										label={
-											showPlansComparisonGrid
-												? translate( 'Hide comparison' )
-												: translate( 'Compare plans' )
-										}
-										ref={ observableForOdieRef }
-									/>
-									<div ref={ plansComparisonGridRef } className={ comparisonGridContainerClasses }>
-										<PlanComparisonHeader className="wp-brand-font">
-											{ translate( 'Compare our plans and find yours' ) }
-										</PlanComparisonHeader>
-										{ ! hidePlanSelector && showPlansComparisonGrid && (
-											<PlanTypeSelector { ...planTypeSelectorProps } />
-										) }
-										<ComparisonGrid
-											gridPlans={ gridPlansForComparisonGrid }
-											gridPlanForSpotlight={ gridPlanForSpotlight }
-											paidDomainName={ paidDomainName }
-											generatedWPComSubdomain={ resolvedSubdomainName }
-											isCustomDomainAllowedOnFreePlan={ isCustomDomainAllowedOnFreePlan }
-											isInSignup={ isInSignup }
-											isLaunchPage={ isLaunchPage }
-											onUpgradeClick={ handleUpgradeClick }
-											flowName={ flowName }
-											selectedFeature={ selectedFeature }
-											selectedPlan={ selectedPlan }
-											siteId={ siteId }
-											isReskinned={ isReskinned }
-											intervalType={ intervalType }
-											hideUnavailableFeatures={ hideUnavailableFeatures }
-											currentSitePlanSlug={ sitePlanSlug }
-											planActionOverrides={ planActionOverrides }
-											intent={ intent }
-											showLegacyStorageFeature={ showLegacyStorageFeature }
-											showUpgradeableStorage={ showUpgradeableStorage }
-											stickyRowOffset={ masterbarHeight }
-											usePricingMetaForGridPlans={ usePricingMetaForGridPlans }
-											allFeaturesList={ FEATURES_LIST }
-											onStorageAddOnClick={ handleStorageAddOnClick }
-											currentPlanManageHref={ currentPlanManageHref }
-											canUserManageCurrentPlan={ canUserManageCurrentPlan }
-											showRefundPeriod={ isAnyHostingFlow( flowName ) }
-										/>
+			{ ( isLoadingGridPlans ||
+				resolvedSubdomainName.isLoading ||
+				isLoadingHostingTrialExperiment ) && <Spinner size={ 30 } /> }
+			{ ! isLoadingGridPlans &&
+				! resolvedSubdomainName.isLoading &&
+				! isLoadingHostingTrialExperiment && (
+					<>
+						{ ! hidePlanSelector && <PlanTypeSelector { ...planTypeSelectorProps } /> }
+						<div
+							className={ classNames(
+								'plans-features-main__group',
+								'is-wpcom',
+								'is-2023-pricing-grid',
+								{
+									'is-scrollable': plansWithScroll,
+								}
+							) }
+							data-e2e-plans="wpcom"
+						>
+							<div className="plans-wrapper">
+								<FeaturesGrid
+									gridPlans={ gridPlansForFeaturesGrid }
+									gridPlanForSpotlight={ gridPlanForSpotlight }
+									paidDomainName={ paidDomainName }
+									generatedWPComSubdomain={ resolvedSubdomainName }
+									isCustomDomainAllowedOnFreePlan={ isCustomDomainAllowedOnFreePlan }
+									isInSignup={ isInSignup }
+									isLaunchPage={ isLaunchPage }
+									onUpgradeClick={ handleUpgradeClick }
+									flowName={ flowName }
+									selectedFeature={ selectedFeature }
+									selectedPlan={ selectedPlan }
+									siteId={ siteId }
+									isReskinned={ isReskinned }
+									intervalType={ intervalType }
+									hideUnavailableFeatures={ hideUnavailableFeatures }
+									currentSitePlanSlug={ sitePlanSlug }
+									planActionOverrides={ planActionOverrides }
+									intent={ intent }
+									showLegacyStorageFeature={ showLegacyStorageFeature }
+									showUpgradeableStorage={ showUpgradeableStorage }
+									stickyRowOffset={ masterbarHeight }
+									usePricingMetaForGridPlans={ usePricingMetaForGridPlans }
+									allFeaturesList={ FEATURES_LIST }
+									onStorageAddOnClick={ handleStorageAddOnClick }
+									currentPlanManageHref={ currentPlanManageHref }
+									canUserManageCurrentPlan={ canUserManageCurrentPlan }
+									showRefundPeriod={ isAnyHostingFlow( flowName ) }
+								/>
+								{ ! hidePlansFeatureComparison && (
+									<>
 										<ComparisonGridToggle
 											onClick={ toggleShowPlansComparisonGrid }
-											label={ translate( 'Hide comparison' ) }
+											label={
+												showPlansComparisonGrid
+													? translate( 'Hide comparison' )
+													: translate( 'Compare plans' )
+											}
+											ref={ observableForOdieRef }
 										/>
-									</div>
-								</>
-							) }
+										<div
+											ref={ plansComparisonGridRef }
+											className={ comparisonGridContainerClasses }
+										>
+											<PlanComparisonHeader className="wp-brand-font">
+												{ translate( 'Compare our plans and find yours' ) }
+											</PlanComparisonHeader>
+											{ ! hidePlanSelector && showPlansComparisonGrid && (
+												<PlanTypeSelector { ...planTypeSelectorProps } />
+											) }
+											<ComparisonGrid
+												gridPlans={ gridPlansForComparisonGrid }
+												gridPlanForSpotlight={ gridPlanForSpotlight }
+												paidDomainName={ paidDomainName }
+												generatedWPComSubdomain={ resolvedSubdomainName }
+												isCustomDomainAllowedOnFreePlan={ isCustomDomainAllowedOnFreePlan }
+												isInSignup={ isInSignup }
+												isLaunchPage={ isLaunchPage }
+												onUpgradeClick={ handleUpgradeClick }
+												flowName={ flowName }
+												selectedFeature={ selectedFeature }
+												selectedPlan={ selectedPlan }
+												siteId={ siteId }
+												isReskinned={ isReskinned }
+												intervalType={ intervalType }
+												hideUnavailableFeatures={ hideUnavailableFeatures }
+												currentSitePlanSlug={ sitePlanSlug }
+												planActionOverrides={ planActionOverrides }
+												intent={ intent }
+												showLegacyStorageFeature={ showLegacyStorageFeature }
+												showUpgradeableStorage={ showUpgradeableStorage }
+												stickyRowOffset={ masterbarHeight }
+												usePricingMetaForGridPlans={ usePricingMetaForGridPlans }
+												allFeaturesList={ FEATURES_LIST }
+												onStorageAddOnClick={ handleStorageAddOnClick }
+												currentPlanManageHref={ currentPlanManageHref }
+												canUserManageCurrentPlan={ canUserManageCurrentPlan }
+												showRefundPeriod={ isAnyHostingFlow( flowName ) }
+											/>
+											<ComparisonGridToggle
+												onClick={ toggleShowPlansComparisonGrid }
+												label={ translate( 'Hide comparison' ) }
+											/>
+										</div>
+									</>
+								) }
+							</div>
 						</div>
-					</div>
-				</>
-			) }
+					</>
+				) }
 		</div>
 	);
 };

--- a/client/my-sites/plans-features-main/test/index.jsx
+++ b/client/my-sites/plans-features-main/test/index.jsx
@@ -46,6 +46,12 @@ jest.mock( 'calypso/my-sites/plans-features-main/hooks/data-store/use-priced-api
 );
 jest.mock( 'calypso/components/data/query-active-promotions', () => jest.fn() );
 jest.mock( 'calypso/components/data/query-products-list', () => jest.fn() );
+jest.mock( 'calypso/my-sites/plans-features-main/hooks/use-free-hosting-trial-assignment', () => ( {
+	useFreeHostingTrialAssignment: jest.fn( () => ( {
+		isLoadingHostingTrialExperiment: false,
+		isAssignedToHostingTrialExperiment: false,
+	} ) ),
+} ) );
 
 import {
 	PLAN_FREE,

--- a/client/state/selectors/is-user-eligible-for-free-hosting-trial.ts
+++ b/client/state/selectors/is-user-eligible-for-free-hosting-trial.ts
@@ -1,12 +1,7 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { getCurrentUser } from '../current-user/selectors';
 import type { AppState } from '../../types';
 
 export const isUserEligibleForFreeHostingTrial = ( state: AppState ) => {
-	if ( ! isEnabled( 'plans/hosting-trial' ) ) {
-		return false;
-	}
-
 	const currentUser = getCurrentUser( state );
 
 	if ( ! currentUser ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This PR switches from using a feature flag for showing/hiding the free trial, to using explat to assign the user to a particular cohort. The feature flag has been left for the time being as a way to force the experiment UI to be shown. This will be useful until everyone on the team is familiar with using the explat tools to assign one-self to a particular cohort.

I have separated out the concept of "eligible" for free trial from the concept of "free trial is visible". In the near future we will show a different UI for users who already have a trial and are therefore ineligible. That means we'll need to be able to distinguish `eligible === false` and `variant === 'control'`.

The experiment itself is still in staging so unless you do something special with explat, the code will always behave as if you're in the control group and you won't _actually_ be assigned to a cohort properly.

This PR:

* Update `isUserEligibleForFreeHostingTrial` selector so it only refers to eligibility and not experiment assignment
* Add `useFreeHostingTrialAssignment` hook for determining whether to show free trial UI based on explat assignment
* Fixes unit tests by forcing experiment assignment to the control group

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test using localhost, or in an environment where the `plans/hosting-trial` flag is set by default
* Start at `/setup/new-hosted-site` and get to the plans grid
   * Confirm you see the free trial option (this is because the `plans/hosting-trial` is set)
   * Confirm you haven't been assigned to a cohort (look in local storage and confirm you don't see a key that looks like `explat-xyz-wpcom_hosting_business_plan_free_trial`)
* Use the bookmarklet feature over at 21452-explat-experiment to assign yourself to a cohort
* Reload the plans page with the `?flags=-plans/hosting-trial` query param 
   * Confirm that you see or don't see the free trial option based on which cohort you picked
   * Confirm you've been assigned to a cohort (look in local storage and confirm you don't see a key that looks like `explat-xyz-wpcom_hosting_business_plan_free_trial`)

If you want to test both cohorts you will need to clear the explat key out from local storage in between reloads. Otherwise the old experiment assignment is cached.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?