### PR TITLE
Launchpad: Use more specific selectors to avoid issues due to CSS load order

### DIFF
--- a/packages/launchpad/src/checklist-item/style.scss
+++ b/packages/launchpad/src/checklist-item/style.scss
@@ -2,7 +2,7 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@automattic/typography/styles/variables";
 
-.checklist-item__task-content {
+.checklist-item__task-content.components-button {
 	align-items: center;
 	background-color: transparent;
 	border-bottom: 1px solid var(--studio-gray-5);
@@ -37,7 +37,7 @@
 		padding: 16px 0 16px 0;
 	}
 
-	&.components-button:focus {
+	&:focus {
 		box-shadow: none;
 		outline: none;
 	}
@@ -71,20 +71,20 @@
 	}
 }
 
-.components-button.checklist-item__task-content:hover:not([disabled]),
-.components-button.checklist-item__task-content:focus:not([disabled]) {
+.checklist-item__task-content.components-button:hover:not([disabled]),
+.checklist-item__task-content.components-button:focus:not([disabled]) {
 	fill: var(--studio-blue-50);
 	color: var(--studio-blue-50);
 	border-bottom: 1px solid var(--studio-gray-5);
 }
 
-.checklist-item__task-content[disabled],
-.checklist-item__task-content[disabled]:focus {
+.checklist-item__task-content.components-button[disabled],
+.checklist-item__task-content.components-button[disabled]:focus {
 	background-color: transparent;
 	pointer-events: none;
 }
 
-.checklist-item__task-content[data-task="verify_email"] {
+.checklist-item__task-content.components-button[data-task="verify_email"] {
 	color: var(--color-text);
 }
 
@@ -131,7 +131,7 @@
 	}
 }
 
-.checklist-item__task-content:hover .checklist-item__subtext {
+.checklist-item__task-content.components-button:hover .checklist-item__subtext {
 	color: var(--color-neutral-100);
 }
 
@@ -219,7 +219,7 @@
 	font-weight: 600;
 }
 
-.checklist-item__checklist-primary-button {
+.checklist-item__checklist-primary-button.components-button {
 	width: 100%;
 	font-weight: 500;
 	padding: 11px;
@@ -245,7 +245,7 @@
 		color: var(--color-text-inverted);
 	}
 
-	&.components-button:disabled {
+	&:disabled {
 		opacity: 1;
 		&:hover {
 			color: var(--color-text-inverted);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
* #83124

## Proposed Changes

* This PR uses more specific CSS selectors for the items in the Launchpad to avoid incorrect styles that can occur when the CSS load order was switched. The changes add `.components-button` as an additional CSS selector to ensure that our styles take priority over the styles from the `.components-button` CSS selector.
  - This issue stems from us landing #83124 _and_ there being a change that resulted in the CSS from `@wordpress/components` being loaded later.

## Screenshots

### Before

<img width="1598" alt="Screenshot 2023-10-26 at 11 07 44" src="https://github.com/Automattic/wp-calypso/assets/3376401/a2e14c07-43ef-4af1-996b-29a5973ec44a">

### After

<img width="1598" alt="Screenshot 2023-10-26 at 11 08 17" src="https://github.com/Automattic/wp-calypso/assets/3376401/7ab95c0f-5876-4ebc-b2de-da8c88456cb1">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch locally or via Calypso.live
* Create a new site via `/start` or `/setup/free`
* Work through the flow until you get to the fullscreen Launchpad
* Verify that the styles for the items in the task list look like the **After** screenshots above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
