### PR TITLE
Newsletter Categories Added userId to useSubscribedNewsletterCategories function

### DIFF
--- a/client/data/newsletter-categories/test/use-subscribed-newsletter-categories-query.test.tsx
+++ b/client/data/newsletter-categories/test/use-subscribed-newsletter-categories-query.test.tsx
@@ -124,4 +124,42 @@ describe( 'useSubscribedNewsletterCategories', () => {
 			`/sites/123/newsletter-categories/subscriptions`
 		);
 	} );
+
+	it( 'should include the subscriptionId when being called with one', async () => {
+		(
+			requestWithSubkeyFallback as jest.MockedFunction< typeof requestWithSubkeyFallback >
+		 ).mockResolvedValue( {
+			success: true,
+		} );
+
+		renderHook( () => useSubscribedNewsletterCategories( { siteId: 123, subscriptionId: 456 } ), {
+			wrapper,
+		} );
+
+		await waitFor( () => expect( requestWithSubkeyFallback ).toHaveBeenCalled() );
+
+		expect( requestWithSubkeyFallback ).toHaveBeenCalledWith(
+			false,
+			`/sites/123/newsletter-categories/subscriptions/456`
+		);
+	} );
+
+	it( 'should call with ?type=wpcom when being passed a user id', async () => {
+		(
+			requestWithSubkeyFallback as jest.MockedFunction< typeof requestWithSubkeyFallback >
+		 ).mockResolvedValue( {
+			success: true,
+		} );
+
+		renderHook( () => useSubscribedNewsletterCategories( { siteId: 123, userId: 456 } ), {
+			wrapper,
+		} );
+
+		await waitFor( () => expect( requestWithSubkeyFallback ).toHaveBeenCalled() );
+
+		expect( requestWithSubkeyFallback ).toHaveBeenCalledWith(
+			false,
+			`/sites/123/newsletter-categories/subscriptions/456?type=wpcom`
+		);
+	} );
 } );

--- a/client/my-sites/subscribers/subscriber-details-page.tsx
+++ b/client/my-sites/subscribers/subscriber-details-page.tsx
@@ -45,11 +45,11 @@ const SubscriberDetailsPage = ( {
 		subscriptionId,
 		userId
 	);
-
 	const { data: subscribedNewsletterCategoriesData, isLoading: isLoadingNewsletterCategories } =
 		useSubscribedNewsletterCategories( {
 			siteId: selectedSiteId as number,
-			subscriptionId: subscriptionId || subscriber?.subscription_id,
+			subscriptionId: subscriber?.subscription_id,
+			userId,
 		} );
 
 	const isLoading = isLoadingDetails || isLoadingNewsletterCategories;


### PR DESCRIPTION
Related to #83513

## Proposed Changes

This commit includes changes to utilize userId in subscribedNewsletterCategoriesData function. The userId is now being used in `useSubscribedNewsletterCategories` function, when the subscriber is a WPCOM user, and related test cases have been added as well. 

Previously we were passing the subscription id from the subscription_matrix, while the endpoint expected a Blog_Subscription id.

## Testing Instructions

Needs this PR applied to your sandbox: D126712-code

1. Apply this PR
2. Using another window subscribe to a site with newsletter categories enabled, choose one category, and confirm your subscription
3. As a site owner view this subscriber and confirm that the right subscriptions are being shown
4. Run the tests: ` yarn test-client client/data/newsletter-categories/test/use-subscribed-newsletter-categories-query.test`
5. Test for regressions

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?