### PR TITLE
Jetpack Manage: Rename Sites Management > Sites, and Plugin Management > Plugins

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -129,7 +129,7 @@ export default function SitesOverview() {
 	}, [ refetch, jetpackSiteDisconnected ] );
 
 	const isNewNavigation = isEnabled( 'jetpack/new-navigation' );
-	const pageTitle = isNewNavigation ? translate( 'Sites Management' ) : translate( 'Dashboard' );
+	const pageTitle = isNewNavigation ? translate( 'Sites' ) : translate( 'Dashboard' );
 
 	const basePath = '/dashboard';
 

--- a/client/jetpack-cloud/sections/plugin-management/plugins-overview/index.tsx
+++ b/client/jetpack-cloud/sections/plugin-management/plugins-overview/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { useQueryJetpackPartnerPortalPartner } from 'calypso/components/data/query-jetpack-partner-portal-partner';
@@ -49,13 +48,9 @@ export default function PluginsOverview( { filter, search, site, pluginSlug, pat
 	}
 
 	if ( hasFetched ) {
-		const isNewNavigation = isEnabled( 'jetpack/new-navigation' );
-		const sectionTitle = isNewNavigation
-			? translate( 'Plugin Management' )
-			: translate( 'Plugins' );
 		return (
 			<div className="plugins-overview__container">
-				<SidebarNavigation sectionTitle={ sectionTitle } />
+				<SidebarNavigation sectionTitle={ translate( 'Plugins' ) } />
 				{ pluginSlug ? (
 					<PluginDetails isJetpackCloud siteUrl={ site } pluginSlug={ pluginSlug } path={ path } />
 				) : (

--- a/client/jetpack-cloud/sections/sidebar-navigation/jetpack-manage.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/jetpack-manage.tsx
@@ -29,7 +29,7 @@ const JetpackManageSidebar = () => {
 			icon: category,
 			path: '/',
 			link: JETPACK_MANAGE_DASHBOARD_LINK,
-			title: translate( 'Sites Management' ),
+			title: translate( 'Sites' ),
 			trackEventProps: {
 				menu_item: 'Jetpack Cloud / Dashboard',
 			},
@@ -38,7 +38,7 @@ const JetpackManageSidebar = () => {
 			icon: plugins,
 			path: '/',
 			link: JETPACK_MANAGE_PLUGINS_LINK,
-			title: translate( 'Plugin Management' ),
+			title: translate( 'Plugins' ),
 			trackEventProps: {
 				menu_item: 'Jetpack Cloud / Plugins',
 			},

--- a/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
@@ -212,7 +212,7 @@ const ManageSelectedSiteSidebar = ( { path }: { path: string } ) => {
 						? {
 								target: '.components-navigator-back-button svg',
 								popoverPosition: 'bottom left',
-								title: translate( 'Back to Sites Management' ),
+								title: translate( 'Back to Sites' ),
 								description: translate(
 									'Click here when you want to return to managing all of your sites.'
 								),

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import {
 	WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS,
 	WPCOM_FEATURES_MANAGE_PLUGINS,
@@ -449,12 +448,9 @@ export class PluginsMain extends Component {
 
 		const { isJetpackCloud, selectedSite } = this.props;
 
-		const isNewNavigation = isEnabled( 'jetpack/new-navigation' );
 		let pageTitle;
 		if ( isJetpackCloud ) {
-			pageTitle = isNewNavigation
-				? this.props.translate( 'Plugin Management', { textOnly: true } )
-				: this.props.translate( 'Plugins', { textOnly: true } );
+			pageTitle = this.props.translate( 'Plugins', { textOnly: true } );
 		} else {
 			pageTitle = this.props.translate( 'Installed Plugins', { textOnly: true } );
 		}


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/81

## Proposed Changes

This PR updates `Sites Management` -> `Sites`, and `Plugin Management` -> `Plugins`

### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Open the Jetpack Cloud live link
2. Visit the /dashboard
3. Verify that the menu items are updated to **Sites** & **Plugins**

<img width="275" alt="Screenshot 2023-10-26 at 3 37 04 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/33b0d92d-28b9-4413-8796-0bf44dcb4fd2">

4. Verify that the page title on the browser tab and heading is updated to **Sites**.

<img width="448" alt="Screenshot 2023-10-26 at 3 37 07 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/5ac6adbb-9a96-4cc6-a62d-2e6645ec0c28">

<img width="264" alt="Screenshot 2023-10-26 at 3 48 27 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/beb1dd23-18ea-44de-8a45-02c3077d328e">


5. Click on Plugins > Verify that the page title on the browser tab and heading is updated to **Plugins** 

<img width="501" alt="Screenshot 2023-10-26 at 3 37 13 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/b80ec074-65f1-42a8-90da-3250af616f81">


6. Go to single site view and verify the onboarding tour shows **Back to Sites** 

<img width="246" alt="Screenshot 2023-10-26 at 3 48 48 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/6f291e76-3656-46c4-b481-7d677e876469">

**How to reset the banner?**

1. On the Jetpack page at the bottom right. Hover on the debug icon and click preferences. Look for **jjetpack-cloud-sidebar-v2-managed-selected-site-tour** and clear it by clicking the **X** button.

<img width="1174" alt="Screen Shot 2023-07-12 at 4 57 50 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/aeb0af42-c99b-409f-a652-fb2fb207b97b">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?