### PR TITLE
Revert "Plans 2023: Avoid showing the loader (or reduce periodicity) on plans page when fetching site-plans data"

### DIFF
--- a/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
+++ b/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
@@ -191,7 +191,7 @@ const usePricingMetaForGridPlans: UsePricingMetaForGridPlans = ( {
 	 * - For now a simple loader is shown until these are resolved
 	 * - We can optimise Error states in the UI / when everything gets ported into data-stores
 	 */
-	if ( ! sitePlans.data || ! pricedAPIPlans ) {
+	if ( sitePlans.isFetching || ! pricedAPIPlans ) {
 		return null;
 	}
 

--- a/client/my-sites/plans-features-main/hooks/test/use-pricing-meta-for-grid-plans.ts
+++ b/client/my-sites/plans-features-main/hooks/test/use-pricing-meta-for-grid-plans.ts
@@ -49,7 +49,8 @@ describe( 'usePricingMetaForGridPlans', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 		Plans.useSitePlans.mockImplementation( () => ( {
-			data: {},
+			isFetching: false,
+			data: null,
 		} ) );
 		getByPurchaseId.mockImplementation( () => undefined );
 		usePricedAPIPlans.mockImplementation( () => ( {


### PR DESCRIPTION
Reverts Automattic/wp-calypso#82995