### PR TITLE
Assembler in-product survey 2 on "Great job!" screen

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -536,8 +536,6 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 				<NavigatorScreen path={ NAVIGATOR_PATHS.MAIN } partialMatch>
 					<ScreenMain
 						onMainItemSelect={ onMainItemSelect }
-						surveyDismissed={ surveyDismissed }
-						setSurveyDismissed={ setSurveyDismissed }
 						hasHeader={ !! header }
 						hasFooter={ !! footer }
 						sections={ sections }
@@ -574,7 +572,11 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 				</NavigatorScreen>
 
 				<NavigatorScreen path={ NAVIGATOR_PATHS.CONFIRMATION } className="screen-confirmation">
-					<ScreenConfirmation onConfirm={ onConfirm } />
+					<ScreenConfirmation
+						onConfirm={ onConfirm }
+						surveyDismissed={ surveyDismissed }
+						setSurveyDismissed={ setSurveyDismissed }
+					/>
 				</NavigatorScreen>
 
 				<NavigatorScreen path={ NAVIGATOR_PATHS.UPSELL } className="screen-upsell">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-confirmation.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-confirmation.tsx
@@ -8,13 +8,16 @@ import { Icon, image, verse, layout } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useScreen } from './hooks';
 import NavigatorTitle from './navigator-title';
+import Survey from './survey';
 import './screen-confirmation.scss';
 
 interface Props {
 	onConfirm: () => void;
+	surveyDismissed: boolean;
+	setSurveyDismissed: ( dismissed: boolean ) => void;
 }
 
-const ScreenConfirmation = ( { onConfirm }: Props ) => {
+const ScreenConfirmation = ( { onConfirm, surveyDismissed, setSurveyDismissed }: Props ) => {
 	const translate = useTranslate();
 	const { title, description, continueLabel } = useScreen( 'confirmation' );
 
@@ -57,6 +60,13 @@ const ScreenConfirmation = ( { onConfirm }: Props ) => {
 						</HStack>
 					) ) }
 				</VStack>
+				{ ! surveyDismissed && (
+					<Survey
+						eventName="assembler-october-2023"
+						eventUrl="https://wordpressdotcom.survey.fm/wordpress-com-design-your-own"
+						setSurveyDismissed={ setSurveyDismissed }
+					/>
+				) }
 			</div>
 			<div className="screen-container__footer">
 				<Button className="pattern-assembler__button" primary onClick={ onConfirm }>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-confirmation.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-confirmation.tsx
@@ -62,8 +62,8 @@ const ScreenConfirmation = ( { onConfirm, surveyDismissed, setSurveyDismissed }:
 				</VStack>
 				{ ! surveyDismissed && (
 					<Survey
-						eventName="assembler-october-2023"
-						eventUrl="https://wordpressdotcom.survey.fm/wordpress-com-design-your-own"
+						eventName="assembler-november-2023"
+						eventUrl="https://automattic.survey.fm/assembler-survey-2"
 						setSurveyDismissed={ setSurveyDismissed }
 					/>
 				) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -12,13 +12,10 @@ import { useScreen, usePatternCountMapByCategory } from './hooks';
 import NavigatorTitle from './navigator-title';
 import PatternCategoryList from './pattern-category-list';
 import PatternCount from './pattern-count';
-import Survey from './survey';
 import { Category, Pattern, PatternType } from './types';
 
 interface Props {
 	onMainItemSelect: ( name: string ) => void;
-	surveyDismissed: boolean;
-	setSurveyDismissed: ( dismissed: boolean ) => void;
 	hasHeader: boolean;
 	hasFooter: boolean;
 	sections: Pattern[];
@@ -30,8 +27,6 @@ interface Props {
 
 const ScreenMain = ( {
 	onMainItemSelect,
-	surveyDismissed,
-	setSurveyDismissed,
 	hasHeader,
 	hasFooter,
 	sections,
@@ -112,7 +107,6 @@ const ScreenMain = ( {
 						</NavigatorItem>
 					</NavigatorItemGroup>
 				</VStack>
-				{ ! surveyDismissed && <Survey setSurveyDismissed={ setSurveyDismissed } /> }
 			</div>
 			<div className="screen-container__footer">
 				<span className="screen-container__footer-description">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/survey/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/survey/index.tsx
@@ -22,10 +22,11 @@ const Survey = ( { eventName, eventUrl, title, setSurveyDismissed }: Props ) => 
 				) : (
 					// Translation to other locales is not required
 					<>
+						We’d love to hear your thoughts. Fill out this{ ' ' }
 						<a href={ eventUrl } target="blank">
-							Fill out this quick survey
+							quick survey
 						</a>{ ' ' }
-						and help us to improve our product.
+						on your onboarding experience.
 					</>
 				)
 			}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/survey/survey.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/survey/survey.scss
@@ -1,7 +1,8 @@
 .pattern-assembler__survey {
 	border-radius: 4px;
 	background: #f0f7fc;
-	margin: 20px 0;
+	margin: 40px 0;
+	text-wrap: pretty;
 
 	.banner__info .banner__title {
 		font-weight: 400;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/4151

## Proposed Changes

* Add survey to the "Great job!" screen 

<img width="358" alt="Screenshot 2566-10-26 at 18 10 13" src="https://github.com/Automattic/wp-calypso/assets/1881481/a4107fc8-37db-4ba6-b19c-0797d0cddbc2">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access the assembler with a newly created site
* Continue until the "Great job!" screen 
* Verify the Survey is there, click the link "quick survey", and click X to dismiss the survey 


https://github.com/Automattic/wp-calypso/assets/1881481/c0a57cc6-c7e2-4cfb-9c7b-ea6a66286885



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?