### PR TITLE
Update Reader Logged out UX

### DIFF
--- a/client/blocks/comments/comment-likes.jsx
+++ b/client/blocks/comments/comment-likes.jsx
@@ -20,19 +20,19 @@ class CommentLikeButtonContainer extends Component {
 
 	handleLikeToggle( liked ) {
 		if ( ! this.props.isLoggedIn ) {
-			this.props.registerLastActionRequiresLogin( {
+			return this.props.registerLastActionRequiresLogin( {
 				type: liked ? 'comment-like' : 'comment-unlike',
 				siteId: this.props.siteId,
 				postId: this.props.postId,
 				commentId: this.props.commentId,
 			} );
-		} else {
-			this.recordLikeToggle( liked );
 		}
-		this.props.onLikeToggle( liked );
+		this.recordLikeToggle( liked );
 	}
 
 	recordLikeToggle = ( liked ) => {
+		this.props.onLikeToggle( liked );
+
 		if ( liked ) {
 			this.props.likeComment( this.props.siteId, this.props.postId, this.props.commentId );
 		} else {

--- a/client/blocks/comments/form.jsx
+++ b/client/blocks/comments/form.jsx
@@ -1,5 +1,3 @@
-import config from '@automattic/calypso-config';
-import { getUrlParts } from '@automattic/calypso-url';
 import { Button, FormInputValidation } from '@automattic/components';
 import classNames from 'classnames';
 import { localize, useTranslate } from 'i18n-calypso';
@@ -8,10 +6,7 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import Gravatar from 'calypso/components/gravatar';
-import { navigate } from 'calypso/lib/navigate';
-import { createAccountUrl } from 'calypso/lib/paths';
 import { ProtectFormGuard } from 'calypso/lib/protect-form';
-import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-tag-embed-page';
 import { recordAction, recordGaEvent, recordTrackForPost } from 'calypso/reader/stats';
 import { writeComment, deleteComment, replyComment } from 'calypso/state/comments/actions';
 import { getCurrentUser, isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -66,22 +61,10 @@ class PostCommentForm extends Component {
 
 	handleTextChange = ( event ) => {
 		if ( ! this.props.isLoggedIn ) {
-			const { pathname } = getUrlParts( window.location.href );
-			// Redirect to create account page when not logged in and on reader tag embed page
-			if ( isReaderTagEmbedPage( window.location ) ) {
-				return window.open(
-					createAccountUrl( { redirectTo: pathname, ref: 'reader-lp' } ),
-					'_blank'
-				);
-			}
-			// Redirect to create account page when not logged in and the login window component is disabled
-			if ( ! config.isEnabled( 'reader/login-window' ) ) {
-				return navigate( createAccountUrl( { redirectTo: pathname, ref: 'reader-lp' } ) );
-			}
-			this.props.registerLastActionRequiresLogin( {
+			return this.props.registerLastActionRequiresLogin( {
 				type: 'comment',
-				siteId: this.props.siteId,
-				postId: this.props.postId,
+				siteId: this.props.post.site_ID,
+				postId: this.props.post.ID,
 				commentId: this.props.placeholderId,
 			} );
 		}
@@ -102,14 +85,13 @@ class PostCommentForm extends Component {
 
 		// Do not submit form if the user is not logged in
 		if ( ! this.props.isLoggedIn ) {
-			this.props.registerLastActionRequiresLogin( {
+			return this.props.registerLastActionRequiresLogin( {
 				type: 'comment-submit',
-				siteId: this.props.siteId,
-				postId: this.props.postId,
+				siteId: this.props.post.site_ID,
+				postId: this.props.post.ID,
 				commentId: this.props.placeholderId,
 				commentText: commentText,
 			} );
-			return false;
 		}
 
 		if ( this.props.placeholderId ) {

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -127,27 +127,15 @@ class PostComment extends PureComponent {
 
 	handleReply = () => {
 		if ( ! this.props.isLoggedIn ) {
-			const { pathname } = getUrlParts( window.location.href );
-			if ( isReaderTagEmbedPage( window.location ) ) {
-				return window.open(
-					createAccountUrl( { redirectTo: pathname, ref: 'reader-lp' } ),
-					'_blank'
-				);
-			}
-			// Do not redirect to create account page when not logged in and the login window component is enabled
-			if ( ! config.isEnabled( 'reader/login-window' ) ) {
-				return navigate( createAccountUrl( { redirectTo: pathname, ref: 'reader-lp' } ) );
-			}
-			this.props.registerLastActionRequiresLogin( {
+			return this.props.registerLastActionRequiresLogin( {
 				type: 'reply',
 				siteId: this.props.post.site_ID,
 				postId: this.props.post.ID,
 				commentId: this.props.commentId,
 			} );
-		} else {
-			this.props.onReplyClick( this.props.commentId );
-			this.setState( { showReplies: true } ); // show the comments when replying
 		}
+		this.props.onReplyClick( this.props.commentId );
+		this.setState( { showReplies: true } ); // show the comments when replying
 	};
 
 	handleAuthorClick = ( event ) => {

--- a/client/blocks/like-button/index.jsx
+++ b/client/blocks/like-button/index.jsx
@@ -31,15 +31,15 @@ class LikeButtonContainer extends Component {
 
 	handleLikeToggle = ( liked ) => {
 		if ( ! this.props.isLoggedIn ) {
-			this.props.registerLastActionRequiresLogin( {
+			return this.props.registerLastActionRequiresLogin( {
 				type: liked ? 'like' : 'unlike',
 				siteId: this.props.siteId,
 				postId: this.props.postId,
 			} );
-		} else {
-			const toggler = liked ? this.props.like : this.props.unlike;
-			toggler( this.props.siteId, this.props.postId, { source: this.props.likeSource } );
 		}
+
+		const toggler = liked ? this.props.like : this.props.unlike;
+		toggler( this.props.siteId, this.props.postId, { source: this.props.likeSource } );
 		this.props.onLikeToggle( liked );
 	};
 

--- a/client/blocks/reader-join-conversation/dialog.jsx
+++ b/client/blocks/reader-join-conversation/dialog.jsx
@@ -2,6 +2,7 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Dialog } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
 import WordPressLogo from 'calypso/components/wordpress-logo';
 import useLoginWindow from 'calypso/data/reader/use-login-window';
 
@@ -13,17 +14,12 @@ const ReaderJoinConversationDialog = ( { onClose, isVisible, loggedInAction, onL
 	const trackEvent = ( eventName ) => {
 		let eventProps = {};
 		if ( loggedInAction ) {
-			eventProps = { type: loggedInAction?.type };
-			// create eventProps from loggedInAction properties if they exist
-			if ( loggedInAction?.siteId ) {
-				eventProps.blog_id = loggedInAction?.siteId;
-			}
-			if ( loggedInAction?.postId ) {
-				eventProps.post_id = loggedInAction?.postId;
-			}
-			if ( loggedInAction?.tag ) {
-				eventProps.tag = loggedInAction?.tag;
-			}
+			eventProps = {
+				type: loggedInAction?.type,
+				blog_id: loggedInAction?.siteId,
+				post_id: loggedInAction?.postId,
+				tag: loggedInAction?.tag,
+			};
 		}
 		recordTracksEvent( eventName, eventProps );
 	};
@@ -33,9 +29,12 @@ const ReaderJoinConversationDialog = ( { onClose, isVisible, loggedInAction, onL
 		onLoginSuccess();
 	};
 
-	if ( isVisible ) {
-		trackEvent( 'calypso_reader_action_clicked_requires_login' );
-	}
+	// Use useEffect to only track the event once when the dialog is first shown
+	useEffect( () => {
+		if ( isVisible ) {
+			trackEvent( 'calypso_reader_dialog_shown' );
+		}
+	}, [ isVisible ] );
 
 	const { login, createAccount } = useLoginWindow( { onLoginSuccess: handleLoginSuccess } );
 

--- a/client/blocks/reader-join-conversation/dialog.jsx
+++ b/client/blocks/reader-join-conversation/dialog.jsx
@@ -15,11 +15,17 @@ const ReaderJoinConversationDialog = ( { onClose, isVisible, loggedInAction, onL
 	const trackEvent = ( eventName ) => {
 		let eventProps = {};
 		if ( loggedInAction ) {
-			eventProps = {
-				type: loggedInAction?.type,
-				blog_id: loggedInAction?.siteId,
-				post_id: loggedInAction?.postId,
-			};
+			eventProps = { type: loggedInAction?.type };
+			// create eventProps from loggedInAction properties if they exist
+			if ( loggedInAction?.siteId ) {
+				eventProps.blog_id = loggedInAction?.siteId;
+			}
+			if ( loggedInAction?.postId ) {
+				eventProps.post_id = loggedInAction?.postId;
+			}
+			if ( loggedInAction?.tag ) {
+				eventProps.tag = loggedInAction?.tag;
+			}
 		}
 		recordTracksEvent( eventName, eventProps );
 	};
@@ -34,11 +40,20 @@ const ReaderJoinConversationDialog = ( { onClose, isVisible, loggedInAction, onL
 		createAccount();
 	};
 
+	const onCloseDialog = () => {
+		trackEvent( 'calypso_reader_dialog_closed' );
+		onClose();
+	};
+
+	if ( isVisible ) {
+		trackEvent( 'calypso_reader_action_clicked_requires_login' );
+	}
+
 	return (
 		<Dialog
 			additionalClassNames="reader-join-conversation-dialog"
 			isVisible={ isVisible }
-			onClose={ onClose }
+			onClose={ onCloseDialog }
 			showCloseIcon={ true }
 			label={ translate( 'Join the conversation' ) }
 			shouldCloseOnEsc={ true }

--- a/client/blocks/reader-join-conversation/dialog.jsx
+++ b/client/blocks/reader-join-conversation/dialog.jsx
@@ -10,8 +10,6 @@ import './style.scss';
 const ReaderJoinConversationDialog = ( { onClose, isVisible, loggedInAction, onLoginSuccess } ) => {
 	const translate = useTranslate();
 
-	const { login, createAccount } = useLoginWindow( { onLoginSuccess: onLoginSuccess } );
-
 	const trackEvent = ( eventName ) => {
 		let eventProps = {};
 		if ( loggedInAction ) {
@@ -30,6 +28,17 @@ const ReaderJoinConversationDialog = ( { onClose, isVisible, loggedInAction, onL
 		recordTracksEvent( eventName, eventProps );
 	};
 
+	const handleLoginSuccess = () => {
+		trackEvent( 'calypso_reader_dialog_login_success' );
+		onLoginSuccess();
+	};
+
+	if ( isVisible ) {
+		trackEvent( 'calypso_reader_action_clicked_requires_login' );
+	}
+
+	const { login, createAccount } = useLoginWindow( { onLoginSuccess: handleLoginSuccess } );
+
 	const onLoginClick = () => {
 		trackEvent( 'calypso_reader_dialog_login_clicked' );
 		login();
@@ -40,20 +49,11 @@ const ReaderJoinConversationDialog = ( { onClose, isVisible, loggedInAction, onL
 		createAccount();
 	};
 
-	const onCloseDialog = () => {
-		trackEvent( 'calypso_reader_dialog_closed' );
-		onClose();
-	};
-
-	if ( isVisible ) {
-		trackEvent( 'calypso_reader_action_clicked_requires_login' );
-	}
-
 	return (
 		<Dialog
 			additionalClassNames="reader-join-conversation-dialog"
 			isVisible={ isVisible }
-			onClose={ onCloseDialog }
+			onClose={ onClose }
 			showCloseIcon={ true }
 			label={ translate( 'Join the conversation' ) }
 			shouldCloseOnEsc={ true }

--- a/client/data/reader/use-login-window.ts
+++ b/client/data/reader/use-login-window.ts
@@ -15,34 +15,19 @@ export default function useLoginWindow( {
 }: UseLoginWindowProps ): UseLoginWindowReturn {
 	const isBrowser: boolean = typeof window !== 'undefined';
 	const environment = config( 'env_id' );
-	let domain = 'wordpress.com';
-	let redirectTo = addQueryArgs(
-		{
-			action: 'verify',
-			service: 'wordpress',
-		},
-		`https://${ domain }/public.api/connect/`
-	);
+	const args = {
+		action: 'verify',
+		service: 'wordpress',
+		// When in development, we need to pass an origin to allow the postMessage to know where to send the message.
+		origin: environment === 'development' ? new URL( window.location.href )?.hostname : undefined,
+	};
 
-	// When in development, we need to redirect to a sandboxed domain to allow us to test changes to /public.api/connect/
-	if ( environment === 'development' ) {
-		domain = 'wpcalypso.wordpress.com';
-		redirectTo = addQueryArgs(
-			{
-				action: 'verify',
-				service: 'wordpress',
-				domain: domain,
-				origin: new URL( window.location.href )?.hostname,
-			},
-			`https://${ domain }/public.api/connect/`
-		);
-	}
-
+	const redirectTo = addQueryArgs( args, 'https://wordpress.com/public.api/connect/' );
 	const loginURL = addQueryArgs( { redirect_to: redirectTo }, 'https://wordpress.com/log-in' );
 	const createAccountURL = addQueryArgs(
 		{
 			redirect_to: redirectTo,
-			ref: 'reader-lw',
+			ref: 'reader-lp',
 		},
 		'https://wordpress.com/start/account'
 	);
@@ -51,7 +36,7 @@ export default function useLoginWindow( {
 	const windowName = 'CalypsoLogin';
 
 	const waitForLogin = ( event: MessageEvent ) => {
-		if ( event.origin !== `https://${ domain }` ) {
+		if ( 'https://wordpress.com' !== event?.origin ) {
 			return;
 		}
 

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { getUrlParts } from '@automattic/calypso-url';
 import { useLocalizeUrl, removeLocaleFromPathLocaleInFront } from '@automattic/i18n-utils';
 import { UniversalNavbarHeader, UniversalNavbarFooter } from '@automattic/wpcom-template-parts';
 import classNames from 'classnames';
@@ -25,6 +26,7 @@ import {
 	isWPJobManagerOAuth2Client,
 	isGravPoweredOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
+import { createAccountUrl } from 'calypso/lib/paths';
 import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-tag-embed-page';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getRedirectToOriginal } from 'calypso/state/login/selectors';
@@ -126,6 +128,14 @@ const LayoutLoggedOut = ( {
 	};
 
 	let masterbar = null;
+
+	// Open new window to create account page when a logged in action was triggered on the Reader tag embed page and the user is not logged in
+	if ( ! isLoggedIn && loggedInAction ) {
+		if ( isReaderTagEmbed ) {
+			const { pathname } = getUrlParts( window.location.href );
+			window.open( createAccountUrl( { redirectTo: pathname, ref: 'reader-lp' } ), '_blank' );
+		}
+	}
 
 	// Uses custom styles for DOPS clients and WooCommerce - which are the only ones with a name property defined
 	if ( useOAuth2Layout && oauth2Client && oauth2Client.name ) {
@@ -244,7 +254,7 @@ const LayoutLoggedOut = ( {
 				/>
 			) }
 
-			{ ! isLoggedIn && config.isEnabled( 'reader/login-window' ) && (
+			{ ! isLoggedIn && ! isReaderTagEmbed && (
 				<ReaderJoinConversationDialog
 					onClose={ () => clearLastActionRequiresLogin() }
 					isVisible={ !! loggedInAction }

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -130,11 +130,9 @@ const LayoutLoggedOut = ( {
 	let masterbar = null;
 
 	// Open new window to create account page when a logged in action was triggered on the Reader tag embed page and the user is not logged in
-	if ( ! isLoggedIn && loggedInAction ) {
-		if ( isReaderTagEmbed ) {
-			const { pathname } = getUrlParts( window.location.href );
-			window.open( createAccountUrl( { redirectTo: pathname, ref: 'reader-lp' } ), '_blank' );
-		}
+	if ( ! isLoggedIn && loggedInAction && isReaderTagEmbed ) {
+		const { pathname } = getUrlParts( window.location.href );
+		window.open( createAccountUrl( { redirectTo: pathname, ref: 'reader-lp' } ), '_blank' );
 	}
 
 	// Uses custom styles for DOPS clients and WooCommerce - which are the only ones with a name property defined

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -1,4 +1,3 @@
-import { getUrlParts } from '@automattic/calypso-url';
 import { localize } from 'i18n-calypso';
 import { find } from 'lodash';
 import PropTypes from 'prop-types';
@@ -6,8 +5,6 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import QueryReaderFollowedTags from 'calypso/components/data/query-reader-followed-tags';
 import QueryReaderTag from 'calypso/components/data/query-reader-tag';
-import { navigate } from 'calypso/lib/navigate';
-import { createAccountUrl } from 'calypso/lib/paths';
 import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-tag-embed-page';
 import ReaderMain from 'calypso/reader/components/reader-main';
 import HeaderBack from 'calypso/reader/header-back';
@@ -19,6 +16,7 @@ import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions'
 import { requestFollowTag, requestUnfollowTag } from 'calypso/state/reader/tags/items/actions';
 import { getReaderTags, getReaderFollowedTags } from 'calypso/state/reader/tags/selectors';
 import getReaderTagBySlug from 'calypso/state/reader/tags/selectors/get-reader-tag-by-slug';
+import { registerLastActionRequiresLogin } from 'calypso/state/reader-ui/actions';
 import EmptyContent from './empty';
 import TagStreamHeader from './header';
 import './style.scss';
@@ -80,8 +78,10 @@ class TagStream extends Component {
 		const toggleAction = isFollowing ? unfollowTag : followTag;
 
 		if ( ! this.props.isLoggedIn ) {
-			const { pathname } = getUrlParts( window.location.href );
-			return navigate( createAccountUrl( { redirectTo: pathname, ref: 'reader-lp' } ) );
+			return this.props.registerLastActionRequiresLogin( {
+				type: 'follow-tag',
+				tag: decodedTagSlug,
+			} );
 		}
 
 		toggleAction( decodedTagSlug );
@@ -191,5 +191,6 @@ export default connect(
 		followTag: requestFollowTag,
 		recordReaderTracksEvent,
 		unfollowTag: requestUnfollowTag,
+		registerLastActionRequiresLogin,
 	}
 )( localize( TagStream ) );

--- a/config/development.json
+++ b/config/development.json
@@ -160,7 +160,6 @@
 		"reader/first-posts-stream": true,
 		"reader/full-errors": true,
 		"reader/list-management": true,
-		"reader/login-window": true,
 		"reader/public-tag-pages": true,
 		"recommend-plugins": true,
 		"redirect-fallback-browsers": false,

--- a/config/production.json
+++ b/config/production.json
@@ -127,7 +127,6 @@
 		"reader/full-errors": false,
 		"reader/list-management": true,
 		"reader/public-tag-pages": true,
-		"reader/login-window": false,
 		"redirect-fallback-browsers": true,
 		"rum-tracking/logstash": true,
 		"safari-idb-mitigation": true,


### PR DESCRIPTION
This is a follow up to both https://github.com/Automattic/wp-calypso/pull/83285 and https://github.com/Automattic/wp-calypso/pull/83031.

This tries to refactor how we handle the logged out UX when a user clicks an action that requires the user to be logged in.

The PR moves the code that decides how to handle that event in the logged-out component, rather than having that logic spread out over many different components.

The PR makes use of the `getLastActionRequiresLogin` selector to know if an action that requires a user to be logged in has been triggered. 

We want to handle this case like so;

* If user is on the Reader tag embed page, we want to open a new window to the create account page
* If user is on any other logged page on Reader, we want to show the Join Conversation dialog
<img width="354" alt="Screenshot 2023-10-11 at 22 00 39" src="https://github.com/Automattic/wp-calypso/assets/5560595/14194ca4-69ec-435f-94d5-bb4e490fe24c">

This PR removes the feature flag around the `reader/login-window` as this method is ready for production.

This PR also adds 2 new track events missing from https://github.com/Automattic/wp-calypso/pull/83031

* `calypso_reader_dialog_login_success` when user has logged in successfully from the Join Conversation dialog
* `calypso_reader_action_clicked_requires_login` when user clicks on an action that requires them to be logged while logged out

### Testing

* Go to http://calypso.localhost:3000/tag/writing and confirm liking a post/comment, replying to comment, entering text in comment form or following a tag opens the Join Conversation Dialog
* Go to Reader embed tag page http://calypso.localhost:3000/tag/nanowrimo?type=embed and confirm clicking on same actions opens new window (Join conversation dialog should not appear)