### PR TITLE
Fixed Stats header background-color and fixed-nav extra padding (issue 1 and partial issue 2)

### DIFF
--- a/client/my-sites/stats/modernized-layout-styles.scss
+++ b/client/my-sites/stats/modernized-layout-styles.scss
@@ -46,10 +46,11 @@ $sidebar-appearance-break-point: 783px;
 		margin-bottom: 32px;
 	}
 
-	&.has-fixed-nav {
-		padding-top: 44px;
-	}
 	.navigation-header {
+		margin-bottom: 0;
+		padding-bottom: 24px;
+		background-color: var(--studio-white);
+
 		@media ( max-width: $break-small ) {
 			margin-bottom: 0;
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 4358-gh-Automattic/dotcom-forge

## Proposed Changes


| Before | After |
|--------|--------|
| <img width="1232" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/a791f3b3-318c-49e2-9b86-f921709b4e8d"> |<img width="1234" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/99b0db4f-b554-4d73-b9d7-0bc6c282b934"> | 
| <img width="1346" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/848a96d9-df32-4616-94f1-113687c084a4"> | <img width="1343" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/c7d4b6b4-077d-4950-87d5-c4deaaa076a7"> |





*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?