### PR TITLE
Newsletter settings: update docs links

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -294,6 +294,14 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/site-monitoring/',
 		post_id: 259521,
 	},
+	'subscriptions-and-newsletters': {
+		link: 'https://wordpress.com/support/subscriptions-and-newsletters/',
+		post_id: 67810,
+	},
+	'featured-images': {
+		link: 'https://wordpress.com/support/featured-images/',
+		post_id: 5259,
+	},
 };
 
 export default contextLinks;

--- a/client/my-sites/site-settings/settings-newsletter/ExcerptSetting.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/ExcerptSetting.tsx
@@ -1,9 +1,9 @@
-import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormRadio from 'calypso/components/forms/form-radio';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 
 type ExcerptSettingProps = {
 	value?: boolean;
@@ -44,10 +44,9 @@ export const ExcerptSetting = ( {
 					{
 						components: {
 							link: (
-								<a
-									href={ localizeUrl( 'https://wordpress.com/support/launch-a-newsletter/' ) }
-									target="_blank"
-									rel="noreferrer"
+								<InlineSupportLink
+									showIcon={ false }
+									supportContext="subscriptions-and-newsletters"
 								/>
 							),
 						},

--- a/client/my-sites/site-settings/settings-newsletter/FeaturedImageEmailSetting.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/FeaturedImageEmailSetting.tsx
@@ -1,7 +1,7 @@
-import { localizeUrl } from '@automattic/i18n-utils';
 import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 
 export const FEATURED_IMAGE_IN_EMAIL_OPTION = 'wpcom_featured_image_in_email';
 
@@ -31,13 +31,7 @@ export const FeaturedImageEmailSetting = ( {
 					"Includes your post's featured image in the email sent out to your readers. {{link}}Learn more about the featured image{{/link}}.",
 					{
 						components: {
-							link: (
-								<a
-									href={ localizeUrl( 'https://wordpress.com/support/featured-images/' ) }
-									target="_blank"
-									rel="noreferrer"
-								/>
-							),
+							link: <InlineSupportLink showIcon={ false } supportContext="featured-images" />,
 						},
 					}
 				) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/wp-calypso/issues/83453

## Proposed Changes

* Updates "excerpt" setting link to another document as suggested in https://github.com/Automattic/wp-calypso/issues/83453
* Update excerpt and featured image docs to open in a modal, instead of new tab.

## Testing Instructions



<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* From the calypso live link below, navigate to Settings -> Newsletter
* Confirm both help articles open correctly

<img width="1570" alt="Screenshot 2023-10-26 at 17 01 17" src="https://github.com/Automattic/wp-calypso/assets/87168/6000a1d6-a893-4da3-9d47-fd4c59aa6fd3">
<img width="1566" alt="Screenshot 2023-10-26 at 17 01 11" src="https://github.com/Automattic/wp-calypso/assets/87168/48e96e1a-56e6-4e42-8023-25294e69dca8">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
