### PR TITLE
Welcome message: allow Jetpack sites to modify

### DIFF
--- a/client/my-sites/site-settings/settings-newsletter/EmailsTextSetting.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/EmailsTextSetting.tsx
@@ -4,7 +4,15 @@ import FormLabel from 'calypso/components/forms/form-label';
 import FormLegend from 'calypso/components/forms/form-legend';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextarea from 'calypso/components/forms/form-textarea';
+import { useSelector } from 'calypso/state';
+import {
+	isJetpackMinimumVersion,
+	isJetpackSite as isJetpackSiteSelector,
+	isSimpleSite as isSimpleSiteSelector,
+} from 'calypso/state/sites/selectors';
+import getSelectedSite from 'calypso/state/ui/selectors/get-selected-site';
 import { SubscriptionOptions } from '../settings-reading/main';
+import type { AppState } from 'calypso/types';
 
 type EmailsTextSettingProps = {
 	value?: SubscriptionOptions;
@@ -18,6 +26,16 @@ type SubscriptionOption = {
 
 export const EmailsTextSetting = ( { value, disabled, updateFields }: EmailsTextSettingProps ) => {
 	const translate = useTranslate();
+	const selectedSite = useSelector( getSelectedSite );
+	const siteId = selectedSite?.ID;
+	const isSimpleSite = useSelector( isSimpleSiteSelector );
+	const isJetpackSite = useSelector( ( state ) => isJetpackSiteSelector( state, siteId ) );
+
+	const isJetpackVersionSupported = useSelector( ( state: AppState ) => {
+		return siteId && isJetpackSite && isJetpackMinimumVersion( state, siteId, '12.8' );
+	} );
+
+	const hasWelcomeEmailFeature = isSimpleSite || isJetpackVersionSupported;
 
 	const updateSubscriptionOptions =
 		( option: string ) => ( event: React.ChangeEvent< HTMLInputElement > ) => {
@@ -41,21 +59,24 @@ export const EmailsTextSetting = ( { value, disabled, updateFields }: EmailsText
 				<FormLegend>
 					{ translate( 'These settings change the emails sent from your site to your readers' ) }
 				</FormLegend>
-
-				<FormLabel htmlFor="welcome_email_message">
-					{ translate( 'Welcome email message' ) }
-				</FormLabel>
-				<FormTextarea
-					name="welcome_email_message"
-					id="welcome_email_message"
-					value={ value?.welcome }
-					onChange={ updateSubscriptionOptions( 'welcome' ) }
-					disabled={ disabled }
-					autoCapitalize="none"
-				/>
-				<FormSettingExplanation>
-					{ translate( 'The email sent out when someone confirms their subscription.' ) }
-				</FormSettingExplanation>
+				{ hasWelcomeEmailFeature && (
+					<>
+						<FormLabel htmlFor="welcome_email_message">
+							{ translate( 'Welcome email message' ) }
+						</FormLabel>
+						<FormTextarea
+							name="welcome_email_message"
+							id="welcome_email_message"
+							value={ value?.welcome }
+							onChange={ updateSubscriptionOptions( 'welcome' ) }
+							disabled={ disabled }
+							autoCapitalize="none"
+						/>
+						<FormSettingExplanation>
+							{ translate( 'The email sent out when someone confirms their subscription.' ) }
+						</FormSettingExplanation>
+					</>
+				) }
 
 				<FormLabel htmlFor="comment_follow_email_message">
 					{ translate( 'Comment follow email message' ) }

--- a/client/my-sites/site-settings/settings-newsletter/EmailsTextSetting.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/EmailsTextSetting.tsx
@@ -4,8 +4,6 @@ import FormLabel from 'calypso/components/forms/form-label';
 import FormLegend from 'calypso/components/forms/form-legend';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextarea from 'calypso/components/forms/form-textarea';
-import { useSelector } from 'calypso/state';
-import { isSimpleSite as isSimpleSiteSelector } from 'calypso/state/sites/selectors';
 import { SubscriptionOptions } from '../settings-reading/main';
 
 type EmailsTextSettingProps = {
@@ -20,7 +18,6 @@ type SubscriptionOption = {
 
 export const EmailsTextSetting = ( { value, disabled, updateFields }: EmailsTextSettingProps ) => {
 	const translate = useTranslate();
-	const isSimpleSite = useSelector( isSimpleSiteSelector );
 
 	const updateSubscriptionOptions =
 		( option: string ) => ( event: React.ChangeEvent< HTMLInputElement > ) => {
@@ -44,6 +41,37 @@ export const EmailsTextSetting = ( { value, disabled, updateFields }: EmailsText
 				<FormLegend>
 					{ translate( 'These settings change the emails sent from your site to your readers' ) }
 				</FormLegend>
+
+				<FormLabel htmlFor="welcome_email_message">
+					{ translate( 'Welcome email message' ) }
+				</FormLabel>
+				<FormTextarea
+					name="welcome_email_message"
+					id="welcome_email_message"
+					value={ value?.welcome }
+					onChange={ updateSubscriptionOptions( 'welcome' ) }
+					disabled={ disabled }
+					autoCapitalize="none"
+				/>
+				<FormSettingExplanation>
+					{ translate( 'The email sent out when someone confirms their subscription.' ) }
+				</FormSettingExplanation>
+
+				<FormLabel htmlFor="comment_follow_email_message">
+					{ translate( 'Comment follow email message' ) }
+				</FormLabel>
+				<FormTextarea
+					name="comment_follow_email_message"
+					id="comment_follow_email_message"
+					value={ value?.comment_follow }
+					onChange={ updateSubscriptionOptions( 'comment_follow' ) }
+					disabled={ disabled }
+					autoCapitalize="none"
+				/>
+				<FormSettingExplanation>
+					{ translate( 'The email sent out when someone follows one of your posts.' ) }
+				</FormSettingExplanation>
+
 				<FormLabel htmlFor="confirmation_email_message">
 					{ translate( 'Confirmation email message' ) }
 				</FormLabel>
@@ -59,40 +87,6 @@ export const EmailsTextSetting = ( { value, disabled, updateFields }: EmailsText
 					{ translate(
 						'The ability to customize the confirmation email message had to be disabled to prevent abuse. It will revert to the default message for all new subscribers.'
 					) }
-				</FormSettingExplanation>
-
-				{ isSimpleSite && (
-					<>
-						<FormLabel htmlFor="welcome_email_message">
-							{ translate( 'Welcome email message' ) }
-						</FormLabel>
-						<FormTextarea
-							name="welcome_email_message"
-							id="welcome_email_message"
-							value={ value?.welcome }
-							onChange={ updateSubscriptionOptions( 'welcome' ) }
-							disabled={ disabled }
-							autoCapitalize="none"
-						/>
-						<FormSettingExplanation>
-							{ translate( 'The email sent out when someone confirms their subscription.' ) }
-						</FormSettingExplanation>
-					</>
-				) }
-
-				<FormLabel htmlFor="comment_follow_email_message">
-					{ translate( 'Comment follow email message' ) }
-				</FormLabel>
-				<FormTextarea
-					name="comment_follow_email_message"
-					id="comment_follow_email_message"
-					value={ value?.comment_follow }
-					onChange={ updateSubscriptionOptions( 'comment_follow' ) }
-					disabled={ disabled }
-					autoCapitalize="none"
-				/>
-				<FormSettingExplanation>
-					{ translate( 'The email sent out when someone follows one of your posts.' ) }
 				</FormSettingExplanation>
 			</FormFieldset>
 		</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Follow up to https://github.com/Automattic/wp-calypso/pull/83238

## Proposed Changes

* Allow Jetpack and Atomic sites edit the welcome message
* Move welcome message be the first. Previously the disabled confirm message was first which doesn't make sense.


<img width="1388" alt="Screenshot 2023-10-26 at 17 39 04" src="https://github.com/Automattic/wp-calypso/assets/87168/a6361e92-848f-43ab-b5c9-d2fc2326e432">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go /settings/newsletter
* Test you can edit the welcome message with simple, atomic and jetpack site
* The setting should get stored

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?