### PR TITLE
Assembler: Pages - Improve tab navigation on Homepage and overall accessibility with a screen reader

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/page-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/page-list.tsx
@@ -54,19 +54,28 @@ const PageList = ( { selectedPages, onSelectPage }: PageListProps ) => {
 			aria-label={ translate( 'Pages' ) }
 		>
 			<VStack spacing={ 0 }>
-				<CompositeItem { ...composite } role="option" as="button" disabled>
+				<CompositeItem
+					{ ...composite }
+					role="checkbox"
+					as="button"
+					disabled={ true }
+					focusable={ true }
+					aria-checked="true"
+				>
 					<PageListItem label={ translate( 'Homepage' ) } isDisabled />
 				</CompositeItem>
 				{ ORDERED_PAGES.map( ( page ) => {
+					const isSelected = selectedPages.includes( page );
 					return (
 						<CompositeItem
-							key={ page }
-							role="option"
-							as="button"
 							{ ...composite }
+							key={ page }
+							role="checkbox"
+							as="button"
+							aria-checked={ isSelected }
 							onClick={ () => onSelectPage( page ) }
 						>
-							<PageListItem label={ page } isSelected={ selectedPages.includes( page ) } />
+							<PageListItem label={ page } isSelected={ isSelected } />
 						</CompositeItem>
 					);
 				} ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #83501

## Proposed Changes

* Make Homepage item focusable but dimmed (read only)
* Use `checkbox` role with `aria-checked` to let users know the items are checkable and their checked status

|BEFORE|AFTER|
|--|--|
|<video src="https://github.com/Automattic/wp-calypso/assets/1881481/8b64f93a-3842-45e7-8449-a12a5c4ae24e">|<video src="https://github.com/Automattic/wp-calypso/assets/1881481/edc6da0c-2307-4506-9fef-02a04954f4d5">| 

References: 

- https://reakit.io/docs/composite/#compositeitem
- https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/checkbox_role
- https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/listbox_role

Notes:
- Composite component is being [migrated from reakit to ariakit](https://github.com/WordPress/gutenberg/pull/54225)
- The component [CheckboxControl](https://wordpress.github.io/gutenberg/?path=/docs/components-checkboxcontrol--docs) from @wordpress/components has a good accessibility but the solution in this PR works well too. 
- I couldn't resist working on this because I like accessibility challenges and I missed testing it earlier. cc: @taipeicoder  

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access the assembler with the param `&flags=pattern-assembler/add-pages`
* Continue until "Add more pages" screen
* Navigate using the keyboard to verify the Homepage is focusable
  * You have to use the tab to get into the list and then use the arrow keys up/down 
* Enable a screen reader (like Voice Over in Mac) and select pages using the spacebar or as Voice Over suggests use Control+Option+Spacebar    

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?