### PR TITLE
Login: Update magic login form styles

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -105,6 +105,8 @@ const LayoutLoggedOut = ( {
 		! currentRoute.startsWith( '/log-in/webauthn' ) &&
 		! currentRoute.startsWith( '/log-in/backup' );
 
+	const isMagicLogin = currentRoute && currentRoute.startsWith( '/log-in/link' );
+
 	const classes = {
 		[ 'is-group-' + sectionGroup ]: sectionGroup,
 		[ 'is-section-' + sectionName ]: sectionName,
@@ -125,6 +127,8 @@ const LayoutLoggedOut = ( {
 		'is-grav-powered-client': isGravPoweredClient,
 		'is-grav-powered-login-page': isGravPoweredLoginPage,
 		'is-woocommerce-core-profiler-flow': isWooCoreProfilerFlow,
+		'is-magic-login': isMagicLogin,
+		'is-wpcom-magic-login': isMagicLogin && ! isJetpackLogin && ! isGravPoweredLoginPage,
 	};
 
 	let masterbar = null;

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -23,6 +23,7 @@ import {
 	isCrowdsignalOAuth2Client,
 	isWooOAuth2Client,
 	isGravatarOAuth2Client,
+	isJetpackCloudOAuth2Client,
 	isWPJobManagerOAuth2Client,
 	isGravPoweredOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
@@ -107,6 +108,13 @@ const LayoutLoggedOut = ( {
 
 	const isMagicLogin = currentRoute && currentRoute.startsWith( '/log-in/link' );
 
+	const isWpcomMagicLogin =
+		isMagicLogin &&
+		! isJetpackLogin &&
+		! isGravPoweredLoginPage &&
+		! isJetpackCloudOAuth2Client( oauth2Client ) &&
+		! isWooOAuth2Client( oauth2Client );
+
 	const classes = {
 		[ 'is-group-' + sectionGroup ]: sectionGroup,
 		[ 'is-section-' + sectionName ]: sectionName,
@@ -128,7 +136,7 @@ const LayoutLoggedOut = ( {
 		'is-grav-powered-login-page': isGravPoweredLoginPage,
 		'is-woocommerce-core-profiler-flow': isWooCoreProfilerFlow,
 		'is-magic-login': isMagicLogin,
-		'is-wpcom-magic-login': isMagicLogin && ! isJetpackLogin && ! isGravPoweredLoginPage,
+		'is-wpcom-magic-login': isWpcomMagicLogin,
 	};
 
 	let masterbar = null;

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -1,3 +1,5 @@
+import { englishLocales } from '@automattic/i18n-utils';
+import { hasTranslation } from '@wordpress/i18n';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { createRef, Component } from 'react';
@@ -17,6 +19,7 @@ import {
 	getRedirectToOriginal,
 	getLastCheckedUsernameOrEmail,
 } from 'calypso/state/login/selectors';
+import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
 import getMagicLoginCurrentView from 'calypso/state/selectors/get-magic-login-current-view';
@@ -38,6 +41,7 @@ class RequestLoginEmailForm extends Component {
 		showCheckYourEmail: PropTypes.bool,
 		userEmail: PropTypes.string,
 		flow: PropTypes.string,
+		locale: PropTypes.string,
 
 		// mapped to dispatch
 		sendEmailLogin: PropTypes.func.isRequired,
@@ -115,6 +119,7 @@ class RequestLoginEmailForm extends Component {
 			hideSubHeaderText,
 			inputPlaceholder,
 			submitButtonLabel,
+			locale,
 		} = this.props;
 
 		const usernameOrEmail = this.getUsernameOrEmailFromState();
@@ -136,6 +141,19 @@ class RequestLoginEmailForm extends Component {
 			typeof requestError === 'string' && requestError.length
 				? requestError
 				: translate( 'Unable to complete request' );
+
+		const subHeaderText =
+			englishLocales.includes( locale ) ||
+			hasTranslation( 'We’ll send you an email with a login link that will log you in right away.' )
+				? translate( 'We’ll send you an email with a login link that will log you in right away.' )
+				: translate(
+						'Get a link sent to the email address associated with your account to log in instantly without your password.'
+				  );
+
+		const buttonLabel =
+			englishLocales.includes( locale ) || hasTranslation( 'Send Link' )
+				? translate( 'Send Link' )
+				: translate( 'Get Link' );
 
 		return (
 			<div className="magic-login__form">
@@ -162,12 +180,7 @@ class RequestLoginEmailForm extends Component {
 					</p>
 				) }
 				<LoggedOutForm onSubmit={ this.onSubmit }>
-					<p className="magic-login__form-sub-header">
-						{ ! hideSubHeaderText &&
-							translate(
-								'We’ll send you an email with a login link that will log you in right away.'
-							) }
-					</p>
+					<p className="magic-login__form-sub-header">{ ! hideSubHeaderText && subHeaderText }</p>
 					<FormLabel htmlFor="usernameOrEmail">
 						{ this.props.translate( 'Email Address or Username' ) }
 					</FormLabel>
@@ -185,7 +198,7 @@ class RequestLoginEmailForm extends Component {
 						{ tosComponent }
 						<div className="magic-login__form-action">
 							<FormButton primary disabled={ ! submitEnabled }>
-								{ submitButtonLabel || translate( 'Send Link' ) }
+								{ submitButtonLabel || buttonLabel }
 							</FormButton>
 						</div>
 					</FormFieldset>
@@ -197,6 +210,7 @@ class RequestLoginEmailForm extends Component {
 
 const mapState = ( state ) => {
 	return {
+		locale: getCurrentLocaleSlug( state ),
 		currentUser: getCurrentUser( state ),
 		isFetching: isFetchingMagicLoginEmail( state ),
 		redirectTo: getRedirectToOriginal( state ),

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -152,8 +152,12 @@ class RequestLoginEmailForm extends Component {
 
 		const buttonLabel =
 			englishLocales.includes( locale ) || hasTranslation( 'Send Link' )
-				? translate( 'Send Link' )
+				? translate( 'Send link' )
 				: translate( 'Get Link' );
+
+		const formLabel = hasTranslation( 'Email address or username' )
+			? this.props.translate( 'Email address or username' )
+			: this.props.translate( 'Email Address or Username' );
 
 		return (
 			<div className="magic-login__form">
@@ -181,9 +185,7 @@ class RequestLoginEmailForm extends Component {
 				) }
 				<LoggedOutForm onSubmit={ this.onSubmit }>
 					<p className="magic-login__form-sub-header">{ ! hideSubHeaderText && subHeaderText }</p>
-					<FormLabel htmlFor="usernameOrEmail">
-						{ this.props.translate( 'Email Address or Username' ) }
-					</FormLabel>
+					<FormLabel htmlFor="usernameOrEmail">{ formLabel }</FormLabel>
 					<FormFieldset className="magic-login__email-fields">
 						<FormTextInput
 							autoCapitalize="off"

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -165,7 +165,7 @@ class RequestLoginEmailForm extends Component {
 					<p className="magic-login__form-sub-header">
 						{ ! hideSubHeaderText &&
 							translate(
-								'Get a link sent to the email address associated with your account to log in instantly without your password.'
+								'We’ll send you an email with a login link that will log you in right away.'
 							) }
 					</p>
 					<FormLabel htmlFor="usernameOrEmail">
@@ -185,7 +185,7 @@ class RequestLoginEmailForm extends Component {
 						{ tosComponent }
 						<div className="magic-login__form-action">
 							<FormButton primary disabled={ ! submitEnabled }>
-								{ submitButtonLabel || translate( 'Get Link' ) }
+								{ submitButtonLabel || translate( 'Send Link' ) }
 							</FormButton>
 						</div>
 					</FormFieldset>

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -38,6 +38,7 @@
 	}
 
 	.logged-out-form {
+		max-width: 340px;
 		padding-top: 0;
 		.magic-login__form-sub-header {
 			text-align: center;
@@ -46,10 +47,6 @@
 		.form-label {
 			font-weight: 400;
 		}
-	}
-
-	.magic-login__request-link {
-		max-width: 340px;
 	}
 
 	.magic-login__form-action {

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -1,6 +1,8 @@
 @import "@automattic/onboarding/styles/mixins";
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@automattic/calypso-color-schemes";
+@import "@automattic/typography/styles/variables";
 
 @media ( max-height: 450px ) {
 	.magic-login__handle-link,
@@ -20,6 +22,12 @@
 			margin-bottom: 20px;
 		}
 	}
+}
+
+.layout.is-white-login {
+	display: flex;
+	align-items: center;
+	justify-content: center;
 }
 
 .is-white-login .magic-login__handle-link,
@@ -53,7 +61,7 @@
 }
 
 .magic-login__request-link {
-	max-width: 400px;
+	max-width: 340px;
 }
 
 .magic-login__form {
@@ -150,9 +158,24 @@
 .magic-login.is-white-login {
 	.magic-login__form-header {
 		@include onboarding-heading-text-mobile;
+		margin-bottom: 0;
 
 		@include break-mobile {
 			@include onboarding-heading-text;
+			font-size: $font-title-large;
+		}
+	}
+
+	.logged-out-form {
+		padding-top: 0;
+		.magic-login__form-sub-header {
+			color: var(--studio-gray-70);
+			text-align: center;
+		}
+
+		.form-label {
+			color: var(--studio-gray-60);
+			font-weight: 400;
 		}
 	}
 
@@ -161,11 +184,14 @@
 		box-shadow: none;
 	}
 
-	.magic-login__form-action .button.is-primary:not([disabled]) {
-		// Match primary button color in Gutenboarding and
-		// change border color to remove 3D effect
-		background-color: #007cba;
-		border-color: #007cba;
+	.magic-login__form-action .button.is-primary {
+		background-color: var(--studio-blue);
+		border-color: var(--studio-blue);
+		color: var(--studio-white);
+	}
+
+	.magic-login__footer {
+		display: none;
 	}
 }
 

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -24,10 +24,32 @@
 	}
 }
 
-.layout.is-white-login {
+.layout.is-wpcom-magic-login {
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	.magic-login__form-header {
+		margin-bottom: 0;
+
+		@include break-mobile {
+			font-size: $font-title-large;
+		}
+	}
+
+	.logged-out-form {
+		padding-top: 0;
+		.magic-login__form-sub-header {
+			text-align: center;
+		}
+
+		.form-label {
+			font-weight: 400;
+		}
+	}
+
+	.magic-login__form-action {
+		margin-top: 16px;
+	}
 }
 
 .is-white-login .magic-login__handle-link,
@@ -158,24 +180,19 @@
 .magic-login.is-white-login {
 	.magic-login__form-header {
 		@include onboarding-heading-text-mobile;
-		margin-bottom: 0;
 
 		@include break-mobile {
 			@include onboarding-heading-text;
-			font-size: $font-title-large;
 		}
 	}
 
 	.logged-out-form {
-		padding-top: 0;
 		.magic-login__form-sub-header {
 			color: var(--studio-gray-70);
-			text-align: center;
 		}
 
 		.form-label {
 			color: var(--studio-gray-60);
-			font-weight: 400;
 		}
 	}
 
@@ -188,10 +205,6 @@
 		background-color: #3858e9;
 		border-color: #3858e9;
 		color: var(--studio-white);
-	}
-
-	.magic-login__form-action {
-		margin-top: 16px;
 	}
 }
 

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -184,14 +184,14 @@
 		box-shadow: none;
 	}
 
-	.magic-login__form-action .button.is-primary {
-		background-color: var(--studio-blue);
-		border-color: var(--studio-blue);
+	.magic-login__form-action .button.is-primary:not([disabled]) {
+		background-color: #3858e9;
+		border-color: #3858e9;
 		color: var(--studio-white);
 	}
 
-	.magic-login__footer {
-		display: none;
+	.magic-login__form-action {
+		margin-top: 16px;
 	}
 }
 

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -28,7 +28,7 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	.magic-login__form-header {
+	.magic-login .magic-login__form-header {
 		margin-bottom: 0;
 
 		@include break-mobile {

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -28,6 +28,7 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
+
 	.magic-login .magic-login__form-header {
 		margin-bottom: 0;
 
@@ -45,6 +46,10 @@
 		.form-label {
 			font-weight: 400;
 		}
+	}
+
+	.magic-login__request-link {
+		max-width: 340px;
 	}
 
 	.magic-login__form-action {
@@ -83,7 +88,7 @@
 }
 
 .magic-login__request-link {
-	max-width: 340px;
+	max-width: 400px;
 }
 
 .magic-login__form {


### PR DESCRIPTION
## Proposed Changes

Updates text/styles for the magic email form login.
   - An important consideration is that these changes be safe and limited to the specific situations we want. In this case, these changes should only affect the magic email login page, and only on wpcom (not jetpack or gravatar, which have different styling). 
   - Figma: 5p3iZ99zPYfl6ronoTYEXO-fi-4_1291
   - P2: p9Jlb4-9mo-p2
   
With changes, form now looks like this on desktop: 
<img width="1496" alt="magic-email-login" src="https://github.com/Automattic/wp-calypso/assets/21228350/505382d1-c507-47f9-91e7-d649bcf68959">

And on mobile: 
<img width="371" alt="magic-email-login-mobile" src="https://github.com/Automattic/wp-calypso/assets/21228350/085d76e2-51ef-4662-8fc4-466ced3b0035">



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Test the expected changes**
   * In an incognito or non-logged-in browser, go to wordpress.com and click the Login link.
   * From the login page, click 'Email me a login link' to go to the magic email login page
   * Replace wordpress.com with http://calypso.localhost:3000 to load this branch's version of the screen
   * Confirm that the styling matches the screenshot above
   * Using your browser tools, adjust the window to mobil size, and confirm styling on mobil looks like above
   * Add an email, click the button, and confirm the functionality works as before

**Test there are not changes where there should not be**
   * Again incognito or non-logged-in browser, go to gravatar.com, click Login, and click the email login link. Again replace wordpress.com with http://calypso.localhost:3000 and confirm the gravatar email login page loads as it did before and is not affected by these changes. 
   * There appears to be a magic email long for jetpack, but I was unable to figure how to access that. 
   * If you know of any other flows that use magic email login, test those as well. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?