### PR TITLE
Remove the back button from the domain only flow

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -347,6 +347,7 @@ export function generateFlows( {
 			lastModified: '2023-10-11',
 			showRecaptcha: true,
 			hideProgressIndicator: true,
+			hideBack: true,
 		},
 		{
 			name: 'site-selected',

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -124,6 +124,10 @@ function showProgressIndicator( flowName ) {
 	const flow = flows.getFlow( flowName );
 	return ! flow.hideProgressIndicator;
 }
+function hideBack( flowName ) {
+	const flow = flows.getFlow( flowName );
+	return flow.hideBack;
+}
 
 class Signup extends Component {
 	static propTypes = {
@@ -819,6 +823,7 @@ class Signup extends Component {
 						this.renderProcessingScreen( isReskinned )
 					) : (
 						<CurrentComponent
+							hideBack={ hideBack( this.props.flowName ) }
 							path={ this.props.path }
 							step={ currentStepProgress }
 							initialContext={ this.props.initialContext }

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1398,6 +1398,7 @@ export class RenderDomainsStep extends Component {
 
 		return (
 			<StepWrapper
+				hideBack={ this.props.hideBack }
 				flowName={ flowName }
 				stepName={ stepName }
 				backUrl={ backUrl }

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -249,6 +249,7 @@ export class PlansStep extends Component {
 		return (
 			<>
 				<StepWrapper
+					hideBack={ this.props.hideBack }
 					flowName={ flowName }
 					stepName={ stepName }
 					positionInFlow={ positionInFlow }

--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -323,6 +323,7 @@ class SiteOrDomain extends Component {
 
 		return (
 			<StepWrapper
+				hideBack={ this.props.hideBack }
 				flowName={ this.props.flowName }
 				stepName={ this.props.stepName }
 				positionInFlow={ this.props.positionInFlow }

--- a/client/signup/steps/site-picker/index.jsx
+++ b/client/signup/steps/site-picker/index.jsx
@@ -48,6 +48,7 @@ class SitePicker extends Component {
 
 		return (
 			<StepWrapper
+				hideBack={ this.props.hideBack }
 				flowName={ this.props.flowName }
 				stepName={ this.props.stepName }
 				positionInFlow={ this.props.positionInFlow }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1698265226460189-slack-CKZHG0QCR

## Proposed Changes

* This PR removes the "< Back" button from the "domain only" flow.
* It does so by defining a property on the flow definition in `flows-pure.js`

### Why
The "< Back" button is unreliable and ultimately mimics the same behavior as the browser's back button.

Examples of the button's unreliability in the "domain only" flow:

-  When a logged-out user first enters the "domain only" flow from /domains, the "< Back" button sends the user to the /en version of the domains page, then that page's "< Back" button directs to /sites, but if the user is logged out, they're sent to the login screen. (Viewable in the video here: p1698265226460189-slack-CKZHG0QCR)
- From the "Choose how to use your domain" page, if the user selects "New site", goes back from the Plans page, then selects "Existing WordPress.com site", then goes back, they are taken to the Plans page, instead of the "Choose how to use your domain" page.
- If you enter the "domain only" flow from https://wordpress.com/domains/manage the "< Back" button takes you to https://wordpress.com/sites

About one-quarter of users use the "< Back" button on the "domain only" flow, and of those, the vast majority are going back after entering the first step of the flow. Which, by and large, takes the user somewhere other than the last page they just saw. By removing the "< Back" button, the user must either A) continue with the flow or B) use the browser's more reliable back button.

Removing the "< Back" button from every flow simultaneously is perilous. However, this PR sets up a framework where the "< Back" button can be removed at the flow level by defining it on the flow definition. This allows us to remove it from the "domain only" flow, where we can easily test the entire flow solely using the browser's native back and forward buttons.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load this PR
* Enter the domain only flow from https://wordpress.com/domains/ and/or https://wordpress.com/domains/manage and/or directly via the URL
* Navigate the flow only using your browser's back and forward buttons
* Make sure that this PR doesn't affect other flows.

Does the removal of the "< Back" button feel like an improvement?

> [!NOTE]  
The Checkout page "Back" button is outside the scope of this PR. But may also need attention.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?