### PR TITLE
Blogroll: add support link

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/src/block-links-map.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/src/block-links-map.ts
@@ -6,6 +6,7 @@ const blockLinks: { [ key: string ]: string } = {
 	 */
 	'core/template-part':
 		'https://wordpress.com/support/full-site-editing/theme-blocks/template-part-block/',
+
 	'core/site-title':
 		'https://wordpress.com/support/full-site-editing/theme-blocks/site-title-block/',
 
@@ -131,6 +132,8 @@ const blockLinks: { [ key: string ]: string } = {
 	/**
 	 * Jetpack Blocks
 	 */
+	'jetpack/blogroll': 'https://wordpress.com/support/wordpress-editor/blocks/blogroll-block/',
+
 	'jetpack/timeline': 'https://wordpress.com/support/wordpress-editor/blocks/timeline-block/',
 
 	'jetpack/story': 'https://wordpress.com/support/wordpress-editor/blocks/story-block/',


### PR DESCRIPTION
## Proposed Changes

With the addition of the new Blogroll block and the new support documentation to match we need to make it easy for people to find the documentation.

This adds the support link to the blogroll block Learn More link.

## Testing Instructions

1. Pull changes
2. `cd apps/editing-toolkit && yarn dev --sync`
3. Sandbox a site and go to edit a post.
4. Add the blogroll block and look for the Learn More link in the block description.