### PR TITLE
Hide the back button on the first step of the domain only flow

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1398,6 +1398,7 @@ export class RenderDomainsStep extends Component {
 
 		return (
 			<StepWrapper
+				hideBack={ flowName === 'domain' }
 				flowName={ flowName }
 				stepName={ stepName }
 				backUrl={ backUrl }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1698265226460189-slack-CKZHG0QCR

## Proposed Changes

* This PR hides the "< Back" button on the first step of the "domain only" flow.

The "< Back" button is broken on the first step of the "domain only" flow, sending the user to the wrong location. We have attempted to fix the button and debated removing the "< Back" button from the flow altogether (see related conversation above). As an initial step we're removing the button from the domain-only flow's first step. By removing the button, the user must continue with the flow or use the browser's back button (which is more reliable). Either case seems like a better experience.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /domains
* Ensure the back button is hidden and the flow works correctly
* Ensure the back button in other flows like `onboarding` is not hidden.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?