### PR TITLE
Launchpad: Use the Modal component on the Launchpad

### DIFF
--- a/packages/launchpad-navigator/src/floating-navigator/index.tsx
+++ b/packages/launchpad-navigator/src/floating-navigator/index.tsx
@@ -1,7 +1,6 @@
-import { Card, Gridicon } from '@automattic/components';
 import { LaunchpadNavigator } from '@automattic/data-stores';
 import { DefaultWiredLaunchpad } from '@automattic/launchpad';
-import { Button } from '@wordpress/components';
+import { Modal } from '@wordpress/components';
 import { select } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 
@@ -26,23 +25,17 @@ const FloatingNavigator = ( { siteSlug, toggleLaunchpadIsVisible }: FloatingNavi
 	const setLaunchpadIsVisible = toggleLaunchpadIsVisible || ( () => {} );
 
 	return (
-		<Card className="launchpad-navigator__floating-navigator">
-			<div className="launchpad-navigator__floating-navigator-header">
-				<h2>{ translate( 'Next steps for your site' ) }</h2>
-				<Button
-					aria-label={ translate( 'Close task list modal' ) }
-					className="launchpad-navigator__floating-navigator-close-button"
-					onClick={ () => setLaunchpadIsVisible( false ) }
-				>
-					<Gridicon icon="cross" size={ 18 } />
-				</Button>
-			</div>
+		<Modal
+			title={ translate( 'Next steps for your site' ) }
+			className="launchpad-navigator__floating-navigator"
+			onRequestClose={ () => setLaunchpadIsVisible( false ) }
+		>
 			<DefaultWiredLaunchpad
 				siteSlug={ siteSlug }
 				checklistSlug={ checklistSlug }
 				launchpadContext={ launchpadContext }
 			/>
-		</Card>
+		</Modal>
 	);
 };
 

--- a/packages/launchpad-navigator/src/floating-navigator/style.scss
+++ b/packages/launchpad-navigator/src/floating-navigator/style.scss
@@ -7,4 +7,10 @@
 	cursor: default;
 	transition: max-height 0.5s;
 	min-width: 25em;
+
+	.components-modal__header .components-modal__header-heading {
+		font-family: $font-sf-pro-display;
+		font-size: $font-title-small;
+		font-weight: 500;
+	}
 }

--- a/packages/launchpad-navigator/src/floating-navigator/style.scss
+++ b/packages/launchpad-navigator/src/floating-navigator/style.scss
@@ -4,37 +4,7 @@
 	position: fixed;
 	top: calc(var(--masterbar-height) + 2px);
 	right: 0.5em;
-	background-color: #fff;
-	color: #000;
-	z-index: 9999;
 	cursor: default;
 	transition: max-height 0.5s;
 	min-width: 25em;
-	padding-top: 16px;
-
-	.launchpad-navigator__floating-navigator-header {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-
-		h2 {
-			font-family: $font-sf-pro-display;
-			font-size: $font-title-small;
-			font-weight: 500;
-		}
-
-		.button.is-borderless .gridicon {
-			height: 18px;
-			top: 4px;
-			width: 18px;
-		}
-	}
-
-	.launchpad-navigator__floating-navigator-close-button {
-		padding: 4px 0;
-		&:focus {
-			outline: none;
-			box-shadow: none;
-		}
-	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* This PR adds the Modal component from the `@wordpress/components` package, this will help us with the basic functionalities of displaying and dismissing the Navigator.
* Note: clicking on a task does not dismiss the Modal. Once we merge https://github.com/Automattic/wp-calypso/pull/83373, it will fix this issue.

<img width="441" alt="Screen Shot 2023-10-26 at 15 08 30" src="https://github.com/Automattic/wp-calypso/assets/1234758/17da3a99-e620-4f09-bb7a-1f42f5f64814">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso Live link below or apply this PR to your local environment
* On a site with an active Launchpad, navigate to `/home/:siteSlug?falgs=launchpad/navigator`
* Click on the progress ring on the master bar, and the Navigator Modal should open.
* Click outside of the Modal to ensure it closes
* Open it up again, and click on X to ensure it also works.
* Note: if clicking on the progress ring doesn't show the Modal, try clicking on a task on the Launchpad. The work Dale's is doing will address this problem: 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?