### PR TITLE
Hosting flow: Add gap between title and CTAs in sites hosting flow view

### DIFF
--- a/client/sites-dashboard/components/hosting-flow-forking-page.tsx
+++ b/client/sites-dashboard/components/hosting-flow-forking-page.tsx
@@ -18,6 +18,7 @@ export const HostingFlowForkingPage = ( { siteCount }: HostingFlowForkingPagePro
 				alignItems: 'center',
 				margin: 0,
 				padding: 0,
+				gap: '32px',
 				[ MEDIA_QUERIES.small ]: {
 					width: '100%',
 					maxWidth: '100%',


### PR DESCRIPTION
Related to p1698343775638809-slack-C041RHH38NQ.

## Proposed Changes

For some reason, the margin between the title and the CTAs in the `/sites?hosting-flow=true` page is gone. This PR re-adds it.

| Before | After |
| ------- | ----- |
| ![image](https://github.com/Automattic/wp-calypso/assets/26530524/0ae6d9b6-2ca3-432f-b649-b186f1335a28) | ![image](https://github.com/Automattic/wp-calypso/assets/26530524/1ecd87c0-bb59-4c5b-bdd6-ab2726be2f97) |