### PR TITLE
Subscription Management: Remove "We're updating your subscriptions" notice timeout

### DIFF
--- a/client/blocks/reader-site-subscription/index.tsx
+++ b/client/blocks/reader-site-subscription/index.tsx
@@ -36,7 +36,6 @@ const useHandleSubscriptionNotFoundError = ( transition?: boolean ) => {
 		if ( transition ) {
 			dispatch(
 				infoNotice( translate( "We're updating your subscriptions. It should be ready shortly." ), {
-					duration: 5000,
 					displayOnNextPage: true,
 					isPersistent: true,
 				} )


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/83491

## Proposed Changes

* Remove "We're updating your subscriptions" notice timeout

## Testing Instructions

* Apply this PR to your local
* Go to http://calypso.localhost:3000/read/site/subscription/xxxxxx?transition=true
* You should be redirected to the subscription list while the notice remains displayed

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?