### PR TITLE
Plans Grid Refactor: remove shopping cart provider from the plans grid

### DIFF
--- a/client/my-sites/plans-grid/index.tsx
+++ b/client/my-sites/plans-grid/index.tsx
@@ -1,5 +1,4 @@
 import { useTranslate } from 'i18n-calypso';
-import CalypsoShoppingCartProvider from '../checkout/calypso-shopping-cart-provider';
 import ComparisonGrid from './components/comparison-grid';
 import FeaturesGrid from './components/features-grid';
 import PlansGridContextProvider from './grid-context';
@@ -88,36 +87,6 @@ const WrappedComparisonGrid = ( {
 		onUpgradeClick,
 	} );
 
-	if ( isInSignup ) {
-		return (
-			<PlansGridContextProvider
-				intent={ intent }
-				gridPlans={ gridPlans }
-				usePricingMetaForGridPlans={ usePricingMetaForGridPlans }
-				allFeaturesList={ allFeaturesList }
-			>
-				<ComparisonGrid
-					intervalType={ intervalType }
-					isInSignup={ isInSignup }
-					isLaunchPage={ isLaunchPage }
-					flowName={ flowName }
-					currentSitePlanSlug={ currentSitePlanSlug }
-					currentPlanManageHref={ currentPlanManageHref }
-					canUserManageCurrentPlan={ canUserManageCurrentPlan }
-					onUpgradeClick={ handleUpgradeClick }
-					siteId={ siteId }
-					selectedPlan={ selectedPlan }
-					selectedFeature={ selectedFeature }
-					showLegacyStorageFeature={ showLegacyStorageFeature }
-					showUpgradeableStorage={ showUpgradeableStorage }
-					stickyRowOffset={ stickyRowOffset }
-					onStorageAddOnClick={ onStorageAddOnClick }
-					{ ...otherProps }
-				/>
-			</PlansGridContextProvider>
-		);
-	}
-
 	return (
 		<PlansGridContextProvider
 			intent={ intent }
@@ -125,26 +94,24 @@ const WrappedComparisonGrid = ( {
 			usePricingMetaForGridPlans={ usePricingMetaForGridPlans }
 			allFeaturesList={ allFeaturesList }
 		>
-			<CalypsoShoppingCartProvider>
-				<ComparisonGrid
-					intervalType={ intervalType }
-					isInSignup={ isInSignup }
-					isLaunchPage={ isLaunchPage }
-					flowName={ flowName }
-					currentSitePlanSlug={ currentSitePlanSlug }
-					currentPlanManageHref={ currentPlanManageHref }
-					canUserManageCurrentPlan={ canUserManageCurrentPlan }
-					onUpgradeClick={ handleUpgradeClick }
-					siteId={ siteId }
-					selectedPlan={ selectedPlan }
-					selectedFeature={ selectedFeature }
-					showLegacyStorageFeature={ showLegacyStorageFeature }
-					showUpgradeableStorage={ showUpgradeableStorage }
-					stickyRowOffset={ stickyRowOffset }
-					onStorageAddOnClick={ onStorageAddOnClick }
-					{ ...otherProps }
-				/>
-			</CalypsoShoppingCartProvider>
+			<ComparisonGrid
+				intervalType={ intervalType }
+				isInSignup={ isInSignup }
+				isLaunchPage={ isLaunchPage }
+				flowName={ flowName }
+				currentSitePlanSlug={ currentSitePlanSlug }
+				currentPlanManageHref={ currentPlanManageHref }
+				canUserManageCurrentPlan={ canUserManageCurrentPlan }
+				onUpgradeClick={ handleUpgradeClick }
+				siteId={ siteId }
+				selectedPlan={ selectedPlan }
+				selectedFeature={ selectedFeature }
+				showLegacyStorageFeature={ showLegacyStorageFeature }
+				showUpgradeableStorage={ showUpgradeableStorage }
+				stickyRowOffset={ stickyRowOffset }
+				onStorageAddOnClick={ onStorageAddOnClick }
+				{ ...otherProps }
+			/>
 		</PlansGridContextProvider>
 	);
 };
@@ -178,27 +145,6 @@ const WrappedFeaturesGrid = ( props: PlansGridProps ) => {
 		onUpgradeClick,
 	} );
 
-	if ( props.isInSignup ) {
-		return (
-			<PlansGridContextProvider
-				intent={ intent }
-				gridPlans={ gridPlans }
-				usePricingMetaForGridPlans={ usePricingMetaForGridPlans }
-				allFeaturesList={ allFeaturesList }
-			>
-				<FeaturesGrid
-					{ ...props }
-					isPlanUpgradeCreditEligible={ isPlanUpgradeCreditEligible }
-					isLargeCurrency={ isLargeCurrency }
-					canUserManageCurrentPlan={ canUserManageCurrentPlan }
-					currentPlanManageHref={ currentPlanManageHref }
-					translate={ translate }
-					handleUpgradeClick={ handleUpgradeClick }
-				/>
-			</PlansGridContextProvider>
-		);
-	}
-
 	return (
 		<PlansGridContextProvider
 			intent={ intent }
@@ -206,17 +152,15 @@ const WrappedFeaturesGrid = ( props: PlansGridProps ) => {
 			usePricingMetaForGridPlans={ usePricingMetaForGridPlans }
 			allFeaturesList={ allFeaturesList }
 		>
-			<CalypsoShoppingCartProvider>
-				<FeaturesGrid
-					{ ...props }
-					isPlanUpgradeCreditEligible={ isPlanUpgradeCreditEligible }
-					isLargeCurrency={ isLargeCurrency }
-					canUserManageCurrentPlan={ canUserManageCurrentPlan }
-					currentPlanManageHref={ currentPlanManageHref }
-					translate={ translate }
-					handleUpgradeClick={ handleUpgradeClick }
-				/>
-			</CalypsoShoppingCartProvider>
+			<FeaturesGrid
+				{ ...props }
+				isPlanUpgradeCreditEligible={ isPlanUpgradeCreditEligible }
+				isLargeCurrency={ isLargeCurrency }
+				canUserManageCurrentPlan={ canUserManageCurrentPlan }
+				currentPlanManageHref={ currentPlanManageHref }
+				translate={ translate }
+				handleUpgradeClick={ handleUpgradeClick }
+			/>
 		</PlansGridContextProvider>
 	);
 };


### PR DESCRIPTION
Fixes: https://github.com/Automattic/wp-calypso/issues/78997

## Proposed Changes

* The shopping cart provider is not required inside the plans grid
* Made sure that using `useShoppingCart` or `withShoppingCart` is not used within the grid.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure purchases from the plans grid work both in `/start` and `/plans`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?