### PR TITLE
JP Manage: 44 - Change existing "/agency/signup" URL & redirect old path

### DIFF
--- a/client/jetpack-cloud/sections/agency-signup/index.ts
+++ b/client/jetpack-cloud/sections/agency-signup/index.ts
@@ -1,6 +1,6 @@
 import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller';
-import { agencySignupBasePath } from 'calypso/lib/jetpack/paths';
+import { agencySignupBasePath, agencySignupLegacyPath } from 'calypso/lib/jetpack/paths';
 import * as controller from './controller';
 
 export default function () {

--- a/client/jetpack-cloud/sections/agency-signup/index.ts
+++ b/client/jetpack-cloud/sections/agency-signup/index.ts
@@ -11,4 +11,6 @@ export default function () {
 		makeLayout,
 		clientRender
 	);
+
+	page( agencySignupLegacyPath(), agencySignupBasePath() );
 }

--- a/client/lib/jetpack/paths.ts
+++ b/client/lib/jetpack/paths.ts
@@ -38,7 +38,8 @@ export const socialPath = ( siteSlug?: string ): string =>
 
 export const partnerPortalBasePath = ( path = '' ) => `/partner-portal${ path }`;
 
-export const agencySignupBasePath = () => '/agency/signup';
+export const agencySignupBasePath = () => '/manage/signup';
+export const agencySignupLegacyPath = () => '/agency/signup';
 
 const pluginsBasePath = '/plugins/manage';
 

--- a/client/sections.js
+++ b/client/sections.js
@@ -599,7 +599,7 @@ const sections = [
 	},
 	{
 		name: 'jetpack-cloud-agency-signup',
-		paths: [ '/agency/signup' ],
+		paths: [ '/manage/signup', '/agency/signup' ],
 		module: 'calypso/jetpack-cloud/sections/agency-signup',
 		group: 'jetpack-cloud',
 	},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-manage/issues/44

## Proposed Changes

* This PR changes the current `/agency/signup` url to `/manage/signup`, and redirects `/agency/signup` to this new url.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open: `http://jetpack.cloud.localhost:3000/manage/signup`
* You should see the Jetpack Manage signup form

* Open: `http://jetpack.cloud.localhost:3000/agency/signup`
* You should be redirected to `http://jetpack.cloud.localhost:3000/manage/signup`


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?