### PR TITLE
ActivityLog: Implement Search component in ActivityLog

### DIFF
--- a/client/my-sites/activity/filterbar/index.jsx
+++ b/client/my-sites/activity/filterbar/index.jsx
@@ -112,7 +112,7 @@ export class Filterbar extends Component {
 		if ( ! filter ) {
 			return true;
 		}
-		if ( filter.group || filter.on || filter.before || filter.after ) {
+		if ( filter.group || filter.on || filter.before || filter.after || filter.textSearch ) {
 			return false;
 		}
 		if ( filter.page !== 1 ) {

--- a/client/my-sites/activity/filterbar/style.scss
+++ b/client/my-sites/activity/filterbar/style.scss
@@ -120,7 +120,7 @@
 			width: 100%;
 
 			@include break-xlarge {
-				width: 60%;
+				width: 65%;
 			}
 		}
 	}

--- a/client/my-sites/activity/filterbar/style.scss
+++ b/client/my-sites/activity/filterbar/style.scss
@@ -112,14 +112,8 @@
 		flex-grow: 1;
 		margin: 0 8px 0 16px;
 
-		.components-text-control__input {
-			border-color: var(--color-neutral-20);
-			font-size: 0.75rem;
-			width: 100%;
-
-			@include break-xlarge {
-				width: 60%;
-			}
+		.search {
+			margin-bottom: 0;
 		}
 	}
 }

--- a/client/my-sites/activity/filterbar/style.scss
+++ b/client/my-sites/activity/filterbar/style.scss
@@ -114,6 +114,14 @@
 
 		.search {
 			margin-bottom: 0;
+
+			border: 1px solid var(--color-neutral-20);
+			font-size: 0.75rem;
+			width: 100%;
+
+			@include break-xlarge {
+				width: 60%;
+			}
 		}
 	}
 }

--- a/client/my-sites/activity/filterbar/text-selector.tsx
+++ b/client/my-sites/activity/filterbar/text-selector.tsx
@@ -31,6 +31,7 @@ const TextSelector: FunctionComponent< Props > = ( { siteId, filter } ) => {
 
 	return (
 		<Search
+			compact
 			delaySearch={ true }
 			hideFocus
 			initialValue={ filter.textSearch || null }

--- a/client/my-sites/activity/filterbar/text-selector.tsx
+++ b/client/my-sites/activity/filterbar/text-selector.tsx
@@ -1,9 +1,8 @@
 import { useMobileBreakpoint } from '@automattic/viewport-react';
-import { TextControl } from '@wordpress/components';
-import { useEffect, useState } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
-import React, { FunctionComponent } from 'react';
+import { FunctionComponent } from 'react';
 import { useDispatch } from 'react-redux';
+import Search from 'calypso/components/search';
 import { updateFilter } from 'calypso/state/activity-log/actions';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import { CalypsoDispatch } from 'calypso/state/types';
@@ -19,54 +18,25 @@ const TextSelector: FunctionComponent< Props > = ( { siteId, filter } ) => {
 	const translate = useTranslate();
 	const isMobile = useMobileBreakpoint();
 
-	const [ searchQuery, setSearchQuery ] = useState( filter.textSearch || '' );
-
-	useEffect( () => {
-		// If the filter is cleared, clear the search query
-		if ( ! filter.textSearch ) {
-			setSearchQuery( '' );
-		}
-	}, [ filter.textSearch ] );
-
 	const dispatch = useDispatch() as CalypsoDispatch;
-	const onKeyDown = ( event: React.KeyboardEvent< HTMLInputElement > ) => {
-		const { value } = event.currentTarget;
-
-		if ( event.key === 'Enter' ) {
-			dispatch( updateFilter( siteId, { textSearch: value } ) );
-			dispatch(
-				recordTracksEvent( 'calypso_activitylog_filterbar_text_search', {
-					characters: value.length,
-				} )
-			);
-		}
-	};
-
-	const onChange = ( value: string ) => {
-		if ( value !== searchQuery && value.length === 0 ) {
-			// Field was cleared, so clear the filter without waiting for enter
-			dispatch( updateFilter( siteId, { textSearch: '' } ) );
-			dispatch(
-				recordTracksEvent( 'calypso_activitylog_filterbar_text_search', {
-					characters: value.length,
-				} )
-			);
-		}
-		setSearchQuery( value );
-	};
 
 	const placeholder = isMobile
 		? translate( 'Search posts' )
 		: translate( 'Search posts by ID, title or author' );
 
+	const handleSearchActivities = ( query: string ) => {
+		dispatch( updateFilter( siteId, { textSearch: query } ) );
+		dispatch( recordTracksEvent( 'calypso_activitylog_filterbar_text_search' ) );
+	};
+
 	return (
-		<TextControl
-			__nextHasNoMarginBottom
-			type="search"
-			onKeyDown={ onKeyDown }
+		<Search
+			delaySearch={ true }
+			hideFocus
+			initialValue={ filter.textSearch || null }
+			isOpen={ false }
+			onSearch={ handleSearchActivities }
 			placeholder={ placeholder }
-			onChange={ onChange }
-			value={ searchQuery }
 		/>
 	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-backup-team/issues/202
## Proposed Changes
* Implement Search UI component in the Activity Log (https://wpcalypso.wordpress.com/devdocs/design/search) so we can keep consistent experience on search functionalities in Calypso.
* Prevent setting the filterbar in loading mode when doing a text search in Calypso Blue. For Jetpack Cloud we will address it in another PR.

### Calypso Blue
| Before | After |
|---|---|
| ![CleanShot 2023-10-27 at 21 19 21](https://github.com/Automattic/wp-calypso/assets/1488641/f43a8daf-9128-41d4-87c6-ba470e3ed54f) | ![CleanShot 2023-10-27 at 21 19 45](https://github.com/Automattic/wp-calypso/assets/1488641/c7fc5022-dcee-453c-831b-db680546b48b) |
| It does not include the magnifier glass; user needs to press ENTER to start searching; the filterbar switches to loading state when the search is happening. | It now has the magnifier glass; search starts when the user stop typing; the filterbar no longer switches to loading state when searching |

### Jetpack Cloud
| Before | After |
|---|---|
| ![CleanShot 2023-10-27 at 21 25 22](https://github.com/Automattic/wp-calypso/assets/1488641/55306c0c-f61a-4f56-b0c8-31fb1b8f673d) | ![CleanShot 2023-10-27 at 21 25 48](https://github.com/Automattic/wp-calypso/assets/1488641/dba088c5-388d-48f7-81e3-dd01e2efdec6) |
| It does not include the magnifier glass; user needs to press ENTER to start searching; the filterbar switches to loading state when the search is happening. | It now has the magnifier glass; search starts when the user stop typing; the filterbar still switches to loading state when searching (we will address this in a separate PR) |

## Testing Instructions
* Spin up a Calypso live branch
* Navigate to the Activity Log
* Ensure the search box is visible and try searching your posts and play around with the filters.
  * The search will be triggered when the user stops typing. This way, they don't need to press ENTER.
* Ensure this search box is visible on Calypso Blue and Jetpack Cloud and it works as shown in the demos shared above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?