### PR TITLE
Login: Update magic login confirmation styles

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -105,6 +105,8 @@ const LayoutLoggedOut = ( {
 		! currentRoute.startsWith( '/log-in/webauthn' ) &&
 		! currentRoute.startsWith( '/log-in/backup' );
 
+	const isMagicLogin = currentRoute && currentRoute.startsWith( '/log-in/link' );
+
 	const classes = {
 		[ 'is-group-' + sectionGroup ]: sectionGroup,
 		[ 'is-section-' + sectionName ]: sectionName,
@@ -125,6 +127,8 @@ const LayoutLoggedOut = ( {
 		'is-grav-powered-client': isGravPoweredClient,
 		'is-grav-powered-login-page': isGravPoweredLoginPage,
 		'is-woocommerce-core-profiler-flow': isWooCoreProfilerFlow,
+		'is-magic-login': isMagicLogin,
+		'is-wpcom-magic-login': isMagicLogin && ! isJetpackLogin && ! isGravPoweredLoginPage,
 	};
 
 	let masterbar = null;

--- a/client/login/magic-login/emailed-login-link-successfully.jsx
+++ b/client/login/magic-login/emailed-login-link-successfully.jsx
@@ -1,4 +1,4 @@
-import { Card, Gridicon } from '@automattic/components';
+import { Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
@@ -45,18 +45,24 @@ class EmailedLoginLinkSuccessfully extends Component {
 		const { translate, emailAddress } = this.props;
 		const line = [
 			emailAddress
-				? translate( 'We just emailed a link to %(emailAddress)s.', {
-						args: {
-							emailAddress,
-						},
-				  } )
+				? translate(
+						'If you have a WordPress.com account, we’ve sent an email to {{span}} %(emailAddress)s {{/span}} with a link you can use to sign in.',
+						{
+							args: {
+								emailAddress,
+							},
+							components: {
+								span: <span className="magic-login__confirmation-email" />,
+							},
+						}
+				  )
 				: translate( 'We just emailed you a link.' ),
 			' ',
 			translate( 'Please check your inbox and click the link to log in.' ),
 		];
 
 		return (
-			<div>
+			<div className="magic-login__confirmation">
 				<RedirectWhenLoggedIn
 					redirectTo="/help"
 					replaceCurrentLocation={ true }
@@ -78,8 +84,7 @@ class EmailedLoginLinkSuccessfully extends Component {
 						} ) }
 						onClick={ this.onClickBackLink }
 					>
-						<Gridicon icon="arrow-left" size={ 18 } />
-						{ translate( 'Back to login' ) }
+						{ translate( 'Enter a password instead' ) }
 					</a>
 				</div>
 			</div>

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -165,7 +165,7 @@ class RequestLoginEmailForm extends Component {
 					<p className="magic-login__form-sub-header">
 						{ ! hideSubHeaderText &&
 							translate(
-								'Get a link sent to the email address associated with your account to log in instantly without your password.'
+								'We’ll send you an email with a login link that will log you in right away.'
 							) }
 					</p>
 					<FormLabel htmlFor="usernameOrEmail">
@@ -185,7 +185,7 @@ class RequestLoginEmailForm extends Component {
 						{ tosComponent }
 						<div className="magic-login__form-action">
 							<FormButton primary disabled={ ! submitEnabled }>
-								{ submitButtonLabel || translate( 'Get Link' ) }
+								{ submitButtonLabel || translate( 'Send Link' ) }
 							</FormButton>
 						</div>
 					</FormFieldset>

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -38,6 +38,7 @@
 	}
 
 	.logged-out-form {
+		max-width: 340px;
 		padding-top: 0;
 		.magic-login__form-sub-header {
 			text-align: center;
@@ -46,10 +47,6 @@
 		.form-label {
 			font-weight: 400;
 		}
-	}
-
-	.magic-login__request-link {
-		max-width: 340px;
 	}
 
 	.magic-login__form-action {

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -1,6 +1,8 @@
 @import "@automattic/onboarding/styles/mixins";
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@automattic/calypso-color-schemes";
+@import "@automattic/typography/styles/variables";
 
 @media ( max-height: 450px ) {
 	.magic-login__handle-link,
@@ -20,6 +22,12 @@
 			margin-bottom: 20px;
 		}
 	}
+}
+
+.layout.is-white-login {
+	display: flex;
+	align-items: center;
+	justify-content: center;
 }
 
 .is-white-login .magic-login__handle-link,
@@ -53,7 +61,7 @@
 }
 
 .magic-login__request-link {
-	max-width: 400px;
+	max-width: 340px;
 }
 
 .magic-login__form {
@@ -150,9 +158,24 @@
 .magic-login.is-white-login {
 	.magic-login__form-header {
 		@include onboarding-heading-text-mobile;
+		margin-bottom: 0;
 
 		@include break-mobile {
 			@include onboarding-heading-text;
+			font-size: $font-title-large;
+		}
+	}
+
+	.logged-out-form {
+		padding-top: 0;
+		.magic-login__form-sub-header {
+			color: var(--studio-gray-70);
+			text-align: center;
+		}
+
+		.form-label {
+			color: var(--studio-gray-60);
+			font-weight: 400;
 		}
 	}
 
@@ -161,11 +184,14 @@
 		box-shadow: none;
 	}
 
-	.magic-login__form-action .button.is-primary:not([disabled]) {
-		// Match primary button color in Gutenboarding and
-		// change border color to remove 3D effect
-		background-color: #007cba;
-		border-color: #007cba;
+	.magic-login__form-action .button.is-primary {
+		background-color: var(--studio-blue);
+		border-color: var(--studio-blue);
+		color: var(--studio-white);
+	}
+
+	.magic-login__footer {
+		display: none;
 	}
 }
 

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -24,10 +24,32 @@
 	}
 }
 
-.layout.is-white-login {
+.layout.is-wpcom-magic-login {
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	.magic-login__form-header {
+		margin-bottom: 0;
+
+		@include break-mobile {
+			font-size: $font-title-large;
+		}
+	}
+
+	.logged-out-form {
+		padding-top: 0;
+		.magic-login__form-sub-header {
+			text-align: center;
+		}
+
+		.form-label {
+			font-weight: 400;
+		}
+	}
+
+	.magic-login__form-action {
+		margin-top: 16px;
+	}
 }
 
 .is-white-login .magic-login__handle-link,
@@ -158,24 +180,19 @@
 .magic-login.is-white-login {
 	.magic-login__form-header {
 		@include onboarding-heading-text-mobile;
-		margin-bottom: 0;
 
 		@include break-mobile {
 			@include onboarding-heading-text;
-			font-size: $font-title-large;
 		}
 	}
 
 	.logged-out-form {
-		padding-top: 0;
 		.magic-login__form-sub-header {
 			color: var(--studio-gray-70);
-			text-align: center;
 		}
 
 		.form-label {
 			color: var(--studio-gray-60);
-			font-weight: 400;
 		}
 	}
 
@@ -188,10 +205,6 @@
 		background-color: #3858e9;
 		border-color: #3858e9;
 		color: var(--studio-white);
-	}
-
-	.magic-login__form-action {
-		margin-top: 16px;
 	}
 }
 

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -184,14 +184,14 @@
 		box-shadow: none;
 	}
 
-	.magic-login__form-action .button.is-primary {
-		background-color: var(--studio-blue);
-		border-color: var(--studio-blue);
+	.magic-login__form-action .button.is-primary:not([disabled]) {
+		background-color: #3858e9;
+		border-color: #3858e9;
 		color: var(--studio-white);
 	}
 
-	.magic-login__footer {
-		display: none;
+	.magic-login__form-action {
+		margin-top: 16px;
 	}
 }
 

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -28,7 +28,7 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	.magic-login__form-header {
+	.magic-login .magic-login__form-header {
 		margin-bottom: 0;
 
 		@include break-mobile {

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -38,7 +38,6 @@
 	}
 
 	.logged-out-form {
-		max-width: 340px;
 		padding-top: 0;
 		.magic-login__form-sub-header {
 			text-align: center;
@@ -51,6 +50,23 @@
 
 	.magic-login__form-action {
 		margin-top: 16px;
+	}
+
+	.magic-login__confirmation {
+		p {
+			text-align: center;
+		}
+		.magic-login__confirmation-email {
+			font-weight: 600;
+		}
+		a:last-of-type {
+			border-bottom: none;
+			color: var(--studio-gray-90);
+			text-decoration: underline;
+			&:hover {
+				color: var(--color-primary);
+			}
+		}
 	}
 }
 

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -28,6 +28,7 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
+
 	.magic-login .magic-login__form-header {
 		margin-bottom: 0;
 
@@ -45,6 +46,10 @@
 		.form-label {
 			font-weight: 400;
 		}
+	}
+
+	.magic-login__request-link {
+		max-width: 340px;
 	}
 
 	.magic-login__form-action {
@@ -83,7 +88,7 @@
 }
 
 .magic-login__request-link {
-	max-width: 340px;
+	max-width: 400px;
 }
 
 .magic-login__form {


### PR DESCRIPTION
## Proposed Changes

Updates styles of the magic email login confirmation screen (shows immediately after clicking send link from magic login page). Caveats: 
   - Figma: 5p3iZ99zPYfl6ronoTYEXO-fi-4_1291
   - P2: p9Jlb4-9mo-p2
   - Changes are based on this PR **which should be merged first**: https://github.com/Automattic/wp-calypso/pull/83546
   - Caveat: The width of the text area is narrower than in designs. Because same page structure is used by many pages, I think there is more complexity  expanding the width only on this page, but not on others. 
   - Caveat: The designs also have a new link for 'I didn't receive my email'. I'm going to add that in a separate follow up PR.
 
**Before**
<img width="1495" alt="magic-email-confirmation-old" src="https://github.com/Automattic/wp-calypso/assets/21228350/fc0c93aa-51f0-4abc-b9c3-4bbd4692b89c">

**After**
<img width="1492" alt="magic-email-confirmation" src="https://github.com/Automattic/wp-calypso/assets/21228350/2b688c79-c4f2-4f61-997f-5eae9d9b1e51">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?