### PR TITLE
Support delete requests in data-layer/http-wpcom

### DIFF
--- a/client/state/data-layer/wpcom-http/index.js
+++ b/client/state/data-layer/wpcom-http/index.js
@@ -20,11 +20,11 @@ const debug = debugModule( 'calypso:data-layer:wpcom-http' );
  */
 const fetcherMap = function ( method, fetcher = 'wpcom' ) {
 	const req = 'wpcomJetpackLicensing' === fetcher ? wpcomJetpackLicensing.req : wpcom.req;
-
 	return get(
 		{
 			GET: req.get.bind( req ),
 			POST: req.post.bind( req ),
+			DELETE: req.del.bind( req ),
 		},
 		method,
 		null
@@ -73,7 +73,7 @@ export const queueRequest =
 			fetcher
 		)(
 			...[
-				{ path, formData, onStreamRecord, responseType },
+				{ path, formData, onStreamRecord, responseType, method },
 				{ ...query }, // wpcom mutates the query so hand it a copy
 				method === 'POST' && body,
 				( error, data, headers ) => {

--- a/packages/wpcom.js/src/lib/util/request.js
+++ b/packages/wpcom.js/src/lib/util/request.js
@@ -55,6 +55,10 @@ Req.prototype.post = Req.prototype.put = function ( params, query, body, fn ) {
 
 /**
  * Make a `delete` request
+ *
+ * Note: to actually send a DELETE request you must define
+ * params.method = 'DELETE' when calling this function; otherwise
+ * it will default to using POST.
  * @param {Object | string} params - params object
  * @param {Object} [query] - query object parameter
  * @param {Function} fn - callback function


### PR DESCRIPTION
This module is specifically intended to interact with the REST API on WPCOM, which uses delete requests. This patch adds support for them in the data layer.

## Proposed Changes

* Support the DELETE method in the handler of WPCOM_HTTP_REQUEST events.

## Testing Instructions

* #83566 relies on this change. The testing instructions on that PR will exercise this code; verify that the request to `/sites/$siteId/async-toast/test-toast` is a DELETE.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
