### PR TITLE
"Change site address" modal: add conditions to custom domain message

### DIFF
--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -37,6 +37,7 @@ export class SiteAddressChanger extends Component {
 		currentDomain: PropTypes.object.isRequired,
 		recordTracksEvent: PropTypes.func.isRequired,
 		onSiteAddressChanged: PropTypes.func,
+		hasNonWpcomDomains: PropTypes.bool,
 
 		// `connect`ed
 		isSiteAddressChangeRequesting: PropTypes.bool,
@@ -335,8 +336,15 @@ export class SiteAddressChanger extends Component {
 	};
 
 	renderNewAddressForm = () => {
-		const { currentDomain, isAvailable, siteId, selectedSiteSlug, translate, isAtomicSite } =
-			this.props;
+		const {
+			currentDomain,
+			isAvailable,
+			siteId,
+			selectedSiteSlug,
+			translate,
+			isAtomicSite,
+			hasNonWpcomDomains,
+		} = this.props;
 
 		if ( isAtomicSite ) {
 			return (
@@ -384,14 +392,18 @@ export class SiteAddressChanger extends Component {
 				<div className="site-address-changer__info">
 					<p>
 						{ translate(
-							'Once you change your site address, %(currentDomainName)s will no longer be available. {{a}}Did you want to add a custom domain instead?{{/a}}',
+							'Once you change your site address, %(currentDomainName)s will no longer be available. ',
 							{
 								args: { currentDomainName },
+							}
+						) }
+						{ ! hasNonWpcomDomains &&
+							// ask when user has no custom domains
+							translate( '{{a}}Did you want to add a custom domain instead?{{/a}}', {
 								components: {
 									a: <a href={ addDomainPath } onClick={ this.handleAddDomainClick } />,
 								},
-							}
-						) }
+							} ) }
 					</p>
 				</div>
 				<div className="site-address-changer__details">

--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -1,5 +1,5 @@
 import { Dialog, FormInputValidation, Gridicon } from '@automattic/components';
-import { localize } from 'i18n-calypso';
+import i18n, { localize } from 'i18n-calypso';
 import { debounce, get, isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -391,19 +391,25 @@ export class SiteAddressChanger extends Component {
 				</FormSectionHeading>
 				<div className="site-address-changer__info">
 					<p>
-						{ translate(
-							'Once you change your site address, %(currentDomainName)s will no longer be available. ',
-							{
-								args: { currentDomainName },
-							}
-						) }
-						{ ! hasNonWpcomDomains &&
-							// ask when user has no custom domains
-							translate( '{{a}}Did you want to add a custom domain instead?{{/a}}', {
-								components: {
-									a: <a href={ addDomainPath } onClick={ this.handleAddDomainClick } />,
-								},
-							} ) }
+						{ hasNonWpcomDomains &&
+						i18n.hasTranslation(
+							'Once you change your site address, %(currentDomainName)s will no longer be available.'
+						)
+							? translate(
+									'Once you change your site address, %(currentDomainName)s will no longer be available.',
+									{
+										args: { currentDomainName },
+									}
+							  )
+							: translate(
+									'Once you change your site address, %(currentDomainName)s will no longer be available. {{a}}Did you want to add a custom domain instead?{{/a}}',
+									{
+										components: {
+											args: { currentDomainName },
+											a: <a href={ addDomainPath } onClick={ this.handleAddDomainClick } />,
+										},
+									}
+							  ) }
 					</p>
 				</div>
 				<div className="site-address-changer__details">

--- a/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
@@ -163,6 +163,7 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 				/>
 				{ changeSiteAddressSourceDomain && (
 					<SiteAddressChanger
+						hasNonWpcomDomains={ hasNonWpcomDomains }
 						currentDomain={ changeSiteAddressSourceDomain }
 						currentDomainSuffix={ changeSiteAddressSourceDomain.name.match( /\.\w+\.\w+$/ )?.[ 0 ] }
 						isDialogVisible

--- a/client/my-sites/domains/domain-management/list/utils.js
+++ b/client/my-sites/domains/domain-management/list/utils.js
@@ -1,5 +1,6 @@
 import { type } from 'calypso/lib/domains/constants';
 
 export const filterOutWpcomDomains = ( domains ) => {
-	return domains.filter( ( domain ) => domain.type !== type.WPCOM );
+	// domain.type might be lowercase, but type.WPCOM is uppercase
+	return domains.filter( ( domain ) => domain.type.toUpperCase() !== type.WPCOM );
 };


### PR DESCRIPTION
… to add a custom domain or not

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/nomado-issues/issues/456
Context: p1698352549146719/1698339003.407839-slack-CKZHG0QCR

## Proposed Changes

When user already has a custom domain
![User already has a custom domain](https://github.com/Automattic/wp-calypso/assets/6586048/bb02c061-36e4-4ce5-98fd-e2742cf61982)

When user doesn't have a custom domain
![user doesn't have custom domain](https://github.com/Automattic/wp-calypso/assets/6586048/fdbb884d-763c-4f0c-8775-14e0b085c16a)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?