### PR TITLE
Trial site shows "upgrage" instead of "renew" banner in purchases screen

### DIFF
--- a/client/me/purchases/manage-purchase/notices.tsx
+++ b/client/me/purchases/manage-purchase/notices.tsx
@@ -9,6 +9,7 @@ import {
 	PLAN_BUSINESS,
 	PLAN_ECOMMERCE_TRIAL_MONTHLY,
 	PLAN_MIGRATION_TRIAL_MONTHLY,
+	PLAN_HOSTING_TRIAL_MONTHLY,
 	is100Year,
 } from '@automattic/calypso-products';
 import { localize } from 'i18n-calypso';
@@ -143,7 +144,6 @@ class PurchaseNotice extends Component<
 
 	/**
 	 * Returns appropriate warning text for a purchase that is expiring but where the expiration is not imminent.
-	 *
 	 * @param  {Object} purchase  The purchase object
 	 * @param  {Component} autoRenewingUpgradesLink  An optional link component, for linking to other purchases on the site that are auto-renewing rather than expiring
 	 * @returns  {string}  Translated text for the warning message.
@@ -307,7 +307,11 @@ class PurchaseNotice extends Component<
 	};
 
 	renderPurchaseExpiringNotice() {
-		const EXCLUDED_PRODUCTS = [ PLAN_ECOMMERCE_TRIAL_MONTHLY, PLAN_MIGRATION_TRIAL_MONTHLY ];
+		const EXCLUDED_PRODUCTS = [
+			PLAN_ECOMMERCE_TRIAL_MONTHLY,
+			PLAN_MIGRATION_TRIAL_MONTHLY,
+			PLAN_HOSTING_TRIAL_MONTHLY,
+		];
 		const {
 			moment,
 			purchase,
@@ -1115,7 +1119,8 @@ class PurchaseNotice extends Component<
 
 		if (
 			purchase.productSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY ||
-			purchase.productSlug === PLAN_MIGRATION_TRIAL_MONTHLY
+			purchase.productSlug === PLAN_MIGRATION_TRIAL_MONTHLY ||
+			purchase.productSlug === PLAN_HOSTING_TRIAL_MONTHLY
 		) {
 			return this.renderTrialNotice( purchase.productSlug );
 		}

--- a/client/my-sites/plans-grid/components/actions.tsx
+++ b/client/my-sites/plans-grid/components/actions.tsx
@@ -8,6 +8,7 @@ import {
 	planMatches,
 	TERM_ANNUALLY,
 	type PlanSlug,
+	PLAN_HOSTING_TRIAL_MONTHLY,
 } from '@automattic/calypso-products';
 import { Button, Gridicon } from '@automattic/components';
 import { formatCurrency } from '@automattic/format-currency';
@@ -276,7 +277,8 @@ const LoggedInPlansFeatureActionButton = ( {
 
 	const isTrialPlan =
 		currentSitePlanSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY ||
-		currentSitePlanSlug === PLAN_MIGRATION_TRIAL_MONTHLY;
+		currentSitePlanSlug === PLAN_MIGRATION_TRIAL_MONTHLY ||
+		currentSitePlanSlug === PLAN_HOSTING_TRIAL_MONTHLY;
 
 	// If the current plan is on a higher-term but lower-tier, then show a "Contact support" button.
 	if (

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -337,14 +337,14 @@ class Plans extends Component {
 		);
 	}
 
-	renderMainContent( { isEcommerceTrial, isBusinessTrial, isWooExpressPlan, isHostingTrial } ) {
+	renderMainContent( { isEcommerceTrial, isBusinessTrial, isWooExpressPlan } ) {
 		if ( isEcommerceTrial ) {
 			return this.renderEcommerceTrialPage();
 		}
 		if ( isWooExpressPlan ) {
 			return this.renderWooExpressPlansPage();
 		}
-		if ( isBusinessTrial || isHostingTrial ) {
+		if ( isBusinessTrial ) {
 			return this.renderBusinessTrialPage();
 		}
 
@@ -374,8 +374,9 @@ class Plans extends Component {
 
 		const currentPlanSlug = selectedSite?.plan?.product_slug;
 		const isEcommerceTrial = currentPlanSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY;
-		const isBusinessTrial = currentPlanSlug === PLAN_MIGRATION_TRIAL_MONTHLY;
-		const isHostingTrial = currentPlanSlug === PLAN_HOSTING_TRIAL_MONTHLY;
+		const isBusinessTrial =
+			currentPlanSlug === PLAN_MIGRATION_TRIAL_MONTHLY ||
+			currentPlanSlug === PLAN_HOSTING_TRIAL_MONTHLY;
 		const isWooExpressPlan = [
 			PLAN_WOOEXPRESS_MEDIUM,
 			PLAN_WOOEXPRESS_MEDIUM_MONTHLY,
@@ -456,7 +457,6 @@ class Plans extends Component {
 									isEcommerceTrial,
 									isBusinessTrial,
 									isWooExpressPlan,
-									isHostingTrial,
 								} ) }
 								<PerformanceTrackerStop />
 							</Main>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->



## Proposed Changes

Reported pdtkmj-1Um-p2#comment-3445

The site purchases page is showing a renew banner at the top. But the a trial plan can't be renewed, only upgraded.

![CleanShot 2023-10-27 at 16 52 30@2x](https://github.com/Automattic/wp-calypso/assets/1500769/e62263e6-ba1b-4423-aae2-d76a758b1640)

It's supposed to show an "upgrade" banner, like the Commerce and Migration trials do.

![CleanShot 2023-10-27 at 16 51 16@2x](https://github.com/Automattic/wp-calypso/assets/1500769/96f3d710-56af-4109-84c4-2ea8eeb17d0c)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

`/purchases/subscriptions/<site_slug>/<subscription_id>`
Or in the sidebar of a trial site click: **Upgrades > Purchases > WordPress.com Business Trial**

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?