### PR TITLE
Patterns: Re-register core patterns to push them down in the editor's inserter list

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -236,7 +236,7 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_wpcom_block_editor_nux' );
  * The reason is that Dotcom curate the pattern list based on their look.
  */
 function reorder_curated_core_patterns() {
-	$pattern_names = [ 'core/social-links-shared-background-color2' ];
+	$pattern_names = [ 'core/social-links-shared-background-color' ];
 	foreach ( $pattern_names as $pattern_name ) {
 		$pattern = \WP_Block_Patterns_Registry::get_instance()->get_registered( $pattern_name );
 		if ( $pattern ) {

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -232,6 +232,22 @@ function load_wpcom_block_editor_nux() {
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_wpcom_block_editor_nux' );
 
 /**
+ * Re-register some core patterns to push them down in the inserter list.
+ * The reason is that Dotcom curate the pattern list based on their look.
+ */
+function re_register_curated_core_patterns() {
+	$pattern_names = [ 'core/social-links-shared-background-color' ];
+	foreach ( $pattern_names as $pattern_name ) {
+		$pattern = \WP_Block_Patterns_Registry::get_instance()->get_registered( $pattern_name );
+		unregister_block_pattern( $pattern_name );	
+		register_block_pattern(
+			$pattern_name,
+			$pattern
+		);
+	}
+}
+
+/**
  * Return a function that loads and register block patterns from the API. This
  * function can be registered to the `rest_dispatch_request` filter.
  *
@@ -259,6 +275,8 @@ function register_patterns_on_api_request( $register_patterns_func ) {
 		};
 
 		$register_patterns_func();
+
+		re_register_curated_core_patterns();
 
 		return $response;
 	};

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -235,15 +235,17 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_wpcom_block_editor_nux' );
  * Re-register some core patterns to push them down in the inserter list.
  * The reason is that Dotcom curate the pattern list based on their look.
  */
-function re_register_curated_core_patterns() {
-	$pattern_names = [ 'core/social-links-shared-background-color' ];
+function reorder_curated_core_patterns() {
+	$pattern_names = [ 'core/social-links-shared-background-color2' ];
 	foreach ( $pattern_names as $pattern_name ) {
 		$pattern = \WP_Block_Patterns_Registry::get_instance()->get_registered( $pattern_name );
-		unregister_block_pattern( $pattern_name );	
-		register_block_pattern(
-			$pattern_name,
-			$pattern
-		);
+		if ( $pattern ) {
+			unregister_block_pattern( $pattern_name );	
+			register_block_pattern(
+				$pattern_name,
+				$pattern
+			);
+		}
 	}
 }
 
@@ -276,7 +278,7 @@ function register_patterns_on_api_request( $register_patterns_func ) {
 
 		$register_patterns_func();
 
-		re_register_curated_core_patterns();
+		reorder_curated_core_patterns();
 
 		return $response;
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #77130

## Proposed Changes

* Re-register the core pattern `core/social-links-shared-background-color` to push it down in the list.
* The function is ready for adding more pattern names easily

This PR allows curating the order of core patterns in the editor's inserter so Dotcom can move some patterns down in the list based on their look. 

|BEFORE|AFTER|
|--|--|
|<img width="651" alt="Screenshot 2566-10-27 at 11 53 17" src="https://github.com/Automattic/wp-calypso/assets/1881481/456b451e-cf7e-4cb5-bc05-6f2e76bfc0bd">|<video src="https://github.com/Automattic/wp-calypso/assets/1881481/07bbbc69-34e4-4485-a28e-6dd89c455178">|


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox the `public-api` and your site
* Run in your sandbox `install-plugin.sh editing-toolkit fix/push-a-core-pattern-down-in-the-list`
* Access the editor `{ SITE }/wp-admin/site-editor.php` or the post/page editor
* Verify the pattern "Social links shared background color" is not at the top of the list in the category "Call to action"
* Revert your sandbox `install-plugin.sh editing-toolkit --revert`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?