### PR TITLE
Add track events on the educational modal

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/live-preview-modal/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/live-preview-modal/index.tsx
@@ -61,7 +61,7 @@ export default function LivePreviewModal() {
 
 	const onClose = ( closedBy = 'close_icon' ) => {
 		setIsModalOpen( false );
-		recordTracksEvent( 'calypso_block_theme_live_preview_modal_close_click', {
+		recordTracksEvent( 'calypso_block_theme_live_preview_modal_close', {
 			theme: themeSlug,
 			closed_by: closedBy,
 		} );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/live-preview-modal/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/live-preview-modal/index.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Dialog } from '@automattic/components';
 import { Button, CheckboxControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -60,6 +61,9 @@ export default function LivePreviewModal() {
 
 	const onClose = () => {
 		setIsModalOpen( false );
+		recordTracksEvent( 'calypso_block_theme_live_preview_modal_close_click', {
+			theme: themeSlug,
+		} );
 	};
 
 	const onContinue = () => {
@@ -67,6 +71,10 @@ export default function LivePreviewModal() {
 			suppressModal();
 		}
 		onClose();
+		recordTracksEvent( 'calypso_block_theme_live_preview_modal_continue_click', {
+			do_not_show_again: shouldSuppressModal,
+			theme: themeSlug,
+		} );
 	};
 
 	return (

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/live-preview-modal/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/live-preview-modal/index.tsx
@@ -59,10 +59,11 @@ export default function LivePreviewModal() {
 	);
 	const themeName = theme?.name?.rendered || themeSlug;
 
-	const onClose = () => {
+	const onClose = ( closedBy = 'close_icon' ) => {
 		setIsModalOpen( false );
 		recordTracksEvent( 'calypso_block_theme_live_preview_modal_close_click', {
 			theme: themeSlug,
+			closed_by: closedBy,
 		} );
 	};
 
@@ -70,7 +71,7 @@ export default function LivePreviewModal() {
 		if ( shouldSuppressModal ) {
 			suppressModal();
 		}
-		onClose();
+		onClose( 'continue_button' );
 		recordTracksEvent( 'calypso_block_theme_live_preview_modal_continue_click', {
 			do_not_show_again: shouldSuppressModal,
 			theme: themeSlug,
@@ -84,7 +85,7 @@ export default function LivePreviewModal() {
 			isVisible={ isModalOpen }
 			isFullScreen
 		>
-			<Button className="live-preview-modal__close-icon" onClick={ onClose }>
+			<Button className="live-preview-modal__close-icon" onClick={ () => onClose() }>
 				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" height="24" width="24">
 					<path d="M18.36 19.78L12 13.41l-6.36 6.37-1.42-1.42L10.59 12 4.22 5.64l1.42-1.42L12 10.59l6.36-6.36 1.41 1.41L13.41 12l6.36 6.36z" />
 				</svg>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4373, https://github.com/Automattic/wp-calypso/pull/82666

## Proposed Changes

This PR adds track events on the educational modal, as suggested in https://github.com/Automattic/dotcom-forge/issues/4373. Slack convo: p1698385525916549/1698382752.950389-slack-CRWCHQGUB

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Patch this change to your sandbox: `install-plugin.sh editing-toolkit update/live-preview-modal-track-events`.
1. Sandbox YOUR SITE.
1. Go to Appearance -> Themes.
1. Choose a Free theme and click "Preview & Customize".
1. Verify that the modal is shown.
1. Click close button at the top-right corner. Verify the modal is closed, and the event is fired.
	<img width="752" alt="Screenshot 2023-10-27 at 15 41 06" src="https://github.com/Automattic/wp-calypso/assets/5287479/4425e3fe-c3d1-42cc-9173-0fafe478f870">
1. Click Continue button. Verify the modal is closed, and the event is fired with the prop `do_not_show_again: false`.
	<img width="749" alt="Screenshot 2023-10-27 at 15 40 26" src="https://github.com/Automattic/wp-calypso/assets/5287479/404d60f5-7fd4-4003-bc71-97a3ab902d85">
1. Tick "Do not show" checkbox then click Continue. Verify the modal is closed, and the event is fired with the prop `do_not_show_again: true`.
	<img width="755" alt="Screenshot 2023-10-27 at 15 39 13" src="https://github.com/Automattic/wp-calypso/assets/5287479/a9d98fad-797c-4acf-b857-e23d832eac63">

You can test it repeatedly by deleting the following `localStorage` without creating a site after clicking "Do not show again".

<img width="780" alt="Screenshot 2023-10-27 at 15 33 44" src="https://github.com/Automattic/wp-calypso/assets/5287479/95b7ad3e-a367-4193-81bb-4fe2a21241a0">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?