### PR TITLE
"Change site address" modal: add conditions to show custom domain copy followup

### DIFF
--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -1,5 +1,5 @@
 import { Dialog, FormInputValidation, Gridicon } from '@automattic/components';
-import i18n, { localize } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import { debounce, get, isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -391,10 +391,7 @@ export class SiteAddressChanger extends Component {
 				</FormSectionHeading>
 				<div className="site-address-changer__info">
 					<p>
-						{ hasNonWpcomDomains &&
-						i18n.hasTranslation(
-							'Once you change your site address, %(currentDomainName)s will no longer be available.'
-						)
+						{ hasNonWpcomDomains
 							? translate(
 									'Once you change your site address, %(currentDomainName)s will no longer be available.',
 									{
@@ -404,8 +401,8 @@ export class SiteAddressChanger extends Component {
 							: translate(
 									'Once you change your site address, %(currentDomainName)s will no longer be available. {{a}}Did you want to add a custom domain instead?{{/a}}',
 									{
+										args: { currentDomainName },
 										components: {
-											args: { currentDomainName },
 											a: <a href={ addDomainPath } onClick={ this.handleAddDomainClick } />,
 										},
 									}


### PR DESCRIPTION
Follow up for https://github.com/Automattic/wp-calypso/pull/83568

## Proposed Changes

* Check information over at https://github.com/Automattic/wp-calypso/pull/83568
I forgot to push the latest changes and merged it.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?