### PR TITLE
Assembler: Support grid layout for large preview 

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -39,7 +39,7 @@ import {
 } from './hooks';
 import withNotices, { NoticesProps } from './notices/notices';
 import PatternAssemblerContainer from './pattern-assembler-container';
-import PatternLargePreview from './pattern-large-preview';
+import PatternPreviewsContainer from './pattern-previews-container';
 import ScreenActivation from './screen-activation';
 import ScreenColorPalettes from './screen-color-palettes';
 import ScreenConfirmation from './screen-confirmation';
@@ -632,7 +632,7 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 					/>
 				</NavigatorScreen>
 			</div>
-			<PatternLargePreview
+			<PatternPreviewsContainer
 				header={ header }
 				sections={ sections }
 				footer={ footer }
@@ -645,6 +645,7 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 				onShuffle={ onShuffle }
 				recordTracksEvent={ recordTracksEvent }
 				isNewSite={ isNewSite }
+				isGridLayout={ navigator.location.path === NAVIGATOR_PATHS.PAGES }
 			/>
 		</div>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -644,8 +644,8 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 				onDeleteFooter={ onDeleteFooter }
 				onShuffle={ onShuffle }
 				recordTracksEvent={ recordTracksEvent }
-				isNewSite={ isNewSite }
 				isGridLayout={ navigator.location.path === NAVIGATOR_PATHS.PAGES }
+				isNewSite={ isNewSite }
 			/>
 		</div>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -24,6 +24,7 @@ interface Props {
 	onDeleteFooter: () => void;
 	onShuffle: ( type: string, pattern: Pattern, position?: number ) => void;
 	recordTracksEvent: ( name: string, eventProperties?: any ) => void;
+	isDisableActionBar: boolean;
 	isNewSite: boolean;
 }
 
@@ -44,6 +45,7 @@ const PatternLargePreview = ( {
 	onDeleteFooter,
 	onShuffle,
 	recordTracksEvent,
+	isDisableActionBar,
 	isNewSite,
 }: Props ) => {
 	const translate = useTranslate();
@@ -143,7 +145,7 @@ const PatternLargePreview = ( {
 						shouldShufflePosts={ isNewSite }
 					/>
 				) }
-				{ isActive && (
+				{ ! isDisableActionBar && isActive && (
 					<Popover
 						animate={ false }
 						focusOnMount={ false }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-previews-container.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-previews-container.scss
@@ -1,0 +1,62 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+@import "@automattic/typography/styles/variables";
+
+$font-family: "SF Pro Text", $sans;
+$row-height: 400;
+$viewport-desktop-width: 1080;
+
+.pattern-assembler__previews {
+	display: grid;
+	flex: 1;
+
+	&--grid {
+		grid-auto-rows: minmax(0, $row-height * 1px);
+		grid-template-columns: repeat(3, 1fr);
+		gap: 36px 48px;
+		padding: 100px 12px;
+
+		.pattern-large-preview {
+			height: 100%;
+			margin-inline-end: 0;
+			margin-inline-start: 0;
+			padding: 0;
+			transition: none;
+
+			.device-switcher__header {
+				display: none;
+			}
+
+			.device-switcher__viewport {
+				> div {
+					height: 100% !important;
+					transform: none !important;
+				}
+			}
+
+			.device-switcher__frame {
+				$scale: calc(var(--viewport-container-width) / $viewport-desktop-width);
+
+				height: calc($row-height * 1px / $scale);
+				max-height: none;
+				max-width: none;
+				transform: scale($scale) !important;
+				width: $viewport-desktop-width * 1px;
+			}
+
+			.pattern-large-preview__pattern {
+				pointer-events: none;
+			}
+		}
+	}
+
+	.pattern-assembler__preview-title {
+		color: var(--studio-gray-100);
+		font-family: $font-family;
+		font-size: $font-body-large;
+		line-height: 26px;
+		margin-inline-end: 10px;
+		margin-inline-start: 10px;
+		margin-top: 16px;
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-previews-container.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-previews-container.tsx
@@ -1,6 +1,7 @@
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import PatternLargePreview from './pattern-large-preview';
+import type { Pattern } from './types';
 import './pattern-previews-container.scss';
 
 type PatternPreviewsContainerProps = {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-previews-container.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-previews-container.tsx
@@ -1,0 +1,53 @@
+import classnames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import PatternLargePreview from './pattern-large-preview';
+import './pattern-previews-container.scss';
+
+const PatternPreviewsContainer = ( {
+	header,
+	sections,
+	footer,
+	activePosition,
+	onDeleteSection,
+	onMoveUpSection,
+	onMoveDownSection,
+	onDeleteHeader,
+	onDeleteFooter,
+	onShuffle,
+	recordTracksEvent,
+	isNewSite,
+	isGridLayout,
+} ) => {
+	const translate = useTranslate();
+
+	return (
+		<div
+			className={ classnames( 'pattern-assembler__previews', {
+				'pattern-assembler__previews--grid': isGridLayout,
+			} ) }
+		>
+			<div className="pattern-assembler__preview">
+				<PatternLargePreview
+					header={ header }
+					sections={ sections }
+					footer={ footer }
+					activePosition={ activePosition }
+					onDeleteSection={ onDeleteSection }
+					onMoveUpSection={ onMoveUpSection }
+					onMoveDownSection={ onMoveDownSection }
+					onDeleteHeader={ onDeleteHeader }
+					onDeleteFooter={ onDeleteFooter }
+					onShuffle={ onShuffle }
+					recordTracksEvent={ recordTracksEvent }
+					isDisableActionBar={ isGridLayout }
+					isNewSite={ isNewSite }
+				/>
+				{ isGridLayout && (
+					<div className="pattern-assembler__preview-title">{ translate( 'Homepage' ) }</div>
+				) }
+			</div>
+		</div>
+	);
+};
+
+export default PatternPreviewsContainer;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-previews-container.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-previews-container.tsx
@@ -3,6 +3,22 @@ import { useTranslate } from 'i18n-calypso';
 import PatternLargePreview from './pattern-large-preview';
 import './pattern-previews-container.scss';
 
+type PatternPreviewsContainerProps = {
+	header: Pattern | null;
+	sections: Pattern[];
+	footer: Pattern | null;
+	activePosition: number;
+	onDeleteSection: ( position: number ) => void;
+	onMoveUpSection: ( position: number ) => void;
+	onMoveDownSection: ( position: number ) => void;
+	onDeleteHeader: () => void;
+	onDeleteFooter: () => void;
+	onShuffle: ( type: string, pattern: Pattern, position?: number ) => void;
+	recordTracksEvent: ( name: string, eventProperties?: any ) => void;
+	isGridLayout: boolean;
+	isNewSite: boolean;
+};
+
 const PatternPreviewsContainer = ( {
 	header,
 	sections,
@@ -15,9 +31,9 @@ const PatternPreviewsContainer = ( {
 	onDeleteFooter,
 	onShuffle,
 	recordTracksEvent,
-	isNewSite,
 	isGridLayout,
-} ) => {
+	isNewSite,
+}: PatternPreviewsContainerProps ) => {
 	const translate = useTranslate();
 
 	return (

--- a/packages/components/src/device-switcher/fixed-viewport.tsx
+++ b/packages/components/src/device-switcher/fixed-viewport.tsx
@@ -43,6 +43,7 @@ const FixedViewport = ( { children, frameRef, device }: Props ) => {
 			className="device-switcher__viewport"
 			style={
 				{
+					'--viewport-container-width': viewportWidth,
 					'--viewport-width': deviceWidthById[ device ],
 					'--viewport-scale': viewportScale,
 				} as CSSProperties


### PR DESCRIPTION
Related to #83450

## Proposed Changes

This PR updates the Assembler to support multiple previews. This is in preparation for the Add Pages screen, where we will display multiple page previews. See screenshot below for reference, or Tv3pYqA3EcRfiXC31IxrXE-fi-2390%3A25403.

![Screenshot 2023-10-27 at 3 19 00 PM](https://github.com/Automattic/wp-calypso/assets/797888/ec2b92c8-e7f6-4c8e-8721-68cf4af1f54e)

Or a screenshot of this PR:
![Screenshot 2023-10-27 at 3 17 04 PM](https://github.com/Automattic/wp-calypso/assets/797888/d1bf35a7-b647-445b-ab30-0e3c258ac63a)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Notes about this PR:
* Adding other pages to the preview grid will be address in a later PR.
* The approach of this PR is primarily to use CSS as much as possible, this is to avoid:
  * Re-rendering the Homepage preview when users enter/exit the Add pages screen.
  * Keep the device/zoom of the large preview when users exist the Add pages screen. 

Testing steps:
* Head to the Assembler with the flag &flags=pattern-assembler/add-pages.
* Go through the Patterns, and Styles screen until you arrive at the Pages screen.
* Ensure that the sidebar interaction works as shown above.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?