### PR TITLE
Update NavigationHeader for reader sections

### DIFF
--- a/client/reader/conversations/stream.js
+++ b/client/reader/conversations/stream.js
@@ -2,7 +2,7 @@ import { useTranslate } from 'i18n-calypso';
 import { get } from 'lodash';
 import ConversationsEmptyContent from 'calypso/blocks/conversations/empty';
 import DocumentHead from 'calypso/components/data/document-head';
-import FormattedHeader from 'calypso/components/formatted-header';
+import NavigationHeader from 'calypso/components/navigation-header';
 import Stream from 'calypso/reader/stream';
 import ConversationsIntro from './intro';
 import './stream.scss';
@@ -28,13 +28,10 @@ export default function ( props ) {
 
 	return (
 		<>
-			<FormattedHeader
-				brandFont
-				headerText={ translate( 'Conversations' ) }
-				subHeaderText={ translate( 'Monitor all of your ongoing discussions.' ) }
-				align="left"
-				hasScreenOptions
-				className="conversations-stream-header"
+			<NavigationHeader
+				navigationItems={ [] }
+				title={ translate( 'Conversations' ) }
+				subtitle={ translate( 'Monitor all of your ongoing discussions.' ) }
 			/>
 			<Stream
 				key="conversations"

--- a/client/reader/conversations/stream.scss
+++ b/client/reader/conversations/stream.scss
@@ -1,5 +1,4 @@
-.formatted-header.is-left-align.conversations-stream-header,
-.formatted-header.is-left-align.has-screen-options.conversations-stream-header {
+.is-section-reader .navigation-header {
 	margin: 0 auto;
 	max-width: 600px;
 	@media only screen and (max-width: 660px) {

--- a/client/reader/discover/discover-navigation.scss
+++ b/client/reader/discover/discover-navigation.scss
@@ -1,4 +1,4 @@
-.formatted-header.is-left-align.discover-stream-header {
+.is-section-reader .navigation-header.discover-stream-header {
 	margin: 0 auto;
 	max-width: 600px;
 	&.reader-dual-column {

--- a/client/reader/discover/discover-stream.js
+++ b/client/reader/discover/discover-stream.js
@@ -2,7 +2,7 @@ import { useLocale } from '@automattic/i18n-utils';
 import { useQuery } from '@tanstack/react-query';
 import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
-import FormattedHeader from 'calypso/components/formatted-header';
+import NavigationHeader from 'calypso/components/navigation-header';
 import withDimensions from 'calypso/lib/with-dimensions';
 import wpcom from 'calypso/lib/wp';
 import { READER_DISCOVER_POPULAR_SITES } from 'calypso/reader/follow-sources';
@@ -69,12 +69,10 @@ const DiscoverStream = ( props ) => {
 	}
 
 	const DiscoverHeader = () => (
-		<FormattedHeader
-			brandFont
-			headerText={ translate( 'Discover' ) }
-			subHeaderText={ subHeaderText }
-			align="left"
-			hasScreenOptions
+		<NavigationHeader
+			navigationItems={ [] }
+			title={ translate( 'Discover' ) }
+			subtitle={ subHeaderText }
 			className={ classNames( 'discover-stream-header', {
 				'reader-dual-column': props.width > WIDE_DISPLAY_CUTOFF,
 			} ) }

--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -1,7 +1,7 @@
-import { __ } from '@wordpress/i18n';
 import classNames from 'classnames';
+import { translate } from 'i18n-calypso';
 import AsyncLoad from 'calypso/components/async-load';
-import FormattedHeader from 'calypso/components/formatted-header';
+import NavigationHeader from 'calypso/components/navigation-header';
 import withDimensions from 'calypso/lib/with-dimensions';
 import SuggestionProvider from 'calypso/reader/search-stream/suggestion-provider';
 import Stream, { WIDE_DISPLAY_CUTOFF } from 'calypso/reader/stream';
@@ -13,12 +13,10 @@ function FollowingStream( { ...props } ) {
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
 		<>
-			<FormattedHeader
-				brandFont
-				headerText={ __( 'Recent' ) }
-				subHeaderText={ __( "Stay current with the blogs you've subscribed to." ) }
-				align="left"
-				hasScreenOptions
+			<NavigationHeader
+				navigationItems={ [] }
+				title={ translate( 'Recent' ) }
+				subtitle={ translate( "Stay current with the blogs you've subscribed to." ) }
 				className={ classNames( 'following-stream-header', {
 					'reader-dual-column': props.width > WIDE_DISPLAY_CUTOFF,
 				} ) }

--- a/client/reader/following/style.scss
+++ b/client/reader/following/style.scss
@@ -1,5 +1,4 @@
-.formatted-header.is-left-align.has-screen-options.following-stream-header,
-.formatted-header.is-left-align.following-stream-header {
+.is-section-reader .navigation-header.following-stream-header {
 	margin: 0 auto;
 	max-width: 600px;
 	&.reader-dual-column {

--- a/client/reader/liked-stream/main.jsx
+++ b/client/reader/liked-stream/main.jsx
@@ -1,8 +1,7 @@
-import { __ } from '@wordpress/i18n';
 import { translate } from 'i18n-calypso';
 import { Component } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
-import FormattedHeader from 'calypso/components/formatted-header';
+import NavigationHeader from 'calypso/components/navigation-header';
 import Stream from 'calypso/reader/stream';
 import EmptyContent from './empty';
 import './style.scss';
@@ -19,13 +18,11 @@ class LikedStream extends Component {
 	render() {
 		return (
 			<>
-				<FormattedHeader
-					brandFont
-					headerText={ __( 'Likes' ) }
-					subHeaderText={ __( 'Rediscover content that you liked.' ) }
-					align="left"
-					hasScreenOptions
-					className="liked-stream-header"
+				<NavigationHeader
+					navigationItems={ [] }
+					title={ translate( 'Likes' ) }
+					subtitle={ translate( 'Rediscover content that you liked.' ) }
+					className="following-stream-header"
 				/>
 				<Stream
 					{ ...this.props }

--- a/client/reader/liked-stream/style.scss
+++ b/client/reader/liked-stream/style.scss
@@ -1,5 +1,4 @@
-.formatted-header.is-left-align.liked-stream-header,
-.formatted-header.is-left-align.has-screen-options.liked-stream-header {
+.navigation-header.liked-stream-header {
 	margin: 0 auto -20px;
 	max-width: 600px;
 	@media only screen and (max-width: 660px) {

--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -15,7 +15,7 @@
 .is-reader-page .following.main,
 .is-reader-page .tag-stream__main.main,
 .is-reader-page .search-stream__with-sites.main {
-	margin: 30px auto;
+	margin: 0 auto;
 	@include breakpoint-deprecated( "<660px" ) {
 		margin: 30px;
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4352

## Proposed Changes

- https://wordpress.com/read
- https://wordpress.com/discover
- https://wordpress.com/activities/likes
- https://wordpress.com/read/conversations

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test the above routes
* Check mobile/desktop screen sizes

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?