### PR TITLE
Headers: Update stats emails & posts header

### DIFF
--- a/client/my-sites/stats/post-detail-highlights-section/index.tsx
+++ b/client/my-sites/stats/post-detail-highlights-section/index.tsx
@@ -70,40 +70,43 @@ export default function PostDetailHighlightsSection( {
 		postId > 0 && isWPcomSite && post?.date && new Date( post?.date ) >= new Date( '2023-05-30' );
 
 	return (
-		<div className="stats__post-detail-highlights-section">
-			{ siteId && (
-				<>
-					<QuerySiteStats siteId={ siteId } statType="stats" query={ {} } />
-					<QuerySiteStats siteId={ siteId } statType="statsInsights" />
-				</>
-			) }
-
-			<div className="highlight-cards">
-				<h1 className="highlight-cards-heading">{ translate( 'Highlights' ) }</h1>
-
-				{ isEmailTabsAvailable && (
+		<>
+			{ isEmailTabsAvailable && (
+				<div className="stats-navigation stats-navigation--modernized">
 					<StatsDetailsNavigation postId={ postId } givenSiteId={ siteId } />
+				</div>
+			) }
+			<div className="stats__post-detail-highlights-section">
+				{ siteId && (
+					<>
+						<QuerySiteStats siteId={ siteId } statType="stats" query={ {} } />
+						<QuerySiteStats siteId={ siteId } statType="statsInsights" />
+					</>
 				) }
 
-				<div className="highlight-cards-list">
-					<PostStatsCard
-						heading={ translate( 'All-time stats' ) }
-						likeCount={ post?.like_count || 0 }
-						post={ postData }
-						viewCount={ viewCount }
-						commentCount={ post?.comment_count || 0 }
-						locale={ userLocale }
-					/>
+				<div className="highlight-cards">
+					<h1 className="highlight-cards-heading">{ translate( 'Highlights' ) }</h1>
 
-					<Card className="highlight-card">
-						<div className="highlight-card-heading">
-							<span>{ translate( 'Post likes' ) }</span>
-							<Count count={ post?.like_count || 0 } />
-						</div>
-						<PostLikes siteId={ siteId } postId={ postId } postType={ post?.type } />
-					</Card>
+					<div className="highlight-cards-list">
+						<PostStatsCard
+							heading={ translate( 'All-time stats' ) }
+							likeCount={ post?.like_count || 0 }
+							post={ postData }
+							viewCount={ viewCount }
+							commentCount={ post?.comment_count || 0 }
+							locale={ userLocale }
+						/>
+
+						<Card className="highlight-card">
+							<div className="highlight-card-heading">
+								<span>{ translate( 'Post likes' ) }</span>
+								<Count count={ post?.like_count || 0 } />
+							</div>
+							<PostLikes siteId={ siteId } postId={ postId } postType={ post?.type } />
+						</Card>
+					</div>
 				</div>
 			</div>
-		</div>
+		</>
 	);
 }

--- a/client/my-sites/stats/post-detail-highlights-section/style.scss
+++ b/client/my-sites/stats/post-detail-highlights-section/style.scss
@@ -5,13 +5,14 @@
 
 .stats__post-detail-highlights-section {
 	@include break-small {
-		padding-top: $vertical-margin;
+		// padding-bottom: $vertical-margin;
 	}
+	padding-top: $vertical-margin;
 
 	padding-bottom: $vertical-margin;
 
 	.stats > & {
-		@media ( max-width: $break-medium ) {
+		@media ( max-width: $break-small ) {
 			padding-left: 0;
 			padding-right: 0;
 		}
@@ -22,12 +23,6 @@
 		box-shadow: none;
 	}
 
-	.highlight-cards-heading {
-		@media ( max-width: $break-medium ) {
-			margin-left: 0.875rem;
-			margin-right: 0.875rem;
-		}
-	}
 
 	.section-nav {
 		box-shadow: inset 0 -1px 0 #0000000d;

--- a/client/my-sites/stats/stats-email-detail/index.jsx
+++ b/client/my-sites/stats/stats-email-detail/index.jsx
@@ -230,15 +230,16 @@ class StatsEmailDetail extends Component {
 					) }
 					{ post ? (
 						<>
-							<div className="main-container">
-								<h1>{ this.getTitle( statType ) }</h1>
-
+							<div className="stats-navigation stats-navigation--modernized">
 								<StatsDetailsNavigation
 									postId={ postId }
 									period={ period }
 									statType={ statType }
 									givenSiteId={ givenSiteId }
 								/>
+							</div>
+							<div class="stats__email-wrapper">
+								<h3 className="highlight-cards-heading">{ this.getTitle( statType ) }</h3>
 
 								<StatsEmailTopRow siteId={ siteId } postId={ postId } statType={ statType } />
 
@@ -288,44 +289,44 @@ class StatsEmailDetail extends Component {
 								/>
 
 								{ ! isSitePrivate && <StatsNoContentBanner siteId={ siteId } siteSlug={ slug } /> }
-							</div>
-							<div className="stats__module-list">
-								<StatsEmailModule
-									path="countries"
-									statType={ statType }
-									postId={ postId }
-									siteId={ siteId }
-									period={ PERIOD_ALL_TIME }
-									date={ queryDate }
-								/>
-
-								<StatsEmailModule
-									path="devices"
-									statType={ statType }
-									postId={ postId }
-									siteId={ siteId }
-									period={ PERIOD_ALL_TIME }
-									date={ queryDate }
-								/>
-
-								<StatsEmailModule
-									path="clients"
-									statType={ statType }
-									postId={ postId }
-									siteId={ siteId }
-									period={ PERIOD_ALL_TIME }
-									date={ queryDate }
-								/>
-								{ statType === 'clicks' && (
+								<div className="stats__module-list">
 									<StatsEmailModule
-										path="links"
+										path="countries"
 										statType={ statType }
 										postId={ postId }
 										siteId={ siteId }
 										period={ PERIOD_ALL_TIME }
 										date={ queryDate }
 									/>
-								) }
+
+									<StatsEmailModule
+										path="devices"
+										statType={ statType }
+										postId={ postId }
+										siteId={ siteId }
+										period={ PERIOD_ALL_TIME }
+										date={ queryDate }
+									/>
+
+									<StatsEmailModule
+										path="clients"
+										statType={ statType }
+										postId={ postId }
+										siteId={ siteId }
+										period={ PERIOD_ALL_TIME }
+										date={ queryDate }
+									/>
+									{ statType === 'clicks' && (
+										<StatsEmailModule
+											path="links"
+											statType={ statType }
+											postId={ postId }
+											siteId={ siteId }
+											period={ PERIOD_ALL_TIME }
+											date={ queryDate }
+										/>
+									) }
+								</div>
 							</div>
 						</>
 					) : (

--- a/client/my-sites/stats/stats-email-detail/style.scss
+++ b/client/my-sites/stats/stats-email-detail/style.scss
@@ -6,7 +6,7 @@ $break-large-stats-countries: 1280px;
 // Countries
 .stats__email-detail {
 	&.main {
-		max-width: $stats-sections-max-width;
+		max-width: none;
 	}
 
 	.no-data {
@@ -31,6 +31,10 @@ $break-large-stats-countries: 1280px;
 			margin-left: 0.875rem;
 			margin-right: 0.875rem;
 		}
+	}
+	.stats__email-wrapper {
+		padding-top: 32px;
+		padding-bottom: 32px;
 	}
 
 	.stats__module-list {

--- a/client/my-sites/stats/stats-email-top-row/style.scss
+++ b/client/my-sites/stats/stats-email-top-row/style.scss
@@ -14,7 +14,7 @@ $vertical-margin: 32px;
 .stats__email-detail {
 	@include break-small {
 		.main-container {
-			padding-top: $vertical-margin;
+			padding: 0;
 		}
 	}
 }


### PR DESCRIPTION
Slack: p1698394729293219/1698319241.541159-slack-C9EJ7KSGH

## Proposed Changes

We updated stats emails & posts header:
- We move the Tab title after the tabs
- Fixed cut off at the sides of the pages
- Update Tabs styles to match /stats

| Before | After |
| --- | --- |
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/5a166679-6a5e-4ee1-94f7-2752c1c3739a) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/2daa0864-6985-4925-b7d9-df52d538f132) |
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/70081777-c987-4cdd-87b7-01b5d87a3a1c) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/acd9f541-d032-45b5-8ae5-d2c8263e4741) |
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/3061421f-888f-40dc-ba4e-45e6b98378cd) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/8f5ad8ab-5324-424b-8ba6-8bd37dc73d97) |

## Testing Instructions

* Go to `/stats`
* Choose a post or email from the list
* Test all tabs in desktop and mobile
* Check if nothing is broken 😉 
