### PR TITLE
Assembler: Populate Add Pages screen sidebar with real data

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
@@ -72,4 +72,6 @@ export const ORDERED_PATTERN_CATEGORIES = [
 
 export const INITIAL_CATEGORY = ORDERED_PATTERN_CATEGORIES[ 0 ];
 
-export const ORDERED_PAGES = [ 'about', 'contact', 'portfolio', 'services', 'blog' ];
+export const PAGES_CATEGORIES = [ 'about', 'contact', 'portfolio', 'posts', 'services' ];
+
+export const ORDERED_PAGES_CATEGORIES = [ 'about', 'contact', 'portfolio', 'services', 'posts' ];

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/index.ts
@@ -5,6 +5,8 @@ export { default as useDotcomPatterns } from './use-dotcom-patterns';
 export { default as useGlobalStylesUpgradeProps } from './use-global-styles-upgrade-props';
 export { default as useInitialPath } from './use-initial-path';
 export { default as usePages } from './use-pages';
+export { default as usePagesMapByCategory } from './use-pages-map-by-category';
+export { default as usePagesOrder } from './use-pages-order';
 export { default as usePatternCategories } from './use-pattern-categories';
 export { default as usePatternCountMapByCategory } from './use-pattern-count-map-by-category';
 export { default as usePatternsMapByCategory } from './use-patterns-map-by-category';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pages-map-by-category.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pages-map-by-category.ts
@@ -1,0 +1,29 @@
+import { useMemo } from 'react';
+import { PAGES_CATEGORIES } from '../constants';
+import { isPriorityPattern, isPagePattern } from '../utils';
+import type { Pattern } from '../types';
+
+const usePagesMapByCategory = ( patterns: Pattern[] ) => {
+	return useMemo( () => {
+		const categoriesMap: Record< string, Pattern[] > = {};
+
+		patterns.reverse().forEach( ( pattern ) => {
+			Object.keys( pattern.categories ).forEach( ( category ) => {
+				if ( ! PAGES_CATEGORIES.includes( category ) || ! isPagePattern( pattern ) ) {
+					return;
+				}
+				if ( ! categoriesMap[ category ] ) {
+					categoriesMap[ category ] = [];
+				}
+				if ( isPriorityPattern( pattern ) ) {
+					categoriesMap[ category ].unshift( pattern );
+				} else {
+					categoriesMap[ category ].push( pattern );
+				}
+			} );
+		} );
+		return categoriesMap;
+	}, [ patterns ] );
+};
+
+export default usePagesMapByCategory;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pages-order.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pages-order.ts
@@ -1,0 +1,28 @@
+import { useMemo } from 'react';
+import { ORDERED_PAGES_CATEGORIES } from '../constants';
+import type { Category } from '../types';
+
+const usePagesOrder = ( categories: Category[] ) => {
+	return useMemo(
+		() =>
+			categories.sort( ( { name: aName }, { name: bName } ) => {
+				if ( aName && bName ) {
+					// Sort categories according to `ORDERED_PAGES_CATEGORIES`.
+					let aIndex = ORDERED_PAGES_CATEGORIES.indexOf( aName );
+					let bIndex = ORDERED_PAGES_CATEGORIES.indexOf( bName );
+					// All other categories should come after that.
+					if ( aIndex < 0 ) {
+						aIndex = ORDERED_PAGES_CATEGORIES.length;
+					}
+					if ( bIndex < 0 ) {
+						bIndex = ORDERED_PAGES_CATEGORIES.length;
+					}
+					return aIndex - bIndex;
+				}
+				return 0;
+			} ),
+		[ categories ]
+	);
+};
+
+export default usePagesOrder;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -31,6 +31,7 @@ import {
 	useGlobalStylesUpgradeProps,
 	useInitialPath,
 	usePages,
+	usePagesMapByCategory,
 	usePatternCategories,
 	usePatternsMapByCategory,
 	useRecipe,
@@ -99,6 +100,7 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 		[ dotcomPatterns ]
 	);
 	const patternsMapByCategory = usePatternsMapByCategory( dotcomPatterns );
+	const pagesMapByCategory = usePagesMapByCategory( dotcomPatterns );
 	const {
 		header,
 		footer,
@@ -566,6 +568,8 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 
 				<NavigatorScreen path={ NAVIGATOR_PATHS.PAGES } partialMatch>
 					<ScreenPages
+						categories={ categories }
+						pagesMapByCategory={ pagesMapByCategory }
 						selectedPages={ pages }
 						onSelect={ onScreenPagesSelect }
 						onContinueClick={ onContinue }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/page-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/page-list.tsx
@@ -9,7 +9,8 @@ import {
 } from '@wordpress/components';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { ORDERED_PAGES } from './constants';
+import { usePagesOrder } from './hooks';
+import type { Pattern } from './types';
 import './page-list.scss';
 
 interface PageListItemProps {
@@ -38,12 +39,20 @@ const PageListItem = ( { label, isSelected, isDisabled }: PageListItemProps ) =>
 };
 
 interface PageListProps {
+	categories: Category[];
+	pagesMapByCategory: Record< string, Pattern[] >;
 	selectedPages: string[];
 	onSelectPage: ( selectedPage: string ) => void;
 }
 
-const PageList = ( { selectedPages, onSelectPage }: PageListProps ) => {
+const PageList = ( {
+	categories,
+	pagesMapByCategory,
+	selectedPages,
+	onSelectPage,
+}: PageListProps ) => {
 	const translate = useTranslate();
+	const categoriesInOrder = usePagesOrder( categories );
 	const composite = useCompositeState( { orientation: 'vertical' } );
 
 	return (
@@ -64,18 +73,24 @@ const PageList = ( { selectedPages, onSelectPage }: PageListProps ) => {
 				>
 					<PageListItem label={ translate( 'Homepage' ) } isDisabled />
 				</CompositeItem>
-				{ ORDERED_PAGES.map( ( page ) => {
-					const isSelected = selectedPages.includes( page );
+				{ categoriesInOrder.map( ( { name, label } ) => {
+					const isSelected = selectedPages.includes( name );
+					const hasPages = name && pagesMapByCategory[ name ]?.length;
+
+					if ( ! hasPages ) {
+						return null;
+					}
+
 					return (
 						<CompositeItem
 							{ ...composite }
-							key={ page }
+							key={ name }
 							role="checkbox"
 							as="button"
 							aria-checked={ isSelected }
-							onClick={ () => onSelectPage( page ) }
+							onClick={ () => onSelectPage( name ) }
 						>
-							<PageListItem label={ page } isSelected={ isSelected } />
+							<PageListItem label={ label } isSelected={ isSelected } />
 						</CompositeItem>
 					);
 				} ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/page-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/page-list.tsx
@@ -10,11 +10,11 @@ import {
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { usePagesOrder } from './hooks';
-import type { Pattern } from './types';
+import type { Category, Pattern } from './types';
 import './page-list.scss';
 
 interface PageListItemProps {
-	label: string;
+	label?: string;
 	isSelected?: boolean;
 	isDisabled?: boolean;
 }
@@ -74,7 +74,7 @@ const PageList = ( {
 					<PageListItem label={ translate( 'Homepage' ) } isDisabled />
 				</CompositeItem>
 				{ categoriesInOrder.map( ( { name, label } ) => {
-					const isSelected = selectedPages.includes( name );
+					const isSelected = name && selectedPages.includes( name );
 					const hasPages = name && pagesMapByCategory[ name ]?.length;
 
 					if ( ! hasPages ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/page-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/page-list.tsx
@@ -74,7 +74,7 @@ const PageList = ( {
 					<PageListItem label={ translate( 'Homepage' ) } isDisabled />
 				</CompositeItem>
 				{ categoriesInOrder.map( ( { name, label } ) => {
-					const isSelected = name && selectedPages.includes( name );
+					const isSelected = name ? selectedPages.includes( name ) : false;
 					const hasPages = name && pagesMapByCategory[ name ]?.length;
 
 					if ( ! hasPages ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-pages.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-pages.tsx
@@ -5,15 +5,25 @@ import { PATTERN_ASSEMBLER_EVENTS } from './events';
 import { useScreen } from './hooks';
 import NavigatorTitle from './navigator-title';
 import PageList from './page-list';
+import type { Category, Pattern } from '../types';
 
 interface Props {
+	categories: Category[];
+	pagesMapByCategory: Record< string, Pattern[] >;
 	selectedPages: string[];
 	onSelect: ( page: string ) => void;
 	onContinueClick: () => void;
 	recordTracksEvent: ( name: string, eventProperties?: any ) => void;
 }
 
-const ScreenPages = ( { selectedPages, onSelect, onContinueClick, recordTracksEvent }: Props ) => {
+const ScreenPages = ( {
+	categories,
+	pagesMapByCategory,
+	selectedPages,
+	onSelect,
+	onContinueClick,
+	recordTracksEvent,
+}: Props ) => {
 	const [ disabled, setDisabled ] = useState( true );
 	const { title, description, continueLabel } = useScreen( 'pages' );
 
@@ -48,7 +58,12 @@ const ScreenPages = ( { selectedPages, onSelect, onContinueClick, recordTracksEv
 			/>
 			<div className="screen-container__body">
 				<VStack spacing="4">
-					<PageList selectedPages={ selectedPages } onSelectPage={ onSelect } />
+					<PageList
+						categories={ categories }
+						pagesMapByCategory={ pagesMapByCategory }
+						selectedPages={ selectedPages }
+						onSelectPage={ onSelect }
+					/>
 				</VStack>
 			</div>
 			<div className="screen-container__footer">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-pages.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-pages.tsx
@@ -5,7 +5,7 @@ import { PATTERN_ASSEMBLER_EVENTS } from './events';
 import { useScreen } from './hooks';
 import NavigatorTitle from './navigator-title';
 import PageList from './page-list';
-import type { Category, Pattern } from '../types';
+import type { Category, Pattern } from './types';
 
 interface Props {
 	categories: Category[];


### PR DESCRIPTION
Related to #83450

## Proposed Changes

This PR replaces the placeholder data in the Add Pages screen's sidebar with actual data from the wpcom endpoint.

| Before | After |
| --- | --- |
|  ![Screenshot 2023-10-27 at 6 19 08 PM](https://github.com/Automattic/wp-calypso/assets/797888/b16abc33-ce60-42b2-aa22-ff5df96a7f91) | ![Screenshot 2023-10-27 at 6 19 15 PM](https://github.com/Automattic/wp-calypso/assets/797888/15093ffe-be66-476b-b39f-93a6bcf04112) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Assembler with the flag `&flags=pattern-assembler/add-pages`.
* Go through the Patterns, and Styles screen until you arrive at the Pages screen.
* Ensure that the pages in the sidebar has the order: "Homepage", "About", "Contact", "Portfolio", "Services", "Blog Posts".
* Ensure that the sidebar interaction works as before.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?