### PR TITLE
Update sidebar to use Join Conversation dialog

### DIFF
--- a/client/blocks/follow-button/index.jsx
+++ b/client/blocks/follow-button/index.jsx
@@ -1,13 +1,11 @@
-import { getUrlParts } from '@automattic/calypso-url';
 import { omitBy } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import { navigate } from 'calypso/lib/navigate';
-import { createAccountUrl } from 'calypso/lib/paths';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { follow, unfollow } from 'calypso/state/reader/follows/actions';
 import { isFollowing } from 'calypso/state/reader/follows/selectors';
+import { registerLastActionRequiresLogin } from 'calypso/state/reader-ui/actions';
 import FollowButton from './button';
 
 const noop = () => {};
@@ -32,8 +30,10 @@ class FollowButtonContainer extends Component {
 
 	handleFollowToggle = ( following ) => {
 		if ( ! this.props.isLoggedIn ) {
-			const { pathname } = getUrlParts( window.location.href );
-			return navigate( createAccountUrl( { redirectTo: pathname, ref: 'reader-lp' } ) );
+			return this.props.registerLastActionRequiresLogin( {
+				type: 'follow-site',
+				siteId: this.props.siteId,
+			} );
 		}
 		if ( following ) {
 			const followData = omitBy(
@@ -48,6 +48,7 @@ class FollowButtonContainer extends Component {
 		} else {
 			this.props.unfollow( this.props.siteUrl );
 		}
+
 		this.props.onFollowToggle( following );
 	};
 
@@ -78,5 +79,6 @@ export default connect(
 	{
 		follow,
 		unfollow,
+		registerLastActionRequiresLogin,
 	}
 )( FollowButtonContainer );

--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -43,8 +43,7 @@ function ReaderSubscriptionListItem( {
 	isFollowing,
 	railcar,
 	isLoggedIn,
-	/* eslint-disable no-shadow */
-	registerLastActionRequiresLogin,
+	registerLastActionRequiresLogin: registerLastActionRequiresLoginProp,
 } ) {
 	const siteTitle = getSiteName( { feed, site } );
 	const siteAuthor = site && site.owner;
@@ -93,7 +92,7 @@ function ReaderSubscriptionListItem( {
 		recordTitleClick();
 		if ( ! isLoggedIn ) {
 			event.preventDefault();
-			registerLastActionRequiresLogin( {
+			registerLastActionRequiresLoginProp( {
 				type: 'sidebar-link',
 				redirectTo: streamLink,
 			} );
@@ -104,7 +103,7 @@ function ReaderSubscriptionListItem( {
 		recordAvatarClick();
 		if ( ! isLoggedIn ) {
 			event.preventDefault();
-			registerLastActionRequiresLogin( {
+			registerLastActionRequiresLoginProp( {
 				type: 'sidebar-link',
 				redirectTo: streamLink,
 			} );

--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -100,6 +100,17 @@ function ReaderSubscriptionListItem( {
 		}
 	};
 
+	const avatarClicked = ( event, streamLink ) => {
+		recordAvatarClick();
+		if ( ! isLoggedIn ) {
+			event.preventDefault();
+			registerLastActionRequiresLogin( {
+				type: 'sidebar-link',
+				redirectTo: streamLink,
+			} );
+		}
+	};
+
 	return (
 		<div className={ classnames( 'reader-subscription-list-item', className ) }>
 			<div className="reader-subscription-list-item__avatar">
@@ -111,7 +122,7 @@ function ReaderSubscriptionListItem( {
 					preferGravatar={ preferGravatar }
 					siteUrl={ streamUrl }
 					isCompact={ true }
-					onClick={ recordAvatarClick }
+					onClick={ ( event ) => avatarClicked( event, streamUrl ) }
 					iconSize={ 32 }
 				/>
 			</div>

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -258,7 +258,11 @@ const LayoutLoggedOut = ( {
 					isVisible={ !! loggedInAction }
 					loggedInAction={ loggedInAction }
 					onLoginSuccess={ () => {
-						window.location.reload();
+						if ( loggedInAction?.redirectTo ) {
+							window.location = loggedInAction.redirectTo;
+						} else {
+							window.location.reload();
+						}
 					} }
 				/>
 			) }

--- a/client/reader/follow-button/index.jsx
+++ b/client/reader/follow-button/index.jsx
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
 import CheckMark from 'calypso/assets/images/icons/check-mark.svg';
 import Plus from 'calypso/assets/images/icons/plus.svg';
 import FollowButtonContainer from 'calypso/blocks/follow-button';
@@ -10,16 +11,21 @@ import {
 	recordFollow as recordFollowTracks,
 	recordUnfollow as recordUnfollowTracks,
 } from 'calypso/reader/stats';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
 function ReaderFollowButton( props ) {
 	const { onFollowToggle, railcar, followSource, hasButtonStyle, isButtonOnly, siteUrl, iconSize } =
 		props;
 
+	const isLoggedIn = useSelector( ( state ) => isUserLoggedIn( state ) );
+
 	function recordFollowToggle( isFollowing ) {
-		if ( isFollowing ) {
-			recordFollowTracks( siteUrl, railcar, { follow_source: followSource } );
-		} else {
-			recordUnfollowTracks( siteUrl, railcar, { follow_source: followSource } );
+		if ( isLoggedIn ) {
+			if ( isFollowing ) {
+				recordFollowTracks( siteUrl, railcar, { follow_source: followSource } );
+			} else {
+				recordUnfollowTracks( siteUrl, railcar, { follow_source: followSource } );
+			}
 		}
 
 		if ( onFollowToggle ) {

--- a/client/reader/stream/reader-list-followed-sites/item.jsx
+++ b/client/reader/stream/reader-list-followed-sites/item.jsx
@@ -42,7 +42,6 @@ const ReaderListFollowingItem = ( props ) => {
 		);
 		if ( ! isLoggedIn ) {
 			event.preventDefault();
-			//get host name from current window
 			return props.registerLastActionRequiresLogin( {
 				type: 'sidebar-link',
 				redirectTo: streamLink,

--- a/client/reader/stream/reader-list-followed-sites/item.jsx
+++ b/client/reader/stream/reader-list-followed-sites/item.jsx
@@ -1,15 +1,17 @@
 import { Count } from '@automattic/components';
 import { get } from 'lodash';
-import { connect, useDispatch } from 'react-redux';
+import { connect, useDispatch, useSelector } from 'react-redux';
 import ReaderAvatar from 'calypso/blocks/reader-avatar';
 import QueryReaderFeed from 'calypso/components/data/query-reader-feed';
 import QueryReaderSite from 'calypso/components/data/query-reader-site';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { formatUrlForDisplay } from 'calypso/reader/lib/feed-display-helper';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import { getFeed } from 'calypso/state/reader/feeds/selectors';
 import { getSite } from 'calypso/state/reader/sites/selectors';
+import { registerLastActionRequiresLogin } from 'calypso/state/reader-ui/actions';
 import ReaderSidebarHelper from '../../sidebar/helper';
 import '../style.scss';
 
@@ -17,6 +19,7 @@ const ReaderListFollowingItem = ( props ) => {
 	const { site, path, isUnseen, feed, follow, siteId } = props;
 	const moment = useLocalizedMoment();
 	const dispatch = useDispatch();
+	const isLoggedIn = useSelector( ( state ) => isUserLoggedIn( state ) );
 	const siteIcon = site ? site.site_icon ?? get( site, 'icon.img' ) : null;
 	let feedIcon = get( follow, 'site_icon' );
 
@@ -29,14 +32,22 @@ const ReaderListFollowingItem = ( props ) => {
 		feedIcon = get( feed, 'image' );
 	}
 
-	const handleSidebarClick = ( selectedSite ) => {
+	const handleSidebarClick = ( event, streamLink ) => {
 		recordAction( 'clicked_reader_sidebar_following_item' );
 		recordGaEvent( 'Clicked Reader Sidebar Following Item' );
 		dispatch(
 			recordReaderTracksEvent( 'calypso_reader_sidebar_following_item_clicked', {
-				blog: decodeURIComponent( selectedSite.URL ),
+				blog: decodeURIComponent( follow?.URL ),
 			} )
 		);
+		if ( ! isLoggedIn ) {
+			event.preventDefault();
+			//get host name from current window
+			return props.registerLastActionRequiresLogin( {
+				type: 'sidebar-link',
+				redirectTo: streamLink,
+			} );
+		}
 	};
 
 	let streamLink;
@@ -64,7 +75,7 @@ const ReaderListFollowingItem = ( props ) => {
 			<a
 				className="reader-sidebar-site_link"
 				href={ streamLink }
-				onClick={ () => handleSidebarClick( follow ) }
+				onClick={ ( event ) => handleSidebarClick( event, streamLink ) }
 			>
 				<span className="reader-sidebar-site_siteicon">
 					{ ! siteIcon && ! feedIcon && ! site && <QueryReaderSite siteId={ siteId } /> }
@@ -100,13 +111,16 @@ const ReaderListFollowingItem = ( props ) => {
 	/* eslint-enable wpcalypso/jsx-classname-namespace */
 };
 
-export default connect( ( state, ownProps ) => {
-	const feedId = get( ownProps.follow, 'feed_ID' );
-	const siteId = get( ownProps.follow, 'blog_ID' );
+export default connect(
+	( state, ownProps ) => {
+		const feedId = get( ownProps.follow, 'feed_ID' );
+		const siteId = get( ownProps.follow, 'blog_ID' );
 
-	return {
-		feed: getFeed( state, feedId ),
-		site: getSite( state, siteId ),
-		siteId: siteId,
-	};
-} )( ReaderListFollowingItem );
+		return {
+			feed: getFeed( state, feedId ),
+			site: getSite( state, siteId ),
+			siteId: siteId,
+		};
+	},
+	{ registerLastActionRequiresLogin }
+)( ReaderListFollowingItem );

--- a/client/reader/stream/reader-tag-sidebar/index.jsx
+++ b/client/reader/stream/reader-tag-sidebar/index.jsx
@@ -21,8 +21,7 @@ import '../style.scss';
 const ReaderTagSidebar = ( {
 	tag,
 	showFollow,
-	/* eslint-disable no-shadow */
-	registerLastActionRequiresLogin,
+	registerLastActionRequiresLogin: registerLastActionRequiresLoginProp,
 } ) => {
 	const translate = useTranslate();
 	const relatedMetaByTag = useRelatedMetaByTag( tag );
@@ -54,7 +53,7 @@ const ReaderTagSidebar = ( {
 		if ( ! isLoggedIn ) {
 			recordAction( 'clicked_reader_sidebar_signup' );
 			dispatch( recordReaderTracksEvent( 'calypso_reader_sidebar_signup_clicked' ) );
-			registerLastActionRequiresLogin( {
+			registerLastActionRequiresLoginProp( {
 				type: 'sidebar-signup',
 				tag: tag,
 			} );
@@ -72,7 +71,7 @@ const ReaderTagSidebar = ( {
 	const toggleFollowing = () => {
 		const toggleAction = isFollowing ? requestUnfollowTag : requestFollowTag;
 		if ( ! isLoggedIn ) {
-			return registerLastActionRequiresLogin( {
+			return registerLastActionRequiresLoginProp( {
 				type: 'follow-tag',
 				tag: tag,
 			} );


### PR DESCRIPTION
This part of the Reader logged out Auth project - p2-pe7F0s-1gz

Follow up to https://github.com/Automattic/wp-calypso/pull/83031 and https://github.com/Automattic/wp-calypso/pull/83532.

We want to show the 'Join Conversation' dialog when a user is logged out and clicks on an action that requires them to be logged in.
<img width="354" alt="Screenshot 2023-10-11 at 22 00 39" src="https://github.com/Automattic/wp-calypso/assets/5560595/14194ca4-69ec-435f-94d5-bb4e490fe24c">

This PR updates the sidebar on logged out pages to open the dialog.

### TODO

- [x] Update discover recommended sidebar, i.e.  http://calypso.localhost:3000/discover
<img width="950" alt="Screenshot 2023-10-27 at 11 43 11" src="https://github.com/Automattic/wp-calypso/assets/5560595/ce6623c6-6d10-4bf9-a594-aeecd5184da8">

- [x] Update discover tag page sidebar. i.e. http://calypso.localhost:3000/discover?selectedTab=family
<img width="976" alt="Screenshot 2023-10-27 at 11 37 11" src="https://github.com/Automattic/wp-calypso/assets/5560595/6f5936cc-4115-4e10-b2dc-9ea040874c81">

### Testing

- Log out of WordPress.com
- Go to the Discover pages linked above and check that the Join Conversation dialog appears when you click on an actino that requires the user to be logged in
- Click all actions on Reader while logged out and confirm Join Conversation dialog appears ( all actions _should_ be handled now)
- Confirm that any link (i.e. Stream URL to Related sites) is redirected to after you successfully login via popup



