### PR TITLE
Signup Improvements: Passwordless existing account fix error notice

### DIFF
--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -122,6 +122,31 @@ class PasswordlessSignupForm extends Component {
 				);
 				return;
 			}
+
+			const errorMessage = (
+				<>
+					{ this.props.translate( 'An account with this email address already exists.' ) }
+					&nbsp;
+					{ this.props.translate( '{{a}}Log in now{{/a}} to finish signing up.', {
+						components: {
+							a: (
+								<a
+									href={ `${ this.props.logInUrl }&email_address=${ encodeURIComponent(
+										this.state.email
+									) }` }
+								/>
+							),
+						},
+					} ) }
+				</>
+			);
+
+			this.setState( {
+				errorMessages: [ errorMessage ],
+				isSubmitting: false,
+			} );
+
+			return;
 		}
 
 		this.setState( {


### PR DESCRIPTION
With https://github.com/Automattic/wp-calypso/pull/83249/ we shipped a behaviour change: if the user exists, we redirect him to the login page.
But we do not do that for passwordless users.

This PR fixes the error notice to bring back the link to login that was removed.

## Testing
1. Live Link
2. Visit `/start/` while in Incognito
3. Signup with an existing passwordless email ( fsdlhfadshfjshkj@dsfkjhfkhs.com for example)
4. You should see the link in the error notice

![image](https://github.com/Automattic/wp-calypso/assets/52076348/c08890d1-7483-4a1f-8b27-9151b7db87fa)
