### PR TITLE
Centralise Launchpad skip handling and set current checklist when skipping

### DIFF
--- a/client/landing/stepper/declarative-flow/build.ts
+++ b/client/landing/stepper/declarative-flow/build.ts
@@ -1,8 +1,9 @@
-import { updateLaunchpadSettings } from '@automattic/data-stores';
+import { LaunchpadNavigator } from '@automattic/data-stores';
 import { useFlowProgress, BUILD_FLOW } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
+import { skipLaunchpad } from 'calypso/landing/stepper/utils/skip-launchpad';
 import wpcom from 'calypso/lib/wp';
 import { useSiteIdParam } from '../hooks/use-site-id-param';
 import { useSiteSlug } from '../hooks/use-site-slug';
@@ -29,7 +30,9 @@ const build: Flow = {
 		const { setStepProgress } = useDispatch( ONBOARD_STORE );
 		const siteId = useSiteIdParam();
 		const siteSlug = useSiteSlug();
+		const { setActiveChecklist } = useDispatch( LaunchpadNavigator.store );
 		const flowProgress = useFlowProgress( { stepName: _currentStep, flowName } );
+
 		setStepProgress( flowProgress );
 
 		// trigger guides on step movement, we don't care about failures or response
@@ -69,10 +72,13 @@ const build: Flow = {
 		const goNext = async () => {
 			switch ( _currentStep ) {
 				case 'launchpad':
-					if ( siteSlug ) {
-						await updateLaunchpadSettings( siteSlug, { launchpad_screen: 'skipped' } );
-					}
-					return window.location.assign( `/home/${ siteId ?? siteSlug }` );
+					skipLaunchpad( {
+						checklistSlug: 'build',
+						setActiveChecklist,
+						siteId,
+						siteSlug,
+					} );
+					return;
 				default:
 					return navigate( 'freeSetup' );
 			}

--- a/client/landing/stepper/declarative-flow/design-first.ts
+++ b/client/landing/stepper/declarative-flow/design-first.ts
@@ -1,4 +1,8 @@
-import { OnboardSelect, updateLaunchpadSettings } from '@automattic/data-stores';
+import {
+	OnboardSelect,
+	LaunchpadNavigator,
+	updateLaunchpadSettings,
+} from '@automattic/data-stores';
 import { useLocale } from '@automattic/i18n-utils';
 import { DESIGN_FIRST_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch, dispatch } from '@wordpress/data';
@@ -17,6 +21,7 @@ import {
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
 import { SITE_STORE, ONBOARD_STORE } from 'calypso/landing/stepper/stores';
+import { skipLaunchpad } from 'calypso/landing/stepper/utils/skip-launchpad';
 import { freeSiteAddressType } from 'calypso/lib/domains/constants';
 import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { requestSiteAddressChange } from 'calypso/state/site-address-change/actions';
@@ -76,6 +81,7 @@ const designFirst: Flow = {
 			[]
 		).getState();
 		const site = useSite();
+		const { setActiveChecklist } = useDispatch( LaunchpadNavigator.store );
 
 		// This flow clear the site_intent when flow is completed.
 		// We need to check if the site is launched and if so, clear the site_intent to avoid errors.
@@ -208,10 +214,13 @@ const designFirst: Flow = {
 		const goNext = async () => {
 			switch ( currentStep ) {
 				case 'launchpad':
-					if ( siteSlug ) {
-						await updateLaunchpadSettings( siteSlug, { launchpad_screen: 'skipped' } );
-					}
-					return window.location.assign( `/home/${ siteId ?? siteSlug }` );
+					skipLaunchpad( {
+						checklistSlug: site?.options?.site_intent,
+						setActiveChecklist,
+						siteId,
+						siteSlug,
+					} );
+					return;
 			}
 		};
 

--- a/client/landing/stepper/declarative-flow/free.ts
+++ b/client/landing/stepper/declarative-flow/free.ts
@@ -1,8 +1,4 @@
-import {
-	updateLaunchpadSettings,
-	type OnboardSelect,
-	type UserSelect,
-} from '@automattic/data-stores';
+import { LaunchpadNavigator, type OnboardSelect, type UserSelect } from '@automattic/data-stores';
 import { isAssemblerDesign } from '@automattic/design-picker';
 import { useLocale } from '@automattic/i18n-utils';
 import { useFlowProgress, FREE_FLOW } from '@automattic/onboarding';
@@ -11,6 +7,7 @@ import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { getLocaleFromQueryParam, getLocaleFromPathname } from 'calypso/boot/locale';
+import { skipLaunchpad } from 'calypso/landing/stepper/utils/skip-launchpad';
 import wpcom from 'calypso/lib/wp';
 import {
 	setSignupCompleteSlug,
@@ -65,6 +62,7 @@ const free: Flow = {
 			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedDesign(),
 			[]
 		);
+		const { setActiveChecklist } = useDispatch( LaunchpadNavigator.store );
 
 		// trigger guides on step movement, we don't care about failures or response
 		wpcom.req.post(
@@ -171,10 +169,13 @@ const free: Flow = {
 		const goNext = async () => {
 			switch ( _currentStep ) {
 				case 'launchpad':
-					if ( siteSlug ) {
-						await updateLaunchpadSettings( siteSlug, { launchpad_screen: 'skipped' } );
-					}
-					return window.location.assign( `/home/${ siteId ?? siteSlug }` );
+					skipLaunchpad( {
+						checklistSlug: 'free',
+						setActiveChecklist,
+						siteId,
+						siteSlug,
+					} );
+					return;
 
 				default:
 					return navigate( 'freeSetup' );

--- a/client/landing/stepper/declarative-flow/link-in-bio-tld.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio-tld.ts
@@ -1,8 +1,9 @@
-import { updateLaunchpadSettings, type UserSelect } from '@automattic/data-stores';
+import { LaunchpadNavigator, type UserSelect } from '@automattic/data-stores';
 import { useFlowProgress, LINK_IN_BIO_TLD_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
+import { skipLaunchpad } from 'calypso/landing/stepper/utils/skip-launchpad';
 import wpcom from 'calypso/lib/wp';
 import {
 	clearSignupDestinationCookie,
@@ -51,6 +52,7 @@ const linkInBio: Flow = {
 			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
 			[]
 		);
+		const { setActiveChecklist } = useDispatch( LaunchpadNavigator.store );
 
 		setStepProgress( flowProgress );
 
@@ -138,10 +140,13 @@ const linkInBio: Flow = {
 		const goNext = async () => {
 			switch ( _currentStepSlug ) {
 				case 'launchpad':
-					if ( siteSlug ) {
-						await updateLaunchpadSettings( siteSlug, { launchpad_screen: 'skipped' } );
-					}
-					return window.location.assign( `/home/${ siteId ?? siteSlug }` );
+					skipLaunchpad( {
+						checklistSlug: 'link-in-bio-tld',
+						setActiveChecklist,
+						siteId,
+						siteSlug,
+					} );
+					return;
 
 				default:
 					return navigate( 'intro' );

--- a/client/landing/stepper/declarative-flow/link-in-bio.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio.ts
@@ -1,9 +1,10 @@
-import { updateLaunchpadSettings, type UserSelect } from '@automattic/data-stores';
+import { LaunchpadNavigator, type UserSelect } from '@automattic/data-stores';
 import { useFlowProgress, LINK_IN_BIO_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
 import { useEffect } from 'react';
+import { skipLaunchpad } from 'calypso/landing/stepper/utils/skip-launchpad';
 import wpcom from 'calypso/lib/wp';
 import {
 	clearSignupDestinationCookie,
@@ -68,6 +69,7 @@ const linkInBio: Flow = {
 			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
 			[]
 		);
+		const { setActiveChecklist } = useDispatch( LaunchpadNavigator.store );
 
 		setStepProgress( flowProgress );
 
@@ -158,10 +160,13 @@ const linkInBio: Flow = {
 		const goNext = async () => {
 			switch ( _currentStepSlug ) {
 				case 'launchpad':
-					if ( siteSlug ) {
-						await updateLaunchpadSettings( siteSlug, { launchpad_screen: 'skipped' } );
-					}
-					return window.location.assign( `/home/${ siteId ?? siteSlug }` );
+					skipLaunchpad( {
+						checklistSlug: 'link-in-bio',
+						setActiveChecklist,
+						siteId,
+						siteSlug,
+					} );
+					return;
 
 				default:
 					return navigate( 'intro' );

--- a/client/landing/stepper/declarative-flow/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/newsletter.ts
@@ -1,10 +1,15 @@
-import { updateLaunchpadSettings, UserSelect } from '@automattic/data-stores';
+import {
+	LaunchpadNavigator,
+	updateLaunchpadSettings,
+	type UserSelect,
+} from '@automattic/data-stores';
 import { useFlowProgress, NEWSLETTER_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
+import { skipLaunchpad } from 'calypso/landing/stepper/utils/skip-launchpad';
 import wpcom from 'calypso/lib/wp';
 import {
 	clearSignupDestinationCookie,
@@ -96,6 +101,8 @@ const newsletter: Flow = {
 			pageTitle: 'Newsletter',
 		} );
 
+		const { setActiveChecklist } = useDispatch( LaunchpadNavigator.store );
+
 		const completeSubscribersTask = async () => {
 			if ( siteSlug ) {
 				await updateLaunchpadSettings( siteSlug, {
@@ -186,10 +193,14 @@ const newsletter: Flow = {
 		const goNext = async () => {
 			switch ( _currentStep ) {
 				case 'launchpad':
-					if ( siteSlug ) {
-						await updateLaunchpadSettings( siteSlug, { launchpad_screen: 'skipped' } );
-					}
-					return window.location.assign( `/home/${ siteId ?? siteSlug }` );
+					skipLaunchpad( {
+						checklistSlug: 'newsletter',
+						setActiveChecklist,
+						siteId,
+						siteSlug,
+					} );
+					return;
+
 				default:
 					return navigate( isComingFromMarketingPage ? 'newsletterSetup' : 'intro' );
 			}

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -1,4 +1,8 @@
-import { OnboardSelect, updateLaunchpadSettings } from '@automattic/data-stores';
+import {
+	LaunchpadNavigator,
+	OnboardSelect,
+	updateLaunchpadSettings,
+} from '@automattic/data-stores';
 import { useLocale } from '@automattic/i18n-utils';
 import { START_WRITING_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch, dispatch } from '@wordpress/data';
@@ -7,14 +11,15 @@ import { getLocaleFromQueryParam, getLocaleFromPathname } from 'calypso/boot/loc
 import { recordSubmitStep } from 'calypso/landing/stepper/declarative-flow/internals/analytics/record-submit-step';
 import { redirect } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/import/util';
 import {
-	AssertConditionResult,
+	type AssertConditionResult,
 	AssertConditionState,
-	Flow,
-	ProvidedDependencies,
+	type Flow,
+	type ProvidedDependencies,
 } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
 import { SITE_STORE, ONBOARD_STORE } from 'calypso/landing/stepper/stores';
+import { skipLaunchpad } from 'calypso/landing/stepper/utils/skip-launchpad';
 import { freeSiteAddressType } from 'calypso/lib/domains/constants';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -74,6 +79,7 @@ const startWriting: Flow = {
 			[]
 		).getState();
 		const site = useSite();
+		const { setActiveChecklist } = useDispatch( LaunchpadNavigator.store );
 
 		// This flow clear the site_intent when flow is completed.
 		// We need to check if the site is launched and if so, clear the site_intent to avoid errors.
@@ -189,10 +195,13 @@ const startWriting: Flow = {
 		const goNext = async () => {
 			switch ( currentStep ) {
 				case 'launchpad':
-					if ( siteSlug ) {
-						await updateLaunchpadSettings( siteSlug, { launchpad_screen: 'skipped' } );
-					}
-					return window.location.assign( `/home/${ siteId ?? siteSlug }` );
+					skipLaunchpad( {
+						checklistSlug: 'start-writing',
+						setActiveChecklist,
+						siteId,
+						siteSlug,
+					} );
+					return;
 			}
 		};
 

--- a/client/landing/stepper/declarative-flow/videopress.ts
+++ b/client/landing/stepper/declarative-flow/videopress.ts
@@ -1,5 +1,5 @@
 import config from '@automattic/calypso-config';
-import { PlansSelect, SiteSelect, updateLaunchpadSettings } from '@automattic/data-stores';
+import { LaunchpadNavigator, PlansSelect, SiteSelect } from '@automattic/data-stores';
 import { useLocale } from '@automattic/i18n-utils';
 import { useFlowProgress, VIDEOPRESS_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -7,6 +7,7 @@ import { translate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { useSupportedPlans } from 'calypso/../packages/plans-grid/src/hooks';
 import { useNewSiteVisibility } from 'calypso/landing/stepper/hooks/use-selected-plan';
+import { skipLaunchpad } from 'calypso/landing/stepper/utils/skip-launchpad';
 import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
 import { cartManagerClient } from 'calypso/my-sites/checkout/cart-manager-client';
 import { useSiteIdParam } from '../hooks/use-site-id-param';
@@ -104,6 +105,7 @@ const videopress: Flow = {
 			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedDomain(),
 			[]
 		);
+		const { setActiveChecklist } = useDispatch( LaunchpadNavigator.store );
 
 		const [ isSiteCreationPending, setIsSiteCreationPending ] = useState( false );
 
@@ -302,10 +304,13 @@ const videopress: Flow = {
 		const goNext = async () => {
 			switch ( _currentStep ) {
 				case 'launchpad':
-					if ( siteSlug ) {
-						await updateLaunchpadSettings( siteSlug, { launchpad_screen: 'skipped' } );
-					}
-					return window.location.assign( `/home/${ siteId ?? siteSlug }` );
+					await skipLaunchpad( {
+						checklistSlug: 'videopress',
+						setActiveChecklist,
+						siteId,
+						siteSlug,
+					} );
+					return;
 
 				default:
 					return navigate( 'intro' );

--- a/client/landing/stepper/declarative-flow/write.ts
+++ b/client/landing/stepper/declarative-flow/write.ts
@@ -1,4 +1,4 @@
-import { updateLaunchpadSettings } from '@automattic/data-stores';
+import { LaunchpadNavigator } from '@automattic/data-stores';
 import { useLocale } from '@automattic/i18n-utils';
 import { useFlowProgress, WRITE_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -6,6 +6,7 @@ import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { getLocaleFromQueryParam, getLocaleFromPathname } from 'calypso/boot/locale';
+import { skipLaunchpad } from 'calypso/landing/stepper/utils/skip-launchpad';
 import wpcom from 'calypso/lib/wp';
 import { useSiteIdParam } from '../hooks/use-site-id-param';
 import { useSiteSlug } from '../hooks/use-site-slug';
@@ -41,6 +42,7 @@ const write: Flow = {
 		setStepProgress( flowProgress );
 		const siteId = useSiteIdParam();
 		const siteSlug = useSiteSlug();
+		const { setActiveChecklist } = useDispatch( LaunchpadNavigator.store );
 
 		// trigger guides on step movement, we don't care about failures or response
 		wpcom.req.post(
@@ -78,10 +80,13 @@ const write: Flow = {
 		const goNext = async () => {
 			switch ( _currentStep ) {
 				case 'launchpad':
-					if ( siteSlug ) {
-						await updateLaunchpadSettings( siteSlug, { launchpad_screen: 'skipped' } );
-					}
-					return window.location.assign( `/home/${ siteId ?? siteSlug }` );
+					skipLaunchpad( {
+						checklistSlug: 'write',
+						setActiveChecklist,
+						siteId,
+						siteSlug,
+					} );
+					return;
 
 				default:
 					return navigate( 'freeSetup' );

--- a/client/landing/stepper/utils/skip-launchpad.ts
+++ b/client/landing/stepper/utils/skip-launchpad.ts
@@ -2,7 +2,7 @@ import { updateLaunchpadSettings } from '@automattic/data-stores';
 
 type SkipLaunchpadProps = {
 	checklistSlug?: string | null;
-	setActiveChecklist: ( siteSlug: string, checklistSlug: string ) => Promise< void >;
+	setActiveChecklist: ( siteSlug: string, checklistSlug: string ) => Promise< unknown >;
 	siteId: string | null;
 	siteSlug: string | null;
 };

--- a/client/landing/stepper/utils/skip-launchpad.ts
+++ b/client/landing/stepper/utils/skip-launchpad.ts
@@ -1,0 +1,29 @@
+import { updateLaunchpadSettings } from '@automattic/data-stores';
+
+type SkipLaunchpadProps = {
+	checklistSlug?: string | null;
+	setActiveChecklist: ( siteSlug: string, checklistSlug: string ) => Promise< void >;
+	siteId: string | null;
+	siteSlug: string | null;
+};
+
+export const skipLaunchpad = async ( {
+	checklistSlug,
+	setActiveChecklist,
+	siteId,
+	siteSlug,
+}: SkipLaunchpadProps ) => {
+	if ( siteSlug ) {
+		if ( checklistSlug ) {
+			// If we're making both API calls, allow them to happen concurrently.
+			await Promise.allSettled( [
+				updateLaunchpadSettings( siteSlug, { launchpad_screen: 'skipped' } ),
+				setActiveChecklist( siteSlug, checklistSlug ),
+			] );
+		} else {
+			await updateLaunchpadSettings( siteSlug, { launchpad_screen: 'skipped' } );
+		}
+	}
+
+	return window.location.assign( `/home/${ siteId ?? siteSlug }` );
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* This PR centralises the logic for the Launchpad-specific skip code in various Stepper flows, as well as updating that logic to set the current checklist for the site. This ensures that when users skip the fullscreen launchpad, the Launchpad Navigator knows that the user should be shown the skipped checklist.

## Testing Instructions

* Run this branch locally or via Calypso.live
* For each of the following flows, work through the signup flow until you get to the fullscreen launchpad
* For each flow, click on the "Skip for now" option in the fullscreen launchpad, and verify that triggers both a call to `PUT /wpcom/v2/sites/:siteSlug/launchpad/navigator` (which sets the active checklist) _and_ a call to `PUT /wpcom/v2/sites/:siteSlug/launchpad` (which updates the `launchpad_screen` option to `'skipped'`).
* You should then be sent to Customer Home showing the same set of tasks, but you should also see that a `GET /wpcom/v2/sites/:siteSlug/launchpad/navigator` API call returns the flow name as the current active checklist
  - `/setup/build` - create a new site via `/start` and choose the build intent ("Promote myself or business")
  - `/setup/design-first` - navigate to `/setup/design-first?ref=calypshowcase`
  - `/setup/free` - create a new site via `/setup/free`
  - `/setup/link-in-bio` - create a new site via `/setup/link-in-bio`
  - `/setup/link-in-bio-tld` - create a new site via `/setup/link-in-bio-tld`, and make sure to click on "Decide later" on the domains step
  - `/setup/newsletter` - create a new site via `/setup/newsletter`
  - `/setup/start-writing` - this requires you to start the flow with a test user that doesn't have any sites
  - `/setup/videopress` - create a new site via `/setup/videopress`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
