### PR TITLE
Ensure we track the active checklist in the Customer Home launchpad

### DIFF
--- a/client/my-sites/customer-home/cards/launchpad/index.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/index.tsx
@@ -2,7 +2,6 @@ import { Button, CircularProgressBar, Gridicon } from '@automattic/components';
 import {
 	updateLaunchpadSettings,
 	useSortedLaunchpadTasks,
-	sortLaunchpadTasksByCompletionStatus,
 	LaunchpadNavigator,
 } from '@automattic/data-stores';
 import { DefaultWiredLaunchpad, type Task } from '@automattic/launchpad';
@@ -33,7 +32,6 @@ const CustomerHomeLaunchpad = ( {
 
 	const translate = useTranslate();
 	const [ isDismissed, setIsDismissed ] = useState( false );
-	const useLaunchpadOptions = { onSuccess: sortLaunchpadTasksByCompletionStatus };
 	const {
 		data: { checklist, is_dismissed: initialIsChecklistDismissed },
 	} = useSortedLaunchpadTasks( siteSlug, checklistSlug );
@@ -61,7 +59,13 @@ const CustomerHomeLaunchpad = ( {
 		if ( siteSlug && checklistSlug ) {
 			setActiveChecklist( siteSlug, checklistSlug );
 		}
-	}, [ checklistSlug, currentNavigatorChecklist, receiveActiveChecklistSlug, setActiveChecklist, siteSlug ] );
+	}, [
+		checklistSlug,
+		currentNavigatorChecklist,
+		receiveActiveChecklistSlug,
+		setActiveChecklist,
+		siteSlug,
+	] );
 
 	// return nothing if the launchpad is dismissed
 	if ( isDismissed ) {

--- a/client/my-sites/customer-home/cards/launchpad/index.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/index.tsx
@@ -6,7 +6,7 @@ import {
 	LaunchpadNavigator,
 } from '@automattic/data-stores';
 import { DefaultWiredLaunchpad, type Task } from '@automattic/launchpad';
-import { select, useDispatch } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { useLaunchpadNavigator } from 'calypso/data/launchpad-navigator/use-launchpad-navigator';
@@ -44,16 +44,24 @@ const CustomerHomeLaunchpad = ( {
 
 	const numberOfSteps = checklist?.length || 0;
 	const completedSteps = ( checklist?.filter( ( task: Task ) => task.completed ) || [] ).length;
-	const { receiveActiveChecklistSlug } = useDispatch( LaunchpadNavigator.store );
 
-	const currentNavigatorChecklistSlug =
-		select( LaunchpadNavigator.store ).getActiveChecklistSlug() || null;
+	const { setActiveChecklist, receiveActiveChecklistSlug } = useDispatch(
+		LaunchpadNavigator.store
+	);
+
 	const {
-		data: { current_checklist },
-	} = useLaunchpadNavigator( siteSlug, currentNavigatorChecklistSlug );
+		data: { current_checklist: currentNavigatorChecklist },
+	} = useLaunchpadNavigator( siteSlug, null );
+
+	// Ensure that if we updated the checklist on the server, we update the navigator.
+	// One case where this can happen is when we launch a site and switch to a post-launch checklist.
 	useEffect( () => {
-		receiveActiveChecklistSlug( current_checklist );
-	}, [ current_checklist ] );
+		receiveActiveChecklistSlug( currentNavigatorChecklist );
+
+		if ( siteSlug && checklistSlug ) {
+			setActiveChecklist( siteSlug, checklistSlug );
+		}
+	}, [ checklistSlug, currentNavigatorChecklist, receiveActiveChecklistSlug, setActiveChecklist, siteSlug ] );
 
 	// return nothing if the launchpad is dismissed
 	if ( isDismissed ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* This PR updates the launchpad card we use in Customer Home to update the currently active checklist. This is particularly important for situations where we take an action that results in the underlying checklist being changed. One example of this is when a site is launched and the back end code detects that we need to switch from a pre-launch checklist to a post-launch checklist.
  - It's worth noting that the implementation relies on `setActiveChecklist()` comparing the currently active slug against the incoming value, and only makes an API call when they are different.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch locally or via Calypso.live
* Create a new site via `/start` and select either the write ("Write & publish") or build ("Promote myself or business") intent from the goals step
* When you get to the fullscreen Launchpad, click on "Skip for now"
* Open your browser's network inspector
* Click on the "Launch site" task to launch the site
* Once the site has been launched, click on the `X` icon to dismiss the launch celebration modal
* Verify that the launchpad checklist updates to the new post-launch tasks for your chosen intent
* Also verify that we made a `PUT /wpcom/v2/sites/:siteSlug/launchpad/navigator` API call where the request body includes an `active_checklist_slug` property with a value of either `'intent-build'` or `'intent-write'` (depending on the intent you chose).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
