### PR TITLE
Signup improvements: Fix return url from login

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -333,17 +333,7 @@ export class LoginForm extends Component {
 						'This email address is already associated with an account. Please consider {{returnToSignup}}using another one{{/returnToSignup}} or log in.',
 						{
 							components: {
-								returnToSignup: (
-									<a
-										href={ addQueryArgs(
-											{
-												user_email: this.state.usernameOrEmail,
-											},
-											signupUrl
-										) }
-										onClick={ this.recordSignUpLinkClick }
-									/>
-								),
+								returnToSignup: <a href={ signupUrl } onClick={ this.recordSignUpLinkClick } />,
 							},
 						}
 					) }


### PR DESCRIPTION
In https://github.com/Automattic/wp-calypso/pull/83249 we added a notice in Login

![image](https://github.com/Automattic/wp-calypso/assets/52076348/38b2bf5e-a2cd-483c-9398-86cfc68caae5)

`using another one` sends users back to signup. But passing the email field, which we do not want.

## Testing
1. Live link and `/start/user-social`
2. Signup with an existing regular email (no passwordless)
3. Land in Login and click `using another one` in the notice
4. You should be back in signup without the email field populated