### PR TITLE
Jetpack Cloud: add 'Get help' link to sidebar footer on all pages

### DIFF
--- a/client/jetpack-cloud/components/sidebar/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/index.tsx
@@ -88,11 +88,30 @@ const JetpackCloudSidebar = ( {
 				</SidebarNavigator>
 			</SidebarMain>
 
-			{ ! isJetpackManage && jetpackAdminUrl && (
-				<SidebarFooter className="jetpack-cloud-sidebar__footer">
-					<ul>
+			<SidebarFooter>
+				<ul>
+					<SidebarNavigatorMenuItem
+						isSelected={ false }
+						title={ translate( 'Get help', {
+							comment: 'Jetpack Cloud sidebar navigation item',
+						} ) }
+						link="https://jetpack.com/support"
+						path=""
+						icon={ <JetpackIcons icon="help" /> }
+						onClickMenuItem={ ( link ) => {
+							dispatch(
+								recordTracksEvent( 'calypso_jetpack_sidebar_menu_click', {
+									menu_item: 'Jetpack Cloud / Support',
+								} )
+							);
+
+							window.open( link, '_blank' );
+						} }
+					/>
+					{ ! isJetpackManage && jetpackAdminUrl && (
 						<SidebarNavigatorMenuItem
 							isExternalLink
+							isSelected={ false }
 							title={ translate( 'WP Admin' ) }
 							link={ jetpackAdminUrl }
 							path={ jetpackAdminUrl }
@@ -101,9 +120,9 @@ const JetpackCloudSidebar = ( {
 								dispatch( recordTracksEvent( 'calypso_jetpack_sidebar_wp_admin_link_click' ) );
 							} }
 						/>
-					</ul>
-				</SidebarFooter>
-			) }
+					) }
+				</ul>
+			</SidebarFooter>
 
 			<SiteSelector
 				showAddNewSite

--- a/client/jetpack-cloud/components/sidebar/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/index.tsx
@@ -88,7 +88,7 @@ const JetpackCloudSidebar = ( {
 				</SidebarNavigator>
 			</SidebarMain>
 
-			<SidebarFooter>
+			<SidebarFooter className="jetpack-cloud-sidebar__footer">
 				<ul>
 					{ ! isJetpackManage && jetpackAdminUrl && (
 						<SidebarNavigatorMenuItem

--- a/client/jetpack-cloud/components/sidebar/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/index.tsx
@@ -90,6 +90,19 @@ const JetpackCloudSidebar = ( {
 
 			<SidebarFooter>
 				<ul>
+					{ ! isJetpackManage && jetpackAdminUrl && (
+						<SidebarNavigatorMenuItem
+							isExternalLink
+							isSelected={ false }
+							title={ translate( 'WP Admin' ) }
+							link={ jetpackAdminUrl }
+							path={ jetpackAdminUrl }
+							icon={ <JetpackIcons icon="wordpress" /> }
+							onClickMenuItem={ () => {
+								dispatch( recordTracksEvent( 'calypso_jetpack_sidebar_wp_admin_link_click' ) );
+							} }
+						/>
+					) }
 					<SidebarNavigatorMenuItem
 						isSelected={ false }
 						title={ translate( 'Get help', {
@@ -108,19 +121,6 @@ const JetpackCloudSidebar = ( {
 							window.open( link, '_blank' );
 						} }
 					/>
-					{ ! isJetpackManage && jetpackAdminUrl && (
-						<SidebarNavigatorMenuItem
-							isExternalLink
-							isSelected={ false }
-							title={ translate( 'WP Admin' ) }
-							link={ jetpackAdminUrl }
-							path={ jetpackAdminUrl }
-							icon={ <JetpackIcons icon="wordpress" /> }
-							onClickMenuItem={ () => {
-								dispatch( recordTracksEvent( 'calypso_jetpack_sidebar_wp_admin_link_click' ) );
-							} }
-						/>
-					) }
 				</ul>
 			</SidebarFooter>
 

--- a/client/jetpack-cloud/components/sidebar/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/index.tsx
@@ -104,6 +104,7 @@ const JetpackCloudSidebar = ( {
 						/>
 					) }
 					<SidebarNavigatorMenuItem
+						isExternalLink
 						isSelected={ false }
 						title={ translate( 'Get help', {
 							comment: 'Jetpack Cloud sidebar navigation item',

--- a/client/layout/sidebar-v2/navigator/navigator-menu-item.tsx
+++ b/client/layout/sidebar-v2/navigator/navigator-menu-item.tsx
@@ -8,6 +8,7 @@ import { Icon, chevronRightSmall, external } from '@wordpress/icons';
 import classnames from 'classnames';
 
 import './style.scss';
+import { TranslateResult } from 'i18n-calypso';
 
 const ICON_SIZE = 24;
 
@@ -16,7 +17,7 @@ interface Props {
 	icon: JSX.Element;
 	path: string;
 	link: string;
-	title: string;
+	title: TranslateResult;
 	onClickMenuItem: ( path: string ) => void;
 	withChevron?: boolean;
 	isExternalLink?: boolean;

--- a/client/layout/sidebar-v2/navigator/navigator-menu-item.tsx
+++ b/client/layout/sidebar-v2/navigator/navigator-menu-item.tsx
@@ -9,7 +9,6 @@ import classnames from 'classnames';
 import { TranslateResult } from 'i18n-calypso';
 
 import './style.scss';
-import { TranslateResult } from 'i18n-calypso';
 
 const ICON_SIZE = 24;
 

--- a/client/layout/sidebar-v2/navigator/navigator-menu-item.tsx
+++ b/client/layout/sidebar-v2/navigator/navigator-menu-item.tsx
@@ -6,6 +6,7 @@ import {
 } from '@wordpress/components';
 import { Icon, chevronRightSmall, external } from '@wordpress/icons';
 import classnames from 'classnames';
+import { TranslateResult } from 'i18n-calypso';
 
 import './style.scss';
 import { TranslateResult } from 'i18n-calypso';


### PR DESCRIPTION
This pull request re-adds a link to 'Get help' in the bottom section of the navigation sidebar, so people can find it without opening the profile dropdown menu.

Resolves https://github.com/Automattic/jetpack-genesis/issues/80.

## Proposed Changes

* `SidebarNavigatorMenuItem`:
	* Update the type of `title` to `TranslateResult`.
	* Add default values to a few props (e.g., `isSelected`), and make those properties optional.
* `SidebarFooter`: add a menu item for 'Get help', to always be displayed as the first item. When clicked, the item emits a Tracks event for analysis.

## Testing Instructions

* In your Jetpack Cloud testing environment (with this PR applied), load any page. (Be sure to test on several pages, including the Purchases section, Sites section, and any page when managing a single site.)
* Verify you see a 'Get help' link in the sidebar footer on all pages.
* Verify that clicking the 'Get help' link opens a new window to `jetpack.com/support`.
* Verify that clicking the 'Get help' link triggers a Tracks event with the name `calypso_jetpack_sidebar_menu_click` and the property `menu_item: Jetpack Cloud / Support`.

## Reference screenshots

### Mobile (in hover state)
<img height="400" src="https://github.com/Automattic/wp-calypso/assets/670067/88c1f420-68d3-41b4-98d3-97dc492c526c" /> <img height="400" src="https://github.com/Automattic/wp-calypso/assets/670067/a1291f9d-0855-436b-beb0-a91e14cc93eb" /> <img height="400" src="https://github.com/Automattic/wp-calypso/assets/670067/1cb4d9c3-b523-4376-8fd7-8d7735c1f48a" />

### Desktop (in non-hover state)

<img height="400" src="https://github.com/Automattic/wp-calypso/assets/670067/f965e4be-d1f0-4ff5-a93c-55e62799bb28" />
