### PR TITLE
Suspended Domains: add Tracks events to evaluate effectiveness of launch site nag

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -47,13 +47,13 @@ function getUrlInfo( url: string ) {
 }
 
 function recordUnverifiedDomainDialogShownTracksEvent( site_id?: number ) {
-	recordTracksEvent( 'calypso_launchpad_unverified_domain_email_shown', {
+	recordTracksEvent( 'calypso_launchpad_unverified_domain_email_dialog_shown', {
 		site_id,
 	} );
 }
 
 function recordUnverifiedDomainContinueAnywayClickedTracksEvent( site_id?: number ) {
-	recordTracksEvent( 'calypso_launchpad_unverified_continue_anyway_clicked', {
+	recordTracksEvent( 'calypso_launchpad_unverified_domain_email_continue_anyway_clicked', {
 		site_id,
 	} );
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -47,7 +47,7 @@ function getUrlInfo( url: string ) {
 }
 
 function recordUnverifiedDomainDialogShownTracksEvent( site_id?: number ) {
-	recordTracksEvent( 'calypso_launchpad_unverified_domain_email_continue_anyway', {
+	recordTracksEvent( 'calypso_launchpad_unverified_domain_email_shown', {
 		site_id,
 	} );
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -46,13 +46,13 @@ function getUrlInfo( url: string ) {
 	return [ siteName, topLevelDomain ];
 }
 
-function recordUnverifiedDomainDialogShownTracksEvent( site_id?: string ) {
+function recordUnverifiedDomainDialogShownTracksEvent( site_id?: number ) {
 	recordTracksEvent( 'calypso_launchpad_unverified_domain_email_continue_anyway', {
 		site_id,
 	} );
 }
 
-function recordUnverifiedDomainContinueAnywayClickedTracksEvent( site_id?: string ) {
+function recordUnverifiedDomainContinueAnywayClickedTracksEvent( site_id?: number ) {
 	recordTracksEvent( 'calypso_launchpad_unverified_continue_anyway_clicked', {
 		site_id,
 	} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -8,7 +8,6 @@ import { useSelect } from '@wordpress/data';
 import { useRef, useState } from '@wordpress/element';
 import { copy, Icon } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect } from 'react';
 import QueryMembershipsSettings from 'calypso/components/data/query-memberships-settings';
 import ClipboardButton from 'calypso/components/forms/clipboard-button';
 import Tooltip from 'calypso/components/tooltip';
@@ -73,12 +72,6 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goToStep, flow }: SidebarPr
 	const [ showConfirmModal, setShowConfirmModal ] = useState( false );
 	const queryClient = useQueryClient();
 
-	useEffect( () => {
-		if ( showConfirmModal ) {
-			recordUnverifiedDomainDialogShownTracksEvent( site?.ID );
-		}
-	}, [ site, showConfirmModal ] );
-
 	const { globalStylesInUse, shouldLimitGlobalStyles } = useSiteGlobalStylesStatus( site?.ID );
 
 	const {
@@ -134,7 +127,10 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goToStep, flow }: SidebarPr
 			getPlanCartItem(),
 			getDomainCartItem(),
 			stripeConnectUrl,
-			() => setShowConfirmModal( true ),
+			() => {
+				recordUnverifiedDomainDialogShownTracksEvent( site?.ID );
+				setShowConfirmModal( true );
+			},
 			isDomainEmailUnverified
 		);
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Add Tracks events to evaluate the effectiveness of Suspended Domains i1 launch site nag. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enable the test store
* Check out this branch
* Buy a test store domain, e.g.`live` or `blog`, and a personal plan
* Use a new unverified email for domain contact details on checkout page
* Complete flow until "What are your goals?" screen and choose "Promote myself or my business."
* Choose a free design and some colours and then you should land at Launchpad
* Confirm "Verify domain email address" is shown
* Click "Launch site", and you will see a dialog. At this stage, the `calypso_launchpad_unverified_continue_anyway_clicked` event should fire
* Make sure "Preserve log" is enable in the Network tab of your browser
* Click "continue anyway" and confirm the `calypso_launchpad_unverified_domain_email_continue_anyway` fires. 
* The site should be recorded with the event

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?