### PR TITLE
[Odie] Additional fixes in Help Center Odie

### DIFF
--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -230,7 +230,8 @@ $head-foot-height: 50px;
 
 	.help-center__container-content-odie {
 		display: flex;
-		height: 750px;
+		height: 100%;
+		max-height: 742px;
 		flex-direction: column;
 
 		.help-center__container-odie-header {

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -231,13 +231,14 @@ $head-foot-height: 50px;
 	.help-center__container-content-odie {
 		display: flex;
 		height: 100%;
-		max-height: 742px;
+		max-height: 752px;
 		flex-direction: column;
 
 		.help-center__container-odie-header {
 			border-bottom-width: 1px;
 			border-style: solid;
 			border-color: rgba(0, 0, 0, 0.1);
+			height: 69px;
 			display: flex;
 			align-items: center;
 			justify-content: space-between;


### PR DESCRIPTION
## Proposed Changes

- Fixes Odie layout issue where text box and submit button would be hidden from view until the user scrolls

## Testing Instructions

- Load Calypso with ?flags=wapuu
- Open help center
- Enter a query and click through to ask Wapuu the question
- Hopefully the text box and submit button are visible

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?