### PR TITLE
Sidebar: treat all items as links instead of buttons

### DIFF
--- a/client/jetpack-cloud/components/sidebar/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/index.tsx
@@ -27,10 +27,10 @@ type Props = {
 		path: string;
 		link: string;
 		title: string;
-		onClickMenuItem: ( path: string ) => void;
+		onClickMenuItem?: ( path: string ) => void;
 		withChevron?: boolean;
 		isExternalLink?: boolean;
-		isSelected: boolean;
+		isSelected?: boolean;
 		trackEventName?: string;
 		trackEventProps?: { [ key: string ]: string };
 	}[];
@@ -79,7 +79,8 @@ const JetpackCloudSidebar = ( {
 									if ( item.trackEventName ) {
 										dispatch( recordTracksEvent( item.trackEventName, item.trackEventProps ) );
 									}
-									item.onClickMenuItem( path );
+
+									item.onClickMenuItem?.( path );
 								} }
 							/>
 						) ) }
@@ -91,16 +92,14 @@ const JetpackCloudSidebar = ( {
 				<SidebarFooter className="jetpack-cloud-sidebar__footer">
 					<ul>
 						<SidebarNavigatorMenuItem
+							isExternalLink
 							title={ translate( 'WP Admin' ) }
 							link={ jetpackAdminUrl }
 							path={ jetpackAdminUrl }
 							icon={ <JetpackIcons icon="wordpress" /> }
-							onClickMenuItem={ ( link ) => {
+							onClickMenuItem={ () => {
 								dispatch( recordTracksEvent( 'calypso_jetpack_sidebar_wp_admin_link_click' ) );
-								window.open( link, '_blank' );
 							} }
-							isExternalLink
-							isSelected={ false }
 						/>
 					</ul>
 				</SidebarFooter>

--- a/client/jetpack-cloud/sections/agency-dashboard/controller.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/controller.tsx
@@ -28,7 +28,7 @@ export function agencyDashboardContext( context: PageJS.Context, next: VoidFunct
 	context.header = <Header />;
 
 	if ( config.isEnabled( 'jetpack/new-navigation' ) ) {
-		context.secondary = <NewJetpackManageSidebar />;
+		context.secondary = <NewJetpackManageSidebar path={ context.path } />;
 	} else {
 		context.secondary = <DashboardSidebar path={ context.path } />;
 	}

--- a/client/jetpack-cloud/sections/partner-portal/controller.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/controller.tsx
@@ -44,7 +44,7 @@ const isNewNavigationEnabled = isEnabled( 'jetpack/new-navigation' );
 
 const setSidebar = ( context: PageJS.Context ): void => {
 	if ( isNewNavigationEnabled ) {
-		context.secondary = <NewPurchasesSidebar />;
+		context.secondary = <NewPurchasesSidebar path={ context.path } />;
 	} else {
 		context.secondary = <PartnerPortalSidebar path={ context.path } />;
 	}
@@ -94,7 +94,7 @@ export function licensesContext( context: PageJS.Context, next: () => void ): vo
 
 	context.header = <Header />;
 	if ( isEnabled( 'jetpack/new-navigation' ) ) {
-		context.secondary = <NewJetpackManageSidebar />;
+		context.secondary = <NewJetpackManageSidebar path={ context.path } />;
 	} else {
 		context.secondary = <PartnerPortalSidebar path={ context.path } />;
 	}

--- a/client/jetpack-cloud/sections/plugin-management/controller.tsx
+++ b/client/jetpack-cloud/sections/plugin-management/controller.tsx
@@ -20,7 +20,7 @@ const redirectIfHasNoAccess = ( context: PageJS.Context ) => {
 
 const setSidebar = ( context: PageJS.Context ): void => {
 	if ( config.isEnabled( 'jetpack/new-navigation' ) ) {
-		context.secondary = <NewJetpackManageSidebar />;
+		context.secondary = <NewJetpackManageSidebar path={ context.path } />;
 	} else {
 		context.secondary = <DashboardSidebar path={ context.path } />;
 	}

--- a/client/jetpack-cloud/sections/sidebar-navigation/jetpack-manage.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/jetpack-manage.tsx
@@ -3,25 +3,24 @@ import { useTranslate } from 'i18n-calypso';
 import JetpackIcons from 'calypso/components/jetpack/sidebar/menu-items/jetpack-icons';
 import GuidedTour from 'calypso/jetpack-cloud/components/guided-tour';
 import NewSidebar from 'calypso/jetpack-cloud/components/sidebar';
+import { itemLinkMatches } from 'calypso/my-sites/sidebar/utils';
 import {
 	JETPACK_MANAGE_DASHBOARD_LINK,
 	JETPACK_MANAGE_PLUGINS_LINK,
 	JETPACK_MANAGE_LICENCES_LINK,
 	JETPACK_MANAGE_BILLING_LINK,
 } from './lib/constants';
-import { redirectPage, isMenuItemSelected } from './lib/sidebar';
 import type { MenuItemProps } from './types';
 
 const BILLING_MENU_ITEM_ID = 'partner-portal-billing-menu-item';
 
-const JetpackManageSidebar = () => {
+const JetpackManageSidebar = ( { path }: { path: string } ) => {
 	const translate = useTranslate();
 
 	const createItem = ( props: MenuItemProps ) => ( {
 		...props,
-		onClickMenuItem: redirectPage,
 		trackEventName: 'calypso_jetpack_sidebar_menu_click',
-		isSelected: isMenuItemSelected( props.link ),
+		isSelected: itemLinkMatches( props.link, path ),
 	} );
 
 	const menuItems = [

--- a/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
@@ -82,7 +82,6 @@ const useMenuItems = ( {
 					path: '/',
 					link: `${ JETPACK_CLOUD_ACTIVITY_LOG_LINK }/${ siteSlug }`,
 					title: translate( 'Activity Log' ),
-					onClickMenuItem: redirectPage,
 					trackEventName: 'calypso_jetpack_sidebar_activity_clicked',
 					enabled: isAdmin,
 					isSelected: itemLinkMatches( path, `${ JETPACK_CLOUD_ACTIVITY_LOG_LINK }/${ siteSlug }` ),
@@ -92,7 +91,6 @@ const useMenuItems = ( {
 					path: '/',
 					link: pluginsPath( siteSlug ),
 					title: translate( 'Plugins' ),
-					onClickMenuItem: redirectPage,
 					trackEventName: 'calypso_jetpack_sidebar_plugins_clicked',
 					enabled: isPluginManagementEnabled && isAgency,
 					isSelected: itemLinkMatches( path, pluginsPath( siteSlug ) ),
@@ -102,7 +100,6 @@ const useMenuItems = ( {
 					path: '/',
 					link: backupPath( siteSlug ),
 					title: translate( 'Backup' ),
-					onClickMenuItem: redirectPage,
 					trackEventName: 'calypso_jetpack_sidebar_backup_clicked',
 					enabled: isAdmin && ! isWPForTeamsSite,
 					isSelected: itemLinkMatches( path, backupPath( siteSlug ) ),
@@ -112,7 +109,6 @@ const useMenuItems = ( {
 					path: '/',
 					link: scanPath( siteSlug ),
 					title: translate( 'Scan' ),
-					onClickMenuItem: redirectPage,
 					trackEventName: 'calypso_jetpack_sidebar_scan_clicked',
 					enabled: isAdmin && ! isWPCOM && ! isWPForTeamsSite,
 					isSelected: itemLinkMatches( path, scanPath( siteSlug ) ),
@@ -122,7 +118,6 @@ const useMenuItems = ( {
 					path: '/',
 					link: `${ JETPACK_CLOUD_SEARCH_LINK }/${ siteSlug }`,
 					title: translate( 'Search' ),
-					onClickMenuItem: redirectPage,
 					trackEventName: 'calypso_jetpack_sidebar_search_clicked',
 					enabled: true,
 					isSelected: itemLinkMatches( path, `${ JETPACK_CLOUD_SEARCH_LINK }/${ siteSlug }` ),
@@ -132,7 +127,6 @@ const useMenuItems = ( {
 					path: '/',
 					link: `${ JETPACK_CLOUD_SOCIAL_LINK }/${ siteSlug }`,
 					title: translate( 'Social' ),
-					onClickMenuItem: redirectPage,
 					trackEventName: 'calypso_jetpack_sidebar_social_clicked',
 					enabled: isAdmin && isSectionNameEnabled( 'jetpack-social' ) && ! isWPForTeamsSite,
 					isSelected: itemLinkMatches( path, `${ JETPACK_CLOUD_SOCIAL_LINK }/${ siteSlug }` ),
@@ -142,7 +136,6 @@ const useMenuItems = ( {
 					path: '/',
 					link: settingsPath( siteSlug ),
 					title: translate( 'Settings' ),
-					onClickMenuItem: redirectPage,
 					trackEventName: 'calypso_jetpack_sidebar_settings_clicked',
 					enabled: shouldShowSettings,
 					isSelected: itemLinkMatches( path, settingsPath( siteSlug ) ),
@@ -152,7 +145,6 @@ const useMenuItems = ( {
 					path: '/',
 					link: purchasesPath( siteSlug ),
 					title: translate( 'Purchases' ),
-					onClickMenuItem: redirectPage,
 					trackEventName: 'calypso_jetpack_sidebar_purchases_clicked',
 					enabled: shouldShowPurchases,
 					isSelected: itemLinkMatches( path, purchasesPath( siteSlug ) ),
@@ -197,6 +189,7 @@ const ManageSelectedSiteSidebar = ( { path }: { path: string } ) => {
 									dispatch(
 										recordTracksEvent( 'calypso_jetpack_sidebar_site_settings_back_button_click' )
 									);
+
 									redirectPage( '/dashboard' );
 								},
 						  }

--- a/client/jetpack-cloud/sections/sidebar-navigation/purchases.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/purchases.tsx
@@ -1,6 +1,7 @@
 import { chevronLeft, formatListBulletsRTL, payment, receipt, store, tag } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import NewSidebar from 'calypso/jetpack-cloud/components/sidebar';
+import { itemLinkMatches } from 'calypso/my-sites/sidebar/utils';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
@@ -12,20 +13,19 @@ import {
 	JETPACK_MANAGE_PAYMENT_METHODS_LINK,
 	JETPACK_MANAGE_PRICES_LINK,
 } from './lib/constants';
-import { isMenuItemSelected, redirectPage } from './lib/sidebar';
+import { redirectPage } from './lib/sidebar';
 import { MenuItemProps } from './types';
 
-const createItem = ( props: Omit< MenuItemProps, 'path' > ) => ( {
-	...props,
-	path: JETPACK_MANAGE_PARTNER_PORTAL_LINK,
-	onClickMenuItem: redirectPage,
-	trackEventName: 'calypso_jetpack_sidebar_menu_click',
-	isSelected: isMenuItemSelected( props.link ),
-} );
-
-const PurchasesSidebar = () => {
+const PurchasesSidebar = ( { path }: { path: string } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+
+	const createItem = ( props: Omit< MenuItemProps, 'path' > ) => ( {
+		...props,
+		path: JETPACK_MANAGE_PARTNER_PORTAL_LINK,
+		trackEventName: 'calypso_jetpack_sidebar_menu_click',
+		isSelected: itemLinkMatches( props.link, path ),
+	} );
 
 	const menuItems = [
 		createItem( {
@@ -83,6 +83,7 @@ const PurchasesSidebar = () => {
 					dispatch(
 						recordTracksEvent( 'calypso_jetpack_sidebar_new_purchases_back_button_click' )
 					);
+
 					redirectPage( JETPACK_MANAGE_DASHBOARD_LINK );
 				},
 			} }

--- a/client/layout/sidebar-v2/navigator/navigator-menu-item.tsx
+++ b/client/layout/sidebar-v2/navigator/navigator-menu-item.tsx
@@ -20,7 +20,7 @@ interface Props {
 	onClickMenuItem: ( path: string ) => void;
 	withChevron?: boolean;
 	isExternalLink?: boolean;
-	isSelected: boolean;
+	isSelected?: boolean;
 }
 
 export const SidebarNavigatorMenuItem = ( {
@@ -30,9 +30,9 @@ export const SidebarNavigatorMenuItem = ( {
 	link,
 	title,
 	onClickMenuItem,
-	withChevron,
-	isExternalLink,
-	isSelected,
+	withChevron = false,
+	isExternalLink = false,
+	isSelected = false,
 }: Props ) => {
 	const SidebarItem = ( { children }: { children?: JSX.Element } ) => {
 		return (

--- a/client/layout/sidebar-v2/navigator/navigator-menu-item.tsx
+++ b/client/layout/sidebar-v2/navigator/navigator-menu-item.tsx
@@ -41,7 +41,9 @@ export const SidebarNavigatorMenuItem = ( {
 					'is-active': isSelected,
 				} ) }
 				onClick={ () => onClickMenuItem( link ) }
+				href={ link }
 				id={ id }
+				as="a"
 			>
 				<HStack justify="flex-start">
 					{ icon && <Icon style={ { fill: 'currentcolor' } } icon={ icon } size={ ICON_SIZE } /> }

--- a/client/layout/sidebar-v2/navigator/style.scss
+++ b/client/layout/sidebar-v2/navigator/style.scss
@@ -30,6 +30,8 @@
 }
 
 .sidebar-v2__menu-item.components-item {
+	color: inherit;
+
 	font-size: rem(13px);
 
 	&:hover:not(.is-active) {


### PR DESCRIPTION
This pull request converts all sidebar menu items from buttons to links, so that they're a little more in line with accessibility standards.

Resolves https://github.com/Automattic/jetpack-genesis/issues/76.

## Proposed Changes

* `SidebarNavigatorMenuItem`:
	* Add a new property `as="a"` to the `Item` child component, so menu items are rendered as `a` tags instead of `button` tags (the default behavior).
	* Add an `href` property to the `Item` child component and assign it the value of the passed-in `link` property, to be used when it's rendered inside an `a` tag.
* Add a styling rule to suppress green link coloring for sidebar menu items.

## Testing Instructions

* Launch this pull request in your Jetpack Cloud testing environment.
* Hover over any sidebar item and confirm you see the item's URL preview in your browser before clicking.
* Verify every sidebar item still functions as it did before, including link behavior and Tracks events.