### PR TITLE
Support subdomain forwarding for external A records

### DIFF
--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -318,18 +318,42 @@ const Settings = ( {
 		);
 	};
 
-	const renderDnsRecordsNotice = () => {
-		if (
-			( ! englishLocales.includes( getLocaleSlug() || '' ) &&
-				! i18n.hasTranslation(
-					"Your domain is using external name servers so the DNS records you're editing won't be in effect until you switch to use WordPress.com name servers. {{a}}Update your name servers now{{/a}}."
-				) ) ||
-			areAllWpcomNameServers() ||
-			! nameservers ||
-			! nameservers.length
-		) {
+	const renderExternalNameserversNotice = ( noticeType: string ) => {
+		if ( areAllWpcomNameServers() || ! nameservers || ! nameservers.length ) {
 			return null;
 		}
+
+		const dnsRecordsNotice = translate(
+			"Your domain is using external name servers so the DNS records you're editing won't be in effect until you switch to use WordPress.com name servers. {{a}}Update your name servers now{{/a}}.",
+			{
+				components: {
+					a: (
+						<a
+							href={ domainManagementEdit( selectedSite.slug, selectedDomainName, currentRoute, {
+								nameservers: true,
+							} ) }
+						/>
+					),
+				},
+			}
+		);
+
+		const domainForwardingNotice = translate(
+			"Your domain is using external name servers so the Domain Forwarding records you're editing won't be in effect until you switch to use WordPress.com name servers. {{a}}Update your name servers now{{/a}}.",
+			{
+				components: {
+					a: (
+						<a
+							href={ domainManagementEdit( selectedSite.slug, selectedDomainName, currentRoute, {
+								nameservers: true,
+							} ) }
+						/>
+					),
+				},
+			}
+		);
+
+		const notice = noticeType === 'DNS' ? dnsRecordsNotice : domainForwardingNotice;
 
 		return (
 			<div className="dns-records-card-notice">
@@ -339,25 +363,7 @@ const Settings = ( {
 					className="dns-records-card-notice__icon gridicon"
 					viewBox="2 2 20 20"
 				/>
-				<div className="dns-records-card-notice__message">
-					{ translate(
-						"Your domain is using external name servers so the DNS records you're editing won't be in effect until you switch to use WordPress.com name servers. {{a}}Update your name servers now{{/a}}.",
-						{
-							components: {
-								a: (
-									<a
-										href={ domainManagementEdit(
-											selectedSite.slug,
-											selectedDomainName,
-											currentRoute,
-											{ nameservers: true }
-										) }
-									/>
-								),
-							},
-						}
-					) }
-				</div>
+				<div className="dns-records-card-notice__message">{ notice }</div>
 			</div>
 		);
 	};
@@ -381,7 +387,7 @@ const Settings = ( {
 				>
 					{ domain.canManageDnsRecords ? (
 						<>
-							{ renderDnsRecordsNotice() }
+							{ renderExternalNameserversNotice( 'DNS' ) }
 							<DnsRecords
 								dns={ dns }
 								selectedDomainName={ selectedDomainName }
@@ -424,7 +430,11 @@ const Settings = ( {
 				subtitle={ translate( 'Forward your domain to another' ) }
 				isDisabled={ domain.isMoveToNewSitePending }
 			>
-				<DomainForwardingCard domain={ domain } />
+				{ renderExternalNameserversNotice( 'DOMAIN_FORWARDING' ) }
+				<DomainForwardingCard
+					domain={ domain }
+					areAllWpcomNameServers={ areAllWpcomNameServers() }
+				/>
 			</Accordion>
 		);
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 4347-gh-Automattic/dotcom-forge

## Proposed Changes

* Update 1: Allow users to edit Subdomains Forwardings if the NS is pointing to us and the DNS A record is pointing away:

	| Before | After |
	|--------|--------|
	|<img width="724" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/4dcd1ef3-ce02-4af8-a717-2a565d8af55c"> | <img width="687" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/2dd965ca-22df-46ff-a96e-e41d752100ec"> | 

* Update 2: Allow users to edit Domain Forwarding even if it's disabled (to match "DNS records" strategy)

	| Before | After |
	|--------|--------|
	| <img width="692" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/7760ff0c-2076-4805-8f1a-a4db0fc60031"> | <img width="664" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/09eaab6c-c68f-4066-8c08-16caf459dab7"> | 

* Update 3: Show a warning message if NS servers are not pointing to DOTCOM: 

	| Before | After |
	|--------|--------|
	|<img width="693" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/fb10763d-e2f3-43ae-9289-1b6d4586cc4b"> | <img width="690" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/2939e732-c30c-42fb-8340-c24a65ffab1b"> | 

	The message is similar to the DNS records:

	<img width="687" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/59daa5c8-9988-4a9b-bc47-51a6a1424028">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Update 1**
* Using a valid domain, change the DNS A record to point outside wordpress.com
* Ensure the warning "You can only forward subdomains. To forward..." will show when DNS A is pointing away (it can take a bit to start showing)
* Apply this diff: D126993-code
* Ensure you can only add subdomain forwarding
* Create a new subdomain forwarding and test if it works as expected

**Update 2 and 3**
* Configure your NS server to be outside wpcom
* Ensure you see the warning message
* Ensure you still can edit Domain Forwarding
* Ensure you won't see two warnings ad the same time. If the NS server is pointing away, we don't expect to show the warning "You can only forward subdomains. To forward..."

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?