### PR TITLE
wp-admin Site Default: Add checked style on `FormRadio` when loading

### DIFF
--- a/client/my-sites/hosting/site-admin-interface-card/index.js
+++ b/client/my-sites/hosting/site-admin-interface-card/index.js
@@ -1,5 +1,6 @@
 /* eslint-disable wpcalypso/jsx-gridicon-size */
 import { Card } from '@automattic/components';
+import styled from '@emotion/styled';
 import { useTranslate, localize } from 'i18n-calypso';
 import { useState, useEffect } from 'react';
 import { connect, useDispatch } from 'react-redux';
@@ -17,6 +18,13 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { useSiteInterfaceMutation } from './use-select-interface-mutation';
 const successNoticeId = 'admin-interface-change-success';
 const failureNoticeId = 'admin-interface-change-failure';
+
+const FormRadioStyled = styled( FormRadio )( {
+	'&.form-radio:disabled:checked::before': {
+		backgroundColor: 'var(--color-primary)',
+		opacity: 0.6,
+	},
+} );
 
 const SiteAdminInterfaceCard = ( { siteId, adminInterface } ) => {
 	const translate = useTranslate();
@@ -86,7 +94,7 @@ const SiteAdminInterfaceCard = ( { siteId, adminInterface } ) => {
 
 			<FormFieldset>
 				<FormLabel>
-					<FormRadio
+					<FormRadioStyled
 						label={ translate( 'Default style' ) }
 						value="calypso"
 						checked={ selectedAdminInterface === 'calypso' }
@@ -100,7 +108,7 @@ const SiteAdminInterfaceCard = ( { siteId, adminInterface } ) => {
 			</FormFieldset>
 			<FormFieldset>
 				<FormLabel>
-					<FormRadio
+					<FormRadioStyled
 						label={ translate( 'Classic style' ) }
 						value="wp-admin"
 						checked={ selectedAdminInterface === 'wp-admin' }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Related to https://github.com/Automattic/dotcom-forge/issues/4291

## Proposed Changes

* Display the checked `FormRadio` even if it's disabled

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to `/hosting-config/$siteSlug` on the current branch.
2. Scroll down to locate the `Admin Interface Style` section.
3. Select `Classic Style` from the available options.
4. Note that the options will be locked, preventing any changes until the mutation process is complete.
5. **Observe that the Radio is always checked even when is disabled when updating.**
6. Try changing the option multiple times.
7. Confirm that the option consistently displays a single value without fluctuating, thereby ensuring that no race condition exists.


## Screenshots

| **Before** | **After** |
| ---------- | --------- |
| <img width="754" alt="Screenshot 2023-10-27 at 20 55 52" src="https://github.com/Automattic/wp-calypso/assets/779993/6b90a2ed-a302-4a65-9e8a-342e25990c38"> |  <img width="754" alt="Screenshot 2023-10-27 at 20 55 24" src="https://github.com/Automattic/wp-calypso/assets/779993/cfe16d32-7985-4c97-8edf-0ff5a05cc4df"> |


## Screencast

https://github.com/Automattic/wp-calypso/assets/779993/7550d77e-0c38-41fd-9d6e-3a43353d5d52



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?