### PR TITLE
JP Manage: 56 - add tooltip to partner opt-in fieldset

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
@@ -220,6 +220,7 @@ export default function CompanyDetailsForm( {
 						<FormLabel htmlFor="partnerProgramOptIn">
 							{ translate( 'Jetpack Agency & Pro Partner program' ) }
 							<Icon
+								className="company-details-form__info"
 								size={ 16 }
 								icon={ info }
 							/>

--- a/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
@@ -1,4 +1,5 @@
 import { Button, Gridicon } from '@automattic/components';
+import { Icon, info } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState, useMemo, ChangeEvent, useEffect } from 'react';
 import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
@@ -218,6 +219,10 @@ export default function CompanyDetailsForm( {
 					<FormFieldset>
 						<FormLabel htmlFor="partnerProgramOptIn">
 							{ translate( 'Jetpack Agency & Pro Partner program' ) }
+							<Icon
+								size={ 16 }
+								icon={ info }
+							/>
 						</FormLabel>
 						<FormInputCheckbox
 							id="partnerProgramOptIn"

--- a/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
@@ -1,14 +1,13 @@
 import { Button, Gridicon } from '@automattic/components';
-import { Icon, info } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState, useMemo, ChangeEvent, useEffect } from 'react';
-import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormRadio from 'calypso/components/forms/form-radio';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
 import { PartnerDetailsPayload } from 'calypso/state/partner-portal/types';
+import PartnerProgramOptInFieldSet from '../partner-program-opt-in-fieldset/partner-program-opt-in-fieldset';
 import SearchableDropdown from '../searchable-dropdown';
 import { Option as CountryOption, useCountriesAndStates } from './hooks/use-countries-and-states';
 
@@ -215,27 +214,11 @@ export default function CompanyDetailsForm( {
 						className={ undefined }
 					/>
 				</FormFieldset>
-				{ showPartnerProgramOptIn && (
-					<FormFieldset>
-						<FormLabel htmlFor="partnerProgramOptIn">
-							{ translate( 'Jetpack Agency & Pro Partner program' ) }
-							<Icon
-								className="company-details-form__info"
-								size={ 16 }
-								icon={ info }
-							/>
-						</FormLabel>
-						<FormInputCheckbox
-							id="partnerProgramOptIn"
-							name="partnerProgramOptIn"
-							checked={ partnerProgramOptIn }
-							disabled={ isLoading }
-							onChange={ ( event: ChangeEvent< HTMLInputElement > ) =>
-								setPartnerProgramOptIn( event.target.checked )
-							}
-						/>
-						<span>{ translate( 'Sign up for the Jetpack Agency & Pro Partner program' ) }</span>
-					</FormFieldset>
+				{ showPartnerProgramOptIn && ! isLoading && (
+					<PartnerProgramOptInFieldSet
+						setPartnerProgramOptIn={ setPartnerProgramOptIn }
+						isChecked={ partnerProgramOptIn }
+					/>
 				) }
 				<FormFieldset>
 					<FormLabel>{ translate( 'Country' ) }</FormLabel>

--- a/client/jetpack-cloud/sections/partner-portal/company-details-form/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/company-details-form/style.scss
@@ -26,3 +26,9 @@
 	line-height: 24px;
 	color: var(--studio-black);
 }
+
+.company-details-form {
+	&__info {
+		vertical-align: text-top;
+	}
+}

--- a/client/jetpack-cloud/sections/partner-portal/company-details-form/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/company-details-form/style.scss
@@ -26,9 +26,4 @@
 		line-height: 24px;
 		color: var(--studio-black);
 	}
-
-	// gives SVG icon better vertical alignment with text
-	&__info {
-		vertical-align: text-top;
-	}
 }

--- a/client/jetpack-cloud/sections/partner-portal/company-details-form/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/company-details-form/style.scss
@@ -1,33 +1,33 @@
-.card.company-details-form {
+.company-details-form {
+
 	// We have to add some "invisible" spacing below the form so
 	// our country and state dropdown have enough space to fold out
 	// and be visible (using position: relative/absolute).
 	margin-bottom: 100px;
-}
 
-.company-details-form__controls {
-	margin-top: 2rem;
-}
+	&__controls {
+		margin-top: 2rem;
+	}
 
-.company-details-form__business-address {
-	input {
-		margin-bottom: 10px !important;
+	&__business-address {
+		input {
+			margin-bottom: 10px !important;
 
-		&:last-child {
-			margin-bottom: 0 !important;
+			&:last-child {
+				margin-bottom: 0 !important;
+			}
 		}
 	}
-}
 
-.company-details-form__tos p {
-	margin: 45px 0 24px;
-	font-weight: 400;
-	font-size: 1rem;
-	line-height: 24px;
-	color: var(--studio-black);
-}
+	&__tos p {
+		margin: 45px 0 24px;
+		font-weight: 400;
+		font-size: 1rem;
+		line-height: 24px;
+		color: var(--studio-black);
+	}
 
-.company-details-form {
+	// gives SVG icon better vertical alignment with text
 	&__info {
 		vertical-align: text-top;
 	}

--- a/client/jetpack-cloud/sections/partner-portal/partner-program-opt-in-fieldset/partner-program-opt-in-fieldset.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/partner-program-opt-in-fieldset/partner-program-opt-in-fieldset.tsx
@@ -1,10 +1,10 @@
+import { Button, Popover } from '@automattic/components';
 import { Icon, info } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { ChangeEvent, useState } from 'react';
+import { ChangeEvent, useRef, useState } from 'react';
 import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
-import JetpackLightbox, { JetpackLightboxMain } from 'calypso/components/jetpack/jetpack-lightbox';
 
 import './style.scss';
 
@@ -21,16 +21,21 @@ export default function PartnerProgramOptInFieldset( {
 
 	const [ showPartnerProgramDetails, setShowPartnerProgramDetails ] = useState( false );
 
+	const detailsRef = useRef< HTMLElement | null >( null );
+
 	return (
 		<FormFieldset className="partner-program-opt-in-field">
 			<FormLabel>
 				{ translate( 'Jetpack Agency & Pro Partner program' ) }
-				<Icon
-					className="partner-program-opt-in-field__info"
-					size={ 16 }
-					icon={ info }
-					onClick={ () => setShowPartnerProgramDetails( true ) }
-				/>
+				<span></span>
+				<span ref={ detailsRef }>
+					<Icon
+						className="partner-program-opt-in-field__details-icon"
+						size={ 16 }
+						icon={ info }
+						onClick={ () => setShowPartnerProgramDetails( true ) }
+					/>
+				</span>
 			</FormLabel>
 			<FormInputCheckbox
 				id="partnerProgramOptIn"
@@ -41,11 +46,31 @@ export default function PartnerProgramOptInFieldset( {
 				}
 			/>
 			<span>{ translate( 'Sign up for the Jetpack Agency & Pro Partner program' ) }</span>
-			{ showPartnerProgramDetails && (
-				<JetpackLightbox isOpen={ true } onClose={ () => setShowPartnerProgramDetails( false ) }>
-					<JetpackLightboxMain>Placeholder</JetpackLightboxMain>
-				</JetpackLightbox>
-			) }
+			<Popover
+				className="partner-program-opt-in-field__details-popover"
+				context={ detailsRef.current }
+				isVisible={ showPartnerProgramDetails }
+				position="bottom"
+				showDelay={ 300 }
+			>
+				<h2>{ translate( 'Agency & Pro program benefits' ) }</h2>
+
+				<p>
+					{ translate(
+						"Our program is more than tooling. We'll provide resources to help you sell Jetpack, onboarding & training, marketing opportunities, access to our vibrant community, and more!"
+					) }
+				</p>
+
+				<p>
+					<a href="https://jetpack.com/agencies-pros/" target="_blank" rel="noreferrer">
+						{ translate( 'Learn more about this program.' ) }
+					</a>
+				</p>
+
+				<Button className="button" onClick={ () => setShowPartnerProgramDetails( false ) }>
+					{ translate( 'Got it' ) }
+				</Button>
+			</Popover>
 		</FormFieldset>
 	);
 }

--- a/client/jetpack-cloud/sections/partner-portal/partner-program-opt-in-fieldset/partner-program-opt-in-fieldset.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/partner-program-opt-in-fieldset/partner-program-opt-in-fieldset.tsx
@@ -21,7 +21,7 @@ export default function PartnerProgramOptInFieldset( {
 
 	const [ showPartnerProgramDetails, setShowPartnerProgramDetails ] = useState( false );
 
-	const detailsRef = useRef< HTMLElement | null >( null );
+	const detailsRef = useRef< HTMLButtonElement | null >( null );
 
 	return (
 		<FormFieldset className="partner-program-opt-in-field">

--- a/client/jetpack-cloud/sections/partner-portal/partner-program-opt-in-fieldset/partner-program-opt-in-fieldset.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/partner-program-opt-in-fieldset/partner-program-opt-in-fieldset.tsx
@@ -27,7 +27,6 @@ export default function PartnerProgramOptInFieldset( {
 		<FormFieldset className="partner-program-opt-in-field">
 			<FormLabel>
 				{ translate( 'Jetpack Agency & Pro Partner program' ) }
-				<span></span>
 				<span ref={ detailsRef }>
 					<Icon
 						className="partner-program-opt-in-field__details-icon"

--- a/client/jetpack-cloud/sections/partner-portal/partner-program-opt-in-fieldset/partner-program-opt-in-fieldset.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/partner-program-opt-in-fieldset/partner-program-opt-in-fieldset.tsx
@@ -27,14 +27,14 @@ export default function PartnerProgramOptInFieldset( {
 		<FormFieldset className="partner-program-opt-in-field">
 			<FormLabel>
 				{ translate( 'Jetpack Agency & Pro Partner program' ) }
-				<span ref={ detailsRef }>
-					<Icon
-						className="partner-program-opt-in-field__details-icon"
-						size={ 16 }
-						icon={ info }
-						onClick={ () => setShowPartnerProgramDetails( true ) }
-					/>
-				</span>
+				<Button
+					ref={ detailsRef }
+					className="partner-program-opt-in-field__details-icon-button"
+					borderless
+					onClick={ () => setShowPartnerProgramDetails( true ) }
+				>
+					<Icon size={ 16 } icon={ info } />
+				</Button>
 			</FormLabel>
 			<FormInputCheckbox
 				id="partnerProgramOptIn"

--- a/client/jetpack-cloud/sections/partner-portal/partner-program-opt-in-fieldset/partner-program-opt-in-fieldset.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/partner-program-opt-in-fieldset/partner-program-opt-in-fieldset.tsx
@@ -1,0 +1,43 @@
+import { Icon, info } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { ChangeEvent } from 'react';
+import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLabel from 'calypso/components/forms/form-label';
+
+import './style.scss';
+
+interface Props {
+	setPartnerProgramOptIn: ( partnerProgramOptIn: boolean ) => void;
+	isChecked: boolean;
+}
+
+export default function PartnerProgramOptInFieldset( {
+	setPartnerProgramOptIn,
+	isChecked,
+}: Props ) {
+	const translate = useTranslate();
+
+
+	return (
+		<FormFieldset className="partner-program-opt-in-field">
+			<FormLabel>
+				{ translate( 'Jetpack Agency & Pro Partner program' ) }
+				<Icon
+					className="partner-program-opt-in-field__info"
+					size={ 16 }
+					icon={ info }
+				/>
+			</FormLabel>
+			<FormInputCheckbox
+				id="partnerProgramOptIn"
+				name="partnerProgramOptIn"
+				checked={ isChecked }
+				onChange={ ( event: ChangeEvent< HTMLInputElement > ) =>
+					setPartnerProgramOptIn( event.target.checked )
+				}
+			/>
+			<span>{ translate( 'Sign up for the Jetpack Agency & Pro Partner program' ) }</span>
+		</FormFieldset>
+	);
+}

--- a/client/jetpack-cloud/sections/partner-portal/partner-program-opt-in-fieldset/partner-program-opt-in-fieldset.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/partner-program-opt-in-fieldset/partner-program-opt-in-fieldset.tsx
@@ -1,5 +1,5 @@
 import { Button, Popover } from '@automattic/components';
-import { Icon, info } from '@wordpress/icons';
+import { Icon, info, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { ChangeEvent, useRef, useState } from 'react';
 import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
@@ -62,7 +62,8 @@ export default function PartnerProgramOptInFieldset( {
 
 				<p>
 					<a href="https://jetpack.com/agencies-pros/" target="_blank" rel="noreferrer">
-						{ translate( 'Learn more about this program.' ) }
+						{ translate( 'More about the program' ) }
+						<Icon icon={ external } size={ 16 } />
 					</a>
 				</p>
 

--- a/client/jetpack-cloud/sections/partner-portal/partner-program-opt-in-fieldset/partner-program-opt-in-fieldset.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/partner-program-opt-in-fieldset/partner-program-opt-in-fieldset.tsx
@@ -1,9 +1,10 @@
 import { Icon, info } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { ChangeEvent } from 'react';
+import { ChangeEvent, useState } from 'react';
 import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
+import JetpackLightbox, { JetpackLightboxMain } from 'calypso/components/jetpack/jetpack-lightbox';
 
 import './style.scss';
 
@@ -18,6 +19,7 @@ export default function PartnerProgramOptInFieldset( {
 }: Props ) {
 	const translate = useTranslate();
 
+	const [ showPartnerProgramDetails, setShowPartnerProgramDetails ] = useState( false );
 
 	return (
 		<FormFieldset className="partner-program-opt-in-field">
@@ -27,6 +29,7 @@ export default function PartnerProgramOptInFieldset( {
 					className="partner-program-opt-in-field__info"
 					size={ 16 }
 					icon={ info }
+					onClick={ () => setShowPartnerProgramDetails( true ) }
 				/>
 			</FormLabel>
 			<FormInputCheckbox
@@ -38,6 +41,11 @@ export default function PartnerProgramOptInFieldset( {
 				}
 			/>
 			<span>{ translate( 'Sign up for the Jetpack Agency & Pro Partner program' ) }</span>
+			{ showPartnerProgramDetails && (
+				<JetpackLightbox isOpen={ true } onClose={ () => setShowPartnerProgramDetails( false ) }>
+					<JetpackLightboxMain>Placeholder</JetpackLightboxMain>
+				</JetpackLightbox>
+			) }
 		</FormFieldset>
 	);
 }

--- a/client/jetpack-cloud/sections/partner-portal/partner-program-opt-in-fieldset/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/partner-program-opt-in-fieldset/style.scss
@@ -1,0 +1,6 @@
+.partner-program-opt-in-field {
+	// gives SVG icon better vertical alignment with text
+	&__info {
+		vertical-align: text-top;
+	}
+}

--- a/client/jetpack-cloud/sections/partner-portal/partner-program-opt-in-fieldset/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/partner-program-opt-in-fieldset/style.scss
@@ -1,6 +1,36 @@
 .partner-program-opt-in-field {
 	// gives SVG icon better vertical alignment with text
-	&__info {
+	&__details-icon {
 		vertical-align: text-top;
 	}
+
+	&__details-popover {
+		.popover__inner {
+			display: flex;
+			gap: 16px;
+			padding: 16px;
+			flex-direction: column;
+			align-items: flex-start;
+		}
+
+		h2 {
+			font-size: rem(14px);
+			line-height: 1.5;
+		}
+
+		p {
+			color: var(--studio-gray-80);
+			font-size: rem(12px);
+			line-height: 1.5;
+			max-width: 220px;
+			text-align: left;
+			margin-block-end: 0;
+		}
+
+		.button {
+			padding: 4px 8px;
+			font-size: rem(12px);
+		}
+	}
+
 }

--- a/client/jetpack-cloud/sections/partner-portal/partner-program-opt-in-fieldset/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/partner-program-opt-in-fieldset/style.scss
@@ -22,7 +22,7 @@
 			color: var(--studio-gray-80);
 			font-size: rem(12px);
 			line-height: 1.5;
-			max-width: 220px;
+			max-width: 300px;
 			text-align: left;
 			margin-block-end: 0;
 		}

--- a/client/jetpack-cloud/sections/partner-portal/partner-program-opt-in-fieldset/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/partner-program-opt-in-fieldset/style.scss
@@ -32,6 +32,10 @@
 			padding: 4px 8px;
 			font-size: rem(12px);
 		}
+
+		svg {
+			vertical-align: text-top;
+		}
 	}
 
 }

--- a/client/jetpack-cloud/sections/partner-portal/partner-program-opt-in-fieldset/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/partner-program-opt-in-fieldset/style.scss
@@ -1,7 +1,8 @@
 .partner-program-opt-in-field {
 	// gives SVG icon better vertical alignment with text
-	&__details-icon {
-		vertical-align: text-top;
+	&__details-icon-button {
+		vertical-align: sub;
+		padding: 0;
 	}
 
 	&__details-popover {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves Automattic/jetpack-manage#56 - add tooltip to partner opt-in fieldset

## Proposed Changes

This does the following:

* Splits the opt-in logic into its own component: `PartnerProgramOptInFieldset`
* Adds an info icon to the fieldset
* Shows a popover if the info icon is clicked

Copy is pulled directly from original issue. Note that the original issue suggested using a lightbox, but upon testing it didn't seem to fit.

**Note:** I welcome any commits to improve the styling, particularly with regards to the "learn more" link. The styling and "Got it" button text was largely pulled from the existing popovers on the JP Manage dashboard:

![image](https://github.com/Automattic/wp-calypso/assets/32492176/1930bc32-947a-4f40-8e25-e6da3e604717)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Using the `add/jp-manage/56-partner_opt-in_tooltip` branch:

1. Go here (may need `?flags=-jetpack/new-navigation`): `http://jetpack.cloud.localhost:3000/manage/signup`
2. Select one of the first two company types.
3. Click on the info icon.

It will look like this:
![image](https://github.com/Automattic/wp-calypso/assets/32492176/c0402bd3-6381-439b-ae46-ab924e0233cc)

I also considered an alternate, with the popover to the right, but slightly preferred the above:
![image](https://github.com/Automattic/wp-calypso/assets/32492176/dded05b9-3089-4db4-b3b5-dc16581579ad)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
