### PR TITLE
Domains: Improve .page & .gay TLDs info icon design

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -36,6 +36,8 @@ import { getProductsList } from 'calypso/state/products-list/selectors';
 import { getCurrentFlowName } from 'calypso/state/signup/flow/selectors';
 import PremiumBadge from './premium-badge';
 
+import './style.scss';
+
 class DomainRegistrationSuggestion extends Component {
 	static propTypes = {
 		isDomainOnly: PropTypes.bool,
@@ -259,8 +261,6 @@ class DomainRegistrationSuggestion extends Component {
 
 	renderDomain() {
 		const {
-			showHstsNotice,
-			showDotGayNotice,
 			suggestion: { domain_name: domain },
 		} = this.props;
 
@@ -273,9 +273,7 @@ class DomainRegistrationSuggestion extends Component {
 
 		return (
 			<div className={ titleWrapperClassName }>
-				<h3 className="domain-registration-suggestion__title">
-					{ title } { ( showHstsNotice || showDotGayNotice ) && this.renderInfoBubble() }
-				</h3>
+				<h3 className="domain-registration-suggestion__title">{ title }</h3>
 				{ this.renderBadges() }
 			</div>
 		);
@@ -320,22 +318,6 @@ class DomainRegistrationSuggestion extends Component {
 		);
 	}
 
-	renderInfoBubble() {
-		const { isFeatured, showHstsNotice, showDotGayNotice } = this.props;
-
-		const infoPopoverSize = isFeatured ? 22 : 18;
-		return (
-			<InfoPopover
-				className="domain-registration-suggestion__hsts-tooltip"
-				iconSize={ infoPopoverSize }
-				position="right"
-			>
-				{ ( showHstsNotice && this.getHstsMessage() ) ||
-					( showDotGayNotice && this.getDotGayMessage() ) }
-			</InfoPopover>
-		);
-	}
-
 	renderBadges() {
 		const {
 			suggestion: { isRecommended, isBestAlternative, is_premium: isPremium },
@@ -343,6 +325,8 @@ class DomainRegistrationSuggestion extends Component {
 			isFeatured,
 			productSaleCost,
 			premiumDomain,
+			showHstsNotice,
+			showDotGayNotice,
 		} = this.props;
 		const badges = [];
 
@@ -371,6 +355,24 @@ class DomainRegistrationSuggestion extends Component {
 		if ( isPremium ) {
 			badges.push(
 				<PremiumBadge key="premium" restrictedPremium={ premiumDomain?.is_price_limit_exceeded } />
+			);
+		}
+
+		if ( showHstsNotice ) {
+			badges.push(
+				<Badge key="hsts-notice">
+					{ translate( 'SSL Required' ) }
+					<InfoPopover iconSize={ 16 }>{ this.getHstsMessage() }</InfoPopover>
+				</Badge>
+			);
+		}
+
+		if ( showDotGayNotice ) {
+			badges.push(
+				<Badge key="lgbtq">
+					{ translate( 'LGBTQ' ) }
+					<InfoPopover iconSize={ 16 }>{ this.getDotGayMessage() }</InfoPopover>
+				</Badge>
 			);
 		}
 

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -362,7 +362,9 @@ class DomainRegistrationSuggestion extends Component {
 			badges.push(
 				<Badge key="hsts-notice">
 					{ translate( 'SSL Required' ) }
-					<InfoPopover iconSize={ 16 }>{ this.getHstsMessage() }</InfoPopover>
+					<InfoPopover iconSize={ 16 } showOnHover>
+						{ this.getHstsMessage() }
+					</InfoPopover>
 				</Badge>
 			);
 		}
@@ -371,7 +373,9 @@ class DomainRegistrationSuggestion extends Component {
 			badges.push(
 				<Badge key="lgbtq">
 					{ translate( 'LGBTQ' ) }
-					<InfoPopover iconSize={ 16 }>{ this.getDotGayMessage() }</InfoPopover>
+					<InfoPopover iconSize={ 16 } showOnHover>
+						{ this.getDotGayMessage() }
+					</InfoPopover>
 				</Badge>
 			);
 		}

--- a/client/components/domains/domain-registration-suggestion/premium-badge/style.scss
+++ b/client/components/domains/domain-registration-suggestion/premium-badge/style.scss
@@ -3,15 +3,6 @@
 		background-color: var(--color-premium-domain);
 		padding-right: 6px;
 		color: var(--color-warning-80);
-		.info-popover {
-			height: 16px;
-			vertical-align: middle;
-			margin-bottom: 1px;
-			margin-left: 5px;
-			.gridicon {
-				color: var(--color-warning-80);
-			}
-		}
 
 		&.restricted-premium {
 			background-color: var(--color-warning-30);

--- a/client/components/domains/domain-registration-suggestion/style.scss
+++ b/client/components/domains/domain-registration-suggestion/style.scss
@@ -1,0 +1,13 @@
+.domain-registration-suggestion__badges {
+	div.badge {
+		.info-popover {
+			height: 16px;
+			vertical-align: middle;
+			margin-bottom: 1px;
+			margin-left: 5px;
+			.gridicon {
+				color: var(--color-warning-80);
+			}
+		}
+	}
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4330

## Proposed Changes

* This PR creates badges for .page & .gay TLD info in domains search in place of the large info icon. This unifies the design presentation.

Before | After
--|--
<img width="1446" alt="Screenshot 2023-10-27 at 5 19 20 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/d4435ce8-c10f-44b3-bac7-eca2e2fd5cdc">  | <img width="1447" alt="Screenshot 2023-10-27 at 5 19 12 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/b2f9b7c9-2e34-431d-ad16-f5bd1395d778">



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /domains and/or /domains/add/[site]
* Search for exampledomain.gay and set the filter to `.page`
* View the new badges and check that they look good and are correct
* Check in mobile
* Make sure the premium domain badge still looks good. You can search for insurance.blog to see one.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?