### PR TITLE
FHT: Add post launch checklist view for hosting flow

### DIFF
--- a/client/my-sites/customer-home/cards/constants.js
+++ b/client/my-sites/customer-home/cards/constants.js
@@ -50,6 +50,7 @@ export const TASK_FIVERR = 'home-task-fiverr';
 export const TASK_DOMAIN_UPSELL = 'home-task-domain-upsell';
 export const TASK_GOOGLE_DOMAIN_OWNERS = 'home-task-google-domain-owners';
 export const LAUNCHPAD_INTENT_BUILD = 'home-launchpad-intent-build';
+export const LAUNCHPAD_INTENT_HOSTING = 'home-launchpad-intent-hosting';
 export const LAUNCHPAD_INTENT_WRITE = 'home-launchpad-intent-write';
 export const LAUNCHPAD_INTENT_FREE_NEWSLETTER = 'home-launchpad-intent-free-newsletter';
 export const LAUNCHPAD_INTENT_PAID_NEWSLETTER = 'home-launchpad-intent-paid-newsletter';

--- a/client/my-sites/customer-home/cards/launchpad/intent-hosting.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/intent-hosting.tsx
@@ -1,0 +1,13 @@
+import CustomerHomeLaunchpad from '.';
+
+const checklistSlug = 'host-site';
+
+const LaunchpadIntentHosting = (): JSX.Element => {
+	return (
+		<>
+			<CustomerHomeLaunchpad checklistSlug={ checklistSlug }></CustomerHomeLaunchpad>
+		</>
+	);
+};
+
+export default LaunchpadIntentHosting;

--- a/client/my-sites/customer-home/cards/launchpad/pre-launch.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/pre-launch.tsx
@@ -1,3 +1,4 @@
+import { updateLaunchpadSettings } from '@automattic/data-stores';
 import { useState } from 'react';
 import { useGetDomainsQuery } from 'calypso/data/domains/use-get-domains-query';
 import useHomeLayoutQuery from 'calypso/data/home/use-home-layout-query';
@@ -36,6 +37,13 @@ const LaunchpadPreLaunch = (): JSX.Element => {
 
 	const onSiteLaunched = () => {
 		setCelebrateLaunchModalIsOpenWrapper( true );
+		// currently the action to update site_launch status on atomic doesn't fire
+		// this is a workaround until that is fixed
+		if ( site?.is_wpcom_atomic ) {
+			updateLaunchpadSettings( siteId, {
+				checklist_statuses: { site_launched: true },
+			} );
+		}
 	};
 
 	return (

--- a/client/my-sites/customer-home/locations/primary/index.jsx
+++ b/client/my-sites/customer-home/locations/primary/index.jsx
@@ -34,8 +34,10 @@ import {
 	TASK_DOMAIN_UPSELL,
 	TASK_GOOGLE_DOMAIN_OWNERS,
 	LAUNCHPAD_INTENT_BUILD,
+	LAUNCHPAD_INTENT_HOSTING,
 } from 'calypso/my-sites/customer-home/cards/constants';
 import LaunchpadIntentBuild from 'calypso/my-sites/customer-home/cards/launchpad/intent-build';
+import LaunchpadIntentHosting from 'calypso/my-sites/customer-home/cards/launchpad/intent-hosting';
 import CelebrateSiteCopy from 'calypso/my-sites/customer-home/cards/notices/celebrate-site-copy';
 import CelebrateSiteCreation from 'calypso/my-sites/customer-home/cards/notices/celebrate-site-creation';
 import CelebrateSiteLaunch from 'calypso/my-sites/customer-home/cards/notices/celebrate-site-launch';
@@ -86,6 +88,7 @@ const cardComponents = {
 	[ TASK_SITE_RESUME_COPY ]: SiteResumeCopy,
 	[ TASK_SITE_SETUP_CHECKLIST ]: SiteSetupList,
 	[ LAUNCHPAD_INTENT_BUILD ]: LaunchpadIntentBuild,
+	[ LAUNCHPAD_INTENT_HOSTING ]: LaunchpadIntentHosting,
 	[ TASK_UPSELL_TITAN ]: TitanBanner,
 	[ TASK_WEBINARS ]: Webinars,
 	[ TASK_WP_COURSES ]: WPCourses,

--- a/client/my-sites/customer-home/locations/secondary/index.jsx
+++ b/client/my-sites/customer-home/locations/secondary/index.jsx
@@ -7,6 +7,7 @@ import {
 	FEATURE_SUPPORT,
 	SECTION_BLOGGING_PROMPT,
 	LAUNCHPAD_INTENT_BUILD,
+	LAUNCHPAD_INTENT_HOSTING,
 	LAUNCHPAD_INTENT_WRITE,
 	LAUNCHPAD_INTENT_FREE_NEWSLETTER,
 	LAUNCHPAD_INTENT_PAID_NEWSLETTER,
@@ -17,6 +18,7 @@ import DomainUpsell from 'calypso/my-sites/customer-home/cards/features/domain-u
 import HelpSearch from 'calypso/my-sites/customer-home/cards/features/help-search';
 import Stats from 'calypso/my-sites/customer-home/cards/features/stats';
 import LaunchpadIntentBuild from 'calypso/my-sites/customer-home/cards/launchpad/intent-build';
+import LaunchpadIntentHosting from 'calypso/my-sites/customer-home/cards/launchpad/intent-hosting';
 import {
 	LaunchpadIntentFreeNewsletter,
 	LaunchpadIntentPaidNewsletter,
@@ -34,6 +36,7 @@ const cardComponents = {
 	[ FEATURE_SUPPORT ]: HelpSearch,
 	[ NOTICE_READER_FIRST_POSTS ]: ReaderFirstPosts,
 	[ LAUNCHPAD_INTENT_BUILD ]: LaunchpadIntentBuild,
+	[ LAUNCHPAD_INTENT_HOSTING ]: LaunchpadIntentHosting,
 	[ LAUNCHPAD_INTENT_WRITE ]: LaunchpadIntentWrite,
 	[ LAUNCHPAD_INTENT_FREE_NEWSLETTER ]: LaunchpadIntentFreeNewsletter,
 	[ LAUNCHPAD_INTENT_PAID_NEWSLETTER ]: LaunchpadIntentPaidNewsletter,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
This PR adds a post launch checklist view for hosting flow to prevent showing the launch celebration view and also shows the checklist if the site was launched before completing the list. 

This PR also adds a slight patch to update `site_launched` checklist item on AT sites, since the current hook that does it is not firing (this will be investigated further later)
Related to #

## Proposed Changes

* Add new post launch views for hosting flow
* call `updateLaunchpadSettings` to set site launched checklist to true.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* See https://github.com/Automattic/jetpack/pull/33698

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?