### PR TITLE
Business Trials: Update "Advanced Design Tools" heading to sentence caps

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/migration-trial-acknowledge.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/migration-trial-acknowledge.tsx
@@ -1,5 +1,6 @@
 import { getPlan, PLAN_BUSINESS, PLAN_MIGRATION_TRIAL_MONTHLY } from '@automattic/calypso-products';
 import { SiteDetails } from '@automattic/data-stores';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { Title, SubTitle, NextButton } from '@automattic/onboarding';
 import { createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
@@ -34,6 +35,7 @@ interface Props {
 
 const MigrationTrialAcknowledgeInternal = function ( props: Props ) {
 	const { __ } = useI18n();
+	const hasEnTranslation = useHasEnTranslation();
 	const urlQueryParams = useQuery();
 	const { user, site, siteSlug, flowName, stepName, submit } = props;
 
@@ -107,7 +109,9 @@ const MigrationTrialAcknowledgeInternal = function ( props: Props ) {
 		<TrialPlan
 			planFeatures={ [
 				__( 'Beautiful themes' ),
-				__( 'Advanced Design Tools' ),
+				hasEnTranslation( 'Advanced design tools' )
+					? __( 'Advanced design tools' )
+					: __( 'Advanced Design Tools' ),
 				__( 'Newsletters' ),
 				__( 'Jetpack backups and restores' ),
 				__( 'Spam protection with Akismet' ),

--- a/client/my-sites/plans/current-plan/trials/use-business-trial-included-features.ts
+++ b/client/my-sites/plans/current-plan/trials/use-business-trial-included-features.ts
@@ -1,4 +1,4 @@
-import { localizeUrl } from '@automattic/i18n-utils';
+import { localizeUrl, useHasEnTranslation } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import advancedDesignTools from 'calypso/assets/images/plans/wpcom/business-trial/advanced-design-tools.svg';
@@ -16,6 +16,7 @@ export default function useBusinessTrialIncludedFeatures(
 	siteAdminUrl: string
 ) {
 	const translate = useTranslate();
+	const hasEnTranslation = useHasEnTranslation();
 
 	return [
 		{
@@ -29,7 +30,9 @@ export default function useBusinessTrialIncludedFeatures(
 		},
 		{
 			id: 'advanced-design-tools',
-			title: translate( 'Advanced Design Tools' ),
+			title: hasEnTranslation( 'Advanced design tools' )
+				? translate( 'Advanced design tools' )
+				: translate( 'Advanced Design Tools' ),
 			text: translate(
 				'Make your site even more unique with extended color schemes, typography, and control over your site’s CSS.'
 			),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Reported pdtkmj-1Um-p2#comment-3467

## Proposed Changes

All the other trial features use sentence caps for their heading, so "Advanced Design Tools" should too.

Checks whether there's a translation available before changing the copy. A correctly translated heading is better than a heading with the wrong capitalisation.

From the Business Trials' `/plans/my-plan` page
![CleanShot 2023-10-30 at 10 56 42@2x](https://github.com/Automattic/wp-calypso/assets/1500769/3c1f4dc3-b49b-4caf-b91d-a234aac0ee39)

From the Migration Trial's `/setup/import-hosted-site/trialAcknowledge` step
![CleanShot 2023-10-30 at 10 54 48@2x](https://github.com/Automattic/wp-calypso/assets/1500769/31cbbf1e-b889-43a6-b38f-e7f3852702c6)


FYI most of the translations appear to already be using sentence caps anyway.
![CleanShot 2023-10-30 at 10 48 53@2x](https://github.com/Automattic/wp-calypso/assets/1500769/0ef7bd34-9c26-4cd6-9be8-69150e9751c2)

`hasEnTranslation()` can be removed once the translation process is complete.




## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test `/plans/my-plan/{ site slug }` in English and non-English translation.
* Use migration flow and test `trialAcknowledge` step in English and non-English translation.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?