### PR TITLE
Business Trials: Fix 'View all' button padding on business trial plans page

### DIFF
--- a/client/my-sites/plans/current-plan/trials/trial-current-plan.scss
+++ b/client/my-sites/plans/current-plan/trials/trial-current-plan.scss
@@ -178,7 +178,13 @@ body.is-section-plans.is-business-trial-plan {
 					padding: 0;
 					text-align: center;
 					width: 100%;
-					margin-top: 20px;
+
+					&.is-ecommerce {
+						margin-top: 20px;
+					}
+					&:not(.is-ecommerce) {
+						margin-bottom: 40px;
+					}
 				}
 
 				.feature-included-card__text {

--- a/client/my-sites/plans/current-plan/trials/trial-current-plan.tsx
+++ b/client/my-sites/plans/current-plan/trials/trial-current-plan.tsx
@@ -6,6 +6,7 @@ import {
 } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { useMediaQuery } from '@wordpress/compose';
+import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { useState } from 'react';
@@ -50,7 +51,6 @@ const TrialCurrentPlan = () => {
 
 	/**
 	 * Redirects to the checkout page with Plan on cart.
-	 *
 	 * @param ctaPosition - The position of the CTA that triggered the redirect.
 	 */
 	const goToCheckoutWithPlan = ( ctaPosition: string ) => {
@@ -100,7 +100,9 @@ const TrialCurrentPlan = () => {
 
 				{ ! displayAllIncluded && (
 					<Button
-						className="trial-current-plan__included-view-all"
+						className={ classnames( 'trial-current-plan__included-view-all', {
+							'is-ecommerce': isEcommerceTrial,
+						} ) }
 						onClick={ viewAllIncludedFeatures }
 					>
 						{ translate( 'View all' ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Reported pdtkmj-1Um-p2#comment-3467

## Proposed Changes

On mobile, the feature list on the Business Trial's `/plans/my-plan/{ site slug }` page hides some of the features. There's a "View all" button to expand and see all the features.

However the padding looks wrong. View all crammed up beside the upgrade button.

![image](https://github.com/Automattic/wp-calypso/assets/1500769/f370d344-b51e-42d4-8aea-515d081b985b)

This PR adjusts padding so the "View all" button is closer to the bottom of the feature list. It controls the feature list so it should be closer to it. The padding below the "View all" button now matches the padding above the feature list. The idea is the feature list is a complete unit, and then below it is a button.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test `/plans/my-plan/{ site slug }` in mobile layout with a Business Trial site. The "View all" button should still disappear and show all features when clicked.
* Test a Woo express site too, since the view all button was originally added for that trial plan screen.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?