### PR TITLE
Business Trials: Fix acknowledge bullet style

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/style.scss
@@ -103,10 +103,17 @@
 			font-size: 0.875rem;
 			letter-spacing: -0.1px;
 
+			display: flex;
+			flex-direction: row;
+			align-items: baseline;
+			gap: 4px;
+
 			svg {
 				fill: var(--color-success);
 				position: relative;
 				top: 4px;
+				flex-grow: 0;
+				flex-shrink: 0;
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Reported pdtkmj-1Um-p2#comment-3465

## Proposed Changes

The custom bullet points in the `trialAcknowedge` step don't wrap like you'd expect bullet points to wrap. The wrapped text shouldn't go underneath the bullet icon.

The `list-style-image` CSS rule can usually be used to set a custom bullet style, and this would automatically get us the correct wrapping behaviour. However the check icon is a custom SVG component, not an image with a URL.

The custom bullet point style is created instead with `display:flex` and `align-items:baseline`

**Before**
![CleanShot 2023-10-30 at 14 29 55@2x](https://github.com/Automattic/wp-calypso/assets/1500769/441bc218-3dbe-49c8-ba3e-89f702c76fa7)


**After**
![CleanShot 2023-10-30 at 14 30 01@2x](https://github.com/Automattic/wp-calypso/assets/1500769/92439f9c-b0fa-4fdd-9f5c-e149bcdaa057)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use `/setup/new-hosted-site` flow
* Append `?flags=plans/hosting-trial` to URL to see the free trial option
* When on the `trialAcknowledge` screen confirm that the bullets wrap correctly at different screen sizes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?