### PR TITLE
Limit logstash logging to one render

### DIFF
--- a/client/my-sites/plans-features-main/hooks/use-suggested-free-domain-from-paid-domain.ts
+++ b/client/my-sites/plans-features-main/hooks/use-suggested-free-domain-from-paid-domain.ts
@@ -1,6 +1,7 @@
 import configApi from '@automattic/calypso-config';
 import { DomainSuggestions } from '@automattic/data-stores';
 import { useMemo } from '@wordpress/element';
+import { useEffect } from 'react';
 import { logToLogstash } from 'calypso/lib/logstash';
 import type { DataResponse } from 'calypso/my-sites/plans-grid/types';
 
@@ -17,16 +18,18 @@ export function useGetFreeSubdomainSuggestion( query: string | null ): {
 
 	const result = ( ! isError && wordPressSubdomainSuggestions?.[ 0 ] ) || undefined;
 
-	if ( query && ! isLoading && ! result ) {
-		logToLogstash( {
-			feature: 'calypso_client',
-			message: `Sub domain suggestion wasn't available for query: ${ query }`,
-			severity: 'warn',
-			properties: {
-				env: configApi( 'env_id' ),
-			},
-		} );
-	}
+	useEffect( () => {
+		if ( query && ! isLoading && ! result ) {
+			logToLogstash( {
+				feature: 'calypso_client',
+				message: `Sub domain suggestion wasn't available for query: ${ query }`,
+				severity: 'warn',
+				properties: {
+					env: configApi( 'env_id' ),
+				},
+			} );
+		}
+	}, [ query, isLoading, result ] );
 
 	return useMemo(
 		() => ( {


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/4331

## Proposed Changes

* Wraps `logToLogstash` call in `useEffect` to prevent repeated logging calls when `/domains/suggestions` are empty or return an error in the `/start/plans` onboarding step

## Testing Instructions

- Sandbox pub api
- Simulate error conditions, both an empty result and a returned error should be handled by the client
- In  `WPCOM_JSON_API_Domains_Suggestions_Endpoint::callback` at the top of the function set: `return [];`
- Also test error cases by returning `return new WP_Error( 'empty_results', __( 'No available domains for that search.' ) );`
- The `logToLogstash` should only be called once during the `/start/plans` step


Testing: 

This error case is happening on the /start/plans step that comes after the /start/domains step so you'll need to either be using the multi domains flow with domains already in your cart in order to continue, or comment out your early return while searching for a domain and then uncommenting before clicking a domain result.

- Go to `/start`
- Enter in any domain search query (early return disabled)
- Enable the early return
- Select your domain and move to `/start/plans`
- Observe less `logToLogstash` calls being made.