### PR TITLE
Jetpack Manage: Restructure the navigator back button to separate the title and icon.

### DIFF
--- a/client/jetpack-cloud/components/sidebar/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/index.tsx
@@ -34,6 +34,7 @@ type Props = {
 		trackEventName?: string;
 		trackEventProps?: { [ key: string ]: string };
 	}[];
+	title?: string;
 	description?: string;
 	backButtonProps?: {
 		icon: JSX.Element;
@@ -47,6 +48,7 @@ const JetpackCloudSidebar = ( {
 	isJetpackManage,
 	path,
 	menuItems,
+	title,
 	description,
 	backButtonProps,
 }: Props ) => {
@@ -68,6 +70,7 @@ const JetpackCloudSidebar = ( {
 				<SidebarNavigator initialPath={ path }>
 					<SidebarNavigatorMenu
 						path={ path }
+						title={ title }
 						description={ description }
 						backButtonProps={ backButtonProps }
 					>

--- a/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
@@ -180,7 +180,7 @@ const ManageSelectedSiteSidebar = ( { path }: { path: string } ) => {
 			<NewSidebar
 				path="/"
 				menuItems={ menuItems }
-				title={ translate( 'Site Settings' ) }
+				title={ translate( 'Manage' ) }
 				backButtonProps={
 					isAgency
 						? {

--- a/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
@@ -180,7 +180,7 @@ const ManageSelectedSiteSidebar = ( { path }: { path: string } ) => {
 			<NewSidebar
 				path="/"
 				menuItems={ menuItems }
-				title={ translate( 'Manage' ) }
+				title={ isAgency ? translate( 'Manage' ) : undefined }
 				backButtonProps={
 					isAgency
 						? {

--- a/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
@@ -180,10 +180,11 @@ const ManageSelectedSiteSidebar = ( { path }: { path: string } ) => {
 			<NewSidebar
 				path="/"
 				menuItems={ menuItems }
+				title={ translate( 'Site Settings' ) }
 				backButtonProps={
 					isAgency
 						? {
-								label: translate( 'Sites' ),
+								label: translate( 'Back to Sites' ),
 								icon: chevronLeft,
 								onClick: () => {
 									dispatch(

--- a/client/jetpack-cloud/sections/sidebar-navigation/purchases.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/purchases.tsx
@@ -75,9 +75,10 @@ const PurchasesSidebar = ( { path }: { path: string } ) => {
 			isJetpackManage
 			path={ JETPACK_MANAGE_PARTNER_PORTAL_LINK }
 			menuItems={ menuItems }
+			title={ translate( 'Purchases' ) }
 			description={ translate( 'Manage all your billing related settings from one place.' ) }
 			backButtonProps={ {
-				label: translate( 'Sites' ),
+				label: translate( 'Back to Sites' ),
 				icon: chevronLeft,
 				onClick: () => {
 					dispatch(

--- a/client/layout/sidebar-v2/navigator/navigator-menu.tsx
+++ b/client/layout/sidebar-v2/navigator/navigator-menu.tsx
@@ -33,23 +33,26 @@ export const SidebarNavigatorMenu = ( {
 				<CardBody className="sidebar-v2__navigator-sub-menu">
 					<VStack spacing={ 0 } justify="flex-start">
 						<ul>
-							{ backButtonProps && (
+							{ ( backButtonProps || title ) && (
 								<li className="sidebar-v2__navigator-sub-menu-header">
-									<NavigatorToParentButton
-										icon={ backButtonProps.icon }
-										onClick={ backButtonProps.onClick }
-										label={ backButtonProps.label }
-										showTooltip
-									/>
+									{ backButtonProps && (
+										<NavigatorToParentButton
+											icon={ backButtonProps.icon }
+											onClick={ backButtonProps.onClick }
+											label={ backButtonProps.label }
+											showTooltip
+										/>
+									) }
 									<span>{ title }</span>
 								</li>
 							) }
-							<div>
+
+							<li>
 								{ description && (
 									<div className="sidebar-v2__navigator-group-description">{ description }</div>
 								) }
 								{ children }
-							</div>
+							</li>
 						</ul>
 					</VStack>
 				</CardBody>

--- a/client/layout/sidebar-v2/navigator/navigator-menu.tsx
+++ b/client/layout/sidebar-v2/navigator/navigator-menu.tsx
@@ -9,17 +9,24 @@ import {
 import './style.scss';
 
 interface Props {
+	title?: string;
 	description?: string;
 	backButtonProps?: {
 		icon: JSX.Element;
-		label: string;
+		label?: string;
 		onClick: () => void;
 	};
 	path: string;
 	children: React.ReactNode;
 }
 
-export const SidebarNavigatorMenu = ( { description, backButtonProps, path, children }: Props ) => {
+export const SidebarNavigatorMenu = ( {
+	title,
+	description,
+	backButtonProps,
+	path,
+	children,
+}: Props ) => {
 	return (
 		<NavigatorScreen path={ path }>
 			<Card>
@@ -27,12 +34,14 @@ export const SidebarNavigatorMenu = ( { description, backButtonProps, path, chil
 					<VStack spacing={ 0 } justify="flex-start">
 						<ul>
 							{ backButtonProps && (
-								<li>
+								<li className="sidebar-v2__navigator-sub-menu-header">
 									<NavigatorToParentButton
 										icon={ backButtonProps.icon }
 										onClick={ backButtonProps.onClick }
-										text={ backButtonProps.label }
+										label={ backButtonProps.label }
+										showTooltip
 									/>
+									<span>{ title }</span>
 								</li>
 							) }
 							<div>

--- a/client/layout/sidebar-v2/navigator/style.scss
+++ b/client/layout/sidebar-v2/navigator/style.scss
@@ -47,6 +47,10 @@
 		color: initial;
 	}
 
+	&:focus {
+		box-shadow: none;
+	}
+
 	&:focus-visible {
 		box-shadow: 0 0 0 1px var(--studio-gray-10);
 	}

--- a/client/layout/sidebar-v2/navigator/style.scss
+++ b/client/layout/sidebar-v2/navigator/style.scss
@@ -7,14 +7,6 @@
 .sidebar-v2__navigator-sub-menu.components-card-body {
 	// Container cuts off content if we do not add 1px padding.
 	padding: 1px;
-
-	.components-navigator-back-button {
-		margin-block-end: 8px;
-		color: var(--studio-gray-90);
-		font-size: rem(16px);
-		font-weight: 600;
-		justify-content: start;
-	}
 }
 
 .sidebar-v2__navigator-group-description {
@@ -29,20 +21,32 @@
 	margin: 0;
 }
 
+.sidebar-v2__navigator-sub-menu-header {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	color: var(--studio-gray-90);
+	font-size: rem(16px);
+	font-weight: 600;
+	justify-content: start;
+	margin-block-end: 8px;
+}
+
 .sidebar-v2__menu-item.components-item {
 	color: inherit;
 
 	font-size: rem(13px);
-
-	&:hover:not(.is-active) {
-		background: var(--studio-gray-0);
-		color: initial;
-	}
 }
 
 .sidebar-v2__navigator-sub-menu .components-navigator-back-button,
 .sidebar-v2__menu-item.components-item {
 	border-radius: 4px;
+
+	&:hover:not(.is-active) {
+		background: var(--studio-gray-0);
+		color: initial;
+	}
+
 	&:focus-visible {
 		box-shadow: 0 0 0 1px var(--studio-gray-10);
 	}


### PR DESCRIPTION
As the core design team recommended, we should separate the back button and the title of the navigation menu. This PR fixes this discrepancy. 

https://github.com/Automattic/wp-calypso/assets/56598660/7d2cc9a5-a720-4bb8-90df-8cce96426641


Closes https://github.com/Automattic/jetpack-genesis/issues/84

## Proposed Changes

* Add another **'title'** prop to the menu item and convert the **'label'** props of the back button as a tooltip text.
* Update consumers accordingly with the new changes.

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

* Use the Jetpack Cloud live link and go to `/partner-portal/billing`
* Confirm that the back button is now a separate element to the menu title. Ensure the hovering tooltip works as expected.
<img width="271" alt="Screen Shot 2023-10-31 at 1 54 49 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/7fc0a932-bdde-4a45-88f5-5ecfe0ea5486">

* Confirm also that the menu title is changed in the single site view to **'Manage'**.
<img width="272" alt="Screen Shot 2023-10-31 at 1 54 58 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/4f981690-24e3-4944-bab8-574b2203f4f0">

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?