### PR TITLE
Live Preview: Add the upgrade notice for Premium and Woo themes

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/editor.scss
+++ b/apps/wpcom-block-editor/src/wpcom/editor.scss
@@ -1,4 +1,5 @@
 @import "./features/use-classic-block-guide";
+@import "./features/live-preview/upgrade-notice";
 
 .blog-onboarding-hide {
 	.components-external-link, // "Connect an account" link in Jetpack sidebar

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-can-preview-but-need-upgrade.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-can-preview-but-need-upgrade.ts
@@ -117,8 +117,13 @@ export const useCanPreviewButNeedUpgrade = ( {
 		};
 		const link =
 			previewingTheme.type === WOOCOMMERCE_THEME
-				? generateCheckoutUrl( PLAN_BUSINESS ) // For a WooCommerce theme, the users should have the Business plan or higher.
-				: generateCheckoutUrl( PLAN_PREMIUM ); // For a Premium theme, the users should have the Premium plan or higher.
+				? /**
+				   * For a WooCommerce theme, the users should have the Business plan or higher,
+				   * AND the WooCommerce plugin has to be installed.
+				   */
+				  generateCheckoutUrl( PLAN_BUSINESS )
+				: // For a Premium theme, the users should have the Premium plan or higher.
+				  generateCheckoutUrl( PLAN_PREMIUM );
 		window.location.href = link;
 
 		// TODO: Add the track event.

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-can-preview-but-need-upgrade.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-can-preview-but-need-upgrade.ts
@@ -2,10 +2,14 @@ import {
 	FEATURE_WOOP,
 	WPCOM_FEATURES_ATOMIC,
 	WPCOM_FEATURES_PREMIUM_THEMES,
+	PLAN_PREMIUM,
+	PLAN_BUSINESS,
 } from '@automattic/calypso-products';
-import { useEffect, useState } from 'react';
+import { getCalypsoUrl } from '@automattic/calypso-url';
+import { useEffect, useState, useCallback } from 'react';
 import wpcom from 'calypso/lib/wp';
 import { PREMIUM_THEME, WOOCOMMERCE_THEME } from '../utils';
+import { usePreviewingTheme } from './use-previewing-theme';
 import type { SiteDetails } from '@automattic/data-stores';
 
 const checkNeedUpgrade = ( {
@@ -13,7 +17,7 @@ const checkNeedUpgrade = ( {
 	previewingThemeType,
 }: {
 	site?: SiteDetails;
-	previewingThemeType: string;
+	previewingThemeType?: string;
 } ) => {
 	const activeFeatures = site?.plan?.features?.active;
 	if ( ! activeFeatures ) {
@@ -42,11 +46,12 @@ const checkNeedUpgrade = ( {
 };
 
 export const useCanPreviewButNeedUpgrade = ( {
-	previewingThemeType,
+	previewingTheme,
 }: {
-	previewingThemeType?: string;
+	previewingTheme: ReturnType< typeof usePreviewingTheme >;
 } ) => {
 	const [ canPreviewButNeedUpgrade, setCanPreviewButNeedUpgrade ] = useState( false );
+	const [ siteSlug, setSiteSlug ] = useState< string | undefined >();
 
 	/**
 	 * Get the theme and site info to decide whether the user needs to upgrade the plan.
@@ -55,16 +60,27 @@ export const useCanPreviewButNeedUpgrade = ( {
 		/**
 		 * Currently, Live Preview only supports upgrades for Woo Commerce and Premium themes.
 		 */
-		if ( previewingThemeType !== WOOCOMMERCE_THEME && previewingThemeType !== PREMIUM_THEME ) {
+		if ( previewingTheme.type !== WOOCOMMERCE_THEME && previewingTheme.type !== PREMIUM_THEME ) {
 			setCanPreviewButNeedUpgrade( false );
 			return;
 		}
 
 		wpcom.req
 			.get( `/sites/${ window._currentSiteId }`, { apiVersion: '1.2' } )
+			.then( ( site: any ) => {
+				let parsedUrl;
+				try {
+					parsedUrl = new URL( site.URL );
+					const { hostname } = parsedUrl;
+					setSiteSlug( hostname );
+				} catch {
+					// Invalid URL
+				}
+				return site;
+			} )
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			.then( ( site: any ) => {
-				if ( ! checkNeedUpgrade( { site, previewingThemeType } ) ) {
+				if ( ! checkNeedUpgrade( { site, previewingThemeType: previewingTheme.type } ) ) {
 					setCanPreviewButNeedUpgrade( false );
 					return;
 				}
@@ -73,9 +89,43 @@ export const useCanPreviewButNeedUpgrade = ( {
 			.catch( () => {
 				// do nothing
 			} );
-	}, [ previewingThemeType, setCanPreviewButNeedUpgrade ] );
+	}, [ previewingTheme.type, setCanPreviewButNeedUpgrade, setSiteSlug ] );
+
+	const upgradePlan = useCallback( () => {
+		const generateCheckoutUrl = ( plan: string ) => {
+			const locationHref = window.location.href;
+			let url = locationHref;
+			try {
+				/**
+				 * If the site has a custom domain, change the hostname to a custom domain.
+				 * This allows the checkout to redirect back to the custom domain.
+				 * @see `client/my-sites/checkout/src/hooks/use-valid-checkout-back-url.ts`
+				 */
+				if ( siteSlug ) {
+					const parsedUrl = new URL( locationHref );
+					parsedUrl.hostname = siteSlug;
+					url = parsedUrl.toString();
+				}
+			} catch ( error ) {
+				// Do nothing.
+			}
+			return `${ getCalypsoUrl() }/checkout/${
+				window._currentSiteId
+			}/${ plan }?redirect_to=${ encodeURIComponent( url ) }&checkoutBackUrl=${ encodeURIComponent(
+				url
+			) }`;
+		};
+		const link =
+			previewingTheme.type === WOOCOMMERCE_THEME
+				? generateCheckoutUrl( PLAN_BUSINESS ) // For a Woo Commerce theme, the users should have the Business plan or higher.
+				: generateCheckoutUrl( PLAN_PREMIUM ); // For a Premium theme, the users should have the Premium plan or higher.
+		window.location.href = link;
+
+		// TODO: Add the track event.
+	}, [ previewingTheme.type, siteSlug ] );
 
 	return {
 		canPreviewButNeedUpgrade,
+		upgradePlan,
 	};
 };

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-can-preview-but-need-upgrade.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-can-preview-but-need-upgrade.ts
@@ -1,0 +1,81 @@
+import {
+	FEATURE_WOOP,
+	WPCOM_FEATURES_ATOMIC,
+	WPCOM_FEATURES_PREMIUM_THEMES,
+} from '@automattic/calypso-products';
+import { useEffect, useState } from 'react';
+import wpcom from 'calypso/lib/wp';
+import { PREMIUM_THEME, WOOCOMMERCE_THEME } from '../utils';
+import type { SiteDetails } from '@automattic/data-stores';
+
+const checkNeedUpgrade = ( {
+	site,
+	previewingThemeType,
+}: {
+	site?: SiteDetails;
+	previewingThemeType: string;
+} ) => {
+	const activeFeatures = site?.plan?.features?.active;
+	if ( ! activeFeatures ) {
+		return false;
+	}
+
+	/**
+	 * This logic is extracted from `client/state/themes/selectors/can-use-theme.js`.
+	 */
+	const canUseWooCommerceTheme =
+		previewingThemeType === WOOCOMMERCE_THEME &&
+		[ WPCOM_FEATURES_PREMIUM_THEMES, FEATURE_WOOP, WPCOM_FEATURES_ATOMIC ].every( ( feature ) =>
+			activeFeatures.includes( feature )
+		);
+	if ( canUseWooCommerceTheme ) {
+		return false;
+	}
+	const canUsePremiumTheme =
+		previewingThemeType === PREMIUM_THEME &&
+		activeFeatures.includes( WPCOM_FEATURES_PREMIUM_THEMES );
+	if ( canUsePremiumTheme ) {
+		return false;
+	}
+
+	return true;
+};
+
+export const useCanPreviewButNeedUpgrade = ( {
+	previewingThemeType,
+}: {
+	previewingThemeType?: string;
+} ) => {
+	const [ canPreviewButNeedUpgrade, setCanPreviewButNeedUpgrade ] = useState( false );
+
+	/**
+	 * Get the theme and site info to decide whether the user needs to upgrade the plan.
+	 */
+	useEffect( () => {
+		/**
+		 * Currently, Live Preview only supports upgrades for Woo Commerce and Premium themes.
+		 */
+		if ( previewingThemeType !== WOOCOMMERCE_THEME && previewingThemeType !== PREMIUM_THEME ) {
+			setCanPreviewButNeedUpgrade( false );
+			return;
+		}
+
+		wpcom.req
+			.get( `/sites/${ window._currentSiteId }`, { apiVersion: '1.2' } )
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			.then( ( site: any ) => {
+				if ( ! checkNeedUpgrade( { site, previewingThemeType } ) ) {
+					setCanPreviewButNeedUpgrade( false );
+					return;
+				}
+				setCanPreviewButNeedUpgrade( true );
+			} )
+			.catch( () => {
+				// do nothing
+			} );
+	}, [ previewingThemeType, setCanPreviewButNeedUpgrade ] );
+
+	return {
+		canPreviewButNeedUpgrade,
+	};
+};

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-can-preview-but-need-upgrade.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-can-preview-but-need-upgrade.ts
@@ -58,7 +58,7 @@ export const useCanPreviewButNeedUpgrade = ( {
 	 */
 	useEffect( () => {
 		/**
-		 * Currently, Live Preview only supports upgrades for Woo Commerce and Premium themes.
+		 * Currently, Live Preview only supports upgrades for WooCommerce and Premium themes.
 		 */
 		if ( previewingTheme.type !== WOOCOMMERCE_THEME && previewingTheme.type !== PREMIUM_THEME ) {
 			setCanPreviewButNeedUpgrade( false );
@@ -117,7 +117,7 @@ export const useCanPreviewButNeedUpgrade = ( {
 		};
 		const link =
 			previewingTheme.type === WOOCOMMERCE_THEME
-				? generateCheckoutUrl( PLAN_BUSINESS ) // For a Woo Commerce theme, the users should have the Business plan or higher.
+				? generateCheckoutUrl( PLAN_BUSINESS ) // For a WooCommerce theme, the users should have the Business plan or higher.
 				: generateCheckoutUrl( PLAN_PREMIUM ); // For a Premium theme, the users should have the Premium plan or higher.
 		window.location.href = link;
 

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-previewing-theme.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-previewing-theme.ts
@@ -30,7 +30,7 @@ export const usePreviewingTheme = () => {
 	);
 	const [ previewingThemeType, setPreviewingThemeType ] = useState< string >();
 	const previewingThemeTypeDisplay =
-		previewingThemeType === WOOCOMMERCE_THEME ? 'Woo Commerce' : 'Premium';
+		previewingThemeType === WOOCOMMERCE_THEME ? 'WooCommerce' : 'Premium';
 	const requiredPlan = previewingThemeType === WOOCOMMERCE_THEME ? 'Business' : 'Premium';
 
 	useEffect( () => {

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-previewing-theme.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-previewing-theme.ts
@@ -31,7 +31,6 @@ export const usePreviewingTheme = () => {
 	const [ previewingThemeType, setPreviewingThemeType ] = useState< string >();
 	const previewingThemeTypeDisplay =
 		previewingThemeType === WOOCOMMERCE_THEME ? 'WooCommerce' : 'Premium';
-	const requiredPlan = previewingThemeType === WOOCOMMERCE_THEME ? 'Business' : 'Premium';
 
 	useEffect( () => {
 		wpcom.req
@@ -60,6 +59,5 @@ export const usePreviewingTheme = () => {
 		name: previewingThemeName,
 		type: previewingThemeType,
 		typeDisplay: previewingThemeTypeDisplay,
-		requiredPlan,
 	};
 };

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-previewing-theme.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-previewing-theme.ts
@@ -1,0 +1,60 @@
+import { useEffect, useState } from 'react';
+import wpcom from 'calypso/lib/wp';
+import { currentlyPreviewingTheme, PREMIUM_THEME, WOOCOMMERCE_THEME } from '../utils';
+import type { Theme } from 'calypso/types';
+
+/**
+ * Get the theme type.
+ * This only support WooCommerce and Premium themes.
+ */
+const getThemeType = ( theme?: Theme ) => {
+	const theme_software_set = theme?.taxonomies?.theme_software_set;
+	const isWooCommerceTheme = theme_software_set && theme_software_set.length > 0;
+	if ( isWooCommerceTheme ) {
+		return WOOCOMMERCE_THEME;
+	}
+	const themeStylesheet = theme?.stylesheet;
+	const isPremiumTheme = themeStylesheet && themeStylesheet.startsWith( 'premium/' );
+	if ( isPremiumTheme ) {
+		return PREMIUM_THEME;
+	}
+	return undefined;
+};
+
+export const usePreviewingTheme = () => {
+	const previewingThemeSlug = currentlyPreviewingTheme();
+	const previewingThemeId =
+		( previewingThemeSlug as string )?.split( '/' )?.[ 1 ] || previewingThemeSlug;
+	const [ previewingThemeName, setPreviewingThemeName ] = useState< string >(
+		previewingThemeSlug as string
+	);
+	const [ previewingThemeType, setPreviewingThemeType ] = useState< string >();
+
+	useEffect( () => {
+		wpcom.req
+			.get( `/themes/${ previewingThemeId }`, { apiVersion: '1.2' } )
+			.then( ( theme: Theme ) => {
+				const name = theme?.name;
+				if ( name ) {
+					setPreviewingThemeName( name );
+				}
+				return theme;
+			} )
+			.then( ( theme: Theme ) => {
+				const type = getThemeType( theme );
+				if ( ! type ) {
+					return;
+				}
+				setPreviewingThemeType( type );
+			} )
+			.catch( () => {
+				// do nothing
+			} );
+		return;
+	}, [ previewingThemeId ] );
+
+	return {
+		name: previewingThemeName,
+		type: previewingThemeType,
+	};
+};

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-previewing-theme.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-previewing-theme.ts
@@ -29,6 +29,9 @@ export const usePreviewingTheme = () => {
 		previewingThemeSlug as string
 	);
 	const [ previewingThemeType, setPreviewingThemeType ] = useState< string >();
+	const previewingThemeTypeDisplay =
+		previewingThemeType === WOOCOMMERCE_THEME ? 'Woo Commerce' : 'Premium';
+	const requiredPlan = previewingThemeType === WOOCOMMERCE_THEME ? 'Business' : 'Premium';
 
 	useEffect( () => {
 		wpcom.req
@@ -56,5 +59,7 @@ export const usePreviewingTheme = () => {
 	return {
 		name: previewingThemeName,
 		type: previewingThemeType,
+		typeDisplay: previewingThemeTypeDisplay,
+		requiredPlan,
 	};
 };

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/index.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/index.tsx
@@ -77,15 +77,15 @@ const LivePreviewNotice: FC< {
 
 const LivePreviewNoticePlugin = () => {
 	const previewingTheme = usePreviewingTheme();
-	const { canPreviewButNeedUpgrade } = useCanPreviewButNeedUpgrade( {
-		previewingThemeType: previewingTheme?.type,
+	const { canPreviewButNeedUpgrade, upgradePlan } = useCanPreviewButNeedUpgrade( {
+		previewingTheme,
 	} );
 	return (
 		<>
 			<LivePreviewNotice
 				{ ...{ canPreviewButNeedUpgrade, previewingThemeName: previewingTheme.name } }
 			/>
-			<LivePreviewUpgradeNotice { ...{ canPreviewButNeedUpgrade, previewingTheme } } />
+			<LivePreviewUpgradeNotice { ...{ canPreviewButNeedUpgrade, previewingTheme, upgradePlan } } />
 		</>
 	);
 };

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/index.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/index.tsx
@@ -18,9 +18,8 @@ const NOTICE_ID = 'wpcom-live-preview/notice';
  * @see https://github.com/Automattic/wp-calypso/issues/82218
  */
 const LivePreviewNotice: FC< {
-	canPreviewButNeedUpgrade: boolean;
 	previewingThemeName: string;
-} > = ( { canPreviewButNeedUpgrade, previewingThemeName } ) => {
+} > = ( { previewingThemeName } ) => {
 	const { createWarningNotice, removeNotice } = useDispatch( 'core/notices' );
 
 	const siteEditorStore = useSelect( ( select ) => select( 'core/edit-site' ), [] );
@@ -36,10 +35,6 @@ const LivePreviewNotice: FC< {
 		}
 		if ( ! isPreviewingTheme() ) {
 			removeNotice( NOTICE_ID );
-			return;
-		}
-		// Avoid showing the redundant notice.
-		if ( canPreviewButNeedUpgrade ) {
 			return;
 		}
 		createWarningNotice(
@@ -64,14 +59,7 @@ const LivePreviewNotice: FC< {
 			}
 		);
 		return () => removeNotice( NOTICE_ID );
-	}, [
-		siteEditorStore,
-		dashboardLink,
-		createWarningNotice,
-		removeNotice,
-		previewingThemeName,
-		canPreviewButNeedUpgrade,
-	] );
+	}, [ siteEditorStore, dashboardLink, createWarningNotice, removeNotice, previewingThemeName ] );
 	return null;
 };
 
@@ -80,14 +68,10 @@ const LivePreviewNoticePlugin = () => {
 	const { canPreviewButNeedUpgrade, upgradePlan } = useCanPreviewButNeedUpgrade( {
 		previewingTheme,
 	} );
-	return (
-		<>
-			<LivePreviewNotice
-				{ ...{ canPreviewButNeedUpgrade, previewingThemeName: previewingTheme.name } }
-			/>
-			<LivePreviewUpgradeNotice { ...{ canPreviewButNeedUpgrade, previewingTheme, upgradePlan } } />
-		</>
-	);
+	if ( canPreviewButNeedUpgrade ) {
+		return <LivePreviewUpgradeNotice { ...{ previewingTheme, upgradePlan } } />;
+	}
+	return <LivePreviewNotice { ...{ previewingThemeName: previewingTheme.name } } />;
 };
 
 const registerLivePreviewPlugin = () => {

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/index.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/index.tsx
@@ -3,31 +3,9 @@ import domReady from '@wordpress/dom-ready';
 import { __, sprintf } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
-import { getQueryArg } from '@wordpress/url';
 import { useEffect } from 'react';
-
-/**
- * Return true if the user is currently previewing a theme.
- * FIXME: This is copied from Gutenberg; we should be creating a selector for the `core/edit-site` store.
- * @see https://github.com/WordPress/gutenberg/blob/053c8f733c85d80c891fa308b071b9a18e5194e9/packages/edit-site/src/utils/is-previewing-theme.js#L6
- * @returns {boolean} isPreviewingTheme
- */
-function isPreviewingTheme() {
-	return getQueryArg( window.location.href, 'wp_theme_preview' ) !== undefined;
-}
-
-/**
- * Return the theme slug if the user is currently previewing a theme.
- * FIXME: This is copied from Gutenberg; we should be creating a selector for the `core/edit-site` store.
- * @see https://github.com/WordPress/gutenberg/blob/053c8f733c85d80c891fa308b071b9a18e5194e9/packages/edit-site/src/utils/is-previewing-theme.js#L6
- * @returns {string|null} currentlyPreviewingTheme
- */
-function currentlyPreviewingTheme() {
-	if ( isPreviewingTheme() ) {
-		return getQueryArg( window.location.href, 'wp_theme_preview' );
-	}
-	return null;
-}
+import { LivePreviewUpgradeNotice } from './upgrade-notice';
+import { currentlyPreviewingTheme, isPreviewingTheme } from './utils';
 
 /**
  * Sometimes Gutenberg doesn't allow you to re-register the module and throws an error.
@@ -117,7 +95,12 @@ const LivePreviewNotice = () => {
 
 const registerLivePreviewPlugin = () => {
 	registerPlugin( 'wpcom-live-preview', {
-		render: () => <LivePreviewNotice />,
+		render: () => (
+			<>
+				<LivePreviewNotice />
+				<LivePreviewUpgradeNotice />
+			</>
+		),
 	} );
 };
 

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/index.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/index.tsx
@@ -2,27 +2,13 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import domReady from '@wordpress/dom-ready';
 import { __, sprintf } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
-import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 import { FC, useEffect } from 'react';
 import { useCanPreviewButNeedUpgrade } from './hooks/use-can-preview-but-need-upgrade';
 import { usePreviewingTheme } from './hooks/use-previewing-theme';
 import { LivePreviewUpgradeNotice } from './upgrade-notice';
-import { isPreviewingTheme } from './utils';
+import { getUnlock, isPreviewingTheme } from './utils';
 
-/**
- * Sometimes Gutenberg doesn't allow you to re-register the module and throws an error.
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let unlock: ( object: any ) => any | undefined;
-try {
-	unlock = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
-		'@wordpress/edit-site'
-	).unlock;
-} catch ( error ) {
-	// eslint-disable-next-line no-console
-	console.error( 'Error: Unable to get the unlock api. Reason: %s', error );
-}
+const unlock = getUnlock();
 
 const NOTICE_ID = 'wpcom-live-preview/notice';
 
@@ -99,9 +85,7 @@ const LivePreviewNoticePlugin = () => {
 			<LivePreviewNotice
 				{ ...{ canPreviewButNeedUpgrade, previewingThemeName: previewingTheme.name } }
 			/>
-			<LivePreviewUpgradeNotice
-				{ ...{ canPreviewButNeedUpgrade, previewingThemeType: previewingTheme.type } }
-			/>
+			<LivePreviewUpgradeNotice { ...{ canPreviewButNeedUpgrade, previewingTheme } } />
 		</>
 	);
 };

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-notice.scss
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-notice.scss
@@ -1,0 +1,4 @@
+.components-notice-list .components-notice__action.components-button {
+	display: flex;
+	align-items: center;
+}

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-notice.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-notice.tsx
@@ -1,10 +1,8 @@
-import { PLAN_PREMIUM, PLAN_BUSINESS } from '@automattic/calypso-products';
-import { getCalypsoUrl } from '@automattic/calypso-url';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
-import { FC, useCallback, useEffect } from 'react';
+import { FC, useEffect } from 'react';
 import { usePreviewingTheme } from './hooks/use-previewing-theme';
-import { WOOCOMMERCE_THEME, getUnlock, isPreviewingTheme } from './utils';
+import { getUnlock, isPreviewingTheme } from './utils';
 
 declare global {
 	interface Window {
@@ -19,7 +17,8 @@ const unlock = getUnlock();
 export const LivePreviewUpgradeNotice: FC< {
 	canPreviewButNeedUpgrade: boolean;
 	previewingTheme: ReturnType< typeof usePreviewingTheme >;
-} > = ( { canPreviewButNeedUpgrade, previewingTheme } ) => {
+	upgradePlan: () => void;
+} > = ( { canPreviewButNeedUpgrade, previewingTheme, upgradePlan } ) => {
 	const siteEditorStore = useSelect( ( select ) => select( 'core/edit-site' ), [] );
 	const { createWarningNotice, removeNotice } = useDispatch( 'core/notices' );
 
@@ -27,23 +26,6 @@ export const LivePreviewUpgradeNotice: FC< {
 		unlock &&
 		siteEditorStore &&
 		unlock( siteEditorStore ).getSettings().__experimentalDashboardLink;
-
-	const upgradePlan = useCallback( () => {
-		const generateCheckoutUrl = ( plan: string ) => {
-			return `${ getCalypsoUrl() }/checkout/${
-				window._currentSiteId
-			}/${ plan }?redirect_to=${ encodeURIComponent(
-				window.location.href
-			) }&checkoutBackUrl=${ encodeURIComponent( window.location.href ) }`;
-		};
-		const link =
-			previewingTheme.type === WOOCOMMERCE_THEME
-				? generateCheckoutUrl( PLAN_BUSINESS ) // For a Woo Commerce theme, the users should have the Business plan or higher.
-				: generateCheckoutUrl( PLAN_PREMIUM ); // For a Premium theme, the users should have the Premium plan or higher.
-		window.location.href = link;
-
-		// TODO: Add the track event.
-	}, [ previewingTheme.type ] );
 
 	useEffect( () => {
 		// Do nothing in the Post Editor context.

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-notice.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-notice.tsx
@@ -45,8 +45,7 @@ export const LivePreviewUpgradeNotice: FC< {
 				'wpcom-live-preview'
 			),
 			previewingTheme.name,
-			previewingTheme.typeDisplay,
-			previewingTheme.requiredPlan
+			previewingTheme.typeDisplay
 		);
 		createWarningNotice( noticeText, {
 			id: UPGRADE_NOTICE_ID,
@@ -79,7 +78,6 @@ export const LivePreviewUpgradeNotice: FC< {
 		previewingTheme.name,
 		dashboardLink,
 		previewingTheme.typeDisplay,
-		previewingTheme.requiredPlan,
 	] );
 	return null;
 };

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-notice.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-notice.tsx
@@ -15,10 +15,9 @@ const UPGRADE_NOTICE_ID = 'wpcom-live-preview/notice/upgrade';
 const unlock = getUnlock();
 
 export const LivePreviewUpgradeNotice: FC< {
-	canPreviewButNeedUpgrade: boolean;
 	previewingTheme: ReturnType< typeof usePreviewingTheme >;
 	upgradePlan: () => void;
-} > = ( { canPreviewButNeedUpgrade, previewingTheme, upgradePlan } ) => {
+} > = ( { previewingTheme, upgradePlan } ) => {
 	const siteEditorStore = useSelect( ( select ) => select( 'core/edit-site' ), [] );
 	const { createWarningNotice, removeNotice } = useDispatch( 'core/notices' );
 
@@ -39,42 +38,39 @@ export const LivePreviewUpgradeNotice: FC< {
 			return;
 		}
 
-		if ( canPreviewButNeedUpgrade ) {
-			const noticeText = sprintf(
-				// translators: %1$s: The previewing theme name, %2$s: The theme type ('WooCommerce' or 'Premium'), %3$s: The required plan name ('Business' or 'Premium')
-				__(
-					'You are previewing %1$s, a %2$s theme. You can try out your own style customizations, which will only be saved if you upgrade and activate this theme.',
-					'wpcom-live-preview'
-				),
-				previewingTheme.name,
-				previewingTheme.typeDisplay,
-				previewingTheme.requiredPlan
-			);
-			createWarningNotice( noticeText, {
-				id: UPGRADE_NOTICE_ID,
-				isDismissible: false,
-				__unstableHTML: true,
-				actions: [
-					{
-						label: __( 'Upgrade now', 'wpcom-live-preview' ),
-						onClick: upgradePlan,
-						variant: 'primary',
-					},
-					...( dashboardLink
-						? [
-								{
-									label: __( 'Back to themes', 'wpcom-live-preview' ),
-									url: dashboardLink,
-									variant: 'secondary',
-								},
-						  ]
-						: [] ),
-				],
-			} );
-		}
+		const noticeText = sprintf(
+			// translators: %1$s: The previewing theme name, %2$s: The theme type ('WooCommerce' or 'Premium'), %3$s: The required plan name ('Business' or 'Premium')
+			__(
+				'You are previewing %1$s, a %2$s theme. You can try out your own style customizations, which will only be saved if you upgrade and activate this theme.',
+				'wpcom-live-preview'
+			),
+			previewingTheme.name,
+			previewingTheme.typeDisplay,
+			previewingTheme.requiredPlan
+		);
+		createWarningNotice( noticeText, {
+			id: UPGRADE_NOTICE_ID,
+			isDismissible: false,
+			__unstableHTML: true,
+			actions: [
+				{
+					label: __( 'Upgrade now', 'wpcom-live-preview' ),
+					onClick: upgradePlan,
+					variant: 'primary',
+				},
+				...( dashboardLink
+					? [
+							{
+								label: __( 'Back to themes', 'wpcom-live-preview' ),
+								url: dashboardLink,
+								variant: 'secondary',
+							},
+					  ]
+					: [] ),
+			],
+		} );
 		return () => removeNotice( UPGRADE_NOTICE_ID );
 	}, [
-		canPreviewButNeedUpgrade,
 		createWarningNotice,
 		removeNotice,
 		siteEditorStore,

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-notice.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-notice.tsx
@@ -39,7 +39,7 @@ export const LivePreviewUpgradeNotice: FC< {
 		}
 
 		const noticeText = sprintf(
-			// translators: %1$s: The previewing theme name, %2$s: The theme type ('WooCommerce' or 'Premium'), %3$s: The required plan name ('Business' or 'Premium')
+			// translators: %1$s: The previewing theme name, %2$s: The theme type ('WooCommerce' or 'Premium')
 			__(
 				'You are previewing %1$s, a %2$s theme. You can try out your own style customizations, which will only be saved if you upgrade and activate this theme.',
 				'wpcom-live-preview'

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-notice.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-notice.tsx
@@ -1,0 +1,195 @@
+import {
+	PLAN_PREMIUM,
+	PLAN_BUSINESS,
+	FEATURE_WOOP,
+	WPCOM_FEATURES_ATOMIC,
+	WPCOM_FEATURES_PREMIUM_THEMES,
+} from '@automattic/calypso-products';
+import { getCalypsoUrl } from '@automattic/calypso-url';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { __, sprintf } from '@wordpress/i18n';
+import { useCallback, useEffect, useState } from 'react';
+import wpcom from 'calypso/lib/wp';
+import { currentlyPreviewingTheme, isPreviewingTheme } from './utils';
+import type { SiteDetails } from '@automattic/data-stores';
+import type { Theme } from 'calypso/types';
+
+declare global {
+	interface Window {
+		_currentSiteId: number;
+	}
+}
+
+const UPGRADE_NOTICE_ID = 'wpcom-live-preview/notice/upgrade';
+const WOOCOMMERCE_THEME = 'woocommerce';
+const PREMIUM_THEME = 'premium';
+
+const getThemeType = ( theme?: Theme ) => {
+	const theme_software_set = theme?.taxonomies?.theme_software_set;
+	const isWooCommerceTheme = theme_software_set && theme_software_set.length > 0;
+	if ( isWooCommerceTheme ) {
+		return WOOCOMMERCE_THEME;
+	}
+	const themeStylesheet = theme?.stylesheet;
+	const isPremiumTheme = themeStylesheet && themeStylesheet.startsWith( 'premium/' );
+	if ( isPremiumTheme ) {
+		return PREMIUM_THEME;
+	}
+	return undefined;
+};
+
+const checkNeedUpgrade = ( { site, themeType }: { site?: SiteDetails; themeType: string } ) => {
+	const activeFeatures = site?.plan?.features?.active;
+	if ( ! activeFeatures ) {
+		return false;
+	}
+
+	/**
+	 * This logic is extracted from `client/state/themes/selectors/can-use-theme.js`.
+	 */
+	const canUseWooCommerceTheme =
+		themeType === WOOCOMMERCE_THEME &&
+		[ WPCOM_FEATURES_PREMIUM_THEMES, FEATURE_WOOP, WPCOM_FEATURES_ATOMIC ].every( ( feature ) =>
+			activeFeatures.includes( feature )
+		);
+	if ( canUseWooCommerceTheme ) {
+		return false;
+	}
+	const canUsePremiumTheme =
+		themeType === PREMIUM_THEME && activeFeatures.includes( WPCOM_FEATURES_PREMIUM_THEMES );
+	if ( canUsePremiumTheme ) {
+		return false;
+	}
+
+	return true;
+};
+
+export const LivePreviewUpgradeNotice = () => {
+	const previewingThemeSlug = currentlyPreviewingTheme();
+	const previewingThemeId =
+		( previewingThemeSlug as string )?.split( '/' )?.[ 1 ] || previewingThemeSlug;
+	const [ previewingThemeName, setPreviewingThemeName ] = useState< string >(
+		previewingThemeSlug as string
+	);
+
+	const [ canPreviewButNeedUpgrade, setCanPreviewButNeedUpgrade ] = useState( false );
+	const [ themeType, setThemeType ] = useState< string >();
+
+	const siteEditorStore = useSelect( ( select ) => select( 'core/edit-site' ), [] );
+	const { createWarningNotice, removeNotice } = useDispatch( 'core/notices' );
+
+	const upgradePlan = useCallback( () => {
+		const generateCheckoutUrl = ( plan: string ) => {
+			return `${ getCalypsoUrl() }/checkout/${
+				window._currentSiteId
+			}/${ plan }?redirect_to=${ encodeURIComponent(
+				window.location.href
+			) }&checkoutBackUrl=${ encodeURIComponent( window.location.href ) }`;
+		};
+		const link =
+			themeType === WOOCOMMERCE_THEME
+				? generateCheckoutUrl( PLAN_BUSINESS ) // For a Woo Commerce theme, the users should have the Business plan or higher.
+				: generateCheckoutUrl( PLAN_PREMIUM ); // For a Premium theme, the users should have the Premium plan or higher.
+		window.location.href = link;
+
+		// TODO: Add the track event.
+	}, [ themeType ] );
+
+	/**
+	 * Get the theme and site info to decide whether the user needs to upgrade the plan.
+	 */
+	useEffect( () => {
+		if ( ! themeType ) {
+			wpcom.req
+				.get( `/themes/${ previewingThemeId }`, { apiVersion: '1.2' } )
+				.then( ( theme: Theme ) => {
+					const name = theme?.name;
+					if ( name ) {
+						setPreviewingThemeName( name );
+					}
+					return theme;
+				} )
+				.then( ( theme: Theme ) => {
+					const type = getThemeType( theme );
+					if ( ! type ) {
+						return;
+					}
+					setThemeType( type );
+				} )
+				.catch( () => {
+					// do nothing
+				} );
+			return;
+		}
+
+		/**
+		 * Currently, Live Preview only supports upgrades for Woo Commerce and Premium themes.
+		 */
+		if ( themeType !== WOOCOMMERCE_THEME && themeType !== PREMIUM_THEME ) {
+			setCanPreviewButNeedUpgrade( false );
+			return;
+		}
+
+		wpcom.req
+			.get( `/sites/${ window._currentSiteId }`, { apiVersion: '1.2' } )
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			.then( ( site: any ) => {
+				if ( ! checkNeedUpgrade( { site, themeType } ) ) {
+					setCanPreviewButNeedUpgrade( false );
+					return;
+				}
+				setCanPreviewButNeedUpgrade( true );
+			} )
+			.catch( () => {
+				// do nothing
+			} );
+	}, [ previewingThemeId, themeType, setThemeType, setCanPreviewButNeedUpgrade ] );
+
+	useEffect( () => {
+		// Do nothing in the Post Editor context.
+		if ( ! siteEditorStore ) {
+			removeNotice( UPGRADE_NOTICE_ID );
+			return;
+		}
+
+		if ( ! isPreviewingTheme() ) {
+			removeNotice( UPGRADE_NOTICE_ID );
+			return;
+		}
+
+		if ( canPreviewButNeedUpgrade ) {
+			const type = themeType === WOOCOMMERCE_THEME ? 'Woo Commerce' : 'Premium';
+			createWarningNotice(
+				sprintf(
+					// translators: %s: The theme type ('Woo Commerce' or 'Premium')
+					__(
+						'You are previewing the %s theme that are only available after upgrading to the Premium plan or higher.',
+						'wpcom-live-preview'
+					),
+					type
+				),
+				{
+					id: UPGRADE_NOTICE_ID,
+					isDismissible: false,
+					actions: [
+						{
+							label: __( 'Upgrade now', 'wpcom-live-preview' ),
+							onClick: upgradePlan,
+							variant: 'primary',
+						},
+					],
+				}
+			);
+		}
+		return () => removeNotice( UPGRADE_NOTICE_ID );
+	}, [
+		canPreviewButNeedUpgrade,
+		createWarningNotice,
+		previewingThemeName,
+		removeNotice,
+		siteEditorStore,
+		themeType,
+		upgradePlan,
+	] );
+	return null;
+};

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-notice.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-notice.tsx
@@ -41,7 +41,7 @@ export const LivePreviewUpgradeNotice: FC< {
 
 		if ( canPreviewButNeedUpgrade ) {
 			const noticeText = sprintf(
-				// translators: %1$s: The previewing theme name, %2$s: The theme type ('Woo Commerce' or 'Premium'), %3$s: The required plan name ('Business' or 'Premium')
+				// translators: %1$s: The previewing theme name, %2$s: The theme type ('WooCommerce' or 'Premium'), %3$s: The required plan name ('Business' or 'Premium')
 				__(
 					'You are previewing %1$s, a %2$s theme. You can try out your own style customizations, which will only be saved if you upgrade and activate this theme.',
 					'wpcom-live-preview'

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-notice.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-notice.tsx
@@ -1,18 +1,9 @@
-import {
-	PLAN_PREMIUM,
-	PLAN_BUSINESS,
-	FEATURE_WOOP,
-	WPCOM_FEATURES_ATOMIC,
-	WPCOM_FEATURES_PREMIUM_THEMES,
-} from '@automattic/calypso-products';
+import { PLAN_PREMIUM, PLAN_BUSINESS } from '@automattic/calypso-products';
 import { getCalypsoUrl } from '@automattic/calypso-url';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
-import { useCallback, useEffect, useState } from 'react';
-import wpcom from 'calypso/lib/wp';
-import { currentlyPreviewingTheme, isPreviewingTheme } from './utils';
-import type { SiteDetails } from '@automattic/data-stores';
-import type { Theme } from 'calypso/types';
+import { FC, useCallback, useEffect } from 'react';
+import { WOOCOMMERCE_THEME, isPreviewingTheme } from './utils';
 
 declare global {
 	interface Window {
@@ -21,60 +12,11 @@ declare global {
 }
 
 const UPGRADE_NOTICE_ID = 'wpcom-live-preview/notice/upgrade';
-const WOOCOMMERCE_THEME = 'woocommerce';
-const PREMIUM_THEME = 'premium';
 
-const getThemeType = ( theme?: Theme ) => {
-	const theme_software_set = theme?.taxonomies?.theme_software_set;
-	const isWooCommerceTheme = theme_software_set && theme_software_set.length > 0;
-	if ( isWooCommerceTheme ) {
-		return WOOCOMMERCE_THEME;
-	}
-	const themeStylesheet = theme?.stylesheet;
-	const isPremiumTheme = themeStylesheet && themeStylesheet.startsWith( 'premium/' );
-	if ( isPremiumTheme ) {
-		return PREMIUM_THEME;
-	}
-	return undefined;
-};
-
-const checkNeedUpgrade = ( { site, themeType }: { site?: SiteDetails; themeType: string } ) => {
-	const activeFeatures = site?.plan?.features?.active;
-	if ( ! activeFeatures ) {
-		return false;
-	}
-
-	/**
-	 * This logic is extracted from `client/state/themes/selectors/can-use-theme.js`.
-	 */
-	const canUseWooCommerceTheme =
-		themeType === WOOCOMMERCE_THEME &&
-		[ WPCOM_FEATURES_PREMIUM_THEMES, FEATURE_WOOP, WPCOM_FEATURES_ATOMIC ].every( ( feature ) =>
-			activeFeatures.includes( feature )
-		);
-	if ( canUseWooCommerceTheme ) {
-		return false;
-	}
-	const canUsePremiumTheme =
-		themeType === PREMIUM_THEME && activeFeatures.includes( WPCOM_FEATURES_PREMIUM_THEMES );
-	if ( canUsePremiumTheme ) {
-		return false;
-	}
-
-	return true;
-};
-
-export const LivePreviewUpgradeNotice = () => {
-	const previewingThemeSlug = currentlyPreviewingTheme();
-	const previewingThemeId =
-		( previewingThemeSlug as string )?.split( '/' )?.[ 1 ] || previewingThemeSlug;
-	const [ previewingThemeName, setPreviewingThemeName ] = useState< string >(
-		previewingThemeSlug as string
-	);
-
-	const [ canPreviewButNeedUpgrade, setCanPreviewButNeedUpgrade ] = useState( false );
-	const [ themeType, setThemeType ] = useState< string >();
-
+export const LivePreviewUpgradeNotice: FC< {
+	canPreviewButNeedUpgrade: boolean;
+	previewingThemeType?: string;
+} > = ( { canPreviewButNeedUpgrade, previewingThemeType } ) => {
 	const siteEditorStore = useSelect( ( select ) => select( 'core/edit-site' ), [] );
 	const { createWarningNotice, removeNotice } = useDispatch( 'core/notices' );
 
@@ -87,63 +29,13 @@ export const LivePreviewUpgradeNotice = () => {
 			) }&checkoutBackUrl=${ encodeURIComponent( window.location.href ) }`;
 		};
 		const link =
-			themeType === WOOCOMMERCE_THEME
+			previewingThemeType === WOOCOMMERCE_THEME
 				? generateCheckoutUrl( PLAN_BUSINESS ) // For a Woo Commerce theme, the users should have the Business plan or higher.
 				: generateCheckoutUrl( PLAN_PREMIUM ); // For a Premium theme, the users should have the Premium plan or higher.
 		window.location.href = link;
 
 		// TODO: Add the track event.
-	}, [ themeType ] );
-
-	/**
-	 * Get the theme and site info to decide whether the user needs to upgrade the plan.
-	 */
-	useEffect( () => {
-		if ( ! themeType ) {
-			wpcom.req
-				.get( `/themes/${ previewingThemeId }`, { apiVersion: '1.2' } )
-				.then( ( theme: Theme ) => {
-					const name = theme?.name;
-					if ( name ) {
-						setPreviewingThemeName( name );
-					}
-					return theme;
-				} )
-				.then( ( theme: Theme ) => {
-					const type = getThemeType( theme );
-					if ( ! type ) {
-						return;
-					}
-					setThemeType( type );
-				} )
-				.catch( () => {
-					// do nothing
-				} );
-			return;
-		}
-
-		/**
-		 * Currently, Live Preview only supports upgrades for Woo Commerce and Premium themes.
-		 */
-		if ( themeType !== WOOCOMMERCE_THEME && themeType !== PREMIUM_THEME ) {
-			setCanPreviewButNeedUpgrade( false );
-			return;
-		}
-
-		wpcom.req
-			.get( `/sites/${ window._currentSiteId }`, { apiVersion: '1.2' } )
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			.then( ( site: any ) => {
-				if ( ! checkNeedUpgrade( { site, themeType } ) ) {
-					setCanPreviewButNeedUpgrade( false );
-					return;
-				}
-				setCanPreviewButNeedUpgrade( true );
-			} )
-			.catch( () => {
-				// do nothing
-			} );
-	}, [ previewingThemeId, themeType, setThemeType, setCanPreviewButNeedUpgrade ] );
+	}, [ previewingThemeType ] );
 
 	useEffect( () => {
 		// Do nothing in the Post Editor context.
@@ -158,7 +50,7 @@ export const LivePreviewUpgradeNotice = () => {
 		}
 
 		if ( canPreviewButNeedUpgrade ) {
-			const type = themeType === WOOCOMMERCE_THEME ? 'Woo Commerce' : 'Premium';
+			const type = previewingThemeType === WOOCOMMERCE_THEME ? 'Woo Commerce' : 'Premium';
 			createWarningNotice(
 				sprintf(
 					// translators: %s: The theme type ('Woo Commerce' or 'Premium')
@@ -185,10 +77,9 @@ export const LivePreviewUpgradeNotice = () => {
 	}, [
 		canPreviewButNeedUpgrade,
 		createWarningNotice,
-		previewingThemeName,
 		removeNotice,
 		siteEditorStore,
-		themeType,
+		previewingThemeType,
 		upgradePlan,
 	] );
 	return null;

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-notice.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-notice.tsx
@@ -40,21 +40,17 @@ export const LivePreviewUpgradeNotice: FC< {
 		}
 
 		if ( canPreviewButNeedUpgrade ) {
-			const noticeTextUpgrade = sprintf(
+			const noticeText = sprintf(
 				// translators: %1$s: The previewing theme name, %2$s: The theme type ('Woo Commerce' or 'Premium'), %3$s: The required plan name ('Business' or 'Premium')
 				__(
-					'You are previewing %1$s, a %2$s theme. To unlock this theme upgrade to the %3$s plan.',
+					'You are previewing %1$s, a %2$s theme. You can try out your own style customizations, which will only be saved if you upgrade and activate this theme.',
 					'wpcom-live-preview'
 				),
 				previewingTheme.name,
 				previewingTheme.typeDisplay,
 				previewingTheme.requiredPlan
 			);
-			const noticeTextCustomize = __(
-				'You can try out your own style customizations, which will only be saved if you activate this theme.',
-				'wpcom-live-preview'
-			);
-			createWarningNotice( noticeTextUpgrade + '<br/>' + noticeTextCustomize, {
+			createWarningNotice( noticeText, {
 				id: UPGRADE_NOTICE_ID,
 				isDismissible: false,
 				__unstableHTML: true,

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/utils.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/utils.ts
@@ -1,0 +1,25 @@
+import { getQueryArg } from '@wordpress/url';
+
+/**
+ * Return true if the user is currently previewing a theme.
+ * FIXME: This is copied from Gutenberg; we should be creating a selector for the `core/edit-site` store.
+ * @see https://github.com/WordPress/gutenberg/blob/053c8f733c85d80c891fa308b071b9a18e5194e9/packages/edit-site/src/utils/is-previewing-theme.js#L6
+ * @returns {boolean} isPreviewingTheme
+ */
+
+export function isPreviewingTheme() {
+	return getQueryArg( window.location.href, 'wp_theme_preview' ) !== undefined;
+}
+/**
+ * Return the theme slug if the user is currently previewing a theme.
+ * FIXME: This is copied from Gutenberg; we should be creating a selector for the `core/edit-site` store.
+ * @see https://github.com/WordPress/gutenberg/blob/053c8f733c85d80c891fa308b071b9a18e5194e9/packages/edit-site/src/utils/is-previewing-theme.js#L6
+ * @returns {string|null} currentlyPreviewingTheme
+ */
+
+export function currentlyPreviewingTheme() {
+	if ( isPreviewingTheme() ) {
+		return getQueryArg( window.location.href, 'wp_theme_preview' );
+	}
+	return null;
+}

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/utils.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/utils.ts
@@ -1,7 +1,27 @@
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 import { getQueryArg } from '@wordpress/url';
 
 export const WOOCOMMERCE_THEME = 'woocommerce';
 export const PREMIUM_THEME = 'premium';
+
+export const getUnlock = () => {
+	/**
+	 * Sometimes Gutenberg doesn't allow you to re-register the module and throws an error.
+	 */
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	let unlock: ( object: any ) => any | undefined;
+	try {
+		unlock = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
+			'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.',
+			'@wordpress/edit-site'
+		).unlock;
+		return unlock;
+	} catch ( error ) {
+		// eslint-disable-next-line no-console
+		console.error( 'Error: Unable to get the unlock api. Reason: %s', error );
+		return undefined;
+	}
+};
 
 /**
  * Return true if the user is currently previewing a theme.

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/utils.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/utils.ts
@@ -1,5 +1,8 @@
 import { getQueryArg } from '@wordpress/url';
 
+export const WOOCOMMERCE_THEME = 'woocommerce';
+export const PREMIUM_THEME = 'premium';
+
 /**
  * Return true if the user is currently previewing a theme.
  * FIXME: This is copied from Gutenberg; we should be creating a selector for the `core/edit-site` store.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/79223, https://github.com/Automattic/wp-calypso/pull/82629

## Proposed Changes

This PR adds the upgrade-needed notice on the Site Editor canvas when live-previewing Premium and WooCommerce themes. 

**The latest copy:**
<img width="1426" alt="Screenshot 2023-11-28 at 16 21 17" src="https://github.com/Automattic/wp-calypso/assets/5287479/24f23e4a-cb40-4605-902c-a3ad625430e3">
<img width="1432" alt="Screenshot 2023-11-28 at 16 20 12" src="https://github.com/Automattic/wp-calypso/assets/5287479/1389bd8f-525c-4829-bcfb-6947e2cd344d">

<!--
<img width="1372" alt="Screenshot 2023-11-07 at 15 25 17" src="https://github.com/Automattic/wp-calypso/assets/5287479/0e3f7ff0-b3c1-4b49-a8bf-674af4f29735">
<img width="1358" alt="Screenshot 2023-11-07 at 15 27 08" src="https://github.com/Automattic/wp-calypso/assets/5287479/ba19c684-ccfc-4120-8c3c-64b0ba19dbf5">
-->

**The flow:**

https://github.com/Automattic/wp-calypso/assets/5287479/63985799-0f78-4472-a5a6-97576edbb04a

<!--
https://github.com/Automattic/wp-calypso/assets/5287479/32adf670-5f16-4794-8a80-eb1dc2be444b
-->

I'll create a follow-up PR for the following (See https://github.com/Automattic/wp-calypso/issues/79223 for more details).

- [x] the notice on the sidebar https://github.com/Automattic/wp-calypso/pull/84676
- [ ] the modal when clicking the Activate button

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `install-plugin.sh wpcom-block-editor add/live-preview-upgrade-notice` on your sandbox.
- Sandbox widgets.wp.com and your site.
- **Upgrade Notice for Premium themes**
	- Prepare a site with the Personal plan or lower plan. 
	- Access `https://<your-site>/wp-admin/site-editor.php?wp_theme_preview=<premium-theme>` to preview a premium theme (e.g., `premium/outland`).
	- Try to edit the homepage and see the upgrade notice.
	- Click `Upgrade now`.
	- Verify the **Premium** plan is in the cart and complete checkout.
	- Verify it redirects to the Site Editor.
	- Verify you don't see the upgrade notice and the plan is upgraded.
- **Upgrade Notice for WooCommerce themes**
	- Prepare a site with the Premium plan or lower plan. 
	- Access `https://<your-site>/wp-admin/site-editor.php?wp_theme_preview=<woo-theme>` to preview a woo commerce theme (e.g. `premium/tsubaki`).
	- Try to edit the homepage and see the upgrade notice.
	- Click `Upgrade now`.
	- Verify the **Business** plan is in the cart and complete checkout.
	- Verify it redirects to the Site Editor.
	- Verify you don't see the upgrade notice and the plan is upgraded.
- **No Upgrade Notices**
	- Prepare a site with the Business plan or higher plan.
	- Access `https://<your-site>/wp-admin/site-editor.php?wp_theme_preview=<premium-theme>` to preview a premium theme (e.g., `premium/outland`). 
		- If your site is on Atomic, you need to install the theme before previewing it. 
	- Verify you don't see the upgrade notice. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
	- I didn't write tests, as most logic is from existing functions and I don’t think it’s a good idea to make it more complicated. I extracted functions and wrote types as much as possible. 
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?