### PR TITLE
Assembler: Add educational copy in the large preview placeholder

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
@@ -77,37 +77,52 @@
 	color: var(--studio-gray-60);
 	background: #f8f8f8;
 
-	.pattern-large-preview__placeholder-icon {
-		margin-bottom: 24px;
-		fill: var(--studio-gray-10);
-	}
-
 	h2 {
 		color: #000;
-		margin-bottom: 4px;
-		font-size: $font-title-small;
-		font-weight: 500;
+		margin-bottom: 16px;
+		font-size: $font-body-large;
+		font-weight: 400;
 	}
 
-	span {
-		color: #000;
-		font-size: $font-body;
-		max-width: 600px;
-		text-align: center;
-		padding: 0 60px;
-	}
-
-	button {
-		border: 1px solid var(--studio-gray-10);
-		border-radius: 4px;
-		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
-		background-color: #fff;
-		color: var(--studio-gray-100);
+	> ul {
+		color: var(--studio-gray-80);
+		counter-reset: li;
+		display: flex;
+		flex-direction: column;
 		font-size: $font-body-small;
-		font-weight: 500;
-		letter-spacing: -0.15px;
+		font-weight: 400;
+		gap: 10px;
 		line-height: 20px;
-		margin-top: 24px;
-		padding: 10px 24px;
+		list-style-type: none;
+		margin: 0;
+		max-width: 300px;
+
+		> li {
+			align-items: center;
+			display: flex;
+			padding-left: 28px;
+			position: relative;
+
+			&::before {
+				align-items: center;
+				border: 0.909px solid var(--studio-gray-100);
+				border-radius: 50%;
+				box-sizing: border-box;
+				color: var(--studio-gray-100);
+				content: counter(li);
+				counter-increment: li;
+				display: flex;
+				font-size: 10.909px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+				font-weight: 400;
+				height: 16px;
+				justify-content: center;
+				left: 0;
+				letter-spacing: -0.061px;
+				line-height: 16px;
+				position: absolute;
+				top: 2px;
+				width: 16px;
+			}
+		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -268,12 +268,12 @@ const PatternLargePreview = ( {
 				<div className="pattern-large-preview__placeholder">
 					<h2>{ translate( 'Welcome to your homepage.' ) }</h2>
 					<ul>
-						<li>{ translate( 'Select patterns for your homepage' ) }</li>
-						<li>{ translate( 'Choose your colors and fonts' ) } </li>
+						<li>{ translate( 'Select patterns for your homepage.' ) }</li>
+						<li>{ translate( 'Choose your colors and fonts.' ) } </li>
 						{ isEnabled( 'pattern-assembler/add-pages' ) && (
-							<li>{ translate( 'Pick additional site pages' ) } </li>
+							<li>{ translate( 'Pick additional site pages.' ) } </li>
 						) }
-						<li>{ translate( 'Add your own content in the Editor' ) } </li>
+						<li>{ translate( 'Add your own content in the Editor.' ) } </li>
 					</ul>
 				</div>
 			) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -1,4 +1,5 @@
 import { PatternRenderer } from '@automattic/block-renderer';
+import { isEnabled } from '@automattic/calypso-config';
 import { DeviceSwitcher } from '@automattic/components';
 import { useGlobalStyle } from '@automattic/global-styles';
 import { Popover } from '@wordpress/components';
@@ -266,9 +267,14 @@ const PatternLargePreview = ( {
 			) : (
 				<div className="pattern-large-preview__placeholder">
 					<h2>{ translate( 'Welcome to your homepage.' ) }</h2>
-					<span>
-						{ translate( "It's time to get creative. Add your first pattern to get started." ) }
-					</span>
+					<ul>
+						<li>{ translate( 'Select patterns for your homepage' ) }</li>
+						<li>{ translate( 'Choose your colors and fonts' ) } </li>
+						{ isEnabled( 'pattern-assembler/add-pages' ) && (
+							<li>{ translate( 'Pick additional site pages' ) } </li>
+						) }
+						<li>{ translate( 'Add your own content in the Editor' ) } </li>
+					</ul>
 				</div>
 			) }
 		</DeviceSwitcher>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/83379

## Proposed Changes

* Add the educational copy in the large preview placeholder to guide user how to get started and let them know they can edit the content later

| Before | After (without pages) | After (with pages)
| - | - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/cbb51a50-7a56-4294-b3ee-906c65b4e329) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/ee04d916-067e-429b-b8c2-ba923d707c0a) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/c237d0ed-d366-4257-95ca-f7c9ee4c4b59) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the Assembler
* Ensure the copy in the large preview placeholder is updated

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?