### PR TITLE
Theme Discovery: Theme Collection loop instead of rewind

### DIFF
--- a/client/components/theme-collection/index.tsx
+++ b/client/components/theme-collection/index.tsx
@@ -85,7 +85,7 @@ export default function ThemeCollection( {
 							prevEl: '.theme-collection__carousel-nav-button--previous',
 						},
 						slideToClickedSlide: false,
-						rewind: true,
+						loop: true,
 						slidesPerView: 1.2,
 						spaceBetween: -16,
 						breakpoints: {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
- https://github.com/Automattic/dotcom-forge/issues/4406

## Proposed Changes

* Changed the Swiper's swipe method from rewind to loop.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso live link
* Navigate to the LoTS and apply `?flags=themes/discovery-lots`
* Scroll the carousel until the end, after you continue scrolling the first element should be displayed without rewinding

Before:

https://github.com/Automattic/wp-calypso/assets/1989914/067d3e69-1a1d-4cb3-b506-9a526fbbe9ec


After:


https://github.com/Automattic/wp-calypso/assets/1989914/f8a5d86f-e4e3-43a8-bb41-a4abb939a16a



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)