### PR TITLE
Site Assembler: pass selected pages to the site-assembler endpoint

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -363,6 +363,12 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 						homeHtml: sections.map( ( pattern ) => pattern.html ).join( '' ),
 						headerHtml: header?.html,
 						footerHtml: footer?.html,
+						pages: pages
+							.map( ( category ) => pagesMapByCategory[ category ] )
+							.map( ( patterns ) => ( {
+								title: patterns[ 0 ].title,
+								content: patterns[ 0 ].html,
+							} ) ),
 						globalStyles: syncedGlobalStylesUserConfig,
 						// Newly created sites with blog patterns reset the starter content created from the default Headstart annotation
 						// TODO: Ask users whether they want all their pages and posts to be replaced with the content from theme demo site

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -466,6 +466,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 			homeHtml,
 			headerHtml,
 			footerHtml,
+			pages,
 			globalStyles,
 			shouldResetContent,
 			siteSetupOption,
@@ -503,6 +504,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 			apiNamespace: 'wpcom/v2',
 			body: {
 				templates,
+				pages,
 				global_styles: globalStyles,
 				should_reset_content: shouldResetContent,
 				site_setup_option: siteSetupOption,

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -509,10 +509,16 @@ export interface SourceSiteMigrationDetails {
 	target_blog_slug?: string;
 }
 
+export interface Page {
+	title: string;
+	content: string;
+}
+
 export interface AssembleSiteOptions {
 	homeHtml?: string;
 	headerHtml?: string;
 	footerHtml?: string;
+	pages?: Page[];
 	globalStyles?: GlobalStyles;
 	shouldResetContent?: boolean;
 	siteSetupOption?: string;


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/wp-calypso/issues/83450

## Proposed Changes

This PR passes the selected pages to the `/site-assembler` endpoint, which is implemented in D127172-code.

## Testing Instructions

1. Patch D127172-code in your sandbox.
1. Go to the Assembler flow with the flag `&flags=pattern-assembler/add-pages`.
1. Go through the Patterns and Styles screen until you arrive at the Pages screen.
1. Select some pages.
1. Finish the flow.
1. Verify that the pages are created with the correct title and content.
1. Repeat with Atomic site.
1. Repeat with existing site, try running the Assembler flow once more, try adding the same pages, and verify that duplicate pages are created (expected)

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?