### PR TITLE
Tooltip to packages (Step 1): Add Tooltip to components package

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -32,6 +32,7 @@
 		"@automattic/data-stores": "workspace:^",
 		"@automattic/search": "workspace:^",
 		"@automattic/typography": "workspace:^",
+		"@automattic/viewport-react": "workspace:^",
 		"@wordpress/base-styles": "^4.35.0",
 		"@wordpress/components": "^25.10.0",
 		"@wordpress/icons": "^9.35.0",

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -59,7 +59,7 @@ export { default as SubmenuPopover, useSubmenuPopoverProps } from './submenu-pop
 export { default as JetpackUpsellCard } from './jetpack-upsell-card';
 export { UpsellMenuGroup } from './upsell-menu-group';
 export { default as PricingSlider } from './pricing-slider';
-export { default as Tootlip } from './tooltip';
+export { default as Tooltip } from './tooltip';
 export * from './theme-type-badge';
 
 // Types

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -59,6 +59,7 @@ export { default as SubmenuPopover, useSubmenuPopoverProps } from './submenu-pop
 export { default as JetpackUpsellCard } from './jetpack-upsell-card';
 export { UpsellMenuGroup } from './upsell-menu-group';
 export { default as PricingSlider } from './pricing-slider';
+export { default as Tootlip } from './tooltip';
 export * from './theme-type-badge';
 
 // Types

--- a/packages/components/src/tooltip/README.md
+++ b/packages/components/src/tooltip/README.md
@@ -1,0 +1,19 @@
+# Tooltip
+
+A `Tooltip` allows you to add contextual and other information where needed. For example, `Tooltip` is used to display extra information, on hover, about icon-only buttons.
+
+## Properties
+
+- `status` - (string) Modifies the style of the `Tooltip`. Can be one of the following: `error`, `warning`, or `success`.
+- `showOnMobile` - (bool) When true, will show `Tooltip` on mobile screens. By default, `Tooltip` is not displayed for mobile devices.
+- `isVisible` - (bool) Whether to display the `Tooltip` or not.
+- `position` - (string) The `position` property can be one of the following values:
+
+  - `top`
+  - `top left`
+  - `top right`
+  - `bottom`
+  - `bottom left`
+  - `bottom right`
+  - `left`
+  - `right`

--- a/packages/components/src/tooltip/docs/example.jsx
+++ b/packages/components/src/tooltip/docs/example.jsx
@@ -1,0 +1,85 @@
+import { PureComponent, createRef } from 'react';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormSelect from 'calypso/components/forms/form-select';
+import TooltipComponent from 'calypso/components/tooltip';
+
+class Tooltip extends PureComponent {
+	tooltipRef = createRef();
+	state = {
+		position: 'bottom right',
+		show: false,
+	};
+
+	open = () => {
+		this.setState( { show: true } );
+	};
+
+	close = () => {
+		this.setState( { show: false } );
+	};
+
+	changePosition = ( event ) => {
+		this.setState( { position: event.target.value } );
+	};
+
+	render() {
+		const size = 30;
+
+		return (
+			<div>
+				<FormLabel>
+					Position
+					<FormSelect value={ this.state.position } onChange={ this.changePosition }>
+						<option value="top">top</option>
+						<option value="top left">top left</option>
+						<option value="top right">top right</option>
+						<option value="left">left</option>
+						<option value="right">right</option>
+						<option value="bottom">bottom</option>
+						<option value="bottom left">bottom left</option>
+						<option value="bottom right">bottom right</option>
+					</FormSelect>
+				</FormLabel>
+
+				<hr />
+
+				<div>
+					Tooltip context&nbsp;
+					<span
+						style={ {
+							width: size,
+							height: size,
+							lineHeight: `${ size }px`,
+							display: 'inline-block',
+							borderRadius: parseInt( size / 2 ),
+							backgroundColor: '#444',
+							color: 'white',
+							fontSize: '12px',
+							cursor: 'pointer',
+							textAlign: 'center',
+						} }
+						onMouseEnter={ this.open }
+						onMouseLeave={ this.close }
+						onClick={ this.close }
+						ref={ this.tooltipRef }
+					>
+						T
+					</span>
+					<TooltipComponent
+						id="tooltip__example"
+						isVisible={ this.state.show }
+						onClose={ this.close }
+						position={ this.state.position }
+						context={ this.tooltipRef.current }
+					>
+						<div style={ { padding: '10px' } }>Simple Tooltip Instance</div>
+					</TooltipComponent>
+				</div>
+			</div>
+		);
+	}
+}
+
+Tooltip.displayName = 'Tooltip';
+
+export default Tooltip;

--- a/packages/components/src/tooltip/docs/example.jsx
+++ b/packages/components/src/tooltip/docs/example.jsx
@@ -1,3 +1,5 @@
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
 import { PureComponent, createRef } from 'react';
 import TooltipComponent from '../';
 import { FormLabel } from '../../forms';

--- a/packages/components/src/tooltip/docs/example.jsx
+++ b/packages/components/src/tooltip/docs/example.jsx
@@ -1,7 +1,6 @@
 import { PureComponent, createRef } from 'react';
-import FormLabel from 'calypso/components/forms/form-label';
-import FormSelect from 'calypso/components/forms/form-select';
-import TooltipComponent from 'calypso/components/tooltip';
+import TooltipComponent from '../';
+import { FormLabel } from '../../forms';
 
 class Tooltip extends PureComponent {
 	tooltipRef = createRef();
@@ -29,7 +28,7 @@ class Tooltip extends PureComponent {
 			<div>
 				<FormLabel>
 					Position
-					<FormSelect value={ this.state.position } onChange={ this.changePosition }>
+					<select value={ this.state.position } onChange={ this.changePosition }>
 						<option value="top">top</option>
 						<option value="top left">top left</option>
 						<option value="top right">top right</option>
@@ -38,7 +37,7 @@ class Tooltip extends PureComponent {
 						<option value="bottom">bottom</option>
 						<option value="bottom left">bottom left</option>
 						<option value="bottom right">bottom right</option>
-					</FormSelect>
+					</select>
 				</FormLabel>
 
 				<hr />

--- a/packages/components/src/tooltip/index.jsx
+++ b/packages/components/src/tooltip/index.jsx
@@ -1,0 +1,56 @@
+import { useMobileBreakpoint } from '@automattic/viewport-react';
+import classnames from 'classnames';
+import PropTypes from 'prop-types';
+import Popover from '../popover';
+
+import './style.scss';
+
+function Tooltip( props ) {
+	const isMobile = useMobileBreakpoint();
+
+	if ( ! props.showOnMobile && isMobile ) {
+		return null;
+	}
+
+	const classes = classnames( [ 'tooltip', props.className ], {
+		[ `is-${ props.status }` ]: props.status,
+	} );
+
+	return (
+		<Popover
+			autoPosition={ props.autoPosition }
+			className={ classes }
+			context={ props.context }
+			id={ props.id }
+			isVisible={ props.isVisible }
+			position={ props.position }
+			showDelay={ props.showDelay }
+			hideArrow
+		>
+			{ props.children }
+		</Popover>
+	);
+}
+
+Tooltip.propTypes = {
+	autoPosition: PropTypes.bool,
+	className: PropTypes.string,
+	id: PropTypes.string,
+	isVisible: PropTypes.bool,
+	position: PropTypes.string,
+	status: PropTypes.string,
+	showDelay: PropTypes.number,
+	showOnMobile: PropTypes.bool,
+	hideArrow: PropTypes.bool,
+	children: PropTypes.node,
+	context: PropTypes.any,
+};
+
+Tooltip.defaultProps = {
+	showDelay: 100,
+	position: 'top',
+	showOnMobile: false,
+	hideArrow: false,
+};
+
+export default Tooltip;

--- a/packages/components/src/tooltip/index.stories.js
+++ b/packages/components/src/tooltip/index.stories.js
@@ -1,0 +1,73 @@
+import { useState, useRef } from 'react';
+import Tooltip from './';
+
+export const Default = ( { position } ) => {
+	const tooltipRef = useRef();
+	const [ show, setShow ] = useState( false );
+
+	const handleOpen = () => {
+		setShow( true );
+	};
+
+	const handleClose = () => {
+		setShow( false );
+	};
+
+	const size = 30;
+	return (
+		<div>
+			<div style={ { padding: '150px' } }>
+				Tooltip context&nbsp;
+				<span
+					style={ {
+						width: size,
+						height: size,
+						lineHeight: `${ size }px`,
+						display: 'inline-block',
+						borderRadius: parseInt( size / 2 ),
+						backgroundColor: '#444',
+						color: 'white',
+						fontSize: '12px',
+						cursor: 'pointer',
+						textAlign: 'center',
+					} }
+					onMouseEnter={ handleOpen }
+					onMouseLeave={ handleClose }
+					onClick={ handleClose }
+					ref={ tooltipRef }
+				>
+					T
+				</span>
+				<Tooltip
+					id="tooltip__example"
+					isVisible={ show }
+					onClose={ handleClose }
+					position={ position }
+					context={ tooltipRef.current }
+				>
+					<div style={ { padding: '10px' } }>Simple Tooltip Instance</div>
+				</Tooltip>
+			</div>
+		</div>
+	);
+};
+
+export default {
+	title: 'packages/components/Tooltip',
+	component: Tooltip,
+	argTypes: {
+		position: {
+			options: [
+				'top',
+				'top left',
+				'top right',
+				'left',
+				'right',
+				'bottom',
+				'bottom left',
+				'bottom right',
+			],
+			control: { type: 'radio' },
+		},
+	},
+};

--- a/packages/components/src/tooltip/index.stories.js
+++ b/packages/components/src/tooltip/index.stories.js
@@ -1,52 +1,68 @@
 import { useState, useRef } from 'react';
+import Button from '../button';
 import Tooltip from './';
 
-export const Default = ( { position } ) => {
-	const tooltipRef = useRef();
+const TooltipWrapper = ( { placement } ) => {
 	const [ show, setShow ] = useState( false );
-
-	const handleOpen = () => {
-		setShow( true );
+	const handleOpen = () => setShow( true );
+	const handleClose = () => setShow( false );
+	const tooltipRef = useRef();
+	const placements = {
+		top: 'top',
+		tl: 'top left',
+		tr: 'top right',
+		left: 'left',
+		right: 'right',
+		bottom: 'bottom',
+		bl: 'bottom left',
+		br: 'bottom right',
 	};
+	const buttonWidth = 80;
 
-	const handleClose = () => {
-		setShow( false );
-	};
-
-	const size = 30;
 	return (
-		<div>
-			<div style={ { padding: '150px' } }>
-				Tooltip context&nbsp;
-				<span
-					style={ {
-						width: size,
-						height: size,
-						lineHeight: `${ size }px`,
-						display: 'inline-block',
-						borderRadius: parseInt( size / 2 ),
-						backgroundColor: '#444',
-						color: 'white',
-						fontSize: '12px',
-						cursor: 'pointer',
-						textAlign: 'center',
-					} }
-					onMouseEnter={ handleOpen }
-					onMouseLeave={ handleClose }
-					onClick={ handleClose }
-					ref={ tooltipRef }
-				>
-					T
-				</span>
-				<Tooltip
-					id="tooltip__example"
-					isVisible={ show }
-					onClose={ handleClose }
-					position={ position }
-					context={ tooltipRef.current }
-				>
-					<div style={ { padding: '10px' } }>Simple Tooltip Instance</div>
-				</Tooltip>
+		<>
+			<Button
+				onMouseEnter={ handleOpen }
+				onMouseLeave={ handleClose }
+				onClick={ handleClose }
+				ref={ tooltipRef }
+				style={ { width: buttonWidth, margin: 4, borderRadius: '6px' } }
+			>
+				{ placement }
+			</Button>
+			<Tooltip
+				position={ placements[ placement.toLowerCase() ] }
+				isVisible={ show }
+				onClose={ handleClose }
+				context={ tooltipRef.current }
+			>
+				<div>Prompt</div>
+			</Tooltip>
+		</>
+	);
+};
+
+export const Default = () => {
+	const buttonWidth = 80;
+	return (
+		<div style={ { padding: '80px' } }>
+			<div className="demo">
+				<div style={ { marginInlineStart: buttonWidth + 4, whiteSpace: 'nowrap' } }>
+					<TooltipWrapper placement="TL" />
+					<TooltipWrapper placement="Top" />
+					<TooltipWrapper placement="TR" />
+				</div>
+				<div style={ { width: buttonWidth, float: 'inline-start' } }>
+					<TooltipWrapper placement="Left" />
+				</div>
+				<div style={ { width: buttonWidth, marginInlineStart: buttonWidth * 4 + 24 } }>
+					<TooltipWrapper placement="Right" />
+				</div>
+				<div style={ { marginInlineStart: buttonWidth, clear: 'both', whiteSpace: 'nowrap' } }>
+					<TooltipWrapper placement="BL" />
+					<TooltipWrapper placement="Bottom" />
+					<TooltipWrapper placement="BR" />
+				</div>
 			</div>
 		</div>
 	);
@@ -55,19 +71,4 @@ export const Default = ( { position } ) => {
 export default {
 	title: 'packages/components/Tooltip',
 	component: Tooltip,
-	argTypes: {
-		position: {
-			options: [
-				'top',
-				'top left',
-				'top right',
-				'left',
-				'right',
-				'bottom',
-				'bottom left',
-				'bottom right',
-			],
-			control: { type: 'radio' },
-		},
-	},
 };

--- a/packages/components/src/tooltip/style.scss
+++ b/packages/components/src/tooltip/style.scss
@@ -1,10 +1,12 @@
+@import "@automattic/typography/styles/variables";
+
 $large-tooltip-box-shadow-color: rgba(0, 0, 0, 0.05);
 
 .tooltip.popover {
 	outline: none;
 
 	// always display the popover on top even inside a modal with a high z index
-	z-index: z-index("root", ".tooltip.popover");
+	z-index: 100000;
 
 	.popover__arrow {
 		border-width: 6px;

--- a/packages/components/src/tooltip/style.scss
+++ b/packages/components/src/tooltip/style.scss
@@ -1,0 +1,222 @@
+$large-tooltip-box-shadow-color: rgba(0, 0, 0, 0.05);
+
+.tooltip.popover {
+	outline: none;
+
+	// always display the popover on top even inside a modal with a high z index
+	z-index: z-index("root", ".tooltip.popover");
+
+	.popover__arrow {
+		border-width: 6px;
+	}
+
+	&.is-bottom-right,
+	&.is-bottom-left,
+	&.is-bottom {
+		.popover__arrow {
+			border-bottom-color: var(--color-neutral-60);
+			top: 4px;
+
+			&::before {
+				display: none;
+			}
+		}
+
+		&.is-error {
+			.popover__arrow {
+				border-bottom-color: var(--color-error);
+			}
+		}
+
+		&.is-warning {
+			.popover__arrow {
+				border-bottom-color: var(--color-warning);
+			}
+		}
+
+		&.is-success {
+			.popover__arrow {
+				border-bottom-color: var(--color-success);
+			}
+		}
+	}
+
+	&.is-top,
+	&.is-top-left,
+	&.is-top-right {
+		.popover__arrow {
+			border-top-color: var(--color-neutral-60);
+			bottom: 4px;
+
+			&::before {
+				display: none;
+			}
+		}
+
+		&.is-error {
+			.popover__arrow {
+				border-top-color: var(--color-error);
+			}
+		}
+
+		&.is-warning {
+			.popover__arrow {
+				border-top-color: var(--color-warning);
+			}
+		}
+
+		&.is-success {
+			.popover__arrow {
+				border-top-color: var(--color-success);
+			}
+		}
+	}
+
+	&.is-bottom-right,
+	&.is-top-right {
+		.popover__arrow {
+			left: 15px #{"/*rtl:ignore*/"};
+			margin-left: -6px #{"/*rtl:ignore*/"};
+		}
+	}
+
+	&.is-bottom-left,
+	&.is-top-left {
+		.popover__arrow {
+			right: 15px #{"/*rtl:ignore*/"};
+			margin-right: -6px #{"/*rtl:ignore*/"};
+		}
+	}
+
+	&.is-top,
+	&.is-bottom {
+		.popover__arrow {
+			margin-left: -6px #{"/*rtl:ignore*/"};
+		}
+	}
+
+	&.is-left,
+	&.is-right {
+		padding-top: 0;
+		.popover__arrow {
+			margin-top: -6px;
+
+			&::before {
+				display: none;
+			}
+		}
+
+		&.is-error {
+			.popover__arrow {
+				border-right-color: var(--color-error);
+			}
+		}
+
+		&.is-warning {
+			.popover__arrow {
+				border-right-color: var(--color-warning);
+			}
+		}
+
+		&.is-success {
+			.popover__arrow {
+				border-right-color: var(--color-success);
+			}
+		}
+	}
+
+	&.is-left {
+		.popover__arrow {
+			margin-right: 4px;
+			border-left-color: var(--color-neutral-60);
+		}
+	}
+
+	&.is-right {
+		.popover__arrow {
+			margin-left: 4px;
+			border-right-color: var(--color-neutral-60);
+		}
+	}
+
+	.popover__inner {
+		border: 0;
+		box-shadow: none;
+		border-radius: 2px;
+		color: var(--color-text-inverted);
+		background: var(--color-neutral-60);
+		font-size: $font-body-extra-small;
+		padding: 6px 10px;
+		text-align: left;
+	}
+
+	&.is-error {
+		.popover__inner {
+			background: var(--color-error);
+		}
+	}
+
+	&.is-warning {
+		.popover__inner {
+			background: var(--color-warning);
+		}
+	}
+
+	&.is-success {
+		.popover__inner {
+			background: var(--color-success);
+		}
+	}
+
+	ul {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+
+		li {
+			font-size: $font-body-extra-small;
+			font-weight: 400;
+			border: 0;
+			padding: 2px 0;
+		}
+	}
+
+	&.tooltip--darker {
+		&.is-bottom-right,
+		&.is-bottom-left,
+		&.is-bottom {
+			.popover__arrow {
+				border-bottom-color: var(--studio-gray-100);
+			}
+		}
+
+		&.is-top,
+		&.is-top-left,
+		&.is-top-right {
+			.popover__arrow {
+				border-top-color: var(--studio-gray-100);
+			}
+		}
+
+		.popover__inner {
+			color: var(--studio-white);
+			background: var(--studio-gray-100);
+		}
+	}
+
+	&.tooltip--large {
+		&.is-top .popover__arrow,
+		&.is-top-left .popover__arrow,
+		&.is-top-right .popover__arrow {
+			border-top-color: var(--color-neutral-100);
+			box-shadow: 0 1px 2px $large-tooltip-box-shadow-color;
+		}
+
+		.popover__inner {
+			background-color: var(--color-neutral-100);
+			box-shadow: 0 1px 2px $large-tooltip-box-shadow-color;
+			border-radius: 4px;
+			padding: 16px 24px;
+		}
+	}
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -533,6 +533,7 @@ __metadata:
     "@automattic/data-stores": "workspace:^"
     "@automattic/search": "workspace:^"
     "@automattic/typography": "workspace:^"
+    "@automattic/viewport-react": "workspace:^"
     "@storybook/addon-actions": ^7.4.6
     "@storybook/react": ^7.4.6
     "@testing-library/dom": ^9.3.3


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/79002

## Proposed Changes

We are migrating `Tooltip` to `@automattic/components` because it is a dependency for plans-grid, which we are in the process of migrating to NPM.

The same principle applies to previous related migrations (see https://github.com/Automattic/wp-calypso/pull/79257):

> The entirety of the migration is a 4 step process that creates easily digestible ( and revertible ) PRs to work with. Unfortunately, this process also eliminates the git history from migrated files unless the 4 steps are condensed into a single one. I don't have a great answer to this, but the tradeoff, to me, is worth the added safety of more understandable, compact, iterative pull requests.

This is Step 1: 
- adding a new component to `@automattic/components` package
- adding Storybook
- fixing references to local Calypso code: typography and z-indices in styles, imported components in docs

### Do we need another "Popover"?

Looking at some of the code, not too deeply, and usages, I think it does raise the question of whether we need a separate "Tooltip" component and not a restyled Popover (assuming that's easy to do). There are a few usages in Calypso (see Step 2/3 PRs).

I think an alternative to migrating this to components' package might be to consider using Popover directly in `plans-grid`, and refactor/restyle Popover accordingly. If that's a possibility/direction worth taking, then we'd need to also flag other usages to do similarly / and mark Tooltip as "deprecated" in that case.

The above said, it does seem easier/quicker to migrate to components and consider a refactor/deprecation thereafter (we have all the code already for the migration, and we'd be cleared of the local dependency without refactoring deeper).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Code review
- Ensure Storybook stories render correctly with no errors: `run yarn storybook:start`

<img width="400" alt="Screenshot 2023-10-30 at 2 45 03 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/19e43866-a36a-42be-87d1-25fc7836951c">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?