### PR TITLE
Subscription Management: Redirect /subscriptions to their relevant /read/subscriptions counterparts.

### DIFF
--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -816,8 +816,8 @@ function wpcomPages( app ) {
 	} );
 
 	app.get( [ '/subscriptions', '/subscriptions/*' ], function ( req, res ) {
-		// For non-logged-in users, redirect to the email login link page.
-		if ( ! req.context.isLoggedIn ) {
+		// For users on subkey, redirect to the email login link page.
+		if ( req.cookies.subkey ) {
 			return res.redirect( 'https://wordpress.com/email-subscriptions' );
 		}
 

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -816,42 +816,42 @@ function wpcomPages( app ) {
 	} );
 
 	app.get( [ '/subscriptions', '/subscriptions/*' ], function ( req, res ) {
-		if ( req.context.isLoggedIn ) {
-			const basePath = 'https://wordpress.com/read/subscriptions';
+		// For non-logged-in users, redirect to the email login link page.
+		if ( ! req.context.isLoggedIn ) {
+			return res.redirect( 'https://wordpress.com/email-subscriptions' );
+		}
 
-			// If user enters /subscriptions/sites(.*),
-			// redirect to /read/subscriptions.
-			if ( req.path.match( '/subscriptions/sites' ) ) {
-				return res.redirect( basePath );
-			}
+		const basePath = 'https://wordpress.com/read/subscriptions';
 
-			// If user enters /site/*,
-			// redirect to /read/site/subscription/*.
-			const siteFragment = req.path.match( /site\/(.*)/i );
-			if ( siteFragment && siteFragment[ 1 ] ) {
-				return res.redirect( 'https://wordpress.com/read/site/subscription/' + siteFragment[ 1 ] );
-			}
-
-			// If user enters /subscriptions/(comments|pending)(.*),
-			// redirect to /read/subscriptions/(comments\pending)(.*)
-			const commentsOrPendingFragment = req.path.match( /(comments(.*)|pending(.*))/gi );
-			if ( commentsOrPendingFragment ) {
-				return res.redirect( basePath + '/' + commentsOrPendingFragment[ 0 ] );
-			}
-
-			// If user enters /subscriptions/settings,
-			// redirect to /me/notifications/subscriptions?referrer=management.
-			if ( req.path.match( '/subscriptions/settings' ) ) {
-				return res.redirect(
-					'https://wordpress.com/me/notifications/subscriptions?referrer=management'
-				);
-			}
-
+		// If user enters /subscriptions/sites(.*),
+		// redirect to /read/subscriptions.
+		if ( req.path.match( '/subscriptions/sites' ) ) {
 			return res.redirect( basePath );
 		}
 
-		// For non-logged-in users, redirect to the email login link page.
-		res.redirect( 'https://wordpress.com/email-subscriptions' );
+		// If user enters /site/*,
+		// redirect to /read/site/subscription/*.
+		const siteFragment = req.path.match( /site\/(.*)/i );
+		if ( siteFragment && siteFragment[ 1 ] ) {
+			return res.redirect( 'https://wordpress.com/read/site/subscription/' + siteFragment[ 1 ] );
+		}
+
+		// If user enters /subscriptions/(comments|pending)(.*),
+		// redirect to /read/subscriptions/(comments\pending)(.*)
+		const commentsOrPendingFragment = req.path.match( /(comments(.*)|pending(.*))/gi );
+		if ( commentsOrPendingFragment ) {
+			return res.redirect( basePath + '/' + commentsOrPendingFragment[ 0 ] );
+		}
+
+		// If user enters /subscriptions/settings,
+		// redirect to /me/notifications/subscriptions?referrer=management.
+		if ( req.path.match( '/subscriptions/settings' ) ) {
+			return res.redirect(
+				'https://wordpress.com/me/notifications/subscriptions?referrer=management'
+			);
+		}
+
+		return res.redirect( basePath );
 	} );
 
 	// Redirects from the /start/domain-transfer flow to the new /setup/domain-transfer.

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -828,7 +828,7 @@ function wpcomPages( app ) {
 			// If user enters /site/*,
 			// redirect to /read/site/subscription/*.
 			const siteFragment = req.path.match( /site\/(.*)/i );
-			if ( siteFragment[ 1 ] ) {
+			if ( siteFragment && siteFragment[ 1 ] ) {
 				return res.redirect( 'https://wordpress.com/read/site/subscription/' + siteFragment[ 1 ] );
 			}
 

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -816,8 +816,8 @@ function wpcomPages( app ) {
 	} );
 
 	app.get( [ '/subscriptions', '/subscriptions/*' ], function ( req, res ) {
-		// For users on subkey, redirect to the email login link page.
-		if ( req.cookies.subkey ) {
+		// For users on subkey or not logged in, redirect to the email login link page.
+		if ( req.cookies.subkey || ! req.context.isLoggedIn ) {
 			return res.redirect( 'https://wordpress.com/email-subscriptions' );
 		}
 


### PR DESCRIPTION
## Proposed Changes

* Sunset external portal by redirecting /subscriptions to their relevant /read/subscription counterparts.

## Testing Instructions

**Test logged-in user:**
* Checkout this PR locally.
* Modify `client/server/pages/index.js` at line 820, just set it to `if ( false )` (to pretend as a logged-in user).
  * This is faster than bootstrapping a WPCOM user (PCYsg-5YE-p2).
* Run `yarn start`.
* Test on the following URLs:
   * http://calypso.localhost:3000/subscriptions
   * http://calypso.localhost:3000/subscriptions/
   * http://calypso.localhost:3000/subscriptions/site
   * http://calypso.localhost:3000/subscriptions/sites
     * These should go to /read/subscriptions.
   * http://calypso.localhost:3000/subscriptions/site/201582167
     * This should go to /read/site/subscription/201582167.
   * http://calypso.localhost:3000/subscriptions/comments
   * http://calypso.localhost:3000/subscriptions/comments/
   * http://calypso.localhost:3000/subscriptions/comments?foobar
     * These should go to /read/subscriptions/comments.
   * http://calypso.localhost:3000/subscriptions/pending
   * http://calypso.localhost:3000/subscriptions/pending/
   * http://calypso.localhost:3000/subscriptions/pending?foobar
     * These should go to /read/subscriptions/pending.
   * http://calypso.localhost:3000/subscriptions/settings
   * http://calypso.localhost:3000/subscriptions/settings/
     * These should go to /me/notifications/subscriptions?referrer=management

**Test logged-out user**
* Revert modification on line 820.
* Restart calypso. Hit CTRL+C and `yarn start`.
* Test the above URLs again on an incognito window as a logged-out user.
  * You should be redirected to `/email-subscriptions`.
 
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?