### PR TITLE
Assembler: Implement list of page previews

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -41,6 +41,7 @@ import {
 import withNotices, { NoticesProps } from './notices/notices';
 import PatternAssemblerContainer from './pattern-assembler-container';
 import PatternLargePreview from './pattern-large-preview';
+import PatternPagePreviewList from './pattern-page-preview-list';
 import ScreenActivation from './screen-activation';
 import ScreenColorPalettes from './screen-color-palettes';
 import ScreenConfirmation from './screen-confirmation';
@@ -615,20 +616,31 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 					/>
 				</NavigatorScreen>
 			</div>
-			<PatternLargePreview
-				header={ header }
-				sections={ sections }
-				footer={ footer }
-				activePosition={ activePosition }
-				onDeleteSection={ onDeleteSection }
-				onMoveUpSection={ onMoveUpSection }
-				onMoveDownSection={ onMoveDownSection }
-				onDeleteHeader={ onDeleteHeader }
-				onDeleteFooter={ onDeleteFooter }
-				onShuffle={ onShuffle }
-				recordTracksEvent={ recordTracksEvent }
-				isNewSite={ isNewSite }
-			/>
+			{ currentScreen.name === 'pages' ? (
+				<PatternPagePreviewList
+					selectedHeader={ header }
+					selectedSections={ sections }
+					selectedFooter={ footer }
+					selectedPages={ pages }
+					pagesMapByCategory={ pagesMapByCategory }
+					isNewSite={ isNewSite }
+				/>
+			) : (
+				<PatternLargePreview
+					header={ header }
+					sections={ sections }
+					footer={ footer }
+					activePosition={ activePosition }
+					onDeleteSection={ onDeleteSection }
+					onMoveUpSection={ onMoveUpSection }
+					onMoveDownSection={ onMoveDownSection }
+					onDeleteHeader={ onDeleteHeader }
+					onDeleteFooter={ onDeleteFooter }
+					onShuffle={ onShuffle }
+					recordTracksEvent={ recordTracksEvent }
+					isNewSite={ isNewSite }
+				/>
+			) }
 		</div>
 	);
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-page-preview-list.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-page-preview-list.scss
@@ -1,0 +1,7 @@
+.pattern-assembler__preview-list {
+	display: flex;
+	flex: 1;
+	flex-wrap: wrap;
+	gap: 36px 48px;
+	padding: 100px 12px;
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-page-preview-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-page-preview-list.tsx
@@ -1,0 +1,59 @@
+import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
+import PatternPagePreview from './pattern-page-preview';
+import type { Pattern } from './types';
+import './pattern-page-preview-list.scss';
+
+interface Props {
+	selectedHeader: Pattern | null;
+	selectedSections: Pattern[];
+	selectedFooter: Pattern | null;
+	selectedPages: string[];
+	pagesMapByCategory: { [ key: string ]: Pattern[] };
+	isNewSite: boolean;
+}
+
+const PatternPagePreviewList = ( {
+	selectedHeader,
+	selectedSections,
+	selectedFooter,
+	selectedPages,
+	pagesMapByCategory,
+	isNewSite,
+}: Props ) => {
+	const translate = useTranslate();
+
+	const pages = useMemo(
+		() => selectedPages.map( ( slug ) => pagesMapByCategory[ slug ]?.[ 0 ] ).filter( Boolean ),
+		[ selectedPages, pagesMapByCategory ]
+	);
+
+	const homepage = useMemo(
+		() => [ selectedHeader, ...selectedSections, selectedFooter ].filter( Boolean ) as Pattern[],
+		[ selectedHeader, selectedSections, selectedFooter ]
+	);
+
+	return (
+		<div className="pattern-assembler__preview-list">
+			<PatternPagePreview
+				title={ translate( 'Homepage' ) }
+				patterns={ homepage }
+				shouldShufflePosts={ isNewSite }
+			/>
+			{ pages.map( ( page ) => (
+				<PatternPagePreview
+					key={ page.ID }
+					title={ page.title }
+					patterns={ [
+						...( selectedHeader ? [ selectedHeader ] : [] ),
+						page,
+						...( selectedFooter ? [ selectedFooter ] : [] ),
+					] }
+					shouldShufflePosts={ false }
+				/>
+			) ) }
+		</div>
+	);
+};
+
+export default PatternPagePreviewList;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-page-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-page-preview.scss
@@ -1,0 +1,42 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+@import "@automattic/typography/styles/variables";
+
+$font-family: "SF Pro Text", $sans;
+
+.pattern-assembler__preview {
+	flex-basis: 300px;
+	flex-shrink: 0;
+
+	.pattern-assembler__preview-frame {
+		background: #f8f8f8;
+		border: 10px solid #f8f8f8;
+		border-radius: 13px;  /* stylelint-disable-line scales/radii */
+		box-shadow:
+			0 5.25469px 5.25469px 0 rgba(0, 0, 0, 0.02),
+			0 11.38516px 8.75781px 0 rgba(0, 0, 0, 0.03);
+		height: 350px;
+		overflow: hidden;
+		position: relative;
+
+		&-content {
+			border-radius: 8.758px;  /* stylelint-disable-line scales/radii */
+			bottom: 0;
+			left: 0;
+			overflow-y: scroll;
+			position: absolute;
+			right: 0;
+			top: 0;
+		}
+	}
+
+	.pattern-assembler__preview-title {
+		color: var(--studio-gray-100);
+		font-family: $font-family;
+		font-size: $font-body-large;
+		line-height: 26px;
+		margin-inline-end: 10px;
+		margin-inline-start: 10px;
+		margin-top: 16px;
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-page-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-page-preview.tsx
@@ -1,0 +1,39 @@
+import { PatternRenderer } from '@automattic/block-renderer';
+import { useMemo } from 'react';
+import { encodePatternId } from './utils';
+import type { Pattern } from './types';
+import './pattern-page-preview.scss';
+
+interface Props {
+	title: string;
+	patterns: Pattern[];
+	shouldShufflePosts: boolean;
+}
+
+const PATTERN_PAGE_PREVIEW_ITEM_VIEWPORT_HEIGHT = 500;
+const PATTERN_PAGE_PREVIEW_ITEM_VIEWPORT_WIDTH = 1080;
+
+const PatternPagePreview = ( { title, patterns, shouldShufflePosts }: Props ) => {
+	const validPatterns = useMemo( () => patterns.filter( Boolean ) as Pattern[], [ patterns ] );
+
+	return (
+		<div className="pattern-assembler__preview">
+			<div className="pattern-assembler__preview-frame">
+				<div className="pattern-assembler__preview-frame-content">
+					{ validPatterns.map( ( pattern ) => (
+						<PatternRenderer
+							key={ pattern.ID }
+							patternId={ encodePatternId( pattern.ID ) }
+							viewportWidth={ PATTERN_PAGE_PREVIEW_ITEM_VIEWPORT_WIDTH }
+							viewportHeight={ PATTERN_PAGE_PREVIEW_ITEM_VIEWPORT_HEIGHT }
+							shouldShufflePosts={ shouldShufflePosts }
+						/>
+					) ) }
+				</div>
+			</div>
+			<div className="pattern-assembler__preview-title">{ title }</div>
+		</div>
+	);
+};
+
+export default PatternPagePreview;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #83450

## Proposed Changes

This PR implements the page previews in the Assembler's Add Pages screen. Currently, the page previews are fixed sized, @lucasmendes-design please review if this is the intended behavior. Note that some page patterns are shorter than the preview height, I propose to address this in a later PR. 

See recording for reference:

https://github.com/Automattic/wp-calypso/assets/797888/206e0d73-b473-4fdc-8a08-9a7340456462

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Assembler with the flag `&flags=pattern-assembler/add-pages`.
* Go through the Patterns, and Styles screen until you arrive at the Pages screen.
* Ensure that the page preview is shown for selected page options.
* Ensure that the sidebar interaction works as shown above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?