### PR TITLE
Fixed paddings on intermediate sizes of the screen

### DIFF
--- a/client/blocks/stats-navigation/style.scss
+++ b/client/blocks/stats-navigation/style.scss
@@ -8,7 +8,7 @@
 		align-items: center;
 
 		// Add gap for not open .section-nav on tablet and mobile.
-		@media ( max-width: $break-medium ) {
+		@media ( max-width: $break-small ) {
 			padding-right: 16px;
 		}
 
@@ -107,7 +107,7 @@
 		.section-nav__panel {
 			padding: 0;
 
-			@media ( max-width: $break-medium ) {
+			@media ( max-width: $break-small ) {
 				padding: 0 16px;
 			}
 		}

--- a/client/my-sites/stats/modernized-layout-styles.scss
+++ b/client/my-sites/stats/modernized-layout-styles.scss
@@ -59,12 +59,6 @@ $sidebar-appearance-break-point: 783px;
 			padding-right: max(calc(50% - #{math.div($stats-sections-max-width, 2)}), 32px);
 		}
 	}
-	.navigation-header__main {
-		@media ( min-width: $break-small ) and ( max-width: $custom-mobile-breakpoint ) {
-			padding-left: 0.825em;
-			padding-right: 0.825em;
-		}
-	}
 }
 
 .is-section-stats,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

* Fixed these padding issues:


https://github.com/Automattic/wp-calypso/assets/1044309/79599c69-beb4-465c-9fe8-c1941989ef0f

- Extra spacing on 740px width:

| Before | Header |
|--------|--------|
|<img width="794" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/9372bb10-1d09-4808-88c2-e20bd128bb85"> | <img width="795" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/9e0f996d-b497-4a3a-b7b3-e08510abf0a3"> | 


- Alignment with 630px width:

| Before | After |
|--------|--------|
|  <img width="679" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/571300d6-f6b6-464d-8f3b-6a2d92601e95"> | <img width="684" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/232da1cb-d88f-4f69-b0c2-67425d989e25"> | 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure the errors above do not occur anymore
* Try to break the screen

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
