### PR TITLE
Signup flow: Flash of masterbar when logged out

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -186,7 +186,7 @@ const LayoutLoggedOut = ( {
 		classes[ 'has-no-masterbar' ] = false;
 		masterbar = <WooCoreProfilerMasterbar />;
 	} else {
-		masterbar = (
+		masterbar = ! masterbarIsHidden && (
 			<MasterbarLoggedOut
 				title={ sectionTitle }
 				sectionName={ sectionName }

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -324,7 +324,11 @@ export default withCurrentRoute(
 			const isWooCoreProfilerFlow = isWooCommerceCoreProfilerFlow( state );
 			const wccomFrom = currentQuery?.[ 'wccom-from' ];
 			const masterbarIsHidden =
-				! masterbarIsVisible( state ) || noMasterbarForSection || noMasterbarForRoute;
+				! ( currentSection || currentRoute ) ||
+				! masterbarIsVisible( state ) ||
+				noMasterbarForSection ||
+				noMasterbarForRoute;
+
 			return {
 				isJetpackLogin,
 				isWhiteLogin,


### PR DESCRIPTION

Context: p1698261748833899-slack-C02T4NVL4JJ

Flash of a black top bar when navigating to `/start` logged out

https://github.com/Automattic/wp-calypso/assets/52076348/f91109d2-01a7-4af8-991c-8a5677db53f4

With this PR, we defer the decision for `masterbarIsHidden` to when section or route is defined. This affects only logged out pages

## Testing
1. Live Link and visit `/start/`
2. Check that the masterbar flashing is gone
 
Fixes https://github.com/Automattic/wp-calypso/issues/83531