### PR TITLE
Multi-Domain: Update CSS margin on Thank You page

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/product/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/product/style.scss
@@ -182,7 +182,7 @@
 
 .is-redesign-v2 {
 	.checkout-thank-you__header-details {
-		margin: 40px 0 0;
+		margin: 20px 0 0;
 		display: flex;
 		flex-direction: row;
 		box-sizing: border-box;
@@ -199,7 +199,6 @@
 
 		@media ( min-width: 480px ) {
 			padding: 20px 25px;
-			margin: 50px 0 0;
 		}
 	}
 

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/subheader/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/subheader/style.scss
@@ -5,8 +5,8 @@
 	.checkout-thank-you__header-text {
 		color: var(--color-text-subtle);
 		font-size: initial;
-		margin: initial;
 		text-align: left;
+		margin-bottom: 20px;
 
 		@include break-mobile {
 			text-align: center;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1698674654680929-slack-CKZHG0QCR

## Proposed Changes

* Decreases the margin between purchased domains in the multi-domain selection thank you page.

Before | After
--|--
<img width="1226" alt="before-ty" src="https://github.com/Automattic/wp-calypso/assets/140841/dce2f0ee-a870-4b2b-b674-4d233bd35330"> <img width="374" alt="before-ty-mobile" src="https://github.com/Automattic/wp-calypso/assets/140841/73ab4707-636b-4618-a072-dd06156bfa95">  | <img width="1228" alt="after-ty" src="https://github.com/Automattic/wp-calypso/assets/140841/6ea2bb6a-a165-4f83-8024-90a7184573c3"> <img width="371" alt="after-ty-mobile" src="https://github.com/Automattic/wp-calypso/assets/140841/202fbf5e-e872-4692-b950-b6621e93322c">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Purchase more than one domain in /domains and view the spacing on the Thank You page.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?