### PR TITLE
Reader Tags Streams - use recency feed by default

### DIFF
--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -52,7 +52,7 @@ function getLocation( path ) {
 	}
 	if ( path.indexOf( '/tag/' ) === 0 ) {
 		const sort = searchParams.get( 'sort' );
-		return `topic_page:${ sort || 'relevance' }`;
+		return `topic_page:${ sort === 'relevance' ? 'relevance' : 'date' }`;
 	}
 	if ( path.match( /^\/read\/(blogs|feeds)\/([0-9]+)\/posts\/([0-9]+)$/i ) ) {
 		return 'single_post';

--- a/client/reader/tag-stream/controller.js
+++ b/client/reader/tag-stream/controller.js
@@ -29,8 +29,9 @@ export const tagListing = ( context, next ) => {
 
 	const encodedTag = encodeURIComponent( tagSlug ).toLowerCase();
 
-	// default to popular tags unless the user explicitly selects 'date'
-	const streamKey = context.query.sort === 'date' ? 'tag:' + tagSlug : 'tag_popular:' + tagSlug;
+	// default to tags by recency unless the user explicitly selects 'relavance'
+	const streamKey =
+		context.query.sort === 'relevance' ? 'tag_popular:' + tagSlug : 'tag:' + tagSlug;
 
 	const mcKey = 'topic';
 	const startDate = getStartDate( context );

--- a/client/reader/tag-stream/header.jsx
+++ b/client/reader/tag-stream/header.jsx
@@ -60,7 +60,7 @@ class TagStreamHeader extends Component {
 			showBack,
 			showSort,
 		} = this.props;
-		const sortOrder = this.props.sort || 'relevance';
+		const sortOrder = this.props.sort || 'date';
 
 		// A bit of a hack: check for a prompt tag (which always have a description) from the slug before waiting for tag info to load,
 		// so we can set a smaller title size and prevent it from resizing as the page loads. Should be refactored if tag descriptions
@@ -86,16 +86,16 @@ class TagStreamHeader extends Component {
 							{ showSort && (
 								<SegmentedControl compact>
 									<SegmentedControl.Item
-										selected={ sortOrder !== 'date' }
-										onClick={ this.useRelevanceSort }
-									>
-										{ this.props.translate( 'Popular' ) }
-									</SegmentedControl.Item>
-									<SegmentedControl.Item
-										selected={ sortOrder === 'date' }
+										selected={ sortOrder !== 'relevance' }
 										onClick={ this.useDateSort }
 									>
 										{ this.props.translate( 'Recent' ) }
+									</SegmentedControl.Item>
+									<SegmentedControl.Item
+										selected={ sortOrder === 'relevance' }
+										onClick={ this.useRelevanceSort }
+									>
+										{ this.props.translate( 'Popular' ) }
 									</SegmentedControl.Item>
 								</SegmentedControl>
 							) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to  converstaion on #  pe7F0s-1lq-p2#comment-1671 after shipping  pe7F0s-1gP-p2 

## Proposed Changes

Sets the default behavior for tags streams to be based off of recency. This is how the tags streams have been for a long time before the above noted project updated them to load 'popular' results by default. This will leave the tab in place to allow users to view the popular/relevance stream if they want, but will ensure we continue to default to recency as we have historically. More info and thoughts in p2s noted above.

Before:
<img width="662" alt="Screenshot 2023-10-30 at 10 44 10 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/509b65c5-c5f4-43ae-a40f-a17c46485030">

After:
<img width="676" alt="Screenshot 2023-10-30 at 10 43 45 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/90cdfbe7-5b3f-450d-8fff-5d7219db1d22">





## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load a tag stream with no 'sort' query in the url.
* Verify it loads with 'recent' selected and that the feed corresponds to this setting.
* verify the tracking event `calypso_reader_tag_loaded` fires with the property `ui_algo: topic_page:date`.
* add `?sort=date` to the url, reload and verify the same results as above.
* change to `?sort=bananas` in the url, reload, and verify the same results as above.
* change to `?sort=relevance` in the url and reload
* Verify the 'Popular' tab is selected and that the feed corresponds to this.
* verify the tracking event `calypso_reader_tag_loaded` now fires with the property `ui_algo: topic_page:relevance`
* Test switching between the tabs manually by clicking, and ensure the corresponding `sort` query is added to the url in the browser.
* Test other actions on these streams (like 'like'ing a post), and verify `ui_algo` property on corresponding events corresponds to what is expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?