### PR TITLE
Jetpack Manage Form: Add new "managed_sites" input

### DIFF
--- a/client/jetpack-cloud/sections/agency-signup/agency-signup-form/index.tsx
+++ b/client/jetpack-cloud/sections/agency-signup/agency-signup-form/index.tsx
@@ -60,6 +60,7 @@ export default function AgencySignupForm() {
 					contact_person: payload.contactPerson,
 					company_website: payload.companyWebsite,
 					company_type: payload.companyType,
+					managed_sites: payload.managedSites,
 					partner_program_opt_in: payload.partnerProgramOptIn,
 					city: payload.city,
 					line1: payload.line1,

--- a/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
@@ -74,7 +74,7 @@ export default function CompanyDetailsForm( {
 	const [ contactPerson, setContactPerson ] = useState( initialValues.contactPerson ?? '' );
 	const [ companyWebsite, setCompanyWebsite ] = useState( initialValues.companyWebsite ?? '' );
 	const [ companyType, setCompanyType ] = useState( initialValues.companyType ?? '' );
-	const [ managedSites, setManagedSites ] = useState( initialValues.managedSites ?? '' );
+	const [ managedSites, setManagedSites ] = useState( initialValues.managedSites ?? '1-5' );
 	const [ partnerProgramOptIn, setPartnerProgramOptIn ] = useState( false );
 
 	const [ showPartnerProgramOptIn, setShowPartnerProgramOptIn ] = useState( false );

--- a/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
@@ -1,4 +1,5 @@
 import { Button, Gridicon } from '@automattic/components';
+import { SelectControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState, useMemo, ChangeEvent, useEffect } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
@@ -39,6 +40,7 @@ interface Props {
 		contactPerson?: string;
 		companyWebsite?: string;
 		companyType?: string;
+		managedSites?: string;
 		partnerProgramOptIn?: boolean;
 		city?: string;
 		line1?: string;
@@ -72,6 +74,7 @@ export default function CompanyDetailsForm( {
 	const [ contactPerson, setContactPerson ] = useState( initialValues.contactPerson ?? '' );
 	const [ companyWebsite, setCompanyWebsite ] = useState( initialValues.companyWebsite ?? '' );
 	const [ companyType, setCompanyType ] = useState( initialValues.companyType ?? '' );
+	const [ managedSites, setManagedSites ] = useState( initialValues.managedSites ?? '' );
 	const [ partnerProgramOptIn, setPartnerProgramOptIn ] = useState( false );
 
 	const [ showPartnerProgramOptIn, setShowPartnerProgramOptIn ] = useState( false );
@@ -106,6 +109,7 @@ export default function CompanyDetailsForm( {
 			contactPerson,
 			companyWebsite,
 			companyType,
+			managedSites,
 			partnerProgramOptIn,
 			city,
 			line1,
@@ -121,6 +125,7 @@ export default function CompanyDetailsForm( {
 			contactPerson,
 			companyWebsite,
 			companyType,
+			managedSites,
 			partnerProgramOptIn,
 			city,
 			line1,
@@ -220,6 +225,23 @@ export default function CompanyDetailsForm( {
 						isChecked={ partnerProgramOptIn }
 					/>
 				) }
+				<FormFieldset>
+					<FormLabel>{ translate( 'How many sites do you manage?' ) }</FormLabel>
+					<SelectControl
+						id="managed_sites"
+						name="managed_sites"
+						value={ managedSites }
+						options={ [
+							{ value: '1-5', label: translate( '1-5' ) },
+							{ value: '6-20', label: translate( '6-20' ) },
+							{ value: '21-50', label: translate( '21-50' ) },
+							{ value: '51-100', label: translate( '51-100' ) },
+							{ value: '101-500', label: translate( '101-500' ) },
+							{ value: '500+', label: translate( '500+' ) },
+						] }
+						onChange={ setManagedSites }
+					/>
+				</FormFieldset>
 				<FormFieldset>
 					<FormLabel>{ translate( 'Country' ) }</FormLabel>
 					{ showCountryFields && (

--- a/client/jetpack-cloud/sections/partner-portal/update-company-details-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/update-company-details-form/index.tsx
@@ -22,6 +22,7 @@ export default function UpdateCompanyDetailsForm() {
 	const contactPerson = partner?.contact_person ?? '';
 	const companyWebsite = partner?.company_website ?? '';
 	const companyType = partner?.company_type ?? '';
+	const managedSites = partner?.managed_sites ?? '';
 	const country = partner?.address.country ?? '';
 	const city = partner?.address.city ?? '';
 	const line1 = partner?.address.line1 ?? '';
@@ -63,6 +64,7 @@ export default function UpdateCompanyDetailsForm() {
 					contact_person: payload.contactPerson,
 					company_website: payload.companyWebsite,
 					company_type: payload.companyType,
+					managed_sites: payload.managedSites,
 					city: payload.city,
 					line1: payload.line1,
 					line2: payload.line2,
@@ -82,6 +84,7 @@ export default function UpdateCompanyDetailsForm() {
 				contactPerson,
 				companyWebsite,
 				companyType,
+				managedSites,
 				country,
 				city,
 				line1,

--- a/client/state/partner-portal/partner/hooks/use-create-partner-mutation.ts
+++ b/client/state/partner-portal/partner/hooks/use-create-partner-mutation.ts
@@ -11,6 +11,7 @@ function createPartner( details: PartnerDetailsPayload ): Promise< APIPartner > 
 			contact_person: details.contactPerson,
 			company_website: details.companyWebsite,
 			company_type: details.companyType,
+			managed_sites: details.managedSites,
 			partner_program_opt_in: details.partnerProgramOptIn,
 			city: details.city,
 			line1: details.line1,

--- a/client/state/partner-portal/partner/hooks/use-update-company-details-mutation.ts
+++ b/client/state/partner-portal/partner/hooks/use-update-company-details-mutation.ts
@@ -12,6 +12,7 @@ function updateCompanyDetails( details: CompanyDetailsPayload ): Promise< APIPar
 			contact_person: details.contactPerson,
 			company_website: details.companyWebsite,
 			company_type: details.companyType,
+			managed_sites: details.managedSites,
 			city: details.city,
 			line1: details.line1,
 			line2: details.line2,

--- a/client/state/partner-portal/partner/utils.ts
+++ b/client/state/partner-portal/partner/utils.ts
@@ -13,6 +13,7 @@ export function translateInvalidPartnerParameterError( parameters: object, detai
 		contact_person: __( 'Contact person' ),
 		company_website: __( 'Company website' ),
 		company_type: __( 'Company type' ),
+		managed_sites: __( 'Managed sites' ),
 		city: __( 'City' ),
 		country: __( 'Country' ),
 		line1: __( 'Address line 1' ),

--- a/client/state/partner-portal/types.ts
+++ b/client/state/partner-portal/types.ts
@@ -75,6 +75,7 @@ export interface APIPartner {
 	contact_person: string;
 	company_website: string;
 	company_type: string;
+	managed_sites: string;
 	address: APIPartnerAddress;
 	keys: APIPartnerKey[];
 	tos: string;

--- a/client/state/partner-portal/types.ts
+++ b/client/state/partner-portal/types.ts
@@ -150,6 +150,7 @@ export interface CompanyDetailsPayload {
 	contactPerson: string;
 	companyWebsite: string;
 	companyType: string;
+	managedSites: string;
 	city: string;
 	line1: string;
 	line2: string;
@@ -191,6 +192,7 @@ export interface Partner {
 	contact_person: string;
 	company_website: string;
 	company_type: string;
+	managed_sites: string;
 	name: string;
 	address: PartnerAddress;
 	keys: PartnerKey[];


### PR DESCRIPTION
Related to https://github.com/Automattic/jetpack-manage/issues/45

## Proposed Changes

* This PR adds new managed_sites input to the <AgencySignupForm> component, above the "Country" field.
  * Label: How many sites do you manage?
  * Options: 
    * 1-5
    * 6-20
    * 21-50
    * 51-100
    * 101-500
    * 500+
* It also updates the tracks event `calypso_partner_portal_create_partner_submit`

## Testing Instructions
  - Open the agency sign up form in staging - http://jetpack.cloud.localhost:3000/agency/signup - and with a new account.
  - There should be a new select input `How many sites do you manage?` 
  - Visit the tracks live view (or use Tracks Vigilante) and watch the calypso_partner_portal_create_partner_submit event for your submission, and check the props. There should be a new prop called `managed_sites`



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?