### PR TITLE
Multi-Domain: Using plural header only if there is a translation

### DIFF
--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -677,13 +677,12 @@ export function generateSteps( {
 			stepName: 'site-or-domain',
 			props: {
 				getHeaderText( domainCart ) {
-					return i18n.translate(
-						'Choose how to use your domain',
-						'Choose how to use your domains',
-						{
-							count: domainCart.length,
-						}
-					);
+					return i18n.getLocaleSlug() === 'en' ||
+						i18n.hasTranslation( 'Choose how to use your domains' )
+						? i18n.translate( 'Choose how to use your domain', 'Choose how to use your domains', {
+								count: domainCart.length,
+						  } )
+						: i18n.translate( 'Choose how to use your domain' );
 				},
 				get subHeaderText() {
 					return i18n.getLocaleSlug() === 'en' ||


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Follow-up of https://github.com/Automattic/wp-calypso/pull/83631

## Proposed Changes

* For non-EN users, only show the plural message if it's translated already

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
