### PR TITLE
Videomaker Trial: Show Premium and Business Plans Only

### DIFF
--- a/client/my-sites/plans-features-main/hooks/use-plan-intent-from-site-meta.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plan-intent-from-site-meta.ts
@@ -26,6 +26,13 @@ const usePlanIntentFromSiteMeta = (): IntentFromSiteMeta => {
 		};
 	}
 
+	if ( 'videopress' === ( siteIntent.data?.site_intent as string ) ) {
+		return {
+			processing: false,
+			intent: 'plans-videopress',
+		};
+	}
+
 	return {
 		processing: false,
 		intent: null, // null -> we've observed metadata but nothing we care about

--- a/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
+++ b/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
@@ -252,7 +252,7 @@ const usePlanTypesWithIntent = ( {
 			];
 			break;
 		case 'plans-videopress':
-			planTypes = [ TYPE_PREMIUM, TYPE_BUSINESS, TYPE_ECOMMERCE ];
+			planTypes = [ TYPE_PREMIUM, TYPE_BUSINESS ];
 			break;
 		default:
 			planTypes = availablePlanTypes;

--- a/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
+++ b/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
@@ -133,6 +133,7 @@ export type PlansIntent =
 	| 'plans-p2'
 	| 'plans-default-wpcom'
 	| 'plans-business-trial'
+	| 'plans-videopress'
 	| 'default';
 
 interface Props {
@@ -249,6 +250,9 @@ const usePlanTypesWithIntent = ( {
 				TYPE_BUSINESS,
 				...( isEnterpriseAvailable ? [ TYPE_ENTERPRISE_GRID_WPCOM ] : [] ),
 			];
+			break;
+		case 'plans-videopress':
+			planTypes = [ TYPE_PREMIUM, TYPE_BUSINESS, TYPE_ECOMMERCE ];
 			break;
 		default:
 			planTypes = availablePlanTypes;

--- a/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-highlight-labels.ts
+++ b/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-highlight-labels.ts
@@ -53,6 +53,10 @@ const useHighlightLabels = ( {
 				if ( isPremiumPlan( planSlug ) ) {
 					label = translate( 'Best for Link in Bio' );
 				}
+			} else if ( 'plans-videopress' === intent ) {
+				if ( isBusinessPlan( planSlug ) ) {
+					label = translate( 'Best for Video' );
+				}
 			} else if ( 'plans-blog-onboarding' === intent ) {
 				if ( isPremiumPlan( planSlug ) ) {
 					label = translate( 'Best for Blog' );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/greenhouse/issues/1894

## Proposed Changes

* Adds some tweaks to the Videomaker trial flow to show the premium and business plans only:

![Screenshot 2023-10-30 at 3 26 54 PM](https://github.com/Automattic/wp-calypso/assets/789137/d1b2a9a4-6950-474c-9327-32c52e149c6e)

Note: This change doesn't _require_ the user to make the purchase, but since the videos won't play on the site and the upsell banner will still show I figured that is ok?

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start at `/setup/videopress` in local dev environment.
* Click on `Showcase my work` to start the videomaker flow.
* Set up a videomaker site.
* When at the site editor, return to the site dashboard by clicking the `W` at the top-left.
* Click on the `Launch site` task, and then click the `Launch site` button.
* Scroll down and skip the domain purchase.
* You should see the plans listed (No free, blogger plans) and `Best for Video` should be above the business plan. I figured it was best for Video because of the additional storage?

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
