### PR TITLE
Multi-Domain: Using plural on first card title only if there is a translation

### DIFF
--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -61,9 +61,12 @@ class SiteOrDomain extends Component {
 		const { translate, isReskinned, isLoggedIn, siteCount } = this.props;
 
 		const domainName = this.getDomainName();
-		let buyADomainTitle = translate( 'Just buy a domain', 'Just buy domains', {
-			count: this.getDomainCart().length,
-		} );
+		let buyADomainTitle =
+			i18n.getLocaleSlug() === 'en' || i18n.hasTranslation( 'Just buy domains' )
+				? translate( 'Just buy a domain', 'Just buy domains', {
+						count: this.getDomainCart().length,
+				  } )
+				: translate( 'Just buy a domain' );
 
 		if ( this.isLeanDomainSearch() && domainName ) {
 			// translators: %s is a domain name


### PR DESCRIPTION
Follow-up of https://github.com/Automattic/wp-calypso/pull/83631

## Proposed Changes

* For non-EN users, only show the plural message for `Just buy domains` if it's already translated 
