### PR TITLE
Free hosting trial: enable escape expired page

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -224,17 +224,17 @@ class MasterbarLoggedIn extends Component {
 		} = this.props;
 		const { isMenuOpen, isResponsiveMenu } = this.state;
 
-		// eslint-disable-next-line no-nested-ternary
-		const homeUrl = hasNoSites
-			? '/sites'
-			: isCustomerHomeEnabled
-			? `/home/${ siteSlug }`
-			: getStatsPathForTab( 'day', siteSlug );
+		const homeUrl =
+			// eslint-disable-next-line no-nested-ternary
+			hasNoSites || isSiteTrialExpired
+				? '/sites'
+				: isCustomerHomeEnabled
+				? `/home/${ siteSlug }`
+				: getStatsPathForTab( 'day', siteSlug );
 
 		let mySitesUrl = domainOnlySite
 			? domainManagementList( siteSlug, currentRoute, true )
 			: homeUrl;
-		mySitesUrl = isSiteTrialExpired ? `/home/` : mySitesUrl;
 
 		const icon =
 			this.state.isMobile && this.props.isInEditor ? 'chevron-left' : this.wordpressIcon();

--- a/client/my-sites/plans/trials/business-trial-expired/index.tsx
+++ b/client/my-sites/plans/trials/business-trial-expired/index.tsx
@@ -15,6 +15,7 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { useSelector } from 'calypso/state';
 import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import wasMigrationTrialSite from 'calypso/state/selectors/was-migration-trial-site';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import './style.scss';
 import { BusinessTrialPlans } from '../business-trial-plans';
@@ -26,6 +27,7 @@ const BusinessTrialExpired = (): JSX.Element => {
 	const siteSlug = selectedSite?.slug ?? null;
 	const sitePurchases = useSelector( ( state ) => getSitePurchases( state, siteId ) );
 	const siteIsAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, siteId ) );
+	const siteIsMigration = useSelector( ( state ) => wasMigrationTrialSite( state, siteId ) );
 
 	const nonBusinessTrialPurchases = useMemo(
 		() =>
@@ -81,9 +83,23 @@ const BusinessTrialExpired = (): JSX.Element => {
 							{ translate( 'Your free trial has ended' ) }
 						</h1>
 						<div className="business-trial-expired__subtitle">
-							{ translate(
-								'Don’t lose all that hard work! Upgrade to a paid plan to launch your migrated website.'
-							) }
+							{ siteIsMigration
+								? translate(
+										'Don’t lose all that hard work! Upgrade to a paid plan to launch your migrated website, or {{a}}create a new site{{/a}}.',
+										{
+											components: {
+												a: <a href="/start" />,
+											},
+										}
+								  )
+								: translate(
+										'Don’t lose all that hard work! Upgrade to a paid plan or {{a}}create a new site{{/a}}.',
+										{
+											components: {
+												a: <a href="/start" />,
+											},
+										}
+								  ) }
 						</div>
 						{ nonBusinessTrialPurchases && nonBusinessTrialPurchases.length > 0 && (
 							<div className="business-trial-expired__manage-purchases">

--- a/client/my-sites/plans/trials/business-trial-expired/style.scss
+++ b/client/my-sites/plans/trials/business-trial-expired/style.scss
@@ -1,3 +1,4 @@
+@import "@automattic/onboarding/styles/mixins";
 @import "@automattic/typography/styles/woo-commerce";
 @import "@wordpress/base-styles/breakpoints";
 
@@ -21,6 +22,7 @@ body.is-section-plans.is-expired-business-trial-plan {
 		}
 
 		.business-trial-expired__title {
+			@include onboarding-font-recoleta;
 			font-size: $woo-font-title-medium;
 
 			@media ( min-width: $break-medium ) {
@@ -29,10 +31,17 @@ body.is-section-plans.is-expired-business-trial-plan {
 		}
 
 		.business-trial-expired__subtitle {
-			margin: 1rem auto 0;
+			margin: 0 auto 0;
+			color: var(--color-neutral-50);
 
 			@media ( min-width: $break-medium ) {
 				max-width: 580px;
+			}
+
+			a {
+				color: var(--studio-gray-90);
+				font-weight: 500;
+				text-decoration: underline;
 			}
 		}
 

--- a/client/state/selectors/was-business-trial-site.ts
+++ b/client/state/selectors/was-business-trial-site.ts
@@ -3,5 +3,10 @@ import type { AppState } from 'calypso/types';
 
 export default function wasBusinessTrialSite( state: AppState, siteId: number ) {
 	const site = getRawSite( state, siteId );
-	return site?.was_migration_trial || site?.was_hosting_trial;
+
+	if ( ! site ) {
+		return false;
+	}
+
+	return site.was_migration_trial || site.was_hosting_trial;
 }

--- a/client/state/selectors/was-migration-trial-site.ts
+++ b/client/state/selectors/was-migration-trial-site.ts
@@ -1,0 +1,14 @@
+import getRawSite from './get-raw-site';
+import type { AppState } from 'calypso/types';
+
+export default function wasMigrationTrialSite(
+	state: AppState,
+	siteId: number | null | undefined
+) {
+	if ( ! siteId ) {
+		return false;
+	}
+
+	const site = getRawSite( state, siteId );
+	return site?.was_migration_trial ?? false;
+}

--- a/client/state/sites/plans/selectors/trials/trials-expiration.ts
+++ b/client/state/sites/plans/selectors/trials/trials-expiration.ts
@@ -1,4 +1,5 @@
 import { Moment } from 'moment';
+import wasTrialSite from 'calypso/state/selectors/was-trial-site';
 import { AppState } from 'calypso/types';
 import getECommerceTrialDaysLeft from './get-ecommerce-trial-days-left';
 import getECommerceTrialExpiration from './get-ecommerce-trial-expiration';
@@ -56,6 +57,10 @@ export function isTrialExpired( state: AppState, siteId: number ): boolean | nul
 
 	if ( isSiteOnHostingTrial( state, siteId ) ) {
 		return isHostingTrialExpired( state, siteId );
+	}
+
+	if ( wasTrialSite( state, siteId ) ) {
+		return true;
 	}
 
 	return null;


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/4372.

## Proposed Changes

This PR lets the user navigate to `/sites` by clicking in the "My Sites" top-left navbar button.

It also adds a "create a new site" link in the subheading.

![image](https://github.com/Automattic/wp-calypso/assets/26530524/aa8ff9f6-e501-46db-bc4f-cfa7a4b01589)

## Testing Instructions

- Browse an expired trial site and verify you can escape the "trial expired" page
- Browse `/hosting-config/%s` for an active trial and verify that the trial countdown banner was not affected