### PR TITLE
Login: Update magic email confirmation styles

### DIFF
--- a/client/login/magic-login/emailed-login-link-successfully.jsx
+++ b/client/login/magic-login/emailed-login-link-successfully.jsx
@@ -1,4 +1,4 @@
-import { Card, Gridicon } from '@automattic/components';
+import { Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
@@ -45,18 +45,26 @@ class EmailedLoginLinkSuccessfully extends Component {
 		const { translate, emailAddress } = this.props;
 		const line = [
 			emailAddress
-				? translate( 'We just emailed a link to %(emailAddress)s.', {
-						args: {
-							emailAddress,
-						},
-				  } )
-				: translate( 'We just emailed you a link.' ),
+				? translate(
+						'If you have a WordPress.com account, we’ve sent an email to {{span}} %(emailAddress)s {{/span}} with a link you can use to sign in.',
+						{
+							args: {
+								emailAddress,
+							},
+							components: {
+								span: <span className="magic-login__confirmation-email" />,
+							},
+						}
+				  )
+				: translate(
+						'If you have a WordPress.com account, we’ve sent an email to your email address with a link you can use to sign in.'
+				  ),
 			' ',
 			translate( 'Please check your inbox and click the link to log in.' ),
 		];
 
 		return (
-			<div>
+			<div className="magic-login__confirmation">
 				<RedirectWhenLoggedIn
 					redirectTo="/help"
 					replaceCurrentLocation={ true }
@@ -78,8 +86,7 @@ class EmailedLoginLinkSuccessfully extends Component {
 						} ) }
 						onClick={ this.onClickBackLink }
 					>
-						<Gridicon icon="arrow-left" size={ 18 } />
-						{ translate( 'Back to login' ) }
+						{ translate( 'Enter a password instead' ) }
 					</a>
 				</div>
 			</div>

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -29,6 +29,10 @@
 	align-items: center;
 	justify-content: center;
 
+	.layout__primary {
+		margin-top: 0 !important;
+	}
+
 	.magic-login .magic-login__form-header {
 		margin-bottom: 0;
 
@@ -51,6 +55,23 @@
 
 	.magic-login__form-action {
 		margin-top: 16px;
+	}
+
+	.magic-login__confirmation {
+		p {
+			text-align: center;
+		}
+		.magic-login__confirmation-email {
+			font-weight: 600;
+		}
+		.magic-login__footer a {
+			border-bottom: none;
+			color: var(--studio-gray-90);
+			text-decoration: underline;
+			&:hover {
+				color: var(--color-primary);
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## Proposed Changes

Updates styles of the magic email login confirmation screen (shows immediately after clicking send link from magic login page). Caveats: 
   - Figma: 5p3iZ99zPYfl6ronoTYEXO-fi-4_1291
   - P2: p9Jlb4-9mo-p2
   - Changes are based on this PR **which should be merged first**: https://github.com/Automattic/wp-calypso/pull/83546
   - Caveat: The width of the text area is narrower than in designs. Because same page structure is used by many pages, I think there is more complexity  expanding the width only on this page, but not on others. 
   - Caveat: The designs also have a new link for 'I didn't receive my email'. I'm going to add that in a separate follow up PR.
 
**Before**
<img width="1495" alt="magic-email-confirmation-old" src="https://github.com/Automattic/wp-calypso/assets/21228350/fc0c93aa-51f0-4abc-b9c3-4bbd4692b89c">

**After**
<img width="1492" alt="magic-email-confirmation" src="https://github.com/Automattic/wp-calypso/assets/21228350/2b688c79-c4f2-4f61-997f-5eae9d9b1e51">

## Testing Instructions

1) In an incognito or non-logged-in browser, go to wordpress.com and click the Login link, and then click 'Email me a login link' to go to the magic email login page
2) Replace wordpress.com with http://calypso.localhost:3000 to load this branch.
3) Enter an email and click Send Link. 
4) The confirmation screen should load. Confirm it looks like the screenshot above
5) Using your browser tools, adjust the window to mobile size and confirm styling adjust well. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?