### PR TITLE
Update/2023 dotcom division meetup support closures

### DIFF
--- a/packages/components/src/gm-closure-notice/gm-closure-notice.tsx
+++ b/packages/components/src/gm-closure-notice/gm-closure-notice.tsx
@@ -45,7 +45,7 @@ export function GMClosureNotice( { displayAt, closesAt, reopensAt, enabled }: Pr
 		during: sprintf(
 			/* translators:  reopens_at is a date */
 			__(
-				'Live chat support is closed until %(reopens_at)s. In the meantime you can still reach us by email.',
+				'Once a year, Happiness Engineers get together to work on improving our services, building new features, and learning how to better serve you. During this time, we will continue to provide support over email. If you need to get in touch with us, please submit a support request from this page, and we will get to it as fast as we can. Chat will re-open at %(reopens_at)s. Thank you for your understanding!',
 				__i18n_text_domain__
 			),
 			{
@@ -64,7 +64,7 @@ export function GMClosureNotice( { displayAt, closesAt, reopensAt, enabled }: Pr
 
 	const heading = sprintf(
 		/* translators: closes and reopens are dates */
-		__( 'Limited Support %(closes)s – %(reopens)s', __i18n_text_domain__ ),
+		__( 'Live chat will be closed from %(closes)s – %(reopens)s', __i18n_text_domain__ ),
 		{
 			closes: format( DATE_FORMAT_SHORT, closesAtDate ),
 			reopens: format( isSameMonth ? 'd' : DATE_FORMAT_SHORT, reopensAtDate ),

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -131,9 +131,9 @@ export const HelpCenterContactPage: FC = () => {
 				{ supportActivity && <HelpCenterActiveTicketNotice tickets={ supportActivity } /> }
 				{ /* Easter */ }
 				<GMClosureNotice
-					displayAt="2023-04-03 00:00Z"
-					closesAt="2023-04-09 00:00Z"
-					reopensAt="2023-04-10 07:00Z"
+					displayAt="2023-10-30 00:00Z"
+					closesAt="2023-11-11 00:00Z"
+					reopensAt="2023-11-21 07:00Z"
 					enabled={ renderChat.render }
 				/>
 

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -129,7 +129,6 @@ export const HelpCenterContactPage: FC = () => {
 			<div className="help-center-contact-page__content">
 				<h3>{ __( 'Contact our WordPress.com experts', __i18n_text_domain__ ) }</h3>
 				{ supportActivity && <HelpCenterActiveTicketNotice tickets={ supportActivity } /> }
-				{ /* Easter */ }
 				<GMClosureNotice
 					displayAt="2023-11-06 00:00Z"
 					closesAt="2023-11-11 00:00Z"

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -131,7 +131,7 @@ export const HelpCenterContactPage: FC = () => {
 				{ supportActivity && <HelpCenterActiveTicketNotice tickets={ supportActivity } /> }
 				{ /* Easter */ }
 				<GMClosureNotice
-					displayAt="2023-10-30 00:00Z"
+					displayAt="2023-11-06 00:00Z"
 					closesAt="2023-11-11 00:00Z"
 					reopensAt="2023-11-21 07:00Z"
 					enabled={ renderChat.render }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Requested on: peCdcN-iJ-p2#comment-820

## Proposed Changes

* Adds a notice for Live Chat closure from Nov 11 to 21.
* Sets the notice to appear since Oct 30.
* Updates the message for the notice to the one proposed on the P2 post.

## Questions

We no longer use Concierge Support, is it necessary to update the message in the following file?

fbhepr%2Skers%2Spnylcfb%2Spyvrag%2Szr%2Spbapvretr%2Sfunerq%2Scevznel%2Qurnqre.wf%3Se%3Q3rs8sq7s%2315-og

If so, I propose we use the same `GMClosureNotice` component.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Change the dates in the code to simulate different cases - before, during and after the closure dates.
2. Test both http://calypso.localhost:3000/help/contact and the Help Center (? in the main menu bar on top). Both should open the Help Center.
3. Check the message at the top when checking the dates for now, during and after the meetup.

Example of the message you should see at the top:
![CleanShot 2023-10-30 at 17 57 26](https://github.com/Automattic/wp-calypso/assets/3696121/af0cc442-08e9-4e6b-b683-1813db5ff9ee)

![CleanShot 2023-10-30 at 17 58 02](https://github.com/Automattic/wp-calypso/assets/3696121/9bee1c00-d0e3-415e-9723-aab674b9b617)
