### PR TITLE
Plugin Details: Update layout breakpoints

### DIFF
--- a/client/my-sites/marketplace/components/billing-interval-switcher/index.tsx
+++ b/client/my-sites/marketplace/components/billing-interval-switcher/index.tsx
@@ -17,6 +17,7 @@ const PluginAnnualSavingLabelMobile = styled.span< PluginAnnualSavingLabelProps 
 
 const BillingIntervalSwitcherContainer = styled.div`
 	display: flex;
+	flex-wrap: wrap;
 	margin-top: -4px;
 	margin-bottom: 16px;
 `;

--- a/client/my-sites/plugins/plugin-details-CTA/style.scss
+++ b/client/my-sites/plugins/plugin-details-CTA/style.scss
@@ -137,6 +137,15 @@
 	font-size: $font-body;
 	height: 40px;
 
+	@include breakpoint-deprecated( "<1280px" ) {
+		font-size: $font-body-small;
+	}
+
+	@include breakpoint-deprecated( "<960px" ) {
+		font-size: $font-body;
+	}
+
+
 	.plugin-details-cta__installed-text-quantity {
 		color: var(--studio-green-50);
 	}

--- a/client/my-sites/plugins/plugin-details-header/style.scss
+++ b/client/my-sites/plugins/plugin-details-header/style.scss
@@ -88,7 +88,7 @@ $mobile-icon-height: 175px;
 		box-sizing: border-box;
 		padding: 0;
 
-		@media screen and ( max-width: 1040px ) {
+		@media screen and ( max-width: 1280px ) {
 			width: 50%;
 			padding-bottom: 12px;
 		}

--- a/client/my-sites/plugins/plugin-details-sidebar-usp/index.jsx
+++ b/client/my-sites/plugins/plugin-details-sidebar-usp/index.jsx
@@ -70,7 +70,7 @@ const PluginDetailsSidebarUSP = ( {
 	links = undefined,
 	first = false,
 } ) => {
-	const isNarrow = useBreakpoint( '<1040px' );
+	const isNarrow = useBreakpoint( '<960px' );
 	const Header = () => {
 		return (
 			<>

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -128,7 +128,7 @@ function PluginDetails( props ) {
 		);
 
 	// Header Navigation and billing period switcher.
-	const isWide = useBreakpoint( '>1280px' );
+	const isWide = useBreakpoint( '>960px' );
 
 	// Determine if the plugin is WPcom or WPorg hosted
 	const productsList = useSelector( ( state ) => getProductsList( state ) );

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -119,19 +119,19 @@ $calypso-header-height: 31px;
 	}
 
 	@include display-grid;
-	grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) 395px;
+	grid-template-columns: minmax(380px, auto) minmax(auto, 395px);
 	grid-column-gap: 60px;
 	grid-template-areas:
-		"header header actions"
-		"content content actions";
+		"header actions"
+		"content actions";
 	grid-auto-rows: auto 1fr;
 
-	@include breakpoint-deprecated( "<1280px" ) {
+	@include breakpoint-deprecated( "<960px" ) {
 		grid-template-areas:
-			"header header header"
-			"actions actions actions"
-			"content content content";
-		grid-template-columns: repeat(3, minmax(0, 1fr));
+			"header"
+			"actions"
+			"content";
+		grid-template-columns: minmax(0, 1fr);
 		padding-top: 20px;
 	}
 
@@ -149,13 +149,21 @@ $calypso-header-height: 31px;
 		grid-area: actions;
 		height: fit-content;
 
-		@include breakpoint-deprecated( "<1280px" ) {
+		@include breakpoint-deprecated( "<960px" ) {
 			margin-top: 40px;
 		}
 
 		.plugin-details__sidebar {
 			background-color: var(--studio-gray-0);
 			padding: 40px;
+
+			@include breakpoint-deprecated( "<1280px" ) {
+				padding: 30px;
+			}
+
+			@include breakpoint-deprecated( "<960px" ) {
+				padding: 40px;
+			}
 		}
 
 		.plugin-details-download-card {


### PR DESCRIPTION
Fixes #83381

## Proposed Changes

Update layout breakpoints to better-fit screens below `1280px`.

* Update layout grid to 2 columns instead of 3
* Lower padding when between 960px and 1280px: 30px instead of 40px
* Use two columns for the header additional information for any screen below 1280px. It used to be 1040px.


| <960px  | >960px and <1280px  | >1280px
| ------------- | ------------- | ------------- |
|![CleanShot 2023-10-30 at 20 40 57@2x](https://github.com/Automattic/wp-calypso/assets/5039531/3838c45b-765f-45c8-95ee-ff4af6b86344)|![CleanShot 2023-10-30 at 20 40 46@2x](https://github.com/Automattic/wp-calypso/assets/5039531/7cf4f125-717f-4926-a88f-c10408dcca6d)|![CleanShot 2023-10-30 at 20 40 35@2x](https://github.com/Automattic/wp-calypso/assets/5039531/707bd091-3a8f-41e1-a243-360589ee9a1c)|



## Testing Instructions

Using your browser resize tool, test the following flows for >1280px, <1280px and >960px, and <960px:
- Less-than-business plan / free (.org) plugin
- Less-than-business plan / Marketplace plugin
- Business-or-higher plan / free (.org) plugin
- Business-or-higher plan / Marketplace plugin
- Logged-out view for free and Marketplace Plugin

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
