### PR TITLE
Login links: Handle missing redirect_to contexts

### DIFF
--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -162,10 +162,13 @@ export function magicLoginUse( context, next ) {
 
 	const { client_id, email, redirect_to, token, transition: isTransition } = previousQuery;
 
-	// redirect_to isn't always given
-	const params = new URLSearchParams( new URL( redirect_to ?? 'https://wordpress.com' ).search );
-	const activate = params.get( 'activate' );
-
+	let activate = '';
+	try {
+		const params = new URLSearchParams( new URL( redirect_to ).search );
+		activate = params.get( 'activate' );
+	} catch ( e ) {
+		// redirect_to isn't always given, the URL constructor will throw in this case
+	}
 	const transition = isTransition === 'true';
 
 	const flow = redirect_to?.includes( 'jetpack/connect' ) ? 'jetpack' : null;

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -161,8 +161,15 @@ export function magicLoginUse( context, next ) {
 	const previousQuery = context.state || {};
 
 	const { client_id, email, redirect_to, token, transition: isTransition } = previousQuery;
-	const params = new URLSearchParams( new URL( redirect_to ).search );
-	const activate = params.get( 'activate' );
+
+	let params = {};
+	let activate = '';
+	try {
+		params = new URLSearchParams( new URL( redirect_to ).search );
+		activate = params.get( 'activate' );
+	} catch ( e ) {
+		// redirect_to isn't always given, the URL constructor will throw in this case
+	}
 	const transition = isTransition === 'true';
 
 	const flow = redirect_to?.includes( 'jetpack/connect' ) ? 'jetpack' : null;

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -162,14 +162,10 @@ export function magicLoginUse( context, next ) {
 
 	const { client_id, email, redirect_to, token, transition: isTransition } = previousQuery;
 
-	let params = {};
-	let activate = '';
-	try {
-		params = new URLSearchParams( new URL( redirect_to ).search );
-		activate = params.get( 'activate' );
-	} catch ( e ) {
-		// redirect_to isn't always given, the URL constructor will throw in this case
-	}
+	// redirect_to isn't always given
+	const params = new URLSearchParams( new URL( redirect_to ?? 'https://wordpress.com' ).search );
+	const activate = params.get( 'activate' );
+
 	const transition = isTransition === 'true';
 
 	const flow = redirect_to?.includes( 'jetpack/connect' ) ? 'jetpack' : null;


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/83684

## Proposed Changes

* Ensures login links still work when they're missing redirect_to 

## Testing Instructions

* Logged out, login with a login link email via wordpress.com - do not enter the login flow from wordpress.com?apprpomo as that includes a redirect_to param in the email.
* When you follow the link you'll land on the error in production
* Copy the /login/use link from redirect logs (e.g. from the redirect trace browser plugin) - it'll look like `https://wordpress.com/log-in/link/use?token=<longtoken>&email=<youremail>&client_id=39911`
* Switch the https://wordpress.com part to calypso.localhost in that link, e.g. `http://calypso.localhost:3000/log-in/link/use?token=<longtoken>&email=<youremail>&client_id=39911`
* The link should now log you in without error
