### PR TITLE
Jetpack Manage: Add target to the SidebarNavigatorMenuItem & minor UI enhancement

### DIFF
--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -152,6 +152,7 @@
 	.site__title-chevron-icon {
 		color: var(--color-text);
 		margin-inline-start: 12px;
+		display: inline-flex;
 	}
 }
 

--- a/client/jetpack-cloud/components/sidebar/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/index.tsx
@@ -93,7 +93,6 @@ const JetpackCloudSidebar = ( {
 					{ ! isJetpackManage && jetpackAdminUrl && (
 						<SidebarNavigatorMenuItem
 							isExternalLink
-							isSelected={ false }
 							title={ translate( 'WP Admin' ) }
 							link={ jetpackAdminUrl }
 							path={ jetpackAdminUrl }
@@ -105,21 +104,18 @@ const JetpackCloudSidebar = ( {
 					) }
 					<SidebarNavigatorMenuItem
 						isExternalLink
-						isSelected={ false }
 						title={ translate( 'Get help', {
 							comment: 'Jetpack Cloud sidebar navigation item',
 						} ) }
 						link="https://jetpack.com/support"
 						path=""
 						icon={ <JetpackIcons icon="help" /> }
-						onClickMenuItem={ ( link ) => {
+						onClickMenuItem={ () => {
 							dispatch(
 								recordTracksEvent( 'calypso_jetpack_sidebar_menu_click', {
 									menu_item: 'Jetpack Cloud / Support',
 								} )
 							);
-
-							window.open( link, '_blank' );
 						} }
 					/>
 				</ul>

--- a/client/layout/sidebar-v2/navigator/navigator-menu-item.tsx
+++ b/client/layout/sidebar-v2/navigator/navigator-menu-item.tsx
@@ -45,6 +45,7 @@ export const SidebarNavigatorMenuItem = ( {
 				href={ link }
 				id={ id }
 				as="a"
+				target={ isExternalLink ? '_blank' : undefined }
 			>
 				<HStack justify="flex-start">
 					{ icon && <Icon style={ { fill: 'currentcolor' } } icon={ icon } size={ ICON_SIZE } /> }

--- a/client/layout/sidebar-v2/navigator/style.scss
+++ b/client/layout/sidebar-v2/navigator/style.scss
@@ -43,7 +43,7 @@
 .sidebar-v2__navigator-sub-menu .components-navigator-back-button,
 .sidebar-v2__menu-item.components-item {
 	border-radius: 4px;
-	&:focus {
+	&:focus-visible {
 		box-shadow: 0 0 0 1px var(--studio-gray-10);
 	}
 }


### PR DESCRIPTION
This PR is built on top of https://github.com/Automattic/wp-calypso/pull/83599

Related to https://github.com/Automattic/jetpack-genesis/issues/76
Fixes https://github.com/Automattic/jetpack-genesis/issues/85

## Proposed Changes

This PR 
- Adds a target to the SidebarNavigatorMenuItem.
- Does a minor CSS fix to show the box shadow only when using tabs to navigate, not when clicking.
- Centre aligns the chevron icon on the site switcher.
- Remove the window.open as it is handled in SidebarNavigatorMenuItem


### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Open the Jetpack Cloud live link
2. Switch site > Click the `WP Admin` & `Get Help` link at the bottom left > Verify the link opens up in a new tab
3. Verify the other navigation menu items work as expected. It should open without reloading the page.
4. Verify that the box shadow for the menu item is visible only when navigating using the keyboard, not when clicking.

<img width="276" alt="Screenshot 2023-10-31 at 9 56 31 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/29f91d1b-b5d2-4e3d-a805-5ee0061fb93a">

5. Verify that the chevron down icon on the site switcher is centre aligned as shown in the screenshot below

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="269" alt="Screenshot 2023-10-31 at 10 01 08 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/3deffc22-0814-4821-9859-000279007d35">
</td>
<td>
<img width="269" alt="Screenshot 2023-10-31 at 10 01 24 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/7b505f43-bb4b-4b0a-bd98-ada81636fbd5">
</td>
</tr>
</table>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?