### PR TITLE
Authentication E2E: update Magic Link spec to normalize URL.

### DIFF
--- a/packages/calypso-e2e/src/email-client.ts
+++ b/packages/calypso-e2e/src/email-client.ts
@@ -1,5 +1,6 @@
 import MailosaurClient from 'mailosaur';
 import { SecretsManager } from './secrets';
+import { envVariables } from '.';
 import type { Message, Link } from 'mailosaur/lib/models';
 
 /**
@@ -122,6 +123,33 @@ export class EmailClient {
 			}
 		}
 		return null;
+	}
+
+	/**
+	 * Specialized method to return human-friendly magic login link.
+	 *
+	 * Also performs normalization of the link.
+	 * (eg. target calypso.live if run from that environment.)
+	 *
+	 * @param {Message} message Representing the message.
+	 * @returns {URL} URL object for the magic link.
+	 * @throws {Error} IF the message did not have any links.
+	 */
+	getMagicLink( message: Message ): URL {
+		const link = message.text?.links?.pop();
+
+		if ( ! link ) {
+			throw new Error( 'Message did not contain text links. ' );
+		}
+
+		const magicLinkURL = new URL( link?.href as string );
+		const baseURL = new URL( envVariables.CALYPSO_BASE_URL );
+
+		// Returns a new URL object with normalized magic link.
+		// Useful when running tests against environments other than the default
+		// CALYPSO_BASE_URL.
+		// Example: https://wordpress.com -> https://container-something.calypso.live.
+		return new URL( magicLinkURL.pathname + magicLinkURL.search, baseURL.origin );
 	}
 
 	/**

--- a/test/e2e/specs/authentication/authentication__magic-link.ts
+++ b/test/e2e/specs/authentication/authentication__magic-link.ts
@@ -13,7 +13,7 @@ describe( DataHelper.createSuiteTitle( 'Authentication: Magic Link' ), function 
 	let page: Page;
 	let loginPage: LoginPage;
 	let emailClient: EmailClient;
-	let magicLinkURL: string;
+	let magicLinkURL: URL;
 	let magicLinkEmail: Message;
 
 	beforeAll( async () => {
@@ -38,18 +38,17 @@ describe( DataHelper.createSuiteTitle( 'Authentication: Magic Link' ), function 
 			sentTo: credentials.email as string,
 			subject: 'Log in to WordPress.com',
 		} );
-		const links = await emailClient.getLinksFromMessage( magicLinkEmail );
-		magicLinkURL = links.find( ( link: string ) => link.includes( 'wpcom_email_click' ) ) as string;
+		magicLinkURL = emailClient.getMagicLink( magicLinkEmail );
 
-		expect( magicLinkURL ).toBeDefined();
+		expect( magicLinkURL.href ).toBeDefined();
 	} );
 
-	it( 'Go to the Magic Link URL', async function () {
-		await page.goto( new URL( magicLinkURL ).toString() );
+	it( 'Open the magic link', async function () {
+		await page.goto( magicLinkURL.href );
 	} );
 
 	it( 'Redirected to Home dashboard', async function () {
-		await page.waitForURL( /home/ );
+		await page.waitForURL( /home/, { timeout: 15 * 1000 } );
 	} );
 
 	afterAll( async () => {


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/83684, https://github.com/Automattic/wp-calypso/pull/83685.

## Proposed Changes

This PR updates the Magic Link E2E spec to normalize the `URL.origin` value, so non-default environments can be targeted.

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)
  - [x] Pre-Release E2E

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?