### PR TITLE
Jetpack E2E: update dashboard smoke test to use the active tab instead of looking for screen reader text.

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/wp-admin/jetpack-dashboard-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/wp-admin/jetpack-dashboard-page.ts
@@ -63,6 +63,8 @@ export class JetpackDashboardPage {
 			.getByRole( 'menuitem', { name: param.tab, exact: true } )
 			.click();
 
+		// Filter the nav tabs to elements that have `.is-selected` (should be only one),
+		// and verify the resulting element is the tab that was clicked on earlier.
 		await this.page
 			.getByRole( 'main' )
 			.filter( { has: this.page.locator( '.is-selected' ) } )

--- a/packages/calypso-e2e/src/lib/pages/wp-admin/jetpack-dashboard-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/wp-admin/jetpack-dashboard-page.ts
@@ -50,7 +50,7 @@ export class JetpackDashboardPage {
 	 * @param {JetpackTabs} param View and tab to click on.
 	 */
 	async clickTab( param: JetpackTabs ) {
-		// Switch to the correct view if required.
+		// Switch to the correct view (Dashboard/Settings) if required.
 		await this.page
 			.getByRole( 'main' )
 			.getByRole( 'link', { name: param.view, exact: true } )
@@ -62,5 +62,11 @@ export class JetpackDashboardPage {
 			.getByRole( 'main' )
 			.getByRole( 'menuitem', { name: param.tab, exact: true } )
 			.click();
+
+		await this.page
+			.getByRole( 'main' )
+			.filter( { has: this.page.locator( '.is-selected' ) } )
+			.filter( { hasText: param.tab } )
+			.waitFor();
 	}
 }

--- a/test/e2e/specs/jetpack/jetpack__dashboard-smoke.ts
+++ b/test/e2e/specs/jetpack/jetpack__dashboard-smoke.ts
@@ -77,18 +77,13 @@ skipDescribeIf( envVariables.TEST_ON_ATOMIC !== true )(
 				{ tab: 'Newsletter' },
 			] )( 'Click on $tab tab in the Settings view', async function ( { tab } ) {
 				await jetpackDashboardPage.clickTab( { view: 'Settings', tab: tab as SettingsTabs } );
-
-				await page.getByRole( 'heading', { name: tab, level: 1 } ).waitFor( { state: 'attached' } );
 			} );
 
+			// Private sites are not eligible for monetization, so we only run this step on non-private sites.
 			skipItIf( envVariables.ATOMIC_VARIATION === 'private' )(
-				'Click on Earn tab in the Settings view',
+				'Click on Monetize tab in the Settings view',
 				async function () {
 					await jetpackDashboardPage.clickTab( { view: 'Settings', tab: 'Monetize' } );
-
-					await page
-						.getByRole( 'heading', { name: 'Monetize', level: 1 } )
-						.waitFor( { state: 'attached' } );
 				}
 			);
 		} );


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/83689, https://github.com/Automattic/wp-calypso/pull/83378.

## Proposed Changes

This PR updates how the Jetpack dashboard smoke test spec was validating whether the navigation took effect, by checking the tab is active instead of a hidden screen reader text.

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Calypso E2E (desktop)
  - [x] Jetpack E2E Simple (mobile)
  - [x] Jetpack E2E Simple (desktop)
  - [x] Jetpack E2E AT (desktop)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?