### PR TITLE
Site Profiler: Tweak WordPress messaging to say self-hosted WordPress

### DIFF
--- a/client/site-profiler/components/heading-information/status-info.tsx
+++ b/client/site-profiler/components/heading-information/status-info.tsx
@@ -26,7 +26,9 @@ export default function StatusInfo( props: Props ) {
 		case 'wordpress-org':
 			return (
 				<p>
-					{ translate( 'This amazing community have great taste–this site runs on WordPress!' ) }
+					{ translate(
+						'This amazing community have great taste–this site runs on self-hosted WordPress!'
+					) }
 				</p>
 			);
 		case 'automattic-com':
@@ -103,7 +105,9 @@ export default function StatusInfo( props: Props ) {
 		case 'transfer-google-domain-hosting-wp':
 			return (
 				<p>
-					{ translate( 'The owner of this site has great taste—this site runs on WordPress!' ) }
+					{ translate(
+						'The owner of this site has great taste—this site runs on self-hosted WordPress!'
+					) }
 				</p>
 			);
 		case 'idle':


### PR DESCRIPTION
See pcmemI-2nH-p2#comment-1932

## Proposed Changes

* Changes plain WordPress messaging to say "self-hosted WordPress"

![CleanShot 2023-10-31 at 11 13 06](https://github.com/Automattic/wp-calypso/assets/533/861c7ef4-02d4-449c-97d2-e459dbe64d60)


## Testing Instructions

* Go to /site-profiler
* Enter in `wordpress.org` and any WordPress site not hosted on WordPress.com

