### PR TITLE
Replace reader tag header with navigation header

### DIFF
--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -747,7 +747,7 @@
 		}
 
 		.reader-tag-sidebar-stats__count {
-			font-size: $font-title-medium;
+			font-size: $font-title-small;
 			font-weight: bold;
 			width: 90px;
 		}

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -810,10 +810,7 @@
 }
 
 .tag-stream__main .stream__header .section-nav {
-	margin-top: 26px;
-	@include break-medium {
-		margin-top: 0;
-	}
+	margin-top: 0;
 }
 
 .stream__header .section-nav {

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -810,7 +810,10 @@
 }
 
 .tag-stream__main .stream__header .section-nav {
-	margin-top: 0;
+	margin-top: 26px;
+	@include break-medium {
+		margin-top: 0;
+	}
 }
 
 .stream__header .section-nav {

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -739,7 +739,9 @@
 		flex-direction: row;
 		gap: 20px;
 		// compensate for line height so that visual margin is 36px;
-		margin-bottom: 29px;
+		padding: 0 0 24px 0;
+		margin-bottom: 16px;
+
 
 		.reader-tag-sidebar-stats__item {
 			display: flex;

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -739,8 +739,7 @@
 		flex-direction: row;
 		gap: 20px;
 		// compensate for line height so that visual margin is 36px;
-		padding: 0 0 24px 0;
-		margin-bottom: 16px;
+		margin-bottom: 29px;
 
 
 		.reader-tag-sidebar-stats__item {

--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -2,7 +2,7 @@
 @import "@wordpress/base-styles/mixins";
 
 .is-group-reader .async-load {
-	margin: 30px auto;
+	margin: 0 auto;
 	width: 50%;
 }
 
@@ -12,12 +12,14 @@
 }
 
 .is-reader-page .recommended-for-you.main,
-.is-reader-page .following.main,
-.is-reader-page .tag-stream__main.main,
 .is-reader-page .search-stream__with-sites.main {
 	margin: 0 auto;
+}
+.is-reader-page .following.main,
+.is-reader-page .tag-stream__main.main {
+	margin: 0 auto;
 	@include breakpoint-deprecated( "<660px" ) {
-		margin: 30px;
+		margin: 16px;
 	}
 }
 

--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -2,7 +2,7 @@
 @import "@wordpress/base-styles/mixins";
 
 .is-group-reader .async-load {
-	margin: 0 auto;
+	margin: 30px auto;
 	width: 50%;
 }
 
@@ -12,14 +12,12 @@
 }
 
 .is-reader-page .recommended-for-you.main,
+.is-reader-page .following.main,
+.is-reader-page .tag-stream__main.main,
 .is-reader-page .search-stream__with-sites.main {
 	margin: 0 auto;
-}
-.is-reader-page .following.main,
-.is-reader-page .tag-stream__main.main {
-	margin: 0 auto;
 	@include breakpoint-deprecated( "<660px" ) {
-		margin: 16px;
+		margin: 30px;
 	}
 }
 

--- a/client/reader/tag-stream/header.jsx
+++ b/client/reader/tag-stream/header.jsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames';
-import { localize, translate } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -60,6 +60,7 @@ class TagStreamHeader extends Component {
 			onFollowToggle,
 			showBack,
 			showSort,
+			translate,
 		} = this.props;
 		const sortOrder = this.props.sort || 'date';
 
@@ -87,13 +88,13 @@ class TagStreamHeader extends Component {
 										selected={ sortOrder !== 'relevance' }
 										onClick={ this.useDateSort }
 									>
-										{ this.props.translate( 'Recent' ) }
+										{ translate( 'Recent' ) }
 									</SegmentedControl.Item>
 									<SegmentedControl.Item
 										selected={ sortOrder === 'relevance' }
 										onClick={ this.useRelevanceSort }
 									>
-										{ this.props.translate( 'Popular' ) }
+										{ translate( 'Popular' ) }
 									</SegmentedControl.Item>
 								</SegmentedControl>
 							) }

--- a/client/reader/tag-stream/header.jsx
+++ b/client/reader/tag-stream/header.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import FollowButton from 'calypso/blocks/follow-button/button';
+import NavigationHeader from 'calypso/components/navigation-header';
 import SegmentedControl from 'calypso/components/segmented-control';
 import { addQueryArgs } from 'calypso/lib/url';
 import ReaderFollowFeedIcon from 'calypso/reader/components/icons/follow-feed-icon';
@@ -76,10 +77,7 @@ class TagStreamHeader extends Component {
 
 		return (
 			<div className={ classes }>
-				<div className="tag-stream__header-title-group">
-					<h1 className="tag-stream__header-title">{ title }</h1>
-					{ description && <h2 className="tag-stream__header-description">{ description }</h2> }
-				</div>
+				<NavigationHeader navigationItems={ [ {} ] } title={ title } subtitle={ description } />
 				{ ( showSort || showFollow ) && (
 					<div className="tag-stream__header-controls">
 						<div className="tag-stream__header-sort-picker">

--- a/client/reader/tag-stream/header.jsx
+++ b/client/reader/tag-stream/header.jsx
@@ -68,6 +68,8 @@ class TagStreamHeader extends Component {
 		// so we can set a smaller title size and prevent it from resizing as the page loads. Should be refactored if tag descriptions
 		// end up getting used for other things besides prompt tags.
 		const isPromptTag = new RegExp( /^dailyprompt-\d+$/ ).test( title );
+		const titleText = description ?? title;
+		const subtitleText = description ? title : null;
 
 		const classes = classnames( {
 			'tag-stream__header': true,
@@ -78,7 +80,11 @@ class TagStreamHeader extends Component {
 
 		return (
 			<div className={ classes }>
-				<NavigationHeader navigationItems={ [ {} ] } title={ title } subtitle={ description } />
+				<NavigationHeader
+					navigationItems={ [ {} ] }
+					title={ titleText }
+					subtitle={ subtitleText }
+				/>
 				{ ( showSort || showFollow ) && (
 					<div className="tag-stream__header-controls">
 						<div className="tag-stream__header-sort-picker">

--- a/client/reader/tag-stream/header.jsx
+++ b/client/reader/tag-stream/header.jsx
@@ -68,6 +68,8 @@ class TagStreamHeader extends Component {
 		// so we can set a smaller title size and prevent it from resizing as the page loads. Should be refactored if tag descriptions
 		// end up getting used for other things besides prompt tags.
 		const isPromptTag = new RegExp( /^dailyprompt-\d+$/ ).test( title );
+
+		// Display the tag description as the title if there is one.
 		const titleText = description ?? title;
 		const subtitleText = description ? title : null;
 
@@ -80,11 +82,7 @@ class TagStreamHeader extends Component {
 
 		return (
 			<div className={ classes }>
-				<NavigationHeader
-					navigationItems={ [ {} ] }
-					title={ titleText }
-					subtitle={ subtitleText }
-				/>
+				<NavigationHeader title={ titleText } subtitle={ subtitleText } />
 				{ ( showSort || showFollow ) && (
 					<div className="tag-stream__header-controls">
 						<div className="tag-stream__header-sort-picker">

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -102,7 +102,9 @@ class TagStream extends Component {
 		const emptyContent = () => <EmptyContent decodedTagSlug={ this.props.decodedTagSlug } />;
 		const title = this.props.decodedTagSlug;
 		const tag = find( this.props.tags, { slug: this.props.encodedTagSlug } );
-		const titleText = title.replace( /-/g, ' ' );
+		const titleText = title.replace( /-/g, ' ' ).replace( /\b[a-z]/g, function ( first ) {
+			return first.toUpperCase();
+		} );
 
 		let imageSearchString = this.props.encodedTagSlug;
 
@@ -133,7 +135,7 @@ class TagStream extends Component {
 
 		// Put the tag stream header at the top of the body, so it can be even with the sidebar in the two column layout.
 		const tagHeader = () => (
-			<>
+			<div>
 				<TagStreamHeader
 					title={ titleText }
 					description={ this.props.description }
@@ -146,7 +148,7 @@ class TagStream extends Component {
 					sort={ this.props.sort }
 					recordReaderTracksEvent={ this.props.recordReaderTracksEvent }
 				/>
-			</>
+			</div>
 		);
 		const sidebarProps = ! isReaderTagEmbedPage( window.location ) && {
 			streamSidebar: () => (

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -3,6 +3,7 @@ import { find } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import titleCase from 'to-title-case';
 import QueryReaderFollowedTags from 'calypso/components/data/query-reader-followed-tags';
 import QueryReaderTag from 'calypso/components/data/query-reader-tag';
 import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-tag-embed-page';
@@ -102,9 +103,7 @@ class TagStream extends Component {
 		const emptyContent = () => <EmptyContent decodedTagSlug={ this.props.decodedTagSlug } />;
 		const title = this.props.decodedTagSlug;
 		const tag = find( this.props.tags, { slug: this.props.encodedTagSlug } );
-		const titleText = title.replace( /-/g, ' ' ).replace( /\b[a-z]/g, function ( first ) {
-			return first.toUpperCase();
-		} );
+		const titleText = titleCase( title.replace( /-/g, ' ' ) );
 
 		let imageSearchString = this.props.encodedTagSlug;
 
@@ -135,20 +134,18 @@ class TagStream extends Component {
 
 		// Put the tag stream header at the top of the body, so it can be even with the sidebar in the two column layout.
 		const tagHeader = () => (
-			<div>
-				<TagStreamHeader
-					title={ titleText }
-					description={ this.props.description }
-					imageSearchString={ imageSearchString }
-					showFollow={ !! ( tag && tag.id ) }
-					following={ this.isSubscribed() }
-					onFollowToggle={ this.toggleFollowing }
-					showBack={ this.props.showBack }
-					showSort={ true }
-					sort={ this.props.sort }
-					recordReaderTracksEvent={ this.props.recordReaderTracksEvent }
-				/>
-			</div>
+			<TagStreamHeader
+				title={ titleText }
+				description={ this.props.description }
+				imageSearchString={ imageSearchString }
+				showFollow={ !! ( tag && tag.id ) }
+				following={ this.isSubscribed() }
+				onFollowToggle={ this.toggleFollowing }
+				showBack={ this.props.showBack }
+				showSort={ true }
+				sort={ this.props.sort }
+				recordReaderTracksEvent={ this.props.recordReaderTracksEvent }
+			/>
 		);
 		const sidebarProps = ! isReaderTagEmbedPage( window.location ) && {
 			streamSidebar: () => (

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -1,8 +1,5 @@
-@import "@automattic/typography/styles/variables";
-@import "@wordpress/base-styles/breakpoints";
-@import "@wordpress/base-styles/mixins";
-
 .tag-stream__header {
+	margin-bottom: 10px;
 	.tag-stream__header-follow .follow-button {
 		background: inherit;
 	}
@@ -35,10 +32,8 @@
 	justify-content: space-between;
 	align-items: flex-start;
 
-	padding: 16px;
-
-	@include break-mobile {
-		padding: 0 0 16px 0;
+	@include breakpoint-deprecated( ">1040px" ) {
+		padding-bottom: 20px;
 	}
 }
 
@@ -61,17 +56,11 @@
 .is-reader-page .card.header-cake {
 	background: none;
 	box-shadow: none;
+	padding: 0;
 	position: relative;
 
 	.button.header-cake__back {
 		padding: 0;
-	}
-
-	padding: 16px;
-	margin: 0;
-
-	@include break-small {
-		padding: 0 0 16px 0;
 	}
 }
 

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -30,7 +30,7 @@
 .tag-stream__header-controls {
 	display: flex;
 	justify-content: space-between;
-	align-items: center;
+	align-items: flex-start;
 
 	@include breakpoint-deprecated( ">1040px" ) {
 		padding-bottom: 20px;

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -1,3 +1,7 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
+
 .is-section-reader .tag-stream__header {
 	&.has-description {
 		.info-popover {
@@ -12,6 +16,15 @@
 		margin: 0 auto;
 		padding: 0 0 16px 0;
 	}
+}
+
+// .has-header-section only applies for logged out views
+.layout.has-header-section.is-section-reader .navigation-header h1 {
+	@extend .wp-brand-font;
+	font-weight: 600;
+	font-size: 2.25rem;
+	line-height: 48px;
+	margin-bottom: 4px;
 }
 
 .tag-stream__header {
@@ -48,7 +61,8 @@
 	justify-content: space-between;
 	align-items: flex-start;
 
-	@include breakpoint-deprecated( ">1040px" ) {
+	@include break-small {
+		padding-top: 20px;
 		padding-bottom: 20px;
 	}
 }

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -19,7 +19,7 @@
 }
 
 // .has-header-section only applies for logged out views
-.layout.has-header-section.is-section-reader .navigation-header h1 {
+.layout.has-header-section.is-section-reader .tag-stream__header .navigation-header h1 {
 	@extend .wp-brand-font;
 	font-weight: 600;
 	font-size: 2.25rem;

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -1,3 +1,19 @@
+.is-section-reader .tag-stream__header {
+	&.has-description {
+		.info-popover {
+			display: none;
+		}
+		.formatted-header__subtitle {
+			display: inline-block;
+		}
+	}
+
+	.navigation-header {
+		margin: 0 auto;
+		padding: 0 0 16px 0;
+	}
+}
+
 .tag-stream__header {
 	margin-bottom: 10px;
 	.tag-stream__header-follow .follow-button {

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -1,5 +1,8 @@
+@import "@automattic/typography/styles/variables";
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 .tag-stream__header {
-	margin-bottom: 10px;
 	.tag-stream__header-follow .follow-button {
 		background: inherit;
 	}
@@ -32,8 +35,10 @@
 	justify-content: space-between;
 	align-items: flex-start;
 
-	@include breakpoint-deprecated( ">1040px" ) {
-		padding-bottom: 20px;
+	padding: 16px;
+
+	@include break-mobile {
+		padding: 0 0 16px 0;
 	}
 }
 
@@ -56,11 +61,17 @@
 .is-reader-page .card.header-cake {
 	background: none;
 	box-shadow: none;
-	padding: 0;
 	position: relative;
 
 	.button.header-cake__back {
 		padding: 0;
+	}
+
+	padding: 16px;
+	margin: 0;
+
+	@include break-small {
+		padding: 0 0 16px 0;
 	}
 }
 


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/4352

## Proposed Changes

* Swaps out stream header h1's for navigation header components
* Swaps tag title for tag description if it's given (in order to match font sizing of existing behavior)
* Moves css ucwords text transform to js to avoid a conflict with the title swap change

## Testing Instructions

* http://calypso.localhost:3000/tag/dailyprompt?sort=date


Before
![Screenshot 2023-10-31 at 17-13-23 Articles   Posts About Dailyprompt ‹ Reader — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/f630f9fd-1667-4fe6-a0cf-9e7fe8133abd)

After
![Screenshot 2023-10-31 at 17-13-15 Articles   Posts About Dailyprompt ‹ Reader — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/8e4029ed-542d-4efe-a015-7059feab25ee)

Tag description behavior Before
![Screenshot 2023-11-01 at 14-55-12 (3) Articles   Posts About Dailyprompt 2106 ‹ Reader — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/e3f51023-0def-4e16-9802-2597dbcc5a18)


Tag description behavior After
![Screenshot 2023-11-01 at 14-55-21 (3) Articles   Posts About Dailyprompt 2106 ‹ Reader — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/6448a52c-3858-4c0b-bda4-d54d69b1c5df)

Logged out before
![Screenshot 2023-11-02 at 15-36-44 Articles   Posts About Dailyprompt 2094 ‹ Reader — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/a3a4906f-4989-4476-bcda-a53a54409cf2)

Logged out after
![Screenshot 2023-11-02 at 15-47-15 Articles   Posts About Dailyprompt 2094 ‹ Reader — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/14b74bac-3cc1-4ff6-ab98-b76e9fa4caec)
