### PR TITLE
Add bloganuary customization to blogging prompts card

### DIFF
--- a/client/components/blogging-prompt-card/index.jsx
+++ b/client/components/blogging-prompt-card/index.jsx
@@ -1,10 +1,10 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Card, Button, Gridicon } from '@automattic/components';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector, useDispatch } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
+import isBloganuary from 'calypso/data/blogging-prompt/is-bloganuary';
 import { useBloggingPrompts } from 'calypso/data/blogging-prompt/use-blogging-prompts';
 import useSkipCurrentViewMutation from 'calypso/data/home/use-skip-current-view-mutation';
 import { SECTION_BLOGGING_PROMPT } from 'calypso/my-sites/customer-home/cards/constants';
@@ -24,7 +24,6 @@ const BloggingPromptCard = ( { siteId, viewContext, showMenu, index } ) => {
 	const maxNumberOfPrompts = 10;
 	const { data: prompts } = useBloggingPrompts( siteId, maxNumberOfPrompts );
 	const { skipCard } = useSkipCurrentViewMutation( siteId );
-	const isBloganuary = isEnabled( 'bloganuary' );
 
 	if ( ! prompts ) {
 		return null;
@@ -76,7 +75,7 @@ const BloggingPromptCard = ( { siteId, viewContext, showMenu, index } ) => {
 					<LightbulbIcon />
 					{ /*`key` is necessary due to behavior of preventWidows function in CardHeading component.*/ }
 					<span className="blogging-prompt__heading-text" key="blogging-prompt__heading-text">
-						{ isBloganuary
+						{ isBloganuary()
 							? translate( 'Bloganuary writing prompt' )
 							: translate( 'Daily writing prompt' ) }
 					</span>

--- a/client/components/blogging-prompt-card/index.jsx
+++ b/client/components/blogging-prompt-card/index.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Card, Button, Gridicon } from '@automattic/components';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -23,6 +24,7 @@ const BloggingPromptCard = ( { siteId, viewContext, showMenu, index } ) => {
 	const maxNumberOfPrompts = 10;
 	const { data: prompts } = useBloggingPrompts( siteId, maxNumberOfPrompts );
 	const { skipCard } = useSkipCurrentViewMutation( siteId );
+	const isBloganuary = isEnabled( 'bloganuary' );
 
 	if ( ! prompts ) {
 		return null;
@@ -74,7 +76,9 @@ const BloggingPromptCard = ( { siteId, viewContext, showMenu, index } ) => {
 					<LightbulbIcon />
 					{ /*`key` is necessary due to behavior of preventWidows function in CardHeading component.*/ }
 					<span className="blogging-prompt__heading-text" key="blogging-prompt__heading-text">
-						{ translate( 'Daily writing prompt' ) }
+						{ isBloganuary
+							? translate( 'Bloganuary writing prompt' )
+							: translate( 'Daily writing prompt' ) }
 					</span>
 					{ showMenu && renderMenu() }
 				</CardHeading>

--- a/client/components/blogging-prompt-card/index.jsx
+++ b/client/components/blogging-prompt-card/index.jsx
@@ -1,6 +1,7 @@
 import { Card, Button, Gridicon } from '@automattic/components';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
+import moment from 'moment';
 import { useSelector, useDispatch } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
@@ -21,9 +22,19 @@ const BloggingPromptCard = ( { siteId, viewContext, showMenu, index } ) => {
 	const translate = useTranslate();
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 	const notificationSettingsLink = '/me/notifications' + ( siteSlug ? '#' + siteSlug : '' );
-	const maxNumberOfPrompts = 10;
-	const { data: prompts } = useBloggingPrompts( siteId, maxNumberOfPrompts );
+
+	const maxNumberOfPrompts = isBloganuary() ? 31 : 10;
+	const today = moment().format( '--MM-DD' );
+	const januaryDate = '--01-01';
+	const startDate = isBloganuary() ? januaryDate : today;
+
+	const { data: prompts } = useBloggingPrompts( siteId, startDate, maxNumberOfPrompts );
 	const { skipCard } = useSkipCurrentViewMutation( siteId );
+
+	if ( ! index && isBloganuary() ) {
+		// get the offset for the day of the month.
+		index = parseInt( moment().format( 'D' ) ) - 1;
+	}
 
 	if ( ! prompts ) {
 		return null;

--- a/client/components/blogging-prompt-card/prompts-navigation.jsx
+++ b/client/components/blogging-prompt-card/prompts-navigation.jsx
@@ -1,10 +1,10 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Button, Gridicon } from '@automattic/components';
 import { addQueryArgs } from '@wordpress/url';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import isBloganuary from 'calypso/data/blogging-prompt/is-bloganuary';
 import { navigate } from 'calypso/lib/navigate';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getEditorUrl from 'calypso/state/selectors/get-editor-url';
@@ -17,7 +17,6 @@ const PromptsNavigation = ( { siteId, prompts, tracksPrefix, index } ) => {
 	const editorUrl = useSelector( ( state ) => getEditorUrl( state, siteId ) );
 	const backIcon = 'arrow-left';
 	const forwardIcon = 'arrow-right';
-	const isBloganuary = isEnabled( 'bloganuary' );
 
 	const initialIndex = index ? index % prompts.length : 0;
 	const [ promptIndex, setPromptIndex ] = useState( initialIndex );
@@ -170,7 +169,7 @@ const PromptsNavigation = ( { siteId, prompts, tracksPrefix, index } ) => {
 		return (
 			<div className="blogging-prompt__prompt-answers">
 				{ renderResponses() }
-				{ isBloganuary && (
+				{ isBloganuary() && (
 					<a
 						href="https://wordpress.com/bloganuary"
 						className="blogging-prompt__bloganuary-link"

--- a/client/components/blogging-prompt-card/prompts-navigation.jsx
+++ b/client/components/blogging-prompt-card/prompts-navigation.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Button, Gridicon } from '@automattic/components';
 import { addQueryArgs } from '@wordpress/url';
 import classnames from 'classnames';
@@ -16,6 +17,7 @@ const PromptsNavigation = ( { siteId, prompts, tracksPrefix, index } ) => {
 	const editorUrl = useSelector( ( state ) => getEditorUrl( state, siteId ) );
 	const backIcon = 'arrow-left';
 	const forwardIcon = 'arrow-right';
+	const isBloganuary = isEnabled( 'bloganuary' );
 
 	const initialIndex = index ? index % prompts.length : 0;
 	const [ promptIndex, setPromptIndex ] = useState( initialIndex );
@@ -83,6 +85,15 @@ const PromptsNavigation = ( { siteId, prompts, tracksPrefix, index } ) => {
 	const trackClickViewAllResponses = () => {
 		dispatch(
 			recordTracksEvent( tracksPrefix + 'view_all_responses', {
+				site_id: siteId,
+				prompt_id: getPrompt()?.id,
+			} )
+		);
+	};
+
+	const trackBloganuaryMoreInfoClick = () => {
+		dispatch(
+			recordTracksEvent( tracksPrefix + 'bloganuary_more_info_click', {
 				site_id: siteId,
 				prompt_id: getPrompt()?.id,
 			} )
@@ -159,6 +170,17 @@ const PromptsNavigation = ( { siteId, prompts, tracksPrefix, index } ) => {
 		return (
 			<div className="blogging-prompt__prompt-answers">
 				{ renderResponses() }
+				{ isBloganuary && (
+					<a
+						href="https://wordpress.com/bloganuary"
+						className="blogging-prompt__bloganuary-link"
+						target="_blank"
+						rel="noopener noreferrer"
+						onClick={ trackBloganuaryMoreInfoClick }
+					>
+						{ translate( 'Learn more' ) }
+					</a>
+				) }
 				<Button href={ getNewPostLink() } onClick={ handleBloggingPromptClick }>
 					{ translate( 'Post Answer', {
 						comment:

--- a/client/components/blogging-prompt-card/style.scss
+++ b/client/components/blogging-prompt-card/style.scss
@@ -91,6 +91,15 @@
 				text-decoration-line: none;
 			}
 		}
+		.blogging-prompt__bloganuary-link {
+			color: var(--studio-gray-80);
+			font-size: $font-body-small;
+			text-decoration-line: underline;
+			margin-right: 8px;
+			&:hover {
+				text-decoration-line: none;
+			}
+		}
 		.blogging-prompt__prompt-no-response {
 			align-items: center;
 			display: flex;

--- a/client/data/blogging-prompt/is-bloganuary.ts
+++ b/client/data/blogging-prompt/is-bloganuary.ts
@@ -1,0 +1,10 @@
+import { isEnabled } from '@automattic/calypso-config';
+
+/**
+ * In future this will be automatically enabled in January. For now it just checks a feature flag.
+ *
+ * @returns true if bloganuary mode is active
+ */
+export default function isBloganuary() {
+	return isEnabled( 'bloganuary' );
+}

--- a/client/data/blogging-prompt/use-blogging-prompts.ts
+++ b/client/data/blogging-prompt/use-blogging-prompts.ts
@@ -31,6 +31,7 @@ export const useBloggingPrompts = (
 			per_page: per_page,
 			after: start_date,
 			order: 'desc',
+			force_year: new Date().getFullYear(),
 		},
 		`/sites/${ siteId }/blogging-prompts`
 	);

--- a/client/data/blogging-prompt/use-blogging-prompts.ts
+++ b/client/data/blogging-prompt/use-blogging-prompts.ts
@@ -1,4 +1,5 @@
 import { Url } from 'url';
+import { isEnabled } from '@automattic/calypso-config';
 import { useQuery, UseQueryResult } from '@tanstack/react-query';
 import moment from 'moment';
 import wp from 'calypso/lib/wp';
@@ -25,13 +26,17 @@ export const useBloggingPrompts = (
 	siteId: SiteId,
 	per_page: number
 ): UseQueryResult< BloggingPrompt[] | null > => {
+	const isBloganuary = isEnabled( 'bloganuary' );
 	const today = moment().format( '--MM-DD' );
+	const januaryDate = '--01-' + moment().format( 'DD' );
+
+	const dateArg = isBloganuary ? januaryDate : today;
 
 	return useQuery( {
-		queryKey: [ 'blogging-prompts', siteId, today, per_page ],
+		queryKey: [ 'blogging-prompts', siteId, today, per_page, isBloganuary ],
 		queryFn: () =>
 			wp.req.get( {
-				path: `/sites/${ siteId }/blogging-prompts?per_page=${ per_page }&after=${ today }&order=desc`,
+				path: `/sites/${ siteId }/blogging-prompts?per_page=${ per_page }&after=${ dateArg }&order=desc`,
 				apiNamespace: 'wpcom/v3',
 			} ),
 		enabled: !! siteId,

--- a/client/data/blogging-prompt/use-blogging-prompts.ts
+++ b/client/data/blogging-prompt/use-blogging-prompts.ts
@@ -1,10 +1,8 @@
 import { Url } from 'url';
 import { useQuery, UseQueryResult } from '@tanstack/react-query';
-import moment from 'moment';
 import { addQueryArgs } from 'calypso/lib/url';
 import wp from 'calypso/lib/wp';
 import { SiteId } from 'calypso/types';
-import isBloganuary from './is-bloganuary';
 
 export interface BloggingPrompt {
 	id: number;
@@ -25,21 +23,19 @@ interface AnsweredUsersSample {
 
 export const useBloggingPrompts = (
 	siteId: SiteId,
+	start_date: string,
 	per_page: number
 ): UseQueryResult< BloggingPrompt[] | null > => {
-	const today = moment().format( '--MM-DD' );
-	const januaryDate = '--01-' + moment().format( 'DD' );
-
 	const path = addQueryArgs(
 		{
 			per_page: per_page,
-			after: isBloganuary() ? januaryDate : today,
+			after: start_date,
 			order: 'desc',
 		},
 		`/sites/${ siteId }/blogging-prompts`
 	);
 	return useQuery( {
-		queryKey: [ 'blogging-prompts', siteId, today, per_page, isBloganuary ],
+		queryKey: [ 'blogging-prompts', siteId, start_date, per_page ],
 		queryFn: () =>
 			wp.req.get( {
 				path: path,

--- a/config/development.json
+++ b/config/development.json
@@ -31,6 +31,7 @@
 	"features": {
 		"ad-tracking": false,
 		"akismet/siteless-checkout": true,
+		"bloganuary": true,
 		"calypso/ai-assembler": true,
 		"calypso/help-center": true,
 		"calypsoify/plugins": true,


### PR DESCRIPTION
Part of pe7F0s-1iI-p2. See suggestion comment for this approach: pe7F0s-1iI-p2#comment-1685

rework of https://github.com/Automattic/wp-calypso/pull/83421/

builds on top of the v3 blogging-prompts endpoint added in https://github.com/Automattic/wp-calypso/pull/76518

## Proposed Changes

If it is "bloganuary", then load all prompts from January, defaulting to the current day of the month. Also adjust some text on the my-home card.

Text and other adjustments are in progress/ to be confirmed, there is still more to do including changing the icon (to be provided). For now I've just made some basic changes to prove the concept, see pe7F0s-1iI-p2#comment-1661

## Testing Instructions

Add ?flags=+bloganuary to the url.
Go to my-home page for a site with site_intent=write.
In the card we should see only prompts from January and should see some modifications to the UI.