### PR TITLE
Jetpack Cloud: The menu should render "on top" of the profile picture & site switcher

### DIFF
--- a/client/jetpack-cloud/components/sidebar/header/style.scss
+++ b/client/jetpack-cloud/components/sidebar/header/style.scss
@@ -39,8 +39,8 @@ html.accessible-focus .jetpack-cloud-sidebar__profile-dropdown-button:focus {
 		right: initial;
 	}
 
-	// The menu should render "on top" of the profile picture
-	z-index: 1;
+	// The menu should render "on top" of the profile picture & site switcher
+	z-index: 20;
 
 	width: 220px;
 	margin: 0;


### PR DESCRIPTION
## Proposed Changes

This PR fixes the issue with the profile dropdown menu not appearing on top of the site switcher.

### Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Open the Jetpack Cloud live link
2. Click on `All Sites` > Click the Profile dropdown > Verify the dropdown items appear on top 

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="464" alt="Screenshot 2023-10-31 at 1 55 10 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/e1ce9094-c558-40fb-969d-0ecbc9d3d6c6">
</td>
<td>
<img width="464" alt="Screenshot 2023-10-31 at 1 54 51 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/2830f187-68dc-4819-a484-ba0a64140088">
</td>
</tr>
</table>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?