### PR TITLE
Update /plans to use NavigationHeader

### DIFF
--- a/client/my-sites/plans/components/plans-header/index.tsx
+++ b/client/my-sites/plans/components/plans-header/index.tsx
@@ -5,6 +5,7 @@ import { useCallback } from '@wordpress/element';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import FormattedHeader from 'calypso/components/formatted-header';
+import NavigationHeader from 'calypso/components/navigation-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import './style.scss';
 
@@ -68,11 +69,11 @@ const PlansHeader: React.FunctionComponent< {
 	}
 
 	return (
-		<FormattedHeader
-			className="plans__formatted-header plans__section-header modernized-header"
-			headerText={ translate( 'Plans' ) }
-			subHeaderText={ plansDescription }
-			align="left"
+		<NavigationHeader
+			className="plans__section-header"
+			navigationItems={ [] }
+			title={ translate( 'Plans' ) }
+			subtitle={ plansDescription }
 		/>
 	);
 };

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -14,7 +14,6 @@ import {
 	isFreeJetpackPlan,
 	isFreePlanProduct,
 	PLAN_ECOMMERCE_TRIAL_MONTHLY,
-	isFreePlan,
 	PLAN_MIGRATION_TRIAL_MONTHLY,
 	PLAN_HOSTING_TRIAL_MONTHLY,
 	JETPACK_COMPLETE_PLANS,
@@ -34,8 +33,8 @@ import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import QuerySiteProducts from 'calypso/components/data/query-site-products';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import QuerySites from 'calypso/components/data/query-sites';
-import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
@@ -234,9 +233,7 @@ class CurrentPlan extends Component {
 
 		return (
 			<div>
-				{ ! isJetpackNotAtomic && (
-					<ModernizedLayout dropShadowOnHeader={ isFreePlan( currentPlanSlug ) } />
-				) }
+				{ ! isJetpackNotAtomic && <ModernizedLayout /> }
 				<DocumentHead title={ translate( 'My Plan' ) } />
 				{ selectedSiteId && (
 					<QueryConciergeInitial key={ selectedSiteId } siteId={ selectedSiteId } />
@@ -247,14 +244,13 @@ class CurrentPlan extends Component {
 				<QuerySiteProducts siteId={ selectedSiteId } />
 				{ shouldQuerySiteDomains && <QuerySiteDomains siteId={ selectedSiteId } /> }
 				<div>
-					<FormattedHeader
-						brandFont
-						className="current-plan__section-header modernized-header"
-						headerText={ translate( 'Plans' ) }
-						subHeaderText={ translate(
+					<NavigationHeader
+						className="plans__section-header"
+						navigationItems={ [] }
+						title={ translate( 'Plans' ) }
+						subtitle={ translate(
 							'Learn about the features included in your WordPress.com plan.'
 						) }
-						align="left"
 					/>
 					<div className="current-plan current-plan__content">
 						{ showThankYou && ! this.state.hideThankYouModal && (

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -411,7 +411,7 @@ class Plans extends Component {
 
 		return (
 			<div>
-				{ ! isJetpackNotAtomic && <ModernizedLayout dropShadowOnHeader={ isFreePlan } /> }
+				{ ! isJetpackNotAtomic && <ModernizedLayout /> }
 				{ selectedSite.ID && <QuerySitePurchases siteId={ selectedSite.ID } /> }
 				<DocumentHead title={ translate( 'Plans', { textOnly: true } ) } />
 				<PageViewTracker path="/plans/:site" title="Plans" />

--- a/client/my-sites/plans/modernized-layout.tsx
+++ b/client/my-sites/plans/modernized-layout.tsx
@@ -8,13 +8,9 @@ import { css, Global } from '@emotion/react';
 import { memo } from '@wordpress/element';
 import './modernized-layout.scss';
 
-const ModernizedLayout: React.FunctionComponent< { dropShadowOnHeader?: boolean } > = ( {
-	dropShadowOnHeader = true,
-} ) => {
+const ModernizedLayout: React.FunctionComponent = () => {
 	const backgroundColor = '#fdfdfd';
 	const sectionMaxWidth = '1224px';
-	const layoutContentPaddingTop = '79px';
-	const sidebarAppearanceBreakPoint = '783px';
 	const breakMedium = '782px';
 	const breakMobile = '480px';
 	// ----------------------------------------------
@@ -26,11 +22,7 @@ const ModernizedLayout: React.FunctionComponent< { dropShadowOnHeader?: boolean 
 	// ----------------------------------------------
 
 	const globalOverrides = css`
-		.plans__section-header,
-		.current-plan__section-header {
-			background-color: var( --studio-white );
-			${ dropShadowOnHeader && 'box-shadow: inset 0 -1px 0 #0000000d;' }
-
+		.navigation-header.plans__section-header {
 			@media ( min-width: ${ customBreakpointSmall } ) {
 				padding: 0 max( calc( 50% - ( ${ sectionMaxWidth } / 2 ) ), 32px );
 			}
@@ -131,16 +123,7 @@ const ModernizedLayout: React.FunctionComponent< { dropShadowOnHeader?: boolean 
 				background-color: ${ backgroundColor };
 			}
 
-			// this overrides the default .layout__content that adds unwanted padding
-			& .layout__content,
 			&.theme-default .focus-content .layout__content {
-				padding: 0;
-				padding-block-start: ${ layoutContentPaddingTop };
-
-				@media ( min-width: ${ sidebarAppearanceBreakPoint } ) {
-					padding-inline-start: calc( var( --sidebar-width-max ) + 1px );
-				}
-
 				.jetpack-colophon {
 					padding-top: ${ verticalMargin };
 					padding-bottom: ${ verticalMargin };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4352

## Proposed Changes

* Clean up some styles and update to use `NavigationHeader`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plans/:site` and `/plans/my-plan/:site` (will only render when on non-free plan)
* Check mobile, desktop

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?