### PR TITLE
wp-admin Site Default: Change the name of the literal type in mutation response

### DIFF
--- a/client/my-sites/hosting/site-admin-interface-card/use-select-interface-mutation.ts
+++ b/client/my-sites/hosting/site-admin-interface-card/use-select-interface-mutation.ts
@@ -8,7 +8,7 @@ import { receiveSite, requestSite } from 'calypso/state/sites/actions';
 const SET_SITE_INTERFACE_MUTATION_KEY = 'set-site-interface-mutation-key';
 
 interface MutationResponse {
-	WPCOM_ADMIN_INTERFACE: 'wp-admin' | 'calypso';
+	interface: 'wp-admin' | 'calypso';
 }
 
 interface MutationError {
@@ -39,12 +39,12 @@ export const useSiteInterfaceMutation = (
 		onSuccess: ( ...params ) => {
 			options?.onSuccess?.( ...params );
 			const [ data ] = params;
-			if ( ! data?.WPCOM_ADMIN_INTERFACE || ! site ) {
+			if ( ! data?.interface || ! site ) {
 				throw new Error( 'Invalid response from hosting/admin-interface' );
 			}
 			const newOptions = {
 				...( site.options || {} ),
-				wpcom_admin_interface: data.WPCOM_ADMIN_INTERFACE,
+				wpcom_admin_interface: data.interface,
 			};
 			// Apply the new interface option to the site on redux store
 			dispatch( receiveSite( { ...site, options: newOptions } ) );


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/4285 and D127041-code

## Proposed Changes

This PR updates `WPCOM_ADMIN_INTERFACE` to `interface` in the mutation response to be consistent with the changes in D127041-code where I am renaming `WPCOM_ADMIN_INTERFACE` to `interface` in the `response_data` object (this was originally requested in https://github.com/Automattic/dotcom-forge/issues/4285).

## Testing Instructions

* Apply D127041-code to your sandbox (if not merged)
* Sandbox public API
* Ensure that you have an Atomic site
* Navigate to `https://wpcalypso.wordpress.com/hosting-config/{yourAtomicSite}
* Scroll down to `Admin interface style` card 
* Try switching between interfaces and confirm there are no errors 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?