### PR TITLE
Assembler: Fix the jetpack blocks might not be rendered

### DIFF
--- a/packages/block-renderer/src/components/block-renderer-container.tsx
+++ b/packages/block-renderer/src/components/block-renderer-container.tsx
@@ -97,20 +97,13 @@ const ScaledBlockRendererContainer = ( {
 		bodyElement.style.width = '100%';
 	}, [] );
 
-	const contentAssetsRef = useRefEffect< HTMLBodyElement >(
-		( bodyElement ) => {
-			if ( ! children ) {
-				return;
-			}
-
-			// Load scripts and styles manually to avoid a flash of unstyled content.
-			Promise.all( [
-				loadStyles( bodyElement, styleAssets ),
-				loadScripts( bodyElement, scriptAssets as HTMLScriptElement[] ),
-			] ).then( () => setIsLoaded( true ) );
-		},
-		[ children ]
-	);
+	const contentAssetsRef = useRefEffect< HTMLBodyElement >( ( bodyElement ) => {
+		// Load scripts and styles manually to avoid a flash of unstyled content.
+		Promise.all( [
+			loadStyles( bodyElement, styleAssets ),
+			loadScripts( bodyElement, scriptAssets as HTMLScriptElement[] ),
+		] ).then( () => setIsLoaded( true ) );
+	}, [] );
 
 	const scale = containerWidth / viewportWidth;
 	const scaledHeight = contentHeight * scale || minHeight;

--- a/packages/block-renderer/src/components/pattern-renderer.tsx
+++ b/packages/block-renderer/src/components/pattern-renderer.tsx
@@ -28,6 +28,7 @@ const PatternRenderer = ( {
 
 	return (
 		<BlockRendererContainer
+			key={ pattern?.ID }
 			styles={ pattern?.styles ?? [] }
 			scripts={ pattern?.scripts ?? '' }
 			viewportWidth={ viewportWidth }
@@ -35,12 +36,10 @@ const PatternRenderer = ( {
 			minHeight={ minHeight }
 			inlineCss={ inlineCss }
 		>
-			{ patternHtml ? (
-				<div
-					// eslint-disable-next-line react/no-danger
-					dangerouslySetInnerHTML={ { __html: patternHtml } }
-				/>
-			) : null }
+			<div
+				// eslint-disable-next-line react/no-danger
+				dangerouslySetInnerHTML={ { __html: patternHtml ?? '' } }
+			/>
 		</BlockRendererContainer>
 	);
 };

--- a/packages/block-renderer/src/components/pattern-renderer.tsx
+++ b/packages/block-renderer/src/components/pattern-renderer.tsx
@@ -35,10 +35,12 @@ const PatternRenderer = ( {
 			minHeight={ minHeight }
 			inlineCss={ inlineCss }
 		>
-			<div
-				// eslint-disable-next-line react/no-danger
-				dangerouslySetInnerHTML={ { __html: patternHtml ?? '' } }
-			/>
+			{ patternHtml ? (
+				<div
+					// eslint-disable-next-line react/no-danger
+					dangerouslySetInnerHTML={ { __html: patternHtml } }
+				/>
+			) : null }
 		</BlockRendererContainer>
 	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/83678

## Proposed Changes

* We tried to load the assets of the pattern only when the component mounted. However, the pattern might not be loaded initially so it leads to the assets of the pattern not being loaded.
* This PR made a change to load the assets only when the pattern is ready (use the key to re-mount the component) to resolve this issue.

![image](https://github.com/Automattic/wp-calypso/assets/13596067/8a9367ba-1477-41c6-835b-426677cbf611)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*Go to the Assembler
* Select Gallery > Slideshow Gallery to insert the pattern
* Refresh the page
* Ensure the Slideshow Gallery pattern is rendered correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?