### PR TITLE
Login: Direct to login link page if user not allowed

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -162,6 +162,7 @@ class Login extends Component {
 		this.handleTwoFactorRequested( 'link' );
 	};
 
+
 	showContinueAsUser = () => {
 		const {
 			isJetpack,

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -31,6 +31,7 @@ import {
 	getRedirectToOriginal,
 	getLastCheckedUsernameOrEmail,
 	getRequestNotice,
+	getRequestError,
 	getTwoFactorNotificationSent,
 	isTwoFactorEnabled,
 	isTwoFactorAuthTypeSupported,
@@ -139,6 +140,20 @@ class Login extends Component {
 			! this.props.isSignupExistingAccount
 		) {
 			this.sendMagicLoginLink();
+		}
+
+		if (
+			this.props.requestError?.field === 'usernameOrEmail' &&
+			this.props.requestError?.code === 'email_login_not_allowed'
+		) {
+			const magicLoginUrl = login( {
+				locale: this.props.locale,
+				twoFactorAuthType: 'link',
+				oauth2ClientId: this.props.currentQuery?.client_id,
+				redirectTo: this.props.currentQuery?.redirect_to,
+			} );
+
+			page( magicLoginUrl );
 		}
 	}
 
@@ -825,6 +840,7 @@ export default connect(
 			getInitialQueryArguments( state )?.is_signup_existing_account ||
 			getCurrentQueryArguments( state )?.is_signup_existing_account
 		),
+		requestError: getRequestError( state ),
 	} ),
 	{
 		rebootAfterLogin,

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -134,11 +134,7 @@ class Login extends Component {
 			window.scrollTo( 0, 0 );
 		}
 
-		if (
-			! prevProps.accountType &&
-			isPasswordlessAccount( this.props.accountType ) &&
-			! this.props.isSignupExistingAccount
-		) {
+		if ( ! prevProps.accountType && isPasswordlessAccount( this.props.accountType ) ) {
 			this.sendMagicLoginLink();
 		}
 
@@ -161,7 +157,6 @@ class Login extends Component {
 		this.props.sendEmailLogin();
 		this.handleTwoFactorRequested( 'link' );
 	};
-
 
 	showContinueAsUser = () => {
 		const {

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -193,12 +193,7 @@ export class LoginForm extends Component {
 	}
 
 	isUsernameOrEmailView() {
-		const { accountType, hasAccountTypeLoaded, socialAccountIsLinking, isSignupExistingAccount } =
-			this.props;
-
-		if ( isSignupExistingAccount && hasAccountTypeLoaded ) {
-			return isPasswordlessAccount( accountType );
-		}
+		const { hasAccountTypeLoaded, socialAccountIsLinking } = this.props;
 
 		return (
 			! socialAccountIsLinking &&

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -101,11 +101,7 @@ export class LoginForm extends Component {
 	};
 
 	componentDidMount() {
-		const { disableAutoFocus, isSignupExistingAccount, userEmail } = this.props;
-
-		if ( isSignupExistingAccount && userEmail ) {
-			this.props.getAuthAccountType( userEmail );
-		}
+		const { disableAutoFocus } = this.props;
 
 		// eslint-disable-next-line react/no-did-mount-set-state
 		this.setState( { isFormDisabledWhileLoading: false }, () => {


### PR DESCRIPTION
10% of users logging in are rejected due to having a suspect email.
we can directly send them an email login link.
When the user clicks on the email link, the email will get verified. We hope to see an increase in verified emails.

## Testing 
1. Insert a suspicious email while logging in
2. Users should see the `log-in/link` page and choose to get a login link
3. Try coming from start with an existing regular and passwordless account. You should see a notice and be able to try to login. And get to point 2 if suspicious email.

To get a suspicious email and you have access to your sandbox, you can make this function
fbhepr%2Skers%2Sjcpbz%2Schoyvp.ncv%2Serfg%2Sjcpbz%2Qwfba%2Qraqcbvagf%2Spynff.jcpbz%2Qwfba%2Qncv%2Qhfre%2Qnhgu%2Qbcgvbaf%2Qraqcbvag.cuc%3Se%3Qpr9416ss%2363%2Q67-og
return 
```
return new WP_Error(
			'email_login_not_allowed',
			__( 'Please log in using your WordPress.com username instead of your email address.' ),
			403
		);
```

Fixes https://github.com/Automattic/wp-calypso/issues/83411