### PR TITLE
Plans Grid: Fixes for overflows/wrapping in certain locales

### DIFF
--- a/client/my-sites/plans-features-main/components/plan-type-selector/style.scss
+++ b/client/my-sites/plans-features-main/components/plan-type-selector/style.scss
@@ -39,6 +39,10 @@ body.is-group-stepper .plans .segmented-control.price-toggle {
 				border-color: rgba(0, 0, 0, 0.04);
 			}
 		}
+
+		.segmented-control__text {
+			white-space: initial;
+		}
 	}
 }
 

--- a/client/my-sites/plans-grid/components/comparison-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/comparison-grid/index.tsx
@@ -78,7 +78,6 @@ const Title = styled.div< { isHiddenInMobile?: boolean } >`
 	border: solid 1px #e0e0e0;
 	border-left: none;
 	border-right: none;
-	max-width: 290px;
 
 	.gridicon {
 		transform: ${ ( props ) =>
@@ -90,6 +89,7 @@ const Title = styled.div< { isHiddenInMobile?: boolean } >`
 		padding-inline-start: 0;
 		border: none;
 		padding: 0;
+		max-width: 290px;
 
 		.gridicon {
 			display: none;

--- a/client/my-sites/plans-grid/components/comparison-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/comparison-grid/index.tsx
@@ -83,6 +83,7 @@ const Title = styled.div< { isHiddenInMobile?: boolean } >`
 	.gridicon {
 		transform: ${ ( props ) =>
 			props.isHiddenInMobile ? 'rotateZ( 180deg )' : 'rotateZ( 0deg )' };
+		flex-shrink: 0;
 	}
 
 	${ plansBreakSmall( css`
@@ -901,7 +902,7 @@ const FeatureGroup = ( {
 			>
 				<Title isHiddenInMobile={ isHiddenInMobile }>
 					<Gridicon icon="chevron-up" size={ 12 } color="#1E1E1E" />
-					{ featureGroup.getTitle() }
+					<span>{ featureGroup.getTitle() }</span>
 				</Title>
 			</TitleRow>
 			{ featureObjects.map( ( feature ) => (

--- a/client/my-sites/plans-grid/components/comparison-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/comparison-grid/index.tsx
@@ -78,6 +78,7 @@ const Title = styled.div< { isHiddenInMobile?: boolean } >`
 	border: solid 1px #e0e0e0;
 	border-left: none;
 	border-right: none;
+	max-width: 290px;
 
 	.gridicon {
 		transform: ${ ( props ) =>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/martech/issues/1670
Fixes https://github.com/Automattic/martech/issues/1672

## Proposed Changes

* Fixes the plan interval toggle view for languages with long text on mobile.

| Before | After |
|--------|--------|
| <img width="430" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/8da37ffa-7c59-48fc-a373-31749c425b0a"> |<img width="431" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/f1a2eee7-ae6e-44f0-85d0-80150b19143b">| 

* Fixes headers overflow in the comparison grid

| Before | After |
|--------|--------|
| <img width="1338" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/63865058-a746-44a5-a8f2-cd3060f75e97"> | <img width="1289" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/7771761d-87a5-4784-a5c6-1104f9f45e51"> | 

* Fixes chevron sizes on mobile

| Before | After |
|--------|--------|
| <img width="349" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/6c55d435-5355-4f0d-8b85-e5c800b3e3ea"> | <img width="445" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/4613604c-dc43-48c6-a4e6-7e4e19b15c66"> | 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch Calypso language to RU and go to `/plans/<site slug>`.
* Confirm that the text in term toggle wraps.
* Open the comparison grid and confirm that the text that overflows the cell wraps correctly.
* On mobile, confirm that the chevrons in the comparison grid headers have equal sizes.
* Repeat the above steps for a few different locales.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?