### PR TITLE
Theme Discovery: Fix Collection Carousels scrolls on keypresses

### DIFF
--- a/client/components/theme-collection/index.tsx
+++ b/client/components/theme-collection/index.tsx
@@ -76,9 +76,6 @@ export default function ThemeCollection( {
 					swiperInstance.current = new Swiper( el, {
 						cssMode: true,
 						mousewheel: true,
-						keyboard: {
-							enabled: false,
-						},
 						navigation: {
 							nextEl: '.theme-collection__carousel-nav-button--next',
 							prevEl: '.theme-collection__carousel-nav-button--previous',

--- a/client/components/theme-collection/index.tsx
+++ b/client/components/theme-collection/index.tsx
@@ -77,8 +77,7 @@ export default function ThemeCollection( {
 						cssMode: true,
 						mousewheel: true,
 						keyboard: {
-							enabled: true,
-							onlyInViewport: false,
+							enabled: false,
 						},
 						navigation: {
 							nextEl: '.theme-collection__carousel-nav-button--next',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
- https://github.com/Automattic/dotcom-forge/issues/4424

When we press the left and arrow keys on our keyboard all the carousels being rendered get scrolled which isn't the best experience. This PR disables the keyboard on the Swiper component.

## Proposed Changes

* Disabled the keyboard for navigating carousels.

## Discarded Proposals
* Set `onlyInViewport: true`, setting this prop still navigates through all the carousels in the viewport which in most cases is > 1.
* Custom implementation, we would need to invest a lot of time in determining what carousel should be scrolled.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso Live Link
* Navigate to the LoTS with `flags=themes/discover-lots` 
* Press the left and right keys on your keyboard.
* The collection carousels should not move.

No before after added since I cant record keystrokes and it would just be a static image.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)