### PR TITLE
Reader: show pretty subscriber count for big sites

### DIFF
--- a/client/blocks/author-compact-profile/index.jsx
+++ b/client/blocks/author-compact-profile/index.jsx
@@ -1,10 +1,11 @@
 import classnames from 'classnames';
-import { numberFormat, localize } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import ReaderAuthorLink from 'calypso/blocks/reader-author-link';
 import ReaderAvatar from 'calypso/blocks/reader-avatar';
 import ReaderSiteStreamLink from 'calypso/blocks/reader-site-stream-link';
+import formatNumberCompact from 'calypso/lib/format-number-compact';
 import { areEqualIgnoringWhitespaceAndCase } from 'calypso/lib/string';
 import ReaderFollowButton from 'calypso/reader/follow-button';
 import { getStreamUrl } from 'calypso/reader/route';
@@ -83,11 +84,10 @@ class AuthorCompactProfile extends Component {
 				<div className="author-compact-profile__follow">
 					{ followCount ? (
 						<div className="author-compact-profile__follow-count">
-							{ this.props.translate( '%(followCount)s follower', '%(followCount)s followers', {
+							{ this.props.translate( '%s subscriber', '%s subscribers', {
 								count: followCount,
-								args: {
-									followCount: numberFormat( followCount ),
-								},
+								args: [ formatNumberCompact( followCount ) ],
+								comment: '%s is the number of subscribers. For example: "120" or "1.2M"',
 							} ) }
 						</div>
 					) : null }

--- a/client/blocks/reader-feed-header/index.jsx
+++ b/client/blocks/reader-feed-header/index.jsx
@@ -8,6 +8,7 @@ import { Component } from 'react';
 import BlogStickers from 'calypso/blocks/blog-stickers';
 import SiteIcon from 'calypso/blocks/site-icon';
 import QueryUserSettings from 'calypso/components/data/query-user-settings';
+import formatNumberCompact from 'calypso/lib/format-number-compact';
 import withDimensions from 'calypso/lib/with-dimensions';
 import {
 	getFollowerCount,
@@ -104,10 +105,10 @@ class FeedHeader extends Component {
 						{ ! wideDisplay && followerCount && (
 							<div className="reader-feed-header__follow-count">
 								{ ' ' }
-								{ translate( '%s follower', '%s followers', {
+								{ translate( '%s subscriber', '%s subscribers', {
 									count: followerCount,
-									args: [ this.props.numberFormat( followerCount ) ],
-									comment: '%s is the number of followers. For example: "12,000,000"',
+									args: [ formatNumberCompact( followerCount ) ],
+									comment: '%s is the number of subscribers. For example: "120" or "1.2M"',
 								} ) }
 							</div>
 						) }

--- a/client/blocks/reader-site-subscription/site-subscription-subheader.tsx
+++ b/client/blocks/reader-site-subscription/site-subscription-subheader.tsx
@@ -1,9 +1,10 @@
 import { Button, __experimentalHStack as HStack } from '@wordpress/components';
-import { numberFormat, useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import ExternalLink from 'calypso/components/external-link';
 import { FeedIcon } from 'calypso/landing/subscriptions/components/settings/icons';
 import { useRecordViewFeedButtonClicked } from 'calypso/landing/subscriptions/tracks';
+import formatNumberCompact from 'calypso/lib/format-number-compact';
 import { getFeedUrl } from 'calypso/reader/route';
 
 type SiteSubscriptionSubheaderProps = {
@@ -47,8 +48,8 @@ const SiteSubscriptionSubheader = ( {
 			<div key={ `subscriber-count-${ subscriberCount }` }>
 				{ translate( '%s subscriber', '%s subscribers', {
 					count: subscriberCount,
-					args: [ numberFormat( subscriberCount, 0 ) ],
-					comment: '%s is the number of subscribers. For example: "12,000,000"',
+					args: [ formatNumberCompact( subscriberCount ) ],
+					comment: '%s is the number of subscribers. For example: "120" or "1.2M"',
 				} ) }
 			</div>
 		);

--- a/client/lib/format-number-compact/index.js
+++ b/client/lib/format-number-compact/index.js
@@ -1,6 +1,10 @@
 import i18n, { numberFormat } from 'i18n-calypso';
 import { THOUSANDS } from './thousands';
 
+const ONE_K = 1000;
+const ONE_M = ONE_K * 1000;
+const ONE_G = ONE_M * 1000;
+
 /**
  * Formats a number to a short format given a language code
  * @param   {number}     number              number to format
@@ -9,8 +13,13 @@ import { THOUSANDS } from './thousands';
  */
 export default function formatNumberCompact( number, code = i18n.getLocaleSlug() ) {
 	//use numberFormat directly from i18n in this case!
-	if ( isNaN( number ) || ! THOUSANDS[ code ] ) {
+	if ( isNaN( number ) ) {
 		return null;
+	}
+
+	// Rely on `formatNumberMetric` we don't support the language, or when the number is 1M+
+	if ( ! THOUSANDS[ code ] || number >= ONE_M ) {
+		return formatNumberMetric( number );
 	}
 
 	const { decimal, grouping, symbol, unitValue = 1000 } = THOUSANDS[ code ];
@@ -34,10 +43,6 @@ export default function formatNumberCompact( number, code = i18n.getLocaleSlug()
 
 	return `${ sign }${ value }${ symbol }`;
 }
-
-const ONE_K = 1000;
-const ONE_M = ONE_K * 1000;
-const ONE_G = ONE_M * 1000;
 
 /*
  * Format a number larger than 1000 by appending a metric unit (K, M, G) and rounding to

--- a/client/lib/format-number-compact/index.js
+++ b/client/lib/format-number-compact/index.js
@@ -1,3 +1,4 @@
+import { englishLocales } from '@automattic/i18n-utils';
 import i18n, { numberFormat } from 'i18n-calypso';
 import { THOUSANDS } from './thousands';
 
@@ -6,7 +7,7 @@ const ONE_M = ONE_K * 1000;
 const ONE_G = ONE_M * 1000;
 
 /**
- * Formats a number to a short format given a language code
+ * Formats a number to a short format given a language code, i.e. 10K, 10.2M, 1G etc
  * @param   {number}     number              number to format
  * @param   {string}     code                language code e.g. 'es'
  * @returns {?string}                        A formatted string.
@@ -17,9 +18,19 @@ export default function formatNumberCompact( number, code = i18n.getLocaleSlug()
 		return null;
 	}
 
-	// Rely on `formatNumberMetric` we don't support the language, or when the number is 1M+
-	if ( ! THOUSANDS[ code ] || number >= ONE_M ) {
+	// Return small numbers as-is
+	if ( number > -ONE_K && number < ONE_K ) {
+		return numberFormat( number );
+	}
+
+	// Rely on `formatNumberMetric` for English locales, when the number is +1M or more, and -1M or less.
+	if ( englishLocales.includes( code ) && ( number >= ONE_M || number <= -ONE_M ) ) {
 		return formatNumberMetric( number );
+	}
+
+	//use numberFormat directly from i18n in this case!
+	if ( ! THOUSANDS[ code ] ) {
+		return null;
 	}
 
 	const { decimal, grouping, symbol, unitValue = 1000 } = THOUSANDS[ code ];
@@ -50,15 +61,15 @@ export default function formatNumberCompact( number, code = i18n.getLocaleSlug()
  * TODO: merge with formatNumberCompact by adding support for metric units other than 'K'
  */
 export function formatNumberMetric( number, decimalPoints = 1 ) {
-	if ( number < ONE_K ) {
+	if ( number < ONE_K && number > -ONE_K ) {
 		return String( number );
 	}
 
-	if ( number < ONE_M ) {
+	if ( number < ONE_M && number > -ONE_M ) {
 		return ( number / ONE_K ).toFixed( decimalPoints ) + 'K';
 	}
 
-	if ( number < ONE_G ) {
+	if ( number < ONE_G && number > -ONE_G ) {
 		return ( number / ONE_M ).toFixed( decimalPoints ) + 'M';
 	}
 

--- a/client/lib/format-number-compact/test/index.js
+++ b/client/lib/format-number-compact/test/index.js
@@ -5,6 +5,10 @@ describe( 'formatNumberCompact', () => {
 		const counts = formatNumberCompact( 999, 'en' );
 		expect( counts ).toEqual( '999' );
 	} );
+	test( 'does nothing for negative number if number is > -1000', () => {
+		const counts = formatNumberCompact( -999, 'en' );
+		expect( counts ).toEqual( '-999' );
+	} );
 	test( 'shows 2 sig figs for counts < 10000', () => {
 		const counts = formatNumberCompact( 1234, 'en' );
 		expect( counts ).toEqual( '1.2K' );
@@ -13,17 +17,21 @@ describe( 'formatNumberCompact', () => {
 		const counts = formatNumberCompact( 123456, 'en' );
 		expect( counts ).toEqual( '123K' );
 	} );
-	test( 'rounds abbreviated counts', () => {
+	test( 'rounds abbreviated counts for thousands', () => {
 		const counts = formatNumberCompact( 1897, 'en' );
 		expect( counts ).toEqual( '1.9K' );
 	} );
-	test( 'shows groupings for huge numbers', () => {
+	test( 'rounds abbreviated counts for millions', () => {
 		const counts = formatNumberCompact( 123456789, 'en' );
-		expect( counts ).toEqual( '123,457K' );
+		expect( counts ).toEqual( '123.5M' );
 	} );
-	test( 'handles negative numbers', () => {
+	test( 'handles negative numbers in thousands', () => {
+		const counts = formatNumberCompact( -1897, 'en' );
+		expect( counts ).toEqual( '-1.9K' );
+	} );
+	test( 'handles negative numbers in millions', () => {
 		const counts = formatNumberCompact( -123456789, 'en' );
-		expect( counts ).toEqual( '-123,457K' );
+		expect( counts ).toEqual( '-123.5M' );
 	} );
 	describe( 'es', () => {
 		test( 'shows 2 sig figs for counts < 10000', () => {

--- a/client/reader/stream/site-feed-sidebar/index.jsx
+++ b/client/reader/stream/site-feed-sidebar/index.jsx
@@ -1,4 +1,4 @@
-import { useTranslate, getLocaleSlug } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { useDispatch } from 'react-redux';
 import ReaderFeedHeaderFollow from 'calypso/blocks/reader-feed-header/follow';
 import TagLink from 'calypso/blocks/reader-post-card/tag-link';
@@ -56,10 +56,10 @@ const FeedStreamSidebar = ( {
 					{ followerCount && (
 						<div className="reader-tag-sidebar-stats__item">
 							<span className="reader-tag-sidebar-stats__count">
-								{ followerCount.toLocaleString( getLocaleSlug() ) }
+								{ formatNumberCompact( followerCount ) }
 							</span>
 							<span className="reader-tag-sidebar-stats__title">
-								{ translate( 'Follower', 'Followers', { count: followerCount } ) }
+								{ translate( 'Subscriber', 'Subscribers', { count: followerCount } ) }
 							</span>
 						</div>
 					) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Part of https://github.com/Automattic/jetpack/issues/32373

## Proposed Changes

* Uses `formatNumberCompact` to show shorter numbers for sites with many subscribers

<img width="314" alt="Screenshot 2023-10-31 at 13 32 30" src="https://github.com/Automattic/wp-calypso/assets/87168/2394b980-fab1-4e6b-aeb0-02139bd2c5b9">
<img width="341" alt="Screenshot 2023-10-31 at 13 30 04" src="https://github.com/Automattic/wp-calypso/assets/87168/2a505c6e-0b4c-40b3-8036-bc5de3ee7790">

<img width="328" alt="Screenshot 2023-10-31 at 13 29 43" src="https://github.com/Automattic/wp-calypso/assets/87168/92555ce6-e330-4880-b746-afe1bd321a01">
<img width="294" alt="Screenshot 2023-10-31 at 13 29 54" src="https://github.com/Automattic/wp-calypso/assets/87168/4cb9f213-090c-4464-8e43-f5cf6f62170e">

<img width="270" alt="Screenshot 2023-10-31 at 14 38 38" src="https://github.com/Automattic/wp-calypso/assets/87168/1a08ec5e-7e4d-4bd6-b7ed-fa1df66e9a22">
<img width="286" alt="Screenshot 2023-10-31 at 14 38 44" src="https://github.com/Automattic/wp-calypso/assets/87168/ce092812-1d84-406f-ac2a-8cbbb59b27e1">

<img width="314" alt="Screenshot 2023-10-31 at 14 39 56" src="https://github.com/Automattic/wp-calypso/assets/87168/83a0d492-08c5-4264-8639-5d1c305b07f7">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

See that different counts work as expected.

Few feeds to test with:

* http://calypso.localhost:3000/read/blogs/3584907/posts/53528
* http://calypso.localhost:3000/read/feeds/25823

* http://calypso.localhost:3000/read/feeds/83824747
* http://calypso.localhost:3000/read/blogs/147750070/posts/12990

* http://calypso.localhost:3000/read/feeds/146228472
* http://calypso.localhost:3000/read/feeds/146228472/posts/4967163628


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?