### PR TITLE
Reader, notifications: update terminology from "following" to "subscribing"

### DIFF
--- a/apps/notifications/src/panel/templates/filters.js
+++ b/apps/notifications/src/panel/templates/filters.js
@@ -64,14 +64,14 @@ export const Filters = {
 		return {
 			name: 'follows',
 			index: 3,
-			label: i18n.translate( 'Follows', {
-				comment: 'Notifications filter: notifications about users following your blogs',
+			label: i18n.translate( 'Subscribers', {
+				comment: 'Notifications filter: notifications about users subscribing to your blogs',
 			} ),
-			emptyMessage: i18n.translate( 'No new followers to report yet.', {
-				comment: 'Notifications follows filter: no notifications',
+			emptyMessage: i18n.translate( 'No new subscribers to report yet.', {
+				comment: 'Notifications subscribers filter: no notifications',
 			} ),
 			emptyLinkMessage: i18n.translate( "Get noticed: comment on posts you've read.", {
-				comment: 'Notifications follows filter: no notifications',
+				comment: 'Notifications subscribers filter: no notifications',
 			} ),
 			emptyLink: 'https://wordpress.com/activities/likes/',
 

--- a/apps/notifications/src/panel/templates/follow-link.jsx
+++ b/apps/notifications/src/panel/templates/follow-link.jsx
@@ -58,8 +58,8 @@ export const FollowLink = ( { site, noteType, isFollowing: initialIsFollowing } 
 
 	const icon = isFollowing ? 'reader-following' : 'reader-follow';
 	const linkText = isFollowing
-		? translate( 'Following', { context: 'you are following' } )
-		: translate( 'Follow', { context: 'verb: imperative' } );
+		? translate( 'Subscribed', { context: 'you are subscribing' } )
+		: translate( 'Subscribe', { context: 'verb: imperative' } );
 
 	return (
 		<button className="follow-link" onClick={ toggleFollowStatus }>

--- a/apps/notifications/src/panel/templates/index.jsx
+++ b/apps/notifications/src/panel/templates/index.jsx
@@ -397,7 +397,7 @@ class Layout extends Component {
 					this.filterController.selectFilter( 'comments' );
 				}
 				break;
-			case KEY_F: // Follows filter
+			case KEY_F: // Subscriptions (previously "follows") filter
 				if ( ! this.props.selectedNoteId ) {
 					this.filterController.selectFilter( 'follows' );
 				}

--- a/client/blocks/author-compact-profile/index.jsx
+++ b/client/blocks/author-compact-profile/index.jsx
@@ -83,7 +83,7 @@ class AuthorCompactProfile extends Component {
 				<div className="author-compact-profile__follow">
 					{ followCount ? (
 						<div className="author-compact-profile__follow-count">
-							{ this.props.translate( '%(followCount)s follower', '%(followCount)s followers', {
+							{ this.props.translate( '%(followCount)s subscriber', '%(followCount)s subscribers', {
 								count: followCount,
 								args: {
 									followCount: numberFormat( followCount ),

--- a/client/blocks/follow-button/button.jsx
+++ b/client/blocks/follow-button/button.jsx
@@ -44,7 +44,9 @@ class FollowButton extends Component {
 	};
 
 	render() {
-		let label = this.props.followLabel ? this.props.followLabel : this.props.translate( 'Follow' );
+		let label = this.props.followLabel
+			? this.props.followLabel
+			: this.props.translate( 'Subscribe' );
 		const menuClasses = [ 'button', 'follow-button', 'has-icon', this.props.className ];
 		const iconSize = this.props.iconSize;
 
@@ -52,7 +54,7 @@ class FollowButton extends Component {
 			menuClasses.push( 'is-following' );
 			label = this.props.followingLabel
 				? this.props.followingLabel
-				: this.props.translate( 'Following' );
+				: this.props.translate( 'Subscribed' );
 		}
 
 		if ( this.props.disabled ) {

--- a/client/blocks/reader-feed-header/index.jsx
+++ b/client/blocks/reader-feed-header/index.jsx
@@ -104,10 +104,10 @@ class FeedHeader extends Component {
 						{ ! wideDisplay && followerCount && (
 							<div className="reader-feed-header__follow-count">
 								{ ' ' }
-								{ translate( '%s follower', '%s followers', {
+								{ translate( '%s subscriber', '%s subscribers', {
 									count: followerCount,
 									args: [ this.props.numberFormat( followerCount ) ],
-									comment: '%s is the number of followers. For example: "12,000,000"',
+									comment: '%s is the number of subscribers. For example: "12,000,000"',
 								} ) }
 							</div>
 						) }

--- a/client/blocks/reader-join-conversation/dialog.jsx
+++ b/client/blocks/reader-join-conversation/dialog.jsx
@@ -60,7 +60,9 @@ const ReaderJoinConversationDialog = ( { onClose, isVisible, loggedInAction, onL
 			<div className="reader-join-conversation-dialog__content">
 				<WordPressLogo size={ 32 } />
 				<h1>{ translate( 'Join the conversation' ) }</h1>
-				<p>{ translate( 'Sign in to like, comment, reblog, and follow your favorite blogs.' ) }</p>
+				<p>
+					{ translate( 'Sign in to like, comment, reblog, and subscribe to your favorite blogs.' ) }
+				</p>
 				<Button
 					isPrimary
 					onClick={ onCreateAccountClick }

--- a/client/blocks/reader-post-options-menu/reader-post-ellipsis-menu.jsx
+++ b/client/blocks/reader-post-options-menu/reader-post-ellipsis-menu.jsx
@@ -310,8 +310,8 @@ class ReaderPostEllipsisMenu extends Component {
 						siteUrl={ post.feed_URL || post.site_URL }
 						followSource={ READER_POST_OPTIONS_MENU }
 						iconSize={ 20 }
-						followLabel={ translate( 'Follow blog' ) }
-						followingLabel={ translate( 'Unfollow blog' ) }
+						followLabel={ translate( 'Subscribe' ) }
+						followingLabel={ translate( 'Unsubscribe' ) }
 						onFollowToggle={ this.openSuggestedFollowsModal }
 					/>
 				) }

--- a/client/blocks/reader-suggested-follows/dialog.jsx
+++ b/client/blocks/reader-suggested-follows/dialog.jsx
@@ -32,13 +32,13 @@ const ReaderSuggestedFollowsDialog = ( { onClose, siteId, postId, isVisible } ) 
 			isVisible={ isVisible }
 			onClose={ onClose }
 			showCloseIcon={ true }
-			label={ translate( 'Suggested subscriptions' ) }
+			label={ translate( 'Suggested sites' ) }
 			shouldCloseOnEsc={ true }
 		>
 			<div className="reader-recommended-follows-dialog__content">
 				<div className="reader-recommended-follows-dialog__header">
 					<h2 className="reader-recommended-follows-dialog__title">
-						{ translate( 'Suggested subscriptions' ) }
+						{ translate( 'Suggested sites' ) }
 					</h2>
 					<p className="reader-recommended-follows-dialog__description">
 						{ translate( "While you're at it, you might check out these sites." ) }

--- a/client/blocks/reader-suggested-follows/dialog.jsx
+++ b/client/blocks/reader-suggested-follows/dialog.jsx
@@ -32,13 +32,13 @@ const ReaderSuggestedFollowsDialog = ( { onClose, siteId, postId, isVisible } ) 
 			isVisible={ isVisible }
 			onClose={ onClose }
 			showCloseIcon={ true }
-			label={ translate( 'Suggested follows' ) }
+			label={ translate( 'Suggested subscriptions' ) }
 			shouldCloseOnEsc={ true }
 		>
 			<div className="reader-recommended-follows-dialog__content">
 				<div className="reader-recommended-follows-dialog__header">
 					<h2 className="reader-recommended-follows-dialog__title">
-						{ translate( 'Suggested follows' ) }
+						{ translate( 'Suggested subscriptions' ) }
 					</h2>
 					<p className="reader-recommended-follows-dialog__description">
 						{ translate( "While you're at it, you might check out these sites." ) }

--- a/client/me/notification-settings/settings-form/locales.js
+++ b/client/me/notification-settings/settings-form/locales.js
@@ -11,7 +11,7 @@ export const settingLabels = {
 
 	new_comment: () => i18n.translate( 'Comments on my site' ),
 	post_like: () => i18n.translate( 'Likes on my posts' ),
-	follow: () => i18n.translate( 'Site follows' ),
+	follow: () => i18n.translate( 'Subscriptions' ),
 	achievement: () => i18n.translate( 'Site achievements' ),
 	mentions: () => i18n.translate( 'Username mentions' ),
 	scheduled_publicize: () => i18n.translate( 'Post Publicized' ),

--- a/client/my-sites/stats/stats-list/action-follow.jsx
+++ b/client/my-sites/stats/stats-list/action-follow.jsx
@@ -69,11 +69,11 @@ class StatsActionFollow extends Component {
 			following: isFollowing,
 		} );
 		const label = isFollowing
-			? this.props.translate( 'Following', {
-					context: 'Stats: Follow action / Following status',
+			? this.props.translate( 'Subscribed', {
+					context: 'Stats: Subscribe action / Subscription status',
 			  } )
-			: this.props.translate( 'Follow', {
-					context: 'Stats: Follow action / Following status',
+			: this.props.translate( 'Subscribe', {
+					context: 'Stats: Subscribe action / Subscription status',
 			  } );
 		const gridiconType = isFollowing ? 'reader-following' : 'reader-follow';
 		const wrapperClassSet = classNames( wrapperClass );
@@ -85,9 +85,9 @@ class StatsActionFollow extends Component {
 					onClick={ this.clickHandler }
 					className={ wrapperClassSet }
 					title={ siteDomain }
-					aria-label={ this.props.translate( 'Follow or unfollow user', {
+					aria-label={ this.props.translate( "Subscribe or unsubscribe to user's site", {
 						textOnly: true,
-						context: 'Stats ARIA label: Follow/Unfollow action',
+						context: 'Stats ARIA label: Subscribe/Unsubscribe action',
 					} ) }
 				>
 					<span className="module-content-list-item-action-label">
@@ -96,8 +96,8 @@ class StatsActionFollow extends Component {
 					</span>
 					<span className="module-content-list-item-action-label unfollow">
 						<Icon className="stats-icon" icon={ close } size={ 18 } />
-						{ this.props.translate( 'Unfollow', {
-							context: 'Stats ARIA label: Unfollow action',
+						{ this.props.translate( 'Unsubscribe', {
+							context: 'Stats ARIA label: Unsubscribe action',
 						} ) }
 					</span>
 				</a>

--- a/client/reader/discover/follow-button.jsx
+++ b/client/reader/discover/follow-button.jsx
@@ -21,12 +21,12 @@ class DiscoverFollowButton extends Component {
 			return null;
 		}
 
-		const followLabel = this.props.translate( 'Follow %(siteName)s', {
+		const followLabel = this.props.translate( 'Subscribe to %(siteName)s', {
 			args: {
 				siteName: this.props.siteName,
 			},
 		} );
-		const followingLabel = this.props.translate( 'Following %(siteName)s', {
+		const followingLabel = this.props.translate( 'Subscribed to %(siteName)s', {
 			args: {
 				siteName: this.props.siteName,
 			},

--- a/client/reader/search-stream/search-follow-button.jsx
+++ b/client/reader/search-stream/search-follow-button.jsx
@@ -104,13 +104,13 @@ class SearchFollowButton extends Component {
 					<strong>{ translate( 'Click below to add this site to your Reader feed:' ) }</strong>
 				</p>
 				<FollowButton
-					followLabel={ translate( 'Follow %s', {
+					followLabel={ translate( 'Subscribe to %s', {
 						args: followTitle,
-						comment: '%s is the name of the site being followed. For example: "Discover"',
+						comment: '%s is the name of the site being subscribed to. For example: "Discover"',
 					} ) }
-					followingLabel={ translate( 'Following %s', {
+					followingLabel={ translate( 'Subscribing to %s', {
 						args: followTitle,
-						comment: '%s is the name of the site being followed. For example: "Discover"',
+						comment: '%s is the name of the site being subscribed to. For example: "Discover"',
 					} ) }
 					siteUrl={ addSchemeIfMissing( followUrl, 'http' ) }
 					followIcon={ ReaderFollowFeedIcon( { iconSize: 20 } ) }


### PR DESCRIPTION
Part of https://github.com/Automattic/wp-calypso/issues/76941

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

We've been updating terms towards "subscribing" in all interfaces. Reader and notifications are some of the last Calypso UIs still using the "follow" terminology.

See also a separate related PR to update subscriber counts to be prettier for big numbers https://github.com/Automattic/wp-calypso/pull/83710

## Proposed Changes

* Update terms in Reader
* Update terms in notifications sidebar
* Update terms in Me → notifications settings
* Update terms in Stats

### Reader

(not really exhaustive list of screenshots)

<img width="450" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/0ef31867-0ed3-404e-bee7-1e75609ff4a4">

<img width="653" alt="Screenshot 2023-10-31 at 11 10 57" src="https://github.com/Automattic/wp-calypso/assets/87168/6a13dd1e-6528-4fd1-98a9-5ffa07e88f4b">

<img width="242" alt="Screenshot 2023-10-31 at 16 19 37" src="https://github.com/Automattic/wp-calypso/assets/87168/2e3d4a1d-ee3f-4339-87d1-149ceb7ce106">

<img width="249" alt="Screenshot 2023-10-31 at 16 19 39" src="https://github.com/Automattic/wp-calypso/assets/87168/8d8f5a58-dfe7-4e91-b1da-0a31312e293f">

### Notification settings

<img width="1466" alt="Screenshot 2023-10-31 at 11 01 45" src="https://github.com/Automattic/wp-calypso/assets/87168/ca86cf20-ba40-472d-8daf-0dc400eb4523">

### Stats

<img width="440" alt="Screenshot 2023-10-31 at 17 03 02" src="https://github.com/Automattic/wp-calypso/assets/87168/a2e02a34-5cfa-4fdc-b7df-287054398363">
<img width="443" alt="Screenshot 2023-10-31 at 17 03 09" src="https://github.com/Automattic/wp-calypso/assets/87168/f05dc049-95c5-4a65-bf0d-d71f65552857">
<img width="432" alt="Screenshot 2023-10-31 at 17 03 15" src="https://github.com/Automattic/wp-calypso/assets/87168/dded9346-23ff-471e-9ceb-235b0611d703">

### Notifications panel

<img width="332" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/c7a54091-0ec1-44ca-9f57-124eb62b8f10">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Click around and check that the terms make sense. Do review English also in the code directly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
