### PR TITLE
add ai response to email ticket

### DIFF
--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -340,7 +340,7 @@ export const HelpCenterContactForm = () => {
 						is_chat_overflow: overflow,
 						source: 'source_wpcom_help_center',
 						blog_url: supportSite.URL,
-						ai_id: gptResponse?.answer_id,
+						ai_chat_id: gptResponse?.answer_id,
 						ai_message: gptResponse?.response,
 					} )
 						.then( () => {

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -340,6 +340,8 @@ export const HelpCenterContactForm = () => {
 						is_chat_overflow: overflow,
 						source: 'source_wpcom_help_center',
 						blog_url: supportSite.URL,
+						ai_id: gptResponse?.answer_id,
+						ai_message: gptResponse?.response,
 					} )
 						.then( () => {
 							recordTracksEvent( 'calypso_inlinehelp_contact_submit', {

--- a/packages/help-center/src/data/use-jetpack-search-ai.ts
+++ b/packages/help-center/src/data/use-jetpack-search-ai.ts
@@ -25,6 +25,7 @@ export type JetpackSearchAIResult = {
 	urls: AIResponseURL[];
 	terms: string[];
 	source: string;
+	answer_id?: string;
 };
 
 export function useJetpackSearchAIQuery( config: JetpackSearchAIConfig ) {

--- a/packages/help-center/src/data/use-submit-support-ticket.ts
+++ b/packages/help-center/src/data/use-submit-support-ticket.ts
@@ -10,7 +10,7 @@ type Ticket = {
 	is_chat_overflow: boolean;
 	source: string;
 	blog_url: string;
-	ai_id?: string;
+	ai_chat_id?: string;
 	ai_message?: string;
 };
 

--- a/packages/help-center/src/data/use-submit-support-ticket.ts
+++ b/packages/help-center/src/data/use-submit-support-ticket.ts
@@ -10,6 +10,8 @@ type Ticket = {
 	is_chat_overflow: boolean;
 	source: string;
 	blog_url: string;
+	ai_id?: string;
+	ai_message?: string;
 };
 
 export function useSubmitTicketMutation() {


### PR DESCRIPTION
Request [context](https://wp.me/peCdcN-io)

## Proposed Changes

* Add AI response and response ID to the submit ticket request

## Testing Instructions

* From the help center select email, fill out a question and:
  * Wait for AI reply and proceed with the email request
  * Skip the AI reply and proceed with the email request

The first request should include the AI information mentioned.
The second shouldn't include any information related to AI.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
