### PR TITLE
Update akismet thank you page, remove plan overlap messaging

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/akismet-checkout-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/akismet-checkout-thank-you.tsx
@@ -1,6 +1,5 @@
-import { AKISMET_PRODUCTS_LIST, isAkismetProduct } from '@automattic/calypso-products';
+import { isAkismetProduct } from '@automattic/calypso-products';
 import { Button, Card } from '@automattic/components';
-import { ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { sprintf, __ } from '@wordpress/i18n';
 import classNames from 'classnames';
@@ -48,13 +47,10 @@ const AkismetCheckoutThankYou: FunctionComponent< AkismetCheckoutThankYouProps >
 		( state ) => getUserPurchases( state )?.filter( ( purchase ) => purchase.active ) ?? []
 	);
 
-	const { overlapMessage, thanksHeadline, thanksMessage } = useMemo( () => {
-		const akismetProducts = AKISMET_PRODUCTS_LIST as ReadonlyArray< string >;
+	const { thanksHeadline, thanksMessage } = useMemo( () => {
 		const akismetPurchases = userActivePurchases.filter(
 			( purchase ) => isAkismetProduct( purchase ) && isAkismetTemporarySitePurchase( purchase )
 		);
-		const purchaseHasAPILimit =
-			akismetProducts.indexOf( productSlug ) >= akismetProducts.indexOf( 'ak_plus_monthly_1' );
 
 		let thanksHeadline = (
 			<>
@@ -65,7 +61,7 @@ const AkismetCheckoutThankYou: FunctionComponent< AkismetCheckoutThankYouProps >
 				</span>
 			</>
 		);
-		let overlapMessage = null;
+
 		let thanksMessage = createInterpolateElement(
 			sprintf(
 				// translators: %s is the product name
@@ -97,20 +93,9 @@ const AkismetCheckoutThankYou: FunctionComponent< AkismetCheckoutThankYouProps >
 				),
 				{ strong: <strong /> }
 			);
-
-			if ( purchaseHasAPILimit ) {
-				overlapMessage = createInterpolateElement(
-					__(
-						'You’ve supercharged your spam protection by increasing your API limit! Make sure to cancel any existing plans that you don’t need on your <a>account page</a>.',
-						'akismet-thank-you'
-					),
-					{ a: <ExternalLink href="https://akismet.com/account/" children={ null } /> }
-				);
-			}
 		}
 
 		return {
-			overlapMessage,
 			thanksHeadline,
 			thanksMessage,
 		};
@@ -149,10 +134,6 @@ const AkismetCheckoutThankYou: FunctionComponent< AkismetCheckoutThankYouProps >
 				>
 					{ thanksMessage }
 				</p>
-
-				{ overlapMessage && (
-					<p className="akismet-checkout-thank-you__overlap-notice">{ overlapMessage }</p>
-				) }
 
 				<ThankYouAPIKeyClipboard />
 

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -874,7 +874,7 @@ main.akismet-checkout-thank-you {
 
 	.akismet-checkout-thank-you__card {
 		box-shadow: 0 0 40px 0 #00000014;
-
+		margin-top: var(--masterbar-checkout-height);
 		padding: 2rem;
 		margin-bottom: 0;
 
@@ -884,6 +884,10 @@ main.akismet-checkout-thank-you {
 			background-position: bottom;
 
 			padding: 5rem;
+		}
+
+		@include break-large {
+			margin-top: calc(var(--masterbar-checkout-height) + 24px);
 		}
 	}
 


### PR DESCRIPTION
## Proposed Changes

* Removes plan overlap messaging from the Akismet thank you page - this was part of a now phased out upgrade path.
* Fixes a style bug on the Akismet thank you page

## Testing Instructions

* Check out this branch locally or use the Calypso live link
* Load the checkout thank you page for a paid Akismet product: `checkout/akismet/thank-you/ak_plus_yearly_1`
* The plan overlap text should no longer show
* There should also be space between the top of the card and the top of the page (there was no space before)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?