### PR TITLE
Blog onboarding: Offer option to logged users to create a new site

### DIFF
--- a/client/landing/stepper/declarative-flow/design-first.ts
+++ b/client/landing/stepper/declarative-flow/design-first.ts
@@ -281,12 +281,8 @@ const designFirst: Flow = {
 		const isSiteCreationStep =
 			currentPath.endsWith( 'setup/design-first' ) ||
 			currentPath.endsWith( 'setup/design-first/' ) ||
-			currentPath.includes( 'setup/design-first/site-creation-step' );
+			currentPath.includes( 'setup/design-first/check-sites' );
 		const userAlreadyHasSites = currentUserSiteCount && currentUserSiteCount > 0;
-
-		// Allow to create a new site if people are from the Theme Showcase or they don't have a site
-		const shouldCreateNewSite =
-			getQueryArg( window.location.href, 'ref' ) === 'calypshowcase' || ! userAlreadyHasSites;
 
 		// There is a race condition where useLocale is reporting english,
 		// despite there being a locale in the URL so we need to look it up manually.
@@ -317,9 +313,7 @@ const designFirst: Flow = {
 				isSiteCreationStep &&
 				( ! userAlreadyHasSites || getQueryArg( window.location.href, 'ref' ) === 'calypshowcase' )
 			) {
-				// Redirect users with existing sites out of the flow as we create a new site as the first step in this flow.
-				// This prevents a bunch of sites being created accidentally.
-				redirect( `/themes` );
+				redirect( '/setup/design-first/site-creation-step' );
 			}
 		}, [] );
 
@@ -330,10 +324,10 @@ const designFirst: Flow = {
 				state: AssertConditionState.CHECKING,
 				message: `${ flowName } requires a logged in user`,
 			};
-		} else if ( isSiteCreationStep && ! shouldCreateNewSite ) {
+		} else if ( isSiteCreationStep && ! userAlreadyHasSites ) {
 			result = {
 				state: AssertConditionState.CHECKING,
-				message: `${ flowName } requires no preexisting sites`,
+				message: `${ flowName } with no preexisting sites`,
 			};
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/index.tsx
@@ -5,6 +5,7 @@ import {
 	IntentScreen,
 	HUNDRED_YEAR_PLAN_FLOW,
 	StepContainer,
+	isBlogOnboardingFlow,
 } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -55,7 +56,24 @@ const useIntentsForFlow = ( flowName: string ): NewOrExistingSiteIntent[] => {
 			},
 		];
 	}
-	return [];
+	return [
+		{
+			key: 'existing-site',
+			title: translate( 'Existing WordPress.com site' ),
+			description: <p>{ translate( 'Using an existing site' ) }</p>,
+			icon: <WordPressLogo size={ 24 } />,
+			value: 'existing-site',
+			actionText: translate( 'Select a site' ),
+		},
+		{
+			key: 'new-site',
+			title: translate( 'New site' ),
+			description: <p>{ translate( 'Creating a new site' ) }</p>,
+			icon: <NewSiteIcon />,
+			value: 'new-site',
+			actionText: translate( 'Start a new site' ),
+		},
+	];
 };
 
 const NewOrExistingSiteStep: Step = function NewOrExistingSiteStep( { navigation, flow } ) {
@@ -69,6 +87,9 @@ const NewOrExistingSiteStep: Step = function NewOrExistingSiteStep( { navigation
 	};
 
 	const getHeaderText = () => {
+		if ( isBlogOnboardingFlow( flow ) ) {
+			return translate( 'New or existing site' );
+		}
 		switch ( flow ) {
 			case HUNDRED_YEAR_PLAN_FLOW:
 				return translate( 'Start your legacy' );
@@ -96,6 +117,7 @@ const NewOrExistingSiteStep: Step = function NewOrExistingSiteStep( { navigation
 			stepName="new-or-existing-site"
 			flowName={ flow }
 			recordTracksEvent={ recordTracksEvent }
+			hideBack={ isBlogOnboardingFlow( flow ) }
 		/>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/index.tsx
@@ -6,9 +6,9 @@ import {
 	HUNDRED_YEAR_PLAN_FLOW,
 	StepContainer,
 	isBlogOnboardingFlow,
+	START_WRITING_FLOW,
 } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
-import QuerySites from 'calypso/components/data/query-sites';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { preventWidows } from 'calypso/lib/formatting';
@@ -23,58 +23,62 @@ type NewOrExistingSiteIntent = SelectItem< ChoiceType >;
 
 const useIntentsForFlow = ( flowName: string ): NewOrExistingSiteIntent[] => {
 	const translate = useTranslate();
-	if ( HUNDRED_YEAR_PLAN_FLOW === flowName ) {
-		return [
-			{
-				key: 'existing-site',
-				title: translate( 'Existing WordPress.com site' ),
-				description: (
-					<p>
-						{ translate( 'Upgrade an existing site to the %(planTitle)s.', {
-							args: {
-								planTitle: getPlan( PLAN_100_YEARS )?.getTitle() || '',
-							},
-						} ) }
-					</p>
-				),
-				icon: <WordPressLogo size={ 24 } />,
-				value: 'existing-site',
-				actionText: translate( 'Select a site' ),
-			},
-			{
-				key: 'new-site',
-				title: translate( 'New site' ),
-				description: (
-					<p>
-						{ translate(
-							"Craft your legacy from the ground up. We'll be by your side every step of the way."
-						) }
-					</p>
-				),
-				icon: <NewSiteIcon />,
-				value: 'new-site',
-				actionText: translate( 'Start a new site' ),
-			},
-		];
+	switch ( flowName ) {
+		case HUNDRED_YEAR_PLAN_FLOW:
+			return [
+				{
+					key: 'existing-site',
+					title: translate( 'Existing WordPress.com site' ),
+					description: (
+						<p>
+							{ translate( 'Upgrade an existing site to the %(planTitle)s.', {
+								args: {
+									planTitle: getPlan( PLAN_100_YEARS )?.getTitle() || '',
+								},
+							} ) }
+						</p>
+					),
+					icon: <WordPressLogo size={ 24 } />,
+					value: 'existing-site',
+					actionText: translate( 'Select a site' ),
+				},
+				{
+					key: 'new-site',
+					title: translate( 'New site' ),
+					description: (
+						<p>
+							{ translate(
+								"Craft your legacy from the ground up. We'll be by your side every step of the way."
+							) }
+						</p>
+					),
+					icon: <NewSiteIcon />,
+					value: 'new-site',
+					actionText: translate( 'Start a new site' ),
+				},
+			];
+		case START_WRITING_FLOW:
+			return [
+				{
+					key: 'existing-site',
+					title: translate( 'Existing WordPress.com site' ),
+					description: <p>{ translate( 'Using an existing site' ) }</p>,
+					icon: <WordPressLogo size={ 24 } />,
+					value: 'existing-site',
+					actionText: translate( 'Select a site' ),
+				},
+				{
+					key: 'new-site',
+					title: translate( 'New site' ),
+					description: <p>{ translate( 'Creating a new site' ) }</p>,
+					icon: <NewSiteIcon />,
+					value: 'new-site',
+					actionText: translate( 'Start a new site' ),
+				},
+			];
+		default:
+			return [];
 	}
-	return [
-		{
-			key: 'existing-site',
-			title: translate( 'Existing WordPress.com site' ),
-			description: <p>{ translate( 'Using an existing site' ) }</p>,
-			icon: <WordPressLogo size={ 24 } />,
-			value: 'existing-site',
-			actionText: translate( 'Select a site' ),
-		},
-		{
-			key: 'new-site',
-			title: translate( 'New site' ),
-			description: <p>{ translate( 'Creating a new site' ) }</p>,
-			icon: <NewSiteIcon />,
-			value: 'new-site',
-			actionText: translate( 'Start a new site' ),
-		},
-	];
 };
 
 const NewOrExistingSiteStep: Step = function NewOrExistingSiteStep( { navigation, flow } ) {
@@ -121,7 +125,6 @@ const NewOrExistingSiteStep: Step = function NewOrExistingSiteStep( { navigation
 				recordTracksEvent={ recordTracksEvent }
 				hideBack={ isBlogOnboardingFlow( flow ) }
 			/>
-			{ isBlogOnboardingFlow( flow ) && <QuerySites allSites /> }
 		</>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/index.tsx
@@ -62,7 +62,7 @@ const useIntentsForFlow = ( flowName: string ): NewOrExistingSiteIntent[] => {
 				{
 					key: 'existing-site',
 					title: translate( 'Existing WordPress.com site' ),
-					description: <p>{ translate( 'Using an existing site' ) }</p>,
+					description: '',
 					icon: <WordPressLogo size={ 24 } />,
 					value: 'existing-site',
 					actionText: translate( 'Select a site' ),
@@ -70,7 +70,7 @@ const useIntentsForFlow = ( flowName: string ): NewOrExistingSiteIntent[] => {
 				{
 					key: 'new-site',
 					title: translate( 'New site' ),
-					description: <p>{ translate( 'Creating a new site' ) }</p>,
+					description: '',
 					icon: <NewSiteIcon />,
 					value: 'new-site',
 					actionText: translate( 'Start a new site' ),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/index.tsx
@@ -7,6 +7,7 @@ import {
 	StepContainer,
 	isBlogOnboardingFlow,
 	START_WRITING_FLOW,
+	DESIGN_FIRST_FLOW,
 } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -57,6 +58,7 @@ const useIntentsForFlow = ( flowName: string ): NewOrExistingSiteIntent[] => {
 					actionText: translate( 'Start a new site' ),
 				},
 			];
+		case DESIGN_FIRST_FLOW:
 		case START_WRITING_FLOW:
 			return [
 				{

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/index.tsx
@@ -106,26 +106,24 @@ const NewOrExistingSiteStep: Step = function NewOrExistingSiteStep( { navigation
 	const Container = flow === HUNDRED_YEAR_PLAN_FLOW ? HundredYearPlanStepWrapper : StepContainer;
 
 	return (
-		<>
-			<Container
-				stepContent={
-					<IntentScreen
-						intents={ intents }
-						onSelect={ newOrExistingSiteSelected }
-						preventWidows={ preventWidows }
-						intentsAlt={ [] }
-					/>
-				}
-				formattedHeader={
-					<FormattedHeader brandFont headerText={ getHeaderText() } subHeaderAlign="center" />
-				}
-				justifyStepContent="center"
-				stepName="new-or-existing-site"
-				flowName={ flow }
-				recordTracksEvent={ recordTracksEvent }
-				hideBack={ isBlogOnboardingFlow( flow ) }
-			/>
-		</>
+		<Container
+			stepContent={
+				<IntentScreen
+					intents={ intents }
+					onSelect={ newOrExistingSiteSelected }
+					preventWidows={ preventWidows }
+					intentsAlt={ [] }
+				/>
+			}
+			formattedHeader={
+				<FormattedHeader brandFont headerText={ getHeaderText() } subHeaderAlign="center" />
+			}
+			justifyStepContent="center"
+			stepName="new-or-existing-site"
+			flowName={ flow }
+			recordTracksEvent={ recordTracksEvent }
+			hideBack={ isBlogOnboardingFlow( flow ) }
+		/>
 	);
 };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/index.tsx
@@ -8,6 +8,7 @@ import {
 	isBlogOnboardingFlow,
 } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
+import QuerySites from 'calypso/components/data/query-sites';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { preventWidows } from 'calypso/lib/formatting';
@@ -101,24 +102,27 @@ const NewOrExistingSiteStep: Step = function NewOrExistingSiteStep( { navigation
 	const Container = flow === HUNDRED_YEAR_PLAN_FLOW ? HundredYearPlanStepWrapper : StepContainer;
 
 	return (
-		<Container
-			stepContent={
-				<IntentScreen
-					intents={ intents }
-					onSelect={ newOrExistingSiteSelected }
-					preventWidows={ preventWidows }
-					intentsAlt={ [] }
-				/>
-			}
-			formattedHeader={
-				<FormattedHeader brandFont headerText={ getHeaderText() } subHeaderAlign="center" />
-			}
-			justifyStepContent="center"
-			stepName="new-or-existing-site"
-			flowName={ flow }
-			recordTracksEvent={ recordTracksEvent }
-			hideBack={ isBlogOnboardingFlow( flow ) }
-		/>
+		<>
+			<Container
+				stepContent={
+					<IntentScreen
+						intents={ intents }
+						onSelect={ newOrExistingSiteSelected }
+						preventWidows={ preventWidows }
+						intentsAlt={ [] }
+					/>
+				}
+				formattedHeader={
+					<FormattedHeader brandFont headerText={ getHeaderText() } subHeaderAlign="center" />
+				}
+				justifyStepContent="center"
+				stepName="new-or-existing-site"
+				flowName={ flow }
+				recordTracksEvent={ recordTracksEvent }
+				hideBack={ isBlogOnboardingFlow( flow ) }
+			/>
+			{ isBlogOnboardingFlow( flow ) && <QuerySites allSites /> }
+		</>
 	);
 };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/styles.scss
@@ -37,3 +37,29 @@
 		}
 	}
 }
+
+.start-writing.new-or-existing-site {
+	.signup-header {
+		.wordpress-logo {
+			position: absolute;
+			inset-block-start: 20px;
+			inset-inline-start: 24px;
+			fill: var(--color-text);
+			transform-origin: 0 0;
+		}
+	}
+	.step-container {
+		display: flex;
+		flex-direction: column;
+		-webkit-box-align: center;
+		align-items: center;
+		-webkit-box-pack: center;
+		justify-content: center;
+		width: 100%;
+		min-height: calc(100vh - 100px);
+
+		.step-container__content {
+			min-height: auto;
+		}
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/styles.scss
@@ -1,3 +1,4 @@
+@import "@wordpress/base-styles/breakpoints";
 @import "@automattic/onboarding/styles/mixins";
 
 .hundred-year-plan-step-wrapper.new-or-existing-site {
@@ -48,6 +49,19 @@
 			transform-origin: 0 0;
 		}
 	}
+	.formatted-header {
+		.formatted-header__title {
+			font-size: rem(32px);
+			@include break-small {
+				font-size: rem(36px);
+			}
+		}
+		margin-top: 72px;
+		@include break-small {
+			margin-top: 0;
+		}
+	}
+
 	.step-container {
 		display: flex;
 		flex-direction: column;
@@ -55,11 +69,33 @@
 		align-items: center;
 		-webkit-box-pack: center;
 		justify-content: center;
-		width: 100%;
-		min-height: calc(100vh - 100px);
+		@include break-small {
+			margin-top: 0;
+			min-height: 100vh;
+		}
 
 		.step-container__content {
 			min-height: auto;
+			@media (max-width: $break-mobile ) {
+				width: 100%;
+			}
+			.select-items {
+				@media (max-width: $break-mobile ) {
+					margin-left: 20px;
+					margin-right: 20px;
+				}
+			}
+			.select-items__item {
+				@media (min-width: $break-small ) {
+					width: 456px;
+				}
+
+				button.select-items__item-button {
+					@media (max-width: $break-mobile ) {
+						width: 279px;
+					}
+				}
+			}
 		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/styles.scss
@@ -39,72 +39,75 @@
 	}
 }
 
-.start-writing.new-or-existing-site {
-	.signup-header {
-		.wordpress-logo {
-			position: absolute;
-			inset-block-start: 20px;
-			inset-inline-start: 24px;
-			fill: var(--color-text);
-			transform-origin: 0 0;
+.start-writing,
+.design-first {
+	&.new-or-existing-site {
+		.signup-header {
+			.wordpress-logo {
+				position: absolute;
+				inset-block-start: 20px;
+				inset-inline-start: 24px;
+				fill: var(--color-text);
+				transform-origin: 0 0;
+			}
 		}
-	}
-	.formatted-header {
-		.formatted-header__title {
-			font-size: rem(32px);
+		.formatted-header {
+			.formatted-header__title {
+				font-size: rem(32px);
+				@include break-small {
+					font-size: rem(36px);
+				}
+			}
+			margin-top: 72px;
 			@include break-small {
-				font-size: rem(36px);
+				margin-top: 0;
 			}
 		}
-		margin-top: 72px;
-		@include break-small {
-			margin-top: 0;
-		}
-	}
 
-	.step-container {
-		display: flex;
-		flex-direction: column;
-		-webkit-box-align: center;
-		align-items: center;
-		-webkit-box-pack: center;
-		justify-content: center;
-		@include break-small {
-			margin-top: 0;
-			min-height: 100vh;
-		}
-
-
-		.step-container__content {
-			min-height: auto;
-			@media (max-width: $break-mobile ) {
-				width: 100%;
+		.step-container {
+			display: flex;
+			flex-direction: column;
+			-webkit-box-align: center;
+			align-items: center;
+			-webkit-box-pack: center;
+			justify-content: center;
+			@include break-small {
+				margin-top: 0;
+				min-height: 100vh;
 			}
-			.select-items {
+
+
+			.step-container__content {
+				min-height: auto;
 				@media (max-width: $break-mobile ) {
-					margin-left: 20px;
-					margin-right: 20px;
+					width: 100%;
 				}
-			}
-			.select-items__item {
-				.select-items__item-icon {
-					@media (min-width: $break-mobile ) {
-						top: 32px;
-					}
-				}
-				@media (min-width: $break-small ) {
-					width: 456px;
-				}
-				.select-items__item-info-wrapper {
-					align-items: center;
-
-					.select-items__item-title {
-						margin-bottom: 0;
-					}
-				}
-				button.select-items__item-button {
+				.select-items {
 					@media (max-width: $break-mobile ) {
-						width: 279px;
+						margin-left: 20px;
+						margin-right: 20px;
+					}
+				}
+				.select-items__item {
+					.select-items__item-icon {
+						@media (min-width: $break-mobile ) {
+							top: 32px;
+						}
+					}
+					@media (min-width: $break-small ) {
+						width: 456px;
+					}
+					.select-items__item-info-wrapper {
+						align-items: center;
+
+						.select-items__item-title {
+							margin-bottom: 0;
+						}
+					}
+					button.select-items__item-button {
+						@media (max-width: $break-mobile ) {
+							width: 279px;
+						}
 					}
 				}
 			}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/styles.scss
@@ -74,6 +74,7 @@
 			min-height: 100vh;
 		}
 
+
 		.step-container__content {
 			min-height: auto;
 			@media (max-width: $break-mobile ) {
@@ -86,10 +87,21 @@
 				}
 			}
 			.select-items__item {
+				.select-items__item-icon {
+					@media (min-width: $break-mobile ) {
+						top: 32px;
+					}
+				}
 				@media (min-width: $break-small ) {
 					width: 456px;
 				}
+				.select-items__item-info-wrapper {
+					align-items: center;
 
+					.select-items__item-title {
+						margin-bottom: 0;
+					}
+				}
 				button.select-items__item-button {
 					@media (max-width: $break-mobile ) {
 						width: 279px;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker-list/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker-list/index.tsx
@@ -121,7 +121,7 @@ const ConfirmationModal = ( {
 				<>
 					<Subtitle>
 						{ translate(
-							'Starting with {{strong}}%(siteDomain)s{{/strong}} will reset content and customization of your site.{{br}}{{/br}}Any blog posts and media uploads will be unpublished and saved.',
+							'Starting with {{strong}}%(siteDomain)s{{/strong}} will reset content and customization of your site.{{br}}{{/br}}{{br}}{{/br}}Any blog posts and media uploads will be unpublished and saved.',
 							{
 								args: {
 									siteDomain: siteDomain || '',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker-list/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker-list/index.tsx
@@ -1,0 +1,239 @@
+import { StepContainer } from '@automattic/onboarding';
+import styled from '@emotion/styled';
+import { Button, Modal } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import QuerySites from 'calypso/components/data/query-sites';
+import FormattedHeader from 'calypso/components/formatted-header';
+import SiteSelector from 'calypso/components/site-selector';
+import { SITE_STORE } from 'calypso/landing/stepper/stores';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import type { Step } from '../../types';
+import type { SiteDetails, SiteSelect } from '@automattic/data-stores';
+import type { SiteId } from 'calypso/types';
+
+import './styles.scss';
+
+const StyledModal = styled( Modal )`
+	max-width: 536px;
+	.components-modal__content {
+		padding: 0;
+	}
+`;
+
+const Subtitle = styled.div< { width?: number } >`
+	color: var( --studio-gray-80 );
+
+	font-family: 'SF Pro Text', sans-serif;
+	font-size: 16px;
+	font-style: normal;
+	font-weight: 500;
+	line-height: 24px; /* 150% */
+	letter-spacing: -0.32px;
+
+	margin: 0 32px;
+
+	width: ${ ( props ) => ( props.width ? `${ props.width }px` : 'initial' ) };
+`;
+
+const List = styled.div`
+	margin: 24px 32px 32px 32px;
+`;
+
+const ListItem = styled.div< { width?: number } >`
+	color: var( --studio-gray-60 );
+	font-family: 'SF Pro Text', sans-serif;
+	font-size: 14px;
+	font-style: normal;
+	font-weight: 400;
+	line-height: 20px; /* 142.857% */
+	letter-spacing: -0.15px;
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	margin-bottom: 5px;
+	width: ${ ( props ) => ( props.width ? `${ props.width }px` : 'initial' ) };
+`;
+
+const Footer = styled.div`
+	border-top: 1px solid var( --gray-gray-0, #f6f7f7 );
+	display: flex;
+	padding: 16px 32px;
+	justify-content: space-between;
+	align-items: center;
+	flex-direction: column-reverse;
+	gap: 8px;
+`;
+
+const ButtonsContainer = styled.div`
+	display: flex;
+	gap: 8px;
+	align-items: center;
+	justify-content: space-between;
+	align-self: center;
+`;
+
+const StyledButton = styled( Button )< { variant: 'primary' | 'secondary' } >`
+	&.components-button {
+		padding: 10px 24px;
+		border-radius: 4px;
+	}
+`;
+
+const Placeholders = () => (
+	<div>
+		<Subtitle width={ 450 } className="is-placeholder" />
+		<List>
+			<ListItem width={ 250 } className="is-placeholder" />
+			<ListItem width={ 250 } className="is-placeholder" />
+			<ListItem width={ 250 } className="is-placeholder" />
+			<ListItem width={ 250 } className="is-placeholder" />
+			<ListItem width={ 250 } className="is-placeholder" />
+		</List>
+	</div>
+);
+
+const ConfirmationModal = ( {
+	isFetching,
+	siteTitle,
+	siteDomain,
+	onConfirm,
+	closeModal,
+}: {
+	isFetching: boolean;
+	siteTitle?: string;
+	siteDomain?: string;
+	onConfirm: () => void;
+	closeModal: () => void;
+} ) => {
+	const translate = useTranslate();
+
+	return (
+		<StyledModal
+			overlayClassName="site-picker__confirmation-modal-overlay"
+			className="site-picker__confirmation-modal"
+			title={ translate( 'Confirm your site selection' ) }
+			onRequestClose={ closeModal }
+		>
+			{ isFetching ? (
+				<Placeholders />
+			) : (
+				<>
+					<Subtitle>
+						{ translate( 'Are you sure use {{strong}}%(siteTitle)s (%(siteDomain)s){{/strong}}?', {
+							args: {
+								siteTitle: siteTitle || '',
+								siteDomain: siteDomain || '',
+							},
+							components: {
+								strong: <strong />,
+							},
+						} ) }
+					</Subtitle>
+					<Footer>
+						<ButtonsContainer>
+							<StyledButton variant="secondary" onClick={ closeModal }>
+								{ translate( 'Cancel' ) }
+							</StyledButton>
+							<StyledButton variant="primary" onClick={ onConfirm }>
+								{ translate( 'Confirm' ) }
+							</StyledButton>
+						</ButtonsContainer>
+					</Footer>
+				</>
+			) }
+		</StyledModal>
+	);
+};
+
+const SitePicker: Step = function SitePicker( { navigation, flow } ) {
+	const translate = useTranslate();
+
+	const [ selectedSiteId, setSelectedSiteId ] = useState< SiteId | null >( null );
+	const [ showConfirmModal, setShowConfirmModal ] = useState( false );
+
+	const siteDomain = useSelect(
+		( select ) =>
+			( selectedSiteId &&
+				( select( SITE_STORE ) as SiteSelect ).getPrimarySiteDomain( selectedSiteId ) ) ||
+			undefined,
+		[ selectedSiteId ]
+	);
+	const siteTitle = useSelect(
+		( select ) =>
+			( selectedSiteId && ( select( SITE_STORE ) as SiteSelect ).getSiteTitle( selectedSiteId ) ) ||
+			'',
+		[ selectedSiteId ]
+	);
+	const site = useSelect(
+		( select ) =>
+			( selectedSiteId && ( select( SITE_STORE ) as SiteSelect ).getSite( selectedSiteId ) ) ||
+			null,
+		[ selectedSiteId ]
+	);
+	const isFetching = ! site || ! siteDomain || ! siteTitle;
+
+	const selectSite = () => {
+		const siteSlug = new URL( site?.URL || '' ).host;
+		const siteId = site?.ID;
+		if ( ! siteSlug || ! siteId ) {
+			return;
+		}
+		navigation.submit?.( { siteSlug, siteId } );
+	};
+
+	const onSelectSite = ( siteId: SiteId ) => {
+		setSelectedSiteId( siteId );
+		setShowConfirmModal( true );
+	};
+
+	const closeModal = () => {
+		setSelectedSiteId( null );
+		setShowConfirmModal( false );
+	};
+
+	const filter = ( site: SiteDetails ) => {
+		return !! (
+			site.capabilities?.manage_options &&
+			( site.is_wpcom_atomic || ! site.jetpack ) &&
+			! site.options?.is_wpforteams_site &&
+			! site.is_wpcom_staging_site
+		);
+	};
+
+	return (
+		<>
+			<StepContainer
+				stepName="site-picker"
+				stepContent={
+					<div className="site-picker__container">
+						<QuerySites allSites />
+						<SiteSelector filter={ filter } onSiteSelect={ onSelectSite } />
+					</div>
+				}
+				formattedHeader={
+					<FormattedHeader
+						align="center"
+						subHeaderAlign="center"
+						headerText={ translate( 'Select your site' ) }
+					/>
+				}
+				recordTracksEvent={ recordTracksEvent }
+				flowName={ flow }
+				hideBack={ true }
+			/>
+			{ showConfirmModal && (
+				<ConfirmationModal
+					isFetching={ isFetching }
+					onConfirm={ selectSite }
+					closeModal={ closeModal }
+					siteTitle={ siteTitle }
+					siteDomain={ siteDomain?.domain }
+				/>
+			) }
+		</>
+	);
+};
+
+export default SitePicker;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker-list/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker-list/index.tsx
@@ -198,7 +198,8 @@ const SitePicker: Step = function SitePicker( { navigation, flow } ) {
 			site.capabilities?.manage_options &&
 			( site.is_wpcom_atomic || ! site.jetpack ) &&
 			! site.options?.is_wpforteams_site &&
-			! site.is_wpcom_staging_site
+			! site.is_wpcom_staging_site &&
+			site.launch_status === 'unlaunched'
 		);
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker-list/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker-list/index.tsx
@@ -1,11 +1,10 @@
 import { StepContainer } from '@automattic/onboarding';
-import styled from '@emotion/styled';
-import { Button, Modal } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import QuerySites from 'calypso/components/data/query-sites';
 import FormattedHeader from 'calypso/components/formatted-header';
+import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import SiteSelector from 'calypso/components/site-selector';
 import { SITE_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -15,184 +14,30 @@ import type { SiteId } from 'calypso/types';
 
 import './styles.scss';
 
-const StyledModal = styled( Modal )`
-	max-width: 536px;
-	.components-modal__content {
-		padding: 0;
-	}
-`;
-
-const Subtitle = styled.div< { width?: number } >`
-	color: var( --studio-gray-80 );
-
-	font-family: 'SF Pro Text', sans-serif;
-	font-size: 16px;
-	font-style: normal;
-	font-weight: 500;
-	line-height: 24px; /* 150% */
-	letter-spacing: -0.32px;
-
-	margin: 0 32px;
-
-	width: ${ ( props ) => ( props.width ? `${ props.width }px` : 'initial' ) };
-`;
-
-const List = styled.div`
-	margin: 24px 32px 32px 32px;
-`;
-
-const ListItem = styled.div< { width?: number } >`
-	color: var( --studio-gray-60 );
-	font-family: 'SF Pro Text', sans-serif;
-	font-size: 14px;
-	font-style: normal;
-	font-weight: 400;
-	line-height: 20px; /* 142.857% */
-	letter-spacing: -0.15px;
-	display: flex;
-	align-items: center;
-	gap: 10px;
-	margin-bottom: 5px;
-	width: ${ ( props ) => ( props.width ? `${ props.width }px` : 'initial' ) };
-`;
-
-const Footer = styled.div`
-	border-top: 1px solid var( --gray-gray-0, #f6f7f7 );
-	display: flex;
-	padding: 16px 32px;
-	justify-content: space-between;
-	align-items: center;
-	flex-direction: column-reverse;
-	gap: 8px;
-`;
-
-const ButtonsContainer = styled.div`
-	display: flex;
-	gap: 8px;
-	align-items: center;
-	justify-content: space-between;
-	align-self: center;
-`;
-
-const StyledButton = styled( Button )< { variant: 'primary' | 'secondary' } >`
-	&.components-button {
-		padding: 10px 24px;
-		border-radius: 4px;
-	}
-`;
-
-const Placeholders = () => (
-	<div>
-		<Subtitle width={ 450 } className="is-placeholder" />
-		<List>
-			<ListItem width={ 250 } className="is-placeholder" />
-			<ListItem width={ 250 } className="is-placeholder" />
-			<ListItem width={ 250 } className="is-placeholder" />
-			<ListItem width={ 250 } className="is-placeholder" />
-			<ListItem width={ 250 } className="is-placeholder" />
-		</List>
-	</div>
-);
-
-const ConfirmationModal = ( {
-	isFetching,
-	siteDomain,
-	onConfirm,
-	closeModal,
-}: {
-	isFetching: boolean;
-	siteTitle?: string;
-	siteDomain?: string;
-	onConfirm: () => void;
-	closeModal: () => void;
-} ) => {
-	const translate = useTranslate();
-
-	return (
-		<StyledModal
-			overlayClassName="site-picker__confirmation-modal-overlay"
-			className="site-picker__confirmation-modal"
-			title={ translate( 'Confirm your site selection' ) }
-			onRequestClose={ closeModal }
-		>
-			{ isFetching ? (
-				<Placeholders />
-			) : (
-				<>
-					<Subtitle>
-						{ translate(
-							'Starting with {{strong}}%(siteDomain)s{{/strong}} will reset content and customization of your site.{{br}}{{/br}}{{br}}{{/br}}Any blog posts and media uploads will be unpublished and saved.',
-							{
-								args: {
-									siteDomain: siteDomain || '',
-								},
-								components: {
-									strong: <strong />,
-									br: <br />,
-								},
-							}
-						) }
-					</Subtitle>
-					<Footer>
-						<ButtonsContainer>
-							<StyledButton variant="secondary" onClick={ closeModal }>
-								{ translate( 'Cancel' ) }
-							</StyledButton>
-							<StyledButton variant="primary" onClick={ onConfirm }>
-								{ translate( 'Confirm' ) }
-							</StyledButton>
-						</ButtonsContainer>
-					</Footer>
-				</>
-			) }
-		</StyledModal>
-	);
-};
-
 const SitePicker: Step = function SitePicker( { navigation, flow } ) {
 	const translate = useTranslate();
 
 	const [ selectedSiteId, setSelectedSiteId ] = useState< SiteId | null >( null );
-	const [ showConfirmModal, setShowConfirmModal ] = useState( false );
 
-	const siteDomain = useSelect(
-		( select ) =>
-			( selectedSiteId &&
-				( select( SITE_STORE ) as SiteSelect ).getPrimarySiteDomain( selectedSiteId ) ) ||
-			undefined,
-		[ selectedSiteId ]
-	);
-	const siteTitle = useSelect(
-		( select ) =>
-			( selectedSiteId && ( select( SITE_STORE ) as SiteSelect ).getSiteTitle( selectedSiteId ) ) ||
-			'',
-		[ selectedSiteId ]
-	);
 	const site = useSelect(
 		( select ) =>
 			( selectedSiteId && ( select( SITE_STORE ) as SiteSelect ).getSite( selectedSiteId ) ) ||
 			null,
 		[ selectedSiteId ]
 	);
-	const isFetching = ! site || ! siteDomain || ! siteTitle;
 
-	const selectSite = () => {
-		const siteSlug = new URL( site?.URL || '' ).host;
-		const siteId = site?.ID;
-		if ( ! siteSlug || ! siteId ) {
+	useEffect( () => {
+		if ( ! site ) {
 			return;
 		}
+		const siteSlug = new URL( site?.URL || '' ).host;
+		const siteId = site?.ID;
+
 		navigation.submit?.( { siteSlug, siteId } );
-	};
+	}, [ site ] );
 
-	const onSelectSite = ( siteId: SiteId ) => {
+	const selectSite = ( siteId: SiteId ) => {
 		setSelectedSiteId( siteId );
-		setShowConfirmModal( true );
-	};
-
-	const closeModal = () => {
-		setSelectedSiteId( null );
-		setShowConfirmModal( false );
 	};
 
 	const filter = ( site: SiteDetails ) => {
@@ -212,7 +57,8 @@ const SitePicker: Step = function SitePicker( { navigation, flow } ) {
 				stepContent={
 					<div className="site-picker__container">
 						<QuerySites allSites />
-						<SiteSelector filter={ filter } onSiteSelect={ onSelectSite } />
+						{ ! selectedSiteId && <SiteSelector filter={ filter } onSiteSelect={ selectSite } /> }
+						{ selectedSiteId && <LoadingEllipsis /> }
 					</div>
 				}
 				formattedHeader={
@@ -226,15 +72,6 @@ const SitePicker: Step = function SitePicker( { navigation, flow } ) {
 				flowName={ flow }
 				hideBack={ true }
 			/>
-			{ showConfirmModal && (
-				<ConfirmationModal
-					isFetching={ isFetching }
-					onConfirm={ selectSite }
-					closeModal={ closeModal }
-					siteTitle={ siteTitle }
-					siteDomain={ siteDomain?.domain }
-				/>
-			) }
 		</>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker-list/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker-list/index.tsx
@@ -96,7 +96,6 @@ const Placeholders = () => (
 
 const ConfirmationModal = ( {
 	isFetching,
-	siteTitle,
 	siteDomain,
 	onConfirm,
 	closeModal,
@@ -121,15 +120,18 @@ const ConfirmationModal = ( {
 			) : (
 				<>
 					<Subtitle>
-						{ translate( 'Are you sure use {{strong}}%(siteTitle)s (%(siteDomain)s){{/strong}}?', {
-							args: {
-								siteTitle: siteTitle || '',
-								siteDomain: siteDomain || '',
-							},
-							components: {
-								strong: <strong />,
-							},
-						} ) }
+						{ translate(
+							'Starting with {{strong}}%(siteDomain)s{{/strong}} will reset content and customization of your site.{{br}}{{/br}}Any blog posts and media uploads will be unpublished and saved.',
+							{
+								args: {
+									siteDomain: siteDomain || '',
+								},
+								components: {
+									strong: <strong />,
+									br: <br />,
+								},
+							}
+						) }
 					</Subtitle>
 					<Footer>
 						<ButtonsContainer>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker-list/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker-list/styles.scss
@@ -88,6 +88,14 @@
 }
 
 .start-writing.site-picker {
+	.formatted-header {
+		.formatted-header__title {
+			font-size: rem(32px);
+			@include break-small {
+				font-size: rem(36px);
+			}
+		}
+	}
 	.signup-header {
 		.wordpress-logo {
 			position: absolute;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker-list/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker-list/styles.scss
@@ -3,6 +3,9 @@
 @import "../hundred-year-plan-step-wrapper/mixins";
 
 .site-picker {
+	.step-container__header {
+		margin-top: 74px;
+	}
 	.step-container__content {
 		.formatted-header {
 			.formatted-header__title {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker-list/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker-list/styles.scss
@@ -1,0 +1,97 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@automattic/onboarding/styles/mixins";
+@import "../hundred-year-plan-step-wrapper/mixins";
+
+.site-picker {
+	.step-container__content {
+		.formatted-header {
+			.formatted-header__title {
+				font-size: rem(32px);
+				@include break-small {
+					font-size: rem(44px);
+				}
+			}
+			margin: 32px 24px 0 24px;
+			@include break-small {
+				margin-top: 72px;
+			}
+		}
+
+		.site-picker__container {
+			width: 100%;
+			display: flex;
+			justify-content: center;
+			@include break-small {
+				max-width: 780px;
+				margin: 0 auto;
+			}
+			.site-selector.sites-list {
+				border-radius: 4px;
+				width: 100%;
+				margin: 0 24px;
+				@include break-small {
+					border: 1px solid var(--studio-gray-5);
+					margin: 0 48px 0 32px;
+				}
+
+				.search {
+					margin-inline-start: 0;
+					margin-inline-end: 0;
+					@include break-small {
+						margin: 24px 24px 18px 24px;
+					}
+				}
+
+				.site-selector__sites {
+					border-top: none;
+
+					@include breakpoint-deprecated( "<660px" ) {
+						max-height: none;
+					}
+
+					.site {
+						cursor: pointer;
+						.site__content {
+							padding: 14px 8px;
+							@include break-small {
+								padding: 14px 24px;
+							}
+							&:hover {
+								background-color: var(--studio-gray-0);
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+.site-picker__confirmation-modal-overlay {
+	background-color: rgba(0, 0, 0, 0.6);
+	align-items: center;
+	justify-content: center;
+}
+.site-picker__confirmation-modal {
+	height: max-content;
+	margin: 0 16px;
+	.is-placeholder {
+		@include onboarding-placeholder;
+	}
+
+	.components-button.is-primary {
+		@include primary-button-black-theme;
+	}
+}
+
+.start-writing.site-picker {
+	.signup-header {
+		.wordpress-logo {
+			position: absolute;
+			inset-block-start: 20px;
+			inset-inline-start: 24px;
+			fill: var(--color-text);
+			transform-origin: 0 0;
+		}
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sites-checker/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sites-checker/index.tsx
@@ -1,0 +1,56 @@
+import { SiteDetails } from '@automattic/data-stores';
+import { StepContainer, isBlogOnboardingFlow } from '@automattic/onboarding';
+import { useI18n } from '@wordpress/react-i18n';
+import { useEffect } from 'react';
+import DocumentHead from 'calypso/components/data/document-head';
+import QuerySites from 'calypso/components/data/query-sites';
+import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { useSelector } from 'calypso/state';
+import getSites from 'calypso/state/selectors/get-sites';
+import { hasAllSitesList } from 'calypso/state/sites/selectors';
+import type { Step } from '../../types';
+
+import './styles.scss';
+
+const SitesChecker: Step = function SitePicker( { navigation, flow } ) {
+	const { __ } = useI18n();
+	const { submit } = navigation;
+	const hasAllSitesFetched = useSelector( ( state ) => hasAllSitesList( state ) );
+	const allSites = useSelector( ( state ) => getSites( state ) );
+
+	useEffect( () => {
+		if ( hasAllSitesFetched ) {
+			const filteredSites = isBlogOnboardingFlow( flow )
+				? allSites?.filter(
+						( site: SiteDetails | null | undefined ) => site?.launch_status === 'unlaunched'
+				  )
+				: allSites;
+			submit?.( { filteredSitesCount: filteredSites.length } );
+			return;
+		}
+	} );
+
+	return (
+		<>
+			<DocumentHead title={ __( 'Checking sites' ) } />
+			<QuerySites allSites />
+			<StepContainer
+				shouldHideNavButtons={ true }
+				hideFormattedHeader={ true }
+				stepName="sites-checker-step"
+				stepContent={
+					<>
+						<div className="sites-checker-step">
+							<h1 className="sites-checker-step__progress-step">{ __( 'Checking sites' ) }</h1>
+							<LoadingEllipsis />
+						</div>
+					</>
+				}
+				recordTracksEvent={ recordTracksEvent }
+			/>
+		</>
+	);
+};
+
+export default SitesChecker;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sites-checker/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sites-checker/styles.scss
@@ -1,0 +1,114 @@
+/* stylelint-disable-next-line scss/at-import-no-partial-leading-underscore */
+@import "calypso/assets/stylesheets/shared/_loading";
+@import "@automattic/onboarding/styles/mixins";
+
+.sites-checker-step {
+	padding: 1em;
+	max-width: 540px;
+	text-align: center;
+	margin: 16vh auto 0;
+
+	&__progress-step {
+		@include onboarding-font-recoleta;
+		/* stylelint-disable-next-line scales/font-sizes */
+		font-size: 1.625rem;
+		line-height: 40px;
+		text-align: center;
+		vertical-align: middle;
+		margin: 0;
+	}
+}
+
+.sites-checker-step__step-wrapper {
+	.step-wrapper__content {
+		padding: 1em;
+		max-width: 540px;
+		text-align: center;
+		margin: 32vh auto;
+	}
+}
+
+.import-focused .step-container__content,
+.site-setup.processing .step-container__content {
+	width: 100%;
+}
+
+.sites-checker-step__subtitle {
+	font-size: 1rem;
+	line-height: 21px;
+	letter-spacing: -0.02em;
+	color: var(--studio-gray-50);
+	margin-top: 24px;
+}
+
+// Processing Copy Site Styles
+.copy-site.processing-copy {
+	.sites-checker-step {
+		margin: 5vh auto 0;
+		max-width: 660px;
+	}
+
+	.sites-checker-step__progress-step {
+		font-size: 3rem;
+		margin-bottom: 24px;
+	}
+
+	.sites-checker-step__progress-bar {
+		max-width: 540px;
+		margin: 0 auto;
+	}
+}
+
+.processing {
+	.signup-header {
+		.wordpress-logo {
+			position: absolute;
+			inset-inline-start: 20px;
+			inset-block-start: 20px;
+			fill: var(--color-text);
+			stroke: none;
+			transform-origin: 0 0;
+		}
+	}
+
+}
+
+.is-videopress-tv-stepper,
+.is-videopress-tv-purchase-stepper {
+	font-family: Inter, -apple-system, system-ui, blinkmacsystemfont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+
+	.sites-checker-step__progress-step {
+		font-family: inherit;
+		font-size: rem(38px); //typography-exception
+		font-weight: 700;
+		letter-spacing: -0.02em;
+	}
+}
+
+.is-videopress-stepper.is-sites-checker-step,
+.is-videopress-tv-stepper,
+.is-videopress-tv-purchase-stepper {
+	padding: 0;
+	color: #fff;
+
+	.sites-checker-step__content {
+		background-color: #fff3;
+		border-radius: 4px;
+		.loading-bar {
+			background-color: #fff3;
+			&::before {
+				background-color: #ffe61c;
+			}
+		}
+	}
+
+	@include break-medium {
+		background-size: auto 50%, auto 50%;
+	}
+
+	@include break-large {
+		background-position-y: 50%, 100%;
+		background-position-x: 0, 100%;
+	}
+}
+

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -297,6 +297,11 @@ const startWriting: Flow = {
 				state: AssertConditionState.CHECKING,
 				message: `${ flowName } requires a logged in user`,
 			};
+		} else if ( isSiteCreationStep && ! userAlreadyHasSites ) {
+			result = {
+				state: AssertConditionState.CHECKING,
+				message: `${ flowName } with no preexisting sites`,
+			};
 		}
 
 		return result;


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/3727

## Proposed Changes

Users currently can't use any of the Blog onboarding flows (start-writing / design-first) if they already have a site.
Now, we want to show a screen to select to use an existing not-launched site or create a new one.
As we can't check for existing sites and filter for not-launched, we created a new step that is only for users with sites.
If the user selects to use an existing site, we show all the not-launched sites, and then select one, we show a modal to confirm.
Copy in process, details: p1698771990960179/1698766219.275149-slack-CKZHG0QCR

### TO DO
- [x] Check CSS on desktop and mobile
- [x] Check for console error on site-selector step.
- [x] Remove subtitle on `new or existing` step.
- [ ] Unpublish posts when selecting an existing site.

### Screenshots
![image](https://github.com/Automattic/wp-calypso/assets/402286/aab9f3e7-374a-4d72-ba8e-d389bde94ba4)
![image](https://github.com/Automattic/wp-calypso/assets/402286/11b9e56c-0ba9-4287-a842-50b072a48ac8)

## Testing Instructions

* Go to `/setup/start-writing` with an account with 0 sites
* Go to `/setup/start-writing` with an account with > 0 sites not-launched
* Select to use an existing site
* Check the sites showing the site-selector step are correct
* If you have already launched sites, it should not show on this step
* Check all the process
* Same tests for `/setup/design-first`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?