### PR TITLE
wp-admin Site Default: delay left admin menu refresh and sync it with the notice

### DIFF
--- a/client/my-sites/hosting/site-admin-interface-card/use-select-interface-mutation.ts
+++ b/client/my-sites/hosting/site-admin-interface-card/use-select-interface-mutation.ts
@@ -1,7 +1,9 @@
 import { useMutation, UseMutationOptions } from '@tanstack/react-query';
+import { useEffect, useState } from 'react';
 import wp from 'calypso/lib/wp';
 import { useDispatch, useSelector } from 'calypso/state';
 import { requestAdminMenu } from 'calypso/state/admin-menu/actions';
+import { getIsRequestingAdminMenu } from 'calypso/state/admin-menu/selectors';
 import getRawSite from 'calypso/state/selectors/get-raw-site';
 import { receiveSite, requestSite } from 'calypso/state/sites/actions';
 
@@ -17,6 +19,11 @@ interface MutationError {
 	message: string;
 }
 
+interface UseSiteInterfaceMutationOptions
+	extends UseMutationOptions< MutationResponse, MutationError, string > {
+	onSuccess?: () => void;
+}
+
 function waitMs( ms: number ) {
 	return new Promise( ( resolve ) => {
 		setTimeout( () => {
@@ -27,11 +34,20 @@ function waitMs( ms: number ) {
 
 export const useSiteInterfaceMutation = (
 	siteId: number,
-	options: UseMutationOptions< MutationResponse, MutationError, string > = {}
+	options: UseSiteInterfaceMutationOptions = {}
 ) => {
 	const dispatch = useDispatch();
 	const site = useSelector( ( state ) => getRawSite( state, siteId ) );
+	const isRequestingMenu = useSelector( ( state ) => getIsRequestingAdminMenu( state ) );
+	const [ hasSuccessfullyFinished, setHasSuccessfullyFinished ] = useState( false );
+	useEffect( () => {
+		if ( hasSuccessfullyFinished && ! isRequestingMenu ) {
+			setHasSuccessfullyFinished( false );
+			options?.onSuccess?.();
+		}
+	}, [ hasSuccessfullyFinished, isRequestingMenu, options ] );
 	const queryKey = [ SET_SITE_INTERFACE_MUTATION_KEY, siteId ];
+
 	const mutation = useMutation< MutationResponse, MutationError, string >( {
 		mutationFn: async ( value: string ) => {
 			const response = await wp.req.post(
@@ -49,7 +65,8 @@ export const useSiteInterfaceMutation = (
 		},
 		mutationKey: queryKey,
 		onSuccess: ( ...params ) => {
-			options?.onSuccess?.( ...params );
+			dispatch( requestAdminMenu( siteId ) );
+			setHasSuccessfullyFinished( true );
 			const [ data ] = params;
 			if ( ! data?.interface || ! site ) {
 				throw new Error( 'Invalid response from hosting/admin-interface' );
@@ -60,7 +77,6 @@ export const useSiteInterfaceMutation = (
 			};
 			// Apply the new interface option to the site on redux store
 			dispatch( receiveSite( { ...site, options: newOptions } ) );
-			dispatch( requestAdminMenu( siteId ) );
 		},
 		onMutate: options?.onMutate,
 		onError( _err: MutationError, _newActive: string, prevValue: unknown ) {
@@ -74,7 +90,8 @@ export const useSiteInterfaceMutation = (
 	const { mutate } = mutation;
 
 	return {
-		setSiteInterface: mutate,
 		...mutation,
+		setSiteInterface: mutate,
+		isLoading: mutation.isLoading || isRequestingMenu,
 	};
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Closes https://github.com/Automattic/dotcom-forge/issues/4408

## Proposed Changes

* Add a delay between update the option and request the admin menu. This delay is due to the persistent data is an async job that sometimes can be slower.
* To improve the UX I'm adding a logic to sync the notice, the menu update and "disabled options/loading" state.

A possible alternative would be adding an active listener making requests until the menu is updated.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use this branch on your local machine or calypso live.
* On an atomic site, navigate to `Settings` > `Hosting configuration` : `/hosting-config/$siteSlug`.
* Scroll down until you find: "Admin interface style".
* Change the option inside the card.
* Observe the options are disabled meaning it's loading.
* After a couple of seconds, Observe the menu on the left is updated at the same time that a success notice appears.

## Screencast


https://github.com/Automattic/wp-calypso/assets/779993/5f02da6c-9c4a-481d-8a4e-91a47cdd10bc



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?