### PR TITLE
Plans 2023: Escape hatch to show all plans in tailored /plans mix (applies for Newsletter sites)

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -797,9 +797,11 @@ const PlansFeaturesMain = ( {
 									showRefundPeriod={ isAnyHostingFlow( flowName ) }
 								/>
 								{ showEscapeHatch && hidePlansFeatureComparison && (
-									<Button onClick={ () => setForceDefaultPlans( true ) }>
-										{ translate( 'View all plans' ) }
-									</Button>
+									<div className="plans-features-main__escape-hatch">
+										<Button borderless onClick={ () => setForceDefaultPlans( true ) }>
+											{ translate( 'View all plans' ) }
+										</Button>
+									</div>
 								) }
 								{ ! hidePlansFeatureComparison && (
 									<>
@@ -813,10 +815,11 @@ const PlansFeaturesMain = ( {
 											ref={ observableForOdieRef }
 										/>
 										{ showEscapeHatch && (
-											<ComparisonGridToggle
-												onClick={ () => setForceDefaultPlans( true ) }
-												label={ translate( 'View all plans' ) }
-											/>
+											<div className="plans-features-main__escape-hatch">
+												<Button borderless onClick={ () => setForceDefaultPlans( true ) }>
+													{ translate( 'View all plans' ) }
+												</Button>
+											</div>
 										) }
 										<div
 											ref={ plansComparisonGridRef }
@@ -862,10 +865,11 @@ const PlansFeaturesMain = ( {
 												label={ translate( 'Hide comparison' ) }
 											/>
 											{ showEscapeHatch && (
-												<ComparisonGridToggle
-													onClick={ () => setForceDefaultPlans( true ) }
-													label={ translate( 'View all plans' ) }
-												/>
+												<div className="plans-features-main__escape-hatch">
+													<Button borderless onClick={ () => setForceDefaultPlans( true ) }>
+														{ translate( 'View all plans' ) }
+													</Button>
+												</div>
 											) }
 										</div>
 									</>

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -375,15 +375,16 @@ const PlansFeaturesMain = ( {
 		...( selectedPlan ? { defaultValue: getPlan( selectedPlan )?.term } : {} ),
 	} );
 
-	// TODO: plans from upsell takes precedence for setting intent right now
-	// - this is currently set to the default wpcom set until we have updated tailored features for all plans
-	// - at which point, we'll inject the upsell plan to the tailored plans mix instead
 	const intentFromSiteMeta = usePlanIntentFromSiteMeta();
 	const planFromUpsells = usePlanFromUpsells();
 	const [ forceDefaultPlans, setForceDefaultPlans ] = useState( false );
 
 	const [ intent, setIntent ] = useState< PlansIntent | undefined >( undefined );
 	useEffect( () => {
+		// TODO: plans from upsell takes precedence for setting intent right now
+		// - this is currently set to the default wpcom set until we have updated tailored features for all plans
+		// - at which point, we'll inject the upsell plan to the tailored plans mix instead
+
 		if ( 'plans-default-wpcom' !== intent && forceDefaultPlans ) {
 			setIntent( 'plans-default-wpcom' );
 		} else if ( ! intent ) {
@@ -395,14 +396,8 @@ const PlansFeaturesMain = ( {
 		}
 	}, [ intent, intentFromProps, intentFromSiteMeta.intent, planFromUpsells, forceDefaultPlans ] );
 
-	const [ showEscapeHatch, setShowEscapeHatch ] = useState( false );
-	useEffect( () => {
-		if ( intentFromSiteMeta.intent && ! isInSignup && intent !== 'plans-default-wpcom' ) {
-			setShowEscapeHatch( true );
-		} else if ( showEscapeHatch ) {
-			setShowEscapeHatch( false );
-		}
-	}, [ intent, intentFromSiteMeta.intent, isInSignup, showEscapeHatch ] );
+	const showEscapeHatch =
+		intentFromSiteMeta.intent && ! isInSignup && 'plans-default-wpcom' !== intent;
 
 	const { isLoadingHostingTrialExperiment, isAssignedToHostingTrialExperiment } =
 		useFreeHostingTrialAssignment();
@@ -801,11 +796,10 @@ const PlansFeaturesMain = ( {
 									canUserManageCurrentPlan={ canUserManageCurrentPlan }
 									showRefundPeriod={ isAnyHostingFlow( flowName ) }
 								/>
-								{ showEscapeHatch && (
-									<ComparisonGridToggle
-										onClick={ () => setForceDefaultPlans( true ) }
-										label={ translate( 'Show all plans' ) }
-									/>
+								{ showEscapeHatch && hidePlansFeatureComparison && (
+									<Button onClick={ () => setForceDefaultPlans( true ) }>
+										{ translate( 'View all plans' ) }
+									</Button>
 								) }
 								{ ! hidePlansFeatureComparison && (
 									<>
@@ -818,6 +812,12 @@ const PlansFeaturesMain = ( {
 											}
 											ref={ observableForOdieRef }
 										/>
+										{ showEscapeHatch && (
+											<ComparisonGridToggle
+												onClick={ () => setForceDefaultPlans( true ) }
+												label={ translate( 'View all plans' ) }
+											/>
+										) }
 										<div
 											ref={ plansComparisonGridRef }
 											className={ comparisonGridContainerClasses }
@@ -861,6 +861,12 @@ const PlansFeaturesMain = ( {
 												onClick={ toggleShowPlansComparisonGrid }
 												label={ translate( 'Hide comparison' ) }
 											/>
+											{ showEscapeHatch && (
+												<ComparisonGridToggle
+													onClick={ () => setForceDefaultPlans( true ) }
+													label={ translate( 'View all plans' ) }
+												/>
+											) }
 										</div>
 									</>
 								) }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -180,7 +180,6 @@ export interface PlansFeaturesMainProps {
 	hideUnavailableFeatures?: boolean; // used to hide features that are not available, instead of strike-through as explained in #76206
 	showLegacyStorageFeature?: boolean;
 	isSpotlightOnCurrentPlan?: boolean;
-	showEscapeHatch?: boolean;
 }
 
 const SecondaryFormattedHeader = ( { siteSlug }: { siteSlug?: string | null } ) => {

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -584,7 +584,9 @@ const PlansFeaturesMain = ( {
 	 * Check : https://github.com/Automattic/wp-calypso/pull/80232 for more details.
 	 */
 	const gridPlanForSpotlight = useMemo( () => {
-		return sitePlanSlug && isSpotlightOnCurrentPlan && SPOTLIGHT_ENABLED_INTENTS.includes( intent )
+		return sitePlanSlug &&
+			isSpotlightOnCurrentPlan &&
+			SPOTLIGHT_ENABLED_INTENTS.includes( intent ?? '' )
 			? gridPlansForFeaturesGrid.find(
 					( { planSlug } ) => getPlanClass( planSlug ) === getPlanClass( sitePlanSlug )
 			  )

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -7,6 +7,20 @@
 	--scss-font-body-small: #{$font-body-small};
 }
 
+.plans-features-main__escape-hatch {
+	display: flex;
+	justify-content: center;
+	margin-top: 10px;
+	margin-left: 20px;
+	margin-right: 20px;
+
+	button {
+		text-decoration: underline;
+		font-size: var(--scss-font-body-small);
+		font-weight: 500;
+	}
+}
+
 .is-2023-pricing-grid {
 	margin: 0 auto;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/78113 (I don't know if this will close this issue or not)

## Proposed Changes

Show a "show all plans" button when visiting `/plans[ site ]` with a site on an intent that has tailored plans mix enabled (currently only "Newsletter"). 

This reverts the context to the `plans-default-wpcom` intent, which means the default features, highlights, etc. get applied. 

### Media

https://github.com/Automattic/wp-calypso/assets/1705499/87614475-df11-4ed1-b032-5ea321f1d9f4


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/plans` or `/plans/[ non-newsletter site ]` (try with `wooexpress` site) and ensure escape hatch is not visible
* Go to `/plans/[ newsletter site ]` and ensure escape hatch is shown. click and confirm the full wpcom plans mix is shown

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?