### PR TITLE
2023 Plans: Remove the manage add-ons button from p2 plans page

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -548,7 +548,7 @@ const PlansFeaturesMain = ( {
 			};
 		}
 
-		if ( sitePlanSlug && isFreePlan( sitePlanSlug ) ) {
+		if ( sitePlanSlug && isFreePlan( sitePlanSlug ) && intent !== 'plans-p2' ) {
 			actionOverrides = {
 				loggedInFreePlan: {
 					status:
@@ -561,6 +561,7 @@ const PlansFeaturesMain = ( {
 					text: translate( 'Manage add-ons', { context: 'verb' } ),
 				},
 			};
+
 			if ( domainFromHomeUpsellFlow ) {
 				actionOverrides.loggedInFreePlan = {
 					...actionOverrides.loggedInFreePlan,

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -548,7 +548,7 @@ const PlansFeaturesMain = ( {
 			};
 		}
 
-		if ( sitePlanSlug && isFreePlan( sitePlanSlug ) ) {
+		if ( sitePlanSlug && isFreePlan( sitePlanSlug ) && intent !== 'plans-p2' ) {
 			actionOverrides = {
 				loggedInFreePlan: {
 					status:
@@ -561,7 +561,6 @@ const PlansFeaturesMain = ( {
 					text: translate( 'Manage add-ons', { context: 'verb' } ),
 				},
 			};
-
 			if ( domainFromHomeUpsellFlow ) {
 				actionOverrides.loggedInFreePlan = {
 					...actionOverrides.loggedInFreePlan,

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -548,7 +548,7 @@ const PlansFeaturesMain = ( {
 			};
 		}
 
-		if ( sitePlanSlug && isFreePlan( sitePlanSlug ) && intent !== 'plans-p2' ) {
+		if ( sitePlanSlug && isFreePlan( sitePlanSlug ) ) {
 			actionOverrides = {
 				loggedInFreePlan: {
 					status:

--- a/client/my-sites/plans-grid/components/actions.tsx
+++ b/client/my-sites/plans-grid/components/actions.tsx
@@ -286,6 +286,10 @@ const LoggedInPlansFeatureActionButton = ( {
 			);
 		}
 
+		if ( isP2FreePlan( planSlug ) && current ) {
+			return null;
+		}
+
 		return (
 			<Button className={ classes } disabled={ true }>
 				{ translate( 'Contact support', { context: 'verb' } ) }
@@ -478,10 +482,6 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 		},
 		[ currentSitePlanSlug, freePlan, freeTrialPlanSlug, onUpgradeClick, planSlug ]
 	);
-
-	if ( isP2FreePlan( planSlug ) ) {
-		return null;
-	}
 
 	if ( isWpcomEnterpriseGridPlan ) {
 		const vipLandingPageUrlWithUtmCampaign = addQueryArgs(

--- a/client/my-sites/plans-grid/components/actions.tsx
+++ b/client/my-sites/plans-grid/components/actions.tsx
@@ -10,6 +10,7 @@ import {
 	type PlanSlug,
 	PLAN_HOSTING_TRIAL_MONTHLY,
 	type StorageOption,
+	isP2FreePlan,
 } from '@automattic/calypso-products';
 import { Button, Gridicon } from '@automattic/components';
 import { WpcomPlansUI } from '@automattic/data-stores';
@@ -477,6 +478,10 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 		},
 		[ currentSitePlanSlug, freePlan, freeTrialPlanSlug, onUpgradeClick, planSlug ]
 	);
+
+	if ( isP2FreePlan( planSlug ) ) {
+		return null;
+	}
 
 	if ( isWpcomEnterpriseGridPlan ) {
 		const vipLandingPageUrlWithUtmCampaign = addQueryArgs(

--- a/packages/calypso-products/src/main.ts
+++ b/packages/calypso-products/src/main.ts
@@ -42,6 +42,7 @@ import {
 	TERM_CENTENNIALLY,
 	PLAN_HOSTING_TRIAL_MONTHLY,
 	PLAN_MIGRATION_TRIAL_MONTHLY,
+	GROUP_P2,
 } from './constants';
 import { featureGroups, wooExpressFeatureGroups } from './feature-group-plan-map';
 import { PLANS_LIST } from './plans-list';
@@ -470,6 +471,10 @@ export function isJetpackFreePlan( planSlug: string ): boolean {
 
 export function isJetpackOfferResetPlan( planSlug: string ): boolean {
 	return ( JETPACK_RESET_PLANS as ReadonlyArray< string > ).includes( planSlug );
+}
+
+export function isP2FreePlan( planSlug: string ): boolean {
+	return planMatches( planSlug, { type: TYPE_FREE, group: GROUP_P2 } );
 }
 
 export function isP2PlusPlan( planSlug: string ): boolean {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/83320#pullrequestreview-1694354197

## Proposed Changes

* Replace the manage add-ons button from p2 plans page with a contact support button if a P2+ plan is purchased ( Because add-ons cannot be purchased on p2 workspace sites )
* Remove CTA when current plan is a free plan

## Screenshots

### Free plan is current plan
<img width="1139" alt="Screenshot 2023-10-31 at 12 08 12 PM" src="https://github.com/Automattic/wp-calypso/assets/5414230/9e8ff91b-0d1a-47d5-889a-36f83649b63e">

### P2+ plan is current plan
<img width="1128" alt="Screenshot 2023-10-31 at 12 08 21 PM" src="https://github.com/Automattic/wp-calypso/assets/5414230/57ba2fe5-0536-4645-8073-9372cb899651">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


* Create a new p2 site by visiting calypso.localhost:3000/start/p2 and following onboarding instructions
* Note the site slug that's created for your new p2 workspace
* Navigate directly to calypso.localhost:3000/plans/{P2_WORKSPACE_SITE_SLUG}
* Verify that no CTA is displayed for free plan
* Purchase a P2+ plan
* Verify that the CTA for the free plan says "Contact support"

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?