### PR TITLE
Plans Grid Refactor: remove is in vertical scrolling experiment prop

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -82,7 +82,6 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 	const isDesktop = useDesktopBreakpoint();
 	const stepName = 'plans';
 	const customerType = 'personal';
-	const isInVerticalScrollingPlansExperiment = true;
 	const headerText = __( 'Choose a plan' );
 	const isInSignup = isDomainUpsellFlow( flowName ) ? false : true;
 	const plansIntent = getPlansIntent( flowName );
@@ -240,7 +239,6 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 	};
 
 	const classes = classNames( 'plans-step', {
-		'in-vertically-scrolled-plans-experiment': isInVerticalScrollingPlansExperiment,
 		'has-no-sidebar': true,
 		'is-wide-layout': false,
 		'is-extra-wide-layout': true,

--- a/client/my-sites/checkout/src/lib/get-flow-plan-features.ts
+++ b/client/my-sites/checkout/src/lib/get-flow-plan-features.ts
@@ -30,27 +30,19 @@ const blogOnboardingFeatures = ( flowName: string, plan: IncompleteWPcomPlan ) =
 	return isBlogOnboardingFlow( flowName ) && plan.getBlogOnboardingSignupFeatures;
 };
 
-const signupFlowDefaultFeatures = (
-	flowName: string,
-	plan: IncompleteWPcomPlan,
-	isInVerticalScrollingPlansExperiment: boolean
-) => {
+const signupFlowDefaultFeatures = ( flowName: string, plan: IncompleteWPcomPlan ) => {
 	if ( ! flowName || isNewsletterOrLinkInBioFlow( flowName ) ) {
 		return;
 	}
 
-	return isInVerticalScrollingPlansExperiment
-		? plan.getSignupFeatures
-		: plan.getSignupCompareAvailableFeatures;
+	return plan.getSignupCompareAvailableFeatures;
 };
 
 const getPlanFeatureAccessor = ( {
 	flowName = '',
-	isInVerticalScrollingPlansExperiment = false,
 	plan,
 }: {
 	flowName?: string;
-	isInVerticalScrollingPlansExperiment?: boolean;
 	plan: IncompleteWPcomPlan;
 } ) => {
 	return [
@@ -58,7 +50,7 @@ const getPlanFeatureAccessor = ( {
 		linkInBioFeatures( flowName, plan ),
 		hostingFeatures( flowName, plan ),
 		blogOnboardingFeatures( flowName, plan ),
-		signupFlowDefaultFeatures( flowName, plan, isInVerticalScrollingPlansExperiment ),
+		signupFlowDefaultFeatures( flowName, plan ),
 	].find( ( accessor ) => {
 		return accessor instanceof Function;
 	} );
@@ -121,7 +113,6 @@ export default function getFlowPlanFeatures(
 	const featureAccessor = getPlanFeatureAccessor( {
 		flowName,
 		plan: planConstantObj,
-		isInVerticalScrollingPlansExperiment: false,
 	} );
 
 	if ( ! featureAccessor ) {

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -271,7 +271,6 @@ export class PlansStep extends Component {
 
 	render() {
 		const classes = classNames( 'plans plans-step', {
-			'in-vertically-scrolled-plans-experiment': this.props.isInVerticalScrollingPlansExperiment, // TODO clk: confirm this is still needed
 			'has-no-sidebar': true,
 			'is-wide-layout': false,
 			'is-extra-wide-layout': true,
@@ -338,10 +337,6 @@ export default connect(
 		customerType: parseQs( path.split( '?' ).pop() ).customerType,
 		hasInitializedSitesBackUrl: hasInitializedSites( state ) ? '/sites/' : false,
 		isLoadingExperiment: false,
-		// IMPORTANT NOTE: The following is always set to true. It's a hack to resolve the bug reported
-		// in https://github.com/Automattic/wp-calypso/issues/50896, till a proper cleanup and deploy of
-		// treatment for the `vertical_plan_listing_v2` experiment is implemented.
-		isInVerticalScrollingPlansExperiment: true,
 		plansLoaded: Boolean( getPlanSlug( state, getPlan( PLAN_FREE )?.getProductId() || 0 ) ),
 	} ),
 	{ recordTracksEvent, saveSignupStep, submitSignupStep, errorNotice }


### PR DESCRIPTION
- Related to: https://github.com/Automattic/wp-calypso/issues/82335
- This is part of a chain of branches, Please Follow order shown here for order in which to review  https://github.com/Automattic/wp-calypso/issues/82335#issuecomment-1781940845


## Proposed Changes
* Removes the unnecessary `isInVerticalScrollingPlansExperiment` flag, the change should not effect any styling of the grids since the it was not utilized in the new layout.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure all tests pass
* Smoke test the plans grid 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?