### PR TITLE
Launchpad: Remove unnecessary domain upsell flow condition

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -85,7 +85,6 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 	const customerType = 'personal';
 	const isInVerticalScrollingPlansExperiment = true;
 	const headerText = __( 'Choose a plan' );
-	const isInSignup = isDomainUpsellFlow( flowName ) ? false : true;
 	const plansIntent = getPlansIntent( flowName );
 	const hideFreePlan = plansIntent
 		? reduxHideFreePlan && 'plans-blog-onboarding' === plansIntent
@@ -145,7 +144,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 					siteId={ site?.ID }
 					showBiennialToggle={ false }
 					hideFreePlan={ hideFreePlan }
-					isInSignup={ isInSignup }
+					isInSignup={ true }
 					isStepperUpgradeFlow={ true }
 					intervalType={ getIntervalType() }
 					onUpgradeClick={ onSelectPlan }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/83661

## Proposed Changes

* Remove a seemingly unnecessary flag that forced `isInSignup` to be false when in the domain upsell flow

## Screenshots

### Before
<img width="1269" alt="Screenshot 2023-10-31 at 3 25 52 PM" src="https://github.com/Automattic/wp-calypso/assets/5414230/91c2f425-8dd1-4ffe-92cb-49a7f4f104c0">

### After
<img width="1264" alt="Screenshot 2023-10-31 at 3 25 40 PM" src="https://github.com/Automattic/wp-calypso/assets/5414230/da8b5468-36ce-483b-affd-1377874db7da">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to`/setup/domain-upsell`
* Choose a custom domain
* Verify that the plans CTA buttons allow the user to upgrade their plan if desired

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?