### PR TITLE
Stats Date Picker: Add outside click handler to close popover

### DIFF
--- a/client/components/stats-date-control/stats-date-control-picker.tsx
+++ b/client/components/stats-date-control/stats-date-control-picker.tsx
@@ -93,6 +93,7 @@ const DateControlPicker = ( {
 				context={ infoReferenceElement?.current }
 				isVisible={ popoverOpened }
 				className="stats-date-control-picker__popover-wrapper"
+				onClose={ () => togglePopoverOpened( false ) }
 			>
 				<div className="stats-date-control-picker__popover-content">
 					<DateControlPickerShortcuts


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #83141

## Proposed Changes

* This PR adds an outside click handler to close/dismiss popover when you click outside the element itself

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load the Calypso live branch
* Navigate to /stats/day/{site URL}
* Open the date picker using the following button:
	
![image](https://github.com/Automattic/wp-calypso/assets/30754158/aadca522-5b78-4a87-9802-4d5b233f28f2)

* Check that if you click elsewhere on the page, the date picker popover is dismissed. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?