### PR TITLE
Assembler: Load rendered patterns by category

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -94,10 +94,6 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 	const categories = usePatternCategories( site?.ID );
 	// Fetching curated patterns and categories from PTK api
 	const dotcomPatterns = useDotcomPatterns( locale );
-	const patternIds = useMemo(
-		() => dotcomPatterns.map( ( pattern ) => encodePatternId( pattern.ID ) ),
-		[ dotcomPatterns ]
-	);
 	const patternsMapByCategory = usePatternsMapByCategory( dotcomPatterns );
 	const pagesMapByCategory = usePatternPagesMapByCategory( dotcomPatterns );
 	const {
@@ -650,7 +646,7 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 				<PatternAssemblerContainer
 					siteId={ site?.ID }
 					stylesheet={ stylesheet }
-					patternIds={ patternIds }
+					patternsMapByCategory={ patternsMapByCategory }
 					siteInfo={ siteInfo }
 					isNewSite={ isNewSite }
 				>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-container.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-container.tsx
@@ -1,12 +1,15 @@
 import { BlockRendererProvider, PatternsRendererProvider } from '@automattic/block-renderer';
 import { PLACEHOLDER_SITE_ID } from '@automattic/data-stores/src/site/constants';
+import { useMemo } from 'react';
 import StepperLoader from '../../components/stepper-loader';
+import { encodePatternId } from './utils';
+import type { Pattern } from './types';
 import type { SiteInfo } from '@automattic/block-renderer';
 
 interface Props {
 	siteId: number | string;
 	stylesheet: string;
-	patternIds: string[];
+	patternsMapByCategory: Record< string, Pattern[] >;
 	children: JSX.Element;
 	siteInfo: SiteInfo;
 	isNewSite?: boolean;
@@ -15,31 +18,44 @@ interface Props {
 const PatternAssemblerContainer = ( {
 	siteId,
 	stylesheet,
-	patternIds,
+	patternsMapByCategory,
 	children,
 	siteInfo,
 	isNewSite,
-}: Props ) => (
-	<BlockRendererProvider
-		siteId={ siteId }
-		stylesheet={ stylesheet }
-		useInlineStyles
-		placeholder={ <StepperLoader /> }
-	>
-		<PatternsRendererProvider
-			// Site used to render site-related things on the previews,
-			// such as the logo, title, tagline, pages, posts, etc.
-			// For the newly created site, we use the placeholder site to render the content.
-			// Otherwise, we use the current site to display the site-related blocks.
-			siteId={ isNewSite ? PLACEHOLDER_SITE_ID : siteId }
+}: Props ) => {
+	const patternIdsByCategory = useMemo(
+		() =>
+			Object.fromEntries(
+				Object.entries( patternsMapByCategory ).map( ( [ category, patterns ] ) => [
+					category,
+					patterns.map( ( pattern ) => encodePatternId( pattern.ID ) ),
+				] )
+			),
+		[ patternsMapByCategory ]
+	);
+
+	return (
+		<BlockRendererProvider
+			siteId={ siteId }
 			stylesheet={ stylesheet }
-			patternIds={ patternIds }
-			// Use siteInfo to overwrite site-related things such as title, and tagline.
-			siteInfo={ siteInfo }
+			useInlineStyles
+			placeholder={ <StepperLoader /> }
 		>
-			{ children }
-		</PatternsRendererProvider>
-	</BlockRendererProvider>
-);
+			<PatternsRendererProvider
+				// Site used to render site-related things on the previews,
+				// such as the logo, title, tagline, pages, posts, etc.
+				// For the newly created site, we use the placeholder site to render the content.
+				// Otherwise, we use the current site to display the site-related blocks.
+				siteId={ isNewSite ? PLACEHOLDER_SITE_ID : siteId }
+				stylesheet={ stylesheet }
+				patternIdsByCategory={ patternIdsByCategory }
+				// Use siteInfo to overwrite site-related things such as title, and tagline.
+				siteInfo={ siteInfo }
+			>
+				{ children }
+			</PatternsRendererProvider>
+		</BlockRendererProvider>
+	);
+};
 
 export default PatternAssemblerContainer;

--- a/packages/block-renderer/src/components/patterns-renderer-provider.tsx
+++ b/packages/block-renderer/src/components/patterns-renderer-provider.tsx
@@ -6,7 +6,7 @@ import type { SiteInfo } from '../types';
 interface Props {
 	siteId: number | string;
 	stylesheet?: string;
-	patternIds: string[];
+	patternIdsByCategory: Record< string, string[] >;
 	children: JSX.Element;
 	siteInfo: SiteInfo;
 }
@@ -14,11 +14,16 @@ interface Props {
 const PatternsRendererProvider = ( {
 	siteId,
 	stylesheet = '',
-	patternIds,
+	patternIdsByCategory,
 	children,
 	siteInfo = {},
 }: Props ) => {
-	const renderedPatterns = useRenderedPatterns( siteId, stylesheet, patternIds, siteInfo );
+	const renderedPatterns = useRenderedPatterns(
+		siteId,
+		stylesheet,
+		patternIdsByCategory,
+		siteInfo
+	);
 
 	return (
 		<PatternsRendererContext.Provider value={ renderedPatterns }>

--- a/packages/block-renderer/src/hooks/use-rendered-patterns.ts
+++ b/packages/block-renderer/src/hooks/use-rendered-patterns.ts
@@ -1,21 +1,19 @@
-import { useEffect, useState } from 'react';
+import { useQueries } from '@tanstack/react-query';
 import wpcomRequest from 'wpcom-proxy-request';
-import type { RenderedPatterns, SiteInfo } from '../types';
-
-const PAGE_SIZE = 20;
+import type { RenderedPattern, RenderedPatterns, SiteInfo } from '../types';
 
 const fetchRenderedPatterns = (
 	siteId: number | string,
 	stylesheet: string,
+	category: string,
 	patternIds: string[],
-	siteInfo: SiteInfo,
-	page = 0
+	siteInfo: SiteInfo
 ): Promise< RenderedPatterns > => {
-	const pattern_ids = patternIds.slice( page * PAGE_SIZE, ( page + 1 ) * PAGE_SIZE ).join( ',' );
 	const { title, tagline } = siteInfo;
 	const params = new URLSearchParams( {
 		stylesheet,
-		pattern_ids,
+		category,
+		pattern_ids: patternIds.join( ',' ),
 		_locale: 'user',
 	} );
 
@@ -37,33 +35,29 @@ const fetchRenderedPatterns = (
 const useRenderedPatterns = (
 	siteId: number | string,
 	stylesheet: string,
-	patternIds: string[],
+	patternIdsByCategory: Record< string, string[] >,
 	siteInfo: SiteInfo = {}
 ) => {
-	const [ renderedPatterns, setRenderedPatterns ] = useState( {} );
+	const queries = Object.entries( patternIdsByCategory ).map( ( [ category, patternIds ] ) => ( {
+		queryKey: [ 'rendered-patterns', siteId, stylesheet, category, patternIds, siteInfo ],
+		queryFn: () => fetchRenderedPatterns( siteId, stylesheet, category, patternIds, siteInfo ),
+		staleTime: 1000 * 60 * 5, // 5 minutes
+		refetchOnWindowFocus: false,
+	} ) );
 
-	useEffect( () => {
-		if ( ! patternIds.length ) {
-			return;
-		}
+	const result = useQueries< RenderedPattern[] >( {
+		queries,
+	} );
 
-		// If we query too many patterns at once, the endpoint will be very slow.
-		// Hence, do local pagination to ensure the performance.
-		const totalPage = Math.ceil( patternIds.length / PAGE_SIZE );
-
-		const promises = [];
-		for ( let i = 0; i < totalPage; i++ ) {
-			promises.push( fetchRenderedPatterns( siteId, stylesheet, patternIds, siteInfo, i ) );
-		}
-
-		Promise.all( promises ).then( ( pages ) => {
-			setRenderedPatterns(
-				pages.reduce( ( previous, current ) => ( { ...previous, ...current } ), {} )
-			);
-		} );
-	}, [ patternIds.length ] );
-
-	return renderedPatterns;
+	return result
+		.filter( ( query ) => !! query.data )
+		.reduce(
+			( acc, cur ) => ( {
+				...acc,
+				...( cur.data as RenderedPattern[] ),
+			} ),
+			{}
+		);
 };
 
 export default useRenderedPatterns;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Refactor how we load the rendered patterns. Instead of loading them in sequence, this PR changes to load them by category.
* Additionally, now we use react-query to load them so we can cache the rendered patterns

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the Assembler
* Browse all categories to ensure the patterns are still rendered correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?