### PR TITLE
CI: send detailed notification of failures for Pre-Release Tests.

### DIFF
--- a/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
+++ b/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
@@ -150,7 +150,7 @@ open class E2EBuildType(
 					set -o errexit
 
 					# Retry failed tests only.
-					RETRY_COUNT=1 xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%JEST_E2E_WORKERS% --group=$testGroup --onlyFailures --json --outputFile=test.json
+					RETRY_COUNT=1 xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%JEST_E2E_WORKERS% --group=$testGroup --onlyFailures
 				"""
 				dockerImage = "%docker_image_e2e%"
 				dockerRunParameters = "-u %env.UID% --shm-size=4g"
@@ -173,7 +173,6 @@ open class E2EBuildType(
 				""".trimIndent()
 				dockerImage = "%docker_image_e2e%"
 			}
-
 			buildSteps()
 		}
 

--- a/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
+++ b/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
@@ -162,16 +162,13 @@ open class E2EBuildType(
 				scriptContent = """
 					set -x
 
-					cd test/e2e
-
 					export slack_oauth_token="%TEAMCITY_SLACK_RICH_NOTIFICATION_APP_OAUTH_TOKEN%"
 					export tc_build_conf_name="%system.teamcity.buildConfName%"
 					export tc_project_name="%system.teamcity.projectName%"
 					export tc_build_number=%build.number%
+					export tc_build_branch=%teamcity.build.branch%
 
-					echo slack_oauth_token
-
-					node ./bin/teamcity-e2e-slack-notify.mjs --file test.json
+					node ./bin/teamcity-e2e-slack-notify.mjs --file test/e2e/test.json
 				"""
 				dockerImage = "%docker_image_e2e%"
 			}

--- a/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
+++ b/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
@@ -157,23 +157,6 @@ open class E2EBuildType(
 			}
 
 			bashNodeScript {
-				name = "Send TeamCity Message"
-				executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
-				scriptContent = """
-					set -x
-
-					export slack_oauth_token="%TEAMCITY_SLACK_RICH_NOTIFICATION_APP_OAUTH_TOKEN%"
-					export tc_build_conf_name="%system.teamcity.buildConfName%"
-					export tc_project_name="%system.teamcity.projectName%"
-					export tc_build_number=%build.number%
-					export tc_build_branch=%teamcity.build.branch%
-
-					node ./bin/teamcity-e2e-slack-notify.mjs --file test/e2e/test.json
-				"""
-				dockerImage = "%docker_image_e2e%"
-			}
-
-			bashNodeScript {
 				name = "Collect results"
 				executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
 				scriptContent = """

--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -851,10 +851,27 @@ object PreReleaseE2ETests : BuildType({
 				set -o errexit
 
 				# Retry failed tests only.
-				RETRY_COUNT=1 xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%JEST_E2E_WORKERS% --group=calypso-release --onlyFailures
+				RETRY_COUNT=1 xvfb-run yarn jest --reporters=jest-teamcity --reporters=default --maxWorkers=%JEST_E2E_WORKERS% --group=calypso-release --onlyFailures --json --outputFile=pre-release-test-results.json
 			"""
 			dockerImage = "%docker_image_e2e%"
 		}
+
+		bashNodeScript {
+				name = "Send TeamCity Message"
+				executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
+				scriptContent = """
+					set -x
+
+					export slack_oauth_token="%TEAMCITY_SLACK_RICH_NOTIFICATION_APP_OAUTH_TOKEN%"
+					export tc_build_conf_name="%system.teamcity.buildConfName%"
+					export tc_project_name="%system.teamcity.projectName%"
+					export tc_build_number=%build.number%
+					export tc_build_branch=%teamcity.build.branch%
+
+					node ./bin/teamcity-e2e-slack-notify.mjs --file test/e2e/pre-release-test-results.json
+				"""
+				dockerImage = "%docker_image_e2e%"
+			}
 
 		bashNodeScript {
 			name = "Collect results"

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -90,6 +90,9 @@ project {
 		password("MATTICBOT_GITHUB_BEARER_TOKEN", "credentialsJSON:34cb38a5-9124-41c4-8497-74ed6289d751", display = ParameterDisplay.HIDDEN, label = "Matticbot GitHub Bearer Token")
 		text("CALYPSO_E2E_DASHBOARD_AWS_S3_ROOT", "s3://a8c-calypso-e2e-reports", label = "Calypso E2E Dashboard S3 bucket root")
 
+		// TeamCity Rich Notificaion App.
+		password("TEAMCITY_SLACK_RICH_NOTIFICATION_APP_OAUTH_TOKEN", "credentialsJSON:1ade13b3-4f88-4b2a-a71a-9c6f95698d00", display=ParameterDisplay.HIDDEN)
+
 		// Values related to the WPCOM VCS
 		password("WPCOM_JETPACK_PLUGIN_PATH", "credentialsJSON:db955a02-2a79-4167-a823-ac4840fd71d7", display = ParameterDisplay.HIDDEN)
 		password("WPCOM_JETPACK_MU_WPCOM_PLUGIN_PATH", "credentialsJSON:81683f57-784e-4535-9af0-26212c9e599b", display = ParameterDisplay.HIDDEN)

--- a/bin/teamcity-e2e-slack-notify.mjs
+++ b/bin/teamcity-e2e-slack-notify.mjs
@@ -66,7 +66,7 @@ function extractFailureMessages( results ) {
 function buildSlackMessage( failures ) {
 	// Build the body using Slack Block Kit.
 	const body = {
-		channel: 'C0615Q8GMFX',
+		channel: 'C02DQP0FP',
 		blocks: [
 			{
 				type: 'section',

--- a/bin/teamcity-e2e-slack-notify.mjs
+++ b/bin/teamcity-e2e-slack-notify.mjs
@@ -1,6 +1,5 @@
 import fs from 'fs';
 import { exit } from 'process';
-import util from 'util';
 import fetch from 'node-fetch';
 import yargs from 'yargs';
 
@@ -26,11 +25,12 @@ const filePath = argv.file;
 function openJestOutputJSON() {
 	let data;
 	try {
+		fs.accessSync( filePath );
 		data = fs.readFileSync( filePath, 'utf8' );
 	} catch ( error ) {
 		console.error( 'An error occurred while accessing the file:', error );
+		exit();
 	}
-
 	return JSON.parse( data );
 }
 
@@ -115,8 +115,6 @@ function buildSlackMessage( failures ) {
 			text: '@gpt, can you tell me more about the error(s) above, provide link(s) to the E2E test file in GitHub, and a snippet of the relevant code section?',
 		},
 	} );
-
-	console.log( util.inspect( body, { showHidden: false, depth: null, colors: true } ) );
 	return body;
 }
 
@@ -145,5 +143,4 @@ if ( failures.length === 0 ) {
 	exit();
 }
 const body = buildSlackMessage( failures );
-const response = await postMessage( body );
-console.log( await response.json() );
+await postMessage( body );

--- a/bin/teamcity-e2e-slack-notify.mjs
+++ b/bin/teamcity-e2e-slack-notify.mjs
@@ -1,0 +1,146 @@
+import fs from 'fs';
+import { exit } from 'process';
+import util from 'util';
+import fetch from 'node-fetch';
+import yargs from 'yargs';
+
+/* CLI Arguments */
+
+/**
+ *
+ */
+const { argv } = yargs( process.argv ).options( {
+	file: {
+		type: 'string',
+		required: true,
+		describe: 'Path to a JSON file produced by Jest',
+	},
+} );
+
+const filePath = argv.file;
+
+/* Methods */
+
+/**
+ *
+ * @returns
+ */
+function openFailuresJSON() {
+	try {
+		const data = fs.readFileSync( filePath, 'utf8' );
+
+		return JSON.parse( data );
+	} catch ( error ) {
+		console.error( 'An error occurred while reading the JSON file:', error );
+	}
+}
+
+/**
+ *
+ * @param {*} results
+ * @returns
+ */
+// Function to recursively search for "failureMessages" in the JSON
+function extractFailureMessages( results ) {
+	const failureMessages = [];
+
+	// Short circuit if nothing consistently failed.
+	// Consistently here means failed on both initial run and then the retry.
+	if ( ! results.numFailedTests ) {
+		exit();
+	}
+
+	for ( const result of results.testResults ) {
+		for ( const step of result.assertionResults ) {
+			if ( step.failureMessages.length !== 0 ) {
+				failureMessages.push( { step: step.ancestorTitles, error: step.failureMessages } );
+			}
+		}
+	}
+	return failureMessages;
+}
+
+/**
+ *
+ * @param {*} failures
+ * @returns
+ */
+function buildSlackMessage( failures ) {
+	// Build the body using Slack Block Kit.
+	const body = {
+		channel: 'C0615Q8GMFX',
+		blocks: [
+			{
+				type: 'section',
+				text: {
+					type: 'mrkdwn',
+					text: `:x: E2E Build Failed: ${ process.env.tc_project_name }: ${ process.env.tc_build_conf_name }, #${ process.env.tc_build_number }`,
+				},
+			},
+			{
+				type: 'section',
+				text: {
+					type: 'mrkdwn',
+					text: ':teamcity: <https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Playwright_desktop/11093402?buildTab=log&focusLine=613&linesState=530.586.587.588.589.665.666.667.668&logView=flowAware|*Build*>',
+				},
+			},
+			{
+				type: 'divider',
+			},
+			{
+				type: 'header',
+				text: {
+					type: 'plain_text',
+					text: 'Stacktraces',
+				},
+			},
+		],
+	};
+	for ( const failure of failures ) {
+		body.blocks.push(
+			{
+				type: 'section',
+				text: {
+					type: 'mrkdwn',
+					text:
+						'*' + failure.step.join( ': ' ) + '*' + '\n' + '```' + failure.error.pop() + '\n```',
+				},
+			},
+			{ type: 'divider' },
+			{
+				type: 'section',
+				text: {
+					type: 'mrkdwn',
+					text: 'placeholder text so that I do not waste a8c GPT bandwidth',
+					// text: '@gpt, can you tell me more about the error in the section above, and give me a link to the E2E test file in GitHub?',
+				},
+			}
+		);
+	}
+
+	console.log( util.inspect( body, { showHidden: false, depth: null, colors: true } ) );
+	return body;
+}
+
+/**
+ *
+ * @param {*} body
+ * @returns
+ */
+async function postMessage( body ) {
+	return await fetch( 'https://slack.com/api/chat.postMessage', {
+		method: 'POST',
+		headers: {
+			'Content-type': 'application/json; charset=utf-8',
+			Authorization: `Bearer ${ process.env.slack_oauth_token }`,
+		},
+		body: JSON.stringify( body ),
+	} );
+}
+
+// Build a mapping of test steps that failed and the corresponding stacktrace.
+const json = openFailuresJSON( filePath );
+const failures = extractFailureMessages( json );
+const body = buildSlackMessage( failures );
+const response = await postMessage( body );
+console.log( await response.json() );

--- a/bin/teamcity-e2e-slack-notify.mjs
+++ b/bin/teamcity-e2e-slack-notify.mjs
@@ -79,7 +79,7 @@ function buildSlackMessage( failures ) {
 				type: 'section',
 				text: {
 					type: 'mrkdwn',
-					text: ':teamcity: <https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Playwright_desktop/11093402?buildTab=log&focusLine=613&linesState=530.586.587.588.589.665.666.667.668&logView=flowAware|*Build*>',
+					text: `:teamcity: <${ process.env.BUILD_URL }|*Build*>`,
 				},
 			},
 			{


### PR DESCRIPTION
## Proposed Changes

This PR adds a richer, more useful and detailed Slack notification for failing tests. For now, this notification is only hooked up to the Pre-Release Tests suite.

**Context**
We currently send failing builds to the #e2eflowtesting-notif channel, but the default Slack messaging that TeamCity enables is rather...lacking. For one, TeamCity default Slack plugin can't even send the details of the failure.

@cometgrrl and I have been discussing ways to emulate what #calypso-alerts has been doing, which is to pinpoint the section of the code that has problems, explain the problem, then ping ChatGPT to give more insight. 

This is still a V1 and hooked up only to the Pre-Release Tests suite to 1. reduce noise, and 2. get feedback.

**Example**

p1698824421275609-slack-C0615Q8GMFX

```
:x: E2E Build Failed on branch try/teamcity-custom-error-message: Web app: Pre-Release E2E Tests, #15313
:teamcity: [Build](https://teamcity.a8c.com/build/11121946)
Stacktraces
Me: Smoke Test
locator.waitFor: Timeout 10000ms exceeded.
=========================== logs ===========================
waiting for getByRole('main').getByRole('heading', { name: 'target' }) to be visible
============================================================
    at waitFor (/home/teamcity-4/buildAgent/work/c4a9d5b38c1dacde/test/e2e/specs/me/me__smoke.ts:61:77)
, can you tell me more about the error(s) above, provide link(s) to the E2E test file in GitHub, and a snippet of the relevant code section?

ChatGPT responds:

The error message generated by the test infrastructure indicates that the test was trying to find a DOM element defined by a role of 'main' that contains a heading with the name 'target', but the element could not be found within the 10000ms (10 seconds) timeout limit.
This test timeout occurred inside the "me__smoke.ts" file. Depending on the architecture, the issue could be a delayed render caused by API responses, a removed or renamed DOM element, or generalized latency issues causing elapse of the timeout period before the element becomes visible in the DOM.
I'm sorry but as an assistant powered by AI, I don't have the ability to link to the actual GitHub E2E test file or provide a snippet of the relevant code section. These require direct file browsing and access to the codebase, which are not currently supported by my capabilities. Please follow up with one of your team members or check out the mentioned test file by yourself.
```

## Testing Instructions

Ensure the following build configurations are passing:
  - [x] Calypso E2E (desktop)
  - [x] Calypso E2E (mobile)
  - [x] Pre-Release E2E

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?