### PR TITLE
Jetpack Manage: Fix the nesting li element in the submenu component.

### DIFF
--- a/client/layout/sidebar-v2/navigator/navigator-menu.tsx
+++ b/client/layout/sidebar-v2/navigator/navigator-menu.tsx
@@ -51,8 +51,9 @@ export const SidebarNavigatorMenu = ( {
 								{ description && (
 									<div className="sidebar-v2__navigator-group-description">{ description }</div>
 								) }
-								{ children }
 							</li>
+
+							{ children }
 						</ul>
 					</VStack>
 				</CardBody>


### PR DESCRIPTION
There is a warning message showing when the new submenu is rendered. This was caused by nesting li on the submenu component.
<img width="878" alt="Screen Shot 2023-11-01 at 1 05 48 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/63187587-19fa-4909-833f-95e7f68e36db">


## Proposed Changes

* Move `children` outside `li` in the submenu template.

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

* Use the Jetpack Cloud live link and go to `/partner-portal/billing`
* Inspect the console log and confirm that there is no more warning message.
* Confirm that the sidebar looks exactly the same in the production.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
