### PR TITLE
Authentication E2E: check for newly introduced link text.

### DIFF
--- a/test/e2e/specs/authentication/authentication__magic-link.ts
+++ b/test/e2e/specs/authentication/authentication__magic-link.ts
@@ -32,6 +32,11 @@ describe( DataHelper.createSuiteTitle( 'Authentication: Magic Link' ), function 
 		await loginPage.fillUsername( credentials.email as string );
 		await loginPage.clickSubmit();
 
+		// Introduced in https://github.com/Automattic/wp-calypso/pull/83674.
+		await page.getByText( 'Enter a password instead' ).waitFor();
+	} );
+
+	it( 'Obtain magic link from email', async function () {
 		emailClient = new EmailClient();
 		magicLinkEmail = await emailClient.getLastMatchingMessage( {
 			inboxId: SecretsManager.secrets.mailosaur.defaultUserInboxId,


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/83674.

## Proposed Changes

This PR updates the Magic Link spec to check for newly introduced text.


## Testing Instructions

Ensure the following build configurations are passing:
  - [ ] Calypso E2E (desktop)
  - [ ] Calypso E2E (mobile)
  - [ ] Pre-Release E2E

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?