### PR TITLE
Assembler: Page preview UI improvements

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-page-preview-list.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-page-preview-list.scss
@@ -1,7 +1,18 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 .pattern-assembler__preview-list {
-	display: flex;
+	box-sizing: border-box;
+	display: grid;
 	flex: 1;
-	flex-wrap: wrap;
 	gap: 36px 48px;
+	grid-template-columns: repeat(3, 1fr);
+	grid-template-rows: min-content;
+	height: 100vh;
+	overflow-y: scroll;
 	padding: 100px 12px;
+
+	@include break-huge {
+		gap: 48px;
+	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-page-preview-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-page-preview-list.tsx
@@ -1,5 +1,6 @@
+import { useGlobalStyle } from '@automattic/global-styles';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo } from 'react';
+import { CSSProperties, useMemo } from 'react';
 import PatternPagePreview from './pattern-page-preview';
 import type { Pattern } from './types';
 import './pattern-page-preview-list.scss';
@@ -23,6 +24,12 @@ const PatternPagePreviewList = ( {
 }: Props ) => {
 	const translate = useTranslate();
 
+	const [ backgroundColor ] = useGlobalStyle( 'color.background' );
+	const patternPagePreviewStyle = useMemo(
+		() => ( { '--pattern-page-preview-background': backgroundColor } ) as CSSProperties,
+		[ backgroundColor ]
+	);
+
 	const pages = useMemo(
 		() => selectedPages.map( ( slug ) => pagesMapByCategory[ slug ]?.[ 0 ] ).filter( Boolean ),
 		[ selectedPages, pagesMapByCategory ]
@@ -37,12 +44,14 @@ const PatternPagePreviewList = ( {
 		<div className="pattern-assembler__preview-list">
 			<PatternPagePreview
 				title={ translate( 'Homepage' ) }
+				style={ patternPagePreviewStyle }
 				patterns={ homepage }
 				shouldShufflePosts={ isNewSite }
 			/>
 			{ pages.map( ( page ) => (
 				<PatternPagePreview
 					key={ page.ID }
+					style={ patternPagePreviewStyle }
 					title={ page.title }
 					patterns={ [
 						...( selectedHeader ? [ selectedHeader ] : [] ),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-page-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-page-preview.scss
@@ -5,21 +5,23 @@
 $font-family: "SF Pro Text", $sans;
 
 .pattern-assembler__preview {
-	flex-basis: 300px;
-	flex-shrink: 0;
+	display: flex;
+	flex-direction: column;
+	aspect-ratio: 3/4;
 
 	.pattern-assembler__preview-frame {
-		background: #f8f8f8;
 		border: 10px solid #f8f8f8;
 		border-radius: 13px;  /* stylelint-disable-line scales/radii */
 		box-shadow:
 			0 5.25469px 5.25469px 0 rgba(0, 0, 0, 0.02),
 			0 11.38516px 8.75781px 0 rgba(0, 0, 0, 0.03);
-		height: 350px;
+		flex: 1;
+		min-height: 350px;
 		overflow: hidden;
 		position: relative;
 
 		&-content {
+			background: var(--pattern-page-preview-background, #f8f8f8);
 			border-radius: 8.758px;  /* stylelint-disable-line scales/radii */
 			bottom: 0;
 			left: 0;
@@ -27,6 +29,15 @@ $font-family: "SF Pro Text", $sans;
 			position: absolute;
 			right: 0;
 			top: 0;
+
+			/**
+			 * Hides the scrollbar to avoid the layout keeps changes forever
+			 * See https://github.com/Automattic/wp-calypso/issues/78357.
+			 */
+			scrollbar-width: none;
+			&::-webkit-scrollbar {
+				display: none;
+			}
 		}
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-page-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-page-preview.tsx
@@ -1,11 +1,12 @@
 import { PatternRenderer } from '@automattic/block-renderer';
-import { useMemo } from 'react';
+import { CSSProperties, useMemo } from 'react';
 import { encodePatternId } from './utils';
 import type { Pattern } from './types';
 import './pattern-page-preview.scss';
 
 interface Props {
 	title: string;
+	style: CSSProperties;
 	patterns: Pattern[];
 	shouldShufflePosts: boolean;
 }
@@ -13,13 +14,13 @@ interface Props {
 const PATTERN_PAGE_PREVIEW_ITEM_VIEWPORT_HEIGHT = 500;
 const PATTERN_PAGE_PREVIEW_ITEM_VIEWPORT_WIDTH = 1080;
 
-const PatternPagePreview = ( { title, patterns, shouldShufflePosts }: Props ) => {
+const PatternPagePreview = ( { title, style, patterns, shouldShufflePosts }: Props ) => {
 	const validPatterns = useMemo( () => patterns.filter( Boolean ) as Pattern[], [ patterns ] );
 
 	return (
 		<div className="pattern-assembler__preview">
 			<div className="pattern-assembler__preview-frame">
-				<div className="pattern-assembler__preview-frame-content">
+				<div className="pattern-assembler__preview-frame-content" style={ style }>
 					{ validPatterns.map( ( pattern ) => (
 						<PatternRenderer
 							key={ pattern.ID }


### PR DESCRIPTION
Related to #83450

## Proposed Changes

This PR addresses several improvement suggestions mentioned in https://github.com/Automattic/wp-calypso/pull/83649#issuecomment-1787378573. Specifically:

1. Fixes an issue where the screen header scrolls down.
![Image](https://user-images.githubusercontent.com/98343583/279413682-db8b8ed4-b1cf-4660-bd6c-14a9b3f3fea5.png)

2. Removes the vertical scrollbar.
![Image](https://user-images.githubusercontent.com/98343583/279414775-7c95bd61-a310-4bda-966b-0e04fae95ff6.png)

3. Fills the preview background with the selected color variation.
![Screenshot 2023-11-01 at 1 57 57 PM](https://github.com/Automattic/wp-calypso/assets/797888/c6acf711-7694-4f75-ae7b-c42c29effb08)

4. Implements responsive size.

https://github.com/Automattic/wp-calypso/assets/797888/bb5bb730-38cb-4424-9f08-5c5ab0f365d3

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Assembler with the flag `&flags=pattern-assembler/add-pages`.
* Go through the Patterns, and Styles screen until you arrive at the Pages screen.
* Ensure that the changes mentioned above work as described.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?