### PR TITLE
Jetpack Manage: Fix issue with page refreshing when selecting a site from the site selector.

### DIFF
--- a/client/jetpack-cloud/sections/landing/controller.tsx
+++ b/client/jetpack-cloud/sections/landing/controller.tsx
@@ -6,6 +6,7 @@ import { isAgencyUser } from 'calypso/state/partner-portal/partner/selectors';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import getFeaturesBySiteId from 'calypso/state/selectors/get-site-features';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
+import ManageSelectedSiteSidebar from '../sidebar-navigation/manage-selected-site';
 import Landing from './main';
 import { isSiteEligibleForJetpackCloud, getLandingPath } from './selectors';
 
@@ -31,6 +32,11 @@ const landForSiteId = ( siteId: number | null, context: PageJS.Context, next: ()
 	const siteFeatures = getFeaturesBySiteId( state, siteId );
 	if ( isEligible === null || ! siteFeatures ) {
 		debug( '[landForSiteId]: rendering interstitial Landing page' );
+
+		// To make the UI feel seamless transition, we want to have the sidebar appear on the interstitial page
+		if ( config.isEnabled( 'jetpack/new-navigation' ) ) {
+			context.secondary = <ManageSelectedSiteSidebar path={ context.path } />;
+		}
 		context.primary = <Landing siteId={ siteId as number } />;
 		next();
 		return;

--- a/client/jetpack-cloud/sections/landing/main.tsx
+++ b/client/jetpack-cloud/sections/landing/main.tsx
@@ -13,7 +13,6 @@ const debug = debugModule( 'calypso:jetpack-cloud:landing:main' );
 /**
  * Check whether or not we've asked for and received an API response
  * describing the features of the site with the given ID.
- *
  * @param siteId The site for which features data should be requested.
  * @returns true if a request and response have taken place (success or failure);
  * false otherwise.
@@ -75,9 +74,7 @@ const Landing: React.FC< { siteId: number } > = ( { siteId } ) => {
 		// By this point, we can assume that landingPath is defined;
 		// let's redirect people to the most appropriate page,
 		// based on the features available to the selected site
-		const redirectUrl = new URL( window.location.href );
-		redirectUrl.pathname = landingPath as string;
-		page.redirect( redirectUrl.toString() );
+		page.redirect( landingPath );
 	}, [ resolvedSiteFeatures, isEligible, landingPath ] );
 
 	return <QuerySiteFeatures siteIds={ [ siteId ] } />;


### PR DESCRIPTION
When selecting a site from the site selector, the page abruptly refreshes before transitioning to the appropriate landing page. This PR fixes the issue. 

https://github.com/Automattic/wp-calypso/assets/56598660/2b4ebf2e-5592-4803-9b20-98f8db5ac97f




Closes https://github.com/Automattic/jetpack-manage/issues/68

## Proposed Changes

* Remove the base URL when redirecting to the appropriate landing page to prevent the page from refreshing.
* Add the new sidebar in the interstitial page to make the page transition seamless.

## Testing Instructions
**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

* Use the Jetpack Cloud live link and go to `/dashboard`
* In the sidebar, click the site selector and select a site.
* Confirm that the page does not refresh when transitioning to the appropriate landing page.

https://github.com/Automattic/wp-calypso/assets/56598660/7965c22b-db08-422b-864b-6b6883bb0fe0



## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?