### PR TITLE
Assembler: Remove the checkbox on the activation screen

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-activation.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-activation.tsx
@@ -1,9 +1,7 @@
 import { Button } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { NavigatorHeader } from '@automattic/onboarding';
-import { CheckboxControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
 import { useScreen } from './hooks';
 import NavigatorTitle from './navigator-title';
 import './screen-activation.scss';
@@ -15,8 +13,6 @@ interface Props {
 const ScreenActivation = ( { onActivate }: Props ) => {
 	const translate = useTranslate();
 	const { title, description, continueLabel } = useScreen( 'activation' );
-	const [ isConfirmed, setIsConfirmed ] = useState( false );
-	const toggleConfirm = () => setIsConfirmed( ( value ) => ! value );
 
 	return (
 		<>
@@ -31,7 +27,7 @@ const ScreenActivation = ( { onActivate }: Props ) => {
 				</strong>
 				<p className="screen-activation__description">
 					{ translate(
-						'After activation, this layout will replace your existing homepage. But you can still access your old content. {{a}}Learn more{{/a}}.',
+						'This will replace your homepage, but your content will remain accessible. {{a}}Learn more{{/a}}.',
 						{
 							components: {
 								a: (
@@ -47,19 +43,7 @@ const ScreenActivation = ( { onActivate }: Props ) => {
 				</p>
 			</div>
 			<div className="screen-container__footer">
-				<CheckboxControl
-					className="screen-activation__checkbox"
-					label={ translate( 'I understand that this layout will replace my existing homepage.' ) }
-					checked={ isConfirmed }
-					onChange={ toggleConfirm }
-				/>
-				<Button
-					className="pattern-assembler__button"
-					primary
-					disabled={ ! isConfirmed }
-					aria-disabled={ ! isConfirmed }
-					onClick={ onActivate }
-				>
+				<Button className="pattern-assembler__button" primary onClick={ onActivate }>
 					{ continueLabel }
 				</Button>
 			</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/83529

## Proposed Changes

* We want to remove the checkbox and reword the copy to make it less "scary"

| Before | After |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/d16784bb-a3a7-4ae9-97ff-bc10a5d621b6) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/90b58544-1fe3-46e9-a07c-bc66a188415a) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the Theme Showcase on your existing site
* Select the Assembler CTA
* On the Assembler
  * Select any patterns
  * Select any styles
  * Ensure the checkbox is removed on the activation screen, and the copy is updated

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?