### PR TITLE
Comparison Grid: refactor visiblePlans to visibleGridPlans and simplify logic for plan visibility adjustments

### DIFF
--- a/packages/plans-grid-next/src/components/comparison-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.tsx
@@ -1004,7 +1004,7 @@ const ComparisonGrid = ( {
 			const newPlanSlug = event.currentTarget.value;
 			setVisibleGridPlans( ( visibleGridPlans ) => {
 				const newPlan = displayedGridPlans.find(
-					( plan ) => plan.planSlug === newPlanSlug
+					( plan ) => getPlanClass( plan.planSlug ) === getPlanClass( newPlanSlug )
 				) as GridPlan;
 				return visibleGridPlans.map( ( plan ) =>
 					plan.planSlug === currentPlan ? newPlan : plan

--- a/packages/plans-grid-next/src/components/comparison-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.tsx
@@ -983,53 +983,35 @@ const ComparisonGrid = ( {
 	const isMediumBreakpoint = usePricingBreakpoint( mediumBreakpoint );
 	const isSmallBreakpoint = usePricingBreakpoint( smallBreakpoint );
 
-	const [ visiblePlans, setVisiblePlans ] = useState< PlanSlug[] >( [] );
+	const [ visibleGridPlans, setVisibleGridPlans ] = useState< GridPlan[] >( [] );
 
 	const displayedGridPlans = useMemo( () => {
 		return sortPlans( gridPlans, currentSitePlanSlug, isMediumBreakpoint );
 	}, [ gridPlans, currentSitePlanSlug, isMediumBreakpoint ] );
 
 	useEffect( () => {
-		let newVisiblePlans = displayedGridPlans.map( ( { planSlug } ) => planSlug );
-		let visibleLength = newVisiblePlans.length;
+		let visibleLength = displayedGridPlans.length;
 
 		visibleLength = isLargeBreakpoint ? 4 : visibleLength;
 		visibleLength = isMediumBreakpoint ? 3 : visibleLength;
 		visibleLength = isSmallBreakpoint ? 2 : visibleLength;
 
-		if ( newVisiblePlans.length !== visibleLength ) {
-			newVisiblePlans = newVisiblePlans.slice( 0, visibleLength );
-		}
-
-		setVisiblePlans( newVisiblePlans );
-	}, [ isLargeBreakpoint, isMediumBreakpoint, isSmallBreakpoint, displayedGridPlans, isInSignup ] );
-
-	const visibleGridPlans = useMemo(
-		() =>
-			visiblePlans.reduce( ( acc, planSlug ) => {
-				const gridPlan = displayedGridPlans.find(
-					( gridPlan ) => getPlanClass( gridPlan.planSlug ) === getPlanClass( planSlug )
-				);
-
-				if ( gridPlan ) {
-					acc.push( gridPlan );
-				}
-
-				return acc;
-			}, [] as GridPlan[] ),
-		[ visiblePlans, displayedGridPlans ]
-	);
+		setVisibleGridPlans( displayedGridPlans.slice( 0, visibleLength ) );
+	}, [ isLargeBreakpoint, isMediumBreakpoint, isSmallBreakpoint, displayedGridPlans ] );
 
 	const onPlanChange = useCallback(
 		( currentPlan: PlanSlug, event: ChangeEvent< HTMLSelectElement > ) => {
-			const newPlan = event.currentTarget.value;
-			const newVisiblePlans = visiblePlans.map( ( plan ) =>
-				plan === currentPlan ? ( newPlan as PlanSlug ) : plan
-			);
-
-			setVisiblePlans( newVisiblePlans );
+			const newPlanSlug = event.currentTarget.value;
+			setVisibleGridPlans( ( visibleGridPlans ) => {
+				const newPlan = displayedGridPlans.find(
+					( plan ) => plan.planSlug === newPlanSlug
+				) as GridPlan;
+				return visibleGridPlans.map( ( plan ) =>
+					plan.planSlug === currentPlan ? newPlan : plan
+				);
+			} );
 		},
-		[ visiblePlans ]
+		[ displayedGridPlans ]
 	);
 
 	const planFeatureFootnotes = useMemo( () => {

--- a/packages/plans-grid-next/src/components/comparison-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.tsx
@@ -1003,15 +1003,13 @@ const ComparisonGrid = ( {
 		( currentPlan: PlanSlug, event: ChangeEvent< HTMLSelectElement > ) => {
 			const newPlanSlug = event.currentTarget.value;
 			setVisibleGridPlans( ( visibleGridPlans ) => {
-				const newPlan = displayedGridPlans.find(
-					( plan ) => getPlanClass( plan.planSlug ) === getPlanClass( newPlanSlug )
-				) as GridPlan;
+				const newPlan = gridPlans.find( ( plan ) => plan.planSlug === newPlanSlug ) as GridPlan;
 				return visibleGridPlans.map( ( plan ) =>
 					plan.planSlug === currentPlan ? newPlan : plan
 				);
 			} );
 		},
-		[ displayedGridPlans ]
+		[ gridPlans ]
 	);
 
 	const planFeatureFootnotes = useMemo( () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pdvytD-oN-p2#comment-199

## Proposed Changes

Previously we were always converting from `visiblePlans` -> `visibleGridPlans`. In this PR, we just keep visibleGridPlans in state, and modify it whenever the selected plans change.

Additionally, the reference to `onPlanChange` will not change whenever a new plan is selected from the drop-down since `visiblePlans` is no longer a dependency on the `useCallback`.

This reduces the render time of the grid from ~131ms to ~58ms (see linked post)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* There should be no change in functionality.
* Go to `/start/plans`. Confirm that the comparison grid works correctly in desktop, tablet and mobile resolutions.
* Confirm that the plans dropdown works correctly in tablet and mobile resolutions. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?