### PR TITLE
Assembler: Preselect the About page

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
@@ -68,7 +68,7 @@ export const ORDERED_PATTERN_CATEGORIES = [
 	'contact',
 ];
 
-export const INITIAL_PAGE = 'about';
+export const INITIAL_PAGES = [ 'about' ];
 
 export const PATTERN_PAGES_CATEGORIES = [ 'about', 'contact', 'portfolio', 'posts', 'services' ];
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
@@ -68,6 +68,8 @@ export const ORDERED_PATTERN_CATEGORIES = [
 	'contact',
 ];
 
+export const INITIAL_PAGE = 'about';
+
 export const PATTERN_PAGES_CATEGORIES = [ 'about', 'contact', 'portfolio', 'posts', 'services' ];
 
 export const ORDERED_PATTERN_PAGES_CATEGORIES = [

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-pages.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-pages.ts
@@ -1,10 +1,11 @@
 import { useSearchParams } from 'react-router-dom';
+import { INITIAL_PAGE } from '../constants';
 
 const usePatternPages = () => {
 	const [ searchParams, setSearchParams ] = useSearchParams();
 	const page_slugs = ( searchParams.get( 'page_slugs' ) || '' ).split( ',' ).filter( Boolean );
 
-	const pages = page_slugs || [];
+	const pages = page_slugs.length ? page_slugs : [ INITIAL_PAGE ];
 
 	const setPages = ( pages: string[] ) => {
 		setSearchParams(

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-pages.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-pages.ts
@@ -1,6 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { useSearchParams } from 'react-router-dom';
-import { INITIAL_PAGE } from '../constants';
+import { INITIAL_PAGES } from '../constants';
 
 const usePatternPages = () => {
 	const [ searchParams, setSearchParams ] = useSearchParams();
@@ -8,7 +8,7 @@ const usePatternPages = () => {
 
 	const pages = page_slugs.length
 		? page_slugs
-		: [ ...( isEnabled( 'pattern-assembler/add-pages' ) ? [ INITIAL_PAGE ] : [] ) ];
+		: [ ...( isEnabled( 'pattern-assembler/add-pages' ) ? INITIAL_PAGES : [] ) ];
 
 	const setPages = ( pages: string[] ) => {
 		setSearchParams(

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-pages.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-pages.ts
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { useSearchParams } from 'react-router-dom';
 import { INITIAL_PAGE } from '../constants';
 
@@ -5,7 +6,9 @@ const usePatternPages = () => {
 	const [ searchParams, setSearchParams ] = useSearchParams();
 	const page_slugs = ( searchParams.get( 'page_slugs' ) || '' ).split( ',' ).filter( Boolean );
 
-	const pages = page_slugs.length ? page_slugs : [ INITIAL_PAGE ];
+	const pages = page_slugs.length
+		? page_slugs
+		: [ ...( isEnabled( 'pattern-assembler/add-pages' ) ? [ INITIAL_PAGE ] : [] ) ];
 
 	const setPages = ( pages: string[] ) => {
 		setSearchParams(

--- a/config/development.json
+++ b/config/development.json
@@ -137,7 +137,7 @@
 		"onboarding/import-redirect-to-themes": true,
 		"p2/p2-plus": true,
 		"page/export": true,
-		"pattern-assembler/add-pages": false,
+		"pattern-assembler/add-pages": true,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,


### PR DESCRIPTION
Related to #83450

## Proposed Changes

This PR updates the Pages screen so that the About page is preselected. This PR also enables the Pages screen by default since the feature is now functional.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Assembler, ensure that the flag `&flags=pattern-assembler/add-pages` is still needed.
* Go through the Patterns, and Styles screen until you arrive at the Pages screen.
* Ensure that the About page is preselected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?