### PR TITLE
Free Hosting Trial: Enforce 100 subscribers limit

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/subscribers/index.tsx
@@ -20,9 +20,9 @@ const Subscribers: Step = function ( { navigation } ) {
 		submit?.();
 	};
 
-	const isSiteOnFreePlan = !! site?.plan?.is_free;
+	const hasSubscriberLimit = !! site?.plan?.is_free;
 
-	const subtitleText = isSiteOnFreePlan
+	const subtitleText = hasSubscriberLimit
 		? translate(
 				'Bring up to 100 subscribers for free — or add some individually — to start spreading the news.'
 		  )
@@ -47,7 +47,7 @@ const Subscribers: Step = function ( { navigation } ) {
 					{ site?.ID && (
 						<AddSubscriberForm
 							siteId={ site.ID }
-							isSiteOnFreePlan={ isSiteOnFreePlan }
+							hasSubscriberLimit={ hasSubscriberLimit }
 							flowName="onboarding_subscribers"
 							submitBtnName={ submitButtonText }
 							onImportFinished={ handleSubmit }

--- a/client/my-sites/people/followers-list/followers.jsx
+++ b/client/my-sites/people/followers-list/followers.jsx
@@ -16,7 +16,7 @@ import { addQueryArgs } from 'calypso/lib/url';
 import NoResults from 'calypso/my-sites/no-results';
 import PeopleListItem from 'calypso/my-sites/people/people-list-item';
 import PeopleListSectionHeader from 'calypso/my-sites/people/people-list-section-header';
-import { isHostingTrialSite } from 'calypso/sites-dashboard/utils';
+import { isBusinessTrialSite } from 'calypso/sites-dashboard/utils';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { successNotice } from 'calypso/state/notices/actions';
 import isEligibleForSubscriberImporter from 'calypso/state/selectors/is-eligible-for-subscriber-importer';
@@ -125,8 +125,8 @@ class Followers extends Component {
 		let emptyTitle;
 		const site = this.props.site;
 		const isFreeSite = site?.plan?.is_free ?? false;
-		const isHostingTrial = site ? isHostingTrialSite( site ) : false;
-		const hasSubscriberLimit = isFreeSite || isHostingTrial;
+		const isBusinessTrial = site ? isBusinessTrialSite( site ) : false;
+		const hasSubscriberLimit = isFreeSite || isBusinessTrial;
 
 		if ( this.siteHasNoFollowers() ) {
 			if ( 'email' === this.props.type ) {

--- a/client/my-sites/people/followers-list/followers.jsx
+++ b/client/my-sites/people/followers-list/followers.jsx
@@ -16,6 +16,7 @@ import { addQueryArgs } from 'calypso/lib/url';
 import NoResults from 'calypso/my-sites/no-results';
 import PeopleListItem from 'calypso/my-sites/people/people-list-item';
 import PeopleListSectionHeader from 'calypso/my-sites/people/people-list-section-header';
+import { isHostingTrialSite } from 'calypso/sites-dashboard/utils';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { successNotice } from 'calypso/state/notices/actions';
 import isEligibleForSubscriberImporter from 'calypso/state/selectors/is-eligible-for-subscriber-importer';
@@ -123,7 +124,9 @@ class Followers extends Component {
 
 		let emptyTitle;
 		const site = this.props.site;
-		const isSiteOnFreePlan = site && site.plan.is_free;
+		const isFreeSite = site?.plan?.is_free ?? false;
+		const isHostingTrial = site ? isHostingTrialSite( site ) : false;
+		const isSiteOnFreePlan = isFreeSite || isHostingTrial;
 
 		if ( this.siteHasNoFollowers() ) {
 			if ( 'email' === this.props.type ) {

--- a/client/my-sites/people/followers-list/followers.jsx
+++ b/client/my-sites/people/followers-list/followers.jsx
@@ -126,7 +126,7 @@ class Followers extends Component {
 		const site = this.props.site;
 		const isFreeSite = site?.plan?.is_free ?? false;
 		const isHostingTrial = site ? isHostingTrialSite( site ) : false;
-		const isSiteOnFreePlan = isFreeSite || isHostingTrial;
+		const hasSubscriberLimit = isFreeSite || isHostingTrial;
 
 		if ( this.siteHasNoFollowers() ) {
 			if ( 'email' === this.props.type ) {
@@ -141,7 +141,7 @@ class Followers extends Component {
 							>
 								<AddSubscriberForm
 									siteId={ this.props.site.ID }
-									isSiteOnFreePlan={ isSiteOnFreePlan }
+									hasSubscriberLimit={ hasSubscriberLimit }
 									flowName="people"
 									showSubtitle={ true }
 									showCsvUpload={ isEnabled( 'subscriber-csv-upload' ) }

--- a/client/my-sites/people/subscribers/index.tsx
+++ b/client/my-sites/people/subscribers/index.tsx
@@ -83,7 +83,7 @@ function Subscribers( props: Props ) {
 
 	const isFreeSite = site?.plan?.is_free ?? false;
 	const isHostingTrial = site ? isHostingTrialSite( site ) : false;
-	const isSiteOnFreePlan = isFreeSite || isHostingTrial;
+	const hasSubscriberLimit = isFreeSite || isHostingTrial;
 
 	switch ( templateState ) {
 		case 'default':
@@ -145,7 +145,7 @@ function Subscribers( props: Props ) {
 									siteId={ site?.ID }
 									submitBtnAlwaysEnable={ true }
 									onImportFinished={ refetch }
-									isSiteOnFreePlan={ isSiteOnFreePlan }
+									hasSubscriberLimit={ hasSubscriberLimit }
 								/>
 							</EmailVerificationGate>
 						</>

--- a/client/my-sites/people/subscribers/index.tsx
+++ b/client/my-sites/people/subscribers/index.tsx
@@ -9,13 +9,13 @@ import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import { addQueryArgs } from 'calypso/lib/url';
 import NoResults from 'calypso/my-sites/no-results';
 import PeopleListItem from 'calypso/my-sites/people/people-list-item';
+import { isHostingTrialSite } from 'calypso/sites-dashboard/utils';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import PeopleListSectionHeader from '../people-list-section-header';
 import type { FollowersQuery } from './types';
 import type { Member } from '../types';
-
 import './style.scss';
 
 interface Props {
@@ -81,6 +81,10 @@ function Subscribers( props: Props ) {
 		templateState = 'default';
 	}
 
+	const isFreeSite = site?.plan?.is_free ?? false;
+	const isHostingTrial = site ? isHostingTrialSite( site ) : false;
+	const isSiteOnFreePlan = isFreeSite || isHostingTrial;
+
 	switch ( templateState ) {
 		case 'default':
 		case 'loading':
@@ -141,6 +145,7 @@ function Subscribers( props: Props ) {
 									siteId={ site?.ID }
 									submitBtnAlwaysEnable={ true }
 									onImportFinished={ refetch }
+									isSiteOnFreePlan={ isSiteOnFreePlan }
 								/>
 							</EmailVerificationGate>
 						</>

--- a/client/my-sites/people/subscribers/index.tsx
+++ b/client/my-sites/people/subscribers/index.tsx
@@ -9,7 +9,7 @@ import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import { addQueryArgs } from 'calypso/lib/url';
 import NoResults from 'calypso/my-sites/no-results';
 import PeopleListItem from 'calypso/my-sites/people/people-list-item';
-import { isHostingTrialSite } from 'calypso/sites-dashboard/utils';
+import { isBusinessTrialSite } from 'calypso/sites-dashboard/utils';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
@@ -82,8 +82,8 @@ function Subscribers( props: Props ) {
 	}
 
 	const isFreeSite = site?.plan?.is_free ?? false;
-	const isHostingTrial = site ? isHostingTrialSite( site ) : false;
-	const hasSubscriberLimit = isFreeSite || isHostingTrial;
+	const isBusinessTrial = site ? isBusinessTrialSite( site ) : false;
+	const hasSubscriberLimit = isFreeSite || isBusinessTrial;
 
 	switch ( templateState ) {
 		case 'default':

--- a/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
+++ b/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
@@ -44,7 +44,7 @@ const AddSubscribersModal = ( { site }: AddSubscribersModalProps ) => {
 
 	const isFreeSite = site?.plan?.is_free ?? false;
 	const isHostingTrial = site ? isHostingTrialSite( site ) : false;
-	const isSiteOnFreePlan = isFreeSite || isHostingTrial;
+	const hasSubscriberLimit = isFreeSite || isHostingTrial;
 
 	return (
 		<Modal
@@ -67,7 +67,7 @@ const AddSubscribersModal = ( { site }: AddSubscribersModalProps ) => {
 
 			<AddSubscriberForm
 				siteId={ site.ID }
-				isSiteOnFreePlan={ isSiteOnFreePlan }
+				hasSubscriberLimit={ hasSubscriberLimit }
 				submitBtnAlwaysEnable={ true }
 				onImportStarted={ onImportStarted }
 				onImportFinished={ onImportFinished }

--- a/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
+++ b/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
@@ -7,7 +7,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { LoadingBar } from 'calypso/components/loading-bar';
 import { useSubscribersPage } from 'calypso/my-sites/subscribers/components/subscribers-page/subscribers-page-context';
-import { isHostingTrialSite } from 'calypso/sites-dashboard/utils';
+import { isBusinessTrialSite } from 'calypso/sites-dashboard/utils';
 import './style.scss';
 
 type AddSubscribersModalProps = {
@@ -43,8 +43,8 @@ const AddSubscribersModal = ( { site }: AddSubscribersModalProps ) => {
 	}
 
 	const isFreeSite = site?.plan?.is_free ?? false;
-	const isHostingTrial = site ? isHostingTrialSite( site ) : false;
-	const hasSubscriberLimit = isFreeSite || isHostingTrial;
+	const isBusinessTrial = site ? isBusinessTrialSite( site ) : false;
+	const hasSubscriberLimit = isFreeSite || isBusinessTrial;
 
 	return (
 		<Modal

--- a/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
+++ b/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
@@ -1,19 +1,20 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { isEnabled } from '@automattic/calypso-config';
+import { SiteDetails } from '@automattic/data-stores';
 import { AddSubscriberForm } from '@automattic/subscriber';
 import { Modal } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { LoadingBar } from 'calypso/components/loading-bar';
 import { useSubscribersPage } from 'calypso/my-sites/subscribers/components/subscribers-page/subscribers-page-context';
+import { isHostingTrialSite } from 'calypso/sites-dashboard/utils';
 import './style.scss';
 
 type AddSubscribersModalProps = {
-	siteId: number;
-	siteTitle: string;
+	site: SiteDetails;
 };
 
-const AddSubscribersModal = ( { siteId, siteTitle }: AddSubscribersModalProps ) => {
+const AddSubscribersModal = ( { site }: AddSubscribersModalProps ) => {
 	const translate = useTranslate();
 	const { showAddSubscribersModal, setShowAddSubscribersModal, addSubscribersCallback } =
 		useSubscribersPage();
@@ -26,7 +27,7 @@ const AddSubscribersModal = ( { siteId, siteTitle }: AddSubscribersModalProps ) 
 	}, [] );
 
 	const modalTitle = translate( 'Add subscribers to %s', {
-		args: [ siteTitle ],
+		args: [ site.title ],
 		comment: "%s is the site's title",
 	} );
 
@@ -40,6 +41,10 @@ const AddSubscribersModal = ( { siteId, siteTitle }: AddSubscribersModalProps ) 
 	if ( ! showAddSubscribersModal ) {
 		return null;
 	}
+
+	const isFreeSite = site?.plan?.is_free ?? false;
+	const isHostingTrial = site ? isHostingTrialSite( site ) : false;
+	const isSiteOnFreePlan = isFreeSite || isHostingTrial;
 
 	return (
 		<Modal
@@ -61,7 +66,8 @@ const AddSubscribersModal = ( { siteId, siteTitle }: AddSubscribersModalProps ) 
 			) }
 
 			<AddSubscriberForm
-				siteId={ siteId }
+				siteId={ site.ID }
+				isSiteOnFreePlan={ isSiteOnFreePlan }
 				submitBtnAlwaysEnable={ true }
 				onImportStarted={ onImportStarted }
 				onImportFinished={ onImportFinished }

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -131,9 +131,7 @@ const SubscribersPage = ( {
 					onCancel={ resetSubscriber }
 					onConfirm={ onConfirmModal }
 				/>
-				{ selectedSite && (
-					<AddSubscribersModal siteId={ selectedSite.ID } siteTitle={ selectedSite.title } />
-				) }
+				{ selectedSite && <AddSubscribersModal site={ selectedSite } /> }
 			</Main>
 		</SubscribersPageProvider>
 	);

--- a/client/sites-dashboard/utils.ts
+++ b/client/sites-dashboard/utils.ts
@@ -70,8 +70,12 @@ export const isECommerceTrialSite = ( site: SiteExcerptNetworkData ) => {
 	return site?.plan?.product_slug === PLAN_ECOMMERCE_TRIAL_MONTHLY;
 };
 
+export const isBusinessTrialSite = ( site: SiteExcerptNetworkData ) => {
+	return isHostingTrialSite( site ) || isECommerceTrialSite( site );
+};
+
 export const isTrialSite = ( site: SiteExcerptNetworkData ) => {
-	return isMigrationTrialSite( site ) || isHostingTrialSite( site ) || isECommerceTrialSite( site );
+	return isMigrationTrialSite( site ) || isBusinessTrialSite( site );
 };
 
 export const siteDefaultInterface = ( site: SiteExcerptNetworkData ) => {

--- a/client/sites-dashboard/utils.ts
+++ b/client/sites-dashboard/utils.ts
@@ -71,11 +71,11 @@ export const isECommerceTrialSite = ( site: SiteExcerptNetworkData ) => {
 };
 
 export const isBusinessTrialSite = ( site: SiteExcerptNetworkData ) => {
-	return isHostingTrialSite( site ) || isECommerceTrialSite( site );
+	return isMigrationTrialSite( site ) || isHostingTrialSite( site );
 };
 
 export const isTrialSite = ( site: SiteExcerptNetworkData ) => {
-	return isMigrationTrialSite( site ) || isBusinessTrialSite( site );
+	return isBusinessTrialSite( site ) || isECommerceTrialSite( site );
 };
 
 export const siteDefaultInterface = ( site: SiteExcerptNetworkData ) => {

--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -27,7 +27,7 @@ import './style.scss';
 
 interface Props {
 	siteId: number;
-	isSiteOnFreePlan?: boolean;
+	hasSubscriberLimit?: boolean;
 	flowName?: string;
 	showTitle?: boolean;
 	showSubtitle?: boolean;
@@ -56,7 +56,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 	};
 	const {
 		siteId,
-		isSiteOnFreePlan,
+		hasSubscriberLimit,
 		flowName,
 		showTitle = true,
 		showSubtitle,
@@ -385,7 +385,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 	}
 
 	function renderImportCsvLabel() {
-		const ariaLabelMsg = isSiteOnFreePlan
+		const ariaLabelMsg = hasSubscriberLimit
 			? translate( 'Or upload a CSV file of up to 100 emails from your existing list. Learn more.' )
 			: translate( 'Or upload a CSV file of emails from your existing list. Learn more.' );
 
@@ -403,7 +403,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 			),
 		};
 
-		const labelText = isSiteOnFreePlan
+		const labelText = hasSubscriberLimit
 			? createInterpolateElement(
 					translate(
 						'Or <uploadBtn>upload a CSV file</uploadBtn> of up to 100 emails from your existing list. <Button>Learn more</Button>.'


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/4349.

## Proposed Changes

Title.

## Testing Instructions

- Create a new hosting trial site;
- Ensure the `subscriber-csv-upload` feature flag is on;
- Try importing the full CSV list attached;
- Make sure you get notified about the limit and only 100 subs are imported.

[499_email_subs.csv](https://github.com/Automattic/wp-calypso/files/13227348/499_email_subs.csv)
