### PR TITLE
Unverified domain email address: show a notice on the relevant screens

### DIFF
--- a/client/my-sites/domains/components/domain-warnings/style.scss
+++ b/client/my-sites/domains/components/domain-warnings/style.scss
@@ -4,6 +4,17 @@
 	padding: 5px;
 }
 
+.domain-warnings__notice {
+	background-color: var(--studio-white);
+	color: var(--color-text);
+	padding-right: 4px !important;
+	border-radius: 0 !important;
+	.notice__action {
+		background-color: var(--color-error-40) !important;
+		margin-right: 4px;
+	}
+}
+
 .domain-warnings__action {
 	background: none;
 	border: none;

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/email/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/email/index.tsx
@@ -37,7 +37,7 @@ const DomainEmailInfoCard = ( { domain, selectedSite }: DomainInfoCardProps ) =>
 			type="href"
 			href={ emailManagement( selectedSite.slug, domain.name ) }
 			title={ translate( 'Email' ) }
-			description={ translate( 'Send and receive emails from your email@%(domainName)s', {
+			description={ translate( 'Send and receive emails from youremail@%(domainName)s', {
 				args: { domainName: domain.name },
 			} ) }
 			ctaText={ translate( 'Add professional email' ) }

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/email/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/email/index.tsx
@@ -37,7 +37,7 @@ const DomainEmailInfoCard = ( { domain, selectedSite }: DomainInfoCardProps ) =>
 			type="href"
 			href={ emailManagement( selectedSite.slug, domain.name ) }
 			title={ translate( 'Email' ) }
-			description={ translate( 'Send and receive emails from youremail@%(domainName)s', {
+			description={ translate( 'Send and receive emails from your email@%(domainName)s', {
 				args: { domainName: domain.name },
 			} ) }
 			ctaText={ translate( 'Add professional email' ) }

--- a/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
@@ -472,7 +472,7 @@ class EditContactInfoFormCard extends Component {
 						) }
 						icon="cross-circle"
 						showDismiss={ false }
-						status="is-warning"
+						status="is-error"
 					>
 						<NoticeAction onClick={ () => this.props.verifyIcannEmail( selectedDomain.domain ) }>
 							{ translate( 'Resend Email' ) }

--- a/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
@@ -1,15 +1,13 @@
 import { Dialog } from '@automattic/components';
 import { camelToSnakeCase, mapRecordKeysRecursively, snakeToCamelCase } from '@automattic/js-utils';
 import { localize } from 'i18n-calypso';
-import { get, isEmpty, isEqual, includes, snakeCase } from 'lodash';
+import { get, includes, isEmpty, isEqual, snakeCase } from 'lodash';
 import moment from 'moment';
 import page from 'page';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import ContactDetailsFormFields from 'calypso/components/domains/contact-details-form-fields';
-import Notice from 'calypso/components/notice';
-import NoticeAction from 'calypso/components/notice/notice-action';
 import { registrar as registrarNames } from 'calypso/lib/domains/constants';
 import { findRegistrantWhois } from 'calypso/lib/domains/whois/utils';
 import wp from 'calypso/lib/wp';
@@ -17,16 +15,12 @@ import DesignatedAgentNotice from 'calypso/my-sites/domains/domain-management/co
 import TransferLockOptOutForm from 'calypso/my-sites/domains/domain-management/components/transfer-lock-opt-out-form';
 import { domainManagementEdit } from 'calypso/my-sites/domains/paths';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { requestWhois, saveWhois } from 'calypso/state/domains/management/actions';
 import {
-	requestWhois,
-	saveWhois,
-	verifyIcannEmail,
-} from 'calypso/state/domains/management/actions';
-import {
-	isUpdatingWhois,
 	getWhoisData,
 	getWhoisSaveError,
 	getWhoisSaveSuccess,
+	isUpdatingWhois,
 } from 'calypso/state/domains/management/selectors';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
@@ -462,23 +456,8 @@ class EditContactInfoFormCard extends Component {
 		}
 
 		const updateWpcomEmailCheckboxDisabled = this.shouldDisableUpdateWpcomEmailCheckbox();
-		const showDomainEmailNotice = this.props.selectedDomain.isPendingIcannVerification;
 		return (
 			<>
-				{ showDomainEmailNotice && (
-					<Notice
-						text={ translate(
-							'You must respond to the ICANN email to verify your domain email address or your domain will stop working. Check your details are correct below. '
-						) }
-						icon="cross-circle"
-						showDismiss={ false }
-						status="is-error"
-					>
-						<NoticeAction onClick={ () => this.props.verifyIcannEmail( selectedDomain.domain ) }>
-							{ translate( 'Resend Email' ) }
-						</NoticeAction>
-					</Notice>
-				) }
 				{ showContactInfoNote && (
 					<p className="edit-contact-info__note">
 						<em>
@@ -531,6 +510,5 @@ export default connect(
 		saveWhois,
 		successNotice,
 		createUserEmailPendingUpdate,
-		verifyIcannEmail,
 	}
 )( localize( EditContactInfoFormCard ) );

--- a/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
@@ -8,6 +8,8 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import ContactDetailsFormFields from 'calypso/components/domains/contact-details-form-fields';
+import Notice from 'calypso/components/notice';
+import NoticeAction from 'calypso/components/notice/notice-action';
 import { registrar as registrarNames } from 'calypso/lib/domains/constants';
 import { findRegistrantWhois } from 'calypso/lib/domains/whois/utils';
 import wp from 'calypso/lib/wp';
@@ -15,7 +17,11 @@ import DesignatedAgentNotice from 'calypso/my-sites/domains/domain-management/co
 import TransferLockOptOutForm from 'calypso/my-sites/domains/domain-management/components/transfer-lock-opt-out-form';
 import { domainManagementEdit } from 'calypso/my-sites/domains/paths';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
-import { requestWhois, saveWhois } from 'calypso/state/domains/management/actions';
+import {
+	requestWhois,
+	saveWhois,
+	verifyIcannEmail,
+} from 'calypso/state/domains/management/actions';
 import {
 	isUpdatingWhois,
 	getWhoisData,
@@ -456,9 +462,23 @@ class EditContactInfoFormCard extends Component {
 		}
 
 		const updateWpcomEmailCheckboxDisabled = this.shouldDisableUpdateWpcomEmailCheckbox();
-
+		const showDomainEmailNotice = this.props.selectedDomain.isPendingIcannVerification;
 		return (
 			<>
+				{ showDomainEmailNotice && (
+					<Notice
+						text={ translate(
+							'You must respond to the ICANN email to verify your domain email address or your domain will stop working. Check your details are correct below. '
+						) }
+						icon="cross-circle"
+						showDismiss={ false }
+						status="is-warning"
+					>
+						<NoticeAction onClick={ () => this.props.verifyIcannEmail( selectedDomain.domain ) }>
+							{ translate( 'Resend Email' ) }
+						</NoticeAction>
+					</Notice>
+				) }
 				{ showContactInfoNote && (
 					<p className="edit-contact-info__note">
 						<em>
@@ -511,5 +531,6 @@ export default connect(
 		saveWhois,
 		successNotice,
 		createUserEmailPendingUpdate,
+		verifyIcannEmail,
 	}
 )( localize( EditContactInfoFormCard ) );

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -596,7 +596,7 @@ const Settings = ( {
 			return (
 				<Notice
 					text={ translate(
-						'You must respond to the ICANN email to verify your domain email address or your domain will stop working. Check your details are correct below. '
+						'You must respond to the ICANN email to verify your domain email address or your domain will stop working. Check your contact information is correct below. '
 					) }
 					icon="cross-circle"
 					showDismiss={ false }

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -600,7 +600,7 @@ const Settings = ( {
 					) }
 					icon="cross-circle"
 					showDismiss={ false }
-					status="is-error"
+					status="is-warning"
 				>
 					<NoticeAction onClick={ () => verifyIcannEmail( domain.domain ) }>
 						{ translate( 'Resend Email' ) }

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -11,6 +11,8 @@ import Accordion from 'calypso/components/domains/accordion';
 import { useMyDomainInputMode } from 'calypso/components/domains/connect-domain-step/constants';
 import TwoColumnsLayout from 'calypso/components/domains/layout/two-columns-layout';
 import Main from 'calypso/components/main';
+import Notice from 'calypso/components/notice';
+import NoticeAction from 'calypso/components/notice/notice-action';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { getSelectedDomain, isDomainInGracePeriod, isDomainUpdateable } from 'calypso/lib/domains';
 import { transferStatus, type as domainTypes } from 'calypso/lib/domains/constants';
@@ -35,7 +37,7 @@ import { useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { getDomainDns } from 'calypso/state/domains/dns/selectors';
-import { requestWhois } from 'calypso/state/domains/management/actions';
+import { requestWhois, verifyIcannEmail } from 'calypso/state/domains/management/actions';
 import { getWhoisData } from 'calypso/state/domains/management/selectors';
 import {
 	getByPurchaseId,
@@ -76,6 +78,7 @@ const Settings = ( {
 	selectedSite,
 	updateNameservers,
 	whoisData,
+	verifyIcannEmail,
 }: SettingsPageProps ) => {
 	const translate = useTranslate();
 	const contactInformation = findRegistrantWhois( whoisData );
@@ -588,6 +591,26 @@ const Settings = ( {
 		);
 	};
 
+	const renderUnverifiedEmailNotice = () => {
+		if ( domain?.isPendingIcannVerification ) {
+			return (
+				<Notice
+					text={ translate(
+						'You must respond to the ICANN email to verify your domain email address or your domain will stop working. Check your details are correct below. '
+					) }
+					icon="cross-circle"
+					showDismiss={ false }
+					status="is-error"
+				>
+					<NoticeAction onClick={ () => verifyIcannEmail( domain.domain ) }>
+						{ translate( 'Resend Email' ) }
+					</NoticeAction>
+				</Notice>
+			);
+		}
+		return null;
+	};
+
 	const renderMainContent = () => {
 		// TODO: If it's a registered domain or transfer and the domain's registrar is in maintenance, show maintenance card
 		if ( ! domain ) {
@@ -595,6 +618,7 @@ const Settings = ( {
 		}
 		return (
 			<>
+				{ renderUnverifiedEmailNotice() }
 				{ renderStatusSection() }
 				{ renderDetailsSection() }
 				{ renderTranferInMappedDomainSection() }
@@ -660,5 +684,6 @@ export default connect(
 	{
 		requestWhois,
 		recordTracksEvent,
+		verifyIcannEmail,
 	}
 )( withDomainNameservers( Settings ) );

--- a/client/my-sites/domains/domain-management/settings/types.tsx
+++ b/client/my-sites/domains/domain-management/settings/types.tsx
@@ -47,6 +47,7 @@ export type SettingsPageNameServerHocProps = {
 export type SettingsPageConnectedDispatchProps = {
 	requestWhois: ( domain: string ) => void;
 	recordTracksEvent: typeof recordTracksEvent;
+	verifyIcannEmail: ( domain: string ) => void;
 };
 
 export type SettingsPageProps = SettingsPagePassedProps &


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
theinked issue.
-->

Related to #

## Proposed Changes

The notice in the sidebar with a "Fix" link sent you to the domain detail page, but there was no error message, so it wasn't clear what you had to do. This PR adds a notice with a "Resend email" option. 

* Show a notice if the domain email is unverified. Now shown at  `/domains/manage/:domain/edit/:site`
* Restyle Calypso sidebar notice to make it more prominent

![image](https://github.com/Automattic/wp-calypso/assets/6851384/711eb94c-5d2e-4650-9d4b-e6ade2931ed9)

![image](https://github.com/Automattic/wp-calypso/assets/6851384/410764e0-e16f-4afe-9deb-73e0d3c15fc6)

![image](https://github.com/Automattic/wp-calypso/assets/6851384/09629e53-b6c5-4d90-8ac4-aaad22df1190)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the test store to buy a domain and use an unverified email address
* Check the two paths above for the new banner. Try resending the email (it will call the API but is ignored on the backend because it's a test store domain)
* Check the new banner in the sidebar. 
* Try with different themes. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?