### PR TITLE
FHT: Ensure start trial CTA is not hidden by the floating action buttons

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/style.scss
@@ -14,6 +14,8 @@
 	margin: auto;
 	padding: 1rem;
 	text-align: center;
+	// 60px is the height of .step-container__navigation.action-buttons
+	padding-bottom: calc(60px + 3rem);
 
 	.onboarding-title {
 		margin-bottom: 0.5rem;


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/4434.

## Proposed Changes

![image](https://github.com/Automattic/wp-calypso/assets/26530524/c2db92d9-1004-4315-b9fa-2ac41cab91f3)

## Testing Instructions

On mobile, navigate to `/setup/new-hosted-site`, pick the trial plan and verify that the CTA on the acknowledge screen is not visible.