### PR TITLE
Make welcome message customizable on Atomic sites.

### DIFF
--- a/client/my-sites/site-settings/settings-newsletter/EmailsTextSetting.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/EmailsTextSetting.tsx
@@ -67,7 +67,7 @@ export const EmailsTextSetting = ( { value, disabled, updateFields }: EmailsText
 						<FormTextarea
 							name="welcome_email_message"
 							id="welcome_email_message"
-							value={ value?.welcome }
+							value={ value?.welcome || '' }
 							onChange={ updateSubscriptionOptions( 'welcome' ) }
 							disabled={ disabled }
 							autoCapitalize="none"

--- a/client/my-sites/site-settings/settings-newsletter/EmailsTextSetting.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/EmailsTextSetting.tsx
@@ -8,7 +8,6 @@ import { useSelector } from 'calypso/state';
 import {
 	isJetpackMinimumVersion,
 	isJetpackSite as isJetpackSiteSelector,
-	isSimpleSite as isSimpleSiteSelector,
 } from 'calypso/state/sites/selectors';
 import getSelectedSite from 'calypso/state/ui/selectors/get-selected-site';
 import { SubscriptionOptions } from '../settings-reading/main';
@@ -28,14 +27,14 @@ export const EmailsTextSetting = ( { value, disabled, updateFields }: EmailsText
 	const translate = useTranslate();
 	const selectedSite = useSelector( getSelectedSite );
 	const siteId = selectedSite?.ID;
-	const isSimpleSite = useSelector( isSimpleSiteSelector );
-	const isJetpackSite = useSelector( ( state ) => isJetpackSiteSelector( state, siteId ) );
 
+	const isJetpackSite = useSelector( ( state ) => isJetpackSiteSelector( state, siteId ) );
 	const isJetpackVersionSupported = useSelector( ( state: AppState ) => {
 		return siteId && isJetpackSite && isJetpackMinimumVersion( state, siteId, '12.8' );
 	} );
 
-	const hasWelcomeEmailFeature = isSimpleSite || isJetpackVersionSupported;
+	// For Simple & Atomic sites. On Jetpack sites, ensure it meets minimum supported version.
+	const hasWelcomeEmailFeature = ! isJetpackSite || ( isJetpackSite && isJetpackVersionSupported );
 
 	const updateSubscriptionOptions =
 		( option: string ) => ( event: React.ChangeEvent< HTMLInputElement > ) => {

--- a/client/my-sites/site-settings/settings-newsletter/EmailsTextSetting.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/EmailsTextSetting.tsx
@@ -30,10 +30,11 @@ export const EmailsTextSetting = ( { value, disabled, updateFields }: EmailsText
 
 	const isJetpackSite = useSelector( ( state ) => isJetpackSiteSelector( state, siteId ) );
 	const isJetpackVersionSupported = useSelector( ( state: AppState ) => {
-		return siteId && isJetpackSite && isJetpackMinimumVersion( state, siteId, '12.8' );
+		return siteId && isJetpackSite && isJetpackMinimumVersion( state, siteId, '12.8-a.11' );
 	} );
 
-	// For Simple & Atomic sites. On Jetpack sites, ensure it meets minimum supported version.
+	// isJetpackSite applies for both Atomic & self-hosted Jetpack,
+	// it needs to meet the minimum version 12.8-a.11 at least.
 	const hasWelcomeEmailFeature = ! isJetpackSite || ( isJetpackSite && isJetpackVersionSupported );
 
 	const updateSubscriptionOptions =


### PR DESCRIPTION
## Proposed Changes

* Opens welcome message customizability to Atomic sites.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go `/settings/newsletter/<youratomicsite_wordpress_com>`.
* Test you can edit the welcome message with simple, atomic and jetpack (> 12.8) site.
* The setting should get stored.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?