### PR TITLE
Signup: User step use email query arg

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -18,6 +18,7 @@ import {
 	pick,
 	omitBy,
 	snakeCase,
+	isEmpty,
 } from 'lodash';
 import page from 'page';
 import PropTypes from 'prop-types';
@@ -646,7 +647,7 @@ class SignupForm extends Component {
 					id="email"
 					name="email"
 					type="email"
-					value={ formState.getFieldValue( this.state.form, 'email' ) }
+					value={ this.getEmailValue() }
 					isError={ formState.isFieldInvalid( this.state.form, 'email' ) }
 					isValid={ this.state.validationInitialized && isEmailValid }
 					onBlur={ this.handleBlur }
@@ -1069,6 +1070,12 @@ class SignupForm extends Component {
 		return this.props.horizontal || 'videopress-account' === this.props.flowName;
 	};
 
+	getEmailValue = () => {
+		return isEmpty( formState.getFieldValue( this.state.form, 'email' ) )
+			? this.props.queryArgs?.user_email
+			: formState.getFieldValue( this.state.form, 'email' );
+	};
+
 	render() {
 		if ( this.getUserExistsError( this.props ) && ! this.props.shouldDisplayUserExistsError ) {
 			return null;
@@ -1178,6 +1185,7 @@ class SignupForm extends Component {
 					isReskinned={ this.props.isReskinned }
 					redirectToAfterLoginUrl={ this.props.redirectToAfterLoginUrl }
 					queryArgs={ this.props.queryArgs }
+					userEmail={ this.getEmailValue() }
 					notice={ this.getNotice( true ) }
 				/>
 			);
@@ -1213,6 +1221,7 @@ class SignupForm extends Component {
 						disabled={ this.props.disabled }
 						disableSubmitButton={ this.props.disableSubmitButton }
 						queryArgs={ this.props.queryArgs }
+						userEmail={ this.getEmailValue() }
 						{ ...gravatarProps }
 					/>
 

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -32,11 +32,17 @@ class PasswordlessSignupForm extends Component {
 		locale: 'en',
 	};
 
-	state = {
-		isSubmitting: false,
-		email: this.props.step && this.props.step.form ? this.props.step.form.email : '',
-		errorMessages: null,
-	};
+	constructor( props ) {
+		super( props );
+
+		const email = props.step?.form?.email ?? props.queryArgs?.user_email;
+
+		this.state = {
+			isSubmitting: false,
+			email,
+			errorMessages: null,
+		};
+	}
 
 	submitTracksEvent = ( isSuccessful, props ) => {
 		const tracksEventName = isSuccessful

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -33,15 +33,11 @@ class PasswordlessSignupForm extends Component {
 		locale: 'en',
 	};
 
-	constructor( props ) {
-		super( props );
-
-		this.state = {
-			isSubmitting: false,
-			email: props.userEmail,
-			errorMessages: null,
-		};
-	}
+	state = {
+		isSubmitting: false,
+		email: this.props.userEmail,
+		errorMessages: null,
+	};
 
 	submitTracksEvent = ( isSuccessful, props ) => {
 		const tracksEventName = isSuccessful

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -26,6 +26,7 @@ class PasswordlessSignupForm extends Component {
 		inputPlaceholder: PropTypes.string,
 		submitButtonLabel: PropTypes.string,
 		submitButtonLoadingLabel: PropTypes.string,
+		userEmail: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -35,11 +36,9 @@ class PasswordlessSignupForm extends Component {
 	constructor( props ) {
 		super( props );
 
-		const email = props.step?.form?.email ?? props.queryArgs?.user_email;
-
 		this.state = {
 			isSubmitting: false,
-			email,
+			email: props.userEmail,
 			errorMessages: null,
 		};
 	}

--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -24,6 +24,7 @@ interface SignupFormSocialFirst {
 	handleSocialResponse: () => void;
 	isReskinned: boolean;
 	queryArgs: object;
+	userEmail: string;
 	notice: JSX.Element | false;
 }
 
@@ -39,6 +40,7 @@ const SignupFormSocialFirst = ( {
 	handleSocialResponse,
 	isReskinned,
 	queryArgs,
+	userEmail,
 	notice,
 }: SignupFormSocialFirst ) => {
 	const [ currentStep, setCurrentStep ] = useState( 'initial' );
@@ -97,6 +99,7 @@ const SignupFormSocialFirst = ( {
 						queryArgs={ queryArgs }
 						labelText={ __( 'Your email' ) }
 						submitButtonLabel={ __( 'Continue' ) }
+						userEmail={ userEmail }
 						{ ...gravatarProps }
 					/>
 					<Button


### PR DESCRIPTION
Context: pdDR7T-172-p2#comment-1317

## What 

The signup page /start/user-social is not handling the user_email URL param. To reproduce:
- Go to /log-in and enter an email that does not have a WP.com account
- Click on the link that asks to create a new account
- I expected the registration page to auto-fill the email field with the value in the user_emailURL param value, but that did not happen.

This PR also centralises the calculation of the email value ( from step form field and then from queryArgs ) and passes it down to the various forms that can be used.

## Testing
Check that the email field is filled, in both:
- /start/user-social?user_email=test%40mail.com
- /start/onboarding-pm/user?user_email=test%40mail.com