### PR TITLE
Hosting config: Update recommended PHP version to 8.1

### DIFF
--- a/client/my-sites/hosting/web-server-settings-card/index.js
+++ b/client/my-sites/hosting/web-server-settings-card/index.js
@@ -184,7 +184,7 @@ const WebServerSettingsCard = ( {
 		);
 	};
 
-	const recommendedValue = '8.0';
+	const recommendedValue = '8.1';
 
 	const changePhpVersion = ( event ) => {
 		const newVersion = event.target.value;
@@ -208,21 +208,18 @@ const WebServerSettingsCard = ( {
 				value: '7.4',
 			},
 			{
+				label: '8.0',
+				value: '8.0',
+			},
+			{
 				label: translate( '%s (recommended)', {
-					args: '8.0',
+					args: '8.1',
 					comment: 'PHP Version for a version switcher',
 				} ),
 				value: recommendedValue,
 			},
 			{
-				label: '8.1',
-				value: '8.1',
-			},
-			{
-				label: translate( '%s (experimental)', {
-					args: '8.2',
-					comment: 'PHP Version for a version switcher',
-				} ),
+				label: '8.2',
 				value: '8.2',
 			},
 		];


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/83752

## Proposed Changes

Move the recommended PHP version from 8.0 to 8.1 to align it with the version updating process on Atomic.

| Before | After |
| - | - |
|<img width="710" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1182160/affa79e6-26c9-4f5e-bbb4-9354022d6a10">|<img width="717" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1182160/6c60faec-cc09-401b-8363-aaef3a9be4c4">|

## Testing Instructions

1. For a WoA site, navigate to `/hosting-config/{site_url}`
2. Verify that the 8.1 is labeled as `Recommended`
3. Verify that the 8.2 is no longer labeled as `Experimental`

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?