### PR TITLE
Big Sky: Bail flow

### DIFF
--- a/client/landing/stepper/declarative-flow/ai-assembler.ts
+++ b/client/landing/stepper/declarative-flow/ai-assembler.ts
@@ -124,7 +124,15 @@ const withAIAssemblerFlow: Flow = {
 			}
 		};
 
-		return { submit, goBack };
+		const goNext = () => {
+			switch ( _currentStep ) {
+				case 'site-prompt': {
+					return navigate( 'patternAssembler' );
+				}
+			}
+		};
+
+		return { submit, goBack, goNext };
 	},
 };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/ai-site-prompt/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/ai-site-prompt/index.tsx
@@ -56,7 +56,7 @@ const AISitePrompt: Step = function ( props ) {
 		event.preventDefault();
 		setLoading( true );
 		wpcomRequest( {
-			path: '/pattern-assembler/ai/v3/generate',
+			path: '/pattern-assembler/ai/latest/generate',
 			method: 'POST',
 			apiNamespace: 'wpcom/v2',
 			body: {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/ai-site-prompt/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/ai-site-prompt/index.tsx
@@ -81,7 +81,7 @@ const AISitePrompt: Step = function ( props ) {
 			.catch( ( error ) => {
 				console.error( 'big sky error', error ); /* eslint-disable-line no-console */
 				setLoading( false );
-				submit?.();
+				goNext?.();
 			} );
 	};
 


### PR DESCRIPTION
This:
- solves https://github.com/Automattic/ai-services/issues/606
- Uses 'latest' version of endpoint and not the hardcoded v3 (which is not latest any more)

This adds the "Skip for now" button so that people can exit the AI assembler flow

<img width="1134" alt="Zrzut ekranu 2023-11-1 o 16 31 04" src="https://github.com/Automattic/wp-calypso/assets/3775068/d317df46-82e3-407d-81a8-410fb67f30fe">

## Testing instructions

1. Open http://calypso.localhost:3000/setup/ai-assembler/site-prompt?siteSlug=YOUR_SITE
2. Click "Skip for now"

