### PR TITLE
Assembler: use the new `can_replace_content` param

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -338,9 +338,6 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 		const design = getDesign() as Design;
 		const stylesheet = design.recipe?.stylesheet ?? '';
 		const themeId = getThemeIdFromStylesheet( stylesheet );
-		const hasBlogPatterns = !! sections.find(
-			( { categories } ) => categories[ 'posts' ] || categories[ 'blog' ]
-		);
 
 		if ( ! siteSlugOrId || ! site?.ID || ! themeId ) {
 			return;
@@ -371,9 +368,10 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 								content: patterns[ 0 ].html,
 							} ) ),
 						globalStyles: syncedGlobalStylesUserConfig,
-						// Newly created sites with blog patterns reset the starter content created from the default Headstart annotation
-						// TODO: Ask users whether they want all their pages and posts to be replaced with the content from theme demo site
-						shouldResetContent: isNewSite && hasBlogPatterns,
+						// Newly created sites can have the content replaced when necessary,
+						// e.g. when the homepage has a blog pattern, we replace the posts with the content from theme demo site.
+						// TODO: Ask users whether they want that.
+						canReplaceContent: isNewSite,
 						// All sites using the assembler set the option wpcom_site_setup
 						siteSetupOption: design.is_virtual ? 'assembler-virtual-theme' : 'assembler',
 					} )

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -468,7 +468,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 			footerHtml,
 			pages,
 			globalStyles,
-			shouldResetContent,
+			canReplaceContent,
 			siteSetupOption,
 		}: AssembleSiteOptions = {}
 	) {
@@ -506,7 +506,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 				templates,
 				pages,
 				global_styles: globalStyles,
-				should_reset_content: shouldResetContent,
+				can_replace_content: canReplaceContent,
 				site_setup_option: siteSetupOption,
 			},
 			method: 'POST',

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -520,6 +520,6 @@ export interface AssembleSiteOptions {
 	footerHtml?: string;
 	pages?: Page[];
 	globalStyles?: GlobalStyles;
-	shouldResetContent?: boolean;
+	canReplaceContent?: boolean;
 	siteSetupOption?: string;
 }


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/wp-calypso/issues/83732

## Proposed Changes

This PR uses the new `can_replace_content` param introduced in D127391-code.

## Testing Instructions

See the test plan in D127391-code.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?