### PR TITLE
Signup: handle passswordless existing accounts

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -133,7 +133,11 @@ class Login extends Component {
 			window.scrollTo( 0, 0 );
 		}
 
-		if ( ! prevProps.accountType && isPasswordlessAccount( this.props.accountType ) ) {
+		if (
+			! prevProps.accountType &&
+			isPasswordlessAccount( this.props.accountType ) &&
+			! this.props.isSignupExistingAccount
+		) {
 			this.props.sendEmailLogin();
 			this.handleTwoFactorRequested( 'link' );
 		}

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -138,10 +138,14 @@ class Login extends Component {
 			isPasswordlessAccount( this.props.accountType ) &&
 			! this.props.isSignupExistingAccount
 		) {
-			this.props.sendEmailLogin();
-			this.handleTwoFactorRequested( 'link' );
+			this.sendMagicLoginLink();
 		}
 	}
+
+	sendMagicLoginLink = () => {
+		this.props.sendEmailLogin();
+		this.handleTwoFactorRequested( 'link' );
+	};
 
 	showContinueAsUser = () => {
 		const {
@@ -728,6 +732,7 @@ class Login extends Component {
 							handleUsernameChange={ handleUsernameChange }
 							signupUrl={ signupUrl }
 							showSocialLoginFormOnly={ true }
+							sendMagicLoginLink={ this.sendMagicLoginLink }
 						/>
 					</Fragment>
 				);
@@ -752,6 +757,7 @@ class Login extends Component {
 				signupUrl={ signupUrl }
 				hideSignupLink={ isGravPoweredLoginPage }
 				isSignupExistingAccount={ isSignupExistingAccount }
+				sendMagicLoginLink={ this.sendMagicLoginLink }
 			/>
 		);
 	}

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -47,7 +47,11 @@ import {
 	getSocialAccountLinkService,
 	isFormDisabled as isFormDisabledSelector,
 } from 'calypso/state/login/selectors';
-import { isPartnerSignupQuery, isRegularAccount } from 'calypso/state/login/utils';
+import {
+	isPartnerSignupQuery,
+	isPasswordlessAccount,
+	isRegularAccount,
+} from 'calypso/state/login/utils';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
@@ -192,7 +196,12 @@ export class LoginForm extends Component {
 	}
 
 	isUsernameOrEmailView() {
-		const { hasAccountTypeLoaded, socialAccountIsLinking } = this.props;
+		const { accountType, hasAccountTypeLoaded, socialAccountIsLinking, isSignupExistingAccount } =
+			this.props;
+
+		if ( isSignupExistingAccount && hasAccountTypeLoaded ) {
+			return isPasswordlessAccount( accountType );
+		}
 
 		return (
 			! socialAccountIsLinking &&

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -91,6 +91,7 @@ export class LoginForm extends Component {
 		currentQuery: PropTypes.object,
 		hideSignupLink: PropTypes.bool,
 		isSignupExistingAccount: PropTypes.bool,
+		sendMagicLoginLink: PropTypes.func,
 	};
 
 	state = {
@@ -257,6 +258,10 @@ export class LoginForm extends Component {
 			} );
 
 			return;
+		}
+
+		if ( isPasswordlessAccount( this.props.accountType ) ) {
+			this.props.sendMagicLoginLink?.();
 		}
 
 		this.loginUser();

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -105,47 +105,15 @@ class PasswordlessSignupForm extends Component {
 		this.submitTracksEvent( false, { action_message: error.message, error_code: error.error } );
 
 		if ( [ 'already_taken', 'already_active', 'email_exists' ].includes( error.error ) ) {
-			const email = typeof this.state.email === 'string' ? this.state.email.trim() : '';
-			const response = await wpcom.req.get(
-				`/users/${ encodeURIComponent( email ) }/auth-options`
+			page(
+				addQueryArgs(
+					{
+						email_address: this.state.email,
+						is_signup_existing_account: true,
+					},
+					this.props.logInUrl
+				)
 			);
-			// Just for https://github.com/Automattic/wp-calypso/pull/83249. Passwordless accounts will be changed to facilitate emailing the login link.
-			if ( ! response?.passwordless ) {
-				page(
-					addQueryArgs(
-						{
-							email_address: this.state.email,
-							is_signup_existing_account: true,
-						},
-						this.props.logInUrl
-					)
-				);
-				return;
-			}
-
-			const errorMessage = (
-				<>
-					{ this.props.translate( 'An account with this email address already exists.' ) }
-					&nbsp;
-					{ this.props.translate( '{{a}}Log in now{{/a}} to finish signing up.', {
-						components: {
-							a: (
-								<a
-									href={ `${ this.props.logInUrl }&email_address=${ encodeURIComponent(
-										this.state.email
-									) }` }
-								/>
-							),
-						},
-					} ) }
-				</>
-			);
-
-			this.setState( {
-				errorMessages: [ errorMessage ],
-				isSubmitting: false,
-			} );
-
 			return;
 		}
 


### PR DESCRIPTION
In https://github.com/Automattic/wp-calypso/pull/83249 we handle regular existing accounts trying to sign up. We directly send them to the login page, with the password input field already shown.

With this PR we handle passwordless existing accounts too, sending them to the login page directly.

## Before

![image](https://github.com/Automattic/wp-calypso/assets/52076348/7593c2c7-85ba-4a4f-be14-79a6cd24a76e)


## After

![image](https://github.com/Automattic/wp-calypso/assets/52076348/bc3f3bc0-2ede-48b9-9a9f-9256dac3f7b2)


## Testing

1. Live Link
2. Visit `/start/` and signup with an existing passwordless account
3. You should reach the After screen


Fixes https://github.com/Automattic/wp-calypso/issues/83467