### PR TITLE
Billing History: show receipt item discounts on each item

### DIFF
--- a/client/me/purchases/billing-history/receipt.tsx
+++ b/client/me/purchases/billing-history/receipt.tsx
@@ -359,7 +359,6 @@ function ReceiptLineItems( { transaction }: { transaction: BillingTransaction } 
 						<span>{ item.variation }</span>
 						<small>({ item.type_localized })</small>
 						{ termLabel && <em>{ termLabel }</em> }
-						<br />
 						{ item.domain && <em>{ item.domain }</em> }
 						{ item.licensed_quantity && (
 							<em>{ renderTransactionQuantitySummary( item, translate ) }</em>

--- a/client/me/purchases/billing-history/receipt.tsx
+++ b/client/me/purchases/billing-history/receipt.tsx
@@ -281,7 +281,26 @@ function VatDetails( { transaction }: { transaction: BillingTransaction } ) {
 	);
 }
 
-function ReceiptItemDiscounts( { item }: { item: BillingTransactionItem } ) {
+function areReceiptItemDiscountsAccurate( receiptDate: string ): boolean {
+	const date = new Date( receiptDate );
+	const receiptDateUnix = date.getTime() / 1000;
+	// D129863-code and D133350-code fixed volume discounts. Before that, cost
+	// override tags may be incomplete. The latter was merged on Jan 2, 2024,
+	// 17:54 UTC.
+	const receiptTagsAccurateAsOf = 1704218040;
+	return receiptDateUnix > receiptTagsAccurateAsOf;
+}
+
+function ReceiptItemDiscounts( {
+	item,
+	receiptDate,
+}: {
+	item: BillingTransactionItem;
+	receiptDate: string;
+} ) {
+	if ( ! areReceiptItemDiscountsAccurate( receiptDate ) ) {
+		return null;
+	}
 	return (
 		<ul className="billing-history__receipt-item-discounts-list">
 			{ item.cost_overrides
@@ -378,7 +397,7 @@ function ReceiptLineItems( { transaction }: { transaction: BillingTransaction } 
 				</tr>
 				<tr>
 					<td className="billing-history__receipt-item-discounts" colSpan={ 2 }>
-						<ReceiptItemDiscounts item={ item } />
+						<ReceiptItemDiscounts item={ item } receiptDate={ transaction.date } />
 					</td>
 				</tr>
 			</>

--- a/client/me/purchases/billing-history/receipt.tsx
+++ b/client/me/purchases/billing-history/receipt.tsx
@@ -386,7 +386,7 @@ function ReceiptLineItems( { transaction }: { transaction: BillingTransaction } 
 							<em>{ renderTransactionQuantitySummary( item, translate ) }</em>
 						) }
 					</td>
-					<td className={ 'billing-history__receipt-amount ' + transaction.credit }>
+					<td className="billing-history__receipt-amount">
 						{ formatCurrency( getReceiptItemOriginalCost( item ), item.currency, {
 							stripZeros: true,
 						} ) }

--- a/client/me/purchases/billing-history/receipt.tsx
+++ b/client/me/purchases/billing-history/receipt.tsx
@@ -331,7 +331,7 @@ function filterCostOverridesForReceiptItem(
 ): LineItemCostOverrideForDisplay[] {
 	return item.cost_overrides
 		.filter( ( costOverride ) => isUserVisibleCostOverride( costOverride ) )
-		.filter( ( costOverride ) =>
+		.map( ( costOverride ) =>
 			makeIntroductoryOfferCostOverrideUnique( costOverride, item, translate )
 		)
 		.map( ( costOverride ) => {

--- a/client/me/purchases/billing-history/receipt.tsx
+++ b/client/me/purchases/billing-history/receipt.tsx
@@ -283,19 +283,20 @@ function VatDetails( { transaction }: { transaction: BillingTransaction } ) {
 function ReceiptItemDiscounts( { item }: { item: BillingTransactionItem } ) {
 	return (
 		<ul className="billing-history__receipt-item-discounts-list">
-			{ item.cost_overrides.map( ( discount ) => {
-				// TODO: filter out discounts we don't want to show, like domain transfer price assignments.
-				const discountAmount = discount.old_price - discount.new_price;
-				const formattedDiscountAmount = formatCurrency( discountAmount, item.currency, {
-					stripZeros: true,
-				} );
-				return (
-					<li key={ discount.id }>
-						<span>{ discount.human_readable_reason }</span>
-						<span>{ formattedDiscountAmount }</span>
-					</li>
-				);
-			} ) }
+			{ item.cost_overrides
+				.filter( ( discount ) => ! discount.does_override_original_cost )
+				.map( ( discount ) => {
+					const discountAmount = discount.old_price - discount.new_price;
+					const formattedDiscountAmount = formatCurrency( discountAmount, item.currency, {
+						stripZeros: true,
+					} );
+					return (
+						<li key={ discount.id }>
+							<span>{ discount.human_readable_reason }</span>
+							<span>{ formattedDiscountAmount }</span>
+						</li>
+					);
+				} ) }
 		</ul>
 	);
 }

--- a/client/me/purchases/billing-history/receipt.tsx
+++ b/client/me/purchases/billing-history/receipt.tsx
@@ -298,18 +298,18 @@ function ReceiptItemDiscounts( {
 	item: BillingTransactionItem;
 	receiptDate: string;
 } ) {
-	if ( ! areReceiptItemDiscountsAccurate( receiptDate ) ) {
-		return null;
-	}
+	const shouldShowDiscount = areReceiptItemDiscountsAccurate( receiptDate );
 	return (
 		<ul className="billing-history__receipt-item-discounts-list">
 			{ item.cost_overrides
 				.filter( ( discount ) => ! discount.does_override_original_cost )
 				.map( ( discount ) => {
 					const discountAmount = discount.old_price - discount.new_price;
-					const formattedDiscountAmount = formatCurrency( -discountAmount, item.currency, {
-						stripZeros: true,
-					} );
+					const formattedDiscountAmount = shouldShowDiscount
+						? formatCurrency( -discountAmount, item.currency, {
+								stripZeros: true,
+						  } )
+						: '';
 					return (
 						<li key={ discount.id }>
 							<span>{ discount.human_readable_reason }</span>
@@ -371,6 +371,7 @@ function ReceiptItemTaxes( { transaction }: { transaction: BillingTransaction } 
 function ReceiptLineItems( { transaction }: { transaction: BillingTransaction } ) {
 	const translate = useTranslate();
 	const groupedTransactionItems = groupDomainProducts( transaction.items, translate );
+	const shouldShowDiscount = areReceiptItemDiscountsAccurate( transaction.date );
 
 	const items = groupedTransactionItems.map( ( item ) => {
 		const termLabel = getTransactionTermLabel( item, translate );
@@ -387,9 +388,13 @@ function ReceiptLineItems( { transaction }: { transaction: BillingTransaction } 
 						) }
 					</td>
 					<td className="billing-history__receipt-amount">
-						{ formatCurrency( getReceiptItemOriginalCost( item ), item.currency, {
-							stripZeros: true,
-						} ) }
+						{ formatCurrency(
+							shouldShowDiscount ? getReceiptItemOriginalCost( item ) : item.raw_subtotal,
+							item.currency,
+							{
+								stripZeros: true,
+							}
+						) }
 						{ transaction.credit && (
 							<span className="billing-history__credit-badge">{ translate( 'Refund' ) }</span>
 						) }

--- a/client/me/purchases/billing-history/receipt.tsx
+++ b/client/me/purchases/billing-history/receipt.tsx
@@ -385,19 +385,61 @@ function ReceiptItemDiscountIntroductoryOfferDate( { item }: { item: BillingTran
 	) {
 		return null;
 	}
+	const dueDate = item.introductory_offer_terms.subscription_auto_renew_date;
+	const dueAmount = item.introductory_offer_terms.renewal_price_integer;
+	const renewAmount = item.introductory_offer_terms.regular_renewal_price_integer;
 
 	return (
 		<div>
-			{ translate( 'Amount paid in transaction: %(price)s', {
-				args: {
-					price: formatCurrency( item.amount_integer, item.currency, {
+			<div>
+				{ translate( 'Amount paid in transaction: %(price)s', {
+					args: {
+						price: formatCurrency( item.amount_integer, item.currency, {
+							isSmallestUnit: true,
+							stripZeros: true,
+						} ),
+					},
+				} ) }
+			</div>
+			<div>
+				{ translate( 'Amount that will be billed %(dueDate)s: %(price)s', {
+					args: {
+						dueDate: new Date( dueDate ).toLocaleDateString( undefined, {
+							dateStyle: 'long',
+						} ),
+						price: formatCurrency( dueAmount, item.currency, {
+							isSmallestUnit: true,
+							stripZeros: true,
+						} ),
+					},
+				} ) }
+			</div>
+			<div>
+				<ReceiptItemRenewalInterval item={ item } />{ ' ' }
+				<span>
+					{ formatCurrency( renewAmount, item.currency, {
 						isSmallestUnit: true,
 						stripZeros: true,
-					} ),
-				},
-			} ) }
+					} ) }
+				</span>
+			</div>
 		</div>
 	);
+}
+
+function ReceiptItemRenewalInterval( { item }: { item: BillingTransactionItem } ) {
+	const translate = useTranslate();
+	switch ( item.months_per_renewal_interval ) {
+		case 1:
+			return <span>{ translate( 'Billed every month' ) }</span>;
+		case 12:
+			return <span>{ translate( 'Billed every year' ) }</span>;
+		case 24:
+			return <>{ translate( 'Billed every two years' ) }</>;
+		case 36:
+			return <>{ translate( 'Billed every three years' ) }</>;
+	}
+	return null;
 }
 
 function ReceiptItemDiscounts( {

--- a/client/me/purchases/billing-history/receipt.tsx
+++ b/client/me/purchases/billing-history/receipt.tsx
@@ -307,6 +307,9 @@ function ReceiptItemDiscounts( { item }: { item: BillingTransactionItem } ) {
  * overrides.
  */
 function getReceiptItemOriginalCost( item: BillingTransactionItem ): number {
+	if ( item.type === 'refund' ) {
+		return item.raw_amount;
+	}
 	const originalCostOverrides = item.cost_overrides.filter(
 		( override ) => override.does_override_original_cost
 	);

--- a/client/me/purchases/billing-history/receipt.tsx
+++ b/client/me/purchases/billing-history/receipt.tsx
@@ -287,7 +287,7 @@ function ReceiptItemDiscounts( { item }: { item: BillingTransactionItem } ) {
 				.filter( ( discount ) => ! discount.does_override_original_cost )
 				.map( ( discount ) => {
 					const discountAmount = discount.old_price - discount.new_price;
-					const formattedDiscountAmount = formatCurrency( discountAmount, item.currency, {
+					const formattedDiscountAmount = formatCurrency( -discountAmount, item.currency, {
 						stripZeros: true,
 					} );
 					return (

--- a/client/me/purchases/billing-history/receipt.tsx
+++ b/client/me/purchases/billing-history/receipt.tsx
@@ -5,6 +5,7 @@ import { formatCurrency } from '@automattic/format-currency';
 import { IntroductoryOfferTerms } from '@automattic/shopping-cart';
 import {
 	LineItemCostOverrideForDisplay,
+	doesIntroductoryOfferHaveDifferentTermLengthThanProduct,
 	getIntroductoryOfferIntervalDisplay,
 	isUserVisibleCostOverride,
 } from '@automattic/wpcom-checkout';
@@ -335,6 +336,23 @@ function filterCostOverridesForReceiptItem(
 			makeIntroductoryOfferCostOverrideUnique( costOverride, item, translate )
 		)
 		.map( ( costOverride ) => {
+			// Introductory offer discounts with term lengths that differ from
+			// the term length of the product (eg: a 3 month discount for an
+			// annual plan) need to be displayed differently because the
+			// discount is only temporary and the user will still be charged
+			// the remainder before the next renewal.
+			if (
+				doesIntroductoryOfferHaveDifferentTermLengthThanProduct(
+					item.cost_overrides,
+					item.introductory_offer_terms,
+					item.months_per_renewal_interval
+				)
+			) {
+				return {
+					humanReadableReason: costOverride.human_readable_reason,
+					overrideCode: costOverride.override_code,
+				};
+			}
 			return {
 				humanReadableReason: costOverride.human_readable_reason,
 				overrideCode: costOverride.override_code,

--- a/client/me/purchases/billing-history/style.scss
+++ b/client/me/purchases/billing-history/style.scss
@@ -90,7 +90,6 @@
 	font-size: $font-body-small;
 	display: flex;
 	justify-content: space-between;
-	margin-left: 30px;
 }
 
 .billing-history__header-row {
@@ -375,6 +374,10 @@ textarea.billing-history__billing-details-editable {
 			}
 		}
 	}
+}
+
+.billing-history__receipt tr td.billing-history__receipt-item-discounts {
+	padding: 4px 10px;
 }
 
 ul.billing-history__receipt-item-discounts-list {

--- a/client/me/purchases/billing-history/style.scss
+++ b/client/me/purchases/billing-history/style.scss
@@ -79,10 +79,18 @@
 	}
 }
 
-.billing-history__transaction-tax-amount {
+.transaction-amount__tax-amount {
 	color: var(--color-text-subtle);
 	font-size: $font-body-extra-small;
 	white-space: nowrap;
+}
+
+.billing-history__transaction-tax-amount {
+	color: var(--color-text-subtle);
+	font-size: $font-body-small;
+	display: flex;
+	justify-content: space-between;
+	margin-left: 30px;
 }
 
 .billing-history__header-row {
@@ -349,7 +357,6 @@ textarea.billing-history__billing-details-editable {
 		tbody tr {
 			td {
 				color: var(--color-neutral);
-				border-bottom: 1px solid var(--color-border-subtle);
 			}
 
 			&:last-child td {

--- a/client/me/purchases/billing-history/style.scss
+++ b/client/me/purchases/billing-history/style.scss
@@ -386,9 +386,13 @@ ul.billing-history__receipt-item-discounts-list {
 	font-size: $font-body-small;
 }
 
-ul.billing-history__receipt-item-discounts-list li {
+li.billing-history__receipt-item-discount {
 	display: flex;
 	justify-content: space-between;
+}
+
+li.billing-history__receipt-item-discount--different-term {
+	display: block;
 }
 
 .billing-history__receipt-links {

--- a/client/me/purchases/billing-history/style.scss
+++ b/client/me/purchases/billing-history/style.scss
@@ -377,7 +377,7 @@ textarea.billing-history__billing-details-editable {
 }
 
 .billing-history__receipt tr td.billing-history__receipt-item-discounts {
-	padding: 4px 10px;
+	padding: 4px 0;
 }
 
 ul.billing-history__receipt-item-discounts-list {

--- a/client/me/purchases/billing-history/style.scss
+++ b/client/me/purchases/billing-history/style.scss
@@ -370,6 +370,17 @@ textarea.billing-history__billing-details-editable {
 	}
 }
 
+ul.billing-history__receipt-item-discounts-list {
+	list-style-type: none;
+	margin: 0 0 0 30px;
+	font-size: $font-body-small;
+}
+
+ul.billing-history__receipt-item-discounts-list li {
+	display: flex;
+	justify-content: space-between;
+}
+
 .billing-history__receipt-links {
 	padding: 0 40px 10px;
 }

--- a/client/me/purchases/billing-history/test/tax.tsx
+++ b/client/me/purchases/billing-history/test/tax.tsx
@@ -68,6 +68,7 @@ const mockItem: BillingTransactionItem = {
 	variation_slug: '',
 	months_per_renewal_interval: 0,
 	wpcom_product_slug: '',
+	cost_overrides: [],
 };
 
 describe( 'transactionIncludesTax', () => {
@@ -211,38 +212,6 @@ test( 'tax includes', async () => {
 	expect( await screen.findByText( `(includes ${ transaction.tax } tax)` ) ).toBeInTheDocument();
 } );
 
-test( 'tax adding', async () => {
-	const transaction = {
-		...mockTransaction,
-		subtotal: '$36.00',
-		tax: '$2.48',
-		amount: '$38.48',
-		subtotal_integer: 3600,
-		tax_integer: 248,
-		amount_integer: 3848,
-		items: [
-			{
-				...mockItem,
-				raw_tax: 2.48,
-				tax_integer: 248,
-			},
-		],
-	};
-
-	const store = createTestReduxStore();
-	const queryClient = new QueryClient();
-	mockGetSupportedCountriesEndpoint( countryList );
-
-	render(
-		<ReduxProvider store={ store }>
-			<QueryClientProvider client={ queryClient }>
-				<TransactionAmount transaction={ transaction } addingTax />
-			</QueryClientProvider>
-		</ReduxProvider>
-	);
-	expect( await screen.findByText( `(+${ transaction.tax } tax)` ) ).toBeInTheDocument();
-} );
-
 test( 'tax includes with localized tax name', async () => {
 	const transaction = {
 		...mockTransaction,
@@ -274,39 +243,6 @@ test( 'tax includes with localized tax name', async () => {
 		</ReduxProvider>
 	);
 	expect( await screen.findByText( `(includes ${ transaction.tax } VAT)` ) ).toBeInTheDocument();
-} );
-
-test( 'tax adding with localized tax name', async () => {
-	const transaction = {
-		...mockTransaction,
-		subtotal: '$36.00',
-		tax: '$2.48',
-		amount: '$38.48',
-		tax_country_code: 'GB',
-		subtotal_integer: 3600,
-		tax_integer: 248,
-		amount_integer: 3848,
-		items: [
-			{
-				...mockItem,
-				raw_tax: 2.48,
-				tax_integer: 248,
-			},
-		],
-	};
-
-	const store = createTestReduxStore();
-	const queryClient = new QueryClient();
-	mockGetSupportedCountriesEndpoint( countryList );
-
-	render(
-		<ReduxProvider store={ store }>
-			<QueryClientProvider client={ queryClient }>
-				<TransactionAmount transaction={ transaction } addingTax />
-			</QueryClientProvider>
-		</ReduxProvider>
-	);
-	expect( await screen.findByText( `(+${ transaction.tax } VAT)` ) ).toBeInTheDocument();
 } );
 
 test( 'tax hidden if not available', async () => {

--- a/client/me/purchases/billing-history/utils.tsx
+++ b/client/me/purchases/billing-history/utils.tsx
@@ -130,7 +130,7 @@ export function TransactionAmount( {
 					stripZeros: true,
 				} ) }
 			</div>
-			<div className="billing-history__transaction-tax-amount">{ includesTaxString }</div>
+			<div className="transaction-amount__tax-amount">{ includesTaxString }</div>
 		</Fragment>
 	);
 }

--- a/client/me/purchases/billing-history/utils.tsx
+++ b/client/me/purchases/billing-history/utils.tsx
@@ -83,10 +83,8 @@ export function transactionIncludesTax( transaction: BillingTransaction ) {
 
 export function TransactionAmount( {
 	transaction,
-	addingTax = false,
 }: {
 	transaction: BillingTransaction;
-	addingTax?: boolean;
 } ): JSX.Element {
 	const translate = useTranslate();
 	const taxName = useTaxName( transaction.tax_country_code );
@@ -101,28 +99,6 @@ export function TransactionAmount( {
 			</>
 		);
 	}
-
-	const addingTaxString = taxName
-		? translate( '(+%(taxAmount)s %(taxName)s)', {
-				args: {
-					taxAmount: formatCurrency( transaction.tax_integer, transaction.currency, {
-						isSmallestUnit: true,
-						stripZeros: true,
-					} ),
-					taxName,
-				},
-				comment:
-					'taxAmount is a localized price, like $12.34 | taxName is a localized tax, like VAT or GST',
-		  } )
-		: translate( '(+%(taxAmount)s tax)', {
-				args: {
-					taxAmount: formatCurrency( transaction.tax_integer, transaction.currency, {
-						isSmallestUnit: true,
-						stripZeros: true,
-					} ),
-				},
-				comment: 'taxAmount is a localized price, like $12.34',
-		  } );
 
 	const includesTaxString = taxName
 		? translate( '(includes %(taxAmount)s %(taxName)s)', {
@@ -146,8 +122,6 @@ export function TransactionAmount( {
 				comment: 'taxAmount is a localized price, like $12.34',
 		  } );
 
-	const taxAmount = addingTax ? addingTaxString : includesTaxString;
-
 	return (
 		<Fragment>
 			<div>
@@ -156,7 +130,7 @@ export function TransactionAmount( {
 					stripZeros: true,
 				} ) }
 			</div>
-			<div className="billing-history__transaction-tax-amount">{ taxAmount }</div>
+			<div className="billing-history__transaction-tax-amount">{ includesTaxString }</div>
 		</Fragment>
 	);
 }

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -234,7 +234,11 @@ function LineItemIntroOfferCostOverrideDetail( { product }: { product: ResponseC
 		return null;
 	}
 
-	const shouldShowDueDate = doesIntroductoryOfferHaveDifferentTermLengthThanProduct( product );
+	const shouldShowDueDate = doesIntroductoryOfferHaveDifferentTermLengthThanProduct(
+		product.cost_overrides,
+		product.introductory_offer_terms,
+		product.months_per_bill_period
+	);
 
 	return (
 		<div>

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -198,7 +198,11 @@ function LineItemIntroOfferCostOverrideDetail( { product }: { product: ResponseC
 	// pricing that is difficult to display as a simple discount. Currently
 	// that is offers with different term lengths or price increases.
 	if (
-		! doesIntroductoryOfferHaveDifferentTermLengthThanProduct( product ) &&
+		! doesIntroductoryOfferHaveDifferentTermLengthThanProduct(
+			product.cost_overrides,
+			product.introductory_offer_terms,
+			product.months_per_bill_period
+		) &&
 		! doesIntroductoryOfferHavePriceIncrease( product )
 	) {
 		return null;

--- a/client/state/billing-transactions/types.ts
+++ b/client/state/billing-transactions/types.ts
@@ -1,3 +1,4 @@
+import type { IntroductoryOfferTerms } from '@automattic/shopping-cart';
 import type { Purchase, TaxVendorInfo } from '@automattic/wpcom-checkout';
 
 export interface IndividualReceipt {
@@ -133,6 +134,15 @@ export interface BillingTransactionItem {
 	 * receipt items made after October 2023.
 	 */
 	cost_overrides: ReceiptCostOverride[];
+
+	/**
+	 * The details of any introductory offer that was applied to this receipt,
+	 * assuming we have that data stored. Will only be available for receipts
+	 * made after `cost_overrides` became available on receipt items and after
+	 * we began using cost overrides for introductory offers in D134600-code
+	 * (February 2024).
+	 */
+	introductory_offer_terms: IntroductoryOfferTerms;
 
 	currency: string;
 	licensed_quantity: number | null;

--- a/client/state/billing-transactions/types.ts
+++ b/client/state/billing-transactions/types.ts
@@ -140,6 +140,12 @@ export interface ReceiptCostOverride {
 	override_code: string;
 
 	/**
+	 * If this is true, the override is not a discount but a reset for the base
+	 * price of the product.
+	 */
+	does_override_original_cost: boolean;
+
+	/**
 	 * The price as it was before this price change was applied. It is a float
 	 * in the currency's standard unit (eg: dollars in USD).
 	 */

--- a/client/state/billing-transactions/types.ts
+++ b/client/state/billing-transactions/types.ts
@@ -77,11 +77,15 @@ export interface BillingTransactionItem {
 	site_id: string;
 
 	/**
+	 * The receipt item's total before taxes in a locale and currency formatted
+	 * string.
 	 * @deprecated use subtotal_integer
 	 */
 	subtotal: string;
 
 	/**
+	 * The receipt item's total before taxes in the currency's standard unit as
+	 * a decimal, floating point number.
 	 * @deprecated use subtotal_integer
 	 */
 	raw_subtotal: number;
@@ -107,11 +111,14 @@ export interface BillingTransactionItem {
 	tax_integer: number;
 
 	/**
+	 * The receipt item's total as a locale and currency formatted string.
 	 * @deprecated use amount_integer
 	 */
 	amount: string;
 
 	/**
+	 * The receipt item's total in the currency's standard unit as a decimal,
+	 * floating point number.
 	 * @deprecated use amount_integer
 	 */
 	raw_amount: number;
@@ -121,6 +128,10 @@ export interface BillingTransactionItem {
 	 */
 	amount_integer: number;
 
+	/**
+	 * Every price change that was made to this receipt item. Only exists for
+	 * receipt items made after October 2023.
+	 */
 	cost_overrides: ReceiptCostOverride[];
 
 	currency: string;

--- a/client/state/billing-transactions/types.ts
+++ b/client/state/billing-transactions/types.ts
@@ -157,16 +157,16 @@ export interface ReceiptCostOverride {
 	does_override_original_cost: boolean;
 
 	/**
-	 * The price as it was before this price change was applied. It is a float
-	 * in the currency's standard unit (eg: dollars in USD).
+	 * The price as it was before this price change was applied. It is a number
+	 * in the curreny's smallest unit.
 	 */
-	old_price: number;
+	old_price_integer: number;
 
 	/**
-	 * The price as it was after this price change was applied. It is a float
-	 * in the currency's standard unit (eg: dollars in USD).
+	 * The price as it was after this price change was applied. It is a number
+	 * in the currency's smallest unit.
 	 */
-	new_price: number;
+	new_price_integer: number;
 }
 
 export interface UpcomingCharge {

--- a/client/state/billing-transactions/types.ts
+++ b/client/state/billing-transactions/types.ts
@@ -121,6 +121,8 @@ export interface BillingTransactionItem {
 	 */
 	amount_integer: number;
 
+	cost_overrides: ReceiptCostOverride[];
+
 	currency: string;
 	licensed_quantity: number | null;
 	new_quantity: number | null;
@@ -130,6 +132,24 @@ export interface BillingTransactionItem {
 	variation_slug: string;
 	months_per_renewal_interval: number;
 	wpcom_product_slug: string;
+}
+
+export interface ReceiptCostOverride {
+	id: string;
+	human_readable_reason: string;
+	override_code: string;
+
+	/**
+	 * The price as it was before this price change was applied. It is a float
+	 * in the currency's standard unit (eg: dollars in USD).
+	 */
+	old_price: number;
+
+	/**
+	 * The price as it was after this price change was applied. It is a float
+	 * in the currency's standard unit (eg: dollars in USD).
+	 */
+	new_price: number;
 }
 
 export interface UpcomingCharge {

--- a/client/state/billing-transactions/types.ts
+++ b/client/state/billing-transactions/types.ts
@@ -142,7 +142,7 @@ export interface BillingTransactionItem {
 	 * we began using cost overrides for introductory offers in D134600-code
 	 * (February 2024).
 	 */
-	introductory_offer_terms: IntroductoryOfferTerms;
+	introductory_offer_terms?: IntroductoryOfferTerms;
 
 	currency: string;
 	licensed_quantity: number | null;

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -580,12 +580,6 @@ export interface IntroductoryOfferTerms {
 	 * months instead of the full year.
 	 */
 	should_prorate_when_offer_ends: boolean;
-
-	subscription_auto_renew_date: string;
-
-	renewal_price_integer: number;
-
-	regular_renewal_price_integer: number;
 }
 
 export interface CartLocation {

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -580,6 +580,12 @@ export interface IntroductoryOfferTerms {
 	 * months instead of the full year.
 	 */
 	should_prorate_when_offer_ends: boolean;
+
+	subscription_auto_renew_date: string;
+
+	renewal_price_integer: number;
+
+	regular_renewal_price_integer: number;
 }
 
 export interface CartLocation {

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -1372,7 +1372,11 @@ function CheckoutLineItem( {
 	} );
 
 	const isIntroductoryOfferWithDifferentLength =
-		doesIntroductoryOfferHaveDifferentTermLengthThanProduct( product );
+		doesIntroductoryOfferHaveDifferentTermLengthThanProduct(
+			product.cost_overrides,
+			product.introductory_offer_terms,
+			product.months_per_bill_period
+		);
 	const amountWithIntroductoryOfferOnly = product.cost_overrides?.reduce(
 		( total, costOverride ) =>
 			costOverride.override_code === 'introductory-offer'

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -181,7 +181,10 @@ export interface LineItemCostOverrideForDisplay {
 	discountAmount?: number;
 }
 
-function isUserVisibleCostOverride( costOverride: ResponseCartCostOverride ): boolean {
+export function isUserVisibleCostOverride( costOverride: {
+	does_override_original_cost: boolean;
+	override_code: string;
+} ): boolean {
 	if ( costOverride.does_override_original_cost ) {
 		// We won't display original cost overrides since they are
 		// included in the original cost that's being displayed. They

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -275,22 +275,23 @@ function getBillPeriodMonthsForIntroductoryOfferInterval(
  * discount for an annual plan).
  */
 export function doesIntroductoryOfferHaveDifferentTermLengthThanProduct(
-	product: ResponseCartProduct
+	costOverrides: { override_code: string }[] | undefined,
+	introductoryOfferTerms: ResponseCartProduct[ 'introductory_offer_terms' ] | undefined,
+	monthsPerBillPeriodForProduct: number | undefined | null
 ): boolean {
 	if (
-		product.cost_overrides?.some(
-			( costOverride ) => costOverride.override_code !== 'introductory-offer'
-		)
+		costOverrides?.some( ( costOverride ) => {
+			costOverride.override_code !== 'introductory-offer';
+		} )
 	) {
 		return false;
 	}
-	if ( ! product.introductory_offer_terms?.enabled ) {
+	if ( ! introductoryOfferTerms?.enabled ) {
 		return false;
 	}
 	if (
-		getBillPeriodMonthsForIntroductoryOfferInterval(
-			product.introductory_offer_terms.interval_unit
-		) === product.months_per_bill_period
+		getBillPeriodMonthsForIntroductoryOfferInterval( introductoryOfferTerms.interval_unit ) ===
+		monthsPerBillPeriodForProduct
 	) {
 		return false;
 	}
@@ -353,7 +354,13 @@ export function filterCostOverridesForLineItem(
 				// annual plan) need to be displayed differently because the
 				// discount is only temporary and the user will still be charged
 				// the remainder before the next renewal.
-				if ( doesIntroductoryOfferHaveDifferentTermLengthThanProduct( product ) ) {
+				if (
+					doesIntroductoryOfferHaveDifferentTermLengthThanProduct(
+						product.cost_overrides,
+						product.introductory_offer_terms,
+						product.months_per_bill_period
+					)
+				) {
 					return {
 						humanReadableReason: costOverride.human_readable_reason,
 						overrideCode: costOverride.override_code,


### PR DESCRIPTION
## Proposed Changes

This PR modifies the billing history receipt view to add a list of each discount applied to its receipt items. This involves reformatting the way that line items are displayed on a receipt in the following ways:

- The line item total was previously the amount paid for that receipt item. Now it is the undiscounted price of the receipt item. That way the discounts which are shown below it will show how they reduced the price from its original total. **This means that the total for each line item is no longer shown anywhere!**
- Taxes were previously shown as subtext below the grand total. Now the tax is shown as a line item above the total. That way the receipt reads like a tally sheet with additions and subtractions to display how the grand total was calculated.

> [!Note]
> The names of each discount for receipts are only shown on receipts which were made after after D126240-code (October 10, 2023) when the data started to be recorded and the amount for each discount is only shown for receipts after D133350-code (January 2, 2024). Receipts before that point should continue to be displayed as they were originally, with the style changes noted above.

> [!Note]
> For introductory offers, this displays the human-readable version of that offer (eg: "First year free" or "Discount for first 3 months"). For offers where the billing term length is different from the product's term length (eg: a 3 month discount for an annual subscription), the discount amount is hidden and replaced with text that reads "Amount paid in transaction: $X" to avoid confusion (if such a discount is -$35, it would be misleading to suggest that the savings is $35 because the customer will be paying $26.25 in 3 months). You can read more about this strategy when we applied it to checkout in https://github.com/Automattic/wp-calypso/pull/87732. See the screenshots below which include such an offer.

Fixes https://github.com/Automattic/wp-calypso/issues/82025

Requires D139433-code

Before             |  After
:-------------------------:|:-------------------------:
<img width="852" alt="Screenshot 2023-11-21 at 10 42 11 AM" src="https://github.com/Automattic/wp-calypso/assets/2036909/61397781-8a0f-402a-a6a7-d3030ba8b87d">  | <img width="846" alt="Screenshot 2023-11-21 at 2 00 55 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/4fd6e595-cfd4-4bc4-bfb2-ecd9323a6247">
<img width="850" alt="Screenshot 2023-11-21 at 2 06 08 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/facebedb-596e-4ab8-9d09-85009cc25121"> | <img width="845" alt="Screenshot 2023-11-21 at 2 06 15 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/0a039843-d3fb-4f3d-a51f-97798d241471">
<img width="958" alt="Screenshot 2024-01-22 at 7 10 15 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/d71d2f01-e2f9-43f7-ae52-350abd515de4"> | <img width="956" alt="Screenshot 2024-01-22 at 7 10 04 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/b4a19ff9-a662-43e5-8610-bb60be4c4529">
<img width="657" alt="Screenshot 2024-02-26 at 1 50 22 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/6e71a21f-538a-43be-9ad1-bbc1c18b3edd"> | <img width="906" alt="Screenshot 2024-03-08 at 7 55 08 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/df96bf81-1def-47df-8c97-2e643fcc59da">


## Testing Instructions

- Make a purchase with a coupon or find an account which has a purchase that already has a coupon or other discount. It must be a purchase made after D133350-code (January 2, 2024).
- Visit https://wordpress.com/me/purchases/billing
- Click to view the receipt of the purchase with the discount.
- Verify that you see the discount listed under the receipt item and that the math of the prices is correct.
- Look at a purchase with discounts before D133350-code (January 2, 2024) but after D126240-code (October 10, 2023). Verify that the names of the discounts are shown but without amounts (since they might be inaccurate) and that the math of the prices is still correct.