### PR TITLE
Reader - Logged out /read - Rediect to /discover instead of signup page.

### DIFF
--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -362,3 +362,24 @@ export async function pendingSubscriptionsManager( context, next ) {
 	);
 	return next();
 }
+
+/**
+ * Middleware to redirect logged out users to /discover.
+ * Intended for reader pages that do not have
+ * logged out support such as /read.
+ *
+ * @param   {Object}   context Context object
+ * @param   {Function} next    Calls next middleware
+ * @returns {void}
+ */
+export function redirectLoggedOutToDiscover( context, next ) {
+	const state = context.store.getState();
+	if ( isUserLoggedIn( state ) ) {
+		next();
+		return;
+	}
+
+	const discoverUrl = window.location.origin + '/discover';
+
+	return page.redirect( discoverUrl );
+}

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -365,8 +365,7 @@ export async function pendingSubscriptionsManager( context, next ) {
 
 /**
  * Middleware to redirect logged out users to /discover.
- * Intended for reader pages that do not have
- * logged out support such as /read.
+ * Intended for reader pages that do not support logged out users such as /read.
  *
  * @param   {Object}   context Context object
  * @param   {Function} next    Calls next middleware
@@ -378,8 +377,5 @@ export function redirectLoggedOutToDiscover( context, next ) {
 		next();
 		return;
 	}
-
-	const discoverUrl = window.location.origin + '/discover';
-
-	return page.redirect( discoverUrl );
+	return page.redirect( '/discover' );
 }

--- a/client/reader/index.js
+++ b/client/reader/index.js
@@ -16,6 +16,7 @@ import {
 	legacyRedirects,
 	readA8C,
 	readFollowingP2,
+	redirectLoggedOutToDiscover,
 	sidebar,
 	updateLastRoute,
 	blogDiscoveryByFeedId,
@@ -48,7 +49,7 @@ export default async function () {
 	if ( config.isEnabled( 'reader' ) ) {
 		page(
 			'/read',
-			redirectLoggedOutToSignup,
+			redirectLoggedOutToDiscover,
 			updateLastRoute,
 			sidebar,
 			following,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # pe7F0s-1dI-p2

## Proposed Changes

* Updates the middleware used by the `/read` route to use a new `redirectLoggedOutToDiscover` instead of previous `redirectLoggedOutToSignup` middleware function.
* When loading `/read` while logged out, you are now redirected to `/discover` instead of the signup page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test this branch logged out.
* Verify `/read` redirects into `/discover`
* Test this logged in.
* Verify `/read` still works as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?