### PR TITLE
Storage Add-ons: Release upsell to all onboarding flows

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -101,10 +101,11 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goToStep, flow }: SidebarPr
 
 	const { title, launchTitle, subtitle } = getLaunchpadTranslations( flow );
 
-	const { getPlanCartItem, getDomainCartItem } = useSelect(
+	const { planCartItem, domainCartItem, productCartItems } = useSelect(
 		( select ) => ( {
-			getPlanCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getPlanCartItem,
-			getDomainCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getDomainCartItem,
+			planCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getPlanCartItem(),
+			domainCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getDomainCartItem(),
+			productCartItems: ( select( ONBOARD_STORE ) as OnboardSelect ).getProductCartItems(),
 		} ),
 		[]
 	);
@@ -124,8 +125,9 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goToStep, flow }: SidebarPr
 			flow,
 			isEmailVerified,
 			checklistStatuses,
-			getPlanCartItem(),
-			getDomainCartItem(),
+			planCartItem,
+			domainCartItem,
+			productCartItems,
 			stripeConnectUrl,
 			() => {
 				recordUnverifiedDomainDialogShownTracksEvent( site?.ID );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -58,6 +58,7 @@ export function getEnhancedTasks(
 	checklistStatuses: LaunchpadStatuses = {},
 	planCartItem?: MinimalRequestCartProduct | null,
 	domainCartItem?: MinimalRequestCartProduct | null,
+	productCartItems?: MinimalRequestCartProduct[] | null,
 	stripeConnectUrl?: string,
 	setShowConfirmModal: () => void = () => {}, // eslint-disable-line @typescript-eslint/no-empty-function
 	isDomainEmailUnverified = false
@@ -409,7 +410,12 @@ export function getEnhancedTasks(
 					};
 					break;
 				case 'blog_launched': {
-					const onboardingCartItems = [ planCartItem, domainCartItem ].filter( Boolean );
+					// If user selected products during onboarding, update cart and redirect to checkout
+					const onboardingCartItems = [
+						planCartItem,
+						domainCartItem,
+						...( productCartItems ?? [] ),
+					].filter( Boolean ) as MinimalRequestCartProduct[];
 					let title = task.title;
 					if ( isBlogOnboardingFlow( flow ) && planCompleted && onboardingCartItems.length ) {
 						title = translate( 'Checkout and launch' );
@@ -440,10 +446,6 @@ export function getEnhancedTasks(
 								) as OnboardActions;
 								setPendingAction( async () => {
 									setProgressTitle( __( 'Directing to checkout' ) );
-									// If user selected products during onboarding, update cart and redirect to checkout
-									const onboardingCartItems = [ planCartItem, domainCartItem ].filter(
-										Boolean
-									) as MinimalRequestCartProduct[];
 									if ( onboardingCartItems.length ) {
 										await replaceProductsInCart( siteSlug as string, onboardingCartItems );
 										const { goToCheckout } = useCheckout();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/step-content.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/step-content.tsx
@@ -70,6 +70,12 @@ jest.mock( '@wordpress/data', () => {
 								product_slug: 'mydomain.com',
 							},
 						],
+						getProductCartItems: () => [
+							{
+								product_slug: 'wordpress_com_1gb_space_addon_yearly',
+								volume: 50,
+							},
+						],
 						getSelectedDomain: () => ( {
 							is_free: false,
 							product_slug: 'mydomain.com',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -111,7 +111,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 		if ( cartItemForStorageAddOn ) {
 			setProductCartItems( [ cartItemForStorageAddOn ] );
 
-			cartItemForStorageAddOn?.extra &&
+			cartItemForStorageAddOn.extra &&
 				recordTracksEvent( 'calypso_signup_storage_add_on_upgrade_click', {
 					add_on_slug: cartItemForStorageAddOn.extra.feature_slug,
 				} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -109,7 +109,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 		);
 
 		if ( cartItemForStorageAddOn ) {
-			setProductCartItems( cartItemForStorageAddOn );
+			setProductCartItems( [ cartItemForStorageAddOn ] );
 
 			cartItemForStorageAddOn?.extra &&
 				recordTracksEvent( 'calypso_signup_storage_add_on_upgrade_click', {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -108,15 +108,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 			( items ) => items.product_slug === PRODUCT_1GB_SPACE
 		);
 
-		if ( cartItemForStorageAddOn ) {
-			setProductCartItems( [ cartItemForStorageAddOn ] );
-
-			cartItemForStorageAddOn.extra &&
-				recordTracksEvent( 'calypso_signup_storage_add_on_upgrade_click', {
-					add_on_slug: cartItemForStorageAddOn.extra.feature_slug,
-				} );
-		}
-
+		cartItemForStorageAddOn && setProductCartItems( [ cartItemForStorageAddOn ] );
 		setPlanCartItem( planCartItem );
 		props.onSubmit?.( planCartItem );
 	};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -1,4 +1,4 @@
-import { getPlan, PLAN_FREE } from '@automattic/calypso-products';
+import { getPlan, PLAN_FREE, PRODUCT_1GB_SPACE } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import {
 	START_WRITING_FLOW,
@@ -38,7 +38,7 @@ import './style.scss';
 interface Props {
 	shouldIncludeFAQ?: boolean;
 	flowName: string | null;
-	onSubmit: ( pickedPlan: MinimalRequestCartProduct | null ) => void;
+	onSubmit: ( planCartItem: MinimalRequestCartProduct | null ) => void;
 	plansLoaded: boolean;
 }
 
@@ -74,7 +74,8 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 	}, [] );
 	const { flowName } = props;
 
-	const { setPlanCartItem, setDomain, setDomainCartItem } = useDispatch( ONBOARD_STORE );
+	const { setPlanCartItem, setDomain, setDomainCartItem, setProductCartItems } =
+		useDispatch( ONBOARD_STORE );
 
 	const site = useSite();
 	const { __ } = useI18n();
@@ -90,7 +91,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 		? reduxHideFreePlan && 'plans-blog-onboarding' === plansIntent
 		: reduxHideFreePlan;
 
-	const onSelectPlan = ( cartItems?: MinimalRequestCartProduct[] | null ) => {
+	const onUpgradeClick = ( cartItems?: MinimalRequestCartProduct[] | null ) => {
 		const planCartItem = getPlanCartItem( cartItems );
 		if ( planCartItem ) {
 			recordTracksEvent( 'calypso_signup_plan_select', {
@@ -103,6 +104,19 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 			} );
 		}
 
+		const cartItemForStorageAddOn = cartItems?.find(
+			( items ) => items.product_slug === PRODUCT_1GB_SPACE
+		);
+
+		if ( cartItemForStorageAddOn ) {
+			setProductCartItems( cartItemForStorageAddOn );
+
+			cartItemForStorageAddOn?.extra &&
+				recordTracksEvent( 'calypso_signup_storage_add_on_upgrade_click', {
+					add_on_slug: cartItemForStorageAddOn.extra.feature_slug,
+				} );
+		}
+
 		setPlanCartItem( planCartItem );
 		props.onSubmit?.( planCartItem );
 	};
@@ -112,7 +126,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 	};
 
 	const handleFreePlanButtonClick = () => {
-		onSelectPlan( null ); // onUpgradeClick expects a cart item -- null means Free Plan.
+		onUpgradeClick( null ); // onUpgradeClick expects a cart item -- null means Free Plan.
 		props.onSubmit( null );
 	};
 
@@ -147,7 +161,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 					isInSignup={ isInSignup }
 					isStepperUpgradeFlow={ true }
 					intervalType={ getIntervalType() }
-					onUpgradeClick={ onSelectPlan }
+					onUpgradeClick={ onUpgradeClick }
 					paidDomainName={ getPaidDomainName() }
 					customerType={ customerType }
 					plansWithScroll={ isDesktop }

--- a/client/lib/trials/get-trial-checkout-url.ts
+++ b/client/lib/trials/get-trial-checkout-url.ts
@@ -1,16 +1,23 @@
+import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { addQueryArgs } from 'calypso/lib/url';
 
 interface TrialCheckoutUrlArguments {
 	productSlug: string;
 	siteSlug: string;
+	addOn?: MinimalRequestCartProduct;
 }
 
 export function getTrialCheckoutUrl( {
 	productSlug,
 	siteSlug,
+	addOn,
 }: TrialCheckoutUrlArguments ): string {
+	const checkoutUrl = addOn
+		? `/checkout/${ siteSlug }/${ productSlug },${ addOn.product_slug }:-q-${ addOn.quantity }`
+		: `/checkout/${ siteSlug }/${ productSlug }`;
+
 	return addQueryArgs(
 		{ redirect_to: `/plans/my-plan/trial-upgraded/${ siteSlug }` },
-		`/checkout/${ siteSlug }/${ productSlug }`
+		checkoutUrl
 	);
 }

--- a/client/my-sites/plans-grid/components/comparison-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/comparison-grid/index.tsx
@@ -571,9 +571,7 @@ const ComparisonGridFeatureGroupRowCell: React.FunctionComponent< {
 	allJetpackFeatures: Set< string >;
 	visibleGridPlans: GridPlan[];
 	planSlug: PlanSlug;
-	isInSignup: boolean;
 	isStorageFeature: boolean;
-	flowName?: string | null;
 	intervalType: string;
 	setActiveTooltipId: Dispatch< SetStateAction< string > >;
 	showUpgradeableStorage: boolean;
@@ -583,9 +581,7 @@ const ComparisonGridFeatureGroupRowCell: React.FunctionComponent< {
 	feature,
 	visibleGridPlans,
 	planSlug,
-	isInSignup,
 	isStorageFeature,
-	flowName,
 	intervalType,
 	activeTooltipId,
 	showUpgradeableStorage,
@@ -623,9 +619,7 @@ const ComparisonGridFeatureGroupRowCell: React.FunctionComponent< {
 	const storageOptions = gridPlan.features.storageOptions;
 	const defaultStorageOption = storageOptions.find( ( option ) => ! option.isAddOn );
 	const canUpgradeStorageForPlan = isStorageUpgradeableForPlan( {
-		flowName: flowName ?? '',
 		intervalType,
-		isInSignup,
 		showUpgradeableStorage,
 		storageOptions,
 	} );
@@ -743,9 +737,7 @@ const ComparisonGridFeatureGroupRow: React.FunctionComponent< {
 	allJetpackFeatures: Set< string >;
 	visibleGridPlans: GridPlan[];
 	planFeatureFootnotes: PlanFeatureFootnotes;
-	isInSignup: boolean;
 	isStorageFeature: boolean;
-	flowName?: string | null;
 	isHighlighted: boolean;
 	intervalType: string;
 	setActiveTooltipId: Dispatch< SetStateAction< string > >;
@@ -758,9 +750,7 @@ const ComparisonGridFeatureGroupRow: React.FunctionComponent< {
 	allJetpackFeatures,
 	visibleGridPlans,
 	planFeatureFootnotes,
-	isInSignup,
 	isStorageFeature,
-	flowName,
 	isHighlighted,
 	intervalType,
 	activeTooltipId,
@@ -835,9 +825,7 @@ const ComparisonGridFeatureGroupRow: React.FunctionComponent< {
 					allJetpackFeatures={ allJetpackFeatures }
 					visibleGridPlans={ visibleGridPlans }
 					planSlug={ planSlug }
-					isInSignup={ isInSignup }
 					isStorageFeature={ isStorageFeature }
-					flowName={ flowName }
 					intervalType={ intervalType }
 					activeTooltipId={ activeTooltipId }
 					setActiveTooltipId={ setActiveTooltipId }
@@ -852,8 +840,6 @@ const ComparisonGridFeatureGroupRow: React.FunctionComponent< {
 const FeatureGroup = ( {
 	featureGroup,
 	selectedFeature,
-	isInSignup,
-	flowName,
 	intervalType,
 	activeTooltipId,
 	setActiveTooltipId,
@@ -865,8 +851,6 @@ const FeatureGroup = ( {
 }: {
 	featureGroup: FeatureGroup;
 	selectedFeature?: string;
-	isInSignup: boolean;
-	flowName?: string | null;
 	intervalType: string;
 	activeTooltipId: string;
 	setActiveTooltipId: Dispatch< SetStateAction< string > >;
@@ -944,9 +928,7 @@ const FeatureGroup = ( {
 					allJetpackFeatures={ allJetpackFeatures }
 					visibleGridPlans={ visibleGridPlans }
 					planFeatureFootnotes={ planFeatureFootnotes }
-					isInSignup={ isInSignup }
 					isStorageFeature={ false }
-					flowName={ flowName }
 					isHighlighted={ feature.getSlug() === selectedFeature }
 					intervalType={ intervalType }
 					activeTooltipId={ activeTooltipId }
@@ -962,9 +944,7 @@ const FeatureGroup = ( {
 					allJetpackFeatures={ allJetpackFeatures }
 					visibleGridPlans={ visibleGridPlans }
 					planFeatureFootnotes={ planFeatureFootnotes }
-					isInSignup={ isInSignup }
 					isStorageFeature={ true }
-					flowName={ flowName }
 					isHighlighted={ false }
 					intervalType={ intervalType }
 					activeTooltipId={ activeTooltipId }
@@ -1152,8 +1132,6 @@ const ComparisonGrid = ( {
 						visibleGridPlans={ visibleGridPlans }
 						featureGroupMap={ featureGroupMap }
 						selectedFeature={ selectedFeature }
-						isInSignup={ isInSignup }
-						flowName={ flowName }
 						intervalType={ intervalType }
 						activeTooltipId={ activeTooltipId }
 						setActiveTooltipId={ setActiveTooltipId }

--- a/client/my-sites/plans-grid/components/features-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/features-grid/index.tsx
@@ -510,14 +510,7 @@ class FeaturesGrid extends Component< FeaturesGridType > {
 	}
 
 	renderPlanStorageOptions( renderedGridPlans: GridPlan[], options?: PlanRowOptions ) {
-		const {
-			translate,
-			intervalType,
-			isInSignup,
-			flowName,
-			onStorageAddOnClick,
-			showUpgradeableStorage,
-		} = this.props;
+		const { translate, intervalType, onStorageAddOnClick, showUpgradeableStorage } = this.props;
 
 		return renderedGridPlans.map( ( { planSlug, features: { storageOptions } } ) => {
 			if ( ! options?.isTableCell && isWpcomEnterpriseGridPlan( planSlug ) ) {
@@ -526,15 +519,9 @@ class FeaturesGrid extends Component< FeaturesGridType > {
 
 			const shouldRenderStorageTitle =
 				storageOptions.length > 0 &&
-				( storageOptions.length === 1 ||
-					intervalType !== 'yearly' ||
-					! showUpgradeableStorage ||
-					( isInSignup && ! ( flowName === 'onboarding' ) ) );
-
+				( storageOptions.length === 1 || intervalType !== 'yearly' || ! showUpgradeableStorage );
 			const canUpgradeStorageForPlan = isStorageUpgradeableForPlan( {
-				flowName: flowName ?? '',
 				intervalType,
-				isInSignup,
 				showUpgradeableStorage,
 				storageOptions,
 			} );

--- a/client/my-sites/plans-grid/lib/is-storage-upgradeable-for-plan.ts
+++ b/client/my-sites/plans-grid/lib/is-storage-upgradeable-for-plan.ts
@@ -1,20 +1,18 @@
 import type { StorageOption } from '@automattic/calypso-products';
 
+/**
+ * Don't show storage add-on-upsells for:
+ *  - the enterprise plan which has no storage options
+ * 	- plans that only have 1 default storage option ( and no upgrades )
+ *  - monthly or multi-year plans
+ *  - environments with a disabled feature flag
+ */
 export const isStorageUpgradeableForPlan = ( {
-	flowName,
 	intervalType,
-	isInSignup,
 	showUpgradeableStorage,
 	storageOptions,
 }: {
-	flowName: string;
 	intervalType: string;
-	isInSignup: boolean;
 	showUpgradeableStorage: boolean;
 	storageOptions: StorageOption[];
-} ) =>
-	// Don't show for the enterprise plan which has no storage options
-	storageOptions.length > 1 &&
-	intervalType === 'yearly' &&
-	showUpgradeableStorage &&
-	( flowName === 'onboarding' || ! isInSignup );
+} ) => storageOptions.length > 1 && intervalType === 'yearly' && showUpgradeableStorage;

--- a/client/my-sites/plans/trials/business-trial-plans/index.tsx
+++ b/client/my-sites/plans/trials/business-trial-plans/index.tsx
@@ -1,4 +1,9 @@
-import { PLAN_FREE, getPlanPath, isBusinessPlan } from '@automattic/calypso-products';
+import {
+	PLAN_FREE,
+	PRODUCT_1GB_SPACE,
+	getPlanPath,
+	isBusinessPlan,
+} from '@automattic/calypso-products';
 import page from 'page';
 import { useCallback } from 'react';
 import { getPlanCartItem } from 'calypso/lib/cart-values/cart-items';
@@ -23,11 +28,15 @@ export function BusinessTrialPlans( props: BusinessTrialPlansProps ) {
 
 			const planPath = getPlanPath( upgradePlanSlug ) ?? '';
 
-			const checkoutUrl = isBusinessPlan( upgradePlanSlug )
-				? getTrialCheckoutUrl( { productSlug: planPath, siteSlug } )
+			const cartItemForStorageAddOn = cartItems?.find(
+				( items ) => items.product_slug === PRODUCT_1GB_SPACE
+			);
+
+			const testUrl = isBusinessPlan( upgradePlanSlug )
+				? getTrialCheckoutUrl( { productSlug: planPath, siteSlug, addOn: cartItemForStorageAddOn } )
 				: `/checkout/${ siteSlug }/${ planPath }`;
 
-			page( checkoutUrl );
+			page( testUrl );
 		},
 		[ siteSlug, triggerTracksEvent ]
 	);

--- a/client/my-sites/plans/trials/business-trial-plans/index.tsx
+++ b/client/my-sites/plans/trials/business-trial-plans/index.tsx
@@ -32,11 +32,11 @@ export function BusinessTrialPlans( props: BusinessTrialPlansProps ) {
 				( items ) => items.product_slug === PRODUCT_1GB_SPACE
 			);
 
-			const testUrl = isBusinessPlan( upgradePlanSlug )
+			const checkoutUrl = isBusinessPlan( upgradePlanSlug )
 				? getTrialCheckoutUrl( { productSlug: planPath, siteSlug, addOn: cartItemForStorageAddOn } )
 				: `/checkout/${ siteSlug }/${ planPath }`;
 
-			page( testUrl );
+			page( checkoutUrl );
 		},
 		[ siteSlug, triggerTracksEvent ]
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/2023

## Proposed Changes

* Show storage add-on upsells to business and WooCommerce plans in all `/start` and `/setup` onboarding flows

## GIFs
### /start/onboarding-pm
![2023-11-01 11 47 10](https://github.com/Automattic/wp-calypso/assets/5414230/18b05f0b-48b1-489f-80fd-55468fae6354)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch
* Navigate to either a `/start` or `/setup` onboarding flow and follow steps until at the plans page ( Ex. `/start/onboarding-pm` )
* Select either a 50GB storage add-on or 100GB storage add-on for a business or WooCommerce plan
* Note that if a business or WooCommerce plan aren't displayed in the onboarding flow, then we expected to see _no_ storage add-on upsells
* Spot check that the header prices and billing timeframes update appropriately when a storage add-on is selected
* Verify that the storage add-on is added to the checkout cart when a plan upgrade button is clicked
* Repeat for a variety of other flows as catalogued in PCYsg-RDT-p2

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?