### PR TITLE
Jetpack Cloud: Dismiss site selector on Escape or outside click

### DIFF
--- a/client/components/jetpack/profile-dropdown/use-outside-click-callback.ts
+++ b/client/components/jetpack/profile-dropdown/use-outside-click-callback.ts
@@ -4,7 +4,6 @@ import * as React from 'react';
 /**
  * Hook that executes `callback` is the 'Escape' key is pressed
  * or if the user clicks outside of `ref`.
- *
  * @param ref       Ref to an HTML element
  * @param callback  Function to be executed
  */
@@ -31,8 +30,13 @@ export default function useOutsideClickCallback(
 	);
 
 	useEffect( () => {
-		document.addEventListener( 'keydown', handleEscape );
-		document.addEventListener( 'click', handleClick );
+		// HACK: adding these event listeners synchronously causes a mysterious
+		// race condition on some pages, but delaying them via setTimeout
+		// seems to take care of it.
+		setTimeout( () => {
+			document.addEventListener( 'keydown', handleEscape );
+			document.addEventListener( 'click', handleClick );
+		}, 0 );
 
 		return () => {
 			document.removeEventListener( 'keydown', handleEscape );

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -427,6 +427,7 @@ export class SiteSelector extends Component {
 
 		return (
 			<div
+				ref={ this.props.forwardRef }
 				className={ selectorClass }
 				onMouseMove={ this.onMouseMove }
 				onMouseLeave={ this.onMouseLeave }

--- a/client/jetpack-cloud/components/sidebar/header/profile-dropdown.tsx
+++ b/client/jetpack-cloud/components/sidebar/header/profile-dropdown.tsx
@@ -6,7 +6,7 @@ import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import { redirectToLogout } from 'calypso/state/current-user/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
-import useOutsideClickCallback from './use-outside-click-callback';
+import useOutsideClickCallback from '../use-outside-click-callback';
 
 import './style.scss';
 

--- a/client/jetpack-cloud/components/sidebar/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/index.tsx
@@ -1,7 +1,6 @@
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import JetpackIcons from 'calypso/components/jetpack/sidebar/menu-items/jetpack-icons';
-import SiteSelector from 'calypso/components/site-selector';
 import Sidebar, {
 	SidebarV2Main as SidebarMain,
 	SidebarV2Footer as SidebarFooter,
@@ -11,10 +10,10 @@ import Sidebar, {
 } from 'calypso/layout/sidebar-v2';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { hasJetpackPartnerAccess } from 'calypso/state/partner-portal/partner/selectors';
 import getJetpackAdminUrl from 'calypso/state/sites/selectors/get-jetpack-admin-url';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import SidebarHeader from './header';
+import JetpackCloudSiteSelector from './site-selector';
 
 import './style.scss';
 
@@ -56,8 +55,6 @@ const JetpackCloudSidebar = ( {
 	const jetpackAdminUrl = useSelector( ( state ) =>
 		siteId ? getJetpackAdminUrl( state, siteId ) : null
 	);
-
-	const canAccessJetpackManage = useSelector( hasJetpackPartnerAccess );
 
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -124,15 +121,7 @@ const JetpackCloudSidebar = ( {
 				</ul>
 			</SidebarFooter>
 
-			<SiteSelector
-				showAddNewSite
-				showAllSites={ canAccessJetpackManage }
-				isJetpackAgencyDashboard={ isJetpackManage }
-				className="jetpack-cloud-sidebar__site-selector"
-				allSitesPath="/dashboard"
-				siteBasePath="/landing"
-				wpcomSiteBasePath="https://wordpress.com/home"
-			/>
+			<JetpackCloudSiteSelector />
 		</Sidebar>
 	);
 };

--- a/client/jetpack-cloud/components/sidebar/site-selector.tsx
+++ b/client/jetpack-cloud/components/sidebar/site-selector.tsx
@@ -46,15 +46,13 @@ const SiteSelector = () => {
 			className="jetpack-cloud-sidebar__site-selector"
 			indicator
 			showAddNewSite
-			showAllSites
-			groups
+			showAllSites={ canAccessJetpackManage }
 			/* eslint-disable-next-line jsx-a11y/no-autofocus */
 			autoFocus={ isVisible }
 			isJetpackAgencyDashboard={ canAccessJetpackManage }
 			allSitesPath="/dashboard"
 			siteBasePath="/landing"
 			wpcomSiteBasePath="https://wordpress.com/home"
-			filter={ () => true }
 		/>
 	);
 };

--- a/client/jetpack-cloud/components/sidebar/site-selector.tsx
+++ b/client/jetpack-cloud/components/sidebar/site-selector.tsx
@@ -14,7 +14,11 @@ import useOutsideClickCallback from './use-outside-click-callback';
 const SITES_FOCUS = 'sites';
 
 const scrollToTop = () => {
-	document.getElementById( 'secondary' ).scrollTop = 0;
+	const sidebarRoot = document.getElementById( 'secondary' );
+	if ( sidebarRoot ) {
+		sidebarRoot.scrollTop = 0;
+	}
+
 	window.scrollTo( 0, 0 );
 };
 

--- a/client/jetpack-cloud/components/sidebar/site-selector.tsx
+++ b/client/jetpack-cloud/components/sidebar/site-selector.tsx
@@ -1,0 +1,62 @@
+import { useRef } from 'react';
+import BaseSiteSelector from 'calypso/components/site-selector';
+import { useDispatch, useSelector } from 'calypso/state';
+import { hasJetpackPartnerAccess } from 'calypso/state/partner-portal/partner/selectors';
+import { setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
+import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
+import useOutsideClickCallback from './use-outside-click-callback';
+
+/* NOTE: Code for this component was borrowed from calypso/my-sites/picker,
+ * with some slight modifications because we can safely assume we're using
+ * Jetpack Cloud.
+ */
+
+const SITES_FOCUS = 'sites';
+
+const scrollToTop = () => {
+	document.getElementById( 'secondary' ).scrollTop = 0;
+	window.scrollTo( 0, 0 );
+};
+
+const useHideSiteSelectorOnFocusOut = () => {
+	const dispatch = useDispatch();
+	const isVisible = useSelector( ( state ) => getCurrentLayoutFocus( state ) === SITES_FOCUS );
+	const siteSelectorRef = useRef( null );
+
+	useOutsideClickCallback( siteSelectorRef, () => {
+		if ( ! isVisible ) {
+			return;
+		}
+
+		dispatch( setLayoutFocus( 'sidebar' ) );
+		scrollToTop();
+	} );
+
+	return siteSelectorRef;
+};
+
+const SiteSelector = () => {
+	const isVisible = useSelector( ( state ) => getCurrentLayoutFocus( state ) === SITES_FOCUS );
+	const siteSelectorRef = useHideSiteSelectorOnFocusOut();
+	const canAccessJetpackManage = useSelector( hasJetpackPartnerAccess );
+
+	return (
+		<BaseSiteSelector
+			forwardRef={ siteSelectorRef }
+			className="jetpack-cloud-sidebar__site-selector"
+			indicator
+			showAddNewSite
+			showAllSites
+			groups
+			/* eslint-disable-next-line jsx-a11y/no-autofocus */
+			autoFocus={ isVisible }
+			isJetpackAgencyDashboard={ canAccessJetpackManage }
+			allSitesPath="/dashboard"
+			siteBasePath="/landing"
+			wpcomSiteBasePath="https://wordpress.com/home"
+			filter={ () => true }
+		/>
+	);
+};
+
+export default SiteSelector;

--- a/client/jetpack-cloud/components/sidebar/use-outside-click-callback.ts
+++ b/client/jetpack-cloud/components/sidebar/use-outside-click-callback.ts
@@ -30,8 +30,13 @@ export default function useOutsideClickCallback(
 	);
 
 	useEffect( () => {
-		document.addEventListener( 'keydown', handleEscape );
-		document.addEventListener( 'click', handleClick );
+		// HACK: adding these event listeners synchronously causes some sort of
+		// race condition on the Plugins page, but delaying them via setTimeout
+		// seems to take care of it.
+		setTimeout( () => {
+			document.addEventListener( 'keydown', handleEscape );
+			document.addEventListener( 'click', handleClick );
+		}, 0 );
 
 		return () => {
 			document.removeEventListener( 'keydown', handleEscape );

--- a/client/jetpack-cloud/components/sidebar/use-outside-click-callback.ts
+++ b/client/jetpack-cloud/components/sidebar/use-outside-click-callback.ts
@@ -4,7 +4,6 @@ import * as React from 'react';
 /**
  * Hook that executes `callback` is the 'Escape' key is pressed
  * or if the user clicks outside of `ref`.
- *
  * @param ref       Ref to an HTML element
  * @param callback  Function to be executed
  */


### PR DESCRIPTION
This pull request adds event handlers to the page such that when someone opens the sidebar's site selector, they're able to dismiss it by clicking elsewhere on the page or by pressing the Escape key.

Resolves https://github.com/Automattic/jetpack-genesis/issues/87.

## Proposed changes

- Wrap `useOutsideClickCallback` event handler registrations in `setTimeout` to address a troublesome race condition on the Plugins page.
- Add a forward ref to the `SiteSelector` component so it can be referenced by other components (and dismissed, in our case).
- Refactor the site selector visibility toggle in the sidebar header to rely on app state, not local state.
- Implement a new site selector for Jetpack Cloud and use it in place of the original one.

## Testing instructions

- In your Jetpack Cloud testing environment, visit all pages, in both All Sites and single-site view. Do this in mobile and desktop viewports.
- On each page, verify the profile dropdown still functions as expected when clicked.
- On each page, verify that you're able to open and close the site selector in an intuitive way:
  - clicking on the site name in the sidebar should open the selector if it's not open
  - clicking outside the sidebar should dismiss the selector if it's open
  - pressing the Escape key should dismiss the selector if it's open
  - clicking or focusing the search bar in the site selector should work as expected (e.g., you can type, and the selector does not dismiss early or unexpectedly)