### PR TITLE
Invalid intent prematurely set when site intent is being loaded from the backend

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -381,10 +381,13 @@ const PlansFeaturesMain = ( {
 
 	const [ intent, setIntent ] = useState< PlansIntent | undefined >( undefined );
 	useEffect( () => {
+		if ( ! intent && intentFromSiteMeta.processing ) {
+			return;
+		}
+
 		// TODO: plans from upsell takes precedence for setting intent right now
 		// - this is currently set to the default wpcom set until we have updated tailored features for all plans
 		// - at which point, we'll inject the upsell plan to the tailored plans mix instead
-
 		if ( 'plans-default-wpcom' !== intent && forceDefaultPlans ) {
 			setIntent( 'plans-default-wpcom' );
 		} else if ( ! intent ) {
@@ -394,7 +397,14 @@ const PlansFeaturesMain = ( {
 					: intentFromProps || intentFromSiteMeta.intent || 'plans-default-wpcom'
 			);
 		}
-	}, [ intent, intentFromProps, intentFromSiteMeta.intent, planFromUpsells, forceDefaultPlans ] );
+	}, [
+		intent,
+		intentFromProps,
+		intentFromSiteMeta.intent,
+		planFromUpsells,
+		forceDefaultPlans,
+		intentFromSiteMeta.processing,
+	] );
 
 	const showEscapeHatch =
 		intentFromSiteMeta.intent && ! isInSignup && 'plans-default-wpcom' !== intent;


### PR DESCRIPTION
- Related: https://github.com/Automattic/wp-calypso/pull/83724

## Proposed Changes

The proper intent based plans were not being shown on first load when the intent was being loaded from the backend for the first time. This was because we were eagerly setting the intent when the site meta intent was being loaded. This change forces to wait until the intent is being loaded.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/newsletter`
* Complete the flow
* Skip the launchpad
* Go to the `/plans` page
* Make sure the newletter flavour of plans are visible with a link to show all plans below.


<img width="810" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3422709/41e3f8e9-2e4a-4b65-a3a9-81821d347abf">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
