### PR TITLE
Fixes the blocked buttons for the Domain Upsell

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -18,7 +18,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
 import { localize, useTranslate } from 'i18n-calypso';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import QueryPlans from 'calypso/components/data/query-plans';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
@@ -30,6 +30,8 @@ import StepWrapper from 'calypso/signup/step-wrapper';
 import { getIntervalType } from 'calypso/signup/steps/plans/util';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getPlanSlug } from 'calypso/state/plans/selectors';
+import { setSelectedSiteId } from 'calypso/state/ui/actions';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { ONBOARD_STORE } from '../../../../stores';
 import type { OnboardSelect } from '@automattic/data-stores';
 import type { PlansIntent } from 'calypso/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans';
@@ -40,6 +42,8 @@ interface Props {
 	flowName: string | null;
 	onSubmit: ( pickedPlan: MinimalRequestCartProduct | null ) => void;
 	plansLoaded: boolean;
+	selectedSiteId: number | null;
+	setSelectedSiteId: ( siteId: number ) => void;
 }
 
 function getPlansIntent( flowName: string | null ): PlansIntent | null {
@@ -72,11 +76,19 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 			 ).getHidePlansFeatureComparison(),
 		};
 	}, [] );
-	const { flowName } = props;
+	const { flowName, selectedSiteId, setSelectedSiteId } = props;
 
 	const { setPlanCartItem, setDomain, setDomainCartItem } = useDispatch( ONBOARD_STORE );
 
 	const site = useSite();
+	const siteId = site?.ID;
+
+	useEffect( () => {
+		if ( ! selectedSiteId && siteId ) {
+			setSelectedSiteId( siteId );
+		}
+	}, [ selectedSiteId, siteId, setSelectedSiteId ] );
+
 	const { __ } = useI18n();
 	const translate = useTranslate();
 	const isDesktop = useDesktopBreakpoint();
@@ -256,8 +268,14 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 	);
 };
 
-export default connect( ( state ) => {
-	return {
-		plansLoaded: Boolean( getPlanSlug( state, getPlan( PLAN_FREE )?.getProductId() || 0 ) ),
-	};
-} )( localize( PlansWrapper ) );
+export default connect(
+	( state ) => {
+		return {
+			plansLoaded: Boolean( getPlanSlug( state, getPlan( PLAN_FREE )?.getProductId() || 0 ) ),
+			selectedSiteId: getSelectedSiteId( state ),
+		};
+	},
+	{
+		setSelectedSiteId: setSelectedSiteId,
+	}
+)( localize( PlansWrapper ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1698690462035789-slack-C01LXBU1N21

## Proposed Changes

* The user could not select a plan on the Domain Upsell. The buttons were blocked and displayed the "Downgrade" text.
* We noticed the `selectedSiteID` variable was null in the `usePlanUpgradeabilityCheck` hook. My reasoning was that this should not happen since we already have the site ID in this flow.

Before:

![Screen Shot 2023-11-01 at 17 32 18](https://github.com/Automattic/wp-calypso/assets/1234758/96d8715f-ece9-4a3d-ae52-dad3261a7964)

After:

![Screen Shot 2023-11-01 at 17 32 53](https://github.com/Automattic/wp-calypso/assets/1234758/b88a9dd2-1b9c-4b34-9a8f-6e5b5975ab4e)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Use the Calypso Live link below or apply this patch to your local environment
2. Navigate to `/pricing` on a incognito tab
3. Select Free plan
4. Create an account (I used email login)
5. Select a theme & Styles
6. Arrive at the launchpad, URL: `/setup/free/launchpad?siteSlug=SITEADDRESS`
7. Add a domain
8. Choose any domain to register, or try connecting a domain
9. Arrive at the plans page, URL:  `/setup/domain-upsell/plans?siteSlug=SITEADDRESS&flowToReturnTo=free&new=Free%20Site`
10. You should be able to select a plan

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?