### PR TITLE
Settings: Update "checklist site title tour" z-index to appear beneath Media modal

### DIFF
--- a/client/layout/guided-tours/tours/checklist-site-title-tour/index.js
+++ b/client/layout/guided-tours/tours/checklist-site-title-tour/index.js
@@ -21,6 +21,7 @@ export const ChecklistSiteTitleTour = makeTour(
 			placement="below"
 			style={ {
 				animationDelay: '0.7s',
+				zIndex: 100190,
 			} }
 		>
 			{ ( { translate } ) => (
@@ -46,7 +47,15 @@ export const ChecklistSiteTitleTour = makeTour(
 			) }
 		</Step>
 
-		<Step name="click-save" target="settings-site-profile-save" arrow="top-right" placement="below">
+		<Step
+			name="click-save"
+			target="settings-site-profile-save"
+			arrow="top-right"
+			placement="below"
+			style={ {
+				zIndex: 100190,
+			} }
+		>
 			{ ( { translate } ) => (
 				<Fragment>
 					<Continue target="settings-site-profile-save" step="finish" click>
@@ -59,7 +68,13 @@ export const ChecklistSiteTitleTour = makeTour(
 			) }
 		</Step>
 
-		<Step name="finish" placement="right">
+		<Step
+			name="finish"
+			placement="right"
+			style={ {
+				zIndex: 100190,
+			} }
+		>
 			{ ( { translate } ) => (
 				<Fragment>
 					<h1 className="tours__title">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/82609

## Proposed Changes

* This PR updates the z-index specifically on the "checklist site title tour" "guided tour" so that it appears beneath the Media modal popup.
* We target the "checklist site title tour" specifically so as not to cause unintended regressions in other "guided tours."
* We keep the z-index high but lower it just enough to be underneath the Media modal.

Before | After
--|--
<img width="1678" alt="Screenshot 2023-11-01 at 4 46 41 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/55e07df1-6848-4dd5-901a-0944a85268c4">  | <img width="1676" alt="Screenshot 2023-11-01 at 4 52 18 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/e761cfae-e2ca-4e94-824b-ba9c4cf388f8">



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/settings/general/?tour=checklistSiteTitle

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?