### PR TITLE
Partner Theme: Allow activation of installed theme

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -78,6 +78,7 @@ import {
 	isWporgTheme,
 	getCanonicalTheme,
 	getPremiumThemePrice,
+	getTheme,
 	getThemeDemoUrl,
 	getThemeDetailsUrl,
 	getThemeForumUrl,
@@ -857,6 +858,7 @@ class ThemeSheet extends Component {
 			isSiteEligibleForManagedExternalThemes,
 			isMarketplaceThemeSubscribed,
 			isThemeActivationSyncStarted,
+			isThemeInstalled,
 		} = this.props;
 		const { isAtomicTransferCompleted } = this.state;
 		if ( isActive ) {
@@ -883,7 +885,8 @@ class ThemeSheet extends Component {
 			} else if (
 				isExternallyManagedTheme &&
 				! isMarketplaceThemeSubscribed &&
-				isSiteEligibleForManagedExternalThemes
+				isSiteEligibleForManagedExternalThemes &&
+				! isThemeInstalled
 			) {
 				return translate( 'Subscribe to activate' );
 			} else if ( isThemeActivationSyncStarted && ! isAtomicTransferCompleted ) {
@@ -1409,6 +1412,7 @@ const ThemeSheetWithOptions = ( props ) => {
 		isStandaloneJetpack,
 		demoUrl,
 		showTryAndCustomize,
+		isThemeInstalled,
 		isBundledSoftwareSet,
 		isExternallyManagedTheme,
 		isSiteEligibleForManagedExternalThemes,
@@ -1435,7 +1439,8 @@ const ThemeSheetWithOptions = ( props ) => {
 	} else if (
 		isExternallyManagedTheme &&
 		isSiteEligibleForManagedExternalThemes &&
-		! isMarketplaceThemeSubscribed
+		! isMarketplaceThemeSubscribed &&
+		! isThemeInstalled
 	) {
 		defaultOption = 'subscribe';
 	} else if ( isPremium && ! isThemePurchased && ! isBundledSoftwareSet ) {
@@ -1514,6 +1519,7 @@ export default connect(
 			isVip: isVipSite( state, siteId ),
 			isPremium: isThemePremium( state, themeId ),
 			isThemePurchased: isPremiumThemeAvailable( state, themeId, siteId ),
+			isThemeInstalled: !! getTheme( state, siteId, themeId ),
 			isBundledSoftwareSet: doesThemeBundleSoftwareSet( state, themeId ),
 			isSiteBundleEligible: isSiteEligibleForBundledSoftware( state, siteId ),
 			forumUrl: getThemeForumUrl( state, themeId, siteId ),

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -1144,6 +1144,7 @@ class ThemeSheet extends Component {
 			translate,
 			isLoggedIn,
 			isPremium,
+			isThemeInstalled,
 			isThemePurchased,
 			isSiteBundleEligible,
 			isSiteEligibleForManagedExternalThemes,
@@ -1242,6 +1243,7 @@ class ThemeSheet extends Component {
 				( isPremium && ! isThemePurchased ) ||
 				( isBundledSoftwareSet && ! isSiteBundleEligible ) ||
 				( isExternallyManagedTheme &&
+					! isThemeInstalled &&
 					( ! isMarketplaceThemeSubscribed || ! isSiteEligibleForManagedExternalThemes ) );
 
 			const upsellNudgePlan =
@@ -1518,8 +1520,8 @@ export default connect(
 			isStandaloneJetpack,
 			isVip: isVipSite( state, siteId ),
 			isPremium: isThemePremium( state, themeId ),
-			isThemePurchased: isPremiumThemeAvailable( state, themeId, siteId ),
 			isThemeInstalled: !! getTheme( state, siteId, themeId ),
+			isThemePurchased: isPremiumThemeAvailable( state, themeId, siteId ),
 			isBundledSoftwareSet: doesThemeBundleSoftwareSet( state, themeId ),
 			isSiteBundleEligible: isSiteEligibleForBundledSoftware( state, siteId ),
 			forumUrl: getThemeForumUrl( state, themeId, siteId ),

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -191,6 +191,7 @@ function getAllThemeOptions( { translate, isFSEActive } ) {
 			! siteId ||
 			isJetpackSiteMultiSite( state, siteId ) ||
 			( isExternallyManagedTheme( state, themeId ) &&
+				! getTheme( state, siteId, themeId ) &&
 				! isMarketplaceThemeSubscribed( state, themeId, siteId ) ) ||
 			isThemeActive( state, themeId, siteId ) ||
 			( ! isWpcomTheme( state, themeId ) && ! isSiteWpcomAtomic( state, siteId ) ) ||


### PR DESCRIPTION
Fixes  #83486


## Proposed Changes

* Show activate option when the theme is installed but inactive
* Hide banner when the Partner theme is already installed
* Show the Activate option on the theme card

| Themes List | Theme details (inactive) | Theme Details (active) |
| ------------- | ------------- |------------- |
|![CleanShot 2023-11-01 at 15 31 15@2x](https://github.com/Automattic/wp-calypso/assets/5039531/6614aa87-8233-4047-bf34-e44ec6a0d0fd)|![CleanShot 2023-11-01 at 15 33 07@2x](https://github.com/Automattic/wp-calypso/assets/5039531/905a8394-dcc5-407c-970f-af798995173b)|![CleanShot 2023-11-01 at 15 33 19@2x](https://github.com/Automattic/wp-calypso/assets/5039531/b12aa28e-7af3-4693-8904-76aaafc5ae06)|




## Testing Instructions

* Upload a Partner Theme and don't activate it
* Go to `/themes`
* Click on the `My themes` tab 
* The installed theme should be on the list and the `Activate` option should be displayed and working
* Activate another theme
* Go again to `My Themes` and click on the uploaded theme
* You should see the activate option as in the image above
* Click to activate and the theme should be activated 
* You should see the option `Customize site` and the image above
* You shouldn't see any upsell banner

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
