### PR TITLE
Happy Blocks: Rename Store to Commerce on header

### DIFF
--- a/apps/happy-blocks/block-library/universal-header/index.php
+++ b/apps/happy-blocks/block-library/universal-header/index.php
@@ -15,8 +15,7 @@ require_once WP_CONTENT_DIR . '/themes/h4/landing/marketing/pages/_common/lib/fu
 if ( ! isset( $args ) ) {
 	$args = array();
 }
-$happy_blocks_is_english = ( 0 === stripos( get_locale(), 'en' ) );
-$website_clasname        = '';
+$website_clasname = '';
 if ( isset( $args['website'] ) ) {
 	$website_clasname = 'is-' . $args['website'];
 }
@@ -178,7 +177,7 @@ if ( isset( $args['website'] ) ) {
 							<a role="menuitem" class="x-dropdown-link x-link"
 								href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/ecommerce/' ) ); ?>"
 								tabindex="-1">
-								<?php echo esc_html( __( 'Store', 'happy-blocks' ) ); ?>
+								<?php echo esc_html( __( 'Commerce', 'happy-blocks' ) ); ?>
 							</a>
 						</li>
 						<li>
@@ -446,7 +445,7 @@ if ( isset( $args['website'] ) ) {
 								<a role="menuitem" class="x-menu-link x-link"
 									href="<?php echo esc_url( localized_wpcom_url( '//wordpress.com/ecommerce/' ) ); ?>"
 									tabindex="-1">
-									<?php echo esc_html( __( 'Store', 'happy-blocks' ) ); ?>
+									<?php echo esc_html( __( 'Commerce', 'happy-blocks' ) ); ?>
 								</a>
 							</li>
 							<li class="x-menu-grid-item">


### PR DESCRIPTION
Slack request: p1698862300973319-slack-CKZHG0QCR

## Proposed Changes

We want to rename Store to Commerce on header.

| Mobile | Desktop |
| --- | --- |
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/41f5bf5e-9254-42d4-8b0a-875169d352a7) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/1c3e72b5-6b08-4f64-a5c5-7b08b9216e56) |

## Testing Instructions

* Sandbox `wordpress.com`
* Go to `/apps/happy-blocks`
* Run `yarn dev --sync`
* Go to https://wordpress.com/learn/ while logged-out
* You should see `Commerce` instead of `Store` in the Products menu