### PR TITLE
Domains: Implement partial BIND file importing

### DIFF
--- a/client/my-sites/domains/domain-management/dns/dns-import-bind-file-button.tsx
+++ b/client/my-sites/domains/domain-management/dns/dns-import-bind-file-button.tsx
@@ -26,36 +26,26 @@ function DnsImportBindFileButton( { domain, isMobile }: DnsImportBindFileButtonP
 	}, 0 );
 
 	const toggleRecord = ( recordIndex: number ) => {
-		if ( recordsToImport ) {
-			const newRecordsToImport: ImportedDnsRecord[] = [];
-			recordsToImport.forEach( ( record: ImportedDnsRecord, index: number ) => {
-				if ( index === recordIndex ) {
-					record.selected = ! record.selected;
-				}
-				newRecordsToImport.push( { ...record } );
-			} );
-			setRecordsToImport( newRecordsToImport );
+		if ( ! recordsToImport ) {
+			return;
 		}
+
+		const newRecordsToImport = [ ...recordsToImport ];
+		newRecordsToImport[ recordIndex ].selected = ! newRecordsToImport[ recordIndex ].selected;
+		setRecordsToImport( newRecordsToImport );
 	};
 
 	const toggleAllRecords = () => {
-		if ( recordsToImport ) {
-			if ( numberOfSelectedRecords === recordsToImport?.length ) {
-				const newRecordsToImport: ImportedDnsRecord[] = [];
-				recordsToImport.forEach( ( record: ImportedDnsRecord ) => {
-					record.selected = false;
-					newRecordsToImport.push( { ...record } );
-				} );
-				setRecordsToImport( newRecordsToImport );
-			} else {
-				const newRecordsToImport: ImportedDnsRecord[] = [];
-				recordsToImport.forEach( ( record: ImportedDnsRecord ) => {
-					record.selected = true;
-					newRecordsToImport.push( { ...record } );
-				} );
-				setRecordsToImport( newRecordsToImport );
-			}
+		if ( ! recordsToImport ) {
+			return;
 		}
+
+		const newSelectedState = numberOfSelectedRecords !== recordsToImport?.length;
+		const newRecordsToImport = [ ...recordsToImport ];
+		newRecordsToImport.forEach( ( record: ImportedDnsRecord ) => {
+			record.selected = newSelectedState;
+		} );
+		setRecordsToImport( newRecordsToImport );
 	};
 
 	const className = classNames( 'dns__breadcrumb-button import-bind-file', {

--- a/client/my-sites/domains/domain-management/dns/dns-import-bind-file-button.tsx
+++ b/client/my-sites/domains/domain-management/dns/dns-import-bind-file-button.tsx
@@ -123,12 +123,12 @@ function DnsImportBindFileButton( { domain, isMobile }: DnsImportBindFileButtonP
 	return (
 		<>
 			<ImportBindFileConfirmationDialog
-				visible={ importBindFileConfirmationDialogIsVisible }
+				numberOfSelectedRecords={ numberOfSelectedRecords }
 				onClose={ closeImportBindFileDialog }
 				recordsToImport={ recordsToImport }
-				toggleRecord={ toggleRecord }
 				toggleAllRecords={ toggleAllRecords }
-				numberOfSelectedRecords={ numberOfSelectedRecords }
+				toggleRecord={ toggleRecord }
+				visible={ importBindFileConfirmationDialogIsVisible }
 			/>
 
 			<FilePicker onPick={ onFileSelected }>

--- a/client/my-sites/domains/domain-management/dns/dns-import-bind-file-button.tsx
+++ b/client/my-sites/domains/domain-management/dns/dns-import-bind-file-button.tsx
@@ -22,13 +22,10 @@ function DnsImportBindFileButton( { domain, isMobile }: DnsImportBindFileButtonP
 	const [ recordsToImport, setRecordsToImport ] = useState< ImportedDnsRecord[] | null >( null );
 
 	const numberOfSelectedRecords = recordsToImport?.reduce( ( numberOfSelectedRecords, record ) => {
-		if ( record.selected ) {
-			return numberOfSelectedRecords + 1;
-		}
-		return numberOfSelectedRecords;
+		return numberOfSelectedRecords + ( record.selected ? 1 : 0 );
 	}, 0 );
 
-	const toggleSelectedRecord = ( recordIndex: number ) => {
+	const toggleRecord = ( recordIndex: number ) => {
 		if ( recordsToImport ) {
 			const newRecordsToImport: ImportedDnsRecord[] = [];
 			recordsToImport.forEach( ( record: ImportedDnsRecord, index: number ) => {
@@ -129,7 +126,7 @@ function DnsImportBindFileButton( { domain, isMobile }: DnsImportBindFileButtonP
 				visible={ importBindFileConfirmationDialogIsVisible }
 				onClose={ closeImportBindFileDialog }
 				recordsToImport={ recordsToImport }
-				toggleSelectedRecord={ toggleSelectedRecord }
+				toggleRecord={ toggleRecord }
 				toggleAllRecords={ toggleAllRecords }
 				numberOfSelectedRecords={ numberOfSelectedRecords }
 			/>

--- a/client/my-sites/domains/domain-management/dns/import-bind-file-confirmation-dialog.jsx
+++ b/client/my-sites/domains/domain-management/dns/import-bind-file-confirmation-dialog.jsx
@@ -1,8 +1,18 @@
 import { Dialog } from '@automattic/components';
+import { CheckboxControl } from '@wordpress/components';
+import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
+import classNames from 'classnames';
 
-function ImportBindFileConfirmationDialog( { onClose, visible, recordsToImport } ) {
-	const { __ } = useI18n();
+function ImportBindFileConfirmationDialog( {
+	numberOfSelectedRecords,
+	onClose,
+	recordsToImport,
+	toggleAllRecords,
+	toggleSelectedRecord,
+	visible,
+} ) {
+	const { __, _n } = useI18n();
 
 	const onImportRecords = () => {
 		onClose( true );
@@ -22,6 +32,7 @@ function ImportBindFileConfirmationDialog( { onClose, visible, recordsToImport }
 			label: __( 'Import records' ),
 			isPrimary: true,
 			onClick: onImportRecords,
+			disabled: numberOfSelectedRecords === 0,
 		},
 	];
 
@@ -51,10 +62,52 @@ function ImportBindFileConfirmationDialog( { onClose, visible, recordsToImport }
 		}
 	};
 
+	const renderHeader = () => {
+		const headerLabel = sprintf(
+			/* translators: %d is the number of selected DNS records to be imported into a domain */
+			_n( '%d record selected', '%d records selected', numberOfSelectedRecords ),
+			numberOfSelectedRecords
+		);
+
+		return (
+			<div className="import-bind-file-confirmation-dialog__header">
+				<CheckboxControl
+					__nextHasNoMarginBottom
+					checked={ numberOfSelectedRecords === recordsToImport.length }
+					indeterminate={
+						numberOfSelectedRecords > 0 && numberOfSelectedRecords < recordsToImport.length
+					}
+					onChange={ () => toggleAllRecords() }
+					label={ headerLabel }
+				/>
+			</div>
+		);
+	};
+
+	const renderRecordAsRow = ( record, index ) => {
+		const className = classNames( 'import-bind-file-confirmation-dialog__row', {
+			'not-selected': ! record.selected,
+		} );
+
+		return (
+			<div key={ index } className={ className }>
+				<CheckboxControl
+					__nextHasNoMarginBottom
+					checked={ record.selected }
+					onChange={ () => toggleSelectedRecord( index ) }
+					label={ renderRecordAsString( record ) }
+				/>
+			</div>
+		);
+	};
+
 	const renderImportedRecords = () => {
-		return recordsToImport.reduce( ( output, record ) => {
-			return output + renderRecordAsString( record ) + '\n';
-		}, '' );
+		return [
+			renderHeader(),
+			recordsToImport.map( ( record, index ) => {
+				return renderRecordAsRow( record, index );
+			} ),
+		];
 	};
 
 	return (
@@ -62,12 +115,13 @@ function ImportBindFileConfirmationDialog( { onClose, visible, recordsToImport }
 			isVisible={ visible }
 			buttons={ recordsToImport && recordsToImport.length > 0 ? importButtons : okButton }
 			onClose={ onCancel }
+			className="import-bind-file-confirmation-dialog"
 		>
 			<h1>{ __( 'Import DNS records' ) }</h1>
 			{ recordsToImport && recordsToImport.length > 0 ? (
 				<>
-					<p>{ __( 'The following DNS records will be added to your domain:' ) }</p>
-					<pre>{ renderImportedRecords() }</pre>
+					<p>{ __( "Please select which DNS records you'd like to import to your domain:" ) }</p>
+					<div>{ renderImportedRecords() }</div>
 				</>
 			) : (
 				<p>{ __( "We couldn't find valid DNS records in the selected BIND file." ) }</p>

--- a/client/my-sites/domains/domain-management/dns/import-bind-file-confirmation-dialog.jsx
+++ b/client/my-sites/domains/domain-management/dns/import-bind-file-confirmation-dialog.jsx
@@ -9,7 +9,7 @@ function ImportBindFileConfirmationDialog( {
 	onClose,
 	recordsToImport,
 	toggleAllRecords,
-	toggleSelectedRecord,
+	toggleRecord,
 	visible,
 } ) {
 	const { __, _n } = useI18n();
@@ -94,7 +94,7 @@ function ImportBindFileConfirmationDialog( {
 				<CheckboxControl
 					__nextHasNoMarginBottom
 					checked={ record.selected }
-					onChange={ () => toggleSelectedRecord( index ) }
+					onChange={ () => toggleRecord( index ) }
 					label={ renderRecordAsString( record ) }
 				/>
 			</div>

--- a/client/my-sites/domains/domain-management/dns/import-bind-file-confirmation-dialog.jsx
+++ b/client/my-sites/domains/domain-management/dns/import-bind-file-confirmation-dialog.jsx
@@ -84,7 +84,7 @@ function ImportBindFileConfirmationDialog( {
 		);
 	};
 
-	const renderRecordAsRow = ( record, index ) => {
+	const renderRecordRow = ( record, index ) => {
 		const className = classNames( 'import-bind-file-confirmation-dialog__row', {
 			'not-selected': ! record.selected,
 		} );
@@ -105,7 +105,7 @@ function ImportBindFileConfirmationDialog( {
 		return [
 			renderHeader(),
 			recordsToImport.map( ( record, index ) => {
-				return renderRecordAsRow( record, index );
+				return renderRecordRow( record, index );
 			} ),
 		];
 	};

--- a/client/my-sites/domains/domain-management/dns/import-bind-file-confirmation-dialog.jsx
+++ b/client/my-sites/domains/domain-management/dns/import-bind-file-confirmation-dialog.jsx
@@ -73,9 +73,9 @@ function ImportBindFileConfirmationDialog( {
 			<div className="import-bind-file-confirmation-dialog__header">
 				<CheckboxControl
 					__nextHasNoMarginBottom
-					checked={ numberOfSelectedRecords === recordsToImport.length }
+					checked={ numberOfSelectedRecords === recordsToImport?.length }
 					indeterminate={
-						numberOfSelectedRecords > 0 && numberOfSelectedRecords < recordsToImport.length
+						numberOfSelectedRecords > 0 && numberOfSelectedRecords < recordsToImport?.length
 					}
 					onChange={ () => toggleAllRecords() }
 					label={ headerLabel }
@@ -113,12 +113,12 @@ function ImportBindFileConfirmationDialog( {
 	return (
 		<Dialog
 			isVisible={ visible }
-			buttons={ recordsToImport && recordsToImport.length > 0 ? importButtons : okButton }
+			buttons={ recordsToImport?.length > 0 ? importButtons : okButton }
 			onClose={ onCancel }
 			className="import-bind-file-confirmation-dialog"
 		>
 			<h1>{ __( 'Import DNS records' ) }</h1>
-			{ recordsToImport && recordsToImport.length > 0 ? (
+			{ recordsToImport?.length > 0 ? (
 				<>
 					<p>{ __( "Please select which DNS records you'd like to import to your domain:" ) }</p>
 					<div>{ renderImportedRecords() }</div>

--- a/client/my-sites/domains/domain-management/dns/style.scss
+++ b/client/my-sites/domains/domain-management/dns/style.scss
@@ -267,3 +267,35 @@ button.dns__breadcrumb-button {
 		}
 	}
 }
+
+.import-bind-file-confirmation-dialog {
+	.import-bind-file-confirmation-dialog__header,
+	.import-bind-file-confirmation-dialog__row {
+		display: flex;
+		padding: 8px;
+		border-bottom: 1px solid $gray-20;
+	}
+
+	.import-bind-file-confirmation-dialog__header label {
+		font-weight: 600;
+		font-family: $sans;
+		font-size: $font-body-small;
+	}
+
+	.import-bind-file-confirmation-dialog__row {
+		border-bottom: 1px solid $gray-5;
+
+		.components-base-control__field {
+			display: flex;
+		}
+
+		label {
+			font-family: $monospace;
+			font-size: $font-body-extra-small;
+		}
+
+		&.not-selected label {
+			color: $gray-20;
+		}
+	}
+}

--- a/client/my-sites/domains/domain-management/dns/types.ts
+++ b/client/my-sites/domains/domain-management/dns/types.ts
@@ -15,6 +15,10 @@ export type DnsRecord = {
 	rdata?: string;
 };
 
+export type ImportedDnsRecord = DnsRecord & {
+	selected: boolean;
+};
+
 type Dns = {
 	isFetching: boolean;
 	hasLoadedFromServer: boolean;


### PR DESCRIPTION
## Proposed Changes

This PR improves upon #81331 by allowing partial BIND files importing. Instead of importing all records for a domain at once, this PR updates the UI to allow selecting which records a user wants to import.

### Screenshots

- Before this PR

> <img width="915" alt="Screenshot 2023-11-01 at 18 53 54" src="https://github.com/Automattic/wp-calypso/assets/5324818/4db94aa6-2030-4833-a2fe-042142889518">

- With this PR

> <img width="713" alt="Screenshot 2023-11-01 at 18 54 39" src="https://github.com/Automattic/wp-calypso/assets/5324818/42e4b634-b0ea-4c4e-9463-f85bb5e7f6c6">

- Some records not selected

> <img width="713" alt="Screenshot 2023-11-01 at 18 55 03" src="https://github.com/Automattic/wp-calypso/assets/5324818/c5529a82-cc61-4f25-9d2d-e9d227fdd037">

## Testing Instructions

- Open the live Calypso link or build this branch locally
- Go to a domain's DNS management page
- Click on the "Import BIND file" button
- Select a BIND file and ensure the processed DNS records are correct
- unselect a few records, import them and ensure they were added correctly to your domain

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?