### PR TITLE
ActivityLog: improve Filterbar loading state in Jetpack Cloud

### DIFF
--- a/client/components/activity-card-list/index.jsx
+++ b/client/components/activity-card-list/index.jsx
@@ -20,6 +20,7 @@ import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import getActivityLogVisibleDays from 'calypso/state/rewind/selectors/get-activity-log-visible-days';
 import getRewindPoliciesRequestStatus from 'calypso/state/rewind/selectors/get-rewind-policies-request-status';
 import getActivityLogFilter from 'calypso/state/selectors/get-activity-log-filter';
+import isRequestingSiteFeatures from 'calypso/state/selectors/is-requesting-site-features';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import VisibleDaysLimitUpsell from './visible-days-limit-upsell';
@@ -206,6 +207,32 @@ class ActivityCardList extends Component {
 		) );
 	}
 
+	/**
+	 * Renders the filter bar for the activity card list.
+	 *
+	 * The filter bar visibility is determined based on the `showFilter` prop and the loading state.
+	 * The filter bar becomes invisible while the `requestingRewindPolicies` or `requestingSiteFeatures` are ongoing.
+	 * @returns the Filterbar component
+	 */
+	renderFilterbar() {
+		const { filter, siteId, requestingRewindPolicies, requestingSiteFeatures, showFilter } =
+			this.props;
+
+		const isLoading = requestingRewindPolicies || requestingSiteFeatures;
+		const shouldShowFilter = showFilter && ! isLoading;
+
+		return (
+			<div className="activity-card-list__filterbar-ctn" ref={ this.filterBarRef }>
+				<Filterbar
+					siteId={ siteId }
+					filter={ filter }
+					isLoading={ isLoading }
+					isVisible={ shouldShowFilter }
+				/>
+			</div>
+		);
+	}
+
 	renderData() {
 		const {
 			applySiteOffset,
@@ -215,9 +242,7 @@ class ActivityCardList extends Component {
 			isBreakpointActive: isMobile,
 			logs,
 			pageSize,
-			showFilter,
 			showPagination,
-			siteId,
 		} = this.props;
 
 		const visibleLimitCutoffDate = Number.isFinite( visibleDays )
@@ -240,19 +265,7 @@ class ActivityCardList extends Component {
 		const showLimitUpsell = visibleLogs.length < logs.length && actualPage >= pageCount;
 
 		return (
-			<div className="activity-card-list">
-				{ showFilter && (
-					<div className="activity-card-list__filterbar-ctn" ref={ this.filterBarRef }>
-						<Filterbar
-							{ ...{
-								siteId,
-								filter,
-								isLoading: false,
-								isVisible: true,
-							} }
-						/>
-					</div>
-				) }
+			<>
 				{ showPagination && (
 					<Pagination
 						compact={ isMobile }
@@ -283,7 +296,7 @@ class ActivityCardList extends Component {
 						total={ visibleLogs.length }
 					/>
 				) }
-			</div>
+			</>
 		);
 	}
 
@@ -293,7 +306,6 @@ class ActivityCardList extends Component {
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<div className="activity-card-list__loading-placeholder">
-				<div className="filterbar" />
 				{ showPagination && (
 					<div
 						className={ classNames( 'activity-card-list__pagination-top', {
@@ -347,15 +359,18 @@ class ActivityCardList extends Component {
 			return this.renderLoading();
 		}
 
+		const isLoading = ! logs || requestingRewindPolicies;
+
 		return (
 			<>
 				<QueryRewindPolicies siteId={ siteId } />
 				<QueryRewindCapabilities siteId={ siteId } />
 				<QueryRewindState siteId={ siteId } />
 				{ ! isAtomic && <QueryJetpackCredentialsStatus siteId={ siteId } role="main" /> }
-
-				{ ( ! logs || requestingRewindPolicies ) && this.renderLoading() }
-				{ logs && this.renderData() }
+				<div className="activity-card-list">
+					{ this.renderFilterbar() }
+					{ isLoading ? this.renderLoading() : this.renderData() }
+				</div>
 			</>
 		);
 	}
@@ -372,6 +387,7 @@ const mapStateToProps = ( state ) => {
 	const rewindPoliciesRequestStatus = getRewindPoliciesRequestStatus( state, siteId );
 
 	const isAtomic = isSiteAutomatedTransfer( state, siteId );
+	const requestingSiteFeatures = isRequestingSiteFeatures( state, siteId );
 
 	return {
 		filter,
@@ -382,6 +398,7 @@ const mapStateToProps = ( state ) => {
 		siteSlug,
 		userLocale,
 		isAtomic,
+		isRequestingSiteFeatures: requestingSiteFeatures,
 	};
 };
 


### PR DESCRIPTION
Related to https://github.com/Automattic/jetpack-backup-team/issues/202

The purpose of this PR is to abstract the filter bar rendering logic on the Activity Log for Jetpack Cloud, so it doesn't switch to a loading state when we start searching using the new text search, as mentioned in https://github.com/Automattic/wp-calypso/pull/83563.

## Proposed Changes

- Move the filter bar rendering logic to its own `renderFilterbar()` function
- Validate filter bar loading state using the selector `isRequestingSiteFeatures` along with `requestingRewindPolicies`.
  - This is because currently, the [visibility of the filterbar depends on the site having the `WPCOM_FEATURES_FULL_ACTIVITY_LOG` feature](https://github.com/Automattic/wp-calypso//blob/4a5698a483d979cf5c08e76307973f4bdf7ed437/client/my-sites/activity/activity-log-v2/index.tsx#L39), so we need to detect when we are still fetching the site features to display the proper loading placeholder.

| Before | After |
|---|---|
| ![CleanShot 2023-11-01 at 17 45 56](https://github.com/Automattic/wp-calypso/assets/1488641/6c7ec6d6-e264-44ec-840f-9b68c081ec0b) | ![CleanShot 2023-11-01 at 17 46 41](https://github.com/Automattic/wp-calypso/assets/1488641/2d73923b-b873-4583-a303-80bdfaeed37a) |

## Testing Instructions
* Spin up a Jetpack Cloud live branch
* Navigate to the Activity Log
* Ensure the search box is visible and try searching your posts and play around with the filters.
  * The search will be triggered when the user stops typing. This way, they don't need to press ENTER.
* Ensure this search box is visible on Jetpack Cloud and it works as shown in the demos shared above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
