### PR TITLE
Header nav: Rename Store to Commerce

### DIFF
--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -140,7 +140,7 @@ const UniversalNavbarHeader = ( {
 														) }
 														<ClickableItem
 															titleValue=""
-															content={ __( 'Store', __i18n_text_domain__ ) }
+															content={ __( 'Commerce', __i18n_text_domain__ ) }
 															urlValue={ localizeUrl( '//wordpress.com/ecommerce/' ) }
 															type="dropdown"
 															target="_self"
@@ -492,7 +492,7 @@ const UniversalNavbarHeader = ( {
 											) }
 											<ClickableItem
 												titleValue=""
-												content={ __( 'Store', __i18n_text_domain__ ) }
+												content={ __( 'Commerce', __i18n_text_domain__ ) }
 												urlValue={ localizeUrl( '//wordpress.com/ecommerce/' ) }
 												type="menu"
 											/>


### PR DESCRIPTION
Slack request: p1698862300973319-slack-CKZHG0QCR

## Proposed Changes

We want to rename Store to Commerce on header.

## Testing Instructions

* Test everything logged-out
* Go to `/plugins`, '/themes', '/tags'
* Make sure `Store` is now named `Commerce`
* Check on mobile
