### PR TITLE
FHT: Disable the plans/hosting-trial flag in development

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -139,7 +139,7 @@
 		"p2/p2-plus": true,
 		"page/export": true,
 		"pattern-assembler/add-pages": true,
-		"plans/hosting-trial": true,
+		"plans/hosting-trial": false,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,
 		"plans/pro-plan": false,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/4208

## Proposed Changes

* Disabled `plans/hosting-trial` in development mode

Now that it's possible to opt-in to the trial behaviour using abacus (21452-explat-experiment) we can remove this feature flag from development mode. This reduces the number of differences between prod and dev.

I've left the flag enabled in `wpcalypso` for now because that might be a useful place to direct a12s who want to try the trial, but who are unfamiliar with abacus.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout
* Test `calypso.localhost:3000/setup/new-hosted-site`
* Whether you're offered a trial should now depend on your test cohort assignment.
