### PR TITLE
Update/2023 dotcom division meetup support closures for Quick Start support

### DIFF
--- a/client/me/concierge/shared/closure-notice.js
+++ b/client/me/concierge/shared/closure-notice.js
@@ -36,7 +36,7 @@ const ClosureNotice = ( { closesAt, displayAt, reopensAt } ) => {
 		);
 	} else {
 		message = translate(
-			'{{strong}}Quick Start Sessions will be closed from %(closesAt)s – %(reopensAt)s.{{/strong}} ' +
+			'{{strong}}Quick Start Sessions will be closed from %(closesAt)s – %(reopensAt)s.{{/strong}}{{br/}}' +
 				'Once a year, Happiness Engineers get together to work on improving our services, building new features, and learning how to better serve you. ' +
 				'During this time, we will continue to provide support over email. If you need to get in touch with us, please submit a {{link}}support request from this page{{/link}} and we will get to it as fast as we can. ' +
 				'Quick Start Sessions will re-open at %(reopensAt)s. Thank you for your understanding!',
@@ -48,6 +48,7 @@ const ClosureNotice = ( { closesAt, displayAt, reopensAt } ) => {
 				components: {
 					link: <a href="/help/contact" />,
 					strong: <strong />,
+					br: <br />,
 				},
 			}
 		);

--- a/client/me/concierge/shared/closure-notice.js
+++ b/client/me/concierge/shared/closure-notice.js
@@ -5,7 +5,7 @@ import { useLocalizedMoment } from 'calypso/components/localized-moment';
 
 const DATE_FORMAT = 'LLL';
 
-const ClosureNotice = ( { closesAt, displayAt, holidayName, reopensAt } ) => {
+const ClosureNotice = ( { closesAt, displayAt, reopensAt } ) => {
 	const translate = useTranslate();
 	const moment = useLocalizedMoment();
 
@@ -20,14 +20,13 @@ const ClosureNotice = ( { closesAt, displayAt, holidayName, reopensAt } ) => {
 
 	if ( currentDate.isBefore( closesAt ) ) {
 		message = translate(
-			'{{strong}}Note:{{/strong}} Quick Start sessions will be closed for %(holidayName)s from %(closesAt)s until %(reopensAt)s. ' +
+			'{{strong}}Notice:{{/strong}} Quick Start sessions will be closed from %(closesAt)s until %(reopensAt)s. ' +
 				'If you need to get in touch with us, you’ll be able to {{link}}submit a support request{{/link}} and we’ll ' +
 				'get to it as fast as we can. Thank you!',
 			{
 				args: {
 					closesAt: moment.tz( closesAt, guessedTimezone ).format( DATE_FORMAT ),
 					reopensAt: moment.tz( reopensAt, guessedTimezone ).format( DATE_FORMAT ),
-					holidayName,
 				},
 				components: {
 					link: <a href="/help/contact" />,
@@ -37,13 +36,14 @@ const ClosureNotice = ( { closesAt, displayAt, holidayName, reopensAt } ) => {
 		);
 	} else {
 		message = translate(
-			'{{strong}}Note:{{/strong}} Quick Start sessions are closed for %(holidayName)s and will reopen %(reopensAt)s. ' +
-				'If you need to get in touch with us, you’ll be able to {{link}}submit a support request{{/link}} and we’ll ' +
-				'get back to you as fast as we can. Thank you!',
+			'{{strong}}Quick Start Sessions will be closed from %(closesAt)s – %(reopensAt)s.{{/strong}} ' +
+				'Once a year, Happiness Engineers get together to work on improving our services, building new features, and learning how to better serve you. ' +
+				'During this time, we will continue to provide support over email. If you need to get in touch with us, please submit a {{link}}support request from this page{{/link}} and we will get to it as fast as we can. ' +
+				'Quick Start Sessions will re-open at %(reopensAt)s. Thank you for your understanding!',
 			{
 				args: {
+					closesAt: moment.tz( closesAt, guessedTimezone ).format( DATE_FORMAT ),
 					reopensAt: moment.tz( reopensAt, guessedTimezone ).format( DATE_FORMAT ),
-					holidayName,
 				},
 				components: {
 					link: <a href="/help/contact" />,

--- a/client/me/concierge/shared/primary-header.js
+++ b/client/me/concierge/shared/primary-header.js
@@ -13,10 +13,9 @@ class PrimaryHeader extends Component {
 		return (
 			<Fragment>
 				<ClosureNotice
-					displayAt="2023-04-03 00:00Z"
-					closesAt="2023-04-09 00:00Z"
-					reopensAt="2023-04-10 07:00Z"
-					holidayName="Easter"
+					displayAt="2023-11-06 00:00Z"
+					closesAt="2023-11-11 00:00Z"
+					reopensAt="2023-11-21 07:00Z"
 				/>
 				<Card>
 					<img


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Requested on: peCdcN-iJ-p2#comment-849

## Proposed Changes

* Adds a notice for Quick Start support closure from Nov 11 to 21.
* Sets the notice to appear since Nov 6.
* Updates the message for the notice to the one proposed on the P2 post.

I decided to use the existing component for the message so we can display a message that replaces Live Chat with Quick Start session.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Change the dates in the code to simulate different cases - before, during and after the closure dates.
2. Test http://calypso.localhost:3000/me/quickstart/ and the support links in the notices
3. Check the message at the top when checking the dates for now, during and after the meetup.

Example of the message you should see at the top:

![CleanShot 2023-11-01 at 18 22 57](https://github.com/Automattic/wp-calypso/assets/3696121/b857ca92-cc23-4738-94a7-eb13c146b3c1)