### PR TITLE
2023 Plans Grid: Use selected site id prop as a fallback for getSelectedSiteId selector

### DIFF
--- a/client/my-sites/plans-features-main/components/plan-type-selector/index.tsx
+++ b/client/my-sites/plans-features-main/components/plan-type-selector/index.tsx
@@ -48,6 +48,7 @@ export type PlanTypeSelectorProps = {
 	hideDiscountLabel?: boolean;
 	redirectTo?: string | null;
 	isStepperUpgradeFlow: boolean;
+	siteId?: number;
 };
 
 interface PathArgs {
@@ -134,6 +135,7 @@ export type IntervalTypeProps = Pick<
 	| 'showBiennialToggle'
 	| 'selectedPlan'
 	| 'selectedFeature'
+	| 'siteId'
 >;
 
 export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = ( props ) => {
@@ -144,7 +146,9 @@ export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = 
 		eligibleForWpcomMonthlyPlans,
 		hideDiscountLabel,
 		showBiennialToggle,
+		siteId,
 	} = props;
+
 	const [ spanRef, setSpanRef ] = useState< HTMLSpanElement >();
 	const segmentClasses = classNames( 'plan-features__interval-type', 'price-toggle', {
 		'is-signup': isInSignup,
@@ -152,7 +156,8 @@ export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = 
 	const popupIsVisible = Boolean( intervalType === 'monthly' && isInSignup && props.plans.length );
 	const maxDiscount = useMaxDiscount( props.plans );
 	const currentPlanBillingPeriod = useSelector( ( state ) => {
-		const currentSitePlanSlug = getSitePlanSlug( state, getSelectedSiteId( state ) );
+		const selectedSiteId = getSelectedSiteId( state ) || siteId;
+		const currentSitePlanSlug = getSitePlanSlug( state, selectedSiteId );
 		return currentSitePlanSlug ? getPlanBillPeriod( state, currentSitePlanSlug ) : null;
 	} );
 

--- a/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
+++ b/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
@@ -28,6 +28,7 @@ interface Props {
 	planSlugs: PlanSlug[];
 	withoutProRatedCredits?: boolean;
 	storageAddOns?: ( AddOnMeta | null )[] | null;
+	siteId?: number;
 }
 
 function getTotalPrices( planPrices: PlanPrices, addOnPrice = 0 ): PlanPrices {
@@ -55,8 +56,9 @@ const usePricingMetaForGridPlans: UsePricingMetaForGridPlans = ( {
 	planSlugs,
 	withoutProRatedCredits = false,
 	storageAddOns,
+	siteId,
 }: Props ) => {
-	const selectedSiteId = useSelector( getSelectedSiteId ) ?? undefined;
+	const selectedSiteId = ( useSelector( getSelectedSiteId ) || siteId ) ?? undefined;
 	const currentPlan = useSelector( ( state: IAppState ) =>
 		getCurrentPlan( state, selectedSiteId )
 	);

--- a/client/my-sites/plans-features-main/hooks/use-current-plan-manage-href.ts
+++ b/client/my-sites/plans-features-main/hooks/use-current-plan-manage-href.ts
@@ -5,16 +5,18 @@ import getSiteSlug from 'calypso/state/sites/selectors/get-site-slug';
 import { IAppState } from 'calypso/state/types';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
-const useCurrentPlanManageHref = () => {
-	const siteId = useSelector( getSelectedSiteId );
+const useCurrentPlanManageHref = ( siteId?: number ) => {
+	const selectedSiteId = useSelector( getSelectedSiteId ) || siteId;
 	const purchaseId = useSelector( ( state: IAppState ) =>
-		siteId ? getCurrentPlanPurchaseId( state, siteId ) : null
+		selectedSiteId ? getCurrentPlanPurchaseId( state, selectedSiteId ) : null
 	);
-	const selectedSiteSlug = useSelector( ( state: IAppState ) => getSiteSlug( state, siteId ) );
+	const selectedSiteSlug = useSelector( ( state: IAppState ) =>
+		getSiteSlug( state, selectedSiteId )
+	);
 
 	return purchaseId && selectedSiteSlug
 		? getManagePurchaseUrlFor( selectedSiteSlug, purchaseId )
-		: `/plans/my-plan/${ siteId }`;
+		: `/plans/my-plan/${ selectedSiteId }`;
 };
 
 export default useCurrentPlanManageHref;

--- a/client/my-sites/plans-features-main/hooks/use-plan-intent-from-site-meta.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plan-intent-from-site-meta.ts
@@ -8,8 +8,8 @@ interface IntentFromSiteMeta {
 	intent: PlansIntent | null | undefined;
 }
 
-const usePlanIntentFromSiteMeta = (): IntentFromSiteMeta => {
-	const selectedSiteId = useSelector( getSelectedSiteId ) ?? undefined;
+const usePlanIntentFromSiteMeta = ( siteId?: number ): IntentFromSiteMeta => {
+	const selectedSiteId = ( useSelector( getSelectedSiteId ) || siteId ) ?? undefined;
 	const siteIntent = useSiteIntent( selectedSiteId );
 
 	if ( siteIntent.isFetching ) {

--- a/client/my-sites/plans-features-main/hooks/use-plan-upgradeability-check.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plan-upgradeability-check.ts
@@ -5,14 +5,15 @@ import type { PlanSlug } from '@automattic/calypso-products';
 
 interface Props {
 	planSlugs: PlanSlug[];
+	siteId?: number;
 }
 
 type PlanUpgradeability = {
 	[ planSlug in PlanSlug ]: boolean;
 };
 
-const usePlanUpgradeabilityCheck = ( { planSlugs }: Props ): PlanUpgradeability => {
-	const selectedSiteId = useSelector( getSelectedSiteId );
+const usePlanUpgradeabilityCheck = ( { planSlugs, siteId }: Props ): PlanUpgradeability => {
+	const selectedSiteId = useSelector( getSelectedSiteId ) || siteId;
 	const planUpgradeability = useSelector( ( state ) => {
 		return planSlugs.reduce( ( acc, planSlug ) => {
 			return {

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -261,7 +261,7 @@ const PlansFeaturesMain = ( {
 	const domainFromHomeUpsellFlow = useSelector( getDomainFromHomeUpsellInQuery );
 	const showUpgradeableStorage = config.isEnabled( 'plans/upgradeable-storage' );
 	const observableForOdieRef = useObservableForOdie();
-	const currentPlanManageHref = useCurrentPlanManageHref();
+	const currentPlanManageHref = useCurrentPlanManageHref( siteId ?? undefined );
 	const canUserManageCurrentPlan = useSelector( ( state: IAppState ) =>
 		siteId
 			? ! isCurrentPlanPaid( state, siteId ) || isCurrentUserCurrentPlanOwner( state, siteId )
@@ -375,7 +375,7 @@ const PlansFeaturesMain = ( {
 		...( selectedPlan ? { defaultValue: getPlan( selectedPlan )?.term } : {} ),
 	} );
 
-	const intentFromSiteMeta = usePlanIntentFromSiteMeta();
+	const intentFromSiteMeta = usePlanIntentFromSiteMeta( siteId ?? undefined );
 	const planFromUpsells = usePlanFromUpsells();
 	const [ forceDefaultPlans, setForceDefaultPlans ] = useState( false );
 
@@ -419,6 +419,7 @@ const PlansFeaturesMain = ( {
 		showLegacyStorageFeature,
 		isSubdomainNotGenerated: ! resolvedSubdomainName.result,
 		storageAddOns,
+		siteId: siteId || undefined,
 	} );
 
 	const planFeaturesForFeaturesGrid = usePlanFeaturesForGridPlans( {
@@ -522,6 +523,7 @@ const PlansFeaturesMain = ( {
 		showBiennialToggle,
 		kind: planTypeSelector,
 		plans: gridPlansForFeaturesGrid.map( ( gridPlan ) => gridPlan.planSlug ),
+		siteId: siteId ?? undefined,
 	};
 	/**
 	 * The effects on /plans page need to be checked if this variable is initialized

--- a/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
+++ b/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
@@ -152,7 +152,13 @@ interface Props {
 	hideEnterprisePlan?: boolean;
 	isInSignup?: boolean;
 	// whether plan is upgradable from current plan (used in logged-in state)
-	usePlanUpgradeabilityCheck?: ( { planSlugs }: { planSlugs: PlanSlug[] } ) => {
+	usePlanUpgradeabilityCheck?: ( {
+		planSlugs,
+		siteId,
+	}: {
+		planSlugs: PlanSlug[];
+		siteId?: number;
+	} ) => {
 		[ key: string ]: boolean;
 	};
 	showLegacyStorageFeature?: boolean;
@@ -162,6 +168,7 @@ interface Props {
 	 */
 	isSubdomainNotGenerated?: boolean;
 	storageAddOns: ( AddOnMeta | null )[] | null;
+	siteId?: number;
 }
 
 const usePlanTypesWithIntent = ( {
@@ -283,6 +290,7 @@ const useGridPlans = ( {
 	eligibleForFreeHostingTrial,
 	isSubdomainNotGenerated,
 	storageAddOns,
+	siteId,
 }: Props ): Omit< GridPlan, 'features' >[] | null => {
 	const freeTrialPlanSlugs = useFreeTrialPlanSlugs( {
 		intent: intent ?? 'default',
@@ -310,7 +318,10 @@ const useGridPlans = ( {
 		term,
 		intent,
 	} );
-	const planUpgradeability = usePlanUpgradeabilityCheck?.( { planSlugs: availablePlanSlugs } );
+	const planUpgradeability = usePlanUpgradeabilityCheck?.( {
+		planSlugs: availablePlanSlugs,
+		siteId,
+	} );
 
 	// only fetch highlights for the plans that are available for the intent
 	const highlightLabels = useHighlightLabels( {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
