### PR TITLE
ActivityLog: display number of activities selected when `showAppliedFiltersCount` prop is passed

### DIFF
--- a/client/my-sites/activity/filterbar/type-selector/activity-type-selector.jsx
+++ b/client/my-sites/activity/filterbar/type-selector/activity-type-selector.jsx
@@ -15,7 +15,7 @@ const ActivityTypeSelector = ( props ) => {
 	return (
 		<TypeSelector
 			{ ...props }
-			title={ translate( 'Activity Type' ) }
+			title={ translate( 'Activity type' ) }
 			showAppliedFiltersCount={ true }
 		/>
 	);

--- a/client/my-sites/activity/filterbar/type-selector/activity-type-selector.jsx
+++ b/client/my-sites/activity/filterbar/type-selector/activity-type-selector.jsx
@@ -12,7 +12,13 @@ import { TypeSelector } from './type-selector';
 const ActivityTypeSelector = ( props ) => {
 	const { translate } = props;
 
-	return <TypeSelector { ...props } title={ translate( 'Activity Type' ) } />;
+	return (
+		<TypeSelector
+			{ ...props }
+			title={ translate( 'Activity Type' ) }
+			showAppliedFiltersCount={ true }
+		/>
+	);
 };
 
 const activityCountsQueryKey = ( siteId, filter ) => [

--- a/client/my-sites/activity/filterbar/type-selector/type-selector.jsx
+++ b/client/my-sites/activity/filterbar/type-selector/type-selector.jsx
@@ -199,7 +199,7 @@ export class TypeSelector extends Component {
 	hasSelectedCheckboxes = () => this.getSelectedCheckboxes().length > 0;
 
 	renderTypeSelectorButton = () => {
-		const { isNested, isVisible, showAppliedFiltersCount, title } = this.props;
+		const { isNested, isVisible, showAppliedFiltersCount, title, translate } = this.props;
 		const selectedCheckboxes = this.getSelectedCheckboxes();
 		const hasSelectedCheckboxes = this.hasSelectedCheckboxes();
 
@@ -215,9 +215,20 @@ export class TypeSelector extends Component {
 		// If the type selector is not nested and has selected checkboxes, we want to display a delimiter.
 		const shouldDisplayDelimiter = ! isNested && hasSelectedCheckboxes;
 
+		const activitiesSelectedText = translate(
+			'%(selectedCount)s activity selected',
+			'%(selectedCount)s activities selected',
+			{
+				count: selectedCheckboxes.length,
+				args: {
+					selectedCount: selectedCheckboxes.length,
+				},
+			}
+		);
+
 		// Decide the display content for selected checkboxes
 		const selectedCheckboxesContent = showAppliedFiltersCount
-			? `${ selectedCheckboxes.length } activities selected`
+			? activitiesSelectedText
 			: selectedCheckboxes.map( this.typeKeyToName ).join( ', ' );
 
 		return (

--- a/client/my-sites/activity/filterbar/type-selector/type-selector.jsx
+++ b/client/my-sites/activity/filterbar/type-selector/type-selector.jsx
@@ -196,29 +196,52 @@ export class TypeSelector extends Component {
 
 	isSelected = ( key ) => this.getSelectedCheckboxes().includes( key );
 
-	render() {
-		const { title, isVisible, isNested } = this.props;
+	hasSelectedCheckboxes = () => this.getSelectedCheckboxes().length > 0;
+
+	renderTypeSelectorButton = () => {
+		const { isNested, isVisible, showAppliedFiltersCount, title } = this.props;
 		const selectedCheckboxes = this.getSelectedCheckboxes();
-		const hasSelectedCheckboxes = selectedCheckboxes.length > 0;
+		const hasSelectedCheckboxes = this.hasSelectedCheckboxes();
 
 		const buttonClass = classnames( 'filterbar__selection', {
 			'is-selected': hasSelectedCheckboxes,
 			'is-active': isVisible && ! hasSelectedCheckboxes,
 		} );
 
+		// If the type selector is nested, we don't want to display the title
+		// unless there are no selected checkboxes.
+		const shouldDisplayTitle = ! isNested || ( isNested && ! hasSelectedCheckboxes );
+
+		// If the type selector is not nested and has selected checkboxes, we want to display a delimiter.
+		const shouldDisplayDelimiter = ! isNested && hasSelectedCheckboxes;
+
+		// Decide the display content for selected checkboxes
+		const selectedCheckboxesContent = showAppliedFiltersCount
+			? `${ selectedCheckboxes.length } activities selected`
+			: selectedCheckboxes.map( this.typeKeyToName ).join( ', ' );
+
+		return (
+			<Button
+				className={ buttonClass }
+				compact
+				borderless
+				onClick={ this.props.onButtonClick }
+				ref={ this.typeButton }
+			>
+				{ shouldDisplayTitle && title }
+				{ shouldDisplayDelimiter && <span>: </span> }
+				{ hasSelectedCheckboxes && selectedCheckboxesContent }
+			</Button>
+		);
+	};
+
+	render() {
+		const { isVisible, isNested } = this.props;
+		const hasSelectedCheckboxes = this.hasSelectedCheckboxes();
+
 		return (
 			<Fragment>
-				<Button
-					className={ buttonClass }
-					compact
-					borderless
-					onClick={ this.props.onButtonClick }
-					ref={ this.typeButton }
-				>
-					{ ( ! isNested || ( isNested && ! hasSelectedCheckboxes ) ) && title }
-					{ ! isNested && hasSelectedCheckboxes && <span>: </span> }
-					{ hasSelectedCheckboxes && selectedCheckboxes.map( this.typeKeyToName ).join( ', ' ) }
-				</Button>
+				{ this.renderTypeSelectorButton() }
 				{ hasSelectedCheckboxes && (
 					<Button
 						className="type-selector__selection-close"

--- a/client/my-sites/activity/filterbar/type-selector/type-selector.jsx
+++ b/client/my-sites/activity/filterbar/type-selector/type-selector.jsx
@@ -215,21 +215,17 @@ export class TypeSelector extends Component {
 		// If the type selector is not nested and has selected checkboxes, we want to display a delimiter.
 		const shouldDisplayDelimiter = ! isNested && hasSelectedCheckboxes;
 
-		const activitiesSelectedText = translate(
-			'%(selectedCount)s activity selected',
-			'%(selectedCount)s activities selected',
-			{
-				count: selectedCheckboxes.length,
-				args: {
-					selectedCount: selectedCheckboxes.length,
-				},
-			}
-		);
+		const activitiesSelectedText = translate( '%(selectedCount)s selected', {
+			args: {
+				selectedCount: selectedCheckboxes.length,
+			},
+		} );
 
 		// Decide the display content for selected checkboxes
-		const selectedCheckboxesContent = showAppliedFiltersCount
-			? activitiesSelectedText
-			: selectedCheckboxes.map( this.typeKeyToName ).join( ', ' );
+		const selectedCheckboxesContent =
+			showAppliedFiltersCount && selectedCheckboxes.length > 1
+				? activitiesSelectedText
+				: selectedCheckboxes.map( this.typeKeyToName ).join( ', ' );
 
 		return (
 			<Button


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-backup-team/issues/203

## Proposed Changes
- Display number of activities selected instead of the name of each activity, by using an optional `showAppliedFiltersCount` prop.
  - This will apply only when there's more than 1 checkbox selected.
- Add a new `showAppliedFiltersCount` prop to `TypeSelector`
- Move render logic for selector button to its function
- Rename `Activity Type` to `Activity type`

| Scenario | Changes description | Before | After |
|---|---|---|---|
| Default state | The button is now labeled as `Activity type` | ![CleanShot 2023-11-02 at 08 56 29](https://github.com/Automattic/wp-calypso/assets/1488641/dad5f9a0-0326-49c9-90c8-f836077c88a3) | ![CleanShot 2023-11-02 at 08 56 01](https://github.com/Automattic/wp-calypso/assets/1488641/954cde1c-cf20-4872-9493-5d1d5ac7aa81) |
| 1 selected | No changes | ![CleanShot 2023-11-02 at 08 53 23](https://github.com/Automattic/wp-calypso/assets/1488641/eb65db65-48e3-4464-82a7-736a0181cabc) | ![CleanShot 2023-11-02 at 08 53 23](https://github.com/Automattic/wp-calypso/assets/1488641/63c53380-4c74-426e-bace-0e706cbf4338) |
| More than 1 selected | The count of activities selected are now displayed instead of the name of each activity. | ![CleanShot 2023-11-02 at 08 59 17](https://github.com/Automattic/wp-calypso/assets/1488641/a9690798-262f-498f-b5a4-39f51aa8b691) | ![CleanShot 2023-11-02 at 08 58 05](https://github.com/Automattic/wp-calypso/assets/1488641/98b2f37a-3e85-4fb6-8107-9db84bb366c5) |

## Demo
### Calypso Blue
![CleanShot 2023-11-02 at 09 04 43](https://github.com/Automattic/wp-calypso/assets/1488641/90277023-5d1c-46d4-b9a0-8eddc9a66d85)

### Jetpack Cloud
![CleanShot 2023-11-02 at 09 07 25](https://github.com/Automattic/wp-calypso/assets/1488641/9e66e97f-6e32-4bfc-9001-82506857f941)

## Testing Instructions
* Spin up a Calypso and Jetpack Cloud live branch
* Navigate to the Activity Log on each
* Ensure that selecting `Activity Type` filters makes the button displays `X activities selected` instead of the name of each filter. Similar behavior described in the screenshots shared above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?