### PR TITLE
Domains: Use availability endpoint to fetch premium domain prices

### DIFF
--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -64,7 +64,7 @@ class DomainProductPrice extends Component {
 
 	renderRenewalPrice() {
 		const { price, renewPrice, translate } = this.props;
-		const isRenewCostDifferent = price !== renewPrice;
+		const isRenewCostDifferent = renewPrice && price !== renewPrice;
 
 		if ( isRenewCostDifferent ) {
 			return (


### PR DESCRIPTION
## Proposed Changes
We currently use the `/price` endpoint to fetch pricing information of premium domains for the domain name suggestion component.
This PR changes it to the `/availability` endpoint - now we can also remove it from the suggestions if it's unavailable.
Depends on #83123.

## Testing Instructions
- _(OPTIONAL): Apply this patch to mock the returned suggestions: 325b1-pb;_
- Search for an unavailable supported premium domain name - or anything if you applied the patch above:
- For the suggestions component:
  - Confirm that you're able to see the renewal price differing from the registration price;
  - Confirm that unavailable domains are not rendered on the suggestions list;
  - Ensure that all other domain components are unchanged and work the same as before.

## Preview

### Before
https://github.com/Automattic/wp-calypso/assets/18705930/d4f225b2-c4ff-48b1-9fcb-117a9d549495

### After
https://github.com/Automattic/wp-calypso/assets/18705930/51f5705d-43be-404d-b60a-f162d837cac5

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?