### PR TITLE
Remove the disabled GF signup tests.

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -39,7 +39,7 @@ import {
 	getFixedDomainSearch,
 } from 'calypso/lib/domains';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
-import { loadExperimentAssignment, ProvideExperimentData } from 'calypso/lib/explat';
+import { ProvideExperimentData } from 'calypso/lib/explat';
 import { logToLogstash } from 'calypso/lib/logstash';
 import { getSitePropertyDefaults } from 'calypso/lib/signup/site-properties';
 import { maybeExcludeEmailsStep } from 'calypso/lib/signup/step-actions';
@@ -365,28 +365,6 @@ export class RenderDomainsStep extends Component {
 					productSlug: suggestion.product_slug,
 			  } )
 			: undefined;
-
-		switch ( flowName ) {
-			case 'onboarding':
-				if ( isPurchasingItem ) {
-					loadExperimentAssignment(
-						'calypso_onboarding_plans_paid_domain_on_free_plan_confidence_check'
-					);
-				} else {
-					loadExperimentAssignment(
-						'calypso_gf_signup_onboarding_free_free_dont_miss_out_modal_v3'
-					);
-				}
-				break;
-			case 'onboarding-pm':
-				if ( isPurchasingItem ) {
-					loadExperimentAssignment( 'calypso_onboardingpm_plans_paid_domain_on_free_plan' );
-				} else {
-					loadExperimentAssignment(
-						'calypso_gf_signup_onboarding_pm_free_free_dont_miss_out_modal_v3'
-					);
-				}
-		}
 
 		suggestion && this.props.submitDomainStepSelection( suggestion, this.getAnalyticsSection() );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This PR cleans up the following disabled GF signup tests:

* calypso_onboarding_plans_paid_domain_on_free_plan_confidence_check
* calypso_gf_signup_onboarding_free_free_dont_miss_out_modal_v3
* calypso_onboardingpm_plans_paid_domain_on_free_plan
* calypso_gf_signup_onboarding_pm_free_free_dont_miss_out_modal_v3

There are already no UX variations based on them, so it is safe to remove them. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `/start/` and `/start/onboarding-pm` should work as expected.
* A confidence check that there is no remnant of these tests left. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
