### PR TITLE
Assembler: Fix issue where the preselect page About cannot be deselected

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-pages.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-pages.ts
@@ -4,17 +4,18 @@ import { INITIAL_PAGES } from '../constants';
 
 const usePatternPages = () => {
 	const [ searchParams, setSearchParams ] = useSearchParams();
-	const page_slugs = ( searchParams.get( 'page_slugs' ) || '' ).split( ',' ).filter( Boolean );
+	const page_slugs = searchParams.get( 'page_slugs' );
 
-	const pages = page_slugs.length
-		? page_slugs
-		: [ ...( isEnabled( 'pattern-assembler/add-pages' ) ? INITIAL_PAGES : [] ) ];
+	const pages =
+		page_slugs !== null
+			? page_slugs.split( ',' ).filter( Boolean )
+			: [ ...( isEnabled( 'pattern-assembler/add-pages' ) ? INITIAL_PAGES : [] ) ];
 
 	const setPages = ( pages: string[] ) => {
 		setSearchParams(
 			( currentSearchParams ) => {
 				if ( pages.length === 0 ) {
-					currentSearchParams.delete( 'page_slugs' );
+					currentSearchParams.set( 'page_slugs', '' );
 				} else {
 					currentSearchParams.set( 'page_slugs', pages.join( ',' ) );
 				}


### PR DESCRIPTION
Related to #83450

## Proposed Changes

See https://github.com/Automattic/wp-calypso/pull/83748#issuecomment-1789964380. This PR fixes an issue where the preselected page About cannot be deselected. The reason for this is that the hook `usePatternPages` cannot differentiate between null page selection and empty page selection, so this PR proposed to use `&page_slugs={empty}` as empty page selection. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Assembler, with the flag `&flags=pattern-assembler/add-pages` if using the calypso.live link.
* Go through the Patterns, and Styles screen until you arrive at the Pages screen.
* Ensure that the About page is still being preselected, and able to be deselected.
* Ensure that once the About page is deselected, re-entering the Pages screen still shows the About page deselected.
* Also ensure that the `pages` parameter sent to the `/site-assembler` endpoint is correct.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?