### PR TITLE
Blogging Prompts: Add 'answered' indicator to my-home card

### DIFF
--- a/client/components/blogging-prompt-card/prompts-navigation.jsx
+++ b/client/components/blogging-prompt-card/prompts-navigation.jsx
@@ -58,6 +58,10 @@ const PromptsNavigation = ( { siteId, prompts, tracksPrefix, index } ) => {
 		// Prevent navigating away so we have time to record the click.
 		e.preventDefault();
 
+		if ( getPrompt()?.answered ) {
+			return;
+		}
+
 		dispatch(
 			recordTracksEvent( tracksPrefix + 'answer_prompt', {
 				site_id: siteId,
@@ -184,6 +188,7 @@ const PromptsNavigation = ( { siteId, prompts, tracksPrefix, index } ) => {
 					href={ getNewPostLink() }
 					onClick={ handleBloggingPromptClick }
 					className="blogging-prompt__new-post-link"
+					disabled={ getPrompt()?.answered }
 				>
 					{ getPrompt()?.answered ? (
 						<>

--- a/client/components/blogging-prompt-card/prompts-navigation.jsx
+++ b/client/components/blogging-prompt-card/prompts-navigation.jsx
@@ -113,17 +113,7 @@ const PromptsNavigation = ( { siteId, prompts, tracksPrefix, index } ) => {
 				>
 					<Gridicon icon={ backIcon } size={ 18 } />
 				</Button>
-				<div className="blogging-prompt__prompt-text">
-					{ getPrompt()?.text }
-					<div className="blogging-prompt__answered-text">
-						{ getPrompt()?.answered && (
-							<>
-								<Gridicon icon="checkmark" size={ 18 } />
-								{ translate( 'Answered' ) }
-							</>
-						) }
-					</div>
-				</div>
+				<div className="blogging-prompt__prompt-text">{ getPrompt()?.text }</div>
 				<Button
 					aria-label={ translate( 'Show next prompt' ) }
 					borderless={ false }
@@ -190,11 +180,22 @@ const PromptsNavigation = ( { siteId, prompts, tracksPrefix, index } ) => {
 						{ translate( 'Learn more' ) }
 					</a>
 				) }
-				<Button href={ getNewPostLink() } onClick={ handleBloggingPromptClick }>
-					{ translate( 'Post Answer', {
-						comment:
-							'"Post" here is a verb meaning "to publish", as in "post an answer to this writing prompt"',
-					} ) }
+				<Button
+					href={ getNewPostLink() }
+					onClick={ handleBloggingPromptClick }
+					className="blogging-prompt__new-post-link"
+				>
+					{ getPrompt()?.answered ? (
+						<>
+							<Gridicon icon="checkmark" size={ 18 } />
+							{ translate( 'Answered' ) }
+						</>
+					) : (
+						translate( 'Post Answer', {
+							comment:
+								'"Post" here is a verb meaning "to publish", as in "post an answer to this writing prompt"',
+						} )
+					) }
 				</Button>
 			</div>
 		);

--- a/client/components/blogging-prompt-card/prompts-navigation.jsx
+++ b/client/components/blogging-prompt-card/prompts-navigation.jsx
@@ -113,7 +113,17 @@ const PromptsNavigation = ( { siteId, prompts, tracksPrefix, index } ) => {
 				>
 					<Gridicon icon={ backIcon } size={ 18 } />
 				</Button>
-				<div className="blogging-prompt__prompt-text">{ getPrompt()?.text }</div>
+				<div className="blogging-prompt__prompt-text">
+					{ getPrompt()?.text }
+					<div className="blogging-prompt__answered-text">
+						{ getPrompt()?.answered && (
+							<>
+								<Gridicon icon="checkmark" size={ 18 } />
+								{ translate( 'Answered' ) }
+							</>
+						) }
+					</div>
+				</div>
 				<Button
 					aria-label={ translate( 'Show next prompt' ) }
 					borderless={ false }

--- a/client/components/blogging-prompt-card/style.scss
+++ b/client/components/blogging-prompt-card/style.scss
@@ -32,7 +32,7 @@
 		width: 100%;
 
 		.blogging-prompt__prompt-navigation {
-			align-items: center;
+			align-items: flex-start;
 			display: flex;
 			gap: 20px;
 		}
@@ -41,6 +41,18 @@
 			font-size: $font-title-small;
 			font-weight: 500;
 			line-height: 26px;
+		}
+		.blogging-prompt__answered-text {
+			font-size: $font-body;
+			text-align: center;
+			line-height: 18px;
+			margin-top: 10px;
+			color: var(--color-success);
+			> svg {
+				position: relative;
+				top: 3px;
+				margin-right: 2px;
+			}
 		}
 		button.navigation-link {
 			border-radius: 50%;

--- a/client/components/blogging-prompt-card/style.scss
+++ b/client/components/blogging-prompt-card/style.scss
@@ -58,11 +58,10 @@
 		margin-top: 24px;
 		width: 100%;
 
-		.blogging-prompt__new-post-link  svg {
+		.blogging-prompt__new-post-link svg {
 			position: relative;
 			top: 4px;
 			margin-right: 4px;
-			color: var(--color-success);
 		}
 		.blogging-prompt__prompt-responses {
 			align-items: center;

--- a/client/components/blogging-prompt-card/style.scss
+++ b/client/components/blogging-prompt-card/style.scss
@@ -42,18 +42,6 @@
 			font-weight: 500;
 			line-height: 26px;
 		}
-		.blogging-prompt__answered-text {
-			font-size: $font-body;
-			text-align: center;
-			line-height: 18px;
-			margin-top: 10px;
-			color: var(--color-success);
-			> svg {
-				position: relative;
-				top: 3px;
-				margin-right: 2px;
-			}
-		}
 		button.navigation-link {
 			border-radius: 50%;
 			height: 44px;
@@ -70,6 +58,12 @@
 		margin-top: 24px;
 		width: 100%;
 
+		.blogging-prompt__new-post-link  svg {
+			position: relative;
+			top: 4px;
+			margin-right: 4px;
+			color: var(--color-success);
+		}
 		.blogging-prompt__prompt-responses {
 			align-items: center;
 			display: flex;

--- a/client/data/blogging-prompt/use-blogging-prompts.ts
+++ b/client/data/blogging-prompt/use-blogging-prompts.ts
@@ -1,8 +1,10 @@
+import { useSelector } from 'react-redux';
 import { Url } from 'url';
 import { useQuery, UseQueryResult } from '@tanstack/react-query';
 import { addQueryArgs } from 'calypso/lib/url';
-import wp from 'calypso/lib/wp';
 import { SiteId } from 'calypso/types';
+import wp from 'calypso/lib/wp';
+import { getMyPostCounts } from 'calypso/state/posts/counts/selectors';
 
 export interface BloggingPrompt {
 	id: number;
@@ -20,6 +22,17 @@ export interface BloggingPrompt {
 interface AnsweredUsersSample {
 	avatar: Url;
 }
+interface PublishedPosts {
+	publish: string;
+}
+
+const selectPrompts = ( response: { prompts: BloggingPrompt[] } ): BloggingPrompt[] | null => {
+	const prompts = response && response.prompts;
+	if ( ! prompts ) {
+		return null;
+	}
+	return prompts;
+};
 
 export const useBloggingPrompts = (
 	siteId: SiteId,
@@ -35,8 +48,13 @@ export const useBloggingPrompts = (
 		},
 		`/sites/${ siteId }/blogging-prompts`
 	);
+	// if a new post is published, we want the cache to be invalidated
+	const publishedPosts = useSelector( ( state: object ) =>
+		getMyPostCounts( state, siteId, 'post' )
+	) as PublishedPosts;
+
 	return useQuery( {
-		queryKey: [ 'blogging-prompts', siteId, start_date, per_page ],
+		queryKey: [ 'blogging-prompts', siteId, start_date, per_page, 'posts-' + publishedPosts?.publish ],
 		queryFn: () =>
 			wp.req.get( {
 				path: path,

--- a/client/data/blogging-prompt/use-blogging-prompts.ts
+++ b/client/data/blogging-prompt/use-blogging-prompts.ts
@@ -1,10 +1,10 @@
-import { useSelector } from 'react-redux';
 import { Url } from 'url';
 import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import { useSelector } from 'react-redux';
 import { addQueryArgs } from 'calypso/lib/url';
-import { SiteId } from 'calypso/types';
 import wp from 'calypso/lib/wp';
 import { getMyPostCounts } from 'calypso/state/posts/counts/selectors';
+import { SiteId } from 'calypso/types';
 
 export interface BloggingPrompt {
 	id: number;
@@ -26,14 +26,6 @@ interface PublishedPosts {
 	publish: string;
 }
 
-const selectPrompts = ( response: { prompts: BloggingPrompt[] } ): BloggingPrompt[] | null => {
-	const prompts = response && response.prompts;
-	if ( ! prompts ) {
-		return null;
-	}
-	return prompts;
-};
-
 export const useBloggingPrompts = (
 	siteId: SiteId,
 	start_date: string,
@@ -54,7 +46,13 @@ export const useBloggingPrompts = (
 	) as PublishedPosts;
 
 	return useQuery( {
-		queryKey: [ 'blogging-prompts', siteId, start_date, per_page, 'posts-' + publishedPosts?.publish ],
+		queryKey: [
+			'blogging-prompts',
+			siteId,
+			start_date,
+			per_page,
+			'posts-' + publishedPosts?.publish,
+		],
 		queryFn: () =>
 			wp.req.get( {
 				path: path,


### PR DESCRIPTION
Part of pe7F0s-1iI-p2#comment-1700
In the mobile apps there is an indicator for when a user has answered a specific prompt, and we also get that data returned by both the v2 and v3 APIs.

This PR adds a simple indicator to the my home card if the user has answered a prompt.

<img width="557" alt="Screen Shot 2023-11-02 at 3 11 25 pm" src="https://github.com/Automattic/wp-calypso/assets/22446385/defc9734-97da-4fbd-b299-5dfd32044c1b">


I also just changed the vertical alignment of the prompt and prev/next buttons so that they don't jump around while cycling through prompts.

### Test instructions
Go to a site with `site_intent=write`
Answer a writing prompt.
Go to the `/home` page
You should see the "✅Answered" indicator on the prompt that you answered