### PR TITLE
NavigationHeader: reader search header

### DIFF
--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
-import FormattedHeader from 'calypso/components/formatted-header';
+import NavigationHeader from 'calypso/components/navigation-header';
 import SearchInput from 'calypso/components/search';
 import SegmentedControl from 'calypso/components/segmented-control';
 import { addQueryArgs } from 'calypso/lib/url';
@@ -179,12 +179,9 @@ class SearchStream extends React.Component {
 					style={ { width: this.props.width } }
 					ref={ this.handleFixedAreaMounted }
 				>
-					<FormattedHeader
-						brandFont
-						headerText={ translate( 'Search' ) }
-						subHeaderText={ translate( 'Search for specific topics, authors, or blogs.' ) }
-						align="left"
-						hasScreenOptions
+					<NavigationHeader
+						title={ translate( 'Search' ) }
+						subtitle={ translate( 'Search for specific topics, authors, or blogs.' ) }
 					/>
 					<CompactCard className="search-stream__input-card">
 						<SearchInput

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -1,3 +1,33 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
+
+.is-section-reader .search-stream__header {
+	&.has-description {
+		.info-popover {
+			display: none;
+		}
+		.formatted-header__subtitle {
+			display: inline-block;
+		}
+	}
+
+	.navigation-header {
+		margin: 0 auto;
+		padding: 0 0 16px 0;
+	}
+}
+
+// .has-header-section only applies for logged out views
+.layout.has-header-section.is-section-reader .navigation-header h1 {
+	@extend .wp-brand-font;
+	font-weight: 600;
+	font-size: 2.25rem;
+	line-height: 48px;
+	margin-bottom: 4px;
+}
+
+
 .is-reader-page .main.search-stream {
 	max-width: 905px;
 }

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -2,24 +2,16 @@
 @import "@wordpress/base-styles/mixins";
 @import "@wordpress/base-styles/variables";
 
-.is-section-reader .search-stream__header {
-	&.has-description {
-		.info-popover {
-			display: none;
-		}
-		.formatted-header__subtitle {
-			display: inline-block;
-		}
-	}
-
+.is-section-reader .search-stream__fixed-area {
+	// Main layout already has mx
 	.navigation-header {
 		margin: 0 auto;
-		padding: 0 0 16px 0;
+		padding: 16px 0 16px 0;
 	}
 }
 
 // .has-header-section only applies for logged out views
-.layout.has-header-section.is-section-reader .navigation-header h1 {
+.layout.has-header-section.is-section-reader .search-stream__fixed-area .navigation-header h1 {
 	@extend .wp-brand-font;
 	font-weight: 600;
 	font-size: 2.25rem;
@@ -97,7 +89,6 @@
 	margin-bottom: 0;
 	border-radius: 4px;
 	@include breakpoint-deprecated( "<660px" ) {
-		margin-top: 20px;
 
 		.search__icon-navigation {
 			border-radius: 4px;


### PR DESCRIPTION
Related to # https://github.com/Automattic/dotcom-forge/issues/4352

## Proposed Changes

- Swaps out stream header h1's for navigation header components

## Testing Instructions

Logged out and logged in:
* http://calypso.localhost:3000/read/search?q=daily+prompt


![Screenshot 2023-11-02 at 16-36-07 daily prompt ‹ Reader — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/469c7d39-4920-4a37-b54e-529dd2e0558d)
![Screenshot 2023-11-02 at 16-35-04 daily prompt ‹ Reader — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/9dfb82c3-ccdd-40df-aea5-f19d7ccf463a)

