### PR TITLE
The hiding free subdomain test on the paid media flow – 2nd attempt

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -186,6 +186,10 @@ export class RenderDomainsStep extends Component {
 		if ( shouldUseMultipleDomainsInCart( this.props.flowName, this.props.currentUser ) ) {
 			this.props.shoppingCartManager.addProductsToCart( [ this.props.multiDomainDefaultPlan ] );
 		}
+
+		if ( this.props.flowName === 'onboarding-pm' ) {
+			loadExperimentAssignment( 'calypso_gf_signup_onboardingpm_domains_hide_free_subdomain_v2' );
+		}
 	}
 
 	getLocale() {
@@ -1011,9 +1015,9 @@ export class RenderDomainsStep extends Component {
 
 		return (
 			<ProvideExperimentData
-				name="calypso_gf_signup_onboardingpm_domains_hide_free_subdomain"
+				name="calypso_gf_signup_onboardingpm_domains_hide_free_subdomain_v2"
 				options={ {
-					isEligible: includeWordPressDotCom && this.props.flowName === 'onboarding-pm',
+					isEligible: this.props.flowName === 'onboarding-pm',
 				} }
 			>
 				{ ( isLoadingExperiment, experimentAssignment ) => (

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -186,10 +186,6 @@ export class RenderDomainsStep extends Component {
 		if ( shouldUseMultipleDomainsInCart( this.props.flowName, this.props.currentUser ) ) {
 			this.props.shoppingCartManager.addProductsToCart( [ this.props.multiDomainDefaultPlan ] );
 		}
-
-		if ( this.props.flowName === 'onboarding-pm' ) {
-			loadExperimentAssignment( 'calypso_gf_signup_onboardingpm_domains_hide_free_subdomain_v2' );
-		}
 	}
 
 	getLocale() {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/growth-foundations#212

## Proposed Changes

This is the 2nd attempt to the hiding free subdomain test. The previous one https://github.com/Automattic/wp-calypso/pull/82708 had experienced the SRM issue so was disabled. In this PR, the experiment is preloaded right in `componentDidMount()` to make sure the assignment happen right at the entrance of the domain step. Previously, it was done bt `<ProvideExperiment>` in `renderContent()`, which can be skipped given certain conditions.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Follow the test instruction in https://github.com/Automattic/wp-calypso/pull/82708, but be cautious that the ExPlat slug is `'calypso_gf_signup_onboardingpm_domains_hide_free_subdomain_v2'`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
