### PR TITLE
Jetpack Manage: Fix internal links causing a full page reload.

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/index.tsx
@@ -197,7 +197,7 @@ export default function SiteStatusContent( {
 						borderless
 						compact
 						href={ siteRedirectURL }
-						target={ isWPCOMAtomicSiteCreationEnabled && isWPCOMAtomicSite ? '_blank' : '_self' }
+						target={ isWPCOMAtomicSiteCreationEnabled && isWPCOMAtomicSite ? '_blank' : undefined }
 						onClick={ handleSiteClick }
 					>
 						{ WPCOMHostedSiteBadgeColumn }
@@ -332,7 +332,7 @@ export default function SiteStatusContent( {
 
 	if ( ! showMultisiteNotSupported ) {
 		if ( link ) {
-			let target = '_self';
+			let target = undefined;
 			let rel;
 			if ( isExternalLink ) {
 				target = '_blank';


### PR DESCRIPTION
When clicking internal links in the Dashboard tables, the page does a full reload instead of just navigating.

<img width="1573" alt="Screen Shot 2023-11-02 at 2 38 29 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/9943359c-ba54-4221-9016-ceb6f099cec4">

https://github.com/Automattic/wp-calypso/assets/56598660/229fb693-dd1a-450f-af72-54c38a072a59



Closes https://github.com/Automattic/jetpack-manage/issues/73

## Proposed Changes

* Update target to undefined for non-external links to avoid page refresh.

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

* Use the Jetpack Cloud live link and go to `/dashboard`
* In the dashboard table, click any JN site's site name and confirm the page does not do a full reload.
* Confirm other internal links (checkmarks, CTA buttons, etc.) do not cause the page to do a full reload.

https://github.com/Automattic/wp-calypso/assets/56598660/95334f92-2603-4559-afb1-a8d794cd851f



## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React, or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?