### PR TITLE
Plans 2023: Migrate and uncouple touch-detect lib

### DIFF
--- a/client/my-sites/plans-grid/components/plans-2023-tooltip.tsx
+++ b/client/my-sites/plans-grid/components/plans-2023-tooltip.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import { TranslateResult } from 'i18n-calypso';
 import { Dispatch, PropsWithChildren, SetStateAction, useEffect, useRef, useState } from 'react';
 import Tooltip from 'calypso/components/tooltip';
-import { hasTouch } from 'calypso/lib/touch-detect';
+import { hasTouch } from '../lib/touch-detect';
 
 const HoverAreaContainer = styled.span`
 	max-width: 220px;

--- a/client/my-sites/plans-grid/hooks/use-manage-tooltip-toggle.ts
+++ b/client/my-sites/plans-grid/hooks/use-manage-tooltip-toggle.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, Dispatch, SetStateAction } from 'react';
-import { hasTouch } from 'calypso/lib/touch-detect';
+import { hasTouch } from '../lib/touch-detect';
 
 export function useManageTooltipToggle(): [ string, Dispatch< SetStateAction< string > > ] {
 	const [ activeTooltipId, setActiveTooltipId ] = useState( '' );

--- a/client/my-sites/plans-grid/lib/touch-detect/README.md
+++ b/client/my-sites/plans-grid/lib/touch-detect/README.md
@@ -1,0 +1,11 @@
+# touch-detect
+
+`touch-detect` is a simple test to see if the browser supports touch events.
+This is not the same as detecting if the current display is a touch screen.
+Depending on the use case, this may be appropriate.
+
+Further reading:
+
+<https://github.com/Modernizr/Modernizr/blob/HEAD/feature-detects/touchevents.js>
+<http://www.stucox.com/blog/you-cant-detect-a-touchscreen/>
+<http://www.html5rocks.com/en/mobile/touchandmouse/>

--- a/client/my-sites/plans-grid/lib/touch-detect/index.js
+++ b/client/my-sites/plans-grid/lib/touch-detect/index.js
@@ -1,0 +1,17 @@
+// eslint-disable-next-line inclusive-language/use-inclusive-words
+/**
+ * This test is for touch events.
+ * It may not accurately detect a touch screen, but may be close enough depending on the use case.
+ * @copyright Modernizr © 2009-2015.
+ * @license MIT
+ * @see https://github.com/Modernizr/Modernizr/blob/master/LICENSE.md
+ * @see https://github.com/Modernizr/Modernizr/blob/HEAD/feature-detects/touchevents.js
+ * @returns {boolean} whether touch screen is available
+ */
+export function hasTouch() {
+	/* global DocumentTouch:true */
+	return (
+		window &&
+		( 'ontouchstart' in window || ( window.DocumentTouch && document instanceof DocumentTouch ) )
+	);
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/81349

## Proposed Changes

We uncouple the plans-grid from touch-detect lib by copying the utility right under `plans-grid/lib`.

I don't really see the need to engineer too much more around this right now (migrate to packages). This was borrowed from `Modernizr` to begin with. A better refactor might be to investigate if anything else (more recent, maybe anything from Core), exists to provide this functionality.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- that build passes and plans pages work without errors I think should be enough

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?