### PR TITLE
Staging Sites: Disable site database sync for production site with Woo

### DIFF
--- a/client/my-sites/hosting/staging-site-card/card-content/staging-sync-card.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/staging-sync-card.tsx
@@ -422,7 +422,7 @@ export const SiteSyncCard = ( {
 	const siteSlug = useSelector(
 		type === 'staging' ? ( state ) => getSiteSlug( state, productionSiteId ) : getSelectedSiteSlug
 	);
-	const isSiteWooStore = useSelector( ( state ) => isSiteStore( state, productionSiteId ) );
+	const isSiteWooStore = !! useSelector( ( state ) => isSiteStore( state, productionSiteId ) );
 	const {
 		progress,
 		resetSyncStatus,

--- a/client/my-sites/hosting/staging-site-card/card-content/staging-sync-card.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/staging-sync-card.tsx
@@ -10,6 +10,7 @@ import NoticeAction from 'calypso/components/notice/notice-action';
 import { urlToSlug } from 'calypso/lib/url';
 import { useSelector } from 'calypso/state';
 import { removeNotice, successNotice } from 'calypso/state/notices/actions';
+import isSiteStore from 'calypso/state/selectors/is-site-store';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { SiteSyncStatus } from 'calypso/state/sync/constants';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -181,6 +182,7 @@ const StagingToProductionSync = ( {
 	isSyncInProgress,
 	onConfirm,
 	showSyncPanel,
+	isSqlsOptionDisabled,
 }: {
 	disabled: boolean;
 	siteSlug: string;
@@ -190,6 +192,7 @@ const StagingToProductionSync = ( {
 	isSyncButtonDisabled: boolean;
 	onConfirm: () => void;
 	showSyncPanel: boolean;
+	isSqlsOptionDisabled: boolean;
 } ) => {
 	const [ typedSiteName, setTypedSiteName ] = useState( '' );
 	const translate = useTranslate();
@@ -203,6 +206,7 @@ const StagingToProductionSync = ( {
 						items={ synchronizationOptions }
 						disabled={ disabled }
 						onChange={ onSelectItems }
+						isSqlsOptionDisabled={ isSqlsOptionDisabled }
 					></SyncOptionsPanel>
 				</>
 			) }
@@ -418,6 +422,7 @@ export const SiteSyncCard = ( {
 	const siteSlug = useSelector(
 		type === 'staging' ? ( state ) => getSiteSlug( state, productionSiteId ) : getSelectedSiteSlug
 	);
+	const isSiteWooStore = useSelector( ( state ) => isSiteStore( state, productionSiteId ) );
 	const {
 		progress,
 		resetSyncStatus,
@@ -541,6 +546,7 @@ export const SiteSyncCard = ( {
 					selectedItems={ selectedItems }
 					isSyncButtonDisabled={ isSyncButtonDisabled }
 					onConfirm={ selectedOption === 'push' ? onPushInternal : onPullInternal }
+					isSqlsOptionDisabled={ isSiteWooStore }
 				/>
 			) }
 			{ selectedOption !== actionForType && (

--- a/client/my-sites/hosting/staging-site-card/sync-options-panel.tsx
+++ b/client/my-sites/hosting/staging-site-card/sync-options-panel.tsx
@@ -63,11 +63,13 @@ export default function SyncOptionsPanel( {
 	reset,
 	disabled,
 	onChange,
+	isSqlsOptionDisabled,
 }: {
 	items: CheckboxOptionItem[];
 	reset: boolean;
 	disabled: boolean;
 	onChange: ( items: CheckboxOptionItem[] ) => void;
+	isSqlsOptionDisabled: boolean;
 } ) {
 	const initialItemsMap = useMemo(
 		() =>
@@ -155,14 +157,31 @@ export default function SyncOptionsPanel( {
 				{ dangerousItems.map( ( item ) => {
 					return (
 						<div data-testid="danger-zone-checkbox" key={ item.name }>
-							<ToggleWithLabelFontSize
-								data-testid="danger-zone-checkbox"
-								disabled={ disabled }
-								help={ <ItemSubtitle>{ item.subTitle }</ItemSubtitle> }
-								label={ item.label }
-								checked={ item.checked }
-								onChange={ () => handleCheckChange( item ) }
-							/>
+							{ 'sqls' === item.name && isSqlsOptionDisabled ? (
+								<ToggleWithLabelFontSize
+									data-testid="danger-zone-checkbox"
+									disabled={ true }
+									help={
+										<ItemSubtitle>
+											{ translate(
+												'Site database synchronization is not supported for Woo Commerce sites.'
+											) }
+										</ItemSubtitle>
+									}
+									label={ item.label }
+									checked={ item.checked }
+									onChange={ () => handleCheckChange( item ) }
+								/>
+							) : (
+								<ToggleWithLabelFontSize
+									data-testid="danger-zone-checkbox"
+									disabled={ disabled || isSqlsOptionDisabled }
+									help={ <ItemSubtitle>{ item.subTitle }</ItemSubtitle> }
+									label={ item.label }
+									checked={ item.checked }
+									onChange={ () => handleCheckChange( item ) }
+								/>
+							) }
 						</div>
 					);
 				} ) }

--- a/client/my-sites/hosting/staging-site-card/sync-options-panel.tsx
+++ b/client/my-sites/hosting/staging-site-card/sync-options-panel.tsx
@@ -164,7 +164,7 @@ export default function SyncOptionsPanel( {
 									help={
 										<ItemSubtitle>
 											{ translate(
-												'Site database synchronization is not supported for Woo Commerce sites.'
+												'Site database synchronization is disabled because WooCommerce sites are not supported.'
 											) }
 										</ItemSubtitle>
 									}

--- a/client/my-sites/hosting/staging-site-card/test/sync-options-panel.js
+++ b/client/my-sites/hosting/staging-site-card/test/sync-options-panel.js
@@ -70,7 +70,9 @@ describe( 'SyncOptionsPanel component', () => {
 		);
 		expect( screen.getByLabelText( 'Site database' ) ).toBeInTheDocument();
 		expect(
-			screen.getByText( 'Site database synchronization is not supported for Woo Commerce sites.' )
+			screen.getByText(
+				'Site database synchronization is disabled because WooCommerce sites are not supported.'
+			)
 		).toBeInTheDocument();
 		expect( screen.queryByText( 'Overwrite the database.' ) ).not.toBeInTheDocument();
 		expect( screen.getAllByTestId( 'danger-zone-checkbox' ) ).toHaveLength( 1 );

--- a/client/my-sites/hosting/staging-site-card/test/sync-options-panel.js
+++ b/client/my-sites/hosting/staging-site-card/test/sync-options-panel.js
@@ -55,6 +55,26 @@ describe( 'SyncOptionsPanel component', () => {
 		expect( screen.getByLabelText( 'Test 3' ) ).toBeInTheDocument();
 		expect( screen.getAllByTestId( 'danger-zone-checkbox' ) ).toHaveLength( 2 );
 	} );
+	it( 'shows disabled sqls item correctly', () => {
+		const items = [
+			{
+				name: 'sqls',
+				label: 'Site database',
+				subTitle: 'Overwrite the database.',
+				checked: false,
+				isDangerous: true,
+			},
+		];
+		render(
+			<SyncOptionsPanel items={ items } isSqlsOptionDisabled={ true } onChange={ jest.fn } />
+		);
+		expect( screen.getByLabelText( 'Site database' ) ).toBeInTheDocument();
+		expect(
+			screen.getByText( 'Site database synchronization is not supported for Woo Commerce sites.' )
+		).toBeInTheDocument();
+		expect( screen.queryByText( 'Overwrite the database.' ) ).not.toBeInTheDocument();
+		expect( screen.getAllByTestId( 'danger-zone-checkbox' ) ).toHaveLength( 1 );
+	} );
 
 	it( 'provides the selected items when onChange function is provided', () => {
 		const items = [


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4436

## Proposed Changes

In this diff, I propose to disable site database synchronization for production sites that have WooCommerce installed.

![Screenshot 2023-11-03 at 14 16 34](https://github.com/Automattic/wp-calypso/assets/727413/12003020-94a4-409b-b686-2b924f386b5b)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Woo on the Business plan

1. Create a Business site and install the Woo Commerce plugin
2. Add a staging site
3. Try synchronizing from staging to production
4. Confirm that the database option is disabled and the label is displayed

### Commerce plan

1. Create a Commerce site
2. Add a staging site
3. Try synchronizing from staging to production
4. Confirm that the database option is disabled and the label is displayed

### Business plan

1. Create a Business site
2. Add a staging site
3. Try synchronizing from staging to production
4. Confirm that the database option is enabled

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?