### PR TITLE
Pricing page: Fix Jetpack Search product CTA

### DIFF
--- a/client/my-sites/plans/jetpack-plans/get-purchase-url-callback.ts
+++ b/client/my-sites/plans/jetpack-plans/get-purchase-url-callback.ts
@@ -31,6 +31,8 @@ export function buildCheckoutURL(
 	urlQueryArgs: QueryArgs = {}
 ): string {
 	const productsArray = Array.isArray( products ) ? products : [ products ];
+	// Since purchases of multiple products are allowed, we need to pass all products separated
+	// by comma in the URL.
 	const productsString = productsArray.join( ',' );
 
 	if ( isJetpackCloud() ) {
@@ -72,9 +74,9 @@ export function buildCheckoutURL(
 		);
 	}
 
-	// If there is not siteSlug, we need to redirect the user to the site selection
-	// step of the flow. Since purchases of multiple products are allowed, we need
-	// to pass all products separated by comma in the URL.
+	// If there is not siteSlug, we need to redirect the user to the site selection step of the
+	// flow (`/checkout/:productSlug` (without a site) will open site selection, if a site has not already been selected).
+	// The Jetpack Search product executes this flow (because price is based on the site's number of posts).
 	const path = siteSlug
 		? `/checkout/${ siteSlug }/${ productsString }`
 		: `/checkout/${ productsString }`;

--- a/client/my-sites/plans/jetpack-plans/get-purchase-url-callback.ts
+++ b/client/my-sites/plans/jetpack-plans/get-purchase-url-callback.ts
@@ -77,10 +77,10 @@ export function buildCheckoutURL(
 	// to pass all products separated by comma in the URL.
 	const path = siteSlug
 		? `/checkout/${ siteSlug }/${ productsString }`
-		: `/jetpack/connect/${ productsString }`;
+		: `/checkout/${ productsString }`;
 
 	return isJetpackCloud()
-		? addQueryArgs( urlQueryArgs, `https://wordpress.com${ path }` )
+		? addQueryArgs( urlQueryArgs, `${ host }${ path }` )
 		: addQueryArgs( urlQueryArgs, path );
 }
 

--- a/client/my-sites/sites/style.scss
+++ b/client/my-sites/sites/style.scss
@@ -17,7 +17,7 @@
 	font-size: $font-title-small;
 	font-weight: 400;
 	line-height: inherit;
-	margin-top: 16px;
+	margin-top: 55px;
 	margin-bottom: 24px;
 
 	strong {


### PR DESCRIPTION
An issue was discovered where clicking the Jetpack Search CTA was taking the user to a /jetpack/connect/ page asking the user to enter their site's URL (see screenshot)
![Markup 2023-11-02 at 08 06 21](https://github.com/Automattic/wp-calypso/assets/11078128/4dfc00e7-25e9-4196-9641-37c86dae5e9b)

Unlike other products, Jetpack Search needs to have the user's site in context because the price for Jetpack Search is based on the number of posts on the site.

Therefore, the intended behavior of the Jetpack Search CTA would be to first redirect to login (if not logged-in already), then to site selection, then to logged-in checkout with the users site selected and Jetpack Search in the cart.

This PR fixes the Jetpack Search CTA to have the above intended behavior.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Internal reference 1: https://github.com/Automattic/wp-calypso/issues/77566
Internal reference 2: https://github.com/orgs/Automattic/projects/724/views/2?pane=issue&itemId=42223110

## Proposed Changes

* Updated the checkout url for Jetpack Search to open login and/or site selection first before landing in checkout.
* Updated comments to be more descriptive.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Checkout this branch and spin up Calypso green (Run `yarn start-jetpack-cloud`).
- Open http://jetpack.cloud.localhost:3000/pricing
- Click the Jetpack Search "Get" CTA.
- Verify you are redirected the site selection page (Or login page (if not logged-in), and then to the site selection page), Select a site, and then you're directed to checkout with Jetpack Search in the cart.

#### Screencast

https://github.com/Automattic/wp-calypso/assets/11078128/de4408d6-f980-4b84-94a3-93930348c4c9



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?