### PR TITLE
Logged-out Reader - Add #comments id to url of blog post link when in a comments context.

### DIFF
--- a/client/reader/utils.js
+++ b/client/reader/utils.js
@@ -31,7 +31,7 @@ export function showSelectedPost( { postKey, comments } ) {
 		const isLoggedIn = isUserLoggedIn( getState() );
 
 		if ( ! isLoggedIn ) {
-			return window.open( post.URL, '_blank' );
+			return window.open( post.URL + ( comments ? '#comments' : '' ), '_blank' );
 		}
 
 		if ( isXPost( post ) ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # p1698923503154179-slack-C03NLNTPZ2T

## Proposed Changes

* Updates the logged out case of the reader helper `showSelectedPost` to add `#comments` to the url if the pre-existing comments option for the function is truthy.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch
* In an incognito window, load wordpress.com/discover
* click on the "comment" button in the post actions, or the "view more comments on the full post" at the bottom of the inline comments section after expanded.
* verify these links open the post in a new tab with the #comments id added to the url. The posts should load scrolled to the comments section.
* click on other main sections of the post card, title, etc. These should continue to open the post without the comments id.
* Test logged-in and verify no regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?