### PR TITLE
Home Launchpad: show unverified email nag dialog on launching WIP

### DIFF
--- a/client/my-sites/customer-home/cards/launchpad/index.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/index.tsx
@@ -1,7 +1,7 @@
 import { Button, CircularProgressBar, Gridicon } from '@automattic/components';
 import {
-	updateLaunchpadSettings,
 	LaunchpadNavigator,
+	updateLaunchpadSettings,
 	useSortedLaunchpadTasks,
 } from '@automattic/data-stores';
 import { Launchpad, type Task } from '@automattic/launchpad';
@@ -11,6 +11,7 @@ import { useEffect, useState } from 'react';
 import { useLaunchpadNavigator } from 'calypso/data/launchpad-navigator/use-launchpad-navigator';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector } from 'calypso/state';
+import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import type { AppState } from 'calypso/types';
@@ -29,6 +30,9 @@ const CustomerHomeLaunchpad = ( {
 	const launchpadContext = 'customer-home';
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( ( state: AppState ) => getSiteSlug( state, siteId ) );
+	const siteDomains = useSelector( ( state ) => getDomainsBySiteId( state, siteId ) );
+	const customDomains = siteDomains?.filter( ( domain ) => ! domain.isWPCOMDomain );
+	const customDomain = customDomains?.length ? customDomains[ 0 ] : undefined;
 
 	const translate = useTranslate();
 	const [ isDismissed, setIsDismissed ] = useState( false );
@@ -122,6 +126,8 @@ const CustomerHomeLaunchpad = ( {
 				checklistSlug={ checklistSlug }
 				launchpadContext={ launchpadContext }
 				onSiteLaunched={ onSiteLaunched }
+				siteId={ siteId }
+				customDomain={ customDomain }
 			/>
 		</div>
 	);

--- a/packages/launchpad/src/checklist-item/index.tsx
+++ b/packages/launchpad/src/checklist-item/index.tsx
@@ -49,7 +49,7 @@ const ChecklistItem = ( { task, isPrimaryAction }: { task: Task; isPrimaryAction
 				<Button
 					className="checklist-item__checklist-primary-button"
 					data-task={ id }
-					onClick={ handlePrimaryAction }
+					onClick={ () => handlePrimaryAction() }
 					{ ...buttonProps }
 				>
 					{ title }
@@ -58,7 +58,7 @@ const ChecklistItem = ( { task, isPrimaryAction }: { task: Task; isPrimaryAction
 				<Button
 					className="checklist-item__task-content"
 					data-task={ id }
-					onClick={ actionDispatch }
+					onClick={ () => actionDispatch?.() }
 					{ ...buttonProps }
 				>
 					{ completed && (

--- a/packages/launchpad/src/index.ts
+++ b/packages/launchpad/src/index.ts
@@ -4,4 +4,5 @@ export { default as LaunchpadInternal } from './launchpad-internal';
 export { default as Launchpad } from './launchpad';
 export { setUpActionsForTasks } from './setup-actions';
 export * from './action-components';
+export * from './unverified-domain-email-nag-dialog';
 export * from './types';

--- a/packages/launchpad/src/types.ts
+++ b/packages/launchpad/src/types.ts
@@ -8,7 +8,7 @@ export interface Task {
 	title?: string;
 	subtitle?: string | React.ReactNode | null;
 	badge_text?: string;
-	actionDispatch?: () => void;
+	actionDispatch?: ( force?: boolean ) => void;
 	isLaunchTask?: boolean;
 	extra_data?: TaskExtraData;
 	calypso_path?: string;
@@ -59,6 +59,7 @@ export interface LaunchpadResponse {
 export interface PermittedActions {
 	setShareSiteModalIsOpen?: ( isOpen: boolean ) => void;
 	setActiveChecklist: ( siteSlug: string, activeChecklistSlug: string ) => void;
+	setUnverifiedDomainEmailModalIsOpen?: () => void;
 }
 
 export type EventHandlers = {
@@ -69,6 +70,7 @@ export type EventHandlers = {
 export interface LaunchpadTaskActionsProps {
 	siteSlug: string | null;
 	tasks: Task[];
+	customDomain?: { name: string; isPendingIcannVerification?: boolean };
 	tracksData: LaunchpadTracksData;
 	extraActions: PermittedActions;
 	uiContext?: 'calypso';

--- a/packages/launchpad/src/unverified-domain-email-nag-dialog.tsx
+++ b/packages/launchpad/src/unverified-domain-email-nag-dialog.tsx
@@ -1,0 +1,64 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { Dialog } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+
+interface Props {
+	domain: string;
+	isVisible: boolean;
+	onClose(): void;
+	onContinue(): void;
+}
+
+export function recordUnverifiedDomainDialogShownTracksEvent( site_id?: number ) {
+	recordTracksEvent( 'calypso_launchpad_unverified_domain_email_dialog_shown', {
+		site_id,
+	} );
+}
+
+export function recordUnverifiedDomainContinueAnywayClickedTracksEvent( site_id?: number ) {
+	recordTracksEvent( 'calypso_launchpad_unverified_domain_email_continue_anyway_clicked', {
+		site_id,
+	} );
+}
+
+export const UnverifiedDomainEmailNagDialog = ( {
+	domain,
+	isVisible,
+	onClose,
+	onContinue,
+}: Props ) => {
+	const translate = useTranslate();
+
+	return (
+		<Dialog
+			isVisible={ isVisible }
+			buttons={ [
+				{
+					action: 'cancel',
+					label: translate( 'Cancel' ),
+				},
+				{
+					action: 'launch',
+					label: translate( 'Continue anyway' ),
+					isPrimary: true,
+					onClick: onContinue,
+				},
+			] }
+			onClose={ onClose }
+		>
+			<p>
+				{ translate(
+					'Your domain email address is still unverified. This will cause {{strong}}%(domain)s{{/strong}} to be suspended in the future.{{break/}}{{break/}}Please check your inbox for the ICANN verification email.',
+					{
+						components: {
+							p: <p />,
+							break: <br />,
+							strong: <strong />,
+						},
+						args: { domain },
+					}
+				) }
+			</p>
+		</Dialog>
+	);
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
