### PR TITLE
Subscriber Stats: Use null values for points before table creation

### DIFF
--- a/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
@@ -40,7 +40,10 @@ function transformData( data: SubscribersData[] ): uPlot.AlignedData {
 	// Note that the incoming data is ordered ascending (newest to oldest)
 	// but uPlot expects descending in its deafult configuration.
 	const x: number[] = data.map( ( point ) => Number( new Date( point.period ) ) / 1000 ).reverse();
-	const y: number[] = data.map( ( point ) => Number( point.subscribers ) ).reverse();
+	// Reserve null values for points with no data.
+	const y: Array< number | null > = data
+		.map( ( point ) => ( point.subscribers === null ? null : Number( point.subscribers ) ) )
+		.reverse();
 
 	return [ x, y ];
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1698928550122359-slack-C057AH42XQD

## Proposed Changes

* Reserve `null` values to show the period with empty data rather than `0` on the line chart.

|Before|After|
|-|-|
|<img width="1277" alt="截圖 2023-11-02 下午10 33 39" src="https://github.com/Automattic/wp-calypso/assets/6869813/a785dee8-0b17-4f7f-a889-493c7f41a80c">|<img width="1276" alt="截圖 2023-11-02 下午10 19 33" src="https://github.com/Automattic/wp-calypso/assets/6869813/c021d1d9-7ee5-4291-bfbb-ec9f4fedc14c">|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply the Diff: D127572-code.
* Sandbox `public-api.wordpress.com`.
* Spin this change up with the Calypso Live link.
* Navigate to Stats > Subscribers page.
* Ensure the chart period before `2023-10-24` shows an empty period rather than continuous `0` points.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?