### PR TITLE
WIP: Use starter design by slug query instead of searching it on the frontend

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -3,7 +3,6 @@ import { Button } from '@automattic/components';
 import {
 	Onboard,
 	updateLaunchpadSettings,
-	useStarterDesignBySlug,
 	useStarterDesignsQuery,
 	getThemeIdFromStylesheet,
 } from '@automattic/data-stores';
@@ -214,7 +213,8 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		pickDesign,
 		pickUnlistedDesign,
 		recordPreviewDesign,
-		recordPreviewStyleVariation
+		recordPreviewStyleVariation,
+		disableCheckoutImmediately
 	);
 
 	const shouldUnlockGlobalStyles =
@@ -226,16 +226,6 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	}, [ isPreviewingDesign ] );
 
 	const selectedDesignHasStyleVariations = ( selectedDesign?.style_variations || [] ).length > 0;
-	const { data: selectedDesignDetails } = useStarterDesignBySlug( selectedDesign?.slug || '', {
-		enabled: isPreviewingDesign,
-		select: ( design: Design ) => {
-			if ( disableCheckoutImmediately && design?.style_variations ) {
-				design.style_variations = [];
-			}
-
-			return design;
-		},
-	} );
 
 	function getEventPropsByDesign(
 		design: Design,
@@ -821,11 +811,9 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 					}
 					title={ headerDesignTitle }
 					selectedDesignTitle={ designTitle }
-					shortDescription={ selectedDesign.description }
-					description={ selectedDesignDetails?.description }
-					variations={
-						selectedDesignHasStyleVariations ? selectedDesignDetails?.style_variations : []
-					}
+					shortDescription={ selectedDesign.shortDescription }
+					description={ selectedDesign?.description }
+					variations={ selectedDesignHasStyleVariations ? selectedDesign?.style_variations : [] }
 					selectedVariation={ selectedStyleVariation }
 					onSelectVariation={ previewDesignVariation }
 					actionButtons={ actionButtons }

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -96,6 +96,7 @@ export interface PreviewData {
 export interface Design {
 	slug: string;
 	title: string;
+	shortDescription?: string | null;
 	description?: string;
 	recipe?: DesignRecipe;
 	is_premium: boolean;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4148

## Proposed Changes

* Instead of filtering the allDesigns array, we are pulling the theme info from the API

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the live link and go to `setup/site-setup/designSetup?siteSlug=your-site`
* Click on a theme and notice that the page loads (make sure that we display a short description)
* Change the `theme` query param to `smithland`
* Make sure the theme preview page loads.
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?