### PR TITLE
jcl: unmangle `fetchTestConnection` from `fetchDashboardSites`

### DIFF
--- a/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
+++ b/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
@@ -1,4 +1,4 @@
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { useTranslate } from 'i18n-calypso';
 import { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
 import { useDispatch } from 'calypso/state';
@@ -6,7 +6,6 @@ import { errorNotice } from 'calypso/state/notices/actions';
 import type {
 	AgencyDashboardFilter,
 	DashboardSortInterface,
-	Site,
 } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
 
 const agencyDashboardFilterToQueryObject = ( filter: AgencyDashboardFilter ) => {
@@ -38,7 +37,7 @@ const useFetchDashboardSites = (
 ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
-	const queryClient = useQueryClient();
+
 	return useQuery( {
 		queryKey: [ 'jetpack-agency-dashboard-sites', searchQuery, currentPage, filter, sort ],
 		queryFn: () =>
@@ -56,20 +55,7 @@ const useFetchDashboardSites = (
 			),
 		select: ( data ) => {
 			return {
-				sites: data.sites.map( ( site: Site ) => {
-					// Since the "sites" API includes the "is_connected" property in the cache of the query set by
-					// the "useFetchTestConnection" hook, we are setting it here again since the "sites" API gets called
-					// more often than the "/test-connection" API which will flush the cache set by the
-					// "useFetchTestConnection" hook
-					const data: { connected: boolean } | undefined = queryClient.getQueryData( [
-						'jetpack-agency-test-connection',
-						site.blog_id,
-					] );
-					return {
-						...site,
-						is_connected: data?.hasOwnProperty( 'connected' ) ? data.connected : true,
-					};
-				} ),
+				sites: data.sites,
 				total: data.total,
 				perPage: data.per_page,
 				totalFavorites: data.total_favorites,

--- a/client/data/agency-dashboard/use-fetch-test-connection.ts
+++ b/client/data/agency-dashboard/use-fetch-test-connection.ts
@@ -1,54 +1,61 @@
-import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { useContext } from 'react';
-import SitesOverviewContext from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/context';
+import { useQueries, useQuery } from '@tanstack/react-query';
 import { Site } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
 import wpcom from 'calypso/lib/wp';
 
-const useFetchTestConnection = (
+// We don't want to trigger another API request to the /test-connection endpoint for a given site
+// one minute after the first successful one.
+const STALE_TIME = 1000 * 60;
+
+const getQueryKey = ( ID: Site[ 'blog_id' ] ) => [ 'jetpack-fetch-test-connection', ID ];
+
+const queryOptions = {
+	refetchOnWindowFocus: false,
+	staleTime: STALE_TIME,
+};
+
+const createQueryFn =
+	( siteId: Site[ 'blog_id' ], isConnectionHealthy: Site[ 'is_connection_healthy' ] ) => () =>
+		wpcom.req.get(
+			{
+				path: `/jetpack-blogs/${ siteId }/test-connection`,
+				apiNamespace: 'rest/v1.1',
+			},
+			{
+				// We call the current health state "stale", as it might be different than the actual state.
+				is_stale_connection_healthy: Boolean( isConnectionHealthy ),
+			}
+		);
+
+export const useFetchTestConnections = ( isPartnerOAuthTokenLoaded: boolean, sites: Site[] ) => {
+	const results = useQueries( {
+		queries: sites.map( ( site ) => ( {
+			queryKey: getQueryKey( site.blog_id ),
+			queryFn: createQueryFn( site.blog_id, site.is_connection_healthy ),
+			enabled: isPartnerOAuthTokenLoaded && Array.isArray( sites ) && sites.length > 0,
+			...queryOptions,
+		} ) ),
+	} );
+
+	return results.map( ( result, index ) => ( {
+		ID: sites[ index ].blog_id,
+		connected: result.data?.connected ?? true,
+	} ) );
+};
+
+export const useFetchTestConnection = (
 	isPartnerOAuthTokenLoaded: boolean,
 	isConnectionHealthy: boolean,
 	siteId: number
 ) => {
-	const queryClient = useQueryClient();
-	const { search, currentPage, filter, sort } = useContext( SitesOverviewContext );
 	return useQuery( {
-		queryKey: [ 'jetpack-agency-test-connection', siteId ],
-		queryFn: () =>
-			wpcom.req.get(
-				{
-					path: `/jetpack-blogs/${ siteId }/test-connection`,
-					apiNamespace: 'rest/v1.1',
-				},
-				{
-					// We call the current health state "stale", as it might be different than the actual state.
-					is_stale_connection_healthy: Boolean( isConnectionHealthy ),
-				}
-			),
-		enabled: isPartnerOAuthTokenLoaded,
-		refetchOnWindowFocus: false,
-		// We don't want to trigger another API request to the /test-connection endpoint for a given site
-		// one minute after the first successful one.
-		staleTime: 1000 * 60,
-		onSuccess: ( data ) => {
-			// We are setting the "is_connected" property of the site in the query cache of the "sites"
-			// API to the value returned by the /test-connection endpoint. We are doing this to filter
-			// the site with connection issues easily in the UI and to have a single source of truth for
-			// the connection state of a site to avoid inconsistencies.
-			const queryKey = [ 'jetpack-agency-dashboard-sites', search, currentPage, filter, sort ];
-			queryClient.setQueryData( queryKey, ( oldSites: any ) => {
-				return {
-					...oldSites,
-					sites: oldSites?.sites.map( ( site: Site ) => {
-						if ( site.blog_id === siteId ) {
-							return {
-								...site,
-								is_connected: data?.hasOwnProperty( 'connected' ) ? data.connected : true,
-							};
-						}
-						return site;
-					} ),
-				};
-			} );
+		queryKey: getQueryKey( siteId ),
+		queryFn: createQueryFn( siteId, isConnectionHealthy ),
+		...queryOptions,
+		select( data ) {
+			return {
+				ID: siteId,
+				connected: data?.connected ?? true,
+			};
 		},
 	} );
 };

--- a/client/data/agency-dashboard/use-fetch-test-connection.ts
+++ b/client/data/agency-dashboard/use-fetch-test-connection.ts
@@ -9,7 +9,6 @@ const STALE_TIME = 1000 * 60;
 const getQueryKey = ( ID: Site[ 'blog_id' ] ) => [ 'jetpack-fetch-test-connection', ID ];
 
 const queryOptions = {
-	refetchOnWindowFocus: false,
 	staleTime: STALE_TIME,
 };
 

--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/edit-button.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/edit-button.tsx
@@ -2,6 +2,9 @@ import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useContext } from 'react';
 import ButtonGroup from 'calypso/components/button-group';
+import { useFetchTestConnections } from 'calypso/data/agency-dashboard/use-fetch-test-connection';
+import { useSelector } from 'calypso/state';
+import { getIsPartnerOAuthTokenLoaded } from 'calypso/state/partner-portal/partner/selectors';
 import { useJetpackAgencyDashboardRecordTrackEvent } from '../hooks';
 import SitesOverviewContext from '../sites-overview/context';
 import type { SiteData } from '../sites-overview/types';
@@ -20,11 +23,19 @@ export default function EditButton( { sites, isLargeScreen, isLoading }: Props )
 	const { setIsBulkManagementActive, setSelectedSites } = useContext( SitesOverviewContext );
 	const recordEvent = useJetpackAgencyDashboardRecordTrackEvent( null, isLargeScreen );
 
+	const isPartnerOAuthTokenLoaded = useSelector( getIsPartnerOAuthTokenLoaded );
+	const connectionTests = useFetchTestConnections(
+		isPartnerOAuthTokenLoaded,
+		sites.map( ( { site } ) => site.value )
+	);
+
 	const handleToggleSelect = () => {
 		// Filter sites with site error or monitor error or is Atomic site as they are not selectable.
-		const filteredSite = sites.filter(
-			( { site, monitor } ) => site.value.is_connected && ! monitor.error && ! site.value.is_atomic
-		);
+		const filteredSite = sites.filter( ( { site, monitor } ) => {
+			const isConnected = connectionTests.find( ( { ID } ) => ID === site.value.blog_id )
+				?.connected;
+			return isConnected && ! monitor.error && ! site.value.is_atomic;
+		} );
 		setSelectedSites( filteredSite.map( ( item ) => item.site.value ) );
 	};
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/index.tsx
@@ -36,9 +36,9 @@ export default function SiteCard( { rows, columns }: Props ) {
 	const blogId = rows.site.value.blog_id;
 	const isConnectionHealthy = rows.site.value?.is_connection_healthy;
 
-	useFetchTestConnection( isPartnerOAuthTokenLoaded, isConnectionHealthy, blogId );
+	const { data } = useFetchTestConnection( isPartnerOAuthTokenLoaded, isConnectionHealthy, blogId );
 
-	const isSiteConnected = rows.site.value.is_connected;
+	const isSiteConnected = data?.connected ?? true;
 
 	const handleSetExpandedColumn = ( column: AllowedTypes ) => {
 		recordEvent( 'expandable_block_column_toggled', {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/test/site-content.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/test/site-content.tsx
@@ -21,6 +21,11 @@ jest.mock(
 	() => 'span'
 );
 
+jest.mock(
+	'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/index',
+	() => () => <tr />
+);
+
 describe( '<SiteContent>', () => {
 	nock( 'https://public-api.wordpress.com' )
 		.persist()

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/index.tsx
@@ -40,7 +40,8 @@ export default function SiteTableRow( { index, columns, item, setExpanded, isExp
 	const selectedLicenses = useSelector( getSelectedLicenses );
 	const selectedLicensesSiteId = useSelector( getSelectedLicensesSiteId );
 
-	useFetchTestConnection( isPartnerOAuthTokenLoaded, isConnectionHealthy, blogId );
+	const { data } = useFetchTestConnection( isPartnerOAuthTokenLoaded, isConnectionHealthy, blogId );
+	const isConnected = data?.connected ?? true;
 
 	const currentSiteHasSelectedLicenses =
 		selectedLicensesSiteId === blogId && selectedLicenses?.length;
@@ -49,7 +50,7 @@ export default function SiteTableRow( { index, columns, item, setExpanded, isExp
 	const shouldDisableLicenseSelection =
 		selectedLicenses?.length && ! currentSiteHasSelectedLicenses;
 
-	const hasSiteConnectionError = ! item.site.value.is_connected;
+	const hasSiteConnectionError = ! isConnected;
 	const siteError = item.monitor.error || hasSiteConnectionError;
 
 	return (

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -95,7 +95,6 @@ export interface Site {
 	onSelect?: () => void;
 	jetpack_boost_scores: BoostData;
 	php_version_num: number;
-	is_connected: boolean;
 	has_paid_agency_monitor: boolean;
 	is_atomic: boolean;
 	has_pending_boost_one_time_score: boolean;


### PR DESCRIPTION
Follow up to #80677 and part of preparing for the `@tanstack/query` v5 update.

## Proposed Changes

- Unmangle query data manipulation for `useFetchTestConnection` and `useFetchDashboardSites`. 

`useFetchTestConnection` used to add a property to data queried by `useFetchDashboardSites` in its `onSuccess` hook. This kind of query cache manipulation is not a good way to combine data from two queries, we rather do it in consumer land.

## Testing Instructions

Run `yarn start-jetpack-cloud` locally or use the calypso.live link provided below to test these changes:

* Go to `http://jetpack.cloud.localhost:3000/dashboard`
* Verify the list of connected sites is showing up as expected
* Verify _Edit All_ (means bulk select) still works as expected (that means disconnected sites, sites which show an error and AT sites are excluded from selection)
* Verify disconnected sites or sites with connection errors show an error notice

Depending on the amount of pages you have connected you should see a network request for each of those sites to `/jetpack-blogs/:blogId/test-connection`. You shouldn't see those requests again within a minute of the last fetch.

You can also verify steps from https://github.com/Automattic/wp-calypso/pull/76029 are still valid.

Note: For testing a disconnected site I used an external WP.org site and after adding it to the list I used basic auth to prevent access and "fake" a connection error. I tried with JN but it didn't really work for me.