### PR TITLE
Domains: Update domain-only flow to show "free domain with plan" promo like /start

### DIFF
--- a/client/lib/cart-values/cart-items.ts
+++ b/client/lib/cart-values/cart-items.ts
@@ -243,7 +243,6 @@ export function planItem( productSlug: string ): { product_slug: string } | null
 
 /**
  * Determines whether a domain Item supports purchasing a privacy subscription
- *
  * @param {string} productSlug - e.g. domain_reg, dotblog_domain
  * @param {{product_slug: string, is_privacy_protection_product_purchase_allowed?: boolean}[]} productsList - The list of products retrieved using getProductsList from state/products-list/selectors
  * @returns {boolean} true if the domainItem supports privacy protection purchase
@@ -260,7 +259,6 @@ export function supportsPrivacyProtectionPurchase(
 
 /**
  * Creates a new shopping cart item for a domain.
- *
  * @param {string} productSlug - the unique string that identifies the product
  * @param {string} domain - domain name
  * @param {string|undefined} [source] - optional source for the domain item, e.g. `getdotblog`.
@@ -284,7 +282,6 @@ export function domainItem(
 
 /**
  * Creates a new shopping cart item for a premium theme.
- *
  * @param {string} themeSlug - the unique string that identifies the product
  * @param {string} [source] - optional source for the domain item, e.g. `getdotblog`.
  * @returns {MinimalRequestCartProduct} the new item
@@ -301,7 +298,6 @@ export function themeItem( themeSlug: string, source?: string ): MinimalRequestC
 
 /**
  * Creates a new shopping cart item for a marketplace theme subscription.
- *
  * @param productSlug the unique string that identifies the product
  * @returns {MinimalRequestCartProduct} the new item
  */
@@ -865,10 +861,6 @@ export function getDomainPriceRule(
 			return 'INCLUDED_IN_HIGHER_PLAN';
 		}
 
-		return 'PRICE';
-	}
-
-	if ( isDomainOnly ) {
 		return 'PRICE';
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4460

## Proposed Changes

* This PR removes a special rule from the domain-only flow so that it will display the free domain with plan promo in the pricing section just like /start does.

Before | After
--|--
<img width="1463" alt="Screenshot 2023-11-02 at 5 44 14 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/fb5d06c5-77fe-4da9-8159-c7129664ae56">  | <img width="1462" alt="Screenshot 2023-11-02 at 5 41 24 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/4c03b86e-882c-457f-a7ec-6aa5b565649f">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Observe how the "Free domain with plan" text displays and behaves on /start. We want it to behave the same way on /domains. You can also refer to this video of the desired behavior.


https://github.com/Automattic/wp-calypso/assets/140841/4a1c966c-ca50-4453-a2e3-c7c20932cd18



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?