### PR TITLE
Stats: Fix a stuck loading indicator for the Traffic chart

### DIFF
--- a/client/components/stats-date-control/types.d.ts
+++ b/client/components/stats-date-control/types.d.ts
@@ -2,7 +2,6 @@ interface StatsDateControlProps {
 	slug: string;
 	queryParams: string;
 	period: 'day' | 'week' | 'month' | 'year';
-	pathTemplate: string;
 	dateRange: any;
 }
 

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -144,7 +144,6 @@ class StatsSite extends Component {
 	};
 
 	onChangeLegend = ( activeLegend ) => this.setState( { activeLegend } );
-	onChangeChartQuantity = ( customChartQuantity ) => this.setState( { customChartQuantity } );
 
 	switchChart = ( tab ) => {
 		if ( ! tab.loading && tab.attr !== this.props.chartTab ) {
@@ -220,6 +219,8 @@ class StatsSite extends Component {
 		// Set up a custom range for the chart.
 		// Dependant on new date range picker controls.
 		let customChartRange = null;
+		let customChartQuantity;
+
 		if ( isDateControlEnabled ) {
 			// Sort out end date for chart.
 			const chartEnd = this.getValidDateOrNullFromInput( context.query?.chartEnd );
@@ -255,7 +256,7 @@ class StatsSite extends Component {
 					? moment( customChartRange.chartEnd )
 					: moment( customChartRange.chartEnd ).endOf( period );
 
-			this.state.customChartQuantity = Math.ceil(
+			customChartQuantity = Math.ceil(
 				adjustedChartEndDate.diff( moment( customChartRange.chartStart ), period, true )
 			);
 
@@ -367,7 +368,7 @@ class StatsSite extends Component {
 							queryDate={ queryDate }
 							period={ this.props.period }
 							chartTab={ this.props.chartTab }
-							customQuantity={ this.state.customChartQuantity }
+							customQuantity={ customChartQuantity }
 							customRange={ customChartRange }
 							hideLegend={ isDateControlEnabled }
 						/>

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -164,7 +164,7 @@ const connectComponent = connect(
 		const counts = getCountRecords( state, siteId, period );
 		const chartData = buildChartData( activeLegend, chartTab, counts, period, queryDate );
 		const loadingTabs = getLoadingTabs( state, siteId, period );
-		const isActiveTabLoading = loadingTabs.includes( chartTab ) || chartData.length !== quantity;
+		const isActiveTabLoading = loadingTabs.includes( chartTab ) || chartData.length < quantity;
 		const timezoneOffset = getSiteOption( state, siteId, 'gmt_offset' ) || 0;
 
 		// The end date of the chart depends on the customRange.

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -118,8 +118,6 @@ class StatsPeriodNavigation extends PureComponent {
 			disableNextArrow,
 			queryParams,
 			slug,
-			pathTemplate,
-			onChangeChartQuantity,
 			isWithNewDateControl,
 			dateRange,
 		} = this.props;
@@ -135,14 +133,7 @@ class StatsPeriodNavigation extends PureComponent {
 				<div className="stats-period-navigation__children">{ children }</div>
 				{ isWithNewDateControl ? (
 					<div className="stats-period-navigation__date-control">
-						<StatsDateControl
-							slug={ slug }
-							queryParams={ queryParams }
-							period={ period }
-							pathTemplate={ pathTemplate }
-							onChangeChartQuantity={ onChangeChartQuantity }
-							dateRange={ dateRange }
-						/>
+						<StatsDateControl slug={ slug } queryParams={ queryParams } dateRange={ dateRange } />
 						<div className="stats-period-navigation__period-control">
 							{ this.props.activeTab && (
 								<Legend


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #83791

## Proposed Changes

* update loading condition to render even if more than the requested quantity is returned
* cleanup code and remove unused properties and methods

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* visit the live branch
* smoke test different date periods and frequency

In some cases, the API returns one data point more than the requested quantity. I couldn't narrow down the condition when it happens, but it sometimes happened for me for `yearly` frequency.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?