### PR TITLE
NavigationHeader: reader lists header

### DIFF
--- a/client/reader/list-stream/header.jsx
+++ b/client/reader/list-stream/header.jsx
@@ -3,6 +3,7 @@ import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import FollowButton from 'calypso/blocks/follow-button/button';
+import NavigationHeader from 'calypso/components/navigation-header';
 import { isExternal } from 'calypso/lib/url';
 import ReaderFollowFeedIcon from 'calypso/reader/components/icons/follow-feed-icon';
 import ReaderFollowingFeedIcon from 'calypso/reader/components/icons/following-feed-icon';
@@ -27,46 +28,38 @@ const ListStreamHeader = ( {
 
 	return (
 		<Card className={ classes }>
-			<span className="list-stream__header-icon">
-				<Gridicon icon="list-unordered" size={ 24 } />
-			</span>
+			<NavigationHeader title={ title } subtitle={ description }>
+				{ ! isPublic && (
+					<div className="list-stream__header-title-privacy">
+						<Gridicon icon="lock" size={ 18 } title={ translate( 'Private list' ) } />
+					</div>
+				) }
 
-			<div className="list-stream__header-details">
-				<div className="list-stream__header-title">
-					<h1>{ title }</h1>
-					{ ! isPublic && (
-						<div className="list-stream__header-title-privacy">
-							<Gridicon icon="lock" size={ 18 } title={ translate( 'Private list' ) } />
-						</div>
-					) }
-				</div>
-				{ description && <p className="list-stream__header-description">{ description }</p> }
-			</div>
+				{ showFollow && (
+					<div className="list-stream__header-follow">
+						<FollowButton
+							iconSize={ 24 }
+							following={ following }
+							onFollowToggle={ onFollowToggle }
+							followIcon={ ReaderFollowFeedIcon( { iconSize: 24 } ) }
+							followingIcon={ ReaderFollowingFeedIcon( { iconSize: 24 } ) }
+						/>
+					</div>
+				) }
 
-			{ showFollow && (
-				<div className="list-stream__header-follow">
-					<FollowButton
-						iconSize={ 24 }
-						following={ following }
-						onFollowToggle={ onFollowToggle }
-						followIcon={ ReaderFollowFeedIcon( { iconSize: 24 } ) }
-						followingIcon={ ReaderFollowingFeedIcon( { iconSize: 24 } ) }
-					/>
-				</div>
-			) }
-
-			{ showEdit && editUrl && (
-				<div className="list-stream__header-edit">
-					<a href={ editUrl } rel={ isExternal( editUrl ) ? 'external' : '' }>
-						<span className="list-stream__header-action-icon">
-							<Gridicon icon="cog" size={ 24 } />
-						</span>
-						<span className="list-stream__header-action-label screen-reader-text">
-							{ translate( 'Edit' ) }
-						</span>
-					</a>
-				</div>
-			) }
+				{ showEdit && editUrl && (
+					<div className="list-stream__header-edit">
+						<a href={ editUrl } rel={ isExternal( editUrl ) ? 'external' : '' }>
+							<span className="list-stream__header-action-icon">
+								<Gridicon icon="cog" size={ 24 } />
+							</span>
+							<span className="list-stream__header-action-label screen-reader-text">
+								{ translate( 'Edit' ) }
+							</span>
+						</a>
+					</div>
+				) }
+			</NavigationHeader>
 		</Card>
 	);
 };

--- a/client/reader/list-stream/header.jsx
+++ b/client/reader/list-stream/header.jsx
@@ -1,4 +1,4 @@
-import { Card, Gridicon } from '@automattic/components';
+import { Card, Gridicon, Button } from '@automattic/components';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -31,7 +31,7 @@ const ListStreamHeader = ( {
 			<NavigationHeader title={ title } subtitle={ description }>
 				{ ! isPublic && (
 					<div className="list-stream__header-title-privacy">
-						<Gridicon icon="lock" size={ 18 } title={ translate( 'Private list' ) } />
+						<Gridicon icon="lock" size={ 24 } title={ translate( 'Private list' ) } />
 					</div>
 				) }
 
@@ -49,14 +49,9 @@ const ListStreamHeader = ( {
 
 				{ showEdit && editUrl && (
 					<div className="list-stream__header-edit">
-						<a href={ editUrl } rel={ isExternal( editUrl ) ? 'external' : '' }>
-							<span className="list-stream__header-action-icon">
-								<Gridicon icon="cog" size={ 24 } />
-							</span>
-							<span className="list-stream__header-action-label screen-reader-text">
-								{ translate( 'Edit' ) }
-							</span>
-						</a>
+						<Button rel={ isExternal( editUrl ) ? 'external' : '' } href={ editUrl }>
+							{ translate( 'Edit' ) }
+						</Button>
 					</div>
 				) }
 			</NavigationHeader>

--- a/client/reader/list-stream/style.scss
+++ b/client/reader/list-stream/style.scss
@@ -4,18 +4,12 @@
 	background: var(--color-neutral-0);
 	display: flex;
 	flex-direction: row;
-	min-height: 48px;
-	margin-top: 24px;
-	padding: 0 14px 14px;
+	padding: 0;
 
 	@include breakpoint-deprecated( ">660px" ) {
 		padding-left: 0;
 		padding-right: 0;
 		margin-top: 0;
-	}
-
-	&.has-description {
-		padding-bottom: 18px;
 	}
 
 	&:hover {
@@ -25,7 +19,7 @@
 	// Main layout already has mx
 	.navigation-header {
 		margin: 0 auto;
-		padding: 16px 0 16px 0;
+		padding: 0 0 16px 0;
 	}
 }
 

--- a/client/reader/list-stream/style.scss
+++ b/client/reader/list-stream/style.scss
@@ -137,11 +137,6 @@
 	margin-left: auto;
 
 	.list-stream__header-action-icon .gridicon {
-		fill: var(--color-neutral-light);
-		margin: auto;
-		position: relative;
-		bottom: 0;
-		top: 12px;
-		right: -6px;
+		fill: var(--color-neutral-dark);
 	}
 }

--- a/client/reader/list-stream/style.scss
+++ b/client/reader/list-stream/style.scss
@@ -21,6 +21,12 @@
 	&:hover {
 		cursor: default;
 	}
+
+	// Main layout already has mx
+	.navigation-header {
+		margin: 0 auto;
+		padding: 16px 0 16px 0;
+	}
 }
 
 .list-stream__header-icon {


### PR DESCRIPTION
Related to # https://github.com/Automattic/dotcom-forge/issues/4352

## Proposed Changes

* Updates headers on list pages

## Testing Instructions

* http://calypso.localhost:3000/read/list/testingtesterson12/test
* Logged in as owner, non owner, public, private


Before

![Screenshot 2023-11-03 at 12-51-45 My Test List ‹ Reader — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/40fd8b90-e5bd-4d0b-b179-4285deb1078a)

After

![Screenshot 2023-11-03 at 12-51-06 My Test List ‹ Reader — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/f33a3287-cb47-4bed-bb3c-ecffc077add6)
![Screenshot 2023-11-03 at 12-50-53 My Test List ‹ Reader — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/1c1f512e-28ff-4332-a23f-20ce9ddc1061)
![Screenshot 2023-11-03 at 12-50-21 My Test List ‹ Reader — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/34e4f63a-943b-43cf-8d90-023c7744c791)
