### PR TITLE
Storage Add-Ons: Hide selected storage add-on price for comparison grid

### DIFF
--- a/client/my-sites/plans-grid/components/comparison-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/comparison-grid/index.tsx
@@ -644,7 +644,7 @@ const ComparisonGridFeatureGroupRowCell: React.FunctionComponent< {
 							planSlug={ planSlug }
 							storageOptions={ gridPlan.features.storageOptions }
 							onStorageAddOnClick={ onStorageAddOnClick }
-							priceOnSeparateLine
+							hideSelectedAddOnPrice
 						/>
 					) : (
 						<StorageButton className="plan-features-2023-grid__storage-button" key={ planSlug }>

--- a/client/my-sites/plans-grid/components/storage-add-on-dropdown.tsx
+++ b/client/my-sites/plans-grid/components/storage-add-on-dropdown.tsx
@@ -15,14 +15,14 @@ type StorageAddOnDropdownProps = {
 	planSlug: PlanSlug;
 	storageOptions: StorageOption[];
 	onStorageAddOnClick?: ( addOnSlug: WPComStorageAddOnSlug ) => void;
-	priceOnSeparateLine?: boolean;
+	hideSelectedAddOnPrice?: boolean;
 };
 
 type StorageAddOnOptionProps = {
 	title?: string;
 	price?: string;
 	isLargeCurrency?: boolean;
-	priceOnSeparateLine?: boolean;
+	hideSelectedAddOnPrice?: boolean;
 };
 
 const getStorageOptionPrice = (
@@ -38,7 +38,7 @@ const StorageAddOnOption = ( {
 	title,
 	price,
 	isLargeCurrency = false,
-	priceOnSeparateLine,
+	hideSelectedAddOnPrice,
 }: StorageAddOnOptionProps ) => {
 	const translate = useTranslate();
 
@@ -48,7 +48,7 @@ const StorageAddOnOption = ( {
 
 	return (
 		<>
-			{ price && ! isLargeCurrency && ! priceOnSeparateLine ? (
+			{ price && ! isLargeCurrency && ! hideSelectedAddOnPrice ? (
 				<div>
 					<span className="storage-add-on-dropdown-option__title">{ title }</span>
 					<div className="storage-add-on-dropdown-option__price-container">
@@ -70,7 +70,7 @@ export const StorageAddOnDropdown = ( {
 	planSlug,
 	storageOptions,
 	onStorageAddOnClick,
-	priceOnSeparateLine = false,
+	hideSelectedAddOnPrice = false,
 }: StorageAddOnDropdownProps ) => {
 	const translate = useTranslate();
 	const { gridPlansIndex } = usePlansGridContext();
@@ -127,7 +127,7 @@ export const StorageAddOnDropdown = ( {
 				title={ selectedOptionTitle }
 				price={ selectedOptionPrice }
 				isLargeCurrency={ isLargeCurrency }
-				priceOnSeparateLine={ priceOnSeparateLine }
+				hideSelectedAddOnPrice={ hideSelectedAddOnPrice }
 			/>
 		),
 	};
@@ -152,7 +152,7 @@ export const StorageAddOnDropdown = ( {
 				value={ selectedOption }
 				onChange={ handleOnChange }
 			/>
-			{ selectedOptionPrice && ( isLargeCurrency || priceOnSeparateLine ) && (
+			{ selectedOptionPrice && isLargeCurrency && ! hideSelectedAddOnPrice && (
 				<div className="storage-add-on-dropdown__offset-price-container">
 					<span className="storage-add-on-dropdown__offset-price">
 						{ ` + ${ selectedOptionPrice }/${ translate( 'month' ) }` }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/1907#issuecomment-1736358542

## Proposed Changes

Sticky plan headers were released for the comparison grid recently. Because of this, and based off of discussions with the design team ( cc @vinimotaa + @saygunnyc ), we can now remove pricing that was displayed for selected add-on upsells in the comparison grid ( since pricing updates are more visually obvious with the sticky headers )

## GIFs
### Before
![2023-11-02 18 58 36](https://github.com/Automattic/wp-calypso/assets/5414230/e7c8dbe8-b2dd-4355-b593-3ee9db2b50cc)

### After
![2023-11-02 18 57 22](https://github.com/Automattic/wp-calypso/assets/5414230/f62e4e04-ffc7-42b8-9790-ad12b4f0f760)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/start/plans`
* Verify that, in the comparison grid, when a storage add-on upgrade is selected, there is no inline pricing displayed alongside the storage add-on dropdown
* Verify that the header price and billing timeframe in the sticky plans updates as expected
* Navigate to `/plans` in Calypso admin
* Verify that the behavior is the same as in `/start/plans` for the comparison grid

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?