### PR TITLE
Improve header margins on mobile screen sizes

### DIFF
--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -13,19 +13,18 @@ function FollowingStream( { ...props } ) {
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
 		<>
-			<NavigationHeader
-				navigationItems={ [] }
-				title={ translate( 'Recent' ) }
-				subtitle={ translate( "Stay current with the blogs you've subscribed to." ) }
-				className={ classNames( 'following-stream-header', {
-					'reader-dual-column': props.width > WIDE_DISPLAY_CUTOFF,
-				} ) }
-			/>
 			<Stream
 				{ ...props }
 				className="following"
 				streamSidebar={ () => <ReaderListFollowedSites path={ window.location.pathname } /> }
 			>
+				<NavigationHeader
+					title={ translate( 'Recent' ) }
+					subtitle={ translate( "Stay current with the blogs you've subscribed to." ) }
+					className={ classNames( 'following-stream-header', {
+						'reader-dual-column': props.width > WIDE_DISPLAY_CUTOFF,
+					} ) }
+				/>
 				<FollowingIntro />
 			</Stream>
 			<AsyncLoad require="calypso/lib/analytics/track-resurrections" placeholder={ null } />

--- a/client/reader/following/style.scss
+++ b/client/reader/following/style.scss
@@ -1,12 +1,20 @@
 .is-section-reader .navigation-header.following-stream-header {
 	margin: 0 auto;
 	max-width: 600px;
+	padding: 0 0 16px 0;
 	&.reader-dual-column {
 		max-width: 968px; // Max width of dual column reader stream.
 	}
-	@media only screen and (max-width: 660px) {
-		margin: 30px 30px -15px;
+
+	@media (max-width: 660px) {
+		.navigation-header__main {
+			min-height: auto;
+		}
 	}
+}
+
+.following.main  .section-nav {
+	margin-top: 0;
 }
 
 .following .search {


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/4352

## Proposed Changes

* Shrink margin sizes on mobile screen sizes 
* Move header component into the stream children - this is just to match behavior with other reader screens and get the header within the `margin: 30px` wrapper (something that probably needs removing separately.

## Testing Instructions

* http://calypso.localhost:3000/read/
* Should be no change to desktop views
* Mobile should have less whitespace

<img width="300" src="https://github.com/Automattic/wp-calypso/assets/811776/4cd43832-ee7f-4d4c-8b88-1bdbe0b778f4" />
<img width="300" src="https://github.com/Automattic/wp-calypso/assets/811776/102ecd2f-e9cd-48da-afb9-59e02707b469" />
