### PR TITLE
Assembler: use the perf test endpoint when flag is true

### DIFF
--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { __ } from '@wordpress/i18n';
 import { SiteGoal } from '../onboard';
 import { wpcomRequest } from '../wpcom-request-controls';
@@ -499,8 +500,10 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 			},
 		].filter( Boolean ) as RequestTemplate[];
 
+		const endpointSuffix = isEnabled( 'pattern-assembler/perf-test' ) ? '-perf-test' : '';
+
 		yield wpcomRequest( {
-			path: `/sites/${ encodeURIComponent( siteSlug ) }/site-assembler`,
+			path: `/sites/${ encodeURIComponent( siteSlug ) }/site-assembler${ endpointSuffix }`,
 			apiNamespace: 'wpcom/v2',
 			body: {
 				templates,


### PR DESCRIPTION
## Proposed Changes

Introduce a temporary flag `pattern-assembler/perf-test`, which will call a duplicate endpoint which we want to experiment with perf optimizations.

## Testing Instructions

1. Patch the corresponding diff D127690-code.
2. Add the flag `&flags=pattern-assembler/perf-test` in Calypso.
3. Open your browser dev tools.
4. Go to the Assembler flow.
5. Verify that the endpoint that was called is the `/site-assembler-perf-test`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?