### PR TITLE
NavigationHeader: likes header

### DIFF
--- a/client/reader/liked-stream/main.jsx
+++ b/client/reader/liked-stream/main.jsx
@@ -19,10 +19,9 @@ class LikedStream extends Component {
 		return (
 			<>
 				<NavigationHeader
-					navigationItems={ [] }
 					title={ translate( 'Likes' ) }
 					subtitle={ translate( 'Rediscover content that you liked.' ) }
-					className="following-stream-header"
+					className="liked-stream-header"
 				/>
 				<Stream
 					{ ...this.props }

--- a/client/reader/liked-stream/style.scss
+++ b/client/reader/liked-stream/style.scss
@@ -1,7 +1,11 @@
-.navigation-header.liked-stream-header {
-	margin: 0 auto -20px;
+.is-section-reader .navigation-header.liked-stream-header {
+	margin: 0 auto;
 	max-width: 600px;
 	@media only screen and (max-width: 660px) {
-		margin: 30px 30px -20px;
+		padding: 30px 30px 0 30px;
+
+		.navigation-header__main {
+			min-height: auto;
+		}
 	}
 }


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/4352

## Proposed Changes

* Padding for likes header in the reader

## Testing Instructions

Test mobile and desktop views of http://calypso.localhost:3000/activities/likes

<img width="300" src="https://github.com/Automattic/wp-calypso/assets/811776/decc0250-563e-4c99-8289-a42c531160dd" />
<img width="300" src="https://github.com/Automattic/wp-calypso/assets/811776/b1aeff41-a7e9-4581-a075-472b013274a9" />
