### PR TITLE
Fix Nextdoor connection description when connected

### DIFF
--- a/client/blocks/post-share/connection.jsx
+++ b/client/blocks/post-share/connection.jsx
@@ -16,7 +16,7 @@ function serviceToIconName( service ) {
 }
 
 function hasRoundIcon( service ) {
-	return [ 'facebook' ].includes( service );
+	return [ 'facebook', 'nextdoor' ].includes( service );
 }
 
 const PostShareConnection = ( { connection, isActive, onToggle } ) => {

--- a/client/blocks/post-share/style.scss
+++ b/client/blocks/post-share/style.scss
@@ -246,6 +246,14 @@ $section-border: solid 1px var(--color-neutral-5);
 		color: var(--color-google-plus);
 	}
 
+	.social-logo.nextdoor {
+		color: var(--color-nextdoor);
+	}
+
+	.social-logo.mastodon {
+		color: var(--color-mastodon);
+	}
+
 	.social-logo.linkedin {
 		color: var(--color-linkedin);
 	}

--- a/client/blocks/post-share/style.scss
+++ b/client/blocks/post-share/style.scss
@@ -181,6 +181,13 @@ $section-border: solid 1px var(--color-neutral-5);
 		border-radius: 50%;
 	}
 
+	// if it's the child of .mastodon class, set border radius to ::before to 30%
+	.mastodon & {
+		&::before {
+			border-radius: 30%;
+		}
+	}
+
 	.google_plus & {
 		top: 11px;
 

--- a/client/my-sites/marketing/connections/service-description.jsx
+++ b/client/my-sites/marketing/connections/service-description.jsx
@@ -237,7 +237,7 @@ class SharingServiceDescription extends Component {
 			},
 			nextdoor() {
 				if ( this.props.numberOfConnections > 0 ) {
-					return this.props.translate( 'Sharing posts to your Nextdoor.' );
+					return this.props.translate( 'Sharing posts to Nextdoor.' );
 				}
 				return this.props.translate( 'Share posts with your local community on Nextdoor.' );
 			},

--- a/client/my-sites/marketing/connections/service-description.jsx
+++ b/client/my-sites/marketing/connections/service-description.jsx
@@ -236,6 +236,9 @@ class SharingServiceDescription extends Component {
 				} );
 			},
 			nextdoor() {
+				if ( this.props.numberOfConnections > 0 ) {
+					return this.props.translate( 'Sharing posts to your Nextdoor.' );
+				}
 				return this.props.translate( 'Share posts with your local community on Nextdoor.' );
 			},
 		} ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Update Nextdoor connection description when connected

## Testing Instructions

* Add the blog sticker to your site:
`add_blog_sticker( 'jetpack-social-nextdoor-connection', null, null, <YOUR_SITE_ID> );` 
* Goto `/marketing/connections/:site` in Calypso Blue
* Connect Nextdoor
* Confirm that the description changes to "Sharing posts to your Nextdoor." when connected
* Goto `/posts/:site`
* Click on actions menu (3 dots) for any post and select Share
* Confirm that Nextdoor icon has the brand color

<img width="366" alt="Screenshot 2023-11-03 at 2 59 21 PM" src="https://github.com/Automattic/wp-calypso/assets/18226415/a9caceaf-6e83-4758-91fb-42a622739835">


<img width="373" alt="Screenshot 2023-11-03 at 2 26 11 PM" src="https://github.com/Automattic/wp-calypso/assets/18226415/994d80cb-7954-4b45-9a1d-f518fcbf769b">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?