### PR TITLE
Jetpack Manage: Fix the issue with the sidebar closing when clicking the search bar.

### DIFF
--- a/client/my-sites/navigation/index.jsx
+++ b/client/my-sites/navigation/index.jsx
@@ -19,6 +19,7 @@ class MySitesNavigation extends Component {
 		};
 
 		let asyncSidebar = null;
+		let showSitePicker = true;
 		let sitePickerProps = {};
 
 		if ( config.isEnabled( 'jetpack-cloud' ) ) {
@@ -29,6 +30,9 @@ class MySitesNavigation extends Component {
 						{ ...asyncProps }
 					/>
 				);
+
+				// For the new Jetpack cloud sidebar, it has its own site picker.
+				showSitePicker = false;
 			} else {
 				asyncSidebar = <AsyncLoad require="calypso/components/jetpack/sidebar" { ...asyncProps } />;
 			}
@@ -49,12 +53,14 @@ class MySitesNavigation extends Component {
 
 		return (
 			<div className="my-sites__navigation">
-				<SitePicker
-					allSitesPath={ this.props.allSitesPath }
-					siteBasePath={ this.props.siteBasePath }
-					onClose={ this.preventPickerDefault }
-					{ ...sitePickerProps }
-				/>
+				{ showSitePicker && (
+					<SitePicker
+						allSitesPath={ this.props.allSitesPath }
+						siteBasePath={ this.props.siteBasePath }
+						onClose={ this.preventPickerDefault }
+						{ ...sitePickerProps }
+					/>
+				) }
 				{ asyncSidebar }
 			</div>
 		);

--- a/client/my-sites/navigation/index.jsx
+++ b/client/my-sites/navigation/index.jsx
@@ -19,7 +19,7 @@ class MySitesNavigation extends Component {
 		};
 
 		let asyncSidebar = null;
-		let showSitePicker = true;
+		let renderSitePicker = true;
 		let sitePickerProps = {};
 
 		if ( config.isEnabled( 'jetpack-cloud' ) ) {
@@ -32,7 +32,7 @@ class MySitesNavigation extends Component {
 				);
 
 				// For the new Jetpack cloud sidebar, it has its own site picker.
-				showSitePicker = false;
+				renderSitePicker = false;
 			} else {
 				asyncSidebar = <AsyncLoad require="calypso/components/jetpack/sidebar" { ...asyncProps } />;
 			}
@@ -53,7 +53,7 @@ class MySitesNavigation extends Component {
 
 		return (
 			<div className="my-sites__navigation">
-				{ showSitePicker && (
+				{ renderSitePicker && (
 					<SitePicker
 						allSitesPath={ this.props.allSitesPath }
 						siteBasePath={ this.props.siteBasePath }


### PR DESCRIPTION
Currently, there is an issue with the site selector in the new sidebar navigation where clicking the search bar closes it. This issue is with conflicting event handlers from two site selectors rendered in the UI (1 is not visible on the screen). This PR fixes this by removing the other site selector.

https://github.com/Automattic/wp-calypso/assets/56598660/394a27f5-2b51-4f9a-9f96-905b57b2bcf3


Closes https://github.com/Automattic/jetpack-genesis/issues/89

## Proposed Changes

* Update the `MySiteNavigation` component so as not to render the existing **sites selector** when loading the new Jetpack sidebar. This avoids conflicting event handlers.

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

* Use the Jetpack Cloud live link and go to `/dashboard`
* Click the site selector in the sidebar, then select a site.
<img width="286" alt="Screen Shot 2023-11-03 at 2 55 28 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/07393f43-73cf-448f-87da-956a228a7546">

* In the single site view, click the site selector again. Once the site selector appears, click the search bar.
* Confirm that the site selector no longer closes.

https://github.com/Automattic/wp-calypso/assets/56598660/d2102f50-5157-417d-852f-f3dba46d4a48



## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?