### PR TITLE
Conversations header fixes - css leaks to search

### DIFF
--- a/client/reader/conversations/stream.js
+++ b/client/reader/conversations/stream.js
@@ -29,9 +29,9 @@ export default function ( props ) {
 	return (
 		<>
 			<NavigationHeader
-				navigationItems={ [] }
 				title={ translate( 'Conversations' ) }
 				subtitle={ translate( 'Monitor all of your ongoing discussions.' ) }
+				className="conversations__header"
 			/>
 			<Stream
 				key="conversations"

--- a/client/reader/conversations/stream.scss
+++ b/client/reader/conversations/stream.scss
@@ -1,8 +1,8 @@
-.is-section-reader .navigation-header {
+.is-section-reader .conversations__header.navigation-header {
 	margin: 0 auto;
 	max-width: 600px;
 	@media only screen and (max-width: 660px) {
-		margin: 30px 30px 0;
+		padding: 0 30px;
 	}
 }
 


### PR DESCRIPTION
Related to # https://github.com/Automattic/dotcom-forge/issues/4352

## Proposed Changes

* Css from conversations page is leaking into the search results page
* Also fixes the padding on mobile screen sizes

## Testing Instructions

Click "Conversations" then "Search" in the reader side bar, the header should not shift across the page.

![Screenshot 2023-11-03 at 14-19-11 Search ‹ Reader — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/9857fbe0-a0fd-4167-b76a-709898e63e8e)
