### PR TITLE
Padding for navigation header on mobile discover page in the reader

### DIFF
--- a/client/reader/discover/discover-navigation.scss
+++ b/client/reader/discover/discover-navigation.scss
@@ -5,9 +5,10 @@
 		max-width: 968px; // Max width of dual column reader stream.
 	}
 	@media only screen and (max-width: 660px) {
-		margin: 30px 30px 0;
+		padding: 0 30px;
 	}
 }
+
 .discover-stream-navigation {
 	position: relative;
 	margin: auto;


### PR DESCRIPTION
Related to # https://github.com/Automattic/dotcom-forge/issues/4352

## Proposed Changes

* Discover page header padding on mobile needs correcting after the navigation header component swap out

## Testing Instructions

* Discover page on mobile

<img width="300" src="https://github.com/Automattic/wp-calypso/assets/811776/af845aee-2645-41fa-b8f8-a090d30e6c94" />
