### PR TITLE
Assembler: remove check icon from the category list

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-category-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-category-list.tsx
@@ -61,11 +61,7 @@ const PatternCategoryList = ( {
 							aria-current={ isActive }
 							onClick={ () => onSelectCategory( name ) }
 						>
-							<NavigatorItem
-								icon={ file }
-								active={ isActive }
-								checked={ patternCountMapByCategory[ name ] > 0 }
-							>
+							<NavigatorItem icon={ file } active={ isActive }>
 								<>
 									{ label }
 									<PatternCount count={ patternCountMapByCategory[ name ] } />

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -71,7 +71,6 @@ const ScreenMain = ( {
 				<VStack spacing="4">
 					<NavigatorItemGroup title={ translate( 'Patterns' ) }>
 						<NavigatorItem
-							checked={ hasHeader }
 							icon={ header }
 							aria-label={ translate( 'Header' ) }
 							onClick={ () => handleSelectCategory( 'header', 'header' ) }
@@ -94,7 +93,6 @@ const ScreenMain = ( {
 						</VStack>
 
 						<NavigatorItem
-							checked={ hasFooter }
 							icon={ footer }
 							aria-label={ translate( 'Footer' ) }
 							onClick={ () => handleSelectCategory( 'footer', 'footer' ) }


### PR DESCRIPTION
Related to: p1698783267063269-slack-CRWCHQGUB

## Proposed Changes

Remove the check icon from selected category, to make the sidebar "less busy".

|Before|After|
|-|-|
|<img width="346" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/815705bc-d2c5-4f5f-a89a-0d0b4add3294">|<img width="346" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/509fc454-79fd-49c1-a95d-1c9dd01b3e7f">|

cc: @lucasmendes-design we'll need your approval on this 🙏 

## Testing Instructions

1. Go to the Assembler flow.
2. Select some patterns.
3. Verify that the categories that have at least one pattern selected, retain their original icon.
4. Verify that you can complete flow as usual.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?