### PR TITLE
Remove free domain copy from mobile view in plans page for Woo Express $1 offer

### DIFF
--- a/client/my-sites/plans-grid/components/features-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/features-grid/index.tsx
@@ -7,6 +7,8 @@ import {
 	isWooExpressSmallPlan,
 	PlanSlug,
 	isWooExpressPlusPlan,
+	isWooExpressPlan,
+	FEATURE_CUSTOM_DOMAIN,
 } from '@automattic/calypso-products';
 import {
 	BloombergLogo,
@@ -188,7 +190,7 @@ class FeaturesGrid extends Component< FeaturesGridType > {
 						{ this.renderPlanTagline( [ gridPlan ] ) }
 						{ this.renderPlanPrice( [ gridPlan ] ) }
 						{ this.renderBillingTimeframe( [ gridPlan ] ) }
-						{ this.renderMobileFreeDomain( gridPlan.planSlug, gridPlan.isMonthlyPlan ) }
+						{ this.renderMobileFreeDomain( gridPlan ) }
 						{ this.renderPlanStorageOptions( [ gridPlan ] ) }
 						{ this.renderTopButtons( [ gridPlan ] ) }
 						<CardContainer
@@ -211,12 +213,24 @@ class FeaturesGrid extends Component< FeaturesGridType > {
 			} );
 	}
 
-	renderMobileFreeDomain( planSlug: PlanSlug, isMonthlyPlan?: boolean ) {
+	renderMobileFreeDomain( gridPlan: GridPlan ) {
 		const { translate } = this.props;
+		const { planSlug, isMonthlyPlan } = gridPlan;
 
 		if ( isMonthlyPlan || isWpComFreePlan( planSlug ) || isWpcomEnterpriseGridPlan( planSlug ) ) {
 			return null;
 		}
+
+		// Remove the custom domain feature for Woo Express plans with introductory offer.
+		if (
+			isWooExpressPlan( planSlug ) &&
+			! gridPlan.features.wpcomFeatures.some(
+				( feature ) => feature.getSlug() === FEATURE_CUSTOM_DOMAIN
+			)
+		) {
+			return null;
+		}
+
 		const { paidDomainName } = this.props;
 
 		const displayText = paidDomainName


### PR DESCRIPTION
## Proposed Changes

Report: p1699002169274869-slack-C03Q87XT1QF

* Remove free domain copy when viewing plans page for Woo Express plans with eligible $1 offer.

## Testing Instructions

* Use an existing Woo Express free trial site
* Alternatively, go to https://woocommerce.com/start/#/ and go through the whole NUX flow and set up a free trial site
* After the site is created, go to http://calypso.localhost:3000/plans/SITE_URL
* Make sure to select the annual tab
* Shrink your screen to mobile size ( < 1052px )
* Observe in both essentials and performance plan do not have `Free domain for one year` displayed

Before:
<img width="300" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3747241/ffd44141-0664-435a-a44c-967d3d7e6acd">

After:
<img width="300" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3747241/50119d77-8056-4199-af86-edcafb7f113d">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
