### PR TITLE
calypso-e2e: Update translateFromPage utility to accept context

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -73,9 +73,9 @@ export class EditorToolbarComponent {
 	/**
 	 * Translate string.
 	 */
-	private async translateFromPage( string: string ): Promise< string > {
+	private async translateFromPage( string: string, context?: string ): Promise< string > {
 		const editorParent = await this.editor.parent();
-		return translateFromPage( editorParent, string );
+		return translateFromPage( editorParent, string, context );
 	}
 
 	/* General helper */
@@ -104,7 +104,10 @@ export class EditorToolbarComponent {
 	async openBlockInserter(): Promise< void > {
 		const editorParent = await this.editor.parent();
 
-		const translatedButtonName = await this.translateFromPage( 'Toggle block inserter' );
+		const translatedButtonName = await this.translateFromPage(
+			'Toggle block inserter',
+			'Generic label for block inserter button'
+		);
 		const blockInserterButton = editorParent.getByRole( 'button', {
 			name: translatedButtonName,
 			exact: true,
@@ -123,7 +126,10 @@ export class EditorToolbarComponent {
 	async closeBlockInserter(): Promise< void > {
 		const editorParent = await this.editor.parent();
 
-		const translatedButtonName = await this.translateFromPage( 'Toggle block inserter' );
+		const translatedButtonName = await this.translateFromPage(
+			'Toggle block inserter',
+			'Generic label for block inserter button'
+		);
 		const blockInserterButton = editorParent.getByRole( 'button', {
 			name: translatedButtonName,
 			exact: true,

--- a/packages/calypso-e2e/src/lib/utils/translate.ts
+++ b/packages/calypso-e2e/src/lib/utils/translate.ts
@@ -3,12 +3,21 @@ import { Locator } from 'playwright';
 /**
  * Translate string by evaluating the `wp.i18n__` translate function from the page.
  */
-export async function translateFromPage( locator: Locator, string: string ): Promise< string > {
+export async function translateFromPage(
+	locator: Locator,
+	string: string,
+	context?: string
+): Promise< string > {
 	return (
 		locator.evaluate(
 			// eslint-disable-next-line @wordpress/i18n-no-variables
-			( _el, string ) => ( window as any )?.wp?.i18n?.__( string ),
-			string
+			( _el, [ string, context ] ) =>
+				context === undefined
+					? // eslint-disable-next-line @wordpress/i18n-no-variables
+					  ( window as any )?.wp?.i18n?.__( string )
+					: // eslint-disable-next-line @wordpress/i18n-no-variables
+					  ( window as any )?.wp?.i18n?._x( string, context ),
+			[ string, context ]
 		) || Promise.resolve( string )
 	);
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1698980612919609-slack-CSD6UPMU4

## Proposed Changes

* Update `translateFromPage` utility function to accept context string.
* Update the open and close block inserter action to use the expected string context so that the button label gets translated correctly.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review.
* Run custom `I18n Tests` build in TeamCity using the changes from this branch.
* Confirm tests pass.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
