### PR TITLE
Fixed button position on the managing plans section

### DIFF
--- a/client/my-sites/plans-grid/components/features-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/features-grid/index.tsx
@@ -134,21 +134,19 @@ class FeaturesGrid extends Component< FeaturesGridType > {
 		}
 
 		const spotlightPlanClasses = classNames(
-			'plan-features-2023-grid__plan-spotlight-card',
+			'plan-features-2023-grid__plan-spotlight',
 			getPlanClass( gridPlanForSpotlight.planSlug )
 		);
 
 		return (
-			<div className="plan-features-2023-grid__plan-spotlight">
-				<div className={ spotlightPlanClasses }>
-					{ this.renderPlanLogos( [ gridPlanForSpotlight ] ) }
-					{ this.renderPlanHeaders( [ gridPlanForSpotlight ] ) }
-					{ this.renderPlanTagline( [ gridPlanForSpotlight ] ) }
-					{ this.renderPlanPrice( [ gridPlanForSpotlight ] ) }
-					{ this.renderBillingTimeframe( [ gridPlanForSpotlight ] ) }
-					{ this.renderPlanStorageOptions( [ gridPlanForSpotlight ] ) }
-					{ this.renderTopButtons( [ gridPlanForSpotlight ] ) }
-				</div>
+			<div className={ spotlightPlanClasses }>
+				{ this.renderPlanLogos( [ gridPlanForSpotlight ] ) }
+				{ this.renderPlanHeaders( [ gridPlanForSpotlight ] ) }
+				{ this.renderPlanTagline( [ gridPlanForSpotlight ] ) }
+				{ this.renderPlanPrice( [ gridPlanForSpotlight ] ) }
+				{ this.renderBillingTimeframe( [ gridPlanForSpotlight ] ) }
+				{ this.renderPlanStorageOptions( [ gridPlanForSpotlight ] ) }
+				{ this.renderTopButtons( [ gridPlanForSpotlight ] ) }
 			</div>
 		);
 	}

--- a/client/my-sites/plans-grid/style.scss
+++ b/client/my-sites/plans-grid/style.scss
@@ -423,6 +423,7 @@ $mobile-card-max-width: 440px;
 .plan-features-2023-grid__plan-spotlight {
 	background-color: var(--studio-white);
 	.plan-features-2023-grid__plan-spotlight-card {
+		position: relative;
 		max-width: 100%;
 		margin-bottom: 64px;
 		border: 1px solid #e0e0e0;

--- a/client/my-sites/plans-grid/style.scss
+++ b/client/my-sites/plans-grid/style.scss
@@ -422,55 +422,53 @@ $mobile-card-max-width: 440px;
 
 .plan-features-2023-grid__plan-spotlight {
 	background-color: var(--studio-white);
-	.plan-features-2023-grid__plan-spotlight-card {
-		position: relative;
-		max-width: 100%;
-		margin-bottom: 64px;
-		border: 1px solid #e0e0e0;
-		/* stylelint-disable-next-line scales/radii */
-		border-radius: 0 0 5px 5px;
-		div.plan-features-2023-grid__table-item {
-			border: none;
-			&.is-top-buttons {
-				position: absolute;
-				top: 46px;
-				right: 0;
-				border-left: 0;
-			}
+	position: relative;
+	max-width: 100%;
+	margin-bottom: 64px;
+	border: 1px solid #e0e0e0;
+	/* stylelint-disable-next-line scales/radii */
+	border-radius: 0 0 5px 5px;
+	div.plan-features-2023-grid__table-item {
+		border: none;
+		&.is-top-buttons {
+			position: absolute;
+			top: 46px;
+			right: 0;
+			border-left: 0;
+		}
 
-			&.plan-features-2023-grid__header-billing-info {
-				padding-bottom: 16px;
-				@include plans-2023-break-small {
-					padding-bottom: 16px;
-				}
-			}
-
-			&.popular-plan-parent-class .plan-features-2023-grid__popular-badge {
-				padding-bottom: 23px;
-			}
-
-			&.plan-features-2023-grid__storage {
-				padding-top: 0;
-				padding-bottom: 32px;
-				width: 205px;
-			}
-
-			.plan-features-2023-grid__header-title {
-				margin-top: 24px;
-			}
-
-			.plan-features-2023-grid__header-tagline {
-				min-height: 0;
+		&.plan-features-2023-grid__header-billing-info {
+			padding-bottom: 16px;
+			@include plans-2023-break-small {
 				padding-bottom: 16px;
 			}
+		}
 
-			.plan-features-2023-grid__header-logo {
-				display: none;
-			}
+		&.popular-plan-parent-class .plan-features-2023-grid__popular-badge {
+			padding-bottom: 23px;
+		}
 
-			.plan-features-2023-gridrison__actions {
-				width: 200px;
-			}
+		&.plan-features-2023-grid__storage {
+			padding-top: 0;
+			padding-bottom: 32px;
+			width: 205px;
+		}
+
+		.plan-features-2023-grid__header-title {
+			margin-top: 24px;
+		}
+
+		.plan-features-2023-grid__header-tagline {
+			min-height: 0;
+			padding-bottom: 16px;
+		}
+
+		.plan-features-2023-grid__header-logo {
+			display: none;
+		}
+
+		.plan-features-2023-gridrison__actions {
+			width: 200px;
 		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 4468-gh-Automattic/dotcom-forge

## Proposed Changes

| Before | After |
|--------|--------|
| <img width="1028" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/29c87928-d519-42bb-9c85-5c0f4d1061ed"> | <img width="1028" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/408ab973-b408-4e1c-9630-511e8d13d2c0"> | 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure the /plans/{site} screen works as expected
* Ensure other plans page like https://wordpress.com/start/plans still works as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?