### PR TITLE
Switch the default category for build intent

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/categories.ts
@@ -2,7 +2,7 @@ import { Category } from '@automattic/design-picker';
 
 const CATEGORY_BLOG = 'blog';
 const CATEGORY_STORE = 'store';
-const CATEGORY_PORTFOLIO = 'portfolio';
+const CATEGORY_BUSINESS = 'business';
 
 /**
  * Ensures the category appears at the top of the design category list
@@ -23,7 +23,7 @@ function makeSortCategoryToTop( slug: string ) {
 
 const sortBlogToTop = makeSortCategoryToTop( CATEGORY_BLOG );
 const sortStoreToTop = makeSortCategoryToTop( CATEGORY_STORE );
-const sortPortfolioToTop = makeSortCategoryToTop( CATEGORY_PORTFOLIO );
+const sortBusinessToTop = makeSortCategoryToTop( CATEGORY_BUSINESS );
 
 export function getCategorizationOptions( intent: string ) {
 	const result = {
@@ -49,8 +49,8 @@ export function getCategorizationOptions( intent: string ) {
 		case 'build':
 			return {
 				...result,
-				defaultSelection: CATEGORY_PORTFOLIO,
-				sort: sortPortfolioToTop,
+				defaultSelection: CATEGORY_BUSINESS,
+				sort: sortBusinessToTop,
 			};
 		default:
 			return {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1698980151472289-slack-CRWCHQGUB & p1698432163773139-slack-C048CUFRGFQ

## Proposed Changes

The 'Promote myself or business' and 'Other' goals in onboarding are collectively the 'build' intent. On the design picker during onboarding this was defaulted to the 'Portfolio' design category since #80751. Staff feedback since then has been consistently against this.

This change will use the 'Business' category rather than the 'Portfolio' category

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Use Calypso live link generated below
2. Go to /start
3. Work your way through onboarding until you reach the 'Goals' screen
4. Choose Promote myself or business and continue
5. Note that the design picker defaults to the Business category
6. Go back and instead choose the 'Other' goal.
7. Note that the design picker defaults to the Business category
8. Try other categories, note that they continue with their current themes e.g. Write goes to Blog

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?