### PR TITLE
Reader's subscription management: add discover link

### DIFF
--- a/client/reader/recommended-sites/recommended-sites.tsx
+++ b/client/reader/recommended-sites/recommended-sites.tsx
@@ -1,4 +1,4 @@
-import { Railcar } from '@automattic/calypso-analytics';
+import { recordTracksEvent, Railcar } from '@automattic/calypso-analytics';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { __experimentalHStack as HStack } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
@@ -74,6 +74,10 @@ const RecommendedSites = () => {
 			.slice( 0, displayRecommendedSitesTotal );
 	}, [ recommendedSites, blockedSites ] );
 
+	const onClickDiscover = () => {
+		recordTracksEvent( 'calypso_reader_subscriptions_recommended_discover_click' );
+	};
+
 	useEffect( () => {
 		if ( filteredRecommendedSites.length <= 4 ) {
 			dispatch( requestRecommendedSites( { seed, offset } ) );
@@ -82,7 +86,14 @@ const RecommendedSites = () => {
 
 	return (
 		<div className="recommended-sites">
-			<h2 className="recommended-sites__heading">{ translate( 'Recommended sites' ) }</h2>
+			<h2 className="recommended-sites__heading">
+				{ translate( 'Recommended sites' ) } (
+				<a href="/discover" onClick={ onClickDiscover }>
+					{ translate( 'Discover more' ) }
+				</a>
+				)
+			</h2>
+
 			<RecommendedSitesResponsiveContainer>
 				{ filteredRecommendedSites.map( ( { blogId, feedId, railcar }, index ) => {
 					return (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

![image](https://github.com/Automattic/wp-calypso/assets/87168/cedae295-797c-4228-90fd-4e7433a3af2b)

Felt like since we’re showing those cards, might as well show where to find more, even if it’s already in the sidebar.

## Proposed Changes

* Adds "discover more" link to [reader subscription management](https://wordpress.com/read/subscriptions) above recommended sites.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* See https://wordpress.com/read/subscriptions

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
