### PR TITLE
Reader suggested follows dialog - add tracking event for initial view.

### DIFF
--- a/client/blocks/reader-suggested-follows/dialog.jsx
+++ b/client/blocks/reader-suggested-follows/dialog.jsx
@@ -16,7 +16,7 @@ const ReaderSuggestedFollowsDialog = ( { onClose, siteId, postId, isVisible } ) 
 
 	useEffect( () => {
 		if ( isVisible ) {
-			dispatch( recordReaderTracksEvent( 'calypso_reader_suggested_follows_viewed' ) );
+			dispatch( recordReaderTracksEvent( 'calypso_reader_suggested_follows_dialog_viewed' ) );
 		}
 	}, [ isVisible, dispatch ] );
 

--- a/client/blocks/reader-suggested-follows/dialog.jsx
+++ b/client/blocks/reader-suggested-follows/dialog.jsx
@@ -1,18 +1,30 @@
 import { Dialog } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
 import SuggestedFollowItem from 'calypso/blocks/reader-suggested-follows';
 import { useRelatedSites } from 'calypso/data/reader/use-related-sites';
 import { READER_SUGGESTED_FOLLOWS_DIALOG } from 'calypso/reader/follow-sources';
+import { useDispatch } from 'calypso/state';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
 import './style.scss';
 
 const ReaderSuggestedFollowsDialog = ( { onClose, siteId, postId, isVisible } ) => {
+	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const { data, isLoading } = useRelatedSites( siteId, postId );
+
+	useEffect( () => {
+		if ( isVisible ) {
+			dispatch( recordReaderTracksEvent( 'calypso_reader_suggested_follows_viewed' ) );
+		}
+	}, [ isVisible, dispatch ] );
+
 	// If we are no longer loading and no data available, don't show the dialog
 	if ( ! isLoading && data === undefined ) {
 		return null;
 	}
+
 	return (
 		<Dialog
 			additionalClassNames="reader-recommended-follows-dialog"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # p1699019100577299/1699008077.238749-slack-C03NLNTPZ2T

## Proposed Changes

* Adds a tracking event `calypso_reader_suggested_follows_dialog_viewed` that fires when the suggested follows dialog opens.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this PR.
* Open and interact with the suggested follows dialog.
* verify this event is sent (can use tracks vigilante) when the dialog is opened, and only then.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?