### PR TITLE
Upgrade Pricing Plan Happy block request doesn't contain user data

### DIFF
--- a/apps/happy-blocks/block-library/pricing-plans/hooks/pricing-plans.ts
+++ b/apps/happy-blocks/block-library/pricing-plans/hooks/pricing-plans.ts
@@ -2,6 +2,7 @@ import { calculateMonthlyPriceForPlan, getPlan, Plan } from '@automattic/calypso
 import formatCurrency from '@automattic/format-currency';
 import { useEffect, useState } from '@wordpress/element';
 import { sprintf, __ } from '@wordpress/i18n';
+import wpcom from 'calypso/lib/wp';
 import config from '../config';
 import { ApiPricingPlan } from '../types.js';
 
@@ -52,10 +53,7 @@ const usePricingPlans = () => {
 			setIsLoading( true );
 			setError( null );
 			try {
-				const response = await fetch(
-					'https://public-api.wordpress.com/rest/v1.5/plans?locale=' + config.locale
-				);
-				const data = await response.json();
+				const data = await wpcom.req.get( '/plans?locale=' + config.locale, { apiVersion: '1.5' } );
 				setPlans( parsePlans( data ) );
 			} catch ( e: unknown ) {
 				setError( e );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Currently, the `fetch` call for the plan's data of the `Upgrade Pricing Plan` block used on support pages (ex. https://wordpress.com/support/domains/register-domain/) doesn't include user info.
This results in incorrect currency shown but also affects any plan experiment assignments which adds noise to the results (more info: pdgrnI-2Cn-p2#comment-4293).
This PR addresses the issue by using the `wpcom.req` library to fetch data (as used in [other places](https://github.com/Automattic/wp-calypso/blob/trunk/client/state/sites/plans/actions.js#L43))
 
## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run yarn dev --sync in `apps/happy-blocks` to sync code to your sandbox (might need to follow the[ instructions](https://github.com/Automattic/wp-calypso/blob/trunk/apps/happy-blocks/README.md#development-environment) and/or the Calypso Apps field guide to get it to work)
* Log with a user with a non-USD currency

* Sandbox `wordpress.com` and `en.support.wordpress.com`
* Handle any certificate errors that appear for the assets

* Go to https://wordpress.com/support/domains/register-domain/
* The currency in `Upgrade Pricing Plan` should match the user's (ex. HUF):
<img width="420" alt="Screenshot 2023-11-03 at 15 48 44" src="https://github.com/Automattic/wp-calypso/assets/2749938/44188854-ef06-4c0d-9332-880497851683">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
