### PR TITLE
Newsletter: Stop flow execution on redirect prevent repeated requests

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -39,7 +39,6 @@ import type { OnboardSelect, StepperInternalSelect } from '@automattic/data-stor
  * 1. It renders a react-router route for every step in the flow.
  * 2. It gives every step the ability to navigate back and forth within the flow
  * 3. It's responsive to the dynamic changes in side the flow's hooks (useSteps and useStepsNavigation)
- *
  * @param props
  * @param props.flow the flow you want to render
  * @returns A React router switch will all the routes
@@ -145,8 +144,6 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 		[]
 	);
 
-	flow.useSideEffect?.( currentStepRoute, _navigate );
-
 	useSyncRoute();
 
 	useEffect( () => {
@@ -228,6 +225,14 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 			'--previous-progress': Math.min( 100, Math.ceil( previousProgressValue * 100 ) ) + '%',
 			'--current-progress': Math.min( 100, Math.ceil( progressValue * 100 ) ) + '%',
 		} as React.CSSProperties;
+	}
+
+	// Some side effects (such as redirecting, etc.) require stopping rendering the flow.
+	// Because the flow can render before redirecting causing a flash of content.
+	const shouldStopFlow = flow.useSideEffect?.( currentStepRoute, _navigate ) === 'STOP_FLOW';
+
+	if ( shouldStopFlow ) {
+		return null;
 	}
 
 	return (

--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -14,14 +14,12 @@ export type NavigationControls = {
 
 	/**
 	 * Call this function if you want to go to the proceed down the flow.
-	 *
 	 * @deprecated Avoid this method. Use submit() instead.
 	 */
 	goNext?: () => void;
 
 	/**
 	 * Call this function if you want to jump to a certain step.
-	 *
 	 * @deprecated Avoid this method. Use submit() instead.
 	 * If you need to skip forward several screens in
 	 * a stepper flow, handle that logic in submit().
@@ -87,13 +85,14 @@ export type UseStepNavigationHook< FlowSteps extends StepperStep[] > = (
 ) => NavigationControls;
 
 export type UseAssertConditionsHook< FlowSteps extends StepperStep[] > = (
-	navigate?: Navigate< FlowSteps >
+	navigate?: Navigate< FlowSteps >,
+	currentStepRoute?: string
 ) => AssertConditionResult;
 
 export type UseSideEffectHook< FlowSteps extends StepperStep[] > = (
 	currentStepSlug: FlowSteps[ number ][ 'slug' ],
 	navigate: Navigate< FlowSteps >
-) => void;
+) => void | 'STOP_FLOW';
 
 export type Flow = {
 	name: string;

--- a/client/landing/stepper/declarative-flow/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/newsletter.ts
@@ -33,7 +33,6 @@ const newsletter: Flow = {
 	useSteps() {
 		const query = useQuery();
 		const isComingFromMarketingPage = query.get( 'ref' ) === 'newsletter-lp';
-
 		return [
 			// Load intro step component only when not coming from the marketing page
 			...( ! isComingFromMarketingPage
@@ -114,6 +113,9 @@ const newsletter: Flow = {
 		// Unless showing intro step, send non-logged-in users to account screen.
 		if ( ! isLoadingIntroScreen && ! userIsLoggedIn ) {
 			window.location.assign( logInUrl );
+			const noop = () => {};
+			// Return a noop navigation object to stop execution of the hook in a TS-safe way.
+			return { goNext: noop, goBack: noop, goToStep: noop, submit: noop };
 		}
 
 		// trigger guides on step movement, we don't care about failures or response


### PR DESCRIPTION
The newsletter flow checks some conditions and then redirects. But Chrome doesn't stop JS execution entirely when the window navigates away, resulting in the flow to continue rendering. This is wasteful and when the flow renders it fetches data and re-renders causing the redirection to be re-issues a couple times until JS actually dies off and the redirection continues. 

This also creates a flash of content. This fix allows flows to return `STOP_FLOW` in `useSideEffect` to prevent rendering when desired. 

![image](https://github.com/Automattic/wp-calypso/assets/17054134/93a9b26e-57bb-4831-b94c-3d110d075862)

### Testing steps
1. In DevTools, go to Network tab and filter by "Doc".
2. Incognito, using the live branch visit /setup/newsletter/?ref=newsletter-lp.
3. You should be redirected once to the login screen.
4. Regression testing: visit /setup/newsletter/intro. You shouldn't be redirected.