### PR TITLE
E2E Test - Update Subscribe Block for New Behavior

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/subscribe.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/subscribe.ts
@@ -19,7 +19,12 @@ export class SubscribeFlow implements BlockFlow {
 		const emailInputLocator = context.page
 			.getByRole( 'main' )
 			.getByRole( 'textbox', { name: 'Type your email' } );
-		await emailInputLocator.fill( 'foo@example.com' );
+
+		// The email input field only appears if not logged in, or if logged in user is not subscribed already.
+		if ( emailInputLocator ) {
+			await emailInputLocator.fill( 'foo@example.com' );
+		}
+
 		// And a subscribe button?
 		const subscribeButtonLocator = context.page
 			.getByRole( 'main' )


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

We’re trying to release Jetpack on wpcom for the daily release, [but the e2e test is failing](https://teamcity.a8c.com/buildConfiguration/calypso_WPComTests_jetpack_simple_deployment_e2e_desktop/11145433?buildTab=log&focusLine=1192&linesState=254.1145.1146.1187.1190.1255.1256.1257.1507.1508.1549.1552&logView=flowAware&logFilter=err) because the https://github.com/Automattic/jetpack/pull/33897 and the email form no longer appears on the front end when you’re already subscribed to the site.[ I believe this is the test that needs to be updated](https://github.com/Automattic/wp-calypso/blob/trunk/packages/calypso-e2e/src/lib/blocks/block-flows/subscribe.ts#L8).

## Testing Instructions

I'm honestly unsure, because you can run the test locally with:

> yarn workspace wp-e2e-tests test -- test/e2e/specs/blocks/blocks__jetpack-grow.ts

But I don't know how to make the test break first so I can see if the fix does anything. I'd need the local e2e test to run the latest Jetpack trunk, but I have no idea where or how that might be configured.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?