### PR TITLE
E2E Test - Update Subscribe Block for New Behavior Take Two

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/subscribe.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/subscribe.ts
@@ -21,7 +21,7 @@ export class SubscribeFlow implements BlockFlow {
 			.getByRole( 'textbox', { name: 'Type your email' } );
 
 		// The email input field only appears if not logged in, or if logged in user is not subscribed already.
-		if ( emailInputLocator ) {
+		if ( emailInputLocator && ( await emailInputLocator.isVisible() ) ) {
 			await emailInputLocator.fill( 'foo@example.com' );
 		}
 

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/subscribe.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/subscribe.ts
@@ -21,7 +21,7 @@ export class SubscribeFlow implements BlockFlow {
 			.getByRole( 'textbox', { name: 'Type your email' } );
 
 		// The email input field only appears if not logged in, or if logged in user is not subscribed already.
-		if ( emailInputLocator && ( await emailInputLocator.isVisible() ) ) {
+		if ( await emailInputLocator.isVisible() ) {
 			await emailInputLocator.fill( 'foo@example.com' );
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

Followup to #83879 that checks if the emailInputLocator is visible, since apparently emailInputLocator still exists even if the textbox isn't visible. 

## Testing Instructions
Pull down, setup env and use JETPACK_TARGET=wpcom-deployment yarn workspace wp-e2e-tests test -- test/e2e/specs/blocks/blocks__jetpack-grow.ts
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
