### PR TITLE
Blog onboarding: Use `key` to fix domains step default search

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
@@ -103,6 +103,7 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 		return (
 			<CalypsoShoppingCartProvider>
 				<RegisterDomainStep
+					key={ domainSuggestion }
 					suggestion={ domainSuggestion }
 					domainsWithPlansOnly={ true }
 					onAddDomain={ submitWithDomain }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
thelinked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4481

## Proposed Changes

* This PR uses `key` on the `RegisterDomainStep` to ensure the Domain search step loads the search results if the site's name was set earlier in the flow.

Before | After
--|--
<img width="1425" alt="Screenshot 2023-11-03 at 2 46 53 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/18d633da-e8dc-40b0-a772-77629eaaf375">  | <img width="1427" alt="Screenshot 2023-11-03 at 2 46 38 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/2b1b39cd-dfc7-4580-bfba-b7fdeb28a9a0">




## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load the start-writing (/setup/start-writing/) or design-first (/setup/design-first/) Blogger flows.
* Step through the flows until you reach the Launchpad.
* Complete the "Name your blog"
* The "Choose a domain" step should default to a search using your site's name
* If you don't complete the "Name your blog" step, the Domains search should be blank.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?