### PR TITLE
Blog onboarding: Use componentDidUpdate and useEffect to fix domains step default search

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -361,6 +361,10 @@ class RegisterDomainStep extends Component {
 				),
 			} );
 		}
+
+		if ( this.props.suggestion !== prevProps.suggestion ) {
+			this.state.lastQuery = getDomainSuggestionSearch( this.props.suggestion, MIN_QUERY_LENGTH );
+		}
 	}
 
 	getOtherManagedSubdomainsQuantity() {
@@ -602,6 +606,7 @@ class RegisterDomainStep extends Component {
 
 		return (
 			<>
+				{ /* Adding a key on `value` to the Search component to force a re-render works.*/ }
 				<Search { ...componentProps }></Search>
 				{ false === this.props.isDomainAndPlanPackageFlow && this.renderSearchFilters() }
 			</>

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -606,7 +606,6 @@ class RegisterDomainStep extends Component {
 
 		return (
 			<>
-				{ /* Adding a key on `value` to the Search component to force a re-render works.*/ }
 				<Search { ...componentProps }></Search>
 				{ false === this.props.isDomainAndPlanPackageFlow && this.renderSearchFilters() }
 			</>

--- a/packages/search/src/search.tsx
+++ b/packages/search/src/search.tsx
@@ -151,6 +151,7 @@ const InnerSearch = (
 		searchMode = 'when-typing',
 		searchIcon,
 		submitOnOpenIconClick = false,
+		value,
 	}: Props,
 	forwardedRef: Ref< ImperativeHandle >
 ) => {
@@ -197,12 +198,11 @@ const InnerSearch = (
 	}, [ onSearch, delayTimeout, delaySearch ] );
 
 	useEffect( () => {
-		if ( keyword ) {
-			onSearch?.( keyword );
-		}
+		onSearch?.( keyword );
 		// Disable reason: This effect covers the case where a keyword was passed in as the default value and we only want to run it on first search; the useUpdateEffect below will handle the rest of the time that keyword updates
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [] );
+	}, [ value ] );
+	// The above doesn't work
 
 	useUpdateEffect( () => {
 		if ( searchMode === 'on-enter' ) {

--- a/packages/search/src/search.tsx
+++ b/packages/search/src/search.tsx
@@ -198,11 +198,16 @@ const InnerSearch = (
 	}, [ onSearch, delayTimeout, delaySearch ] );
 
 	useEffect( () => {
-		onSearch?.( keyword );
+		if ( keyword ) {
+			onSearch?.( keyword );
+		}
 		// Disable reason: This effect covers the case where a keyword was passed in as the default value and we only want to run it on first search; the useUpdateEffect below will handle the rest of the time that keyword updates
 		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
+
+	useEffect( () => {
+		setKeyword( value ?? '' );
 	}, [ value ] );
-	// The above doesn't work
 
 	useUpdateEffect( () => {
 		if ( searchMode === 'on-enter' ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4481

## Proposed Changes

This is an alternative approach to https://github.com/Automattic/wp-calypso/pull/83884. This PR works. 🎉 but is causing some unit tests to fail. :(

https://github.com/Automattic/wp-calypso/pull/83884 uses a `key` on the `RegisterDomainStep` component to force a reload of the component when the `domainSuggestion` changes from `null` to populated.

This PR attempts to avoid using `key` and use `componentDidUpdate` and `useEffect` so we don't remount the entire `RegisterDomainStep` component.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?