### PR TITLE
Set TXT record limit to 2048 characters

### DIFF
--- a/client/my-sites/domains/domain-management/dns/txt-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/txt-record.jsx
@@ -24,9 +24,9 @@ class TxtRecord extends Component {
 
 		if ( value?.length === 0 ) {
 			return translate( 'TXT records may not be empty' );
-		} else if ( value?.length > 65535 ) {
+		} else if ( value?.length > 2048 ) {
 			return translate(
-				'TXT records may not exceed 65535 characters. {{supportLink}}Learn more{{/supportLink}}.',
+				'TXT records may not exceed 2048 characters. {{supportLink}}Learn more{{/supportLink}}.',
 				{
 					components: {
 						supportLink: (

--- a/client/state/domains/dns/utils.js
+++ b/client/state/domains/dns/utils.js
@@ -83,7 +83,7 @@ function isValidData( data, type ) {
 		case 'MX':
 			return isValidDomain( data );
 		case 'TXT':
-			return data.length > 0 && data.length < 2049;
+			return data.length > 0 && data.length <= 2048;
 	}
 }
 

--- a/client/state/domains/dns/utils.js
+++ b/client/state/domains/dns/utils.js
@@ -83,7 +83,7 @@ function isValidData( data, type ) {
 		case 'MX':
 			return isValidDomain( data );
 		case 'TXT':
-			return data.length > 0 && data.length < 65536;
+			return data.length > 0 && data.length < 2049;
 	}
 }
 


### PR DESCRIPTION

## Proposed Changes

* This PR sets the TXT record limit to a more sane value of 2048.


## Testing Instructions

Try to create a TXT record with length greater than 2048. Make sure you get a validation error.
