### PR TITLE
Add feedback capabilities to the Odie client

### DIFF
--- a/client/odie/message/index.tsx
+++ b/client/odie/message/index.tsx
@@ -15,7 +15,6 @@ import AsyncLoad from 'calypso/components/async-load';
 import Gravatar from 'calypso/components/gravatar';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { useOdieAssistantContext } from '../context';
-import { useOdieGetMessageFeedback } from '../query';
 import CustomALink from './custom-a-link';
 import { uriTransformer } from './uri-transformer';
 import WasThisHelpfulButtons from './was-this-helpful-buttons';
@@ -47,9 +46,6 @@ const ChatMessage = ( { message, scrollToBottom }: ChatMessageProps ) => {
 	const currentUser = useSelector( getCurrentUser );
 	const translate = useTranslate();
 
-	const { data: existingFeedback, isFetching: isFetchingExistingFeedback } =
-		useOdieGetMessageFeedback( isUser, message.message_id || null );
-
 	const realTimeMessage = useTyper( message.content, ! isUser && message.type === 'message', {
 		delayBetweenCharacters: 66,
 		randomDelayBetweenCharacters: true,
@@ -57,6 +53,7 @@ const ChatMessage = ( { message, scrollToBottom }: ChatMessageProps ) => {
 	} );
 
 	const hasSources = message?.context?.sources && message.context?.sources.length > 0;
+	const hasFeedback = !! message?.rating_value;
 	const sources = message?.context?.sources ?? [];
 	const isTypeMessageOrEmpty = ! message.type || message.type === 'message';
 	const isSimulatedTypingFinished = message.simulateTyping && message.content === realTimeMessage;
@@ -176,10 +173,9 @@ const ChatMessage = ( { message, scrollToBottom }: ChatMessageProps ) => {
 						>
 							{ isUser || ! message.simulateTyping ? message.content : realTimeMessage }
 						</AsyncLoad>
-						{ ! isFetchingExistingFeedback &&
-							! existingFeedback &&
-							! isUser &&
-							messageFullyTyped && <WasThisHelpfulButtons message={ message } /> }
+						{ ! hasFeedback && ! isUser && messageFullyTyped && (
+							<WasThisHelpfulButtons message={ message } />
+						) }
 					</>
 				) }
 				{ message.type === 'introduction' && (

--- a/client/odie/message/index.tsx
+++ b/client/odie/message/index.tsx
@@ -15,6 +15,7 @@ import AsyncLoad from 'calypso/components/async-load';
 import Gravatar from 'calypso/components/gravatar';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { useOdieAssistantContext } from '../context';
+import { useOdieGetMessageFeedback } from '../query';
 import CustomALink from './custom-a-link';
 import { uriTransformer } from './uri-transformer';
 import WasThisHelpfulButtons from './was-this-helpful-buttons';
@@ -45,6 +46,9 @@ const ChatMessage = ( { message, scrollToBottom }: ChatMessageProps ) => {
 	const [ isFullscreen, setIsFullscreen ] = useState( false );
 	const currentUser = useSelector( getCurrentUser );
 	const translate = useTranslate();
+
+	const { data: existingFeedback, isFetching: isFetchingExistingFeedback } =
+		useOdieGetMessageFeedback( isUser, message.message_id || null );
 
 	const realTimeMessage = useTyper( message.content, ! isUser && message.type === 'message', {
 		delayBetweenCharacters: 66,
@@ -172,7 +176,10 @@ const ChatMessage = ( { message, scrollToBottom }: ChatMessageProps ) => {
 						>
 							{ isUser || ! message.simulateTyping ? message.content : realTimeMessage }
 						</AsyncLoad>
-						{ ! isUser && messageFullyTyped && <WasThisHelpfulButtons message={ message } /> }
+						{ ! isFetchingExistingFeedback &&
+							! existingFeedback &&
+							! isUser &&
+							messageFullyTyped && <WasThisHelpfulButtons message={ message } /> }
 					</>
 				) }
 				{ message.type === 'introduction' && (

--- a/client/odie/message/was-this-helpful-buttons.tsx
+++ b/client/odie/message/was-this-helpful-buttons.tsx
@@ -1,20 +1,29 @@
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useOdieAssistantContext } from '../context';
+import { useOdieSendMessageFeedback } from '../query';
 import { ThumbsDownIcon, ThumbsUpIcon } from './thumbs-icons';
 import type { Message } from '../types';
 
 import './style.scss';
 
 const WasThisHelpfulButtons = ( { message }: { message: Message } ) => {
+	const THUMBS_DOWN_RATING_VALUE = 2;
+	const THUMBS_UP_RATING_VALUE = 4;
+
 	const translate = useTranslate();
 	const { setMessageLikedStatus } = useOdieAssistantContext();
+	const { mutateAsync: sendOdieMessageFeedback } = useOdieSendMessageFeedback();
 
 	const liked = message.liked === true;
 	const disliked = message.liked === false;
 	const rated = message.liked !== null && message.liked !== undefined;
 
 	const handleIsHelpful = ( isHelpful: boolean ) => {
+		sendOdieMessageFeedback( {
+			message,
+			rating_value: isHelpful ? THUMBS_UP_RATING_VALUE : THUMBS_DOWN_RATING_VALUE,
+		} );
 		setMessageLikedStatus( message, isHelpful );
 	};
 

--- a/client/odie/query/index.ts
+++ b/client/odie/query/index.ts
@@ -65,11 +65,13 @@ const buildGetChatMessage = (
 	botNameSlug: OdieAllowedBots,
 	chat_id: number | null | undefined,
 	page: number,
-	perPage: number
+	perPage: number,
+	includeFeedback: boolean
 ): Promise< Chat > => {
 	const urlQueryParams = new URLSearchParams( {
 		page_number: page.toString(),
 		items_per_page: perPage.toString(),
+		include_feedback: includeFeedback.toString(),
 	} );
 	const baseApiPath = `/help-center/odie/chat/${ botNameSlug }/${ chat_id }?${ urlQueryParams.toString() }`;
 	const wpcomBaseApiPath = `/odie/chat/${ botNameSlug }/${ chat_id }?${ urlQueryParams.toString() }`;
@@ -93,39 +95,15 @@ export const useOdieGetChat = (
 	botNameSlug: OdieAllowedBots,
 	chatId: number | undefined | null,
 	page = 1,
-	perPage = 10
+	perPage = 10,
+	includeFeedback = true
 ) => {
 	const { chat } = useOdieAssistantContext();
 	return useQuery< Chat, unknown >( {
-		queryKey: [ 'chat', botNameSlug, chatId, page, perPage ],
-		queryFn: () => buildGetChatMessage( botNameSlug, chatId, page, perPage ),
+		queryKey: [ 'chat', botNameSlug, chatId, page, perPage, includeFeedback ],
+		queryFn: () => buildGetChatMessage( botNameSlug, chatId, page, perPage, includeFeedback ),
 		refetchOnWindowFocus: false,
 		enabled: !! chatId && ! chat.chat_id,
-	} );
-};
-
-const odieWpcomGetMessageFeedback = (
-	botNameSlug: OdieAllowedBots,
-	chatId: number | null,
-	messageId: number | null
-) => {
-	const path = `/odie/chat/${ botNameSlug }/${ chatId }/${ messageId }/feedback`;
-
-	return wpcom.req.get( {
-		path,
-		apiNamespace: 'wpcom/v2',
-	} ) as Promise< number >;
-};
-
-export const useOdieGetMessageFeedback = ( isUser: boolean, messageId: number | null ) => {
-	const { chat, botNameSlug } = useOdieAssistantContext();
-	const chatId = chat.chat_id;
-
-	return useQuery( {
-		queryKey: [ 'feedback', botNameSlug, chatId, messageId ],
-		queryFn: () => odieWpcomGetMessageFeedback( botNameSlug, chatId || 0, messageId || 0 ),
-		refetchOnWindowFocus: false,
-		enabled: ! isUser && !! chatId && !! messageId,
 	} );
 };
 

--- a/client/odie/query/index.ts
+++ b/client/odie/query/index.ts
@@ -92,8 +92,8 @@ function odieWpcomGetChat( path: string ): Promise< Chat > {
 export const useOdieGetChat = (
 	botNameSlug: OdieAllowedBots,
 	chatId: number | undefined | null,
-	page: number = 1,
-	perPage: number = 10
+	page = 1,
+	perPage = 10
 ) => {
 	const { chat } = useOdieAssistantContext();
 	return useQuery< Chat, unknown >( {

--- a/client/odie/types/index.ts
+++ b/client/odie/types/index.ts
@@ -41,6 +41,7 @@ export type Message = {
 	liked?: boolean | null;
 	simulateTyping?: boolean;
 	context?: Context;
+	rating_value?: number;
 };
 
 export type Chat = {

--- a/client/odie/types/index.ts
+++ b/client/odie/types/index.ts
@@ -33,6 +33,7 @@ export type MessageType =
 	| 'introduction';
 
 export type Message = {
+	message_id?: number;
 	content: string;
 	meta?: Record< string, string >;
 	role: MessageRole;
@@ -40,7 +41,6 @@ export type Message = {
 	liked?: boolean | null;
 	simulateTyping?: boolean;
 	context?: Context;
-	id?: string;
 };
 
 export type Chat = {


### PR DESCRIPTION
## Proposed Changes

* Retrieve feedback for bot messages, show the feedback buttons for messages with no recorded feedback
* On click of feedback buttons (👍 or 👎 ), save the feedback to the WPCOM table

## Testing Instructions

Requires the associated diff D127828

* Start a new or existing chat
* Click on a feedback button
* Reload the page and verify that the feedback buttons don't appear for that message
* Can also check the feedback table to make sure the record has been saved

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?