### PR TITLE
Checkout v2: Set checkoutVersion config to true for staging

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -26,7 +26,7 @@
 		"catch-js-errors": true,
 		"checkout/google-pay": true,
 		"checkout/vat-form": true,
-		"checkout/checkout-version": false,
+		"checkout/checkout-version": true,
 		"cloudflare": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -26,7 +26,7 @@
 		"catch-js-errors": false,
 		"checkout/google-pay": true,
 		"checkout/vat-form": true,
-		"checkout/checkout-version": false,
+		"checkout/checkout-version": true,
 		"cloudflare": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -26,7 +26,7 @@
 		"catch-js-errors": false,
 		"checkout/google-pay": true,
 		"checkout/vat-form": true,
-		"checkout/checkout-version": true,
+		"checkout/checkout-version": false,
 		"cloudflare": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,


### PR DESCRIPTION
This PR will set the feature flag `checkout/checkout-version` to `true` for the staging environment.

Related to https://github.com/Automattic/payments-shilling/issues/1969

## Testing Instructions

* Once these configs are set to true, you should be able to access the new version (currently under development) of Checkout by adding the following query string to the end of any checkout URL: 

`http://calypso.localhost:3000/checkout/[YOUR_SITE_URL]?checkoutVersion=2`

