### PR TITLE
Checkout: Group and clean up cost overrides in sidebar behind flag

### DIFF
--- a/client/my-sites/checkout/src/components/item-variation-picker/item-variation-dropdown.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/item-variation-dropdown.tsx
@@ -67,7 +67,7 @@ const Option = styled.li< OptionProps >`
 const Dropdown = styled.div`
 	position: relative;
 	width: 100%;
-	margin: 16px 0;
+	margin: ${ hasCheckoutVersion( '2' ) ? '6px 0' : '16px 0' };
 	> ${ Option } {
 		border-radius: 3px;
 	}

--- a/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
@@ -43,6 +43,10 @@ const CouponLinkWrapper = styled.div`
 	font-size: 14px;
 `;
 
+const CouponAreaWrapper = styled.div`
+	padding-bottom: ${ hasCheckoutVersion( '2' ) ? '24px' : 'inherit' };
+`;
+
 const CouponField = styled( Coupon )``;
 
 const CouponEnableButton = styled.button`
@@ -64,6 +68,7 @@ const SitePreviewWrapper = styled.div`
 		aspect-ratio: 16 / 9;
 	}
 `;
+
 export default function WPCheckoutOrderReview( {
 	className,
 	removeProductFromCart,
@@ -217,25 +222,29 @@ function CouponFieldArea( {
 
 	if ( isCouponFieldVisible ) {
 		return (
-			<CouponField
-				id="order-review-coupon"
-				disabled={ formStatus !== FormStatus.READY }
-				couponStatus={ couponStatus }
-				couponFieldStateProps={ couponFieldStateProps }
-			/>
+			<CouponAreaWrapper>
+				<CouponField
+					id="order-review-coupon"
+					disabled={ formStatus !== FormStatus.READY }
+					couponStatus={ couponStatus }
+					couponFieldStateProps={ couponFieldStateProps }
+				/>
+			</CouponAreaWrapper>
 		);
 	}
 
 	return (
-		<CouponLinkWrapper>
-			{ translate( 'Have a coupon? ' ) }{ ' ' }
-			<CouponEnableButton
-				className="wp-checkout-order-review__show-coupon-field-button"
-				onClick={ () => setCouponFieldVisible( true ) }
-			>
-				{ translate( 'Add a coupon code' ) }
-			</CouponEnableButton>
-		</CouponLinkWrapper>
+		<CouponAreaWrapper>
+			<CouponLinkWrapper>
+				{ translate( 'Have a coupon? ' ) }{ ' ' }
+				<CouponEnableButton
+					className="wp-checkout-order-review__show-coupon-field-button"
+					onClick={ () => setCouponFieldVisible( true ) }
+				>
+					{ translate( 'Add a coupon code' ) }
+				</CouponEnableButton>
+			</CouponLinkWrapper>
+		</CouponAreaWrapper>
 	);
 }
 

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -133,7 +133,7 @@ function CheckoutSummaryPriceList() {
 						<span>{ subtotalLineItem.formattedAmount }</span>
 					</CheckoutSummaryLineItem>
 				) }
-				{ couponLineItem && (
+				{ ! hasCheckoutVersion( '2' ) && couponLineItem && (
 					<CheckoutSummaryLineItem key={ 'checkout-summary-line-item-' + couponLineItem.id }>
 						<span>{ couponLineItem.label }</span>
 						<span>{ couponLineItem.formattedAmount }</span>

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -28,7 +28,6 @@ import {
 	getCouponLineItemFromCart,
 	getTaxBreakdownLineItemsFromCart,
 	getTotalLineItemFromCart,
-	getCreditsLineItemFromCart,
 	getSubtotalLineItemFromCart,
 	hasCheckoutVersion,
 } from '@automattic/wpcom-checkout';
@@ -120,7 +119,6 @@ function CheckoutSummaryPriceList() {
 	const subtotalLineItem = getSubtotalLineItemFromCart( responseCart );
 	const couponLineItem = getCouponLineItemFromCart( responseCart );
 	const taxLineItems = getTaxBreakdownLineItemsFromCart( responseCart );
-	const creditsLineItem = getCreditsLineItemFromCart( responseCart );
 	const totalLineItem = getTotalLineItemFromCart( responseCart );
 	const translate = useTranslate();
 
@@ -146,12 +144,6 @@ function CheckoutSummaryPriceList() {
 					</CheckoutSummaryLineItem>
 				) ) }
 
-				{ hasCheckoutVersion( '2' ) && creditsLineItem && responseCart.sub_total_integer > 0 && (
-					<CheckoutSummaryLineItem key={ 'checkout-summary-line-item-' + creditsLineItem.id }>
-						<span>{ creditsLineItem?.label }</span>
-						<span>{ creditsLineItem.formattedAmount }</span>
-					</CheckoutSummaryLineItem>
-				) }
 				<CheckoutSummaryTotal>
 					<span>{ translate( 'Total' ) }</span>
 					<span className="wp-checkout-order-summary__total-price">

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -76,7 +76,7 @@ function CostOverridesList( {
 		<>
 			{ costOverridesList.map( ( costOverride ) => {
 				return (
-					<div className="cost-overrides-list-item">
+					<div className="cost-overrides-list-item" key={ costOverride.human_readable_reason }>
 						<span className="cost-overrides-list-item__reason">
 							{ costOverride.human_readable_reason }
 						</span>

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -62,26 +62,28 @@ const CostOverridesListStyle = styled.div`
 	}
 `;
 
+interface CostOverrideForDisplay {
+	humanReadableReason: string;
+	discountAmount: number;
+}
+
 function CostOverridesList( {
 	costOverridesList,
 	currency,
 }: {
-	costOverridesList: Array< {
-		human_readable_reason: string;
-		discount_amount: number;
-	} >;
+	costOverridesList: Array< CostOverrideForDisplay >;
 	currency: string;
 } ) {
 	return (
 		<>
 			{ costOverridesList.map( ( costOverride ) => {
 				return (
-					<div className="cost-overrides-list-item" key={ costOverride.human_readable_reason }>
+					<div className="cost-overrides-list-item" key={ costOverride.humanReadableReason }>
 						<span className="cost-overrides-list-item__reason">
-							{ costOverride.human_readable_reason }
+							{ costOverride.humanReadableReason }
 						</span>
 						<span className="cost-overrides-list-item__discount">
-							{ formatCurrency( -costOverride.discount_amount, currency ) }
+							{ formatCurrency( -costOverride.discountAmount, currency ) }
 						</span>
 					</div>
 				);
@@ -137,7 +139,7 @@ export function WPOrderReviewLineItems( {
 	// Collect cost overrides from each line item and group them by type so we
 	// can show them all together after the line item list.
 	const costOverridesGrouped = responseCart.products.reduce<
-		Record< string, { human_readable_reason: string; discount_amount: number } >
+		Record< string, CostOverrideForDisplay >
 	>( ( grouped, product ) => {
 		// Store product cost_overrides object
 		const costOverrides = product?.cost_overrides;
@@ -147,11 +149,11 @@ export function WPOrderReviewLineItems( {
 
 		// Return array of human readable reasons with discount amount
 		costOverrides.forEach( ( costOverride ) => {
-			const discountAmount = grouped[ costOverride.override_code ]?.discount_amount ?? 0;
+			const discountAmount = grouped[ costOverride.override_code ]?.discountAmount ?? 0;
 			const newDiscountAmount = costOverride.old_price - costOverride.new_price;
 			grouped[ costOverride.override_code ] = {
-				human_readable_reason: costOverride.human_readable_reason,
-				discount_amount: discountAmount + newDiscountAmount,
+				humanReadableReason: costOverride.human_readable_reason,
+				discountAmount: discountAmount + newDiscountAmount,
 			};
 		} );
 		return grouped;

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -55,10 +55,14 @@ const CostOverridesListStyle = styled.div`
 		display: flex;
 		justify-content: space-between;
 		padding: 2px 0px;
+	}
 
-		&__reason {
-			color: #008a20;
-		}
+	& .cost-overrides-list-item__reason {
+		color: #008a20;
+	}
+
+	& .cost-overrides-list-item__discount {
+		white-space: nowrap;
 	}
 `;
 

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -186,7 +186,7 @@ export function WPOrderReviewLineItems( {
 					}
 				/>
 			) ) }
-			{ couponLineItem && (
+			{ ! hasCheckoutVersion( '2' ) && couponLineItem && (
 				<WPOrderReviewListItem key={ couponLineItem.id }>
 					<CouponLineItem
 						lineItem={ couponLineItem }

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -121,10 +121,12 @@ function CostOverridesList( {
 	costOverridesList,
 	currency,
 	removeCoupon,
+	couponCode,
 }: {
 	costOverridesList: Array< CostOverrideForDisplay >;
 	currency: string;
 	removeCoupon: RemoveCouponFromCart;
+	couponCode: ResponseCart[ 'coupon' ];
 } ) {
 	const translate = useTranslate();
 	// Let's put the coupon code last because it will have its own "Remove" button.
@@ -152,7 +154,9 @@ function CostOverridesList( {
 				return (
 					<div className="cost-overrides-list-item" key={ costOverride.humanReadableReason }>
 						<span className="cost-overrides-list-item__reason">
-							{ costOverride.humanReadableReason }
+							{ couponCode.length > 0
+								? translate( 'Coupon: %(couponCode)s', { args: { couponCode } } )
+								: costOverride.humanReadableReason }
 						</span>
 						<span className="cost-overrides-list-item__discount">
 							{ formatCurrency( -costOverride.discountAmount, currency ) }
@@ -272,6 +276,7 @@ export function WPOrderReviewLineItems( {
 						costOverridesList={ costOverridesList }
 						currency={ responseCart.currency }
 						removeCoupon={ removeCoupon }
+						couponCode={ responseCart.coupon }
 					/>
 				</CostOverridesListStyle>
 			) }

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -85,6 +85,12 @@ function filterAndGroupCostOverridesForDisplay(
 		}
 
 		costOverrides.forEach( ( costOverride ) => {
+			if ( costOverride.does_override_original_cost ) {
+				// We won't display original cost overrides since they are
+				// included in the original cost that's being displayed. They
+				// are not discounts.
+				return;
+			}
 			const discountAmount = grouped[ costOverride.override_code ]?.discountAmount ?? 0;
 			const newDiscountAmount = costOverride.old_price - costOverride.new_price;
 			grouped[ costOverride.override_code ] = {

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -49,7 +49,7 @@ const CostOverridesListStyle = styled.div`
 	display: flex;
 	flex-direction: column;
 	justify-content: space-between;
-	font-size: 14px;
+	font-size: 12px;
 	font-weight: 400;
 
 	& .cost-overrides-list-item {

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -13,6 +13,7 @@ import {
 	LineItem,
 	getPartnerCoupon,
 	hasCheckoutVersion,
+	doesPurchaseHaveFullCredits,
 } from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
@@ -128,11 +129,13 @@ function CostOverridesList( {
 	currency,
 	removeCoupon,
 	couponCode,
+	creditsInteger,
 }: {
 	costOverridesList: Array< CostOverrideForDisplay >;
 	currency: string;
 	removeCoupon: RemoveCouponFromCart;
 	couponCode: ResponseCart[ 'coupon' ];
+	creditsInteger: number;
 } ) {
 	const translate = useTranslate();
 	// Let's put the coupon code last because it will have its own "Remove" button.
@@ -158,6 +161,14 @@ function CostOverridesList( {
 					</div>
 				);
 			} ) }
+			{ creditsInteger > 0 && (
+				<div className="cost-overrides-list-item" key="credits-override">
+					<span className="cost-overrides-list-item__reason">{ translate( 'Credits' ) }</span>
+					<span className="cost-overrides-list-item__discount">
+						{ formatCurrency( -creditsInteger, currency, { isSmallestUnit: true } ) }
+					</span>
+				</div>
+			) }
 			{ couponOverrides.map( ( costOverride ) => {
 				return (
 					<div className="cost-overrides-list-item" key={ costOverride.humanReadableReason }>
@@ -232,6 +243,11 @@ export function WPOrderReviewLineItems( {
 	const [ initialProducts ] = useState( () => responseCart.products );
 
 	const costOverridesList = filterAndGroupCostOverridesForDisplay( responseCart );
+	const isFullCredits = doesPurchaseHaveFullCredits( responseCart );
+	// Clamp the credits display value to the total
+	const creditsForDisplay = isFullCredits
+		? responseCart.sub_total_with_taxes_integer
+		: responseCart.credits_integer;
 
 	return (
 		<WPOrderReviewList className={ joinClasses( [ className, 'order-review-line-items' ] ) }>
@@ -287,6 +303,7 @@ export function WPOrderReviewLineItems( {
 						currency={ responseCart.currency }
 						removeCoupon={ removeCoupon }
 						couponCode={ responseCart.coupon }
+						creditsInteger={ creditsForDisplay }
 					/>
 				</CostOverridesListStyle>
 			) }

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -1,5 +1,5 @@
 import { isAkismetProduct, isJetpackPurchasableItem } from '@automattic/calypso-products';
-import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
+import { FormStatus, useFormStatus, Button } from '@automattic/composite-checkout';
 import formatCurrency from '@automattic/format-currency';
 import { isCopySiteFlow } from '@automattic/onboarding';
 import {
@@ -117,6 +117,12 @@ function filterAndGroupCostOverridesForDisplay(
 	return Object.values( costOverridesGrouped );
 }
 
+const DeleteButton = styled( Button )< { theme?: Theme } >`
+	width: auto;
+	font-size: ${ hasCheckoutVersion( '2' ) ? '14px' : 'inherit' };
+	color: ${ ( props ) => props.theme.colors.textColorLight };
+`;
+
 function CostOverridesList( {
 	costOverridesList,
 	currency,
@@ -136,6 +142,8 @@ function CostOverridesList( {
 	const couponOverrides = costOverridesList.filter(
 		( override ) => override.overrideCode === 'coupon-discount'
 	);
+	const { formStatus } = useFormStatus();
+	const isDisabled = formStatus !== FormStatus.READY;
 	return (
 		<>
 			{ nonCouponOverrides.map( ( costOverride ) => {
@@ -162,13 +170,15 @@ function CostOverridesList( {
 							{ formatCurrency( -costOverride.discountAmount, currency ) }
 						</span>
 						<span className="cost-overrides-list-item__actions">
-							<button
+							<DeleteButton
+								buttonType="text-button"
+								disabled={ isDisabled }
 								className="cost-overrides-list-item__actions-remove"
 								onClick={ removeCoupon }
 								aria-label={ translate( 'Remove coupon' ) }
 							>
 								{ translate( 'Remove' ) }
-							</button>
+							</DeleteButton>
 						</span>
 					</div>
 				);

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -1114,12 +1114,16 @@ function CheckoutLineItem( {
 				) }
 			</LineItemTitle>
 			<span aria-labelledby={ itemSpanId } className="checkout-line-item__price">
-				<LineItemPrice
-					isDiscounted={ isDiscounted }
-					actualAmount={ actualAmountDisplay }
-					originalAmount={ originalAmountDisplay }
-					isSummary={ isSummary }
-				/>
+				{ hasCheckoutVersion( '2' ) ? (
+					<LineItemPrice actualAmount={ originalAmountDisplay } isSummary={ isSummary } />
+				) : (
+					<LineItemPrice
+						isDiscounted={ isDiscounted }
+						actualAmount={ actualAmountDisplay }
+						originalAmount={ originalAmountDisplay }
+						isSummary={ isSummary }
+					/>
+				) }
 			</span>
 
 			{ ! hasCheckoutVersion( '2' ) && product && ! containsPartnerCoupon && (

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -118,6 +118,7 @@ const LineItemMeta = styled.div< { theme?: Theme } >`
 	align-content: center;
 	justify-content: space-between;
 	flex-wrap: wrap;
+	overflow-wrap: anywhere;
 	gap: 2px 10px;
 `;
 


### PR DESCRIPTION
## Proposed Changes

In the still-in-progress redesigned checkout layout (see pbOQVh-45k-p2), line items are shown with only their full, undiscounted prices (unlike the current checkout UI which shows the undiscounted price crossed-out next to the actual price). Then there is a separate section below the list of line items which displays every discount and its reason. An initial version of this discount list component was added in https://github.com/Automattic/wp-calypso/pull/83204.

In this PR, we update each line item to display its full price, then merge the discounts by type (there may, for example, be two "Item on sale" discounts; one for each of two items).

The previous checkout layout also included a coupon line item if a coupon was applied, but in this PR we move coupon discounts to the discount list only.

> [!NOTE] 
> The redesigned checkout remains hidden behind both a feature flag and a query string parameter. It is only available currently in development (`calypso.localhost`) and on `wpcalypso` which is used by the `calypso.live` branches below.

Part of https://github.com/Automattic/payments-shilling/issues/1969

## Screenshots

Line items in current checkout without the new design active. This is just for comparison purposes; **the current checkout UI will not change**!

<img width="522" alt="Screenshot 2023-11-14 at 6 17 35 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/22587c2c-b960-4d1c-9c07-db697bf00782">

Line items in this PR with the redesigned layout active:

Before             |  After
:-------------------------:|:-------------------------:
<img width="260" alt="Screenshot 2023-11-16 at 11 36 58 AM" src="https://github.com/Automattic/wp-calypso/assets/2036909/ba3e4346-fc45-421c-8c97-d4e7a52ae804">  | <img width="254" alt="Screenshot 2023-11-16 at 11 36 42 AM" src="https://github.com/Automattic/wp-calypso/assets/2036909/2bf12c46-c75d-4bbf-a23c-8317e3202fa4">

## Testing Instructions

We need to get a discounted product into the cart. Here's one way, but feel free to test others (eg: bundled domains, etc.):

- Use a site with an existing plan.
- Add a plan upgrade (a higher level plan) to your cart and visit checkout.
- Add `?checkoutVersion=2` to the end of the checkout URL and reload checkout.
- Verify that you see the list of products in the sidebar and that each line item shows the _original_ price of the product, not its current price (ie: you should see the price that used to be crossed-out in checkout before the new design).
- Verify that you see the list of discounts in the sidebar and that it includes at least `Prorated balance from previous plan`.
- Verify that each discount shows the difference saved by that price change.

We should also test coupons:

- Click to add a coupon to the cart and enter a valid coupon.
- Verify that the `Coupon code` discount appears in the list of discounts and that it contains the correct discount amount.
- Click to remove the coupon and verify it was removed.