### PR TITLE
Storage Add-Ons: Track spotlight plan card add-on upgrade CTA

### DIFF
--- a/client/my-sites/plans-grid/components/actions.tsx
+++ b/client/my-sites/plans-grid/components/actions.tsx
@@ -297,6 +297,11 @@ const LoggedInPlansFeatureActionButton = ( {
 			return (
 				<Button
 					className={ classNames( classes, 'is-storage-upgradeable' ) }
+					onClick={ () =>
+						recordTracksEvent( 'calypso_signup_storage_add_on_upgrade_click', {
+							add_on_slug: selectedStorageOptionForPlan,
+						} )
+					}
 					href={ storageAddOnCheckoutHref }
 				>
 					{ translate( 'Upgrade' ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/2023

## Proposed Changes

* Records tracks event for storage add-on upgrade button click in the spotlight plan card

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this PR or use Calypso Live
* Visit a site on a business or WooCommerce plan. Alternatively, create new site and upgrade to the business or WooCommerce plan `/start/plans`
* Choose a storage add-on dropdown in the spotlight plan card. Click on the "Upgrade" button.  Ensure that a tracks event is dispatched using either the tracks vigilante chrome dev tool or or searching for `.gif storage` in the dev tools network tab `calypso_signup_storage_add_on_upgrade_click`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?