### PR TITLE
Domains Table: Fix loading experience where checkbox column has too much space

### DIFF
--- a/packages/domains-table/src/domains-table-header/header-loading.tsx
+++ b/packages/domains-table/src/domains-table-header/header-loading.tsx
@@ -2,13 +2,15 @@ import { useDomainsTable } from '../domains-table/domains-table';
 import { DomainsTablePlaceholder } from '../domains-table/domains-table-placeholder';
 
 export default function DomainsTableHeaderLoading() {
-	const { domainsTableColumns } = useDomainsTable();
+	const { canSelectAnyDomains, domainsTableColumns } = useDomainsTable();
 
 	return (
 		<tr className="domains-table-header-loading-placeholder">
-			<th className="domains-table-header-loading-placeholder-checkbox-column">
-				<DomainsTablePlaceholder isHeader delayMS={ 50 } />
-			</th>
+			{ canSelectAnyDomains && (
+				<th className="domains-table-header-loading-placeholder-checkbox-column">
+					<DomainsTablePlaceholder isHeader delayMS={ 50 } />
+				</th>
+			) }
 			<th>
 				<DomainsTablePlaceholder isHeader delayMS={ 50 } />
 			</th>

--- a/packages/domains-table/src/domains-table/domains-table-row-loading.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row-loading.tsx
@@ -2,12 +2,14 @@ import { useDomainsTable } from './domains-table';
 import { DomainsTablePlaceholder } from './domains-table-placeholder';
 
 export default function DomainsTableRowLoading() {
-	const { domainsTableColumns } = useDomainsTable();
+	const { canSelectAnyDomains, domainsTableColumns } = useDomainsTable();
 	return (
 		<tr>
-			<td className="domains-table-row-loading-placeholder-checkbox-column">
-				<DomainsTablePlaceholder delayMS={ 50 } />
-			</td>
+			{ canSelectAnyDomains && (
+				<td className="domains-table-row-loading-placeholder-checkbox-column">
+					<DomainsTablePlaceholder delayMS={ 50 } />
+				</td>
+			) }
 			<td className="domains-table-row-loading-placeholder-domain-column">
 				<DomainsTablePlaceholder delayMS={ 50 } />
 			</td>


### PR DESCRIPTION

## Proposed Changes

The DomainsTable placeholder sometimes looks messy during loading because we show a placeholder for the checkbox when the internal table state has `canSelectAnyDomains === false`. This internal state (even though it's intermediate loading state) controls the CSS grid layout, and therefore if the placeholder renders a cell for the checkbox it won't align with the grid layout.

Looks like this:
![CleanShot 2023-11-06 at 17 15 59@2x](https://github.com/Automattic/wp-calypso/assets/1500769/2276e605-380a-48c6-b79a-d65c43cefacc)


Quick fix is to have the placeholder match the internal table state of `canSelectAnyDomains` even when it's just intermediate loading data.

A better solution for loading might be to show a consistent loading experience that doesn't depend on intermediary state.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* To force the loading state you can test with `calypso.localhost` and [change this line](https://github.com/Automattic/wp-calypso/blob/95d7c862e94903d44d960309c52c7bf53266bd34/packages/domains-table/src/domains-table/domains-table.tsx#L427) to `isLoadingDomains: true,`
* It's worth testing each case with a hot and a cold cache. Clear the cache by deleting the indexdb database
* Test `/domains/manage`
* Test `/domains/manage/{ site slug }`
* Test with a table where you know one of the domains will eventually be selectable
* Test with a table where you know none of the domains will be selectable (an easy way is create a brand new site with only a `.wordpress.com` subdomain)
