### PR TITLE
Jetpack Manage: Fix page break when the site is expanded & minor UI issue.

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/backup-storage.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/backup-storage.tsx
@@ -67,7 +67,8 @@ const BackupStorageContent = ( {
 
 	// Show plugin name only if it is a activity from a plugin
 	const pluginName =
-		backup?.activityName.startsWith( 'plugin__' ) && backup.activityDescription[ 0 ]?.children[ 0 ];
+		backup?.activityName.startsWith( 'plugin__' ) &&
+		backup.activityDescription?.[ 0 ]?.children?.[ 0 ];
 
 	const showLoader = isLoading || ! backup;
 	const extractedBackupTitle = useExtractedBackupTitle( backup );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/hooks/use-extracted-backup-title.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/hooks/use-extracted-backup-title.ts
@@ -20,7 +20,7 @@ const useExtractedBackupTitle = ( backup: Backup | null ) => {
 	const translate = useTranslate();
 
 	return useMemo( () => {
-		const backupText = backup?.activityDescription[ 0 ]?.children[ 0 ]?.text;
+		const backupText = backup?.activityDescription?.[ 0 ]?.children?.[ 0 ]?.text;
 
 		if ( ! backupText ) {
 			return backup?.activityTitle;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -15,6 +15,10 @@
 		// The -76px is to undo the padding of layout.has-no-masterbar (32px), .layout__content (32px) and .sites-overview_container (6px + 6px)
 		min-height: calc(100vh - 76px);
 	}
+
+	.is-sticky .sites-overview__licenses-buttons {
+		margin-block: auto;
+	}
 }
 
 .sites-overview__large-screen {


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-manage/issues/95

## Proposed Changes

This PR

- Fixes the page breaking issue when the site is expanded when the latest Backup is for a setting change.
- Fixes the spacing issues with the sticky header

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Open the Jetpack Cloud live link
2. Click the `+Add` button next to Backup> Verify there is no padding issue and the buttons are aligned in the center.

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="555" alt="Screenshot 2023-11-06 at 12 06 50 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/77e24bbd-9d49-4e67-a149-3dd5c2f7554d">
</td>
<td>
<img width="555" alt="Screenshot 2023-11-06 at 12 06 54 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/727bc10a-13e7-4ee0-bcd0-b95f1600771c">
</td>
</tr>
</table>

3. Assign a Backup license > Visit https://wordpress.com/settings/general/{site} > Wait for the backup to finish > Expand the site content and verify that the page doesn't break. Check https://cloud.jetpack.com/ to see if the page breaks there.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?