### PR TITLE
Subscriber Stats: Align subscribers total within the All-time stats and chart sections

### DIFF
--- a/client/my-sites/stats/hooks/use-subscribers-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-query.tsx
@@ -54,7 +54,8 @@ function selectSubscribers( payload: SubscriberPayload ): SubscribersData {
 			return {
 				[ payload.fields[ 0 ] ]:
 					payload.unit !== 'week' ? dataSet[ 0 ] : dataSet[ 0 ].replaceAll( 'W', '-' ),
-				[ payload.fields[ 1 ] ]: dataSet[ 1 ],
+				// Exclude the site owner count to align with the `Total subscribers` count from querySubscribersTotals.
+				[ payload.fields[ 1 ] ]: dataSet[ 1 ] > 0 ? dataSet[ 1 ] - 1 : dataSet[ 1 ],
 				[ payload.fields[ 2 ] ]: dataSet[ 2 ],
 			};
 		} ),

--- a/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
@@ -2,9 +2,12 @@ import { useQueries } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 
 const querySubscribersTotals = ( siteId: number | null ): Promise< any > => {
-	return wpcom.req.get( {
-		path: `/sites/${ siteId }/stats/followers`,
-	} );
+	return wpcom.req.get(
+		{
+			path: `/sites/${ siteId }/stats/followers`,
+		},
+		{ type: 'all' }
+	);
 };
 
 const queryMore = ( siteId: number | null ): Promise< any > => {

--- a/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
@@ -20,6 +20,7 @@ const selectSubscribers = ( payload: {
 	total_wpcom: number;
 } ) => {
 	return {
+		total: payload.total,
 		total_email: payload.total_email,
 		total_wpcom: payload.total_wpcom,
 	};
@@ -62,7 +63,7 @@ export default function useSubscribersTotalsQueries( siteId: number | null ) {
 		data: {
 			total_email: queries[ 0 ]?.data?.total_email,
 			total_wpcom: queries[ 0 ]?.data?.total_wpcom,
-			total: queries[ 1 ]?.data?.email_subscribers,
+			total: queries[ 0 ]?.data?.total,
 			paid_subscribers: queries[ 1 ]?.data?.paid_subscribers,
 			free_subscribers:
 				queries[ 1 ]?.data?.email_subscribers !== undefined &&


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/80610#issuecomment-1789957605

## Proposed Changes

* Use the total amount within the filtered subscriber list by D127415-code for the `Total subscribers` count alignment.
* Subtract the default admin subscriber count to keep the subscribers counts in the chart section aligned with the `Total subscribers`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox `public-api.wordpress.com`.
* Apply D127415-code.
* Spin this change up with the Live Branch link.
* Navigate to Stats > Subscribers page.
* Ensure all the subscribers' counts in the All-time stats and Subscribers chart section are aligned.

|Before|After|
|-|-|
|<img width="1306" alt="截圖 2023-11-06 上午11 44 45" src="https://github.com/Automattic/wp-calypso/assets/6869813/9f266b71-5318-47eb-8498-0ab806a3533e">|<img width="1329" alt="截圖 2023-11-06 下午3 48 44" src="https://github.com/Automattic/wp-calypso/assets/6869813/b6f3ebf9-ea55-4a2b-8cae-6428886ad45e">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?