### PR TITLE
Assembler: Implement click to enlarge page preview

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/events.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/events.ts
@@ -47,8 +47,10 @@ export const PATTERN_ASSEMBLER_EVENTS = {
 	/*
 	 * Screen Pages
 	 */
-	SCREEN_PAGES_ADD_PAGE: 'calypso_signup_pattern_assembler_screen_pages_add_page',
-	SCREEN_PAGES_REMOVE_PAGE: 'calypso_signup_pattern_assembler_screen_pages_remove_page',
+	SCREEN_PAGES_PAGE_ADD: 'calypso_signup_pattern_assembler_screen_pages_page_add',
+	SCREEN_PAGES_PAGE_REMOVE: 'calypso_signup_pattern_assembler_screen_pages_page_remove',
+	SCREEN_PAGES_PAGE_PREVIEW_CLICK:
+		'calypso_signup_pattern_assembler_screen_pages_page_preview_click',
 
 	/**
 	 * Pattern Panels

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -518,10 +518,10 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 	const onScreenPagesSelect = ( page: string ) => {
 		if ( pages.includes( page ) ) {
 			setPages( pages.filter( ( item ) => item !== page ) );
-			recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_PAGES_REMOVE_PAGE, { page } );
+			recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_PAGES_PAGE_REMOVE, { page } );
 		} else {
 			setPages( [ ...pages, page ] );
-			recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_PAGES_ADD_PAGE, { page } );
+			recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_PAGES_PAGE_ADD, { page } );
 		}
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-page-preview-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-page-preview-list.tsx
@@ -1,7 +1,11 @@
 import { useGlobalStyle } from '@automattic/global-styles';
+import {
+	__unstableComposite as Composite,
+	__unstableUseCompositeState as useCompositeState,
+} from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { CSSProperties, useMemo } from 'react';
-import PatternPagePreview from './pattern-page-preview';
+import { CSSProperties, useMemo, useState } from 'react';
+import PatternPagePreview, { PatternPagePreviewModal } from './pattern-page-preview';
 import type { Pattern } from './types';
 import './pattern-page-preview-list.scss';
 
@@ -23,6 +27,8 @@ const PatternPagePreviewList = ( {
 	isNewSite,
 }: Props ) => {
 	const translate = useTranslate();
+	const composite = useCompositeState( { orientation: 'horizontal' } );
+	const [ zoomedPage, setZoomedPage ] = useState< Pattern[] >( [] );
 
 	const [ backgroundColor ] = useGlobalStyle( 'color.background' );
 	const patternPagePreviewStyle = useMemo(
@@ -40,28 +46,45 @@ const PatternPagePreviewList = ( {
 		[ selectedHeader, selectedSections, selectedFooter ]
 	);
 
+	const handleClick = ( patterns: Pattern[] ) => {
+		setZoomedPage( patterns );
+	};
+
 	return (
-		<div className="pattern-assembler__preview-list">
-			<PatternPagePreview
-				title={ translate( 'Homepage' ) }
-				style={ patternPagePreviewStyle }
-				patterns={ homepage }
-				shouldShufflePosts={ isNewSite }
-			/>
-			{ pages.map( ( page ) => (
+		<>
+			<Composite { ...composite } role="listbox" className="pattern-assembler__preview-list">
 				<PatternPagePreview
-					key={ page.ID }
+					composite={ composite }
+					title={ translate( 'Homepage' ) }
 					style={ patternPagePreviewStyle }
-					title={ page.title }
-					patterns={ [
-						...( selectedHeader ? [ selectedHeader ] : [] ),
-						page,
-						...( selectedFooter ? [ selectedFooter ] : [] ),
-					] }
-					shouldShufflePosts={ false }
+					patterns={ homepage }
+					shouldShufflePosts={ isNewSite }
+					onClick={ handleClick }
 				/>
-			) ) }
-		</div>
+				{ pages.map( ( page ) => (
+					<PatternPagePreview
+						key={ page.ID }
+						composite={ composite }
+						style={ patternPagePreviewStyle }
+						title={ page.title }
+						patterns={ [
+							...( selectedHeader ? [ selectedHeader ] : [] ),
+							page,
+							...( selectedFooter ? [ selectedFooter ] : [] ),
+						] }
+						shouldShufflePosts={ isNewSite }
+						onClick={ handleClick }
+					/>
+				) ) }
+			</Composite>
+			<PatternPagePreviewModal
+				style={ patternPagePreviewStyle }
+				patterns={ zoomedPage }
+				shouldShufflePosts={ isNewSite }
+				isOpen={ !! zoomedPage.length }
+				onClose={ () => setZoomedPage( [] ) }
+			/>
+		</>
 	);
 };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-page-preview-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-page-preview-list.tsx
@@ -5,6 +5,8 @@ import {
 } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { CSSProperties, useMemo, useState } from 'react';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { PATTERN_ASSEMBLER_EVENTS } from './events';
 import PatternPagePreview, { PatternPagePreviewModal } from './pattern-page-preview';
 import type { Pattern } from './types';
 import './pattern-page-preview-list.scss';
@@ -46,8 +48,12 @@ const PatternPagePreviewList = ( {
 		[ selectedHeader, selectedSections, selectedFooter ]
 	);
 
-	const handleClick = ( patterns: Pattern[] ) => {
+	const handleClick = ( patterns: Pattern[], pageSlug: string ) => {
 		setZoomedPage( patterns );
+		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_PAGES_PAGE_PREVIEW_CLICK, {
+			pattern_names: patterns.map( ( pattern ) => pattern.name ).join( ',' ),
+			page_slug: pageSlug,
+		} );
 	};
 
 	return (
@@ -59,9 +65,9 @@ const PatternPagePreviewList = ( {
 					style={ patternPagePreviewStyle }
 					patterns={ homepage }
 					shouldShufflePosts={ isNewSite }
-					onClick={ handleClick }
+					onClick={ ( patterns ) => handleClick( patterns, 'homepage' ) }
 				/>
-				{ pages.map( ( page ) => (
+				{ pages.map( ( page, index ) => (
 					<PatternPagePreview
 						key={ page.ID }
 						composite={ composite }
@@ -73,7 +79,7 @@ const PatternPagePreviewList = ( {
 							...( selectedFooter ? [ selectedFooter ] : [] ),
 						] }
 						shouldShufflePosts={ isNewSite }
-						onClick={ handleClick }
+						onClick={ ( patterns ) => handleClick( patterns, selectedPages[ index ] ) }
 					/>
 				) ) }
 			</Composite>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-page-preview-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-page-preview-list.tsx
@@ -32,6 +32,11 @@ const PatternPagePreviewList = ( {
 	const composite = useCompositeState( { orientation: 'horizontal' } );
 	const [ zoomedPage, setZoomedPage ] = useState< Pattern[] >( [] );
 
+	// Using zoomedPage to control whether the modal is opened or not causes a flash of empty content.
+	// To prevent this, we use another separate state.
+	// See: https://github.com/Automattic/wp-calypso/pull/83902#discussion_r1383357522.
+	const [ isModalOpen, setIsModalOpen ] = useState( false );
+
 	const [ backgroundColor ] = useGlobalStyle( 'color.background' );
 	const patternPagePreviewStyle = useMemo(
 		() => ( { '--pattern-page-preview-background': backgroundColor } ) as CSSProperties,
@@ -50,6 +55,8 @@ const PatternPagePreviewList = ( {
 
 	const handleClick = ( patterns: Pattern[], pageSlug: string ) => {
 		setZoomedPage( patterns );
+		setIsModalOpen( true );
+
 		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_PAGES_PAGE_PREVIEW_CLICK, {
 			pattern_names: patterns.map( ( pattern ) => pattern.name ).join( ',' ),
 			page_slug: pageSlug,
@@ -87,8 +94,8 @@ const PatternPagePreviewList = ( {
 				style={ patternPagePreviewStyle }
 				patterns={ zoomedPage }
 				shouldShufflePosts={ isNewSite }
-				isOpen={ !! zoomedPage.length }
-				onClose={ () => setZoomedPage( [] ) }
+				isOpen={ isModalOpen }
+				onClose={ () => setIsModalOpen( false ) }
 			/>
 		</>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-page-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-page-preview.scss
@@ -10,15 +10,27 @@ $font-family: "SF Pro Text", $sans;
 	aspect-ratio: 3/4;
 
 	.pattern-assembler__preview-frame {
+		background-color: #f8f8f8;
 		border: 10px solid #f8f8f8;
 		border-radius: 13px;  /* stylelint-disable-line scales/radii */
 		box-shadow:
 			0 5.25469px 5.25469px 0 rgba(0, 0, 0, 0.02),
 			0 11.38516px 8.75781px 0 rgba(0, 0, 0, 0.03);
+		cursor: pointer;
 		flex: 1;
 		min-height: 350px;
 		overflow: hidden;
 		position: relative;
+		transition: border-color 0.2s;
+
+		&:hover {
+			background-color: #ebebeb;
+			border-color: #ebebeb;
+		}
+
+		&:focus-visible {
+			outline: 2px solid var(--color-primary-light);
+		}
 
 		&-content {
 			background: var(--pattern-page-preview-background, #f8f8f8);
@@ -29,6 +41,7 @@ $font-family: "SF Pro Text", $sans;
 			position: absolute;
 			right: 0;
 			top: 0;
+			user-select: none;
 
 			/**
 			 * Hides the scrollbar to avoid the layout keeps changes forever
@@ -49,5 +62,39 @@ $font-family: "SF Pro Text", $sans;
 		margin-inline-end: 10px;
 		margin-inline-start: 10px;
 		margin-top: 16px;
+	}
+}
+
+.pattern-assembler__preview-modal {
+	background-color: #f8f8f8;
+	border: 18px solid #f8f8f8;
+	border-radius: 24.894px;  /* stylelint-disable-line scales/radii */
+	box-shadow:
+		0 9.95778px 9.95778px 0 rgba(0, 0, 0, 0.02),
+		0 21.57518px 16.59629px 0 rgba(0, 0, 0, 0.03);
+
+	&__backdrop {
+		background-color: rgba(0, 0, 0, 0.18) !important;
+	}
+
+	&__wrapper {
+		border-radius: 16.596px;  /* stylelint-disable-line scales/radii */
+		padding: 0;
+
+		/**
+		 * Hides the scrollbar to avoid the layout keeps changes forever
+		 * See https://github.com/Automattic/wp-calypso/issues/78357.
+		 */
+		scrollbar-width: none;
+		&::-webkit-scrollbar {
+			display: none;
+		}
+	}
+
+	&__content {
+		background: var(--pattern-page-preview-background, #f8f8f8);
+		height: 80vh;
+		user-select: none;
+		width: 60vw;
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-page-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-page-preview.tsx
@@ -1,25 +1,84 @@
 import { PatternRenderer } from '@automattic/block-renderer';
+import { Dialog } from '@automattic/components';
+import { __unstableCompositeItem as CompositeItem } from '@wordpress/components';
 import { CSSProperties, useMemo } from 'react';
 import { encodePatternId } from './utils';
 import type { Pattern } from './types';
 import './pattern-page-preview.scss';
 
-interface Props {
+interface PatternPagePreviewModalProps {
+	style: CSSProperties;
+	patterns: Pattern[];
+	shouldShufflePosts: boolean;
+	isOpen: boolean;
+	onClose: () => void;
+}
+
+interface PatternPagePreviewProps {
+	composite: Record< string, unknown >;
 	title: string;
 	style: CSSProperties;
 	patterns: Pattern[];
 	shouldShufflePosts: boolean;
+	onClick: ( patterns: Pattern[] ) => void;
 }
 
 const PATTERN_PAGE_PREVIEW_ITEM_VIEWPORT_HEIGHT = 500;
 const PATTERN_PAGE_PREVIEW_ITEM_VIEWPORT_WIDTH = 1080;
 
-const PatternPagePreview = ( { title, style, patterns, shouldShufflePosts }: Props ) => {
+export const PatternPagePreviewModal = ( {
+	style,
+	patterns,
+	shouldShufflePosts,
+	isOpen,
+	onClose,
+}: PatternPagePreviewModalProps ) => {
+	return (
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
+		<Dialog
+			additionalClassNames="pattern-assembler__preview-modal"
+			additionalOverlayClassNames="pattern-assembler__preview-modal__backdrop"
+			className="pattern-assembler__preview-modal__wrapper"
+			isVisible={ isOpen }
+			isFullScreen
+			shouldCloseOnEsc
+			onClose={ onClose }
+		>
+			<div className="pattern-assembler__preview-modal__content" style={ style }>
+				{ patterns.map( ( pattern ) => (
+					<PatternRenderer
+						key={ pattern.ID }
+						patternId={ encodePatternId( pattern.ID ) }
+						viewportWidth={ PATTERN_PAGE_PREVIEW_ITEM_VIEWPORT_WIDTH }
+						viewportHeight={ PATTERN_PAGE_PREVIEW_ITEM_VIEWPORT_HEIGHT }
+						shouldShufflePosts={ shouldShufflePosts }
+					/>
+				) ) }
+			</div>
+		</Dialog>
+	);
+};
+
+const PatternPagePreview = ( {
+	composite,
+	title,
+	style,
+	patterns,
+	shouldShufflePosts,
+	onClick,
+}: PatternPagePreviewProps ) => {
 	const validPatterns = useMemo( () => patterns.filter( Boolean ) as Pattern[], [ patterns ] );
 
 	return (
 		<div className="pattern-assembler__preview">
-			<div className="pattern-assembler__preview-frame">
+			<CompositeItem
+				{ ...composite }
+				role="option"
+				as="button"
+				className="pattern-assembler__preview-frame"
+				aria-label={ title }
+				onClick={ () => onClick( validPatterns ) }
+			>
 				<div className="pattern-assembler__preview-frame-content" style={ style }>
 					{ validPatterns.map( ( pattern ) => (
 						<PatternRenderer
@@ -31,7 +90,7 @@ const PatternPagePreview = ( { title, style, patterns, shouldShufflePosts }: Pro
 						/>
 					) ) }
 				</div>
-			</div>
+			</CompositeItem>
 			<div className="pattern-assembler__preview-title">{ title }</div>
 		</div>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #83450

## Proposed Changes

This PR implements clicking on a page preview to open a modal with an enlarged version of the preview. See recording for reference:

https://github.com/Automattic/wp-calypso/assets/797888/e5544979-174b-47f8-8ad0-6fa996d89e4a

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Assembler with the flag `&flags=pattern-assembler/add-pages`.
* Go through the Patterns, and Styles screen until you arrive at the Pages screen.
* Ensure that clicking any page preview would open a modal with a large version of the page preview.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?