### PR TITLE
Launchpad: Add the `subscribers-launchpad` feature flag

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -194,6 +194,7 @@
 		"storage-addon": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
+		"subscribers-launchpad": true,
 		"subscription-gifting": true,
 		"subscription-management-add-sites-modal": true,
 		"subscription-management-comments-view": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -132,6 +132,7 @@
 		"storage-addon": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
+		"subscribers-launchpad": false,
 		"subscription-gifting": true,
 		"subscription-management-add-sites-modal": true,
 		"subscription-management-comments-view": true,

--- a/config/production.json
+++ b/config/production.json
@@ -160,6 +160,7 @@
 		"storage-addon": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
+		"subscribers-launchpad": false,
 		"subscription-gifting": true,
 		"subscription-management-add-sites-modal": true,
 		"subscription-management-comments-view": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -155,6 +155,7 @@
 		"storage-addon": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
+		"subscribers-launchpad": false,
 		"subscription-gifting": true,
 		"subscription-management-add-sites-modal": true,
 		"subscription-management-comments-view": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -164,6 +164,7 @@
 		"storage-addon": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
+		"subscribers-launchpad": false,
 		"subscription-gifting": true,
 		"subscription-management-add-sites-modal": true,
 		"subscription-management-comments-view": true,


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/83852.

## Proposed Changes

* add the `subscribers-launchpad` feature flag; enable it for the development environment only

## Testing Instructions

Please check for typos or some other things that could have been overlooked.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?