### PR TITLE
Remove margin for NavigationHeader and fix /plans Header

### DIFF
--- a/client/components/navigation-header/style.scss
+++ b/client/components/navigation-header/style.scss
@@ -9,7 +9,6 @@
 	margin-bottom: 0;
 	@include break-small {
 		padding: 0 0 24px 0;
-		margin-bottom: 16px;
 	}
 
 	.breadcrumbs {

--- a/client/my-sites/plans/modernized-layout.tsx
+++ b/client/my-sites/plans/modernized-layout.tsx
@@ -24,7 +24,7 @@ const ModernizedLayout: React.FunctionComponent = () => {
 	const globalOverrides = css`
 		.navigation-header.plans__section-header {
 			@media ( min-width: ${ customBreakpointSmall } ) {
-				padding: 0 max( calc( 50% - ( ${ sectionMaxWidth } / 2 ) ), 32px );
+				padding: 0 max( calc( 50% - ( ${ sectionMaxWidth } / 2 ) ), 32px ) 24px;
 			}
 		}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/83900

## Proposed Changes

| Before  | After |
| :-------------: | :-------------: |
| <img src="https://github.com/Automattic/wp-calypso/assets/6586048/cf1920c3-9ba8-43f7-8ef0-8836b55a52f4">  | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/eb3871ad-de68-4fb6-a650-0a144c9a1208">|


* Remove the bottom 16px margin
* Add padding to the bottom of `/plans`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check around Calypso to make sure nothing looks weird for desktop/mobile

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?