### PR TITLE
Stats: Update chart range in response to nav arrows

### DIFF
--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -64,7 +64,7 @@ class StatsPeriodNavigation extends PureComponent {
 	calculatePeriod = ( period ) => ( this.isHoursPeriod( period ) ? 'day' : period );
 
 	queryParamsForNextDate = ( nextDay ) => {
-		const { dateRange, moment, queryParams } = this.props;
+		const { dateRange, moment } = this.props;
 		// Takes a 'YYYY-MM-DD' string.
 		const newParams = { startDate: nextDay };
 		// Maintain previous behaviour if we don't have a date range to work with.
@@ -72,10 +72,10 @@ class StatsPeriodNavigation extends PureComponent {
 			return newParams;
 		}
 		// Test if we need to update the chart start/end dates.
-		const isAfter = moment( nextDay ).isAfter( moment( queryParams.chartEnd ) );
+		const isAfter = moment( nextDay ).isAfter( moment( dateRange.chartEnd ) );
 		if ( isAfter ) {
-			newParams.chartStart = moment( queryParams.chartEnd ).add( 1, 'days' ).format( 'YYYY-MM-DD' );
-			newParams.chartEnd = moment( queryParams.chartEnd )
+			newParams.chartStart = moment( dateRange.chartEnd ).add( 1, 'days' ).format( 'YYYY-MM-DD' );
+			newParams.chartEnd = moment( dateRange.chartEnd )
 				.add( dateRange.daysInRange, 'days' )
 				.format( 'YYYY-MM-DD' );
 		}
@@ -96,7 +96,7 @@ class StatsPeriodNavigation extends PureComponent {
 	};
 
 	queryParamsForPreviousDate = ( previousDay ) => {
-		const { dateRange, moment, queryParams } = this.props;
+		const { dateRange, moment } = this.props;
 		// Takes a 'YYYY-MM-DD' string.
 		const newParams = { startDate: previousDay };
 		// Maintain previous behaviour if we don't have a date range to work with.
@@ -104,12 +104,12 @@ class StatsPeriodNavigation extends PureComponent {
 			return newParams;
 		}
 		// Test if we need to update the chart start/end dates.
-		const isBefore = moment( previousDay ).isBefore( moment( queryParams.chartStart ) );
+		const isBefore = moment( previousDay ).isBefore( moment( dateRange.chartStart ) );
 		if ( isBefore ) {
-			newParams.chartEnd = moment( queryParams.chartStart )
+			newParams.chartEnd = moment( dateRange.chartStart )
 				.subtract( 1, 'days' )
 				.format( 'YYYY-MM-DD' );
-			newParams.chartStart = moment( queryParams.chartStart )
+			newParams.chartStart = moment( dateRange.chartStart )
 				.subtract( dateRange.daysInRange, 'days' )
 				.format( 'YYYY-MM-DD' );
 		}

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -63,16 +63,49 @@ class StatsPeriodNavigation extends PureComponent {
 
 	calculatePeriod = ( period ) => ( this.isHoursPeriod( period ) ? 'day' : period );
 
+	queryParamsForNextDate = ( nextDay ) => {
+		const { dateRange, moment, queryParams } = this.props;
+		// Test if we need to update the chart start/end dates.
+		// Takes a 'YYYY-MM-DD' string.
+		const newParams = { startDate: nextDay };
+		const isAfter = moment( nextDay ).isAfter( moment( queryParams.chartEnd ) );
+		if ( isAfter ) {
+			newParams.chartStart = moment( queryParams.chartEnd ).add( 1, 'days' ).format( 'YYYY-MM-DD' );
+			newParams.chartEnd = moment( queryParams.chartEnd )
+				.add( dateRange.daysInRange, 'days' )
+				.format( 'YYYY-MM-DD' );
+		}
+		return newParams;
+	};
+
 	handleArrowNext = () => {
 		const { date, moment, period, url, queryParams, isEmailStats, maxBars } = this.props;
 		const numberOfDAys = this.getNumberOfDays( isEmailStats, period, maxBars );
 		const usedPeriod = this.calculatePeriod( period );
 		const nextDay = moment( date ).add( numberOfDAys, usedPeriod ).format( 'YYYY-MM-DD' );
-		const nextDayQuery = qs.stringify( Object.assign( {}, queryParams, { startDate: nextDay } ), {
+		const newQueryParams = this.queryParamsForNextDate( nextDay );
+		const nextDayQuery = qs.stringify( Object.assign( {}, queryParams, newQueryParams ), {
 			addQueryPrefix: true,
 		} );
 		const href = `${ url }${ nextDayQuery }`;
 		this.handleArrowEvent( 'next', href );
+	};
+
+	queryParamsForPreviousDate = ( previousDay ) => {
+		const { dateRange, moment, queryParams } = this.props;
+		// Test if we need to update the chart start/end dates.
+		// Takes a 'YYYY-MM-DD' string.
+		const newParams = { startDate: previousDay };
+		const isBefore = moment( previousDay ).isBefore( moment( queryParams.chartStart ) );
+		if ( isBefore ) {
+			newParams.chartEnd = moment( queryParams.chartStart )
+				.subtract( 1, 'days' )
+				.format( 'YYYY-MM-DD' );
+			newParams.chartStart = moment( queryParams.chartStart )
+				.subtract( dateRange.daysInRange, 'days' )
+				.format( 'YYYY-MM-DD' );
+		}
+		return newParams;
 	};
 
 	handleArrowPrevious = () => {
@@ -80,10 +113,10 @@ class StatsPeriodNavigation extends PureComponent {
 		const numberOfDAys = this.getNumberOfDays( isEmailStats, period, maxBars );
 		const usedPeriod = this.calculatePeriod( period );
 		const previousDay = moment( date ).subtract( numberOfDAys, usedPeriod ).format( 'YYYY-MM-DD' );
-		const previousDayQuery = qs.stringify(
-			Object.assign( {}, queryParams, { startDate: previousDay } ),
-			{ addQueryPrefix: true }
-		);
+		const newQueryParams = this.queryParamsForPreviousDate( previousDay );
+		const previousDayQuery = qs.stringify( Object.assign( {}, queryParams, newQueryParams ), {
+			addQueryPrefix: true,
+		} );
 		const href = `${ url }${ previousDayQuery }`;
 		this.handleArrowEvent( 'previous', href );
 	};

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -65,9 +65,13 @@ class StatsPeriodNavigation extends PureComponent {
 
 	queryParamsForNextDate = ( nextDay ) => {
 		const { dateRange, moment, queryParams } = this.props;
-		// Test if we need to update the chart start/end dates.
 		// Takes a 'YYYY-MM-DD' string.
 		const newParams = { startDate: nextDay };
+		// Maintain previous behaviour if we don't have a date range to work with.
+		if ( dateRange === undefined ) {
+			return newParams;
+		}
+		// Test if we need to update the chart start/end dates.
 		const isAfter = moment( nextDay ).isAfter( moment( queryParams.chartEnd ) );
 		if ( isAfter ) {
 			newParams.chartStart = moment( queryParams.chartEnd ).add( 1, 'days' ).format( 'YYYY-MM-DD' );
@@ -93,9 +97,13 @@ class StatsPeriodNavigation extends PureComponent {
 
 	queryParamsForPreviousDate = ( previousDay ) => {
 		const { dateRange, moment, queryParams } = this.props;
-		// Test if we need to update the chart start/end dates.
 		// Takes a 'YYYY-MM-DD' string.
 		const newParams = { startDate: previousDay };
+		// Maintain previous behaviour if we don't have a date range to work with.
+		if ( dateRange === undefined ) {
+			return newParams;
+		}
+		// Test if we need to update the chart start/end dates.
 		const isBefore = moment( previousDay ).isBefore( moment( queryParams.chartStart ) );
 		if ( isBefore ) {
 			newParams.chartEnd = moment( queryParams.chartStart )


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #83570.

## Proposed Changes

When updating the bar chart via the navigation arrows we now check the new query date and update the chart boundaries as needed.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open the Live branch.
2. Navigate to Stats → Traffic.
3. Select the "Last 7 Days" shortcut.
4. Confirm the "next" arrow is greyed out.
5. Click the "previous" arrow (the left-pointing one) until the selection goes off screen. (note: there's a bug in the chart currently that doesn't show the full date range, which is why it doesn't update the chart yet)
6. Click the arrow again to update the chart.
7. Pick a random range from the date range picker and test the range is updated correctly. (ie: if you set a range of two weeks, arrowing past either end of the chart should update with two more weeks of data)

**Bug Note:** The chart in the above scenario should show 7 days but currently only shows six. The logic used here respects the date range from the URL so it will only update the `chartStart` and `chartEnd` values when the `startDate` (the actual selected date) moves outside those bounds.

The missing data in the chart should be addressed separately.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?