### PR TITLE
Add behaviour in theme intro screen to go back using history

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -1003,6 +1003,14 @@ class ThemeSheet extends Component {
 	goBack = () => {
 		const { backPath, locale, isLoggedIn, themeId } = this.props;
 		this.props.recordTracksEvent( 'calypso_theme_sheet_back_click', { theme_name: themeId } );
+
+		// Use history back when coming from customize your store screen.
+		const urlParams = new URLSearchParams( window.location.search );
+		if ( urlParams.has( 'from', 'customize-store' ) && window.history.length > 1 ) {
+			window.history.back();
+			return;
+		}
+
 		page( localizeThemesPath( backPath, locale, ! isLoggedIn ) );
 	};
 


### PR DESCRIPTION
Partially fixes https://github.com/woocommerce/woocommerce/issues/41230.

## Proposed Changes

* Add a behaviour to the themes detail screen to go back using history when presented with URL parameter `from=customize-store`

## Testing Instructions

1. From your browser, go to https://google.com
2. With an ecommerce or Woo Express site, manually type the URL `http://calypso.localhost:3000/theme/tazza/SITE_URL?from=customize-store` and navigate
3. Click on `Back to themes` button
4. Observe you're redirected back to https://google.com

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
