### PR TITLE
Signup: Add email validation failure tracks event

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -73,11 +73,13 @@ const debug = debugModule( 'calypso:signup-form:form' );
 let usernamesSearched = [];
 let timesUsernameValidationFailed = 0;
 let timesPasswordValidationFailed = 0;
+let timesEmailValidationFailed = 0;
 
 const resetAnalyticsData = () => {
 	usernamesSearched = [];
 	timesUsernameValidationFailed = 0;
 	timesPasswordValidationFailed = 0;
+	timesEmailValidationFailed = 0;
 };
 
 class SignupForm extends Component {
@@ -321,6 +323,14 @@ class SignupForm extends Component {
 
 						timesPasswordValidationFailed++;
 					}
+
+					if ( field === 'email' ) {
+						recordTracksEvent( 'calypso_signup_email_validation_failed', {
+							error: keys( fieldError )[ 0 ],
+						} );
+
+						timesEmailValidationFailed++;
+					}
 				} );
 
 				if ( fields.email ) {
@@ -454,6 +464,7 @@ class SignupForm extends Component {
 				unique_usernames_searched: usernamesSearched.length,
 				times_username_validation_failed: timesUsernameValidationFailed,
 				times_password_validation_failed: timesPasswordValidationFailed,
+				times_email_validation_failed: timesEmailValidationFailed,
 			};
 
 			this.props.submitForm( this.state.form, this.getUserData(), analyticsData, () => {

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -327,6 +327,7 @@ class SignupForm extends Component {
 					if ( field === 'email' ) {
 						recordTracksEvent( 'calypso_signup_email_validation_failed', {
 							error: keys( fieldError )[ 0 ],
+							email: fields.email,
 						} );
 
 						timesEmailValidationFailed++;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/83360

## Proposed Changes

* Add `calypso_signup_email_validation_failed` event to track sign up email failures

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch (or use live link)
* Navigate to `/start/user?flags=-signup/social-first`
* Enter an existing email in the `Email` input field and verify the `calypso_signup_email_validation_failed` event is triggered with the `email` value passed as well (You can use the browser network tab).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?