### PR TITLE
SignUp: ON HOLD Fix back button on login

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -123,14 +123,8 @@ class Login extends Component {
 	};
 
 	componentWillMount() {
-		if ( ! this.props.isRequesting ) {
-			if (
-				! this.props.isMagicLoginEmailRequested &&
-				( isPasswordlessAccount( this.props.accountType ) ||
-					this.props.accountType === 'email_login_not_allowed' )
-			) {
-				this.sendMagicLoginLink();
-			}
+		if ( this.shouldSendMagicLoginLink() ) {
+			this.sendMagicLoginLink();
 		}
 	}
 
@@ -146,10 +140,28 @@ class Login extends Component {
 		const hasNotice = this.props.requestNotice !== prevProps.requestNotice;
 		const isNewPage = this.props.twoFactorAuthType !== prevProps.twoFactorAuthType;
 
+		if ( this.shouldSendMagicLoginLink() ) {
+			this.sendMagicLoginLink();
+		}
+
 		if ( isNewPage || hasNotice ) {
 			window.scrollTo( 0, 0 );
 		}
 	}
+
+	shouldSendMagicLoginLink = () => {
+		if ( ! this.props.isRequesting ) {
+			if (
+				! this.props.isMagicLoginEmailRequested &&
+				( isPasswordlessAccount( this.props.accountType ) ||
+					this.props.accountType === 'email_login_not_allowed' )
+			) {
+				return true;
+			}
+		}
+		return false;
+	};
+
 	sendMagicLoginLink = () => {
 		this.props.sendEmailLogin();
 		this.handleTwoFactorRequested( 'link' );

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -196,7 +196,7 @@ export class LoginForm extends Component {
 		const { hasAccountTypeLoaded, socialAccountIsLinking, userEmail, accountType } = this.props;
 
 		return (
-			userEmail && accountType !== 'passwordless',
+			userEmail && ! accountType,
 			! socialAccountIsLinking &&
 				! hasAccountTypeLoaded &&
 				! ( this.props.isWoo && ! this.props.isPartnerSignup )

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -193,12 +193,13 @@ export class LoginForm extends Component {
 	}
 
 	isUsernameOrEmailView() {
-		const { hasAccountTypeLoaded, socialAccountIsLinking } = this.props;
+		const { hasAccountTypeLoaded, socialAccountIsLinking, userEmail, accountType } = this.props;
 
 		return (
+			userEmail && accountType !== 'passwordless',
 			! socialAccountIsLinking &&
-			! hasAccountTypeLoaded &&
-			! ( this.props.isWoo && ! this.props.isPartnerSignup )
+				! hasAccountTypeLoaded &&
+				! ( this.props.isWoo && ! this.props.isPartnerSignup )
 		);
 	}
 

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -196,7 +196,7 @@ export class LoginForm extends Component {
 		const { hasAccountTypeLoaded, socialAccountIsLinking, userEmail, accountType } = this.props;
 
 		return (
-			userEmail && ! accountType,
+			userEmail && ! accountType !== 'passwordless',
 			! socialAccountIsLinking &&
 				! hasAccountTypeLoaded &&
 				! ( this.props.isWoo && ! this.props.isPartnerSignup )

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -22,6 +22,7 @@ import { login, lostPassword } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/url';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { getAuthAccountType } from 'calypso/state/login/actions';
 import { resetMagicLoginRequestForm } from 'calypso/state/login/magic-login/actions';
 import { isPartnerSignupQuery } from 'calypso/state/login/utils';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
@@ -88,6 +89,8 @@ export class LoginLinks extends Component {
 
 	handleMagicLoginLinkClick = ( event ) => {
 		event.preventDefault();
+
+		this.props.getAuthAccountType( this.props.usernameOrEmail );
 
 		this.props.recordTracksEvent( 'calypso_login_magic_login_request_click', {
 			origin: 'login-links',
@@ -387,5 +390,6 @@ export default connect(
 	{
 		recordTracksEvent,
 		resetMagicLoginRequestForm,
+		getAuthAccountType,
 	}
 )( localize( LoginLinks ) );

--- a/client/state/login/reducer.js
+++ b/client/state/login/reducer.js
@@ -409,7 +409,7 @@ export const authAccountType = ( state = null, action ) => {
 		case LOGIN_AUTH_ACCOUNT_TYPE_REQUEST:
 			return null;
 		case LOGIN_AUTH_ACCOUNT_TYPE_REQUEST_FAILURE:
-			return null;
+			return action.error.code;
 		case LOGIN_AUTH_ACCOUNT_TYPE_REQUEST_SUCCESS: {
 			const {
 				data: { type },
@@ -418,8 +418,8 @@ export const authAccountType = ( state = null, action ) => {
 		}
 		case LOGIN_AUTH_ACCOUNT_TYPE_RESET:
 			return null;
-		case ROUTE_SET:
-			return null;
+		// case ROUTE_SET:
+		// 	return 'null 3 ROUTE_SET';
 	}
 
 	return state;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #53495

## Proposed Changes

When loading the login form, checks if there's email or username filled, if so, load the form with password field visible.
This is helpful in this https://github.com/Automattic/wp-calypso/issues/53495 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull and run this branch or use calypso live link
* Navigate using incognito or logged-out user to /log-in
* Fill your email or username and click in continue
* In the next step, click in "Email a login link"
* Click on “enter a password instead”
* You should see the login for with the password field enabled.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?