### PR TITLE
state(invites): refactor away from `lodash`

### DIFF
--- a/client/state/invites/actions.js
+++ b/client/state/invites/actions.js
@@ -1,6 +1,5 @@
 import config from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
-import { get, truncate } from 'lodash';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getLocaleSlug } from 'calypso/lib/i18n-utils';
 import wpcom from 'calypso/lib/wp';
@@ -101,10 +100,11 @@ export function deleteInvite( siteId, inviteId ) {
 const deleteInvitesFailureNotice = ( siteId, inviteIds ) => ( dispatch, getState ) => {
 	for ( const inviteId of inviteIds ) {
 		const invite = getInviteForSite( getState(), siteId, inviteId );
+		const invitee = invite.user.email || invite.user.login;
 		dispatch(
 			errorNotice(
 				translate( 'An error occurred while deleting the invite for %s.', {
-					args: truncate( invite.user.email || invite.user.login, { length: 20 } ),
+					args: invitee.length > 20 ? invitee.slice( 0, 20 ) + '…' : invitee,
 				} )
 			)
 		);
@@ -187,8 +187,8 @@ export function createAccount( userData, invite ) {
 		result
 			.then( () => {
 				recordTracksEvent( 'calypso_invite_account_created', {
-					is_p2_site: get( invite, 'site.is_wpforteams_site', false ),
-					inviter_blog_id: get( invite, 'site.ID', false ),
+					is_p2_site: invite?.site?.is_wpforteams_site ?? false,
+					inviter_blog_id: invite?.site?.ID ?? false,
 				} );
 			} )
 			.catch( ( error ) => {

--- a/client/state/invites/actions.js
+++ b/client/state/invites/actions.js
@@ -100,7 +100,7 @@ export function deleteInvite( siteId, inviteId ) {
 const deleteInvitesFailureNotice = ( siteId, inviteIds ) => ( dispatch, getState ) => {
 	for ( const inviteId of inviteIds ) {
 		const invite = getInviteForSite( getState(), siteId, inviteId );
-		const invitee = invite.user.email || invite.user.login;
+		const invitee = ( invite.user.email || invite.user.login ) ?? '';
 		dispatch(
 			errorNotice(
 				translate( 'An error occurred while deleting the invite for %s.', {
@@ -187,8 +187,8 @@ export function createAccount( userData, invite ) {
 		result
 			.then( () => {
 				recordTracksEvent( 'calypso_invite_account_created', {
-					is_p2_site: invite?.site?.is_wpforteams_site ?? false,
-					inviter_blog_id: invite?.site?.ID ?? false,
+					is_p2_site: invite.site?.is_wpforteams_site ?? false,
+					inviter_blog_id: invite.site?.ID ?? false,
 				} );
 			} )
 			.catch( ( error ) => {

--- a/client/state/invites/actions.js
+++ b/client/state/invites/actions.js
@@ -103,9 +103,11 @@ const deleteInvitesFailureNotice = ( siteId, inviteIds ) => ( dispatch, getState
 		const invitee = ( invite.user.email || invite.user.login ) ?? '';
 		dispatch(
 			errorNotice(
-				translate( 'An error occurred while deleting the invite for %s.', {
-					args: invitee.length > 20 ? invitee.slice( 0, 20 ) + '…' : invitee,
-				} )
+				invitee.length > 20
+					? translate( 'An error occurred while deleting the invite for %s….', {
+							args: invitee.slice( 0, 20 ),
+					  } )
+					: translate( 'An error occurred while deleting the invite for %s.', { args: invitee } )
 			)
 		);
 	}

--- a/client/state/invites/reducer.js
+++ b/client/state/invites/reducer.js
@@ -58,13 +58,13 @@ export const items = withSchemaValidation( inviteItemsSchema, ( state = {}, acti
 			const siteInvites = { pending: [], accepted: [] };
 			action.invites.forEach( ( invite ) => {
 				// Not renaming `avatar_URL` because it is used as-is by <Gravatar>
-				const { login, email, name, avatar_URL } = invite.user;
+				const { login, email, name, avatar_URL } = invite.user ?? {};
 				const user = { login, email, name, avatar_URL };
 				const {
 					name: invitedByName,
 					login: invitedByLogin,
 					avatar_URL: invitedByAvatar_URL,
-				} = invite.invited_by;
+				} = invite.invited_by ?? {};
 				const invitedBy = {
 					name: invitedByName,
 					login: invitedByLogin,
@@ -148,8 +148,8 @@ export const links = withSchemaValidation( inviteLinksSchema, ( state = {}, acti
  * @returns {Array}                  Updated array of invite objects.
  */
 function deleteInvites( siteInvites, invitesToDelete ) {
-	if ( ! Array.isArray( siteInvites ) || ! Array.isArray( invitesToDelete ) ) {
-		return siteInvites ?? [];
+	if ( ! Array.isArray( invitesToDelete ) ) {
+		return siteInvites;
 	}
 	return siteInvites.filter( ( siteInvite ) => ! invitesToDelete.includes( siteInvite.key ) );
 }

--- a/client/state/invites/reducer.js
+++ b/client/state/invites/reducer.js
@@ -1,5 +1,4 @@
 import { withStorageKey } from '@automattic/state-utils';
-import { includes, pick } from 'lodash';
 import moment from 'moment';
 import {
 	INVITES_DELETE_REQUEST,
@@ -59,8 +58,19 @@ export const items = withSchemaValidation( inviteItemsSchema, ( state = {}, acti
 			const siteInvites = { pending: [], accepted: [] };
 			action.invites.forEach( ( invite ) => {
 				// Not renaming `avatar_URL` because it is used as-is by <Gravatar>
-				const user = pick( invite.user, 'login', 'email', 'name', 'avatar_URL' );
-				const invitedBy = pick( invite.invited_by, 'name', 'login', 'avatar_URL' );
+				const { login, email, name, avatar_URL } = invite.user;
+				const user = { login, email, name, avatar_URL };
+				const {
+					name: invitedByName,
+					login: invitedByLogin,
+					avatar_URL: invitedByAvatar_URL,
+				} = invite.invited_by;
+				const invitedBy = {
+					name: invitedByName,
+					login: invitedByLogin,
+					avatar_URL: invitedByAvatar_URL,
+				};
+
 				const inviteForState = {
 					key: invite.invite_key,
 					role: invite.role,
@@ -138,7 +148,10 @@ export const links = withSchemaValidation( inviteLinksSchema, ( state = {}, acti
  * @returns {Array}                  Updated array of invite objects.
  */
 function deleteInvites( siteInvites, invitesToDelete ) {
-	return siteInvites.filter( ( siteInvite ) => ! includes( invitesToDelete, siteInvite.key ) );
+	if ( ! Array.isArray( siteInvites ) || ! Array.isArray( invitesToDelete ) ) {
+		return siteInvites ?? [];
+	}
+	return siteInvites.filter( ( siteInvite ) => ! invitesToDelete.includes( siteInvite.key ) );
 }
 
 /**

--- a/client/state/invites/selectors.js
+++ b/client/state/invites/selectors.js
@@ -1,5 +1,4 @@
 import treeSelect from '@automattic/tree-select';
-import { get, find } from 'lodash';
 
 import 'calypso/state/invites/init';
 
@@ -69,6 +68,8 @@ export function getNumberOfInvitesFoundForSite( state, siteId ) {
 	return state.invites.counts[ siteId ] || null;
 }
 
+const findInvite = ( invites, inviteId ) =>
+	Array.isArray( invites ) ? invites.find( ( invite ) => invite.key === inviteId ) : undefined;
 /**
  * Returns an invite object for the given site and invite ID, or `null` if no
  * invite with the given ID exists for the site.
@@ -84,8 +85,8 @@ export const getInviteForSite = treeSelect(
 			return null;
 		}
 		return (
-			find( siteInvites.pending, { key: inviteId } ) ||
-			find( siteInvites.accepted, { key: inviteId } ) ||
+			findInvite( siteInvites.pending, inviteId ) ||
+			findInvite( siteInvites.accepted, inviteId ) ||
 			null
 		);
 	}
@@ -100,7 +101,7 @@ export const getInviteForSite = treeSelect(
  * @returns {boolean}          Whether invites resend is being requested
  */
 export function isRequestingInviteResend( state, siteId, inviteId ) {
-	return 'requesting' === get( state, [ 'invites', 'requestingResend', siteId, inviteId ], false );
+	return 'requesting' === state.invites.requestingResend[ siteId ]?.[ inviteId ];
 }
 
 /**
@@ -112,7 +113,7 @@ export function isRequestingInviteResend( state, siteId, inviteId ) {
  * @returns {boolean}          Whether invite resend was a success
  */
 export function didInviteResendSucceed( state, siteId, inviteId ) {
-	return 'success' === get( state, [ 'invites', 'requestingResend', siteId, inviteId ], false );
+	return 'success' === state.invites.requestingResend[ siteId ]?.[ inviteId ];
 }
 
 /**
@@ -124,7 +125,7 @@ export function didInviteResendSucceed( state, siteId, inviteId ) {
  * @returns {boolean}          Whether invites resend is being requested
  */
 export function isDeletingInvite( state, siteId, inviteId ) {
-	return 'requesting' === get( state, [ 'invites', 'deleting', siteId, inviteId ], false );
+	return 'requesting' === state.invites.deleting[ siteId ]?.[ inviteId ];
 }
 
 /**
@@ -136,7 +137,7 @@ export function isDeletingInvite( state, siteId, inviteId ) {
  * @returns {boolean}          Whether invites resend is being requested
  */
 export function didInviteDeletionSucceed( state, siteId, inviteId ) {
-	return 'success' === get( state, [ 'invites', 'deleting', siteId, inviteId ], false );
+	return 'success' === state.invites.deleting[ siteId ]?.[ inviteId ];
 }
 
 /**
@@ -147,10 +148,11 @@ export function didInviteDeletionSucceed( state, siteId, inviteId ) {
  * @returns {boolean}          Whether an invite is being deleted
  */
 export function isDeletingAnyInvite( state, siteId ) {
-	return (
-		-1 !==
-		Object.values( get( state, [ 'invites', 'deleting', siteId ], {} ) ).indexOf( 'requesting' )
-	);
+	const invites = state.invites.deleting[ siteId ];
+	if ( ! invites ) {
+		return false;
+	}
+	return -1 !== Object.values( invites ).indexOf( 'requesting' );
 }
 
 /**

--- a/client/state/invites/selectors.js
+++ b/client/state/invites/selectors.js
@@ -68,8 +68,7 @@ export function getNumberOfInvitesFoundForSite( state, siteId ) {
 	return state.invites.counts[ siteId ] || null;
 }
 
-const findInvite = ( invites, inviteId ) =>
-	Array.isArray( invites ) ? invites.find( ( invite ) => invite.key === inviteId ) : undefined;
+const findInvite = ( invites, inviteId ) => invites.find( ( { key } ) => key === inviteId );
 /**
  * Returns an invite object for the given site and invite ID, or `null` if no
  * invite with the given ID exists for the site.
@@ -148,11 +147,11 @@ export function didInviteDeletionSucceed( state, siteId, inviteId ) {
  * @returns {boolean}          Whether an invite is being deleted
  */
 export function isDeletingAnyInvite( state, siteId ) {
-	const invites = state.invites.deleting[ siteId ];
-	if ( ! invites ) {
+	const siteInvites = state.invites.deleting[ siteId ];
+	if ( ! siteInvites ) {
 		return false;
 	}
-	return -1 !== Object.values( invites ).indexOf( 'requesting' );
+	return Object.values( siteInvites ).includes( 'requesting' );
 }
 
 /**

--- a/client/state/invites/test/selectors.js
+++ b/client/state/invites/test/selectors.js
@@ -1,4 +1,3 @@
-import { cloneDeep } from 'lodash';
 import {
 	isRequestingInvitesForSite,
 	getPendingInvitesForSite,
@@ -267,7 +266,7 @@ describe( 'selectors', () => {
 			const call2 = getInviteForSite( state, 12345, '123456asdf789' );
 			expect( call1 ).toBe( call2 );
 
-			const newState = cloneDeep( state );
+			const newState = structuredClone( state );
 			const call3 = getInviteForSite( newState, 12345, '123456asdf789' );
 			expect( call3 ).toEqual( newState.invites.items[ 12345 ].accepted[ 0 ] );
 			expect( call3 ).not.toBe( call2 );


### PR DESCRIPTION
## Proposed Changes

This PR refactors away from using lodash methods in `client/state/invites`

## Testing Instructions

* Smoke test invites:
  * Go to `/people/team/:siteSlug` and try adding new team members and deleting existing invites
  * Also try accepting an invite with an email address that's not associated with a WP.com account
* Changes are partly covered by unit tests, verify they still pass
* As with a lot of lodash methods it's good practice to ensure we don't accidentally miss guards for whether we operate on the expected data structure.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
