### PR TITLE
Fixed typo in magic link message

### DIFF
--- a/client/login/magic-login/resend-email.jsx
+++ b/client/login/magic-login/resend-email.jsx
@@ -33,7 +33,7 @@ export const getResendEmailErrorMessages = ( translate ) => {
 		subscription_not_found: translate( 'There is no subscription with this email address.' ),
 		invalid_token: translate( 'The token is not valid for the provided email address.' ),
 		rest_invalid_param: translate(
-			'One of the parameters is not valid. Please checkc your inbox for a more recent email.'
+			'One of the parameters is not valid. Please check your inbox for a more recent email.'
 		),
 		rest_missing_callback_param: translate(
 			'One of the parameters is missing. Please check your inbox for a more recent email.'


### PR DESCRIPTION
## Proposed Changes

This PR fixes a type in one of the magic links messages.

From:

`One of the parameters is not valid. Please checkc your inbox for a more recent email.`

to this:

`One of the parameters is not valid. Please check your inbox for a more recent email.`


## Testing Instructions

Not necessary.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?