### PR TITLE
Newsletter: require the site slug before redirect

### DIFF
--- a/client/landing/stepper/declarative-flow/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/newsletter.ts
@@ -164,14 +164,14 @@ const newsletter: Flow = {
 						);
 					}
 
-					if ( providedDependencies?.goToCheckout ) {
+					if ( providedDependencies?.goToCheckout && providedDependencies?.siteSlug ) {
 						persistSignupDestination( launchpadUrl );
 						setSignupCompleteSlug( providedDependencies?.siteSlug );
 						setSignupCompleteFlowName( flowName );
 
 						return window.location.assign(
 							`/checkout/${ encodeURIComponent(
-								( providedDependencies?.siteSlug as string ) ?? ''
+								providedDependencies?.siteSlug as string
 							) }?redirect_to=${ launchpadUrl }&signup=1`
 						);
 					}


### PR DESCRIPTION
This requires the value as recommended here: p7H4VZ-4vn-p2


## Proposed Changes

* Make sure to never redirect when the site slug is missing. This will fix at least part of https://github.com/Automattic/wp-calypso/issues/83868.

## Testing Instructions
1. Go to throw the newsletter flow and make sure to buy a paid plan.
2. You should land in checkout and should work well. 