### PR TITLE
Stats: Add "I don't solicit donations or sponsorships" to site identification conditions

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -51,6 +51,7 @@ const PersonalPurchase = ( {
 	const [ isAdsChecked, setAdsChecked ] = useState( false );
 	const [ isSellingChecked, setSellingChecked ] = useState( false );
 	const [ isBusinessChecked, setBusinessChecked ] = useState( false );
+	const [ isDonationChecked, setDonationChecked ] = useState( false );
 	const {
 		sliderStepPrice,
 		minSliderPrice,
@@ -184,6 +185,16 @@ const PersonalPurchase = ( {
 								} }
 							/>
 						</li>
+						<li>
+							<CheckboxControl
+								className={ `${ COMPONENT_CLASS_NAME }__control--checkbox` }
+								checked={ isDonationChecked }
+								label={ translate( `I don't solicite donations or sponsorships` ) }
+								onChange={ ( value ) => {
+									setDonationChecked( value );
+								} }
+							/>
+						</li>
 					</ul>
 				</div>
 			) }
@@ -192,7 +203,9 @@ const PersonalPurchase = ( {
 				<ButtonComponent
 					variant="primary"
 					primary={ isWPCOMSite ? true : undefined }
-					disabled={ ! isAdsChecked || ! isSellingChecked || ! isBusinessChecked }
+					disabled={
+						! isAdsChecked || ! isSellingChecked || ! isBusinessChecked || ! isDonationChecked
+					}
 					onClick={ () =>
 						gotoCheckoutPage( { from, type: 'free', siteSlug, adminUrl, redirectUri } )
 					}

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -189,7 +189,7 @@ const PersonalPurchase = ( {
 							<CheckboxControl
 								className={ `${ COMPONENT_CLASS_NAME }__control--checkbox` }
 								checked={ isDonationChecked }
-								label={ translate( `I don't solicite donations or sponsorships on my site` ) }
+								label={ translate( `I don't solicit donations or sponsorships on my site` ) }
 								onChange={ ( value ) => {
 									setDonationChecked( value );
 								} }

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -189,7 +189,7 @@ const PersonalPurchase = ( {
 							<CheckboxControl
 								className={ `${ COMPONENT_CLASS_NAME }__control--checkbox` }
 								checked={ isDonationChecked }
-								label={ translate( `I don't solicite donations or sponsorships` ) }
+								label={ translate( `I don't solicite donations or sponsorships on my site` ) }
 								onChange={ ( value ) => {
 									setDonationChecked( value );
 								} }

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -83,7 +83,6 @@ const StatsCommercialPurchase = ( {
 	redirectUri,
 	showClassificationDispute = true,
 }: StatsCommercialPurchaseProps ) => {
-	showClassificationDispute = true;
 	const translate = useTranslate();
 	const isWPCOMSite = useSelector( ( state ) => siteId && getIsSiteWPCOM( state, siteId ) );
 

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -83,6 +83,7 @@ const StatsCommercialPurchase = ( {
 	redirectUri,
 	showClassificationDispute = true,
 }: StatsCommercialPurchaseProps ) => {
+	showClassificationDispute = true;
 	const translate = useTranslate();
 	const isWPCOMSite = useSelector( ( state ) => siteId && getIsSiteWPCOM( state, siteId ) );
 
@@ -91,6 +92,7 @@ const StatsCommercialPurchase = ( {
 	const [ isAdsChecked, setAdsChecked ] = useState( false );
 	const [ isSellingChecked, setSellingChecked ] = useState( false );
 	const [ isBusinessChecked, setBusinessChecked ] = useState( false );
+	const [ isDonationChecked, setDonationChecked ] = useState( false );
 
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 
@@ -107,7 +109,8 @@ I'm writing to dispute the classification of my site '${ siteSlug }' as commerci
 I can confirm that,
 - I don't have ads on my site.
 - I don't sell products/services on my site.
-- I don't promote a business on my site.\n
+- I don't promote a business on my site.
+- I don't solicite donations or sponsorships.\n
 Could you please take a look at my site and update the classification if necessary?\n
 Thanks\n\n`;
 		const emailHref = `mailto:${ mailTo }?subject=${ encodeURIComponent(
@@ -174,11 +177,26 @@ Thanks\n\n`;
 											} }
 										/>
 									</li>
+									<li>
+										<CheckboxControl
+											className={ `${ COMPONENT_CLASS_NAME }__control--checkbox` }
+											checked={ isDonationChecked }
+											label={ translate( `I don't solicite donations or sponsorships` ) }
+											onChange={ ( value ) => {
+												setDonationChecked( value );
+											} }
+										/>
+									</li>
 								</ul>
-								{ isAdsChecked && isSellingChecked && isBusinessChecked && (
+								{ isAdsChecked && isSellingChecked && isBusinessChecked && isDonationChecked && (
 									<Button
 										variant="secondary"
-										disabled={ ! isAdsChecked || ! isSellingChecked || ! isBusinessChecked }
+										disabled={
+											! isAdsChecked ||
+											! isSellingChecked ||
+											! isBusinessChecked ||
+											! isDonationChecked
+										}
 										onClick={ ( e: React.MouseEvent ) => handleClick( e, isOdysseyStats ) }
 									>
 										{ translate( 'Request update' ) }

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -110,7 +110,7 @@ I can confirm that,
 - I don't have ads on my site.
 - I don't sell products/services on my site.
 - I don't promote a business on my site.
-- I don't solicite donations or sponsorships.\n
+- I don't solicite donations or sponsorships on my site.\n
 Could you please take a look at my site and update the classification if necessary?\n
 Thanks\n\n`;
 		const emailHref = `mailto:${ mailTo }?subject=${ encodeURIComponent(
@@ -181,7 +181,7 @@ Thanks\n\n`;
 										<CheckboxControl
 											className={ `${ COMPONENT_CLASS_NAME }__control--checkbox` }
 											checked={ isDonationChecked }
-											label={ translate( `I don't solicite donations or sponsorships` ) }
+											label={ translate( `I don't solicite donations or sponsorships on my site` ) }
 											onChange={ ( value ) => {
 												setDonationChecked( value );
 											} }

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -109,7 +109,7 @@ I can confirm that,
 - I don't have ads on my site.
 - I don't sell products/services on my site.
 - I don't promote a business on my site.
-- I don't solicite donations or sponsorships on my site.\n
+- I don't solicit donations or sponsorships on my site.\n
 Could you please take a look at my site and update the classification if necessary?\n
 Thanks\n\n`;
 		const emailHref = `mailto:${ mailTo }?subject=${ encodeURIComponent(
@@ -180,7 +180,7 @@ Thanks\n\n`;
 										<CheckboxControl
 											className={ `${ COMPONENT_CLASS_NAME }__control--checkbox` }
 											checked={ isDonationChecked }
-											label={ translate( `I don't solicite donations or sponsorships on my site` ) }
+											label={ translate( `I don't solicit donations or sponsorships on my site` ) }
 											onChange={ ( value ) => {
 												setDonationChecked( value );
 											} }


### PR DESCRIPTION
Discussion: p7pQDF-8Yq-p2#comment-24253

## Proposed Changes

The PR proposes to add 'I don't solicit donations or sponsorships on my site' to the checklist for both Free plan selection and Commercial site disputation process, as the the condition is clearly stated in https://jetpack.com/support/jetpack-stats/free-or-paid/#how-is-a-commercial-site-defined .

## Testing Instructions

* Open a Calypso Live for a personal site `/stats/purchase/:siteSlug`
* Choose $0 a month
* Ensure the checklist is shown
* Check the checkboxes
* Ensure only when all checkboxes are checked, the purchase button becomes available

<img width="675" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/ff13a646-3866-4672-be32-0a2717eefb29">

* Open a Calypso Live for a commercial site `/stats/purchase/:siteSlug`
* Click 'This is not a commercial site'
* Check the checkboxes
* Ensure only when all checkboxes are checked, the 'Request update' button becomes available

<img width="657" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/9d8e0a14-e015-4b8f-ac1d-435a3c6fa63e">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?