### PR TITLE
Login: Add site icon to magic login

### DIFF
--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -392,6 +392,7 @@ class MagicLogin extends Component {
 						tosComponent={ this.renderGravPoweredMagicLoginTos() }
 						onSendEmailLogin={ ( usernameOrEmail ) => this.setState( { usernameOrEmail } ) }
 						createAccountForNewUser
+						blogId={ query?.blog_id }
 					/>
 					<hr className="grav-powered-magic-login__divider grav-powered-magic-login__divider--email-form" />
 					<div className="grav-powered-magic-login__login-page-link">

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -392,7 +392,6 @@ class MagicLogin extends Component {
 						tosComponent={ this.renderGravPoweredMagicLoginTos() }
 						onSendEmailLogin={ ( usernameOrEmail ) => this.setState( { usernameOrEmail } ) }
 						createAccountForNewUser
-						blogId={ query?.blog_id }
 					/>
 					<hr className="grav-powered-magic-login__divider grav-powered-magic-login__divider--email-form" />
 					<div className="grav-powered-magic-login__login-page-link">

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -117,6 +117,44 @@ class RequestLoginEmailForm extends Component {
 		return this.state.usernameOrEmail;
 	}
 
+	getSubHeaderText() {
+		const { translate, locale } = this.props;
+		const siteName = this.state.site?.name;
+
+		// If we have a siteName and new translation is available
+		if (
+			siteName &&
+			( englishLocales.includes( locale ) ||
+				hasTranslation(
+					'We’ll send you an email with a login link that will log you in right away to {site name}.'
+				) )
+		) {
+			return translate(
+				'We’ll send you an email with a login link that will log you in right away to %(siteName)s.',
+				{
+					args: {
+						siteName,
+					},
+				}
+			);
+		}
+
+		// If no siteName but new translation is available
+		if (
+			englishLocales.includes( locale ) ||
+			hasTranslation( 'We’ll send you an email with a login link that will log you in right away.' )
+		) {
+			return translate(
+				'We’ll send you an email with a login link that will log you in right away.'
+			);
+		}
+
+		// Fallback is old text
+		return translate(
+			'Get a link sent to the email address associated with your account to log in instantly without your password.'
+		);
+	}
+
 	render() {
 		const {
 			currentUser,
@@ -159,14 +197,6 @@ class RequestLoginEmailForm extends Component {
 			typeof requestError === 'string' && requestError.length
 				? requestError
 				: translate( 'Unable to complete request' );
-
-		const subHeaderText =
-			englishLocales.includes( locale ) ||
-			hasTranslation( 'We’ll send you an email with a login link that will log you in right away.' )
-				? translate( 'We’ll send you an email with a login link that will log you in right away.' )
-				: translate(
-						'Get a link sent to the email address associated with your account to log in instantly without your password.'
-				  );
 
 		const buttonLabel =
 			englishLocales.includes( locale ) || hasTranslation( 'Send Link' )
@@ -212,7 +242,9 @@ class RequestLoginEmailForm extends Component {
 					</p>
 				) }
 				<LoggedOutForm onSubmit={ this.onSubmit }>
-					<p className="magic-login__form-sub-header">{ ! hideSubHeaderText && subHeaderText }</p>
+					<p className="magic-login__form-sub-header">
+						{ ! hideSubHeaderText && this.getSubHeaderText() }
+					</p>
 					<FormLabel htmlFor="usernameOrEmail">{ formLabel }</FormLabel>
 					<FormFieldset className="magic-login__email-fields">
 						<FormTextInput

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -183,8 +183,8 @@ class RequestLoginEmailForm extends Component {
 					<div className="magic-login__form-header-icon">
 						<img
 							src={ siteIcon }
-							width={ 60 }
-							height={ 60 }
+							width={ 64 }
+							height={ 64 }
 							alt={ `${ this.state.site?.name } icon` }
 						/>
 					</div>

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -173,12 +173,7 @@ class RequestLoginEmailForm extends Component {
 		} = this.props;
 
 		const usernameOrEmail = this.getUsernameOrEmailFromState();
-
-		const siteIcon =
-			this.state.site?.icon?.ico ??
-			this.state.site?.icon?.img ??
-			this.state.site?.logo?.url ??
-			null;
+		const siteIcon = this.state.site?.icon?.ico ?? this.state.site?.icon?.img ?? null;
 
 		if ( showCheckYourEmail ) {
 			const emailAddress = usernameOrEmail.indexOf( '@' ) > 0 ? usernameOrEmail : null;

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -44,7 +44,6 @@
 	}
 
 	.logged-out-form {
-		max-width: 340px;
 		padding-top: 0;
 		.magic-login__form-sub-header {
 			text-align: center;

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -32,7 +32,7 @@
 	.magic-login__form-header-icon {
 		text-align: center;
 		img {
-			border-radius: 50%;
+			border-radius: 4px;
 		}
 	}
 	.magic-login .magic-login__form-header {

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -29,6 +29,12 @@
 	align-items: center;
 	justify-content: center;
 
+	.magic-login__form-header-icon {
+		text-align: center;
+		img {
+			border-radius: 50%;
+		}
+	}
 	.magic-login .magic-login__form-header {
 		margin-bottom: 0;
 


### PR DESCRIPTION
## Proposed Changes

* Personalizes the magic login screen by showing a site logo above the form. Only applies when a reader arrives at this screen by clicking the 'already subscribed' / login link in the subscribe block on as post where access is limited to a subscribers. See Figma here: 5p3iZ99zPYfl6ronoTYEXO-fi-4_1291
* Adding a site icon depends whether the blog_id exists as a query parameter. We added the ability to include that query param in a an earlier phab dif (rWPGITdc2373c9eff6-code) and are setting the blog from the subscribe code in Jetpack (rWPGITdc2373c9eff6-code). As of now, that spot in Jetpack is the only place where a blog_id will be set. When the blog_id is not set, the magic logic screen should load just as before. 

**Before**
<img width="1501" alt="magic-login-before2" src="https://github.com/Automattic/wp-calypso/assets/21228350/08ac8fe8-87ac-41e3-a27c-9a290ad266e0">

**After**

## Testing Instructions

1) You'll need a WordPress simple test site that has a site logo or icon set and a blog post with paywall block for subscribers only. 
2) In a logged out or incognito browser, visit that post and click the 'I am already a subscriber link'.
3) When you arrive on the magic login screen, confirm the icon from your test site shows above the form and looks like the screenshot above. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?