### PR TITLE
Make font size consistent for inline comments (on p2s)

### DIFF
--- a/client/blocks/comments/post-comment-list.scss
+++ b/client/blocks/comments/post-comment-list.scss
@@ -66,6 +66,10 @@
 			}
 		}
 	}
+
+	&.is-inline * {
+		font-size: 1rem;
+	}
 }
 
 .comments__info-bar {

--- a/client/blocks/comments/post-comment-list.scss
+++ b/client/blocks/comments/post-comment-list.scss
@@ -68,7 +68,7 @@
 	}
 
 	&.is-inline * {
-		font-size: 1rem;
+		font-size: $font-body;
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/82087

Comments on p2s support headings, but when the headings are shown inline, it currently looks a bit strange because they appear oversized.

This fix, simply makes the size of all text on inline comments consistent.
*before*
<img width="621" alt="Screen Shot 2023-11-07 at 1 03 01 pm" src="https://github.com/Automattic/wp-calypso/assets/22446385/33946933-a873-42d7-89e9-e2ca3a6f2d28">

*After*
<img width="609" alt="Screen Shot 2023-11-07 at 1 02 36 pm" src="https://github.com/Automattic/wp-calypso/assets/22446385/5a8f3a18-9461-4c82-aea5-3b479df7805d">

### Test instructions
Observe this feed, or create your own p2 and add a comment with headings in it.
https://wordpress.com/read/feeds/123633328