### PR TITLE
2023 Plans Grid: Hide labels if plans is not purchaseable

### DIFF
--- a/client/my-sites/plans-features-main/hooks/test/use-plan-upgradeability-check.ts
+++ b/client/my-sites/plans-features-main/hooks/test/use-plan-upgradeability-check.ts
@@ -1,0 +1,132 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react';
+import { useSelector } from 'react-redux';
+import usePlanUpgradeabilityCheck from '../use-plan-upgradeability-check';
+
+jest.mock( 'react-redux', () => ( {
+	useSelector: jest.fn(),
+} ) );
+
+describe( 'usePlanUpgradeabilityCheck', () => {
+	const businessPlanSlug = 'business-bundle';
+
+	describe( 'when a site is selected', () => {
+		const selectedSiteId = 123123;
+
+		describe( 'and the selected site is on a lower tier plan', () => {
+			const freePlan = {
+				expired: false,
+				is_free: true,
+				product_id: 1,
+				product_name_short: 'Free',
+				product_slug: 'free_plan',
+				user_is_owner: false,
+			};
+
+			describe( 'and the plan being evaluated is a higher tier plan', () => {
+				it( 'marks the plan as upgradeable', () => {
+					useSelector.mockImplementation( ( selector ) =>
+						selector( {
+							ui: { selectedSiteId },
+							sites: {
+								items: {
+									123123: { plan: freePlan },
+								},
+								plans: {
+									[ selectedSiteId ]: {
+										data: [
+											{
+												productName: 'WordPress.com Free',
+												productSlug: 'free_plan',
+												currentPlan: true,
+												userIsOwner: true,
+											},
+											{
+												productName: 'WordPress.com Business',
+												productSlug: 'business-bundle',
+												currentPlan: false,
+												userIsOwner: false,
+											},
+										],
+									},
+								},
+							},
+						} )
+					);
+					const { result } = renderHook( () =>
+						usePlanUpgradeabilityCheck( { planSlugs: [ businessPlanSlug ] } )
+					);
+
+					expect( result.current ).toEqual( { [ businessPlanSlug ]: true } );
+				} );
+			} );
+		} );
+
+		describe( 'and the selected site is on a higher tier plan', () => {
+			const businessPlan = {
+				product_id: 1008,
+				product_slug: 'business-bundle',
+				product_name_short: 'Business',
+				expired: false,
+				user_is_owner: true,
+				is_free: false,
+			};
+
+			describe( 'and the plan being evaluated is a lower tier plan', () => {
+				it( 'marks the plan as not upgradeable', () => {
+					useSelector.mockImplementation( ( selector ) =>
+						selector( {
+							ui: { selectedSiteId },
+							sites: {
+								items: {
+									123123: { plan: businessPlan },
+								},
+								plans: {
+									[ selectedSiteId ]: {
+										data: [
+											{
+												productName: 'WordPress.com Free',
+												productSlug: 'free_plan',
+												currentPlan: false,
+												userIsOwner: false,
+											},
+											{
+												productName: 'WordPress.com Business',
+												productSlug: 'business-bundle',
+												currentPlan: true,
+												useIsOwner: true,
+											},
+										],
+									},
+								},
+							},
+						} )
+					);
+					const { result } = renderHook( () =>
+						usePlanUpgradeabilityCheck( { planSlugs: [ businessPlanSlug ] } )
+					);
+
+					expect( result.current ).toEqual( { [ businessPlanSlug ]: false } );
+				} );
+			} );
+		} );
+	} );
+
+	describe( 'when a site is not selected', () => {
+		it( 'assumes that the hook is being called from onboarding or signup and marks the plan as upgradeable', () => {
+			useSelector.mockImplementation( ( selector ) =>
+				selector( {
+					ui: { selectedSiteId: undefined },
+					sites: { items: [], plans: {} },
+				} )
+			);
+			const { result } = renderHook( () =>
+				usePlanUpgradeabilityCheck( { planSlugs: [ businessPlanSlug ] } )
+			);
+
+			expect( result.current ).toEqual( { [ businessPlanSlug ]: true } );
+		} );
+	} );
+} );

--- a/client/my-sites/plans-features-main/hooks/use-plan-upgradeability-check.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plan-upgradeability-check.ts
@@ -11,6 +11,11 @@ type PlanUpgradeability = {
 	[ planSlug in PlanSlug ]: boolean;
 };
 
+/**
+ * Returns a dictionary of plan slugs and whether or not they are available for purchase.
+ * Note that if there is no selectedSiteId, then we assume that we are in onboarding or
+ * signup, which will, by default, make the plan purchaseable.
+ */
 const usePlanUpgradeabilityCheck = ( { planSlugs }: Props ): PlanUpgradeability => {
 	const selectedSiteId = useSelector( getSelectedSiteId );
 	const planUpgradeability = useSelector( ( state ) => {

--- a/client/my-sites/plans-features-main/hooks/use-plan-upgradeability-check.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plan-upgradeability-check.ts
@@ -5,22 +5,20 @@ import type { PlanSlug } from '@automattic/calypso-products';
 
 interface Props {
 	planSlugs: PlanSlug[];
-	sitePlanSlug: PlanSlug | null;
 }
 
 type PlanUpgradeability = {
 	[ planSlug in PlanSlug ]: boolean;
 };
 
-const usePlanUpgradeabilityCheck = ( { planSlugs, sitePlanSlug }: Props ): PlanUpgradeability => {
+const usePlanUpgradeabilityCheck = ( { planSlugs }: Props ): PlanUpgradeability => {
 	const selectedSiteId = useSelector( getSelectedSiteId );
 	const planUpgradeability = useSelector( ( state ) => {
 		return planSlugs.reduce( ( acc, planSlug ) => {
 			return {
 				...acc,
 				[ planSlug ]:
-					! sitePlanSlug ||
-					( !! selectedSiteId && isPlanAvailableForPurchase( state, selectedSiteId, planSlug ) ),
+					! selectedSiteId || isPlanAvailableForPurchase( state, selectedSiteId, planSlug ),
 			};
 		}, {} as PlanUpgradeability );
 	} );

--- a/client/my-sites/plans-features-main/hooks/use-plan-upgradeability-check.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plan-upgradeability-check.ts
@@ -5,20 +5,22 @@ import type { PlanSlug } from '@automattic/calypso-products';
 
 interface Props {
 	planSlugs: PlanSlug[];
+	sitePlanSlug: PlanSlug | null;
 }
 
 type PlanUpgradeability = {
 	[ planSlug in PlanSlug ]: boolean;
 };
 
-const usePlanUpgradeabilityCheck = ( { planSlugs }: Props ): PlanUpgradeability => {
+const usePlanUpgradeabilityCheck = ( { planSlugs, sitePlanSlug }: Props ): PlanUpgradeability => {
 	const selectedSiteId = useSelector( getSelectedSiteId );
 	const planUpgradeability = useSelector( ( state ) => {
 		return planSlugs.reduce( ( acc, planSlug ) => {
 			return {
 				...acc,
 				[ planSlug ]:
-					!! selectedSiteId && isPlanAvailableForPurchase( state, selectedSiteId, planSlug ),
+					! sitePlanSlug ||
+					( !! selectedSiteId && isPlanAvailableForPurchase( state, selectedSiteId, planSlug ) ),
 			};
 		}, {} as PlanUpgradeability );
 	} );

--- a/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
+++ b/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
@@ -149,7 +149,6 @@ interface Props {
 	selectedPlan?: PlanSlug;
 	sitePlanSlug?: PlanSlug | null;
 	hideEnterprisePlan?: boolean;
-	isInSignup?: boolean;
 	// whether plan is upgradable from current plan (used in logged-in state)
 	usePlanUpgradeabilityCheck?: ( {
 		planSlugs,
@@ -282,7 +281,6 @@ const useGridPlans = ( {
 	selectedPlan,
 	sitePlanSlug,
 	hideEnterprisePlan,
-	isInSignup,
 	usePlanUpgradeabilityCheck,
 	eligibleForFreeHostingTrial,
 	isSubdomainNotGenerated,
@@ -344,7 +342,7 @@ const useGridPlans = ( {
 		const planConstantObj = applyTestFiltersToPlansList( planSlug, undefined );
 		const planObject = pricedAPIPlans.data?.[ planSlug ];
 		const isMonthlyPlan = isMonthly( planSlug );
-		const availableForPurchase = !! ( isInSignup || planUpgradeability?.[ planSlug ] );
+		const availableForPurchase = !! planUpgradeability?.[ planSlug ];
 		const isCurrentPlan = sitePlanSlug ? isSamePlan( sitePlanSlug, planSlug ) : false;
 
 		let tagline: TranslateResult = '';

--- a/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
+++ b/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
@@ -151,7 +151,13 @@ interface Props {
 	hideEnterprisePlan?: boolean;
 	isInSignup?: boolean;
 	// whether plan is upgradable from current plan (used in logged-in state)
-	usePlanUpgradeabilityCheck?: ( { planSlugs }: { planSlugs: PlanSlug[] } ) => {
+	usePlanUpgradeabilityCheck?: ( {
+		planSlugs,
+		sitePlanSlug,
+	}: {
+		planSlugs: PlanSlug[];
+		sitePlanSlug: string | null;
+	} ) => {
 		[ key: string ]: boolean;
 	};
 	showLegacyStorageFeature?: boolean;
@@ -308,7 +314,10 @@ const useGridPlans = ( {
 		term,
 		intent,
 	} );
-	const planUpgradeability = usePlanUpgradeabilityCheck?.( { planSlugs: availablePlanSlugs } );
+	const planUpgradeability = usePlanUpgradeabilityCheck?.( {
+		planSlugs: availablePlanSlugs,
+		sitePlanSlug: sitePlanSlug ?? null,
+	} );
 
 	// only fetch highlights for the plans that are available for the intent
 	const highlightLabels = useHighlightLabels( {

--- a/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
+++ b/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
@@ -156,7 +156,7 @@ interface Props {
 		sitePlanSlug,
 	}: {
 		planSlugs: PlanSlug[];
-		sitePlanSlug: string | null;
+		sitePlanSlug: PlanSlug | null;
 	} ) => {
 		[ key: string ]: boolean;
 	};

--- a/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
+++ b/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
@@ -149,14 +149,9 @@ interface Props {
 	selectedPlan?: PlanSlug;
 	sitePlanSlug?: PlanSlug | null;
 	hideEnterprisePlan?: boolean;
+	isInSignup?: boolean;
 	// whether plan is upgradable from current plan (used in logged-in state)
-	usePlanUpgradeabilityCheck?: ( {
-		planSlugs,
-		sitePlanSlug,
-	}: {
-		planSlugs: PlanSlug[];
-		sitePlanSlug: PlanSlug | null;
-	} ) => {
+	usePlanUpgradeabilityCheck?: ( { planSlugs }: { planSlugs: PlanSlug[] } ) => {
 		[ key: string ]: boolean;
 	};
 	showLegacyStorageFeature?: boolean;
@@ -281,6 +276,7 @@ const useGridPlans = ( {
 	selectedPlan,
 	sitePlanSlug,
 	hideEnterprisePlan,
+	isInSignup,
 	usePlanUpgradeabilityCheck,
 	eligibleForFreeHostingTrial,
 	isSubdomainNotGenerated,
@@ -314,7 +310,6 @@ const useGridPlans = ( {
 	} );
 	const planUpgradeability = usePlanUpgradeabilityCheck?.( {
 		planSlugs: availablePlanSlugs,
-		sitePlanSlug: sitePlanSlug ?? null,
 	} );
 
 	// only fetch highlights for the plans that are available for the intent
@@ -342,7 +337,7 @@ const useGridPlans = ( {
 		const planConstantObj = applyTestFiltersToPlansList( planSlug, undefined );
 		const planObject = pricedAPIPlans.data?.[ planSlug ];
 		const isMonthlyPlan = isMonthly( planSlug );
-		const availableForPurchase = !! planUpgradeability?.[ planSlug ];
+		const availableForPurchase = !! ( isInSignup || planUpgradeability?.[ planSlug ] );
 		const isCurrentPlan = sitePlanSlug ? isSamePlan( sitePlanSlug, planSlug ) : false;
 
 		let tagline: TranslateResult = '';

--- a/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-highlight-labels.ts
+++ b/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-highlight-labels.ts
@@ -43,6 +43,8 @@ const useHighlightLabels = ( {
 			let label;
 			if ( isCurrentPlan ) {
 				label = translate( 'Your plan' );
+			} else if ( ! isPlanAvailableForUpgrade ) {
+				label = null;
 			} else if ( isSuggestedPlan ) {
 				label = translate( 'Suggested' );
 			} else if ( 'plans-newsletter' === intent ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/1831

If a user has purchased a higher tier plan, there isn't a need to continue displaying badges like "popular" or "suggested" for plans which would require a downgrade.

## Proposed Changes

* Remove highlight badge labels if a user cannot upgrade to the plan

## Screenshots
| Before | After |
| ----- | ----- |
|  <img width="1239" alt="Screenshot 2023-12-08 at 10 55 23 AM" src="https://github.com/Automattic/wp-calypso/assets/5414230/b16991d5-d267-4c5c-b7dc-9bbc362642ba"> | <img width="1200" alt="Screenshot 2023-12-08 at 10 55 14 AM" src="https://github.com/Automattic/wp-calypso/assets/5414230/8128350d-777e-4b8e-b390-2f9258155ad6">  |
| <img width="1267" alt="Screenshot 2023-12-08 at 11 05 25 AM" src="https://github.com/Automattic/wp-calypso/assets/5414230/2425dbcb-3d03-4fad-bd12-69bed563ffc7"> | <img width="1286" alt="Screenshot 2023-12-08 at 10 59 59 AM" src="https://github.com/Automattic/wp-calypso/assets/5414230/9036543b-0a04-41e5-8e91-e677464a420d"> | 

#### Highlight Labels for Onboarding + Signup Flows remain Unchanged
<img width="1264" alt="Screenshot 2023-12-08 at 10 57 18 AM" src="https://github.com/Automattic/wp-calypso/assets/5414230/2de27550-91fa-4828-97f5-9532c5d044db">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out branch or use calypso live
* Navigate to Calypso admin `/plans` for a given site
* Verify that, if a site is at a higher tiered plan, lower tiered plans no longer display highlight labels
  * Ex. For a fresh site, the "Popular" highlight label is shown for the Premium plan. Upgrade to either a Business or WooCommerce plan and confirm that the "Popular" label disappears
  * Ex. For a fresh site, "Best for devs" is show above a Business plan. Upgrade to a WooCommerce plan and confirm that the label is hidden
* Verify that the "Your plan" label is still shown for the site's current plan
* Navigate to `/start/plans`
* Verify that all highlight labels continue to display as before by cross checking with production 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?