### PR TITLE
Jetpack Manage: Update Atomic Business plan features heading to support clickable Premium plan link.

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/card-content.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/card-content.tsx
@@ -23,7 +23,6 @@ interface PlanInfo {
 	jetpackFeatures: Array< { text: string; tooltipText: string } >;
 	storage: string;
 	logo: JSX.Element | null;
-	previousProductName: string;
 }
 
 export default function CardContent( {
@@ -63,12 +62,23 @@ export default function CardContent( {
 		}
 	};
 
-	const getPreviousProductName = ( planSlug: string ) => {
+	const getFeaturesHeading = ( planSlug: string ) => {
 		switch ( planSlug ) {
 			case PLAN_BUSINESS:
-				return 'Premium';
+				return translate( 'Everything in {{a}}Premium{{/a}}, plus:', {
+					components: {
+						a: (
+							// For Business plan, we want to redirect user to find out more about features included in the  Premium plan.
+							<a
+								href="https://wordpress.com/pricing/#lpc-pricing"
+								target="_blank"
+								rel="noreferrer"
+							/>
+						),
+					},
+				} );
 			case PLAN_ECOMMERCE:
-				return 'Business';
+				return translate( 'Everything in Business, plus:' );
 			default:
 				return '';
 		}
@@ -112,7 +122,6 @@ export default function CardContent( {
 			} ) ),
 			storage: '50GB',
 			logo: getLogo( planSlug ),
-			previousProductName: getPreviousProductName( planSlug ),
 		};
 	};
 
@@ -165,9 +174,7 @@ export default function CardContent( {
 				</Button>
 				<div className="wpcom-atomic-hosting__card-features">
 					<div className="wpcom-atomic-hosting__card-features-heading">
-						{ translate( 'Everything in %(previousProductName)s, plus:', {
-							args: { previousProductName: plan.previousProductName },
-						} ) }
+						{ getFeaturesHeading( planSlug ) }
 					</div>
 					{ plan.wpcomFeatures.length > 0 &&
 						plan.wpcomFeatures.map( ( { text, tooltipText } ) => (

--- a/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/style.scss
@@ -52,6 +52,11 @@
 	color: #7f54b3;
 	font-size: 0.75rem;
 	font-weight: 600;
+
+	a {
+		color: #7f54b3;
+		text-decoration: underline;
+	}
 }
 
 .wpcom-atomic-hosting__card-feature {


### PR DESCRIPTION
One issue with the Atomic site pricing page is that we don't show any information about what features are included in the Premium plan. This PR fixes the issue by adding a clickable Premium plan link that lets users learn more.

**Before**
<img width="700" alt="Screen Shot 2023-11-07 at 1 34 45 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/3a10010e-d826-4929-ad8b-340f9890c802">
**After**
<img width="700" alt="Screen Shot 2023-11-07 at 1 36 26 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/156f7e2f-5860-4870-bf3f-388d1d3c49e2">


Closes https://github.com/Automattic/jetpack-manage/issues/61

## Proposed Changes

* Update the Business plan features heading to include a clickable Premium link.

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

* Use the Jetpack Cloud live link and go to  `/partner-portal/create-site`
* Confirm that the Premium text in the features heading is clickable and redirects to WPCOM pricing page.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?