### PR TITLE
Implement the total elapsed time tracking between `calypso_signup_start` and `calypso_signup_complete`

### DIFF
--- a/client/lib/analytics/signup.js
+++ b/client/lib/analytics/signup.js
@@ -9,15 +9,12 @@ import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import { identifyUser } from 'calypso/lib/analytics/identify-user';
 import { addToQueue } from 'calypso/lib/analytics/queue';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import {
-	setSignupStartTimeInSeconds,
-	getSignupCompleteElapsedTimeInSeconds,
-} from 'calypso/signup/storageUtils';
+import { setSignupStartTime, getSignupCompleteElapsedTime } from 'calypso/signup/storageUtils';
 
 const signupDebug = debug( 'calypso:analytics:signup' );
 
 export function recordSignupStart( flow, ref, optionalProps ) {
-	setSignupStartTimeInSeconds();
+	setSignupStartTime();
 
 	// Tracks
 	recordTracksEvent( 'calypso_signup_start', {
@@ -56,7 +53,7 @@ export function recordSignupComplete(
 		isTransfer,
 		isMapping,
 		signupDomainOrigin,
-		elapsedTime = null,
+		elapsedTimeSinceStart = null,
 	},
 	now
 ) {
@@ -68,7 +65,7 @@ export function recordSignupComplete(
 			'signup',
 			'recordSignupComplete',
 			{
-				elapsedTime: elapsedTime ?? getSignupCompleteElapsedTimeInSeconds(),
+				elapsedTimeSinceStart: elapsedTimeSinceStart ?? getSignupCompleteElapsedTime(),
 				flow,
 				siteId,
 				isNewUser,
@@ -93,7 +90,7 @@ export function recordSignupComplete(
 	// blog_id instead of site_id here. We keep using "siteId" otherwise since
 	// all the other fields still refer with "site". e.g. isNewSite
 	recordTracksEvent( 'calypso_signup_complete', {
-		elapsed_time: elapsedTime ?? getSignupCompleteElapsedTimeInSeconds(),
+		elapsed_time_since_start: elapsedTimeSinceStart ?? getSignupCompleteElapsedTime(),
 		flow,
 		blog_id: siteId,
 		is_new_user: isNewUser,

--- a/client/lib/analytics/signup.js
+++ b/client/lib/analytics/signup.js
@@ -42,6 +42,7 @@ export const SIGNUP_DOMAIN_ORIGIN = {
 
 export function recordSignupComplete(
 	{
+		elapsedTime,
 		flow,
 		siteId,
 		isNewUser,
@@ -60,7 +61,6 @@ export function recordSignupComplete(
 	now
 ) {
 	const isNewSite = !! siteId;
-	const elapsedTime = getSignupCompleteElapsedTimeInSeconds();
 
 	if ( ! now ) {
 		// Delay using the analytics localStorage queue.
@@ -68,7 +68,7 @@ export function recordSignupComplete(
 			'signup',
 			'recordSignupComplete',
 			{
-				elapsedTime,
+				elapsedTime: elapsedTime ?? getSignupCompleteElapsedTimeInSeconds(),
 				flow,
 				siteId,
 				isNewUser,
@@ -93,7 +93,7 @@ export function recordSignupComplete(
 	// blog_id instead of site_id here. We keep using "siteId" otherwise since
 	// all the other fields still refer with "site". e.g. isNewSite
 	recordTracksEvent( 'calypso_signup_complete', {
-		elapsed_time: elapsedTime,
+		elapsed_time: elapsedTime ?? getSignupCompleteElapsedTimeInSeconds(),
 		flow,
 		blog_id: siteId,
 		is_new_user: isNewUser,

--- a/client/lib/analytics/signup.js
+++ b/client/lib/analytics/signup.js
@@ -17,13 +17,12 @@ import {
 const signupDebug = debug( 'calypso:analytics:signup' );
 
 export function recordSignupStart( flow, ref, optionalProps ) {
-	const startTime = setSignupStartTimeInSeconds();
+	setSignupStartTimeInSeconds();
 
 	// Tracks
 	recordTracksEvent( 'calypso_signup_start', {
 		flow,
 		ref,
-		start_time: startTime,
 		...optionalProps,
 	} );
 	// Google Analytics

--- a/client/lib/analytics/signup.js
+++ b/client/lib/analytics/signup.js
@@ -42,7 +42,6 @@ export const SIGNUP_DOMAIN_ORIGIN = {
 
 export function recordSignupComplete(
 	{
-		elapsedTime,
 		flow,
 		siteId,
 		isNewUser,
@@ -57,6 +56,7 @@ export function recordSignupComplete(
 		isTransfer,
 		isMapping,
 		signupDomainOrigin,
+		elapsedTime = null,
 	},
 	now
 ) {

--- a/client/lib/analytics/signup.js
+++ b/client/lib/analytics/signup.js
@@ -9,12 +9,23 @@ import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 import { identifyUser } from 'calypso/lib/analytics/identify-user';
 import { addToQueue } from 'calypso/lib/analytics/queue';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import {
+	setSignupStartTimeInSeconds,
+	getSignupCompleteElapsedTimeInSeconds,
+} from 'calypso/signup/storageUtils';
 
 const signupDebug = debug( 'calypso:analytics:signup' );
 
 export function recordSignupStart( flow, ref, optionalProps ) {
+	const startTime = setSignupStartTimeInSeconds();
+
 	// Tracks
-	recordTracksEvent( 'calypso_signup_start', { flow, ref, ...optionalProps } );
+	recordTracksEvent( 'calypso_signup_start', {
+		flow,
+		ref,
+		start_time: startTime,
+		...optionalProps,
+	} );
 	// Google Analytics
 	gaRecordEvent( 'Signup', 'calypso_signup_start' );
 	// Marketing
@@ -50,6 +61,7 @@ export function recordSignupComplete(
 	now
 ) {
 	const isNewSite = !! siteId;
+	const elapsedTime = getSignupCompleteElapsedTimeInSeconds();
 
 	if ( ! now ) {
 		// Delay using the analytics localStorage queue.
@@ -57,6 +69,7 @@ export function recordSignupComplete(
 			'signup',
 			'recordSignupComplete',
 			{
+				elapsedTime,
 				flow,
 				siteId,
 				isNewUser,
@@ -81,6 +94,7 @@ export function recordSignupComplete(
 	// blog_id instead of site_id here. We keep using "siteId" otherwise since
 	// all the other fields still refer with "site". e.g. isNewSite
 	recordTracksEvent( 'calypso_signup_complete', {
+		elapsed_time: elapsedTime,
 		flow,
 		blog_id: siteId,
 		is_new_user: isNewUser,

--- a/client/signup/storageUtils.js
+++ b/client/signup/storageUtils.js
@@ -83,25 +83,24 @@ export const getSignupCompleteStepNameAndClear = () => {
 	clearSignupCompleteStepName();
 	return value;
 };
-export const setSignupStartTimeInSeconds = () =>
+export const setSignupStartTime = () =>
 	ignoreFatalsForSessionStorage( () =>
-		sessionStorage?.setItem( 'wpcom_signup_start_time_in_second', Math.floor( Date.now() / 1000 ) )
+		sessionStorage?.setItem( 'wpcom_signup_start_time', performance.now() )
 	);
-export const getSignupStartTimeInSeconds = () =>
-	ignoreFatalsForSessionStorage( () =>
-		sessionStorage?.getItem( 'wpcom_signup_start_time_in_second' )
-	);
-export const clearSignupStartTimeInSeconds = () =>
-	ignoreFatalsForSessionStorage( () =>
-		sessionStorage?.removeItem( 'wpcom_signup_start_time_in_second' )
-	);
-export const getSignupCompleteElapsedTimeInSeconds = () => {
-	const startTime = getSignupStartTimeInSeconds();
+export const getSignupStartTime = () =>
+	ignoreFatalsForSessionStorage( () => sessionStorage?.getItem( 'wpcom_signup_start_time' ) );
+
+export const clearSignupStartTime = () =>
+	ignoreFatalsForSessionStorage( () => sessionStorage?.removeItem( 'wpcom_signup_start_time' ) );
+
+export const getSignupCompleteElapsedTime = () => {
+	const startTime = getSignupStartTime();
 
 	if ( startTime == null ) {
 		return null;
 	}
-	clearSignupStartTimeInSeconds();
 
-	return Math.floor( Date.now() / 1000 ) - startTime;
+	clearSignupStartTime();
+
+	return Math.floor( performance.now() - startTime );
 };

--- a/client/signup/storageUtils.js
+++ b/client/signup/storageUtils.js
@@ -96,12 +96,12 @@ export const clearSignupStartTimeInSeconds = () =>
 		sessionStorage?.removeItem( 'wpcom_signup_start_time_in_second' )
 	);
 export const getSignupCompleteElapsedTimeInSeconds = () => {
-	const beginTime = getSignupStartTimeInSeconds();
+	const startTime = getSignupStartTimeInSeconds();
 
-	if ( beginTime == null ) {
+	if ( startTime == null ) {
 		return null;
 	}
 	clearSignupStartTimeInSeconds();
 
-	return Math.floor( Date.now() / 1000 ) - beginTime;
+	return Math.floor( Date.now() / 1000 ) - startTime;
 };

--- a/client/signup/storageUtils.js
+++ b/client/signup/storageUtils.js
@@ -83,3 +83,29 @@ export const getSignupCompleteStepNameAndClear = () => {
 	clearSignupCompleteStepName();
 	return value;
 };
+export const setSignupStartTimeInSeconds = () => {
+	const currentTimeInSeconds = Math.floor( Date.now() / 1000 );
+
+	ignoreFatalsForSessionStorage( () =>
+		sessionStorage?.setItem( 'wpcom_signup_start_time_in_second', currentTimeInSeconds )
+	);
+	return currentTimeInSeconds;
+};
+export const getSignupStartTimeInSeconds = () =>
+	ignoreFatalsForSessionStorage( () =>
+		sessionStorage?.getItem( 'wpcom_signup_start_time_in_second' )
+	);
+export const clearSignupStartTimeInSeconds = () =>
+	ignoreFatalsForSessionStorage( () =>
+		sessionStorage?.removeItem( 'wpcom_signup_start_time_in_second' )
+	);
+export const getSignupCompleteElapsedTimeInSeconds = () => {
+	const beginTime = getSignupStartTimeInSeconds();
+
+	if ( beginTime == null ) {
+		return null;
+	}
+	clearSignupStartTimeInSeconds();
+
+	return Math.floor( Date.now() / 1000 ) - beginTime;
+};

--- a/client/signup/storageUtils.js
+++ b/client/signup/storageUtils.js
@@ -83,14 +83,10 @@ export const getSignupCompleteStepNameAndClear = () => {
 	clearSignupCompleteStepName();
 	return value;
 };
-export const setSignupStartTimeInSeconds = () => {
-	const currentTimeInSeconds = Math.floor( Date.now() / 1000 );
-
+export const setSignupStartTimeInSeconds = () =>
 	ignoreFatalsForSessionStorage( () =>
-		sessionStorage?.setItem( 'wpcom_signup_start_time_in_second', currentTimeInSeconds )
+		sessionStorage?.setItem( 'wpcom_signup_start_time_in_second', Math.floor( Date.now() / 1000 ) )
 	);
-	return currentTimeInSeconds;
-};
 export const getSignupStartTimeInSeconds = () =>
 	ignoreFatalsForSessionStorage( () =>
 		sessionStorage?.getItem( 'wpcom_signup_start_time_in_second' )


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This PR implements the request of Automattic/martech#2383, adding the tracking to the total elapsed time for completing a sign-up flow. The time is computed as between `calypso_signup_start` and `calypso_signup_complete`. It's implemented using the session storage along side other signup storage utilities for the following reasons:

1. Tracking elapsed time per session would make the most sense, since it should cover majority of the cases and resuming a flow after closing a tab is very fragile anyway. If we want to cover the case outside of a session, we should fix the case of resuming a flow between sessions first.
2. The newly added storage utilities are called inside the `lib/analytics/signup` module directly. While this dependency relationship is questionable, it's the easiest way to get this functionality working across the classic signup framework and the Stepper framework that I can think of for now.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the network inspector, turn on "Preserve log", and filter for "elapsed_time". That will filter out `calypso_signup_complete` event with the new prop `elapsed_time`.
* Completing a new signup from `/start`, `calypso_signup_complete` should contain `elaped_time` field indicating how many seconds has been taken.
* Completing `/start` as a logged-in user, the same 
* Pick a few other classic signup flows to make sure it applies, e.g. `/start/do-it-for-me`, `/start/domain`
* Pick a few Stepper flows to make sure it applies, e.g. `/setup/newsletter`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
