### PR TITLE
Assembler: Add Store to the Pages screen

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
@@ -70,12 +70,20 @@ export const ORDERED_PATTERN_CATEGORIES = [
 
 export const INITIAL_PAGES = [ 'about' ];
 
-export const PATTERN_PAGES_CATEGORIES = [ 'about', 'contact', 'portfolio', 'posts', 'services' ];
-
-export const ORDERED_PATTERN_PAGES_CATEGORIES = [
+export const PATTERN_PAGES_CATEGORIES = [
 	'about',
 	'contact',
 	'portfolio',
-	'services',
 	'posts',
+	'services',
+	'store',
+];
+
+export const ORDERED_PATTERN_PAGES_CATEGORIES = [
+	'about',
+	'services',
+	'portfolio',
+	'store',
+	'posts',
+	'contact',
 ];

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-page-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-page-list.tsx
@@ -56,6 +56,9 @@ const PatternPageList = ( {
 	const categoriesInOrder = useCategoriesOrder( categories, ORDERED_PATTERN_PAGES_CATEGORIES );
 	const composite = useCompositeState( { orientation: 'vertical' } );
 
+	const getCategoryLabel = ( category: Category ) =>
+		category.name === 'posts' ? translate( 'Blog' ) : category.label;
+
 	return (
 		<Composite
 			{ ...composite }
@@ -74,7 +77,8 @@ const PatternPageList = ( {
 				>
 					<PatternPageListItem label={ translate( 'Homepage' ) } isDisabled />
 				</CompositeItem>
-				{ categoriesInOrder.map( ( { name, label } ) => {
+				{ categoriesInOrder.map( ( category: Category ) => {
+					const { name } = category;
 					const isSelected = name ? selectedPages.includes( name ) : false;
 					const hasPages = name && pagesMapByCategory[ name ]?.length;
 
@@ -91,7 +95,10 @@ const PatternPageList = ( {
 							aria-checked={ isSelected }
 							onClick={ () => onSelectPage( name ) }
 						>
-							<PatternPageListItem label={ label } isSelected={ isSelected } />
+							<PatternPageListItem
+								label={ getCategoryLabel( category ) }
+								isSelected={ isSelected }
+							/>
 						</CompositeItem>
 					);
 				} ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-page-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-page-list.tsx
@@ -56,9 +56,6 @@ const PatternPageList = ( {
 	const categoriesInOrder = useCategoriesOrder( categories, ORDERED_PATTERN_PAGES_CATEGORIES );
 	const composite = useCompositeState( { orientation: 'vertical' } );
 
-	const getCategoryLabel = ( category: Category ) =>
-		category.name === 'posts' ? translate( 'Blog' ) : category.label;
-
 	return (
 		<Composite
 			{ ...composite }
@@ -96,7 +93,7 @@ const PatternPageList = ( {
 							onClick={ () => onSelectPage( name ) }
 						>
 							<PatternPageListItem
-								label={ getCategoryLabel( category ) }
+								label={ pagesMapByCategory[ name ][ 0 ].title }
 								isSelected={ isSelected }
 							/>
 						</CompositeItem>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #83450

## Proposed Changes

See p1699321095326379-slack-CRWCHQGUB. This PR adds the category Store to the Pages screen, while reordering the list of pages as mentioned in the same conversation. Additionally, this PR renames the category Blog Posts to Blog as discussed in p1699252791925829-slack-CRWCHQGUB.

![Screenshot 2023-11-07 at 2 35 56 PM](https://github.com/Automattic/wp-calypso/assets/797888/6d5ef72a-3736-4299-b8e9-39344a53ee1f)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Assembler.
* Go through the Patterns, and Styles screen until you arrive at the Pages screen.
* Ensure that the list of pages is: About, Services, Portfolio, Store, Blog, and Contact.
* Ensure that the category Blog Posts is renamed to Blog.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?