### PR TITLE
Live Preview: Use the single tracking event for the modal

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/live-preview-modal/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/live-preview-modal/index.tsx
@@ -62,8 +62,13 @@ export default function LivePreviewModal() {
 	const onClose = ( closedBy = 'close_icon' ) => {
 		setIsModalOpen( false );
 		recordTracksEvent( 'calypso_block_theme_live_preview_modal_close', {
-			theme: themeSlug,
 			closed_by: closedBy,
+			/**
+			 * "Do not show this modal again" is active only when the modal is closed by "Continue" button.
+			 * https://github.com/Automattic/wp-calypso/pull/83572#issuecomment-1797122244
+			 */
+			do_not_show_again: closedBy === 'continue_button' ? shouldSuppressModal : null,
+			theme: themeSlug,
 		} );
 	};
 
@@ -72,10 +77,6 @@ export default function LivePreviewModal() {
 			suppressModal();
 		}
 		onClose( 'continue_button' );
-		recordTracksEvent( 'calypso_block_theme_live_preview_modal_continue_click', {
-			do_not_show_again: shouldSuppressModal,
-			theme: themeSlug,
-		} );
 	};
 
 	return (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/83572

## Proposed Changes

This PR unifies the tracking events for the modal into one. This is mainly for creating/maintaining funnels easier. See https://github.com/Automattic/wp-calypso/pull/83572#issuecomment-1797122244.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Patch this change to your sandbox: `install-plugin.sh editing-toolkit fix/live-preview-modal-tracking-event`.
1. Sandbox YOUR SITE.
1. Go to Appearance -> Themes.
1. Choose a Free theme and click "Preview & Customize".
1. Verify that the modal is shown.
1. Click close button at the top-right corner. Verify the modal is closed, and the event is fired with the prop `do_not_show_again: null`.
	<img width="744" alt="Screenshot 2023-11-07 at 15 56 43" src="https://github.com/Automattic/wp-calypso/assets/5287479/f24c1bd1-47af-47a9-b251-73c90d141a1d">
1. Click Continue button. Verify the modal is closed, and the event is fired with the prop `do_not_show_again: false`.
	<img width="744" alt="Screenshot 2023-11-07 at 15 57 45" src="https://github.com/Automattic/wp-calypso/assets/5287479/4d84e14d-3d71-42fe-bf10-ab8047136a10">
1. Tick "Do not show" checkbox then click Continue. Verify the modal is closed, and the event is fired with the prop `do_not_show_again: true`.
	<img width="745" alt="Screenshot 2023-11-07 at 15 58 35" src="https://github.com/Automattic/wp-calypso/assets/5287479/450ab4ca-45e1-4b08-9e04-0f06330bd6f1">

You can test it repeatedly by deleting the following `localStorage` without creating a site after clicking "Do not show again".

<img width="780" alt="Screenshot 2023-10-27 at 15 33 44" src="https://github.com/Automattic/wp-calypso/assets/5287479/95b7ad3e-a367-4193-81bb-4fe2a21241a0">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?