### PR TITLE
Add alias user general function to tracks

### DIFF
--- a/packages/calypso-analytics/package.json
+++ b/packages/calypso-analytics/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/calypso-analytics",
-	"version": "1.0.0-alpha.2",
+	"version": "1.1.0",
 	"description": "Automattic Analytics.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/calypso-analytics/src/tracks.ts
+++ b/packages/calypso-analytics/src/tracks.ts
@@ -174,6 +174,16 @@ export function identifyUser( userData: any ): any {
 	pushEventToTracksQueue( [ 'identifyUser', currentUser.ID, currentUser.username ] );
 }
 
+/**
+ * For tracking users between our products, generally passing the id via a request parameter.
+ *
+ * Use 'anon' for userIdType for anonymous users.
+ */
+export function signalUserFromAnotherProduct( userId: string, userIdType: string ): any {
+	debug( 'Tracks signalUserFromAnotherProduct.', userId, userIdType );
+	pushEventToTracksQueue( [ 'signalAliasUserGeneral', userId, userIdType ] );
+}
+
 export function recordTracksEvent( eventName: string, eventProperties?: any ) {
 	eventProperties = eventProperties || {};
 


### PR DESCRIPTION
**This PR adds signalAliasUserGeneral to the calypso-analytics library.**

Once merged and released this is ready to be implemented.