### PR TITLE
Fix mailbox header

### DIFF
--- a/client/my-sites/email/mailboxes/mailbox-selection-list/style.scss
+++ b/client/my-sites/email/mailboxes/mailbox-selection-list/style.scss
@@ -5,10 +5,6 @@ body.is-section-mailboxes.theme-default.color-scheme {
 	--color-surface-backdrop: var(--studio-white);
 }
 
-body.is-section-mailboxes .layout.is-section-mailboxes > .layout__content {
-	padding-top: 120px;
-}
-
 .mailbox-selection-list__loader-error-container {
 	align-items: center;
 	box-sizing: border-box;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4219

## Proposed Changes

Removed the extra padding

### With mailboxes

![image](https://github.com/Automattic/wp-calypso/assets/6586048/24445b33-e817-4a54-8ced-bdcc318447a7)


### Without mailboxes
![before](https://github.com/Automattic/wp-calypso/assets/6586048/6a32a552-c42b-4b35-b431-d32f9a271891)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/mailboxes/:site`
* Check for mobile/desktop
* Check for with/without mailboxes case
* See if it aligns with headers on other pages, e.g. /posts

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?