### PR TITLE
hide author box if author count less than 2

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -163,7 +163,7 @@ class StatsSite extends Component {
 		// handles hiding author card if there is only one author
 		if ( moduleName === 'authors' ) {
 			// return this.props.authorsCount <= 1;
-			return true;
+			return true; // temporarily force this for testing
 		}
 
 		if (

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -20,6 +20,7 @@ import DocumentHead from 'calypso/components/data/document-head';
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
 import QueryKeyringConnections from 'calypso/components/data/query-keyring-connections';
 import QuerySiteKeyrings from 'calypso/components/data/query-site-keyrings';
+import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import EmptyContent from 'calypso/components/empty-content';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
@@ -117,6 +118,7 @@ class StatsSite extends Component {
 		activeTab: null,
 		activeLegend: null,
 		customChartQuantity: null,
+		shouldHideAuthorsStats: true,
 	};
 
 	static getDerivedStateFromProps( props, state ) {
@@ -157,6 +159,13 @@ class StatsSite extends Component {
 	isModuleHidden( moduleName ) {
 		// Determine which modules are hidden.
 		// @TODO: Rearrange the layout of modules to be more flexible with hidden blocks.
+
+		// handles hiding author card if there is only one author
+		if ( moduleName === 'authors' ) {
+			// return this.props.authorsCount <= 1;
+			return true;
+		}
+
 		if (
 			HIDDABLE_MODULES.includes( moduleName ) &&
 			this.props.moduleToggles[ moduleName ] === false
@@ -290,6 +299,8 @@ class StatsSite extends Component {
 			}
 		);
 
+		const statType = 'statsTopAuthors';
+
 		return (
 			<div className="stats">
 				{ ! isOdysseyStats && (
@@ -325,6 +336,15 @@ class StatsSite extends Component {
 				<HighlightsSection siteId={ siteId } currentPeriod={ defaultPeriod } />
 				<div id="my-stats-content" className={ wrapperClass }>
 					<>
+						<h1> Anna test </h1>
+						<QuerySiteStats
+							siteId={ siteId }
+							statType={ statType }
+							query={ query }
+							requesting={ this.props.isRequestingTopAuthors } // You need to manage this in your component state or Redux store
+							requestSiteStats={ this.props.requestSiteStats } // Make sure this action is connected in your Redux setup
+							requestAllSiteStats={ this.props.requestAllSiteStats } // Make sure this action is connected in your Redux setup
+						/>
 						<StatsPeriodHeader>
 							<StatsPeriodNavigation
 								date={ date }

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -144,13 +144,6 @@ class StatsModule extends Component {
 			'stats-module__footer-actions--summary': summary,
 		} );
 
-		if (
-			this.props.statType === 'statsTopAuthors' &&
-			( ! this.props.data || this.props.data.length <= 1 )
-		) {
-			return null;
-		}
-
 		return (
 			<>
 				{ siteId && statType && (

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -144,6 +144,13 @@ class StatsModule extends Component {
 			'stats-module__footer-actions--summary': summary,
 		} );
 
+		if (
+			this.props.statType === 'statsTopAuthors' &&
+			( ! this.props.data || this.props.data.length <= 1 )
+		) {
+			return null;
+		}
+
 		return (
 			<>
 				{ siteId && statType && (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
