### PR TITLE
Revert "Upgrade Pricing Plan Happy block request doesn't contain user data"

### DIFF
--- a/apps/happy-blocks/block-library/pricing-plans/hooks/pricing-plans.ts
+++ b/apps/happy-blocks/block-library/pricing-plans/hooks/pricing-plans.ts
@@ -2,7 +2,6 @@ import { calculateMonthlyPriceForPlan, getPlan, Plan } from '@automattic/calypso
 import formatCurrency from '@automattic/format-currency';
 import { useEffect, useState } from '@wordpress/element';
 import { sprintf, __ } from '@wordpress/i18n';
-import wpcom from 'calypso/lib/wp';
 import config from '../config';
 import { ApiPricingPlan } from '../types.js';
 
@@ -53,7 +52,10 @@ const usePricingPlans = () => {
 			setIsLoading( true );
 			setError( null );
 			try {
-				const data = await wpcom.req.get( '/plans?locale=' + config.locale, { apiVersion: '1.5' } );
+				const response = await fetch(
+					'https://public-api.wordpress.com/rest/v1.5/plans?locale=' + config.locale
+				);
+				const data = await response.json();
 				setPlans( parsePlans( data ) );
 			} catch ( e: unknown ) {
 				setError( e );


### PR DESCRIPTION
Reverts Automattic/wp-calypso#83870

There's an error when the JS assets get concatenated.

<img width="340" alt="Screenshot 2023-11-07 at 09 26 23" src="https://github.com/Automattic/wp-calypso/assets/2749938/8e4c829d-97dc-4d4e-8e54-d604f28e2b2a">
