### PR TITLE
Plans Grid: Do not change URL when changing interval

### DIFF
--- a/client/my-sites/plans-features-main/components/plan-type-selector/index.tsx
+++ b/client/my-sites/plans-features-main/components/plan-type-selector/index.tsx
@@ -28,6 +28,7 @@ import {
 } from 'calypso/state/plans/selectors';
 import { getSitePlanSlug } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import type { IntervalType } from '../../types';
 import type { IAppState } from 'calypso/state/types';
 import './style.scss';
 
@@ -48,6 +49,7 @@ export type PlanTypeSelectorProps = {
 	hideDiscountLabel?: boolean;
 	redirectTo?: string | null;
 	isStepperUpgradeFlow: boolean;
+	onToggleChange: ( interval: IntervalType ) => void;
 };
 
 interface PathArgs {
@@ -134,6 +136,7 @@ export type IntervalTypeProps = Pick<
 	| 'showBiennialToggle'
 	| 'selectedPlan'
 	| 'selectedFeature'
+	| 'onToggleChange'
 >;
 
 export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = ( props ) => {
@@ -144,6 +147,7 @@ export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = 
 		eligibleForWpcomMonthlyPlans,
 		hideDiscountLabel,
 		showBiennialToggle,
+		onToggleChange,
 	} = props;
 	const [ spanRef, setSpanRef ] = useState< HTMLSpanElement >();
 	const segmentClasses = classNames( 'plan-features__interval-type', 'price-toggle', {
@@ -169,20 +173,6 @@ export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = 
 		}
 	}
 
-	const additionalPathProps = {
-		...( props.redirectTo ? { redirect_to: props.redirectTo } : {} ),
-		...( props.selectedPlan ? { plan: props.selectedPlan } : {} ),
-		...( props.selectedFeature ? { feature: props.selectedFeature } : {} ),
-	};
-
-	const isDomainUpsellFlow = new URLSearchParams( window.location.search ).get( 'domain' );
-
-	const isDomainAndPlanPackageFlow = new URLSearchParams( window.location.search ).get(
-		'domainAndPlanPackage'
-	);
-
-	const isJetpackAppFlow = new URLSearchParams( window.location.search ).get( 'jetpackAppPlans' );
-
 	const intervalTabs = showBiennialToggle ? [ 'yearly', '2yearly' ] : [ 'monthly', 'yearly' ];
 
 	return (
@@ -195,13 +185,7 @@ export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = 
 					<SegmentedControl.Item
 						key={ interval }
 						selected={ intervalType === interval }
-						path={ generatePath( props, {
-							intervalType: interval,
-							domain: isDomainUpsellFlow,
-							domainAndPlanPackage: isDomainAndPlanPackageFlow,
-							jetpackAppPlans: isJetpackAppFlow,
-							...additionalPathProps,
-						} ) }
+						onClick={ () => onToggleChange( interval as IntervalType ) }
 						isPlansInsideStepper={ props.isPlansInsideStepper }
 					>
 						<span

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -230,7 +230,7 @@ const PlansFeaturesMain = ( {
 	showBiennialToggle,
 	customerType = 'personal',
 	planTypeSelector = 'interval',
-	intervalType = 'yearly',
+	intervalType: intervalTypeFromProps = 'yearly',
 	hidePlansFeatureComparison = false,
 	hideUnavailableFeatures = false,
 	isInSignup = false,
@@ -369,6 +369,8 @@ const PlansFeaturesMain = ( {
 		},
 		[ onUpgradeClick, resolveModal, siteSlug, withDiscount ]
 	);
+
+	const [ intervalType, setIntervalType ] = useState< IntervalType >( intervalTypeFromProps );
 
 	const term = usePlanBillingPeriod( {
 		intervalType,
@@ -532,6 +534,7 @@ const PlansFeaturesMain = ( {
 		showBiennialToggle,
 		kind: planTypeSelector,
 		plans: gridPlansForFeaturesGrid.map( ( gridPlan ) => gridPlan.planSlug ),
+		onToggleChange: ( interval: IntervalType ) => setIntervalType( interval ),
 	};
 	/**
 	 * The effects on /plans page need to be checked if this variable is initialized


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

More info here: pdvytD-oN-p2#comment-213

This PR introduces a new state variable `intervalType` which will act as a replacement for the variable of the same name which is received from the component's props. The value received from the props will now act as the initial value of the state variable.

By not changing the URL, the no. of renders is reduced from 5 to 2, and the total time reduces from ~870ms to ~470ms.

Before
<img width="1246" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/29eba213-4e35-417d-901a-82226844f1f1">

After
<img width="754" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/b8c669b2-d708-407f-993d-5f0f028aa6dc">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start` and confirm that the interval toggle works correctly on the plans page.
* Go to `/plans/<site slug>` for a site on the free plan and confirm that the interval toggle works correctly.
* Go to `/setup/newsletter/plans` and confirm that the interval toggle works correctly.
* Go to `/domains/add/<site slug>?domainAndPlanPackage=true` and confirm that the interval toggle works correctly on the plans page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?