### PR TITLE
state(siteSettings): refactor away from `lodash`

### DIFF
--- a/client/my-sites/media-library/test/list-item-video.jsx
+++ b/client/my-sites/media-library/test/list-item-video.jsx
@@ -14,7 +14,9 @@ const WIDTH = 450;
 const styleUrl = ( url ) => `url(${ url })`;
 
 const initialReduxState = {
-	siteSettings: {},
+	siteSettings: {
+		items: {},
+	},
 	sites: {
 		items: [],
 	},

--- a/client/state/selectors/test/is-authors-email-blocked.js
+++ b/client/state/selectors/test/is-authors-email-blocked.js
@@ -18,7 +18,7 @@ const state = {
 	},
 };
 
-const noSiteSettingsState = { siteSettings: {} };
+const noSiteSettingsState = { siteSettings: { items: {} } };
 
 describe( 'isAuthorsEmailBlocked()', () => {
 	test( 'should return true if email is blocked', () => {

--- a/client/state/selectors/test/is-site-supporting-image-editor.js
+++ b/client/state/selectors/test/is-site-supporting-image-editor.js
@@ -9,7 +9,9 @@ describe( 'isSiteSupportingImageEditor()', () => {
 				},
 				// isPrivateSite falls back on siteSettings.
 				// An empty siteSettings object allows getSiteSettings to pass
-				siteSettings: {},
+				siteSettings: {
+					items: {},
+				},
 			},
 			2916284
 		);

--- a/client/state/site-settings/reducer.js
+++ b/client/state/site-settings/reducer.js
@@ -1,5 +1,4 @@
 import { withStorageKey } from '@automattic/state-utils';
-import { includes } from 'lodash';
 import {
 	MEDIA_DELETE,
 	SITE_SETTINGS_RECEIVE,
@@ -109,7 +108,10 @@ export const items = withSchemaValidation( itemSchemas, ( state = {}, action ) =
 		case MEDIA_DELETE: {
 			const { siteId, mediaIds } = action;
 			const settings = state[ siteId ];
-			if ( ! settings || ! includes( mediaIds, settings.site_icon ) ) {
+			if (
+				! settings ||
+				! ( Array.isArray( mediaIds ) && mediaIds.includes( settings.site_icon ) )
+			) {
 				return state;
 			}
 

--- a/client/state/site-settings/selectors.js
+++ b/client/state/site-settings/selectors.js
@@ -1,5 +1,3 @@
-import { get } from 'lodash';
-
 import 'calypso/state/site-settings/init';
 
 /**
@@ -9,7 +7,7 @@ import 'calypso/state/site-settings/init';
  * @returns {boolean}        Whether site settings is being requested
  */
 export function isRequestingSiteSettings( state, siteId ) {
-	return get( state.siteSettings.requesting, [ siteId ], false );
+	return state.siteSettings.requesting[ siteId ] ?? false;
 }
 
 /**
@@ -19,7 +17,7 @@ export function isRequestingSiteSettings( state, siteId ) {
  * @returns {boolean}        Whether site settings is being requested
  */
 export function isSavingSiteSettings( state, siteId ) {
-	return get( state.siteSettings.saveRequests, [ siteId, 'saving' ], false );
+	return state.siteSettings.saveRequests[ siteId ]?.saving ?? false;
 }
 
 /**
@@ -29,7 +27,7 @@ export function isSavingSiteSettings( state, siteId ) {
  * @returns {string}         The request status (peding, success or error)
  */
 export function getSiteSettingsSaveRequestStatus( state, siteId ) {
-	return get( state.siteSettings.saveRequests, [ siteId, 'status' ] );
+	return state.siteSettings.saveRequests[ siteId ]?.status;
 }
 
 /**
@@ -51,7 +49,7 @@ export function getSiteSettingsSaveRequestStatus( state, siteId ) {
  * @returns {SiteSettingsItem}        Site settings
  */
 export function getSiteSettings( state, siteId ) {
-	return get( state.siteSettings.items, [ siteId ], null );
+	return state.siteSettings.items[ siteId ] ?? null;
 }
 
 /**
@@ -71,5 +69,5 @@ export function isSiteSettingsSaveSuccessful( state, siteId ) {
  * @returns {string}         The request error
  */
 export function getSiteSettingsSaveError( state, siteId ) {
-	return get( state.siteSettings.saveRequests, [ siteId, 'error' ], false );
+	return state.siteSettings.saveRequests[ siteId ]?.error ?? false;
 }


### PR DESCRIPTION
## Proposed Changes

This PR refactors `siteSettings` state (`client/state/site-settings`) away from lodash. We replace any used methods with native JS code.

## Testing Instructions

* Changes are covered by unit tests, verify they still pass
* As with a lot of lodash methods it's good practice to ensure we don't accidentally miss guards for whether we operate on the expected data structure.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
