### PR TITLE
[Odie] Offer extra contact options & AB test code

### DIFF
--- a/client/odie/context/index.tsx
+++ b/client/odie/context/index.tsx
@@ -140,15 +140,31 @@ const OdieAssistantProvider = ( {
 			// Normalize message to always be an array
 			const newMessages = Array.isArray( message ) ? message : [ message ];
 
-			// Determine if the last message is a placeholder
-			const shouldRemovePlaceholder =
-				prevChat.messages[ prevChat.messages.length - 1 ]?.type === 'placeholder';
+			// Check if the last message is a placeholder
+			const lastMessage = prevChat.messages[ prevChat.messages.length - 1 ];
+			const isLastMessagePlaceholder = lastMessage?.type === 'placeholder';
 
+			// Check if the new message is of type 'dislike-feedback'
+			const isNewMessageDislikeFeedback = newMessages.some(
+				( msg ) => msg.type === 'dislike-feedback'
+			);
+
+			// If there's a placeholder and the new message is 'dislike-feedback', insert before placeholder
+			if ( isLastMessagePlaceholder && isNewMessageDislikeFeedback ) {
+				return {
+					chat_id: prevChat.chat_id,
+					messages: [
+						...prevChat.messages.slice( 0, -1 ), // Take all messages except placeholder
+						...newMessages, // Insert new messages
+						lastMessage, // Re-insert placeholder at the end
+					],
+				};
+			}
+
+			// For all other cases, append new messages at the end
 			return {
 				chat_id: prevChat.chat_id,
-				messages: shouldRemovePlaceholder
-					? [ ...prevChat.messages.slice( 0, -1 ), ...newMessages ] // Remove placeholder and add new messages
-					: [ ...prevChat.messages, ...newMessages ], // Just add new messages
+				messages: [ ...prevChat.messages, ...newMessages ],
 			};
 		} );
 	};

--- a/client/odie/context/index.tsx
+++ b/client/odie/context/index.tsx
@@ -28,6 +28,7 @@ interface OdieAssistantContextInterface {
 	isLoading: boolean;
 	isNudging: boolean;
 	isVisible: boolean;
+	extraContactOptions?: ReactNode;
 	lastNudge: Nudge | null;
 	sendNudge: ( nudge: Nudge ) => void;
 	setChat: ( chat: Chat ) => void;
@@ -77,12 +78,14 @@ const OdieAssistantProvider = ( {
 	botNameSlug = null,
 	botSetting = 'wapuu',
 	initialUserMessage,
+	extraContactOptions,
 	children,
 }: {
 	botName?: string;
 	botNameSlug: OdieAllowedBots;
 	botSetting?: string;
 	initialUserMessage?: string | null | undefined;
+	extraContactOptions?: ReactNode;
 	children?: ReactNode;
 } ) => {
 	const dispatch = useDispatch();
@@ -163,6 +166,7 @@ const OdieAssistantProvider = ( {
 				botSetting,
 				chat,
 				clearChat,
+				extraContactOptions,
 				initialUserMessage,
 				isLoadingChat: false,
 				isLoading: isLoading,

--- a/client/odie/context/index.tsx
+++ b/client/odie/context/index.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { createContext, useCallback, useContext, useEffect, useState } from 'react';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -79,17 +78,18 @@ const OdieAssistantProvider = ( {
 	botSetting = 'wapuu',
 	initialUserMessage,
 	extraContactOptions,
+	enabled = true,
 	children,
 }: {
 	botName?: string;
 	botNameSlug: OdieAllowedBots;
 	botSetting?: string;
+	enabled?: boolean;
 	initialUserMessage?: string | null | undefined;
 	extraContactOptions?: ReactNode;
 	children?: ReactNode;
 } ) => {
 	const dispatch = useDispatch();
-	const odieIsEnabled = config.isEnabled( 'wapuu' );
 
 	const [ isVisible, setIsVisible ] = useState( false );
 	const [ isLoading, setIsLoading ] = useState( false );
@@ -153,7 +153,7 @@ const OdieAssistantProvider = ( {
 		} );
 	};
 
-	if ( ! odieIsEnabled ) {
+	if ( ! enabled ) {
 		return <>{ children }</>;
 	}
 

--- a/client/odie/index.tsx
+++ b/client/odie/index.tsx
@@ -65,7 +65,7 @@ const OdieAssistant = () => {
 							<ChatMessage message={ message } key={ index } scrollToBottom={ scrollToBottom } />
 						);
 					} ) }
-					<div className="odie-chatbox-bottom-edge" ref={ bottomRef }></div>
+					<div className="odie-chatbox-bottom-edge" ref={ bottomRef } />
 				</div>
 				<OdieSendMessageButton
 					scrollToBottom={ () => scrollToBottom( true, true ) }

--- a/client/odie/message/index.tsx
+++ b/client/odie/message/index.tsx
@@ -40,7 +40,7 @@ type ChatMessageProps = {
 
 const ChatMessage = ( { message, scrollToBottom }: ChatMessageProps ) => {
 	const isUser = message.role === 'user';
-	const { botName, extraContactOptions } = useOdieAssistantContext();
+	const { botName, extraContactOptions, addMessage } = useOdieAssistantContext();
 	const [ scrolledToBottom, setScrolledToBottom ] = useState( false );
 	const [ isFullscreen, setIsFullscreen ] = useState( false );
 	const currentUser = useSelector( getCurrentUser );
@@ -158,6 +158,22 @@ const ChatMessage = ( { message, scrollToBottom }: ChatMessageProps ) => {
 		<div className={ `message-header ${ isUser ? 'user' : 'bot' }` }>{ messageAvatarHeader }</div>
 	);
 
+	const onDislike = () => {
+		setTimeout( () => {
+			addMessage( {
+				content: translate(
+					'I’m sorry my last response didn’t meet your expectations! Here’s some other ways to get more in-depth help:',
+					{
+						context: 'Message displayed when the user dislikes a message from the bot',
+						textOnly: true,
+					}
+				),
+				role: 'bot',
+				type: 'dislike-feedback',
+			} );
+		}, 600 );
+	};
+
 	const messageContent = (
 		<div className="odie-chatbox-message-sources-container">
 			<div className={ messageClasses }>
@@ -175,7 +191,7 @@ const ChatMessage = ( { message, scrollToBottom }: ChatMessageProps ) => {
 							{ isUser || ! message.simulateTyping ? message.content : realTimeMessage }
 						</AsyncLoad>
 						{ ! hasFeedback && ! isUser && messageFullyTyped && (
-							<WasThisHelpfulButtons message={ message } />
+							<WasThisHelpfulButtons message={ message } onDislike={ onDislike } />
 						) }
 					</>
 				) }
@@ -184,7 +200,20 @@ const ChatMessage = ( { message, scrollToBottom }: ChatMessageProps ) => {
 						<div className="odie-chatbox-introduction-message">{ message.content }</div>
 					</div>
 				) }
-				{ isRequestingHumanSupport && extraContactOptions }
+				{ message.type === 'dislike-feedback' && (
+					<AsyncLoad
+						require="react-markdown"
+						placeholder={ <ComponentLoadedReporter callback={ scrollToBottom } /> }
+						transformLinkUri={ uriTransformer }
+						components={ {
+							a: CustomALink,
+						} }
+					>
+						{ message.content }
+					</AsyncLoad>
+				) }
+				{ ( isRequestingHumanSupport || message.type === 'dislike-feedback' ) &&
+					extraContactOptions }
 			</div>
 			{ hasSources && messageFullyTyped && (
 				<FoldableCard

--- a/client/odie/message/index.tsx
+++ b/client/odie/message/index.tsx
@@ -40,7 +40,7 @@ type ChatMessageProps = {
 
 const ChatMessage = ( { message, scrollToBottom }: ChatMessageProps ) => {
 	const isUser = message.role === 'user';
-	const { botName } = useOdieAssistantContext();
+	const { botName, extraContactOptions } = useOdieAssistantContext();
 	const [ scrolledToBottom, setScrolledToBottom ] = useState( false );
 	const [ isFullscreen, setIsFullscreen ] = useState( false );
 	const currentUser = useSelector( getCurrentUser );
@@ -57,6 +57,7 @@ const ChatMessage = ( { message, scrollToBottom }: ChatMessageProps ) => {
 	const sources = message?.context?.sources ?? [];
 	const isTypeMessageOrEmpty = ! message.type || message.type === 'message';
 	const isSimulatedTypingFinished = message.simulateTyping && message.content === realTimeMessage;
+	const isRequestingHumanSupport = message.context?.flags?.forward_to_human_support;
 
 	const messageFullyTyped =
 		isTypeMessageOrEmpty && ( ! message.simulateTyping || isSimulatedTypingFinished );
@@ -183,6 +184,7 @@ const ChatMessage = ( { message, scrollToBottom }: ChatMessageProps ) => {
 						<div className="odie-chatbox-introduction-message">{ message.content }</div>
 					</div>
 				) }
+				{ isRequestingHumanSupport && extraContactOptions }
 			</div>
 			{ hasSources && messageFullyTyped && (
 				<FoldableCard

--- a/client/odie/message/was-this-helpful-buttons.tsx
+++ b/client/odie/message/was-this-helpful-buttons.tsx
@@ -1,13 +1,19 @@
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useOdieAssistantContext } from '../context';
+import { noop, useOdieAssistantContext } from '../context';
 import { useOdieSendMessageFeedback } from '../query';
 import { ThumbsDownIcon, ThumbsUpIcon } from './thumbs-icons';
 import type { Message } from '../types';
 
 import './style.scss';
 
-const WasThisHelpfulButtons = ( { message }: { message: Message } ) => {
+const WasThisHelpfulButtons = ( {
+	message,
+	onDislike = noop,
+}: {
+	message: Message;
+	onDislike?: () => void;
+} ) => {
 	const THUMBS_DOWN_RATING_VALUE = 2;
 	const THUMBS_UP_RATING_VALUE = 4;
 
@@ -25,6 +31,9 @@ const WasThisHelpfulButtons = ( { message }: { message: Message } ) => {
 			rating_value: isHelpful ? THUMBS_UP_RATING_VALUE : THUMBS_DOWN_RATING_VALUE,
 		} );
 		setMessageLikedStatus( message, isHelpful );
+		if ( ! isHelpful ) {
+			onDislike();
+		}
 	};
 
 	const thumbsUpClasses = classnames( {

--- a/client/odie/query/index.ts
+++ b/client/odie/query/index.ts
@@ -48,7 +48,7 @@ export const useOdieSendMessage = (): UseMutationResult<
 	unknown,
 	{ message: Message }
 > => {
-	const { chat, setChat, botNameSlug } = useOdieAssistantContext();
+	const { chat, setChat, botNameSlug, setIsLoading } = useOdieAssistantContext();
 
 	return useMutation( {
 		mutationFn: ( { message }: { message: Message } ) => {
@@ -57,6 +57,12 @@ export const useOdieSendMessage = (): UseMutationResult<
 		onSuccess: ( data ) => {
 			setChat( { messages: chat.messages, chat_id: parseInt( data.chat_id ) } );
 			setOdieStorage( 'chat_id', data.chat_id );
+		},
+		onMutate: () => {
+			setIsLoading( true );
+		},
+		onSettled: () => {
+			setIsLoading( false );
 		},
 	} );
 };

--- a/client/odie/send-message-input/index.tsx
+++ b/client/odie/send-message-input/index.tsx
@@ -23,7 +23,7 @@ export const OdieSendMessageButton = ( {
 } ) => {
 	const [ messageString, setMessageString ] = useState< string >( '' );
 	const divContainerRef = useRef< HTMLDivElement >( null );
-	const { addMessage, setIsLoading, botNameSlug, initialUserMessage, chat } =
+	const { addMessage, setIsLoading, botNameSlug, initialUserMessage, chat, isLoading } =
 		useOdieAssistantContext();
 	const { mutateAsync: sendOdieMessage } = useOdieSendMessage();
 	const dispatch = useDispatch();
@@ -94,10 +94,19 @@ export const OdieSendMessageButton = ( {
 	};
 
 	const handleKeyPress = async ( event: KeyboardEvent< HTMLTextAreaElement > ) => {
+		if ( isLoading ) {
+			return;
+		}
 		scrollToBottom();
 		if ( event.key === 'Enter' && ! event.shiftKey ) {
 			event.preventDefault();
 			await sendMessageIfNotEmpty();
+		}
+	};
+
+	const handleKeyUp = () => {
+		if ( ! isLoading ) {
+			scrollToBottom( false );
 		}
 	};
 
@@ -130,12 +139,12 @@ export const OdieSendMessageButton = ( {
 							setMessageString( event.currentTarget.value )
 						}
 						onKeyPress={ handleKeyPress }
-						onKeyUp={ () => scrollToBottom( false ) }
+						onKeyUp={ handleKeyUp }
 					/>
 					<button
 						type="submit"
 						className="odie-send-message-inner-button"
-						disabled={ messageString.trim() === '' }
+						disabled={ messageString.trim() === '' || isLoading }
 					>
 						<img
 							src={ ArrowUp }

--- a/client/odie/types/index.ts
+++ b/client/odie/types/index.ts
@@ -6,6 +6,29 @@ export type Source = {
 	heading: string;
 };
 
+type Feature =
+	| 'login'
+	| 'logout'
+	| 'theme'
+	| 'plugin'
+	| 'admin'
+	| 'site-editing'
+	| 'domain'
+	| 'email'
+	| 'subscription'
+	| 'notification'
+	| 'podcast'
+	| 'facebook'
+	| 'unrelated-to-wordpress';
+
+type InquiryType =
+	| 'help'
+	| 'suggestion'
+	| 'refund'
+	| 'billing'
+	| 'unrelated-to-wordpress'
+	| 'request-for-human-support';
+
 export type Context = {
 	nudge_id?: string | undefined;
 	section_name?: string;
@@ -13,6 +36,16 @@ export type Context = {
 	site_id: number | null;
 	user_tracking?: OdieUserTracking[];
 	sources?: Source[];
+	prompt_tags?: {
+		feature?: Feature;
+		inquiry_type?: InquiryType;
+		language?: string;
+		product?: string;
+	};
+	flags?: {
+		forward_to_human_support?: boolean;
+		canned_response?: boolean;
+	};
 };
 
 export type Nudge = {

--- a/client/odie/types/index.ts
+++ b/client/odie/types/index.ts
@@ -62,6 +62,7 @@ export type MessageType =
 	| 'meta'
 	| 'error'
 	| 'placeholder'
+	| 'dislike-feedback'
 	| 'help-link'
 	| 'introduction';
 

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -88,6 +88,7 @@ export const HelpCenterContactForm = () => {
 	const params = new URLSearchParams( search );
 	const mode = params.get( 'mode' ) as Mode;
 	const overflow = params.get( 'overflow' ) === 'true';
+	const wapuuFlow = params.get( 'wapuuFlow' ) === 'true';
 	const navigate = useNavigate();
 	const [ hideSiteInfo, setHideSiteInfo ] = useState( false );
 	const [ hasSubmittingError, setHasSubmittingError ] = useState< boolean >( false );
@@ -185,6 +186,12 @@ export const HelpCenterContactForm = () => {
 
 	const [ debouncedMessage ] = useDebounce( message || '', 500 );
 	const [ debouncedSubject ] = useDebounce( subject || '', 500 );
+
+	// if the user was chatting with Wapuu, we need to disable GPT (no more AI)
+	if ( wapuuFlow ) {
+		params.set( 'disable-gpt', 'true' );
+		params.set( 'show-gpt', 'false' );
+	}
 
 	const enableGPTResponse =
 		config.isEnabled( 'help/gpt-response' ) && ! ( params.get( 'disable-gpt' ) === 'true' );

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -127,6 +127,29 @@ export const HelpCenterContactPage: FC< HelpCenterContactPageProps > = ( {
 		);
 	}
 
+	// Create URLSearchParams for forum
+	const forumUrlSearchParams = new URLSearchParams( {
+		mode: 'FORUM',
+		wapuuFlow: hideHeaders.toString(),
+	} );
+	const forumUrl = `/contact-form?${ forumUrlSearchParams.toString() }`;
+
+	// Create URLSearchParams for chat
+	const chatUrlSearchParams = new URLSearchParams( {
+		mode: 'CHAT',
+		wapuuFlow: hideHeaders.toString(),
+	} );
+	const chatUrl = `/contact-form?${ chatUrlSearchParams.toString() }`;
+
+	// Create URLSearchParams for email
+	const emailUrlSearchParams = new URLSearchParams( {
+		mode: 'EMAIL',
+		// Set overflow flag when chat is not available nor closed, and the user is eligible to chat, but still sends a support ticket
+		overflow: ( renderChat.eligible && renderChat.state !== 'AVAILABLE' ).toString(),
+		wapuuFlow: hideHeaders.toString(),
+	} );
+	const emailUrl = `/contact-form?${ emailUrlSearchParams.toString() }`;
+
 	return (
 		<div className="help-center-contact-page">
 			{ ! hideHeaders && <BackButton /> }
@@ -143,7 +166,7 @@ export const HelpCenterContactPage: FC< HelpCenterContactPageProps > = ( {
 				/>
 
 				<div className={ classnames( 'help-center-contact-page__boxes' ) }>
-					<Link to="/contact-form?mode=FORUM">
+					<Link to={ forumUrl }>
 						<div
 							className={ classnames( 'help-center-contact-page__box', 'forum' ) }
 							role="button"
@@ -161,10 +184,7 @@ export const HelpCenterContactPage: FC< HelpCenterContactPageProps > = ( {
 
 					{ renderChat.render && (
 						<div className={ classnames( { disabled: renderChat.state !== 'AVAILABLE' } ) }>
-							<ConditionalLink
-								active={ renderChat.state === 'AVAILABLE' }
-								to="/contact-form?mode=CHAT"
-							>
+							<ConditionalLink active={ renderChat.state === 'AVAILABLE' } to={ chatUrl }>
 								<div
 									className={ classnames( 'help-center-contact-page__box', 'chat', {
 										'is-disabled': renderChat.state !== 'AVAILABLE',
@@ -189,12 +209,7 @@ export const HelpCenterContactPage: FC< HelpCenterContactPageProps > = ( {
 					) }
 
 					{ renderEmail.render && (
-						<Link
-							// set overflow flag when chat is not available nor closed, and the user is eligible to chat, but still sends a support ticket
-							to={ `/contact-form?mode=EMAIL&overflow=${ (
-								renderChat.eligible && renderChat.state !== 'AVAILABLE'
-							).toString() }` }
-						>
+						<Link to={ emailUrl }>
 							<div
 								className={ classnames( 'help-center-contact-page__box', 'email' ) }
 								role="button"

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -21,7 +21,6 @@ import { getSectionName } from 'calypso/state/ui/selectors';
 import { BackButton } from '..';
 import {
 	useChatStatus,
-	useIsWapuuEnabled,
 	useShouldRenderChatOption,
 	useShouldRenderEmailOption,
 	useStillNeedHelpURL,
@@ -37,10 +36,15 @@ const ConditionalLink: FC< { active: boolean } & LinkProps > = ( { active, ...pr
 	return <span { ...props }></span>;
 };
 
-export const HelpCenterContactPage: FC = () => {
+type HelpCenterContactPageProps = {
+	hideHeaders?: boolean;
+};
+
+export const HelpCenterContactPage: FC< HelpCenterContactPageProps > = ( {
+	hideHeaders = false,
+} ) => {
 	const { __ } = useI18n();
 	const locale = useLocale();
-	const isWapuuEnabled = useIsWapuuEnabled();
 	const renderEmail = useShouldRenderEmailOption();
 	const {
 		hasActiveChats,
@@ -125,9 +129,11 @@ export const HelpCenterContactPage: FC = () => {
 
 	return (
 		<div className="help-center-contact-page">
-			<BackButton />
+			{ ! hideHeaders && <BackButton /> }
 			<div className="help-center-contact-page__content">
-				<h3>{ __( 'Contact our WordPress.com experts', __i18n_text_domain__ ) }</h3>
+				{ ! hideHeaders && (
+					<h3>{ __( 'Contact our WordPress.com experts', __i18n_text_domain__ ) }</h3>
+				) }
 				{ supportActivity && <HelpCenterActiveTicketNotice tickets={ supportActivity } /> }
 				<GMClosureNotice
 					displayAt="2023-11-06 00:00Z"
@@ -200,23 +206,6 @@ export const HelpCenterContactPage: FC = () => {
 								<div>
 									<h2>{ emailHeaderText }</h2>
 									<p>{ __( 'An expert will get back to you soon', __i18n_text_domain__ ) }</p>
-								</div>
-							</div>
-						</Link>
-					) }
-					{ isWapuuEnabled && (
-						<Link to="/odie">
-							<div
-								className={ classnames( 'help-center-contact-page__box', 'odie' ) }
-								role="button"
-								tabIndex={ 0 }
-							>
-								<div className="help-center-contact-page__box-icon">
-									<Icon icon={ comment } />
-								</div>
-								<div>
-									<h2>{ __( 'Wapuu', __i18n_text_domain__ ) }</h2>
-									<p>{ __( 'Get an immediate reply using a trained AI', __i18n_text_domain__ ) }</p>
 								</div>
 							</div>
 						</Link>

--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -77,6 +77,7 @@ const HelpCenterContent: React.FC< { isRelative?: boolean } > = () => {
 							botSetting="supportDocs"
 							botName="Wapuu"
 							initialUserMessage={ searchTerm }
+							extraContactOptions={ <HelpCenterContactPage hideHeaders /> }
 						>
 							<HelpCenterOdie />
 						</OdieAssistantProvider>

--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -14,6 +14,7 @@ import { getSectionName } from 'calypso/state/ui/selectors';
 /**
  * Internal Dependencies
  */
+import { useIsWapuuEnabled } from '../hooks';
 import { HELP_CENTER_STORE } from '../stores';
 import { HelpCenterContactForm } from './help-center-contact-form';
 import { HelpCenterContactPage } from './help-center-contact-page';
@@ -29,6 +30,7 @@ const HelpCenterContent: React.FC< { isRelative?: boolean } > = () => {
 	const navigate = useNavigate();
 	const containerRef = useRef< HTMLDivElement >( null );
 	const section = useSelector( getSectionName );
+	const isWapuuEnabled = useIsWapuuEnabled();
 
 	useEffect( () => {
 		recordTracksEvent( 'calypso_helpcenter_page_open', {
@@ -76,6 +78,7 @@ const HelpCenterContent: React.FC< { isRelative?: boolean } > = () => {
 							botNameSlug="wpcom-support-chat"
 							botSetting="supportDocs"
 							botName="Wapuu"
+							enabled={ isWapuuEnabled }
 							initialUserMessage={ searchTerm }
 							extraContactOptions={ <HelpCenterContactPage hideHeaders /> }
 						>

--- a/packages/help-center/src/hooks/use-chat-status.ts
+++ b/packages/help-center/src/hooks/use-chat-status.ts
@@ -37,5 +37,6 @@ export default function useChatStatus(
 		isPrecancellationChatOpen: Boolean( chatStatus?.is_precancellation_chat_open ),
 		supportActivity,
 		supportLevel: chatStatus?.supportLevel,
+		wapuuAssistantEnabled: chatStatus?.wapuu_assistant_enabled,
 	};
 }

--- a/packages/help-center/src/hooks/use-is-wapuu-enabled.ts
+++ b/packages/help-center/src/hooks/use-is-wapuu-enabled.ts
@@ -4,6 +4,7 @@ import { useSelector } from 'calypso/state';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { useSupportAvailability } from '../data/use-support-availability';
+import useChatStatus from './use-chat-status';
 
 /**
  * Helper hook to determine if Wapuu should be enabled.
@@ -16,6 +17,7 @@ import { useSupportAvailability } from '../data/use-support-availability';
  */
 export const useIsWapuuEnabled = () => {
 	const { data: supportAvailability, isLoading } = useSupportAvailability( 'OTHER' );
+	const { wapuuAssistantEnabled } = useChatStatus();
 	const isFreeUser = ! supportAvailability?.is_user_eligible_for_tickets;
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const isSiteJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
@@ -25,5 +27,5 @@ export const useIsWapuuEnabled = () => {
 		return false;
 	}
 
-	return isWapuuConfigEnabled && ! isSiteJetpack;
+	return ( wapuuAssistantEnabled || isWapuuConfigEnabled ) && ! isSiteJetpack;
 };

--- a/packages/help-center/src/hooks/use-is-wapuu-enabled.ts
+++ b/packages/help-center/src/hooks/use-is-wapuu-enabled.ts
@@ -1,9 +1,5 @@
 /* eslint-disable no-restricted-imports */
 import config from '@automattic/calypso-config';
-import { useSelector } from 'calypso/state';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { useSupportAvailability } from '../data/use-support-availability';
 import useChatStatus from './use-chat-status';
 
 /**
@@ -16,16 +12,8 @@ import useChatStatus from './use-chat-status';
  * }
  */
 export const useIsWapuuEnabled = () => {
-	const { data: supportAvailability, isLoading } = useSupportAvailability( 'OTHER' );
 	const { wapuuAssistantEnabled } = useChatStatus();
-	const isFreeUser = ! supportAvailability?.is_user_eligible_for_tickets;
-	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
-	const isSiteJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
+	// A way to enable it via flag
 	const isWapuuConfigEnabled = config.isEnabled( 'wapuu' );
-
-	if ( isSiteJetpack === null || isFreeUser || isLoading ) {
-		return false;
-	}
-
-	return ( wapuuAssistantEnabled || isWapuuConfigEnabled ) && ! isSiteJetpack;
+	return wapuuAssistantEnabled || isWapuuConfigEnabled;
 };

--- a/packages/help-center/src/types.ts
+++ b/packages/help-center/src/types.ts
@@ -95,6 +95,7 @@ export interface ChatAvailability {
 	availability: Availability;
 	is_presales_chat_open: boolean;
 	is_precancellation_chat_open: boolean;
+	wapuu_assistant_enabled: boolean;
 }
 
 export interface OtherSupportAvailability {


### PR DESCRIPTION
## Proposed Changes

User might wish to get out of the loop of Wapuu and we need to identifies those cases. This first iteration will offer the user different links to click based on their preferences and subscriptions. 

## Testing Instructions

1. Use the live link
2. Use a simple site
3. Amend `?flags=wapuu` at the end of the URL
4. Ask Wapuu for a refund or just ask him to contact with human support.

Keep checking that the Wapuu assistant is not visible when the flag is removed

![image](https://github.com/Automattic/wp-calypso/assets/5689927/8688302c-4f44-49f1-923f-ef205f9e051d)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?