### PR TITLE
`state(siteAddressChange): refactor away from `lodash`

### DIFF
--- a/client/state/site-address-change/actions.js
+++ b/client/state/site-address-change/actions.js
@@ -1,5 +1,4 @@
 import { translate } from 'i18n-calypso';
-import { get } from 'lodash';
 import page from 'page';
 import wpcom from 'calypso/lib/wp';
 import { domainManagementEdit } from 'calypso/my-sites/domains/paths';
@@ -146,7 +145,7 @@ export const requestSiteAddressChange =
 				}
 			);
 
-			const newSlug = get( data, 'new_slug' );
+			const newSlug = data?.new_slug;
 
 			if ( newSlug ) {
 				dispatch( recordTracksEvent( 'calypso_siteaddresschange_success', eventProperties ) );

--- a/client/state/site-address-change/reducer.js
+++ b/client/state/site-address-change/reducer.js
@@ -1,5 +1,4 @@
 import { withStorageKey } from '@automattic/state-utils';
-import { get } from 'lodash';
 import {
 	SITE_ADDRESS_AVAILABILITY_REQUEST,
 	SITE_ADDRESS_AVAILABILITY_SUCCESS,
@@ -54,7 +53,7 @@ export const validation = ( state = {}, action ) => {
 			return {
 				...state,
 				[ siteId ]: {
-					...get( state, siteId, {} ),
+					...( state[ siteId ] ?? {} ),
 					pending: true,
 					error: null,
 					isAvailable: null,
@@ -67,7 +66,7 @@ export const validation = ( state = {}, action ) => {
 			return {
 				...state,
 				[ siteId ]: {
-					...get( state, siteId, {} ),
+					...( state[ siteId ] ?? {} ),
 					pending: false,
 					error: null,
 					isAvailable: true,
@@ -80,7 +79,7 @@ export const validation = ( state = {}, action ) => {
 			return {
 				...state,
 				[ siteId ]: {
-					...get( state, siteId, {} ),
+					...( state[ siteId ] ?? {} ),
 					isAvailable: false,
 					pending: false,
 					error: {
@@ -97,7 +96,7 @@ export const validation = ( state = {}, action ) => {
 			return {
 				...state,
 				[ siteId ]: {
-					...get( state, siteId, {} ),
+					...( state[ siteId ] ?? {} ),
 					error: null,
 					isAvailable: null,
 				},


### PR DESCRIPTION
## Proposed Changes

This PR refactors `siteAddressChange` state (`client/state/site-address-change`) away from lodash. We replace any used methods with native JS code.

## Testing Instructions

* Smoke test a site address change.
  * Use a simple site which uses a WP.com subdomain
  * Go to `/domains/manage/:siteSlug`
  * Use the three-dots menu and click on _Change Site Address_
  * Verify going through the process still works as expected
* As with a lot of lodash methods it's good practice to ensure we don't accidentally miss guards for whether we operate on the expected data structure.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
