### PR TITLE
Jetpack Manage: Create tailored site-connection process for Jetpack Manage users

### DIFF
--- a/client/components/jetpack/add-new-site-button/index.tsx
+++ b/client/components/jetpack/add-new-site-button/index.tsx
@@ -26,6 +26,8 @@ const AddNewSiteButton = ( {
 }: Props ): JSX.Element => {
 	const translate = useTranslate();
 
+	const jetpackConnectUrl = 'https://wordpress.com/jetpack/connect?source=jetpack-manage';
+
 	return (
 		<SplitButton
 			primary
@@ -36,17 +38,14 @@ const AddNewSiteButton = ( {
 			toggleIcon={ showMainButtonLabel ? undefined : 'plus' }
 			onToggle={ onToggleMenu }
 			onClick={ onClickAddNewSite }
-			href="https://wordpress.com/jetpack/connect"
+			href={ jetpackConnectUrl }
 		>
 			<PopoverMenuItem onClick={ onClickWpcomMenuItem } href="/partner-portal/create-site">
 				<WordPressLogo className="gridicon" size={ 18 } />
 				<span>{ translate( 'Create a new WordPress.com site' ) }</span>
 			</PopoverMenuItem>
 
-			<PopoverMenuItem
-				onClick={ onClickJetpackMenuItem }
-				href="https://wordpress.com/jetpack/connect?source=jetpack-manage"
-			>
+			<PopoverMenuItem onClick={ onClickJetpackMenuItem } href={ jetpackConnectUrl }>
 				<JetpackLogo className="gridicon" size={ 18 } />
 				<span>{ translate( 'Connect a site to Jetpack' ) }</span>
 			</PopoverMenuItem>

--- a/client/components/jetpack/add-new-site-button/index.tsx
+++ b/client/components/jetpack/add-new-site-button/index.tsx
@@ -45,7 +45,7 @@ const AddNewSiteButton = ( {
 
 			<PopoverMenuItem
 				onClick={ onClickJetpackMenuItem }
-				href="https://wordpress.com/jetpack/connect"
+				href="https://wordpress.com/jetpack/connect?source=jetpack-manage"
 			>
 				<JetpackLogo className="gridicon" size={ 18 } />
 				<span>{ translate( 'Connect a site to Jetpack' ) }</span>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -36,6 +36,7 @@ import SiteAddLicenseNotification from './site-add-license-notification';
 import SiteContent from './site-content';
 import useDashboardShowLargeScreen from './site-content/hooks/use-dashboard-show-large-screen';
 import SiteContentHeader from './site-content-header';
+import SiteNotifications from './site-notifications';
 import SiteSearchFilterContainer from './site-search-filter-container/SiteSearchFilterContainer';
 import SiteTopHeaderButtons from './site-top-header-buttons';
 import type { Site } from '../sites-overview/types';
@@ -276,6 +277,7 @@ export default function SitesOverview() {
 		<div className="sites-overview">
 			<DocumentHead title={ pageTitle } />
 			<SidebarNavigation sectionTitle={ pageTitle } />
+			<SiteNotifications />
 			<div className="sites-overview__container">
 				<div className="sites-overview__tabs">
 					<div className="sites-overview__content-wrapper">

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-notifications/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-notifications/index.tsx
@@ -1,0 +1,5 @@
+import JetpackSiteConnected from './jetpack-site-connected';
+
+export default function SiteNotifications() {
+	return <JetpackSiteConnected />;
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-notifications/jetpack-site-connected.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-notifications/jetpack-site-connected.tsx
@@ -1,6 +1,6 @@
+import page from '@automattic/calypso-router';
 import { getQueryArg, removeQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import page from 'page';
 import { useEffect, useState } from 'react';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-notifications/jetpack-site-connected.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-notifications/jetpack-site-connected.tsx
@@ -1,0 +1,50 @@
+import { getQueryArg, removeQueryArgs } from '@wordpress/url';
+import { useTranslate } from 'i18n-calypso';
+import page from 'page';
+import { useEffect, useState } from 'react';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { successNotice } from 'calypso/state/notices/actions';
+
+export default function JetpackSiteConnected() {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const jetpackConnectedSite = ( getQueryArg( window.location.href, 'site_connected' ) ??
+		'' ) as string;
+	const [ successNotification, setSuccessNotification ] = useState< React.ReactNode >( null );
+
+	// Set the success notification when the site is connected and remove the query arg from the URL
+	useEffect( () => {
+		if ( jetpackConnectedSite ) {
+			setSuccessNotification( () =>
+				translate( '{{em}}%(jetpackConnectedSite)s{{/em}} was successfully connected to Jetpack', {
+					args: {
+						jetpackConnectedSite,
+					},
+					comment: '%(jetpackConnectedSite) is the site URL that was connected to Jetpack',
+					components: {
+						em: <em />,
+					},
+				} )
+			);
+			page.redirect(
+				removeQueryArgs( window.location.pathname + window.location.search, 'site_connected' )
+			);
+		}
+	}, [ jetpackConnectedSite, translate, setSuccessNotification ] );
+
+	// Show the success notification when the site is connected and record the event
+	useEffect( () => {
+		if ( successNotification ) {
+			dispatch( successNotice( successNotification ) );
+			dispatch(
+				recordTracksEvent( 'calypso_jetpack_complete_page_open', {
+					siteUrl: jetpackConnectedSite,
+				} )
+			);
+		}
+	}, [ dispatch, jetpackConnectedSite, successNotification ] );
+
+	return null;
+}

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -270,7 +270,10 @@ export class JetpackAuthorize extends Component {
 		const source = urlParams.get( 'source' );
 
 		if ( source === 'jetpack-manage' ) {
-			const urlRedirect = `${ JPC_JETPACK_MANAGE_PATH }?site_connected=${ urlToSlug( homeUrl ) }`;
+			const urlRedirect = addQueryArgs(
+				{ site_connected: urlToSlug( homeUrl ) },
+				JPC_JETPACK_MANAGE_PATH
+			);
 			navigate( urlRedirect );
 		}
 

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -69,7 +69,12 @@ import {
 	USER_IS_ALREADY_CONNECTED_TO_SITE,
 	XMLRPC_ERROR,
 } from './connection-notice-types';
-import { JPC_PATH_PLANS, JPC_PATH_PLANS_COMPLETE, REMOTE_PATH_AUTH } from './constants';
+import {
+	JPC_JETPACK_MANAGE_PATH,
+	JPC_PATH_PLANS,
+	JPC_PATH_PLANS_COMPLETE,
+	REMOTE_PATH_AUTH,
+} from './constants';
 import Disclaimer from './disclaimer';
 import { JetpackFeatures } from './features';
 import { OFFER_RESET_FLOW_TYPES } from './flow-types';
@@ -259,6 +264,14 @@ export class JetpackAuthorize extends Component {
 			clearSource();
 			debug( 'Closing window after authorize - from migration flow' );
 			window.close();
+		}
+
+		const urlParams = new URLSearchParams( window.location.search );
+		const source = urlParams.get( 'source' );
+
+		if ( source === 'jetpack-manage' ) {
+			const urlRedirect = `${ JPC_JETPACK_MANAGE_PATH }?site_connected=${ urlToSlug( homeUrl ) }`;
+			navigate( urlRedirect );
 		}
 
 		if ( this.isJetpackPartnerCoupon() ) {

--- a/client/jetpack-connect/constants.js
+++ b/client/jetpack-connect/constants.js
@@ -26,3 +26,4 @@ export const JETPACK_COUPON_PRESET_MAPPING = {
 	RDCA: 'jetpack_backup_daily',
 	HMOA: 'jetpack_backup_daily',
 };
+export const JPC_JETPACK_MANAGE_PATH = 'https://cloud.jetpack.com/dashboard';

--- a/client/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/jetpack-connect/jetpack-connect-notices.jsx
@@ -177,6 +177,12 @@ export class JetpackConnectNotices extends Component {
 				noticeValues.icon = 'notice';
 				return noticeValues;
 
+			case ALREADY_CONNECTED:
+				noticeValues.text = translate( 'This site is already connected' );
+				noticeValues.status = 'is-info';
+				noticeValues.icon = 'notice';
+				return noticeValues;
+
 			case ALREADY_CONNECTED_BY_OTHER_USER:
 				noticeValues.text = translate(
 					'This site is already connected to a different WordPress.com user, ' +

--- a/client/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/jetpack-connect/jetpack-connect-notices.jsx
@@ -1,3 +1,4 @@
+import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -87,7 +88,13 @@ export class JetpackConnectNotices extends Component {
 					"This site can't be connected to WordPress.com because it violates our {{a}}Terms of Service{{/a}}.",
 					{
 						components: {
-							a: <a href="https://wordpress.com/tos/" rel="noopener noreferrer" target="_blank" />,
+							a: (
+								<a
+									href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+									rel="noopener noreferrer"
+									target="_blank"
+								/>
+							),
 						},
 					}
 				);

--- a/client/jetpack-connect/jetpack-connection.jsx
+++ b/client/jetpack-connect/jetpack-connection.jsx
@@ -103,7 +103,9 @@ const jetpackConnection = ( WrappedComponent ) => {
 			if ( status === ALREADY_CONNECTED && ! this.state.redirecting ) {
 				const currentPlan = retrievePlan();
 				clearPlan();
-				if ( currentPlan ) {
+				if ( source === 'jetpack-manage' ) {
+					this.setState( { status: ALREADY_CONNECTED } );
+				} else if ( currentPlan ) {
 					if ( currentPlan === PLAN_JETPACK_FREE ) {
 						debug( `Redirecting to wpadmin` );
 						return navigate( this.props.siteHomeUrl + JETPACK_ADMIN_PATH );

--- a/client/jetpack-connect/jetpack-connection.jsx
+++ b/client/jetpack-connect/jetpack-connection.jsx
@@ -88,6 +88,8 @@ const jetpackConnection = ( WrappedComponent ) => {
 
 			this.setState( { url, status } );
 
+			const source = queryArgs?.source;
+
 			if (
 				( status === NOT_CONNECTED_JETPACK || status === NOT_CONNECTED_USER ) &&
 				this.isCurrentUrlFetched() &&
@@ -95,7 +97,7 @@ const jetpackConnection = ( WrappedComponent ) => {
 				! this.state.redirecting
 			) {
 				debug( `Redirecting to remote_auth ${ this.props.siteHomeUrl }` );
-				this.redirect( 'remote_auth', this.props.siteHomeUrl );
+				this.redirect( 'remote_auth', this.props.siteHomeUrl, null, null, source );
 			}
 
 			if ( status === ALREADY_CONNECTED && ! this.state.redirecting ) {
@@ -145,11 +147,11 @@ const jetpackConnection = ( WrappedComponent ) => {
 			} );
 		};
 
-		redirect = ( type, url, product, queryArgs ) => {
+		redirect = ( type, url, product, queryArgs, source = null ) => {
 			if ( ! this.state.redirecting ) {
 				this.setState( { redirecting: true } );
 
-				redirect( type, url, product, queryArgs );
+				redirect( type, url, product, queryArgs, source );
 			}
 		};
 

--- a/client/jetpack-connect/jetpack-connection.jsx
+++ b/client/jetpack-connect/jetpack-connection.jsx
@@ -97,7 +97,7 @@ const jetpackConnection = ( WrappedComponent ) => {
 				! this.state.redirecting
 			) {
 				debug( `Redirecting to remote_auth ${ this.props.siteHomeUrl }` );
-				this.redirect( 'remote_auth', this.props.siteHomeUrl, null, null, source );
+				this.redirect( 'remote_auth', this.props.siteHomeUrl, null, source ? { source } : null );
 			}
 
 			if ( status === ALREADY_CONNECTED && ! this.state.redirecting ) {
@@ -149,11 +149,11 @@ const jetpackConnection = ( WrappedComponent ) => {
 			} );
 		};
 
-		redirect = ( type, url, product, queryArgs, source = null ) => {
+		redirect = ( type, url, product, queryArgs ) => {
 			if ( ! this.state.redirecting ) {
 				this.setState( { redirecting: true } );
 
-				redirect( type, url, product, queryArgs, source );
+				redirect( type, url, product, queryArgs );
 			}
 		};
 

--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -81,7 +81,10 @@ export class JetpackConnectMain extends Component {
 		// Track that connection was started by button-click, so we can auto-approve at auth step.
 		persistSession( this.state.currentUrl );
 
-		if ( this.props.isRequestingSites ) {
+		// Set state to show spinner only if we're installing.
+		// We don't want to show a spinner if user tries to connect a
+		// site that's already connected before fetching sites.
+		if ( this.props.isRequestingSites && this.isInstall() ) {
 			this.setState( { waitingForSites: true } );
 		} else {
 			this.checkUrl( this.state.currentUrl );

--- a/client/jetpack-connect/utils.js
+++ b/client/jetpack-connect/utils.js
@@ -148,7 +148,7 @@ export function parseAuthorizationQuery( query ) {
  * @param  {?Object}    queryArgs Query parameters
  * @returns {string}        Redirect url
  */
-export function redirect( type, url, product = null, queryArgs = {}, source = null ) {
+export function redirect( type, url, product = null, queryArgs = {} ) {
 	let urlRedirect = '';
 	const instr = '/jetpack/connect/instructions';
 
@@ -163,10 +163,7 @@ export function redirect( type, url, product = null, queryArgs = {}, source = nu
 	}
 
 	if ( type === 'remote_auth' ) {
-		urlRedirect = addCalypsoEnvQueryArg( url + REMOTE_PATH_AUTH );
-		if ( source ) {
-			urlRedirect = addQueryArgs( { source }, urlRedirect );
-		}
+		urlRedirect = addQueryArgs( queryArgs, addCalypsoEnvQueryArg( url + REMOTE_PATH_AUTH ) );
 		navigate( urlRedirect );
 	}
 

--- a/client/jetpack-connect/utils.js
+++ b/client/jetpack-connect/utils.js
@@ -148,7 +148,7 @@ export function parseAuthorizationQuery( query ) {
  * @param  {?Object}    queryArgs Query parameters
  * @returns {string}        Redirect url
  */
-export function redirect( type, url, product = null, queryArgs = {} ) {
+export function redirect( type, url, product = null, queryArgs = {}, source = null ) {
 	let urlRedirect = '';
 	const instr = '/jetpack/connect/instructions';
 
@@ -164,6 +164,9 @@ export function redirect( type, url, product = null, queryArgs = {} ) {
 
 	if ( type === 'remote_auth' ) {
 		urlRedirect = addCalypsoEnvQueryArg( url + REMOTE_PATH_AUTH );
+		if ( source ) {
+			urlRedirect = addQueryArgs( { source }, urlRedirect );
+		}
 		navigate( urlRedirect );
 	}
 


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-manage/issues/34
Resolves https://github.com/Automattic/jetpack-manage/issues/98

## Proposed Changes

This PR:

- Appends `?source=jetpack-manage` to the Jetpack connect URL.
- Shows the info message `This site is already connected` if a user tries to connect an existing site & is coming from Jetpack Manage(if the source in query param is `jetpack-manage`).
- Redirects to /dashboard and shows a notification after connecting the site.

## Testing Instructions

- Start Calypso Green(yarn start-jetpack-cloud-p) & Calypso Blue(yarn start) servers 
- Visit http://jetpack.cloud.localhost:3001/dashboard> Click the dropdown in the `Add new site` button > Click the `Connect a site to Jetpack` option > Verify that you are redirected to https://wordpress.com/jetpack/connect?source=jetpack-manage. Notice the `?source=jetpack-manage`. 
- Visit http://calypso.localhost:3000/jetpack/connect?source=jetpack-manage > Enter a site URL that is already connected > Verify that a message is shown that the site is already connected. Repeat this without adding `?source=jetpack-manage` & verify it works fine 

<img width="515" alt="Screenshot 2023-11-08 at 11 23 08 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/030814f5-a40c-4643-b83c-add71181db2a">

- Create a new [JN](https://jurassic.ninja/specialops/) site > Enter the URL of the site in the input box in the Jetpack connect page > Verify that the site is secured and you are redirected to https://cloud.jetpack.com/dashboard?site_connected={site_url}. Repeat this without adding `?source=jetpack-manage` & verify it works fine 

- Now http://jetpack.cloud.localhost:3001/dashboard?site_connected={site_url} and verify that a notification is shown and the `site_connected` query param from the URL is removed.

<img width="627" alt="Screenshot 2023-11-08 at 11 35 36 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/8e972286-2edc-46ec-aaf6-7e766721b477">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?