### PR TITLE
Plans 2023: Fix 'credits applied' badge alignment

### DIFF
--- a/client/my-sites/plans-grid/components/comparison-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/comparison-grid/index.tsx
@@ -465,6 +465,7 @@ const ComparisonGridHeaderCell = ( {
 				isLargeCurrency={ isLargeCurrency }
 				currentSitePlanSlug={ currentSitePlanSlug }
 				siteId={ siteId }
+				visibleGridPlans={ visibleGridPlans }
 			/>
 			<div className="plan-comparison-grid__billing-info">
 				<PlanFeatures2023GridBillingTimeframe

--- a/client/my-sites/plans-grid/components/features-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/features-grid/index.tsx
@@ -253,6 +253,7 @@ class FeaturesGrid extends Component< FeaturesGridType > {
 						isLargeCurrency={ isLargeCurrency }
 						currentSitePlanSlug={ currentSitePlanSlug }
 						siteId={ siteId }
+						visibleGridPlans={ renderedGridPlans }
 					/>
 					{ isWooExpressPlus && (
 						<div className="plan-features-2023-grid__header-tagline">

--- a/client/my-sites/plans-grid/components/header-price.tsx
+++ b/client/my-sites/plans-grid/components/header-price.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import PlanPrice from 'calypso/my-sites/plan-price';
 import { usePlansGridContext } from '../grid-context';
+import type { GridPlan } from '../hooks/npm-ready/data-store/use-grid-plans';
 
 interface PlanFeatures2023GridHeaderPriceProps {
 	planSlug: PlanSlug;
@@ -10,6 +11,7 @@ interface PlanFeatures2023GridHeaderPriceProps {
 	isPlanUpgradeCreditEligible: boolean;
 	currentSitePlanSlug?: string | null;
 	siteId?: number | null;
+	visibleGridPlans: GridPlan[];
 }
 
 const PricesGroup = styled.div< { isLargeCurrency: boolean } >`
@@ -20,7 +22,7 @@ const PricesGroup = styled.div< { isLargeCurrency: boolean } >`
 	gap: 4px;
 `;
 
-const Badge = styled.div< { isForIntroOffer?: boolean } >`
+const Badge = styled.div< { isForIntroOffer?: boolean; isHidden?: boolean } >`
 	text-align: center;
 	white-space: nowrap;
 	font-size: 0.75rem;
@@ -38,6 +40,7 @@ const Badge = styled.div< { isForIntroOffer?: boolean } >`
 	color: ${ ( { isForIntroOffer } ) =>
 		isForIntroOffer ? 'var( --studio-blue-50 )' : 'var( --studio-green-40 )' };
 	text-transform: ${ ( { isForIntroOffer } ) => ( isForIntroOffer ? 'uppercase' : 'none' ) };
+	visibility: ${ ( { isHidden } ) => ( isHidden ? 'hidden' : 'visible' ) };
 `;
 
 const HeaderPriceContainer = styled.div`
@@ -128,6 +131,7 @@ const PlanFeatures2023GridHeaderPrice = ( {
 	planSlug,
 	isLargeCurrency,
 	isPlanUpgradeCreditEligible,
+	visibleGridPlans,
 }: PlanFeatures2023GridHeaderPriceProps ) => {
 	const translate = useTranslate();
 	const { gridPlansIndex } = usePlansGridContext();
@@ -136,6 +140,9 @@ const PlanFeatures2023GridHeaderPrice = ( {
 		pricing: { currencyCode, originalPrice, discountedPrice, introOffer },
 	} = gridPlansIndex[ planSlug ];
 	const shouldShowDiscountedPrice = Boolean( discountedPrice.monthly );
+	const isAnyVisibleGridPlanDiscounted = visibleGridPlans.some(
+		( { pricing } ) => pricing.discountedPrice.monthly
+	);
 	const isPricedPlan = null !== originalPrice.monthly;
 	const shouldShowIntroPricing = introOffer && ! introOffer.isOfferComplete;
 
@@ -147,7 +154,7 @@ const PlanFeatures2023GridHeaderPrice = ( {
 		<>
 			{ isPricedPlan ? (
 				<HeaderPriceContainer>
-					{ shouldShowIntroPricing && (
+					{ shouldShowIntroPricing ? (
 						<>
 							{ ! current && (
 								<Badge className="plan-features-2023-grid__badge" isForIntroOffer={ true }>
@@ -163,45 +170,52 @@ const PlanFeatures2023GridHeaderPrice = ( {
 								priceDisplayWrapperClassName="plans-grid-2023__html-price-display-wrapper"
 							/>
 						</>
-					) }
-					{ ! shouldShowIntroPricing && shouldShowDiscountedPrice && (
+					) : (
 						<>
-							<Badge className="plan-features-2023-grid__badge">
-								{ isPlanUpgradeCreditEligible
-									? translate( 'Credit applied' )
-									: translate( 'One time discount' ) }
-							</Badge>
-							<PricesGroup isLargeCurrency={ isLargeCurrency }>
-								<PlanPrice
-									currencyCode={ currencyCode }
-									rawPrice={ originalPrice.monthly }
-									displayPerMonthNotation={ false }
-									isLargeCurrency={ isLargeCurrency }
-									isSmallestUnit={ true }
-									priceDisplayWrapperClassName="plans-grid-2023__html-price-display-wrapper"
-									original
-								/>
-								<PlanPrice
-									currencyCode={ currencyCode }
-									rawPrice={ discountedPrice.monthly }
-									displayPerMonthNotation={ false }
-									isLargeCurrency={ isLargeCurrency }
-									isSmallestUnit={ true }
-									priceDisplayWrapperClassName="plans-grid-2023__html-price-display-wrapper"
-									discounted
-								/>
-							</PricesGroup>
+							{ shouldShowDiscountedPrice ? (
+								<>
+									<Badge className="plan-features-2023-grid__badge">
+										{ isPlanUpgradeCreditEligible
+											? translate( 'Credit applied' )
+											: translate( 'One time discount' ) }
+									</Badge>
+									<PricesGroup isLargeCurrency={ isLargeCurrency }>
+										<PlanPrice
+											currencyCode={ currencyCode }
+											rawPrice={ originalPrice.monthly }
+											displayPerMonthNotation={ false }
+											isLargeCurrency={ isLargeCurrency }
+											isSmallestUnit={ true }
+											priceDisplayWrapperClassName="plans-grid-2023__html-price-display-wrapper"
+											original
+										/>
+										<PlanPrice
+											currencyCode={ currencyCode }
+											rawPrice={ discountedPrice.monthly }
+											displayPerMonthNotation={ false }
+											isLargeCurrency={ isLargeCurrency }
+											isSmallestUnit={ true }
+											priceDisplayWrapperClassName="plans-grid-2023__html-price-display-wrapper"
+											discounted
+										/>
+									</PricesGroup>
+								</>
+							) : (
+								<>
+									{ isAnyVisibleGridPlanDiscounted && (
+										<Badge className="plan-features-2023-grid__badge" isHidden={ true }></Badge>
+									) }
+									<PlanPrice
+										currencyCode={ currencyCode }
+										rawPrice={ originalPrice.monthly }
+										displayPerMonthNotation={ false }
+										isLargeCurrency={ isLargeCurrency }
+										isSmallestUnit={ true }
+										priceDisplayWrapperClassName="plans-grid-2023__html-price-display-wrapper"
+									/>
+								</>
+							) }
 						</>
-					) }
-					{ ! shouldShowIntroPricing && ! shouldShowDiscountedPrice && (
-						<PlanPrice
-							currencyCode={ currencyCode }
-							rawPrice={ originalPrice.monthly }
-							displayPerMonthNotation={ false }
-							isLargeCurrency={ isLargeCurrency }
-							isSmallestUnit={ true }
-							priceDisplayWrapperClassName="plans-grid-2023__html-price-display-wrapper"
-						/>
 					) }
 				</HeaderPriceContainer>
 			) : null }

--- a/client/my-sites/plans-grid/components/header-price.tsx
+++ b/client/my-sites/plans-grid/components/header-price.tsx
@@ -146,80 +146,76 @@ const PlanFeatures2023GridHeaderPrice = ( {
 	const isPricedPlan = null !== originalPrice.monthly;
 	const shouldShowIntroPricing = introOffer && ! introOffer.isOfferComplete;
 
-	if ( isWpcomEnterpriseGridPlan( planSlug ) ) {
+	if ( isWpcomEnterpriseGridPlan( planSlug ) || ! isPricedPlan ) {
 		return null;
 	}
 
+	if ( shouldShowIntroPricing ) {
+		return (
+			<HeaderPriceContainer>
+				{ ! current && (
+					<Badge className="plan-features-2023-grid__badge" isForIntroOffer={ true }>
+						{ translate( 'Limited Time Offer' ) }
+					</Badge>
+				) }
+				<PlanPrice
+					currencyCode={ currencyCode }
+					rawPrice={ introOffer.rawPrice }
+					displayPerMonthNotation={ false }
+					isLargeCurrency={ isLargeCurrency }
+					isSmallestUnit={ false }
+					priceDisplayWrapperClassName="plans-grid-2023__html-price-display-wrapper"
+				/>
+			</HeaderPriceContainer>
+		);
+	}
+
 	return (
-		<>
-			{ isPricedPlan ? (
-				<HeaderPriceContainer>
-					{ shouldShowIntroPricing ? (
-						<>
-							{ ! current && (
-								<Badge className="plan-features-2023-grid__badge" isForIntroOffer={ true }>
-									{ translate( 'Limited Time Offer' ) }
-								</Badge>
-							) }
-							<PlanPrice
-								currencyCode={ currencyCode }
-								rawPrice={ introOffer.rawPrice }
-								displayPerMonthNotation={ false }
-								isLargeCurrency={ isLargeCurrency }
-								isSmallestUnit={ false }
-								priceDisplayWrapperClassName="plans-grid-2023__html-price-display-wrapper"
-							/>
-						</>
-					) : (
-						<>
-							{ shouldShowDiscountedPrice ? (
-								<>
-									<Badge className="plan-features-2023-grid__badge">
-										{ isPlanUpgradeCreditEligible
-											? translate( 'Credit applied' )
-											: translate( 'One time discount' ) }
-									</Badge>
-									<PricesGroup isLargeCurrency={ isLargeCurrency }>
-										<PlanPrice
-											currencyCode={ currencyCode }
-											rawPrice={ originalPrice.monthly }
-											displayPerMonthNotation={ false }
-											isLargeCurrency={ isLargeCurrency }
-											isSmallestUnit={ true }
-											priceDisplayWrapperClassName="plans-grid-2023__html-price-display-wrapper"
-											original
-										/>
-										<PlanPrice
-											currencyCode={ currencyCode }
-											rawPrice={ discountedPrice.monthly }
-											displayPerMonthNotation={ false }
-											isLargeCurrency={ isLargeCurrency }
-											isSmallestUnit={ true }
-											priceDisplayWrapperClassName="plans-grid-2023__html-price-display-wrapper"
-											discounted
-										/>
-									</PricesGroup>
-								</>
-							) : (
-								<>
-									{ isAnyVisibleGridPlanDiscounted && (
-										<Badge className="plan-features-2023-grid__badge" isHidden={ true }></Badge>
-									) }
-									<PlanPrice
-										currencyCode={ currencyCode }
-										rawPrice={ originalPrice.monthly }
-										displayPerMonthNotation={ false }
-										isLargeCurrency={ isLargeCurrency }
-										isSmallestUnit={ true }
-										priceDisplayWrapperClassName="plans-grid-2023__html-price-display-wrapper"
-									/>
-								</>
-							) }
-						</>
+		<HeaderPriceContainer>
+			{ shouldShowDiscountedPrice ? (
+				<>
+					<Badge className="plan-features-2023-grid__badge">
+						{ isPlanUpgradeCreditEligible
+							? translate( 'Credit applied' )
+							: translate( 'One time discount' ) }
+					</Badge>
+					<PricesGroup isLargeCurrency={ isLargeCurrency }>
+						<PlanPrice
+							currencyCode={ currencyCode }
+							rawPrice={ originalPrice.monthly }
+							displayPerMonthNotation={ false }
+							isLargeCurrency={ isLargeCurrency }
+							isSmallestUnit={ true }
+							priceDisplayWrapperClassName="plans-grid-2023__html-price-display-wrapper"
+							original
+						/>
+						<PlanPrice
+							currencyCode={ currencyCode }
+							rawPrice={ discountedPrice.monthly }
+							displayPerMonthNotation={ false }
+							isLargeCurrency={ isLargeCurrency }
+							isSmallestUnit={ true }
+							priceDisplayWrapperClassName="plans-grid-2023__html-price-display-wrapper"
+							discounted
+						/>
+					</PricesGroup>
+				</>
+			) : (
+				<>
+					{ isAnyVisibleGridPlanDiscounted && (
+						<Badge className="plan-features-2023-grid__badge" isHidden={ true }></Badge>
 					) }
-				</HeaderPriceContainer>
-			) : null }
-		</>
+					<PlanPrice
+						currencyCode={ currencyCode }
+						rawPrice={ originalPrice.monthly }
+						displayPerMonthNotation={ false }
+						isLargeCurrency={ isLargeCurrency }
+						isSmallestUnit={ true }
+						priceDisplayWrapperClassName="plans-grid-2023__html-price-display-wrapper"
+					/>
+				</>
+			) }
+		</HeaderPriceContainer>
 	);
 };
 

--- a/client/my-sites/plans-grid/components/test/header-price.tsx
+++ b/client/my-sites/plans-grid/components/test/header-price.tsx
@@ -28,6 +28,7 @@ describe( 'PlanFeatures2023GridHeaderPrice', () => {
 		isLargeCurrency: false,
 		planSlug: PLAN_PERSONAL as PlanSlug,
 		isPlanUpgradeCreditEligible: false,
+		visibleGridPlans: [],
 	};
 
 	beforeEach( () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/martech/issues/2378

## Proposed Changes

* Fixes the misalignment in the pricing for respective blocks with missing "credits applied" badge.
* This is not a full-fledged solution, but it fixes the current situation. Ideally, these badges could be rendered in own row and be easier to align

### Media

**Before**

<img width="700" alt="Screenshot 2023-11-07 at 3 28 34 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/d37db299-1d58-44fe-9145-b192cbc90b3c">


**After**

<img width="700" alt="Screenshot 2023-11-07 at 3 28 54 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/5359963e-afb6-402d-99d5-36063aa9f3c7">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plans` with a paid site to get the prorated credit and confirm the media above
* Go to `/plans` with a free site and confirm pricing renders as before
* Go to `/plans` with a locale that forces currency discounts and confirm the "One time discount" badge is shown
* Go to `/plans` with a WooExpress site and confirm the "Limited Time Offer" badge is shown

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?