### PR TITLE
Sign up: don't go to checkout automatically without a site slug

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -291,6 +291,14 @@ function removeP2DetailsStepFromFlow( flow ) {
 }
 
 function filterDestination( destination, dependencies, flowName, localeSlug ) {
+	// Check for site slug before heading to checkout.
+	// Sometimes, previous visits to the signup flow will have cart items leftovers.
+	// In this cast redirecting to checkout would be incorrect, and it would redirect to /checkout/undefined.
+	// If a flow wants us to go to checkout, it will have `siteSlug` set.
+	if ( ! dependencies.siteSlug ) {
+		return destination;
+	}
+
 	if ( dependenciesContainCartItem( dependencies ) ) {
 		return getCheckoutUrl( dependencies, localeSlug, flowName );
 	}

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -293,7 +293,7 @@ function removeP2DetailsStepFromFlow( flow ) {
 function filterDestination( destination, dependencies, flowName, localeSlug ) {
 	// Check for site slug before heading to checkout.
 	// Sometimes, previous visits to the signup flow will have cart items leftovers.
-	// In this cast redirecting to checkout would be incorrect, and it would redirect to /checkout/undefined.
+	// In this case, redirecting to checkout would be incorrect, and it would redirect to /checkout/undefined.
 	// If a flow wants us to go to checkout, it will have `siteSlug` set.
 	if ( ! dependencies.siteSlug ) {
 		return destination;


### PR DESCRIPTION
When filtering the signup destination, in [these lines](https://github.com/Automattic/wp-calypso/blob/8d5c4b11318a44b6aa0d60dac7b3def449079ab9/client/signup/config/flows.js#L293-L298), we check if the cart has any items, and if it does, we redirect to the checkout instead of the destination that is requested by the current flow.

When you go to a plan-specific flow, eg VideoPress, you add a premium plan to the cart, and when you leave it, the item stays in the cart. This breaks all the following visits to any other flow because the `destination` will always be overwritten by the cart.

Fixes: https://github.com/Automattic/wp-calypso/issues/83868

## Proposed Changes

- This checks that `siteSlug` is present before honoring cart items. This makes the redirect to checkout more intentional. 

This is a neat reminder that magic always carries risks. I would require flows to choose to go to checkout based on their own terms, not the signup framework terms.

## Testing Instructions
1. Make sure https://github.com/Automattic/wp-calypso/issues/83868 is not reproducible against the live link.
