### PR TITLE
Account removal: update copy for siteless accounts

### DIFF
--- a/client/me/account-close/confirm-dialog.jsx
+++ b/client/me/account-close/confirm-dialog.jsx
@@ -65,26 +65,37 @@ class AccountCloseConfirmDialog extends Component {
 	};
 
 	render() {
-		const { currentUsername, isVisible, translate } = this.props;
+		const { currentUsername, siteCount, isVisible, translate } = this.props;
 		const isDeleteButtonDisabled = currentUsername && this.state.inputValue !== currentUsername;
 
 		const alternativeOptions = [
-			{
-				englishText: 'Start a new site',
-				text: translate( 'Start a new site' ),
-				href: onboardingUrl() + '?ref=me-account-close',
-				supportLink: localizeUrl(
-					'https://wordpress.com/support/create-a-blog/#adding-a-new-site-or-blog-to-an-existing-account'
-				),
-				supportPostId: 3991,
-			},
-			{
-				englishText: "Change your site's address",
-				text: translate( "Change your site's address" ),
-				href: '/settings/general',
-				supportLink: localizeUrl( 'https://wordpress.com/support/changing-site-address/' ),
-				supportPostId: 11280,
-			},
+			...( siteCount > 0
+				? [
+						{
+							englishText: 'Start a new site',
+							text: translate( 'Start a new site' ),
+							href: onboardingUrl() + '?ref=me-account-close',
+							supportLink: localizeUrl(
+								'https://wordpress.com/support/create-a-blog/#adding-a-new-site-or-blog-to-an-existing-account'
+							),
+							supportPostId: 3991,
+						},
+						{
+							englishText: "Change your site's address",
+							text: translate( "Change your site's address" ),
+							href: '/settings/general',
+							supportLink: localizeUrl( 'https://wordpress.com/support/changing-site-address/' ),
+							supportPostId: 11280,
+						},
+						{
+							englishText: 'Delete a site',
+							text: translate( 'Delete a site' ),
+							href: '/settings/delete-site',
+							supportLink: localizeUrl( 'https://wordpress.com/support/delete-site/' ),
+							supportPostId: 14411,
+						},
+				  ]
+				: [] ),
 			{
 				englishText: 'Change your username',
 				text: translate( 'Change your username' ),
@@ -98,13 +109,6 @@ class AccountCloseConfirmDialog extends Component {
 				href: '/me/security',
 				supportLink: localizeUrl( 'https://wordpress.com/support/passwords/#change-your-password' ),
 				supportPostId: 89,
-			},
-			{
-				englishText: 'Delete a site',
-				text: translate( 'Delete a site' ),
-				href: '/settings/delete-site',
-				supportLink: localizeUrl( 'https://wordpress.com/support/delete-site/' ),
-				supportPostId: 14411,
 			},
 		];
 
@@ -214,6 +218,7 @@ export default connect(
 
 		return {
 			currentUsername: user && user.username,
+			siteCount: user && user.site_count,
 		};
 	},
 	{

--- a/client/me/account-close/confirm-dialog.jsx
+++ b/client/me/account-close/confirm-dialog.jsx
@@ -72,15 +72,6 @@ class AccountCloseConfirmDialog extends Component {
 			...( siteCount > 0
 				? [
 						{
-							englishText: 'Start a new site',
-							text: translate( 'Start a new site' ),
-							href: onboardingUrl() + '?ref=me-account-close',
-							supportLink: localizeUrl(
-								'https://wordpress.com/support/create-a-blog/#adding-a-new-site-or-blog-to-an-existing-account'
-							),
-							supportPostId: 3991,
-						},
-						{
 							englishText: "Change your site's address",
 							text: translate( "Change your site's address" ),
 							href: '/settings/general',
@@ -96,6 +87,15 @@ class AccountCloseConfirmDialog extends Component {
 						},
 				  ]
 				: [] ),
+			{
+				englishText: 'Start a new site',
+				text: translate( 'Start a new site' ),
+				href: onboardingUrl() + '?ref=me-account-close',
+				supportLink: localizeUrl(
+					'https://wordpress.com/support/create-a-blog/#adding-a-new-site-or-blog-to-an-existing-account'
+				),
+				supportPostId: 3991,
+			},
 			{
 				englishText: 'Change your username',
 				text: translate( 'Change your username' ),

--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -123,15 +123,17 @@ class AccountSettingsClose extends Component {
 											<ActionPanelFigureListItem>
 												{ translate( 'Media' ) }
 											</ActionPanelFigureListItem>
+											<ActionPanelFigureListItem>
+												{ translate( 'Domains' ) }
+											</ActionPanelFigureListItem>
 										</Fragment>
 									) }
-									<ActionPanelFigureListItem>{ translate( 'Domains' ) }</ActionPanelFigureListItem>
-									<ActionPanelFigureListItem>{ translate( 'Gravatar' ) }</ActionPanelFigureListItem>
 									{ purchasedPremiumThemes && purchasedPremiumThemes.length > 0 && (
 										<ActionPanelFigureListItem>
 											{ translate( 'Premium themes' ) }
 										</ActionPanelFigureListItem>
 									) }
+									<ActionPanelFigureListItem>{ translate( 'Gravatar' ) }</ActionPanelFigureListItem>
 								</ActionPanelFigureList>
 							</ActionPanelFigure>
 						) }
@@ -173,9 +175,11 @@ class AccountSettingsClose extends Component {
 						{ ( isLoading || isDeletePossible ) && (
 							<Fragment>
 								<p className="account-close__body-copy">
-									{ translate(
-										'Account closure cannot be undone. It will remove your account along with all your sites and all their content.'
-									) }
+									{ this.props.sitesToBeDeleted.length > 0
+										? translate(
+												'Account closure cannot be undone. It will remove your account along with all your sites and all their content.'
+										  )
+										: translate( 'Account closure cannot be undone.' ) }
 								</p>
 								{ purchasedPremiumThemes && purchasedPremiumThemes.length > 0 && (
 									<Fragment>

--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -133,7 +133,7 @@ class AccountSettingsClose extends Component {
 											{ translate( 'Premium themes' ) }
 										</ActionPanelFigureListItem>
 									) }
-									<ActionPanelFigureListItem>{ translate( 'Gravatar' ) }</ActionPanelFigureListItem>
+									<ActionPanelFigureListItem>Gravatar</ActionPanelFigureListItem>
 								</ActionPanelFigureList>
 							</ActionPanelFigure>
 						) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

When signing up via Reader, subscribing to a blog, or commenting on blog, you end up with accounts without sites. Then when removing the account, the removal step had copy and suggestions assuming that user has site.

#### Before

<img width="1110" alt="Screenshot 2023-11-07 at 16 26 23" src="https://github.com/Automattic/wp-calypso/assets/87168/4afc58d1-05c6-4a60-9f80-46e8907d825f">

<img width="667" alt="Screenshot 2023-11-07 at 16 29 29" src="https://github.com/Automattic/wp-calypso/assets/87168/a19dbc84-217a-4a54-9fca-ded63ecab2c4">


#### After

<img width="1106" alt="Screenshot 2023-11-07 at 16 29 08" src="https://github.com/Automattic/wp-calypso/assets/87168/6889d6fc-9bf6-4aa6-ac83-cd79d3a4842d">

<img width="561" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/ff5a0cdf-1402-4ede-ae2e-ed15d259ea94">



## Proposed Changes

In this PR I'm adjusting copy and removing site-related suggestions.

Also moving "domains" in the deleted list to show only when there are sites.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Me → Account settings → Close your account
    <img width="595" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/df52638c-c58a-4612-8000-6f863e535eeb">
 * Confirm new copy for user without sites, test also user with sites
 * Confirm no more site specific tasks for the siteless user in the modal that appears after pressing "close account"

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?