### PR TITLE
Subscriber page: Update modal opening mechanism to respond to URL hash changes

### DIFF
--- a/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
+++ b/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
@@ -63,7 +63,7 @@ const AddSubscribersModal = ( { site }: AddSubscribersModalProps ) => {
 			title={ modalTitle as string }
 			onRequestClose={ () => {
 				if ( window.location.hash === '#add-subscribers' ) {
-					// Doing this instead of window.location.hash = '' because window.location.hash keepts the # symbol
+					// Doing this instead of window.location.hash = '' because window.location.hash keeps the # symbol
 					// Also this makes the back button show the modal again, which is neat
 					history.pushState(
 						'',

--- a/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
+++ b/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
@@ -61,7 +61,18 @@ const AddSubscribersModal = ( { site }: AddSubscribersModalProps ) => {
 	return (
 		<Modal
 			title={ modalTitle as string }
-			onRequestClose={ () => setShowAddSubscribersModal( false ) }
+			onRequestClose={ () => {
+				if ( window.location.hash === '#add-subscribers' ) {
+					// Doing this instead of window.location.hash = '' because window.location.hash keepts the # symbol
+					// Also this makes the back button show the modal again, which is neat
+					history.pushState(
+						'',
+						document.title,
+						window.location.pathname + window.location.search
+					);
+				}
+				setShowAddSubscribersModal( false );
+			} }
 			overlayClassName="add-subscribers-modal"
 		>
 			{ isUploading && (

--- a/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
+++ b/client/my-sites/subscribers/components/add-subscribers-modal/add-subscribers-modal.tsx
@@ -20,10 +20,22 @@ const AddSubscribersModal = ( { site }: AddSubscribersModalProps ) => {
 		useSubscribersPage();
 
 	useEffect( () => {
-		// Open "add subscribers" modal by default via URL
-		if ( window.location.hash === '#add-subscribers' ) {
-			setShowAddSubscribersModal( true );
-		}
+		const handleHashChange = () => {
+			// Open "add subscribers" via URL hash
+			if ( window.location.hash === '#add-subscribers' ) {
+				setShowAddSubscribersModal( true );
+			}
+		};
+
+		// Listen to the hashchange event
+		window.addEventListener( 'hashchange', handleHashChange );
+
+		// Make it work on load as well
+		handleHashChange();
+
+		return () => {
+			window.removeEventListener( 'hashchange', handleHashChange );
+		};
 	}, [] );
 
 	const modalTitle = translate( 'Add subscribers to %s', {


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/83861

## Proposed Changes

This PR listens for hash changes on the subscriber list page, when the hash changes it checks whether it's `#add-subscribers`, and if it is it shows the Add subscribers modal.

Previously this check only happened on load, which made it impossible show the modal from the page by changing the hash.

<img width="2095" alt="image" src="https://github.com/Automattic/wp-calypso/assets/528287/f26674f6-4b58-4f26-89a3-77a4b7664de3">


## Testing Instructions

1. Apply this PR
2. Visit http://calypso.localhost:3000/subscribers/[yoursite]#add-subscribers . The modal should load.
3. Now remove the hash (#add-subscribers) 
4. Open the JS console and type: `window.location.hash = 'add-subscribers';` You should see the hash getting appended in the URL bar, and the modal should open.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?