### PR TITLE
Subscriber Stats: Use Jetpack's main color for the subscriber chart on Odyssey Stats

### DIFF
--- a/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
@@ -146,7 +146,15 @@ export default function SubscribersChartSection( {
 			) }
 			{ errorMessage && <div>Error: { errorMessage }</div> }
 			{ ! isLoading && chartData.length !== 0 && (
-				<UplotChart data={ chartData } legendContainer={ legendRef } period={ period } />
+				<UplotChart
+					data={ chartData }
+					legendContainer={ legendRef }
+					period={ period }
+					// Use variable --studio-jetpack-green for chart colors on Odyssey Stats.
+					mainColor={ isOdysseyStats ? '#069e08' : undefined }
+					fillColorFrom={ isOdysseyStats ? 'rgba(6, 158, 8, 0.4)' : undefined }
+					fillColorTo={ isOdysseyStats ? 'rgba(6, 158, 8, 0)' : undefined }
+				/>
 			) }
 		</div>
 	);

--- a/packages/components/src/chart-uplot/index.tsx
+++ b/packages/components/src/chart-uplot/index.tsx
@@ -21,7 +21,9 @@ const DEFAULT_DIMENSIONS = {
 
 interface UplotChartProps {
 	data: uPlot.AlignedData;
-	fillColor?: string;
+	mainColor?: string;
+	fillColorFrom?: string;
+	fillColorTo?: string;
 	options?: Partial< uPlot.Options >;
 	legendContainer?: React.RefObject< HTMLDivElement >;
 	solidFill?: boolean;
@@ -30,7 +32,9 @@ interface UplotChartProps {
 
 export default function UplotChart( {
 	data,
-	fillColor = 'rgba(48, 87, 220, 0.4)',
+	mainColor = '#3057DC',
+	fillColorFrom = 'rgba(48, 87, 220, 0.4)',
+	fillColorTo = 'rgba(48, 87, 220, 0)',
 	legendContainer,
 	options: propOptions,
 	solidFill = false,
@@ -41,7 +45,7 @@ export default function UplotChart( {
 	const uplotContainer = useRef( null );
 	const { spline } = uPlot.paths;
 
-	const scaleGradient = useScaleGradient( fillColor );
+	const scaleGradient = useScaleGradient( fillColorFrom );
 
 	const [ options ] = useState< uPlot.Options >(
 		useMemo( () => {
@@ -116,9 +120,11 @@ export default function UplotChart( {
 						},
 					},
 					{
-						fill: solidFill ? fillColor : getGradientFill( fillColor, scaleGradient ),
+						fill: solidFill
+							? fillColorFrom
+							: getGradientFill( fillColorFrom, fillColorTo, scaleGradient ),
 						label: translate( 'Subscribers' ),
-						stroke: '#3057DC',
+						stroke: mainColor,
 						width: 2,
 						paths: ( u, seriesIdx, idx0, idx1 ) => {
 							return spline?.()( u, seriesIdx, idx0, idx1 ) || null;
@@ -149,7 +155,18 @@ export default function UplotChart( {
 				...defaultOptions,
 				...( typeof propOptions === 'object' ? propOptions : {} ),
 			};
-		}, [ fillColor, legendContainer, propOptions, scaleGradient, solidFill, spline, translate ] )
+		}, [
+			mainColor,
+			fillColorFrom,
+			fillColorTo,
+			legendContainer,
+			propOptions,
+			scaleGradient,
+			solidFill,
+			spline,
+			translate,
+			period,
+		] )
 	);
 
 	useResize( uplot, uplotContainer );

--- a/packages/components/src/chart-uplot/lib/get-gradient-fill.ts
+++ b/packages/components/src/chart-uplot/lib/get-gradient-fill.ts
@@ -2,7 +2,8 @@ import type { ScaleGradientFunction } from '../hooks/use-scale-gradient';
 import type uPlot from 'uplot';
 
 export default function getGradientFill(
-	fillColor: string,
+	fillColorFrom: string,
+	fillColorTo: string,
 	scaleGradient: ScaleGradientFunction
 ): ( self: uPlot, seriesIdx: number ) => CanvasRenderingContext2D[ 'fillStyle' ] {
 	return ( u, seriesIdx ) => {
@@ -12,7 +13,7 @@ export default function getGradientFill(
 
 		// if values are not initialised default to a solid color
 		if ( s.min === Infinity || s.max === -Infinity ) {
-			return fillColor;
+			return fillColorFrom;
 		}
 
 		let min = Infinity;
@@ -35,8 +36,8 @@ export default function getGradientFill(
 		}
 
 		return scaleGradient( u, s.scale || 'y', 1, [
-			[ min + range * 0.0, 'rgba(48, 87, 220, 0)' ],
-			[ min + range * 1.0, 'rgba(48, 87, 220, 0.4)' ],
+			[ min + range * 0.0, fillColorTo ],
+			[ min + range * 1.0, fillColorFrom ],
 		] );
 	};
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1699329327073909-slack-C04UCBZMBAA

## Proposed Changes

* Use primary Jetpack color `--studio-jetpack-green` for the main color and fill color of the subscriber stats chart.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin the change up on the local Jetpack site: `cd /some-path-to/wp-calypso/apps/odyssey-stats && STATS_PACKAGE_PATH=/some-path-to/jetpack/projects/packages/stats-admin yarn dev`.
* Navigate to Stats > Subscriber page.
* Ensure the subscriber line chart is filled with the Jetpack primary color.

<img width="1272" alt="截圖 2023-11-08 上午12 06 43" src="https://github.com/Automattic/wp-calypso/assets/6869813/bfbd7a36-6f2a-4b91-9373-28956d3dcaeb">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?