### PR TITLE
Social first sign up: autofocus email signup field

### DIFF
--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -256,6 +256,8 @@ class PasswordlessSignupForm extends Component {
 							onChange={ this.onInputChange }
 							disabled={ isSubmitting || !! this.props.disabled }
 							placeholder={ this.props.inputPlaceholder }
+							// eslint-disable-next-line jsx-a11y/no-autofocus -- It's the only field on the page
+							autoFocus
 						/>
 					</ValidationFieldset>
 					{ this.props.renderTerms?.() }


### PR DESCRIPTION
Since the email field is the only field on the page in email sign up mode, auto focus the field.

Fixes https://github.com/Automattic/wp-calypso/issues/83972

## Proposed Changes

* Add autofocus prop to the field

## Testing Instructions

- Incognito, visit `/start/user-social`.
- Click "Continue with email"
- The field should be focused.