### PR TITLE
Theme Discovery: Fix Carousel Sizes on LiTS and LoTS

### DIFF
--- a/client/components/theme-collection/index.tsx
+++ b/client/components/theme-collection/index.tsx
@@ -91,13 +91,22 @@ export default function ThemeCollection( {
 							? {
 									// break-small in Gutenberg breakpoints
 									600: {
-										slidesPerView: 2.2,
+										//slidesPerView: 2.2,
 										spaceBetween: -24,
 									},
 									// break-large in Gutenberg breakpoints
 									960: {
-										slidesPerView: 3,
+										slidesPerView: 1.2,
 										spaceBetween: -32,
+									},
+									// Breakpoint adjusted to the navigation sidebar
+									1009: {
+										slidesPerView: 2.1,
+										spaceBetween: -32,
+									},
+									// Breakpoint adjusted to the navigation sidebar
+									1361: {
+										slidesPerView: 3,
 									},
 							  }
 							: {

--- a/client/components/theme-collection/index.tsx
+++ b/client/components/theme-collection/index.tsx
@@ -3,9 +3,9 @@ import { Button } from '@wordpress/components';
 import { chevronLeft, chevronRight, Icon } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { PropsWithChildren, ReactElement, useEffect, useRef, useState } from 'react';
-import { useSelector } from 'react-redux';
 import { Swiper as SwiperType } from 'swiper/types';
 import { preventWidows } from 'calypso/lib/formatting';
+import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import './style.scss';
 
@@ -91,7 +91,7 @@ export default function ThemeCollection( {
 							? {
 									// break-small in Gutenberg breakpoints
 									600: {
-										//slidesPerView: 2.2,
+										slidesPerView: 1.2,
 										spaceBetween: -24,
 									},
 									// break-large in Gutenberg breakpoints
@@ -99,26 +99,32 @@ export default function ThemeCollection( {
 										slidesPerView: 1.2,
 										spaceBetween: -32,
 									},
-									// Breakpoint adjusted to the navigation sidebar
+									// Breakpoint adjusted for CSS grid repositioning
 									1009: {
 										slidesPerView: 2.1,
 										spaceBetween: -32,
 									},
-									// Breakpoint adjusted to the navigation sidebar
+									// Breakpoint adjusted for CSS grid repositioning
 									1361: {
 										slidesPerView: 3,
+										spaceBetween: -32,
 									},
 							  }
 							: {
 									// deprecated Calypso breakpoints used in the Theme Showcase
 									660: {
-										slidesPerView: 2.2,
+										slidesPerView: 1.2,
+										spaceBetween: -32,
+									},
+									// Breakpoint adjusted for CSS grid repositioning
+									736: {
+										slidesPerView: 2.1,
 										spaceBetween: -32,
 									},
 									// break-xlarge in Gutenberg breakpoints
 									1080: {
 										slidesPerView: 3,
-										spaceBetween: -48,
+										spaceBetween: -32,
 									},
 							  },
 						modules: [ Navigation, Keyboard, Mousewheel ],

--- a/client/components/theme-collection/index.tsx
+++ b/client/components/theme-collection/index.tsx
@@ -3,8 +3,10 @@ import { Button } from '@wordpress/components';
 import { chevronLeft, chevronRight, Icon } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { PropsWithChildren, ReactElement, useEffect, useRef, useState } from 'react';
+import { useSelector } from 'react-redux';
 import { Swiper as SwiperType } from 'swiper/types';
 import { preventWidows } from 'calypso/lib/formatting';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import './style.scss';
 
 interface ThemeCollectionProps {
@@ -23,6 +25,7 @@ export default function ThemeCollection( {
 	onSeeAll,
 	collectionIndex,
 }: PropsWithChildren< ThemeCollectionProps > ): ReactElement {
+	const isLoggedIn = useSelector( isUserLoggedIn );
 	const swiperInstance = useRef< SwiperType | null >( null );
 	const swiperContainerId = `swiper-container-${ collectionSlug }`;
 
@@ -84,18 +87,31 @@ export default function ThemeCollection( {
 						rewind: true,
 						slidesPerView: 1.2,
 						spaceBetween: -16,
-						breakpoints: {
-							// deprecated Calypso breakpoints used in the Theme Showcase
-							'660': {
-								slidesPerView: 2.2,
-								spaceBetween: -32,
-							},
-							// break-xlarge in Gutenberg breakpoints
-							'1080': {
-								slidesPerView: 3,
-								spaceBetween: -48,
-							},
-						},
+						breakpoints: isLoggedIn
+							? {
+									// break-small in Gutenberg breakpoints
+									600: {
+										slidesPerView: 2.2,
+										spaceBetween: -24,
+									},
+									// break-large in Gutenberg breakpoints
+									960: {
+										slidesPerView: 3,
+										spaceBetween: -32,
+									},
+							  }
+							: {
+									// deprecated Calypso breakpoints used in the Theme Showcase
+									660: {
+										slidesPerView: 2.2,
+										spaceBetween: -32,
+									},
+									// break-xlarge in Gutenberg breakpoints
+									1080: {
+										slidesPerView: 3,
+										spaceBetween: -48,
+									},
+							  },
 						modules: [ Navigation, Keyboard, Mousewheel ],
 					} );
 					setSwiperLoaded( true );
@@ -106,7 +122,7 @@ export default function ThemeCollection( {
 		return () => {
 			swiperInstance.current?.destroy();
 		};
-	}, [ swiperContainerId, isSwiperLoaded ] );
+	}, [ isLoggedIn, swiperContainerId, isSwiperLoaded ] );
 
 	return (
 		<div className="theme-collection__container swiper-container" id={ swiperContainerId }>

--- a/client/components/theme-collection/style.scss
+++ b/client/components/theme-collection/style.scss
@@ -75,16 +75,6 @@
 		margin-left: 0;
 		margin-right: 0;
 	}
-
-	@include breakpoint-deprecated( ">660px" ) {
-		margin-left: 0;
-		max-width: 48%;
-		padding: 0 32px;
-	}
-	@include break-xlarge {
-		max-width: 37%;
-		padding: 0 48px;
-	}
 }
 
 .theme-collection__list-wrapper {

--- a/client/my-sites/themes/collections/style.scss
+++ b/client/my-sites/themes/collections/style.scss
@@ -8,6 +8,7 @@
 		grid-column: 1/-1;
 		grid-row-start: 3;
 		margin-bottom: 48px;
+		margin-top: 0;
 
 		&:last-child {
 			// Ensure the bottom is well padded.

--- a/client/my-sites/themes/collections/style.scss
+++ b/client/my-sites/themes/collections/style.scss
@@ -30,10 +30,6 @@
 			margin-left: -16px;
 			margin-right: -16px;
 		}
-		@include break-xlarge {
-			margin-left: -32px;
-			margin-right: -32px;
-		}
 	}
 	.theme-collection__meta {
 		margin-left: 16px;
@@ -43,20 +39,18 @@
 			margin-left: 32px;
 			margin-right: 32px;
 		}
-		@include break-xlarge {
-			margin-left: 48px;
-			margin-right: 48px;
-		}
 	}
 	.theme-collection__list-item.swiper-slide {
 		@include breakpoint-deprecated( ">660px" ) {
 			margin-left: 0;
-			max-width: 48%;
 			padding: 0 32px;
+		}
+		@media (min-width: 736px) {
+			max-width: 48%;
 		}
 		@include break-xlarge {
 			max-width: 37%;
-			padding: 0 48px;
+			padding: 0 32px;
 		}
 	}
 }

--- a/client/my-sites/themes/collections/style.scss
+++ b/client/my-sites/themes/collections/style.scss
@@ -3,17 +3,11 @@
 
 .themes__showcase {
 	.theme-collection__container {
-		margin-left: -16px;
-		margin-right: -16px;
-
-		@include breakpoint-deprecated( ">660px" ) {
-			margin-left: -32px;
-			margin-right: -32px;
-		}
-		@include break-xlarge {
-			margin-left: -48px;
-			margin-right: -48px;
-		}
+		padding-top: 48px;
+		background-color: var(--studio-gray-0);
+		grid-column: 1/-1;
+		grid-row-start: 1;
+		margin-bottom: 48px;
 
 		&:last-child {
 			// Ensure the bottom is well padded.
@@ -27,7 +21,19 @@
 			margin-top: 48px;
 		}
 	}
+}
 
+.is-logged-out .themes__showcase {
+	.theme-collection__container {
+		@include breakpoint-deprecated( ">660px" ) {
+			margin-left: -16px;
+			margin-right: -16px;
+		}
+		@include break-xlarge {
+			margin-left: -48px;
+			margin-right: -48px;
+		}
+	}
 	.theme-collection__meta {
 		margin-left: 16px;
 		margin-right: 16px;
@@ -41,18 +47,52 @@
 			margin-right: 48px;
 		}
 	}
+	.theme-collection__list-item.swiper-slide {
+		@include breakpoint-deprecated( ">660px" ) {
+			margin-left: 0;
+			max-width: 48%;
+			padding: 0 32px;
+		}
+		@include break-xlarge {
+			max-width: 37%;
+			padding: 0 48px;
+		}
+	}
 }
 
-.themes-list {
+.is-logged-in .themes__showcase {
 	.theme-collection__container {
-		padding-top: 48px;
-		background-color: var(--studio-gray-0);
-		grid-column: 1/-1;
-		grid-row-start: 3;
-		margin: 0 0 48px;
+		@include break-small {
+			margin-left: -8px;
+			margin-right: -8px;
+		}
+		@include break-large {
+			margin-left: -16px;
+			margin-right: -16px;
+		}
+	}
+	.theme-collection__meta {
+		margin-left: 16px;
+		margin-right: 16px;
 
-		@include breakpoint-deprecated( ">660px" ) {
-			margin: 0 -32px 48px;
+		@include break-small {
+			margin-left: 24px;
+			margin-right: 24px;
+		}
+		@include break-large {
+			margin-left: 32px;
+			margin-right: 32px;
+		}
+	}
+	.theme-collection__list-item.swiper-slide {
+		@include break-small {
+			margin-left: 0;
+			max-width: 48%;
+			padding: 0 24px;
+		}
+		@include break-large {
+			max-width: 37%;
+			padding: 0 32px;
 		}
 	}
 }

--- a/client/my-sites/themes/collections/style.scss
+++ b/client/my-sites/themes/collections/style.scss
@@ -6,7 +6,7 @@
 		padding-top: 48px;
 		background-color: var(--studio-gray-0);
 		grid-column: 1/-1;
-		grid-row-start: 1;
+		grid-row-start: 3;
 		margin-bottom: 48px;
 
 		&:last-child {

--- a/client/my-sites/themes/collections/style.scss
+++ b/client/my-sites/themes/collections/style.scss
@@ -30,8 +30,8 @@
 			margin-right: -16px;
 		}
 		@include break-xlarge {
-			margin-left: -48px;
-			margin-right: -48px;
+			margin-left: -32px;
+			margin-right: -32px;
 		}
 	}
 	.theme-collection__meta {

--- a/client/my-sites/themes/collections/style.scss
+++ b/client/my-sites/themes/collections/style.scss
@@ -88,12 +88,16 @@
 	.theme-collection__list-item.swiper-slide {
 		@include break-small {
 			margin-left: 0;
-			max-width: 48%;
 			padding: 0 24px;
 		}
 		@include break-large {
-			max-width: 37%;
 			padding: 0 32px;
+		}
+		@media (min-width: 1009px) {
+			max-width: 50%;
+		}
+		@media (min-width: 1361px) {
+			max-width: 37%;
 		}
 	}
 }

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -35,10 +35,6 @@
 		@include breakpoint-deprecated( ">660px" ) {
 			padding: 64px 32px 16px;
 		}
-		@include break-xlarge {
-			padding-left: 48px;
-			padding-right: 48px;
-		}
 
 		h1 {
 			color: var(--studio-blue-50);
@@ -70,9 +66,6 @@
 
 			@include breakpoint-deprecated( ">660px" ) {
 				padding: 0 32px;
-			}
-			@include break-xlarge {
-				padding: 0 48px;
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4442

## Proposed Changes

LiTS and LoTS use slightly different breakpoints to adjust the content.
The Theme Discovery carousels all used the LoTS breakpoints; this PR splits LiTS and LoTS CSS (and JS) rules to make them cleaner and more obvious.

| Size | LoTS | LiTS |
|--------|--------|--------|
| S | <img width="511" alt="Screenshot 2023-11-07 at 17 09 39" src="https://github.com/Automattic/wp-calypso/assets/2070010/0ee4b674-6676-49b6-ba1b-73c2b9a4a992"> | <img width="511" alt="Screenshot 2023-11-07 at 17 09 34" src="https://github.com/Automattic/wp-calypso/assets/2070010/d57b191a-05c4-4ea3-a597-7adb76413b82"> |
| L | <img width="773" alt="Screenshot 2023-11-07 at 17 13 08" src="https://github.com/Automattic/wp-calypso/assets/2070010/b253492f-9773-490e-ba27-5b81655f9e8d"> | <img width="773" alt="Screenshot 2023-11-07 at 17 13 04" src="https://github.com/Automattic/wp-calypso/assets/2070010/c7c7a8ae-e6c5-41b3-942f-35572531d05a"> |
| XL | <img width="1298" alt="Screenshot 2023-11-07 at 17 12 01" src="https://github.com/Automattic/wp-calypso/assets/2070010/ae378fef-a047-4996-b593-6bf2caf884de"> | <img width="1298" alt="Screenshot 2023-11-07 at 17 11 53" src="https://github.com/Automattic/wp-calypso/assets/2070010/f07aac5c-da65-41a9-bbcc-7e8367e41f4e"> |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open LiTS with the `?flags=themes/discovery-lits` flag and LoTS with the `?flags=themes/discovery-lots` one.
* Play around with the windows width, and ensure:
  * The collection content is always aligned with the regular list.
  * The collection container (the grey background) is always aligned with the wrapper (either the window itself, or the main Calypso content), without accidental overflowing that might cause unnecessary scrolls.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?