### PR TITLE
Odyssey Stats: only show Subscriber chart section for stats admin >= 0.11.0-alpha

### DIFF
--- a/client/my-sites/stats/stats-subscribers/index.tsx
+++ b/client/my-sites/stats/stats-subscribers/index.tsx
@@ -9,8 +9,13 @@ import JetpackColophon from 'calypso/components/jetpack-colophon';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
+import version_compare from 'calypso/lib/version-compare';
 import { useSelector } from 'calypso/state';
-import { isJetpackSite, getSiteSlug } from 'calypso/state/sites/selectors';
+import {
+	isJetpackSite,
+	getSiteSlug,
+	getJetpackStatsAdminVersion,
+} from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import Followers from '../stats-followers';
 import StatsModuleEmails from '../stats-module-emails';
@@ -38,8 +43,14 @@ const StatsSubscribersPage = ( { period }: StatsSubscribersPageProps ) => {
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
 	// Run-time configuration.
+	const statsAdminVersion = useSelector( ( state ) =>
+		getJetpackStatsAdminVersion( state, siteId )
+	);
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
-	const isChartVisible = config.isEnabled( 'stats/subscribers-chart-section' );
+	// Always show chart for Calypso, and check compatibility for Odyssey.
+	const isChartVisible =
+		! isOdysseyStats ||
+		( statsAdminVersion && version_compare( statsAdminVersion, '0.11.0-alpha', '>=' ) );
 
 	const today = new Date().toISOString().slice( 0, 10 );
 

--- a/config/client.json
+++ b/config/client.json
@@ -25,7 +25,6 @@
 	"signup_url",
 	"stats/date-control",
 	"stats/new-video-summary",
-	"stats/subscribers-chart-section",
 	"stats/paid-wpcom-stats",
 	"stats/type-detection",
 	"wpcom_concierge_schedule_id",

--- a/config/development.json
+++ b/config/development.json
@@ -187,7 +187,6 @@
 		"ssr/prefetch-timebox": false,
 		"stats/date-control": true,
 		"stats/new-video-summary": true,
-		"stats/subscribers-chart-section": true,
 		"stats/paid-wpcom-stats": true,
 		"stats/type-detection": true,
 		"stepper-woocommerce-poc": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -124,7 +124,6 @@
 		"site-profiler": true,
 		"ssr/prefetch-timebox": true,
 		"stats/new-video-summary": false,
-		"stats/subscribers-chart-section": true,
 		"stats/paid-wpcom-stats": true,
 		"stats/date-control": true,
 		"stats/type-detection": true,

--- a/config/production.json
+++ b/config/production.json
@@ -152,7 +152,6 @@
 		"ssr/prefetch-timebox": true,
 		"ssr/sample-log-cache-misses": true,
 		"stats/new-video-summary": false,
-		"stats/subscribers-chart-section": true,
 		"stats/paid-wpcom-stats": true,
 		"stats/date-control": true,
 		"stats/type-detection": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -147,7 +147,6 @@
 		"site-profiler": true,
 		"ssr/prefetch-timebox": true,
 		"stats/new-video-summary": false,
-		"stats/subscribers-chart-section": true,
 		"stats/paid-wpcom-stats": true,
 		"stats/type-detection": true,
 		"stats/date-control": true,

--- a/config/test.json
+++ b/config/test.json
@@ -104,7 +104,6 @@
 		"site-profiler": true,
 		"ssr/prefetch-timebox": true,
 		"stats/new-video-summary": false,
-		"stats/subscribers-chart-section": true,
 		"stats/paid-wpcom-stats": true,
 		"stats/date-control": true,
 		"stats/type-detection": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -156,7 +156,6 @@
 		"site-profiler": true,
 		"ssr/prefetch-timebox": true,
 		"stats/new-video-summary": false,
-		"stats/subscribers-chart-section": true,
 		"stats/paid-wpcom-stats": true,
 		"stats/date-control": true,
 		"stats/type-detection": true,


### PR DESCRIPTION
## Proposed Changes

The support was added in https://github.com/Automattic/jetpack/pull/31394, stats-admin version `0.11.0-alpha`. So we only enable the chart for versions that support it.

The PR took the chance to remove legacy flag `stats/subscribers-chart-section` too.

## Testing Instructions

Ensure the Subscriber Chart still works for Calypso Stats and then please follow instructions at https://github.com/Automattic/wp-calypso/pull/83977.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?