### PR TITLE
Hide jetpack and akismet checkout 2 year upsell if the 2 year plan isn't a better deal

### DIFF
--- a/client/my-sites/checkout/src/components/jetpack-akismet-checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/src/components/jetpack-akismet-checkout-sidebar-plan-upsell/index.tsx
@@ -140,32 +140,19 @@ const JetpackAkismetCheckoutSidebarPlanUpsell: FC = () => {
 		{ strong: <strong /> }
 	);
 
-	const yearOnePrice = formatCurrency(
-		isComparisonWithIntroOffer ? currentVariant.priceInteger : currentVariant.priceBeforeDiscounts,
-		currentVariant.currency,
-		currencyConfig
-	);
+	const yearOnePrice = isComparisonWithIntroOffer
+		? currentVariant.priceInteger
+		: currentVariant.priceBeforeDiscounts;
 
-	const yearTwoPrice = formatCurrency(
-		currentVariant.priceBeforeDiscounts,
-		currentVariant.currency,
-		currencyConfig
-	);
+	const yearTwoPrice = currentVariant.priceBeforeDiscounts;
 
-	const twoYearTotal = formatCurrency(
+	const twoYearTotal =
 		currentVariant.priceBeforeDiscounts +
-			( isComparisonWithIntroOffer
-				? currentVariant.priceInteger
-				: currentVariant.priceBeforeDiscounts ),
-		currentVariant.currency,
-		currencyConfig
-	);
+		( isComparisonWithIntroOffer
+			? currentVariant.priceInteger
+			: currentVariant.priceBeforeDiscounts );
 
-	const twoYearTotalBiennial = formatCurrency(
-		biennialVariant.priceInteger,
-		biennialVariant.currency,
-		currencyConfig
-	);
+	const twoYearTotalBiennial = biennialVariant.priceInteger;
 
 	// We don't want to call out the two year plan if it doesn't save them money
 	if ( twoYearTotal >= twoYearTotalBiennial ) {
@@ -177,15 +164,29 @@ const JetpackAkismetCheckoutSidebarPlanUpsell: FC = () => {
 			<div className="checkout-sidebar-plan-upsell__plan-grid">
 				<UpsellLine label={ __( 'Yearly plan' ) } boldLabel isTitle />
 
-				<UpsellLine label={ __( 'Year One' ) } value={ yearOnePrice } />
+				<UpsellLine
+					label={ __( 'Year One' ) }
+					value={ formatCurrency( yearOnePrice, currentVariant.currency, currencyConfig ) }
+				/>
 
-				<UpsellLine label={ __( 'Year Two' ) } value={ yearTwoPrice } />
+				<UpsellLine
+					label={ __( 'Year Two' ) }
+					value={ formatCurrency( yearTwoPrice, currentVariant.currency, currencyConfig ) }
+				/>
 
-				<UpsellLine label={ __( 'Total' ) } value={ twoYearTotal } boldValue />
+				<UpsellLine
+					label={ __( 'Total' ) }
+					value={ formatCurrency( twoYearTotal, currentVariant.currency, currencyConfig ) }
+					boldValue
+				/>
 
 				<UpsellLine label={ __( 'Two-year plan' ) } boldLabel isTitle />
 
-				<UpsellLine label={ __( 'Two-year total' ) } value={ twoYearTotalBiennial } boldValue />
+				<UpsellLine
+					label={ __( 'Two-year total' ) }
+					value={ formatCurrency( twoYearTotalBiennial, biennialVariant.currency, currencyConfig ) }
+					boldValue
+				/>
 			</div>
 
 			<PromoCardCTA

--- a/client/my-sites/checkout/src/components/jetpack-akismet-checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/src/components/jetpack-akismet-checkout-sidebar-plan-upsell/index.tsx
@@ -155,7 +155,7 @@ const JetpackAkismetCheckoutSidebarPlanUpsell: FC = () => {
 	const twoYearTotalBiennial = biennialVariant.priceInteger;
 
 	// We don't want to call out the two year plan if it doesn't save them money
-	if ( twoYearTotal >= twoYearTotalBiennial ) {
+	if ( twoYearTotal <= twoYearTotalBiennial ) {
 		return null;
 	}
 

--- a/client/my-sites/checkout/src/components/jetpack-akismet-checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/src/components/jetpack-akismet-checkout-sidebar-plan-upsell/index.tsx
@@ -140,55 +140,52 @@ const JetpackAkismetCheckoutSidebarPlanUpsell: FC = () => {
 		{ strong: <strong /> }
 	);
 
+	const yearOnePrice = formatCurrency(
+		isComparisonWithIntroOffer ? currentVariant.priceInteger : currentVariant.priceBeforeDiscounts,
+		currentVariant.currency,
+		currencyConfig
+	);
+
+	const yearTwoPrice = formatCurrency(
+		currentVariant.priceBeforeDiscounts,
+		currentVariant.currency,
+		currencyConfig
+	);
+
+	const twoYearTotal = formatCurrency(
+		currentVariant.priceBeforeDiscounts +
+			( isComparisonWithIntroOffer
+				? currentVariant.priceInteger
+				: currentVariant.priceBeforeDiscounts ),
+		currentVariant.currency,
+		currencyConfig
+	);
+
+	const twoYearTotalBiennial = formatCurrency(
+		biennialVariant.priceInteger,
+		biennialVariant.currency,
+		currencyConfig
+	);
+
+	// We don't want to call out the two year plan if it doesn't save them money
+	if ( twoYearTotal >= twoYearTotalBiennial ) {
+		return null;
+	}
+
 	return (
 		<PromoCard title={ cardTitle } className="checkout-sidebar-plan-upsell jetpack">
 			<div className="checkout-sidebar-plan-upsell__plan-grid">
 				<UpsellLine label={ __( 'Yearly plan' ) } boldLabel isTitle />
 
-				<UpsellLine
-					label={ __( 'Year One' ) }
-					value={ formatCurrency(
-						isComparisonWithIntroOffer
-							? currentVariant.priceInteger
-							: currentVariant.priceBeforeDiscounts,
-						currentVariant.currency,
-						currencyConfig
-					) }
-				/>
+				<UpsellLine label={ __( 'Year One' ) } value={ yearOnePrice } />
 
-				<UpsellLine
-					label={ __( 'Year Two' ) }
-					value={ formatCurrency(
-						currentVariant.priceBeforeDiscounts,
-						currentVariant.currency,
-						currencyConfig
-					) }
-				/>
+				<UpsellLine label={ __( 'Year Two' ) } value={ yearTwoPrice } />
 
-				<UpsellLine
-					label={ __( 'Total' ) }
-					value={ formatCurrency(
-						currentVariant.priceBeforeDiscounts +
-							( isComparisonWithIntroOffer
-								? currentVariant.priceInteger
-								: currentVariant.priceBeforeDiscounts ),
-						currentVariant.currency,
-						currencyConfig
-					) }
-					boldValue
-				/>
+				<UpsellLine label={ __( 'Total' ) } value={ twoYearTotal } boldValue />
 
 				<UpsellLine label={ __( 'Two-year plan' ) } boldLabel isTitle />
 
-				<UpsellLine
-					label={ __( 'Two-year total' ) }
-					value={ formatCurrency(
-						biennialVariant.priceInteger,
-						biennialVariant.currency,
-						currencyConfig
-					) }
-					boldValue
-				/>
+				<UpsellLine label={ __( 'Two-year total' ) } value={ twoYearTotalBiennial } boldValue />
 			</div>
 
 			<PromoCardCTA


### PR DESCRIPTION
## Proposed Changes

* Move the price calculations for the 2 year upsell to variables
* Compare 2 year total with yearly plans to bi-yearly total and return null if it's not a better deal

## Testing Instructions

1. Use the Calypso live link or checkout this branch
2. Using a jurassic ninja or ephemural site, purchase a Jetpack Anti-Spam 2 year plan. Make sure the 2 year plan upsell shows up when the yearly plan is selected 
![image](https://github.com/Automattic/wp-calypso/assets/65001528/8342a392-cf8e-4a2d-85f7-b360a7570305)
3. Immediately go to https://wordpress.com/me/purchases and cancel the plan
4. Go back to your site and go to checkout with a 1 year Anti-Spam plan in the cart. The intro offer for 2 year plans will no longer be available, so the upsell should no longer show (previously you would see "Save -100%")
![image](https://github.com/Automattic/wp-calypso/assets/65001528/b12deada-ffec-4bc4-bd9b-49ffce06c7da)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?