### PR TITLE
Checkout: Collapse Payment Method step if a payment method is selected behind flag

### DIFF
--- a/client/my-sites/checkout/src/components/payment-method-step.tsx
+++ b/client/my-sites/checkout/src/components/payment-method-step.tsx
@@ -53,7 +53,7 @@ const TotalPrice = styled.div`
 	padding: 16px 0;
 `;
 
-export default function PaymentMethodStep() {
+export default function BeforeSubmitCheckoutHeader() {
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
 	const taxLineItems = getTaxBreakdownLineItemsFromCart( responseCart );

--- a/client/my-sites/checkout/src/components/payment-method-step.tsx
+++ b/client/my-sites/checkout/src/components/payment-method-step.tsx
@@ -10,7 +10,6 @@ import {
 import styled from '@emotion/styled';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import CheckoutTerms from '../components/checkout-terms';
-import { useShouldCollapseLastStep } from '../hooks/use-should-collapse-last-step';
 import { WPOrderReviewSection } from './wp-order-review-line-items';
 
 const CheckoutTermsWrapper = styled.div`
@@ -59,14 +58,11 @@ export default function PaymentMethodStep() {
 	const { responseCart } = useShoppingCart( cartKey );
 	const taxLineItems = getTaxBreakdownLineItemsFromCart( responseCart );
 	const creditsLineItem = getCreditsLineItemFromCart( responseCart );
-	const shouldCollapseLastStep = useShouldCollapseLastStep();
 	return (
 		<>
-			{ ! shouldCollapseLastStep && (
-				<CheckoutTermsWrapper>
-					<CheckoutTerms cart={ responseCart } />
-				</CheckoutTermsWrapper>
-			) }
+			<CheckoutTermsWrapper>
+				<CheckoutTerms cart={ responseCart } />
+			</CheckoutTermsWrapper>
 
 			{ ! hasCheckoutVersion( '2' ) && (
 				<WPOrderReviewSection>

--- a/client/my-sites/checkout/src/components/payment-method-step.tsx
+++ b/client/my-sites/checkout/src/components/payment-method-step.tsx
@@ -42,10 +42,6 @@ const CheckoutTermsWrapper = styled.div< { shouldCollapseLastStep: boolean } >`
 	}
 `;
 
-const PriceTallySection = styled.div< { shouldCollapseLastStep: boolean } >`
-	padding-bottom: ${ ( { shouldCollapseLastStep } ) => ( shouldCollapseLastStep ? '24px' : '0' ) };
-`;
-
 const NonTotalPrices = styled.div`
 	font-size: 12px;
 	border-top: ${ ( props ) => '1px solid ' + props.theme.colors.borderColorLight };
@@ -70,7 +66,7 @@ export default function BeforeSubmitCheckoutHeader() {
 			</CheckoutTermsWrapper>
 
 			{ ! hasCheckoutVersion( '2' ) && (
-				<PriceTallySection shouldCollapseLastStep={ shouldCollapseLastStep }>
+				<div>
 					<NonTotalPrices>
 						<NonProductLineItem subtotal lineItem={ getSubtotalLineItemFromCart( responseCart ) } />
 						{ taxLineItems.map( ( taxLineItem ) => (
@@ -83,7 +79,7 @@ export default function BeforeSubmitCheckoutHeader() {
 					<TotalPrice>
 						<NonProductLineItem total lineItem={ getTotalLineItemFromCart( responseCart ) } />
 					</TotalPrice>
-				</PriceTallySection>
+				</div>
 			) }
 		</>
 	);

--- a/client/my-sites/checkout/src/components/payment-method-step.tsx
+++ b/client/my-sites/checkout/src/components/payment-method-step.tsx
@@ -11,6 +11,7 @@ import styled from '@emotion/styled';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import CheckoutTerms from '../components/checkout-terms';
 import { useShouldCollapseLastStep } from '../hooks/use-should-collapse-last-step';
+import { WPOrderReviewSection } from './wp-order-review-line-items';
 
 const CheckoutTermsWrapper = styled.div< { shouldCollapseLastStep: boolean } >`
 	& > * {
@@ -66,7 +67,7 @@ export default function BeforeSubmitCheckoutHeader() {
 			</CheckoutTermsWrapper>
 
 			{ ! hasCheckoutVersion( '2' ) && (
-				<div>
+				<WPOrderReviewSection>
 					<NonTotalPrices>
 						<NonProductLineItem subtotal lineItem={ getSubtotalLineItemFromCart( responseCart ) } />
 						{ taxLineItems.map( ( taxLineItem ) => (
@@ -79,7 +80,7 @@ export default function BeforeSubmitCheckoutHeader() {
 					<TotalPrice>
 						<NonProductLineItem total lineItem={ getTotalLineItemFromCart( responseCart ) } />
 					</TotalPrice>
-				</div>
+				</WPOrderReviewSection>
 			) }
 		</>
 	);

--- a/client/my-sites/checkout/src/components/payment-method-step.tsx
+++ b/client/my-sites/checkout/src/components/payment-method-step.tsx
@@ -9,7 +9,39 @@ import {
 } from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
+import CheckoutTerms from '../components/checkout-terms';
+import { useShouldCollapseLastStep } from '../hooks/use-should-collapse-last-step';
 import { WPOrderReviewSection } from './wp-order-review-line-items';
+
+const CheckoutTermsWrapper = styled.div`
+	& > * {
+		margin: 16px 0;
+		padding-left: 24px;
+		position: relative;
+	}
+
+	.rtl & > * {
+		margin: 16px 0;
+		padding-right: 24px;
+		padding-left: 0;
+	}
+
+	& div:first-of-type {
+		padding-right: 0;
+		padding-left: 0;
+		margin-right: 0;
+		margin-left: 0;
+		margin-top: 32px;
+	}
+
+	a {
+		text-decoration: underline;
+	}
+
+	a:hover {
+		text-decoration: none;
+	}
+`;
 
 const NonTotalPrices = styled.div`
 	font-size: 12px;
@@ -27,8 +59,15 @@ export default function PaymentMethodStep() {
 	const { responseCart } = useShoppingCart( cartKey );
 	const taxLineItems = getTaxBreakdownLineItemsFromCart( responseCart );
 	const creditsLineItem = getCreditsLineItemFromCart( responseCart );
+	const shouldCollapseLastStep = useShouldCollapseLastStep();
 	return (
 		<>
+			{ ! shouldCollapseLastStep && (
+				<CheckoutTermsWrapper>
+					<CheckoutTerms cart={ responseCart } />
+				</CheckoutTermsWrapper>
+			) }
+
 			{ ! hasCheckoutVersion( '2' ) && (
 				<WPOrderReviewSection>
 					<NonTotalPrices>

--- a/client/my-sites/checkout/src/components/payment-method-step.tsx
+++ b/client/my-sites/checkout/src/components/payment-method-step.tsx
@@ -10,7 +10,7 @@ import {
 import styled from '@emotion/styled';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import CheckoutTerms from '../components/checkout-terms';
-import { WPOrderReviewSection } from './wp-order-review-line-items';
+import { useShouldCollapseLastStep } from '../hooks/use-should-collapse-last-step';
 
 const CheckoutTermsWrapper = styled.div`
 	& > * {
@@ -42,6 +42,10 @@ const CheckoutTermsWrapper = styled.div`
 	}
 `;
 
+const PriceTallySection = styled.div< { shouldCollapseLastStep: boolean } >`
+	padding-bottom: ${ ( { shouldCollapseLastStep } ) => ( shouldCollapseLastStep ? '24px' : '0' ) };
+`;
+
 const NonTotalPrices = styled.div`
 	font-size: 12px;
 	border-top: ${ ( props ) => '1px solid ' + props.theme.colors.borderColorLight };
@@ -58,6 +62,7 @@ export default function BeforeSubmitCheckoutHeader() {
 	const { responseCart } = useShoppingCart( cartKey );
 	const taxLineItems = getTaxBreakdownLineItemsFromCart( responseCart );
 	const creditsLineItem = getCreditsLineItemFromCart( responseCart );
+	const shouldCollapseLastStep = useShouldCollapseLastStep();
 	return (
 		<>
 			<CheckoutTermsWrapper>
@@ -65,7 +70,7 @@ export default function BeforeSubmitCheckoutHeader() {
 			</CheckoutTermsWrapper>
 
 			{ ! hasCheckoutVersion( '2' ) && (
-				<WPOrderReviewSection>
+				<PriceTallySection shouldCollapseLastStep={ shouldCollapseLastStep }>
 					<NonTotalPrices>
 						<NonProductLineItem subtotal lineItem={ getSubtotalLineItemFromCart( responseCart ) } />
 						{ taxLineItems.map( ( taxLineItem ) => (
@@ -78,7 +83,7 @@ export default function BeforeSubmitCheckoutHeader() {
 					<TotalPrice>
 						<NonProductLineItem total lineItem={ getTotalLineItemFromCart( responseCart ) } />
 					</TotalPrice>
-				</WPOrderReviewSection>
+				</PriceTallySection>
 			) }
 		</>
 	);

--- a/client/my-sites/checkout/src/components/payment-method-step.tsx
+++ b/client/my-sites/checkout/src/components/payment-method-step.tsx
@@ -12,7 +12,7 @@ import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import CheckoutTerms from '../components/checkout-terms';
 import { useShouldCollapseLastStep } from '../hooks/use-should-collapse-last-step';
 
-const CheckoutTermsWrapper = styled.div`
+const CheckoutTermsWrapper = styled.div< { shouldCollapseLastStep: boolean } >`
 	& > * {
 		margin: 16px 0;
 		padding-left: 24px;
@@ -30,7 +30,7 @@ const CheckoutTermsWrapper = styled.div`
 		padding-left: 0;
 		margin-right: 0;
 		margin-left: 0;
-		margin-top: 32px;
+		margin-top: ${ ( { shouldCollapseLastStep } ) => ( shouldCollapseLastStep ? '0' : '32px' ) };
 	}
 
 	a {
@@ -65,7 +65,7 @@ export default function BeforeSubmitCheckoutHeader() {
 	const shouldCollapseLastStep = useShouldCollapseLastStep();
 	return (
 		<>
-			<CheckoutTermsWrapper>
+			<CheckoutTermsWrapper shouldCollapseLastStep={ shouldCollapseLastStep }>
 				<CheckoutTerms cart={ responseCart } />
 			</CheckoutTermsWrapper>
 

--- a/client/my-sites/checkout/src/components/payment-method-step.tsx
+++ b/client/my-sites/checkout/src/components/payment-method-step.tsx
@@ -9,38 +9,7 @@ import {
 } from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
-import CheckoutTerms from '../components/checkout-terms';
 import { WPOrderReviewSection } from './wp-order-review-line-items';
-
-const CheckoutTermsWrapper = styled.div`
-	& > * {
-		margin: 16px 0;
-		padding-left: 24px;
-		position: relative;
-	}
-
-	.rtl & > * {
-		margin: 16px 0;
-		padding-right: 24px;
-		padding-left: 0;
-	}
-
-	& div:first-of-type {
-		padding-right: 0;
-		padding-left: 0;
-		margin-right: 0;
-		margin-left: 0;
-		margin-top: 32px;
-	}
-
-	a {
-		text-decoration: underline;
-	}
-
-	a:hover {
-		text-decoration: none;
-	}
-`;
 
 const NonTotalPrices = styled.div`
 	font-size: 12px;
@@ -60,10 +29,6 @@ export default function PaymentMethodStep() {
 	const creditsLineItem = getCreditsLineItemFromCart( responseCart );
 	return (
 		<>
-			<CheckoutTermsWrapper>
-				<CheckoutTerms cart={ responseCart } />
-			</CheckoutTermsWrapper>
-
 			{ ! hasCheckoutVersion( '2' ) && (
 				<WPOrderReviewSection>
 					<NonTotalPrices>

--- a/client/my-sites/checkout/src/components/summary-details.js
+++ b/client/my-sites/checkout/src/components/summary-details.js
@@ -13,4 +13,6 @@ export const SummaryLine = styled.li`
 	margin: 0;
 	padding: 0;
 	list-style: none;
+	display: flex;
+	gap: 8px;
 `;

--- a/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
@@ -41,7 +41,6 @@ const SiteSummary = styled.div`
 
 const CouponLinkWrapper = styled.div`
 	font-size: 14px;
-	margin-bottom: 2em;
 `;
 
 const CouponField = styled( Coupon )``;
@@ -229,7 +228,7 @@ function CouponFieldArea( {
 
 	return (
 		<CouponLinkWrapper>
-			{ translate( 'Have a coupon? ' ) }
+			{ translate( 'Have a coupon? ' ) }{ ' ' }
 			<CouponEnableButton
 				className="wp-checkout-order-review__show-coupon-field-button"
 				onClick={ () => setCouponFieldVisible( true ) }

--- a/client/my-sites/checkout/src/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout.tsx
@@ -326,6 +326,7 @@ export default function WPCheckout( {
 
 	const { transactionStatus } = useTransactionStatus();
 	const paymentMethod = usePaymentMethod();
+	const shouldCollapseLastStep = useShouldCollapseLastStep();
 
 	const hasMarketplaceProduct = useSelector( ( state ) => {
 		return responseCart?.products?.some( ( p ) => isMarketplaceProduct( state, p.product_slug ) );
@@ -613,27 +614,29 @@ export default function WPCheckout( {
 					<PaymentMethodStep
 						activeStepHeader={ <GoogleDomainsCopy responseCart={ responseCart } /> }
 						activeStepFooter={
-							<>
-								<PaymentMethodStepContent />
-								{ hasMarketplaceProduct && (
-									<AcceptTermsOfServiceCheckbox
-										isAccepted={ is3PDAccountConsentAccepted }
-										onChange={ setIs3PDAccountConsentAccepted }
-										isSubmitted={ isSubmitted }
-										message={ translate(
-											'You agree that an account may be created on a third party developer’s site related to the products you have purchased.'
-										) }
-									/>
-								) }
-								{ has100YearPlan && (
-									<AcceptTermsOfServiceCheckbox
-										isAccepted={ is100YearPlanTermsAccepted }
-										onChange={ setIs100YearPlanTermsAccepted }
-										isSubmitted={ isSubmitted }
-										message={ translate( 'I have read and agree to all of the above.' ) }
-									/>
-								) }
-							</>
+							! shouldCollapseLastStep && (
+								<>
+									<PaymentMethodStepContent />
+									{ hasMarketplaceProduct && (
+										<AcceptTermsOfServiceCheckbox
+											isAccepted={ is3PDAccountConsentAccepted }
+											onChange={ setIs3PDAccountConsentAccepted }
+											isSubmitted={ isSubmitted }
+											message={ translate(
+												'You agree that an account may be created on a third party developer’s site related to the products you have purchased.'
+											) }
+										/>
+									) }
+									{ has100YearPlan && (
+										<AcceptTermsOfServiceCheckbox
+											isAccepted={ is100YearPlanTermsAccepted }
+											onChange={ setIs100YearPlanTermsAccepted }
+											isSubmitted={ isSubmitted }
+											message={ translate( 'I have read and agree to all of the above.' ) }
+										/>
+									) }
+								</>
+							)
 						}
 						editButtonText={ String( translate( 'Edit' ) ) }
 						editButtonAriaLabel={ String( translate( 'Edit the payment method' ) ) }

--- a/client/my-sites/checkout/src/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout.tsx
@@ -800,8 +800,10 @@ const CheckoutSummaryBody = styled.div`
 const CheckoutTermsAndCheckboxesWrapper = styled.div`
 	display: flex;
 	flex-direction: column;
-	padding-top: 32px;
-	padding-left: 40px;
+	padding: 32px 20px 0 24px;
+	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
+		padding: 32px 20px 0 40px;
+	}
 `;
 
 function CheckoutTermsAndCheckboxes( {

--- a/client/my-sites/checkout/src/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout.tsx
@@ -647,8 +647,12 @@ export default function WPCheckout( {
 						validatingButtonAriaLabel={ validatingButtonText }
 						isCompleteCallback={ () => {
 							// We want to consider this step complete only if there is a
-							// payment method selected.
-							return Boolean( paymentMethod );
+							// payment method selected and it does not have required fields.
+							// This will not prevent the form from being submitted because
+							// the submit button will be active as long as the last step is
+							// shown, but it will prevent the payment method step from
+							// automatically collapsing when checkout loads.
+							return Boolean( paymentMethod ) && ! paymentMethod?.hasRequiredFields;
 						} }
 					/>
 					<CheckoutFormSubmit

--- a/client/my-sites/checkout/src/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout.tsx
@@ -60,6 +60,7 @@ import { saveContactDetailsCache } from 'calypso/state/domains/management/action
 import { errorNotice, removeNotice } from 'calypso/state/notices/actions';
 import { isMarketplaceProduct } from 'calypso/state/products-list/selectors';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
+import CheckoutTerms from '../components/checkout-terms';
 import useCouponFieldState from '../hooks/use-coupon-field-state';
 import { validateContactDetails } from '../lib/contact-validation';
 import getContactDetailsType from '../lib/get-contact-details-type';
@@ -783,18 +784,13 @@ const CheckoutSummaryBody = styled.div`
 `;
 
 function SubmitButtonHeader() {
-	const translate = useTranslate();
-
-	const scrollToTOS = () => document?.getElementById( 'checkout-terms' )?.scrollIntoView();
+	const cartKey = useCartKey();
+	const { responseCart } = useShoppingCart( cartKey );
 
 	return (
-		<SubmitButtonHeaderWrapper>
-			{ translate( 'By continuing, you agree to our {{button}}Terms of Service{{/button}}.', {
-				components: {
-					button: <button onClick={ scrollToTOS } />,
-				},
-			} ) }
-		</SubmitButtonHeaderWrapper>
+		<CheckoutTermsWrapper>
+			<CheckoutTerms cart={ responseCart } />
+		</CheckoutTermsWrapper>
 	);
 }
 
@@ -884,31 +880,33 @@ const JetpackSealText = styled.span`
 	padding: 0.1875rem 0 0 0;
 `;
 
-const SubmitButtonHeaderWrapper = styled.div`
-	display: none;
-	font-size: 13px;
-	margin-top: -5px;
-	margin-bottom: 10px;
-	text-align: center;
-
-	.checkout__step-wrapper--last-step & {
-		display: block;
-
-		@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
-			display: none;
-		}
+const CheckoutTermsWrapper = styled.div`
+	& > * {
+		margin: 16px 0;
+		padding-left: 24px;
+		position: relative;
 	}
 
-	button {
-		color: ${ ( props ) => props.theme.colors.highlight };
-		display: inline;
-		font-size: 13px;
-		text-decoration: underline;
-		width: auto;
+	.rtl & > * {
+		margin: 16px 0;
+		padding-right: 24px;
+		padding-left: 0;
+	}
 
-		&:hover {
-			color: ${ ( props ) => props.theme.colors.highlightOver };
-		}
+	& div:first-of-type {
+		padding-right: 0;
+		padding-left: 0;
+		margin-right: 0;
+		margin-left: 0;
+		margin-top: 32px;
+	}
+
+	a {
+		text-decoration: underline;
+	}
+
+	a:hover {
+		text-decoration: none;
 	}
 `;
 

--- a/client/my-sites/checkout/src/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout.tsx
@@ -62,6 +62,7 @@ import { isMarketplaceProduct } from 'calypso/state/products-list/selectors';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 import CheckoutTerms from '../components/checkout-terms';
 import useCouponFieldState from '../hooks/use-coupon-field-state';
+import { useShouldCollapseLastStep } from '../hooks/use-should-collapse-last-step';
 import { validateContactDetails } from '../lib/contact-validation';
 import getContactDetailsType from '../lib/get-contact-details-type';
 import { updateCartContactDetailsForCheckout } from '../lib/update-cart-contact-details-for-checkout';
@@ -786,11 +787,27 @@ const CheckoutSummaryBody = styled.div`
 function SubmitButtonHeader() {
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
+	const translate = useTranslate();
+	const shouldCollapseLastStep = useShouldCollapseLastStep();
+
+	if ( shouldCollapseLastStep ) {
+		return (
+			<CheckoutTermsWrapper>
+				<CheckoutTerms cart={ responseCart } />
+			</CheckoutTermsWrapper>
+		);
+	}
+
+	const scrollToTOS = () => document?.getElementById( 'checkout-terms' )?.scrollIntoView();
 
 	return (
-		<CheckoutTermsWrapper>
-			<CheckoutTerms cart={ responseCart } />
-		</CheckoutTermsWrapper>
+		<SubmitButtonHeaderWrapper>
+			{ translate( 'By continuing, you agree to our {{button}}Terms of Service{{/button}}.', {
+				components: {
+					button: <button onClick={ scrollToTOS } />,
+				},
+			} ) }
+		</SubmitButtonHeaderWrapper>
 	);
 }
 
@@ -878,6 +895,34 @@ const JetpackCheckoutSealsSection = styled.div< React.HTMLAttributes< HTMLDivEle
 
 const JetpackSealText = styled.span`
 	padding: 0.1875rem 0 0 0;
+`;
+
+const SubmitButtonHeaderWrapper = styled.div`
+	display: none;
+	font-size: 13px;
+	margin-top: -5px;
+	margin-bottom: 10px;
+	text-align: center;
+
+	.checkout__step-wrapper--last-step & {
+		display: block;
+
+		@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
+			display: none;
+		}
+	}
+
+	button {
+		color: ${ ( props ) => props.theme.colors.highlight };
+		display: inline;
+		font-size: 13px;
+		text-decoration: underline;
+		width: auto;
+
+		&:hover {
+			color: ${ ( props ) => props.theme.colors.highlightOver };
+		}
+	}
 `;
 
 const CheckoutTermsWrapper = styled.div`

--- a/client/my-sites/checkout/src/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout.tsx
@@ -655,17 +655,16 @@ export default function WPCheckout( {
 							return Boolean( paymentMethod ) && ! paymentMethod?.hasRequiredFields;
 						} }
 					/>
+					<CheckoutTermsAndCheckboxes
+						is3PDAccountConsentAccepted={ is3PDAccountConsentAccepted }
+						setIs3PDAccountConsentAccepted={ setIs3PDAccountConsentAccepted }
+						is100YearPlanTermsAccepted={ is100YearPlanTermsAccepted }
+						setIs100YearPlanTermsAccepted={ setIs100YearPlanTermsAccepted }
+						isSubmitted={ isSubmitted }
+					/>
 					<CheckoutFormSubmit
 						validateForm={ validateForm }
-						submitButtonHeader={
-							<SubmitButtonHeader
-								is3PDAccountConsentAccepted={ is3PDAccountConsentAccepted }
-								setIs3PDAccountConsentAccepted={ setIs3PDAccountConsentAccepted }
-								is100YearPlanTermsAccepted={ is100YearPlanTermsAccepted }
-								setIs100YearPlanTermsAccepted={ setIs100YearPlanTermsAccepted }
-								isSubmitted={ isSubmitted }
-							/>
-						}
+						submitButtonHeader={ <SubmitButtonHeader /> }
 						submitButtonFooter={ <JetpackCheckoutSeals /> }
 					/>
 				</CheckoutStepGroup>
@@ -798,7 +797,14 @@ const CheckoutSummaryBody = styled.div`
 	}
 `;
 
-function SubmitButtonHeader( {
+const CheckoutTermsAndCheckboxesWrapper = styled.div`
+	display: flex;
+	flex-direction: column;
+	padding-top: 32px;
+	padding-left: 40px;
+`;
+
+function CheckoutTermsAndCheckboxes( {
 	is3PDAccountConsentAccepted,
 	setIs3PDAccountConsentAccepted,
 	is100YearPlanTermsAccepted,
@@ -821,31 +827,36 @@ function SubmitButtonHeader( {
 	const translate = useTranslate();
 	const shouldCollapseLastStep = useShouldCollapseLastStep();
 
-	if ( shouldCollapseLastStep ) {
-		return (
-			<>
-				<BeforeSubmitCheckoutHeader />
-				{ hasMarketplaceProduct && (
-					<AcceptTermsOfServiceCheckbox
-						isAccepted={ is3PDAccountConsentAccepted }
-						onChange={ setIs3PDAccountConsentAccepted }
-						isSubmitted={ isSubmitted }
-						message={ translate(
-							'You agree that an account may be created on a third party developer’s site related to the products you have purchased.'
-						) }
-					/>
-				) }
-				{ has100YearPlan && (
-					<AcceptTermsOfServiceCheckbox
-						isAccepted={ is100YearPlanTermsAccepted }
-						onChange={ setIs100YearPlanTermsAccepted }
-						isSubmitted={ isSubmitted }
-						message={ translate( 'I have read and agree to all of the above.' ) }
-					/>
-				) }
-			</>
-		);
+	if ( ! shouldCollapseLastStep ) {
+		return null;
 	}
+	return (
+		<CheckoutTermsAndCheckboxesWrapper>
+			<BeforeSubmitCheckoutHeader />
+			{ hasMarketplaceProduct && (
+				<AcceptTermsOfServiceCheckbox
+					isAccepted={ is3PDAccountConsentAccepted }
+					onChange={ setIs3PDAccountConsentAccepted }
+					isSubmitted={ isSubmitted }
+					message={ translate(
+						'You agree that an account may be created on a third party developer’s site related to the products you have purchased.'
+					) }
+				/>
+			) }
+			{ has100YearPlan && (
+				<AcceptTermsOfServiceCheckbox
+					isAccepted={ is100YearPlanTermsAccepted }
+					onChange={ setIs100YearPlanTermsAccepted }
+					isSubmitted={ isSubmitted }
+					message={ translate( 'I have read and agree to all of the above.' ) }
+				/>
+			) }
+		</CheckoutTermsAndCheckboxesWrapper>
+	);
+}
+
+function SubmitButtonHeader() {
+	const translate = useTranslate();
 
 	const scrollToTOS = () => document?.getElementById( 'checkout-terms' )?.scrollIntoView();
 

--- a/client/my-sites/checkout/src/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout.tsx
@@ -20,6 +20,7 @@ import {
 	CheckoutFormSubmit,
 	PaymentMethodStep,
 	FormStatus,
+	usePaymentMethod,
 } from '@automattic/composite-checkout';
 import { formatCurrency } from '@automattic/format-currency';
 import { useLocale } from '@automattic/i18n-utils';
@@ -322,6 +323,7 @@ export default function WPCheckout( {
 		} );
 
 	const { transactionStatus } = useTransactionStatus();
+	const paymentMethod = usePaymentMethod();
 
 	const hasMarketplaceProduct = useSelector( ( state ) => {
 		return responseCart?.products?.some( ( p ) => isMarketplaceProduct( state, p.product_slug ) );
@@ -639,7 +641,11 @@ export default function WPCheckout( {
 						) }
 						validatingButtonText={ validatingButtonText }
 						validatingButtonAriaLabel={ validatingButtonText }
-						isCompleteCallback={ () => false }
+						isCompleteCallback={ () => {
+							// We want to consider this step complete only if there is a
+							// payment method selected.
+							return Boolean( paymentMethod );
+						} }
 					/>
 					<CheckoutFormSubmit
 						validateForm={ validateForm }

--- a/client/my-sites/checkout/src/hooks/use-cached-domain-contact-details.ts
+++ b/client/my-sites/checkout/src/hooks/use-cached-domain-contact-details.ts
@@ -98,7 +98,7 @@ function useCachedContactDetailsForCheckoutForm(
 				if ( cachedContactDetails.countryCode ) {
 					setShouldShowContactDetailsValidationErrors( false );
 					debug( 'Contact details are populated; attempting to skip to payment method step' );
-					return setStepCompleteStatus( 'contact-form' );
+					return setStepCompleteStatus( 'payment-method-step' );
 				}
 				return false;
 			} )

--- a/client/my-sites/checkout/src/hooks/use-cached-domain-contact-details.ts
+++ b/client/my-sites/checkout/src/hooks/use-cached-domain-contact-details.ts
@@ -12,6 +12,7 @@ import getContactDetailsCache from 'calypso/state/selectors/get-contact-details-
 import { convertErrorToString } from '../lib/analytics';
 import { CHECKOUT_STORE } from '../lib/wpcom-store';
 import useCountryList from './use-country-list';
+import { useShouldCollapseLastStep } from './use-should-collapse-last-step';
 import type {
 	PossiblyCompleteDomainContactDetails,
 	CountryListItem,
@@ -61,6 +62,8 @@ function useCachedContactDetailsForCheckoutForm(
 	}
 	const { loadDomainContactDetailsFromCache } = checkoutStoreActions;
 
+	const shouldCollapseLastStep = useShouldCollapseLastStep();
+
 	const isMounted = useRef( true );
 	useEffect( () => {
 		isMounted.current = true;
@@ -98,7 +101,10 @@ function useCachedContactDetailsForCheckoutForm(
 				if ( cachedContactDetails.countryCode ) {
 					setShouldShowContactDetailsValidationErrors( false );
 					debug( 'Contact details are populated; attempting to skip to payment method step' );
-					return setStepCompleteStatus( 'payment-method-step' );
+					if ( shouldCollapseLastStep ) {
+						return setStepCompleteStatus( 'payment-method-step' );
+					}
+					return setStepCompleteStatus( 'contact-form' );
 				}
 				return false;
 			} )
@@ -129,6 +135,7 @@ function useCachedContactDetailsForCheckoutForm(
 				} );
 			} );
 	}, [
+		shouldCollapseLastStep,
 		setShouldShowContactDetailsValidationErrors,
 		reduxDispatch,
 		setStepCompleteStatus,

--- a/client/my-sites/checkout/src/hooks/use-should-collapse-last-step.tsx
+++ b/client/my-sites/checkout/src/hooks/use-should-collapse-last-step.tsx
@@ -1,3 +1,8 @@
+import { hasCheckoutVersion } from '@automattic/wpcom-checkout';
+
 export function useShouldCollapseLastStep(): boolean {
-	return true;
+	if ( hasCheckoutVersion( 'collapse-steps' ) ) {
+		return true;
+	}
+	return false;
 }

--- a/client/my-sites/checkout/src/hooks/use-should-collapse-last-step.tsx
+++ b/client/my-sites/checkout/src/hooks/use-should-collapse-last-step.tsx
@@ -1,0 +1,3 @@
+export function useShouldCollapseLastStep(): boolean {
+	return true;
+}

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -26,7 +26,7 @@
 		"catch-js-errors": false,
 		"checkout/google-pay": true,
 		"checkout/vat-form": true,
-		"checkout/checkout-version": false,
+		"checkout/checkout-version": true,
 		"cloudflare": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,


### PR DESCRIPTION
There are currently two steps in checkout: the billing info step (sometimes even that does not exist for certain free purchases) and the payment method step. Each `CheckoutStep` as defined by the `@automattic/composite-checkout` package has the ability to be rendered in an "active" and an "inactive" state. For example, when you enter your billing info into the first step and press "Continue", the step is changed to its "inactive" state which displays the billing info without the editable fields.

We have a feature which attempts to auto-complete the billing info step using cached contact details when checkout loads, but there is no way to complete the payment method step because a `CheckoutStep` will not display the "Continue" button for the last step. This is so it doesn't conflict with the `CheckoutFormSubmit` which is the page's primary call-to-action.

## Proposed Changes

In this PR, we modify the auto-complete feature to also attempt to complete the payment method step when checkout loads. Since this is done programmatically, it allows marking the step as inactive even though there's no manual way to do so. 

Doing this required also moving the Terms of Service and checkboxes section from the bottom of the payment method step to a component between the payment method step and the submit button so that they will be visible even if the step is collapsed. One side effect of this is that the Terms of Service are no longer hidden when the billing step is active, but I don't know if that will be a problem.

> [!IMPORTANT]
> This feature and the associated UI is disabled by default. We will A/B test this in a follow-up PR. For now, it can be activated by adding the `?checkoutVersion=collapse-steps` query string to the checkout URL.

> [!NOTE]  
> If the user clicks to edit the step, there is no way to manually collapse it again. This is by design because a "Complete" button would look strange on the last step and add additional friction. If any step is not complete (eg: if the billing info is invalid or if a payment method with required fields is selected), the step will not be collapsed. This is also by design.

> [!NOTE]
> For free purchases that allow a choice between assigning a payment method (for later renewals) and not assigning one at all, this further hides the "Assign a payment method later" option, since it is no longer in view at all (assuming the user has a saved card) unless the user clicks to edit the payment method step. This is probably fine since we want people to save payment methods but it's worth mentioning.

The motivation for this change is to reduce visual noise on the checkout page for returning customers who want to continue using a saved payment method.

This is part of the project to update checkout's UI: https://github.com/Automattic/payments-shilling/issues/1969

## Screenshots

Before             |  After
:-------------------------:|:-------------------------:
<img width="835" alt="before-83985" src="https://github.com/Automattic/wp-calypso/assets/2036909/9c7b2248-32a6-44f4-aec7-393121b435bc">  | <img width="840" alt="Screenshot 2023-11-08 at 6 40 57 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/d4a844fc-31a3-4612-9439-4dd678e00d75">

## Testing Instructions

There are several things to test. 

- First, we want to be sure that this does not affect people who do not have the feature enabled. Because it is disabled by default, you can do this by visiting checkout on this branch without adding anything to the URL. Verify that checkout looks unchanged from how it looks in production.

Next, we want to enable the new UI which will be used for A/B testing this feature. Reload checkout on this branch but add `?checkoutVersion=collapse-steps` to the end of the URL query string. Use that for the remaining tests.

- Use an account with saved billing info and a saved credit card. Visit checkout and verify that both the billing and the payment method step are collapsed. Click to edit either step and verify that they become active.
- Use an account with saved billing info and no saved credit card (or modify `useCreateExistingCards` to return an empty array) and verify that the billing step is collapsed but the payment method step is active with the "Credit or debit card" payment method selected.

