### PR TITLE
Assembler: Inject page title to page patterns

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-page-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-page-preview.tsx
@@ -29,7 +29,7 @@ const PATTERN_PAGE_PREVIEW_ITEM_VIEWPORT_WIDTH = 1080;
 // A copy of the title block in Creatio 2's page.html.
 const getPageTitlePattern = ( title: string ) => `
 	<div
-		class="wp-block-group has-global-padding is-layout-constrained wp-container-9 wp-block-group-is-layout-constrained"
+		class="wp-block-group has-global-padding is-layout-constrained wp-block-group-is-layout-constrained"
 		style="margin-top:var(--wp--preset--spacing--60);margin-bottom:var(--wp--preset--spacing--60)"
 	>
 		<h2 class="has-text-align-left alignwide wp-block-post-title has-xxxx-large-font-size">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-page-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-page-preview.tsx
@@ -2,7 +2,7 @@ import { PatternRenderer } from '@automattic/block-renderer';
 import { Dialog } from '@automattic/components';
 import { __unstableCompositeItem as CompositeItem } from '@wordpress/components';
 import { CSSProperties, useMemo } from 'react';
-import { encodePatternId } from './utils';
+import { encodePatternId, isPagePattern } from './utils';
 import type { Pattern } from './types';
 import './pattern-page-preview.scss';
 
@@ -25,6 +25,17 @@ interface PatternPagePreviewProps {
 
 const PATTERN_PAGE_PREVIEW_ITEM_VIEWPORT_HEIGHT = 500;
 const PATTERN_PAGE_PREVIEW_ITEM_VIEWPORT_WIDTH = 1080;
+
+// A copy of the title block in Creatio 2's page.html.
+const getPageTitlePattern = ( title: string ) => `
+	<div
+		class="wp-block-group has-global-padding is-layout-constrained wp-container-9 wp-block-group-is-layout-constrained"
+		style="margin-top:var(--wp--preset--spacing--60);margin-bottom:var(--wp--preset--spacing--60)"
+	>
+		<h2 class="has-text-align-left alignwide wp-block-post-title has-xxxx-large-font-size">
+			${ title }
+		</h2>
+	</div>`;
 
 export const PatternPagePreviewModal = ( {
 	style,
@@ -52,6 +63,7 @@ export const PatternPagePreviewModal = ( {
 						viewportWidth={ PATTERN_PAGE_PREVIEW_ITEM_VIEWPORT_WIDTH }
 						viewportHeight={ PATTERN_PAGE_PREVIEW_ITEM_VIEWPORT_HEIGHT }
 						shouldShufflePosts={ shouldShufflePosts }
+						prependHtml={ isPagePattern( pattern ) ? getPageTitlePattern( pattern.title ) : '' }
 					/>
 				) ) }
 			</div>
@@ -86,6 +98,7 @@ const PatternPagePreview = ( {
 							patternId={ encodePatternId( pattern.ID ) }
 							viewportWidth={ PATTERN_PAGE_PREVIEW_ITEM_VIEWPORT_WIDTH }
 							viewportHeight={ PATTERN_PAGE_PREVIEW_ITEM_VIEWPORT_HEIGHT }
+							prependHtml={ isPagePattern( pattern ) ? getPageTitlePattern( pattern.title ) : '' }
 							shouldShufflePosts={ shouldShufflePosts }
 						/>
 					) ) }

--- a/packages/block-renderer/src/components/pattern-renderer.tsx
+++ b/packages/block-renderer/src/components/pattern-renderer.tsx
@@ -10,6 +10,7 @@ interface Props {
 	minHeight?: number;
 	maxHeight?: 'none' | number;
 	placeholder?: JSX.Element;
+	prependHtml?: string;
 	shouldShufflePosts: boolean;
 }
 
@@ -19,11 +20,12 @@ const PatternRenderer = ( {
 	viewportHeight,
 	minHeight,
 	maxHeight,
+	prependHtml = '',
 	shouldShufflePosts,
 }: Props ) => {
 	const renderedPatterns = usePatternsRendererContext();
 	const pattern = renderedPatterns[ patternId ];
-	const patternHtml = usePatternMinHeightVh( pattern?.html, viewportHeight );
+	const patternHtml = usePatternMinHeightVh( prependHtml + pattern?.html, viewportHeight );
 	const inlineCss = usePatternInlineCss( patternId, patternHtml, shouldShufflePosts );
 
 	return (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #83450

## Proposed Changes

See #83936 and p1698760288104839-slack-CRWCHQGUB. This PR injects HTML to page patterns in order to display the page title. The page title block is copied from Creatio 2's [page.html](https://github.com/Automattic/themes/blob/1a4d4d8d6ab94dea9c530a568de0ef46a2f93649/creatio-2/templates/page.html).

| Before | After | 
| --- | --- |
| ![Screenshot 2023-11-08 at 2 03 54 PM](https://github.com/Automattic/wp-calypso/assets/797888/ac5e87ea-8cde-47d6-8e97-274ad9e26652) |  ![Screenshot 2023-11-08 at 2 03 11 PM](https://github.com/Automattic/wp-calypso/assets/797888/cd9994a9-85e8-4e15-84fa-f990bc4c64ed)|


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Assembler.
* Go through the Patterns, and Styles screen until you arrive at the Pages screen.
* Ensure that each page except the Homepage shows the page title in the page preview.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?