### PR TITLE
Jetpack Manage: Fix the issue with the dashboard table responsive view.

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/hooks/use-dashboard-show-large-screen.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/hooks/use-dashboard-show-large-screen.ts
@@ -10,31 +10,34 @@ const useDashboardShowLargeScreen = (
 	const isDesktop = useBreakpoint( DESKTOP_BREAKPOINT );
 
 	const [ isOverflowing, setIsOverflowing ] = useState( false );
+	const [ tableWidth, setTableWidth ] = useState( 0 );
 
 	const checkIfOverflowing = useCallback( () => {
+		setIsOverflowing( tableWidth > containerRef?.current?.clientWidth );
+	}, [ containerRef, tableWidth ] );
+
+	// We will need to remember the table width once to properly check if it is overflowing
+	useEffect( () => {
 		const siteTableEle = siteTableRef ? siteTableRef.current : null;
 
-		if ( siteTableEle ) {
-			if ( siteTableEle.clientWidth > containerRef?.current?.clientWidth ) {
-				setTimeout( () => {
-					setIsOverflowing( true );
-				}, 1 );
-			}
+		if ( ! tableWidth && siteTableEle ) {
+			setTableWidth( siteTableEle.clientWidth );
 		}
-	}, [ siteTableRef, containerRef ] );
+	}, [ siteTableRef, tableWidth ] );
 
-	useEffect( () => {
-		window.addEventListener( 'resize', checkIfOverflowing );
-		return () => {
-			window.removeEventListener( 'resize', checkIfOverflowing );
-		};
-	}, [ checkIfOverflowing ] );
+	useEffect(
+		() => {
+			checkIfOverflowing();
 
-	useEffect( () => {
-		checkIfOverflowing();
+			window.addEventListener( 'resize', checkIfOverflowing );
+			return () => {
+				window.removeEventListener( 'resize', checkIfOverflowing );
+			};
+		},
 		// Do not add checkIfOverflowing to the dependency array as it will cause an infinite loop
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [] );
+		[]
+	);
 
 	return isDesktop && ! isOverflowing;
 };

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/hooks/use-dashboard-show-large-screen.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/hooks/use-dashboard-show-large-screen.ts
@@ -9,35 +9,36 @@ const useDashboardShowLargeScreen = (
 ) => {
 	const isDesktop = useBreakpoint( DESKTOP_BREAKPOINT );
 
+	const [ overflowingBreakpoint, setOverflowingBreakpoint ] = useState( 0 );
 	const [ isOverflowing, setIsOverflowing ] = useState( false );
-	const [ tableWidth, setTableWidth ] = useState( 0 );
 
 	const checkIfOverflowing = useCallback( () => {
-		setIsOverflowing( tableWidth > containerRef?.current?.clientWidth );
-	}, [ containerRef, tableWidth ] );
-
-	// We will need to remember the table width once to properly check if it is overflowing
-	useEffect( () => {
 		const siteTableEle = siteTableRef ? siteTableRef.current : null;
 
-		if ( ! tableWidth && siteTableEle ) {
-			setTableWidth( siteTableEle.clientWidth );
+		if ( siteTableEle ) {
+			if ( siteTableEle.clientWidth > containerRef?.current?.clientWidth ) {
+				// We will need to remember the breakpoint where we overflowed so that we can
+				// check if we are still overflowing when the window is resized to bigger size
+				setOverflowingBreakpoint( siteTableEle.clientWidth );
+				setIsOverflowing( true );
+			}
+		} else if ( overflowingBreakpoint < containerRef?.current?.clientWidth ) {
+			setIsOverflowing( false );
 		}
-	}, [ siteTableRef, tableWidth ] );
+	}, [ siteTableRef, overflowingBreakpoint, containerRef ] );
 
-	useEffect(
-		() => {
-			checkIfOverflowing();
+	useEffect( () => {
+		window.addEventListener( 'resize', checkIfOverflowing );
+		return () => {
+			window.removeEventListener( 'resize', checkIfOverflowing );
+		};
+	}, [ checkIfOverflowing ] );
 
-			window.addEventListener( 'resize', checkIfOverflowing );
-			return () => {
-				window.removeEventListener( 'resize', checkIfOverflowing );
-			};
-		},
+	useEffect( () => {
+		checkIfOverflowing();
 		// Do not add checkIfOverflowing to the dependency array as it will cause an infinite loop
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-		[]
-	);
+	}, [] );
 
 	return isDesktop && ! isOverflowing;
 };

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/hooks/use-dashboard-show-large-screen.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/hooks/use-dashboard-show-large-screen.ts
@@ -17,7 +17,7 @@ const useDashboardShowLargeScreen = (
 
 		if ( siteTableEle ) {
 			if ( siteTableEle.clientWidth > containerRef?.current?.clientWidth ) {
-				// We will need to remember the breakpoint where we overflowed so that we can
+				// We will need to remember the breakpoint where it overflowed so that we can
 				// check if we are still overflowing when the window is resized to bigger size
 				setOverflowingBreakpoint( siteTableEle.clientWidth );
 				setIsOverflowing( true );


### PR DESCRIPTION
Currently, the dashboard table tends to be stuck in the mobile view when resizing the screen width. This PR fixes this issue.

**Before**

https://github.com/Automattic/wp-calypso/assets/56598660/5736b64b-fe9f-46cf-8ccc-64e628562806

**After**

https://github.com/Automattic/wp-calypso/assets/56598660/3ee656eb-53a4-4a6b-a13f-dc2de53822f8

Closes https://github.com/Automattic/jetpack-manage/issues/115



## Proposed Changes

* Refactor useDashboardShowLargeScreen hook to remember the table width and use it to set if the page is overflowing or not.

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

* Use the Jetpack Cloud live link and go to `/dashboard`
* Confirm that when resizing the browser, the Dashboard table updates the view correctly.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?