### PR TITLE
FHT: Only assign user to FHT experiment in hosting onboarding

### DIFF
--- a/client/my-sites/plans-features-main/hooks/use-free-hosting-trial-assignment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-free-hosting-trial-assignment.ts
@@ -1,14 +1,15 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { useExperiment } from 'calypso/lib/explat';
+import type { PlansIntent } from 'calypso/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans';
 
-export function useFreeHostingTrialAssignment(): {
+export function useFreeHostingTrialAssignment( intent: PlansIntent | undefined ): {
 	isLoadingHostingTrialExperiment: boolean;
 	isAssignedToHostingTrialExperiment: boolean;
 } {
 	const [ isLoadingHostingTrialExperiment, experimentAssignment ] = useExperiment(
-		'wpcom_hosting_business_plan_free_trial',
+		'wpcom_hosting_business_plan_free_trial_v2',
 		{
-			isEligible: ! isEnabled( 'plans/hosting-trial' ),
+			isEligible: intent === 'plans-new-hosted-site' && ! isEnabled( 'plans/hosting-trial' ),
 		}
 	);
 
@@ -17,7 +18,7 @@ export function useFreeHostingTrialAssignment(): {
 			isLoadingHostingTrialExperiment: false,
 
 			// The plans/hosting-trial flag forces the user to be treated as if they're in the treatment group.
-			isAssignedToHostingTrialExperiment: true,
+			isAssignedToHostingTrialExperiment: intent === 'plans-new-hosted-site',
 		};
 	}
 

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -408,7 +408,7 @@ const PlansFeaturesMain = ( {
 		intentFromSiteMeta.intent && ! isInSignup && 'plans-default-wpcom' !== intent;
 
 	const { isLoadingHostingTrialExperiment, isAssignedToHostingTrialExperiment } =
-		useFreeHostingTrialAssignment();
+		useFreeHostingTrialAssignment( intent );
 	const eligibleForFreeHostingTrial = useSelector( isUserEligibleForFreeHostingTrial );
 
 	const gridPlans = useGridPlans( {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

As discussed p1699322657563999-slack-C7HH3V5AS we have a bug in our experiment assignment code for `wpcom_hosting_business_plan_free_trial`. Currently the cohort is assigned whenever a plans grid is rendered, and this assigns many users to a cohort who have nothing to do with the experiment. We don't want these users in the analysis.

* Only assign users in the `/setup/new-hosted-site` flow
* Changes experiment name to add `_v2`

This PR works hand-in-hand with the new experiment abacus experiment: 21507-explat-experiment

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
To reproduce the issue in production:

* Open dev tools
* Delete the `explat-experiment--wpcom_hosting_business_plan_free_trial` item from local storage
* Load a random page that contains a plans grid like `/plans/{{ site slug }}`
* Observe that the `explat-experiment--wpcom_hosting_business_plan_free_trial` is added when the page renders. This means we've loaded your experiment assignment, and if you didn't have an assignment you would been given one.

To test fix:

* Follow the same steps as above but with the `explat-experiment--wpcom_hosting_business_plan_free_trial_v2` local storage key
* Test various pages that have the plans grid that should not assign you to a cohort
  * `/plans/{{ site slug }}`
  * The vanilla `/start` plans grid
  * The migration trial flow
  * The WooExpress flow
  * The launch flow
* None of the above flows should set a value in local storage
* Test that the `/setup/new-hosted-site` flow does set something in localstorage.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?