### PR TITLE
Jetpack Manage: Redirect plugin links to WordPress.com if the site is Atomic

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/hooks/test/use-row-metadata.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/hooks/test/use-row-metadata.ts
@@ -250,7 +250,7 @@ describe( 'useRowMetadata', () => {
 		const expected = {
 			eventName: 'calypso_jetpack_agency_dashboard_update_plugins_click_small_screen',
 			isExternalLink: true,
-			link: `https://wordpress.com/plugins/updates/${ FAKE_SITE.url }`,
+			link: `${ FAKE_SITE.url_with_scheme }/wp-admin/plugins.php`,
 			isSupported: true,
 			row: rows.plugin,
 			siteDown: false,

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/lib/get-links.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/lib/get-links.ts
@@ -63,7 +63,7 @@ const getLinks = (
 			break;
 		}
 		case 'plugin': {
-			link = `https://wordpress.com/plugins/${ siteUrlWithMultiSiteSupport }`;
+			link = `${ siteUrlWithScheme }/wp-admin/plugins.php`;
 			isExternalLink = true;
 			// FIXME: Remove this condition when we enable plugin management in production
 			if ( config.isEnabled( 'jetpack/plugin-management' ) && ! isAtomicSite ) {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/lib/get-links.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/lib/get-links.ts
@@ -63,10 +63,10 @@ const getLinks = (
 			break;
 		}
 		case 'plugin': {
-			link = `https://wordpress.com/plugins/updates/${ siteUrlWithMultiSiteSupport }`;
+			link = `https://wordpress.com/plugins/${ siteUrlWithMultiSiteSupport }`;
 			isExternalLink = true;
 			// FIXME: Remove this condition when we enable plugin management in production
-			if ( config.isEnabled( 'jetpack/plugin-management' ) ) {
+			if ( config.isEnabled( 'jetpack/plugin-management' ) && ! isAtomicSite ) {
 				link =
 					status === 'warning'
 						? `/plugins/updates/${ siteUrlWithMultiSiteSupport }`

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/test/site-table.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/test/site-table.tsx
@@ -188,7 +188,7 @@ describe( '<SiteTable>', () => {
 
 		const pluginEle = getByTestId( `row-${ blogId }-plugin` );
 		expect( pluginEle.getAttribute( 'href' ) ).toEqual(
-			`https://wordpress.com/plugins/updates/${ urlToSlug( siteUrl ) }`
+			`${ siteObj.url_with_scheme }/wp-admin/plugins.php`
 		);
 		expect( getByText( `${ pluginUpdates.length } Available` ) ).toBeInTheDocument();
 	} );


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-manage/issues/99

## Proposed Changes

This PR updates the plugin links for Atomic sites to redirect to WordPress.com.

## Testing Instructions

- Open the Jetpack Live link
- Click the link for the plugin column for an Atomic site & verify that you are redirected to WordPress.com(/plugins/:site)
- Click the link for the plugin column for a Jetpack site & verify that you are redirected to /plugins/manage/:site inside Jetpack Cloud.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?