### PR TITLE
Fix `getThemesForQueryIgnoringPage` selector dependency list

### DIFF
--- a/client/state/themes/selectors/get-themes-for-query-ignoring-page.js
+++ b/client/state/themes/selectors/get-themes-for-query-ignoring-page.js
@@ -80,6 +80,6 @@ export const getThemesForQueryIgnoringPage = createSelector(
 		// over different pages) which we need to remove manually here for now.
 		return [ ...new Set( themesForQueryIgnoringPage ) ];
 	},
-	( state ) => state.themes.queries,
+	( state ) => [ state.themes.queries, state.sites?.plans ],
 	( state, siteId, query ) => getSerializedThemesQueryWithoutPage( query, siteId )
 );

--- a/client/state/themes/selectors/get-themes-for-query-ignoring-page.js
+++ b/client/state/themes/selectors/get-themes-for-query-ignoring-page.js
@@ -1,7 +1,6 @@
-import { isWooExpressPlan } from '@automattic/calypso-products';
 import { createSelector } from '@automattic/state-utils';
 import { flatMap } from 'lodash';
-import { getSitePlanSlug } from 'calypso/state/sites/plans/selectors';
+import { isSiteOnWooExpress, isSiteOnECommerceTrial } from 'calypso/state/sites/plans/selectors';
 import {
 	getActiveTheme,
 	getCanonicalTheme,
@@ -57,7 +56,6 @@ export const getThemesForQueryIgnoringPage = createSelector(
 
 		// Set active theme to be the first theme in the array.
 		if ( selectedSiteId ) {
-			const sitePlanSlug = getSitePlanSlug( state, selectedSiteId );
 			const currentThemeId = getActiveTheme( state, selectedSiteId );
 			const currentTheme = getCanonicalTheme( state, selectedSiteId, currentThemeId );
 			const index = themesForQueryIgnoringPage.findIndex(
@@ -70,8 +68,13 @@ export const getThemesForQueryIgnoringPage = createSelector(
 				// If activated theme is retired or a 3rd party theme, we have to show it
 				// if query is default
 				themesForQueryIgnoringPage.unshift( currentTheme );
-			} else if ( isWooExpressPlan( sitePlanSlug ) && isWooExpressDefaultQuery && currentTheme ) {
-				// Show the activate theme if the plan is WooExpress and the query is default
+			} else if (
+				( isSiteOnWooExpress( state, selectedSiteId ) ||
+					isSiteOnECommerceTrial( state, selectedSiteId ) ) &&
+				isWooExpressDefaultQuery &&
+				currentTheme
+			) {
+				// Show active theme if query is default and site is on WooExpress or eCommerce trial.
 				themesForQueryIgnoringPage.unshift( currentTheme );
 			}
 		}

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -856,6 +856,9 @@ describe( 'themes selectors', () => {
 		test( 'should return null if the query is not tracked', () => {
 			const themes = getThemesForQueryIgnoringPage(
 				{
+					sites: {
+						plans: {},
+					},
 					themes: {
 						queries: {},
 					},
@@ -870,6 +873,9 @@ describe( 'themes selectors', () => {
 		test( 'should return null if the query manager has not received items for query', () => {
 			const themes = getThemesForQueryIgnoringPage(
 				{
+					sites: {
+						plans: {},
+					},
 					themes: {
 						queries: {
 							2916284: new ThemeQueryManager( {
@@ -889,6 +895,9 @@ describe( 'themes selectors', () => {
 		test( 'should return a concatenated array of all site themes ignoring page', () => {
 			const themes = getThemesForQueryIgnoringPage(
 				{
+					sites: {
+						plans: {},
+					},
 					themes: {
 						queries: {
 							2916284: new ThemeQueryManager( {
@@ -918,6 +927,9 @@ describe( 'themes selectors', () => {
 		test( 'should remove recommendedThemes with no filter and no search in query', () => {
 			const themes = getThemesForQueryIgnoringPage(
 				{
+					sites: {
+						plans: {},
+					},
 					themes: {
 						queries: {
 							2916284: new ThemeQueryManager( {
@@ -946,6 +958,9 @@ describe( 'themes selectors', () => {
 		test( "should omit found items for which the requested result hasn't been received", () => {
 			const themes = getThemesForQueryIgnoringPage(
 				{
+					sites: {
+						plans: {},
+					},
 					themes: {
 						queries: {
 							2916284: new ThemeQueryManager( {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

We fixed an issue where the active theme was not being displayed in the themes showcase (#83945). 

However, this fix is not effective in the PROD wpcom environment because it somehow renders the theme component before fetching the plan data, and the `getThemesForQueryIgnoringPage` selector is not triggered again

This PR updates the dependency list so the selector can be re-triggered when plan data is fetched.

Apart from that, I also updated the plan check logic to include the free trial plan.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

I wasn't able to reproduce the issue locally but you can use `Chrome Local Overrides` with [this gist](https://gist.github.com/chihsuan/f07619ce914d3ad17677819e257c4f37) to test this PR.


* Create a Woo Express Free Trial from [WooCommerce.com NUX](https://href.li/?https://woocommerce.com/start/).
* Go to `https://wordpress.com/themes/<site-url>`
* Search `Twenty Twenty-Three` theme
* Install and activate TT3 theme
* Go to `https://wordpress.com/themes/<site-url>`
* Open Dev tool > Network tab
* Search themes js
* Override it via [`Chrome Local Overrides`] (https://developer.chrome.com/docs/devtools/overrides/#make-changes)
* Observe that TT3 is listed first as the active theme

https://github.com/Automattic/wp-calypso/assets/4344253/823d0a60-f3fd-4dd5-9f9c-88507828abf2


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?