### PR TITLE
Subscriber Page: Add SubscriberLaunchpad to manage subscriber tasks

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-launchpad/index.ts
+++ b/client/my-sites/subscribers/components/subscriber-launchpad/index.ts
@@ -1,0 +1,1 @@
+export { default as SubscriberLaunchpad } from './subscriber-launchpad';

--- a/client/my-sites/subscribers/components/subscriber-launchpad/styles.scss
+++ b/client/my-sites/subscribers/components/subscriber-launchpad/styles.scss
@@ -1,0 +1,52 @@
+.subscriber-launchpad {
+	padding: 16px 24px;
+	box-shadow: 0 0 0 1px var(--color-border-subtle);
+	gap: 30px;
+	background: #fff;
+	margin: 60px auto;
+	max-width: 569px;
+
+	.subscriber-launchpad__header {
+		display: flex;
+		justify-content: space-between;
+		padding: 20px 0;
+		.subscriber-launchpad__progress-bar-container {
+			margin: 0 0 10px 6px;
+		}
+		.subscriber-launchpad__title {
+			font-weight: 500;
+		}
+		.subscriber-launchpad__description {
+			margin-bottom: 0;
+			color: var(--color-neutral-60);
+			font-size: $font-body-small;
+		}
+	}
+	.launchpad__checklist-wrapper {
+		flex: 1;
+		display: flex;
+		align-items: center;
+		.checklist__tasks {
+			flex: 1;
+			.checklist-item__task-content {
+				padding: 16px 0;
+
+				&.is-placeholder {
+					border-bottom: 1px solid var(--studio-gray-5);
+					.checklist-item__content {
+						min-height: 20px;
+					}
+				}
+
+				&.is-placeholder:last-child {
+					border-bottom: none;
+				}
+
+				.checklist-item__text {
+					font-weight: 500;
+					line-height: 20px;
+				}
+			}
+		}
+	}
+}

--- a/client/my-sites/subscribers/components/subscriber-launchpad/subscriber-launchpad.tsx
+++ b/client/my-sites/subscribers/components/subscriber-launchpad/subscriber-launchpad.tsx
@@ -1,0 +1,44 @@
+import { CircularProgressBar } from '@automattic/components';
+import { Launchpad } from '@automattic/launchpad';
+import { useTranslate } from 'i18n-calypso';
+import { useSubscriberLaunchpadTasks } from 'calypso/my-sites/subscribers/hooks';
+import { useSelector } from 'calypso/state';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import './styles.scss';
+
+const SubscriberLaunchpad = () => {
+	const { checklistSlug, taskFilter, numberOfSteps, completedSteps } =
+		useSubscriberLaunchpadTasks();
+	const translate = useTranslate();
+	const site = useSelector( ( state ) => getSelectedSite( state ) );
+
+	return (
+		<div className="subscriber-launchpad">
+			<div className="subscriber-launchpad__header">
+				<div>
+					<h2 className="subscriber-launchpad__title">{ translate( 'No subscribers yet?' ) }</h2>
+					<p className="subscriber-launchpad__description">
+						{ translate( 'Follow these steps to get started.' ) }
+					</p>
+				</div>
+				<div className="subscriber-launchpad__progress-bar-container">
+					<CircularProgressBar
+						size={ 40 }
+						enableDesktopScaling
+						numberOfSteps={ numberOfSteps }
+						currentStep={ completedSteps }
+					/>
+				</div>
+			</div>
+
+			<Launchpad
+				siteSlug={ site?.slug ?? null }
+				checklistSlug={ checklistSlug }
+				onPostFilterTasks={ taskFilter }
+				launchpadContext="subscriber-list"
+			/>
+		</div>
+	);
+};
+
+export default SubscriberLaunchpad;

--- a/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
@@ -32,7 +32,7 @@ const SubscriberListContainer = ( {
 
 	return (
 		<section className="subscriber-list-container">
-			{ ! isLoading && Boolean( grandTotal ) && (
+			{ ! isLoading && ( Boolean( grandTotal ) || searchTerm ) && (
 				<>
 					<div className="subscriber-list-container__header">
 						<span className="subscriber-list-container__title">
@@ -79,7 +79,7 @@ const SubscriberListContainer = ( {
 					<GrowYourAudience />
 				</>
 			) }
-			{ ! isLoading && ! grandTotal && <EmptyComponent /> }
+			{ ! isLoading && ! grandTotal && ! searchTerm && <EmptyComponent /> }
 		</section>
 	);
 };

--- a/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
@@ -1,13 +1,16 @@
+import config from '@automattic/calypso-config';
 import { numberFormat, translate } from 'i18n-calypso';
 import Pagination from 'calypso/components/pagination';
 import { EmptyListView } from 'calypso/my-sites/subscribers/components/empty-list-view';
 import { NoSearchResults } from 'calypso/my-sites/subscribers/components/no-search-results';
+import { SubscriberLaunchpad } from 'calypso/my-sites/subscribers/components/subscriber-launchpad';
 import { SubscriberList } from 'calypso/my-sites/subscribers/components/subscriber-list';
 import { SubscriberListActionsBar } from 'calypso/my-sites/subscribers/components/subscriber-list-actions-bar';
 import { useSubscribersPage } from 'calypso/my-sites/subscribers/components/subscribers-page/subscribers-page-context';
 import { Subscriber } from 'calypso/my-sites/subscribers/types';
 import { useRecordSearch } from '../../tracks';
 import { GrowYourAudience } from '../grow-your-audience';
+
 import './style.scss';
 
 type SubscriberListContainerProps = {
@@ -22,6 +25,10 @@ const SubscriberListContainer = ( {
 	const { grandTotal, total, perPage, page, pageChangeCallback, searchTerm, isLoading } =
 		useSubscribersPage();
 	useRecordSearch();
+
+	const EmptyComponent = config.isEnabled( 'subscribers-launchpad' )
+		? SubscriberLaunchpad
+		: EmptyListView;
 
 	return (
 		<section className="subscriber-list-container">
@@ -72,7 +79,7 @@ const SubscriberListContainer = ( {
 					<GrowYourAudience />
 				</>
 			) }
-			{ ! isLoading && ! grandTotal && <EmptyListView /> }
+			{ ! isLoading && ! grandTotal && <EmptyComponent /> }
 		</section>
 	);
 };

--- a/client/my-sites/subscribers/hooks/index.ts
+++ b/client/my-sites/subscribers/hooks/index.ts
@@ -1,4 +1,5 @@
 export { default as usePagination } from './use-pagination';
+export { default as useSubscriberLaunchpadTasks } from './use-subscriber-launchpad-tasks';
 export { default as useSubscriberStatsRate } from './use-subscriber-stats-rate';
 export { default as useSubscriptionPlans } from './use-subscription-plans';
 export { default as useUnsubscribeModal } from './use-unsubscribe-modal';

--- a/client/my-sites/subscribers/hooks/use-subscriber-launchpad-tasks.ts
+++ b/client/my-sites/subscribers/hooks/use-subscriber-launchpad-tasks.ts
@@ -1,0 +1,34 @@
+import { useLaunchpad } from '@automattic/data-stores';
+import { Task } from '@automattic/launchpad';
+import { useSelector } from 'calypso/state';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+
+const useSubscriberLaunchpadTasks = () => {
+	const checklistSlug = 'subscribers';
+	const site = useSelector( ( state ) => getSelectedSite( state ) );
+
+	const {
+		data: { checklist },
+	} = useLaunchpad( site?.slug ?? null, checklistSlug );
+
+	// We can alter the tasks here, keeping this in for future use
+	const taskFilter = ( tasks: Task[] ): Task[] => {
+		if ( ! tasks ) {
+			return [];
+		}
+		return tasks;
+	};
+
+	const enhancedChecklist = checklist ? taskFilter( checklist ) : [];
+	const numberOfSteps = enhancedChecklist.length;
+	const completedSteps = enhancedChecklist.filter( ( task ) => task.completed ).length;
+
+	return {
+		checklistSlug,
+		taskFilter,
+		numberOfSteps,
+		completedSteps,
+	};
+};
+
+export default useSubscriberLaunchpadTasks;


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/83850

## Proposed Changes

- This PR adds the subscriber launchpad to the subscribers page
- This PR does not add the "Dismiss guide" button when all tasks are completed. I discussed this with @crisbusquets and the page looks way too empty with the Launchpad dismissed.

![CleanShot 2023-11-08 at 10 38 12@2x](https://github.com/Automattic/wp-calypso/assets/528287/16ea4b6a-6c28-42cf-86eb-08a179839f26)


## Testing Instructions

1. Apply this PR
2. Visit http://calypso.localhost:3000/subscribers/<yoursite> on a site with no subscribers.

On Simple this should show you the Subscriber launchpad, on Atomic you'll need to install the latest trunk version of jetpack-mu-wpcom using the Jetpack beta plugin: see PCYsg-Osp-p2

Since this PR is mainly about adding the component, testing on Atomic could be seen as out of scope for this PR (it was already tested in the task definition PR).

Make sure the design matches h8tMpJlCqNFemEerU9owHI-fi-3991_89819
 
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?