### PR TITLE
Stats: Use date input for example formatting.

### DIFF
--- a/client/components/stats-date-control/stats-date-control-picker-date.tsx
+++ b/client/components/stats-date-control/stats-date-control-picker-date.tsx
@@ -3,11 +3,6 @@ import { useTranslate } from 'i18n-calypso';
 import DateInput from './stats-date-control-date-input';
 import { DateControlPickerDateProps } from './types';
 
-const getLocaleDateFormat = () => {
-	const date = new Date( 2001, 11, 25 ).toLocaleDateString().substring( 0, 10 );
-	return date.replace( '2001', 'yyyy' ).replace( '12', 'mm' ).replace( '25', 'dd' );
-};
-
 const DateControlPickerDate = ( {
 	startDate = '',
 	endDate = '',
@@ -22,7 +17,8 @@ const DateControlPickerDate = ( {
 		<div className="date-control-picker-date">
 			<h2 className="date-control-picker-date__heading">
 				{ translate( 'Date Range' ) }
-				<span> ({ getLocaleDateFormat() }) </span>
+				<span> &#8212;</span>
+				<input id="date-example" type="date" disabled />
 			</h2>
 			<div className="stats-date-control-picker-dates__inputs">
 				<div className="stats-date-control-picker-dates__inputs-input-group">

--- a/client/components/stats-date-control/style.scss
+++ b/client/components/stats-date-control/style.scss
@@ -140,6 +140,13 @@ $date-control-shortcut-min-width: 140px;
 		line-height: 18px;
 		letter-spacing: -0.24px;
 	}
-
+	#date-example {
+		border: none;
+		background-color: inherit;
+		color: var(--gray-gray-50, #646970);
+		font-size: 12px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		font-weight: 500;
+		line-height: 18px;
+		letter-spacing: -0.24px;
+	}
 }
-


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #83148.

## Proposed Changes

Another attempt at localizing the example format string, this time using a disabled date input. In this way, we know the example will always match the active date inputs.

<img width="577" alt="SCR-20231108-qpoh" src="https://github.com/Automattic/wp-calypso/assets/40267301/a4c1c9b2-11ee-41e4-88f6-29b906cf164a">

Another option would be to remove the example format string altogether. Now that we are using a date input, the example isn't really necessarily.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Visit the Live link.
2. Visit Stats → Traffic.
3. Open the date range picker.
4. Confirm the example format matches that of the date input fields.

Bonus Points: Try updating your date format in the system settings (System Settings → General → Language & Region → Date format) and seeing if the new formatting is reflected in the browser. I could get this to work in Chrome by closing the current tab and reloading the page. In Safari and Firefox the new format wasn't picked up, though the example still matched the date inputs.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?