### PR TITLE
Plans 2023: Refactor use of createSelector in main add-ons hook (take 2)

### DIFF
--- a/client/my-sites/add-ons/hooks/use-add-ons.ts
+++ b/client/my-sites/add-ons/hooks/use-add-ons.ts
@@ -273,8 +273,8 @@ const useAddOns = ( siteId?: number, isInSignup = false ): ( AddOnMeta | null )[
 				} )
 				.map( ( addOn ) => {
 					const product = productsList[ addOn.productSlug ];
-					const name = addOn.name ? addOn.name : product.product_name;
-					const description = addOn.description ?? product.description;
+					const name = addOn.name ? addOn.name : product?.product_name;
+					const description = addOn.description ?? product?.description;
 
 					// if it's a storage add on
 					if ( addOn.productSlug === PRODUCT_1GB_SPACE ) {

--- a/client/my-sites/add-ons/hooks/use-add-ons.ts
+++ b/client/my-sites/add-ons/hooks/use-add-ons.ts
@@ -185,6 +185,7 @@ const useActiveAddOnsDefs = ( selectedSite: SiteDetails | null ) => {
 		[
 			addOnPrices1GBSpace100,
 			addOnPrices1GBSpace50,
+			checkoutLink,
 			displayCost1GBSpace100,
 			displayCost1GBSpace50,
 			displayCostCustomDesign,
@@ -198,6 +199,7 @@ const useActiveAddOnsDefs = ( selectedSite: SiteDetails | null ) => {
 			featureSlugsJetpackStatsPWYWYearly,
 			featureSlugsJetpackStatsYearly,
 			featureSlugsUnlimitedThemes,
+			selectedSite?.slug,
 			translate,
 		]
 	);

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -47,6 +47,7 @@ import {
 import { isValidFeatureKey, FEATURES_LIST } from 'calypso/lib/plans/features-list';
 import scrollIntoViewport from 'calypso/lib/scroll-into-viewport';
 import { addQueryArgs } from 'calypso/lib/url';
+import useStorageAddOns from 'calypso/my-sites/add-ons/hooks/use-storage-add-ons';
 import PlanNotice from 'calypso/my-sites/plans-features-main/components/plan-notice';
 import PlanTypeSelector from 'calypso/my-sites/plans-features-main/components/plan-type-selector';
 import useIsFreePlanCustomDomainUpsellEnabled from 'calypso/my-sites/plans-features-main/hooks/use-is-free-plan-custom-domain-upsell-enabled';
@@ -63,7 +64,6 @@ import isEligibleForWpComMonthlyPlan from 'calypso/state/selectors/is-eligible-f
 import { isUserEligibleForFreeHostingTrial } from 'calypso/state/selectors/is-user-eligible-for-free-hosting-trial';
 import { getCurrentPlan, isCurrentUserCurrentPlanOwner } from 'calypso/state/sites/plans/selectors';
 import { getSitePlanSlug, getSiteSlug, isCurrentPlanPaid } from 'calypso/state/sites/selectors';
-import useStorageAddOns from '../add-ons/hooks/use-storage-add-ons';
 import ComparisonGridToggle from './components/comparison-grid-toggle';
 import { LoadingPlaceHolder } from './components/loading-placeholder';
 import PlanUpsellModal from './components/plan-upsell-modal';

--- a/client/my-sites/plans-features-main/test/index.jsx
+++ b/client/my-sites/plans-features-main/test/index.jsx
@@ -23,6 +23,7 @@ jest.mock( '../hooks/use-suggested-free-domain-from-paid-domain', () => () => ( 
 jest.mock( 'calypso/state/purchases/selectors', () => ( {
 	getByPurchaseId: jest.fn(),
 } ) );
+jest.mock( 'calypso/my-sites/add-ons/hooks/use-storage-add-ons.ts', () => jest.fn() );
 jest.mock( 'calypso/state/selectors/is-eligible-for-wpcom-monthly-plan', () => jest.fn() );
 jest.mock( 'calypso/state/selectors/can-upgrade-to-plan', () => jest.fn() );
 jest.mock( 'calypso/state/ui/selectors', () => ( {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

This is redone from https://github.com/Automattic/wp-calypso/pull/83706, which was reverted due to pre-release tests failing.

## Proposed Changes

We introduced `createSelector` to memoize some parts from the use-add-ons hook that required state access. However, we can achieve a simpler setup via `useMemo` and a few tweaks to how we access product details for the add-ons. So this be more in the spirit of the NPM migration, whereby these hooks will remain as hooks and `state` be replaced with however we decide to bring products and features into the hook.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plans/[ site ]` and `/start/plans` and ensure the storage add-ons dropdowns render and work as expected
* Go to `/add-ons` and ensure add-ons render and function properly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?