### PR TITLE
wp-admin Site Default: Enable for all environments

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -191,7 +191,7 @@
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,
 		"yolo/hosting-metrics-i1": true,
-		"yolo/wp-admin-site-default": false,
+		"yolo/wp-admin-site-default": true,
 		"yolo/command-pallette": false
 	},
 	"siftscience_key": "a4f69f6759",

--- a/config/stage.json
+++ b/config/stage.json
@@ -185,7 +185,7 @@
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,
 		"yolo/hosting-metrics-i1": true,
-		"yolo/wp-admin-site-default": false,
+		"yolo/wp-admin-site-default": true,
 		"yolo/command-pallette": false
 	},
 	"siftscience_key": "e00e878351",


### PR DESCRIPTION
See https://github.com/Automattic/dotcom-forge/issues/4444

## Proposed Changes

Enables the 'Admin interface style' for all environments.

## Testing Instructions

Verify feature is live in production after deploy.