### PR TITLE
Launchpad: Mark import subscribers task complete when adding subscribers or uploading CSV

### DIFF
--- a/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
+++ b/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
@@ -1,10 +1,13 @@
+import { updateLaunchpadSettings } from '@automattic/data-stores';
 import { translate } from 'i18n-calypso';
 import React, { createContext, useState, useContext, useEffect, useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 import { useDebounce } from 'use-debounce';
 import { usePagination } from 'calypso/my-sites/subscribers/hooks';
 import { Subscriber } from 'calypso/my-sites/subscribers/types';
+import { useSelector } from 'calypso/state';
 import { successNotice } from 'calypso/state/notices/actions';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { SubscribersFilterBy, SubscribersSortBy } from '../../constants';
 import useManySubsSite from '../../hooks/use-many-subs-site';
 import { useSubscribersQuery } from '../../queries';
@@ -89,8 +92,19 @@ export const SubscribersPageProvider = ( {
 		subscribersQueryResult.isFetching
 	);
 
+	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
+	const completeImportSubscribersTask = async () => {
+		if ( selectedSiteSlug ) {
+			await updateLaunchpadSettings( selectedSiteSlug, {
+				checklist_statuses: { import_subscribers: true },
+			} );
+		}
+	};
+
 	const addSubscribersCallback = () => {
 		setShowAddSubscribersModal( false );
+		completeImportSubscribersTask();
+
 		dispatch(
 			successNotice(
 				translate(

--- a/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
+++ b/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
@@ -1,4 +1,5 @@
 import { updateLaunchpadSettings } from '@automattic/data-stores';
+import { useQueryClient } from '@tanstack/react-query';
 import { translate } from 'i18n-calypso';
 import React, { createContext, useState, useContext, useEffect, useCallback } from 'react';
 import { useDispatch } from 'react-redux';
@@ -92,6 +93,7 @@ export const SubscribersPageProvider = ( {
 		subscribersQueryResult.isFetching
 	);
 
+	const queryClient = useQueryClient();
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 	const completeImportSubscribersTask = async () => {
 		if ( selectedSiteSlug ) {
@@ -99,6 +101,7 @@ export const SubscribersPageProvider = ( {
 				checklist_statuses: { import_subscribers: true },
 			} );
 		}
+		queryClient.invalidateQueries( { queryKey: [ 'launchpad' ] } );
 	};
 
 	const addSubscribersCallback = () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/wp-calypso/issues/83994.

## Proposed Changes

* introduce `completeImportSubscribersTask` that is triggered when `addSubscribersCallback` is run and completes the `import_subscribers` launchpad task

![Markup on 2023-11-09 at 10:46:19](https://github.com/Automattic/wp-calypso/assets/25105483/bff4d472-6eb8-4219-b6a8-03f1b22167f5)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build it.
2. Navigate to `http://calypso.localhost:3000/subscribers/[site-slug]` - for a site where you haven't imported the subscribers yet.
3. Import subscribers (either using the form or CSV file).
4. The "Import existing subscribers" step should complete.

> Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?

The feature currently works for Simple sites only; Atomic site are still waiting to receive the underlying launchpad changes and the Jetpack sites won't have the feature (will be addressed in https://github.com/Automattic/wp-calypso/issues/84039).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?: