### PR TITLE
Site Monitoring: Add a 429 error code to site monitoring chart

### DIFF
--- a/client/my-sites/site-monitoring/metrics-tab.tsx
+++ b/client/my-sites/site-monitoring/metrics-tab.tsx
@@ -231,6 +231,12 @@ const useErrorHttpCodeSeries = () => {
 			stroke: 'rgba(9, 181, 133, 1)',
 		},
 		{
+			statusCode: 429,
+			fill: 'rgba(164, 92, 64, 0.1)',
+			label: __( '429: Too Many Requests' ),
+			stroke: 'rgba(164, 92, 64, 1)',
+		},
+		{
 			statusCode: 500,
 			fill: 'rgba(235, 101, 148, 0.1)',
 			label: __( '500: Internal server error' ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4448

## Proposed Changes

In this diff, I propose to add 429 error code to 'Unsuccessful HTTP responses' chart in Tools -> Site Monitoring.

![Screenshot 2023-11-08 at 14 05 20](https://github.com/Automattic/wp-calypso/assets/727413/7c835d92-0685-4039-8111-a61c0cedff89)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a Business site and enable hosting features
2. Connect to site via SSH and add lines to the `wp-config.php`:
```
header( 'HTTP/1.1 429 Too Many Requests' );
die( 'Simulate 429 for metrics api work' );
```
3. Load the site's homepage and confirm 429 error is thrown
4. Wait a few minutes and confirm that 429 error is shown in the chart in Tools -> Site Monitoring

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?