### PR TITLE
Add new tier hash and fix display prices for plans

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -29,6 +29,7 @@ import { PLANS_LIST } from 'calypso/../packages/calypso-products/src/plans-list'
 import { NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import useCheckout from 'calypso/landing/stepper/hooks/use-checkout';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { ADD_TIER_PLAN_HASH } from 'calypso/my-sites/earn/memberships/constants';
 import { isVideoPressFlow } from 'calypso/signup/utils';
 import { ONBOARD_STORE, SITE_STORE } from '../../../../stores';
 import { launchpadFlowTasks } from './tasks';
@@ -587,7 +588,7 @@ export function getEnhancedTasks(
 							site?.ID
 								? setShowPlansModal( true )
 								: window.location.assign(
-										`/earn/payments-plans/${ siteSlug }?launchpad=add-product#add-newsletter-payment-plan`
+										`/earn/payments-plans/${ siteSlug }?launchpad=add-product${ ADD_TIER_PLAN_HASH }`
 								  );
 						},
 					};

--- a/client/my-sites/earn/memberships/constants.ts
+++ b/client/my-sites/earn/memberships/constants.ts
@@ -1,5 +1,8 @@
 export const ADD_NEW_PAYMENT_PLAN_HASH = '#add-new-payment-plan';
-export const ADD_NEWSLETTER_PAYMENT_PLAN_HASH = '#add-newsletter-payment-plan';
+export const ADD_TIER_PLAN_HASH = '#add-tier-plan';
+
+// @todo: remove once Jetpack 12.9 is out
+export const OLD_ADD_NEWSLETTER_PAYMENT_PLAN_HASH = '#add-newsletter-payment-plan';
 export const LAUNCHPAD_HASH = '#launchpad';
 
 export const PLAN_MONTHLY_FREQUENCY = '1 month';

--- a/client/my-sites/earn/memberships/products.tsx
+++ b/client/my-sites/earn/memberships/products.tsx
@@ -212,7 +212,7 @@ function MembershipsProductsSection( { query }: MembersProductsSectionProps ) {
 				<RecurringPaymentsPlanAddEditModal
 					closeDialog={ closeDialog }
 					product={ Object.assign( product ?? {}, {
-						subscribe_as_site_subscriber: subscribe_as_site_subscriber,
+						type: default_product_type,
 					} ) }
 					annualProduct={ annualProduct }
 				/>

--- a/client/my-sites/earn/memberships/products.tsx
+++ b/client/my-sites/earn/memberships/products.tsx
@@ -127,6 +127,18 @@ function MembershipsProductsSection( { query }: MembersProductsSectionProps ) {
 		setShowDeleteDialog( false );
 	}
 
+	function getPriceFromProduct( product: Product, price: string ) {
+		switch ( product.renewal_schedule ) {
+			case PLAN_MONTHLY_FREQUENCY:
+				return translate( '%s/month', { args: price } );
+			case PLAN_YEARLY_FREQUENCY:
+				return translate( '%s/year', { args: price } );
+			case PLAN_ONE_TIME_FREQUENCY:
+			default:
+				return price;
+		}
+	}
+
 	return (
 		<div>
 			<QueryMembershipsSettings siteId={ site?.ID ?? 0 } />
@@ -188,12 +200,13 @@ function MembershipsProductsSection( { query }: MembersProductsSectionProps ) {
 										{ currentProduct?.title }
 									</div>
 									<sub className="memberships__products-product-price">
-										{ currentProduct.subscribe_as_site_subscriber
-											? translate( '%s/month', { args: price } )
-											: price }
-										{ currentAnnualProduct && translate( ' (%s/year)', { args: annualPrice } ) }
+										{ getPriceFromProduct( currentProduct, price ) }
+										{ currentAnnualProduct &&
+											translate( ' (%s)', {
+												args: getPriceFromProduct( currentAnnualProduct, annualPrice ),
+											} ) }
 									</sub>
-									{ currentProduct?.subscribe_as_site_subscriber && (
+									{ currentProduct.type === TYPE_TIER && (
 										<div className="memberships__products-product-badge">
 											<Badge type="info">{ translate( 'Newsletter tier' ) }</Badge>
 										</div>

--- a/client/my-sites/earn/memberships/products.tsx
+++ b/client/my-sites/earn/memberships/products.tsx
@@ -24,7 +24,15 @@ import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import RecurringPaymentsPlanAddEditModal from '../components/add-edit-plan-modal';
 import { Product, Query } from '../types';
-import { ADD_NEW_PAYMENT_PLAN_HASH, ADD_NEWSLETTER_PAYMENT_PLAN_HASH } from './constants';
+import {
+	ADD_NEW_PAYMENT_PLAN_HASH,
+	ADD_TIER_PLAN_HASH,
+	OLD_ADD_NEWSLETTER_PAYMENT_PLAN_HASH,
+	PLAN_MONTHLY_FREQUENCY,
+	PLAN_ONE_TIME_FREQUENCY,
+	PLAN_YEARLY_FREQUENCY,
+	TYPE_TIER,
+} from './constants';
 import RecurringPaymentsPlanDeleteModal from './delete-plan-modal';
 import MembershipsSection from './section';
 import './style.scss';
@@ -35,7 +43,8 @@ type MembersProductsSectionProps = {
 
 const showAddEditDialogInitially =
 	window.location.hash === ADD_NEW_PAYMENT_PLAN_HASH ||
-	window.location.hash === ADD_NEWSLETTER_PAYMENT_PLAN_HASH;
+	window.location.hash === OLD_ADD_NEWSLETTER_PAYMENT_PLAN_HASH ||
+	window.location.hash === ADD_TIER_PLAN_HASH;
 
 function MembershipsProductsSection( { query }: MembersProductsSectionProps ) {
 	const translate = useTranslate();
@@ -64,9 +73,10 @@ function MembershipsProductsSection( { query }: MembersProductsSectionProps ) {
 	const hasStripeFeature =
 		hasDonationsFeature || hasPremiumContentFeature || hasRecurringPaymentsFeature;
 
-	const subscribe_as_site_subscriber = product
-		? product?.subscribe_as_site_subscriber
-		: window.location.hash === ADD_NEWSLETTER_PAYMENT_PLAN_HASH;
+	const defaultToTierPanel =
+		window.location.hash === OLD_ADD_NEWSLETTER_PAYMENT_PLAN_HASH ||
+		window.location.hash === ADD_TIER_PLAN_HASH;
+	const default_product_type = product?.type ?? ( defaultToTierPanel ? TYPE_TIER : null );
 
 	const trackUpgrade = () =>
 		dispatch( bumpStat( 'calypso_earn_page', 'payment-plans-upgrade-button' ) );

--- a/client/my-sites/earn/memberships/products.tsx
+++ b/client/my-sites/earn/memberships/products.tsx
@@ -76,7 +76,7 @@ function MembershipsProductsSection( { query }: MembersProductsSectionProps ) {
 	const defaultToTierPanel =
 		window.location.hash === OLD_ADD_NEWSLETTER_PAYMENT_PLAN_HASH ||
 		window.location.hash === ADD_TIER_PLAN_HASH;
-	const default_product_type = product?.type ?? ( defaultToTierPanel ? TYPE_TIER : null );
+	const default_product_type = defaultToTierPanel ? TYPE_TIER : null;
 
 	const trackUpgrade = () =>
 		dispatch( bumpStat( 'calypso_earn_page', 'payment-plans-upgrade-button' ) );
@@ -225,7 +225,7 @@ function MembershipsProductsSection( { query }: MembersProductsSectionProps ) {
 				<RecurringPaymentsPlanAddEditModal
 					closeDialog={ closeDialog }
 					product={ Object.assign( product ?? {}, {
-						type: default_product_type,
+						type: product ? product.type : default_product_type,
 					} ) }
 					annualProduct={ annualProduct }
 				/>

--- a/client/my-sites/earn/memberships/section.tsx
+++ b/client/my-sites/earn/memberships/section.tsx
@@ -214,7 +214,7 @@ function MembershipsSection( { query }: MembershipsSectionProps ) {
 					<NoticeAction
 						external
 						icon="create"
-						href={ `/earn/payments-plans/${ site?.slug }${ ADD_NEWSLETTER_PAYMENT_PLAN_HASH }` }
+						href={ `/earn/payments-plans/${ site?.slug }${ ADD_TIER_PLAN_HASH }` }
 					>
 						{ translate( 'Add payments' ) }
 					</NoticeAction>

--- a/client/my-sites/earn/memberships/section.tsx
+++ b/client/my-sites/earn/memberships/section.tsx
@@ -216,7 +216,7 @@ function MembershipsSection( { query }: MembershipsSectionProps ) {
 						icon="create"
 						href={ `/earn/payments-plans/${ site?.slug }${ ADD_TIER_PLAN_HASH }` }
 					>
-						{ translate( 'Add payments' ) }
+						{ translate( 'Add tiers' ) }
 					</NoticeAction>
 				</Notice>
 			);

--- a/client/my-sites/earn/memberships/section.tsx
+++ b/client/my-sites/earn/memberships/section.tsx
@@ -24,7 +24,11 @@ import {
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import CommissionFees from '../components/commission-fees';
 import { Query } from '../types';
-import { ADD_NEWSLETTER_PAYMENT_PLAN_HASH, LAUNCHPAD_HASH } from './constants';
+import {
+	ADD_TIER_PLAN_HASH,
+	OLD_ADD_NEWSLETTER_PAYMENT_PLAN_HASH,
+	LAUNCHPAD_HASH,
+} from './constants';
 import './style.scss';
 
 type MembershipsSectionProps = {
@@ -379,7 +383,10 @@ function MembershipsSection( { query }: MembershipsSectionProps ) {
  * connection, this source is used to redirect the user the appropriate place.
  */
 function getSource() {
-	if ( window.location.hash === ADD_NEWSLETTER_PAYMENT_PLAN_HASH ) {
+	if (
+		window.location.hash === OLD_ADD_NEWSLETTER_PAYMENT_PLAN_HASH ||
+		window.location.hash === ADD_TIER_PLAN_HASH
+	) {
 		return 'earn-newsletter';
 	}
 	if ( window.location.hash === LAUNCHPAD_HASH ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack/pull/34011

## Proposed Changes

* Handle new tier hash as well as old one
* Redirect tot he right tier modal (it only enabled `subscribe_as_site_subcribers` right now).
* Fix issue with prices displayed for Monetize plans

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure going to 
```
https://wordpress.com/earn/payments-plans/{SITE_DOMAIN}#add-tier-plan
```
OR
```
https://wordpress.com/earn/payments-plans/{SITE_DOMAIN}#add-newsletter-payment-plan
```

Goes to the same page.

<img width="400" alt="Screenshot 2023-11-08 at 13 09 21" src="https://github.com/Automattic/wp-calypso/assets/790558/a7984010-6981-4209-b83a-e93388819759">



### Prices

Go to settings for `individual-chameleon.jurassic.ninja` or create a few plans with a variety of parameters

| Before | After |
| ----- | ----- |
| <img width="1097" alt="Screenshot 2023-11-08 at 13 03 53" src="https://github.com/Automattic/wp-calypso/assets/790558/47bf6747-fe53-408c-b4d2-192446e18863"> | <img width="1124" alt="Screenshot 2023-11-08 at 13 06 02" src="https://github.com/Automattic/wp-calypso/assets/790558/04fc19fe-8b86-4549-a056-c9c465e76412"> |



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?