### PR TITLE
Subscriber page: Don't hide the search bar when there are no search results

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
@@ -22,10 +22,9 @@ const SubscriberListContainer = ( {
 	const { grandTotal, total, perPage, page, pageChangeCallback, searchTerm, isLoading } =
 		useSubscribersPage();
 	useRecordSearch();
-
 	return (
 		<section className="subscriber-list-container">
-			{ ! isLoading && Boolean( grandTotal ) && (
+			{ ! isLoading && ( Boolean( grandTotal ) || searchTerm ) && (
 				<>
 					<div className="subscriber-list-container__header">
 						<span className="subscriber-list-container__title">
@@ -72,7 +71,7 @@ const SubscriberListContainer = ( {
 					<GrowYourAudience />
 				</>
 			) }
-			{ ! isLoading && ! grandTotal && <EmptyListView /> }
+			{ ! isLoading && ! grandTotal && ! searchTerm && <EmptyListView /> }
 		</section>
 	);
 };


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/84007

## Proposed Changes

The search bar was being hidden during searching when no subscribers were found.

## Testing Instructions

- Apply this PR
- Visit http://calypso.localhost:3000/subscribers/<yoursite>
- Enter some random characters in the search field
- The search field should not disappear

![CleanShot 2023-11-08 at 15 41 55@2x](https://github.com/Automattic/wp-calypso/assets/528287/dea592ba-06a5-4d8a-9469-39e3edb5f171)



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?