### PR TITLE
Revert "Upgrade Pricing Plan Happy block request doesn't contain user data - 2nd attempt"

### DIFF
--- a/apps/happy-blocks/block-library/pricing-plans/hooks/pricing-plans.ts
+++ b/apps/happy-blocks/block-library/pricing-plans/hooks/pricing-plans.ts
@@ -48,27 +48,23 @@ const usePricingPlans = () => {
 	const [ error, setError ] = useState< unknown >( null );
 
 	useEffect( () => {
-		( async () => {
-			// Dynamically importing wpcom allows us to avoid issues when the JS assets are concatenated.
-			const { default: wpcom } = await import( 'calypso/lib/wp' );
+		const fetchPlans = async () => {
+			setIsLoading( true );
+			setError( null );
+			try {
+				const response = await fetch(
+					'https://public-api.wordpress.com/rest/v1.5/plans?locale=' + config.locale
+				);
+				const data = await response.json();
+				setPlans( parsePlans( data ) );
+			} catch ( e: unknown ) {
+				setError( e );
+			} finally {
+				setIsLoading( false );
+			}
+		};
 
-			const fetchPlans = async () => {
-				setIsLoading( true );
-				setError( null );
-				try {
-					const data = await wpcom.req.get( '/plans?locale=' + config.locale, {
-						apiVersion: '1.5',
-					} );
-					setPlans( parsePlans( data ) );
-				} catch ( e: unknown ) {
-					setError( e );
-				} finally {
-					setIsLoading( false );
-				}
-			};
-
-			fetchPlans();
-		} )();
+		fetchPlans();
 	}, [] );
 
 	return { data: plans, isLoading, error };


### PR DESCRIPTION
Reverts Automattic/wp-calypso#83957

The changes cause an issue when JS assets become concatenated
<img width="796" alt="Screenshot 2023-11-08 at 16 44 22" src="https://github.com/Automattic/wp-calypso/assets/2749938/5edcc260-e68b-4c2e-8cb3-722fb2558748">
