### PR TITLE
wp-admin Site Default: Enable wp-admin on staging and production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -191,7 +191,7 @@
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,
 		"yolo/hosting-metrics-i1": true,
-		"yolo/wp-admin-site-default": false,
+		"yolo/wp-admin-site-default": true,
 		"yolo/command-pallette": false
 	},
 	"siftscience_key": "a4f69f6759",

--- a/config/stage.json
+++ b/config/stage.json
@@ -185,7 +185,7 @@
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,
 		"yolo/hosting-metrics-i1": true,
-		"yolo/wp-admin-site-default": false,
+		"yolo/wp-admin-site-default": true,
 		"yolo/command-pallette": false
 	},
 	"siftscience_key": "e00e878351",


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/84001

## Proposed Changes

This PR enables the `yolo/wp-admin-site-default` feature on staging and production, thus making it available on all environments. 

## Testing Instructions

* Verify that the feature is set to `true` on `production.json` and `stage.json`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?