### PR TITLE
Ensure fallback menu has consistent string labels for users submenu.

### DIFF
--- a/client/my-sites/sidebar/static-data/fallback-menu.js
+++ b/client/my-sites/sidebar/static-data/fallback-menu.js
@@ -448,14 +448,14 @@ export default function buildFallbackResponse( {
 				{
 					parent: 'users.php',
 					slug: 'users-all-people',
-					title: translate( 'All People' ),
+					title: translate( 'All Users' ),
 					type: 'submenu-item',
 					url: `/people/team/${ siteDomain }`,
 				},
 				{
 					parent: 'users.php',
 					slug: 'users-add-new',
-					title: translate( 'Add New', { context: 'user' } ),
+					title: translate( 'Add New User', { context: 'user' } ),
 					type: 'submenu-item',
 					url: `/people/new/${ siteDomain }`,
 				},


### PR DESCRIPTION
## Proposed Changes

* This is just to ensure the fallback menu has the same submenu structure as:
  * Simple: D128198-code
  * Atomic: https://github.com/Automattic/jetpack/pull/34008

## Testing Instructions

* Code review is fine.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?