### PR TITLE
Hosting Command Palette: fetch atomic hosting to read SSH user information

### DIFF
--- a/client/components/command-pallette/use-command-pallette.tsx
+++ b/client/components/command-pallette/use-command-pallette.tsx
@@ -80,7 +80,7 @@ export const useCommandPallette = ( {
 	);
 
 	// Call the generateCommandsArray function to get the commands array
-	const commands = useCommandsArrayWpcom( { setSelectedCommandName, __, createSiteUrl } );
+	const commands = useCommandsArrayWpcom( { setSelectedCommandName, __, createSiteUrl, allSites } );
 
 	const selectedCommand = commands.find( ( c ) => c.name === selectedCommandName );
 	let sitesToPick = null;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Related to https://github.com/Automattic/dotcom-forge/issues/4471

Hi @katinthehatsite , this is a way to fetch the information we need. This may not be a perfect solution, because we need to call two API endpoints.

And as you pointed out, this logic cannot be shared with Raycast because we don't have the Redux state.

Feel free to try it and see if it works.