### PR TITLE
Upgrade Pricing Plan Happy block request doesn't contain user data - 3rd attempt

### DIFF
--- a/apps/happy-blocks/block-library/pricing-plans/hooks/pricing-plans.ts
+++ b/apps/happy-blocks/block-library/pricing-plans/hooks/pricing-plans.ts
@@ -48,23 +48,27 @@ const usePricingPlans = () => {
 	const [ error, setError ] = useState< unknown >( null );
 
 	useEffect( () => {
-		const fetchPlans = async () => {
-			setIsLoading( true );
-			setError( null );
-			try {
-				const response = await fetch(
-					'https://public-api.wordpress.com/rest/v1.5/plans?locale=' + config.locale
-				);
-				const data = await response.json();
-				setPlans( parsePlans( data ) );
-			} catch ( e: unknown ) {
-				setError( e );
-			} finally {
-				setIsLoading( false );
-			}
-		};
+		( async () => {
+			// Dynamicallt importing wpcom allows us to avoid issues when the JS assets are concatenated.
+			const { default: wpcom } = await import( 'calypso/lib/wp' );
 
-		fetchPlans();
+			const fetchPlans = async () => {
+				setIsLoading( true );
+				setError( null );
+				try {
+					const data = await wpcom.req.get( '/plans?locale=' + config.locale, {
+						apiVersion: '1.5',
+					} );
+					setPlans( parsePlans( data ) );
+				} catch ( e: unknown ) {
+					setError( e );
+				} finally {
+					setIsLoading( false );
+				}
+			};
+
+			fetchPlans();
+		} )();
 	}, [] );
 
 	return { data: plans, isLoading, error };

--- a/apps/happy-blocks/block-library/pricing-plans/hooks/pricing-plans.ts
+++ b/apps/happy-blocks/block-library/pricing-plans/hooks/pricing-plans.ts
@@ -49,7 +49,7 @@ const usePricingPlans = () => {
 
 	useEffect( () => {
 		( async () => {
-			// Dynamicallt importing wpcom allows us to avoid issues when the JS assets are concatenated.
+			// Dynamically importing wpcom allows us to avoid issues when the JS assets are concatenated.
 			const { default: wpcom } = await import( 'calypso/lib/wp' );
 
 			const fetchPlans = async () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to [#83870](https://github.com/Automattic/wp-calypso/pull/83870) #83957

## Proposed Changes

This revisits #83870 and #83957 where loading the `wpcom.req` library was [causing issues](https://github.com/Automattic/wp-calypso/pull/83953) when the deployed JS assets were concatenated.
To fix it, this tries using `wpcom-proxy-request` instead of `wpcom.req`.
## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow the steps from #83957 
* Make sure the block also works on https://wordpress.com/support/domains/register-domain/?concat_js=yes

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
