### PR TITLE
Adding a videopress-purchase flow.

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/use-processing-loading-messages.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/hooks/use-processing-loading-messages.tsx
@@ -6,6 +6,7 @@ import {
 	VIDEOPRESS_FLOW,
 	VIDEOPRESS_TV_FLOW,
 	VIDEOPRESS_TV_PURCHASE_FLOW,
+	VIDEOPRESS_PURCHASE_FLOW,
 } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
@@ -169,7 +170,7 @@ export function useProcessingLoadingMessages( flow?: string | null ): LoadingMes
 			{ title: __( 'Starting up your channel' ), duration: 5000 },
 		];
 		return videoPressLoadingMessages;
-	} else if ( VIDEOPRESS_TV_PURCHASE_FLOW === flow ) {
+	} else if ( VIDEOPRESS_TV_PURCHASE_FLOW === flow || VIDEOPRESS_PURCHASE_FLOW === flow ) {
 		const videoPressLoadingMessages = [
 			{ title: __( 'Scouting the locations' ), duration: 5000 },
 			{ title: __( 'Kicking off the casting' ), duration: 5000 },

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -10,6 +10,7 @@ import {
 	IMPORT_HOSTED_SITE_FLOW,
 	DOMAIN_TRANSFER,
 	VIDEOPRESS_TV_FLOW,
+	VIDEOPRESS_PURCHASE_FLOW,
 	VIDEOPRESS_TV_PURCHASE_FLOW,
 	GOOGLE_TRANSFER,
 } from '@automattic/onboarding';
@@ -118,6 +119,12 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 
 	'domain-user-transfer': () =>
 		import( /* webpackChunkName: "domain-user-transfer-flow" */ './domain-user-transfer' ),
+
+	[ VIDEOPRESS_PURCHASE_FLOW ]: () =>
+		import(
+			/* webpackChunkName: "videopress-purchase-flow" */
+			`../declarative-flow/videopress-purchase`
+		),
 };
 
 const videoPressTvFlows: Record< string, () => Promise< { default: Flow } > > = config.isEnabled(

--- a/client/landing/stepper/declarative-flow/videopress-purchase.ts
+++ b/client/landing/stepper/declarative-flow/videopress-purchase.ts
@@ -123,7 +123,7 @@ const videopressPurchase: Flow = {
 							{
 								product_slug: planProductObject.storeSlug,
 								extra: {
-									signup_flow: VIDEOPRESS_TV_PURCHASE_FLOW,
+									signup_flow: VIDEOPRESS_PURCHASE_FLOW,
 								},
 							},
 					  ]
@@ -141,7 +141,7 @@ const videopressPurchase: Flow = {
 						);
 						persistSignupDestination( redirectTo );
 						setSignupCompleteSlug( _siteSlug || '' );
-						setSignupCompleteFlowName( VIDEOPRESS_TV_PURCHASE_FLOW );
+						setSignupCompleteFlowName( VIDEOPRESS_PURCHASE_FLOW );
 
 						window.location.replace(
 							`/checkout/${ _siteSlug }?signup=1&redirect_to=${ redirectTo }`

--- a/client/landing/stepper/declarative-flow/videopress-purchase.ts
+++ b/client/landing/stepper/declarative-flow/videopress-purchase.ts
@@ -1,0 +1,205 @@
+import { useLocale } from '@automattic/i18n-utils';
+import { VIDEOPRESS_PURCHASE_FLOW } from '@automattic/onboarding';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { translate } from 'i18n-calypso';
+import { useEffect, useState } from 'react';
+import { useSupportedPlans } from 'calypso/../packages/plans-grid/src/hooks';
+import { cartManagerClient } from 'calypso/my-sites/checkout/cart-manager-client';
+import {
+	setSignupCompleteSlug,
+	persistSignupDestination,
+	setSignupCompleteFlowName,
+} from 'calypso/signup/storageUtils';
+import { useSiteSlug } from '../hooks/use-site-slug';
+import { PLANS_STORE, SITE_STORE, USER_STORE, ONBOARD_STORE } from '../stores';
+import './internals/videopress.scss';
+import ProcessingStep from './internals/steps-repository/processing-step';
+import VideoPressTvRedirectStep from './internals/steps-repository/videopress-tv-redirect';
+import type { Flow, ProvidedDependencies } from './internals/types';
+import type { UserSelect, SiteSelect, PlansSelect } from '@automattic/data-stores';
+import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
+
+const videopressPurchase: Flow = {
+	name: VIDEOPRESS_PURCHASE_FLOW,
+	get title() {
+		return translate( 'VideoPress' );
+	},
+	useSteps() {
+		return [
+			{ slug: 'processing', component: ProcessingStep },
+			{ slug: 'redirect', component: VideoPressTvRedirectStep },
+		];
+	},
+
+	useStepNavigation( _currentStep, navigate ) {
+		if ( document.body ) {
+			// Make sure we only target videopress tv stepper for body css
+			if ( ! document.body.classList.contains( 'is-videopress-tv-purchase-stepper' ) ) {
+				document.body.classList.add( 'is-videopress-tv-purchase-stepper' );
+			}
+		}
+
+		const name = this.name;
+		const locale = useLocale();
+		const { setPendingAction, setProgress, setSelectedSite } = useDispatch( ONBOARD_STORE );
+		const { setIntentOnSite } = useDispatch( SITE_STORE );
+		const { supportedPlans } = useSupportedPlans( locale, 'MONTHLY' );
+		const _siteSlug = useSiteSlug();
+		const userIsLoggedIn = useSelect(
+			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
+			[]
+		);
+		const userData = useSelect(
+			( select ) => ( select( USER_STORE ) as UserSelect ).getCurrentUser(),
+			[]
+		);
+		const siteData = useSelect(
+			( select ) => ( select( SITE_STORE ) as SiteSelect ).getSite( _siteSlug || '' ),
+			[]
+		) || {
+			plan: null,
+			site_owner: null,
+			ID: null,
+		};
+		const getPlanProduct = useSelect(
+			( select ) => ( select( PLANS_STORE ) as PlansSelect ).getPlanProduct,
+			[]
+		);
+
+		const [ isVideoPressTvPurchasePending, setIsVideoPressTvPurchasePending ] = useState( false );
+
+		const addVideoPressPendingAction = () => {
+			// if the supported plans haven't been received yet, wait for next rerender to try again.
+			if ( 0 === supportedPlans.length ) {
+				return;
+			}
+
+			// If the site is already on a plan, we don't need to add a pending action. Maybe redirect to site?
+			const siteFreePlan = siteData?.plan?.is_free;
+			if ( ! siteFreePlan ) {
+				return;
+			}
+
+			// If the user is not logged in, we don't need to add a pending action.
+			if ( ! userIsLoggedIn ) {
+				return;
+			}
+
+			// If the user is logged in, and the site does not belong to them, we don't need to add a pending action.
+			if ( userData?.ID !== siteData?.site_owner ) {
+				return;
+			}
+
+			// only allow one call to this action to occur
+			if ( isVideoPressTvPurchasePending ) {
+				return;
+			}
+
+			setIsVideoPressTvPurchasePending( true );
+
+			// If the user is logged in, and the site belongs to them, and they are not on a plan, we need to add a pending action.
+			setPendingAction( async () => {
+				setProgress( 0 );
+				setSelectedSite( siteData?.ID || 0 );
+				setIntentOnSite( _siteSlug || '', VIDEOPRESS_PURCHASE_FLOW );
+
+				// select the premium plan for now. This will be replaced with our video plan.
+				let planObject = supportedPlans.find( ( plan ) => 'premium' === plan.periodAgnosticSlug );
+				if ( ! planObject ) {
+					planObject = supportedPlans.find( ( plan ) => 'business' === plan.periodAgnosticSlug );
+				}
+
+				const cartKey = _siteSlug
+					? await cartManagerClient.getCartKeyForSiteSlug( _siteSlug )
+					: null;
+				if ( ! cartKey ) {
+					return;
+				}
+				setProgress( 0.5 );
+
+				const planProductObject = getPlanProduct( planObject?.periodAgnosticSlug, 'MONTHLY' );
+				const productsToAdd: MinimalRequestCartProduct[] = planProductObject
+					? [
+							{
+								product_slug: planProductObject.storeSlug,
+								extra: {
+									signup_flow: VIDEOPRESS_TV_PURCHASE_FLOW,
+								},
+							},
+					  ]
+					: [];
+
+				// Add plan to cart.
+				setProgress( 0.75 );
+				cartManagerClient
+					.forCartKey( cartKey )
+					.actions.addProductsToCart( productsToAdd )
+					.then( () => {
+						setProgress( 1.0 );
+						const redirectTo = encodeURIComponent(
+							`/setup/${ name }/redirect?siteSlug=${ _siteSlug }`
+						);
+						persistSignupDestination( redirectTo );
+						setSignupCompleteSlug( _siteSlug || '' );
+						setSignupCompleteFlowName( VIDEOPRESS_TV_PURCHASE_FLOW );
+
+						window.location.replace(
+							`/checkout/${ _siteSlug }?signup=1&redirect_to=${ redirectTo }`
+						);
+					} );
+			} );
+		};
+
+		// needs to be wrapped in a useEffect because validation can call `navigate` which needs to be called in a useEffect
+		useEffect( () => {
+			switch ( _currentStep ) {
+				case 'processing':
+					if ( ! userIsLoggedIn ) {
+						const redirectTo = encodeURIComponent(
+							`/setup/videopress-tv-purchase?siteSlug=${ _siteSlug }`
+						);
+						window.location.replace(
+							`/start/videopress-account/user/${ locale }?variationName=${ name }&flow=${ name }&pageTitle=VideoPress.TV&redirect_to=${ redirectTo }`
+						);
+						return;
+					}
+					addVideoPressPendingAction();
+					break;
+				case 'redirect':
+					window.location.href = `https://${ _siteSlug }`;
+				default:
+					break;
+			}
+		} );
+
+		async function submit( providedDependencies: ProvidedDependencies = {} ) {
+			return providedDependencies;
+		}
+
+		const goBack = () => {
+			return;
+		};
+
+		const goNext = () => {
+			switch ( _currentStep ) {
+				case 'redirect':
+					window.location.href = `https://${ _siteSlug }`;
+				default:
+					return navigate( 'processing' );
+			}
+		};
+
+		const goToStep = ( step: string ) => {
+			const siteBelongsToUser = siteData && userData && siteData.site_owner === userData.ID;
+			if ( 'redirect' === step && siteBelongsToUser ) {
+				window.location.href = `https://${ _siteSlug }`;
+			}
+
+			return navigate( step );
+		};
+
+		return { goNext, goBack, goToStep, submit };
+	},
+};
+
+export default videopressPurchase;

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -13,6 +13,7 @@ export const VIDEOPRESS_FLOW = 'videopress';
 export const VIDEOPRESS_ACCOUNT = 'videopress-account';
 export const VIDEOPRESS_TV_FLOW = 'videopress-tv';
 export const VIDEOPRESS_TV_PURCHASE_FLOW = 'videopress-tv-purchase';
+export const VIDEOPRESS_PURCHASE_FLOW = 'videopress-purchase';
 export const IMPORT_FOCUSED_FLOW = 'import-focused';
 export const IMPORT_HOSTED_SITE_FLOW = 'import-hosted-site';
 export const SENSEI_FLOW = 'sensei';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


Related to https://github.com/Automattic/greenhouse/issues/1933

## Proposed Changes

* Adds a purchase flow similar to the VideoPress TV purchase flow.

## Testing Instructions

* You need a trial site.
* Apply test and try to use for a videomaker trial site: `calypso.localhost:3000/setup/videopress-purchase/?siteSlug=yoursiteslug`
* You are redirected to checkout
* There is a premium plan in your cart.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?