### PR TITLE
Add suggested tags to post publish share modal

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/index.tsx
@@ -71,7 +71,9 @@ const SharingModalInner: React.FC = () => {
 	const [ isOpen, setIsOpen ] = useState( true );
 	const closeModal = () => setIsOpen( false );
 	const { createNotice } = useDispatch( noticesStore );
-	const shouldShowSuggestedTags = postMeta?.reader_suggested_tags?.length > 0;
+	const [ shouldShowSuggestedTags, setShouldShowSuggestedTags ] = React.useState(
+		postMeta?.reader_suggested_tags?.length > 0
+	);
 
 	useEffect( () => {
 		// The first post will show a different modal.
@@ -287,7 +289,7 @@ const SharingModalInner: React.FC = () => {
 				</div>
 				<div className="wpcom-block-editor-post-published-sharing-modal__right">
 					{ shouldShowSuggestedTags ? (
-						<SuggestedTags />
+						<SuggestedTags setShouldShowSuggestedTags={ setShouldShowSuggestedTags } />
 					) : (
 						<img
 							className="wpcom-block-editor-post-published-sharing-modal__image"

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/index.tsx
@@ -23,16 +23,12 @@ import useSharingModalDismissed from './use-sharing-modal-dismissed';
 
 import './style.scss';
 
-type PostMeta = {
-	reader_suggested_tags: string;
-};
 type CoreEditorPlaceholder = {
 	getCurrentPost: ( ...args: unknown[] ) => {
 		link: string;
 		title: string;
 		status: string;
 		password: string;
-		meta: PostMeta;
 	};
 	getCurrentPostType: ( ...args: unknown[] ) => string;
 	isCurrentPostPublished: ( ...args: unknown[] ) => boolean;
@@ -51,7 +47,6 @@ const SharingModalInner: React.FC = () => {
 		title,
 		status: postStatus,
 		password: postPassword,
-		meta: postMeta,
 	} = useSelect(
 		( select ) => ( select( 'core/editor' ) as CoreEditorPlaceholder ).getCurrentPost(),
 		[]
@@ -71,12 +66,10 @@ const SharingModalInner: React.FC = () => {
 	const shouldShowVideoCelebrationModal =
 		useShouldShowVideoCelebrationModal( isCurrentPostPublished );
 
-	const [ isOpen, setIsOpen ] = useState( true );
+	const [ isOpen, setIsOpen ] = useState( false );
 	const closeModal = () => setIsOpen( false );
 	const { createNotice } = useDispatch( noticesStore );
-	const [ shouldShowSuggestedTags, setShouldShowSuggestedTags ] = React.useState(
-		postMeta?.reader_suggested_tags?.length > 0
-	);
+	const [ shouldShowSuggestedTags, setShouldShowSuggestedTags ] = React.useState( true );
 
 	useEffect( () => {
 		// The first post will show a different modal.

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/index.tsx
@@ -23,13 +23,16 @@ import useSharingModalDismissed from './use-sharing-modal-dismissed';
 
 import './style.scss';
 
+type PostMeta = {
+	reader_suggested_tags: string;
+};
 type CoreEditorPlaceholder = {
 	getCurrentPost: ( ...args: unknown[] ) => {
 		link: string;
 		title: string;
 		status: string;
 		password: string;
-		meta: object;
+		meta: PostMeta;
 	};
 	getCurrentPostType: ( ...args: unknown[] ) => string;
 	isCurrentPostPublished: ( ...args: unknown[] ) => boolean;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/index.tsx
@@ -195,7 +195,7 @@ const SharingModalInner: React.FC = () => {
 					<p>
 						{ createInterpolateElement(
 							__(
-								'TEST: Your post is now live and was delivered to each of <a>your subscribers</a>.',
+								'Your post is now live and was delivered to each of <a>your subscribers</a>.',
 								'full-site-editing'
 							),
 							{
@@ -286,8 +286,9 @@ const SharingModalInner: React.FC = () => {
 					</div>
 				</div>
 				<div className="wpcom-block-editor-post-published-sharing-modal__right">
-					{ shouldShowSuggestedTags && <SuggestedTags /> }
-					{ ! shouldShowSuggestedTags && (
+					{ shouldShowSuggestedTags ? (
+						<SuggestedTags />
+					) : (
 						<img
 							className="wpcom-block-editor-post-published-sharing-modal__image"
 							src={ postPublishedImage }

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/index.tsx
@@ -18,6 +18,7 @@ import useShouldShowVideoCelebrationModal from '../../../dotcom-fse/lib/video-ce
 import postPublishedImage from './images/illo-share.svg';
 import InlineSocialLogo from './inline-social-logo';
 import InlineSocialLogosSprite from './inline-social-logos-sprite';
+import SuggestedTags from './suggested-tags';
 import useSharingModalDismissed from './use-sharing-modal-dismissed';
 
 import './style.scss';
@@ -28,6 +29,7 @@ type CoreEditorPlaceholder = {
 		title: string;
 		status: string;
 		password: string;
+		meta: object;
 	};
 	getCurrentPostType: ( ...args: unknown[] ) => string;
 	isCurrentPostPublished: ( ...args: unknown[] ) => boolean;
@@ -46,6 +48,7 @@ const SharingModalInner: React.FC = () => {
 		title,
 		status: postStatus,
 		password: postPassword,
+		meta: postMeta,
 	} = useSelect(
 		( select ) => ( select( 'core/editor' ) as CoreEditorPlaceholder ).getCurrentPost(),
 		[]
@@ -65,9 +68,10 @@ const SharingModalInner: React.FC = () => {
 	const shouldShowVideoCelebrationModal =
 		useShouldShowVideoCelebrationModal( isCurrentPostPublished );
 
-	const [ isOpen, setIsOpen ] = useState( false );
+	const [ isOpen, setIsOpen ] = useState( true );
 	const closeModal = () => setIsOpen( false );
 	const { createNotice } = useDispatch( noticesStore );
+	const shouldShowSuggestedTags = postMeta?.reader_suggested_tags?.length > 0;
 
 	useEffect( () => {
 		// The first post will show a different modal.
@@ -191,7 +195,7 @@ const SharingModalInner: React.FC = () => {
 					<p>
 						{ createInterpolateElement(
 							__(
-								'Your post is now live and was delivered to each of <a>your subscribers</a>.',
+								'TEST: Your post is now live and was delivered to each of <a>your subscribers</a>.',
 								'full-site-editing'
 							),
 							{
@@ -282,11 +286,14 @@ const SharingModalInner: React.FC = () => {
 					</div>
 				</div>
 				<div className="wpcom-block-editor-post-published-sharing-modal__right">
-					<img
-						className="wpcom-block-editor-post-published-sharing-modal__image"
-						src={ postPublishedImage }
-						alt={ __( 'Share Post', 'full-site-editing' ) }
-					/>
+					{ shouldShowSuggestedTags && <SuggestedTags /> }
+					{ ! shouldShowSuggestedTags && (
+						<img
+							className="wpcom-block-editor-post-published-sharing-modal__image"
+							src={ postPublishedImage }
+							alt={ __( 'Share Post', 'full-site-editing' ) }
+						/>
+					) }
 				</div>
 			</div>
 		</Modal>

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/style.scss
@@ -125,16 +125,6 @@
 			width: 250px;
 			flex: fit-content;
 		}
-		.wpcom-block-editor-post-published-sharing-modal__save-tags {
-			display: flex;
-			p {
-				/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-				font-size: 14px;
-				font-weight: 500;
-				margin: 8px;
-				color: var(--studio-green-50);
-			}
-		}
 	}
 }
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/style.scss
@@ -36,6 +36,7 @@
 				border-left: 1px solid var(--studio-gray-5);
 				display: flex;
 				justify-content: center;
+				min-width: 300px;
 			}
 
 			@media only screen and (max-width: 600px) {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/style.scss
@@ -121,6 +121,20 @@
 				height: 1.3125rem;
 			}
 		}
+		.wpcom-block-editor-post-published-sharing-modal__suggest-tags {
+			width: 250px;
+			flex: fit-content;
+		}
+		.wpcom-block-editor-post-published-sharing-modal__save-tags {
+			display: flex;
+			p {
+				/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+				font-size: 14px;
+				font-weight: 500;
+				margin: 8px;
+				color: var(--studio-green-50);
+			}
+		}
 	}
 }
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/suggested-tags.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/suggested-tags.tsx
@@ -88,7 +88,7 @@ function SuggestedTags( props: SuggestedTagsProps ) {
 	);
 
 	recordTracksEvent( 'calypso_reader_post_publish_show_suggested_tags', {
-		number_of_selected_tags: selectedTags?.length ?? 0,
+		number_of_original_suggested_tags: origSuggestedTags?.length ?? 0,
 	} );
 
 	return (

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/suggested-tags.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/suggested-tags.tsx
@@ -73,17 +73,14 @@ function SuggestedTags( props: SuggestedTagsProps ) {
 	const { saveTags } = useAddTagsToPost( postId, selectedTags, onAddTagsButtonClick );
 
 	useEffect( () => {
-		if ( origSuggestedTags?.length > 0 ) {
+		if ( origSuggestedTags?.length === 0 ) {
+			props.setShouldShowSuggestedTags( false );
+		} else {
 			recordTracksEvent( 'calypso_reader_post_publish_show_suggested_tags', {
 				number_of_original_suggested_tags: origSuggestedTags.length,
 			} );
 		}
 	}, [] );
-
-	if ( origSuggestedTags?.length === 0 ) {
-		props.setShouldShowSuggestedTags( false );
-		return null;
-	}
 
 	const onChangeSelectedTags = ( newTags: ( string | TokenItem )[] ) => {
 		setSelectedTags( newTags );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/suggested-tags.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/suggested-tags.tsx
@@ -2,30 +2,41 @@ import { Button, FormTokenField } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import * as React from 'react';
+import useAddTagsToPost from './use-add-tags-to-post';
 
 type CoreEditorPlaceholder = {
 	getCurrentPost: ( ...args: unknown[] ) => {
+		id: number;
 		meta: object;
 	};
 };
 
 function SuggestedTags() {
 	const { __ } = useI18n();
-	const { meta: postMeta } = useSelect(
+	const { id: postId, meta: postMeta } = useSelect(
 		( select ) => ( select( 'core/editor' ) as CoreEditorPlaceholder ).getCurrentPost(),
 		[]
 	);
 	const [ selectedTags, setSelectedTags ] = React.useState(
 		postMeta?.reader_suggested_tags ? JSON.parse( postMeta.reader_suggested_tags ) : false
 	);
+	const { tagsAddedToPost, setTagsAddedToPost, saveTags } = useAddTagsToPost(
+		postId,
+		selectedTags
+	);
 	if ( ! selectedTags ) {
 		return null;
 	}
 
+	const onChangeSelectedTags = ( newTags: string[] ) => {
+		setSelectedTags( newTags );
+		setTagsAddedToPost( false );
+	};
+
 	const tokenField = (
 		<FormTokenField
 			value={ selectedTags }
-			onChange={ setSelectedTags }
+			onChange={ onChangeSelectedTags }
 			label={ __( 'Tags', 'full-site-editing' ) }
 		/>
 	);
@@ -41,15 +52,16 @@ function SuggestedTags() {
 			</p>
 			{ tokenField }
 			<p>{ __( 'Adding tags can help drive more traffic to your post.', 'full-site-editing' ) }</p>
-			<Button
-				className="wpcom-block-editor-post-published-sharing-modal__save-tags"
-				onClick={ () => {
-					console.log( 'click', selectedTags );
-				} } //TODO: need to figure out how to save tags
-				isPrimary={ true }
-			>
-				{ __( 'Add these tags', 'full-site-editing' ) }
-			</Button>
+			<div className="wpcom-block-editor-post-published-sharing-modal__save-tags">
+				<Button onClick={ saveTags } isPrimary={ true }>
+					{ __( 'Add these tags', 'full-site-editing' ) }
+				</Button>
+				{ tagsAddedToPost && (
+					<p className="wpcom-block-editor-post-published-sharing-modal__save-tags-status">
+						{ __( 'Tags Added', 'full-site-editing' ) }
+					</p>
+				) }
+			</div>
 		</div>
 	);
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/suggested-tags.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/suggested-tags.tsx
@@ -1,4 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { useLocale } from '@automattic/i18n-utils';
 import { Button, FormTokenField } from '@wordpress/components';
 import { TokenItem } from '@wordpress/components/build-types/form-token-field/types';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -32,6 +33,7 @@ type SuggestedTagsProps = {
 
 function SuggestedTags( props: SuggestedTagsProps ) {
 	const { __, _n } = useI18n();
+	const localeSlug = useLocale();
 	const { id: postId, meta: postMeta } = useSelect(
 		( select ) => ( select( 'core/editor' ) as CoreEditorPlaceholder ).getCurrentPost(),
 		[]
@@ -74,6 +76,10 @@ function SuggestedTags( props: SuggestedTagsProps ) {
 
 	useEffect( () => {
 		if ( origSuggestedTags?.length === 0 ) {
+			// Check if localeSlug begins with 'en'
+			if ( localeSlug && localeSlug.startsWith( 'en' ) ) {
+				recordTracksEvent( 'calypso_reader_post_publish_no_suggested_tags' );
+			}
 			props.setShouldShowSuggestedTags( false );
 		} else {
 			recordTracksEvent( 'calypso_reader_post_publish_show_suggested_tags', {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/suggested-tags.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/suggested-tags.tsx
@@ -1,0 +1,57 @@
+import { Button, FormTokenField } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { useI18n } from '@wordpress/react-i18n';
+import * as React from 'react';
+
+type CoreEditorPlaceholder = {
+	getCurrentPost: ( ...args: unknown[] ) => {
+		meta: object;
+	};
+};
+
+function SuggestedTags() {
+	const { __ } = useI18n();
+	const { meta: postMeta } = useSelect(
+		( select ) => ( select( 'core/editor' ) as CoreEditorPlaceholder ).getCurrentPost(),
+		[]
+	);
+	const [ selectedTags, setSelectedTags ] = React.useState(
+		postMeta?.reader_suggested_tags ? JSON.parse( postMeta.reader_suggested_tags ) : false
+	);
+	if ( ! selectedTags ) {
+		return null;
+	}
+
+	const tokenField = (
+		<FormTokenField
+			value={ selectedTags }
+			onChange={ setSelectedTags }
+			label={ __( 'Tags', 'full-site-editing' ) }
+		/>
+	);
+
+	return (
+		<div className="wpcom-block-editor-post-published-sharing-modal__suggest-tags">
+			<h1>{ __( 'Recommended tags:', 'full-site-editing' ) }</h1>
+			<p>
+				{ __(
+					'Based on the topics and themes in your post, here are some suggested tags to consider:',
+					'full-site-editing'
+				) }
+			</p>
+			{ tokenField }
+			<p>{ __( 'Adding tags can help drive more traffic to your post.', 'full-site-editing' ) }</p>
+			<Button
+				className="wpcom-block-editor-post-published-sharing-modal__save-tags"
+				onClick={ () => {
+					console.log( 'click', selectedTags );
+				} } //TODO: need to figure out how to save tags
+				isPrimary={ true }
+			>
+				{ __( 'Add these tags', 'full-site-editing' ) }
+			</Button>
+		</div>
+	);
+}
+
+export default React.memo( SuggestedTags );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/suggested-tags.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/suggested-tags.tsx
@@ -1,5 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button, FormTokenField } from '@wordpress/components';
+import { TokenItem } from '@wordpress/components/build-types/form-token-field/types';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
 import { useI18n } from '@wordpress/react-i18n';
@@ -43,7 +44,9 @@ function SuggestedTags( props: SuggestedTagsProps ) {
 		// Compare origSuggestedTags and selectedTags and determine the number of tags that are different
 		const numSuggestedTags = origSuggestedTags.length;
 		const numSelectedTags = selectedTags.length;
-		const numSameTags = origSuggestedTags.filter( ( tag ) => selectedTags.includes( tag ) ).length;
+		const numSameTags = origSuggestedTags.filter( ( tag: string ) =>
+			selectedTags.includes( tag )
+		).length;
 		const eventProps: SuggestedTagsEventProps = {
 			number_of_original_suggested_tags: numSuggestedTags,
 			number_of_selected_tags: numSelectedTags,
@@ -61,7 +64,7 @@ function SuggestedTags( props: SuggestedTagsProps ) {
 		return null;
 	}
 
-	const onChangeSelectedTags = ( newTags: string[] ) => {
+	const onChangeSelectedTags = ( newTags: ( string | TokenItem )[] ) => {
 		setSelectedTags( newTags );
 	};
 
@@ -87,7 +90,7 @@ function SuggestedTags( props: SuggestedTagsProps ) {
 			<Button
 				className="wpcom-block-editor-post-published-sharing-modal__save-tags"
 				onClick={ saveTags }
-				isPrimary={ true }
+				variant="primary"
 			>
 				{ __( 'Add these tags', 'full-site-editing' ) }
 			</Button>

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/suggested-tags.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/suggested-tags.tsx
@@ -54,9 +54,19 @@ function SuggestedTags( props: SuggestedTagsProps ) {
 			number_of_added_tags: numAddedTags,
 		};
 		recordTracksEvent( 'calypso_reader_post_publish_add_tags', eventProps );
-		createNotice( 'success', _n( 'Tag Added.', 'Tags Added.', numAddedTags, 'full-site-editing' ), {
-			type: 'snackbar',
-		} );
+		if ( numAddedTags > 0 ) {
+			createNotice(
+				'success',
+				_n( 'Tag Added.', 'Tags Added.', numAddedTags, 'full-site-editing' ),
+				{
+					type: 'snackbar',
+				}
+			);
+		} else {
+			createNotice( 'warning', __( 'No Tags Added.', 'full-site-editing' ), {
+				type: 'snackbar',
+			} );
+		}
 		props.setShouldShowSuggestedTags( false );
 	};
 	const { saveTags } = useAddTagsToPost( postId, selectedTags, onAddTagsButtonClick );
@@ -66,6 +76,7 @@ function SuggestedTags( props: SuggestedTagsProps ) {
 
 	const onChangeSelectedTags = ( newTags: ( string | TokenItem )[] ) => {
 		setSelectedTags( newTags );
+		recordTracksEvent( 'calypso_reader_post_publish_update_suggested_tags' );
 	};
 
 	const tokenField = (
@@ -75,6 +86,8 @@ function SuggestedTags( props: SuggestedTagsProps ) {
 			label={ __( 'Tags', 'full-site-editing' ) }
 		/>
 	);
+
+	recordTracksEvent( 'calypso_reader_post_publish_show_suggested_tags' );
 
 	return (
 		<div className="wpcom-block-editor-post-published-sharing-modal__suggest-tags">

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/suggested-tags.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/suggested-tags.tsx
@@ -2,6 +2,7 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button, FormTokenField } from '@wordpress/components';
 import { TokenItem } from '@wordpress/components/build-types/form-token-field/types';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
 import { store as noticesStore } from '@wordpress/notices';
 import { useI18n } from '@wordpress/react-i18n';
 import * as React from 'react';
@@ -70,7 +71,17 @@ function SuggestedTags( props: SuggestedTagsProps ) {
 		props.setShouldShowSuggestedTags( false );
 	};
 	const { saveTags } = useAddTagsToPost( postId, selectedTags, onAddTagsButtonClick );
-	if ( ! selectedTags ) {
+
+	useEffect( () => {
+		if ( origSuggestedTags?.length > 0 ) {
+			recordTracksEvent( 'calypso_reader_post_publish_show_suggested_tags', {
+				number_of_original_suggested_tags: origSuggestedTags.length,
+			} );
+		}
+	}, [] );
+
+	if ( origSuggestedTags?.length === 0 ) {
+		props.setShouldShowSuggestedTags( false );
 		return null;
 	}
 
@@ -86,10 +97,6 @@ function SuggestedTags( props: SuggestedTagsProps ) {
 			label={ __( 'Tags', 'full-site-editing' ) }
 		/>
 	);
-
-	recordTracksEvent( 'calypso_reader_post_publish_show_suggested_tags', {
-		number_of_original_suggested_tags: origSuggestedTags?.length ?? 0,
-	} );
 
 	return (
 		<div className="wpcom-block-editor-post-published-sharing-modal__suggest-tags">

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/suggested-tags.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/suggested-tags.tsx
@@ -1,5 +1,7 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button, FormTokenField } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { store as noticesStore } from '@wordpress/notices';
 import { useI18n } from '@wordpress/react-i18n';
 import * as React from 'react';
 import useAddTagsToPost from './use-add-tags-to-post';
@@ -11,19 +13,46 @@ type CoreEditorPlaceholder = {
 	};
 };
 
-function SuggestedTags() {
-	const { __ } = useI18n();
+type SuggestedTagsEventProps = {
+	number_of_original_suggested_tags: number;
+	number_of_selected_tags: number;
+	number_of_suggested_tags_selected: number;
+	number_of_added_tags: number;
+};
+
+type SuggestedTagsProps = {
+	setShouldShowSuggestedTags: ( shouldShow: boolean ) => void;
+};
+
+function SuggestedTags( props: SuggestedTagsProps ) {
+	const { __, _n } = useI18n();
 	const { id: postId, meta: postMeta } = useSelect(
 		( select ) => ( select( 'core/editor' ) as CoreEditorPlaceholder ).getCurrentPost(),
 		[]
 	);
-	const [ selectedTags, setSelectedTags ] = React.useState(
-		postMeta?.reader_suggested_tags ? JSON.parse( postMeta.reader_suggested_tags ) : false
-	);
-	const { tagsAddedToPost, setTagsAddedToPost, saveTags } = useAddTagsToPost(
-		postId,
-		selectedTags
-	);
+	const { createNotice } = useDispatch( noticesStore );
+	const origSuggestedTags = postMeta?.reader_suggested_tags
+		? JSON.parse( postMeta.reader_suggested_tags )
+		: [];
+	const [ selectedTags, setSelectedTags ] = React.useState( origSuggestedTags );
+	const onAddTagsButtonClick = ( numAddedTags ) => {
+		// Compare origSuggestedTags and selectedTags and determine the number of tags that are different
+		const numSuggestedTags = origSuggestedTags.length;
+		const numSelectedTags = selectedTags.length;
+		const numSameTags = origSuggestedTags.filter( ( tag ) => selectedTags.includes( tag ) ).length;
+		const eventProps: SuggestedTagsEventProps = {
+			number_of_original_suggested_tags: numSuggestedTags,
+			number_of_selected_tags: numSelectedTags,
+			number_of_suggested_tags_selected: numSameTags,
+			number_of_added_tags: numAddedTags,
+		};
+		recordTracksEvent( 'calypso_reader_post_publish_add_tags', eventProps );
+		createNotice( 'success', _n( 'Tag Added.', 'Tags Added.', numAddedTags, 'full-site-editing' ), {
+			type: 'snackbar',
+		} );
+		props.setShouldShowSuggestedTags( false );
+	};
+	const { saveTags } = useAddTagsToPost( postId, selectedTags, onAddTagsButtonClick );
 	if ( ! selectedTags ) {
 		return null;
 	}
@@ -52,16 +81,13 @@ function SuggestedTags() {
 			</p>
 			{ tokenField }
 			<p>{ __( 'Adding tags can help drive more traffic to your post.', 'full-site-editing' ) }</p>
-			<div className="wpcom-block-editor-post-published-sharing-modal__save-tags">
-				<Button onClick={ saveTags } isPrimary={ true }>
-					{ __( 'Add these tags', 'full-site-editing' ) }
-				</Button>
-				{ tagsAddedToPost && (
-					<p className="wpcom-block-editor-post-published-sharing-modal__save-tags-status">
-						{ __( 'Tags Added', 'full-site-editing' ) }
-					</p>
-				) }
-			</div>
+			<Button
+				className="wpcom-block-editor-post-published-sharing-modal__save-tags"
+				onClick={ saveTags }
+				isPrimary={ true }
+			>
+				{ __( 'Add these tags', 'full-site-editing' ) }
+			</Button>
 		</div>
 	);
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/suggested-tags.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/suggested-tags.tsx
@@ -59,7 +59,6 @@ function SuggestedTags( props: SuggestedTagsProps ) {
 
 	const onChangeSelectedTags = ( newTags: string[] ) => {
 		setSelectedTags( newTags );
-		setTagsAddedToPost( false );
 	};
 
 	const tokenField = (

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/suggested-tags.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/suggested-tags.tsx
@@ -87,7 +87,9 @@ function SuggestedTags( props: SuggestedTagsProps ) {
 		/>
 	);
 
-	recordTracksEvent( 'calypso_reader_post_publish_show_suggested_tags' );
+	recordTracksEvent( 'calypso_reader_post_publish_show_suggested_tags', {
+		number_of_selected_tags: selectedTags?.length ?? 0,
+	} );
 
 	return (
 		<div className="wpcom-block-editor-post-published-sharing-modal__suggest-tags">

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/suggested-tags.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/suggested-tags.tsx
@@ -6,10 +6,14 @@ import { useI18n } from '@wordpress/react-i18n';
 import * as React from 'react';
 import useAddTagsToPost from './use-add-tags-to-post';
 
+type PostMeta = {
+	reader_suggested_tags: string;
+};
+
 type CoreEditorPlaceholder = {
 	getCurrentPost: ( ...args: unknown[] ) => {
 		id: number;
-		meta: object;
+		meta: PostMeta;
 	};
 };
 
@@ -35,7 +39,7 @@ function SuggestedTags( props: SuggestedTagsProps ) {
 		? JSON.parse( postMeta.reader_suggested_tags )
 		: [];
 	const [ selectedTags, setSelectedTags ] = React.useState( origSuggestedTags );
-	const onAddTagsButtonClick = ( numAddedTags ) => {
+	const onAddTagsButtonClick = ( numAddedTags: number ) => {
 		// Compare origSuggestedTags and selectedTags and determine the number of tags that are different
 		const numSuggestedTags = origSuggestedTags.length;
 		const numSelectedTags = selectedTags.length;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/use-add-tags-to-post.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/use-add-tags-to-post.ts
@@ -1,18 +1,21 @@
 import apiFetch from '@wordpress/api-fetch';
-import { useState } from '@wordpress/element';
 
-const useAddTagsToPost = ( postId, tags ) => {
-	const [ tagsAddedToPost, setTagsAddedToPost ] = useState( false );
+type HasAddedTagsResult = {
+	added_tags: number;
+	success: boolean;
+};
+
+const useAddTagsToPost = ( postId, tags, onSaveTags ) => {
 	function saveTags() {
 		apiFetch( {
 			method: 'POST',
 			path: `/wpcom/v2/read/sites/${ window._currentSiteId }/posts/${ postId }/tags/add`,
 			data: { tags },
-		} ).finally( () => {
-			setTagsAddedToPost( true );
+		} ).then( ( result: HasAddedTagsResult ) => {
+			onSaveTags( result.added_tags );
 		} );
 	}
-	return { tagsAddedToPost, setTagsAddedToPost, saveTags };
+	return { saveTags };
 };
 
 export default useAddTagsToPost;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/use-add-tags-to-post.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/use-add-tags-to-post.ts
@@ -5,15 +5,22 @@ type HasAddedTagsResult = {
 	success: boolean;
 };
 
-const useAddTagsToPost = ( postId, tags, onSaveTags ) => {
-	function saveTags() {
-		apiFetch( {
-			method: 'POST',
-			path: `/wpcom/v2/read/sites/${ window._currentSiteId }/posts/${ postId }/tags/add`,
-			data: { tags },
-		} ).then( ( result: HasAddedTagsResult ) => {
-			onSaveTags( result.added_tags );
-		} );
+// OnSaveTags is a function callback that takes the number of tags added
+// to the post as an argument.
+type OnSaveTagsCallback = ( addedTags: number ) => void;
+const useAddTagsToPost = ( postId: number, tags: string[], onSaveTags: OnSaveTagsCallback ) => {
+	async function saveTags() {
+		try {
+			const result: HasAddedTagsResult = await apiFetch( {
+				method: 'POST',
+				path: `/wpcom/v2/read/sites/${ window._currentSiteId }/posts/${ postId }/tags/add`,
+				data: { tags },
+			} );
+			onSaveTags( result.added_tags ?? 0 );
+		} catch ( error ) {
+			// eslint-disable-next-line no-console
+			console.error( 'Error: Unable to add tags. Reason: %s', error );
+		}
 	}
 	return { saveTags };
 };

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/use-add-tags-to-post.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/use-add-tags-to-post.ts
@@ -1,0 +1,18 @@
+import apiFetch from '@wordpress/api-fetch';
+import { useState } from '@wordpress/element';
+
+const useAddTagsToPost = ( postId, tags ) => {
+	const [ tagsAddedToPost, setTagsAddedToPost ] = useState( false );
+	function saveTags() {
+		apiFetch( {
+			method: 'POST',
+			path: `/wpcom/v2/read/sites/${ window._currentSiteId }/posts/${ postId }/tags/add`,
+			data: { tags },
+		} ).finally( () => {
+			setTagsAddedToPost( true );
+		} );
+	}
+	return { tagsAddedToPost, setTagsAddedToPost, saveTags };
+};
+
+export default useAddTagsToPost;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/use-add-tags-to-post.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/use-add-tags-to-post.ts
@@ -5,22 +5,22 @@ type HasAddedTagsResult = {
 	success: boolean;
 };
 
-// OnSaveTags is a function callback that takes the number of tags added
-// to the post as an argument.
 type OnSaveTagsCallback = ( addedTags: number ) => void;
 const useAddTagsToPost = ( postId: number, tags: string[], onSaveTags: OnSaveTagsCallback ) => {
 	async function saveTags() {
+		let addedTags = 0;
 		try {
 			const result: HasAddedTagsResult = await apiFetch( {
 				method: 'POST',
 				path: `/wpcom/v2/read/sites/${ window._currentSiteId }/posts/${ postId }/tags/add`,
 				data: { tags },
 			} );
-			onSaveTags( result.added_tags ?? 0 );
+			addedTags = result.added_tags ?? 0;
 		} catch ( error ) {
 			// eslint-disable-next-line no-console
-			console.error( 'Error: Unable to add tags. Reason: %s', error );
+			console.error( 'Error: Unable to add tags. Reason: %s', JSON.stringify( error ) );
 		}
+		onSaveTags( addedTags );
 	}
 	return { saveTags };
 };


### PR DESCRIPTION
This PR intends to add a list of suggested tags based on the post content to the post-publish share modal.

The suggested tags will only show for;

* Users with suggested tags in post meta

The suggested tags are added when;

* The post has post content (more than 50 words)
* The site is in an English locale
* The post auto saves **AND** there are no suggested tags saved in post meta
* The user manually saves the post

The project can be found here - p2-pe7F0s-1jr

### Tracks Events

* `calypso_reader_post_publish_add_tags` - Tracks when a user clicks Add tags button which sends API request to save tags to post meta
* `calypso_reader_post_publish_update_suggested_tags` - Tracks when a user changes the tags in the textfield
* `calypso_reader_post_publish_show_suggested_tags` - Tracks when a user is shown the suggested tags

### Design

![tags-1](https://github.com/Automattic/wp-calypso/assets/5560595/47cf8e28-bda6-4922-8b29-721676387df7)

### Result

https://github.com/Automattic/wp-calypso/assets/5560595/b79ff86a-3a07-4b1d-bb6c-1ea1626091c8


### Testing

* Apply the patch code-D128037 on sandbox
* Apply this change to editing-toolkit to your sandbox with `cd apps/editing-toolkit && yarn dev --sync`
* Create a post on a test sandboxed site with more than 50 words. The AI assistant block is useful here.
* Publish the post and you should see the suggested tags in the post publish modal
* To retest, you can switch the post to a draft and publish again to see the post publish modal.
