### PR TITLE
Receipts: Enable multiple tax names and ID numbers in Calypso receipts 

### DIFF
--- a/client/me/purchases/billing-history/vat-vendor-details.tsx
+++ b/client/me/purchases/billing-history/vat-vendor-details.tsx
@@ -12,7 +12,9 @@ export function VatVendorDetails( { transaction }: { transaction: BillingTransac
 		<li>
 			<strong>
 				{ translate( 'Vendor %(combinedTaxName)s Details', {
-					args: { combinedTaxName: vendorInfoCombinedTaxName },
+					args: {
+						combinedTaxName: Object.keys( vendorInfo.tax_name_and_vendor_id_array ).join( '/' ),
+					},
 					comment: 'combinedTaxName is a localized tax, like VAT or GST',
 				} ) }
 			</strong>
@@ -21,9 +23,13 @@ export function VatVendorDetails( { transaction }: { transaction: BillingTransac
 					<div key={ addressLine }>{ addressLine }</div>
 				) ) }
 			</span>
-			{ <span className="receipt__vat-vendor-details-number">
-				{ vendorInfoTaxNamesAndIDs }
-				</span> }
+			<span className="receipt__vat-vendor-details-number">
+				{ Object.entries( vendorInfo.tax_name_and_vendor_id_array ).map( ( [ taxName, taxID ] ) => (
+					<div key={ taxName }>
+						<strong>{ taxName }</strong> { taxID }
+					</div>
+				) ) }
+			</span>
 		</li>
 	);
 }

--- a/client/me/purchases/billing-history/vat-vendor-details.tsx
+++ b/client/me/purchases/billing-history/vat-vendor-details.tsx
@@ -8,12 +8,20 @@ export function VatVendorDetails( { transaction }: { transaction: BillingTransac
 		return null;
 	}
 
+	// We need a combined string of the object properties for the combinedTaxName in the vendor info header
+	const vendorInfoCombinedTaxName = Object.keys( vendorInfo.tax_name_and_vendor_id_object ).join( '/' );
+
+	// We need to create a string of the taxName and taxID that contains each combination
+	// const vendorInfoTaxNamesAndIDs = Object.keys(vendorInfo.tax_name_and_vendor_id_object).map(function(taxName, taxID) {
+	// 	return '<strong>'+taxName+'</strong> '+taxID+' <br />';
+	// });
+
 	return (
 		<li>
 			<strong>
-				{ translate( 'Vendor %(taxName)s Details', {
-					args: { taxName: vendorInfo.tax_name },
-					comment: 'taxName is a localized tax, like VAT or GST',
+				{ translate( 'Vendor %(combinedTaxName)s Details', {
+					args: { combinedTaxName: vendorInfoCombinedTaxName },
+					comment: 'combinedTaxName is a localized tax, like VAT or GST',
 				} ) }
 			</strong>
 			<span>
@@ -21,11 +29,9 @@ export function VatVendorDetails( { transaction }: { transaction: BillingTransac
 					<div key={ addressLine }>{ addressLine }</div>
 				) ) }
 			</span>
-			{ vendorInfo.tax_name_and_vendor_id_object && (
-				<span className="receipt__vat-vendor-details-number">
-					<strong>{ vendorInfo.tax_name }</strong> { vendorInfo.vat_id }
-				</span>
-			) }
+			{ /* <span className="receipt__vat-vendor-details-number">
+				{ vendorInfoTaxNamesAndIDs }
+				</span> */ }
 		</li>
 	);
 }

--- a/client/me/purchases/billing-history/vat-vendor-details.tsx
+++ b/client/me/purchases/billing-history/vat-vendor-details.tsx
@@ -12,9 +12,9 @@ export function VatVendorDetails( { transaction }: { transaction: BillingTransac
 	const vendorInfoCombinedTaxName = Object.keys( vendorInfo.tax_name_and_vendor_id_object ).join( '/' );
 
 	// We need to create a string of the taxName and taxID that contains each combination
-	// const vendorInfoTaxNamesAndIDs = Object.keys(vendorInfo.tax_name_and_vendor_id_object).map(function(taxName, taxID) {
-	// 	return '<strong>'+taxName+'</strong> '+taxID+' <br />';
-	// });
+	const vendorInfoTaxNamesAndIDs = Object.keys(vendorInfo.tax_name_and_vendor_id_object).map(function(taxName, taxID) {
+		return '<strong>'+taxName+'</strong> '+taxID+' <br />';
+	});
 
 	return (
 		<li>
@@ -29,9 +29,9 @@ export function VatVendorDetails( { transaction }: { transaction: BillingTransac
 					<div key={ addressLine }>{ addressLine }</div>
 				) ) }
 			</span>
-			{ /* <span className="receipt__vat-vendor-details-number">
+			{ <span className="receipt__vat-vendor-details-number">
 				{ vendorInfoTaxNamesAndIDs }
-				</span> */ }
+				</span> }
 		</li>
 	);
 }

--- a/client/me/purchases/billing-history/vat-vendor-details.tsx
+++ b/client/me/purchases/billing-history/vat-vendor-details.tsx
@@ -21,7 +21,7 @@ export function VatVendorDetails( { transaction }: { transaction: BillingTransac
 					<div key={ addressLine }>{ addressLine }</div>
 				) ) }
 			</span>
-			{ vendorInfo.vat_id && (
+			{ vendorInfo.tax_name_and_vendor_id_object && (
 				<span className="receipt__vat-vendor-details-number">
 					<strong>{ vendorInfo.tax_name }</strong> { vendorInfo.vat_id }
 				</span>

--- a/client/me/purchases/billing-history/vat-vendor-details.tsx
+++ b/client/me/purchases/billing-history/vat-vendor-details.tsx
@@ -11,11 +11,11 @@ export function VatVendorDetails( { transaction }: { transaction: BillingTransac
 	return (
 		<li>
 			<strong>
-				{ translate( 'Vendor %(combinedTaxName)s Details', {
+				{ translate( 'Vendor %(taxName)s Details', {
 					args: {
-						combinedTaxName: Object.keys( vendorInfo.tax_name_and_vendor_id_array ).join( '/' ),
+						taxName: Object.keys( vendorInfo.tax_name_and_vendor_id_array ).join( '/' ),
 					},
-					comment: 'combinedTaxName is a localized tax, like VAT or GST',
+					comment: 'taxName is a localized tax, like VAT or GST',
 				} ) }
 			</strong>
 			<span>

--- a/client/me/purchases/billing-history/vat-vendor-details.tsx
+++ b/client/me/purchases/billing-history/vat-vendor-details.tsx
@@ -8,14 +8,6 @@ export function VatVendorDetails( { transaction }: { transaction: BillingTransac
 		return null;
 	}
 
-	// We need a combined string of the object properties for the combinedTaxName in the vendor info header
-	const vendorInfoCombinedTaxName = Object.keys( vendorInfo.tax_name_and_vendor_id_object ).join( '/' );
-
-	// We need to create a string of the taxName and taxID that contains each combination
-	const vendorInfoTaxNamesAndIDs = Object.keys(vendorInfo.tax_name_and_vendor_id_object).map(function(taxName, taxID) {
-		return '<strong>'+taxName+'</strong> '+taxID+' <br />';
-	});
-
 	return (
 		<li>
 			<strong>

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -34,20 +34,33 @@ export interface TaxVendorInfo {
 	country_code: string;
 
 	/**
-	 * The localized name of the tax (eg: "VAT", "GST", etc.).
-	 */
-	tax_name: string;
-
-	/**
 	 * The mailing address to display on receipts as a list of strings (each
 	 * string should be on its own line).
 	 */
 	address: string[];
 
 	/**
+	 * An object containing tax names and corresponding vendor ids that are used for the user's country
+	 *
+	 * This will deprecate the vat_id and tax_name properties
+	 * For now, those two properties will stay in place for backwards compatibility
+	 *
+	 * Property: The localized name of the tax (eg: "VAT", "GST", etc.).
+	 * Value: A8c vendor id for that specific tax
+	 */
+	tax_name_and_vendor_id_object: object;
+
+	/**
 	 * The vendor's VAT id.
+	 * @deprecated This is still in place for backwards compability with cached clients
 	 */
 	vat_id: string;
+
+	/**
+	 * The localized name of the tax (eg: "VAT", "GST", etc.).
+	 * @deprecated This is still in place for backwards compability with cached clients
+	 */
+	tax_name: string;
 }
 
 export interface Purchase {

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -45,10 +45,10 @@ export interface TaxVendorInfo {
 	 * This will deprecate the vat_id and tax_name properties
 	 * For now, those two properties will stay in place for backwards compatibility
 	 *
-	 * Property: The localized name of the tax (eg: "VAT", "GST", etc.).
+	 * Key:   The localized name of the tax (eg: "VAT", "GST", etc.).
 	 * Value: A8c vendor id for that specific tax
 	 */
-	tax_name_and_vendor_id_array: object;
+	tax_name_and_vendor_id_array: Record< string, string >;
 
 	/**
 	 * The vendor's VAT id.

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -48,7 +48,7 @@ export interface TaxVendorInfo {
 	 * Property: The localized name of the tax (eg: "VAT", "GST", etc.).
 	 * Value: A8c vendor id for that specific tax
 	 */
-	tax_name_and_vendor_id_object: object;
+	tax_name_and_vendor_id_array: object;
 
 	/**
 	 * The vendor's VAT id.


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/payments-shilling/issues/1510

## Proposed Changes
We have made a series of changes to implement handling multiple tax names and IDs when displaying our tax vendor information. Since the changes have been completed on the backend, we can now turn our attention to improving the formatting of those changes on the front end.

This PR updates the vendor details section of a billing receipt so that the tax names and associated ID's for our business entities are easier to read.

Now that code-D127664 has been deployed, the vendor details currently appear like this:

![Screenshot 2023-11-08 at 14 24 54](https://github.com/Automattic/wp-calypso/assets/12505355/fb87c425-a526-41dc-b3dc-7c70aeba2277)

The changes here will update the information to appear like this:

![Screenshot 2023-11-08 at 16 06 40](https://github.com/Automattic/wp-calypso/assets/12505355/17a9ca5e-933b-428d-ab12-caba71e5f6af)

It may seem redundant to have `PST` twice in the second line. However, the first `PST` is the label describing the type of tax. The second `PST` is part of the identification number itself and needs to be in place. For this reason, I have decided to show both.

## Testing Instructions

- Make a purchase from with a billing address from a Canadian province that has multiple tax names. For example, use Golden, British Columbia, V0A 0A0 as your city, state, and postal code, respectively.
- View the receipt in `me/purchases/billing/{your purchase receipt ID}`
- Notice the one-line version of multiple tax names and ID numbers
- Apply this patch
- Reload your billing receipt
- Notice the tax names and ID numbers are separated onto two lines

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
