### PR TITLE
Multi-domain: Update selection logic to reduce API calls

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -581,10 +581,10 @@ export class RenderDomainsStep extends Component {
 			const productsInCart = [ ...this.props.cart.products, ...productsToAdd ];
 
 			// Sort products to ensure the user gets the best deal with the free domain bundle promotion.
-			const sortedProducts = await this.sortProductsByPriceDescending( productsInCart );
+			const sortedProducts = this.sortProductsByPriceDescending( productsInCart );
 
 			// Replace the products in the cart with the freshly sorted products.
-			this.props.shoppingCartManager.replaceProductsInCart( sortedProducts );
+			await this.props.shoppingCartManager.replaceProductsInCart( sortedProducts );
 		} else {
 			await this.props.shoppingCartManager.addProductsToCart( registration );
 		}
@@ -592,29 +592,27 @@ export class RenderDomainsStep extends Component {
 		this.setState( { isCartPendingUpdateDomain: null } );
 	}
 
-	async sortProductsByPriceDescending( productsInCart ) {
+	sortProductsByPriceDescending( productsInCart ) {
 		// Sort products by price descending, considering promotions.
-		productsInCart.sort( ( a, b ) => {
-			const getSortingValue = ( product ) => {
-				if ( product.item_subtotal_integer !== 0 ) {
-					return product.item_subtotal_integer;
-				}
+		const getSortingValue = ( product ) => {
+			if ( product.item_subtotal_integer !== 0 ) {
+				return product.item_subtotal_integer;
+			}
 
-				// Use the lowest non-zero new_price or fallback to item_original_cost_integer.
-				const nonZeroPrices =
-					product.cost_overrides
-						?.map( ( override ) => override.new_price * 100 )
-						.filter( ( price ) => price > 0 ) || [];
+			// Use the lowest non-zero new_price or fallback to item_original_cost_integer.
+			const nonZeroPrices =
+				product.cost_overrides
+					?.map( ( override ) => override.new_price * 100 )
+					.filter( ( price ) => price > 0 ) || [];
 
-				return nonZeroPrices.length
-					? Math.min( ...nonZeroPrices )
-					: product.item_original_cost_integer;
-			};
+			return nonZeroPrices.length
+				? Math.min( ...nonZeroPrices )
+				: product.item_original_cost_integer;
+		};
 
+		return productsInCart.sort( ( a, b ) => {
 			return getSortingValue( b ) - getSortingValue( a );
 		} );
-
-		return productsInCart;
 	}
 
 	removeDomainClickHandler = ( domain ) => () => {

--- a/client/signup/steps/domains/test/index.js
+++ b/client/signup/steps/domains/test/index.js
@@ -54,7 +54,7 @@ describe( 'sortProductsByPriceDescending', () => {
 			},
 		];
 
-		const sortedProducts = await instance.sortProductsByPriceDescending( products );
+		const sortedProducts = instance.sortProductsByPriceDescending( products );
 		expect( sortedProducts[ 0 ].meta ).toBe( 'domain.com' );
 		expect( sortedProducts[ 1 ].meta ).toBe( 'domain.net' );
 	} );
@@ -81,7 +81,7 @@ describe( 'sortProductsByPriceDescending', () => {
 			},
 		];
 
-		const sortedProducts = await instance.sortProductsByPriceDescending( products );
+		const sortedProducts = instance.sortProductsByPriceDescending( products );
 		expect( sortedProducts[ 0 ].meta ).toBe( 'domain.kitchen' );
 		expect( sortedProducts[ 1 ].meta ).toBe( 'domain.com' );
 	} );
@@ -137,7 +137,7 @@ describe( 'sortProductsByPriceDescending', () => {
 			},
 		];
 
-		const sortedProducts = await instance.sortProductsByPriceDescending( products );
+		const sortedProducts = instance.sortProductsByPriceDescending( products );
 		expect( sortedProducts[ 0 ].meta ).toBe( 'domain.fish' );
 		expect( sortedProducts[ 1 ].meta ).toBe( 'domain.kitchen' );
 		expect( sortedProducts[ 2 ].meta ).toBe( 'domain.blog' );

--- a/client/signup/steps/domains/test/index.js
+++ b/client/signup/steps/domains/test/index.js
@@ -39,7 +39,7 @@ describe( 'sortProductsByPriceDescending', () => {
 	} );
 
 	test( 'should sort products by item_subtotal_integer', async () => {
-		instance.props.cart.products = [
+		const products = [
 			{
 				meta: 'domain.com',
 				item_subtotal_integer: 200, // The price we consider when sorting.
@@ -54,13 +54,13 @@ describe( 'sortProductsByPriceDescending', () => {
 			},
 		];
 
-		const sortedProducts = await instance.sortProductsByPriceDescending();
+		const sortedProducts = await instance.sortProductsByPriceDescending( products );
 		expect( sortedProducts[ 0 ].meta ).toBe( 'domain.com' );
 		expect( sortedProducts[ 1 ].meta ).toBe( 'domain.net' );
 	} );
 
 	test( 'should sort products by item_original_cost_integer', async () => {
-		instance.props.cart.products = [
+		const products = [
 			{
 				meta: 'domain.com',
 				item_subtotal_integer: 2000, // The price we consider when sorting.
@@ -81,13 +81,13 @@ describe( 'sortProductsByPriceDescending', () => {
 			},
 		];
 
-		const sortedProducts = await instance.sortProductsByPriceDescending();
+		const sortedProducts = await instance.sortProductsByPriceDescending( products );
 		expect( sortedProducts[ 0 ].meta ).toBe( 'domain.kitchen' );
 		expect( sortedProducts[ 1 ].meta ).toBe( 'domain.com' );
 	} );
 
 	test( 'should sort products considering cost_overrides', async () => {
-		instance.props.cart.products = [
+		const products = [
 			{
 				meta: 'domain.store',
 				item_subtotal_integer: 96,
@@ -137,7 +137,7 @@ describe( 'sortProductsByPriceDescending', () => {
 			},
 		];
 
-		const sortedProducts = await instance.sortProductsByPriceDescending();
+		const sortedProducts = await instance.sortProductsByPriceDescending( products );
 		expect( sortedProducts[ 0 ].meta ).toBe( 'domain.fish' );
 		expect( sortedProducts[ 1 ].meta ).toBe( 'domain.kitchen' );
 		expect( sortedProducts[ 2 ].meta ).toBe( 'domain.blog' );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/4213

## Proposed Changes

* This PR updates the multi-domain selection logic to reduce the number of calls to the `/v1.1/me/shopping-cart/no-site` endpoint when a domain is selected.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test /start to ensure domain multi-selection is still working correctly
* Domains should still be sorted in the mini-cart with the highest price on top
* Test a flow other than `onboarding` or `domain` to ensure their are no regressions

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?