### PR TITLE
Magic Login: Adjust password link styling

### DIFF
--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -164,7 +164,6 @@ class MagicLogin extends Component {
 			<>
 				<div className="magic-login__footer">
 					<a href={ login( loginParameters ) } onClick={ this.onClickEnterPasswordInstead }>
-						<Gridicon icon="arrow-left" size={ 18 } />
 						{ translate( 'Enter a password instead' ) }
 					</a>
 				</div>

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -44,7 +44,7 @@
 	}
 
 	.logged-out-form {
-		padding-top: 0;
+		padding: 0 24px 0 24px;
 		.magic-login__form-sub-header {
 			text-align: center;
 		}
@@ -148,7 +148,7 @@
 .magic-login__footer {
 	a {
 		border-bottom: 1px solid #c8d7e1;
-		color: var(--color-neutral-50);
+		color: var(--studio-gray-90);
 		display: block;
 		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		line-height: 4em;
@@ -156,7 +156,7 @@
 		font-weight: 600;
 		padding: 0 24px;
 		text-align: center;
-		text-decoration: none;
+		text-decoration: underline;
 
 		&:hover {
 			color: var(--color-primary);


### PR DESCRIPTION
## Proposed Changes

Small PR to tweak the styling of the 'Enter a password instead' link on the magic login screen to get it fully in line with designs in Figma here: 5p3iZ99zPYfl6ronoTYEXO-fi-2_596

**Before**
<img width="1501" alt="magic login link" src="https://github.com/Automattic/wp-calypso/assets/21228350/35055c01-9d1d-4d9f-9a88-c3520e2fc330">


**After**
<img width="1500" alt="magic logic link" src="https://github.com/Automattic/wp-calypso/assets/21228350/1b090df7-fa6f-42ea-941d-6a5ef0c7c94e">


## Testing Instructions

1) In an incognito or non-logged-in browser, go to wordpress.com and click the Login link, and then click 'Email me a login link' to go to the magic email login page
2) Replace wordpress.com with http://calypso.localhost:3000 to load this branch.
3) Confirm new password link styling shows and looks like screenshot above. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?