### PR TITLE
ETK: Hide the start page options modal from Core - second try

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/block-patterns/class-block-patterns-from-api.php
@@ -157,6 +157,7 @@ class Block_Patterns_From_API {
 		}
 
 		$this->update_core_patterns_with_wpcom_categories();
+		$this->update_pattern_block_types();
 
 		// Temporarily removing the call to `update_pattern_post_types` while we investigate
 		// https://github.com/Automattic/wp-calypso/issues/79145.
@@ -294,6 +295,30 @@ class Block_Patterns_From_API {
 
 				$pattern['postTypes'] = $post_types;
 				$pattern_name         = $pattern['name'];
+				unset( $pattern['name'] );
+				register_block_pattern( $pattern_name, $pattern );
+			}
+		}
+	}
+
+	/**
+	 * Ensure that all patterns with a blockType property are registered with appropriate postTypes.
+	 */
+	private function update_pattern_block_types() {
+		if ( ! class_exists( 'WP_Block_Patterns_Registry' ) ) {
+			return;
+		}
+		foreach ( \WP_Block_Patterns_Registry::get_instance()->get_all_registered() as $pattern ) {
+			if ( ! array_key_exists( 'blockTypes', $pattern ) || empty( $pattern['blockTypes'] ) ) {
+				continue;
+			}
+
+			$post_content_offset = array_search( 'core/post-content', $pattern['blockTypes'], true );
+			if ( $post_content_offset !== false ) {
+				unregister_block_pattern( $pattern['name'] );
+
+				$pattern['blockTypes'] = array_splice( $pattern['blockTypes'], $post_content_offset, 1 );
+				$pattern_name          = $pattern['name'];
 				unset( $pattern['name'] );
 				register_block_pattern( $pattern_name, $pattern );
 			}

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
@@ -234,6 +234,9 @@ class Starter_Page_Templates {
 				'name'  => 'current',
 			),
 		);
+
+		$registered_page_templates = $this->get_registered_page_templates();
+
 		/**
 		 * Filters the config before it's passed to the frontend.
 		 *
@@ -242,7 +245,7 @@ class Starter_Page_Templates {
 		$config = apply_filters(
 			'fse_starter_page_templates_config',
 			array(
-				'templates'    => array_merge( $default_templates, $page_templates ),
+				'templates'    => array_merge( $default_templates, $page_templates, $registered_page_templates ),
 				// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 				'screenAction' => isset( $_GET['new-homepage'] ) ? 'add' : $screen->action,
 			)
@@ -339,5 +342,62 @@ class Starter_Page_Templates {
 		// Make sure to get blog locale, not user locale.
 		$language = function_exists( 'get_blog_lang_code' ) ? get_blog_lang_code() : get_locale();
 		return get_iso_639_locale( $language );
+	}
+
+	/**
+	 * Gets the registered page templates
+	 */
+	public function get_registered_page_templates() {
+		$registered_page_templates = array();
+
+		if ( class_exists( 'WP_Block_Patterns_Registry' ) ) {
+			$registered_categories = $this->get_registered_categories();
+			foreach ( \WP_Block_Patterns_Registry::get_instance()->get_all_registered() as $pattern ) {
+				if ( ! array_key_exists( 'blockTypes', $pattern ) ) {
+					continue;
+				}
+
+				$post_content_offset = array_search( 'core/post-content', $pattern['blockTypes'], true );
+				if ( $post_content_offset !== false ) {
+					$categories = array();
+					foreach ( $pattern['categories'] as $category ) {
+						$registered_category = $registered_categories[ $category ];
+						if ( $registered_category ) {
+							$categories[ $category ] = array(
+								'slug'        => $registered_category['name'],
+								'title'       => $registered_category['label'],
+								'description' => $registered_category['description'],
+							);
+						}
+					}
+
+					$registered_page_templates[] = array(
+						'ID'          => null,
+						'title'       => $pattern['title'],
+						'description' => $pattern['description'],
+						'name'        => $pattern['name'],
+						'html'        => $pattern['content'],
+						'categories'  => $categories,
+					);
+				}
+			}
+		}
+
+		return $registered_page_templates;
+	}
+
+	/**
+	 * Gets the registered categories.
+	 */
+	public function get_registered_categories() {
+		$registered_categories = array();
+
+		if ( class_exists( 'WP_Block_Pattern_Categories_Registry' ) ) {
+			foreach ( \WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered() as $category ) {
+				$registered_categories[ $category['name'] ] = $category;
+			}
+		}
+
+		return $registered_categories;
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
