### PR TITLE
2023 Plans: Remove the manage add-ons button from p2 plans page ( part 2 )

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -548,7 +548,7 @@ const PlansFeaturesMain = ( {
 			};
 		}
 
-		if ( sitePlanSlug && isFreePlan( sitePlanSlug ) && intent !== 'plans-p2' ) {
+		if ( sitePlanSlug && isFreePlan( sitePlanSlug ) && intentFromProps !== 'plans-p2' ) {
 			actionOverrides = {
 				loggedInFreePlan: {
 					status:


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/83726

## Proposed Changes

* After a rebase, we mistakenly used `intent` instead of `intentFromProps` for a condition

## Screenshots

### Free plan is current plan
<img width="1139" alt="Screenshot 2023-10-31 at 12 08 12 PM" src="https://github.com/Automattic/wp-calypso/assets/5414230/9e8ff91b-0d1a-47d5-889a-36f83649b63e">

### P2+ plan is current plan
<img width="1128" alt="Screenshot 2023-10-31 at 12 08 21 PM" src="https://github.com/Automattic/wp-calypso/assets/5414230/57ba2fe5-0536-4645-8073-9372cb899651">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


* Create a new p2 site by visiting calypso.localhost:3000/start/p2 and following onboarding instructions
* Note the site slug that's created for your new p2 workspace
* Navigate directly to calypso.localhost:3000/plans/{P2_WORKSPACE_SITE_SLUG}
* Verify that no CTA is displayed for free plan
* Purchase a P2+ plan
* Verify that the CTA for the free plan says "Contact support"

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?