### PR TITLE
Assembler: Improve responsiveness in the Pages screen

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-page-preview-list.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-page-preview-list.scss
@@ -5,14 +5,20 @@
 	box-sizing: border-box;
 	display: grid;
 	flex: 1;
-	gap: 36px 48px;
-	grid-template-columns: repeat(3, 1fr);
+	gap: 48px;
+	grid-template-columns: 1fr;
 	grid-template-rows: min-content;
 	height: 100vh;
 	overflow-y: scroll;
 	padding: 100px 12px;
 
+	@include break-medium {
+		gap: 48px 24px;
+		grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+	}
+
 	@include break-huge {
 		gap: 48px;
+		grid-template-columns: repeat(3, 1fr);
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-page-preview-list.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-page-preview-list.scss
@@ -21,4 +21,12 @@
 		gap: 48px;
 		grid-template-columns: repeat(3, 1fr);
 	}
+
+	@media (min-width: 1600px) {
+		grid-template-columns: repeat(4, 1fr);
+	}
+
+	@media (min-width: 2560px) {
+		grid-template-columns: repeat(5, 1fr);
+	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-page-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-page-preview.scss
@@ -37,7 +37,7 @@ $font-family: "SF Pro Text", $sans;
 			border-radius: 8.758px;  /* stylelint-disable-line scales/radii */
 			bottom: 0;
 			left: 0;
-			overflow-y: scroll;
+			overflow: hidden;
 			position: absolute;
 			right: 0;
 			top: 0;
@@ -50,6 +50,10 @@ $font-family: "SF Pro Text", $sans;
 			scrollbar-width: none;
 			&::-webkit-scrollbar {
 				display: none;
+			}
+
+			@include break-huge {
+				overflow-y: scroll;
 			}
 		}
 	}


### PR DESCRIPTION
Related to #83937

## Proposed Changes

This PR improves the responsiveness of the Pages screen in the Assembler. The responsive UI behavior references to this https://github.com/Automattic/wp-calypso/pull/83649#issuecomment-1788833601:

> RESPONSIVENESS
> We could set a minimum size for the page preview. I'm afraid to have very small page previews for small screens. So, for small screen we could have 3 pages preview per row, 2 page preview per row for example. WDYT? Maybe the minimum width could be between 280 - 300 pixels.

See the before/after comparison:

Before:

https://github.com/Automattic/wp-calypso/assets/797888/892d56ef-4905-4197-b7c2-29ae8059f8f5

After:

https://github.com/Automattic/wp-calypso/assets/797888/7de232a3-a495-4c82-8588-965c9ef06824

After ([version 2](https://github.com/Automattic/wp-calypso/pull/84033#issuecomment-1803191699)):

https://github.com/Automattic/wp-calypso/assets/797888/b612fa85-647f-4ab2-8b42-8c07bc58f519



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Assembler.
* Go through the Patterns, and Styles screen until you arrive at the Pages screen.
* Ensure that the responsive UI is as shown above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?