### PR TITLE
Domains onboarding: Only search domain suggestions once on load

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1271,9 +1271,8 @@ class RegisterDomainStep extends Component {
 		} );
 	};
 
-	onSearch = async ( searchQuery, { shouldQuerySubdomains = true } = {} ) => {
+	onSearch = ( searchQuery, { shouldQuerySubdomains = true } = {} ) => {
 		debug( 'onSearch handler was triggered with query', searchQuery );
-
 		const domain = getDomainSuggestionSearch( searchQuery, MIN_QUERY_LENGTH );
 
 		this.setState(

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -318,7 +318,7 @@ class RegisterDomainStep extends Component {
 		const query = this.state.lastQuery || storedQuery || this.getInitialQueryInLaunchFlow();
 
 		if ( query && ! this.state.searchResults && ! this.state.subdomainSearchResults ) {
-			this.onSearch( query );
+			// We used to run the initial search here, it's now triggered on mount in a useEffect inside <Search />
 
 			// Delete the stored query once it is consumed.
 			globalThis?.sessionStorage?.removeItem( SESSION_STORAGE_QUERY_KEY );


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/4213

## Proposed Changes

* Removes search on component mount as this [already runs inside `<Search />`'s useEffect](https://github.com/Automattic/wp-calypso/blob/trunk/packages/search/src/search.tsx#L201).

## Testing Instructions

* Enable debugging for the domains step `localStorage.setItem( 'debug', 'calypso:domains:register-domain-step' );`
* Test domains search runs on load
* Please test multiple domains screens e.g.
* /start, /start/onboarding-pm, launch site flow, add domain sidebar nudge
