### PR TITLE
Site Monitoring: Replace 'Cache efficiency' chart with http_verb chart

### DIFF
--- a/client/components/legend-item/index.js
+++ b/client/components/legend-item/index.js
@@ -37,13 +37,12 @@ class LegendItem extends Component {
 		const { percent, value } = this.props;
 
 		let valueString = '';
-
 		if ( value && percent ) {
 			valueString = `${ value } (${ percent }%)`;
 		} else if ( value ) {
 			valueString = value;
 		} else if ( percent ) {
-			valueString = `${ percent }%`;
+			valueString = percent === '0' ? '-' : `${ percent }%`;
 		}
 
 		return valueString.length > 0 ? (

--- a/client/my-sites/site-monitoring/components/site-monitoring-pie-chart/style.scss
+++ b/client/my-sites/site-monitoring/components/site-monitoring-pie-chart/style.scss
@@ -29,8 +29,7 @@
 		.legend-item {
 			flex-direction: row;
 			.legend-item__title::after {
-				content: "-";
-				padding-left: 3px;
+				content: ":";
 				padding-right: 3px;
 			}
 			.legend-item__detail {

--- a/client/my-sites/site-monitoring/metrics-tab.tsx
+++ b/client/my-sites/site-monitoring/metrics-tab.tsx
@@ -166,6 +166,7 @@ function useAggregateHttpVerbData(
 		dimension
 	);
 	const allowedVerbs: string[] = [ 'GET', 'POST', 'HEAD', 'DELETE' ];
+
 	return {
 		formattedData: Object.keys( data.formattedData ).reduce(
 			( filtered: Record< string, number >, key: string ) => {

--- a/client/my-sites/site-monitoring/metrics-tab.tsx
+++ b/client/my-sites/site-monitoring/metrics-tab.tsx
@@ -165,7 +165,18 @@ function useAggregateHttpVerbData(
 		metric,
 		dimension
 	);
-	const allowedVerbs: string[] = [ 'GET', 'POST', 'HEAD', 'DELETE', 'PUT', 'PATCH' ];
+	const allowedVerbs: string[] = [ 'GET', 'POST', 'HEAD', 'DELETE' ];
+
+	const defaultData: Record< ( typeof allowedVerbs )[ number ], number > = allowedVerbs.reduce(
+		( acc, verb ) => {
+			acc[ verb ] = 0;
+			return acc;
+		},
+		{} as Record< ( typeof allowedVerbs )[ number ], number >
+	);
+
+	data.formattedData = { ...defaultData, ...data.formattedData };
+
 	return {
 		formattedData: Object.keys( data.formattedData ).reduce(
 			( filtered: Record< string, number >, key: string ) => {
@@ -371,20 +382,11 @@ export const MetricsTab = () => {
 							name: 'HEAD',
 							className: 'verb-head',
 						},
-						PUT: {
-							name: 'PUT',
-							className: 'verb-put',
-						},
-						PATCH: {
-							name: 'PATCH',
-							className: 'verb-patch',
-						},
 						DELETE: {
 							name: 'DELETE',
 							className: 'verb-delete',
 						},
 					} ) }
-					fixedOrder
 				></SiteMonitoringPieChart>
 				<SiteMonitoringPieChart
 					title={ __( 'Response types' ) }

--- a/client/my-sites/site-monitoring/metrics-tab.tsx
+++ b/client/my-sites/site-monitoring/metrics-tab.tsx
@@ -384,7 +384,7 @@ export const MetricsTab = () => {
 							name: 'DELETE',
 							className: 'verb-delete',
 						},
-					} ).reverse() }
+					} ) }
 					fixedOrder
 				></SiteMonitoringPieChart>
 				<SiteMonitoringPieChart

--- a/client/my-sites/site-monitoring/metrics-tab.tsx
+++ b/client/my-sites/site-monitoring/metrics-tab.tsx
@@ -166,7 +166,6 @@ function useAggregateHttpVerbData(
 		dimension
 	);
 	const allowedVerbs: string[] = [ 'GET', 'POST', 'HEAD', 'DELETE', 'PUT', 'PATCH' ];
-
 	return {
 		formattedData: Object.keys( data.formattedData ).reduce(
 			( filtered: Record< string, number >, key: string ) => {

--- a/client/my-sites/site-monitoring/metrics-tab.tsx
+++ b/client/my-sites/site-monitoring/metrics-tab.tsx
@@ -165,7 +165,7 @@ function useAggregateHttpVerbData(
 		metric,
 		dimension
 	);
-	const allowedVerbs: string[] = [ 'GET', 'POST', 'HEAD', 'DELETE' ];
+	const allowedVerbs: string[] = [ 'GET', 'POST', 'HEAD', 'DELETE', 'PUT', 'PATCH' ];
 
 	return {
 		formattedData: Object.keys( data.formattedData ).reduce(
@@ -360,17 +360,25 @@ export const MetricsTab = () => {
 					subtitle={ __( 'Percentage of traffic per HTTP request method' ) }
 					className="site-monitoring-http-verbs-pie-chart"
 					data={ getFormattedDataForPieChart( httpVerbFormattedData, {
-						POST: {
-							name: 'POST',
-							className: 'verb-post',
-						},
 						GET: {
 							name: 'GET',
 							className: 'verb-get',
 						},
+						POST: {
+							name: 'POST',
+							className: 'verb-post',
+						},
 						HEAD: {
 							name: 'HEAD',
 							className: 'verb-head',
+						},
+						PUT: {
+							name: 'PUT',
+							className: 'verb-put',
+						},
+						PATCH: {
+							name: 'PATCH',
+							className: 'verb-patch',
 						},
 						DELETE: {
 							name: 'DELETE',

--- a/client/my-sites/site-monitoring/style.scss
+++ b/client/my-sites/site-monitoring/style.scss
@@ -156,6 +156,24 @@ $section-max-width: 1224px;
 		fill: var(--studio-blue-30);
 	}
 }
+.site-monitoring-http-verbs-pie-chart {
+	.pie-chart__chart-section-verb-post,
+	.pie-chart__legend-sample-verb-post {
+		fill: var(--studio-blue-20);
+	}
+	.pie-chart__chart-section-verb-get,
+	.pie-chart__legend-sample-verb-get {
+		fill: var(--studio-blue-30);
+	}
+	.pie-chart__chart-section-verb-delete,
+	.pie-chart__legend-sample-verb-delete {
+		fill: var(--studio-blue-40);
+	}
+	.pie-chart__chart-section-verb-head,
+	.pie-chart__legend-sample-verb-head {
+		fill: var(--studio-blue-50);
+	}
+}
 
 .site-monitoring-php-static-pie-chart {
 	.pie-chart__chart-section-dynamic,

--- a/client/my-sites/site-monitoring/style.scss
+++ b/client/my-sites/site-monitoring/style.scss
@@ -146,16 +146,6 @@ $section-max-width: 1224px;
 	}
 }
 
-.site-monitoring-cache-pie-chart {
-	.pie-chart__chart-section-cache-miss,
-	.pie-chart__legend-sample-cache-miss {
-		fill: #bae0f9;
-	}
-	.pie-chart__chart-section-cache-hit,
-	.pie-chart__legend-sample-cache-hit {
-		fill: var(--studio-blue-30);
-	}
-}
 .site-monitoring-http-verbs-pie-chart {
 	.pie-chart__chart-section-verb-post,
 	.pie-chart__legend-sample-verb-post {

--- a/client/my-sites/site-monitoring/style.scss
+++ b/client/my-sites/site-monitoring/style.scss
@@ -163,6 +163,14 @@ $section-max-width: 1224px;
 	.pie-chart__legend-sample-verb-head {
 		fill: var(--studio-blue-50);
 	}
+	.pie-chart__chart-section-verb-put,
+	.pie-chart__legend-sample-verb-put {
+		fill: var(--studio-blue-60);
+	}
+	.pie-chart__chart-section-verb-patch,
+	.pie-chart__legend-sample-verb-patch {
+		fill: var(--studio-blue-70);
+	}
 }
 
 .site-monitoring-php-static-pie-chart {

--- a/client/my-sites/site-monitoring/style.scss
+++ b/client/my-sites/site-monitoring/style.scss
@@ -149,7 +149,7 @@ $section-max-width: 1224px;
 .site-monitoring-http-verbs-pie-chart {
 	.pie-chart__chart-section-verb-post,
 	.pie-chart__legend-sample-verb-post {
-		fill: var(--studio-blue-20);
+		fill: var(--studio-blue-60);
 	}
 	.pie-chart__chart-section-verb-get,
 	.pie-chart__legend-sample-verb-get {
@@ -157,19 +157,11 @@ $section-max-width: 1224px;
 	}
 	.pie-chart__chart-section-verb-delete,
 	.pie-chart__legend-sample-verb-delete {
-		fill: var(--studio-blue-40);
+		fill: var(--studio-red-10);
 	}
 	.pie-chart__chart-section-verb-head,
 	.pie-chart__legend-sample-verb-head {
-		fill: var(--studio-blue-50);
-	}
-	.pie-chart__chart-section-verb-put,
-	.pie-chart__legend-sample-verb-put {
-		fill: var(--studio-blue-60);
-	}
-	.pie-chart__chart-section-verb-patch,
-	.pie-chart__legend-sample-verb-patch {
-		fill: var(--studio-blue-70);
+		fill: var(--studio-blue-5);
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, to avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4505

The data used for the cache hits chart is not really adding value as it is not reliable. Instead of the cache hit chart we want to display the HTTP Verbs chart.

## Proposed Changes

* Replace the cache hit chart with an HTTP request methods chart.
* Wrap the `useAggregateSiteMetricsData` function with a function that filters out the verbs we don't want to include in the chart.
* Add colors for the various HTTP methods that are included in the chart

<img width="1243" alt="CleanShot 2566-11-09 at 16 14 45@2x" src="https://github.com/Automattic/wp-calypso/assets/10244734/a060d645-918b-464e-868f-9cbe8b7f6005">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the site monitoring page and verify that the cache hit chart is replace with a HTTP method chart. 
* Ensure that we are displaying POST, GET, PUT, PATCH, HEAD and DELETE requests and no other HTTP verbs.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?