### PR TITLE
Signup: Add email suggestion if typos in domain are detected

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -163,6 +163,7 @@ class SignupForm extends Component {
 			},
 			form: stateWithFilledUsername,
 			validationInitialized: false,
+			suggestDomainTypoFix: true,
 		};
 	}
 
@@ -264,6 +265,121 @@ class SignupForm extends Component {
 		);
 	};
 
+	// TODO: REMOVE THIS ALGORITHM
+	// Using Jaccard algorithm
+
+	// suggestEmailDomainUsingJaccard( inputDomain, validDomains, minSimilarity ) {
+	// 	// Function to calculate Jaccard similarity between two sets
+	// 	function calculateJaccardSimilarity( setA, setB ) {
+	// 		const intersection = new Set( [ ...setA ].filter( ( x ) => setB.has( x ) ) );
+	// 		const union = new Set( [ ...setA, ...setB ] );
+	// 		return intersection.size / union.size;
+	// 	}
+
+	// 	let suggestedDomain = null;
+	// 	const inputSet = new Set( inputDomain );
+
+	// 	for ( let i = 0; i < validDomains.length; i++ ) {
+	// 		const domainSet = new Set( validDomains[ i ] );
+	// 		const similarity = calculateJaccardSimilarity( inputSet, domainSet );
+	// 		if ( similarity >= minSimilarity ) {
+	// 			suggestedDomain = validDomains[ i ];
+	// 			break; // Exit the loop as soon as a valid domain with sufficient similarity is found
+	// 		}
+	// 	}
+
+	// 	return suggestedDomain;
+	// }
+
+	// TODO: REMOVE THIS COMMENT AND CLEAN UP ALGORITHM
+	// Using the Levenshtein algorithm
+
+	suggestEmailDomainWithinDistance( inputDomain, validDomains, maxDistance ) {
+		// TODO: Check algorithm and remove one of them
+		// Function to calculate the Levenshtein distance between two strings
+		// function calculateLevenshteinDistance( str1, str2 ) {
+		// 	const m = str1.length;
+		// 	const n = str2.length;
+		// 	const dp = [ ...Array( m + 1 ) ].map( () => Array( n + 1 ).fill( 0 ) );
+
+		// 	for ( let i = 0; i <= m; i++ ) {
+		// 		for ( let j = 0; j <= n; j++ ) {
+		// 			if ( i === 0 ) {
+		// 				dp[ i ][ j ] = j;
+		// 			} else if ( j === 0 ) {
+		// 				dp[ i ][ j ] = i;
+		// 			} else if ( str1[ i - 1 ] === str2[ j - 1 ] ) {
+		// 				dp[ i ][ j ] = dp[ i - 1 ][ j - 1 ];
+		// 			} else {
+		// 				dp[ i ][ j ] = 1 + Math.min( dp[ i - 1 ][ j ], dp[ i ][ j - 1 ], dp[ i - 1 ][ j - 1 ] );
+		// 			}
+		// 		}
+		// 	}
+
+		// 	return dp[ m ][ n ];
+		// }
+
+		function calculateDamerauLevenshteinDistance( str1, str2 ) {
+			const m = str1.length;
+			const n = str2.length;
+			const dp = Array.from( Array( m + 1 ), () => Array( n + 1 ).fill( 0 ) );
+
+			for ( let i = 0; i <= m; i++ ) {
+				dp[ i ][ 0 ] = i;
+			}
+
+			for ( let j = 0; j <= n; j++ ) {
+				dp[ 0 ][ j ] = j;
+			}
+
+			for ( let i = 1; i <= m; i++ ) {
+				for ( let j = 1; j <= n; j++ ) {
+					if ( str1[ i - 1 ] === str2[ j - 1 ] ) {
+						dp[ i ][ j ] = dp[ i - 1 ][ j - 1 ];
+					} else {
+						dp[ i ][ j ] = Math.min(
+							dp[ i - 1 ][ j - 1 ] + 1, // substitution
+							dp[ i ][ j - 1 ] + 1, // insertion
+							dp[ i - 1 ][ j ] + 1 // deletion
+						);
+
+						if (
+							i > 1 &&
+							j > 1 &&
+							str1[ i - 1 ] === str2[ j - 2 ] &&
+							str1[ i - 2 ] === str2[ j - 1 ]
+						) {
+							dp[ i ][ j ] = Math.min( dp[ i ][ j ], dp[ i - 2 ][ j - 2 ] + 1 ); // transposition
+						}
+					}
+				}
+			}
+
+			return dp[ m ][ n ];
+		}
+
+		let suggestedDomain = null;
+
+		for ( let i = 0; i < validDomains.length; i++ ) {
+			// const currentDistance = calculateLevenshteinDistance( inputDomain, validDomains[ i ] );
+			const currentDistance = calculateDamerauLevenshteinDistance( inputDomain, validDomains[ i ] );
+			if ( currentDistance <= maxDistance ) {
+				suggestedDomain = validDomains[ i ];
+				break; // Exit the loop as soon as a valid domain within max distance is found
+			}
+		}
+
+		return suggestedDomain;
+	}
+
+	extractDomainWithExtension( email ) {
+		const atIndex = email.indexOf( '@' );
+		if ( atIndex !== -1 ) {
+			return email.slice( atIndex + 1 );
+		}
+		return;
+	}
+
 	validate = ( fields, onComplete ) => {
 		const fieldsForValidation = filter( [
 			'email',
@@ -324,6 +440,181 @@ class SignupForm extends Component {
 				} );
 
 				if ( fields.email ) {
+					const extractedEmailDomainAddress = this.extractDomainWithExtension( fields.email );
+					// TODO: MOVE validDomains array
+					const validDomains = [
+						'gmail.com',
+						'yahoo.com',
+						'hotmail.com',
+						'aol.com',
+						'hotmail.co.uk',
+						'hotmail.fr',
+						'msn.com',
+						'yahoo.fr',
+						'wanadoo.fr',
+						'orange.fr',
+						'comcast.net',
+						'yahoo.co.uk',
+						'yahoo.com.br',
+						'yahoo.co.in',
+						'live.com',
+						'rediffmail.com',
+						'free.fr',
+						'gmx.de',
+						'web.de',
+						'yandex.ru',
+						'ymail.com',
+						'libero.it',
+						'outlook.com',
+						'uol.com.br',
+						'bol.com.br',
+						'mail.ru',
+						'cox.net',
+						'hotmail.it',
+						'sbcglobal.net',
+						'sfr.fr',
+						'live.fr',
+						'verizon.net',
+						'live.co.uk',
+						'googlemail.com',
+						'yahoo.es',
+						'ig.com.br',
+						'live.nl',
+						'bigpond.com',
+						'terra.com.br',
+						'yahoo.it',
+						'neuf.fr',
+						'yahoo.de',
+						'alice.it',
+						'rocketmail.com',
+						'att.net',
+						'laposte.net',
+						'facebook.com',
+						'bellsouth.net',
+						'yahoo.in',
+						'hotmail.es',
+						'charter.net',
+						'yahoo.ca',
+						'yahoo.com.au',
+						'rambler.ru',
+						'hotmail.de',
+						'tiscali.it',
+						'shaw.ca',
+						'yahoo.co.jp',
+						'sky.com',
+						'earthlink.net',
+						'optonline.net',
+						'freenet.de',
+						't-online.de',
+						'aliceadsl.fr',
+						'virgilio.it',
+						'home.nl',
+						'qq.com',
+						'telenet.be',
+						'me.com',
+						'yahoo.com.ar',
+						'tiscali.co.uk',
+						'yahoo.com.mx',
+						'voila.fr',
+						'gmx.net',
+						'mail.com',
+						'planet.nl',
+						'tin.it',
+						'live.it',
+						'ntlworld.com',
+						'arcor.de',
+						'yahoo.co.id',
+						'frontiernet.net',
+						'hetnet.nl',
+						'live.com.au',
+						'yahoo.com.sg',
+						'zonnet.nl',
+						'club-internet.fr',
+						'juno.com',
+						'optusnet.com.au',
+						'blueyonder.co.uk',
+						'bluewin.ch',
+						'skynet.be',
+						'sympatico.ca',
+						'windstream.net',
+						'mac.com',
+						'centurytel.net',
+						'chello.nl',
+						'live.ca',
+						'aim.com',
+						'bigpond.net.au',
+					];
+					const maxDistance = 2;
+					let suggestedDomain;
+
+					if (
+						extractedEmailDomainAddress &&
+						! messages?.email &&
+						this.state.suggestDomainTypoFix
+					) {
+						suggestedDomain = this.suggestEmailDomainWithinDistance(
+							extractedEmailDomainAddress,
+							validDomains,
+							maxDistance
+						);
+
+						if ( suggestedDomain ) {
+							const suggestedEmail = fields.email.replace( /\\@.*/, `@${ suggestedDomain }` );
+							messages = Object.assign( {}, messages, {
+								email: {
+									invalid: this.props.translate(
+										`Did you mean {{suggestedDomain/}}? {{confirmEmailSuggestion}}Yes{{/confirmEmailSuggestion}}, {{ignoreEmailSuggestion}}Nope{{/ignoreEmailSuggestion}}`,
+										{
+											components: {
+												suggestedDomain: <span>{ suggestedEmail }</span>,
+												confirmEmailSuggestion: (
+													<Button
+														plain={ true }
+														className="signup-form__domain-suggestion-confirmation"
+														onClick={ () => {
+															this.formStateController.handleFieldChange( {
+																name: 'email',
+																value: suggestedEmail,
+															} );
+															this.setState( ( prevState ) => ( {
+																...prevState,
+																suggestDomainTypoFix: false,
+															} ) );
+														} }
+													/>
+												),
+												ignoreEmailSuggestion: (
+													<Button
+														plain={ true }
+														className="signup-form__domain-suggestion-confirmation"
+														onClick={ () => {
+															this.setState( ( prevState ) => ( {
+																...prevState,
+																isFieldDirty: {
+																	...prevState.isFieldDirty,
+																	email: false,
+																},
+																form: {
+																	...prevState.form,
+																	email: {
+																		...prevState.form.email,
+																		errors: [],
+																		isShowingErrors: false,
+																	},
+																},
+																suggestDomainTypoFix: false,
+															} ) );
+														} }
+													/>
+												),
+											},
+										}
+									),
+								},
+							} );
+						}
+					}
+
 					if ( this.props.signupDependencies && this.props.signupDependencies.domainItem ) {
 						const domainInEmail = fields.email.split( '@' )[ 1 ];
 						if ( this.props.signupDependencies.domainItem.meta === domainInEmail ) {

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -641,7 +641,7 @@ class SignupForm extends Component {
 												plain={ true }
 												className="signup-form__domain-suggestion-confirmation"
 												onClick={ () => {
-													handleEmailSuggestionOption( this.state.emailSuggestion?.domain );
+													handleEmailSuggestionOption( this.state.emailSuggestion?.full );
 												} }
 											>
 												Yes

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -165,7 +165,7 @@ class SignupForm extends Component {
 			form: stateWithFilledUsername,
 			validationInitialized: false,
 			suggestDomainTypoFix: true,
-			suggestedEmailAddress: null,
+			emailSuggestion: null,
 		};
 	}
 
@@ -336,18 +336,18 @@ class SignupForm extends Component {
 
 				if ( fields.email ) {
 					if ( ! messages?.email && this.state.suggestDomainTypoFix ) {
-						const suggestedDomain = emailSpellChecker.run( {
+						const emailSuggestion = emailSpellChecker.run( {
 							email: fields.email,
 						} );
 
-						if ( suggestedDomain ) {
+						if ( emailSuggestion ) {
 							// Error message handled in getErrorMessagesWithLogin()
 							messages = Object.assign( {}, messages, {
 								email: {
 									suggest_domain: '',
 								},
 							} );
-							this.setState( { suggestedEmailAddress: suggestedDomain?.full } );
+							this.setState( { emailSuggestion } );
 						}
 					}
 
@@ -632,16 +632,16 @@ class SignupForm extends Component {
 					<span key={ error_code }>
 						<p>
 							{ this.props.translate(
-								'Did you mean {{suggestedEmail/}}? {{acceptEmailSuggestion/}}, {{ignoreEmailSuggestion/}}.',
+								'Did you mean @{{emailSuggestion/}}? {{acceptEmailSuggestion/}}, {{ignoreEmailSuggestion/}}.',
 								{
 									components: {
-										suggestedEmail: <span>{ this.state.suggestedEmailAddress }</span>,
+										emailSuggestion: <span>{ this.state.emailSuggestion?.domain }</span>,
 										acceptEmailSuggestion: (
 											<Button
 												plain={ true }
 												className="signup-form__domain-suggestion-confirmation"
 												onClick={ () => {
-													handleEmailSuggestionOption( this.state.suggestedEmailAddress );
+													handleEmailSuggestionOption( this.state.emailSuggestion?.domain );
 												} }
 											>
 												Yes

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -582,6 +582,7 @@ class SignupForm extends Component {
 															this.formStateController.handleFieldChange( {
 																name: 'email',
 																value: suggestedEmail,
+																hideError: true,
 															} );
 														} }
 													/>

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -544,22 +544,25 @@ class SignupForm extends Component {
 						'aim.com',
 						'bigpond.net.au',
 					];
-					const maxDistance = 2;
-					let suggestedDomain;
+
+					if ( validDomains.includes( extractedEmailDomainAddress ) ) {
+						return;
+					}
 
 					if (
 						extractedEmailDomainAddress &&
 						! messages?.email &&
 						this.state.suggestDomainTypoFix
 					) {
-						suggestedDomain = this.suggestEmailDomainWithinDistance(
+						const levenshteinMaxDistance = 2;
+						const suggestedDomain = this.suggestEmailDomainWithinDistance(
 							extractedEmailDomainAddress,
 							validDomains,
-							maxDistance
+							levenshteinMaxDistance
 						);
 
 						if ( suggestedDomain ) {
-							const suggestedEmail = fields.email.replace( /\\@.*/, `@${ suggestedDomain }` );
+							const suggestedEmail = fields.email.replace( /@.*/, `@${ suggestedDomain }` );
 							messages = Object.assign( {}, messages, {
 								email: {
 									invalid: this.props.translate(
@@ -572,14 +575,14 @@ class SignupForm extends Component {
 														plain={ true }
 														className="signup-form__domain-suggestion-confirmation"
 														onClick={ () => {
-															this.formStateController.handleFieldChange( {
-																name: 'email',
-																value: suggestedEmail,
-															} );
 															this.setState( ( prevState ) => ( {
 																...prevState,
 																suggestDomainTypoFix: false,
 															} ) );
+															this.formStateController.handleFieldChange( {
+																name: 'email',
+																value: suggestedEmail,
+															} );
 														} }
 													/>
 												),
@@ -942,7 +945,12 @@ class SignupForm extends Component {
 					isError={ formState.isFieldInvalid( this.state.form, 'email' ) }
 					isValid={ this.state.validationInitialized && isEmailValid }
 					onBlur={ this.handleBlur }
-					onChange={ this.handleChangeEvent }
+					onChange={ ( event ) => {
+						this.setState( {
+							suggestDomainTypoFix: true,
+						} );
+						this.handleChangeEvent( event );
+					} }
 				/>
 				{ this.emailDisableExplanation() }
 

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -115,6 +115,16 @@
 	}
 }
 
+.signup-form__domain-suggestion-confirmation {
+	color: var(--color-link);
+	cursor: pointer;
+
+	&:hover {
+		color: var(--color-link-dark);
+	}
+
+}
+
 // Replace recaptcha badge with ToS text and space
 // everything out a little more.
 @media (max-width: 660px) {

--- a/package.json
+++ b/package.json
@@ -179,6 +179,7 @@
 		"@wordpress/is-shallow-equal": "^4.44.0",
 		"@wordpress/primitives": "^3.42.0",
 		"@wordpress/url": "^3.45.0",
+		"@zootools/email-spell-checker": "^1.12.0",
 		"browserslist": "^4.16.0",
 		"calypso": "workspace:^",
 		"calypso-codemods": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10162,6 +10162,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@zootools/email-spell-checker@npm:^1.12.0":
+  version: 1.12.0
+  resolution: "@zootools/email-spell-checker@npm:1.12.0"
+  checksum: 0b2fa9d0aaf1e6d846fe9e261276fecbd5c48db2689814b702bcec6b63729d097b245f59cdfb3dfca65d66b68de24b67e3b317494bcfbfdd166c244cd298a0cc
+  languageName: node
+  linkType: hard
+
 "WordPressDesktop@workspace:desktop":
   version: 0.0.0-use.local
   resolution: "WordPressDesktop@workspace:desktop"
@@ -32447,6 +32454,7 @@ __metadata:
     "@wordpress/primitives": ^3.42.0
     "@wordpress/stylelint-config": ^21.27.0
     "@wordpress/url": ^3.45.0
+    "@zootools/email-spell-checker": ^1.12.0
     babel-loader: ^8.2.3
     browserslist: ^4.16.0
     bunyan: ^1.8.15


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/53380

## Proposed Changes

* These changes provide users with a hint to correct their email address in case of easy-to-catch typos.
`random_email@gmaii.com` -> `random_email@gmail.com`

<img width="407" alt="CleanShot 2023-11-09 at 16 37 53@2x" src="https://github.com/Automattic/wp-calypso/assets/10482592/cf4f7ab3-55d3-4682-bb81-9c09fc20ffe0">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch or use live link
* Navigate to `/start/user?flags=-signup%2Fsocial-first`
* Enter an email with an invalid domain (such as gmail.com, proton.me, etc.)
* Verify the message is suggesting a domain that makes sense for the typo in your email
* Test both actions for accepting/ignoring the email suggestion. `Yes` should populate the email address input field with the  fixed full email address. `Nope` should ignore the suggestion. Both actions should clear the suggestion message.
* Test different email domain typos.


Fixes https://github.com/Automattic/wp-calypso/issues/53380

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?