### PR TITLE
Stats: Update styles for Period button

### DIFF
--- a/client/components/stats-interval-dropdown/index.jsx
+++ b/client/components/stats-interval-dropdown/index.jsx
@@ -1,5 +1,6 @@
 import { Button, Dropdown } from '@wordpress/components';
 import { check, Icon, chevronDown } from '@wordpress/icons';
+import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import page from 'page';
 import qs from 'qs';
@@ -22,7 +23,9 @@ const StatsIntervalDropdownListing = ( { selected, onSelection, intervals } ) =>
 
 					return (
 						<li
-							className="stats-interval-dropdown-listing__interval"
+							className={ classNames( 'stats-interval-dropdown-listing__interval', {
+								[ 'is-selected' ]: isSelectedItem( intervalKey ),
+							} ) }
 							key={ intervalKey }
 							role="none"
 						>

--- a/client/components/stats-interval-dropdown/style.scss
+++ b/client/components/stats-interval-dropdown/style.scss
@@ -29,6 +29,13 @@
 	}
 }
 
+.is-section-stats {
+	.components-popover__content {
+		border-radius: 4px;
+		padding: 16px;
+	}
+}
+
 .stats-interval-dropdown__container {
 	position: relative;
 	width: 196px;

--- a/client/components/stats-interval-dropdown/style.scss
+++ b/client/components/stats-interval-dropdown/style.scss
@@ -19,8 +19,7 @@
 	}
 
 	>.components-button {
-
-		border-radius: 2px;
+		border-radius: 4px;
 		border: 1px solid var(--gray-gray-10);
 		width: 146px;
 		display: flex;

--- a/client/components/stats-interval-dropdown/style.scss
+++ b/client/components/stats-interval-dropdown/style.scss
@@ -49,6 +49,10 @@
 	&:hover {
 		background-color: var(--color-primary-0);
 	}
+	& + & {
+		// Prevent overlap between outline and hover.
+		margin-top: 2px;
+	}
 	&.is-selected {
 		background-color: var(--color-accent-5);
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

A few small updates to make the Period button/dropdown consistent with the date picker.

- Updates button border radius to match date picker button
- Updates list output to apply selected style to selected period
- Adds small bit of margin to prevent hover and selection styles from overlapping
- Updates border radius of container view

![SCR-20231109-ppzu](https://github.com/Automattic/wp-calypso/assets/40267301/a37d9c98-820a-42bd-8090-ad76206b87e3)

## Questions

These changes make the two controls (date picker & period picker) match in terms of presentation. With these changes in place I'm wondering:

1. Do we need the row color for the selected item? It's green in the screenshot but this is pulled from the selected theme. If we keep it, should we make it a bit lighter?
2. Is the 16px padding from the date range picker too much? It looks good in the date range picker but it looks like too much here. I'm fine to keep it but wanted to call it out.
3. Should we update the button fonts to match? The font on the Period button is a bit lighter. Weight of 400 vs 500.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Live branch.
* Navigate to Stats → Traffic.
* Confirm the Period button and dropdown styles look correct (based on screenshot above) and in comparison to the date range picker.
* Leave feedback based on the 3 questions above!

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?