### PR TITLE
Reading settings: remove newsletter redirect

### DIFF
--- a/client/my-sites/site-settings/settings-reading/main.tsx
+++ b/client/my-sites/site-settings/settings-reading/main.tsx
@@ -1,15 +1,13 @@
-import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import { JetpackConnectionHealthBanner } from 'calypso/components/jetpack/connection-health';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
-import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import { useSelector } from 'calypso/state';
 import { useIsJetpackConnectionProblem } from 'calypso/state/jetpack-connection-health/selectors/is-jetpack-connection-problem.js';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
-import { getSiteSlug, getSiteUrl, isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSiteUrl, isJetpackSite } from 'calypso/state/sites/selectors';
 import { IAppState } from 'calypso/state/types';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import ReaderSettingsSection from '../reader-settings';
@@ -94,12 +92,10 @@ const getFormSettings = ( settings: unknown & Fields ) => {
 
 const connectComponent = connect( ( state: IAppState ) => {
 	const siteId = getSelectedSiteId( state );
-	const siteSlug = siteId && getSiteSlug( state, siteId );
 	const siteUrl = siteId && getSiteUrl( state, siteId );
 	const siteIsJetpack = isJetpackSite( state, siteId );
 	const isAtomic = isSiteAutomatedTransfer( state, siteId );
 	return {
-		...( siteSlug && { siteSlug } ),
 		...( siteUrl && { siteUrl } ),
 		siteIsJetpack,
 		isAtomic,
@@ -116,7 +112,6 @@ type ReadingSettingsFormProps = {
 	isRequestingSettings: boolean;
 	isSavingSettings: boolean;
 	siteIsJetpack: boolean | null;
-	siteSlug?: string;
 	siteUrl?: string;
 	updateFields: ( fields: Fields ) => void;
 };
@@ -133,11 +128,9 @@ const ReadingSettingsForm = wrapSettingsForm( getFormSettings )(
 			isRequestingSettings,
 			isSavingSettings,
 			siteIsJetpack,
-			siteSlug,
 			siteUrl,
 			updateFields,
 		}: ReadingSettingsFormProps ) => {
-			const translate = useTranslate();
 			const disabled = isRequestingSettings || isSavingSettings;
 			return (
 				<form onSubmit={ handleSubmitForm }>
@@ -151,21 +144,6 @@ const ReadingSettingsForm = wrapSettingsForm( getFormSettings )(
 						isSavingSettings={ isSavingSettings }
 						updateFields={ updateFields }
 					/>
-
-					{ /* @ts-expect-error SettingsSectionHeader is not typed and is causing errors */ }
-					<SettingsSectionHeader
-						id="newsletter-settings"
-						title={ translate( 'Newsletter settings' ) }
-					/>
-					<Card className="site-settings__card">
-						<em>
-							{ translate( 'Newsletter settings have moved to their {{a}}own page{{/a}}.', {
-								components: {
-									a: <a href={ `/settings/newsletter/${ siteSlug }` } />,
-								},
-							} ) }
-						</em>
-					</Card>
 					<ReaderSettingsSection
 						fields={ fields }
 						handleAutosavingToggle={ handleAutosavingToggle }


### PR DESCRIPTION
Newsletter settings were moved to their own /newsletter page a while back, so we can already remove the redirect nudge at Reading settings where the newsletter settings were previously.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->



## Proposed Changes

* Remove "newsletter" section from Reading settings

<img width="885" alt="Screenshot 2023-11-09 at 12 21 19" src="https://github.com/Automattic/wp-calypso/assets/87168/1a24bcfe-c317-4440-a6b3-ee78e712c559">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Reading, no more section

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
