### PR TITLE
Launchpad: Make sure Subscribers page tasks are available to Simple and Atomic sites only

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
@@ -8,17 +8,22 @@ import { SubscriberList } from 'calypso/my-sites/subscribers/components/subscrib
 import { SubscriberListActionsBar } from 'calypso/my-sites/subscribers/components/subscriber-list-actions-bar';
 import { useSubscribersPage } from 'calypso/my-sites/subscribers/components/subscribers-page/subscribers-page-context';
 import { Subscriber } from 'calypso/my-sites/subscribers/types';
+import { useSelector } from 'calypso/state';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
+import { isSimpleSite } from 'calypso/state/sites/selectors';
 import { useRecordSearch } from '../../tracks';
 import { GrowYourAudience } from '../grow-your-audience';
 
 import './style.scss';
 
 type SubscriberListContainerProps = {
+	siteId: number | null;
 	onClickView: ( subscriber: Subscriber ) => void;
 	onClickUnsubscribe: ( subscriber: Subscriber ) => void;
 };
 
 const SubscriberListContainer = ( {
+	siteId,
 	onClickView,
 	onClickUnsubscribe,
 }: SubscriberListContainerProps ) => {
@@ -26,9 +31,13 @@ const SubscriberListContainer = ( {
 		useSubscribersPage();
 	useRecordSearch();
 
-	const EmptyComponent = config.isEnabled( 'subscribers-launchpad' )
-		? SubscriberLaunchpad
-		: EmptyListView;
+	const isSimple = useSelector( isSimpleSite );
+	const isAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
+
+	const EmptyComponent =
+		config.isEnabled( 'subscribers-launchpad' ) && ( isSimple || isAtomic )
+			? SubscriberLaunchpad
+			: EmptyListView;
 
 	return (
 		<section className="subscriber-list-container">

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -122,6 +122,7 @@ const SubscribersPage = ( {
 				<SubscribersHeader selectedSiteId={ selectedSite?.ID } />
 
 				<SubscriberListContainer
+					siteId={ siteId }
 					onClickView={ onClickView }
 					onClickUnsubscribe={ onClickUnsubscribe }
 				/>


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/84039.

## Proposed Changes

* add check that makes sure the `SubscriberLaunchpad` component is loaded for Simple and Atomic sites only. It won't be available for Atomic sites.

## Testing Instructions

1. Check out the PR branch and build it.
2. Navigate to the Subscribers page of a Simple site that doesn't have any subscribers (`http://calypso.localhost:3000/subscribers/[site-slug]`).
3. The `SubscriberLaunchpad` component should render correctly.
4. Repeat the steps 2 and 3 with Atomic and also Jetpack site (Jurassic Ninja can be used).
5. For the Atomic site, the `SubscriberLaunchpad` component should render as well, but not for a Jetpack site. Jetpack site should load the `GrowYourAudience` component only:

![Markup on 2023-11-09 at 12:02:02](https://github.com/Automattic/wp-calypso/assets/25105483/92650c39-1ab8-4032-8330-f6feeeea96cc)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?