### PR TITLE
Plans 2023: Use the pricing hook abstraction in plan-type-selector

### DIFF
--- a/client/my-sites/plans-features-main/components/plan-type-selector/index.tsx
+++ b/client/my-sites/plans-features-main/components/plan-type-selector/index.tsx
@@ -156,7 +156,7 @@ export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = 
 		storageAddOns: null,
 	} );
 	const currentPlanBillingPeriod = currentSitePlanSlug
-		? pricingMeta?.[ currentSitePlanSlug ].billingPeriod
+		? pricingMeta?.[ currentSitePlanSlug ]?.billingPeriod
 		: null;
 
 	if ( showBiennialToggle ) {

--- a/client/my-sites/plans-features-main/components/plan-type-selector/index.tsx
+++ b/client/my-sites/plans-features-main/components/plan-type-selector/index.tsx
@@ -41,7 +41,7 @@ export type PlanTypeSelectorProps = {
 	hideDiscountLabel?: boolean;
 	redirectTo?: string | null;
 	isStepperUpgradeFlow: boolean;
-	currentSitePlanSlug?: PlanSlug;
+	currentSitePlanSlug?: PlanSlug | null;
 	usePricingMetaForGridPlans: UsePricingMetaForGridPlans;
 };
 

--- a/client/my-sites/plans-features-main/components/plan-type-selector/index.tsx
+++ b/client/my-sites/plans-features-main/components/plan-type-selector/index.tsx
@@ -1,10 +1,12 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import {
-	getYearlyPlanByMonthly,
 	isWpComPlan,
 	plansLink,
 	isMonthly,
 	PLAN_ANNUAL_PERIOD,
+	PlanSlug,
+	getPlanSlugForTermVariant,
+	TERM_ANNUALLY,
 } from '@automattic/calypso-products';
 import { Popover } from '@automattic/components';
 import styled from '@emotion/styled';
@@ -17,18 +19,8 @@ import CSSTransition from 'react-transition-group/CSSTransition';
 import { Primitive } from 'utility-types';
 import SegmentedControl from 'calypso/components/segmented-control';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { ProvideExperimentData } from 'calypso/lib/explat';
 import { addQueryArgs } from 'calypso/lib/url';
-import { useSelector } from 'calypso/state';
-import {
-	getPlanBySlug,
-	getPlanRawPrice,
-	getDiscountedRawPrice,
-	getPlanBillPeriod,
-} from 'calypso/state/plans/selectors';
-import { getSitePlanSlug } from 'calypso/state/sites/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import type { IAppState } from 'calypso/state/types';
+import type { UsePricingMetaForGridPlans } from 'calypso/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans';
 import './style.scss';
 
 export type PlanTypeSelectorProps = {
@@ -42,12 +34,14 @@ export type PlanTypeSelectorProps = {
 	selectedFeature?: string;
 	showBiennialToggle?: boolean;
 	isInSignup: boolean;
-	plans: string[];
+	plans: PlanSlug[];
 	eligibleForWpcomMonthlyPlans?: boolean;
 	isPlansInsideStepper: boolean;
 	hideDiscountLabel?: boolean;
 	redirectTo?: string | null;
 	isStepperUpgradeFlow: boolean;
+	currentSitePlanSlug?: PlanSlug;
+	usePricingMetaForGridPlans: UsePricingMetaForGridPlans;
 };
 
 interface PathArgs {
@@ -56,7 +50,7 @@ interface PathArgs {
 
 type GeneratePathFunction = ( props: Partial< PlanTypeSelectorProps >, args: PathArgs ) => string;
 
-export const generatePath: GeneratePathFunction = ( props, additionalArgs = {} ) => {
+const generatePath: GeneratePathFunction = ( props, additionalArgs = {} ) => {
 	const { intervalType = '' } = additionalArgs;
 	const defaultArgs = {
 		customerType: null,
@@ -96,7 +90,7 @@ type PopupMessageProps = {
 };
 
 // eslint-disable @typescript-eslint/no-use-before-define
-export const PopupMessages: React.FunctionComponent< PopupMessageProps > = ( {
+const PopupMessages: React.FunctionComponent< PopupMessageProps > = ( {
 	context,
 	children,
 	isVisible,
@@ -122,7 +116,7 @@ export const PopupMessages: React.FunctionComponent< PopupMessageProps > = ( {
 	);
 };
 
-export type IntervalTypeProps = Pick<
+type IntervalTypeProps = Pick<
 	PlanTypeSelectorProps,
 	| 'intervalType'
 	| 'plans'
@@ -134,9 +128,11 @@ export type IntervalTypeProps = Pick<
 	| 'showBiennialToggle'
 	| 'selectedPlan'
 	| 'selectedFeature'
+	| 'currentSitePlanSlug'
+	| 'usePricingMetaForGridPlans'
 >;
 
-export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = ( props ) => {
+const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = ( props ) => {
 	const translate = useTranslate();
 	const {
 		intervalType,
@@ -144,17 +140,23 @@ export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = 
 		eligibleForWpcomMonthlyPlans,
 		hideDiscountLabel,
 		showBiennialToggle,
+		currentSitePlanSlug,
+		usePricingMetaForGridPlans,
 	} = props;
 	const [ spanRef, setSpanRef ] = useState< HTMLSpanElement >();
 	const segmentClasses = classNames( 'plan-features__interval-type', 'price-toggle', {
 		'is-signup': isInSignup,
 	} );
 	const popupIsVisible = Boolean( intervalType === 'monthly' && isInSignup && props.plans.length );
-	const maxDiscount = useMaxDiscount( props.plans );
-	const currentPlanBillingPeriod = useSelector( ( state ) => {
-		const currentSitePlanSlug = getSitePlanSlug( state, getSelectedSiteId( state ) );
-		return currentSitePlanSlug ? getPlanBillPeriod( state, currentSitePlanSlug ) : null;
+	const maxDiscount = useMaxDiscount( props.plans, usePricingMetaForGridPlans );
+	const pricingMeta = usePricingMetaForGridPlans( {
+		planSlugs: currentSitePlanSlug ? [ currentSitePlanSlug ] : [],
+		withoutProRatedCredits: true,
+		storageAddOns: null,
 	} );
+	const currentPlanBillingPeriod = currentSitePlanSlug
+		? pricingMeta?.[ currentSitePlanSlug ].billingPeriod
+		: null;
 
 	if ( showBiennialToggle ) {
 		// skip showing toggle if current plan's term is higher than 1 year
@@ -232,29 +234,9 @@ export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = 
 	);
 };
 
-export const ExperimentalIntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = (
-	props
-) => {
-	return (
-		<ProvideExperimentData name="calypso_show_interval_type_selector_2022_07">
-			{ ( isLoading, experimentAssignment ) => {
-				if ( isLoading || ! props.intervalType ) {
-					return <></>;
-				}
-
-				if ( 'treatment' !== experimentAssignment?.variationName ) {
-					return <></>;
-				}
-
-				return <IntervalTypeToggle { ...props } />;
-			} }
-		</ProvideExperimentData>
-	);
-};
-
 type CustomerTypeProps = Pick< PlanTypeSelectorProps, 'customerType' | 'isInSignup' >;
 
-export const CustomerTypeToggle: React.FunctionComponent< CustomerTypeProps > = ( props ) => {
+const CustomerTypeToggle: React.FunctionComponent< CustomerTypeProps > = ( props ) => {
 	const translate = useTranslate();
 	const { customerType } = props;
 	const segmentClasses = classNames( 'plan-features__interval-type', 'is-customer-type-toggle' );
@@ -299,28 +281,49 @@ const PlanTypeSelector: React.FunctionComponent< PlanTypeSelectorProps > = ( {
 	return null;
 };
 
-function useMaxDiscount( plans: string[] ): number {
-	const wpcomMonthlyPlans = ( plans || [] ).filter( isWpComPlan ).filter( isMonthly );
+function useMaxDiscount(
+	plans: PlanSlug[],
+	usePricingMetaForGridPlans: UsePricingMetaForGridPlans
+): number {
 	const [ maxDiscount, setMaxDiscount ] = useState( 0 );
-	const discounts = useSelector( ( state: IAppState ) => {
-		return wpcomMonthlyPlans.map( ( planSlug ) => {
-			const monthlyPlan = getPlanBySlug( state, planSlug );
-			const yearlyPlan = getPlanBySlug( state, getYearlyPlanByMonthly( planSlug ) );
+	const wpcomMonthlyPlans = ( plans || [] ).filter( isWpComPlan ).filter( isMonthly );
+	const yearlyVariantPlanSlugs = wpcomMonthlyPlans
+		.map( ( planSlug ) => getPlanSlugForTermVariant( planSlug, TERM_ANNUALLY ) )
+		.filter( Boolean ) as PlanSlug[];
 
-			if ( ! yearlyPlan ) {
-				return 0;
-			}
+	const monthlyPlansPricing = usePricingMetaForGridPlans( {
+		planSlugs: wpcomMonthlyPlans,
+		withoutProRatedCredits: true,
+		storageAddOns: null,
+	} );
+	const yearlyPlansPricing = usePricingMetaForGridPlans( {
+		planSlugs: yearlyVariantPlanSlugs,
+		withoutProRatedCredits: true,
+		storageAddOns: null,
+	} );
 
-			const monthlyPlanAnnualCost =
-				( getPlanRawPrice( state, monthlyPlan?.product_id ?? 0 ) ?? 0 ) * 12;
-			const rawPrice = getPlanRawPrice( state, yearlyPlan.product_id );
-			const discountPrice = getDiscountedRawPrice( state, yearlyPlan.product_id );
-			const yearlyPlanCost = discountPrice || rawPrice || 0;
+	const discounts = wpcomMonthlyPlans.map( ( planSlug ) => {
+		const yearlyVariantPlanSlug = getPlanSlugForTermVariant( planSlug, TERM_ANNUALLY );
 
-			return Math.floor(
-				( ( monthlyPlanAnnualCost - yearlyPlanCost ) / ( monthlyPlanAnnualCost || 1 ) ) * 100
-			);
-		} );
+		if ( ! yearlyVariantPlanSlug ) {
+			return 0;
+		}
+
+		const monthlyPlanAnnualCost =
+			( monthlyPlansPricing?.[ planSlug ]?.originalPrice.full ?? 0 ) * 12;
+
+		if ( ! monthlyPlanAnnualCost ) {
+			return 0;
+		}
+
+		const yearlyPlanAnnualCost =
+			yearlyPlansPricing?.[ yearlyVariantPlanSlug ]?.discountedPrice.full ||
+			yearlyPlansPricing?.[ yearlyVariantPlanSlug ]?.originalPrice.full ||
+			0;
+
+		return Math.floor(
+			( ( monthlyPlanAnnualCost - yearlyPlanAnnualCost ) / ( monthlyPlanAnnualCost || 1 ) ) * 100
+		);
 	} );
 	const currentMaxDiscount = discounts.length ? Math.max( ...discounts ) : 0;
 

--- a/client/my-sites/plans-features-main/components/plan-type-selector/index.tsx
+++ b/client/my-sites/plans-features-main/components/plan-type-selector/index.tsx
@@ -19,6 +19,7 @@ import CSSTransition from 'react-transition-group/CSSTransition';
 import { Primitive } from 'utility-types';
 import SegmentedControl from 'calypso/components/segmented-control';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { ProvideExperimentData } from 'calypso/lib/explat';
 import { addQueryArgs } from 'calypso/lib/url';
 import type { UsePricingMetaForGridPlans } from 'calypso/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans';
 import './style.scss';
@@ -50,7 +51,7 @@ interface PathArgs {
 
 type GeneratePathFunction = ( props: Partial< PlanTypeSelectorProps >, args: PathArgs ) => string;
 
-const generatePath: GeneratePathFunction = ( props, additionalArgs = {} ) => {
+export const generatePath: GeneratePathFunction = ( props, additionalArgs = {} ) => {
 	const { intervalType = '' } = additionalArgs;
 	const defaultArgs = {
 		customerType: null,
@@ -90,7 +91,7 @@ type PopupMessageProps = {
 };
 
 // eslint-disable @typescript-eslint/no-use-before-define
-const PopupMessages: React.FunctionComponent< PopupMessageProps > = ( {
+export const PopupMessages: React.FunctionComponent< PopupMessageProps > = ( {
 	context,
 	children,
 	isVisible,
@@ -116,7 +117,7 @@ const PopupMessages: React.FunctionComponent< PopupMessageProps > = ( {
 	);
 };
 
-type IntervalTypeProps = Pick<
+export type IntervalTypeProps = Pick<
 	PlanTypeSelectorProps,
 	| 'intervalType'
 	| 'plans'
@@ -132,7 +133,7 @@ type IntervalTypeProps = Pick<
 	| 'usePricingMetaForGridPlans'
 >;
 
-const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = ( props ) => {
+export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = ( props ) => {
 	const translate = useTranslate();
 	const {
 		intervalType,
@@ -234,9 +235,29 @@ const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = ( props
 	);
 };
 
+export const ExperimentalIntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = (
+	props
+) => {
+	return (
+		<ProvideExperimentData name="calypso_show_interval_type_selector_2022_07">
+			{ ( isLoading, experimentAssignment ) => {
+				if ( isLoading || ! props.intervalType ) {
+					return <></>;
+				}
+
+				if ( 'treatment' !== experimentAssignment?.variationName ) {
+					return <></>;
+				}
+
+				return <IntervalTypeToggle { ...props } />;
+			} }
+		</ProvideExperimentData>
+	);
+};
+
 type CustomerTypeProps = Pick< PlanTypeSelectorProps, 'customerType' | 'isInSignup' >;
 
-const CustomerTypeToggle: React.FunctionComponent< CustomerTypeProps > = ( props ) => {
+export const CustomerTypeToggle: React.FunctionComponent< CustomerTypeProps > = ( props ) => {
 	const translate = useTranslate();
 	const { customerType } = props;
 	const segmentClasses = classNames( 'plan-features__interval-type', 'is-customer-type-toggle' );

--- a/client/my-sites/plans-features-main/components/test/plan-type-selector.jsx
+++ b/client/my-sites/plans-features-main/components/test/plan-type-selector.jsx
@@ -27,6 +27,7 @@ describe( '<PlanTypeSelector />', () => {
 		selectedPlan: PLAN_FREE,
 		hideFreePlan: true,
 		withWPPlanTabs: true,
+		usePricingMetaForGridPlans: () => null,
 	};
 
 	test( 'Should show CustomerTypeToggle when kind is set to `customer`', () => {

--- a/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
+++ b/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
@@ -61,7 +61,6 @@ const usePricingMetaForGridPlans: UsePricingMetaForGridPlans = ( {
 		getCurrentPlan( state, selectedSiteId )
 	);
 	const currentSitePlanSlug = currentPlan?.productSlug;
-
 	const pricedAPIPlans = usePricedAPIPlans( { planSlugs: planSlugs } );
 	const sitePlans = Plans.useSitePlans( { siteId: selectedSiteId } );
 	const selectedStorageOptions = useSelect( ( select ) => {

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -529,6 +529,8 @@ const PlansFeaturesMain = ( {
 		showBiennialToggle,
 		kind: planTypeSelector,
 		plans: gridPlansForFeaturesGrid.map( ( gridPlan ) => gridPlan.planSlug ),
+		currentSitePlanSlug: sitePlanSlug,
+		usePricingMetaForGridPlans,
 	};
 	/**
 	 * The effects on /plans page need to be checked if this variable is initialized


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Part of addressing https://github.com/Automattic/wp-calypso/issues/81117 (which will help with addressing https://github.com/Automattic/martech/issues/2403)

## Proposed Changes

- Incorporates the `usePricingMetaForGridPlans` hook for deriving the discounts and billing periods needed by the toggle, in place of the direct state/selector access.
- This is part of migrating the `plan-type-selector` under the `plans-grid` package to allow usage within the grids and be exported for reuse outside of Calypso.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Got to `/plans/[ free ]` and `/start/plans` to show the monthly/yearly toggle
* Ensure it works
* Ensure the correct "savings" are shown in the tooltip when viewing monthly plans
* Go to `/start/onboarding-pm` and ensure the 1-year/2-year toggle is shown and that it is functional

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?