### PR TITLE
Launchpad: Launch the new Subscribers page launchpad (`subscribers-launchpad` feature flag removal)

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-launchpad/subscriber-launchpad.tsx
+++ b/client/my-sites/subscribers/components/subscriber-launchpad/subscriber-launchpad.tsx
@@ -1,6 +1,6 @@
 import { CircularProgressBar } from '@automattic/components';
 import { Launchpad } from '@automattic/launchpad';
-import { useTranslate } from 'i18n-calypso';
+import i18n, { useTranslate } from 'i18n-calypso';
 import { useSubscriberLaunchpadTasks } from 'calypso/my-sites/subscribers/hooks';
 import { useSelector } from 'calypso/state';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
@@ -38,6 +38,14 @@ const SubscriberLaunchpad = () => {
 				launchpadContext="subscriber-list"
 			/>
 		</div>
+	);
+};
+
+SubscriberLaunchpad.hasTranslationsAvailable = ( locale: string ) => {
+	return (
+		locale === 'en' ||
+		( i18n.hasTranslation( 'No subscribers yet?' ) &&
+			i18n.hasTranslation( 'Follow these steps to get started.' ) )
 	);
 };
 

--- a/client/my-sites/subscribers/components/subscriber-launchpad/subscriber-launchpad.tsx
+++ b/client/my-sites/subscribers/components/subscriber-launchpad/subscriber-launchpad.tsx
@@ -43,7 +43,7 @@ const SubscriberLaunchpad = () => {
 
 SubscriberLaunchpad.hasTranslationsAvailable = ( locale: string ) => {
 	return (
-		locale === 'en' ||
+		locale.startsWith( 'en' ) ||
 		( i18n.hasTranslation( 'No subscribers yet?' ) &&
 			i18n.hasTranslation( 'Follow these steps to get started.' ) )
 	);

--- a/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
@@ -1,3 +1,4 @@
+import { useLocale } from '@automattic/i18n-utils';
 import { numberFormat, translate } from 'i18n-calypso';
 import Pagination from 'calypso/components/pagination';
 import { EmptyListView } from 'calypso/my-sites/subscribers/components/empty-list-view';
@@ -32,8 +33,11 @@ const SubscriberListContainer = ( {
 
 	const isSimple = useSelector( isSimpleSite );
 	const isAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
-
-	const EmptyComponent = isSimple || isAtomic ? SubscriberLaunchpad : EmptyListView;
+	const locale = useLocale();
+	const EmptyComponent =
+		( isSimple || isAtomic ) && SubscriberLaunchpad.hasTranslationsAvailable( locale )
+			? SubscriberLaunchpad
+			: EmptyListView;
 
 	return (
 		<section className="subscriber-list-container">

--- a/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { numberFormat, translate } from 'i18n-calypso';
 import Pagination from 'calypso/components/pagination';
 import { EmptyListView } from 'calypso/my-sites/subscribers/components/empty-list-view';
@@ -34,10 +33,7 @@ const SubscriberListContainer = ( {
 	const isSimple = useSelector( isSimpleSite );
 	const isAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
 
-	const EmptyComponent =
-		config.isEnabled( 'subscribers-launchpad' ) && ( isSimple || isAtomic )
-			? SubscriberLaunchpad
-			: EmptyListView;
+	const EmptyComponent = isSimple || isAtomic ? SubscriberLaunchpad : EmptyListView;
 
 	return (
 		<section className="subscriber-list-container">

--- a/config/development.json
+++ b/config/development.json
@@ -193,7 +193,6 @@
 		"storage-addon": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
-		"subscribers-launchpad": true,
 		"subscription-gifting": true,
 		"subscription-management-add-sites-modal": true,
 		"subscription-management-comments-view": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -131,7 +131,7 @@
 		"storage-addon": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
-		"subscribers-launchpad": false,
+		"subscribers-launchpad": true,
 		"subscription-gifting": true,
 		"subscription-management-add-sites-modal": true,
 		"subscription-management-comments-view": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -131,7 +131,6 @@
 		"storage-addon": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
-		"subscribers-launchpad": true,
 		"subscription-gifting": true,
 		"subscription-management-add-sites-modal": true,
 		"subscription-management-comments-view": true,

--- a/config/production.json
+++ b/config/production.json
@@ -159,7 +159,6 @@
 		"storage-addon": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
-		"subscribers-launchpad": true,
 		"subscription-gifting": true,
 		"subscription-management-add-sites-modal": true,
 		"subscription-management-comments-view": true,

--- a/config/production.json
+++ b/config/production.json
@@ -159,7 +159,7 @@
 		"storage-addon": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
-		"subscribers-launchpad": false,
+		"subscribers-launchpad": true,
 		"subscription-gifting": true,
 		"subscription-management-add-sites-modal": true,
 		"subscription-management-comments-view": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -154,7 +154,7 @@
 		"storage-addon": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
-		"subscribers-launchpad": false,
+		"subscribers-launchpad": true,
 		"subscription-gifting": true,
 		"subscription-management-add-sites-modal": true,
 		"subscription-management-comments-view": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -154,7 +154,6 @@
 		"storage-addon": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
-		"subscribers-launchpad": true,
 		"subscription-gifting": true,
 		"subscription-management-add-sites-modal": true,
 		"subscription-management-comments-view": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -163,7 +163,6 @@
 		"storage-addon": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
-		"subscribers-launchpad": true,
 		"subscription-gifting": true,
 		"subscription-management-add-sites-modal": true,
 		"subscription-management-comments-view": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -163,7 +163,7 @@
 		"storage-addon": true,
 		"subscriber-csv-upload": true,
 		"subscriber-importer": true,
-		"subscribers-launchpad": false,
+		"subscribers-launchpad": true,
 		"subscription-gifting": true,
 		"subscription-management-add-sites-modal": true,
 		"subscription-management-comments-view": true,


### PR DESCRIPTION
**⚠️ Please do not merge until we are ready with the launchpad launch! ⚠️** 

---

Resolves https://github.com/Automattic/wp-calypso/issues/83853. https://github.com/Automattic/wp-calypso/issues/84052

TODO:

- [x] rebase after https://github.com/Automattic/wp-calypso/pull/84047 goes in
- [-x] consider https://github.com/Automattic/wp-calypso/issues/84052

## Proposed Changes

* remove the `subscribers-launchpad` feature flag
* add the translation check

## Testing Instructions

1. Check out the PR branch and build it.
2. Navigate to the Subscribers page of a site that doesn't have any subscribers (`http://calypso.localhost:3000/subscribers/[site-slug]`).
3. Experiment with the new Launchpad. Everything should work well.
4. The Launchpad should only work on the translated languages

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?