### PR TITLE
Sections: move /advertising near the top

### DIFF
--- a/client/sections.js
+++ b/client/sections.js
@@ -31,6 +31,12 @@ const sections = [
 		group: 'me',
 	},
 	{
+		name: 'promote-post-i2',
+		paths: [ '/advertising' ],
+		module: 'calypso/my-sites/promote-post-i2',
+		group: 'sites',
+	},
+	{
 		name: 'concierge',
 		paths: [ '/me/concierge', '/me/quickstart' ],
 		module: 'calypso/me/concierge',
@@ -631,12 +637,6 @@ const sections = [
 		name: 'add-ons',
 		paths: [ '/add-ons', '/add-ons/[^\\/]+' ],
 		module: 'calypso/my-sites/add-ons',
-		group: 'sites',
-	},
-	{
-		name: 'promote-post-i2',
-		paths: [ '/advertising' ],
-		module: 'calypso/my-sites/promote-post-i2',
 		group: 'sites',
 	},
 	{


### PR DESCRIPTION
To test the hypothesis that deep call stacks in page.js routing cause mobile web view loading errors for `/advertising`, let's move the section near the top, so that the route is matched sooner, and the call stack depths are smaller.