### PR TITLE
[Odie] Contact options are being displayed in Firefox always

### DIFF
--- a/client/odie/message/index.tsx
+++ b/client/odie/message/index.tsx
@@ -174,6 +174,10 @@ const ChatMessage = ( { message, scrollToBottom }: ChatMessageProps ) => {
 		}, 600 );
 	};
 
+	const shouldRenderExtraContactOptions =
+		( isRequestingHumanSupport !== undefined && isRequestingHumanSupport ) ||
+		( message && message.type === 'dislike-feedback' );
+
 	const messageContent = (
 		<div className="odie-chatbox-message-sources-container">
 			<div className={ messageClasses }>
@@ -212,8 +216,7 @@ const ChatMessage = ( { message, scrollToBottom }: ChatMessageProps ) => {
 						{ message.content }
 					</AsyncLoad>
 				) }
-				{ ( isRequestingHumanSupport || message.type === 'dislike-feedback' ) &&
-					extraContactOptions }
+				{ shouldRenderExtraContactOptions && extraContactOptions }
 			</div>
 			{ hasSources && messageFullyTyped && (
 				<FoldableCard


### PR DESCRIPTION
## Proposed Changes

@sirino has found that while using Firefox the extra contact options are displayed by default. This is addressing the issue for Firefox browsers 

## Testing Instructions
Using the calypso live link, log into a simple site and assign yourself the Wapuu experiment.
Open the help center, type in the search box, wait for the results and click "Still need help?"
Assert that there is only one message from Wapuu

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?