### PR TITLE
Remove confirmation email message textfield.

### DIFF
--- a/client/my-sites/site-settings/settings-newsletter/EmailsTextSetting.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/EmailsTextSetting.tsx
@@ -96,14 +96,6 @@ export const EmailsTextSetting = ( { value, disabled, updateFields }: EmailsText
 				<FormLabel htmlFor="confirmation_email_message">
 					{ translate( 'Confirmation email message' ) }
 				</FormLabel>
-				<FormTextarea
-					name="confirmation_email_message"
-					id="confirmation_email_message"
-					value={ value?.invitation }
-					onChange={ updateSubscriptionOptions( 'invitation' ) }
-					autoCapitalize="none"
-					disabled
-				/>
 				<FormSettingExplanation>
 					{ translate(
 						'The ability to customize the confirmation email message had to be disabled to prevent abuse. It will revert to the default message for all new subscribers.'


### PR DESCRIPTION
## Proposed Changes

* Simple PR to remove the confirmaton email message textfield to reduce user confusion.

## Testing Instructions

* Go to `/settings/newsletter/yoursitehere.wpcomstaging.com`.
* You should not see the textfield under "Confirmation email message anymore".

| Before | After |
| --- | --- |
| <img width="760" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1287077/2593f85c-68f3-4009-8fbb-e4088897cea7"> | <img width="753" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1287077/4afc03c5-7b6b-4038-a6ab-90229de2a18f"> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?