### PR TITLE
Add loading to Join Conversation Dialog

### DIFF
--- a/client/blocks/reader-join-conversation/dialog.jsx
+++ b/client/blocks/reader-join-conversation/dialog.jsx
@@ -79,25 +79,7 @@ const ReaderJoinConversationDialog = ( { onClose, isVisible, loggedInAction, onL
 				<p>
 					{ translate( 'Sign in to like, comment, reblog, and subscribe to your favorite blogs.' ) }
 				</p>
-				{ ! isLoginPopupOpen && (
-					<Button
-						isPrimary
-						onClick={ onCreateAccountClick }
-						className="reader-join-conversation-dialog__create-account-button"
-					>
-						{ translate( 'Create a new account' ) }
-					</Button>
-				) }
-				{ ! isLoginPopupOpen && (
-					<Button
-						isLink
-						onClick={ onLoginClick }
-						className="reader-join-conversation-dialog__login"
-					>
-						{ translate( 'Log in' ) }
-					</Button>
-				) }
-				{ isLoginPopupOpen && (
+				{ isLoginPopupOpen ? (
 					<>
 						<SpinnerLine />
 						<Button
@@ -106,6 +88,23 @@ const ReaderJoinConversationDialog = ( { onClose, isVisible, loggedInAction, onL
 							className="reader-join-conversation-dialog__cancel"
 						>
 							{ translate( 'Cancel' ) }
+						</Button>
+					</>
+				) : (
+					<>
+						<Button
+							isPrimary
+							onClick={ onCreateAccountClick }
+							className="reader-join-conversation-dialog__create-account-button"
+						>
+							{ translate( 'Create a new account' ) }
+						</Button>
+						<Button
+							isLink
+							onClick={ onLoginClick }
+							className="reader-join-conversation-dialog__login"
+						>
+							{ translate( 'Log in' ) }
 						</Button>
 					</>
 				) }

--- a/client/blocks/reader-join-conversation/dialog.jsx
+++ b/client/blocks/reader-join-conversation/dialog.jsx
@@ -2,7 +2,8 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Dialog } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
+import SpinnerLine from 'calypso/components/spinner-line';
 import WordPressLogo from 'calypso/components/wordpress-logo';
 import useLoginWindow from 'calypso/data/reader/use-login-window';
 
@@ -10,6 +11,9 @@ import './style.scss';
 
 const ReaderJoinConversationDialog = ( { onClose, isVisible, loggedInAction, onLoginSuccess } ) => {
 	const translate = useTranslate();
+
+	// useState to track if login popup is open
+	const [ isLoginPopupOpen, setIsLoginPopupOpen ] = useState( false );
 
 	const trackEvent = ( eventName ) => {
 		let eventProps = {};
@@ -25,6 +29,7 @@ const ReaderJoinConversationDialog = ( { onClose, isVisible, loggedInAction, onL
 	};
 
 	const handleLoginSuccess = () => {
+		setIsLoginPopupOpen( false );
 		trackEvent( 'calypso_reader_dialog_login_success' );
 		onLoginSuccess();
 	};
@@ -36,16 +41,27 @@ const ReaderJoinConversationDialog = ( { onClose, isVisible, loggedInAction, onL
 		}
 	}, [ isVisible ] );
 
-	const { login, createAccount } = useLoginWindow( { onLoginSuccess: handleLoginSuccess } );
+	const { login, createAccount, loginWindow } = useLoginWindow( {
+		onLoginSuccess: handleLoginSuccess,
+		onWindowClose: () => setIsLoginPopupOpen( false ),
+	} );
 
 	const onLoginClick = () => {
+		setIsLoginPopupOpen( true );
 		trackEvent( 'calypso_reader_dialog_login_clicked' );
 		login();
 	};
 
 	const onCreateAccountClick = () => {
+		setIsLoginPopupOpen( true );
 		trackEvent( 'calypso_reader_dialog_create_account_clicked' );
 		createAccount();
+	};
+
+	const onCancelClick = () => {
+		setIsLoginPopupOpen( false );
+		trackEvent( 'calypso_reader_dialog_cancel_clicked' );
+		loginWindow?.close();
 	};
 
 	return (
@@ -63,16 +79,36 @@ const ReaderJoinConversationDialog = ( { onClose, isVisible, loggedInAction, onL
 				<p>
 					{ translate( 'Sign in to like, comment, reblog, and subscribe to your favorite blogs.' ) }
 				</p>
-				<Button
-					isPrimary
-					onClick={ onCreateAccountClick }
-					className="reader-join-conversation-dialog__create-account-button"
-				>
-					{ translate( 'Create a new account' ) }
-				</Button>
-				<Button isLink onClick={ onLoginClick } className="reader-join-conversation-dialog__login">
-					{ translate( 'Log in' ) }
-				</Button>
+				{ ! isLoginPopupOpen && (
+					<Button
+						isPrimary
+						onClick={ onCreateAccountClick }
+						className="reader-join-conversation-dialog__create-account-button"
+					>
+						{ translate( 'Create a new account' ) }
+					</Button>
+				) }
+				{ ! isLoginPopupOpen && (
+					<Button
+						isLink
+						onClick={ onLoginClick }
+						className="reader-join-conversation-dialog__login"
+					>
+						{ translate( 'Log in' ) }
+					</Button>
+				) }
+				{ isLoginPopupOpen && (
+					<>
+						<SpinnerLine />
+						<Button
+							isLink
+							onClick={ onCancelClick }
+							className="reader-join-conversation-dialog__cancel"
+						>
+							{ translate( 'Cancel' ) }
+						</Button>
+					</>
+				) }
 			</div>
 		</Dialog>
 	);

--- a/client/blocks/reader-join-conversation/dialog.jsx
+++ b/client/blocks/reader-join-conversation/dialog.jsx
@@ -64,11 +64,18 @@ const ReaderJoinConversationDialog = ( { onClose, isVisible, loggedInAction, onL
 		loginWindow?.close();
 	};
 
+	const onCloseClick = () => {
+		setIsLoginPopupOpen( false );
+		trackEvent( 'calypso_reader_dialog_close_clicked' );
+		loginWindow?.close();
+		onClose();
+	};
+
 	return (
 		<Dialog
 			additionalClassNames="reader-join-conversation-dialog"
 			isVisible={ isVisible }
-			onClose={ onClose }
+			onClose={ onCloseClick }
 			showCloseIcon={ true }
 			label={ translate( 'Join the conversation' ) }
 			shouldCloseOnEsc={ true }

--- a/client/blocks/reader-join-conversation/style.scss
+++ b/client/blocks/reader-join-conversation/style.scss
@@ -54,7 +54,10 @@
 		}
 	}
 
-
+	hr.spinner-line {
+		width: 50%;
+		margin: 15px 0;
+	}
 }
 
 @media only screen and (max-width: 600px) {

--- a/client/blocks/reader-join-conversation/style.scss
+++ b/client/blocks/reader-join-conversation/style.scss
@@ -55,8 +55,10 @@
 	}
 
 	hr.spinner-line {
-		width: 50%;
-		margin: 15px 0;
+		width: 80%;
+		margin: 12px 0;
+		height: 12px;
+		border-radius: 3px;
 	}
 }
 


### PR DESCRIPTION
Follow up to https://github.com/Automattic/wp-calypso/pull/83580

This is part of the p2-pe7F0s-1gz project - Reader Logged out auth v1

This PR adds a loading animation when a user opens a popup login window. This was part of the original design mockup but was missed/overlooked.

### Testing

* Go to Reader while logged out
* Click on any action, i.e. like a post
* You should see the join conversation dialog
* Click on either the login link or create account button and you should see them replaced with a spinner line loading animation 
* Click the cancel to show the login link and create account button again
* Check that closing the popup removes the loading animation and shows the login link and create account button again