### PR TITLE
Staging sites: remove `onError` callbacks from query hooks

### DIFF
--- a/client/my-sites/hosting/staging-site-card/index.js
+++ b/client/my-sites/hosting/staging-site-card/index.js
@@ -44,9 +44,7 @@ export const StagingSiteCard = ( {
 	const { __ } = useI18n();
 	const dispatch = useDispatch();
 	const queryClient = useQueryClient();
-	const [ loadingError, setLoadingError ] = useState( false );
 	const [ syncError, setSyncError ] = useState( null );
-	const [ isErrorValidQuota, setIsErrorValidQuota ] = useState( false );
 	const isSyncInProgress = useSelector( ( state ) => getIsSyncingInProgress( state, siteId ) );
 
 	const removeAllNotices = () => {
@@ -56,27 +54,31 @@ export const StagingSiteCard = ( {
 		dispatch( removeNotice( stagingSiteDeleteFailureNoticeId ) );
 	};
 
-	const { data: hasValidQuota, isLoading: isLoadingQuotaValidation } = useHasValidQuotaQuery(
-		siteId,
-		{
-			enabled: ! disabled,
-			onError: () => {
-				setIsErrorValidQuota( true );
-			},
-		}
-	);
-
-	const { data: stagingSites, isLoading: isLoadingStagingSites } = useStagingSite( siteId, {
+	const {
+		data: hasValidQuota,
+		isLoading: isLoadingQuotaValidation,
+		error: isErrorValidQuota,
+	} = useHasValidQuotaQuery( siteId, {
 		enabled: ! disabled,
-		onError: ( error ) => {
+	} );
+
+	const {
+		data: stagingSites,
+		isLoading: isLoadingStagingSites,
+		error: loadingError,
+	} = useStagingSite( siteId, {
+		enabled: ! disabled,
+	} );
+
+	useEffect( () => {
+		if ( loadingError ) {
 			dispatch(
 				recordTracksEvent( 'calypso_hosting_configuration_staging_site_load_failure', {
-					code: error.code,
+					code: loadingError.code,
 				} )
 			);
-			setLoadingError( error );
-		},
-	} );
+		}
+	}, [ dispatch, loadingError ] );
 
 	const stagingSite = useMemo( () => {
 		return stagingSites && stagingSites.length ? stagingSites[ 0 ] : [];

--- a/client/my-sites/hosting/staging-site-card/staging-site-production-card.tsx
+++ b/client/my-sites/hosting/staging-site-card/staging-site-production-card.tsx
@@ -2,7 +2,7 @@ import { Button, Card, Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
 import { localize } from 'i18n-calypso';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import dividerPattern from 'calypso/assets/images/hosting/divider-pattern.svg';
 import CardHeading from 'calypso/components/card-heading';
@@ -59,22 +59,27 @@ type CardProps = {
 function StagingSiteProductionCard( { disabled, siteId, translate }: CardProps ) {
 	const { __ } = useI18n();
 	const dispatch = useDispatch();
-	const [ loadingError, setLoadingError ] = useState( null );
 	const [ syncError, setSyncError ] = useState< string | null >( null );
 	const stagingSiteUrl = useSelector( ( state ) => getSiteUrl( state, siteId ) );
 
-	const { data: productionSite, isLoading } = useProductionSiteDetail( siteId, {
+	const {
+		data: productionSite,
+		isLoading,
+		error: loadingError,
+	} = useProductionSiteDetail( siteId, {
 		enabled: ! disabled,
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		onError: ( error: any ) => {
+	} );
+
+	useEffect( () => {
+		if ( loadingError ) {
 			dispatch(
 				recordTracksEvent( 'calypso_hosting_configuration_staging_site_load_failure', {
-					code: error.code,
+					code: loadingError.code,
 				} )
 			);
-			setLoadingError( error );
-		},
-	} );
+		}
+	}, [ dispatch, loadingError ] );
+
 	const isSyncInProgress = useSelector( ( state ) =>
 		getIsSyncingInProgress( state, productionSite?.id as number )
 	);

--- a/client/my-sites/hosting/staging-site-card/test/index.js
+++ b/client/my-sites/hosting/staging-site-card/test/index.js
@@ -136,7 +136,6 @@ describe( 'StagingSiteCard component', () => {
 		);
 		expect( useStagingSite ).toHaveBeenCalledWith( defaultProps.siteId, {
 			enabled: true,
-			onError: expect.any( Function ),
 		} );
 
 		expect( screen.getByTestId( 'loading-placeholder' ) ).toBeInTheDocument();

--- a/client/my-sites/hosting/staging-site-card/use-has-valid-quota.ts
+++ b/client/my-sites/hosting/staging-site-card/use-has-valid-quota.ts
@@ -3,7 +3,9 @@ import wp from 'calypso/lib/wp';
 
 export const USE_VALID_QUOTA_QUERY_KEY = 'valid-quota';
 
-export const useHasValidQuotaQuery = ( siteId: number, options: UseQueryOptions ) => {
+type HasValidQuotaOptions = Pick< UseQueryOptions, 'enabled' >;
+
+export const useHasValidQuotaQuery = ( siteId: number, options: HasValidQuotaOptions ) => {
 	return useQuery< boolean, unknown, boolean >( {
 		queryKey: [ USE_VALID_QUOTA_QUERY_KEY, siteId ],
 		queryFn: () =>
@@ -12,13 +14,9 @@ export const useHasValidQuotaQuery = ( siteId: number, options: UseQueryOptions 
 				apiNamespace: 'wpcom/v2',
 			} ),
 		enabled: !! siteId && ( options?.enabled ?? true ),
-		select: ( data ) => {
-			return data;
-		},
 		meta: {
 			persist: false,
 		},
 		staleTime: 10 * 1000,
-		onError: options?.onError,
 	} );
 };

--- a/client/my-sites/hosting/staging-site-card/use-production-site-detail.ts
+++ b/client/my-sites/hosting/staging-site-card/use-production-site-detail.ts
@@ -9,8 +9,14 @@ export interface ProductionSite {
 	url: string;
 }
 
-export const useProductionSiteDetail = ( siteId: number, options: UseQueryOptions ) => {
-	return useQuery< ProductionSite, unknown, ProductionSite >( {
+type ProductionSiteOptions = Pick< UseQueryOptions, 'enabled' >;
+
+interface ErrorResponse extends Error {
+	code?: string;
+}
+
+export const useProductionSiteDetail = ( siteId: number, options: ProductionSiteOptions ) => {
+	return useQuery< ProductionSite, ErrorResponse, ProductionSite >( {
 		queryKey: [ USE_PRODUCTION_SITE_DETAIL_QUERY_KEY, siteId ],
 		queryFn: () =>
 			wp.req.get( {
@@ -18,13 +24,9 @@ export const useProductionSiteDetail = ( siteId: number, options: UseQueryOption
 				apiNamespace: 'wpcom/v2',
 			} ),
 		enabled: !! siteId && ( options.enabled ?? true ),
-		select: ( data ) => {
-			return data;
-		},
 		meta: {
 			persist: false,
 		},
 		staleTime: 10 * 1000,
-		onError: options.onError,
 	} );
 };

--- a/client/my-sites/hosting/staging-site-card/use-staging-site.ts
+++ b/client/my-sites/hosting/staging-site-card/use-staging-site.ts
@@ -10,7 +10,9 @@ export interface StagingSite {
 	user_has_permission: boolean;
 }
 
-export const useStagingSite = ( siteId: number, options: UseQueryOptions ) => {
+type StagingSiteOptions = Pick< UseQueryOptions, 'enabled' >;
+
+export const useStagingSite = ( siteId: number, options: StagingSiteOptions ) => {
 	return useQuery< Array< StagingSite >, unknown, Array< StagingSite > >( {
 		queryKey: [ USE_STAGING_SITE_QUERY_KEY, siteId ],
 		queryFn: () =>
@@ -19,13 +21,9 @@ export const useStagingSite = ( siteId: number, options: UseQueryOptions ) => {
 				apiNamespace: 'wpcom/v2',
 			} ),
 		enabled: !! siteId && ( options.enabled ?? true ),
-		select: ( data ) => {
-			return data;
-		},
 		meta: {
 			persist: false,
 		},
 		staleTime: 10 * 1000,
-		onError: options.onError,
 	} );
 };


### PR DESCRIPTION
Preparatory PR for the upcoming `@tanstack/query` v5 upgrade.

## Proposed Changes

PR removes usages of `onError` callbacks on `useQuery` hooks. They're removed with v5 of the library.

## Testing Instructions

To properly test this you need one AT site without a staging site and one AT site with a staging site. In any case you should visit `/hosting-config` and verify the **Staging site card** is behaving as described below. You also need to use the _Network request blocking_ feature of your browser devtools (or use your sandbox to throw errors but I think the former is easier).

The `staleTime` for those queries is set to 10 seconds so either block the URL before you navigate to `/hosting-config` or wait 10 seconds and focus in and out of the window to trigger `refetchOnWindowFocus`. Alternatively, use React Query Devtools to invalidate the query and trigger a refetch.

### AT site without staging site

- Block network requests to `/validate-quota`
- After 3 unsuccessful request attempts you should see an error message which looks like this:

<img width="696" alt="Screenshot 2023-11-09 at 16 43 39" src="https://github.com/Automattic/wp-calypso/assets/9202899/0c162884-7a32-4ca8-bda1-87665986f8f7">

### AT site with staging site

- Block network requests to `/staging-site`
- After 3 unsuccessful request attempts you should see an error message which looks like this:

<img width="709" alt="Screenshot 2023-11-09 at 16 47 44" src="https://github.com/Automattic/wp-calypso/assets/9202899/6307ac91-b73e-4362-9417-feefedd61105">

#### Staging site

This can be a bit tricky to test because the error is only shown when there's no cached data. So make sure to remove the data from the query cache (e.g. via React Query Devtools) before you follow the steps:

- Block network requests to `/production-site-details`
- After 3 unsuccessful request attempts you should see an error message which looks like this:

<img width="703" alt="Screenshot 2023-11-09 at 16 51 39" src="https://github.com/Automattic/wp-calypso/assets/9202899/53bef27c-6824-4cc8-a3e7-ce815df6799d">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
