### PR TITLE
Add calypso_page_view tracking on Subscription Management.

### DIFF
--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -333,11 +333,32 @@ export async function blogDiscoveryByFeedId( context, next ) {
 }
 
 export async function siteSubscriptionsManager( context, next ) {
+	const basePath = sectionify( context.path );
+	const fullAnalyticsPageTitle = analyticsPageTitle + ' > Subscription Management > Sites';
+	const mcKey = 'subscription-sites';
+	trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
+
 	context.primary = <AsyncLoad require="calypso/reader/site-subscriptions-manager" />;
 	return next();
 }
 
 export async function siteSubscription( context, next ) {
+	// It can be the 2 following:
+	// - /read/subscriptions/<subscription_id>
+	// - /read/site/subscription
+	const basePath = context.params.subscription_id
+		? '/read/subscriptions/<subscription_id>'
+		: sectionify( context.path );
+
+	const fullAnalyticsPageTitle =
+		analyticsPageTitle +
+		' > Subscription Management > Site ' +
+		( context.params.subscription_id
+			? 'Subscription: ' + context.params.subscription_id
+			: 'Blog: ' + context.params.blog_id );
+	const mcKey = 'subscription-site';
+	trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
+
 	context.primary = (
 		<AsyncLoad
 			require="calypso/reader/site-subscription"
@@ -350,6 +371,11 @@ export async function siteSubscription( context, next ) {
 }
 
 export async function commentSubscriptionsManager( context, next ) {
+	const basePath = sectionify( context.path );
+	const fullAnalyticsPageTitle = analyticsPageTitle + ' > Subscription Management > Comments';
+	const mcKey = 'subscription-comments';
+	trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
+
 	context.primary = (
 		<AsyncLoad require="calypso/reader/site-subscriptions-manager/comment-subscriptions-manager" />
 	);
@@ -357,6 +383,11 @@ export async function commentSubscriptionsManager( context, next ) {
 }
 
 export async function pendingSubscriptionsManager( context, next ) {
+	const basePath = sectionify( context.path );
+	const fullAnalyticsPageTitle = analyticsPageTitle + ' > Subscription Management > Comments';
+	const mcKey = 'subscription-pending';
+	trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
+
 	context.primary = (
 		<AsyncLoad require="calypso/reader/site-subscriptions-manager/pending-subscriptions-manager" />
 	);

--- a/client/reader/site-subscriptions-manager/reader-site-subscriptions.tsx
+++ b/client/reader/site-subscriptions-manager/reader-site-subscriptions.tsx
@@ -22,12 +22,14 @@ const SEARCH_KEY = 's';
 
 const setUrlQuery = ( key: string, value: string ) => {
 	const path = window.location.pathname + window.location.search;
+	const nextPath = ! value
+		? removeQueryArgs( path, key )
+		: addQueryArgs( path, { [ key ]: value } );
 
-	if ( ! value ) {
-		return page.show( removeQueryArgs( path, key ) );
+	// Only trigger a page show when path has changed.
+	if ( nextPath !== path ) {
+		page.show( nextPath );
 	}
-
-	return page.show( addQueryArgs( path, { [ key ]: value } ) );
 };
 
 const initialUrlQuerySearchTerm = getUrlQuerySearchTerm();


### PR DESCRIPTION
## Proposed Changes

* It appears that `calypso_page_view` is not being recorded when navigating through Subscription Management pages.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On your Network panel, add `calypso_page_view` to the filter.
* Go to `/read/subscriptions` & `/read/site/subscription/<blog_id>`.
* Click around different tabs, including individual subscription page.
* You should see `calypso_page_view` being recorded.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?