### PR TITLE
Site Monitoring: Add initial severity filter for error logs

### DIFF
--- a/client/data/hosting/use-site-logs-query.ts
+++ b/client/data/hosting/use-site-logs-query.ts
@@ -20,11 +20,16 @@ export type SiteLogsData = {
 
 export type SiteLogsTab = 'php' | 'web';
 
+export interface FilterType {
+	severity?: Array< string >;
+	request_type?: Array< string >;
+}
+
 export interface SiteLogsParams {
 	logType: SiteLogsTab;
 	start: number;
 	end: number;
-	filter: any;
+	filter: FilterType;
 	sortOrder?: 'asc' | 'desc';
 	pageSize?: number;
 	pageIndex?: number;
@@ -138,7 +143,7 @@ function areRequestParamsEqual( a: SiteLogsParams, b: SiteLogsParams ) {
 	);
 }
 
-function areFilterParamsEqual( a: any, b: any ) {
+function areFilterParamsEqual( a: FilterType, b: FilterType ) {
 	if ( a.severity && b.severity && a.severity.toString() !== b.severity.toString() ) {
 		return false;
 	}

--- a/client/data/hosting/use-site-logs-query.ts
+++ b/client/data/hosting/use-site-logs-query.ts
@@ -143,5 +143,13 @@ function areFilterParamsEqual( a: any, b: any ) {
 		return false;
 	}
 
+	if (
+		a.request_type &&
+		b.request_type &&
+		a.request_type.toString() !== b.request_type.toString()
+	) {
+		return false;
+	}
+
 	return true;
 }

--- a/client/data/hosting/use-site-logs-query.ts
+++ b/client/data/hosting/use-site-logs-query.ts
@@ -144,17 +144,7 @@ function areRequestParamsEqual( a: SiteLogsParams, b: SiteLogsParams ) {
 }
 
 function areFilterParamsEqual( a: FilterType, b: FilterType ) {
-	if ( a.severity && b.severity && a.severity.toString() !== b.severity.toString() ) {
-		return false;
-	}
-
-	if (
-		a.request_type &&
-		b.request_type &&
-		a.request_type.toString() !== b.request_type.toString()
-	) {
-		return false;
-	}
-
-	return true;
+	return Object.keys( a ).every( ( filter ) => {
+		return b.hasOwnProperty( filter ) && a[ filter ].toString() === b[ filter ].toString();
+	} );
 }

--- a/client/data/hosting/use-site-logs-query.ts
+++ b/client/data/hosting/use-site-logs-query.ts
@@ -24,6 +24,7 @@ export interface SiteLogsParams {
 	logType: SiteLogsTab;
 	start: number;
 	end: number;
+	filter: any;
 	sortOrder?: 'asc' | 'desc';
 	pageSize?: number;
 	pageIndex?: number;
@@ -66,6 +67,7 @@ export function useSiteLogsQuery(
 				{
 					start: params.start,
 					end: params.end,
+					filter: params.filter,
 					sort_order: params.sortOrder,
 					page_size: params.pageSize,
 					scroll_id: scrollId,
@@ -116,6 +118,7 @@ function buildQueryKey( siteId: number | null | undefined, params: SiteLogsParam
 		...buildPartialQueryKey( siteId, params ),
 		params.start,
 		params.end,
+		params.filter,
 		params.sortOrder,
 		params.pageSize,
 		params.pageIndex,
@@ -130,6 +133,15 @@ function areRequestParamsEqual( a: SiteLogsParams, b: SiteLogsParams ) {
 		a.start === b.start &&
 		a.end === b.end &&
 		a.sortOrder === b.sortOrder &&
-		a.pageSize === b.pageSize
+		a.pageSize === b.pageSize &&
+		areFilterParamsEqual( a.filter, b.filter )
 	);
+}
+
+function areFilterParamsEqual( a: any, b: any ) {
+	if ( a.severity && b.severity && a.severity.toString() !== b.severity.toString() ) {
+		return false;
+	}
+
+	return true;
 }

--- a/client/data/hosting/use-site-logs-query.ts
+++ b/client/data/hosting/use-site-logs-query.ts
@@ -143,7 +143,25 @@ function areRequestParamsEqual( a: SiteLogsParams, b: SiteLogsParams ) {
 }
 
 function areFilterParamsEqual( a: FilterType, b: FilterType ) {
-	return Object.keys( a ).every( ( filter ) => {
-		return b.hasOwnProperty( filter ) && a[ filter ].toString() === b[ filter ].toString();
-	} );
+	for ( const filter in a ) {
+		if ( ! b.hasOwnProperty( filter ) ) {
+			return false;
+		}
+
+		if ( a[ filter ].toString() !== b[ filter ].toString() ) {
+			return false;
+		}
+	}
+
+	for ( const filter in b ) {
+		if ( ! a.hasOwnProperty( filter ) ) {
+			return false;
+		}
+
+		if ( b[ filter ].toString() !== a[ filter ].toString() ) {
+			return false;
+		}
+	}
+
+	return true;
 }

--- a/client/data/hosting/use-site-logs-query.ts
+++ b/client/data/hosting/use-site-logs-query.ts
@@ -21,9 +21,7 @@ export type SiteLogsData = {
 export type SiteLogsTab = 'php' | 'web';
 
 export interface FilterType {
-	severity?: Array< string >;
-	request_type?: Array< string >;
-	status?: Array< string >;
+	[ key: string ]: Array< string >;
 }
 
 export interface SiteLogsParams {

--- a/client/data/hosting/use-site-logs-query.ts
+++ b/client/data/hosting/use-site-logs-query.ts
@@ -23,6 +23,7 @@ export type SiteLogsTab = 'php' | 'web';
 export interface FilterType {
 	severity?: Array< string >;
 	request_type?: Array< string >;
+	status?: Array< string >;
 }
 
 export interface SiteLogsParams {

--- a/client/my-sites/site-monitoring/components/site-logs-table/index.tsx
+++ b/client/my-sites/site-monitoring/components/site-logs-table/index.tsx
@@ -15,6 +15,7 @@ type SiteLogs = SiteLogsData[ 'logs' ];
 interface SiteLogsTableProps {
 	logs?: SiteLogs;
 	logType?: LogType;
+	latestLogType?: LogType | null;
 	isLoading?: boolean;
 	headerTitles: string[];
 }

--- a/client/my-sites/site-monitoring/components/site-logs-table/index.tsx
+++ b/client/my-sites/site-monitoring/components/site-logs-table/index.tsx
@@ -1,7 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
-import { memo, useEffect, useMemo, useState } from 'react';
+import { memo, useMemo } from 'react';
 import { SiteLogsData } from 'calypso/data/hosting/use-site-logs-query';
 import { useCurrentSiteGmtOffset } from '../../hooks/use-current-site-gmt-offset';
 import { LogType } from '../../logs-tab';
@@ -42,6 +42,7 @@ export const SiteLogsTable = memo( function SiteLogsTable( {
 	isLoading,
 	headerTitles,
 	logType,
+	latestLogType,
 }: SiteLogsTableProps ) {
 	const { __ } = useI18n();
 	const columns = useSiteColumns( logs, headerTitles );
@@ -50,13 +51,6 @@ export const SiteLogsTable = memo( function SiteLogsTable( {
 	const logsWithKeys = useMemo( () => {
 		return generateRowKeys( logs );
 	}, [ logs ] );
-
-	const [ latestLogType, setLatestLogType ] = useState< LogType | undefined | null >( null );
-	useEffect( () => {
-		if ( ! isLoading && logType !== latestLogType ) {
-			setLatestLogType( logType );
-		}
-	}, [ latestLogType, logType, isLoading ] );
 
 	if ( isLoading && logType !== latestLogType ) {
 		const skeletonClassName =

--- a/client/my-sites/site-monitoring/components/site-logs-toolbar/index.tsx
+++ b/client/my-sites/site-monitoring/components/site-logs-toolbar/index.tsx
@@ -95,7 +95,10 @@ export const SiteLogsToolbar = ( {
 	const requestTypes = [
 		{ value: '', label: translate( 'All types' ) },
 		{ value: 'GET', label: translate( 'GET' ) },
+		{ value: 'HEAD', label: translate( 'HEAD' ) },
 		{ value: 'POST', label: translate( 'POST' ) },
+		{ value: 'PUT', label: translate( 'PUT' ) },
+		{ value: 'DELETE', label: translate( 'DELETE' ) },
 	];
 
 	const selectedSeverity =

--- a/client/my-sites/site-monitoring/components/site-logs-toolbar/index.tsx
+++ b/client/my-sites/site-monitoring/components/site-logs-toolbar/index.tsx
@@ -134,7 +134,7 @@ export const SiteLogsToolbar = ( {
 					min={ startDateTime }
 				/>
 				{ logType === 'php' && (
-					<>
+					<div className="site-logs-toolbar-filter-element">
 						<label htmlFor="site-logs-severity">{ translate( 'Severity' ) }</label>
 						<SelectDropdown
 							id="site-logs-severity"
@@ -153,46 +153,50 @@ export const SiteLogsToolbar = ( {
 								</SelectDropdown.Item>
 							) ) }
 						</SelectDropdown>
-					</>
+					</div>
 				) }
 				{ logType === 'web' && (
 					<>
-						<label htmlFor="site-logs-request-type">{ translate( 'Request Type' ) }</label>
-						<SelectDropdown
-							id="site-logs-request-type"
-							className="site-logs-toolbar-filter-request-type"
-							selectedText={ selectedRequestType.label }
-							initialSelected={ requestType }
-						>
-							{ requestTypes.map( ( option ) => (
-								<SelectDropdown.Item
-									key={ option.value }
-									onClick={ () => onRequestTypeChange( option.value ) }
-								>
-									<span>
-										<strong>{ option.label }</strong>
-									</span>
-								</SelectDropdown.Item>
-							) ) }
-						</SelectDropdown>
-						<label htmlFor="site-logs-request-status">{ translate( 'Status' ) }</label>
-						<SelectDropdown
-							id="site-logs-request-status"
-							className="site-logs-toolbar-filter-request-status"
-							selectedText={ selectedRequestStatus.label }
-							initialSelected={ requestStatus }
-						>
-							{ requestStatuses.map( ( option ) => (
-								<SelectDropdown.Item
-									key={ option.value }
-									onClick={ () => onRequestStatusChange( option.value ) }
-								>
-									<span>
-										<strong>{ option.label }</strong>
-									</span>
-								</SelectDropdown.Item>
-							) ) }
-						</SelectDropdown>
+						<div className="site-logs-toolbar-filter-element">
+							<label htmlFor="site-logs-request-type">{ translate( 'Request Type' ) }</label>
+							<SelectDropdown
+								id="site-logs-request-type"
+								className="site-logs-toolbar-filter-request-type"
+								selectedText={ selectedRequestType.label }
+								initialSelected={ requestType }
+							>
+								{ requestTypes.map( ( option ) => (
+									<SelectDropdown.Item
+										key={ option.value }
+										onClick={ () => onRequestTypeChange( option.value ) }
+									>
+										<span>
+											<strong>{ option.label }</strong>
+										</span>
+									</SelectDropdown.Item>
+								) ) }
+							</SelectDropdown>
+						</div>
+						<div className="site-logs-toolbar-filter-element">
+							<label htmlFor="site-logs-request-status">{ translate( 'Status' ) }</label>
+							<SelectDropdown
+								id="site-logs-request-status"
+								className="site-logs-toolbar-filter-request-status"
+								selectedText={ selectedRequestStatus.label }
+								initialSelected={ requestStatus }
+							>
+								{ requestStatuses.map( ( option ) => (
+									<SelectDropdown.Item
+										key={ option.value }
+										onClick={ () => onRequestStatusChange( option.value ) }
+									>
+										<span>
+											<strong>{ option.label }</strong>
+										</span>
+									</SelectDropdown.Item>
+								) ) }
+							</SelectDropdown>
+						</div>
 					</>
 				) }
 

--- a/client/my-sites/site-monitoring/components/site-logs-toolbar/index.tsx
+++ b/client/my-sites/site-monitoring/components/site-logs-toolbar/index.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import SelectDropdown from 'calypso/components/select-dropdown';
 import { SiteLogsTab } from 'calypso/data/hosting/use-site-logs-query';
 import { useCurrentSiteGmtOffset } from '../../hooks/use-current-site-gmt-offset';
 import { useSiteLogsDownloader } from '../../hooks/use-site-logs-downloader';
@@ -36,6 +37,8 @@ const SiteLogsToolbarDownloadProgress = ( {
 
 type Props = {
 	onDateTimeChange: ( startDateTime: Moment, endDateTime: Moment ) => void;
+	onSeverityChange: ( severity: string ) => void;
+	severity: string;
 	logType: SiteLogsTab;
 	startDateTime: Moment;
 	endDateTime: Moment;
@@ -44,6 +47,8 @@ type Props = {
 
 export const SiteLogsToolbar = ( {
 	onDateTimeChange,
+	onSeverityChange,
+	severity,
 	logType,
 	startDateTime,
 	endDateTime,
@@ -67,6 +72,21 @@ export const SiteLogsToolbar = ( {
 		onDateTimeChange( newStart || startDateTime, newEnd || endDateTime );
 	};
 
+	const handleSeverityChange = ( newSeverity: string ) => {
+		onSeverityChange( newSeverity );
+	};
+
+	const severities = [
+		{ value: '', label: translate( 'All levels' ) },
+		{ value: 'User', label: translate( 'User' ) },
+		{ value: 'Warning', label: translate( 'Warning' ) },
+		{ value: 'Deprecated', label: translate( 'Deprecated' ) },
+		{ value: 'Fatal error', label: translate( 'Fatal error' ) },
+	];
+
+	const selectedSeverity =
+		severities.find( ( item ) => severity === item.value ) || severities[ 0 ];
+
 	return (
 		<div className="site-logs-toolbar">
 			<div className="site-logs-toolbar__top-row">
@@ -88,6 +108,24 @@ export const SiteLogsToolbar = ( {
 					max={ moment() }
 					min={ startDateTime }
 				/>
+				{ logType === 'php' && (
+					<>
+						<label htmlFor="severity">{ translate( 'Severity' ) }</label>
+						<SelectDropdown
+							id="severity"
+							selectedText={ selectedSeverity.label }
+							initialSelected={ severity }
+						>
+							{ severities.map( ( option ) => (
+								<SelectDropdown.Item onClick={ () => handleSeverityChange( option.value ) }>
+									<span>
+										<strong>{ option.label }</strong>
+									</span>
+								</SelectDropdown.Item>
+							) ) }
+						</SelectDropdown>
+					</>
+				) }
 
 				<Button
 					disabled={ isDownloading }

--- a/client/my-sites/site-monitoring/components/site-logs-toolbar/index.tsx
+++ b/client/my-sites/site-monitoring/components/site-logs-toolbar/index.tsx
@@ -5,6 +5,7 @@ import SelectDropdown from 'calypso/components/select-dropdown';
 import { SiteLogsTab } from 'calypso/data/hosting/use-site-logs-query';
 import { useCurrentSiteGmtOffset } from '../../hooks/use-current-site-gmt-offset';
 import { useSiteLogsDownloader } from '../../hooks/use-site-logs-downloader';
+import { buildFilterParam } from '../../logs-tab';
 import { DateTimePicker } from './date-time-picker';
 import type { Moment } from 'moment';
 
@@ -210,7 +211,14 @@ export const SiteLogsToolbar = ( {
 					disabled={ isDownloading }
 					isBusy={ isDownloading }
 					variant="primary"
-					onClick={ () => downloadLogs( { logType, startDateTime, endDateTime } ) }
+					onClick={ () =>
+						downloadLogs( {
+							logType,
+							startDateTime,
+							endDateTime,
+							filter: buildFilterParam( logType, severity, requestType, requestStatus ),
+						} )
+					}
 				>
 					{ translate( 'Download logs' ) }
 				</Button>

--- a/client/my-sites/site-monitoring/components/site-logs-toolbar/index.tsx
+++ b/client/my-sites/site-monitoring/components/site-logs-toolbar/index.tsx
@@ -129,7 +129,10 @@ export const SiteLogsToolbar = ( {
 							initialSelected={ severity }
 						>
 							{ severities.map( ( option ) => (
-								<SelectDropdown.Item onClick={ () => onSeverityChange( option.value ) }>
+								<SelectDropdown.Item
+									key={ option.value }
+									onClick={ () => onSeverityChange( option.value ) }
+								>
 									<span>
 										<strong>{ option.label }</strong>
 									</span>
@@ -147,7 +150,10 @@ export const SiteLogsToolbar = ( {
 							initialSelected={ requestType }
 						>
 							{ requestTypes.map( ( option ) => (
-								<SelectDropdown.Item onClick={ () => onRequestTypeChange( option.value ) }>
+								<SelectDropdown.Item
+									key={ option.value }
+									onClick={ () => onRequestTypeChange( option.value ) }
+								>
 									<span>
 										<strong>{ option.label }</strong>
 									</span>

--- a/client/my-sites/site-monitoring/components/site-logs-toolbar/index.tsx
+++ b/client/my-sites/site-monitoring/components/site-logs-toolbar/index.tsx
@@ -76,14 +76,6 @@ export const SiteLogsToolbar = ( {
 		onDateTimeChange( newStart || startDateTime, newEnd || endDateTime );
 	};
 
-	const handleSeverityChange = ( newSeverity: string ) => {
-		onSeverityChange( newSeverity );
-	};
-
-	const handleRequestTypeChange = ( newRequestType: string ) => {
-		onRequestTypeChange( newRequestType );
-	};
-
 	const severities = [
 		{ value: '', label: translate( 'All levels' ) },
 		{ value: 'User', label: translate( 'User' ) },
@@ -137,7 +129,7 @@ export const SiteLogsToolbar = ( {
 							initialSelected={ severity }
 						>
 							{ severities.map( ( option ) => (
-								<SelectDropdown.Item onClick={ () => handleSeverityChange( option.value ) }>
+								<SelectDropdown.Item onClick={ () => onSeverityChange( option.value ) }>
 									<span>
 										<strong>{ option.label }</strong>
 									</span>
@@ -155,7 +147,7 @@ export const SiteLogsToolbar = ( {
 							initialSelected={ requestType }
 						>
 							{ requestTypes.map( ( option ) => (
-								<SelectDropdown.Item onClick={ () => handleRequestTypeChange( option.value ) }>
+								<SelectDropdown.Item onClick={ () => onRequestTypeChange( option.value ) }>
 									<span>
 										<strong>{ option.label }</strong>
 									</span>

--- a/client/my-sites/site-monitoring/components/site-logs-toolbar/index.tsx
+++ b/client/my-sites/site-monitoring/components/site-logs-toolbar/index.tsx
@@ -38,20 +38,24 @@ const SiteLogsToolbarDownloadProgress = ( {
 type Props = {
 	onDateTimeChange: ( startDateTime: Moment, endDateTime: Moment ) => void;
 	onSeverityChange: ( severity: string ) => void;
-	severity: string;
+	onRequestTypeChange: ( severity: string ) => void;
 	logType: SiteLogsTab;
 	startDateTime: Moment;
 	endDateTime: Moment;
+	severity: string;
+	requestType: string;
 	children?: React.ReactNode;
 };
 
 export const SiteLogsToolbar = ( {
 	onDateTimeChange,
 	onSeverityChange,
-	severity,
+	onRequestTypeChange,
 	logType,
 	startDateTime,
 	endDateTime,
+	severity,
+	requestType,
 	children,
 }: Props ) => {
 	const translate = useTranslate();
@@ -76,6 +80,10 @@ export const SiteLogsToolbar = ( {
 		onSeverityChange( newSeverity );
 	};
 
+	const handleRequestTypeChange = ( newRequestType: string ) => {
+		onRequestTypeChange( newRequestType );
+	};
+
 	const severities = [
 		{ value: '', label: translate( 'All levels' ) },
 		{ value: 'User', label: translate( 'User' ) },
@@ -84,8 +92,17 @@ export const SiteLogsToolbar = ( {
 		{ value: 'Fatal error', label: translate( 'Fatal error' ) },
 	];
 
+	const requestTypes = [
+		{ value: '', label: translate( 'All types' ) },
+		{ value: 'GET', label: translate( 'GET' ) },
+		{ value: 'POST', label: translate( 'POST' ) },
+	];
+
 	const selectedSeverity =
 		severities.find( ( item ) => severity === item.value ) || severities[ 0 ];
+
+	const selectedRequestType =
+		requestTypes.find( ( item ) => requestType === item.value ) || requestTypes[ 0 ];
 
 	return (
 		<div className="site-logs-toolbar">
@@ -118,6 +135,24 @@ export const SiteLogsToolbar = ( {
 						>
 							{ severities.map( ( option ) => (
 								<SelectDropdown.Item onClick={ () => handleSeverityChange( option.value ) }>
+									<span>
+										<strong>{ option.label }</strong>
+									</span>
+								</SelectDropdown.Item>
+							) ) }
+						</SelectDropdown>
+					</>
+				) }
+				{ logType === 'web' && (
+					<>
+						<label htmlFor="requestType">{ translate( 'Request Type' ) }</label>
+						<SelectDropdown
+							id="severity"
+							selectedText={ selectedRequestType.label }
+							initialSelected={ requestType }
+						>
+							{ requestTypes.map( ( option ) => (
+								<SelectDropdown.Item onClick={ () => handleRequestTypeChange( option.value ) }>
 									<span>
 										<strong>{ option.label }</strong>
 									</span>

--- a/client/my-sites/site-monitoring/components/site-logs-toolbar/index.tsx
+++ b/client/my-sites/site-monitoring/components/site-logs-toolbar/index.tsx
@@ -81,7 +81,7 @@ export const SiteLogsToolbar = ( {
 	};
 
 	const severities = [
-		{ value: '', label: translate( 'All levels' ) },
+		{ value: '', label: translate( 'All' ) },
 		{ value: 'User', label: translate( 'User' ) },
 		{ value: 'Warning', label: translate( 'Warning' ) },
 		{ value: 'Deprecated', label: translate( 'Deprecated' ) },
@@ -89,7 +89,7 @@ export const SiteLogsToolbar = ( {
 	];
 
 	const requestTypes = [
-		{ value: '', label: translate( 'All types' ) },
+		{ value: '', label: translate( 'All' ) },
 		{ value: 'GET', label: translate( 'GET' ) },
 		{ value: 'HEAD', label: translate( 'HEAD' ) },
 		{ value: 'POST', label: translate( 'POST' ) },
@@ -98,7 +98,7 @@ export const SiteLogsToolbar = ( {
 	];
 
 	const requestStatuses = [
-		{ value: '', label: translate( 'All statuses' ) },
+		{ value: '', label: translate( 'All' ) },
 		{ value: '200', label: translate( '200' ) },
 		{ value: '404', label: translate( '404' ) },
 	];
@@ -135,9 +135,10 @@ export const SiteLogsToolbar = ( {
 				/>
 				{ logType === 'php' && (
 					<>
-						<label htmlFor="severity">{ translate( 'Severity' ) }</label>
+						<label htmlFor="site-logs-severity">{ translate( 'Severity' ) }</label>
 						<SelectDropdown
-							id="severity"
+							id="site-logs-severity"
+							className="site-logs-toolbar-filter-severity"
 							selectedText={ selectedSeverity.label }
 							initialSelected={ severity }
 						>
@@ -156,9 +157,10 @@ export const SiteLogsToolbar = ( {
 				) }
 				{ logType === 'web' && (
 					<>
-						<label htmlFor="requestType">{ translate( 'Request Type' ) }</label>
+						<label htmlFor="site-logs-request-type">{ translate( 'Request Type' ) }</label>
 						<SelectDropdown
-							id="requestType"
+							id="site-logs-request-type"
+							className="site-logs-toolbar-filter-request-type"
 							selectedText={ selectedRequestType.label }
 							initialSelected={ requestType }
 						>
@@ -173,9 +175,10 @@ export const SiteLogsToolbar = ( {
 								</SelectDropdown.Item>
 							) ) }
 						</SelectDropdown>
-						<label htmlFor="requestStatus">{ translate( 'Request Status' ) }</label>
+						<label htmlFor="site-logs-request-status">{ translate( 'Status' ) }</label>
 						<SelectDropdown
-							id="requestStatus"
+							id="site-logs-request-status"
+							className="site-logs-toolbar-filter-request-status"
 							selectedText={ selectedRequestStatus.label }
 							initialSelected={ requestStatus }
 						>

--- a/client/my-sites/site-monitoring/components/site-logs-toolbar/index.tsx
+++ b/client/my-sites/site-monitoring/components/site-logs-toolbar/index.tsx
@@ -100,7 +100,13 @@ export const SiteLogsToolbar = ( {
 	const requestStatuses = [
 		{ value: '', label: translate( 'All' ) },
 		{ value: '200', label: translate( '200' ) },
+		{ value: '301', label: translate( '301' ) },
+		{ value: '302', label: translate( '302' ) },
+		{ value: '400', label: translate( '400' ) },
+		{ value: '401', label: translate( '401' ) },
+		{ value: '403', label: translate( '403' ) },
 		{ value: '404', label: translate( '404' ) },
+		{ value: '500', label: translate( '500' ) },
 	];
 
 	const selectedSeverity =

--- a/client/my-sites/site-monitoring/components/site-logs-toolbar/index.tsx
+++ b/client/my-sites/site-monitoring/components/site-logs-toolbar/index.tsx
@@ -38,12 +38,14 @@ const SiteLogsToolbarDownloadProgress = ( {
 type Props = {
 	onDateTimeChange: ( startDateTime: Moment, endDateTime: Moment ) => void;
 	onSeverityChange: ( severity: string ) => void;
-	onRequestTypeChange: ( severity: string ) => void;
+	onRequestTypeChange: ( requestType: string ) => void;
+	onRequestStatusChange: ( requestStatus: string ) => void;
 	logType: SiteLogsTab;
 	startDateTime: Moment;
 	endDateTime: Moment;
 	severity: string;
 	requestType: string;
+	requestStatus: string;
 	children?: React.ReactNode;
 };
 
@@ -51,11 +53,13 @@ export const SiteLogsToolbar = ( {
 	onDateTimeChange,
 	onSeverityChange,
 	onRequestTypeChange,
+	onRequestStatusChange,
 	logType,
 	startDateTime,
 	endDateTime,
 	severity,
 	requestType,
+	requestStatus,
 	children,
 }: Props ) => {
 	const translate = useTranslate();
@@ -93,11 +97,20 @@ export const SiteLogsToolbar = ( {
 		{ value: 'DELETE', label: translate( 'DELETE' ) },
 	];
 
+	const requestStatuses = [
+		{ value: '', label: translate( 'All statuses' ) },
+		{ value: '200', label: translate( '200' ) },
+		{ value: '404', label: translate( '404' ) },
+	];
+
 	const selectedSeverity =
 		severities.find( ( item ) => severity === item.value ) || severities[ 0 ];
 
 	const selectedRequestType =
 		requestTypes.find( ( item ) => requestType === item.value ) || requestTypes[ 0 ];
+
+	const selectedRequestStatus =
+		requestStatuses.find( ( item ) => requestStatus === item.value ) || requestStatuses[ 0 ];
 
 	return (
 		<div className="site-logs-toolbar">
@@ -145,7 +158,7 @@ export const SiteLogsToolbar = ( {
 					<>
 						<label htmlFor="requestType">{ translate( 'Request Type' ) }</label>
 						<SelectDropdown
-							id="severity"
+							id="requestType"
 							selectedText={ selectedRequestType.label }
 							initialSelected={ requestType }
 						>
@@ -153,6 +166,23 @@ export const SiteLogsToolbar = ( {
 								<SelectDropdown.Item
 									key={ option.value }
 									onClick={ () => onRequestTypeChange( option.value ) }
+								>
+									<span>
+										<strong>{ option.label }</strong>
+									</span>
+								</SelectDropdown.Item>
+							) ) }
+						</SelectDropdown>
+						<label htmlFor="requestStatus">{ translate( 'Request Status' ) }</label>
+						<SelectDropdown
+							id="requestStatus"
+							selectedText={ selectedRequestStatus.label }
+							initialSelected={ requestStatus }
+						>
+							{ requestStatuses.map( ( option ) => (
+								<SelectDropdown.Item
+									key={ option.value }
+									onClick={ () => onRequestStatusChange( option.value ) }
 								>
 									<span>
 										<strong>{ option.label }</strong>

--- a/client/my-sites/site-monitoring/components/site-logs-toolbar/style.scss
+++ b/client/my-sites/site-monitoring/components/site-logs-toolbar/style.scss
@@ -23,18 +23,6 @@
 		padding-bottom: 16px;
 	}
 
-	@media screen and ( max-width: 600px ) {
-		.site-logs-toolbar__top-row {
-			flex-direction: column;
-			align-items: stretch;
-		}
-	}
-
-	button {
-		height: 42px;
-		justify-content: center;
-	}
-
 	.site-logs-toolbar-filter-severity {
 		width: 140px;
 	}
@@ -45,6 +33,26 @@
 
 	.site-logs-toolbar-filter-request-status {
 		width: 90px;
+	}
+
+	@media screen and ( max-width: 600px ) {
+		.site-logs-toolbar__top-row {
+			flex-direction: column;
+			align-items: stretch;
+		}
+
+		.select-dropdown .select-dropdown__container {
+			width: 100%;
+		}
+
+		.select-dropdown {
+			width: 100%;
+		}
+	}
+
+	button {
+		height: 42px;
+		justify-content: center;
 	}
 }
 

--- a/client/my-sites/site-monitoring/components/site-logs-toolbar/style.scss
+++ b/client/my-sites/site-monitoring/components/site-logs-toolbar/style.scss
@@ -34,6 +34,18 @@
 		height: 42px;
 		justify-content: center;
 	}
+
+	.site-logs-toolbar-filter-severity {
+		width: 140px;
+	}
+
+	.site-logs-toolbar-filter-request-type {
+		width: 110px;
+	}
+
+	.site-logs-toolbar-filter-request-status {
+		width: 90px;
+	}
 }
 
 .site-logs-toolbar__download-progress {

--- a/client/my-sites/site-monitoring/components/site-logs-toolbar/style.scss
+++ b/client/my-sites/site-monitoring/components/site-logs-toolbar/style.scss
@@ -6,12 +6,17 @@
 		display: flex;
 		gap: 16px;
 		flex-direction: row;
-		align-items: center;
+		align-items: top;
 		justify-content: space-between;
 	}
 
 	.components-toggle-control {
 		display: inline-block;
+		margin-top: 12px;
+
+		.components-toggle-control__label {
+			text-wrap: nowrap;
+		}
 	}
 
 	.site-logs-toolbar__top-row {
@@ -21,6 +26,12 @@
 		justify-content: flex-start;
 		gap: 16px;
 		padding-bottom: 16px;
+
+		.site-logs-toolbar-filter-element {
+			display: flex;
+			align-items: center;
+			gap: 16px;
+		}
 	}
 
 	.site-logs-toolbar-filter-severity {
@@ -39,6 +50,11 @@
 		.site-logs-toolbar__top-row {
 			flex-direction: column;
 			align-items: stretch;
+
+			.site-logs-toolbar-filter-element {
+				flex-direction: column;
+				align-items: stretch;
+			}
 		}
 
 		.select-dropdown .select-dropdown__container {

--- a/client/my-sites/site-monitoring/components/site-monitoring-tab-panel/index.tsx
+++ b/client/my-sites/site-monitoring/components/site-monitoring-tab-panel/index.tsx
@@ -5,6 +5,7 @@ import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getQuerySearchForTab } from '../../site-monitoring-filter-params';
 import type { SiteMonitoringTab } from '../../site-monitoring-filter-params';
 import './style.scss';
 
@@ -37,10 +38,8 @@ export const SiteMonitoringTabPanel = ( {
 							key={ name }
 							path={
 								name === 'metrics'
-									? `/site-monitoring/${ siteSlug }${ new URL( window.location.href ).search }`
-									: `/site-monitoring/${ siteSlug }/${ name }${
-											new URL( window.location.href ).search
-									  }`
+									? `/site-monitoring/${ siteSlug }${ getQuerySearchForTab( name ) }`
+									: `/site-monitoring/${ siteSlug }/${ name }${ getQuerySearchForTab( name ) }`
 							}
 							selected={ selectedTab === name }
 						>

--- a/client/my-sites/site-monitoring/hooks/use-site-logs-downloader.ts
+++ b/client/my-sites/site-monitoring/hooks/use-site-logs-downloader.ts
@@ -2,7 +2,7 @@ import { useTranslate } from 'i18n-calypso';
 import { get, isEmpty, map } from 'lodash';
 import { useReducer } from 'react';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
-import { SiteLogsTab } from 'calypso/data/hosting/use-site-logs-query';
+import { FilterType, SiteLogsTab } from 'calypso/data/hosting/use-site-logs-query';
 import wpcom from 'calypso/lib/wp';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -83,6 +83,7 @@ interface UseSiteLogsDownloaderArgs {
 	logType: SiteLogsTab;
 	startDateTime: Moment;
 	endDateTime: Moment;
+	filter: FilterType;
 }
 
 export const useSiteLogsDownloader = ( {
@@ -118,6 +119,7 @@ export const useSiteLogsDownloader = ( {
 		logType,
 		startDateTime,
 		endDateTime,
+		filter,
 	}: UseSiteLogsDownloaderArgs ) => {
 		dispatch( {
 			type: 'DOWNLOAD_START',
@@ -177,6 +179,7 @@ export const useSiteLogsDownloader = ( {
 					{
 						start: startTime,
 						end: endTime,
+						filter: filter,
 						page_size: 500,
 						scroll_id: scrollId,
 					}

--- a/client/my-sites/site-monitoring/logs-tab.tsx
+++ b/client/my-sites/site-monitoring/logs-tab.tsx
@@ -20,6 +20,10 @@ import type { Moment } from 'moment';
 
 export type LogType = 'php' | 'web';
 
+interface FilterType {
+	severity?: Array< string >;
+}
+
 const DEFAULT_PAGE_SIZE = 50;
 
 export const LogsTab = ( {
@@ -63,7 +67,7 @@ export const LogsTab = ( {
 	useInterval( autoRefreshCallback, autoRefresh && 10 * 1000 );
 
 	const buildFilterParam = ( logType: string, severity: string ) => {
-		const filters = {};
+		const filters: FilterType = {};
 
 		if ( logType === 'php' ) {
 			if ( severity ) {

--- a/client/my-sites/site-monitoring/logs-tab.tsx
+++ b/client/my-sites/site-monitoring/logs-tab.tsx
@@ -22,6 +22,32 @@ export type LogType = 'php' | 'web';
 
 const DEFAULT_PAGE_SIZE = 50;
 
+export function buildFilterParam(
+	logType: string,
+	severity: string,
+	requestType: string,
+	requestStatus: string
+): FilterType {
+	const filters: FilterType = {};
+
+	if ( logType === 'php' ) {
+		if ( severity ) {
+			filters.severity = [ severity ];
+		}
+	}
+
+	if ( logType === 'web' ) {
+		if ( requestType ) {
+			filters.request_type = [ requestType ];
+		}
+		if ( requestStatus ) {
+			filters.status = [ requestStatus ];
+		}
+	}
+
+	return filters;
+}
+
 export const LogsTab = ( {
 	logType,
 	pageSize = DEFAULT_PAGE_SIZE,
@@ -69,32 +95,6 @@ export const LogsTab = ( {
 		setCurrentPageIndex( 0 );
 	}, [ getLatestDateRange ] );
 	useInterval( autoRefreshCallback, autoRefresh && 10 * 1000 );
-
-	const buildFilterParam = (
-		logType: string,
-		severity: string,
-		requestType: string,
-		requestStatus: string
-	) => {
-		const filters: FilterType = {};
-
-		if ( logType === 'php' ) {
-			if ( severity ) {
-				filters.severity = [ severity ];
-			}
-		}
-
-		if ( logType === 'web' ) {
-			if ( requestType ) {
-				filters.request_type = [ requestType ];
-			}
-			if ( requestStatus ) {
-				filters.status = [ requestStatus ];
-			}
-		}
-
-		return filters;
-	};
 
 	const { data, isInitialLoading, isFetching } = useSiteLogsQuery( siteId, {
 		logType,

--- a/client/my-sites/site-monitoring/logs-tab.tsx
+++ b/client/my-sites/site-monitoring/logs-tab.tsx
@@ -58,6 +58,10 @@ export const LogsTab = ( {
 		return getFilterQueryParam( 'requestType' ) || '';
 	} );
 
+	const [ requestStatus, setRequestStatus ] = useState( () => {
+		return getFilterQueryParam( 'requestStatus' ) || '';
+	} );
+
 	const [ currentPageIndex, setCurrentPageIndex ] = useState( 0 );
 
 	const autoRefreshCallback = useCallback( () => {
@@ -66,7 +70,12 @@ export const LogsTab = ( {
 	}, [ getLatestDateRange ] );
 	useInterval( autoRefreshCallback, autoRefresh && 10 * 1000 );
 
-	const buildFilterParam = ( logType: string, severity: string, requestType: string ) => {
+	const buildFilterParam = (
+		logType: string,
+		severity: string,
+		requestType: string,
+		requestStatus: string
+	) => {
 		const filters: FilterType = {};
 
 		if ( logType === 'php' ) {
@@ -79,6 +88,9 @@ export const LogsTab = ( {
 			if ( requestType ) {
 				filters.request_type = [ requestType ];
 			}
+			if ( requestStatus ) {
+				filters.status = [ requestStatus ];
+			}
 		}
 
 		return filters;
@@ -88,7 +100,7 @@ export const LogsTab = ( {
 		logType,
 		start: dateRange.startTime.unix(),
 		end: dateRange.endTime.unix(),
-		filter: buildFilterParam( logType, severity, requestType ),
+		filter: buildFilterParam( logType, severity, requestType, requestStatus ),
 		sortOrder: 'desc',
 		pageSize,
 		pageIndex: currentPageIndex,
@@ -159,6 +171,12 @@ export const LogsTab = ( {
 		updateFilterQueryParam( 'requestType', requestType );
 	};
 
+	const handleRequestStatusChange = ( requestStatus: string ) => {
+		setRequestStatus( requestStatus );
+		setAutoRefresh( false );
+		updateFilterQueryParam( 'requestStatus', requestStatus );
+	};
+
 	const headerTitles =
 		logType === 'php'
 			? [ 'severity', 'timestamp', 'message' ]
@@ -173,8 +191,10 @@ export const LogsTab = ( {
 				onDateTimeChange={ handleDateTimeChange }
 				onSeverityChange={ handleSeverityChange }
 				onRequestTypeChange={ handleRequestTypeChange }
+				onRequestStatusChange={ handleRequestStatusChange }
 				severity={ severity }
 				requestType={ requestType }
+				requestStatus={ requestStatus }
 			>
 				<ToggleControl
 					className="site-logs__auto-refresh"

--- a/client/my-sites/site-monitoring/logs-tab.tsx
+++ b/client/my-sites/site-monitoring/logs-tab.tsx
@@ -15,6 +15,8 @@ import {
 	updateDateRangeQueryParam,
 	getSeverityQueryParam,
 	updateSeverityQueryParam,
+	getRequestTypeQueryParam,
+	updateRequestTypeQueryParam,
 } from './site-monitoring-filter-params';
 import type { Moment } from 'moment';
 
@@ -22,6 +24,7 @@ export type LogType = 'php' | 'web';
 
 interface FilterType {
 	severity?: Array< string >;
+	request_type?: Array< string >;
 }
 
 const DEFAULT_PAGE_SIZE = 50;
@@ -58,6 +61,10 @@ export const LogsTab = ( {
 		return getSeverityQueryParam() || '';
 	} );
 
+	const [ requestType, setRequestType ] = useState( () => {
+		return getRequestTypeQueryParam() || '';
+	} );
+
 	const [ currentPageIndex, setCurrentPageIndex ] = useState( 0 );
 
 	const autoRefreshCallback = useCallback( () => {
@@ -66,12 +73,18 @@ export const LogsTab = ( {
 	}, [ getLatestDateRange ] );
 	useInterval( autoRefreshCallback, autoRefresh && 10 * 1000 );
 
-	const buildFilterParam = ( logType: string, severity: string ) => {
+	const buildFilterParam = ( logType: string, severity: string, requestType: string ) => {
 		const filters: FilterType = {};
 
 		if ( logType === 'php' ) {
 			if ( severity ) {
 				filters.severity = [ severity ];
+			}
+		}
+
+		if ( logType === 'web' ) {
+			if ( requestType ) {
+				filters.request_type = [ requestType ];
 			}
 		}
 
@@ -82,7 +95,7 @@ export const LogsTab = ( {
 		logType,
 		start: dateRange.startTime.unix(),
 		end: dateRange.endTime.unix(),
-		filter: buildFilterParam( logType, severity ),
+		filter: buildFilterParam( logType, severity, requestType ),
 		sortOrder: 'desc',
 		pageSize,
 		pageIndex: currentPageIndex,
@@ -147,6 +160,12 @@ export const LogsTab = ( {
 		updateSeverityQueryParam( severity );
 	};
 
+	const handleRequestTypeChange = ( requestType: string ) => {
+		setRequestType( requestType );
+		setAutoRefresh( false );
+		updateRequestTypeQueryParam( requestType );
+	};
+
 	const headerTitles =
 		logType === 'php'
 			? [ 'severity', 'timestamp', 'message' ]
@@ -160,7 +179,9 @@ export const LogsTab = ( {
 				endDateTime={ dateRange.endTime }
 				onDateTimeChange={ handleDateTimeChange }
 				onSeverityChange={ handleSeverityChange }
+				onRequestTypeChange={ handleRequestTypeChange }
 				severity={ severity }
+				requestType={ requestType }
 			>
 				<ToggleControl
 					className="site-logs__auto-refresh"

--- a/client/my-sites/site-monitoring/logs-tab.tsx
+++ b/client/my-sites/site-monitoring/logs-tab.tsx
@@ -55,11 +55,11 @@ export const LogsTab = ( {
 	} );
 
 	const [ requestType, setRequestType ] = useState( () => {
-		return getFilterQueryParam( 'requestType' ) || '';
+		return getFilterQueryParam( 'request_type' ) || '';
 	} );
 
 	const [ requestStatus, setRequestStatus ] = useState( () => {
-		return getFilterQueryParam( 'requestStatus' ) || '';
+		return getFilterQueryParam( 'request_status' ) || '';
 	} );
 
 	const [ currentPageIndex, setCurrentPageIndex ] = useState( 0 );
@@ -168,13 +168,13 @@ export const LogsTab = ( {
 	const handleRequestTypeChange = ( requestType: string ) => {
 		setRequestType( requestType );
 		setAutoRefresh( false );
-		updateFilterQueryParam( 'requestType', requestType );
+		updateFilterQueryParam( 'request_type', requestType );
 	};
 
 	const handleRequestStatusChange = ( requestStatus: string ) => {
 		setRequestStatus( requestStatus );
 		setAutoRefresh( false );
-		updateFilterQueryParam( 'requestStatus', requestStatus );
+		updateFilterQueryParam( 'request_status', requestStatus );
 	};
 
 	const headerTitles =

--- a/client/my-sites/site-monitoring/logs-tab.tsx
+++ b/client/my-sites/site-monitoring/logs-tab.tsx
@@ -4,7 +4,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useState } from 'react';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import Pagination from 'calypso/components/pagination';
-import { useSiteLogsQuery } from 'calypso/data/hosting/use-site-logs-query';
+import { useSiteLogsQuery, FilterType } from 'calypso/data/hosting/use-site-logs-query';
 import { useInterval } from 'calypso/lib/interval';
 import { useSelector } from 'calypso/state';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -21,11 +21,6 @@ import {
 import type { Moment } from 'moment';
 
 export type LogType = 'php' | 'web';
-
-interface FilterType {
-	severity?: Array< string >;
-	request_type?: Array< string >;
-}
 
 const DEFAULT_PAGE_SIZE = 50;
 

--- a/client/my-sites/site-monitoring/logs-tab.tsx
+++ b/client/my-sites/site-monitoring/logs-tab.tsx
@@ -13,10 +13,8 @@ import { SiteLogsToolbar } from './components/site-logs-toolbar';
 import {
 	getDateRangeQueryParam,
 	updateDateRangeQueryParam,
-	getSeverityQueryParam,
-	updateSeverityQueryParam,
-	getRequestTypeQueryParam,
-	updateRequestTypeQueryParam,
+	getFilterQueryParam,
+	updateFilterQueryParam,
 } from './site-monitoring-filter-params';
 import type { Moment } from 'moment';
 
@@ -53,11 +51,11 @@ export const LogsTab = ( {
 	} );
 
 	const [ severity, setSeverity ] = useState( () => {
-		return getSeverityQueryParam() || '';
+		return getFilterQueryParam( 'severity' ) || '';
 	} );
 
 	const [ requestType, setRequestType ] = useState( () => {
-		return getRequestTypeQueryParam() || '';
+		return getFilterQueryParam( 'requestType' ) || '';
 	} );
 
 	const [ currentPageIndex, setCurrentPageIndex ] = useState( 0 );
@@ -152,13 +150,13 @@ export const LogsTab = ( {
 	const handleSeverityChange = ( severity: string ) => {
 		setSeverity( severity );
 		setAutoRefresh( false );
-		updateSeverityQueryParam( severity );
+		updateFilterQueryParam( 'severity', severity );
 	};
 
 	const handleRequestTypeChange = ( requestType: string ) => {
 		setRequestType( requestType );
 		setAutoRefresh( false );
-		updateRequestTypeQueryParam( requestType );
+		updateFilterQueryParam( 'requestType', requestType );
 	};
 
 	const headerTitles =

--- a/client/my-sites/site-monitoring/logs-tab.tsx
+++ b/client/my-sites/site-monitoring/logs-tab.tsx
@@ -1,7 +1,7 @@
 import { ToggleControl } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import Pagination from 'calypso/components/pagination';
 import { useSiteLogsQuery, FilterType } from 'calypso/data/hosting/use-site-logs-query';
@@ -106,6 +106,18 @@ export const LogsTab = ( {
 		pageIndex: currentPageIndex,
 	} );
 
+	const [ latestLogType, setLatestLogType ] = useState< LogType | undefined | null >( null );
+	useEffect( () => {
+		if ( ! isFetching && logType !== latestLogType ) {
+			setLatestLogType( logType );
+			if ( latestLogType ) {
+				setSeverity( '' );
+				setRequestType( '' );
+				setRequestStatus( '' );
+			}
+		}
+	}, [ latestLogType, logType, isFetching ] );
+
 	const handleAutoRefreshClick = ( isChecked: boolean ) => {
 		if ( isChecked ) {
 			setDateRange( getLatestDateRange() );
@@ -208,6 +220,7 @@ export const LogsTab = ( {
 				isLoading={ isFetching }
 				headerTitles={ headerTitles }
 				logType={ logType }
+				latestLogType={ latestLogType }
 			/>
 			{ paginationText && (
 				<div className="site-monitoring__pagination-text">{ paginationText }</div>

--- a/client/my-sites/site-monitoring/site-monitoring-filter-params.ts
+++ b/client/my-sites/site-monitoring/site-monitoring-filter-params.ts
@@ -46,43 +46,18 @@ export function updateDateRangeQueryParam(
 	page.replace( url.pathname + url.search );
 }
 
-export function getSeverityQueryParam(): string {
+export function getFilterQueryParam( filter: string ): string {
 	const { searchParams } = new URL( window.location.href );
-	return searchParams.get( 'severity' ) || '';
+	return searchParams.get( filter ) || '';
 }
 
-export function updateSeverityQueryParam( severity: string | null ) {
+export function updateFilterQueryParam( filter: string, value: string | null ) {
 	const url = new URL( window.location.href );
 
-	if ( severity ) {
-		if ( ! severity ) {
-			return;
-		}
-
-		url.searchParams.set( 'severity', severity );
+	if ( value ) {
+		url.searchParams.set( filter, value );
 	} else {
-		url.searchParams.delete( 'severity' );
-	}
-
-	page.replace( url.pathname + url.search );
-}
-
-export function getRequestTypeQueryParam(): string {
-	const { searchParams } = new URL( window.location.href );
-	return searchParams.get( 'requestType' ) || '';
-}
-
-export function updateRequestTypeQueryParam( requestType: string | null ) {
-	const url = new URL( window.location.href );
-
-	if ( requestType ) {
-		if ( ! requestType ) {
-			return;
-		}
-
-		url.searchParams.set( 'requestType', requestType );
-	} else {
-		url.searchParams.delete( 'requestType' );
+		url.searchParams.delete( filter );
 	}
 
 	page.replace( url.pathname + url.search );

--- a/client/my-sites/site-monitoring/site-monitoring-filter-params.ts
+++ b/client/my-sites/site-monitoring/site-monitoring-filter-params.ts
@@ -66,3 +66,24 @@ export function updateSeverityQueryParam( severity: string | null ) {
 
 	page.replace( url.pathname + url.search );
 }
+
+export function getRequestTypeQueryParam(): string {
+	const { searchParams } = new URL( window.location.href );
+	return searchParams.get( 'requestType' ) || '';
+}
+
+export function updateRequestTypeQueryParam( requestType: string | null ) {
+	const url = new URL( window.location.href );
+
+	if ( requestType ) {
+		if ( ! requestType ) {
+			return;
+		}
+
+		url.searchParams.set( 'requestType', requestType );
+	} else {
+		url.searchParams.delete( 'requestType' );
+	}
+
+	page.replace( url.pathname + url.search );
+}

--- a/client/my-sites/site-monitoring/site-monitoring-filter-params.ts
+++ b/client/my-sites/site-monitoring/site-monitoring-filter-params.ts
@@ -45,3 +45,24 @@ export function updateDateRangeQueryParam(
 
 	page.replace( url.pathname + url.search );
 }
+
+export function getSeverityQueryParam(): string {
+	const { searchParams } = new URL( window.location.href );
+	return searchParams.get( 'severity' ) || '';
+}
+
+export function updateSeverityQueryParam( severity: string | null ) {
+	const url = new URL( window.location.href );
+
+	if ( severity ) {
+		if ( ! severity ) {
+			return;
+		}
+
+		url.searchParams.set( 'severity', severity );
+	} else {
+		url.searchParams.delete( 'severity' );
+	}
+
+	page.replace( url.pathname + url.search );
+}

--- a/client/my-sites/site-monitoring/site-monitoring-filter-params.ts
+++ b/client/my-sites/site-monitoring/site-monitoring-filter-params.ts
@@ -3,7 +3,11 @@ import type { Moment } from 'moment';
 
 export type SiteMonitoringTab = 'metrics' | 'php' | 'web';
 
-const SiteMonitoringTabParams = {
+interface SiteMonitoringTabParamsType {
+	[ key: string ]: string[];
+}
+
+const SiteMonitoringTabParams: SiteMonitoringTabParamsType = {
 	metrics: [],
 	php: [ 'from', 'to', 'severity' ],
 	web: [ 'from', 'to', 'requestType', 'status' ],
@@ -69,7 +73,7 @@ export function updateFilterQueryParam( filter: string, value: string | null ) {
 	page.replace( url.pathname + url.search );
 }
 
-export function getQuerySearchForTab( tabName ): string {
+export function getQuerySearchForTab( tabName: string ): string {
 	if ( ! SiteMonitoringTabParams[ tabName ].length ) {
 		return '';
 	}

--- a/client/my-sites/site-monitoring/site-monitoring-filter-params.ts
+++ b/client/my-sites/site-monitoring/site-monitoring-filter-params.ts
@@ -3,6 +3,12 @@ import type { Moment } from 'moment';
 
 export type SiteMonitoringTab = 'metrics' | 'php' | 'web';
 
+const SiteMonitoringTabParams = {
+	metrics: [],
+	php: [ 'from', 'to', 'severity' ],
+	web: [ 'from', 'to', 'requestType', 'status' ],
+};
+
 export function getPageQueryParam(): SiteMonitoringTab | null {
 	const param = new URL( window.location.href ).searchParams.get( 'page' );
 	return param && [ 'metrics', 'php', 'web' ].includes( param )
@@ -61,4 +67,20 @@ export function updateFilterQueryParam( filter: string, value: string | null ) {
 	}
 
 	page.replace( url.pathname + url.search );
+}
+
+export function getQuerySearchForTab( tabName ): string {
+	if ( ! SiteMonitoringTabParams[ tabName ].length ) {
+		return '';
+	}
+
+	const url = new URL( window.location.href );
+
+	url.searchParams.forEach( ( value, key ) => {
+		if ( ! SiteMonitoringTabParams[ tabName ].includes( key ) ) {
+			url.searchParams.delete( key );
+		}
+	} );
+
+	return url.search;
 }

--- a/client/my-sites/site-monitoring/site-monitoring-filter-params.ts
+++ b/client/my-sites/site-monitoring/site-monitoring-filter-params.ts
@@ -80,7 +80,7 @@ export function getQuerySearchForTab( tabName: string ): string {
 
 	const url = new URL( window.location.href );
 
-	const keysToDelete = [];
+	const keysToDelete: string[] = [];
 
 	url.searchParams.forEach( ( value, key ) => {
 		if ( ! SiteMonitoringTabParams[ tabName ].includes( key ) ) {

--- a/client/my-sites/site-monitoring/site-monitoring-filter-params.ts
+++ b/client/my-sites/site-monitoring/site-monitoring-filter-params.ts
@@ -10,7 +10,7 @@ interface SiteMonitoringTabParamsType {
 const SiteMonitoringTabParams: SiteMonitoringTabParamsType = {
 	metrics: [],
 	php: [ 'from', 'to', 'severity' ],
-	web: [ 'from', 'to', 'requestType', 'status' ],
+	web: [ 'from', 'to', 'request_type', 'request_status' ],
 };
 
 export function getPageQueryParam(): SiteMonitoringTab | null {
@@ -80,10 +80,16 @@ export function getQuerySearchForTab( tabName: string ): string {
 
 	const url = new URL( window.location.href );
 
+	const keysToDelete = [];
+
 	url.searchParams.forEach( ( value, key ) => {
 		if ( ! SiteMonitoringTabParams[ tabName ].includes( key ) ) {
-			url.searchParams.delete( key );
+			keysToDelete.push( key );
 		}
+	} );
+
+	keysToDelete.forEach( ( key ) => {
+		url.searchParams.delete( key );
 	} );
 
 	return url.search;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
thelinked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4449

## Proposed Changes

In this PR, I propose to add a Severity filter for PHP error logs and Request Type and Status filters for access logs.

![Screenshot 2023-11-28 at 10 43 21](https://github.com/Automattic/wp-calypso/assets/727413/a05305e1-3285-4bab-beeb-3bd83854620a)

![Screenshot 2023-11-28 at 10 43 31](https://github.com/Automattic/wp-calypso/assets/727413/b5f23750-ea75-4a4d-a658-7ddfc42fb965)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a site with a Business plan
2. Navigate to Settings -> Hosting Configuration and activate hosting features
3. Navigate to Tools -> Site monitoring
4. Confirm that new filter fields in log tabs work fine, that only required parameters are preserved between tabs, check pagination, log auto-refresh and elements flow in different screen sizes

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?