### PR TITLE
Revert "Multi-Domains: Only add plan to mini-cart on mount if it already contains domains"

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -31,7 +31,6 @@ import {
 	hasDomainInCart,
 	planItem,
 	hasPlan,
-	hasDomainRegistration,
 } from 'calypso/lib/cart-values/cart-items';
 import {
 	getDomainProductSlug,
@@ -182,12 +181,8 @@ export class RenderDomainsStep extends Component {
 			);
 		}
 
-		// We add a plan to cart on Multi Domains to show the proper discount on the mini-cart.
-		if (
-			shouldUseMultipleDomainsInCart( this.props.flowName ) &&
-			hasDomainRegistration( this.props.cart )
-		) {
-			// This call is expensive, so we only do it if the mini-cart hasDomainRegistration.
+		// We add a plan to cart on Multi Domains to show the proper discount on the mini-cart
+		if ( shouldUseMultipleDomainsInCart( this.props.flowName ) ) {
 			this.props.shoppingCartManager.addProductsToCart( [ this.props.multiDomainDefaultPlan ] );
 		}
 	}


### PR DESCRIPTION
Reverts Automattic/wp-calypso#84070