### PR TITLE
Fixed magic link flow when there was a transition from email user to wpcom user

### DIFF
--- a/client/login/magic-login/handle-emailed-link-form.jsx
+++ b/client/login/magic-login/handle-emailed-link-form.jsx
@@ -8,6 +8,7 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import EmptyContent from 'calypso/components/empty-content';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
+import WordPressLogo from 'calypso/components/wordpress-logo';
 import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
 import { isGravPoweredOAuth2Client, isWPJobManagerOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { login } from 'calypso/lib/paths';
@@ -252,6 +253,11 @@ class HandleEmailedLinkForm extends Component {
 					/>
 				</div>
 			);
+		}
+
+		// transition is a GET parameter for when the user is transitioning from email user to WPCom user
+		if ( isFetching || transition ) {
+			return <WordPressLogo size={ 72 } className="wpcom-site__logo" />;
 		}
 
 		return (


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/84048

## Proposed Changes

### The Problem

When an email user does certain operations, like confirming a blog subscription, we create an account for them using a magic link. That operation is synchronous and lasts several seconds (something we want to improve in other PR), but it's performed only once per user. The problem was that, during those seconds, the screen showed 3 different things: a white screen, a welcome message that didn't make much sense to the user then, and a WordPress logo in the middle of the screen.

### The Solution 

Instead of seeing those 3 phases, the user will see only one during the whole process: the WordPress logo that we show when loading Calypso.

## Testing Instructions

1. Apply this PR and start the application.
2. In an incognito window, go to a blog you want to subscribe to and enter an email not attached to any WPCom user.
3. Check your mail for the confirmation email. Copy the link in the `Confirm now` button:
<img width="768" alt="Screenshot 2023-11-09 at 21 46 22" src="https://github.com/Automattic/wp-calypso/assets/3832570/44a0dead-737a-453f-84ce-90090faeee1f">
5. From that link, extract the `redirect_to` parameter and change `https://wordpress.com` for `calypso.localhost:3000`.
6. Paste that modified link into the incognito window. You will see the WordPress logo in the middle of the screen for several seconds and then be redirected to the final site.

A good regression test would be testing that login with magic link still works:
1 . With Calypso running in localhost, go to wordpress.com and click Login:
<img width="1066" alt="Screenshot 2023-11-09 at 21 50 39" src="https://github.com/Automattic/wp-calypso/assets/3832570/ac07ddb6-0344-4038-9736-8c41a5c2a53c">
2 . Click on "Email me a login link":
.
<img width="566" alt="Screenshot 2023-11-09 at 21 51 44" src="https://github.com/Automattic/wp-calypso/assets/3832570/01b7ddf3-97d7-4091-8689-099d21e580c9">

4. Enter the email for one of your WPCom accounts and request the link.

5. Check your mail for the confirmation email. Copy the link in the `Login to WordPress.com` button:

<img width="770" alt="Screenshot 2023-11-09 at 21 53 49" src="https://github.com/Automattic/wp-calypso/assets/3832570/0c52f058-b745-4062-a04e-fcbe9024eb4b">

6. From that link, extract the `redirect_to` parameter and change `https://wordpress.com` for `calypso.localhost:3000`.

7. Paste that modified link into the incognito window. You should be logged into Calypso.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?