### PR TITLE
Reader: Add app promo to the reader stream

### DIFF
--- a/client/blocks/app-promo-sidebar/index.jsx
+++ b/client/blocks/app-promo-sidebar/index.jsx
@@ -1,4 +1,5 @@
 import { Gridicon } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
 import { localize, translate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -16,7 +17,7 @@ import './style.scss';
 const noop = () => {};
 
 const getRandomPromo = () => {
-	const desktopAppLink = <span className="app-promo__wp-app-link" />;
+	const desktopAppLink = <span className="app-promo-sidebar__wp-app-link" />;
 
 	const promoOptions = [
 		{
@@ -82,7 +83,9 @@ const getRandomPromo = () => {
 export const getPromoLink = ( location, promoDetails ) => {
 	const { type, promoCode } = promoDetails;
 
-	return `https://apps.wordpress.com/${ type }/?ref=promo_${ location }_${ promoCode }`;
+	return localizeUrl(
+		`https://apps.wordpress.com/${ type }/?ref=promo_${ location }_${ promoCode }`
+	);
 };
 
 export class AppPromoSidebar extends Component {
@@ -127,7 +130,7 @@ export class AppPromoSidebar extends Component {
 
 	dismissButton = () => (
 		<Button
-			className="app-promo__dismiss"
+			className="app-promo-sidebar__dismiss"
 			onClick={ this.dismiss }
 			aria-label={ this.props.translate( 'Dismiss' ) }
 		>
@@ -141,14 +144,20 @@ export class AppPromoSidebar extends Component {
 		return (
 			<Button
 				onClick={ this.recordClickEvent }
-				className="app-promo__link"
+				className="app-promo-sidebar__link"
 				title="Try the desktop app!"
 				href={ this.props.getPromoLink( location, promoItem ) }
 				target="_blank"
 				rel="noopener noreferrer"
 			>
-				<img className="app-promo__icon" src={ wordpressLogoImage } width="32" height="32" alt="" />
-				<p className="app-promo__paragraph">{ promoItem.message }</p>
+				<img
+					className="app-promo-sidebar__icon"
+					src={ wordpressLogoImage }
+					width="32"
+					height="32"
+					alt=""
+				/>
+				<p className="app-promo-sidebar__paragraph">{ promoItem.message }</p>
 			</Button>
 		);
 	};
@@ -160,7 +169,7 @@ export class AppPromoSidebar extends Component {
 			'{{span}}Get the Jetpack app{{/span}} to use Reader anywhere, any time.',
 			{
 				components: {
-					span: <span className="app-promo__jetpack-app-link" />,
+					span: <span className="app-promo-sidebar__jetpack-app-link" />,
 				},
 			}
 		);
@@ -168,20 +177,20 @@ export class AppPromoSidebar extends Component {
 		return (
 			<Button
 				onClick={ this.recordClickEvent }
-				className="app-promo__link"
+				className="app-promo-sidebar__link"
 				title="Try the mobile app!"
 				href={ this.props.getPromoLink( location, promoItem ) }
 				target="_blank"
 				rel="noopener noreferrer"
 			>
 				<img
-					className="app-promo__icon"
+					className="app-promo-sidebar__icon"
 					src={ jetpackLogoImage }
 					width={ 25 }
 					height={ 43 }
 					alt=""
 				/>
-				<p className="app-promo__paragraph">{ message }</p>
+				<p className="app-promo-sidebar__paragraph">{ message }</p>
 			</Button>
 		);
 	};
@@ -192,7 +201,7 @@ export class AppPromoSidebar extends Component {
 		}
 		const { promoItem } = this.state;
 		return (
-			<div className="app-promo">
+			<div className="app-promo-sidebar">
 				{ promoItem.type === 'mobile'
 					? this.mobilePromo( promoItem )
 					: this.desktopPromo( promoItem ) }

--- a/client/blocks/app-promo-sidebar/style.scss
+++ b/client/blocks/app-promo-sidebar/style.scss
@@ -1,4 +1,4 @@
-.app-promo {
+.app-promo-sidebar {
 	align-items: flex-start;
 	display: flex;
 	max-width: 300px;
@@ -12,63 +12,62 @@
 	@include breakpoint-deprecated( "<660px" ) {
 		display: none;
 	}
-}
 
-.app-promo .app-promo__dismiss {
-	cursor: pointer;
-	height: auto;
-	padding: 8px;
-
-	svg {
-		fill: var(--color-text-subtle);
-	}
-}
-
-.app-promo .app-promo__link {
-	height: auto;
-	border-radius: 0;
-	line-height: 1.5;
-	padding: 8px 0 8px 8px;
-	color: var(--color-text);
-	font-size: $font-body-extra-small;
-	font-weight: 400;
-	align-items: flex-start;
-
-	span {
-		font-weight: 700;
-
-		&.app-promo__jetpack-app-link {
-			color: var(--studio-jetpack-green-40);
-			border-bottom: 1.5px solid var(--studio-jetpack-green-40);
-		}
-
-		&.app-promo__wp-app-link {
-			color: var(--color-link);
-			border-bottom: 1.5px solid var(--color-link);
-		}
-	}
-
-	&:active,
-	&:focus,
-	&:hover {
-		color: var(--color-text);
+	.app-promo-sidebar__dismiss {
 		cursor: pointer;
+		height: auto;
+		padding: 8px;
+
+		svg {
+			fill: var(--color-text-subtle);
+		}
+	}
+
+	.app-promo-sidebar__link {
+		height: auto;
+		border-radius: 0;
+		line-height: 1.5;
+		padding: 8px 0 8px 8px;
+		color: var(--color-text);
+		font-size: $font-body-extra-small;
+		font-weight: 400;
+		align-items: flex-start;
 
 		span {
-			border-bottom: none;
+			font-weight: 700;
 
-			&.app-promo__jetpack-app-link {
-				color: var(--studio-jetpack-green-60);
+			&.app-promo-sidebar__jetpack-app-link {
+				color: var(--studio-jetpack-green-40);
+				border-bottom: 1.5px solid var(--studio-jetpack-green-40);
 			}
 
-			&.app-promo__wp-app-link {
-				color: var(--color-link-dark);
+			&.app-promo-sidebar__wp-app-link {
+				color: var(--color-link);
+				border-bottom: 1.5px solid var(--color-link);
+			}
+		}
+
+		&:active,
+		&:focus,
+		&:hover {
+			color: var(--color-text);
+			cursor: pointer;
+
+			span {
+				border-bottom: none;
+
+				&.app-promo-sidebar__jetpack-app-link {
+					color: var(--studio-jetpack-green-60);
+				}
+
+				&.app-promo-sidebar__wp-app-link {
+					color: var(--color-link-dark);
+				}
 			}
 		}
 	}
-}
-
-.app-promo .app-promo__paragraph {
-	margin-bottom: 0;
-	padding: 0 10px;
+	.app-promo-sidebar__paragraph {
+		margin-bottom: 0;
+		padding: 0 10px;
+	}
 }

--- a/client/blocks/app-promo-sidebar/test/index.jsx
+++ b/client/blocks/app-promo-sidebar/test/index.jsx
@@ -31,9 +31,9 @@ describe( 'AppPromoSidebar', () => {
 		test( 'should render the primary components', () => {
 			const { container } = render( AppPromoSidebarComponent );
 
-			expect( container.getElementsByClassName( 'app-promo' ) ).toHaveLength( 1 );
-			expect( container.getElementsByClassName( 'app-promo__dismiss' ) ).toHaveLength( 1 );
-			expect( container.getElementsByClassName( 'app-promo__icon' ) ).toHaveLength( 1 );
+			expect( container.getElementsByClassName( 'app-promo-sidebar' ) ).toHaveLength( 1 );
+			expect( container.getElementsByClassName( 'app-promo-sidebar__dismiss' ) ).toHaveLength( 1 );
+			expect( container.getElementsByClassName( 'app-promo-sidebar__icon' ) ).toHaveLength( 1 );
 		} );
 
 		test( 'should render the promo text', () => {
@@ -47,7 +47,7 @@ describe( 'AppPromoSidebar', () => {
 		test( 'should render the promo link', () => {
 			const { container } = render( AppPromoSidebarComponent );
 
-			const promoLink = container.getElementsByClassName( 'app-promo__link' );
+			const promoLink = container.getElementsByClassName( 'app-promo-sidebar__link' );
 			expect( promoLink ).toHaveLength( 1 );
 			expect( promoLink[ 0 ].getAttribute( 'href' ) ).toBe( appPromoSidebarLink );
 		} );

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -6,6 +6,7 @@ import { createRef, Component, Fragment } from 'react';
 import * as React from 'react';
 import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
+import AppPromo from 'calypso/blocks/app-promo';
 import InfiniteList from 'calypso/components/infinite-list';
 import ListEnd from 'calypso/components/list-end';
 import SectionNav from 'calypso/components/section-nav';
@@ -418,6 +419,23 @@ class ReaderStream extends Component {
 		} );
 	};
 
+	renderAppPromo = ( index ) => {
+		// Only show it once in the 4th position.
+		if ( index !== 3 ) {
+			return;
+		}
+		return (
+			<AppPromo
+				iconSize={ 40 }
+				campaign="reader-stream"
+				title={ this.props.translate( 'Get the Jetpack App' ) }
+				subheader={ this.props.translate( 'Discover more blogs on the go' ) }
+				hasQRCode={ true }
+				hasGetAppButton={ false }
+			/>
+		);
+	};
+
 	getPostRef = ( postKey ) => {
 		return keyToString( postKey );
 	};
@@ -436,6 +454,7 @@ class ReaderStream extends Component {
 
 		return (
 			<Fragment key={ itemKey }>
+				{ this.renderAppPromo( index ) }
 				<PostLifecycle
 					ref={ itemKey /* The ref is stored into `InfiniteList`'s `this.ref` map */ }
 					isSelected={ isSelected }

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -430,7 +430,7 @@ class ReaderStream extends Component {
 			isDiscoverStream && (
 				<AppPromo
 					iconSize={ 40 }
-					campaign="reader-stream"
+					campaign="calypso-reader-stream"
 					title={ this.props.translate( 'Read on the go with the Jetpack Mobile App' ) }
 					hasQRCode={ true }
 					hasGetAppButton={ false }

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -420,18 +420,22 @@ class ReaderStream extends Component {
 	};
 
 	renderAppPromo = ( index ) => {
+		const { isDiscoverStream } = this.props;
 		// Only show it once in the 4th position.
 		if ( index !== 3 ) {
 			return;
 		}
+
 		return (
-			<AppPromo
-				iconSize={ 40 }
-				campaign="reader-stream"
-				title={ this.props.translate( 'Read on the go with the Jetpack Mobile App' ) }
-				hasQRCode={ true }
-				hasGetAppButton={ false }
-			/>
+			isDiscoverStream && (
+				<AppPromo
+					iconSize={ 40 }
+					campaign="reader-stream"
+					title={ this.props.translate( 'Read on the go with the Jetpack Mobile App' ) }
+					hasQRCode={ true }
+					hasGetAppButton={ false }
+				/>
+			)
 		);
 	};
 

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -428,8 +428,7 @@ class ReaderStream extends Component {
 			<AppPromo
 				iconSize={ 40 }
 				campaign="reader-stream"
-				title={ this.props.translate( 'Get the Jetpack App' ) }
-				subheader={ this.props.translate( 'Discover more blogs on the go' ) }
+				title={ this.props.translate( 'Read on the go with the Jetpack Mobile App' ) }
 				hasQRCode={ true }
 				hasGetAppButton={ false }
 			/>

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -607,13 +607,38 @@
 		width: 100%;
 
 		.app-promo {
-			background-color: #f0f2eb;
 			border-radius: 6px; /* stylelint-disable-line scales/radii */
-			box-shadow: none;
-			border-bottom: 1px solid #e9e9ea;
+			background-color: transparent;
+
+			.app-promo__qr-code {
+				margin: -10px 0 0;
+				flex-direction: row-reverse;
+			}
+
+			.get-apps__card-text {
+				padding: 0;
+			}
+			.app-promo__qr-code-canvas {
+				margin-left: 16px;
+			}
 
 			.app-promo__title {
-				margin-bottom: 0;
+				font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
+			}
+
+			@include break-medium {
+				.app-promo__qr-code {
+					margin: -20px 0 0;
+				}
+
+				.app-promo__qr-code-canvas {
+					margin-top: -10px;
+				}
+
+				.app-promo__title {
+					margin-bottom: 0;
+					margin-right: 110px;
+				}
 			}
 		}
 	}

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -605,6 +605,17 @@
 
 	.stream__list {
 		width: 100%;
+
+		.app-promo {
+			background-color: #f0f2eb;
+			border-radius: 6px; /* stylelint-disable-line scales/radii */
+			box-shadow: none;
+			border-bottom: 1px solid #e9e9ea;
+
+			.app-promo__title {
+				margin-bottom: 0;
+			}
+		}
 	}
 }
 
@@ -925,3 +936,4 @@
 .is-site-stream .stream__two-column .stream__right-column {
 	margin-top: 0;
 }
+


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/83330

## Proposed Changes
This PR adds the AppPromo to the reader Steam. 

See
<img width="300" alt="Screenshot 2023-11-10 at 11 27 18 AM" src="https://github.com/Automattic/wp-calypso/assets/115071/1e801bec-b769-49dc-a8d8-0e0539bc54ca">
<img width="300" alt="Screenshot 2023-11-10 at 11 29 10 AM" src="https://github.com/Automattic/wp-calypso/assets/115071/f35ffe64-522d-48a3-9649-17304055c2ca">


## Testing Instructions

Logged out and logged in visit the reader. Notice the new App Promo. 
Resize it. Does it look as expected?

Request the page as a iPhone user Does it look as expected? 
Request the page as an Android user does it look as expected?

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or

 use (p4TIVU-ajp-p2)?