### PR TITLE
Fix: jetpack app domain managment top spacing

### DIFF
--- a/client/my-sites/domains/domain-management/settings/style.scss
+++ b/client/my-sites/domains/domain-management/settings/style.scss
@@ -198,6 +198,14 @@ body.edit__body-white.theme-default.color-scheme {
 	}
 }
 
-.is-mobile-app-view .domain-settings-page .breadcrumbs-back {
-	display: none;
+.is-mobile-app-view {
+	&.is-section-domains .focus-content:not(.has-no-sidebar) .layout__content {
+		padding-top: 0;
+	}
+	.domain-settings-page {
+		.navigation-header,
+		.breadcrumbs-back {
+			display: none;
+		}
+	}
 }


### PR DESCRIPTION
Related to pcdRpT-3PI-p2#comment-6374

This Pr removes the top header form the Jetpack mobile app. 

Before:
<img width="300" alt="Screenshot 2023-11-09 at 5 29 10 PM" src="https://github.com/Automattic/wp-calypso/assets/115071/640a904b-fe5e-4882-916a-83a2ad0adcf5">


After:
<img width="300" alt="Screenshot 2023-11-09 at 5 28 41 PM" src="https://github.com/Automattic/wp-calypso/assets/115071/ab80d1df-0dd0-4352-b09c-cf77754d97b0">

## Proposed Changes
* Remove the header using target CSS. 

## Testing Instructions
1. Set the user agent to match the Jetpack app webview. `Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/16B91 wp-iphone/12.1`
2. Navigate to a domain screen. 
3. Notice that it doesn't have the empty space at the top of the page.

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?