### PR TITLE
Stats: Remove single bar shortcuts

### DIFF
--- a/client/components/stats-date-control/index.tsx
+++ b/client/components/stats-date-control/index.tsx
@@ -22,20 +22,6 @@ const StatsDateControl = ( { slug, queryParams, dateRange }: StatsDateControlPro
 
 	const shortcutList = [
 		{
-			id: 'today',
-			label: translate( 'Today' ),
-			offset: 0,
-			range: 0,
-			period: 'day',
-		},
-		{
-			id: 'yesterday',
-			label: translate( 'Yesterday' ),
-			offset: 1,
-			range: 0,
-			period: 'day',
-		},
-		{
 			id: 'last-7-days',
 			label: translate( 'Last 7 Days' ),
 			offset: 0,
@@ -48,6 +34,13 @@ const StatsDateControl = ( { slug, queryParams, dateRange }: StatsDateControlPro
 			offset: 0,
 			range: 29,
 			period: 'day',
+		},
+		{
+			id: 'last-3-months',
+			label: translate( 'Last 90 Days' ),
+			offset: 0,
+			range: 89,
+			period: 'week',
 		},
 		{
 			id: 'last-year',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #84082

## Proposed Changes

* remove `Today` and `Yesterday` shortcuts
* add `Last 90 Days` shortcut showing the period as weeks

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to live branch
* open the date picker and verify that the shortcuts don't list `today` and `yesterday`
* verify that the new option for last 90 days is available
* verify that the shortcuts work

| Before | After |
| --- | --- |
| <img width="552" alt="SCR-20231110-lxzp" src="https://github.com/Automattic/wp-calypso/assets/112354940/f341e8e4-1f79-4df5-81f8-c827eb2ae29a"> | <img width="561" alt="SCR-20231110-lxvr" src="https://github.com/Automattic/wp-calypso/assets/112354940/4f7b165e-d9ca-4786-b823-9a2c51ff6bfc"> |


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?