### PR TITLE
Jetpack Manage: host column enhancements in dashboard

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/hooks/use-default-site-columns.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/hooks/use-default-site-columns.tsx
@@ -12,7 +12,7 @@ type SiteColumn = {
 	showInfo?: boolean;
 };
 
-const useDefaultSiteColumns = (): SiteColumns => {
+const useDefaultSiteColumns = ( isLargeScreen = false ): SiteColumns => {
 	const translate = useTranslate();
 	const isBoostEnabled = isEnabled( 'jetpack/pro-dashboard-jetpack-boost' );
 	const isPaidMonitorEnabled = isEnabled( 'jetpack/pro-dashboard-monitor-paid-tier' );
@@ -35,13 +35,14 @@ const useDefaultSiteColumns = (): SiteColumns => {
 		return [
 			{
 				key: 'site',
-				title: isWPCOMAtomicSiteCreationEnabled
-					? ( translate( '{{div}}Host{{/div}} Site', {
-							components: {
-								div: <div className="fixed-host-column" />,
-							},
-					  } ) as string )
-					: translate( 'Site' ),
+				title:
+					isWPCOMAtomicSiteCreationEnabled && isLargeScreen
+						? ( translate( '{{div}}Host{{/div}} Site', {
+								components: {
+									div: <div className="site-host-info" />,
+								},
+						  } ) as string )
+						: translate( 'Site' ),
 				isSortable: true,
 			},
 			{
@@ -77,7 +78,13 @@ const useDefaultSiteColumns = (): SiteColumns => {
 				className: 'width-fit-content',
 			},
 		];
-	}, [ isBoostEnabled, isPaidMonitorEnabled, isWPCOMAtomicSiteCreationEnabled, translate ] );
+	}, [
+		isBoostEnabled,
+		isPaidMonitorEnabled,
+		isWPCOMAtomicSiteCreationEnabled,
+		translate,
+		isLargeScreen,
+	] );
 };
 
 export default useDefaultSiteColumns;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/index.tsx
@@ -16,6 +16,7 @@ import SiteErrorContent from '../site-error-content';
 import SiteExpandedContent from '../site-expanded-content';
 import SitePhpVersion from '../site-expanded-content/site-php-version';
 import SiteStatusContent from '../site-status-content';
+import { SiteHostInfo } from '../site-status-content/site-host-info';
 import type { SiteData, SiteColumns, AllowedTypes } from '../types';
 
 import './style.scss';
@@ -169,6 +170,7 @@ export default function SiteCard( { rows, columns }: Props ) {
 								);
 							}
 						} ) }
+					<SiteHostInfo site={ rows.site.value } />
 					<div className="site-card__expanded-content-list site-card__content-list-no-error">
 						<SitePhpVersion phpVersion={ rows.site.value.php_version_num } />
 					</div>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/style.scss
@@ -78,6 +78,7 @@
 			max-width: 250px;
 			overflow: hidden;
 			text-overflow: ellipsis;
+			white-space: nowrap;
 		}
 	}
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/style.scss
@@ -1,3 +1,5 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
 
 .site-card__card-toggle-icon {
 	vertical-align: middle;
@@ -58,6 +60,27 @@
 	top: 50%;
 	transform: translateY(-50%);
 	display: flex;
+
+	.site-host-info {
+		display: inline-flex;
+		justify-content: end;
+		margin-inline-end: 0;
+	}
+
+	.site-host-info__plan-name {
+		font-size: 0.875rem;
+		text-wrap: nowrap;
+		margin-inline-start: 8px;
+		display: none;
+
+		@include break-mobile {
+			display: inline-block;
+			max-width: 200px;
+			overflow: hidden;
+			text-overflow: ellipsis;
+		}
+	}
+
 }
 
 .site-card__actions-small-screen {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-card/style.scss
@@ -75,7 +75,7 @@
 
 		@include break-mobile {
 			display: inline-block;
-			max-width: 200px;
+			max-width: 250px;
 			overflow: hidden;
 			text-overflow: ellipsis;
 		}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/index.tsx
@@ -47,7 +47,7 @@ const SiteContent = ( { data, isLoading, currentPage, isFavoritesTab }: Props, r
 		addPageArgs( pageNumber );
 	};
 
-	const siteColumns = useDefaultSiteColumns();
+	const siteColumns = useDefaultSiteColumns( isLargeScreen );
 	const firstColumn = siteColumns[ 0 ];
 
 	return (

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/hooks/use-wp-plan-name.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/hooks/use-wp-plan-name.ts
@@ -1,0 +1,35 @@
+import {
+	PLAN_BUSINESS,
+	PLAN_ECOMMERCE,
+	PLAN_PREMIUM,
+	PLAN_PERSONAL,
+} from '@automattic/calypso-products';
+import { useTranslate } from 'i18n-calypso';
+
+const useWPPlanName = ( plans: Array< string > ) => {
+	const translate = useTranslate();
+
+	const getPlanName = () => {
+		for ( const plan of plans ) {
+			switch ( true ) {
+				// Plans could be either monthly, 1 year, 2 years, or 3 years.
+				// So we need to check if the plan starts with the plan slug.
+				case plan.startsWith( PLAN_BUSINESS ):
+					return translate( 'WordPress.com Business Plan' );
+				case plan.startsWith( PLAN_ECOMMERCE ):
+					return translate( 'WordPress.com Commerce Plan' );
+				case plan.startsWith( PLAN_PREMIUM ):
+					return translate( 'WordPress.com Premium Plan' );
+				case plan.startsWith( PLAN_PERSONAL ):
+					return translate( 'WordPress.com Personal Plan' );
+				default:
+					return '';
+			}
+		}
+		return '';
+	};
+
+	return getPlanName();
+};
+
+export default useWPPlanName;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-host-info.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-host-info.tsx
@@ -1,0 +1,52 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { WordPressLogo } from '@automattic/components';
+import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import useWPPlanName from './hooks/use-wp-plan-name';
+import type { Site } from '../types';
+
+export const SiteHostInfo = ( {
+	site,
+	isLargeScreen = false,
+}: {
+	site: Site;
+	isLargeScreen?: boolean;
+} ) => {
+	const translate = useTranslate();
+
+	const isWPCOMAtomicSiteCreationEnabled = isEnabled(
+		'jetpack/pro-dashboard-wpcom-atomic-hosting'
+	);
+
+	const isWPCOMAtomicSite = site.is_atomic;
+
+	const planName = useWPPlanName( site.active_paid_subscription_slugs );
+
+	return (
+		isWPCOMAtomicSiteCreationEnabled &&
+		( isLargeScreen ? (
+			<div className="site-host-info">
+				<WordPressLogo
+					className={ classNames( 'wordpress-logo', { 'is-visible': isWPCOMAtomicSite } ) }
+					size={ 18 }
+				/>
+			</div>
+		) : (
+			isWPCOMAtomicSite && (
+				<div className="site-card__expanded-content-list site-card__content-list-no-error">
+					<div className="site-card__expanded-content-header">
+						<span className="site-card__expanded-content-key">{ translate( 'Host' ) }</span>
+						<span className="site-card__expanded-content-value">
+							<span className="site-card__expanded-content-status">
+								<div className="site-host-info">
+									<WordPressLogo className="wordpress-logo is-visible" size={ 18 } />
+								</div>
+								{ planName && <span className="site-host-info__plan-name">{ planName }</span> }
+							</span>
+						</span>
+					</div>
+				</div>
+			)
+		) )
+	);
+};

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-host-info.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-host-info.tsx
@@ -26,7 +26,7 @@ export const SiteHostInfo = ( {
 
 	const isWPCOMAtomicSite = site.is_atomic;
 
-	const planName = useWPPlanName( site.active_paid_subscription_slugs );
+	const planName = useWPPlanName( site.active_paid_subscription_slugs ?? [] );
 
 	const props = {
 		className: 'site-host-info',
@@ -40,9 +40,12 @@ export const SiteHostInfo = ( {
 		} ),
 	};
 
-	return (
-		isWPCOMAtomicSiteCreationEnabled &&
-		( isLargeScreen ? (
+	if ( ! isWPCOMAtomicSiteCreationEnabled ) {
+		return null;
+	}
+
+	if ( isLargeScreen ) {
+		return (
 			<>
 				<div { ...props }>
 					<WordPressLogo
@@ -54,22 +57,23 @@ export const SiteHostInfo = ( {
 					{ planName }
 				</Tooltip>
 			</>
-		) : (
-			isWPCOMAtomicSite && (
-				<div className="site-card__expanded-content-list site-card__content-list-no-error">
-					<div className="site-card__expanded-content-header">
-						<span className="site-card__expanded-content-key">{ translate( 'Host' ) }</span>
-						<span className="site-card__expanded-content-value">
-							<span className="site-card__expanded-content-status">
-								<div className="site-host-info">
-									<WordPressLogo className="wordpress-logo is-visible" size={ 18 } />
-								</div>
-								{ planName && <span className="site-host-info__plan-name">{ planName }</span> }
-							</span>
+		);
+	} else if ( isWPCOMAtomicSite ) {
+		return (
+			<div className="site-card__expanded-content-list site-card__content-list-no-error">
+				<div className="site-card__expanded-content-header">
+					<span className="site-card__expanded-content-key">{ translate( 'Host' ) }</span>
+					<span className="site-card__expanded-content-value">
+						<span className="site-card__expanded-content-status">
+							<div className="site-host-info">
+								<WordPressLogo className="wordpress-logo is-visible" size={ 18 } />
+							</div>
+							{ planName && <span className="site-host-info__plan-name">{ planName }</span> }
 						</span>
-					</div>
+					</span>
 				</div>
-			)
-		) )
-	);
+			</div>
+		);
+	}
+	return null;
 };

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-host-info.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-host-info.tsx
@@ -2,6 +2,8 @@ import { isEnabled } from '@automattic/calypso-config';
 import { WordPressLogo } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
+import { useRef, useState } from 'react';
+import Tooltip from 'calypso/components/tooltip';
 import useWPPlanName from './hooks/use-wp-plan-name';
 import type { Site } from '../types';
 
@@ -14,6 +16,10 @@ export const SiteHostInfo = ( {
 } ) => {
 	const translate = useTranslate();
 
+	const [ showPopover, setShowPopover ] = useState( false );
+
+	const ref = useRef< HTMLDivElement | null >( null );
+
 	const isWPCOMAtomicSiteCreationEnabled = isEnabled(
 		'jetpack/pro-dashboard-wpcom-atomic-hosting'
 	);
@@ -22,15 +28,32 @@ export const SiteHostInfo = ( {
 
 	const planName = useWPPlanName( site.active_paid_subscription_slugs );
 
+	const props = {
+		className: 'site-host-info',
+		...( isWPCOMAtomicSite && {
+			ref,
+			role: 'button',
+			tabIndex: 0,
+			onMouseEnter: () => setShowPopover( true ),
+			onMouseLeave: () => setShowPopover( false ),
+			onMouseDown: () => setShowPopover( false ),
+		} ),
+	};
+
 	return (
 		isWPCOMAtomicSiteCreationEnabled &&
 		( isLargeScreen ? (
-			<div className="site-host-info">
-				<WordPressLogo
-					className={ classNames( 'wordpress-logo', { 'is-visible': isWPCOMAtomicSite } ) }
-					size={ 18 }
-				/>
-			</div>
+			<>
+				<div { ...props }>
+					<WordPressLogo
+						className={ classNames( 'wordpress-logo', { 'is-visible': isWPCOMAtomicSite } ) }
+						size={ 18 }
+					/>
+				</div>
+				<Tooltip context={ ref.current } isVisible={ showPopover }>
+					{ planName }
+				</Tooltip>
+			</>
 		) : (
 			isWPCOMAtomicSite && (
 				<div className="site-card__expanded-content-list site-card__content-list-no-error">

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-name-column.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-name-column.tsx
@@ -1,5 +1,4 @@
-import { isEnabled } from '@automattic/calypso-config';
-import { Button, Gridicon, WordPressLogo } from '@automattic/components';
+import { Button, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { useContext } from 'react';
 import { useDispatch } from 'calypso/state';
@@ -9,6 +8,7 @@ import SiteBackupStaging from '../site-backup-staging';
 import SiteSelectCheckbox from '../site-select-checkbox';
 import SiteSetFavorite from '../site-set-favorite';
 import { RowMetaData, SiteData } from '../types';
+import { SiteHostInfo } from './site-host-info';
 
 type Props = {
 	rows: SiteData;
@@ -33,13 +33,8 @@ export default function SiteNameColumn( {
 
 	const { link, isExternalLink, tooltip } = metadata;
 
-	const isWPCOMAtomicSiteCreationEnabled = isEnabled(
-		'jetpack/pro-dashboard-wpcom-atomic-hosting'
-	);
-
 	const siteId = rows.site.value.blog_id;
 	const siteUrl = rows.site.value.url;
-	const isWPCOMAtomicSite = rows.site.value.is_atomic;
 
 	// Site issues is the sum of scan threats and plugin updates
 	let siteIssuesCount = rows.scan.threats + rows.plugin.updates;
@@ -72,15 +67,6 @@ export default function SiteNameColumn( {
 		);
 	}
 
-	const WPCOMHostedSiteBadgeColumn = isWPCOMAtomicSiteCreationEnabled && (
-		<div className="fixed-host-column">
-			<WordPressLogo
-				className={ classNames( 'wordpress-logo', { 'is-visible': isWPCOMAtomicSite } ) }
-				size={ 18 }
-			/>
-		</div>
-	);
-
 	const handleSiteClick = () => {
 		dispatch( recordTracksEvent( 'calypso_jetpack_agency_dashboard_site_link_click' ) );
 	};
@@ -111,14 +97,13 @@ export default function SiteNameColumn( {
 					target={ isExternalLink ? '_blank' : undefined }
 					onClick={ handleSiteClick }
 				>
-					{ WPCOMHostedSiteBadgeColumn }
+					<SiteHostInfo isLargeScreen site={ rows.site.value } />
 					{ siteUrl }
 					<SiteBackupStaging siteId={ siteId } />
 				</Button>
 			) : (
 				<>
 					<span className="sites-overview__row-text">
-						{ WPCOMHostedSiteBadgeColumn }
 						{ siteUrl } <SiteBackupStaging siteId={ siteId } />
 					</span>
 				</>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -283,8 +283,8 @@
 	}
 }
 
-.fixed-host-column {
-	display: none;
+.site-host-info {
+	display: inline-block;
 	margin-inline-end: 10px;
 	min-width: 40px;
 	text-align: center;
@@ -298,10 +298,6 @@
 		&.is-visible {
 			visibility: visible;
 		}
-	}
-
-	@include break-wide {
-		display: inline-block;
 	}
 }
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -98,6 +98,7 @@ export interface Site {
 	has_paid_agency_monitor: boolean;
 	is_atomic: boolean;
 	has_pending_boost_one_time_score: boolean;
+	active_paid_subscription_slugs: Array< string >;
 }
 export interface SiteNode {
 	value: Site;


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-manage/issues/64


## Proposed Changes

This PR:

- Shows the plan name when hovering over the WordPress icon on large screens
- Hides the host when switching to a small screen & shows the host info in the expanded view along with the active WordPress plan.

## Testing Instructions

- Apply patch: D128362-code
- Open the Jetpack Live link
- Visit /dashboard> Verify the host column shows the WordPress icon & hovering over it shows the active WordPress plan.

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="483" alt="Screenshot 2023-11-10 at 10 55 25 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/9b8f1ea2-b26a-4c50-9997-fcf75c302b8e">
</td>
<td>
<img width="485" alt="Screenshot 2023-11-10 at 10 55 15 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/f5321458-1631-405e-91ce-36a2c0806e85">
</td>
</tr>
</table>

- Switch to small screen view(1280px) > Verify that the host column is hidden and shows the host information in the expanded view

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="922" alt="Screenshot 2023-11-10 at 10 53 45 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/c6d883a1-1808-44e8-ad09-d9eb5fa4a5af">
</td>
<td>
<img width="922" alt="Screenshot 2023-11-10 at 10 54 16 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/48fc99f9-1591-425b-a6ac-f55f2f00009f">
</td>
</tr>
</table>

- Switch the mobile view(375px) > Verify that the host info is shown in the expanded view(now, without the plan name). This is done since we don't have enough space.

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="283" alt="Screenshot 2023-11-10 at 10 52 19 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/ef4460b3-55a4-4527-9cec-be560d33d16b">
</td>
<td>
<img width="283" alt="Screenshot 2023-11-10 at 10 52 11 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/e070114d-d3c0-4db4-a32c-cc590917ebd7">
</td>
</tr>
</table>


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?