### PR TITLE
Reduce amount of products lookedup on page load for domains onboarding step

### DIFF
--- a/client/components/data/query-products-list/index.jsx
+++ b/client/components/data/query-products-list/index.jsx
@@ -16,13 +16,23 @@ const request =
 		dispatch( requestProductsList( props ) );
 	};
 
-export function useQueryProductsList( { type = 'all', currency, persist } = {} ) {
+/**
+ *
+ * @param {Object} props 			The list of component props.
+ * @param {string} [props.type] 	The type of products to request:
+ *									"jetpack" for Jetpack products only, or undefined for all products.
+ * @param {string} [props.currency] The currency code to override the currency used on the account.
+ * @param {boolean} [props.persist] Set to true to persist the products list in the store.
+ * @param {string} [props.product_slugs] A comma-separated list of product to return. If not specified all products are returned.
+ * @returns {null} 					No visible output.
+ */
+export function useQueryProductsList( { type = 'all', currency, persist, product_slugs } = {} ) {
 	const dispatch = useDispatch();
 
 	// Only runs on mount.
 	useEffect( () => {
-		dispatch( request( { type, currency, persist } ) );
-	}, [ dispatch, type, persist, currency ] );
+		dispatch( request( { type, currency, persist, product_slugs } ) );
+	}, [ dispatch, type, persist, currency, product_slugs ] );
 
 	return null;
 }
@@ -34,8 +44,9 @@ export function useQueryProductsList( { type = 'all', currency, persist } = {} )
  *									"jetpack" for Jetpack products only, or undefined for all products.
  * @param {string} [props.currency] The currency code to override the currency used on the account.
  * @param {boolean} [props.persist] Set to true to persist the products list in the store.
+ * @param {string} [props.product_slugs] A comma-separated list of product to return. If not specified all products are returned.
  * @returns {null} 					No visible output.
  */
-export default function QueryProductsList( { type = 'all', currency, persist } ) {
-	return useQueryProductsList( { type, currency, persist } );
+export default function QueryProductsList( { type = 'all', currency, persist, product_slugs } ) {
+	return useQueryProductsList( { type, currency, persist, product_slugs } );
 }

--- a/client/components/data/query-products-list/index.jsx
+++ b/client/components/data/query-products-list/index.jsx
@@ -23,16 +23,16 @@ const request =
  *									"jetpack" for Jetpack products only, or undefined for all products.
  * @param {string} [props.currency] The currency code to override the currency used on the account.
  * @param {boolean} [props.persist] Set to true to persist the products list in the store.
- * @param {string} [props.product_slugs] A comma-separated list of product to return. If not specified all products are returned.
+ * @param {string} [props.productSlugs] A comma-separated list of product to return. If not specified all products are returned.
  * @returns {null} 					No visible output.
  */
-export function useQueryProductsList( { type = 'all', currency, persist, product_slugs } = {} ) {
+export function useQueryProductsList( { type = 'all', currency, persist, productSlugs } = {} ) {
 	const dispatch = useDispatch();
 
 	// Only runs on mount.
 	useEffect( () => {
-		dispatch( request( { type, currency, persist, product_slugs } ) );
-	}, [ dispatch, type, persist, currency, product_slugs ] );
+		dispatch( request( { type, currency, persist, product_slugs: productSlugs } ) );
+	}, [ dispatch, type, persist, currency, productSlugs ] );
 
 	return null;
 }
@@ -44,9 +44,9 @@ export function useQueryProductsList( { type = 'all', currency, persist, product
  *									"jetpack" for Jetpack products only, or undefined for all products.
  * @param {string} [props.currency] The currency code to override the currency used on the account.
  * @param {boolean} [props.persist] Set to true to persist the products list in the store.
- * @param {string} [props.product_slugs] A comma-separated list of product to return. If not specified all products are returned.
+ * @param {string} [props.productSlugs] A comma-separated list of product to return. If not specified all products are returned.
  * @returns {null} 					No visible output.
  */
-export default function QueryProductsList( { type = 'all', currency, persist, product_slugs } ) {
-	return useQueryProductsList( { type, currency, persist, product_slugs } );
+export default function QueryProductsList( { type = 'all', currency, persist, productSlugs } ) {
+	return useQueryProductsList( { type, currency, persist, productSlugs } );
 }

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1349,8 +1349,7 @@ class RegisterDomainStep extends Component {
 	}
 
 	renderExampleSuggestions() {
-		const { isReskinned, domainsWithPlansOnly, offerUnavailableOption, products, path } =
-			this.props;
+		const { isReskinned, offerUnavailableOption } = this.props;
 
 		if ( isReskinned ) {
 			return this.renderBestNamesPrompt();
@@ -1358,11 +1357,7 @@ class RegisterDomainStep extends Component {
 
 		return (
 			<ExampleDomainSuggestions
-				domainsWithPlansOnly={ domainsWithPlansOnly }
 				offerUnavailableOption={ offerUnavailableOption }
-				onClickExampleSuggestion={ this.handleClickExampleSuggestion }
-				path={ path }
-				products={ products }
 				url={ this.getUseYourDomainUrl() }
 			/>
 		);

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -29,7 +29,6 @@ import {
 	getDomainRegistrations,
 	updatePrivacyForDomain,
 	hasDomainInCart,
-	planItem,
 	hasPlan,
 	hasDomainRegistration,
 } from 'calypso/lib/cart-values/cart-items';
@@ -1386,7 +1385,12 @@ export class RenderDomainsStep extends Component {
 				fallbackHeaderText={ headerText }
 				fallbackSubHeaderText={ fallbackSubHeaderText }
 				shouldHideNavButtons={ this.shouldHideNavButtons() }
-				stepContent={ <div>{ this.renderContent() }</div> }
+				stepContent={
+					<div>
+						<QueryProductsList type="domains" />
+						{ this.renderContent() }
+					</div>
+				}
 				allowBackFirstStep={ !! backUrl }
 				backLabelText={ backLabelText }
 				hideSkip={ true }
@@ -1436,7 +1440,7 @@ const RenderDomainsStepConnect = connect(
 		const productsLoaded = ! isEmpty( productsList );
 		const isPlanStepSkipped = isPlanStepExistsAndSkipped( state );
 		const selectedSite = getSelectedSite( state );
-		const multiDomainDefaultPlan = planItem( PLAN_PERSONAL );
+		const multiDomainDefaultPlan = { product_slug: PLAN_PERSONAL };
 
 		return {
 			designType: getDesignType( state ),
@@ -1472,7 +1476,6 @@ const RenderDomainsStepConnect = connect(
 export default function DomainsStep( props ) {
 	return (
 		<CalypsoShoppingCartProvider>
-			<QueryProductsList productSlugs="personal-bundle" />
 			<RenderDomainsStepConnect { ...props } />
 		</CalypsoShoppingCartProvider>
 	);

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1386,12 +1386,7 @@ export class RenderDomainsStep extends Component {
 				fallbackHeaderText={ headerText }
 				fallbackSubHeaderText={ fallbackSubHeaderText }
 				shouldHideNavButtons={ this.shouldHideNavButtons() }
-				stepContent={
-					<div>
-						<QueryProductsList />
-						{ this.renderContent() }
-					</div>
-				}
+				stepContent={ <div>{ this.renderContent() }</div> }
 				allowBackFirstStep={ !! backUrl }
 				backLabelText={ backLabelText }
 				hideSkip={ true }
@@ -1477,6 +1472,7 @@ const RenderDomainsStepConnect = connect(
 export default function DomainsStep( props ) {
 	return (
 		<CalypsoShoppingCartProvider>
+			<QueryProductsList productSlugs="personal-bundle" />
 			<RenderDomainsStepConnect { ...props } />
 		</CalypsoShoppingCartProvider>
 	);


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/4213

## Proposed Changes

* Attempt at reducing the size/cost of the /products api call on page load for domains.
* Ultimately I'm not seeing any real benefit here but wanted to see if anyone else could see a way to make this work.

## Testing Instructions

* Domains multi select should work as previously
* Other domains pages should work as previously https://github.com/Automattic/wp-calypso/pull/84035#pullrequestreview-1721851666
