### PR TITLE
BBE: update the new/existing step for the store flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/difm-starting-point/index.tsx
@@ -1,3 +1,4 @@
+import { PLAN_PREMIUM } from '@automattic/calypso-products';
 import { StepContainer } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -33,6 +34,7 @@ const DIFMStartingPoint: Step = function ( { navigation } ) {
 						onPrimarySubmit={ onSubmit }
 						showNewOrExistingSiteChoice={ false }
 						siteId={ siteId }
+						planSlug={ PLAN_PREMIUM }
 					/>
 				}
 				recordTracksEvent={ recordTracksEvent }

--- a/client/signup/steps/new-or-existing-site/index.tsx
+++ b/client/signup/steps/new-or-existing-site/index.tsx
@@ -1,3 +1,4 @@
+import { PLAN_BUSINESS, PLAN_PREMIUM } from '@automattic/calypso-products';
 import { useEffect } from 'react';
 import difmImage from 'calypso/assets/images/difm/difm.svg';
 import DIFMLanding from 'calypso/my-sites/marketing/do-it-for-me/difm-landing';
@@ -6,7 +7,7 @@ import StepWrapper from 'calypso/signup/step-wrapper';
 import { useDispatch } from 'calypso/state';
 import { removeSiteSlugDependency } from 'calypso/state/signup/actions';
 import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
-import { ChoiceType } from './types';
+import type { ChoiceType } from './types';
 
 import './style.scss';
 
@@ -22,7 +23,7 @@ interface Props {
 export default function NewOrExistingSiteStep( props: Props ) {
 	const dispatch = useDispatch();
 
-	const { stepName, goToNextStep, existingSiteCount } = props;
+	const { stepName, goToNextStep, existingSiteCount, flowName } = props;
 
 	useEffect( () => {
 		dispatch( saveSignupStep( { stepName } ) );
@@ -49,6 +50,7 @@ export default function NewOrExistingSiteStep( props: Props ) {
 	};
 
 	const showNewOrExistingSiteChoice = existingSiteCount > 0;
+	const planSlug = 'do-it-for-me-store' === flowName ? PLAN_BUSINESS : PLAN_PREMIUM;
 
 	return (
 		<StepWrapper
@@ -61,6 +63,7 @@ export default function NewOrExistingSiteStep( props: Props ) {
 					}
 					onSecondarySubmit={ () => newOrExistingSiteSelected( 'new-site' ) }
 					showNewOrExistingSiteChoice={ showNewOrExistingSiteChoice }
+					planSlug={ planSlug }
 				/>
 			}
 			hideFormattedHeader={ true }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1699548253984269-slack-C02KVCAL7GX

## Proposed Changes

* Show the Business plan details instead of the Premium plan details when in the store flow.
* This includes the plan title, cost and storage available.

### Screenshots

#### Store flow
<img width="722" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/ab67ccad-5043-42aa-af40-92cd4382b03f">
<img width="1308" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/861cf5bd-5850-4f46-8763-a4e8f4b54c3a">

#### Regular flow
<img width="712" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/719641cf-2c9f-4dc1-82d2-c24d8e0a3246">
<img width="1325" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/3405e790-b45b-48b9-958c-be4dd89617bc">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/do-it-for-me-store`.
* Confirm that the subheading mentions the `Business` plan.
* Confirm that the 2nd FAQ item mentions the Business plan and correctly shows the cost, and storage for the plan.

-----

* Go to `/start/do-it-for-me`.
* Confirm that the subheading mentions the `Premium` plan.
* Confirm that the 2nd FAQ item mentions the Premium plan and correctly shows the cost, and storage for the plan.

-----

* Go to `/setup/site-setup/difmStartingPoint?siteSlug=<site slug>` where `siteSlug` is a site on a Premium or higher plan.
* Confirm that the subheading does not mention that a plan is required. 
<img width="683" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/6f4c7cb5-eb43-44c1-a61f-e2c725f3ccda">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?