### PR TITLE
Jetpack Cloud: Fetch me/sites on window focus in Jetpack Cloud

### DIFF
--- a/client/components/data/fetch-sites/README.md
+++ b/client/components/data/fetch-sites/README.md
@@ -1,0 +1,24 @@
+`<FetchSites />` is a React component that uses React Query to manage network requests for the `me/sites` endpoint.
+
+## Usage
+
+This component does not accept any children, nor does it render any elements itself.
+
+Its sole purpose is to fetch and manage the data from the `me/sites` endpoint. After fetching the data, it updates the Redux state with the fetched sites data.
+
+```jsx
+import FetchSites from 'calypso/components/data/fetch-sites';
+
+function MyComponent() {
+	return (
+		<div>
+			<FetchSites />
+			{ /* Other components */ }
+		</div>
+	);
+}
+
+export default MyComponent;
+```
+
+When `<FetchSites />` is included in a component, it automatically triggers a network request to fetch the sites associated with the current user. The fetched data is then managed by React Query and subsequently updates the Redux state.

--- a/client/components/data/fetch-sites/index.tsx
+++ b/client/components/data/fetch-sites/index.tsx
@@ -1,0 +1,7 @@
+import { useFetchSites } from 'calypso/data/sites/use-fetch-sites';
+
+export default function FetchSites() {
+	useFetchSites();
+
+	return null;
+}

--- a/client/data/sites/use-fetch-sites.ts
+++ b/client/data/sites/use-fetch-sites.ts
@@ -1,0 +1,49 @@
+import { useQuery } from '@tanstack/react-query';
+import { useEffect } from 'react';
+import { useDispatch } from 'calypso/state';
+import {
+	SITES_RECEIVE,
+	SITES_REQUEST,
+	SITES_REQUEST_SUCCESS,
+	SITES_REQUEST_FAILURE,
+} from 'calypso/state/action-types';
+import { fetchSitesAPI, getSiteParams } from 'calypso/state/sites/actions';
+
+export const useFetchSites = () => {
+	const dispatch = useDispatch();
+
+	const siteParams = getSiteParams();
+
+	const { isFetching, isSuccess, isError, data } = useQuery( {
+		queryKey: [ 'sites-data', ...Object.values( siteParams ) ],
+		queryFn: () => fetchSitesAPI( siteParams ),
+	} );
+
+	useEffect( () => {
+		if ( isFetching ) {
+			dispatch( {
+				type: SITES_REQUEST,
+			} );
+		}
+	}, [ dispatch, isFetching ] );
+
+	useEffect( () => {
+		if ( isSuccess && data?.sites ) {
+			dispatch( {
+				type: SITES_RECEIVE,
+				sites: data.sites,
+			} );
+			dispatch( {
+				type: SITES_REQUEST_SUCCESS,
+			} );
+		}
+	}, [ dispatch, isSuccess, data ] );
+
+	useEffect( () => {
+		if ( isError ) {
+			dispatch( {
+				type: SITES_REQUEST_FAILURE,
+			} );
+		}
+	}, [ dispatch, isError ] );
+};

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -10,6 +10,7 @@ import { useCallback, useEffect, Component } from 'react';
 import { connect } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
 import DocumentHead from 'calypso/components/data/document-head';
+import FetchSites from 'calypso/components/data/fetch-sites';
 import QueryPreferences from 'calypso/components/data/query-preferences';
 import QuerySiteFeatures from 'calypso/components/data/query-site-features';
 import QuerySiteSelectedEditor from 'calypso/components/data/query-site-selected-editor';
@@ -282,7 +283,11 @@ class Layout extends Component {
 				<HtmlIsIframeClassname />
 				<DocumentHead />
 				<QuerySites primaryAndRecent={ ! config.isEnabled( 'jetpack-cloud' ) } />
-				{ this.props.shouldQueryAllSites && <QuerySites allSites /> }
+				{ isJetpackCloud() ? (
+					<FetchSites />
+				) : (
+					this.props.shouldQueryAllSites && <QuerySites allSites />
+				) }
 				<QueryPreferences />
 				<QuerySiteFeatures siteIds={ [ this.props.siteId ] } />
 				{ config.isEnabled( 'layout/query-selected-editor' ) && (

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -66,6 +66,25 @@ export function receiveSites( sites ) {
 	};
 }
 
+export const getSiteParams = () => {
+	const siteFilter = config( 'site_filter' );
+	return {
+		apiVersion: '1.2',
+		site_visibility: 'all',
+		include_domain_only: true,
+		site_activity: 'active',
+		fields: SITE_REQUEST_FIELDS,
+		options: SITE_REQUEST_OPTIONS,
+		filters: siteFilter?.length > 0 ? siteFilter.join( ',' ) : undefined,
+	};
+};
+
+/**
+ * Returns a promise that resolves to the sites
+ * @returns {Promise} Promise that resolves to the sites
+ */
+export const fetchSitesAPI = ( params ) => wpcom.me().sites( params );
+
 /**
  * Triggers a network request to request all visible sites
  * @returns {Function}        Action thunk
@@ -75,19 +94,8 @@ export function requestSites() {
 		dispatch( {
 			type: SITES_REQUEST,
 		} );
-		const siteFilter = config( 'site_filter' );
 
-		return wpcom
-			.me()
-			.sites( {
-				apiVersion: '1.2',
-				site_visibility: 'all',
-				include_domain_only: true,
-				site_activity: 'active',
-				fields: SITE_REQUEST_FIELDS,
-				options: SITE_REQUEST_OPTIONS,
-				filters: siteFilter.length > 0 ? siteFilter.join( ',' ) : undefined,
-			} )
+		return fetchSitesAPI( getSiteParams() )
 			.then( ( response ) => {
 				dispatch( receiveSites( response.sites ) );
 				dispatch( {


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/65
Resolves https://github.com/Automattic/jetpack-genesis/issues/46

## Proposed Changes

This PR solves the issue of `me/sites` API data being obsolete by re-fetching the data on window focus.

Note:

Testing Window Focus: Visit any other window or tab and revisit the page you were viewing earlier.

## Testing Instructions

- Visit the Jetpack Cloud link
- Create a new JN site > Visit the dashboard again
- Verify that the newly created site is loaded on the dashboard & site selector without refreshing
- Verify that https://github.com/Automattic/jetpack-genesis/issues/65 & https://github.com/Automattic/jetpack-genesis/issues/46 is now solved.
- Verify that the API call to refetch `me/sites` is made every time there is a window focus.
- Visit the Calypso live link and verify the API call to `me/sites` is being made as usual and not API call is being made on window focus. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?