### PR TITLE
Add Creator to JP Complete products

### DIFF
--- a/client/components/jetpack/jetpack-product-info/hooks/use-included-product-description-map.tsx
+++ b/client/components/jetpack/jetpack-product-info/hooks/use-included-product-description-map.tsx
@@ -12,6 +12,7 @@ import {
 	JETPACK_CRM_PRODUCTS,
 	JETPACK_COMPLETE_PLANS,
 	JETPACK_STATS_PRODUCTS,
+	JETPACK_CREATOR_PRODUCTS,
 } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
@@ -61,6 +62,7 @@ export const useIncludedProductDescriptionMap = ( productSlug: string ) => {
 			'Manage your sales funnel. Entrepreneur plan with 30 extensions.'
 		);
 		const statsDescription = translate( 'Simple, yet powerful stats to grow your site.' );
+		const creatorDescription = translate( 'Create, grow, and monetize your audience.' );
 
 		const INCLUDED_PRODUCT_DESCRIPTION_T1_MAP: Record< string, ProductDescription > = {
 			...setProductDescription(
@@ -113,6 +115,10 @@ export const useIncludedProductDescriptionMap = ( productSlug: string ) => {
 			...setProductDescription( JETPACK_ANTI_SPAM_PRODUCTS, {
 				value: antiSpamDescription,
 				calloutText: translate( '60k API calls/mo' ),
+			} ),
+
+			...setProductDescription( JETPACK_CREATOR_PRODUCTS, {
+				value: creatorDescription,
 			} ),
 		};
 

--- a/client/components/jetpack/jetpack-product-info/style.scss
+++ b/client/components/jetpack/jetpack-product-info/style.scss
@@ -305,6 +305,7 @@ p.jetpack-product-info__product-list-item-description {
 
 	img {
 		width: 45%;
+		max-width: 24px;
 		height: auto;
 	}
 }

--- a/client/my-sites/plans/jetpack-plans/slug-to-selector-product.ts
+++ b/client/my-sites/plans/jetpack-plans/slug-to-selector-product.ts
@@ -214,9 +214,7 @@ function itemToSelectorProduct(
 			description: getForCurrentCROIteration( item.getDescription ),
 			featuredDescription: getFeaturedPlanDescription( item ),
 			lightboxDescription: getLightboxPlanDescription( item ),
-			productsIncluded:
-				// There are no products included for Jetpack Creator plans, so we don't want to show the "Included" section
-				item.getProductsIncluded?.() || [],
+			productsIncluded: item.getProductsIncluded?.() || [],
 			whatIsIncluded: item.getWhatIsIncluded
 				? getForCurrentCROIteration( item.getWhatIsIncluded )
 				: [],

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -446,6 +446,9 @@ import {
 	FEATURE_JETPACK_1_YEAR_ARCHIVE_ACTIVITY_LOG,
 	FEATURE_COMMISSION_FEE_WOO_FEATURES,
 	FEATURE_COMMISSION_FEE_STANDARD_FEATURES,
+	PRODUCT_JETPACK_CREATOR_BI_YEARLY,
+	PRODUCT_JETPACK_CREATOR_YEARLY,
+	PRODUCT_JETPACK_CREATOR_MONTHLY,
 } from './constants';
 import type {
 	BillingTerm,
@@ -3198,6 +3201,7 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 			PRODUCT_JETPACK_SEARCH_BI_YEARLY,
 			PRODUCT_JETPACK_STATS_BI_YEARLY,
 			PRODUCT_JETPACK_CRM,
+			PRODUCT_JETPACK_CREATOR_BI_YEARLY,
 		],
 		getWhatIsIncluded: () => [
 			translate( 'VaultPress Backup: Real-time backups as you edit' ),
@@ -3233,6 +3237,7 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 			PRODUCT_JETPACK_SEARCH,
 			PRODUCT_JETPACK_STATS_YEARLY,
 			PRODUCT_JETPACK_CRM,
+			PRODUCT_JETPACK_CREATOR_YEARLY,
 		],
 		getWhatIsIncluded: () => [
 			translate( 'VaultPress Backup: Real-time backups as you edit' ),
@@ -3268,6 +3273,7 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 			PRODUCT_JETPACK_SEARCH_MONTHLY,
 			PRODUCT_JETPACK_STATS_MONTHLY,
 			PRODUCT_JETPACK_CRM_MONTHLY,
+			PRODUCT_JETPACK_CREATOR_MONTHLY,
 		],
 		getWhatIsIncluded: () => [
 			translate( 'VaultPress Backup: Real-time backups as you edit' ),

--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -781,7 +781,7 @@ export const getJetpackProductsShortDescriptions = (): Record< string, Translate
 	const aiAssistantShortDescription = translate(
 		'Experience the ease of crafting content with intuitive and powerful AI.'
 	);
-	const creatorShortDescription = translate( 'Create, grow, and monetize your audience' );
+	const creatorShortDescription = translate( 'Create, grow, and monetize your audience.' );
 	const boostShortDescription = translate(
 		'Speed up your site and improve SEO - no developer required.'
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-marketing/issues/333

## Proposed Changes

All JP Creator features are included in the Jetpack Complete plan. Thus we want to inform you about it on the pricing page.

![CleanShot 2023-11-10 at 11 53 14@2x](https://github.com/Automattic/wp-calypso/assets/8419292/f6e05000-1488-4823-b81b-1ce5fe83e275)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Jetpack Cloud live link
* Go to `/pricing#jetpack_complete` and make sure that Jetpack Creator product is included on the list there

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?