### PR TITLE
SegmentedControl to packages (Step 1): Add SegmentedControl to components package

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -45,6 +45,7 @@
 		"lodash": "^4.17.21",
 		"prop-types": "^15.7.2",
 		"react-modal": "^3.16.1",
+		"react-router-dom": "^6.10.0",
 		"react-slider": "^2.0.5",
 		"utility-types": "^3.10.0",
 		"uuid": "^8.3.2",

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -61,6 +61,7 @@ export { UpsellMenuGroup } from './upsell-menu-group';
 export { default as PricingSlider } from './pricing-slider';
 export { default as Tooltip } from './tooltip';
 export { default as SegmentedControl } from './segmented-control';
+export { default as SimplifiedSegmentedControl } from './segmented-control/simplified';
 export * from './theme-type-badge';
 
 // Types

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -60,6 +60,7 @@ export { default as JetpackUpsellCard } from './jetpack-upsell-card';
 export { UpsellMenuGroup } from './upsell-menu-group';
 export { default as PricingSlider } from './pricing-slider';
 export { default as Tooltip } from './tooltip';
+export { default as SegmentedControl } from './segmented-control';
 export * from './theme-type-badge';
 
 // Types

--- a/packages/components/src/segmented-control/README.md
+++ b/packages/components/src/segmented-control/README.md
@@ -1,0 +1,163 @@
+# Segmented Control
+
+Segmented Control manipulates the content shown following an exclusive or “either/or” pattern.
+
+## Usage
+
+It can be utilized via two different techniques: **child components** or an **options array**. These techniques are available because certain use cases prefer the "selection" logic to be built into `SegmentedControl`, while others prefer to explicitly define that logic elsewhere.
+
+### Child components
+
+The children technique is appropriate when you'd like to define the "selection" logic at the same point where `<SegmentedControl>` is implemented.
+
+A good example for this case is navigation. Sometimes the option that is selected is defined by the route, other times it's a state value, external prop, etc.
+
+```jsx
+import { Component } from 'react';
+import { SegmentedControl } from '@automattic/components';
+
+export default class extends Component {
+	// ...
+
+	render() {
+		return (
+			<SegmentedControl>
+				<SegmentedControl.Item
+					selected={ this.state.selected === 'all' }
+					onClick={ this.handleFilterClick( 'all' ) }
+				>
+					All
+				</SegmentedControl.Item>
+
+				<SegmentedControl.Item
+					selected={ this.state.selected === 'unread' }
+					onClick={ this.handleFilterClick( 'unread' ) }
+				>
+					Unread
+				</SegmentedControl.Item>
+
+				<SegmentedControl.Item
+					selected={ this.state.selected === 'comments' }
+					onClick={ this.handleFilterClick( 'comments' ) }
+				>
+					Comments
+				</SegmentedControl.Item>
+
+				<SegmentedControl.Item
+					selected={ this.state.selected === 'follows' }
+					onClick={ this.handleFilterClick( 'follows' ) }
+				>
+					Follows
+				</SegmentedControl.Item>
+
+				<SegmentedControl.Item
+					selected={ this.state.selected === 'likes' }
+					onClick={ this.handleFilterClick( 'likes' ) }
+				>
+					Likes
+				</SegmentedControl.Item>
+			</SegmentedControl>
+		);
+	}
+
+	handleFilterClick( value ) {
+		return () => {
+			// ... (track analytics, add to state, etc.)
+
+			this.setState( {
+				selected: value,
+				// ...
+			} );
+		};
+	}
+}
+```
+
+The key here is that it's up to the parent component to explicitly define things such as the selected item, potential `onClick` callbacks, etc.
+
+#### Props
+
+##### Segmented Control
+
+| Name        | Type     | Default | Description                               |
+| ----------- | -------- | ------- | ----------------------------------------- |
+| `className` | `string` | `0`     | Class(es) applied to `.segmented-control` |
+| `style`     | `string` | `0`     | Inline styles applied to the main element |
+| `compact`   | `bool`   | `false` | Decreases the size                        |
+
+##### Control Item
+
+| Name         | Type     | Default | Description                                             |
+| ------------ | -------- | ------- | ------------------------------------------------------- |
+| `selected`\* | `bool`   | `false` | Determines the selected item                            |
+| `path`       | `string` | `null`  | URL to navigate to when item is clicked                 |
+| `title`      | `string` | `null`  | Title to show when hovering over item                   |
+| `onClick`    |          | `null`  | Callback applied when `SegmentedControlItem` is clicked |
+
+### Options array
+
+We also provide `SimplifiedSegmentedControl` which uses an `options` array as a prop. This technique is great for situations where you don't want to explicitly define things like what happens when an item is clicked or which item is currently selected, etc.
+
+A good example for this case is a form element. You don't want to have to write the logic for updating the component when a new selection is made, but you might want to hook into certain events like: when a new selection is made, what was the option?
+
+**NOTE**: _there is still more work here in order to be fully functional as a form element. This is currently experimental._
+
+```jsx
+import SimplifiedSegmentedControl from '@automattic/components/segmented-control/simplified';
+
+const options = [
+	{ value: 'all', label: 'All' },
+	{ value: 'unread', label: 'Unread' },
+	{ value: 'comments', label: 'Comments' },
+	{ value: 'follows', label: 'Follows' },
+	{ value: 'likes', label: 'Likes' },
+];
+
+export default class extends React.Component {
+	// ...
+
+	handleOnSelect = ( option ) => {
+		console.log( 'selected option:', option ); // full object of selected option
+	};
+
+	render() {
+		return <SimplifiedSegmentedControl options={ options } onSelect={ this.handleOnSelect } />;
+	}
+}
+```
+
+Note that all the "selection" logic will be applied in `SimplifiedSegmentedControl` itself using a simple `selected` value comparison in state. It will update itself when an option has been clicked.
+
+#### Props
+
+| Name              | Type     | Default | Description                                      |
+| ----------------- | -------- | ------- | ------------------------------------------------ |
+| `options`\*       | `array`  | `null`  | The main data set for rendering options          |
+| `initialSelected` | `string` | `null`  | Represents the initial selected option's `value` |
+| `onSelect`        |          | `null`  | Callback whenever a new item has been clicked    |
+
+##### `options` prop example
+
+```js
+const options = [
+	{
+		value: 'the value', // *required* - (string) tracked by component
+		label: 'the label', // *required* - (string) displayed to user
+		path: 'a path', // optional - (string) URL to navigate when clicked
+	},
+	// ...
+];
+```
+
+### General guidelines
+
+- There are two states: selected and non-selected. There must always be only one selected state, no more, no less.
+- The primary style is preferred. Use your best judgement if you want to use the non-primary style to remove visual conflict with another primary elements in the view.
+- Text should be concise and specific. Use no more than two words.
+- A default selection is required. The default selection is the first option in the segmented control.
+
+## Related components
+
+- To group buttons together, use the `ButtonGroup` component.
+- To navigate between multiple pages of items, use the `Pagination` component.
+- To alternate among related views within the same context with _tabs_, use the `SectionNav` component.

--- a/packages/components/src/segmented-control/README.md
+++ b/packages/components/src/segmented-control/README.md
@@ -13,8 +13,8 @@ The children technique is appropriate when you'd like to define the "selection" 
 A good example for this case is navigation. Sometimes the option that is selected is defined by the route, other times it's a state value, external prop, etc.
 
 ```jsx
-import { Component } from 'react';
 import { SegmentedControl } from '@automattic/components';
+import { Component } from 'react';
 
 export default class extends Component {
 	// ...

--- a/packages/components/src/segmented-control/docs/example.jsx
+++ b/packages/components/src/segmented-control/docs/example.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { PureComponent } from 'react';
 import SegmentedControl from '../';
 import SimplifiedSegmentedControl from '../simplified';

--- a/packages/components/src/segmented-control/docs/example.jsx
+++ b/packages/components/src/segmented-control/docs/example.jsx
@@ -1,0 +1,131 @@
+import { PureComponent } from 'react';
+import SegmentedControl from '../';
+import SimplifiedSegmentedControl from '../simplified';
+
+class SegmentedControlDemo extends PureComponent {
+	static displayName = 'SegmentedControl';
+
+	static defaultProps = {
+		options: [
+			{ value: 'all', label: 'All' },
+			{ value: 'unread', label: 'Unread' },
+			{ value: 'comments', label: 'Comments' },
+			{ value: 'follows', label: 'Follows' },
+			{ value: 'likes', label: 'Likes' },
+		],
+	};
+
+	state = {
+		childSelected: 'all',
+		compact: false,
+	};
+
+	toggleCompact = () => {
+		this.setState( { compact: ! this.state.compact } );
+	};
+
+	render() {
+		const controlDemoStyles = { maxWidth: 386 };
+
+		return (
+			<div>
+				<button className="docs__design-toggle button" onClick={ this.toggleCompact }>
+					{ this.state.compact ? 'Normal' : 'Compact' }
+				</button>
+
+				<h3>Items passed as options prop</h3>
+				<SimplifiedSegmentedControl
+					options={ this.props.options }
+					onSelect={ this.selectSegment }
+					style={ controlDemoStyles }
+					compact={ this.state.compact }
+				/>
+
+				<h3 style={ { marginTop: 20 } }>Primary version</h3>
+				<SegmentedControl
+					selectedText={ this.state.childSelected }
+					style={ controlDemoStyles }
+					primary={ true }
+					compact={ this.state.compact }
+				>
+					<SegmentedControl.Item
+						selected={ this.state.childSelected === 'all' }
+						onClick={ this.selectChildSegment.bind( this, 'all' ) }
+					>
+						All
+					</SegmentedControl.Item>
+
+					<SegmentedControl.Item
+						selected={ this.state.childSelected === 'unread' }
+						onClick={ this.selectChildSegment.bind( this, 'unread' ) }
+					>
+						Unread
+					</SegmentedControl.Item>
+
+					<SegmentedControl.Item
+						selected={ this.state.childSelected === 'comments' }
+						onClick={ this.selectChildSegment.bind( this, 'comments' ) }
+					>
+						Comments
+					</SegmentedControl.Item>
+
+					<SegmentedControl.Item
+						selected={ this.state.childSelected === 'follows' }
+						onClick={ this.selectChildSegment.bind( this, 'follows' ) }
+					>
+						Follows
+					</SegmentedControl.Item>
+
+					<SegmentedControl.Item
+						selected={ this.state.childSelected === 'likes' }
+						onClick={ this.selectChildSegment.bind( this, 'likes' ) }
+					>
+						Likes
+					</SegmentedControl.Item>
+				</SegmentedControl>
+
+				<h3 style={ { marginTop: 20 } }>Three items</h3>
+				<SegmentedControl
+					compact={ this.state.compact }
+					selectedText={ this.state.childSelected }
+					style={ { maxWidth: 280 } }
+				>
+					<SegmentedControl.Item
+						selected={ this.state.childSelected === 'all' }
+						onClick={ this.selectChildSegment.bind( this, 'all' ) }
+					>
+						All
+					</SegmentedControl.Item>
+
+					<SegmentedControl.Item
+						selected={ this.state.childSelected === 'unread' }
+						onClick={ this.selectChildSegment.bind( this, 'unread' ) }
+					>
+						Unread
+					</SegmentedControl.Item>
+
+					<SegmentedControl.Item
+						selected={ this.state.childSelected === 'comments' }
+						onClick={ this.selectChildSegment.bind( this, 'comments' ) }
+					>
+						Comments
+					</SegmentedControl.Item>
+				</SegmentedControl>
+			</div>
+		);
+	}
+
+	selectChildSegment = ( childSelected, event ) => {
+		event.preventDefault();
+		this.setState( {
+			childSelected: childSelected,
+		} );
+		console.log( 'Segmented Control (selected):', childSelected );
+	};
+
+	selectSegment = ( option ) => {
+		console.log( 'Segmented Control (selected):', option );
+	};
+}
+
+export default SegmentedControlDemo;

--- a/packages/components/src/segmented-control/index.jsx
+++ b/packages/components/src/segmented-control/index.jsx
@@ -1,0 +1,35 @@
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import { Component } from 'react';
+import SegmentedControlItem from './item';
+
+import './style.scss';
+
+export default class SegmentedControl extends Component {
+	static Item = SegmentedControlItem;
+
+	static propTypes = {
+		className: PropTypes.string,
+		compact: PropTypes.bool,
+		primary: PropTypes.bool,
+		style: PropTypes.object,
+		children: PropTypes.node.isRequired,
+	};
+
+	render() {
+		const segmentedClasses = {
+			'is-compact': this.props.compact,
+			'is-primary': this.props.primary,
+		};
+
+		return (
+			<ul
+				className={ classNames( 'segmented-control', segmentedClasses, this.props.className ) }
+				style={ this.props.style }
+				role="radiogroup"
+			>
+				{ this.props.children }
+			</ul>
+		);
+	}
+}

--- a/packages/components/src/segmented-control/index.stories.js
+++ b/packages/components/src/segmented-control/index.stories.js
@@ -1,0 +1,90 @@
+import { useState } from 'react';
+import SimplifiedSegmentedControl from './simplified';
+import SegmentedControl from './';
+
+export default {
+	title: 'packages/components/SegmentedControl',
+	component: SegmentedControl,
+	argTypes: {
+		compact: { control: 'boolean' },
+	},
+};
+
+export const Default = ( { compact } ) => {
+	const [ selected, setSelected ] = useState( 'all' );
+	const options = [
+		{ value: 'all', label: 'All' },
+		{ value: 'unread', label: 'Unread' },
+		{ value: 'comments', label: 'Comments' },
+		{ value: 'follows', label: 'Follows' },
+		{ value: 'likes', label: 'Likes' },
+	];
+	const controlDemoStyles = { maxWidth: 386 };
+
+	const selectChildSegment = ( childSelected, event ) => {
+		event.preventDefault();
+		setSelected( childSelected );
+		console.log( 'Segmented Control (selected):', childSelected );
+	};
+
+	const selectSegment = ( option ) => {
+		console.log( 'Segmented Control (selected):', option );
+	};
+
+	return (
+		<div>
+			<h3>Items passed as options prop</h3>
+
+			<SimplifiedSegmentedControl
+				options={ options }
+				onSelect={ selectSegment }
+				style={ controlDemoStyles }
+				compact={ compact }
+			/>
+
+			<h3 style={ { marginTop: 20 } }>Primary version</h3>
+
+			<SegmentedControl
+				selectedText={ selected }
+				style={ controlDemoStyles }
+				primary={ true }
+				compact={ compact }
+			>
+				<SegmentedControl.Item
+					selected={ selected === 'all' }
+					onClick={ selectChildSegment.bind( this, 'all' ) }
+				>
+					All
+				</SegmentedControl.Item>
+
+				<SegmentedControl.Item
+					selected={ selected === 'unread' }
+					onClick={ selectChildSegment.bind( this, 'unread' ) }
+				>
+					Unread
+				</SegmentedControl.Item>
+
+				<SegmentedControl.Item
+					selected={ selected === 'comments' }
+					onClick={ selectChildSegment.bind( this, 'comments' ) }
+				>
+					Comments
+				</SegmentedControl.Item>
+
+				<SegmentedControl.Item
+					selected={ selected === 'follows' }
+					onClick={ selectChildSegment.bind( this, 'follows' ) }
+				>
+					Follows
+				</SegmentedControl.Item>
+
+				<SegmentedControl.Item
+					selected={ selected === 'likes' }
+					onClick={ selectChildSegment.bind( this, 'likes' ) }
+				>
+					Likes
+				</SegmentedControl.Item>
+			</SegmentedControl>
+		</div>
+	);
+};

--- a/packages/components/src/segmented-control/index.stories.js
+++ b/packages/components/src/segmented-control/index.stories.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { useState } from 'react';
 import SimplifiedSegmentedControl from './simplified';
 import SegmentedControl from './';

--- a/packages/components/src/segmented-control/item.jsx
+++ b/packages/components/src/segmented-control/item.jsx
@@ -1,0 +1,71 @@
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import { Component } from 'react';
+import { Link } from 'react-router-dom';
+
+const ConditionalLink = ( { active, ...props } ) => {
+	if ( active ) {
+		return <Link to={ props.href } { ...props } />;
+	}
+	return <a { ...props }></a>;
+};
+
+class SegmentedControlItem extends Component {
+	static propTypes = {
+		children: PropTypes.node.isRequired,
+		path: PropTypes.string,
+		selected: PropTypes.bool,
+		title: PropTypes.string,
+		value: PropTypes.string,
+		onClick: PropTypes.func,
+		index: PropTypes.number,
+		isPlansInsideStepper: PropTypes.bool,
+	};
+
+	static defaultProps = {
+		selected: false,
+		isPlansInsideStepper: false,
+	};
+
+	handleKeyEvent = ( event ) => {
+		switch ( event.keyCode ) {
+			case 13: // enter
+			case 32: // space
+				event.preventDefault();
+				document.activeElement.click();
+				break;
+		}
+	};
+
+	render() {
+		const itemClassName = classNames( {
+			'segmented-control__item': true,
+			'is-selected': this.props.selected,
+		} );
+
+		const linkClassName = classNames( 'segmented-control__link', {
+			[ `item-index-${ this.props.index }` ]: this.props.index != null,
+		} );
+
+		return (
+			<li className={ itemClassName } role="none">
+				<ConditionalLink
+					active={ this.props.isPlansInsideStepper }
+					href={ this.props.path }
+					className={ linkClassName }
+					onClick={ this.props.onClick }
+					title={ this.props.title }
+					data-e2e-value={ this.props.value }
+					role="radio"
+					tabIndex={ 0 }
+					aria-checked={ this.props.selected }
+					onKeyDown={ this.handleKeyEvent }
+				>
+					<span className="segmented-control__text">{ this.props.children }</span>
+				</ConditionalLink>
+			</li>
+		);
+	}
+}
+
+export default SegmentedControlItem;

--- a/packages/components/src/segmented-control/simplified.jsx
+++ b/packages/components/src/segmented-control/simplified.jsx
@@ -1,0 +1,50 @@
+import PropTypes from 'prop-types';
+import { useState } from 'react';
+import SegmentedControl from '.';
+
+const noop = () => {};
+
+function SimplifiedSegmentedControl( {
+	options,
+	initialSelected = options[ 0 ].value,
+	onSelect = noop,
+	...props
+} ) {
+	const [ selected, setSelected ] = useState( initialSelected );
+
+	const renderedOptions = options.map( ( option, index ) => (
+		<SegmentedControl.Item
+			index={ index }
+			key={ index }
+			onClick={ () => {
+				setSelected( option.value );
+				onSelect( option );
+			} }
+			path={ option.path }
+			selected={ selected === option.value }
+			value={ option.value }
+		>
+			{ option.label }
+		</SegmentedControl.Item>
+	) );
+
+	return <SegmentedControl { ...props }>{ renderedOptions }</SegmentedControl>;
+}
+
+SimplifiedSegmentedControl.propTypes = {
+	className: PropTypes.string,
+	compact: PropTypes.bool,
+	primary: PropTypes.bool,
+	style: PropTypes.object,
+	initialSelected: PropTypes.string,
+	onSelect: PropTypes.func,
+	options: PropTypes.arrayOf(
+		PropTypes.shape( {
+			value: PropTypes.string.isRequired,
+			label: PropTypes.string.isRequired,
+			path: PropTypes.string,
+		} )
+	).isRequired,
+};
+
+export default SimplifiedSegmentedControl;

--- a/packages/components/src/segmented-control/style.scss
+++ b/packages/components/src/segmented-control/style.scss
@@ -1,0 +1,119 @@
+
+@import "@automattic/typography/styles/variables";
+
+/**
+ * Segmented Control
+ *
+ */
+
+.segmented-control {
+	display: flex;
+	margin: 0;
+	border-radius: 2px;
+	background-color: var(--color-surface);
+	list-style: none;
+}
+
+.segmented-control__item {
+	flex: 1 1 auto;
+	cursor: pointer;
+
+	&:first-of-type .segmented-control__link {
+		border-top-left-radius: 2px;
+		border-bottom-left-radius: 2px;
+	}
+
+	&:last-of-type .segmented-control__link {
+		border-right: solid 1px var(--color-neutral-10);
+		border-top-right-radius: 2px;
+		border-bottom-right-radius: 2px;
+	}
+
+	&.is-selected + .segmented-control__item .segmented-control__link {
+		border-left-color: var(--color-neutral-70);
+	}
+}
+
+.segmented-control__link {
+	display: block;
+	padding: 8px 12px;
+	border: solid 1px var(--color-neutral-10);
+	border-right: none;
+	font-size: $font-body-small;
+	line-height: 18px;
+	color: var(--color-text-subtle);
+	text-align: center;
+	transition: color 0.1s linear, background-color 0.1s linear;
+
+	.segmented-control__item:not(.is-selected) &:focus {
+		color: var(--color-neutral-70);
+		outline: none;
+		background-color: var(--color-neutral-0);
+	}
+
+	.accessible-focus &:focus {
+		box-shadow: 0 0 0 2px var(--color-primary-light);
+		outline: none;
+	}
+}
+
+.segmented-control__item.is-selected .segmented-control__link {
+	border-color: var(--color-neutral-70);
+	color: var(--color-neutral-70);
+}
+
+.notouch .segmented-control__link:hover {
+	color: var(--color-neutral-70);
+	background-color: var(--color-neutral-0);
+}
+
+.segmented-control__text {
+	display: block;
+	max-width: 100%;
+	color: inherit;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+	overflow: hidden;
+}
+
+.segmented-control.is-compact {
+	.segmented-control__link {
+		font-size: $font-body-small;
+		padding: 4px 8px;
+	}
+}
+
+//Primary variation
+.segmented-control.is-primary {
+	.segmented-control__item {
+		&.is-selected {
+			.segmented-control__link {
+				border-color: var(--color-primary);
+				background-color: var(--color-primary);
+				color: var(--color-text-inverted);
+
+				&:focus {
+					background-color: var(--color-primary-dark);
+					border-color: var(--color-primary-dark);
+				}
+			}
+
+			+ .segmented-control__item .segmented-control__link {
+				border-left-color: var(--color-primary);
+			}
+		}
+	}
+
+	.segmented-control__link:focus {
+		background-color: var(--color-neutral-0);
+	}
+}
+
+.notouch .segmented-control.is-primary {
+	.segmented-control__link:hover {
+		background-color: var(--color-neutral-0);
+	}
+	.segmented-control__item.is-selected .segmented-control__link:hover {
+		background-color: var(--color-primary-light);
+	}
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -561,6 +561,7 @@ __metadata:
     prop-types: "npm:^15.7.2"
     qrcode.react: "npm:^3.1.0"
     react-modal: "npm:^3.16.1"
+    react-router-dom: "npm:^6.10.0"
     react-slider: "npm:^2.0.5"
     resize-observer-polyfill: "npm:^1.5.1"
     typescript: "npm:^5.2.2"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/81117

## Proposed Changes

We are migrating `SegmentedControl` to `@automattic/components` because it is a dependency for plans-grid (plan-type-selector), which we are in the process of migrating to NPM.

The same principle applies to previous related migrations (see https://github.com/Automattic/wp-calypso/pull/79257):

> The entirety of the migration is a 4 step process that creates easily digestible ( and revertible ) PRs to work with. Unfortunately, this process also eliminates the git history from migrated files unless the 4 steps are condensed into a single one. I don't have a great answer to this, but the tradeoff, to me, is worth the added safety of more understandable, compact, iterative pull requests.

This is Step 1: 
- adding a new component to `@automattic/components` package
- adding Storybook

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Code review
- Ensure Storybook stories render correctly with no errors: `run yarn storybook:start`:

<img width="532" alt="Screenshot 2023-11-10 at 12 35 20 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/8bb76cff-d9ba-44f2-baec-95272647439f">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?