### PR TITLE
Paid newsletter onboarding: create a tier when onboarding into paid

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -18,6 +18,7 @@ import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { ResponseDomain } from 'calypso/lib/domains/types';
 import RecurringPaymentsPlanAddEditModal from 'calypso/my-sites/earn/components/add-edit-plan-modal';
+import { TYPE_TIER } from 'calypso/my-sites/earn/memberships/constants';
 import { useSelector } from 'calypso/state';
 import { isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
 import { getConnectUrlForSiteId } from 'calypso/state/memberships/settings/selectors';
@@ -268,7 +269,12 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goToStep, flow }: SidebarPr
 					{ showPlansModal && site?.ID && (
 						<RecurringPaymentsPlanAddEditModal
 							closeDialog={ () => setShowPlansModal( false ) }
-							product={ { subscribe_as_site_subscriber: true, price: 5 } }
+							product={ {
+								price: 5,
+								subscribe_as_site_subscriber: true,
+								title: translate( 'Paid newsletter' ),
+								type: TYPE_TIER,
+							} }
 							annualProduct={ { subscribe_as_site_subscriber: true, price: 5 * 12 } }
 							siteId={ site.ID }
 						/>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

**Before**

<img width="1173" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/0da3e6aa-a58d-48ea-a111-f2f0ef47be5b">

**After**

![image](https://github.com/Automattic/wp-calypso/assets/87168/bb603c47-2cd6-4ccc-97d8-047b72c4c130)


## Proposed Changes

* Pass tier to the payment modal component in the paid newsletter onboarding flow
* Set simpler plan name instead of "default Paid newsletter tier" since they're creating just one paid plan during onboarding.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go via `/setup/newsletter`
* Pick paid newsletter
* In the launchpad, choose "create paid newsletter" option

    <img width="300" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/a5bb627d-f166-4e19-bef9-8a37338b3cde">
* Create and save paid tier
* Connect stripe from launchpad as well
* Confirm the paid plans gets created properly, test the paid modal on the frontend of the site
    <img width="354" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/9eb31735-ff83-4f08-b75e-2b976d592e71">
    <img width="463" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/aa12d2d1-d168-4ee5-a0e3-d202303bd729">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?