### PR TITLE
Fix Jetpack Sale Banner and update text for BF 2023

### DIFF
--- a/client/jetpack-cloud/sections/pricing/header/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/header/index.tsx
@@ -1,16 +1,32 @@
+import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import * as React from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { preventWidows } from 'calypso/lib/formatting';
+import { useSelector } from 'calypso/state';
+import { getJetpackSaleCoupon } from 'calypso/state/marketing/selectors';
 
 import './style.scss';
 
+const useHasSaleBanner = () => {
+	const moment = useLocalizedMoment();
+	const coupon = useSelector( getJetpackSaleCoupon );
+
+	const now = moment.utc().unix();
+	const expiryDate = moment.utc( coupon?.expiry_date ).unix();
+	const isBeforeExpiry = coupon && now <= expiryDate;
+
+	return isBeforeExpiry;
+};
+
 const Header: React.FC< Props > = ( { title } ) => {
 	const translate = useTranslate();
+	const hasSaleBanner = useHasSaleBanner();
 
 	return (
 		<>
-			<div className="header">
+			<div className={ classNames( 'header', { 'has-sale-banner': hasSaleBanner } ) }>
 				<FormattedHeader
 					className="header__main-title"
 					headerText={ preventWidows(

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
@@ -71,10 +71,9 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
 		<>
-			{ jetpackSaleCoupon && <JetpackSaleBanner coupon={ jetpackSaleCoupon } /> }
-
 			<div className="jpcom-masterbar">
 				<header className="header js-header force-opaque">
+					{ jetpackSaleCoupon && <JetpackSaleBanner coupon={ jetpackSaleCoupon } /> }
 					<div className="header__content-wrapper">
 						<div className="header__content-background-wrapper-sentinal" { ...outerDivProps }></div>
 						<div className={ classes }>

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
@@ -17,7 +17,6 @@
 		top: 0;
 		left: 0;
 		width: 100%;
-		padding: 2rem 0;
 		color: #101517;
 		font-size: 1.125rem; /* stylelint-disable-line scales/font-sizes */
 		transition: background 0.1s;
@@ -26,6 +25,7 @@
 		text-align: left;
 		display: flex;
 		justify-content: space-between;
+		padding: 2rem 0;
 		flex: 1;
 		min-width: 0;
 	}

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
@@ -133,7 +133,7 @@
 	@media ( max-width: 900px ) {
 		.header {
 			position: relative;
-			padding: 1.5rem 0;
+			padding: 0;
 			height: auto;
 			background-color: var(--studio-white);
 		}
@@ -155,7 +155,14 @@
 	}
 
 	.header__content-wrapper {
+		position: relative;
 		width: 100%;
+	}
+
+	@media ( max-width: 900px ) {
+		.header__content-wrapper {
+			padding: 1.5rem 0;
+		}
 	}
 
 	.header__content-background-wrapper {

--- a/client/jetpack-cloud/sections/pricing/sale-banner/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/sale-banner/index.tsx
@@ -63,7 +63,7 @@ const SaleBanner: React.FC< Props > = ( { coupon } ) => {
 							<b>{ saleTitle }</b>
 							&nbsp;
 							{ translate(
-								'Take %(discount)d%% off new annual Jetpack Security and Complete purchases.',
+								'Take up to %(discount)d%% off all annual Jetpack bundles and products.',
 								{
 									args: { discount: coupon.final_discount },
 									comment: '%(discount)d%% is discount amount in percentage, e.g. 65%',

--- a/client/my-sites/plans/jetpack-plans/product-store/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/style.scss
@@ -6,8 +6,14 @@
 	flex-direction: column;
 
 	.header {
+		$sale-banner-height: 3.5rem;
+
 		margin-bottom: 36px;
 		margin-top: 8.5rem;
+
+		&.has-sale-banner {
+			margin-top: 8.5rem + $sale-banner-height;
+		}
 	}
 
 	.header .formatted-header {

--- a/client/my-sites/plans/jetpack-plans/product-store/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/style.scss
@@ -12,7 +12,18 @@
 		margin-top: 8.5rem;
 
 		&.has-sale-banner {
+			$mobile-offset: 6rem;
+
 			margin-top: 8.5rem + $sale-banner-height;
+
+			// tablets
+			@media ( max-width: 900px ) {
+				margin-top: 8.5rem + $sale-banner-height + $mobile-offset / 3;
+			}
+			// mobiles
+			@media ( max-width: 560px ) {
+				margin-top: 8.5rem + $sale-banner-height + $mobile-offset;
+			}
 		}
 	}
 


### PR DESCRIPTION
## Proposed Changes

Currently, Sale Banner is covered by megamenu. As we're launching the BF promo soon, we're fixing the display of it. Additionally, we adjust the text for purposes of the sale.

- Update discount text
- Fix displaying of the sale banner

## Testing Instructions

* Follow test instructions here: D128241-code
* Point public-api.wordpress.com to your sandbox
* Use the Jetpack Cloud live link and go to the `/pricing` page
* You should see the sale banner properly on top of the page. It shouldn't cover nor be covered by the menu.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?