### PR TITLE
[Odie] Call for testing fixes - 1

### DIFF
--- a/client/odie/index.tsx
+++ b/client/odie/index.tsx
@@ -1,4 +1,4 @@
-import { WheelEvent, useCallback, useEffect, useRef, useState } from 'react';
+import { forwardRef, WheelEvent, useCallback, useEffect, useRef, useState } from 'react';
 import { useInView } from 'react-intersection-observer';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { useOdieAssistantContext } from './context';
@@ -9,6 +9,8 @@ import './style.scss';
 
 export const WAPUU_ERROR_MESSAGE =
 	"Wapuu oopsie! 😺 My bad, but even cool pets goof. Let's laugh it off! 🎉, ask me again as I forgot what you said!";
+
+const ForwardedChatMessage = forwardRef( ChatMessage );
 
 const OdieAssistant = () => {
 	const { chat, botNameSlug } = useOdieAssistantContext();
@@ -23,7 +25,8 @@ const OdieAssistant = () => {
 					if ( bottomElement?.target ) {
 						bottomElement.target.scrollIntoView( {
 							behavior: smooth ? 'smooth' : 'auto',
-							block: 'end',
+							block: 'start',
+							inline: 'nearest',
 						} );
 					}
 				} );
@@ -62,10 +65,14 @@ const OdieAssistant = () => {
 				>
 					{ chat.messages.map( ( message, index ) => {
 						return (
-							<ChatMessage message={ message } key={ index } scrollToBottom={ scrollToBottom } />
+							<ForwardedChatMessage
+								message={ message }
+								key={ index }
+								scrollToBottom={ scrollToBottom }
+								ref={ chat.messages.length - 1 === index ? bottomRef : undefined }
+							/>
 						);
 					} ) }
-					<div className="odie-chatbox-bottom-edge" ref={ bottomRef } />
 				</div>
 				<OdieSendMessageButton
 					scrollToBottom={ scrollToBottom }

--- a/client/odie/index.tsx
+++ b/client/odie/index.tsx
@@ -68,7 +68,7 @@ const OdieAssistant = () => {
 					<div className="odie-chatbox-bottom-edge" ref={ bottomRef } />
 				</div>
 				<OdieSendMessageButton
-					scrollToBottom={ () => scrollToBottom( true, true ) }
+					scrollToBottom={ scrollToBottom }
 					enableStickToBottom={ () => setStickToBottom( true ) }
 					enableJumpToRecent={ ! inView && ! stickToBottom }
 				/>

--- a/client/odie/message/custom-a-link.tsx
+++ b/client/odie/message/custom-a-link.tsx
@@ -1,4 +1,3 @@
-import { Gridicon } from '@automattic/components';
 import classnames from 'classnames';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';

--- a/client/odie/message/custom-a-link.tsx
+++ b/client/odie/message/custom-a-link.tsx
@@ -47,7 +47,6 @@ const CustomALink = ( {
 			>
 				{ children }
 			</a>
-			<Gridicon icon="external" size={ 18 } />
 		</span>
 	);
 };

--- a/client/odie/message/index.tsx
+++ b/client/odie/message/index.tsx
@@ -276,6 +276,7 @@ const ChatMessage = ( { message, scrollToBottom }: ChatMessageProps ) => {
 			</div>
 			{ hasSources && messageFullyTyped && (
 				<FoldableCard
+					className="odie-sources-foldable-card"
 					clickableHeader
 					header={ translate( 'Sources', {
 						context:

--- a/client/odie/message/index.tsx
+++ b/client/odie/message/index.tsx
@@ -38,7 +38,10 @@ type ChatMessageProps = {
 	scrollToBottom: () => void;
 };
 
-const ChatMessage = ( { message, scrollToBottom }: ChatMessageProps ) => {
+const ChatMessage = (
+	{ message, scrollToBottom }: ChatMessageProps,
+	ref: React.Ref< HTMLDivElement >
+) => {
 	const isUser = message.role === 'user';
 	const { botName, extraContactOptions, addMessage } = useOdieAssistantContext();
 	const [ scrolledToBottom, setScrolledToBottom ] = useState( false );
@@ -224,7 +227,7 @@ const ChatMessage = ( { message, scrollToBottom }: ChatMessageProps ) => {
 
 	const messageContent = (
 		<div className={ odieChatBoxMessageSourcesContainerClass } ref={ fullscreenRef }>
-			<div className={ messageClasses }>
+			<div className={ messageClasses } ref={ ref }>
 				{ messageHeader }
 				{ ( message.type === 'message' || ! message.type ) && (
 					<>

--- a/client/odie/message/index.tsx
+++ b/client/odie/message/index.tsx
@@ -203,7 +203,15 @@ const ChatMessage = ( { message, scrollToBottom }: ChatMessageProps ) => {
 		<div className={ `message-header ${ isUser ? 'user' : 'bot' }` }>{ messageAvatarHeader }</div>
 	);
 
+	const shouldRenderExtraContactOptions =
+		( ( isRequestingHumanSupport !== undefined && isRequestingHumanSupport ) ||
+			( message && message.type === 'dislike-feedback' ) ) &&
+		messageFullyTyped;
+
 	const onDislike = () => {
+		if ( shouldRenderExtraContactOptions ) {
+			return;
+		}
 		setTimeout( () => {
 			addMessage( {
 				content: translate(
@@ -216,12 +224,8 @@ const ChatMessage = ( { message, scrollToBottom }: ChatMessageProps ) => {
 				role: 'bot',
 				type: 'dislike-feedback',
 			} );
-		}, 600 );
+		}, 1200 );
 	};
-
-	const shouldRenderExtraContactOptions =
-		( isRequestingHumanSupport !== undefined && isRequestingHumanSupport ) ||
-		( message && message.type === 'dislike-feedback' );
 
 	const odieChatBoxMessageSourcesContainerClass = classnames(
 		'odie-chatbox-message-sources-container',
@@ -273,7 +277,7 @@ const ChatMessage = ( { message, scrollToBottom }: ChatMessageProps ) => {
 			{ hasSources && messageFullyTyped && (
 				<FoldableCard
 					clickableHeader
-					header={ translate( 'Sources:', {
+					header={ translate( 'Sources', {
 						context:
 							'Below this text are links to sources for the current message received from the bot.',
 						textOnly: true,

--- a/client/odie/message/index.tsx
+++ b/client/odie/message/index.tsx
@@ -56,7 +56,6 @@ const ChatMessage = ( { message, scrollToBottom }: ChatMessageProps ) => {
 	const hasSources = message?.context?.sources && message.context?.sources.length > 0;
 	const hasFeedback = !! message?.rating_value;
 
-	const hasNegativeFeedback = message?.rating_value && message?.rating_value < 3;
 	const sources = message?.context?.sources ?? [];
 	const isTypeMessageOrEmpty = ! message.type || message.type === 'message';
 	const isSimulatedTypingFinished = message.simulateTyping && message.content === realTimeMessage;
@@ -206,10 +205,7 @@ const ChatMessage = ( { message, scrollToBottom }: ChatMessageProps ) => {
 	);
 
 	const shouldRenderExtraContactOptions =
-		( ( isRequestingHumanSupport !== undefined && isRequestingHumanSupport ) ||
-			( message && message.type === 'dislike-feedback' ) ||
-			hasNegativeFeedback ) &&
-		messageFullyTyped;
+		isRequestingHumanSupport && ! hasFeedback && messageFullyTyped;
 
 	const onDislike = () => {
 		if ( shouldRenderExtraContactOptions ) {
@@ -258,22 +254,25 @@ const ChatMessage = ( { message, scrollToBottom }: ChatMessageProps ) => {
 					</div>
 				) }
 				{ message.type === 'dislike-feedback' && (
-					<AsyncLoad
-						require="react-markdown"
-						placeholder={ <ComponentLoadedReporter callback={ scrollToBottom } /> }
-						transformLinkUri={ uriTransformer }
-						components={ {
-							a: CustomALink,
-						} }
-					>
-						{ translate(
-							'I’m sorry my last response didn’t meet your expectations! Here’s some other ways to get more in-depth help:',
-							{
-								context: 'Message displayed when the user dislikes a message from the bot',
-								textOnly: true,
-							}
-						) }
-					</AsyncLoad>
+					<>
+						<AsyncLoad
+							require="react-markdown"
+							placeholder={ <ComponentLoadedReporter callback={ scrollToBottom } /> }
+							transformLinkUri={ uriTransformer }
+							components={ {
+								a: CustomALink,
+							} }
+						>
+							{ translate(
+								'I’m sorry my last response didn’t meet your expectations! Here’s some other ways to get more in-depth help:',
+								{
+									context: 'Message displayed when the user dislikes a message from the bot',
+									textOnly: true,
+								}
+							) }
+						</AsyncLoad>
+						{ extraContactOptions }
+					</>
 				) }
 				{ shouldRenderExtraContactOptions && extraContactOptions }
 			</div>

--- a/client/odie/message/index.tsx
+++ b/client/odie/message/index.tsx
@@ -45,7 +45,6 @@ const ChatMessage = ( { message, scrollToBottom }: ChatMessageProps ) => {
 	const [ isFullscreen, setIsFullscreen ] = useState( false );
 	const currentUser = useSelector( getCurrentUser );
 	const translate = useTranslate();
-	const [ isSourcesExpanded, setIsSourcesExpanded ] = useState( false );
 
 	const realTimeMessage = useTyper( message.content, ! isUser && message.type === 'message', {
 		delayBetweenCharacters: 66,
@@ -133,13 +132,6 @@ const ChatMessage = ( { message, scrollToBottom }: ChatMessageProps ) => {
 			setScrolledToBottom( true );
 		}
 	}, [ messageFullyTyped, scrolledToBottom, scrollToBottom ] );
-
-	useEffect( () => {
-		if ( isSourcesExpanded ) {
-			fullscreenRef.current?.scrollTo( 0, fullscreenRef.current?.scrollHeight );
-			scrollToBottom();
-		}
-	}, [ isSourcesExpanded, scrollToBottom ] );
 
 	if ( ! currentUser || ! botName ) {
 		return;
@@ -289,8 +281,6 @@ const ChatMessage = ( { message, scrollToBottom }: ChatMessageProps ) => {
 						textOnly: true,
 					} ) }
 					screenReaderText="More"
-					onOpen={ () => setIsSourcesExpanded( true ) }
-					onClose={ () => setIsSourcesExpanded( false ) }
 				>
 					<div className="odie-chatbox-message-sources">
 						{ sources.map( ( source: Source, index: number ) => (

--- a/client/odie/message/index.tsx
+++ b/client/odie/message/index.tsx
@@ -204,8 +204,7 @@ const ChatMessage = (
 		<div className={ `message-header ${ isUser ? 'user' : 'bot' }` }>{ messageAvatarHeader }</div>
 	);
 
-	const shouldRenderExtraContactOptions =
-		isRequestingHumanSupport && ! hasFeedback && messageFullyTyped;
+	const shouldRenderExtraContactOptions = isRequestingHumanSupport && messageFullyTyped;
 
 	const onDislike = () => {
 		if ( shouldRenderExtraContactOptions ) {
@@ -229,7 +228,7 @@ const ChatMessage = (
 
 	const messageContent = (
 		<div className={ odieChatBoxMessageSourcesContainerClass } ref={ fullscreenRef }>
-			<div className={ messageClasses } ref={ ref }>
+			<div className={ messageClasses }>
 				{ messageHeader }
 				{ ( message.type === 'message' || ! message.type ) && (
 					<>
@@ -316,7 +315,11 @@ const ChatMessage = (
 			</>
 		);
 	}
-	return messageContent;
+	return (
+		<div className={ odieChatBoxMessageSourcesContainerClass } ref={ ref }>
+			{ messageContent }
+		</div>
+	);
 };
 
 export default ChatMessage;

--- a/client/odie/message/index.tsx
+++ b/client/odie/message/index.tsx
@@ -60,7 +60,9 @@ const ChatMessage = (
 
 	// dedupe sources based on url
 	let sources = message?.context?.sources ?? [];
-	sources = [ ...new Map( sources.map( ( source ) => [ source.url, source ] ) ).values() ];
+	if ( sources.length > 0 ) {
+		sources = [ ...new Map( sources.map( ( source ) => [ source.url, source ] ) ).values() ];
+	}
 
 	const isTypeMessageOrEmpty = ! message.type || message.type === 'message';
 	const isSimulatedTypingFinished = message.simulateTyping && message.content === realTimeMessage;
@@ -286,11 +288,12 @@ const ChatMessage = (
 					screenReaderText="More"
 				>
 					<div className="odie-chatbox-message-sources">
-						{ sources.map( ( source: Source, index: number ) => (
-							<CustomALink key={ index } href={ source.url } inline={ false }>
-								{ source?.title }
-							</CustomALink>
-						) ) }
+						{ sources.length > 0 &&
+							sources.map( ( source: Source, index: number ) => (
+								<CustomALink key={ index } href={ source.url } inline={ false }>
+									{ source?.title }
+								</CustomALink>
+							) ) }
 					</div>
 				</FoldableCard>
 			) }

--- a/client/odie/message/index.tsx
+++ b/client/odie/message/index.tsx
@@ -56,7 +56,10 @@ const ChatMessage = ( { message, scrollToBottom }: ChatMessageProps ) => {
 	const hasSources = message?.context?.sources && message.context?.sources.length > 0;
 	const hasFeedback = !! message?.rating_value;
 
-	const sources = message?.context?.sources ?? [];
+	// dedupe sources based on url
+	let sources = message?.context?.sources ?? [];
+	sources = [ ...new Map( sources.map( ( source ) => [ source.url, source ] ) ).values() ];
+
 	const isTypeMessageOrEmpty = ! message.type || message.type === 'message';
 	const isSimulatedTypingFinished = message.simulateTyping && message.content === realTimeMessage;
 	const isRequestingHumanSupport = message.context?.flags?.forward_to_human_support;

--- a/client/odie/message/index.tsx
+++ b/client/odie/message/index.tsx
@@ -55,6 +55,8 @@ const ChatMessage = ( { message, scrollToBottom }: ChatMessageProps ) => {
 
 	const hasSources = message?.context?.sources && message.context?.sources.length > 0;
 	const hasFeedback = !! message?.rating_value;
+
+	const hasNegativeFeedback = message?.rating_value && message?.rating_value < 3;
 	const sources = message?.context?.sources ?? [];
 	const isTypeMessageOrEmpty = ! message.type || message.type === 'message';
 	const isSimulatedTypingFinished = message.simulateTyping && message.content === realTimeMessage;
@@ -205,7 +207,8 @@ const ChatMessage = ( { message, scrollToBottom }: ChatMessageProps ) => {
 
 	const shouldRenderExtraContactOptions =
 		( ( isRequestingHumanSupport !== undefined && isRequestingHumanSupport ) ||
-			( message && message.type === 'dislike-feedback' ) ) &&
+			( message && message.type === 'dislike-feedback' ) ||
+			hasNegativeFeedback ) &&
 		messageFullyTyped;
 
 	const onDislike = () => {
@@ -214,13 +217,7 @@ const ChatMessage = ( { message, scrollToBottom }: ChatMessageProps ) => {
 		}
 		setTimeout( () => {
 			addMessage( {
-				content: translate(
-					'I’m sorry my last response didn’t meet your expectations! Here’s some other ways to get more in-depth help:',
-					{
-						context: 'Message displayed when the user dislikes a message from the bot',
-						textOnly: true,
-					}
-				),
+				content: '...',
 				role: 'bot',
 				type: 'dislike-feedback',
 			} );
@@ -269,7 +266,13 @@ const ChatMessage = ( { message, scrollToBottom }: ChatMessageProps ) => {
 							a: CustomALink,
 						} }
 					>
-						{ message.content }
+						{ translate(
+							'I’m sorry my last response didn’t meet your expectations! Here’s some other ways to get more in-depth help:',
+							{
+								context: 'Message displayed when the user dislikes a message from the bot',
+								textOnly: true,
+							}
+						) }
 					</AsyncLoad>
 				) }
 				{ shouldRenderExtraContactOptions && extraContactOptions }

--- a/client/odie/message/style.scss
+++ b/client/odie/message/style.scss
@@ -123,7 +123,7 @@
 }
 
 .odie-sources-inline {
-	display: inline-flex;
+	display: inline;
 	padding: 0 8px;
 	margin: 0;
 }

--- a/client/odie/message/style.scss
+++ b/client/odie/message/style.scss
@@ -21,6 +21,10 @@
 	}
 }
 
+.odie-sources-foldable-card {
+	overflow-x: hidden !important;
+}
+
 .odie-chatbox-message p:last-of-type {
 	margin-bottom: 0;
 }
@@ -100,7 +104,7 @@
 		.odie-chatbox-message-sources-container-fullscreen {
 			max-width: 800px;
 			max-height: 80vh;
-			overflow: auto;
+			overflow-y: auto;
 		}
 	}
 }

--- a/client/odie/message/style.scss
+++ b/client/odie/message/style.scss
@@ -81,21 +81,27 @@
 	left: 0;
 	right: 0;
 	bottom: 0;
-	background-color: rgba(0, 0, 0, 0.1);
 	z-index: 9999;
 	display: flex;
 	justify-content: center;
 	align-items: center;
+	background-color: rgba(0, 0, 0, 0.1);
 
-	.odie-chatbox-message {
-		box-shadow: 0 0 0 1px var(--color-border-subtle);
-		max-width: 800px;
-		max-height: 800px;
-		width: auto;
-		height: auto;
-		margin: auto;
-		overflow-y: auto;
-		font-size: $font-body;
+	.odie-fullscreen-backdrop {
+
+		.odie-chatbox-message {
+			box-shadow: 0 0 0 1px var(--color-border-subtle);
+			width: auto;
+			height: auto;
+			margin: auto;
+			font-size: $font-body;
+		}
+
+		.odie-chatbox-message-sources-container-fullscreen {
+			max-width: 800px;
+			max-height: 80vh;
+			overflow: auto;
+		}
 	}
 }
 
@@ -369,6 +375,7 @@ $custom-border-corner-size: 16px;
 }
 
 .odie-chatbox-message-sources-container {
+
 	.foldable-card {
 		margin: 0 !important;
 		width: 100% !important;

--- a/client/odie/message/style.scss
+++ b/client/odie/message/style.scss
@@ -117,13 +117,13 @@
 
 .odie-sources {
 	display: flex;
-	padding: 4px 8px;
 	align-items: center;
 	gap: 4px;
 	align-self: stretch;
 	border-radius: 4px;
 	background-color: var(--studio-gray-0);
 	width: fit-content;
+	padding: 0;
 	margin: 4px 0;
 
 	.odie-sources-link {
@@ -131,6 +131,7 @@
 		color: var(--studio-blue-40);
 		font-style: normal;
 		font-weight: 600;
+		padding: 4px 16px;
 	}
 
 	svg.gridicons-external {
@@ -140,8 +141,12 @@
 
 .odie-sources-inline {
 	display: inline;
-	padding: 0 8px;
+	padding: 0;
 	margin: 0;
+
+	.odie-sources-link {
+		padding: 0 8px;
+	}
 }
 
 $feedback-button-size: 28px;

--- a/client/odie/message/style.scss
+++ b/client/odie/message/style.scss
@@ -19,6 +19,12 @@
 		margin: 0 0 1.5em 1.5em;
 		width: calc(100% - 1.5em);
 	}
+
+	.help-center-contact-page {
+		.help-center-contact-page__content {
+			margin-bottom: 0 !important;
+		}
+	}
 }
 
 .odie-sources-foldable-card {

--- a/client/odie/message/style.scss
+++ b/client/odie/message/style.scss
@@ -145,7 +145,7 @@
 	margin: 0;
 
 	.odie-sources-link {
-		padding: 0 8px;
+		padding: 0 4px;
 	}
 }
 

--- a/client/odie/message/style.scss
+++ b/client/odie/message/style.scss
@@ -105,6 +105,14 @@
 			height: auto;
 			margin: auto;
 			font-size: $font-body;
+			padding-top: 0;
+
+			.message-header {
+				padding-top: 16px;
+				position: sticky;
+				top: 0;
+				background-color: #fff;
+			}
 		}
 
 		.odie-chatbox-message-sources-container-fullscreen {

--- a/client/odie/query/index.ts
+++ b/client/odie/query/index.ts
@@ -4,7 +4,7 @@ import { canAccessWpcomApis } from 'wpcom-proxy-request';
 import wpcom from 'calypso/lib/wp';
 import { useOdieAssistantContext } from '../context';
 import { setOdieStorage } from '../data';
-import type { Chat, Message, OdieAllowedBots } from '../types';
+import type { Chat, Message, MessageRole, MessageType, OdieAllowedBots } from '../types';
 
 // Either we use wpcom or apiFetch for the request for accessing odie endpoint for atomic or wpcom sites
 const buildSendChatMessage = (
@@ -110,6 +110,35 @@ export const useOdieGetChat = (
 		queryFn: () => buildGetChatMessage( botNameSlug, chatId, page, perPage, includeFeedback ),
 		refetchOnWindowFocus: false,
 		enabled: !! chatId && ! chat.chat_id,
+		select: ( data ) => {
+			const negativeFeedbackThreshold = 3;
+			const modifiedMessages: Message[] = [];
+
+			data.messages.forEach( ( message ) => {
+				modifiedMessages.push( message );
+
+				// Check if the message has negative feedback
+				if (
+					message.rating_value &&
+					message.rating_value < negativeFeedbackThreshold &&
+					! message.context?.flags?.forward_to_human_support
+				) {
+					// Add a new 'dislike-feedback' message right after the current message
+					const dislikeFeedbackMessage = {
+						content: '...',
+						role: 'bot' as MessageRole,
+						type: 'dislike-feedback' as MessageType,
+						simulateTyping: false,
+					};
+					modifiedMessages.push( dislikeFeedbackMessage );
+				}
+			} );
+
+			return {
+				...data,
+				messages: modifiedMessages,
+			};
+		},
 	} );
 };
 

--- a/client/odie/send-message-input/index.tsx
+++ b/client/odie/send-message-input/index.tsx
@@ -13,11 +13,13 @@ import { Message } from '../types';
 import './style.scss';
 
 export const OdieSendMessageButton = ( {
+	scrollToRecent,
 	scrollToBottom,
 	enableStickToBottom,
 	enableJumpToRecent,
 }: {
-	scrollToBottom: ( smooth?: boolean, force?: boolean ) => void;
+	scrollToRecent: () => void;
+	scrollToBottom: ( force?: boolean ) => void;
 	enableStickToBottom: () => void;
 	enableJumpToRecent: boolean;
 } ) => {
@@ -90,6 +92,7 @@ export const OdieSendMessageButton = ( {
 			return;
 		}
 		setMessageString( '' );
+		enableStickToBottom();
 		await sendMessage();
 		scrollToBottom( true );
 	};
@@ -107,7 +110,6 @@ export const OdieSendMessageButton = ( {
 
 	const handleSubmit = async ( event: FormEvent< HTMLFormElement > ) => {
 		event.preventDefault();
-		enableStickToBottom();
 		await sendMessageIfNotEmpty();
 	};
 
@@ -116,7 +118,7 @@ export const OdieSendMessageButton = ( {
 	return (
 		<>
 			<JumpToRecent
-				scrollToBottom={ () => scrollToBottom( true, true ) }
+				scrollToBottom={ scrollToRecent }
 				enableJumpToRecent={ enableJumpToRecent }
 				bottomOffset={ divContainerHeight ?? 0 }
 			/>

--- a/client/odie/send-message-input/index.tsx
+++ b/client/odie/send-message-input/index.tsx
@@ -17,7 +17,7 @@ export const OdieSendMessageButton = ( {
 	enableStickToBottom,
 	enableJumpToRecent,
 }: {
-	scrollToBottom: ( smooth?: boolean ) => void;
+	scrollToBottom: ( smooth?: boolean, force?: boolean ) => void;
 	enableStickToBottom: () => void;
 	enableJumpToRecent: boolean;
 } ) => {
@@ -91,22 +91,17 @@ export const OdieSendMessageButton = ( {
 		}
 		setMessageString( '' );
 		await sendMessage();
+		scrollToBottom( true );
 	};
 
 	const handleKeyPress = async ( event: KeyboardEvent< HTMLTextAreaElement > ) => {
+		scrollToBottom( false );
 		if ( isLoading ) {
 			return;
 		}
-		scrollToBottom();
 		if ( event.key === 'Enter' && ! event.shiftKey ) {
 			event.preventDefault();
 			await sendMessageIfNotEmpty();
-		}
-	};
-
-	const handleKeyUp = () => {
-		if ( ! isLoading ) {
-			scrollToBottom( false );
 		}
 	};
 
@@ -139,7 +134,6 @@ export const OdieSendMessageButton = ( {
 							setMessageString( event.currentTarget.value )
 						}
 						onKeyPress={ handleKeyPress }
-						onKeyUp={ handleKeyUp }
 					/>
 					<button
 						type="submit"

--- a/client/odie/send-message-input/index.tsx
+++ b/client/odie/send-message-input/index.tsx
@@ -116,7 +116,7 @@ export const OdieSendMessageButton = ( {
 	return (
 		<>
 			<JumpToRecent
-				scrollToBottom={ () => scrollToBottom( true ) }
+				scrollToBottom={ () => scrollToBottom( true, true ) }
 				enableJumpToRecent={ enableJumpToRecent }
 				bottomOffset={ divContainerHeight ?? 0 }
 			/>

--- a/packages/components/src/foldable-card/index.jsx
+++ b/packages/components/src/foldable-card/index.jsx
@@ -15,6 +15,7 @@ class FoldableCard extends Component {
 		actionButton: PropTypes.node,
 		actionButtonExpanded: PropTypes.node,
 		cardKey: PropTypes.string,
+		clickableHeader: PropTypes.bool,
 		compact: PropTypes.bool,
 		disabled: PropTypes.bool,
 		expandedSummary: PropTypes.node,

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -187,14 +187,10 @@ export const HelpCenterContactForm = () => {
 	const [ debouncedMessage ] = useDebounce( message || '', 500 );
 	const [ debouncedSubject ] = useDebounce( subject || '', 500 );
 
-	// if the user was chatting with Wapuu, we need to disable GPT (no more AI)
-	if ( wapuuFlow ) {
-		params.set( 'disable-gpt', 'true' );
-		params.set( 'show-gpt', 'false' );
-	}
-
 	const enableGPTResponse =
-		config.isEnabled( 'help/gpt-response' ) && ! ( params.get( 'disable-gpt' ) === 'true' );
+		config.isEnabled( 'help/gpt-response' ) &&
+		! ( params.get( 'disable-gpt' ) === 'true' ) &&
+		! wapuuFlow;
 
 	const showingSearchResults = params.get( 'show-results' ) === 'true';
 	const showingGPTResponse = enableGPTResponse && params.get( 'show-gpt' ) === 'true';
@@ -268,7 +264,7 @@ export const HelpCenterContactForm = () => {
 	}
 
 	function handleCTA() {
-		if ( ! enableGPTResponse && ! showingSearchResults ) {
+		if ( ! enableGPTResponse && ! showingSearchResults && ! wapuuFlow ) {
 			params.set( 'show-results', 'true' );
 			navigate( {
 				pathname: '/contact-form',
@@ -277,13 +273,19 @@ export const HelpCenterContactForm = () => {
 			return;
 		}
 
-		if ( ! showingGPTResponse && enableGPTResponse ) {
+		if ( ! showingGPTResponse && enableGPTResponse && ! wapuuFlow ) {
 			params.set( 'show-gpt', 'true' );
 			navigate( {
 				pathname: '/contact-form',
 				search: params.toString(),
 			} );
 			return;
+		}
+
+		// if the user was chatting with Wapuu, we need to disable GPT (no more AI)
+		if ( wapuuFlow ) {
+			params.set( 'disable-gpt', 'true' );
+			params.set( 'show-gpt', 'false' );
 		}
 
 		const productSlug = ( supportSite as HelpCenterSite )?.plan.product_slug;

--- a/packages/help-center/src/components/help-center-search.scss
+++ b/packages/help-center/src/components/help-center-search.scss
@@ -38,6 +38,7 @@
 
 			.search {
 				height: 40px;
+				border: 1px;
 			}
 
 			input.search__input {


### PR DESCRIPTION
Related to pdtkmj-20q-p2

## Proposed Changes

This is addressing a number of issues detected in the cFt. More Pull Request to come.

1. Full-screen mode for messages is now fully adjusted to the screen
2. Scrolling now is not being propagated to the parent while on full-screen
3. Inline help is now not changing its size while focused 
4. Removed semicolon after sources:` sources: => sources`
5. The Sources header is now clickable
6. The message is still rendered in the list of messages even after setting the full-screen mode for the message itself
7. Fixed a strange wobbling happening in Firefox while typing a long message.
8. Do not display again the contact options if we are already showing it as part of the message (downvoting an answer)
9. Fixed the display of long inline links.
10. Fixed copy/pasting the above texts that contained links, adding line breaks when they were not necessary
11. Disabled scroll to the bottom when typing in the message input box
12. For a split second an horizontal scroll appears in the full screen message while clicking on the sources
13. If message has been rated negatively, persist the contact options when reloading
14. Wapuu flows directly to email or chat when asked to do so (no more AI involved after Wapuu)

## Testing Instructions

Please, test as per the attached link

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?