### PR TITLE
Promote Post: fix infinite loop in redirectToPrimarySite

### DIFF
--- a/client/my-sites/promote-post-i2/index.js
+++ b/client/my-sites/promote-post-i2/index.js
@@ -1,8 +1,10 @@
 import page from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { getSiteFragment } from 'calypso/lib/route';
-import { navigation, sites, siteSelection } from 'calypso/my-sites/controller';
-import getPrimarySiteSlug from 'calypso/state/selectors/get-primary-site-slug';
+import { navigation, redirectToPrimary, sites, siteSelection } from 'calypso/my-sites/controller';
+import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
+import { requestSite } from 'calypso/state/sites/actions';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
 import {
 	promoteWidget,
 	promotedPosts,
@@ -18,14 +20,28 @@ export const redirectToPrimarySite = ( context, next ) => {
 		return next();
 	}
 
-	const state = context.store.getState();
-	const primarySiteSlug = getPrimarySiteSlug( state );
-	if ( primarySiteSlug !== null ) {
-		page( `${ context.pathname }/${ primarySiteSlug }` );
-	} else {
-		siteSelection( context, next );
-		page( getAdvertisingDashboardPath( '' ) );
+	const { getState, dispatch } = context.store;
+	const primarySiteId = getPrimarySiteId( getState() );
+	const primarySiteSlug = getSiteSlug( getState(), primarySiteId );
+
+	if ( primarySiteSlug ) {
+		redirectToPrimary( context, primarySiteSlug );
+		return;
 	}
+
+	// Fetch the primary site by ID and then try to determine its slug again.
+	dispatch( requestSite( primarySiteId ) )
+		.catch( () => null )
+		.then( () => {
+			const freshPrimarySiteSlug = getSiteSlug( getState(), primarySiteId );
+			if ( freshPrimarySiteSlug ) {
+				redirectToPrimary( context, freshPrimarySiteSlug );
+				return;
+			}
+
+			// no redirection happened, proceed to showing the sites list
+			next();
+		} );
 };
 
 const promotePage = ( url, controller ) => {
@@ -44,6 +60,7 @@ export default () => {
 	page(
 		getAdvertisingDashboardPath( '/' ),
 		redirectToPrimarySite,
+		siteSelection,
 		sites,
 		makeLayout,
 		clientRender


### PR DESCRIPTION
Fixes a bug in the `/advertising` route handler which would enter an infinite redirect loop (from `/advertising` to `/advertising`) if the primary site slug is not in Redux state (`state.sites`).

To reproduce, first delete the local `calypso` IndexedDB database, so that there is no cached Redux state. Then open `/advertising`. The `primarySiteSlug` is going to be `null`, because sites are not fetched yet. And the `page( getAdvertisingDashboardPath( '' ) )` call will trigger handling the same route (`/advertising`) over and over again in an infinite loop.

To fix this, I copied the bit of code from `siteSelection` that fetches the site info and does the primary redirect.

Note that we need `redirectToPrimarySite` at all only because we want a special behavior: to redirect to the primary site even when the user has multiple sites. For a single-site user, `siteSelection` would do this automatically. But to do it for multiple-site user, we need extra code. Otherwise `siteSelection` would select "all sites" (`null`) and the route handler would display the site selection UI.