### PR TITLE
Subscribers launchpad: show Help Center for add subscribe block task

### DIFF
--- a/packages/launchpad/src/setup-actions.ts
+++ b/packages/launchpad/src/setup-actions.ts
@@ -1,6 +1,8 @@
 import config from '@automattic/calypso-config';
-import { updateLaunchpadSettings } from '@automattic/data-stores';
+import { HelpCenter, updateLaunchpadSettings } from '@automattic/data-stores';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { isMobile } from '@automattic/viewport';
+import { dispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import wpcomRequest from 'wpcom-proxy-request';
 import type { LaunchpadTaskActionsProps, Task } from './types';
@@ -45,10 +47,15 @@ export const setUpActionsForTasks = ( {
 		let logMissingCalypsoPath = false;
 		let useCalypsoPath = true;
 		const hasCalypsoPath = task.calypso_path !== undefined;
+		const HELP_CENTER_STORE = HelpCenter.register();
 
 		if ( uiContext === 'calypso' && hasCalypsoPath ) {
 			if ( task.id === 'drive_traffic' && ! isMobile() && hasCalypsoPath ) {
 				task.calypso_path = addQueryArgs( task.calypso_path, { tour: 'marketingConnectionsTour' } );
+			}
+
+			if ( task.id === 'add_subscribe_block' ) {
+				useCalypsoPath = false;
 			}
 
 			// Enable task in 'calypso' context
@@ -61,6 +68,13 @@ export const setUpActionsForTasks = ( {
 					updateLaunchpadSettings( siteSlug, {
 						checklist_statuses: { [ task.id ]: true },
 					} );
+				}
+				if ( task.id === 'add_subscribe_block' ) {
+					dispatch( HELP_CENTER_STORE ).setShowHelpCenter( true );
+					dispatch( HELP_CENTER_STORE ).setShowSupportDoc(
+						localizeUrl( 'https://wordpress.com/support/wordpress-editor/blocks/subscribe-block/' ),
+						170164
+					);
 				}
 			};
 		} else {


### PR DESCRIPTION
Context: pdDOJh-2Ee-p2#comment-2022 

## Proposed Changes

- Open Help Center when clicking the Add subscribe block task.

## Testing Instructions

1. Apply this PR
2. Go to http://calypso.localhost:3000/subscribers/yoursite
3. Make sure you don't have any subscribers & have not yet added the subscribe block
4. Click the "Add subscribe block" task

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?