### PR TITLE
Monetize: fix automatically generated yearly plan name

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -275,7 +275,11 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goToStep, flow }: SidebarPr
 								title: translate( 'Paid newsletter' ),
 								type: TYPE_TIER,
 							} }
-							annualProduct={ { subscribe_as_site_subscriber: true, price: 5 * 12 } }
+							annualProduct={ {
+								price: 5 * 12,
+								subscribe_as_site_subscriber: true,
+								title: `${ translate( 'Paid newsletter' ) } ${ translate( '(yearly)' ) }`,
+							} }
 							siteId={ site.ID }
 						/>
 					) }

--- a/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
+++ b/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
@@ -1,7 +1,6 @@
 import { Dialog, FormInputValidation, FoldableCard } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import { ToggleControl } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
 import { useTranslate } from 'i18n-calypso';
 import { ChangeEvent, useState, useEffect, useMemo } from 'react';
 import CountedTextArea from 'calypso/components/forms/counted-textarea';
@@ -228,7 +227,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 		ID: annualProduct?.ID, // will the the ID if already existing
 		price: currentAnnualPrice,
 		interval: PLAN_YEARLY_FREQUENCY,
-		title: `${ productDetails.title } ${ __( '(yearly)' ) }`,
+		title: `${ productDetails.title } ${ translate( '(yearly)' ) }`,
 	} );
 
 	const getCurrentProductDetails = (): Product => {

--- a/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
+++ b/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
@@ -228,7 +228,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 		ID: annualProduct?.ID, // will the the ID if already existing
 		price: currentAnnualPrice,
 		interval: PLAN_YEARLY_FREQUENCY,
-		title: productDetails.title + __( '(yearly)', 'jetpack' ),
+		title: `${ productDetails.title } ${ __( '(yearly)' ) }`,
 	} );
 
 	const getCurrentProductDetails = (): Product => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Follow-up to https://github.com/Automattic/wp-calypso/pull/84099

Fixes two issues — 
- "yearly" not appended to annual plan, at least that I could see in the frontend
 - "Yearly" label not having space before it when paid plans are created via `/earn`

<img width="433" alt="Screenshot 2023-11-10 at 15 04 55" src="https://github.com/Automattic/wp-calypso/assets/87168/7333b3be-9a43-42af-917a-4b48f8583ff5">


## Proposed Changes

* Add space before "yearly" in the modal when generating yearly name
* Pass yearly name from the onboarding modal

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow instructions from https://github.com/Automattic/wp-calypso/pull/84099 to create a plan during onboarding
* The plan should have "yearly" label added to it in the frontend
* Create another plan directly from `/earn` — the "yearly" should have space before it

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?