### PR TITLE
Remove axios

### DIFF
--- a/packages/calypso-mp-data-analysis/.eslintrc.cjs
+++ b/packages/calypso-mp-data-analysis/.eslintrc.cjs
@@ -1,0 +1,4 @@
+const nodeConfig = require( '@automattic/calypso-eslint-overrides/node' );
+module.exports = {
+	...nodeConfig,
+};

--- a/packages/calypso-mp-data-analysis/README.md
+++ b/packages/calypso-mp-data-analysis/README.md
@@ -1,5 +1,5 @@
 # calypso-mp-data-analysis
 
-This package derivates the top products from the `top-100-searches.csv` file. This file should be a csv containing a `search_term` column, a `count` column and a `language` column.
+This package contains NodeJS scripts which derive the top products from the `top-100-searches.csv` file. This file should be a csv containing a `search_term` column, a `count` column and a `language` column.
 
 To generate the csv reports navigate into this repo and run `yarn generate` the results will appear under `results/`.

--- a/packages/calypso-mp-data-analysis/get-top-categories.js
+++ b/packages/calypso-mp-data-analysis/get-top-categories.js
@@ -1,4 +1,3 @@
-import { get } from 'axios';
 import { parse } from 'csv-parse/sync';
 import { stringify } from 'csv-stringify/sync';
 import fs from 'fs-extra';
@@ -175,25 +174,24 @@ const records = parse( csvFileContent, {
 } );
 
 for ( const record of records ) {
-	const { data: wporgData } = await get( 'https://api.wordpress.org/plugins/info/1.2/', {
-		params: {
-			action: 'query_plugins',
-			'request[page]': 1,
-			'request[per_page]': 24,
-			'request[search]': record.search_term,
-			'request[locale]': getLocale( record.language ),
-		},
-	} );
+	const { data: wporgData } = await fetch(
+		'https://api.wordpress.org/plugins/info/1.2?' +
+			new URLSearchParams( {
+				action: 'query_plugins',
+				'request[page]': 1,
+				'request[per_page]': 24,
+				'request[search]': record.search_term,
+				'request[locale]': getLocale( record.language ),
+			} )
+	);
 
-	const { data: wpcomData } = await get(
-		'https://public-api.wordpress.com/wpcom/v2/marketplace/products',
-		{
-			params: {
+	const { data: wpcomData } = await fetch(
+		'https://public-api.wordpress.com/wpcom/v2/marketplace/products?' +
+			new URLSearchParams( {
 				type: 'all',
 				_envelope: 1,
 				q: record.search_term,
-			},
-		}
+			} )
 	);
 
 	const wpcomPlugins = Object.values( wpcomData.body.results );
@@ -201,7 +199,6 @@ for ( const record of records ) {
 
 	const plugins = [ ...wpcomPlugins, ...wporgPlugins ].slice( 0, 6 ); // show top 6 plugins
 
-	// eslint-disable-next-line no-console
 	console.log(
 		`fetched plugins for ${ record.search_term }: locale - ${ getLocale(
 			record.language

--- a/packages/calypso-mp-data-analysis/get-top-categories.js
+++ b/packages/calypso-mp-data-analysis/get-top-categories.js
@@ -1,8 +1,7 @@
-// eslint-disable-next-line import/no-nodejs-modules
-const { get } = require( 'axios' );
-const { parse } = require( 'csv-parse/sync' );
-const { stringify } = require( 'csv-stringify/sync' );
-const fs = require( 'fs-extra' );
+import { get } from 'axios';
+import { parse } from 'csv-parse/sync';
+import { stringify } from 'csv-stringify/sync';
+import fs from 'fs-extra';
 
 // empty translation becaue laziness
 const __ = ( name ) => name;
@@ -166,90 +165,86 @@ const getLocale = ( lang ) => {
 	return lang.replace( '-', '_' );
 };
 
-const getTopTagsAndCategories = async () => {
-	const tagsCountMap = {};
-	const csvFileContent = await fs.readFile( './top-100-searches.csv', {
-		encoding: 'utf-8',
-	} );
-	const records = parse( csvFileContent, {
-		columns: true,
-		skip_empty_lines: true,
+const tagsCountMap = {};
+const csvFileContent = await fs.readFile( './top-100-searches.csv', {
+	encoding: 'utf-8',
+} );
+const records = parse( csvFileContent, {
+	columns: true,
+	skip_empty_lines: true,
+} );
+
+for ( const record of records ) {
+	const { data: wporgData } = await get( 'https://api.wordpress.org/plugins/info/1.2/', {
+		params: {
+			action: 'query_plugins',
+			'request[page]': 1,
+			'request[per_page]': 24,
+			'request[search]': record.search_term,
+			'request[locale]': getLocale( record.language ),
+		},
 	} );
 
-	for ( const record of records ) {
-		const { data: wporgData } = await get( 'https://api.wordpress.org/plugins/info/1.2/', {
+	const { data: wpcomData } = await get(
+		'https://public-api.wordpress.com/wpcom/v2/marketplace/products',
+		{
 			params: {
-				action: 'query_plugins',
-				'request[page]': 1,
-				'request[per_page]': 24,
-				'request[search]': record.search_term,
-				'request[locale]': getLocale( record.language ),
+				type: 'all',
+				_envelope: 1,
+				q: record.search_term,
 			},
-		} );
-
-		const { data: wpcomData } = await get(
-			'https://public-api.wordpress.com/wpcom/v2/marketplace/products',
-			{
-				params: {
-					type: 'all',
-					_envelope: 1,
-					q: record.search_term,
-				},
-			}
-		);
-
-		const wpcomPlugins = Object.values( wpcomData.body.results );
-		const wporgPlugins = Object.values( wporgData.plugins );
-
-		const plugins = [ ...wpcomPlugins, ...wporgPlugins ].slice( 0, 6 ); // show top 6 plugins
-
-		// eslint-disable-next-line no-console
-		console.log(
-			`fetched plugins for ${ record.search_term }: locale - ${ getLocale(
-				record.language
-			) } results - wpcom: ${ wpcomPlugins.length } | wporg: ${ wporgPlugins.length }`
-		);
-
-		plugins.forEach( ( plugin ) => {
-			Object.keys( plugin.tags || {} ).forEach( ( tag ) => {
-				tagsCountMap[ tag ] = tagsCountMap[ tag ]
-					? tagsCountMap[ tag ] + parseInt( record.count )
-					: parseInt( record.count );
-			} );
-		} );
-	}
-
-	const topTags = Object.keys( tagsCountMap )
-		.map( ( tag ) => ( {
-			tag: tag,
-			count: tagsCountMap[ tag ],
-		} ) )
-		.sort( ( a, b ) => a.count - b.count )
-		.reverse();
-
-	await fs.outputFile(
-		'results/top-tags.csv',
-		stringify( topTags, { columns: [ { key: 'tag' }, { key: 'count' } ], header: true } )
+		}
 	);
 
-	const topCategories = Object.values( categories )
-		.map( ( category ) => {
-			const count = category.tags.reduce( ( acc, categoryTag ) => {
-				return acc + ( topTags.find( ( { tag } ) => tag === categoryTag )?.count ?? 0 );
-			}, 0 );
+	const wpcomPlugins = Object.values( wpcomData.body.results );
+	const wporgPlugins = Object.values( wporgData.plugins );
 
-			return {
-				category: category.slug,
-				count,
-			};
-		} )
-		.sort( ( a, b ) => a.count - b.count )
-		.reverse();
+	const plugins = [ ...wpcomPlugins, ...wporgPlugins ].slice( 0, 6 ); // show top 6 plugins
 
-	await fs.outputFile(
-		'results/top-categories.csv',
-		stringify( topCategories, { columns: [ { key: 'category' }, { key: 'count' } ], header: true } )
+	// eslint-disable-next-line no-console
+	console.log(
+		`fetched plugins for ${ record.search_term }: locale - ${ getLocale(
+			record.language
+		) } results - wpcom: ${ wpcomPlugins.length } | wporg: ${ wporgPlugins.length }`
 	);
-};
 
-getTopTagsAndCategories();
+	plugins.forEach( ( plugin ) => {
+		Object.keys( plugin.tags || {} ).forEach( ( tag ) => {
+			tagsCountMap[ tag ] = tagsCountMap[ tag ]
+				? tagsCountMap[ tag ] + parseInt( record.count )
+				: parseInt( record.count );
+		} );
+	} );
+}
+
+const topTags = Object.keys( tagsCountMap )
+	.map( ( tag ) => ( {
+		tag: tag,
+		count: tagsCountMap[ tag ],
+	} ) )
+	.sort( ( a, b ) => a.count - b.count )
+	.reverse();
+
+await fs.outputFile(
+	'results/top-tags.csv',
+	stringify( topTags, { columns: [ { key: 'tag' }, { key: 'count' } ], header: true } )
+);
+
+const topCategories = Object.values( categories )
+	.map( ( category ) => {
+		const count = category.tags.reduce( ( acc, categoryTag ) => {
+			return acc + ( topTags.find( ( { tag } ) => tag === categoryTag )?.count ?? 0 );
+		}, 0 );
+
+		return {
+			category: category.slug,
+			count,
+		};
+	} )
+	.sort( ( a, b ) => a.count - b.count )
+	.reverse();
+
+await fs.outputFile(
+	'results/top-categories.csv',
+	stringify( topCategories, { columns: [ { key: 'category' }, { key: 'count' } ], header: true } )
+);

--- a/packages/calypso-mp-data-analysis/get-top-categories.js
+++ b/packages/calypso-mp-data-analysis/get-top-categories.js
@@ -174,7 +174,7 @@ const records = parse( csvFileContent, {
 } );
 
 for ( const record of records ) {
-	const { data: wporgData } = await fetch(
+	const wporgResponse = await fetch(
 		'https://api.wordpress.org/plugins/info/1.2?' +
 			new URLSearchParams( {
 				action: 'query_plugins',
@@ -185,7 +185,7 @@ for ( const record of records ) {
 			} )
 	);
 
-	const { data: wpcomData } = await fetch(
+	const wpcomResponse = await fetch(
 		'https://public-api.wordpress.com/wpcom/v2/marketplace/products?' +
 			new URLSearchParams( {
 				type: 'all',
@@ -193,6 +193,9 @@ for ( const record of records ) {
 				q: record.search_term,
 			} )
 	);
+
+	const wporgData = await wporgResponse.json();
+	const wpcomData = await wpcomResponse.json();
 
 	const wpcomPlugins = Object.values( wpcomData.body.results );
 	const wporgPlugins = Object.values( wporgData.plugins );

--- a/packages/calypso-mp-data-analysis/get-top-products.js
+++ b/packages/calypso-mp-data-analysis/get-top-products.js
@@ -24,7 +24,7 @@ const records = parse( csvFileContent, {
 } );
 
 for ( const record of records ) {
-	const { data: wporgData } = await fetch(
+	const wporgResponse = await fetch(
 		'https://api.wordpress.org/plugins/info/1.2?' +
 			new URLSearchParams( {
 				action: 'query_plugins',
@@ -35,7 +35,7 @@ for ( const record of records ) {
 			} )
 	);
 
-	const { data: wpcomData } = await fetch(
+	const wpcomResponse = await fetch(
 		'https://public-api.wordpress.com/wpcom/v2/marketplace/products?' +
 			new URLSearchParams( {
 				type: 'all',
@@ -43,6 +43,9 @@ for ( const record of records ) {
 				q: record.search_term,
 			} )
 	);
+
+	const wporgData = await wporgResponse.json();
+	const wpcomData = await wpcomResponse.json();
 
 	const wpcomPlugins = Object.values( wpcomData.body.results );
 	const wporgPlugins = Object.values( wporgData.plugins );

--- a/packages/calypso-mp-data-analysis/get-top-products.js
+++ b/packages/calypso-mp-data-analysis/get-top-products.js
@@ -1,8 +1,7 @@
-// eslint-disable-next-line import/no-nodejs-modules
-const { get } = require( 'axios' );
-const { parse } = require( 'csv-parse/sync' );
-const { stringify } = require( 'csv-stringify/sync' );
-const fs = require( 'fs-extra' );
+import { get } from 'axios';
+import { parse } from 'csv-parse/sync';
+import { stringify } from 'csv-stringify/sync';
+import fs from 'fs-extra';
 
 const getLocale = ( lang ) => {
 	if ( lang === 'en' ) {
@@ -16,73 +15,69 @@ const getLocale = ( lang ) => {
 	return lang.replace( '-', '_' );
 };
 
-const getTopProducts = async () => {
-	const productsCountMap = {};
-	const csvFileContent = await fs.readFile( './top-100-searches.csv', {
-		encoding: 'utf-8',
-	} );
-	const records = parse( csvFileContent, {
-		columns: true,
-		skip_empty_lines: true,
+const productsCountMap = {};
+const csvFileContent = await fs.readFile( './top-100-searches.csv', {
+	encoding: 'utf-8',
+} );
+const records = parse( csvFileContent, {
+	columns: true,
+	skip_empty_lines: true,
+} );
+
+for ( const record of records ) {
+	const { data: wporgData } = await get( 'https://api.wordpress.org/plugins/info/1.2/', {
+		params: {
+			action: 'query_plugins',
+			'request[page]': 1,
+			'request[per_page]': 24,
+			'request[search]': record.search_term,
+			'request[locale]': getLocale( record.language ),
+		},
 	} );
 
-	for ( const record of records ) {
-		const { data: wporgData } = await get( 'https://api.wordpress.org/plugins/info/1.2/', {
+	const { data: wpcomData } = await get(
+		'https://public-api.wordpress.com/wpcom/v2/marketplace/products',
+		{
 			params: {
-				action: 'query_plugins',
-				'request[page]': 1,
-				'request[per_page]': 24,
-				'request[search]': record.search_term,
-				'request[locale]': getLocale( record.language ),
+				type: 'all',
+				_envelope: 1,
+				q: record.search_term,
 			},
-		} );
-
-		const { data: wpcomData } = await get(
-			'https://public-api.wordpress.com/wpcom/v2/marketplace/products',
-			{
-				params: {
-					type: 'all',
-					_envelope: 1,
-					q: record.search_term,
-				},
-			}
-		);
-
-		const wpcomPlugins = Object.values( wpcomData.body.results );
-		const wporgPlugins = Object.values( wporgData.plugins );
-
-		const plugins = [ ...wpcomPlugins, ...wporgPlugins ].slice( 0, 6 ); // show top 6 plugins
-
-		// eslint-disable-next-line no-console
-		console.log(
-			`fetched plugins for ${ record.search_term }: locale - ${ getLocale(
-				record.language
-			) } results - wpcom: ${ wpcomPlugins.length } | wporg: ${ wporgPlugins.length }`
-		);
-
-		plugins.forEach( ( plugin ) => {
-			productsCountMap[ plugin.slug ] = {
-				count: productsCountMap[ plugin.slug ]
-					? productsCountMap[ plugin.slug ].count + parseInt( record.count )
-					: parseInt( record.count ),
-			};
-		} );
-	}
-
-	const results = Object.keys( productsCountMap )
-		.map( ( slug ) => ( {
-			product: slug,
-			count: productsCountMap[ slug ].count,
-			locales: productsCountMap[ slug ].locales,
-		} ) )
-		.sort( ( a, b ) => a.count - b.count )
-		.reverse()
-		.slice( 0, 250 ); // limit to 250 records
-
-	await fs.outputFile(
-		'results/top-products.csv',
-		stringify( results, { columns: [ { key: 'product' }, { key: 'count' } ], header: true } )
+		}
 	);
-};
 
-getTopProducts();
+	const wpcomPlugins = Object.values( wpcomData.body.results );
+	const wporgPlugins = Object.values( wporgData.plugins );
+
+	const plugins = [ ...wpcomPlugins, ...wporgPlugins ].slice( 0, 6 ); // show top 6 plugins
+
+	// eslint-disable-next-line no-console
+	console.log(
+		`fetched plugins for ${ record.search_term }: locale - ${ getLocale(
+			record.language
+		) } results - wpcom: ${ wpcomPlugins.length } | wporg: ${ wporgPlugins.length }`
+	);
+
+	plugins.forEach( ( plugin ) => {
+		productsCountMap[ plugin.slug ] = {
+			count: productsCountMap[ plugin.slug ]
+				? productsCountMap[ plugin.slug ].count + parseInt( record.count )
+				: parseInt( record.count ),
+		};
+	} );
+}
+
+const results = Object.keys( productsCountMap )
+	.map( ( slug ) => ( {
+		product: slug,
+		count: productsCountMap[ slug ].count,
+		locales: productsCountMap[ slug ].locales,
+	} ) )
+	.sort( ( a, b ) => a.count - b.count )
+	.reverse()
+	.slice( 0, 250 ); // limit to 250 records
+
+await fs.outputFile(
+	'results/top-products.csv',
+	stringify( results, { columns: [ { key: 'product' }, { key: 'count' } ], header: true } )
+);

--- a/packages/calypso-mp-data-analysis/get-top-products.js
+++ b/packages/calypso-mp-data-analysis/get-top-products.js
@@ -1,4 +1,3 @@
-import { get } from 'axios';
 import { parse } from 'csv-parse/sync';
 import { stringify } from 'csv-stringify/sync';
 import fs from 'fs-extra';
@@ -25,25 +24,24 @@ const records = parse( csvFileContent, {
 } );
 
 for ( const record of records ) {
-	const { data: wporgData } = await get( 'https://api.wordpress.org/plugins/info/1.2/', {
-		params: {
-			action: 'query_plugins',
-			'request[page]': 1,
-			'request[per_page]': 24,
-			'request[search]': record.search_term,
-			'request[locale]': getLocale( record.language ),
-		},
-	} );
+	const { data: wporgData } = await fetch(
+		'https://api.wordpress.org/plugins/info/1.2?' +
+			new URLSearchParams( {
+				action: 'query_plugins',
+				'request[page]': 1,
+				'request[per_page]': 24,
+				'request[search]': record.search_term,
+				'request[locale]': getLocale( record.language ),
+			} )
+	);
 
-	const { data: wpcomData } = await get(
-		'https://public-api.wordpress.com/wpcom/v2/marketplace/products',
-		{
-			params: {
+	const { data: wpcomData } = await fetch(
+		'https://public-api.wordpress.com/wpcom/v2/marketplace/products?' +
+			new URLSearchParams( {
 				type: 'all',
 				_envelope: 1,
 				q: record.search_term,
-			},
-		}
+			} )
 	);
 
 	const wpcomPlugins = Object.values( wpcomData.body.results );
@@ -51,7 +49,6 @@ for ( const record of records ) {
 
 	const plugins = [ ...wpcomPlugins, ...wporgPlugins ].slice( 0, 6 ); // show top 6 plugins
 
-	// eslint-disable-next-line no-console
 	console.log(
 		`fetched plugins for ${ record.search_term }: locale - ${ getLocale(
 			record.language

--- a/packages/calypso-mp-data-analysis/package.json
+++ b/packages/calypso-mp-data-analysis/package.json
@@ -4,6 +4,7 @@
 	"description": "Extracts data snapshots from the top 100 searches.",
 	"author": "Automattic Inc.",
 	"license": "GPL-2.0-or-later",
+	"type": "module",
 	"repository": {
 		"type": "git",
 		"url": "git://github.com/Automattic/wp-calypso.git",
@@ -14,6 +15,9 @@
 		"csv-parse": "^5.1.0",
 		"csv-stringify": "^6.1.0",
 		"fs-extra": "^10.1.0"
+	},
+	"devDependencies": {
+		"@automattic/calypso-eslint-overrides": "workspace:^"
 	},
 	"scripts": {
 		"generate": "node get-top-categories.js && node get-top-products.js"

--- a/packages/calypso-mp-data-analysis/package.json
+++ b/packages/calypso-mp-data-analysis/package.json
@@ -11,7 +11,6 @@
 		"directory": "packages/calypso-mp-data-analysis"
 	},
 	"dependencies": {
-		"axios": "^0.27.2",
 		"csv-parse": "^5.1.0",
 		"csv-stringify": "^6.1.0",
 		"fs-extra": "^10.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -403,7 +403,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/calypso-mp-data-analysis@workspace:packages/calypso-mp-data-analysis"
   dependencies:
-    axios: ^0.27.2
+    "@automattic/calypso-eslint-overrides": "workspace:^"
     csv-parse: ^5.1.0
     csv-stringify: ^6.1.0
     fs-extra: ^10.1.0
@@ -11134,16 +11134,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^0.27.2":
-  version: 0.27.2
-  resolution: "axios@npm:0.27.2"
-  dependencies:
-    follow-redirects: ^1.14.9
-    form-data: ^4.0.0
-  checksum: 76d673d2a90629944b44d6f345f01e58e9174690f635115d5ffd4aca495d99bcd8f95c590d5ccb473513f5ebc1d1a6e8934580d0c57cdd0498c3a101313ef771
-  languageName: node
-  linkType: hard
-
 "axobject-query@npm:^3.1.1":
   version: 3.1.1
   resolution: "axobject-query@npm:3.1.1"
@@ -17238,7 +17228,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.14.9":
+"follow-redirects@npm:^1.0.0":
   version: 1.15.1
   resolution: "follow-redirects@npm:1.15.1"
   peerDependenciesMeta:


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #64529

## Proposed Changes
We'd like to move away from axios now that NodeJS includes the fetch API natively. This PR changes from axios.get to fetch, using URLSearchParams 

I've also added some drive-by improvements:
- Use ESM
- Rely on top-level await, since it's now supported
- Instead of using eslint-disable, rely on our global NodeJS eslint configuration (which allows console.log for example)

## Testing Instructions
Not sure. At this point, I'd like to pass this off to the team which added this to test that it sill works! I don't know how to get the CSV file to verify this still works correctly. But I think it'd just need minor changes if things are broken.

You just need to cd to this package directory, and then run `yarn generate`