### PR TITLE
Newsletter payment plans: drop "(yearly)" from the name

### DIFF
--- a/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
+++ b/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
@@ -227,7 +227,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 		ID: annualProduct?.ID, // will the the ID if already existing
 		price: currentAnnualPrice,
 		interval: PLAN_YEARLY_FREQUENCY,
-		title: `${ productDetails.title } ${ translate( '(yearly)' ) }`,
+		title: productDetails.title,
 	} );
 
 	const getCurrentProductDetails = (): Product => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Alternative to https://github.com/Automattic/wp-calypso/pull/84108, resolves https://github.com/Automattic/jetpack/issues/34145

Slack convo p1699611627810099-slack-C052XEUUBL4

## Proposed Changes

* Drop "(yearly)" from genereated annual plan name as we have enough other ways to present "yearly" in UIs where this name is visible.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go `/earn`, and create a new newsletter plan
* Observe how plan is presented at plans list, and at the frontend of the site

<img width="500" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/57fab324-de26-45d6-8f31-09947f4cacec">

![image](https://github.com/Automattic/wp-calypso/assets/87168/fc11e483-af55-4392-a0e6-3f8f2e9cb060)

There could still be places where we'd rely on plan name to communicate "Yearly" nature of it, so thouse might need adjusting. E.g. emails, subscriber management, or stats?

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?