### PR TITLE
Happy Blocks: fix Your site, built for you banner

### DIFF
--- a/apps/happy-blocks/block-library/support-content-footer/style.scss
+++ b/apps/happy-blocks/block-library/support-content-footer/style.scss
@@ -35,7 +35,6 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 		display: flex;
 		margin-bottom: 2rem;
 		font-size: 1.25rem;
-		height: 202px;
 
 		.support-content-cta-left {
 			flex: 1;
@@ -54,11 +53,15 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 		}
 
 		.support-content-cta-right {
-			text-align: right;
+			display: flex;
+			justify-content: flex-end;
 			flex: 1;
 
 			img {
 				height: 100%;
+				max-height: 202px;
+				// To prevent any white space around the image.
+				display: block;
 			}
 
 			figure {


### PR DESCRIPTION
Fixes: https://github.com/Automattic/wp-calypso/issues/84078

### Testing
1. cd into `apps/happy-blocks`.
2. run `yarn dev --sync`.
3. Using Firefox, visit `/support`.
4. In Console, file a link that has failed to load due to SSL errors, click it, and load it anyways using the UI.
5. Refresh the page.
6. Make sure the issue isn't reprodicuble. 