### PR TITLE
Reader/Discover: Update to use the Discover stream for tag posts

### DIFF
--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import warn from '@wordpress/warning';
 import i18n from 'i18n-calypso';
 import { random, map, includes, get } from 'lodash';
@@ -30,7 +29,6 @@ const noop = () => {};
  * `following`
  * `site:1234`
  * `search:a:value` ( prefix is `search`, suffix is `a:value` )
- *
  * @param  {string} streamKey The stream ID to break apart
  * @returns {string}          The stream ID suffix
  */
@@ -208,17 +206,13 @@ const streamApis = {
 	discover: {
 		path: ( { streamKey } ) => {
 			if ( streamKeySuffix( streamKey ).includes( 'recommended' ) ) {
-				if ( config.isEnabled( 'reader/discover-stream' ) ) {
-					return '/read/streams/discover';
-				}
-
-				return '/read/tags/cards';
+				return '/read/streams/discover';
 			} else if ( streamKeySuffix( streamKey ).includes( 'latest' ) ) {
 				return '/read/tags/posts';
 			} else if ( streamKeySuffix( streamKey ).includes( 'firstposts' ) ) {
 				return '/read/streams/first-posts';
 			}
-			return `/read/tags/${ streamKeySuffix( streamKey ) }/cards`;
+			return `/read/streams/discover?tags=${ streamKeySuffix( streamKey ) }`;
 		},
 		dateProperty: 'date',
 		query: ( extras, { streamKey } ) =>
@@ -307,7 +301,7 @@ const streamApis = {
 		dateProperty: 'date',
 	},
 	tag_popular: {
-		path: ( { streamKey } ) => `/read/tags/${ streamKeySuffix( streamKey ) }/cards`,
+		path: ( { streamKey } ) => `/read/streams/discover?tags=${ streamKeySuffix( streamKey ) }`,
 		apiNamespace: 'wpcom/v2',
 		query: ( extras, { streamKey } ) =>
 			getQueryString( {
@@ -328,7 +322,6 @@ const streamApis = {
 
 /**
  * Request a page for the given stream
- *
  * @param  {Object}   action   Action being handled
  * @returns {Object | undefined} http action for data-layer to dispatch
  */

--- a/client/state/data-layer/wpcom/read/streams/test/index.js
+++ b/client/state/data-layer/wpcom/read/streams/test/index.js
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import deepfreeze from 'deep-freeze';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import {
@@ -76,9 +75,7 @@ describe( 'streams', () => {
 					stream: 'discover:recommended',
 					expected: {
 						method: 'GET',
-						path: config.isEnabled( 'reader/discover-stream' )
-							? '/read/streams/discover'
-							: '/read/tags/cards',
+						path: '/read/streams/discover',
 						apiNamespace: 'wpcom/v2',
 						query: {
 							...query,
@@ -94,7 +91,7 @@ describe( 'streams', () => {
 					stream: 'discover:dailyprompt',
 					expected: {
 						method: 'GET',
-						path: `/read/tags/dailyprompt/cards`,
+						path: `/read/streams/discover?tags=dailyprompt`,
 						apiNamespace: 'wpcom/v2',
 						query: {
 							...query,

--- a/config/development.json
+++ b/config/development.json
@@ -160,7 +160,6 @@
 		"push-notifications": true,
 		"reader": true,
 		"reader/comment-polling": false,
-		"reader/discover-stream": true,
 		"reader/first-posts-stream": true,
 		"reader/full-errors": true,
 		"reader/list-management": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -102,7 +102,6 @@
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
 		"reader": true,
-		"reader/discover-stream": true,
 		"reader/first-posts-stream": true,
 		"reader/list-management": true,
 		"reader/public-tag-pages": true,

--- a/config/production.json
+++ b/config/production.json
@@ -125,7 +125,6 @@
 		"purchases/new-payment-methods": true,
 		"push-notifications": true,
 		"reader": true,
-		"reader/discover-stream": true,
 		"reader/first-posts-stream": true,
 		"reader/full-errors": false,
 		"reader/list-management": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -122,7 +122,6 @@
 		"purchases/new-payment-methods": true,
 		"push-notifications": true,
 		"reader": true,
-		"reader/discover-stream": true,
 		"reader/first-posts-stream": true,
 		"reader/full-errors": false,
 		"reader/list-management": true,

--- a/config/test.json
+++ b/config/test.json
@@ -87,7 +87,6 @@
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
 		"reader": true,
-		"reader/discover-stream": true,
 		"reader/first-posts-stream": true,
 		"reader/full-errors": true,
 		"reader/list-management": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -130,7 +130,6 @@
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
 		"reader": true,
-		"reader/discover-stream": true,
 		"reader/first-posts-stream": true,
 		"reader/full-errors": true,
 		"reader/list-management": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #83542

## Proposed Changes

This switches over the "Discover" page of the Reader to use the new `/read/streams/discover` endpoint for the individual tag tabs. Previously we only used the new endpoint for the "Recommended" tab.

Noting that this was originally done in #83434 and reverted in #83544 due to issues with blank posts.

At this point in time, it appears that the blank post issues have been resolved.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this branch locally or use the calypso.live link.
* Go to `/discover` and verify the "Recommended" tab functions as expected.
* Then visit any of the specific tag tabs (eg "Food") and verify it functions as expected and you get a list of related tags in the right sidebar.
* When clicking "Recommended" or any of the specific tag tabs, check the developer console to verify that all calls are going to `/read/streams/discover`.
* Scroll down a lot and verify that all the displayed posts have content. Note that some posts may not have any text content but _do_ have an image. These posts are fine.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
