### PR TITLE
Subscriber Stats: Exclude site owner from the Free subscribers amount

### DIFF
--- a/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
@@ -38,7 +38,12 @@ const selectPaidSubscribers = ( payload: {
 	};
 } ) => {
 	return {
-		email_subscribers: payload?.counts?.email_subscribers,
+		// The `email_subscribers` consists of email and wpcom subscribers, including the site owner.
+		// Exclude the site owner count to align with the `Total subscribers` count from querySubscribersTotals that has filtered the site owner.
+		email_subscribers:
+			payload?.counts?.email_subscribers > 0
+				? payload.counts.email_subscribers - 1
+				: payload.counts.email_subscribers,
 		paid_subscribers: payload?.counts?.paid_subscribers,
 		social_followers: payload?.counts?.social_followers,
 	};

--- a/packages/components/src/highlight-cards/count-comparison-card.tsx
+++ b/packages/components/src/highlight-cards/count-comparison-card.tsx
@@ -62,7 +62,11 @@ export default function CountComparisonCard( {
 			>
 				<span
 					className="highlight-card-count-value"
-					title={ Number.isFinite( count ) ? String( count ) : undefined }
+					title={
+						heading && Number.isFinite( count )
+							? `${ String( count ) } ${ String( heading ).toLowerCase() }`
+							: undefined
+					}
 					ref={ textRef }
 				>
 					<ShortenedNumber value={ count } />


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1699618062074619-slack-C0438NHCLSY

## Proposed Changes

* Adjust the title attribute of highlight cards on the `All-time stats` of the subscriber page.

<img width="884" alt="截圖 2023-11-11 上午8 28 07" src="https://github.com/Automattic/wp-calypso/assets/6869813/0bbe65a3-e45f-4a80-9c0b-204fdaff2b38">

* Exclude the site owner count of `Free subscribers` to align with the `Total subscribers` count from the endpoint `/stats/followers` that has filtered the site owner.

#### Before

<img width="1319" alt="image (1)" src="https://github.com/Automattic/wp-calypso/assets/6869813/d3eb6963-a203-4ab1-ba2d-fd0804c33702">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up this change with the Live Calypso link.
* Navigate to Stats > Subscribers page for **a site that enables paid subscription features and owns subscribers**.
* Ensure the `Free subscribers` count aligns with other total subscriber counts on the page.

#### After

<img width="1345" alt="截圖 2023-11-11 上午7 53 48" src="https://github.com/Automattic/wp-calypso/assets/6869813/05cf3d59-6562-4511-8b17-508055c79a73">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?