### PR TITLE
Open the contact support form upon clicking the downgrade button.

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -18,6 +18,8 @@ import {
 import page from '@automattic/calypso-router';
 import { Button, Spinner, LoadingPlaceholder } from '@automattic/components';
 import { WpcomPlansUI } from '@automattic/data-stores';
+import { useStillNeedHelpURL } from '@automattic/help-center/src/hooks';
+import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
 import { isAnyHostingFlow } from '@automattic/onboarding';
 import styled from '@emotion/styled';
 import { useDispatch } from '@wordpress/data';
@@ -257,6 +259,8 @@ const PlansFeaturesMain = ( {
 	);
 	const previousRoute = useSelector( ( state: IAppState ) => getPreviousRoute( state ) );
 	const { setShowDomainUpsellDialog } = useDispatch( WpcomPlansUI.store );
+	const { setShowHelpCenter, setInitialRoute } = useDispatch( HELP_CENTER_STORE );
+	const { url: stillNeedHelpUrl } = useStillNeedHelpURL();
 	const domainFromHomeUpsellFlow = useSelector( getDomainFromHomeUpsellInQuery );
 	const showUpgradeableStorage = config.isEnabled( 'plans/upgradeable-storage' );
 	const observableForOdieRef = useObservableForOdie();
@@ -370,8 +374,8 @@ const PlansFeaturesMain = ( {
 	);
 
 	const handleDowngradeClick = useCallback( () => {
-		// just an intermediate implementation.
-		page( '/help' );
+		setInitialRoute( stillNeedHelpUrl );
+		setShowHelpCenter( true );
 	}, [ siteSlug ] );
 
 	const term = usePlanBillingPeriod( {

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -369,6 +369,11 @@ const PlansFeaturesMain = ( {
 		[ onUpgradeClick, resolveModal, siteSlug, withDiscount ]
 	);
 
+	const handleDowngradeClick = useCallback( () => {
+		// just an intermediate implementation.
+		page( '/help' );
+	}, [ siteSlug ] );
+
 	const term = usePlanBillingPeriod( {
 		intervalType,
 		...( selectedPlan ? { defaultValue: getPlan( selectedPlan )?.term } : {} ),
@@ -797,6 +802,7 @@ const PlansFeaturesMain = ( {
 									isInSignup={ isInSignup }
 									isLaunchPage={ isLaunchPage }
 									onUpgradeClick={ handleUpgradeClick }
+									onDowngradeClick={ handleDowngradeClick }
 									flowName={ flowName }
 									selectedFeature={ selectedFeature }
 									selectedPlan={ selectedPlan }
@@ -860,6 +866,7 @@ const PlansFeaturesMain = ( {
 												isInSignup={ isInSignup }
 												isLaunchPage={ isLaunchPage }
 												onUpgradeClick={ handleUpgradeClick }
+												onDowngradeClick={ handleDowngradeClick }
 												flowName={ flowName }
 												selectedFeature={ selectedFeature }
 												selectedPlan={ selectedPlan }

--- a/client/my-sites/plans-grid/components/actions.tsx
+++ b/client/my-sites/plans-grid/components/actions.tsx
@@ -399,6 +399,7 @@ const LoggedInPlansFeatureActionButton = ( {
 				setActiveTooltipId={ setActiveTooltipId }
 				activeTooltipId={ activeTooltipId }
 				showOnMobile={ false }
+				display="block"
 				id="downgrade"
 			>
 				<Button className={ classes } onClick={ handleDowngradeButtonClick }>

--- a/client/my-sites/plans-grid/components/actions.tsx
+++ b/client/my-sites/plans-grid/components/actions.tsx
@@ -291,12 +291,6 @@ const LoggedInPlansFeatureActionButton = ( {
 		if ( isP2FreePlan( planSlug ) && current ) {
 			return null;
 		}
-
-		return (
-			<Button className={ classes } disabled={ true }>
-				{ translate( 'Contact support', { context: 'verb' } ) }
-			</Button>
-		);
 	}
 
 	if ( current && planSlug !== PLAN_P2_FREE ) {

--- a/client/my-sites/plans-grid/components/actions.tsx
+++ b/client/my-sites/plans-grid/components/actions.tsx
@@ -16,7 +16,6 @@ import { Button, Gridicon } from '@automattic/components';
 import { WpcomPlansUI } from '@automattic/data-stores';
 import { formatCurrency } from '@automattic/format-currency';
 import { isMobile } from '@automattic/viewport';
-import styled from '@emotion/styled';
 import { useSelect } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 import { addQueryArgs } from '@wordpress/url';
@@ -54,18 +53,6 @@ type PlanFeaturesActionsButtonProps = {
 	isLargeCurrency?: boolean;
 	storageOptions?: StorageOption[];
 };
-
-const DummyDisabledButton = styled.div`
-	background-color: var( --studio-white );
-	color: var( --studio-gray-5 );
-	box-shadow: inset 0 0 0 1px var( --studio-gray-10 );
-	font-weight: 500;
-	line-height: 20px;
-	border-radius: 4px;
-	padding: 10px 14px;
-	border: unset;
-	text-align: center;
-`;
 
 const SignupFlowPlanFeatureActionButton = ( {
 	freePlan,
@@ -414,9 +401,9 @@ const LoggedInPlansFeatureActionButton = ( {
 				showOnMobile={ false }
 				id="downgrade"
 			>
-				<DummyDisabledButton onClick={ handleDowngradeButtonClick }>
+				<Button className={ classes } onClick={ handleDowngradeButtonClick }>
 					{ translate( 'Downgrade', { context: 'verb' } ) }
-				</DummyDisabledButton>
+				</Button>
 				{ isMobile() && (
 					<div className="plan-features-2023-grid__actions-downgrade-context-mobile">
 						{ translate( 'Please contact support to downgrade your plan.' ) }
@@ -464,6 +451,7 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 		'is-current-plan': current,
 		'is-stuck': isStuck,
 		'is-large-currency': isLargeCurrency,
+		'is-downgrade': ! availableForPurchase && ! isWpcomEnterpriseGridPlan,
 	} );
 
 	const handleUpgradeButtonClick = useCallback(

--- a/client/my-sites/plans-grid/components/actions.tsx
+++ b/client/my-sites/plans-grid/components/actions.tsx
@@ -41,6 +41,7 @@ type PlanFeaturesActionsButtonProps = {
 	isLaunchPage?: boolean | null;
 	isMonthlyPlan?: boolean;
 	onUpgradeClick: ( overridePlanSlug?: PlanSlug ) => void;
+	onDowngradeClick: () => void;
 	planSlug: PlanSlug;
 	flowName?: string | null;
 	buttonText?: string;
@@ -216,6 +217,7 @@ const LoggedInPlansFeatureActionButton = ( {
 	isMonthlyPlan,
 	planTitle,
 	handleUpgradeButtonClick,
+	handleDowngradeButtonClick,
 	planSlug,
 	currentPlanManageHref,
 	canUserManageCurrentPlan,
@@ -233,6 +235,7 @@ const LoggedInPlansFeatureActionButton = ( {
 	isMonthlyPlan?: boolean;
 	planTitle: TranslateResult;
 	handleUpgradeButtonClick: () => void;
+	handleDowngradeButtonClick: () => void;
 	planSlug: PlanSlug;
 	currentPlanManageHref?: string;
 	canUserManageCurrentPlan?: boolean | null;
@@ -417,7 +420,9 @@ const LoggedInPlansFeatureActionButton = ( {
 				showOnMobile={ false }
 				id="downgrade"
 			>
-				<DummyDisabledButton>{ translate( 'Downgrade', { context: 'verb' } ) }</DummyDisabledButton>
+				<DummyDisabledButton onClick={ handleDowngradeButtonClick }>
+					{ translate( 'Downgrade', { context: 'verb' } ) }
+				</DummyDisabledButton>
 				{ isMobile() && (
 					<div className="plan-features-2023-grid__actions-downgrade-context-mobile">
 						{ translate( 'Please contact support to downgrade your plan.' ) }
@@ -440,6 +445,7 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 	isInSignup,
 	isLaunchPage,
 	onUpgradeClick,
+	onDowngradeClick,
 	planSlug,
 	flowName,
 	buttonText,
@@ -481,6 +487,10 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 		},
 		[ currentSitePlanSlug, freePlan, freeTrialPlanSlug, onUpgradeClick, planSlug ]
 	);
+
+	const handleDowngradeButtonClick = useCallback( () => {
+		onDowngradeClick?.();
+	}, [ onDowngradeClick ] );
 
 	if ( isWpcomEnterpriseGridPlan ) {
 		const vipLandingPageUrlWithUtmCampaign = addQueryArgs(
@@ -566,6 +576,7 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 			availableForPurchase={ availableForPurchase }
 			classes={ classes }
 			handleUpgradeButtonClick={ handleUpgradeButtonClick }
+			handleDowngradeButtonClick={ handleDowngradeButtonClick }
 			currentPlanManageHref={ currentPlanManageHref }
 			canUserManageCurrentPlan={ canUserManageCurrentPlan }
 			currentSitePlanSlug={ currentSitePlanSlug }

--- a/client/my-sites/plans-grid/components/comparison-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/comparison-grid/index.tsx
@@ -331,6 +331,7 @@ type ComparisonGridProps = {
 	currentPlanManageHref?: string;
 	canUserManageCurrentPlan?: boolean | null;
 	onUpgradeClick: ( planSlug: PlanSlug ) => void;
+	onDowngradeClick: () => void;
 	siteId?: number | null;
 	planActionOverrides?: PlanActionOverrides;
 	selectedPlan?: string;
@@ -354,6 +355,7 @@ type ComparisonGridHeaderProps = {
 	currentPlanManageHref?: string;
 	canUserManageCurrentPlan?: boolean | null;
 	onUpgradeClick: ( planSlug: PlanSlug ) => void;
+	onDowngradeClick: () => void;
 	siteId?: number | null;
 	planActionOverrides?: PlanActionOverrides;
 	selectedPlan?: string;
@@ -391,6 +393,7 @@ const ComparisonGridHeaderCell = ( {
 	flowName,
 	isLargeCurrency,
 	onUpgradeClick,
+	onDowngradeClick,
 	planActionOverrides,
 	isPlanUpgradeCreditEligible,
 	siteId,
@@ -488,6 +491,7 @@ const ComparisonGridHeaderCell = ( {
 				planSlug={ planSlug }
 				flowName={ flowName }
 				onUpgradeClick={ ( overridePlanSlug ) => onUpgradeClick( overridePlanSlug ?? planSlug ) }
+				onDowngradeClick={ onDowngradeClick }
 				planActionOverrides={ planActionOverrides }
 				showMonthlyPrice={ false }
 				isStuck={ false }
@@ -510,6 +514,7 @@ const ComparisonGridHeader = forwardRef< HTMLDivElement, ComparisonGridHeaderPro
 			currentPlanManageHref,
 			canUserManageCurrentPlan,
 			onUpgradeClick,
+			onDowngradeClick,
 			siteId,
 			planActionOverrides,
 			selectedPlan,
@@ -555,6 +560,7 @@ const ComparisonGridHeader = forwardRef< HTMLDivElement, ComparisonGridHeaderPro
 						canUserManageCurrentPlan={ canUserManageCurrentPlan }
 						flowName={ flowName }
 						onUpgradeClick={ onUpgradeClick }
+						onDowngradeClick={ onDowngradeClick }
 						isLaunchPage={ isLaunchPage }
 						isLargeCurrency={ isLargeCurrency }
 						planActionOverrides={ planActionOverrides }
@@ -969,6 +975,7 @@ const ComparisonGrid = ( {
 	currentPlanManageHref,
 	canUserManageCurrentPlan,
 	onUpgradeClick,
+	onDowngradeClick,
 	siteId,
 	planActionOverrides,
 	selectedPlan,
@@ -1121,6 +1128,7 @@ const ComparisonGrid = ( {
 							currentPlanManageHref={ currentPlanManageHref }
 							canUserManageCurrentPlan={ canUserManageCurrentPlan }
 							onUpgradeClick={ onUpgradeClick }
+							onDowngradeClick={ onDowngradeClick }
 							planActionOverrides={ planActionOverrides }
 							selectedPlan={ selectedPlan }
 							showRefundPeriod={ showRefundPeriod }
@@ -1155,6 +1163,7 @@ const ComparisonGrid = ( {
 					currentPlanManageHref={ currentPlanManageHref }
 					canUserManageCurrentPlan={ canUserManageCurrentPlan }
 					onUpgradeClick={ onUpgradeClick }
+					onDowngradeClick={ onDowngradeClick }
 					siteId={ siteId }
 					planActionOverrides={ planActionOverrides }
 					selectedPlan={ selectedPlan }

--- a/client/my-sites/plans-grid/components/features-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/features-grid/index.tsx
@@ -51,6 +51,7 @@ interface FeaturesGridType extends PlansGridProps {
 	currentPlanManageHref?: string;
 	isPlanUpgradeCreditEligible: boolean;
 	handleUpgradeClick: ( planSlug: PlanSlug ) => void;
+	handleDowngradeClick: () => void;
 }
 
 class FeaturesGrid extends Component< FeaturesGridType > {
@@ -367,6 +368,7 @@ class FeaturesGrid extends Component< FeaturesGridType > {
 			siteId,
 			isLargeCurrency,
 			handleUpgradeClick,
+			handleDowngradeClick,
 		} = this.props;
 
 		return renderedGridPlans.map(
@@ -410,6 +412,7 @@ class FeaturesGrid extends Component< FeaturesGridType > {
 							onUpgradeClick={ ( overridePlanSlug ) =>
 								handleUpgradeClick( overridePlanSlug ?? planSlug )
 							}
+							onDowngradeClick={ handleDowngradeClick }
 							planSlug={ planSlug }
 							flowName={ flowName }
 							currentSitePlanSlug={ currentSitePlanSlug }

--- a/client/my-sites/plans-grid/components/features-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/features-grid/index.tsx
@@ -65,6 +65,11 @@ class FeaturesGrid extends Component< FeaturesGridType > {
 			'plan-features-2023-grid__table',
 			`has-${ gridPlansWithoutSpotlight.length }-cols`
 		);
+		// when all the plans are non-purchasable, we want to disable the sticky bar
+		// since all the CTAs will be just "Downgrade" leading to support. That'd defeat the purpose of the sticky bar.
+		const disableSticky = gridPlansWithoutSpotlight.every(
+			( { availableForPurchase } ) => ! availableForPurchase
+		);
 
 		return (
 			<table className={ tableClasses }>
@@ -83,6 +88,7 @@ class FeaturesGrid extends Component< FeaturesGridType > {
 						stickyClass="is-sticky-top-buttons-row"
 						element="tr"
 						stickyOffset={ stickyRowOffset }
+						disabled={ disableSticky }
 					>
 						{ ( isStuck: boolean ) =>
 							this.renderTopButtons( gridPlansWithoutSpotlight, { isTableCell: true, isStuck } )

--- a/client/my-sites/plans-grid/components/plans-2023-tooltip.tsx
+++ b/client/my-sites/plans-grid/components/plans-2023-tooltip.tsx
@@ -4,8 +4,14 @@ import { Dispatch, PropsWithChildren, SetStateAction, useRef } from 'react';
 import Tooltip from 'calypso/components/tooltip';
 import { hasTouch } from '../lib/touch-detect';
 
-const HoverAreaContainer = styled.span`
-	max-width: 220px;
+// TODO:
+// The hover area container should ideally fit the dimensions of the child components
+// However, it's not easy to find a configuration that fits all possible display,
+// e.g. the feature copies in the plans table is an `inline` element, the downgrade button
+// is a `inline-block` element having 100% width. Looking into @wordpress/tooltip, I think
+// there is a way, but this intermediate solution seems to provide a less intrusive solution for the current needs.
+const HoverAreaContainer = styled.div< { display?: 'block' | 'inline-block' } >`
+	display: ${ ( { display = 'block' } ) => display };
 `;
 
 const StyledTooltip = styled( Tooltip )`
@@ -27,6 +33,7 @@ const StyledTooltip = styled( Tooltip )`
 
 export const Plans2023Tooltip = ( {
 	showOnMobile = true,
+	display = 'inline-block',
 	...props
 }: PropsWithChildren< {
 	text?: TranslateResult;
@@ -34,10 +41,12 @@ export const Plans2023Tooltip = ( {
 	activeTooltipId: string;
 	id: string;
 	showOnMobile?: boolean;
+	display?: 'block' | 'inline-block';
 } > ) => {
 	const { activeTooltipId, setActiveTooltipId, id } = props;
 	const tooltipRef = useRef< HTMLDivElement >( null );
 	const isTouch = hasTouch();
+	const isVisible = activeTooltipId === id;
 
 	if ( ! props.text ) {
 		return <>{ props.children }</>;
@@ -52,8 +61,6 @@ export const Plans2023Tooltip = ( {
 		return id;
 	};
 
-	const isVisible = activeTooltipId === id;
-
 	return (
 		<>
 			<HoverAreaContainer
@@ -63,6 +70,7 @@ export const Plans2023Tooltip = ( {
 				onMouseLeave={ () => ! isTouch && setActiveTooltipId( '' ) }
 				onTouchStart={ () => isTouch && setActiveTooltipId( getMobileActiveTooltip() ) }
 				id={ props.id }
+				display={ display }
 			>
 				{ props.children }
 			</HoverAreaContainer>

--- a/client/my-sites/plans-grid/components/plans-2023-tooltip.tsx
+++ b/client/my-sites/plans-grid/components/plans-2023-tooltip.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import { TranslateResult } from 'i18n-calypso';
-import { Dispatch, PropsWithChildren, SetStateAction, useEffect, useRef, useState } from 'react';
+import { Dispatch, PropsWithChildren, SetStateAction, useRef } from 'react';
 import Tooltip from 'calypso/components/tooltip';
 import { hasTouch } from '../lib/touch-detect';
 
@@ -35,14 +35,9 @@ export const Plans2023Tooltip = ( {
 	id: string;
 	showOnMobile?: boolean;
 } > ) => {
-	const [ isVisible, setIsVisible ] = useState( false );
 	const { activeTooltipId, setActiveTooltipId, id } = props;
 	const tooltipRef = useRef< HTMLDivElement >( null );
 	const isTouch = hasTouch();
-
-	useEffect( () => {
-		activeTooltipId === id ? setIsVisible( true ) : setIsVisible( false );
-	}, [ activeTooltipId, id ] );
 
 	if ( ! props.text ) {
 		return <>{ props.children }</>;
@@ -56,6 +51,8 @@ export const Plans2023Tooltip = ( {
 
 		return id;
 	};
+
+	const isVisible = activeTooltipId === id;
 
 	return (
 		<>

--- a/client/my-sites/plans-grid/index.tsx
+++ b/client/my-sites/plans-grid/index.tsx
@@ -38,6 +38,7 @@ export interface PlansGridProps {
 	isLaunchPage?: boolean | null;
 	isReskinned?: boolean;
 	onUpgradeClick?: ( cartItems?: MinimalRequestCartProduct[] | null ) => void;
+	onDowngradeClick?: () => void;
 	onStorageAddOnClick?: ( addOnSlug: WPComStorageAddOnSlug ) => void;
 	flowName?: string | null;
 	paidDomainName?: string;
@@ -68,6 +69,7 @@ const WrappedComparisonGrid = ( {
 	usePricingMetaForGridPlans,
 	allFeaturesList,
 	onUpgradeClick,
+	onDowngradeClick,
 	intervalType,
 	isInSignup,
 	isLaunchPage,
@@ -104,6 +106,7 @@ const WrappedComparisonGrid = ( {
 				currentPlanManageHref={ currentPlanManageHref }
 				canUserManageCurrentPlan={ canUserManageCurrentPlan }
 				onUpgradeClick={ handleUpgradeClick }
+				onDowngradeClick={ () => onDowngradeClick?.() }
 				siteId={ siteId }
 				selectedPlan={ selectedPlan }
 				selectedFeature={ selectedFeature }
@@ -125,6 +128,7 @@ const WrappedFeaturesGrid = ( props: PlansGridProps ) => {
 		usePricingMetaForGridPlans,
 		allFeaturesList,
 		onUpgradeClick,
+		onDowngradeClick,
 		currentPlanManageHref,
 		canUserManageCurrentPlan,
 	} = props;
@@ -161,6 +165,7 @@ const WrappedFeaturesGrid = ( props: PlansGridProps ) => {
 				currentPlanManageHref={ currentPlanManageHref }
 				translate={ translate }
 				handleUpgradeClick={ handleUpgradeClick }
+				handleDowngradeClick={ () => onDowngradeClick?.() }
 			/>
 		</PlansGridContextProvider>
 	);

--- a/client/my-sites/plans-grid/style.scss
+++ b/client/my-sites/plans-grid/style.scss
@@ -129,7 +129,8 @@ $mobile-card-max-width: 440px;
 				}
 			}
 
-			&.is-current-plan {
+			&.is-current-plan,
+			&.is-downgrade {
 				background-color: var(--studio-white);
 				color: var(--studio-gray-100);
 				box-shadow: inset 0 0 0 1px var(--studio-gray-10);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolve Automattic/martech#1458

## Proposed Changes

This PR adds the bahavior of opening up the contact support form upon clicking the Downgrade button.

https://github.com/Automattic/wp-calypso/assets/1842898/0db6cb18-a9f5-410b-8359-49fb3cc256d1

Some notable changes:

* The CTA of the Free plan is no longer "Contact support"
* The downgrading CTAs are no longer appeared to be disabled. 
* Clicking on the downgrade button opens the help center pop-up.

Also, when all the CTAs in the CTA row are plans that are not purchasable, the sticky behavior will be disabled:

https://github.com/Automattic/wp-calypso/assets/1842898/2a7fd8c4-bead-4681-b528-5f93349d2254

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Log into a site with a paid plan.
* Click on the downgrade button, and the help center pop-up should show.
* The rest of the CTA button behavior, e.g. upgrade, should not be affected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
