### PR TITLE
[Experiment] Wapuu: Try wpcom-support-assistant

### DIFF
--- a/client/odie/context/get-odie-initial-message.ts
+++ b/client/odie/context/get-odie-initial-message.ts
@@ -16,7 +16,7 @@ const getOdieInitialPrompt = ( botNameSlug: OdieAllowedBots = 'wpcom-support-cha
 };
 
 export const getOdieInitialMessage = (
-	botNameSlug: OdieAllowedBots = 'wpcom-support-chat'
+	botNameSlug: OdieAllowedBots = 'wpcom-support-assistant'
 ): Message => {
 	return {
 		content: getOdieInitialPrompt( botNameSlug ),

--- a/client/odie/message/jump-to-recent.tsx
+++ b/client/odie/message/jump-to-recent.tsx
@@ -46,7 +46,7 @@ export const JumpToRecent = ( {
 		};
 	}, [] );
 
-	if ( isMinimized && botNameSlug === 'wpcom-support-chat' ) {
+	if ( isMinimized && botNameSlug === 'wpcom-support-assistant' ) {
 		return null;
 	}
 

--- a/client/odie/types/index.ts
+++ b/client/odie/types/index.ts
@@ -92,4 +92,4 @@ export type OdieAllowedSectionNames =
 	| 'checkout'
 	| 'help-center';
 
-export type OdieAllowedBots = 'wpcom-support-chat' | null;
+export type OdieAllowedBots = 'wpcom-support-assistant' | null;

--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -75,7 +75,7 @@ const HelpCenterContent: React.FC< { isRelative?: boolean } > = () => {
 					path="/odie"
 					element={
 						<OdieAssistantProvider
-							botNameSlug="wpcom-support-chat"
+							botNameSlug="wpcom-support-assistant"
 							botSetting="supportDocs"
 							botName="Wapuu"
 							enabled={ isWapuuEnabled }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Try the new wpcom-support-assistant bot. 

## Proposed Changes

Switches the bot. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Should work same as before. 
- ?flags=wapuu
- Start a chat
- Check the MC tool for the chat. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?