### PR TITLE
composite-checkout: Allow displaying all steps as inactive

### DIFF
--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -102,9 +102,6 @@ function createCheckoutStepGroupActions(
 	onStateChange: () => void
 ): CheckoutStepGroupActions {
 	const setActiveStepNumber = ( stepNumber: number ) => {
-		if ( stepNumber < 1 ) {
-			throw new Error( `Cannot set step number to '${ stepNumber }' because it is too low` );
-		}
 		if ( stepNumber > state.totalSteps && state.totalSteps === 0 ) {
 			throw new Error(
 				`Cannot set step number to '${ stepNumber }' because the total number of steps is 0`
@@ -289,7 +286,7 @@ export const CheckoutStepGroupInner = ( {
 				}
 				if ( isElementAStep( child ) ) {
 					stepNumber = nextStepNumber || 0;
-					nextStepNumber = stepNumber === totalSteps ? null : stepNumber + 1;
+					nextStepNumber = stepNumber === totalSteps ? 0 : stepNumber + 1;
 					const isStepActive = areStepsActive && activeStepNumber === stepNumber;
 					const isStepComplete = !! stepCompleteStatus[ stepNumber ];
 					return (
@@ -441,7 +438,7 @@ export const CheckoutStep = ( {
 		const completeResult = Boolean( await Promise.resolve( isCompleteCallback() ) );
 		debug( `isCompleteCallback for step ${ stepNumber } finished with`, completeResult );
 		setThisStepCompleteStatus( completeResult );
-		if ( completeResult && nextStepNumber ) {
+		if ( completeResult && nextStepNumber !== null ) {
 			setActiveStepNumber( nextStepNumber );
 		}
 		setFormReady();

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -273,7 +273,7 @@ export const CheckoutStepGroupInner = ( {
 		'active step',
 		activeStepNumber,
 		'step complete status',
-		stepCompleteStatus,
+		JSON.stringify( stepCompleteStatus ),
 		'total steps',
 		totalSteps
 	);


### PR DESCRIPTION
## Proposed Changes

The `@automattic/composite-checkout` package provides, amongst other things, a multi-step form system comprised of the `CheckoutStepGroup` and `CheckoutStep` components. `CheckoutStepGroup` keeps track of which step is the active step and each step has a "Continue" button to move to the following step. Since the last step has no following steps, it has no "Continue" button. There must always be at least one active step and so when the form is complete, typically the last step remains active until the form is submitted.

In this PR we modify `CheckoutStepGroup` so that it's possible to set the active step to `0`, in which case all steps are marked as inactive. (This was extracted from https://github.com/Automattic/wp-calypso/pull/83985 where we need this feature.)

The final step still has no "Continue" button, so there is no way to manually mark all steps as inactive, but it can be done programmatically using the `useSetStepComplete()` React hook. 

## Testing Instructions

See https://github.com/Automattic/wp-calypso/pull/83985

This PR should not have any noticeable effect on its own.