### PR TITLE
composite-checkout: Add hasRequiredFields property to PaymentMethod object

### DIFF
--- a/client/my-sites/checkout/src/payment-methods/credit-card/index.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/index.tsx
@@ -16,6 +16,7 @@ import CreditCardFields from './credit-card-fields';
 import CreditCardPayButton from './credit-card-pay-button';
 import type { WpcomCreditCardSelectors } from './store';
 import type { CardFieldState, CardStoreType } from './types';
+import type { PaymentMethod } from '@automattic/composite-checkout';
 import type { ReactNode } from 'react';
 
 export { createCreditCardPaymentMethodStore } from './store';
@@ -32,11 +33,12 @@ export function createCreditCardMethod( {
 	shouldShowTaxFields?: boolean;
 	submitButtonContent: ReactNode;
 	allowUseForAllSubscriptions?: boolean;
-} ) {
+} ): PaymentMethod {
 	return {
 		id: 'card',
 		paymentProcessorId: 'card',
 		label: <CreditCardLabel />,
+		hasRequiredFields: true,
 		activeContent: (
 			<CreditCardFields
 				shouldUseEbanx={ shouldUseEbanx }

--- a/client/my-sites/checkout/src/payment-methods/netbanking.tsx
+++ b/client/my-sites/checkout/src/payment-methods/netbanking.tsx
@@ -148,6 +148,7 @@ export function createNetBankingMethod( {
 } ): PaymentMethod {
 	return {
 		id: 'netbanking',
+		hasRequiredFields: true,
 		paymentProcessorId: 'netbanking',
 		label: <NetBankingLabel />,
 		activeContent: <NetBankingFields />,

--- a/client/my-sites/checkout/src/payment-methods/wechat/index.tsx
+++ b/client/my-sites/checkout/src/payment-methods/wechat/index.tsx
@@ -82,6 +82,7 @@ export function createWeChatMethod( {
 } ): PaymentMethod {
 	return {
 		id: 'wechat',
+		hasRequiredFields: true,
 		paymentProcessorId: 'wechat',
 		label: <WeChatLabel />,
 		activeContent: <WeChatFields />,

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -66,6 +66,7 @@ Each payment method is an object with the following properties:
 - `id: string`. A unique id for this instance of this payment method.
 - `paymentProcessorId: string`. The id that will be used to map this payment method to a payment processor function. Unlike the `id`, this does not have to be unique.
 - `label?: React.ReactNode`. A component that displays that payment method selection button which can be as simple as the name and an icon.
+- `hasRequiredFields?: boolean`. If the payment method `activeContent` contains fields or other required interactions, this must be true!
 - `activeContent?: React.ReactNode`. A component that displays that payment method (this can return null or something like a credit card form).
 - `inactiveContent?: React.ReactNode`. A component that renders a summary of the selected payment method when the step is inactive.
 - `submitButton: React.ReactNode`. A component button that is used to submit the payment method. This button should include a click handler that performs the actual payment process. When disabled, it will be provided with the `disabled` prop and must disable the button.

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -42,6 +42,7 @@ export interface PaymentMethod {
 	inactiveContent?: React.ReactNode;
 	submitButton: ReactElement< PaymentMethodSubmitButtonProps >;
 	getAriaLabel: ( localize: ( value: string ) => string ) => string;
+	hasRequiredFields?: boolean;
 }
 
 export type ExternalPaymentMethod = Partial< PaymentMethod >;

--- a/packages/wpcom-checkout/src/payment-methods/alipay.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/alipay.tsx
@@ -77,6 +77,7 @@ export function createAlipayMethod( {
 } ): PaymentMethod {
 	return {
 		id: 'alipay',
+		hasRequiredFields: true,
 		paymentProcessorId: 'alipay',
 		label: <AlipayLabel />,
 		activeContent: <AlipayFields />,

--- a/packages/wpcom-checkout/src/payment-methods/bancontact.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/bancontact.tsx
@@ -68,6 +68,7 @@ export function createBancontactMethod( {
 } ): PaymentMethod {
 	return {
 		id: 'bancontact',
+		hasRequiredFields: true,
 		paymentProcessorId: 'bancontact',
 		label: <BancontactLabel />,
 		activeContent: <BancontactFields />,

--- a/packages/wpcom-checkout/src/payment-methods/eps.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/eps.tsx
@@ -67,6 +67,7 @@ export function createEpsMethod( {
 } ): PaymentMethod {
 	return {
 		id: 'eps',
+		hasRequiredFields: true,
 		paymentProcessorId: 'eps',
 		label: <EpsLabel />,
 		activeContent: <EpsFields />,

--- a/packages/wpcom-checkout/src/payment-methods/giropay.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/giropay.tsx
@@ -80,6 +80,7 @@ export function createGiropayMethod( {
 } ): PaymentMethod {
 	return {
 		id: 'giropay',
+		hasRequiredFields: true,
 		paymentProcessorId: 'giropay',
 		label: <GiropayLabel />,
 		activeContent: <GiropayFields />,

--- a/packages/wpcom-checkout/src/payment-methods/ideal.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/ideal.tsx
@@ -77,6 +77,7 @@ export function createIdealMethod( {
 } ): PaymentMethod {
 	return {
 		id: 'ideal',
+		hasRequiredFields: true,
 		paymentProcessorId: 'ideal',
 		label: <IdealLabel />,
 		activeContent: <IdealFields />,

--- a/packages/wpcom-checkout/src/payment-methods/p24.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/p24.tsx
@@ -93,6 +93,7 @@ export function createP24Method( {
 } ): PaymentMethod {
 	return {
 		id: 'p24',
+		hasRequiredFields: true,
 		paymentProcessorId: 'p24',
 		label: <P24Label />,
 		activeContent: <P24Fields />,

--- a/packages/wpcom-checkout/src/payment-methods/sofort.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/sofort.tsx
@@ -79,6 +79,7 @@ export function createSofortMethod( {
 } ): PaymentMethod {
 	return {
 		id: 'sofort',
+		hasRequiredFields: true,
 		paymentProcessorId: 'sofort',
 		label: <SofortLabel />,
 		activeContent: <SofortFields />,


### PR DESCRIPTION
## Proposed Changes

The `@automattic/composite-checkout` package defines a `PaymentMethod` object type which is used to create payment methods. The type includes an ID, a label component, a submit button component, and other properties. Some payment methods can just be selected with no additional input (eg: saved credit cards, PayPal), but other payment methods have required input fields (eg: new credit cards, iDEAL). 

Because each payment method's validation occurs internally, there is no way for the form itself or components outside the form to know if a payment method's required fields are complete. In https://github.com/Automattic/wp-calypso/pull/83985 we are collapsing the payment method step if it needs no additional interaction, so we need to know if a payment method has required fields.

In this PR we add a new property to the `PaymentMethod` type: `hasRequiredFields`. If set, this will signal that the payment method needs interaction and should not be automatically collapsed.

## Testing Instructions

See https://github.com/Automattic/wp-calypso/pull/83985

This PR should not have any noticeable effect on its own.