### PR TITLE
Fix ESLint errors about toBeCalled

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/index.tsx
@@ -143,7 +143,7 @@ describe( 'Launchpad', () => {
 					);
 				const initialReduxState = { currentUser: { id: user.ID } };
 				renderLaunchpad( props, defaultSiteDetails, initialReduxState, siteSlug );
-				expect( replaceMock ).not.toBeCalled();
+				expect( replaceMock ).not.toHaveBeenCalled();
 			} );
 		} );
 
@@ -168,8 +168,8 @@ describe( 'Launchpad', () => {
 					initialReduxState,
 					siteSlug
 				);
-				expect( replaceMock ).toBeCalledTimes( 1 );
-				expect( replaceMock ).toBeCalledWith( `/home/${ siteSlug }` );
+				expect( replaceMock ).toHaveBeenCalledTimes( 1 );
+				expect( replaceMock ).toHaveBeenCalledWith( `/home/${ siteSlug }` );
 			} );
 		} );
 
@@ -186,7 +186,7 @@ describe( 'Launchpad', () => {
 					{},
 					siteSlug
 				);
-				expect( replaceMock ).toBeCalledWith( `/home/${ siteSlug }` );
+				expect( replaceMock ).toHaveBeenCalledWith( `/home/${ siteSlug }` );
 			} );
 		} );
 
@@ -204,7 +204,7 @@ describe( 'Launchpad', () => {
 					initialReduxState,
 					''
 				);
-				expect( replaceMock ).toBeCalledWith( `/home` );
+				expect( replaceMock ).toHaveBeenCalledWith( `/home` );
 			} );
 		} );
 	} );

--- a/client/lib/query-args/test/index.ts
+++ b/client/lib/query-args/test/index.ts
@@ -12,14 +12,14 @@ describe( '#setQueryArgs', () => {
 		const expectedResult = '/read/search';
 		setQueryArgs( {} );
 
-		expect( page ).toBeCalledWith( expectedResult );
+		expect( page ).toHaveBeenCalledWith( expectedResult );
 	} );
 
 	test( 'should navigate to original url if there is no search', () => {
 		global.window.location.href = 'https://wordpress.com/plugins';
 		setQueryArgs( {} );
 
-		expect( page ).toBeCalledWith( '/plugins' );
+		expect( page ).toHaveBeenCalledWith( '/plugins' );
 	} );
 
 	test( 'should replace current query with new one even when using custom query key', () => {
@@ -37,7 +37,7 @@ describe( '#setQueryArgs', () => {
 		global.window.location.href = 'https://wordpress.com';
 		setQueryArgs( {} );
 
-		expect( page ).toBeCalledWith( '/' );
+		expect( page ).toHaveBeenCalledWith( '/' );
 	} );
 
 	test( 'should replace page url on a query search', () => {

--- a/client/my-sites/site-settings/test/form-general.jsx
+++ b/client/my-sites/site-settings/test/form-general.jsx
@@ -272,14 +272,14 @@ describe( 'SiteSettingsFormGeneral', () => {
 			expect( getByLabelText( 'Private' ) ).toBeChecked();
 
 			await userEvent.click( publicRadio );
-			expect( testProps.updateFields ).toBeCalledWith( {
+			expect( testProps.updateFields ).toHaveBeenCalledWith( {
 				blog_public: 1,
 				wpcom_coming_soon: 0,
 				wpcom_public_coming_soon: 0,
 			} );
 
 			await userEvent.click( discourageRadio );
-			expect( testProps.updateFields ).toBeCalledWith( {
+			expect( testProps.updateFields ).toHaveBeenCalledWith( {
 				blog_public: 0,
 				wpcom_coming_soon: 0,
 				wpcom_public_coming_soon: 0,
@@ -368,7 +368,7 @@ describe( 'SiteSettingsFormGeneral', () => {
 			expect( discourageRadio ).not.toBeChecked();
 
 			await userEvent.click( discourageRadio );
-			expect( testProps.updateFields ).toBeCalledWith( {
+			expect( testProps.updateFields ).toHaveBeenCalledWith( {
 				blog_public: 0,
 				wpcom_coming_soon: 0,
 				wpcom_public_coming_soon: 0,
@@ -493,7 +493,7 @@ describe( 'SiteSettingsFormGeneral', () => {
 			expect( getByLabelText( 'Private' ) ).not.toBeChecked();
 
 			await userEvent.click( publicRadio );
-			expect( testProps.updateFields ).toBeCalledWith( {
+			expect( testProps.updateFields ).toHaveBeenCalledWith( {
 				blog_public: 0,
 				wpcom_coming_soon: 0,
 				wpcom_public_coming_soon: 0,
@@ -584,7 +584,7 @@ describe( 'SiteSettingsFormGeneral', () => {
 			expect( publicRadio ).not.toBeChecked();
 
 			await userEvent.click( hiddenCheckbox );
-			expect( testProps.updateFields ).toBeCalledWith( {
+			expect( testProps.updateFields ).toHaveBeenCalledWith( {
 				blog_public: 0,
 				wpcom_coming_soon: 0,
 				wpcom_public_coming_soon: 0,
@@ -604,7 +604,7 @@ describe( 'SiteSettingsFormGeneral', () => {
 			expect( publicRadio ).toBeChecked();
 
 			await userEvent.click( hiddenCheckbox );
-			expect( testProps.updateFields ).toBeCalledWith( {
+			expect( testProps.updateFields ).toHaveBeenCalledWith( {
 				blog_public: 1,
 				wpcom_coming_soon: 0,
 				wpcom_public_coming_soon: 0,
@@ -647,7 +647,7 @@ describe( 'SiteSettingsFormGeneral', () => {
 					const radioButton = getByLabelText( text, { exact: false } );
 					expect( radioButton ).not.toBeChecked();
 					await userEvent.click( radioButton );
-					expect( testProps.updateFields ).toBeCalledWith( updatedFields );
+					expect( testProps.updateFields ).toHaveBeenCalledWith( updatedFields );
 				} );
 			} );
 

--- a/packages/design-picker/src/utils/__tests__/available-designs.test.ts
+++ b/packages/design-picker/src/utils/__tests__/available-designs.test.ts
@@ -255,8 +255,8 @@ describe( 'Design Picker design utils', () => {
 
 			getAvailableDesigns( { randomize: true } ).featured;
 
-			expect( shuffle ).toBeCalledTimes( 1 );
-			expect( shuffle ).toBeCalledWith( designs );
+			expect( shuffle ).toHaveBeenCalledTimes( 1 );
+			expect( shuffle ).toHaveBeenCalledWith( designs );
 		} );
 	} );
 } );


### PR DESCRIPTION
Fixes several ESLint errors reported by the `jest/no-alias-methods` rule, like:
```
src/wp-calypso/client/lib/query-args/test/index.ts
  15:18  error  Replace toBeCalledWith() with its canonical name of toHaveBeenCalledWith()  jest/no-alias-methods
```

Fixing them is a prerequisite for #84096 which modifies some of the files with pre-existing unrelated errors.