### PR TITLE
Domains Table: Remove domains/bulk-actions-contact-info-editing feature flag

### DIFF
--- a/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-all-domains.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { DomainsTable, useDomainsTable } from '@automattic/domains-table';
 import { useTranslate } from 'i18n-calypso';
 import { UsePresalesChat } from 'calypso/components/data/domain-management';
@@ -72,9 +71,6 @@ export default function BulkAllDomains( props: BulkAllDomainsProps ) {
 					isLoadingDomains={ isLoading }
 					domains={ domains }
 					isAllSitesView
-					shouldDisplayContactInfoBulkAction={ isEnabled(
-						'domains/bulk-actions-contact-info-editing'
-					) }
 					domainStatusPurchaseActions={ purchaseActions }
 					currentUserCanBulkUpdateContactInfo={ ! isInSupportSession }
 					onDomainAction={ ( action, domain ) => {

--- a/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { useSiteDomainsQuery } from '@automattic/data-stores';
 import { DomainsTable, ResponseDomain } from '@automattic/domains-table';
 import { useTranslate } from 'i18n-calypso';
@@ -95,9 +94,6 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 					domains={ data?.domains }
 					isAllSitesView={ false }
 					siteSlug={ site?.slug ?? null }
-					shouldDisplayContactInfoBulkAction={ isEnabled(
-						'domains/bulk-actions-contact-info-editing'
-					) }
 					domainStatusPurchaseActions={ purchaseActions }
 					userCanSetPrimaryDomains={ userCanSetPrimaryDomains }
 					currentUserCanBulkUpdateContactInfo={ ! isInSupportSession }

--- a/config/development.json
+++ b/config/development.json
@@ -58,7 +58,6 @@
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/max-characters-filter": false,
 		"domains/kracken-ui/pagination": true,
-		"domains/bulk-actions-contact-info-editing": true,
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
 		"email-accounts/enabled": true,

--- a/config/production.json
+++ b/config/production.json
@@ -38,7 +38,6 @@
 		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
-		"domains/bulk-actions-contact-info-editing": true,
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
 		"external-media": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -36,7 +36,6 @@
 		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
-		"domains/bulk-actions-contact-info-editing": true,
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
 		"external-media": true,

--- a/config/test.json
+++ b/config/test.json
@@ -38,7 +38,6 @@
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": true,
 		"difm/allow-extra-pages": false,
-		"domains/bulk-actions-contact-info-editing": true,
 		"domains/transfer-to-any-user": true,
 		"cookie-banner": false,
 		"google-my-business": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -41,7 +41,6 @@
 		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
-		"domains/bulk-actions-contact-info-editing": true,
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
 		"domains/transfer-to-any-user": true,

--- a/packages/domains-table/src/bulk-actions-toolbar/index.tsx
+++ b/packages/domains-table/src/bulk-actions-toolbar/index.tsx
@@ -3,7 +3,6 @@ import { createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { useState } from 'react';
-import { useDomainsTable } from '../domains-table/domains-table';
 import contactIcon from './contact.svg';
 import transformIcon from './transform.svg';
 import './style.scss';
@@ -21,7 +20,6 @@ export function BulkActionsToolbar( {
 	selectedDomainCount,
 	canUpdateContactInfo,
 }: BulkActionsToolbarProps ) {
-	const { shouldDisplayContactInfoBulkAction } = useDomainsTable();
 	const { __, _n } = useI18n();
 	const [ controlKey, setControlKey ] = useState( 1 );
 
@@ -68,18 +66,16 @@ export function BulkActionsToolbar( {
 
 	return (
 		<div className="domains-table-bulk-actions-toolbar">
-			{ shouldDisplayContactInfoBulkAction && (
-				<Button onClick={ onUpdateContactInfo } disabled={ ! canUpdateContactInfo }>
-					<img
-						className="domains-table-bulk-actions-toolbar__icon"
-						src={ contactIcon }
-						width={ 18 }
-						height={ 18 }
-						alt=""
-					/>{ ' ' }
-					{ __( 'Edit contact information', __i18n_text_domain__ ) }
-				</Button>
-			) }
+			<Button onClick={ onUpdateContactInfo } disabled={ ! canUpdateContactInfo }>
+				<img
+					className="domains-table-bulk-actions-toolbar__icon"
+					src={ contactIcon }
+					width={ 18 }
+					height={ 18 }
+					alt=""
+				/>{ ' ' }
+				{ __( 'Edit contact information', __i18n_text_domain__ ) }
+			</Button>
 			<SelectDropdown
 				key={ controlKey }
 				className="domains-table-bulk-actions-toolbar__select"

--- a/packages/domains-table/src/domains-table/__tests__/index.tsx
+++ b/packages/domains-table/src/domains-table/__tests__/index.tsx
@@ -705,7 +705,6 @@ describe( 'column sorting', () => {
 test( 'when current user is the owner, they can bulk update contact info', () => {
 	render(
 		<DomainsTable
-			shouldDisplayContactInfoBulkAction
 			currentUserCanBulkUpdateContactInfo
 			domains={ [ testPartialDomain( { domain: 'example1.com', current_user_is_owner: true } ) ] }
 			isAllSitesView
@@ -722,7 +721,6 @@ test( 'when current user is the owner, they can bulk update contact info', () =>
 test( 'when current user is not the owner, they cannot bulk update contact info', () => {
 	render(
 		<DomainsTable
-			shouldDisplayContactInfoBulkAction
 			currentUserCanBulkUpdateContactInfo
 			domains={ [
 				testPartialDomain( { domain: 'example1.com', current_user_is_owner: false } ),
@@ -744,7 +742,6 @@ test( 'when current user is not the owner, they cannot bulk update contact info'
 test( 'when the current user is not allowed to bulk update the contact info, disable the action', () => {
 	render(
 		<DomainsTable
-			shouldDisplayContactInfoBulkAction
 			currentUserCanBulkUpdateContactInfo={ false }
 			isAllSitesView
 			domains={ [ testPartialDomain( { domain: 'example1.com' } ) ] }

--- a/packages/domains-table/src/domains-table/domains-table.tsx
+++ b/packages/domains-table/src/domains-table/domains-table.tsx
@@ -52,7 +52,6 @@ interface BaseDomainsTableProps {
 	domainStatusPurchaseActions?: DomainStatusPurchaseActions;
 	onDomainAction?: OnDomainAction;
 	userCanSetPrimaryDomains?: boolean;
-	shouldDisplayContactInfoBulkAction?: boolean;
 	isLoadingDomains?: boolean;
 
 	// These props allow table users to provide their own fetching functions. This is used for
@@ -117,7 +116,6 @@ type Value = {
 	onDomainAction( ...parameters: Parameters< OnDomainAction > ): void;
 	updatingDomain: DomainsTableUpdatingDomain | null;
 	userCanSetPrimaryDomains: BaseDomainsTableProps[ 'userCanSetPrimaryDomains' ];
-	shouldDisplayContactInfoBulkAction: boolean;
 	domainsTableColumns: DomainsTableColumn[];
 	currentUsersOwnsAllSelectedDomains: boolean;
 	currentUserCanBulkUpdateContactInfo: boolean;
@@ -141,7 +139,6 @@ export const useGenerateDomainsTableState = ( props: DomainsTableProps ) => {
 		domainStatusPurchaseActions,
 		onDomainAction,
 		userCanSetPrimaryDomains,
-		shouldDisplayContactInfoBulkAction = false,
 		isLoadingDomains,
 		currentUserCanBulkUpdateContactInfo = false,
 	} = props;
@@ -422,7 +419,6 @@ export const useGenerateDomainsTableState = ( props: DomainsTableProps ) => {
 		},
 		updatingDomain,
 		userCanSetPrimaryDomains,
-		shouldDisplayContactInfoBulkAction,
 		domainsTableColumns,
 		isLoadingDomains,
 		currentUserCanBulkUpdateContactInfo,


### PR DESCRIPTION


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/3855

## Proposed Changes

* Remove `domains/bulk-actions-contact-info-editing` feature flag

This flag has been `true` in all environments for a while. I don't foresee us rolling it back now.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test all-domains table variation
* Test site-specific domains table variation
* There should be no difference in behaviour from production
