### PR TITLE
Fix two incorrect imports of the page module

### DIFF
--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -1,6 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { FEATURE_REPUBLICIZE } from '@automattic/calypso-products';
 import { Button, Gridicon } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { get, includes, map, concat } from 'lodash';
@@ -399,7 +400,10 @@ class PostShare extends Component {
 						}
 					>
 						{ connection.service === 'facebook' && (
-							<NoticeAction href="https://wordpress.com/support/publicize/#facebook-pages" external>
+							<NoticeAction
+								href={ localizeUrl( 'https://wordpress.com/support/publicize/#facebook-pages' ) }
+								external
+							>
 								{ translate( 'Learn More' ) }
 							</NoticeAction>
 						) }

--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -4,7 +4,7 @@ import { Button, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { get, includes, map, concat } from 'lodash';
-import { current as currentPage } from 'page';
+import page from 'page';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -187,7 +187,7 @@ class PostShare extends Component {
 			{ service_all: 0 }
 		);
 		const additionalProperties = {
-			context_path: sectionify( currentPage ),
+			context_path: sectionify( page.current ),
 			is_jetpack: isJetpack,
 			blog_id: siteId,
 		};

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -1,4 +1,3 @@
-import { current as currentPage } from 'page';
 import {
 	addAddOnsToCart,
 	addPlanToCart,
@@ -35,7 +34,6 @@ export default generateSteps( {
 	createWpForTeamsSite,
 	createSiteOrDomain,
 	createSiteWithCart,
-	currentPage,
 	setDesignOnSite,
 	setThemeOnSite,
 	setOptionsOnSite,


### PR DESCRIPTION
As a prerequisite to #84096, this PR is fixing two incorrect imports of the `page` module:
- in Signup config steps, the `currentPage` import/parameter is not needed at all. The `generateSteps` used to use it (for the "survey" step) but at some point in the past the "survey" step got removed and the parameter got orphaned
- in `PostShare`, let's import the default export of `page`, because it doesn't have a named `current` export. Importing named `current` works only thanks to some ESM/CJS compat.