### PR TITLE
Fix jsdoc/tag-lines ESLint errors

### DIFF
--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -228,7 +228,6 @@ export function getiOSDeepLink( currentRoute, currentSection ) {
 /**
  * Returns the universal link that then gets used to send the user to the correct editor.
  * If the app is installed otherwise they will end up on the new site creaton flow after creating an account.
- *
  * @param {string} currentRoute
  * @returns string
  */

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -495,7 +495,6 @@ class PostCommentList extends Component {
 
 	/**
 	 * Gets comments for display
-	 *
 	 * @param {Array<number>} commentIds The top level commentIds to take from
 	 * @param {number} numberToTake How many top level comments to take
 	 * @returns {Object} that has the displayed comments + total displayed count including children

--- a/client/blocks/reader-excerpt/index.jsx
+++ b/client/blocks/reader-excerpt/index.jsx
@@ -42,7 +42,6 @@ const convertExcerptNewlinesToBreaks = ( excerpt ) => {
 
 /**
  * Removes double spaces and also &nbsp; characters which may be present in the excerpt.
- *
  * @param {string} str the string to normalize
  * @returns a string with single space characters.
  */
@@ -52,7 +51,6 @@ const normalizeWhitespace = ( str ) => {
 
 /**
  * Gets the writing prompt text which was inserted as a pullquote at the begining of the post's content.
- *
  * @param {Object} post the post object
  * @returns writing prompt text
  */

--- a/client/blocks/site-icon/docs/example.jsx
+++ b/client/blocks/site-icon/docs/example.jsx
@@ -6,7 +6,6 @@ import SiteIcon from '../';
 /**
  * Site ID of en.blog.wordpress.com, to be used as fallback for SiteIcon if
  * current user does not have a primary site.
- *
  * @type {number}
  */
 const EN_BLOG_SITE_ID = 3584907;

--- a/client/blocks/user-mentions/add.jsx
+++ b/client/blocks/user-mentions/add.jsx
@@ -9,7 +9,6 @@ const keys = { tab: 9, enter: 13, esc: 27, spaceBar: 32, upArrow: 38, downArrow:
  * addUserMentions is a higher-order component that adds user mention support to whatever input it wraps.
  *
  * Suggestions can be provided via the suggestions prop, or by the connectUserMentions higher-order component.
- *
  * @example addUserMentions( Component )
  * @param {Object} WrappedComponent - React component to wrap
  * @returns {Object} the enhanced component

--- a/client/blocks/user-mentions/connect.jsx
+++ b/client/blocks/user-mentions/connect.jsx
@@ -8,7 +8,6 @@ import { getUserSuggestions } from 'calypso/state/user-suggestions/selectors';
  * connectUserMentions is a higher-order component that connects the child component to user suggestions from the API.
  *
  * example: connectUserMentions( Component )
- *
  * @param {Object} WrappedComponent - React component to wrap
  * @returns {Object} the enhanced component
  */

--- a/client/blocks/user-mentions/index.jsx
+++ b/client/blocks/user-mentions/index.jsx
@@ -4,7 +4,6 @@ import connectUserMentions from './connect';
 
 /**
  * withUserMentions is a higher-order component that adds connected user mention support to whatever input it wraps.
- *
  * @example withUserMentions( Component )
  * @param {Object} WrappedComponent - React component to wrap
  * @returns {Object} the enhanced component

--- a/client/blocks/video-editor/index.jsx
+++ b/client/blocks/video-editor/index.jsx
@@ -64,7 +64,6 @@ class VideoEditor extends Component {
 
 	/**
 	 * Updates the poster by selecting a particular frame of the video.
-	 *
 	 * @param {number} currentTime - Time at which to capture the frame
 	 * @param {boolean} isMillisec - Whether the time is in milliseconds
 	 */
@@ -108,7 +107,6 @@ class VideoEditor extends Component {
 
 	/**
 	 * Uploads an image to use as the poster for the video.
-	 *
 	 * @param {Object} file - Uploaded image
 	 */
 	uploadImage = ( file ) => {

--- a/client/components/auto-direction/index.jsx
+++ b/client/components/auto-direction/index.jsx
@@ -15,7 +15,6 @@ const SPACE_CHARACTERS = {
 
 /**
  * Checks whether a character is a space character
- *
  * @param {string} character character to examine
  * @returns {boolean} true if character is a space character, false otherwise
  */
@@ -23,7 +22,6 @@ const isSpaceCharacter = ( character ) => !! SPACE_CHARACTERS[ character ];
 
 /**
  * Get index of the first character that is not within a tag
- *
  * @param {string} text text to examine
  * @returns {number} index not within a tag
  */
@@ -50,7 +48,6 @@ const getTaglessIndex = ( text ) => {
 
 /**
  * Gets text content from react element in case that's a leaf element
- *
  * @param {Element} reactElement react element
  * @returns {string|null} returns a text content of the react element or null if it's not a leaf element
  */
@@ -98,7 +95,6 @@ const getContent = ( reactElement ) => {
 /**
  * Gets the main directionality in a text
  * It returns what kind of characters we had the most, RTL or LTR according to some ratio
- *
  * @param {string}  text  the text to be examined
  * @param {boolean} isRtl whether current language is RTL
  * @returns {string} either 'rtl' or 'ltr'
@@ -151,7 +147,6 @@ const getChildDirection = ( child, isRtl ) => {
  * That function intended to be used recursively with React.Children.map
  * It will set directionality only to the leaf components - because it does so according
  * to text content and only leaf components have those.
- *
  * @param {Element} child element to transform
  * @param {boolean}       isRtl whether current language is RTL
  * @returns {Element} transformed child
@@ -184,7 +179,6 @@ const setChildDirection = ( child, isRtl ) => {
 
 /**
  * Auto direction component that will set direction to child components according to their text content
- *
  * @param {Object.children} props react element props that must contain some children
  * @returns {Element} returns a react element with adjusted children
  */

--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -15,7 +15,6 @@ const isTouch = hasTouch();
 
 /**
  * Auxiliary method to calculate the maximum value for the Y axis, based on a dataset.
- *
  * @param {Array} values An array of numeric values.
  * @returns {number} The maximum value for the Y axis.
  */

--- a/client/components/community-translator/index.jsx
+++ b/client/components/community-translator/index.jsx
@@ -72,7 +72,6 @@ class CommunityTranslator extends Component {
 
 	/**
 	 * Wraps translation in a DOM object and attaches `toString()` method in case in can't be rendered
-	 *
 	 * @param {string} originalFromPage - original string
 	 * @param {string} displayedTranslationFromPage - translated string
 	 * @param  { Object } optionsFromPage - i18n.translate options

--- a/client/components/diff-viewer/index.jsx
+++ b/client/components/diff-viewer/index.jsx
@@ -24,7 +24,6 @@ const decompose = ( path ) => {
  * added by `git` and other utilities to separate the left
  * from the right when looking at the contents of a single
  * file over time.
- *
  * @param {Object} options deconstructed argument
  * @param {string} options.oldFileName filename of left contents
  * @param {string} options.newFileName filename of right contents

--- a/client/components/forms/form-section-heading/index.jsx
+++ b/client/components/forms/form-section-heading/index.jsx
@@ -3,7 +3,6 @@ import classnames from 'classnames';
 import './style.scss';
 /**
  * Render a form section heading
- *
  * @param {Object} props Component props
  * @param {string=} props.className optional extra CSS class(es) to be added to the component
  * @param {import('react').ReactNode=} props.children react element props that must contain some children

--- a/client/components/gsuite/gsuite-price/index.jsx
+++ b/client/components/gsuite/gsuite-price/index.jsx
@@ -8,7 +8,6 @@ import './style.scss';
 
 /**
  * Determines whether a discount can be applied to the specified product via a sales coupon.
- *
  * @param {undefined|null|{sale_cost?: number, sale_coupon?:{start_date?: string; expires?: string}}} product - G Suite product
  * @returns {boolean} - true if a discount can be applied, false otherwise
  */

--- a/client/components/infinite-list/index.jsx
+++ b/client/components/infinite-list/index.jsx
@@ -326,7 +326,6 @@ export default class InfiniteList extends Component {
 	 *
 	 * This includes any items that are partially visible in the viewport.
 	 * Instance method that is called externally (via a ref) by a parent component.
-	 *
 	 * @param {Object} options - offset properties
 	 * @param {number} options.offsetTop - in pixels, 0 if unspecified
 	 * @param {number} options.offsetBottom - in pixels, 0 if unspecified
@@ -461,7 +460,6 @@ export default class InfiniteList extends Component {
 
 	/**
 	 * Determine whether context is available or still being rendered.
-	 *
 	 * @returns {boolean} whether context is available
 	 */
 	_contextLoaded() {

--- a/client/components/keyed-suggestions/index.jsx
+++ b/client/components/keyed-suggestions/index.jsx
@@ -147,7 +147,6 @@ class KeyedSuggestions extends Component {
 	/**
 	 * Provides keybord support for suggestings component by managing items highlith position
 	 * and calling suggestion callback when user hits Enter
-	 *
 	 * @param  {Object} event  Keybord event
 	 * @returns {boolean}      true indicates suggestion was chosen and send to parent using suggest prop callback
 	 */
@@ -206,7 +205,6 @@ class KeyedSuggestions extends Component {
 	 * do not match provided input param. At the end keys that have empty lists are removed.
 	 * showAll parameter if provided sidesteps the matching logic for the key value in showAll
 	 * and passes all filters for that key. For showAll also soome reordering happens - explained in code
-	 *
 	 * @param  {string}  input   text that will be matched against the taxonomies
 	 * @param  {string}  showAll taxonomy for which we want all filters
 	 * @returns {Object}          filtered taxonomy:[ terms ] object

--- a/client/components/marked-lines/index.jsx
+++ b/client/components/marked-lines/index.jsx
@@ -7,7 +7,6 @@ import './style.scss';
 /**
  * Surrounds a text string in a <mark>
  * Just a small helper function
- *
  * @example
  * mark( 'be kind' ) =>
  *   <mark key="be kind" className="marked-lines__mark">be kind</mark>
@@ -23,7 +22,6 @@ const mark = ( text ) => (
 /**
  * Translates marked-file context input
  * into React component output
- *
  * @example
  * const marks = [ [ 2, 4 ], [ 5, 9 ] ]
  * const content = '->^^-_____<--'

--- a/client/components/post-schedule/clock.jsx
+++ b/client/components/post-schedule/clock.jsx
@@ -105,7 +105,6 @@ class PostScheduleClock extends Component {
 
 	/**
 	 * Converts a 12-hour time to a 24-hour time, depending on time format.
-	 *
 	 * @param {number}  hour The hour to convert.
 	 * @returns {number}      The converted hour.
 	 */

--- a/client/components/theme/more-button.jsx
+++ b/client/components/theme/more-button.jsx
@@ -12,7 +12,6 @@ import PopoverMenuSeparator from 'calypso/components/popover-menu/separator';
  * Note that the check this function implements is incomplete --
  * it only returns false for absolute URLs, so it misses
  * relative URLs, or pure query strings, or hashbangs.
- *
  * @param  url URL to check
  * @returns     true if the given URL is located outside of Calypso
  */

--- a/client/components/title-format-editor/index.jsx
+++ b/client/components/title-format-editor/index.jsx
@@ -83,7 +83,6 @@ export class TitleFormatEditor extends Component {
 	 * Returns a new editorState that forces
 	 * selection to hop over tokens, preventing
 	 * navigating the cursor into a token
-	 *
 	 * @param {EditorState} editorState new state of editor after changes
 	 * @returns {EditorState} maybe filtered state for editor
 	 */

--- a/client/devdocs/docs-selectors/param-type.jsx
+++ b/client/devdocs/docs-selectors/param-type.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 
 /**
  * Matches an expression type
- *
  * @type {RegExp}
  */
 const REGEXP_EXPRESSION_TYPE = /(.*)Type$/;

--- a/client/layout/masterbar/masterbar-notifications/notifications-button.jsx
+++ b/client/layout/masterbar/masterbar-notifications/notifications-button.jsx
@@ -84,7 +84,6 @@ class MasterbarItemNotifications extends Component {
 	 * and the locally-stored cache of that value to
 	 * determine what state the notifications indicator
 	 * should be in: on, off, or animate-to-on
-	 *
 	 * @param {number} currentUnseenCount Number of reported unseen notifications
 	 */
 	setNotesIndicator = ( currentUnseenCount ) => {

--- a/client/lib/paste-to-link/index.jsx
+++ b/client/lib/paste-to-link/index.jsx
@@ -6,7 +6,6 @@ import { resemblesUrl } from 'calypso/lib/url';
  *
  * If the clipboard contains a URL and some text is selected, pasting will wrap the selected text
  * in an <a> element with the href set to the URL in the clipboard.
- *
  * @example withPasteToLink( Component )
  * @param {Object} WrappedComponent - React component to wrap
  * @returns {Object} Enhanced component

--- a/client/lib/with-dimensions/index.jsx
+++ b/client/lib/with-dimensions/index.jsx
@@ -18,11 +18,10 @@ const OVERFLOW_BUFFER = 4; // fairly arbitrary. feel free to tweak
  * How to specify which domNode to keep track of? In React it is always a bit awkward to get a handle on
  * actual domnodes so this HoC provides a few methods:
  * 1. default: wrap child component in a div and track the div.  requires no ref passing.  means the component essentially gets its own
- *     available width/height/overflow properties
+ *    available width/height/overflow properties
  * 2. provide a prom domTarget to the created component: <EnhancedComponent domTarget={ domNode } />
  * 3. call the provided setWithDimensionsRef function:
  *    withDimensions( ({}) => <div> <span ref ={ this.props.setWithDimensionsRef }> </span></div> )
- *
  * @example withDimensions( Component )
  * @param {Object} EnhancedComponent - react component to wrap and give the prop width/height to
  * @returns {Object} the enhanced component

--- a/client/my-sites/activity/activity-log-banner/progress-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/progress-banner.jsx
@@ -16,7 +16,6 @@ import ActivityLogBanner from './index';
  * The chosen comparison date is older than
  * WordPress so no backups should already
  * exist prior to that date 😉
- *
  * @param {number} ts timestamp in 's' or 'ms'
  * @returns {number} timestamp in 'ms'
  */

--- a/client/my-sites/activity/activity-log-banner/success-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/success-banner.jsx
@@ -26,7 +26,6 @@ import './success-banner.scss';
  * The chosen comparison date is older than
  * WordPress so no backups should already
  * exist prior to that date 😉
- *
  * @param {number} ts timestamp in 's' or 'ms'
  * @returns {number} timestamp in 'ms'
  */

--- a/client/my-sites/activity/activity-log-switch/index.jsx
+++ b/client/my-sites/activity/activity-log-switch/index.jsx
@@ -25,7 +25,6 @@ class ActivityLogSwitch extends Component {
 
 	/**
 	 * Renders the main button whose functionality and label varies depending on why Jetpack Backup is unavailable.
-	 *
 	 * @returns {Object} Primary button.
 	 */
 	getMainButton() {

--- a/client/my-sites/activity/activity-log-tasklist/index.jsx
+++ b/client/my-sites/activity/activity-log-tasklist/index.jsx
@@ -29,7 +29,6 @@ import './style.scss';
 
 /**
  * Checks if the plugin, theme or core update is enqueued to be updated, searching it in the list by its slug.
- *
  * @param {string} updateSlug  Plugin or theme slug, or 'wordpress' for core updates.
  * @param {Array}  updateQueue Collection of plugins or themes currently queued to be updated.
  * @returns {boolean}   True if the plugin or theme is enqueued to be updated.
@@ -79,7 +78,6 @@ class ActivityLogTasklist extends Component {
 	 * Adds a single or multiple plugin or theme slugs to a list of dismissed items.
 	 * If it receives a string, it assumes it's a valid plugin or theme slug and adds it to the dismissed list.
 	 * When it doesn't receive a string, it adds all the plugin and theme slugs to the dismissed list.
-	 *
 	 * @param {Object} item Plugin or theme to dismiss.
 	 */
 	dismiss = ( item ) => {
@@ -102,7 +100,6 @@ class ActivityLogTasklist extends Component {
 
 	/**
 	 * Goes to general plugin management screen.
-	 *
 	 * @returns {Object} Action to redirect to plugins management.
 	 */
 	goManagePlugins = () =>
@@ -114,7 +111,6 @@ class ActivityLogTasklist extends Component {
 
 	/**
 	 * Goes to single theme or plugin management screen.
-	 *
 	 * @param {string} slug Plugin or theme slug, like "hello-dolly" or "dara".
 	 * @param {string} type Indicates if it's "plugin" or "theme".
 	 * @returns {Object} Action to redirect to plugin management.
@@ -133,7 +129,6 @@ class ActivityLogTasklist extends Component {
 
 	/**
 	 * Add a plugin, theme, or core update to the update queue. Insert a prop to track enqueue origin later.
-	 *
 	 * @param {Object} item Plugin, theme, or core update to enqueue.
 	 * @param {string} from Pass '_from_error' when calling from error notice. Otherwise it's empty.
 	 */
@@ -149,7 +144,6 @@ class ActivityLogTasklist extends Component {
 
 	/**
 	 * Remove a plugin from the update queue.
-	 *
 	 * @returns {undefined}
 	 */
 	finishUpdate = () =>
@@ -175,7 +169,6 @@ class ActivityLogTasklist extends Component {
 	};
 	/**
 	 * Expand the list of updates to show all of them
-	 *
 	 * @param {Object} event Synthetic event
 	 */
 	showAllUpdates = ( event ) => {
@@ -186,7 +179,6 @@ class ActivityLogTasklist extends Component {
 
 	/**
 	 * Starts the update process for a specified plugin/theme. Displays an informational notice.
-	 *
 	 * @param {Object} item Plugin/theme information that includes
 	 * {
 	 * 		{string} slug Plugin or theme slug, like "hello-dolly". Slug for core updates is "wordpress".

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -54,7 +54,6 @@ export function checkoutJetpackSiteless( context, next ) {
 	 * is not a site in context, such as siteless checkout. As opposed to `siteSlug` which is the
 	 * site slug present when the site is in context (ie- when site is connected and user is
 	 * logged in).
-	 *
 	 * @type {string|undefined}
 	 */
 	const fromSiteSlug = context.query?.from_site_slug;
@@ -276,7 +275,6 @@ export function checkoutPending( context, next ) {
 	 * is not a site in context, such as siteless checkout. As opposed to `siteSlug` which is the
 	 * site slug present when the site is in context (ie- when site is connected and user is
 	 * logged in).
-	 *
 	 * @type {string|undefined}
 	 */
 	const fromSiteSlug = context.query?.from_site_slug;

--- a/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
+++ b/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
@@ -61,7 +61,6 @@ const getTitanClickHandler = ( app ) => {
 
 /**
  * Returns the available menu items for Titan Emails
- *
  * @param {Object} titanMenuParams The argument for this function.
  * @param {import('calypso/lib/domains/types').ResponseDomain} titanMenuParams.domain The domain object.
  * @param {Object} titanMenuParams.mailbox The mailbox object.
@@ -113,7 +112,6 @@ const getTitanMenuItems = ( {
 
 /**
  * Get the list of applicable menu items for a G Suite or Google Workspace mailbox.
- *
  * @param {Object} gSuiteMenuParams Parameter for this function.
  * @param {Object} gSuiteMenuParams.account The account the current mailbox is linked to.
  * @param {Object} gSuiteMenuParams.mailbox The mailbox object.

--- a/client/my-sites/marketing/connections/service-tip.jsx
+++ b/client/my-sites/marketing/connections/service-tip.jsx
@@ -17,13 +17,11 @@ import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
  *
  * When adding tips for more services, please update the list in addition to adding
  * a method with the tip's content.
- *
  * @type {string[]}
  */
 const SERVICES_WITH_TIPS = [ 'instagram', 'google_plus' ];
 /**
  * List of services we provide tips for, only if the site is connected to Jetpack.
- *
  * @type {string[]}
  */
 const JETPACK_SERVICES_WITH_TIPS = SERVICES_WITH_TIPS.concat( [ 'facebook', 'twitter' ] );

--- a/client/my-sites/marketing/connections/services/instagram.jsx
+++ b/client/my-sites/marketing/connections/services/instagram.jsx
@@ -21,7 +21,6 @@ export class Instagram extends SharingService {
 
 	/**
 	 * Deletes the passed connections.
-	 *
 	 * @param {Array} [connections] List of connections to delete. If undefined, delete all connections.
 	 */
 	removeConnection = ( connections ) => {

--- a/client/my-sites/media-library/scale.jsx
+++ b/client/my-sites/media-library/scale.jsx
@@ -15,14 +15,12 @@ import { setPreference, savePreference } from 'calypso/state/preferences/actions
 
 /**
  * Number of steps on the rendered input range
- *
  * @type {number}
  */
 const SLIDER_STEPS = 100;
 
 /**
  * Scale size for small viewports grid option (3 items per row).
- *
  * @type {number}
  */
 

--- a/client/my-sites/media-library/upload-button.jsx
+++ b/client/my-sites/media-library/upload-button.jsx
@@ -60,7 +60,6 @@ class MediaLibraryUploadButton extends Component {
 	 * of type `file`. This is a non-standard use of the `accept` attribute,
 	 * but is supported in Internet Explorer and Chrome browsers. Further input
 	 * validation will occur when attempting to upload the file.
-	 *
 	 * @returns {string} Supported file extensions, as comma-separated string
 	 */
 	getInputAccept = () => {

--- a/client/my-sites/plugins/plugins-browser/single-list-view/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/single-list-view/index.jsx
@@ -21,7 +21,6 @@ function isNotBlocked( plugin ) {
 
 /**
  * Returns a boolean indicating if a plugin is already installed or not
- *
  * @param plugin plugin object to be tested
  * @param installedPlugins list of installed plugins aggregated by plugin slug
  * @returns Boolean weather a plugin is not installed on not

--- a/client/my-sites/post-relative-time-status/index.jsx
+++ b/client/my-sites/post-relative-time-status/index.jsx
@@ -188,7 +188,6 @@ class PostRelativeTime extends PureComponent {
 
 	/**
 	 * Get Newsletter status label
-	 *
 	 * @param {string} status Newsletter tatus
 	 */
 	getNewsletterStatus( status ) {
@@ -237,10 +236,9 @@ class PostRelativeTime extends PureComponent {
 
 	/**
 	 * Get Label for the status
-	 *
 	 * @param {string} statusText text status
 	 * @param {string} extraStatusClassName extra CSS class to be added to the label
-	 * @param {string} [statusIcon="aside"] icon for the label
+	 * @param {string} [statusIcon] icon for the label
 	 */
 	getLabel( statusText, extraStatusClassName, statusIcon = 'aside' ) {
 		if ( statusText ) {

--- a/client/my-sites/site-settings/press-this/link.jsx
+++ b/client/my-sites/site-settings/press-this/link.jsx
@@ -6,7 +6,6 @@ import { newPost } from 'calypso/lib/paths';
 /**
  * Retrieves selection, title, and URL from current page and pops
  * open new editor window with contents
- *
  * @param  {string} postURL Editor URL for selected site
  */
 const pressThis = function ( postURL ) {
@@ -59,7 +58,6 @@ class PressThisLink extends Component {
 
 	/**
 	 * generate press-this link pointing to current environment
-	 *
 	 * @returns {string} javascript pseudo-protocol link
 	 */
 	buildPressThisLink() {

--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -150,7 +150,6 @@ class Search extends Component {
 
 		/**
 		 * Call WPCOM endpoints to update remote Jetpack sites' settings
-		 *
 		 * @param {boolean} jetpackSearchEnabled Whether Jetpack Search is enabled
 		 */
 		const handleJetpackSearchToggle = ( jetpackSearchEnabled ) => {
@@ -164,7 +163,6 @@ class Search extends Component {
 
 		/**
 		 * Call WPCOM endpoints to update remote Jetpack sites' settings
-		 *
 		 * @param {boolean} instantSearchEnabled Whether Instant Search is enabled
 		 */
 		const handleInstantSearchToggle = ( instantSearchEnabled ) => {
@@ -224,7 +222,6 @@ class Search extends Component {
 
 		/**
 		 * Change instant toggle status with Jetpack Search toggle and then save settings
-		 *
 		 * @param {boolean} jetpackSearchEnabled Whether Jetpack Search is enabled
 		 */
 		const handleJetpackSearchToggle = ( jetpackSearchEnabled ) => {

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -352,7 +352,6 @@ class ThemeSheet extends Component {
 			source,
 			/**
 			 * To see tracks as the UI changes depending on whether Live Preview is available or not.
-			 *
 			 * @see https://github.com/Automattic/wp-calypso/pull/80540
 			 */
 			has_live_preview_cta: isLivePreviewSupported,

--- a/client/my-sites/types/post-type-unsupported/index.jsx
+++ b/client/my-sites/types/post-type-unsupported/index.jsx
@@ -14,7 +14,6 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 /**
  * Post types which can be configured in the Writing Site Settings for a site,
  * regardless of whether the current theme supports it.
- *
  * @type {Array}
  */
 const CONFIGURABLE_TYPES = [ 'jetpack-portfolio', 'jetpack-testimonial' ];

--- a/client/notifications/index.jsx
+++ b/client/notifications/index.jsx
@@ -6,8 +6,6 @@
  *  - keyboard hotkeys
  *  - window/pane scrolling
  *  - service worker
- *
- *
  * @module notifications
  */
 
@@ -34,7 +32,6 @@ import './style.scss';
 /**
  * Returns whether or not the browser session
  * is currently visible to the user
- *
  * @returns {boolean} is the browser session visible
  */
 const getIsVisible = () => {

--- a/client/post-editor/media-modal/detail/detail-item.jsx
+++ b/client/post-editor/media-modal/detail/detail-item.jsx
@@ -50,7 +50,6 @@ export class EditorMediaModalDetailItem extends Component {
 
 	/**
 	 * This function returns true if the video editor can be enabled/shown.
-	 *
 	 * @param  {Object}  item Media item
 	 * @returns {boolean} Whether the video editor can be enabled
 	 */
@@ -78,7 +77,6 @@ export class EditorMediaModalDetailItem extends Component {
 	/**
 	 * This function returns true if the image editor can be
 	 * enabled/shown
-	 *
 	 * @param  {Object} item - media item
 	 * @returns {boolean} `true` if the image-editor can be enabled.
 	 */

--- a/client/reader/search-stream/search-follow-button.jsx
+++ b/client/reader/search-stream/search-follow-button.jsx
@@ -18,7 +18,6 @@ class SearchFollowButton extends Component {
 
 	/**
 	 * Check if the query looks like a feed URL
-	 *
 	 * @param url
 	 * @returns {boolean}
 	 */

--- a/client/reader/search-stream/suggestion-provider.jsx
+++ b/client/reader/search-stream/suggestion-provider.jsx
@@ -22,7 +22,6 @@ function createRandomId( randomBytesLength = 9 ) {
 
 /**
  * Build suggestions from subscribed tags
- *
  * @param  {number} count The number of suggestions required
  * @param  {Array} tags  An array of subscribed tags
  * @returns {Array}       An array of suggestions, or null if no tags where provided
@@ -43,7 +42,6 @@ function suggestionsFromTags( count, tags ) {
 
 /**
  * Maps trending tags to tags
- *
  * @param {Array} trendingTags Trending tag results from the API.
  * @returns {Array} An array of tag objects
  */

--- a/client/signup/steps/rewind-form-creds/index.jsx
+++ b/client/signup/steps/rewind-form-creds/index.jsx
@@ -35,7 +35,6 @@ class RewindFormCreds extends Component {
 
 	/**
 	 * Don't update the component if the Rewind state is the same.
-	 *
 	 * @param {Object} nextProps Props received by component for next update.
 	 * @returns {boolean} False if the Rewind state is the same.
 	 */

--- a/client/signup/steps/rewind-migrate/index.jsx
+++ b/client/signup/steps/rewind-migrate/index.jsx
@@ -25,7 +25,6 @@ class RewindMigrate extends Component {
 	/**
 	 * Before component updates, check if we have to go somewhere else.
 	 * If Rewind was activated, user clicked the Switch now button so let's go to migrate creds.
-	 *
 	 * @param {Object} nextProps Props received by component for next update.
 	 */
 	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!


### PR DESCRIPTION
Fixes instances of violations of the `jsdoc/tag-lines` ESLint rule, i.e., lines between the block description and list of tags. Also fixes one instance of `jsdoc/no-defaults`.

Prerequisite for #84096, fixing pre-existing ESLint errors in files modified by that PR.