### PR TITLE
Change wording in Sources to be "Related Guides"

### DIFF
--- a/client/odie/message/index.tsx
+++ b/client/odie/message/index.tsx
@@ -279,7 +279,7 @@ const ChatMessage = (
 				<FoldableCard
 					className="odie-sources-foldable-card"
 					clickableHeader
-					header={ translate( 'Sources', {
+					header={ translate( 'Related Guides', {
 						context:
 							'Below this text are links to sources for the current message received from the bot.',
 						textOnly: true,

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -360,7 +360,9 @@ export const HelpCenterContactForm = () => {
 								section: sectionName,
 							} );
 							navigate( '/success' );
-							resetStore();
+							if ( ! wapuuFlow ) {
+								resetStore();
+							}
 							// reset support-history cache
 							setTimeout( () => {
 								// wait 30 seconds until support-history endpoint actually updates
@@ -473,7 +475,7 @@ export const HelpCenterContactForm = () => {
 
 		// We're prefetching the GPT response,
 		// so only disabling the button while fetching if we're on the response screen
-		if ( showingGPTResponse && isFetchingGPTResponse ) {
+		if ( showingGPTResponse && isFetchingGPTResponse && ! wapuuFlow ) {
 			return true;
 		}
 


### PR DESCRIPTION
## Proposed Changes

Sources sound too technical, rename it to be "Related Guides"
Also fix email send button when the user tries to send 2 emails in a row (this also fails in the regular flow, but only fixing it for Wapuu)

## Testing Instructions

Visual inspection of sources when asking Wapuu should be enough & try to send two emails in a row without refreshing or enabling/disabling the Help Center

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?