### PR TITLE
Fix ESLint errors when calling expect.toThrowError

### DIFF
--- a/packages/calypso-e2e/src/lib/utils/test/get-account-by-feature.test.ts
+++ b/packages/calypso-e2e/src/lib/utils/test/get-account-by-feature.test.ts
@@ -97,7 +97,7 @@ describe( 'getTestAccountByFeature', function () {
 		expect( () =>
 			/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
 			getTestAccountByFeature( { coblocks: 'foo', siteType: 'bar' } as any )
-		).toThrowError();
+		).toThrow();
 	} );
 
 	it( 'will keep the existing feature criteria when more are passed to the function', () => {

--- a/packages/calypso-e2e/src/test/rest-api-client.getBearerToken.test.ts
+++ b/packages/calypso-e2e/src/test/rest-api-client.getBearerToken.test.ts
@@ -78,8 +78,6 @@ describe( 'RestAPIClient: getBearerToken', function () {
 			password: 'fake_password',
 		} );
 
-		await expect( restAPIClient.getBearerToken() ).rejects.toThrowError(
-			`${ code }: ${ message }`
-		);
+		await expect( restAPIClient.getBearerToken() ).rejects.toThrow( `${ code }: ${ message }` );
 	} );
 } );

--- a/packages/calypso-e2e/src/test/rest-api-client.invites.test.ts
+++ b/packages/calypso-e2e/src/test/rest-api-client.invites.test.ts
@@ -131,6 +131,6 @@ describe( 'RestAPIClient: createInvite', function () {
 				email: testSuccessfulEmails.concat( testFailedEmails ),
 				role: role,
 			} )
-		).rejects.toThrowError();
+		).rejects.toThrow();
 	} );
 } );

--- a/packages/calypso-e2e/src/test/rest-api-client.test.ts
+++ b/packages/calypso-e2e/src/test/rest-api-client.test.ts
@@ -75,7 +75,7 @@ describe( 'RestAPIClient: getMyAccountInformation', function () {
 			.get( requestURL.pathname )
 			.reply( 400, { error: code, message: message } );
 
-		await expect( restAPIClient.getMyAccountInformation() ).rejects.toThrowError(
+		await expect( restAPIClient.getMyAccountInformation() ).rejects.toThrow(
 			`${ code }: ${ message }`
 		);
 	} );
@@ -120,7 +120,7 @@ describe( 'RestAPIClient: getAllDomains', function () {
 			.get( requestURL.pathname )
 			.reply( 400, { error: code, message: message } );
 
-		await expect( restAPIClient.getAllDomains() ).rejects.toThrowError( `${ code }: ${ message }` );
+		await expect( restAPIClient.getAllDomains() ).rejects.toThrow( `${ code }: ${ message }` );
 	} );
 } );
 

--- a/packages/explat-client/src/internal/test/timing.ts
+++ b/packages/explat-client/src/internal/test/timing.ts
@@ -29,15 +29,15 @@ describe( 'timeoutPromise', () => {
 	it( 'should reject if promises rejected below the timeout', async () => {
 		const promise = Timing.timeoutPromise( Promise.reject( new Error( 'error-123' ) ), 1 );
 		jest.advanceTimersByTime( 1 );
-		await expect( promise ).rejects.toThrowError( 'error-123' );
+		await expect( promise ).rejects.toThrow( 'error-123' );
 	} );
 	it( 'should throw if promise gets timed-out', async () => {
 		const promise1 = Timing.timeoutPromise( delayedValue( null, 4 ), 1 );
 		jest.advanceTimersByTime( 5 );
-		await expect( promise1 ).rejects.toThrowError();
+		await expect( promise1 ).rejects.toThrow();
 		const promise2 = Timing.timeoutPromise( delayedValue( null, 5 ), 2 );
 		jest.advanceTimersByTime( 6 );
-		await expect( promise2 ).rejects.toThrowError();
+		await expect( promise2 ).rejects.toThrow();
 	} );
 } );
 
@@ -53,7 +53,7 @@ describe( 'asyncOneAtATime', () => {
 		const f = Timing.asyncOneAtATime( async () => {
 			throw new Error( 'error-123' );
 		} );
-		await expect( f() ).rejects.toThrowError( 'error-123' );
+		await expect( f() ).rejects.toThrow( 'error-123' );
 	} );
 
 	it( 'should return the same promise when called multiple times, only calling the original function once', async () => {
@@ -79,7 +79,7 @@ describe( 'asyncOneAtATime', () => {
 		const c = f();
 		expect( a ).toBe( b );
 		expect( b ).toBe( c );
-		await expect( a ).rejects.toThrowError( 'error-123' );
+		await expect( a ).rejects.toThrow( 'error-123' );
 		expect( origF.mock.calls.length ).toBe( 1 );
 	} );
 
@@ -115,7 +115,7 @@ describe( 'asyncOneAtATime', () => {
 		const a = f();
 		const b = f();
 		expect( a ).toBe( b );
-		await expect( a ).rejects.toThrowError( 'error-123' );
+		await expect( a ).rejects.toThrow( 'error-123' );
 		expect( origF.mock.calls.length ).toBe( 1 );
 
 		isReject = false;


### PR DESCRIPTION
Following up to #84133, fixes another set of ESLint errors reported by the `jest/no-alias-methods`, this time converting usages of `.toThrowError` into the canonical `.toThrow`.
