### PR TITLE
Fix more expect.toThrowError linter errors

### DIFF
--- a/client/my-sites/checkout/src/test/existing-card-processor.ts
+++ b/client/my-sites/checkout/src/test/existing-card-processor.ts
@@ -72,7 +72,7 @@ describe( 'existingCardProcessor', () => {
 
 	it( 'throws an error if there is no storedDetailsId passed', async () => {
 		const submitData = {};
-		await expect( existingCardProcessor( submitData, options ) ).rejects.toThrowError(
+		await expect( existingCardProcessor( submitData, options ) ).rejects.toThrow(
 			/requires saved card information and none was provided/
 		);
 	} );
@@ -82,7 +82,7 @@ describe( 'existingCardProcessor', () => {
 			storedDetailsId: 'stored-details-id',
 			name: 'test name',
 		};
-		await expect( existingCardProcessor( submitData, options ) ).rejects.toThrowError(
+		await expect( existingCardProcessor( submitData, options ) ).rejects.toThrow(
 			/requires a Stripe token and none was provided/
 		);
 	} );
@@ -93,7 +93,7 @@ describe( 'existingCardProcessor', () => {
 			name: 'test name',
 			paymentMethodToken: 'stripe-token',
 		};
-		await expect( existingCardProcessor( submitData, options ) ).rejects.toThrowError(
+		await expect( existingCardProcessor( submitData, options ) ).rejects.toThrow(
 			/requires a processor id and none was provided/
 		);
 	} );

--- a/client/my-sites/checkout/src/test/multi-partner-card-processor.tsx
+++ b/client/my-sites/checkout/src/test/multi-partner-card-processor.tsx
@@ -197,14 +197,14 @@ describe( 'multiPartnerCardProcessor', () => {
 
 	it( 'throws an error if there is no paymentPartner', async () => {
 		const submitData = {};
-		await expect( multiPartnerCardProcessor( submitData, options ) ).rejects.toThrowError(
+		await expect( multiPartnerCardProcessor( submitData, options ) ).rejects.toThrow(
 			/paymentPartner/
 		);
 	} );
 
 	it( 'throws an error if there is an unknown paymentPartner', async () => {
 		const submitData = { paymentPartner: 'unknown' };
-		await expect( multiPartnerCardProcessor( submitData, options ) ).rejects.toThrowError(
+		await expect( multiPartnerCardProcessor( submitData, options ) ).rejects.toThrow(
 			/Unrecognized card payment partner/
 		);
 	} );
@@ -212,7 +212,7 @@ describe( 'multiPartnerCardProcessor', () => {
 	describe( 'for a stripe paymentPartner', () => {
 		it( 'throws an error if there is no stripe object', async () => {
 			const submitData = { paymentPartner: 'stripe' };
-			await expect( multiPartnerCardProcessor( submitData, options ) ).rejects.toThrowError(
+			await expect( multiPartnerCardProcessor( submitData, options ) ).rejects.toThrow(
 				/requires stripe and none was provided/
 			);
 		} );
@@ -222,7 +222,7 @@ describe( 'multiPartnerCardProcessor', () => {
 				paymentPartner: 'stripe',
 				stripe,
 			};
-			await expect( multiPartnerCardProcessor( submitData, options ) ).rejects.toThrowError(
+			await expect( multiPartnerCardProcessor( submitData, options ) ).rejects.toThrow(
 				/requires stripeConfiguration and none was provided/
 			);
 		} );
@@ -233,7 +233,7 @@ describe( 'multiPartnerCardProcessor', () => {
 				stripe,
 				stripeConfiguration,
 			};
-			await expect( multiPartnerCardProcessor( submitData, options ) ).rejects.toThrowError(
+			await expect( multiPartnerCardProcessor( submitData, options ) ).rejects.toThrow(
 				/requires credit card field and none was provided/
 			);
 		} );

--- a/client/my-sites/checkout/src/test/web-pay-processor.ts
+++ b/client/my-sites/checkout/src/test/web-pay-processor.ts
@@ -65,14 +65,14 @@ describe( 'webPayProcessor', () => {
 
 	it( 'throws an error if there is no stripe object', async () => {
 		const submitData = { paymentPartner: 'stripe' };
-		await expect( webPayProcessor( 'apple-pay', submitData, options ) ).rejects.toThrowError(
+		await expect( webPayProcessor( 'apple-pay', submitData, options ) ).rejects.toThrow(
 			/requires stripe and none was provided/
 		);
 	} );
 
 	it( 'throws an error if there is no stripeConfiguration object', async () => {
 		const submitData = { paymentPartner: 'stripe', stripe };
-		await expect( webPayProcessor( 'apple-pay', submitData, options ) ).rejects.toThrowError(
+		await expect( webPayProcessor( 'apple-pay', submitData, options ) ).rejects.toThrow(
 			/requires stripeConfiguration and none was provided/
 		);
 	} );


### PR DESCRIPTION
Follow-up to #84143, fixing more instances where `.toThrowError` needs changing to `.toThrow`. Somehow my VSCode didn't find all instances the first time.
