### PR TITLE
Me/Security: Improve security key text

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -286,6 +286,10 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/traffic/',
 		post_id: 155209,
 	},
+	'two-step-authentication-security-key': {
+		link: 'https://wordpress.com/support/security/two-step-authentication/security-key-authentication/',
+		post_id: 263616,
+	},
 	'webmaster-tools': {
 		link: 'https://wordpress.com/support/webmaster-tools/',
 		post_id: 5022,

--- a/client/me/security-2fa-key/index.jsx
+++ b/client/me/security-2fa-key/index.jsx
@@ -130,7 +130,7 @@ class Security2faKey extends Component {
 						{ ! isBrowserSupported && (
 							<p>
 								{ this.props.translate(
-									"Your browser doesn't support the FIDO2 security key standard yet. To use a second factor security key to sign in please try a supported browsers like Chrome, Safari, or Firefox."
+									"Your browser doesn't support the FIDO2 security key standard yet. To use a second factor security key to sign in please try a supported browser like Chrome, Safari, or Firefox."
 								) }
 							</p>
 						) }

--- a/client/me/security-2fa-key/index.jsx
+++ b/client/me/security-2fa-key/index.jsx
@@ -1,6 +1,7 @@
 import { Button, Card, Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import { get } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -115,23 +116,22 @@ class Security2faKey extends Component {
 						{ isBrowserSupported && (
 							<p>
 								<>
-									{ this.props.translate( 'Use a second factor security key to sign in.' ) }{ ' ' }
-									<a
-										href={ localizeUrl(
-											'https://wordpress.com/support/security/two-step-authentication/security-key-authentication'
-										) }
-										target="_blank"
-										rel="noopener noreferrer"
+									{ this.props.translate(
+										'Security keys are a more robust version of two-step authentication. Your security key may be a physical device, or you can use passkey support built into your browser.'
+									) }{ ' ' }
+									<InlineSupportLink
+										showIcon={ false }
+										supportContext="two-step-authentication-security-key"
 									>
 										{ translate( 'Learn more' ) }
-									</a>
+									</InlineSupportLink>
 								</>
 							</p>
 						) }
 						{ ! isBrowserSupported && (
 							<p>
 								{ this.props.translate(
-									"Your browser doesn't support the FIDO2 security key standard yet. To use a second factor security key to sign in please try a supported browsers like Chrome or Firefox."
+									"Your browser doesn't support the FIDO2 security key standard yet. To use a second factor security key to sign in please try a supported browsers like Chrome, Safari, or Firefox."
 								) }
 							</p>
 						) }

--- a/client/me/security-2fa-key/index.jsx
+++ b/client/me/security-2fa-key/index.jsx
@@ -1,10 +1,9 @@
 import { Button, Card, Gridicon } from '@automattic/components';
-import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
-import InlineSupportLink from 'calypso/components/inline-support-link';
 import { get } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import Notice from 'calypso/components/notice';
 import SectionHeader from 'calypso/components/section-header';
 import { isWebAuthnSupported } from 'calypso/lib/webauthn';

--- a/client/me/security-2fa-key/index.jsx
+++ b/client/me/security-2fa-key/index.jsx
@@ -117,7 +117,7 @@ class Security2faKey extends Component {
 							<p>
 								<>
 									{ this.props.translate(
-										'Security keys offer more robust form of two-step authentication. Your security key may be a physical device, or you can use passkey support built into your browser.'
+										'Security keys offer a more robust form of two-step authentication. Your security key may be a physical device, or you can use passkey support built into your browser.'
 									) }{ ' ' }
 									<InlineSupportLink
 										showIcon={ false }

--- a/client/me/security-2fa-key/index.jsx
+++ b/client/me/security-2fa-key/index.jsx
@@ -117,7 +117,7 @@ class Security2faKey extends Component {
 							<p>
 								<>
 									{ this.props.translate(
-										'Security keys are a more robust version of two-step authentication. Your security key may be a physical device, or you can use passkey support built into your browser.'
+										'Security keys offer more robust form of two-step authentication. Your security key may be a physical device, or you can use passkey support built into your browser.'
 									) }{ ' ' }
 									<InlineSupportLink
 										showIcon={ false }


### PR DESCRIPTION
## Proposed Changes

Improves the text on the Security Key card. Also uses an inline support link instead of linking off-page.

**Before**

![CleanShot 2023-11-13 at 08 53 15@2x](https://github.com/Automattic/wp-calypso/assets/36432/a1313241-acaa-47ee-8975-825d1d7c18d1)

**After**

![CleanShot 2023-11-13 at 08 52 06@2x](https://github.com/Automattic/wp-calypso/assets/36432/fa97edcf-bbb1-4327-bba7-7ed9e160c3d2)

## Testing Instructions

1. Verify the language is correct.