### PR TITLE
Config: Enable devdocs/redirect-loggedout-homepage for wpcalypso

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -37,7 +37,7 @@
 		"dev/preferences-helper": true,
 		"devdocs": true,
 		"devdocs/color-scheme-picker": true,
-		"devdocs/redirect-loggedout-homepage": false,
+		"devdocs/redirect-loggedout-homepage": true,
 		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,


### PR DESCRIPTION
## Proposed Changes

Currently, on wpcalypso's home page we show a blank page when logged out. This PR alters it so it displays the devdocs start page instead, just like it does on the dev environment.

## Testing Instructions

* Open `/` in wpcalypso as a logged-out user.
* Verify you are redirected to `/devdocs/start` from where you can log in if you wish.
* Open `/` in wpcalypso as a logged-in user.
* Verify it still works as in production.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?