### PR TITLE
Business trial: Display post-upgrade screen exit

### DIFF
--- a/client/my-sites/plans/current-plan/trials/business-trial-included.tsx
+++ b/client/my-sites/plans/current-plan/trials/business-trial-included.tsx
@@ -9,9 +9,10 @@ import useBusinessTrialIncludedFeatures from './use-business-trial-included-feat
 interface Props {
 	translate: typeof translate;
 	displayAll: boolean;
+	displayOnlyActionableItems?: boolean;
 }
 const BusinessTrialIncluded: FunctionComponent< Props > = ( props ) => {
-	const { displayAll = true } = props;
+	const { displayAll = true, displayOnlyActionableItems = false } = props;
 
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) ) || -1;
 	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) ) || '';
@@ -19,10 +20,14 @@ const BusinessTrialIncluded: FunctionComponent< Props > = ( props ) => {
 
 	const allIncludedFeatures = useBusinessTrialIncludedFeatures( siteSlug, siteAdminUrl || '' );
 
-	const whatsIncluded = displayAll
+	let whatsIncluded = displayAll
 		? allIncludedFeatures
 		: // Show only first 4 items
 		  allIncludedFeatures.slice( 0, 4 );
+
+	if ( displayOnlyActionableItems ) {
+		whatsIncluded = whatsIncluded.filter( ( item ) => item.buttonClick );
+	}
 
 	return (
 		<>

--- a/client/my-sites/plans/current-plan/trials/trial-current-plan.tsx
+++ b/client/my-sites/plans/current-plan/trials/trial-current-plan.tsx
@@ -81,7 +81,7 @@ const TrialCurrentPlan = () => {
 			return <EcommerceTrialIncluded displayAll={ displayAllIncluded } />;
 		}
 
-		return <BusinessTrialIncluded displayAll={ displayAllIncluded } />;
+		return <BusinessTrialIncluded displayAll={ displayAllIncluded } tracksContext="current_plan" />;
 	};
 
 	return (

--- a/client/my-sites/plans/ecommerce-trial/business-upgrade-confirmation/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/business-upgrade-confirmation/index.tsx
@@ -63,7 +63,11 @@ const BusinessUpgradeConfirmation = () => {
 								</div>
 							</div>
 							<div className="trial-upgrade-confirmation__tasks">
-								<BusinessTrialIncluded displayAll={ true } displayOnlyActionableItems />
+								<BusinessTrialIncluded
+									displayAll={ true }
+									displayOnlyActionableItems
+									tracksContext="upgrade_confirmation"
+								/>
 							</div>
 						</>
 					}

--- a/client/my-sites/plans/ecommerce-trial/business-upgrade-confirmation/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/business-upgrade-confirmation/index.tsx
@@ -1,14 +1,11 @@
 import { useTranslate } from 'i18n-calypso';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
-import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import Main from 'calypso/components/main';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import BusinessTrialIncluded from 'calypso/my-sites/plans/current-plan/trials/business-trial-included';
 import { useSelector } from 'calypso/state';
-import { isRequestingSitePlans } from 'calypso/state/sites/plans/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import type { AppState } from 'calypso/types';
 
 import './style.scss';
 
@@ -16,20 +13,10 @@ const BusinessUpgradeConfirmation = () => {
 	const selectedSite = useSelector( getSelectedSite );
 	const translate = useTranslate();
 
-	const isFetchingSitePlan = useSelector( ( state: AppState ) => {
-		if ( ! selectedSite?.ID ) {
-			return false;
-		}
-		return isRequestingSitePlans( state, selectedSite.ID );
-	} );
-
-	const currentPlanName = isFetchingSitePlan ? '' : selectedSite?.plan?.product_name_short ?? '';
-
 	return (
 		<>
 			<BodySectionCssClass bodyClass={ [ 'business-trial-upgraded' ] } />
-			<QuerySitePlans siteId={ selectedSite?.ID ?? 0 } />
-			<QueryJetpackPlugins siteIds={ [ selectedSite?.ID ?? 0 ] } />
+			{ selectedSite && <QueryJetpackPlugins siteIds={ [ selectedSite.ID ] } /> }
 			<Main wideLayout>
 				<PageViewTracker
 					path="/plans/my-plan/trial-upgraded/:site"
@@ -41,14 +28,12 @@ const BusinessUpgradeConfirmation = () => {
 					</h1>
 					<div className="trial-upgrade-confirmation__subtitle">
 						<span className="trial-upgrade-confirmation__subtitle-line">
-							{ currentPlanName &&
-								translate(
-									"Your purchase is complete, and you're now on the {{strong}}%(planName)s plan{{/strong}}. It's time to take your website to the next level. What would you like to do next?",
-									{
-										args: { planName: currentPlanName },
-										components: { strong: <strong /> },
-									}
-								) }
+							{ translate(
+								"Your purchase is complete, and you're now on the {{strong}}Business plan{{/strong}}. It's time to take your website to the next level. What would you like to do next?",
+								{
+									components: { strong: <strong /> },
+								}
+							) }
 						</span>
 					</div>
 				</div>

--- a/client/my-sites/plans/ecommerce-trial/business-upgrade-confirmation/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/business-upgrade-confirmation/index.tsx
@@ -1,17 +1,32 @@
+import { StepContainer } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
+import page from 'page';
+import { useLayoutEffect } from 'react';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 import Main from 'calypso/components/main';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import BusinessTrialIncluded from 'calypso/my-sites/plans/current-plan/trials/business-trial-included';
-import { useSelector } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
+import { hideMasterbar, showMasterbar } from 'calypso/state/ui/actions';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 
+const noop = () => {};
+
 const BusinessUpgradeConfirmation = () => {
 	const selectedSite = useSelector( getSelectedSite );
+	const dispatch = useDispatch();
 	const translate = useTranslate();
+
+	useLayoutEffect( () => {
+		dispatch( hideMasterbar() );
+
+		return () => {
+			dispatch( showMasterbar() );
+		};
+	}, [ dispatch ] );
 
 	return (
 		<>
@@ -22,24 +37,37 @@ const BusinessUpgradeConfirmation = () => {
 					path="/plans/my-plan/trial-upgraded/:site"
 					title="Plans > Business Trial Post Upgrade Actions"
 				/>
-				<div className="trial-upgrade-confirmation__header">
-					<h1 className="trial-upgrade-confirmation__title">
-						{ translate( 'Welcome to the Business plan' ) }
-					</h1>
-					<div className="trial-upgrade-confirmation__subtitle">
-						<span className="trial-upgrade-confirmation__subtitle-line">
-							{ translate(
-								"Your purchase is complete, and you're now on the {{strong}}Business plan{{/strong}}. It's time to take your website to the next level. What would you like to do next?",
-								{
-									components: { strong: <strong /> },
-								}
-							) }
-						</span>
-					</div>
-				</div>
-				<div className="trial-upgrade-confirmation__tasks">
-					<BusinessTrialIncluded displayAll={ true } displayOnlyActionableItems />
-				</div>
+				<StepContainer
+					stepName="business-trial-upgraded"
+					hideBack
+					skipLabelText={ translate( 'Skip to dashboard' ) }
+					goNext={ () => page.redirect( `/home/${ selectedSite?.slug }` ) }
+					recordTracksEvent={ noop }
+					stepContent={
+						<>
+							<div className="trial-upgrade-confirmation__header">
+								<h1 className="trial-upgrade-confirmation__title">
+									{ translate( 'Welcome to the Business plan' ) }
+								</h1>
+								<div className="trial-upgrade-confirmation__subtitle">
+									<span className="trial-upgrade-confirmation__subtitle-line">
+										{ translate(
+											"Your purchase is complete, and you're now on the {{strong}}Business plan{{/strong}}. It's time to take your website to the next level—here are some options.",
+											{
+												components: {
+													strong: <strong />,
+												},
+											}
+										) }
+									</span>
+								</div>
+							</div>
+							<div className="trial-upgrade-confirmation__tasks">
+								<BusinessTrialIncluded displayAll={ true } displayOnlyActionableItems />
+							</div>
+						</>
+					}
+				/>
 			</Main>
 		</>
 	);

--- a/client/my-sites/plans/ecommerce-trial/business-upgrade-confirmation/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/business-upgrade-confirmation/index.tsx
@@ -53,7 +53,7 @@ const BusinessUpgradeConfirmation = () => {
 					</div>
 				</div>
 				<div className="trial-upgrade-confirmation__tasks">
-					<BusinessTrialIncluded displayAll={ true } />
+					<BusinessTrialIncluded displayAll={ true } displayOnlyActionableItems />
 				</div>
 			</Main>
 		</>


### PR DESCRIPTION
Related to p1699906636605729-slack-C04H4NY6STW.

## Proposed Changes

Right now, it's not possible to go to `/home/%s` from the post-checkout trial upgraded screen. This PR adds a top-right link letting the user leave the screen.

<img width="1112" alt="image" src="https://github.com/Automattic/wp-calypso/assets/26530524/13715e21-0ee3-4d6d-95ad-888a954a7753">

## Testing Instructions

Upgrade a migration or hosting trial site and verify that you can skip to the dashboard.