### PR TITLE
JCL: remove remaining `useQuery.onError` usages

### DIFF
--- a/client/state/partner-portal/licenses/hooks/use-products-query.ts
+++ b/client/state/partner-portal/licenses/hooks/use-products-query.ts
@@ -1,5 +1,6 @@
 import { useQuery, UseQueryResult } from '@tanstack/react-query';
 import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
 import selectAlphabeticallySortedProductOptions from 'calypso/jetpack-cloud/sections/partner-portal/lib/select-alphabetically-sorted-product-options';
 import { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
 import { useDispatch } from 'calypso/state';
@@ -49,11 +50,16 @@ export default function useProductsQuery(): UseQueryResult< APIProductFamilyProd
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	return useQuery( {
+	const query = useQuery( {
 		queryKey: [ 'partner-portal', 'licenses', 'products' ],
 		queryFn: queryProducts,
 		select: selectAlphabeticallySortedProductOptions,
-		onError: () => {
+	} );
+
+	const { isError } = query;
+
+	useEffect( () => {
+		if ( isError ) {
 			dispatch(
 				errorNotice(
 					translate(
@@ -64,6 +70,8 @@ export default function useProductsQuery(): UseQueryResult< APIProductFamilyProd
 					}
 				)
 			);
-		},
-	} );
+		}
+	}, [ dispatch, translate, isError ] );
+
+	return query;
 }


### PR DESCRIPTION
Preparatory PR for the upcoming `@tanstack/react-query` v5 update. 

## Proposed Changes

`onError` callback on `useQuery` hooks are deprecated and therefore need to be removed. We utilize `useEffect` to dispatch corresponding error messages.

## Testing Instructions

Run yarn start-jetpack-cloud locally or use the calypso.live link provided below to test these changes. **Please be aware you need an agency/partner account.**

To test these changes the easiest way is probably to block network requests to the following endpoints:

* `/jetpack-licensing/partner/product-families`
* `/jetpack-licensing/licenses/billing`

Run yarn start-jetpack-cloud locally or use the calypso.live link provided below and follow these steps:

* Go to `http://jetpack.cloud.localhost:3000/dashboard`
* After 3 unsuccessful attempts of fetching product info you should see an error notice
* Then go to `http://jetpack.cloud.localhost:3000/partner-portal/billing`
* After 3 unsuccessful attempts to fetch billing information you should see an error notice

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
