### PR TITLE
Fix "Log In" alignment on cloud.jetpack.com/pricing

### DIFF
--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/components/user-menu.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/components/user-menu.tsx
@@ -105,9 +105,11 @@ const UserMenu: FC = () => {
 					'is-logged-in': isLoggedIn,
 				} ) }
 			>
-				<MenuButton isMenuOpen={ isMenuOpen } user={ user } toggleUserMenu={ toggleUserMenu } />
 				{ isLoggedIn ? (
-					<Profile isMenuOpen={ isMenuOpen } user={ user } toggleUserMenu={ toggleUserMenu } />
+					<>
+						<MenuButton isMenuOpen={ isMenuOpen } user={ user } toggleUserMenu={ toggleUserMenu } />
+						<Profile isMenuOpen={ isMenuOpen } user={ user } toggleUserMenu={ toggleUserMenu } />
+					</>
 				) : (
 					<a className="header__action-link js-login" href={ localizeUrl( '/login/', locale ) }>
 						{ translate( 'Log in' ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* This PR fixes a bug where the user avatar component was rendering even if the user was not logged in

Before:
<img width="1220" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5714212/21c09bf9-1757-4d36-ae2e-624edc43d3f0">

After:
<img width="1223" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5714212/74400ad6-636c-4984-b5ee-828405f5385c">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the Jetpack Cloud live link
* Open /pricing in incognito mode
* Confirm that "Log In" is aligned with the other menu items
* Open the same page in a browser that you're already logged in, and confirm everything looks ok

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?