### PR TITLE
E2E: Resolve the framed editor page redirection

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/wp-admin/wp-admin-dashboard-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/wp-admin/wp-admin-dashboard-page.ts
@@ -1,0 +1,28 @@
+import { Page } from 'playwright';
+
+/**
+ * Represents the dashboard page in WP-Admin.
+ */
+export class WpAdminDashboardPage {
+	private page: Page;
+
+	/**
+	 * Constructs an instance of the page.
+	 *
+	 * @param {Page} page Instance of the Page object.
+	 */
+	constructor( page: Page ) {
+		this.page = page;
+	}
+
+	/**
+	 * Navigates to the WP-Admin dashboard landing page for a site.
+	 *
+	 * @param {string} siteSlug Site slug.
+	 */
+	async visit( siteSlug: string ) {
+		await this.page.goto( `https://${ siteSlug }/wp-admin/`, {
+			timeout: 15 * 1000,
+		} );
+	}
+}

--- a/packages/calypso-e2e/src/lib/test-account.ts
+++ b/packages/calypso-e2e/src/lib/test-account.ts
@@ -10,6 +10,7 @@ import { SecretsManager } from '../secrets';
 import { TOTPClient } from '../totp-client';
 import { SidebarComponent } from './components/sidebar-component';
 import { LoginPage } from './pages/login-page';
+import { WpAdminDashboardPage } from './pages/wp-admin/wp-admin-dashboard-page';
 import type { TestAccountCredentials } from '../secrets';
 
 /**
@@ -58,6 +59,22 @@ export class TestAccount {
 			const sidebarComponent = new SidebarComponent( page );
 			await sidebarComponent.waitForSidebarInitialization();
 		}
+	}
+
+	/**
+	 * Authenticates the account on WP-Admin page.
+	 *
+	 * @param {Page} page Page object.
+	 */
+	async authenticateWpAdmin( page: Page ) {
+		const url = page.url();
+
+		// Go to the wp-admin page to init the cookie
+		const wpAdminDashboardPage = new WpAdminDashboardPage( page );
+		await wpAdminDashboardPage.visit( this.getSiteURL( { protocol: false } ) );
+
+		// Go back to the current page
+		await page.goto( url );
 	}
 
 	/**

--- a/test/e2e/specs/blocks/blocks__coblocks__blocks.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__blocks.ts
@@ -52,6 +52,7 @@ describe( 'CoBlocks: Blocks', function () {
 		editorPage = new EditorPage( page );
 
 		await testAccount.authenticate( page );
+		await testAccount.authenticateWpAdmin( page );
 	} );
 
 	it( 'Go to the new post page', async () => {

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__cover-styles.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__cover-styles.ts
@@ -43,6 +43,7 @@ describe( 'CoBlocks: Extensions: Cover Styles', function () {
 
 		testAccount = new TestAccount( accountName );
 		await testAccount.authenticate( page );
+		await testAccount.authenticateWpAdmin( page );
 
 		editorPage = new EditorPage( page );
 	} );

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__gutter-control.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__gutter-control.ts
@@ -41,6 +41,7 @@ describe( 'CoBlocks: Extensions: Gutter Control', function () {
 		editorPage = new EditorPage( page );
 
 		await testAccount.authenticate( page );
+		await testAccount.authenticateWpAdmin( page );
 	} );
 
 	it( 'Go to the new post page', async () => {

--- a/test/e2e/specs/blocks/blocks__coblocks__extensions__replace-image.ts
+++ b/test/e2e/specs/blocks/blocks__coblocks__extensions__replace-image.ts
@@ -45,6 +45,7 @@ describe( 'CoBlocks: Extensions: Replace Image', function () {
 
 		const testAccount = new TestAccount( accountName );
 		await testAccount.authenticate( page );
+		await testAccount.authenticateWpAdmin( page );
 	} );
 
 	it( 'Go to the new post page', async () => {

--- a/test/e2e/specs/blocks/blocks__media.ts
+++ b/test/e2e/specs/blocks/blocks__media.ts
@@ -70,6 +70,7 @@ describe( DataHelper.createSuiteTitle( 'Blocks: Media (Upload)' ), function () {
 
 		testAccount = new TestAccount( accountName );
 		await testAccount.authenticate( page );
+		await testAccount.authenticateWpAdmin( page );
 	} );
 
 	it( 'Start new post', async function () {

--- a/test/e2e/specs/blocks/blocks__story.ts
+++ b/test/e2e/specs/blocks/blocks__story.ts
@@ -41,6 +41,7 @@ describe( DataHelper.createSuiteTitle( 'Blocks: Jetpack Story' ), function () {
 
 		testAccount = new TestAccount( accountName );
 		await testAccount.authenticate( page );
+		await testAccount.authenticateWpAdmin( page );
 
 		for ( const path of [ TEST_IMAGE_PATH, ALT_TEST_IMAGE_PATH ] ) {
 			const testFile = await MediaHelper.createTestFile( path );

--- a/test/e2e/specs/blocks/shared/block-smoke-testing.ts
+++ b/test/e2e/specs/blocks/shared/block-smoke-testing.ts
@@ -42,6 +42,7 @@ export function createBlockTests( specName: string, blockFlows: BlockFlow[] ): v
 			editorPage = new EditorPage( page );
 			const testAccount = new TestAccount( accountName );
 			await testAccount.authenticate( page );
+			await testAccount.authenticateWpAdmin( page );
 		} );
 
 		it( 'Go to the new post page', async () => {

--- a/test/e2e/specs/editor-tracking/editor-tracking__block-inserted-event.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__block-inserted-event.ts
@@ -143,6 +143,7 @@ describe(
 
 				const testAccount = new TestAccount( accountName );
 				await testAccount.authenticate( page );
+				await testAccount.authenticateWpAdmin( page );
 
 				editorTracksEventManager = new EditorTracksEventManager( page );
 				editorPage = new EditorPage( page );

--- a/test/e2e/specs/editor-tracking/editor-tracking__pattern-events.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__pattern-events.ts
@@ -29,6 +29,7 @@ describe( DataHelper.createSuiteTitle( 'Editor tracking: Pattern-related events'
 
 			const testAccount = new TestAccount( accountName );
 			await testAccount.authenticate( page );
+			await testAccount.authenticateWpAdmin( page );
 
 			eventManager = new EditorTracksEventManager( page );
 			editorPage = new EditorPage( page );

--- a/test/e2e/specs/editor/editor__navbar.ts
+++ b/test/e2e/specs/editor/editor__navbar.ts
@@ -36,6 +36,7 @@ describe( DataHelper.createSuiteTitle( `Editor: Navbar` ), function () {
 
 		const testAccount = new TestAccount( accountName );
 		await testAccount.authenticate( page );
+		await testAccount.authenticateWpAdmin( page );
 	} );
 
 	it( 'Go to the new post page', async function () {

--- a/test/e2e/specs/editor/editor__page-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__page-basic-flow.ts
@@ -45,6 +45,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 
 		const testAccount = new TestAccount( accountName );
 		await testAccount.authenticate( page );
+		await testAccount.authenticateWpAdmin( page );
 	} );
 
 	it( 'Visit Pages page', async function () {

--- a/test/e2e/specs/editor/editor__post-advanced-flow.ts
+++ b/test/e2e/specs/editor/editor__post-advanced-flow.ts
@@ -43,6 +43,7 @@ describe( `Editor: Advanced Post Flow`, function () {
 
 		testAccount = new TestAccount( accountName );
 		await testAccount.authenticate( page );
+		await testAccount.authenticateWpAdmin( page );
 	} );
 
 	describe( 'Publish post', function () {

--- a/test/e2e/specs/editor/editor__post-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__post-basic-flow.ts
@@ -44,6 +44,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Post Flow' ), function () 
 
 		testAccount = new TestAccount( accountName );
 		await testAccount.authenticate( page );
+		await testAccount.authenticateWpAdmin( page );
 	} );
 
 	it( 'Go to the new post page', async function () {

--- a/test/e2e/specs/editor/editor__revisions.ts
+++ b/test/e2e/specs/editor/editor__revisions.ts
@@ -36,6 +36,7 @@ describe( `Editor: Revisions`, function () {
 
 		const testAccount = new TestAccount( accountName );
 		await testAccount.authenticate( page );
+		await testAccount.authenticateWpAdmin( page );
 	} );
 
 	it( 'Go to the new post page', async function () {

--- a/test/e2e/specs/editor/editor__schedule.ts
+++ b/test/e2e/specs/editor/editor__schedule.ts
@@ -38,6 +38,7 @@ describe( DataHelper.createSuiteTitle( `Editor: Schedule` ), function () {
 
 		const testAccount = new TestAccount( accountName );
 		await testAccount.authenticate( page );
+		await testAccount.authenticateWpAdmin( page );
 	} );
 
 	it( 'Go to the new post page', async function () {

--- a/test/e2e/specs/editor/shared/privacy-testing.ts
+++ b/test/e2e/specs/editor/shared/privacy-testing.ts
@@ -40,6 +40,7 @@ export function createPrivacyTests( { visibility }: { visibility: ArticlePrivacy
 
 				const testAccount = new TestAccount( accountName );
 				await testAccount.authenticate( page );
+				await testAccount.authenticateWpAdmin( page );
 			} );
 
 			afterAll( async function () {

--- a/test/e2e/specs/i18n/i18n__editor.ts
+++ b/test/e2e/specs/i18n/i18n__editor.ts
@@ -269,6 +269,7 @@ describe( 'I18N: Editor', function () {
 		} );
 
 		await testAccount.authenticate( page );
+		await testAccount.authenticateWpAdmin( page );
 		restAPIClient = new RestAPIClient( testAccount.credentials );
 
 		editorPage = new EditorPage( page );

--- a/test/e2e/specs/infrastructure/infrastructure__experimental-gutenberg.ts
+++ b/test/e2e/specs/infrastructure/infrastructure__experimental-gutenberg.ts
@@ -27,6 +27,7 @@ describe( DataHelper.createSuiteTitle( 'Gutenberg: Experimental Features' ), fun
 
 		const testAccount = new TestAccount( accountName );
 		await testAccount.authenticate( page );
+		await testAccount.authenticateWpAdmin( page );
 	} );
 
 	it( 'Go to the new post page', async function () {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1699970263836159/1699420653.772289-slack-C02FMH4G8, https://github.com/Automattic/wp-calypso/issues/82927, p1699986083126169-slack-C02FMH4G8

## Proposed Changes

* Resolve the failed tests due to the redirection of the framed pages under the `/wp-admin`. See p1699887613006189-slack-CBTN58FTJ.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Trigger the E2E tests on atomic sites, and ensure the tests related to the page/post editor are passed

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?