### PR TITLE
Sensei setup: Focus on input field on load, show error message

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-setup/index.tsx
@@ -1,10 +1,10 @@
-import { Gridicon } from '@automattic/components';
+import { FormInputValidation, Gridicon } from '@automattic/components';
 import { useDesktopBreakpoint } from '@automattic/viewport-react';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useState } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
-import { CSSProperties, useEffect } from 'react';
+import { CSSProperties, useEffect, useRef } from 'react';
 import FormRadioWithThumbnail from 'calypso/components/forms/form-radio-with-thumbnail';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { preventWidows } from 'calypso/lib/formatting';
@@ -58,6 +58,7 @@ const ThemeStylePreviews = ( {
 const SenseiSetup: Step = ( { navigation } ) => {
 	const { __ } = useI18n();
 	const isDesktop = useDesktopBreakpoint();
+	const inputRef = useRef( null );
 
 	const initialSiteTitle = useSelect(
 		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedSiteTitle(),
@@ -65,6 +66,8 @@ const SenseiSetup: Step = ( { navigation } ) => {
 	);
 	const [ siteTitle, setSiteTitle ] = useState< string >( initialSiteTitle );
 	const [ checked, setChecked ] = useState< string >( 'green' );
+	const [ hasSubmitted, setHasSubmitted ] = useState< boolean >( false );
+	const [ hasSiteTitleError, setHasSiteTitleError ] = useState< boolean >( false );
 
 	const handleChange = ( event: React.ChangeEvent< HTMLInputElement > ) => {
 		setChecked?.( event.target.value );
@@ -77,7 +80,21 @@ const SenseiSetup: Step = ( { navigation } ) => {
 		dispatch.resetOnboardStore();
 	}, [ dispatch ] );
 
+	const focusOnSiteTitleInput = () => {
+		// Focus on the input when the step is mounted.
+		if ( inputRef.current ) {
+			inputRef.current.focus();
+		}
+	};
+
 	const handleSubmit = useCallback( () => {
+		setHasSubmitted( true );
+
+		if ( hasSiteTitleError ) {
+			focusOnSiteTitleInput();
+			return;
+		}
+
 		dispatch.setSiteTitle( siteTitle );
 		const variation = styles.find( ( style ) => style.name === checked ) || styles[ 0 ];
 		dispatch.setSelectedStyleVariation( {
@@ -89,6 +106,14 @@ const SenseiSetup: Step = ( { navigation } ) => {
 
 	const preview = <ThemeStylePreviews styles={ styles } active={ checked } />;
 
+	useEffect( () => {
+		focusOnSiteTitleInput();
+	}, [] );
+
+	useEffect( () => {
+		setHasSiteTitleError( ! siteTitle || siteTitle.length < 3 );
+	}, [ siteTitle ] );
+
 	return (
 		<SenseiStepContainer stepName="senseiSetup" recordTracksEvent={ recordTracksEvent }>
 			<div className="sensei-start-row">
@@ -99,11 +124,19 @@ const SenseiSetup: Step = ( { navigation } ) => {
 						id="sensei_site_title"
 						type="text"
 						onChange={ ( ev ) => {
+							setHasSubmitted( false );
 							setSiteTitle( ev.target.value );
 						} }
 						placeholder={ __( 'Photography Class' ) }
 						value={ siteTitle }
+						ref={ inputRef }
 					/>
+					{ hasSubmitted && hasSiteTitleError && (
+						<FormInputValidation
+							isError={ true }
+							text={ __( `Oops. Looks like your course site doesn't have a name yet.` ) }
+						/>
+					) }
 					<Label>{ __( 'Pick a style' ) }</Label>
 					<Hint>
 						{ __( 'Choose a different theme style now, or customize colors and fonts later.' ) }
@@ -126,11 +159,7 @@ const SenseiSetup: Step = ( { navigation } ) => {
 					{ ! isDesktop && preview }
 					<div className="sensei-onboarding-action">
 						<div className="sensei-onboarding-action__content">
-							<button
-								className="sensei-button"
-								disabled={ siteTitle.length < 2 }
-								onClick={ handleSubmit }
-							>
+							<button className="sensei-button" onClick={ handleSubmit }>
 								{ __( 'Continue' ) }
 							</button>
 							<p className="sensei-style-notice">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-setup/index.tsx
@@ -58,7 +58,7 @@ const ThemeStylePreviews = ( {
 const SenseiSetup: Step = ( { navigation } ) => {
 	const { __ } = useI18n();
 	const isDesktop = useDesktopBreakpoint();
-	const inputRef = useRef( null );
+	const inputRef = useRef< HTMLInputElement >( null );
 
 	const initialSiteTitle = useSelect(
 		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedSiteTitle(),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-setup/index.tsx
@@ -67,7 +67,6 @@ const SenseiSetup: Step = ( { navigation } ) => {
 	const [ siteTitle, setSiteTitle ] = useState< string >( initialSiteTitle );
 	const [ checked, setChecked ] = useState< string >( 'green' );
 	const [ hasSubmitted, setHasSubmitted ] = useState< boolean >( false );
-	const [ hasSiteTitleError, setHasSiteTitleError ] = useState< boolean >( false );
 
 	const handleChange = ( event: React.ChangeEvent< HTMLInputElement > ) => {
 		setChecked?.( event.target.value );
@@ -87,10 +86,12 @@ const SenseiSetup: Step = ( { navigation } ) => {
 		}
 	};
 
+	const isValidSiteTitle = () => siteTitle && siteTitle.length > 2;
+
 	const handleSubmit = useCallback( () => {
 		setHasSubmitted( true );
 
-		if ( hasSiteTitleError ) {
+		if ( ! isValidSiteTitle() ) {
 			focusOnSiteTitleInput();
 			return;
 		}
@@ -110,10 +111,6 @@ const SenseiSetup: Step = ( { navigation } ) => {
 		focusOnSiteTitleInput();
 	}, [] );
 
-	useEffect( () => {
-		setHasSiteTitleError( ! siteTitle || siteTitle.length < 3 );
-	}, [ siteTitle ] );
-
 	return (
 		<SenseiStepContainer stepName="senseiSetup" recordTracksEvent={ recordTracksEvent }>
 			<div className="sensei-start-row">
@@ -131,7 +128,7 @@ const SenseiSetup: Step = ( { navigation } ) => {
 						value={ siteTitle }
 						ref={ inputRef }
 					/>
-					{ hasSubmitted && hasSiteTitleError && (
+					{ hasSubmitted && ! isValidSiteTitle() && (
 						<FormInputValidation
 							isError={ true }
 							text={ __( `Oops. Looks like your course site doesn't have a name yet.` ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-setup/index.tsx
@@ -86,7 +86,7 @@ const SenseiSetup: Step = ( { navigation } ) => {
 		}
 	};
 
-	const isValidSiteTitle = useCallback( () => siteTitle && siteTitle.length > 2, [ siteTitle ] );
+	const isValidSiteTitle = useCallback( () => siteTitle && siteTitle.length >= 2, [ siteTitle ] );
 
 	const handleSubmit = useCallback( () => {
 		setHasSubmitted( true );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-setup/index.tsx
@@ -86,7 +86,7 @@ const SenseiSetup: Step = ( { navigation } ) => {
 		}
 	};
 
-	const isValidSiteTitle = () => siteTitle && siteTitle.length > 2;
+	const isValidSiteTitle = useCallback( () => siteTitle && siteTitle.length > 2, [ siteTitle ] );
 
 	const handleSubmit = useCallback( () => {
 		setHasSubmitted( true );
@@ -103,7 +103,7 @@ const SenseiSetup: Step = ( { navigation } ) => {
 			title: variation.title,
 		} as StyleVariation );
 		submit?.();
-	}, [ siteTitle, dispatch, submit, checked ] );
+	}, [ siteTitle, dispatch, submit, checked, isValidSiteTitle ] );
 
 	const preview = <ThemeStylePreviews styles={ styles } active={ checked } />;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-setup/index.tsx
@@ -86,12 +86,10 @@ const SenseiSetup: Step = ( { navigation } ) => {
 		}
 	};
 
-	const isValidSiteTitle = useCallback( () => siteTitle && siteTitle.length >= 2, [ siteTitle ] );
-
 	const handleSubmit = useCallback( () => {
 		setHasSubmitted( true );
 
-		if ( ! isValidSiteTitle() ) {
+		if ( ! siteTitle ) {
 			focusOnSiteTitleInput();
 			return;
 		}
@@ -103,7 +101,7 @@ const SenseiSetup: Step = ( { navigation } ) => {
 			title: variation.title,
 		} as StyleVariation );
 		submit?.();
-	}, [ siteTitle, dispatch, submit, checked, isValidSiteTitle ] );
+	}, [ siteTitle, dispatch, submit, checked ] );
 
 	const preview = <ThemeStylePreviews styles={ styles } active={ checked } />;
 
@@ -128,7 +126,7 @@ const SenseiSetup: Step = ( { navigation } ) => {
 						value={ siteTitle }
 						ref={ inputRef }
 					/>
-					{ hasSubmitted && ! isValidSiteTitle() && (
+					{ hasSubmitted && ! siteTitle && (
 						<FormInputValidation
 							isError={ true }
 							text={ __( `Oops. Looks like your course site doesn't have a name yet.` ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/84118

## Proposed Changes

* Added an error message below Site Title
* Made the Continue button in the bottom Active by default (before it was deactivated)
* Site title is focused on site load
* if Site Title is < 3 characters long and user clicks on Continue, cursor is moved to site title and error message is shown
* When the user starts typing again, error message is removed

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/setup/sensei/senseiSetup
* Check that the site title input is focused, cursor is blinking on site title
* Make sure no error message is there by default
* Click on the Continue button without typing anything in the site title field
* Make sure you see an error message below site title
* Make sure you are automatically focused on site title
* Start typing something
* Check that the error message is removed
* Remove whatever you typed
* Click on Continue button
* The message should appear again
* Now write a site title
* Click on Continue
* It should take you to the next page
* Check the whole flow on other screen size as well

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?