### PR TITLE
Shopping Cart: Add does_override_original_cost to ResponseCartCostOverride

### DIFF
--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -549,8 +549,10 @@ export interface ResponseCartCostOverride {
 	new_price: number;
 	old_price: number;
 	override_code: string;
+	does_override_original_cost: boolean;
 	reason: string;
 }
+
 export interface IntroductoryOfferTerms {
 	enabled: boolean;
 	interval_unit: string;


### PR DESCRIPTION
## Proposed Changes

This PR adds the `does_override_original_cost` type to the cost override TypeScript type for each shopping cart product.

## Testing Instructions

None should be needed.