### PR TITLE
p2Completer: Pass ?skip_description=true to endpoint

### DIFF
--- a/apps/o2-blocks/src/p2-autocomplete/editor.js
+++ b/apps/o2-blocks/src/p2-autocomplete/editor.js
@@ -13,7 +13,7 @@ const COMMON_PREFIXES = /(team|a8c|woo|happiness)/i;
 const stripCommonWords = ( str ) => str.replace( COMMON_PREFIXES, ' ' );
 
 const p2s = apiFetch( {
-	path: '/internal/P2s',
+	path: '/internal/P2s?skip_description=true',
 } ).then( ( result ) =>
 	map( result.list, ( p2, subdomain ) => {
 		const keywords = [ subdomain ];


### PR DESCRIPTION
## Proposed Changes

* When the p2 completer asks for the list of P2s, add `?skip_description=true` to the query string of the endpoint. This way, it will ask the endpoint to compute less data, and less data will be passed over the wire.

## Testing Instructions

This involves O2 blocks which has its own build process. Since this is such a small change I found it easy to directly change on the sandbox:

* `cp wp-content/a8c-plugins/a8c-blocks/dist/editor.js wp-content/a8c-plugins/a8c-blocks/dist/editor.min.js`
* `vim wp-content/a8c-plugins/a8c-blocks/dist/editor.min.js`
* Around line 300, change the path of the endpoint from `/internal/P2s` to `/internal/P2s?skip_description=true`
* Sandbox and visit a p2
* Start to write a comment, then type `+` and the name of a P2.
* The autocomplete should work as normal.

Additionally, in the network tab, you should see 2 requests to the P2 endpoint. One is coming from the o2 blocks in calypso, the code modified by this PR. The other is caused by the P2 theme and won't be changed. It lets you see a before and after:

![2023-11-14_17-29](https://github.com/Automattic/wp-calypso/assets/937354/f492fc2e-0f84-406f-8cfe-d4a3bdf89c14)

Additionally, you can confirm the description is not used anywhere in the completer, so there's no benefit to requesting the data:
```
const p2Completer = {
	name: 'p2s',
	triggerPrefix: '+',
	options: p2s,
	getOptionKeywords: ( site ) => site.keywords,
	getOptionLabel: ( site ) => (
		<div className="p2-autocomplete">
			<span className="p2-autocomplete__subdomain">+{ site.subdomain }</span>
			<span className="p2-autocomplete__title">{ unescape( site.title ) }</span>
			{ site.blavatar ? (
				<img
					src={ `${ site.blavatar }?s=20` }
					srcset={ `${ site.blavatar }?s=20 1x, ${ site.blavatar }?s=40 2x` }
					width="20"
					height="20"
					className="p2-autocomplete__blavatar"
					alt=""
				/>
			) : (
				<span className="p2-autocomplete__blavatar-placeholder" />
			) }
		</div>
	),
	getOptionCompletion: ( site ) => `+${ site.subdomain }`,
	isDebounced: true,
};
```


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?