### PR TITLE
Stats: Add marks to new TierUpgradeSlider component

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -11,6 +11,7 @@ import { useSelector } from 'calypso/state';
 import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
 import gotoCheckoutPage from './stats-purchase-checkout-redirect';
 import { COMPONENT_CLASS_NAME, MIN_STEP_SPLITS } from './stats-purchase-wizard';
+import TierUpgradeSlider from './stats-purchase-tier-upgrade-slider';
 
 interface PersonalPurchaseProps {
 	subscriptionValue: number;
@@ -106,6 +107,7 @@ const PersonalPurchase = ( {
 					}
 				) }
 			</div>
+			<TierUpgradeSlider />
 
 			<PricingSlider
 				className={ `${ COMPONENT_CLASS_NAME }__slider` }

--- a/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.tsx
@@ -1,0 +1,92 @@
+import { PricingSlider } from '@automattic/components';
+import React, { useState } from 'react';
+import { COMPONENT_CLASS_NAME } from './stats-purchase-wizard';
+
+function getPlanTiers() {
+	// Pulled from the API/Redux.
+	const planTiers = [
+		{
+			id: '10k',
+			price: '$9',
+			views: '10k',
+			description: '$9/month for 10k views',
+		},
+		{
+			id: '100k',
+			price: '$19',
+			views: '100k',
+			description: '$19/month for 100k views',
+		},
+		{
+			id: '250k',
+			price: '$29',
+			views: '250k',
+			description: '$29/month for 250k views',
+		},
+		{
+			id: '500k',
+			price: '$49',
+			views: '500k',
+			description: '$49/month for 500k views',
+		},
+		{
+			id: '1M',
+			price: '$69',
+			views: '1M',
+			description: '$69/month for 1M views',
+		},
+		{
+			id: '1M++',
+			price: '$69++',
+			views: '1M++',
+			description: '$25/month per million views if views exceed 1M',
+		},
+	];
+
+	return planTiers;
+}
+
+function TierUpgradeSlider() {
+	// Get the plan details.
+	const plans = getPlanTiers();
+
+	// Adjust available plans based on current tier.
+	const availablePlans = plans;
+
+	// Slider state.
+	const [ currentPlanIndex, setCurrentPlanIndex ] = useState( 0 );
+	const sliderMin = 0;
+	const sliderMax = plans.length - 1;
+
+	const handleSliderChange = ( value: number ) => {
+		// console.log( 'slider did change. value: ', value );
+		// console.log( 'plan info: ', plans[value] );
+		setCurrentPlanIndex( value );
+	};
+
+	// Render content.
+	return (
+		<div className="stats-tier-upgrade-slider">
+			<div className="stats-tier-upgrade-slider__plan-callouts">
+				<div className="stats-tier-upgrade-slider__plan-callout">
+					<h2>Monthly site views limit</h2>
+					<p>{ plans[ currentPlanIndex ].views }</p>
+				</div>
+				<div className="stats-tier-upgrade-slider__plan-callout">
+					<h2>You will pay</h2>
+					<p className="right-aligned">{ plans[ currentPlanIndex ].price }</p>
+				</div>
+			</div>
+			<PricingSlider
+				className={ `${ COMPONENT_CLASS_NAME }__slider` }
+				value={ currentPlanIndex }
+				minValue={ sliderMin }
+				maxValue={ sliderMax }
+				onChange={ handleSliderChange }
+			/>
+			<p className="stats-tier-upgrade-slider__info-message">Price per month, billed yearly</p>
+		</div>
+	);
+}
+
+export default TierUpgradeSlider;

--- a/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.tsx
@@ -50,19 +50,17 @@ function TierUpgradeSlider() {
 	// Get the plan details.
 	const plans = getPlanTiers();
 
-	// Adjust available plans based on current tier.
-	const availablePlans = plans;
-
 	// Slider state.
 	const [ currentPlanIndex, setCurrentPlanIndex ] = useState( 0 );
 	const sliderMin = 0;
 	const sliderMax = plans.length - 1;
 
 	const handleSliderChange = ( value: number ) => {
-		// console.log( 'slider did change. value: ', value );
-		// console.log( 'plan info: ', plans[value] );
 		setCurrentPlanIndex( value );
 	};
+
+	// Create an array of indices for the marks
+	const marks = plans.map( ( _, index ) => index );
 
 	// Render content.
 	return (
@@ -83,6 +81,7 @@ function TierUpgradeSlider() {
 				minValue={ sliderMin }
 				maxValue={ sliderMax }
 				onChange={ handleSliderChange }
+				marks={ marks } // Passing the new marks array
 			/>
 			<p className="stats-tier-upgrade-slider__info-message">Price per month, billed yearly</p>
 		</div>

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -134,6 +134,41 @@ $button-padding: 8px 32px;
 	}
 }
 
+.stats-tier-upgrade-slider {
+	margin: 2px;
+	padding: 10px;
+	background: pink;
+
+	.jp-components-pricing-slider__thumb {
+		border-radius: 24px;
+		border-color: #008710;
+		background-color: #008710;
+		color: white;
+	}
+}
+.stats-tier-upgrade-slider__info-message {
+	color: green;
+	margin: 12px 0px;
+	text-align: center;
+}
+.stats-tier-upgrade-slider__plan-callouts {
+	display: flex;
+	justify-content: space-between;
+
+	h2 {
+		font-weight: 500;
+	}
+	p {
+		font-size: 2em;
+		font-weight: 500;
+		margin: 0;
+	}
+	.right-aligned {
+		text-align: right;
+	}
+}
+
+
 .stats-purchase-page__loader {
 	display: flex;
 	justify-content: center;

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -137,18 +137,32 @@ $button-padding: 8px 32px;
 .stats-tier-upgrade-slider {
 	margin: 2px;
 	padding: 10px;
-	background: pink;
 
 	.jp-components-pricing-slider__thumb {
-		border-radius: 24px;
+		border-radius: 4px;
 		border-color: #008710;
 		background-color: #008710;
-		color: white;
+		color: #fff;
+	}
+
+	.jp-components-pricing-slider__track {
+		height: 4px;
+	}
+
+	.jp-components-pricing-slider__control .mark {
+		position: absolute;
+		height: 10px;
+		width: 10px;
+		background-color: #d3d3d3;
+		border-radius: 50%;
+		top: 50%;
+		transform: translate(-50%, -50%);
+		z-index: 10;
 	}
 }
 .stats-tier-upgrade-slider__info-message {
-	color: green;
-	margin: 12px 0px;
+	color: #008710;
+	margin: 12px 0;
 	text-align: center;
 }
 .stats-tier-upgrade-slider__plan-callouts {
@@ -159,6 +173,7 @@ $button-padding: 8px 32px;
 		font-weight: 500;
 	}
 	p {
+		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 2em;
 		font-weight: 500;
 		margin: 0;

--- a/packages/components/src/pricing-slider/index.tsx
+++ b/packages/components/src/pricing-slider/index.tsx
@@ -7,7 +7,6 @@ import './style.scss';
 /**
  * Generate Pricing Slider
  * More support from the original ReactSlider component: https://zillow.github.io/react-slider/
- *
  * @param {PricingSliderProps} props - Props
  * @returns {React.ReactElement} - JSX element
  */
@@ -21,6 +20,7 @@ const PricingSlider: React.FC< PricingSliderProps > = ( {
 	onBeforeChange,
 	onAfterChange,
 	renderThumb,
+	marks, // Add marks to the component props
 } ) => {
 	const [ isThumbHolding, setIsThumbHolding ] = React.useState( false );
 
@@ -57,6 +57,7 @@ const PricingSlider: React.FC< PricingSliderProps > = ( {
 				thumbClassName="jp-components-pricing-slider__thumb"
 				thumbActiveClassName="jp-components-pricing-slider__thumb--is-active"
 				trackClassName="jp-components-pricing-slider__track"
+				marks={ marks } // Pass marks to ReactSlider
 				value={ value }
 				max={ maxValue }
 				min={ minValue }

--- a/packages/components/src/pricing-slider/types.ts
+++ b/packages/components/src/pricing-slider/types.ts
@@ -9,6 +9,12 @@ export type RenderThumbFunction = (
 	state: { index: number; value: number | ReadonlyArray< number >; valueNow: number }
 ) => JSX.Element | null;
 
+// Define the type for the mark object
+export interface Mark {
+	value: number;
+	label: string;
+}
+
 export type PricingSliderProps = {
 	/**
 	 * The wrapper class name of this PricingSlider component.
@@ -37,19 +43,16 @@ export type PricingSliderProps = {
 
 	/**
 	 * Callback called on every value change.
-	 * The function will be called with two arguments, the first being the new value(s) the second being thumb index.
 	 */
 	onChange?: ( value: number ) => void;
 
 	/**
-	 * Callback called before starting to move a thumb. The callback will only be called if the action will result in a change.
-	 * The function will be called with two arguments, the first being the initial value(s) the second being thumb index.
+	 * Callback called before starting to move a thumb.
 	 */
 	onBeforeChange?: ( value: number ) => void;
 
 	/**
-	 * Callback called only after moving a thumb has ended. The callback will only be called if the action resulted in a change.
-	 * The function will be called with two arguments, the first being the result value(s) the second being thumb index.
+	 * Callback called only after moving a thumb has ended.
 	 */
 	onAfterChange?: ( value: number ) => void;
 
@@ -57,4 +60,9 @@ export type PricingSliderProps = {
 	 * Node to render on the slider.
 	 */
 	renderThumb?: RenderThumbFunction;
+
+	/**
+	 * The marks on the slider, represented as an array of numbers.
+	 */
+	marks?: number[];
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
