### PR TITLE
Assembler: Add the price of the plan to the Upsell screen

### DIFF
--- a/client/components/premium-global-styles-upgrade-modal/use-global-styles-upgrade-translations.tsx
+++ b/client/components/premium-global-styles-upgrade-modal/use-global-styles-upgrade-translations.tsx
@@ -19,6 +19,7 @@ const useGlobalStylesUpgradeTranslations = ( { numOfSelectedGlobalStyles = 1 }: 
 	];
 
 	return {
+		planTitle,
 		featuresTitle: translate( 'Included with your Premium plan' ),
 		features: features,
 		description: translate(
@@ -36,7 +37,7 @@ const useGlobalStylesUpgradeTranslations = ( { numOfSelectedGlobalStyles = 1 }: 
 		),
 		cancel: translate( 'Decide later' ),
 		upgrade: translate( 'Upgrade plan' ),
-		upgradeWithPlan: translate( 'Get %(planTitle)s', {
+		upgradeWithPlan: translate( 'Get %(planTitle)s plan', {
 			args: { planTitle },
 		} ),
 	};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-screen.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-screen.tsx
@@ -75,7 +75,9 @@ const useScreen = ( screenName: ScreenName, options: UseScreenOptions = {} ): Sc
 		upsell: {
 			name: 'upsell',
 			title: translate( 'Premium styles' ),
-			description: translate( "You've chosen a premium style and action is required." ),
+			description: translate(
+				"You've chosen premium styles which are exclusive to the Premium plan or higher."
+			),
 			continueLabel: translate( 'Continue' ),
 			backLabel: hasEnTranslation( 'premium styles' ) ? translate( 'premium styles' ) : undefined,
 			initialPath: NAVIGATOR_PATHS.UPSELL,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.scss
@@ -14,8 +14,49 @@
 		}
 	}
 
+	.screen-upsell__plan {
+		margin: 10px 0 16px;
+
+		.screen-upsell__plan-heading {
+			margin-bottom: 8px;
+			font-size: 20px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+			font-weight: 500;
+			line-height: 26px;
+			color: var(--studio-gray-100, #101517);
+		}
+
+		.screen-upsell__plan-price {
+			display: flex;
+
+			.plan-price__integer {
+				font-size: 32px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+				font-weight: 500;
+				color: var(--studio-gray-100, #101517);
+			}
+
+			.plan-price__currency-symbol {
+				margin-top: 2px;
+				font-size: 16px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+				font-weight: 500;
+				color: var(--studio-gray-100, #101517);
+			}
+		}
+
+		.screen-upsell__plan-billing-time-frame {
+			font-size: $font-body-extra-small;
+			color: var(--studio-gray-70, #3c434a);
+		}
+	}
+
+	.screen-upsell__features-heading {
+		margin-bottom: 8px;
+		font-size: $font-body-small;
+		font-weight: 500;
+		line-height: 20px;
+	}
+
 	ul.screen-upsell__features {
-		margin: 0;
+		margin: 0 0 40px;
 		font-size: $font-body-small;
 		list-style: none;
 
@@ -24,6 +65,11 @@
 			align-items: center;
 			margin-top: 8px;
 			gap: 16px;
+
+			/** Highlight the “Premium styles” feature */
+			&:nth-child(2) strong {
+				font-weight: 600;
+			}
 		}
 
 		strong {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.scss
@@ -1,19 +1,6 @@
 @import "@automattic/typography/styles/fonts";
 
 .screen-upsell {
-	.screen-upsell__heading {
-		margin-bottom: 4px;
-	}
-
-	.screen-upsell__description {
-		margin-bottom: 32px;
-		font-size: $font-body-small;
-
-		p {
-			margin-bottom: 16px;
-		}
-	}
-
 	.screen-upsell__plan {
 		margin: 10px 0 16px;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.tsx
@@ -1,7 +1,12 @@
+import { PLAN_PREMIUM } from '@automattic/calypso-products';
 import { Button, Gridicon, PremiumBadge } from '@automattic/components';
+import { formatCurrency } from '@automattic/format-currency';
 import { NavigatorHeader } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
+import QueryPlans from 'calypso/components/data/query-plans';
 import useGlobalStylesUpgradeTranslations from 'calypso/components/premium-global-styles-upgrade-modal/use-global-styles-upgrade-translations';
+import PlanPrice from 'calypso/my-sites/plan-price';
+import usePricingMetaForGridPlans from 'calypso/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans';
 import { useScreen } from './hooks';
 import NavigatorTitle from './navigator-title';
 import './screen-upsell.scss';
@@ -16,15 +21,65 @@ const ScreenUpsell = ( { numOfSelectedGlobalStyles = 1, onCheckout, onTryStyle }
 	const translate = useTranslate();
 	const { title, description } = useScreen( 'upsell' );
 	const translations = useGlobalStylesUpgradeTranslations( { numOfSelectedGlobalStyles } );
+	const pricingMeta = usePricingMetaForGridPlans( {
+		planSlugs: [ PLAN_PREMIUM ],
+		storageAddOns: null,
+	} );
+
+	const pricing = pricingMeta?.[ PLAN_PREMIUM ];
 
 	return (
 		<>
+			<QueryPlans />
 			<NavigatorHeader
 				title={ <NavigatorTitle title={ title } /> }
 				description={ description }
 				hideBack
 			/>
 			<div className="screen-container__body">
+				{ pricing && pricing.originalPrice.full && (
+					<div className="screen-upsell__plan">
+						<div className="screen-upsell__plan-heading">
+							{ translate( '%(planTitle)s plan', {
+								args: { planTitle: translations.planTitle },
+							} ) }
+						</div>
+						<PlanPrice
+							className="screen-upsell__plan-price"
+							currencyCode={ pricing.currencyCode }
+							rawPrice={ pricing.originalPrice.monthly }
+							displayPerMonthNotation={ false }
+							isLargeCurrency
+							isSmallestUnit
+						/>
+						<div className="screen-upsell__plan-billing-time-frame">
+							{ translate( 'per month, %(rawPrice)s billed annually, Excl. Taxes', {
+								args: {
+									rawPrice: formatCurrency(
+										pricing.originalPrice.full,
+										pricing.currencyCode ?? '',
+										{
+											stripZeros: true,
+											isSmallestUnit: true,
+										}
+									),
+								},
+								comment: 'Excl. Taxes is short for excluding taxes',
+							} ) }
+						</div>
+					</div>
+				) }
+				<strong className="screen-upsell__features-heading">
+					{ translate( 'Included with the plan:' ) }
+				</strong>
+				<ul className="screen-upsell__features">
+					{ translations.features.map( ( feature, i ) => (
+						<li key={ i }>
+							<Gridicon icon="checkmark" size={ 16 } />
+							{ feature }
+						</li>
+					) ) }
+				</ul>
 				<strong className="screen-upsell__heading">
 					{ translate( 'Premium styles' ) }
 					<PremiumBadge
@@ -34,17 +89,12 @@ const ScreenUpsell = ( { numOfSelectedGlobalStyles = 1, onCheckout, onTryStyle }
 					/>
 				</strong>
 				<div className="screen-upsell__description">
-					<p>{ translations.description }</p>
+					<p>
+						{ translate(
+							'Your colors and fonts choices are exclusive to the Premium plan and above.'
+						) }
+					</p>
 				</div>
-				<strong>{ translations.featuresTitle }</strong>
-				<ul className="screen-upsell__features">
-					{ translations.features.map( ( feature, i ) => (
-						<li key={ i }>
-							<Gridicon icon="checkmark" size={ 16 } />
-							{ feature }
-						</li>
-					) ) }
-				</ul>
 			</div>
 			<div className="screen-container__footer">
 				<Button className="pattern-assembler__button" onClick={ onTryStyle }>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.tsx
@@ -1,5 +1,5 @@
 import { PLAN_PREMIUM } from '@automattic/calypso-products';
-import { Button, Gridicon, PremiumBadge, LoadingPlaceholder } from '@automattic/components';
+import { Button, Gridicon, LoadingPlaceholder } from '@automattic/components';
 import { formatCurrency } from '@automattic/format-currency';
 import { NavigatorHeader } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
@@ -89,21 +89,6 @@ const ScreenUpsell = ( { numOfSelectedGlobalStyles = 1, onCheckout, onTryStyle }
 						</li>
 					) ) }
 				</ul>
-				<strong className="screen-upsell__heading">
-					{ translate( 'Premium styles' ) }
-					<PremiumBadge
-						shouldHideTooltip
-						shouldCompactWithAnimation
-						labelText={ translate( 'Upgrade' ) }
-					/>
-				</strong>
-				<div className="screen-upsell__description">
-					<p>
-						{ translate(
-							'Your colors and fonts choices are exclusive to the Premium plan and above.'
-						) }
-					</p>
-				</div>
 			</div>
 			<div className="screen-container__footer">
 				<Button className="pattern-assembler__button" onClick={ onTryStyle }>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.tsx
@@ -1,5 +1,5 @@
 import { PLAN_PREMIUM } from '@automattic/calypso-products';
-import { Button, Gridicon, PremiumBadge } from '@automattic/components';
+import { Button, Gridicon, PremiumBadge, LoadingPlaceholder } from '@automattic/components';
 import { formatCurrency } from '@automattic/format-currency';
 import { NavigatorHeader } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
@@ -27,6 +27,8 @@ const ScreenUpsell = ( { numOfSelectedGlobalStyles = 1, onCheckout, onTryStyle }
 	} );
 
 	const pricing = pricingMeta?.[ PLAN_PREMIUM ];
+	const isPricingLoaded =
+		pricing?.currencyCode && pricing?.originalPrice.monthly && pricing?.originalPrice.full;
 
 	return (
 		<>
@@ -37,38 +39,45 @@ const ScreenUpsell = ( { numOfSelectedGlobalStyles = 1, onCheckout, onTryStyle }
 				hideBack
 			/>
 			<div className="screen-container__body">
-				{ pricing && pricing.originalPrice.full && (
-					<div className="screen-upsell__plan">
-						<div className="screen-upsell__plan-heading">
-							{ translate( '%(planTitle)s plan', {
-								args: { planTitle: translations.planTitle },
-							} ) }
-						</div>
+				<div className="screen-upsell__plan">
+					<div className="screen-upsell__plan-heading">
+						{ translate( '%(planTitle)s plan', {
+							args: { planTitle: translations.planTitle },
+						} ) }
+					</div>
+					{ isPricingLoaded ? (
 						<PlanPrice
 							className="screen-upsell__plan-price"
-							currencyCode={ pricing.currencyCode }
-							rawPrice={ pricing.originalPrice.monthly }
+							currencyCode={ pricing?.currencyCode }
+							rawPrice={ pricing?.originalPrice?.monthly }
 							displayPerMonthNotation={ false }
 							isLargeCurrency
 							isSmallestUnit
 						/>
-						<div className="screen-upsell__plan-billing-time-frame">
-							{ translate( 'per month, %(rawPrice)s billed annually, Excl. Taxes', {
-								args: {
-									rawPrice: formatCurrency(
-										pricing.originalPrice.full,
-										pricing.currencyCode ?? '',
-										{
+					) : (
+						<LoadingPlaceholder style={ { height: '48px' } } />
+					) }
+					<div className="screen-upsell__plan-billing-time-frame">
+						{ translate( 'per month, {{span}}%(rawPrice)s{{/span}} billed annually, Excl. Taxes', {
+							args: {
+								rawPrice: isPricingLoaded
+									? formatCurrency( pricing?.originalPrice.full ?? 0, pricing?.currencyCode ?? '', {
 											stripZeros: true,
 											isSmallestUnit: true,
-										}
-									),
-								},
-								comment: 'Excl. Taxes is short for excluding taxes',
-							} ) }
-						</div>
+									  } )
+									: '',
+							},
+							comment: 'Excl. Taxes is short for excluding taxes',
+							components: {
+								span: isPricingLoaded ? (
+									<span />
+								) : (
+									<LoadingPlaceholder style={ { display: 'inline-block', width: '30%' } } />
+								),
+							},
+						} ) }
 					</div>
-				) }
+				</div>
 				<strong className="screen-upsell__features-heading">
 					{ translate( 'Included with the plan:' ) }
 				</strong>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/83504

## Proposed Changes

* Add the price of the Premium plan to the Upsell screen
* Update copy

| Before | After |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/c050caf8-3e16-43b6-9c35-ba61138aecf0) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/2cb8d990-9ebf-45c5-a363-ce8d02c56bc3) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the Assembler on your free site
* Pick any patterns
* Pick any styles
* When you land on the Upsell screen, ensure you're able to see the price of the plan

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?