### PR TITLE
Import page.js types, don't rely on PageJS global

### DIFF
--- a/client/jetpack-app/controller.tsx
+++ b/client/jetpack-app/controller.tsx
@@ -1,9 +1,9 @@
-import page from 'page';
+import page, { type Callback } from 'page';
 import { isWpMobileApp } from 'calypso/lib/mobile-app';
 import JetpackAppEmptyContent from './empty';
 import JetpackAppPlans from './plans/main';
 
-export function jetpackAppPlans( context: PageJS.Context, next: () => void ) {
+export const jetpackAppPlans: Callback = ( context, next ) => {
 	context.primary = (
 		<JetpackAppPlans
 			paidDomainName={ context.query.paid_domain_name }
@@ -12,17 +12,17 @@ export function jetpackAppPlans( context: PageJS.Context, next: () => void ) {
 	);
 
 	next();
-}
+};
 
-export function redirectIfNotJetpackApp( _context: PageJS.Context, next: () => void ) {
+export const redirectIfNotJetpackApp: Callback = ( _context, next ) => {
 	if ( ! isWpMobileApp() ) {
 		page.redirect( '/' );
 	} else {
 		next();
 	}
-}
+};
 
-export function pageNotFound( context: PageJS.Context, next: () => void ) {
+export const pageNotFound: Callback = ( context, next ) => {
 	context.primary = <JetpackAppEmptyContent />;
 	next();
-}
+};

--- a/client/jetpack-app/page-middleware/layout.tsx
+++ b/client/jetpack-app/page-middleware/layout.tsx
@@ -3,6 +3,7 @@ import { Provider as ReduxProvider } from 'react-redux';
 import CalypsoI18nProvider from 'calypso/components/calypso-i18n-provider';
 import { RouteProvider } from 'calypso/components/route';
 import { CalypsoReactQueryDevtools } from 'calypso/lib/react-query-devtools-helper';
+import type { Callback } from 'page';
 import type { FunctionComponent } from 'react';
 import type { Store } from 'redux';
 
@@ -39,8 +40,10 @@ export const ProviderWrappedLayout: FunctionComponent< ProviderWrappedLayoutProp
 	);
 };
 
-export function makeJetpackAppLayoutMiddleware( LayoutComponent: typeof ProviderWrappedLayout ) {
-	return ( context: PageJS.Context, next: () => void ) => {
+export function makeJetpackAppLayoutMiddleware(
+	LayoutComponent: typeof ProviderWrappedLayout
+): Callback {
+	return ( context, next ) => {
 		const { store, queryClient, pathname, query, primary } = context;
 
 		context.layout = (

--- a/client/jetpack-cloud/sections/agency-dashboard/controller.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/controller.tsx
@@ -1,5 +1,5 @@
 import config from '@automattic/calypso-config';
-import page from 'page';
+import page, { type Callback } from 'page';
 import NewJetpackManageSidebar from 'calypso/jetpack-cloud/sections/sidebar-navigation/jetpack-manage';
 import { isAgencyUser } from 'calypso/state/partner-portal/partner/selectors';
 import { setAllSitesSelected } from 'calypso/state/ui/actions';
@@ -7,7 +7,7 @@ import DashboardOverview from './dashboard-overview';
 import Header from './header';
 import DashboardSidebar from './sidebar';
 
-export function agencyDashboardContext( context: PageJS.Context, next: VoidFunction ): void {
+export const agencyDashboardContext: Callback = ( context, next ) => {
 	const { s: search, page: contextPage, issue_types, sort_field, sort_direction } = context.query;
 	const filter = {
 		issueTypes: issue_types?.split( ',' ),
@@ -46,4 +46,4 @@ export function agencyDashboardContext( context: PageJS.Context, next: VoidFunct
 	context.store.dispatch( setAllSitesSelected() );
 
 	next();
-}
+};

--- a/client/jetpack-cloud/sections/agency-signup/controller.tsx
+++ b/client/jetpack-cloud/sections/agency-signup/controller.tsx
@@ -1,9 +1,9 @@
-import page from 'page';
+import page, { type Callback } from 'page';
 import AgencySignUp from 'calypso/jetpack-cloud/sections/agency-signup/primary/agency-signup';
 import { partnerPortalBasePath } from 'calypso/lib/jetpack/paths';
 import { getCurrentPartner } from 'calypso/state/partner-portal/partner/selectors';
 
-export function requireNoPartnerRecordContext( context: PageJS.Context, next: () => void ): void {
+export const requireNoPartnerRecordContext: Callback = ( context, next ) => {
 	const state = context.store.getState();
 	const partner = getCurrentPartner( state );
 
@@ -14,9 +14,9 @@ export function requireNoPartnerRecordContext( context: PageJS.Context, next: ()
 	}
 
 	next();
-}
+};
 
-export function signUpContext( context: PageJS.Context, next: () => void ): void {
+export const signUpContext: Callback = ( context, next ) => {
 	context.primary = <AgencySignUp />;
 	next();
-}
+};

--- a/client/jetpack-cloud/sections/auth/controller.tsx
+++ b/client/jetpack-cloud/sections/auth/controller.tsx
@@ -2,13 +2,14 @@ import config from '@automattic/calypso-config';
 import debugFactory from 'debug';
 import store from 'store';
 import Connect from './connect';
+import type { Callback, Context } from 'page';
 
 const WP_AUTHORIZE_ENDPOINT = 'https://public-api.wordpress.com/oauth2/authorize';
 const debug = debugFactory( 'calypso:jetpack-cloud-connect' );
 
 const DEFAULT_NEXT_LOCATION = '/';
 
-export const connect: PageJS.Callback = ( context, next ) => {
+export const connect: Callback = ( context, next ) => {
 	if ( config.isEnabled( 'oauth' ) && config( 'oauth_client_id' ) ) {
 		const redirectUri = new URL( '/connect/oauth/token', window.location.origin );
 
@@ -29,12 +30,12 @@ export const connect: PageJS.Callback = ( context, next ) => {
 	next();
 };
 
-// The type of `PageJS.Context.hash` is `string`, but here it is being used as
+// The type of `Context.hash` is `string`, but here it is being used as
 // an object. Assuming the types are wrong, here we override them to fix TS
 // errors until the types can be corrected.
-type OverriddenPageContext = PageJS.Context & { hash?: Record< string, string > };
+type OverriddenPageContext = Context & { hash?: Record< string, string > };
 
-export const tokenRedirect: PageJS.Callback = ( ctx: unknown, next ) => {
+export const tokenRedirect: Callback = ( ctx, next ) => {
 	const context = ctx as OverriddenPageContext;
 	// We didn't get an auth token; take a step back
 	// and ask for authorization from the user again

--- a/client/jetpack-cloud/sections/comparison/controller.tsx
+++ b/client/jetpack-cloud/sections/comparison/controller.tsx
@@ -1,4 +1,4 @@
-import page from 'page';
+import page, { type Callback } from 'page';
 import { addQueryArgs } from 'calypso/lib/route';
 import { hideMasterbar } from 'calypso/state/ui/actions';
 import JetpackComFooter from '../pricing/jpcom-footer';
@@ -6,7 +6,7 @@ import JetpackComMasterbar from '../pricing/jpcom-masterbar';
 import { Content } from './content';
 import Header from './header';
 
-export function jetpackComparisonContext( context: PageJS.Context, next: () => void ): void {
+export const jetpackComparisonContext: Callback = ( context, next ) => {
 	const urlQueryArgs = context.query;
 	const { lang } = context.params;
 	const path = context.path;
@@ -32,4 +32,4 @@ export function jetpackComparisonContext( context: PageJS.Context, next: () => v
 		/>
 	);
 	next();
-}
+};

--- a/client/jetpack-cloud/sections/golden-token/controller.tsx
+++ b/client/jetpack-cloud/sections/golden-token/controller.tsx
@@ -1,11 +1,12 @@
 import config from '@automattic/calypso-config';
+import page, { type Callback } from 'page';
 import { GoldenTokenDialog } from './golden-token-dialog';
 
-export function goldenTokenContext( context: PageJS.Context, next: () => void ): void {
+export const goldenTokenContext: Callback = ( context, next ) => {
 	if ( ! config.isEnabled( 'jetpack/golden-token' ) ) {
 		page.redirect( '/' );
 	}
 
 	context.primary = <GoldenTokenDialog />;
 	next();
-}
+};

--- a/client/jetpack-cloud/sections/jetpack-social/controller.tsx
+++ b/client/jetpack-cloud/sections/jetpack-social/controller.tsx
@@ -1,5 +1,5 @@
 import { translate } from 'i18n-calypso';
-import page from 'page';
+import page, { type Callback } from 'page';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
@@ -12,7 +12,7 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
 import ConnectionsPage from './connections';
 import PromoPage from './promo';
 
-export const connections: PageJS.Callback = ( context, next ) => {
+export const connections: Callback = ( context, next ) => {
 	const { store } = context;
 	const { dispatch } = store;
 	const state = store.getState();
@@ -42,7 +42,7 @@ export const connections: PageJS.Callback = ( context, next ) => {
 	next();
 };
 
-export const redirectIfNotJetpackCloud: PageJS.Callback = ( context, next ) => {
+export const redirectIfNotJetpackCloud: Callback = ( context, next ) => {
 	const state = context.store.getState();
 	const site = getSelectedSite( state );
 

--- a/client/jetpack-cloud/sections/landing/controller.tsx
+++ b/client/jetpack-cloud/sections/landing/controller.tsx
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import debugModule from 'debug';
-import page from 'page';
+import page, { type Callback, type Context } from 'page';
 import { dashboardPath } from 'calypso/lib/jetpack/paths';
 import { isAgencyUser } from 'calypso/state/partner-portal/partner/selectors';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
@@ -12,7 +12,7 @@ import { isSiteEligibleForJetpackCloud, getLandingPath } from './selectors';
 
 const debug = debugModule( 'calypso:jetpack-cloud:landing:controller' );
 
-const landForSiteId = ( siteId: number | null, context: PageJS.Context, next: () => void ) => {
+const landForSiteId = ( siteId: number | null, context: Context, next: () => void ) => {
 	debug( '[landForSiteId]: function entry', { siteId, context } );
 
 	// Landing requires a site ID;
@@ -47,7 +47,7 @@ const landForSiteId = ( siteId: number | null, context: PageJS.Context, next: ()
 	page.redirect( landingPath );
 };
 
-export const landForPrimarySite = ( context: PageJS.Context, next: () => void ) => {
+export const landForPrimarySite: Callback = ( context, next ) => {
 	debug( '[landForPrimarySite]: function entry', context );
 
 	const state = context.store.getState();
@@ -66,7 +66,7 @@ export const landForPrimarySite = ( context: PageJS.Context, next: () => void ) 
 	landForSiteId( primarySiteId, context, next );
 };
 
-export const landForSelectedSite = ( context: PageJS.Context, next: () => void ) => {
+export const landForSelectedSite: Callback = ( context, next ) => {
 	debug( '[landForSelectedSite]: function entry', context );
 
 	const state = context.store.getState();

--- a/client/jetpack-cloud/sections/partner-portal/controller.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/controller.tsx
@@ -1,5 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
-import page from 'page';
+import page, { type Callback, type Context } from 'page';
 import {
 	publicToInternalLicenseFilter,
 	publicToInternalLicenseSortField,
@@ -38,11 +38,10 @@ import getSites from 'calypso/state/selectors/get-sites';
 import { setAllSitesSelected } from 'calypso/state/ui/actions/set-sites';
 import Header from './header';
 import WPCOMAtomicHosting from './primary/wpcom-atomic-hosting';
-import type PageJS from 'page';
 
 const isNewNavigationEnabled = isEnabled( 'jetpack/new-navigation' );
 
-const setSidebar = ( context: PageJS.Context ): void => {
+const setSidebar = ( context: Context ) => {
 	if ( isNewNavigationEnabled ) {
 		context.secondary = <NewPurchasesSidebar path={ context.path } />;
 	} else {
@@ -50,38 +49,38 @@ const setSidebar = ( context: PageJS.Context ): void => {
 	}
 };
 
-export function allSitesContext( context: PageJS.Context, next: () => void ): void {
+export const allSitesContext: Callback = ( context, next ) => {
 	// Many (if not all) Partner Portal pages do not select any one specific site
 	context.store.dispatch( setAllSitesSelected() );
 	next();
-}
+};
 
-export function partnerContext( context: PageJS.Context, next: () => void ): void {
+export const partnerContext: Callback = ( context, next ) => {
 	context.header = <Header />;
 	context.primary = <PartnerAccess />;
 	next();
-}
+};
 
-export function termsOfServiceContext( context: PageJS.Context, next: () => void ): void {
+export const termsOfServiceContext: Callback = ( context, next ) => {
 	context.header = <Header />;
 	context.primary = <TermsOfServiceConsent />;
 	next();
-}
+};
 
-export function partnerKeyContext( context: PageJS.Context, next: () => void ): void {
+export const partnerKeyContext: Callback = ( context, next ) => {
 	context.header = <Header />;
 	context.primary = <LicenseSelectPartnerKey />;
 	next();
-}
+};
 
-export function billingDashboardContext( context: PageJS.Context, next: () => void ): void {
+export const billingDashboardContext: Callback = ( context, next ) => {
 	context.header = <Header />;
 	setSidebar( context );
 	context.primary = <BillingDashboard />;
 	next();
-}
+};
 
-export function licensesContext( context: PageJS.Context, next: () => void ): void {
+export const licensesContext: Callback = ( context, next ) => {
 	const { s: search, sort_field, sort_direction, page } = context.query;
 	const filter = publicToInternalLicenseFilter( context.params.filter, LicenseFilter.NotRevoked );
 	const currentPage = parseInt( page ) || 1;
@@ -108,9 +107,9 @@ export function licensesContext( context: PageJS.Context, next: () => void ): vo
 		/>
 	);
 	next();
-}
+};
 
-export function issueLicenseContext( context: PageJS.Context, next: () => void ): void {
+export const issueLicenseContext: Callback = ( context, next ) => {
 	const { site_id: siteId, product_slug: suggestedProduct } = context.query;
 	const state = context.store.getState();
 	const sites = getSites( state );
@@ -121,16 +120,16 @@ export function issueLicenseContext( context: PageJS.Context, next: () => void )
 		<IssueLicense selectedSite={ selectedSite } suggestedProduct={ suggestedProduct } />
 	);
 	next();
-}
+};
 
-export function downloadProductsContext( context: PageJS.Context, next: () => void ): void {
+export const downloadProductsContext: Callback = ( context, next ) => {
 	context.header = <Header />;
 	setSidebar( context );
 	context.primary = <DownloadProducts />;
 	next();
-}
+};
 
-export function assignLicenseContext( context: PageJS.Context, next: () => void ): void {
+export const assignLicenseContext: Callback = ( context, next ) => {
 	const { page, search } = context.query;
 	const state = context.store.getState();
 	const sites = getSites( state );
@@ -142,16 +141,16 @@ export function assignLicenseContext( context: PageJS.Context, next: () => void 
 		<AssignLicense sites={ sites } currentPage={ currentPage } search={ search || '' } />
 	);
 	next();
-}
+};
 
-export function paymentMethodListContext( context: PageJS.Context, next: () => void ): void {
+export const paymentMethodListContext: Callback = ( context, next ) => {
 	context.header = <Header />;
 	setSidebar( context );
 	context.primary = <PaymentMethodList />;
 	next();
-}
+};
 
-export function paymentMethodAddContext( context: PageJS.Context, next: () => void ): void {
+export const paymentMethodAddContext: Callback = ( context, next ) => {
 	context.header = <Header />;
 	setSidebar( context );
 
@@ -161,47 +160,44 @@ export function paymentMethodAddContext( context: PageJS.Context, next: () => vo
 	const selectedSite = siteId ? sites?.find( ( site ) => site?.ID === parseInt( siteId ) ) : null;
 	context.primary = <PaymentMethodAdd selectedSite={ selectedSite } />;
 	next();
-}
+};
 
-export function invoicesDashboardContext( context: PageJS.Context, next: () => void ): void {
+export const invoicesDashboardContext: Callback = ( context, next ) => {
 	context.header = <Header />;
 	setSidebar( context );
 	context.primary = <InvoicesDashboard />;
 	next();
-}
+};
 
-export function companyDetailsDashboardContext( context: PageJS.Context, next: () => void ): void {
+export const companyDetailsDashboardContext: Callback = ( context, next ) => {
 	context.header = <Header />;
 	setSidebar( context );
 	context.primary = <CompanyDetailsDashboard />;
 	next();
-}
+};
 
-export function pricesContext( context: PageJS.Context, next: () => void ): void {
+export const pricesContext: Callback = ( context, next ) => {
 	context.header = <Header />;
 	setSidebar( context );
 	context.primary = <Prices />;
 	next();
-}
+};
 
-export function landingPageContext() {
+export const landingPageContext: Callback = () => {
 	page.redirect( isNewNavigationEnabled ? '/partner-portal/billing' : '/partner-portal/licenses' );
-	return;
-}
+};
 
-export function wpcomAtomicHostingContext( context: PageJS.Context, next: () => void ): void {
+export const wpcomAtomicHostingContext: Callback = ( context, next ) => {
 	context.header = <Header />;
 	setSidebar( context );
 	context.primary = <WPCOMAtomicHosting />;
 	next();
-}
+};
 
 /**
  * Require the user to have a partner with at least 1 active partner key.
- * @param {PageJS.Context} context PageJS context.
- * @param {() => void} next Next context callback.
  */
-export function requireAccessContext( context: PageJS.Context, next: () => void ): void {
+export const requireAccessContext: Callback = ( context, next ) => {
 	const state = context.store.getState();
 	const partner = getCurrentPartner( state );
 	const { pathname, search } = window.location;
@@ -219,17 +215,12 @@ export function requireAccessContext( context: PageJS.Context, next: () => void 
 			'/partner-portal/partner'
 		)
 	);
-}
+};
 
 /**
  * Require the user to have consented to the terms of service.
- * @param {PageJS.Context} context PageJS context.
- * @param {() => void} next Next context callback.
  */
-export function requireTermsOfServiceConsentContext(
-	context: PageJS.Context,
-	next: () => void
-): void {
+export const requireTermsOfServiceConsentContext: Callback = ( context, next ) => {
 	const { pathname, search } = window.location;
 	const state = context.store.getState();
 	const partner = getCurrentPartner( state );
@@ -249,17 +240,12 @@ export function requireTermsOfServiceConsentContext(
 			'/partner-portal/terms-of-service'
 		)
 	);
-}
+};
 
 /**
  * Require the user to have selected a partner key to use.
- * @param {PageJS.Context} context PageJS context.
- * @param {() => void} next Next context callback.
  */
-export function requireSelectedPartnerKeyContext(
-	context: PageJS.Context,
-	next: () => void
-): void {
+export const requireSelectedPartnerKeyContext: Callback = ( context, next ) => {
 	const state = context.store.getState();
 	const hasKey = hasActivePartnerKey( state );
 	const { pathname, search } = window.location;
@@ -279,14 +265,12 @@ export function requireSelectedPartnerKeyContext(
 			'/partner-portal/partner-key'
 		)
 	);
-}
+};
 
 /**
  * Require the user to have a valid payment method registered.
- * @param {PageJS.Context} context PageJS context.
- * @param {() => void} next Next context callback.
  */
-export function requireValidPaymentMethod( context: PageJS.Context, next: () => void ) {
+export const requireValidPaymentMethod: Callback = ( context, next ) => {
 	const state = context.store.getState();
 	const paymentMethodRequired = doesPartnerRequireAPaymentMethod( state );
 	const { pathname, search } = window.location;
@@ -306,4 +290,4 @@ export function requireValidPaymentMethod( context: PageJS.Context, next: () => 
 	}
 
 	next();
-}
+};

--- a/client/jetpack-cloud/sections/plugin-management/controller.tsx
+++ b/client/jetpack-cloud/sections/plugin-management/controller.tsx
@@ -1,12 +1,12 @@
 import config from '@automattic/calypso-config';
-import page from 'page';
+import page, { type Callback, type Context } from 'page';
 import NewJetpackManageSidebar from 'calypso/jetpack-cloud/sections/sidebar-navigation/jetpack-manage';
 import { isAgencyUser } from 'calypso/state/partner-portal/partner/selectors';
 import Header from '../agency-dashboard/header';
 import DashboardSidebar from '../agency-dashboard/sidebar';
 import PluginsOverview from './plugins-overview';
 
-const redirectIfHasNoAccess = ( context: PageJS.Context ) => {
+const redirectIfHasNoAccess = ( context: Context ) => {
 	const state = context.store.getState();
 	const isAgency = isAgencyUser( state );
 	const isAgencyEnabled = config.isEnabled( 'jetpack/agency-dashboard' );
@@ -18,7 +18,7 @@ const redirectIfHasNoAccess = ( context: PageJS.Context ) => {
 	}
 };
 
-const setSidebar = ( context: PageJS.Context ): void => {
+const setSidebar = ( context: Context ) => {
 	if ( config.isEnabled( 'jetpack/new-navigation' ) ) {
 		context.secondary = <NewJetpackManageSidebar path={ context.path } />;
 	} else {
@@ -26,7 +26,7 @@ const setSidebar = ( context: PageJS.Context ): void => {
 	}
 };
 
-export function pluginManagementContext( context: PageJS.Context, next: VoidFunction ): void {
+export const pluginManagementContext: Callback = ( context, next ) => {
 	redirectIfHasNoAccess( context );
 	const { filter = 'all', site } = context.params;
 	const { s: search } = context.query;
@@ -43,9 +43,9 @@ export function pluginManagementContext( context: PageJS.Context, next: VoidFunc
 		/>
 	);
 	next();
-}
+};
 
-export function pluginDetailsContext( context: PageJS.Context, next: VoidFunction ): void {
+export const pluginDetailsContext: Callback = ( context, next ) => {
 	redirectIfHasNoAccess( context );
 	const { plugin, site } = context.params;
 	context.header = <Header />;
@@ -55,4 +55,4 @@ export function pluginDetailsContext( context: PageJS.Context, next: VoidFunctio
 	}
 	context.primary = <PluginsOverview pluginSlug={ plugin } site={ site } path={ context.path } />;
 	next();
-}
+};

--- a/client/jetpack-cloud/sections/pricing/controller.tsx
+++ b/client/jetpack-cloud/sections/pricing/controller.tsx
@@ -1,5 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
-import page from 'page';
+import page, { type Callback } from 'page';
 import { addQueryArgs } from 'calypso/lib/route';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import { hideMasterbar } from 'calypso/state/ui/actions';
@@ -7,7 +7,7 @@ import Header from './header';
 import JetpackComFooter from './jpcom-footer';
 import JetpackComMasterbar from './jpcom-masterbar';
 
-export function jetpackPricingContext( context: PageJS.Context, next: () => void ): void {
+export const jetpackPricingContext: Callback = ( context, next ) => {
 	const urlQueryArgs = context.query;
 	const { lang } = context.params;
 	const path = context.path;
@@ -36,4 +36,4 @@ export function jetpackPricingContext( context: PageJS.Context, next: () => void
 	context.header = <PricingHeader />;
 	context.footer = <JetpackComFooter />;
 	next();
-}
+};

--- a/client/jetpack-cloud/sections/settings/controller.tsx
+++ b/client/jetpack-cloud/sections/settings/controller.tsx
@@ -18,13 +18,14 @@ import HasRetentionCapabilitiesSwitch from './has-retention-capabilities-switch'
 import HasSiteCredentialsSwitch from './has-site-credentials-switch';
 import AdvancedCredentialsLoadingPlaceholder from './loading';
 import SettingsPage from './main';
+import type { Callback } from 'page';
 
-export const settings: PageJS.Callback = ( context, next ) => {
+export const settings: Callback = ( context, next ) => {
 	context.primary = <SettingsPage />;
 	next();
 };
 
-export const advancedCredentials: PageJS.Callback = ( context, next ) => {
+export const advancedCredentials: Callback = ( context, next ) => {
 	const { host, action } = context.query;
 	const siteId = getSelectedSiteId( context.store.getState() ) as number;
 	const sectionElt = <AdvancedCredentials action={ action } host={ host } role="main" />;
@@ -80,7 +81,7 @@ export const advancedCredentials: PageJS.Callback = ( context, next ) => {
 	next();
 };
 
-export const showNotAuthorizedForNonAdmins: PageJS.Callback = ( context, next ) => {
+export const showNotAuthorizedForNonAdmins: Callback = ( context, next ) => {
 	context.primary = (
 		<IsCurrentUserAdminSwitch
 			trueComponent={ context.primary }
@@ -91,7 +92,7 @@ export const showNotAuthorizedForNonAdmins: PageJS.Callback = ( context, next ) 
 	next();
 };
 
-export const disconnectSite: PageJS.Callback = ( context, next ) => {
+export const disconnectSite: Callback = ( context, next ) => {
 	context.primary = (
 		<DisconnectSite
 			// Ignore type checking because TypeScript is incorrectly inferring the prop type due to the redirectNonJetpack HOC.
@@ -105,7 +106,7 @@ export const disconnectSite: PageJS.Callback = ( context, next ) => {
 	next();
 };
 
-export const disconnectSiteConfirm: PageJS.Callback = ( context, next ) => {
+export const disconnectSiteConfirm: Callback = ( context, next ) => {
 	const { reason, type, text } = context.query;
 	const dashboardHref = dashboardPath();
 	context.primary = (

--- a/client/lib/jetpack/types.ts
+++ b/client/lib/jetpack/types.ts
@@ -1,8 +1,8 @@
 import { ReactNode } from 'react';
-import type PageJS from 'page';
+import type { Context as PageContext } from 'page';
 import type Redux from 'redux';
 
-export interface Context extends PageJS.Context {
+export interface Context extends PageContext {
 	primary?: ReactNode;
 	store: Redux.Store;
 }

--- a/client/lib/protect-form/index.tsx
+++ b/client/lib/protect-form/index.tsx
@@ -1,7 +1,7 @@
 import { createHigherOrderComponent } from '@wordpress/compose';
 import debugModule from 'debug';
 import i18n from 'i18n-calypso';
-import page from 'page';
+import page, { type Callback } from 'page';
 import { useRef, useCallback, useEffect, ComponentType } from 'react';
 
 /**
@@ -117,7 +117,7 @@ function windowConfirm() {
 	return window.confirm( confirmText );
 }
 
-export const checkFormHandler: PageJS.Callback = ( context, next ) => {
+export const checkFormHandler: Callback = ( context, next ) => {
 	if ( ! formsChanged.size ) {
 		return next();
 	}

--- a/client/lib/route/normalize.ts
+++ b/client/lib/route/normalize.ts
@@ -1,10 +1,10 @@
-import page from 'page';
+import page, { type Callback } from 'page';
 import untrailingslashit from './untrailingslashit';
 
 const appendQueryString = ( basepath: string, querystring: string ): string =>
 	basepath + ( querystring ? '?' + querystring : '' );
 
-const normalize: PageJS.Callback = ( context, next ) => {
+const normalize: Callback = ( context, next ) => {
 	const normalizedPathName = untrailingslashit( context.pathname );
 	if ( normalizedPathName !== context.pathname ) {
 		page.redirect( appendQueryString( normalizedPathName, context.querystring ) );

--- a/client/my-sites/add-ons/controller.tsx
+++ b/client/my-sites/add-ons/controller.tsx
@@ -1,10 +1,10 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
-import page from 'page';
+import page, { type Callback } from 'page';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import AddOnsMain from './main';
 
-export const addOnsSiteSelectionHeader = ( context: PageJS.Context, next: () => void ) => {
+export const addOnsSiteSelectionHeader: Callback = ( context, next ) => {
 	context.getSiteSelectionHeaderText = () => {
 		return translate( 'Select a site to open {{strong}}Add-Ons{{/strong}}', {
 			components: {
@@ -16,7 +16,7 @@ export const addOnsSiteSelectionHeader = ( context: PageJS.Context, next: () => 
 	next();
 };
 
-export const addOnsManagement = ( context: PageJS.Context, next: () => void ) => {
+export const addOnsManagement: Callback = ( context, next ) => {
 	const state = context.store.getState();
 	const selectedSite = getSelectedSite( state );
 
@@ -26,12 +26,12 @@ export const addOnsManagement = ( context: PageJS.Context, next: () => void ) =>
 		return null;
 	}
 
-	context.primary = <AddOnsMain context={ context } />;
+	context.primary = <AddOnsMain />;
 
 	next();
 };
 
-export const redirectIfNotEnabled = ( context: PageJS.Context, next: () => void ) => {
+export const redirectIfNotEnabled: Callback = ( context, next ) => {
 	const state = context.store.getState();
 	const selectedSite = getSelectedSite( state );
 

--- a/client/my-sites/add-ons/main.tsx
+++ b/client/my-sites/add-ons/main.tsx
@@ -90,11 +90,7 @@ const NoAccess = () => {
 	);
 };
 
-interface Props {
-	context?: PageJS.Context;
-}
-
-const AddOnsMain: React.FunctionComponent< Props > = () => {
+const AddOnsMain = () => {
 	const translate = useTranslate();
 	const selectedSite = useSelector( getSelectedSite ) ?? null;
 	const addOns = useAddOns( selectedSite?.ID );

--- a/client/my-sites/checkout/utils.ts
+++ b/client/my-sites/checkout/utils.ts
@@ -2,6 +2,7 @@ import { doesStringResembleDomain } from '@automattic/onboarding';
 import { untrailingslashit } from 'calypso/lib/route';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+import type { Context } from 'page';
 
 /**
  * Return the product slug or product alias from a checkout route.
@@ -26,17 +27,9 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
  * 5. `/checkout/example.com::blog/pro` (path contains a domain followed by a product)
  * 6. `/checkout/pro/example.com::blog` (path contains a product followed by a domain)
  */
-export function getProductSlugFromContext( context: PageJS.Context ): string | undefined {
+export function getProductSlugFromContext( context: Context ): string | undefined {
 	const { params, store, pathname } = context;
-	const {
-		domainOrProduct,
-		product,
-		productSlug,
-	}: {
-		domainOrProduct: string | undefined;
-		product: string | undefined;
-		productSlug: string | undefined;
-	} = params;
+	const { domainOrProduct, product, productSlug } = params;
 	const state = store.getState();
 	const selectedSite = getSelectedSite( state );
 	const isGiftPurchase = pathname.includes( '/gift/' );
@@ -111,7 +104,7 @@ export function addHttpIfMissing( inputUrl: string, httpsIsDefault = true ): str
 	return untrailingslashit( url );
 }
 
-export function isContextJetpackSitelessCheckout( context: PageJS.Context ): boolean {
+export function isContextJetpackSitelessCheckout( context: Context ): boolean {
 	const hasJetpackPurchaseToken = Boolean( context.query.purchasetoken );
 	const hasJetpackPurchaseNonce = Boolean( context.query.purchaseNonce );
 	const isUserComingFromLoginForm = context.query?.flow === 'coming_from_login';

--- a/client/my-sites/domains/domain-management/edit-contact-info-page/bulk-edit-contact-info-page.tsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info-page/bulk-edit-contact-info-page.tsx
@@ -10,7 +10,7 @@ import { useQueries } from '@tanstack/react-query';
 import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import moment from 'moment';
-import page from 'page';
+import page, { type Context } from 'page';
 import { useId, useState } from 'react';
 import { useSelector } from 'react-redux';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
@@ -42,7 +42,7 @@ import './style.scss';
 
 interface BulkEditContactInfoPageProps {
 	selectedSite: SiteDetails | null;
-	context: PageJS.Context;
+	context: Context;
 }
 
 export default function BulkEditContactInfoPage( {

--- a/client/my-sites/plans/jetpack-plans/controller.tsx
+++ b/client/my-sites/plans/jetpack-plans/controller.tsx
@@ -14,6 +14,7 @@ import { StoragePricing } from './storage-pricing';
 import { StoragePricingHeader } from './storage-pricing-header';
 import JetpackUpsellPage from './upsell';
 import type { Duration, QueryArgs } from './types';
+import type { Callback } from 'page';
 
 function stringToDuration( duration?: string ): Duration | undefined {
 	if ( duration === undefined ) {
@@ -50,7 +51,7 @@ function getHighlightedProduct( productSlug?: string ): [ string, string ] | nul
 }
 
 export const productSelect =
-	( rootUrl: string ): PageJS.Callback =>
+	( rootUrl: string ): Callback =>
 	( context, next ) => {
 		// If the URL contains a duration, use it to determine the default duration. Ignore selected site's duration.
 		const state = context.store.getState();
@@ -88,31 +89,31 @@ export const productSelect =
 		next();
 	};
 
-export function offerJetpackComplete( context: PageJS.Context, next: () => void ): void {
+export const offerJetpackComplete: Callback = ( context, next ) => {
 	const { site } = context.params;
 	const urlQueryArgs: QueryArgs = context.query;
 	context.primary = (
 		<JetpackCompletePage urlQueryArgs={ urlQueryArgs } siteSlug={ site || context.query.site } />
 	);
 	next();
-}
+};
 
-export function jetpackFreeWelcome( context: PageJS.Context, next: () => void ): void {
+export const jetpackFreeWelcome: Callback = ( context, next ) => {
 	context.primary = <JetpackFreeWelcomePage />;
 	next();
-}
+};
 
-export function jetpackBoostWelcome( context: PageJS.Context, next: () => void ): void {
+export const jetpackBoostWelcome: Callback = ( context, next ) => {
 	context.primary = <JetpackBoostWelcomePage />;
 	next();
-}
+};
 
-export function jetpackSocialWelcome( context: PageJS.Context, next: () => void ): void {
+export const jetpackSocialWelcome: Callback = ( context, next ) => {
 	context.primary = <JetpackSocialWelcomePage />;
 	next();
-}
+};
 
-export const jetpackStoragePricing = ( context: PageJS.Context, next: () => void ) => {
+export const jetpackStoragePricing: Callback = ( context, next ) => {
 	const { site, duration } = getParamsFromContext( context );
 	const urlQueryArgs: QueryArgs = context.query;
 	const { lang } = context.params;
@@ -132,8 +133,8 @@ export const jetpackStoragePricing = ( context: PageJS.Context, next: () => void
 };
 
 export const jetpackProductUpsell =
-	( rootUrl: string ): PageJS.Callback =>
-	( context: PageJS.Context, next: () => void ) => {
+	( rootUrl: string ): Callback =>
+	( context, next ) => {
 		const { site, product } = context.params;
 		const urlQueryArgs = context.query;
 

--- a/client/my-sites/plans/jetpack-plans/get-params-from-context.ts
+++ b/client/my-sites/plans/jetpack-plans/get-params-from-context.ts
@@ -1,6 +1,5 @@
-/* eslint-disable jsdoc/no-undefined-types */
-
 import { Duration } from './types';
+import type { Context } from 'page';
 
 type Params = {
 	duration: Duration | undefined;
@@ -17,11 +16,11 @@ type Params = {
  * /pricing/example.com        > { duration: undefined, site: 'example.com' }
  * /pricing/annual/example.com > { duration: 'annual', site: 'example.com' }
  * /pricing/weekly/example.com > { duration: undefined, site: 'example.com' }
- * @param {PageJS.Context} context Page context
+ * @param {Context} context Page context
  * @returns {Params} Parameters
  */
-export default function getParamsFromContext( { params }: PageJS.Context ): Params {
-	const { duration: rawDuration, site: rawSite } = params;
+export default function getParamsFromContext( context: Context ): Params {
+	const { duration: rawDuration, site: rawSite } = context.params;
 	const duration = [ 'annual', 'monthly' ].includes( rawDuration ) ? rawDuration : undefined;
 	const site = ( rawSite || ( duration ? undefined : rawDuration ) ) ?? undefined;
 

--- a/client/my-sites/plans/jetpack-plans/index.ts
+++ b/client/my-sites/plans/jetpack-plans/index.ts
@@ -1,5 +1,5 @@
 import config, { isEnabled } from '@automattic/calypso-config';
-import page from 'page';
+import page, { type Callback } from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller/index.web';
 import {
 	jetpackBoostWelcome,
@@ -9,7 +9,7 @@ import {
 	productSelect,
 } from './controller';
 
-export default function ( rootUrl: string, ...rest: PageJS.Callback[] ): void {
+export default function ( rootUrl: string, ...rest: Callback[] ): void {
 	const addBoostAndSocialRoutes = config.isEnabled( 'jetpack/pricing-add-boost-social' );
 
 	page( `${ rootUrl }/jetpack-free/welcome`, jetpackFreeWelcome, makeLayout, clientRender );

--- a/client/my-sites/plans/jetpack-plans/jetpack-storage-plans.ts
+++ b/client/my-sites/plans/jetpack-plans/jetpack-storage-plans.ts
@@ -1,7 +1,7 @@
-import page from 'page';
+import page, { type Callback } from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller/index.web';
 import { jetpackStoragePricing } from './controller';
 
-export const jetpackStoragePlans = ( rootUrl: string, ...rest: PageJS.Callback[] ) => {
+export const jetpackStoragePlans = ( rootUrl: string, ...rest: Callback[] ) => {
 	page( `${ rootUrl }/storage/:site`, ...rest, jetpackStoragePricing, makeLayout, clientRender );
 };

--- a/client/my-sites/plans/jetpack-plans/jetpack-upsell.ts
+++ b/client/my-sites/plans/jetpack-plans/jetpack-upsell.ts
@@ -1,8 +1,8 @@
-import page from 'page';
+import page, { type Callback } from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { jetpackProductUpsell } from './controller';
 
-export const jetpackUpsell = ( rootUrl: string, ...rest: PageJS.Callback[] ) => {
+export const jetpackUpsell = ( rootUrl: string, ...rest: Callback[] ) => {
 	page(
 		`${ rootUrl }/upsell/:product/:site?`,
 		...rest,

--- a/client/my-sites/plans/jetpack-plans/plan-upgrade/utils.ts
+++ b/client/my-sites/plans/jetpack-plans/plan-upgrade/utils.ts
@@ -10,18 +10,17 @@ import type {
 	JetpackLegacyPlanSlug,
 	JetpackPurchasableItemSlug,
 } from '@automattic/calypso-products';
+import type { Context } from 'page';
 
-export function getComparePlansFromContext( {
-	query,
-}: PageJS.Context ): JetpackPurchasableItemSlug[] {
-	const value = query[ COMPARE_PLANS_QUERY_PARAM ] ?? '';
+export function getComparePlansFromContext( context: Context ): JetpackPurchasableItemSlug[] {
+	const value = context.query[ COMPARE_PLANS_QUERY_PARAM ] ?? '';
 	const plans = value.split( ',' );
 
 	return plans.filter( ( p: string ) => isJetpackPurchasableItem( p, { includeLegacy: true } ) );
 }
 
 export function getPlanRecommendationFromContext(
-	context: PageJS.Context
+	context: Context
 ): PlanRecommendation | undefined {
 	const plans = getComparePlansFromContext( context );
 

--- a/client/my-sites/plans/jetpack-plans/plans-header.tsx
+++ b/client/my-sites/plans/jetpack-plans/plans-header.tsx
@@ -15,9 +15,10 @@ import getSitePlan from 'calypso/state/sites/selectors/get-site-plan';
 import getSiteProducts from 'calypso/state/sites/selectors/get-site-products';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { getPlanRecommendationFromContext } from './plan-upgrade/utils';
+import type { Context } from 'page';
 
 type HeaderProps = {
-	context: PageJS.Context;
+	context: Context;
 	shouldShowPlanRecommendation?: boolean;
 };
 
@@ -100,7 +101,7 @@ const PlansHeader = ( { context, shouldShowPlanRecommendation }: HeaderProps ) =
 	);
 };
 
-export default function setJetpackHeader( context: PageJS.Context ): void {
+export default function setJetpackHeader( context: Context ) {
 	const planRecommendation = getPlanRecommendationFromContext( context );
 	const shouldShowPlanRecommendation = !! planRecommendation;
 

--- a/client/my-sites/site-monitoring/controller.tsx
+++ b/client/my-sites/site-monitoring/controller.tsx
@@ -3,8 +3,9 @@ import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { SiteMetrics } from './main';
+import type { Callback } from 'page';
 
-export const siteMetrics: PageJS.Callback = ( context, next ) => {
+export const siteMetrics: Callback = ( context, next ) => {
 	context.primary = (
 		<>
 			<PageViewTracker path="/site-monitoring/:site" title="Site Monitoring" delay={ 500 } />
@@ -14,7 +15,7 @@ export const siteMetrics: PageJS.Callback = ( context, next ) => {
 	next();
 };
 
-export const redirectHomeIfIneligible: PageJS.Callback = ( context, next ) => {
+export const redirectHomeIfIneligible: Callback = ( context, next ) => {
 	const state = context.store.getState();
 	const siteId = getSelectedSiteId( state );
 

--- a/client/my-sites/site-monitoring/index.ts
+++ b/client/my-sites/site-monitoring/index.ts
@@ -1,4 +1,4 @@
-import page from 'page';
+import page, { type Callback } from 'page';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
 import { redirectHomeIfIneligible, siteMetrics } from './controller';
@@ -17,7 +17,7 @@ export default function () {
 	);
 
 	// Legacy redirect for Site Logs.
-	const redirectSiteLogsToMonitoring: PageJS.Callback = ( context ) => {
+	const redirectSiteLogsToMonitoring: Callback = ( context ) => {
 		if ( context.params?.siteId ) {
 			context.page.replace( `/site-monitoring/${ context.params.siteId }` );
 		} else {

--- a/client/site-profiler/controller.tsx
+++ b/client/site-profiler/controller.tsx
@@ -1,20 +1,20 @@
 import config from '@automattic/calypso-config';
 import { UniversalNavbarFooter } from '@automattic/wpcom-template-parts';
-import page from 'page';
+import page, { type Callback } from 'page';
 import { ChangeEvent } from 'react';
 import Main from 'calypso/components/main';
 import SiteProfiler from 'calypso/site-profiler/components/site-profiler';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
-export function featureFlagFirewall( context: PageJS.Context, next: () => void ) {
+export const featureFlagFirewall: Callback = ( _context, next ) => {
 	if ( config.isEnabled( 'site-profiler' ) ) {
 		next();
 	} else {
 		page.redirect( '/' );
 	}
-}
+};
 
-export function handleDomainQueryParam( context: PageJS.Context, next: () => void ) {
+export const handleDomainQueryParam: Callback = ( context, next ) => {
 	const { querystring } = context;
 	const queryParams = new URLSearchParams( querystring );
 	const domainQueryParam = queryParams.get( 'domain' ) || '';
@@ -24,9 +24,9 @@ export function handleDomainQueryParam( context: PageJS.Context, next: () => voi
 	} else {
 		page.redirect( `/site-profiler/${ domainQueryParam }` );
 	}
-}
+};
 
-export function redirectToBaseSiteProfilerRoute( context: PageJS.Context ) {
+export const redirectToBaseSiteProfilerRoute: Callback = ( context ) => {
 	const { params, querystring } = context;
 
 	if ( params?.domain ) {
@@ -36,9 +36,9 @@ export function redirectToBaseSiteProfilerRoute( context: PageJS.Context ) {
 	} else {
 		page.redirect( '/site-profiler' );
 	}
-}
+};
 
-export function siteProfilerContext( context: PageJS.Context, next: () => void ): void {
+export const siteProfilerContext: Callback = ( context, next ) => {
 	const isLoggedIn = isUserLoggedIn( context.store.getState() );
 	const pathName = context.pathname || '';
 	const routerDomain = pathName.split( '/site-profiler/' )[ 1 ]?.trim() || '';
@@ -58,4 +58,4 @@ export function siteProfilerContext( context: PageJS.Context, next: () => void )
 	);
 
 	next();
-}
+};


### PR DESCRIPTION
As a preparation for Calypso Router in #84096, this PR fixes how `page` types are used and imported. We no longer rely on the `PageJS` global namespace (the Calypso Router PR is going to remove it), but carefully `import` the types wherever they are needed.

We also start to use the `Callback` type to annotate handlers, which has the advantage that the types for `context`, `next` parameters and for the return value are inferred and don't need to be specified explicitly.

Lastly, there is a fix for the `AddOnsMain` component which didn't use its `context` prop, so I'm removing it. (cc @chriskmnds)

**How to test:**
Verify that all code changes are types only, no runtime behavior changes.