### PR TITLE
Tooltip to packages (Step 3): Update references to use new package component

### DIFF
--- a/client/blocks/taxonomy-manager/list-item.jsx
+++ b/client/blocks/taxonomy-manager/list-item.jsx
@@ -1,5 +1,5 @@
 import page from '@automattic/calypso-router';
-import { Count, Dialog, Gridicon } from '@automattic/components';
+import { Count, Dialog, Gridicon, Tooltip } from '@automattic/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
@@ -10,7 +10,6 @@ import EllipsisMenu from 'calypso/components/ellipsis-menu';
 import PodcastIndicator from 'calypso/components/podcast-indicator';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import PopoverMenuSeparator from 'calypso/components/popover-menu/separator';
-import Tooltip from 'calypso/components/tooltip';
 import { decodeEntities } from 'calypso/lib/formatting';
 import { recordGoogleEvent, bumpStat } from 'calypso/state/analytics/actions';
 import getPodcastingCategoryId from 'calypso/state/selectors/get-podcasting-category-id';

--- a/client/components/backup-retention-management/info-tooltip/index.tsx
+++ b/client/components/backup-retention-management/info-tooltip/index.tsx
@@ -1,8 +1,7 @@
-import { Button, Gridicon } from '@automattic/components';
+import { Button, Gridicon, Tooltip } from '@automattic/components';
 import { useRef, useState } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
-import Tooltip from 'calypso/components/tooltip';
 import { STORAGE_RETENTION_LEARN_MORE_LINK } from '../constants';
 import './style.scss';
 

--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -1,9 +1,9 @@
+import { Tooltip } from '@automattic/components';
 import classNames from 'classnames';
 import { localize, withRtl } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { useState, useCallback, useMemo, useEffect } from 'react';
 import Notice from 'calypso/components/notice';
-import Tooltip from 'calypso/components/tooltip';
 import { hasTouch } from 'calypso/lib/touch-detect';
 import { useWindowResizeCallback } from 'calypso/lib/track-element-size';
 import BarContainer from './bar-container';

--- a/client/components/date-picker/events-tooltip.jsx
+++ b/client/components/date-picker/events-tooltip.jsx
@@ -1,8 +1,8 @@
+import { Tooltip } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { map } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
-import Tooltip from 'calypso/components/tooltip';
 import { CalendarEvent } from './event';
 
 const noop = () => {};

--- a/client/components/line-chart/index.js
+++ b/client/components/line-chart/index.js
@@ -1,3 +1,4 @@
+import { Tooltip } from '@automattic/components';
 import { extent as d3Extent } from 'd3-array';
 import { axisBottom as d3AxisBottom, axisRight as d3AxisRight } from 'd3-axis';
 import { scaleLinear as d3ScaleLinear, scaleTime as d3TimeScale } from 'd3-scale';
@@ -8,7 +9,6 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import D3Base from 'calypso/components/d3-base';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
-import Tooltip from 'calypso/components/tooltip';
 import LineChartLegend from './legend';
 
 import './style.scss';

--- a/client/components/podcast-indicator/index.jsx
+++ b/client/components/podcast-indicator/index.jsx
@@ -1,9 +1,8 @@
-import { Gridicon } from '@automattic/components';
+import { Gridicon, Tooltip } from '@automattic/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { createRef, Component } from 'react';
-import Tooltip from 'calypso/components/tooltip';
 
 import './style.scss';
 

--- a/client/components/token-field/token.jsx
+++ b/client/components/token-field/token.jsx
@@ -1,8 +1,7 @@
-import { Gridicon } from '@automattic/components';
+import { Gridicon, Tooltip } from '@automattic/components';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
-import Tooltip from 'calypso/components/tooltip';
 
 export default class extends PureComponent {
 	static displayName = 'Token';

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/not-available-badge/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/not-available-badge/index.tsx
@@ -1,7 +1,6 @@
-import { Badge } from '@automattic/components';
+import { Badge, Tooltip } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useRef, useState } from 'react';
-import Tooltip from 'calypso/components/tooltip';
 
 import './style.scss';
 

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/index.tsx
@@ -1,12 +1,11 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { Button } from '@automattic/components';
+import { Button, Tooltip } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { ReactNode, useState, useRef } from 'react';
 import alertIcon from 'calypso/assets/images/jetpack/alert-icon.svg';
 import clockIcon from 'calypso/assets/images/jetpack/clock-icon.svg';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
-import Tooltip from 'calypso/components/tooltip';
 import { useSelector } from 'calypso/state';
 import { getSiteMonitorStatuses } from 'calypso/state/jetpack-agency-dashboard/selectors';
 import { useJetpackAgencyDashboardRecordTrackEvent, useToggleActivateMonitor } from '../../hooks';

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
@@ -1,9 +1,8 @@
-import { Button, Gridicon } from '@automattic/components';
+import { Button, Gridicon, Tooltip } from '@automattic/components';
 import { Icon, help } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useRef, useState, useMemo } from 'react';
-import Tooltip from 'calypso/components/tooltip';
 import { useSelector } from 'calypso/state';
 import { getCurrentPartner } from 'calypso/state/partner-portal/partner/selectors';
 import { jetpackBoostDesktopIcon, jetpackBoostMobileIcon } from '../../icons';

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/in-progress-icon.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/in-progress-icon.tsx
@@ -1,7 +1,6 @@
-import { Gridicon } from '@automattic/components';
+import { Gridicon, Tooltip } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useRef, useState } from 'react';
-import Tooltip from 'calypso/components/tooltip';
 
 export default function InProgressIcon() {
 	const translate = useTranslate();

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-select-checkbox/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-select-checkbox/index.tsx
@@ -1,6 +1,6 @@
+import { Tooltip } from '@automattic/components';
 import { ReactNode, useRef, useState } from 'react';
 import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
-import Tooltip from 'calypso/components/tooltip';
 import { useJetpackAgencyDashboardRecordTrackEvent } from '../../hooks';
 import type { SiteData } from '../types';
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-host-info.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-host-info.tsx
@@ -1,9 +1,8 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { WordPressLogo } from '@automattic/components';
+import { WordPressLogo, Tooltip } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useRef, useState } from 'react';
-import Tooltip from 'calypso/components/tooltip';
 import useWPPlanName from './hooks/use-wp-plan-name';
 import type { Site } from '../types';
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-status-column.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-status-column.tsx
@@ -1,9 +1,8 @@
 import page from '@automattic/calypso-router';
-import { Gridicon } from '@automattic/components';
+import { Gridicon, Tooltip } from '@automattic/components';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo, useRef, useState } from 'react';
-import Tooltip from 'calypso/components/tooltip';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { selectLicense, unselectLicense } from 'calypso/state/jetpack-agency-dashboard/actions';

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-expand/site-table-tooltip.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-expand/site-table-tooltip.tsx
@@ -1,6 +1,6 @@
+import { Tooltip } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { forwardRef } from 'react';
-import Tooltip from 'calypso/components/tooltip';
 
 interface Props {
 	siteId: number;

--- a/client/jetpack-cloud/sections/partner-portal/billing-summary/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/billing-summary/index.tsx
@@ -1,9 +1,8 @@
-import { Button, Card, Gridicon } from '@automattic/components';
+import { Button, Card, Gridicon, Tooltip } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import { numberFormat, useTranslate } from 'i18n-calypso';
 import { useCallback, useRef, useState } from 'react';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
-import Tooltip from 'calypso/components/tooltip';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';

--- a/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/card-content.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/card-content.tsx
@@ -1,10 +1,9 @@
 import { getPlan, PLAN_BUSINESS, PLAN_ECOMMERCE } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
-import { Button, JetpackLogo, WooLogo, CloudLogo } from '@automattic/components';
+import { Button, JetpackLogo, WooLogo, CloudLogo, Tooltip } from '@automattic/components';
 import { formatCurrency } from '@automattic/format-currency';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useRef, useState } from 'react';
-import Tooltip from 'calypso/components/tooltip';
 import useIssueLicenses from 'calypso/jetpack-cloud/sections/partner-portal/hooks/use-issue-licenses';
 import { getPlanFeaturesObject } from 'calypso/lib/plans/features-list';
 import { useDispatch } from 'calypso/state';

--- a/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/feature-item.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/feature-item.tsx
@@ -1,5 +1,5 @@
+import { Tooltip } from '@automattic/components';
 import { useRef, useState } from 'react';
-import Tooltip from 'calypso/components/tooltip';
 
 interface Props {
 	feature: string;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -1,5 +1,5 @@
 import { PLAN_PREMIUM } from '@automattic/calypso-products';
-import { Badge, CircularProgressBar, Gridicon } from '@automattic/components';
+import { Badge, CircularProgressBar, Gridicon, Tooltip } from '@automattic/components';
 import { OnboardSelect, useLaunchpad } from '@automattic/data-stores';
 import { LaunchpadInternal } from '@automattic/launchpad';
 import { isBlogOnboardingFlow } from '@automattic/onboarding';
@@ -10,7 +10,6 @@ import { copy, Icon } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import QueryMembershipsSettings from 'calypso/components/data/query-memberships-settings';
 import ClipboardButton from 'calypso/components/forms/clipboard-button';
-import Tooltip from 'calypso/components/tooltip';
 import { type NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';

--- a/client/me/security-2fa-backup-codes-list/index.jsx
+++ b/client/me/security-2fa-backup-codes-list/index.jsx
@@ -1,4 +1,4 @@
-import { Button, Gridicon } from '@automattic/components';
+import { Button, Gridicon, Tooltip } from '@automattic/components';
 import { saveAs } from 'browser-filesaver';
 import Clipboard from 'clipboard';
 import { localize } from 'i18n-calypso';
@@ -13,7 +13,6 @@ import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import FormLabel from 'calypso/components/forms/form-label';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import Notice from 'calypso/components/notice';
-import Tooltip from 'calypso/components/tooltip';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserName } from 'calypso/state/current-user/selectors';
 

--- a/client/my-sites/comments/comment/comment-author.jsx
+++ b/client/my-sites/comments/comment/comment-author.jsx
@@ -1,4 +1,4 @@
-import { Gridicon } from '@automattic/components';
+import { Gridicon, Tooltip } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
@@ -7,7 +7,6 @@ import { connect } from 'react-redux';
 import ExternalLink from 'calypso/components/external-link';
 import Gravatar from 'calypso/components/gravatar';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
-import Tooltip from 'calypso/components/tooltip';
 import { decodeEntities } from 'calypso/lib/formatting';
 import { urlToDomainAndPath } from 'calypso/lib/url';
 import CommentLink from 'calypso/my-sites/comments/comment/comment-link';

--- a/client/my-sites/customer-home/components/celebrate-launch-modal.jsx
+++ b/client/my-sites/customer-home/components/celebrate-launch-modal.jsx
@@ -1,11 +1,10 @@
-import { Gridicon, ConfettiAnimation } from '@automattic/components';
+import { Gridicon, ConfettiAnimation, Tooltip } from '@automattic/components';
 import { Button, Modal } from '@wordpress/components';
 import { Icon, copy } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState, useRef } from 'react';
 import { useDispatch } from 'react-redux';
 import ClipboardButton from 'calypso/components/forms/clipboard-button';
-import Tooltip from 'calypso/components/tooltip';
 import { omitUrlParams } from 'calypso/lib/url';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { createSiteDomainObject } from 'calypso/state/sites/domains/assembler';

--- a/client/my-sites/exporter/export-card/post-type-options.jsx
+++ b/client/my-sites/exporter/export-card/post-type-options.jsx
@@ -1,10 +1,10 @@
+import { Tooltip } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import Label from 'calypso/components/forms/form-label';
 import FormRadio from 'calypso/components/forms/form-radio';
-import Tooltip from 'calypso/components/tooltip';
 import { setPostType } from 'calypso/state/exporter/actions';
 import {
 	getSelectedPostType,

--- a/client/my-sites/plans-grid/components/plans-2023-tooltip.tsx
+++ b/client/my-sites/plans-grid/components/plans-2023-tooltip.tsx
@@ -1,7 +1,7 @@
+import { Tooltip } from '@automattic/components';
 import styled from '@emotion/styled';
 import { TranslateResult } from 'i18n-calypso';
 import { Dispatch, PropsWithChildren, SetStateAction, useRef } from 'react';
-import Tooltip from 'calypso/components/tooltip';
 import { hasTouch } from '../lib/touch-detect';
 
 const HoverAreaContainer = styled.span`

--- a/client/my-sites/stats/post-trends/day.jsx
+++ b/client/my-sites/stats/post-trends/day.jsx
@@ -1,9 +1,9 @@
+import { Tooltip } from '@automattic/components';
 import { Icon, postContent } from '@wordpress/icons';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { createRef, PureComponent, Fragment } from 'react';
-import Tooltip from 'calypso/components/tooltip';
 
 class PostTrendsDay extends PureComponent {
 	static propTypes = {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/79002

We should wait for https://github.com/Automattic/wp-calypso/pull/83646 to sit in production for several days before merging this PR. It will allow us to see if there were any problems with our migration.

## Proposed Changes

- Repoints any references to `Tooltip` from Calypso components to `@automattic/components`
- This is a change that touches many files. We effectively made this change in the background with https://github.com/Automattic/wp-calypso/pull/83646, so all `Tooltip` components are running the new/relocated code already. This PR repoints the reference from the wrapper to the "real" code, so I don't expect this to cause any issues.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Make sure tests pass.
- Do a spot-check of `Tooltip` instances to ensure they still look/work as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?