### PR TITLE
Jetpack Cloud landing page: fix redirect when no primary site

### DIFF
--- a/client/jetpack-cloud/sections/landing/controller.tsx
+++ b/client/jetpack-cloud/sections/landing/controller.tsx
@@ -19,7 +19,7 @@ const landForSiteId = ( siteId: number | null, context: Context, next: () => voi
 	// if we don't have one, redirect to the site selection page
 	if ( ! Number.isInteger( siteId ) ) {
 		debug( '[landForSiteId]: site ID not specified; redirecting to site selection' );
-		return '/landing';
+		return page.redirect( '/landing' );
 	}
 
 	const state = context.store.getState();


### PR DESCRIPTION
Fixes a bug in Jetpack Cloud's `landForSiteId` helper that I noticed when working on #84181.

There'no point for a page.js handler to return a path, nobody will use the return value. Instead we want to call `page.redirect()` on the path. That's the fix. The bug was probably introduced during some refactoring involving the `getLandingPath`, which does return paths.

**How to test:**
Probably the only scenario where the modified code matters is the redirect from `/` to `/landing` when the user has no primary site ID set. A very rare edge case.

`landForSiteId` is also used when redirecting from `/landing/unknown.site` to `/landing`, but not really: in that case, the `siteSelection` handler will do the redirect first (to `/landing?site=unknown.site`).