### PR TITLE
VideoPress Onboarding: Disable user intent

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/components/step-route/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/index.tsx
@@ -53,13 +53,7 @@ const StepRoute = ( {
 				kebabCase( step.slug )
 			) }
 		>
-			{
-				! isEnabled( 'videopress-onboarding-user-intent' ) &&
-					'videopress' === flow.name &&
-					'intro' === step.slug && (
-						<VideoPressIntroBackground />
-					) /* Temporary disbale intro background while we run videopress-onboarding-intent as intro page */
-			}
+			{ 'videopress' === flow.name && 'intro' === step.slug && <VideoPressIntroBackground /> }
 			{ renderProgressBar() }
 			<SignupHeader pageTitle={ flow.title } showWooLogo={ showWooLogo } />
 			{ renderStep( step ) }

--- a/client/landing/stepper/declarative-flow/videopress.ts
+++ b/client/landing/stepper/declarative-flow/videopress.ts
@@ -29,15 +29,10 @@ const videopress: Flow = {
 		return translate( 'Video' );
 	},
 	useSteps() {
-		const isIntentEnabled = config.isEnabled( 'videopress-onboarding-user-intent' );
-
 		return [
 			{
 				slug: 'intro',
-				asyncComponent: () =>
-					isIntentEnabled
-						? import( './internals/steps-repository/videopress-onboarding-intent' )
-						: import( './internals/steps-repository/intro' ),
+				asyncComponent: () => import( './internals/steps-repository/intro' ),
 			},
 			{ slug: 'videomakerSetup', component: VideomakerSetup },
 			{ slug: 'options', component: SiteOptions },

--- a/config/development.json
+++ b/config/development.json
@@ -214,7 +214,6 @@
 		"user-management-revamp": true,
 		"videomaker-trial": true,
 		"videopress-tv": true,
-		"videopress-onboarding-user-intent": true,
 		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -152,7 +152,6 @@
 		"user-management-revamp": true,
 		"videomaker-trial": false,
 		"videopress-tv": true,
-		"videopress-onboarding-user-intent": true,
 		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,

--- a/config/production.json
+++ b/config/production.json
@@ -180,7 +180,6 @@
 		"user-management-revamp": true,
 		"videomaker-trial": false,
 		"videopress-tv": false,
-		"videopress-onboarding-user-intent": true,
 		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -174,7 +174,6 @@
 		"use-translation-chunks": true,
 		"user-management-revamp": true,
 		"videomaker-trial": false,
-		"videopress-onboarding-user-intent": true,
 		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,

--- a/config/test.json
+++ b/config/test.json
@@ -112,7 +112,6 @@
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,
 		"videomaker-trial": false,
-		"videopress-onboarding-user-intent": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": false,
 		"yolo/hosting-metrics-i1": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -183,7 +183,6 @@
 		"use-translation-chunks": true,
 		"user-management-revamp": true,
 		"videomaker-trial": false,
-		"videopress-onboarding-user-intent": true,
 		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/greenhouse/issues/1958

## Proposed Changes

* Disables The user intent experiment.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Visit `http://calypso.localhost:3000/setup/videopress`
* Intro shows up.
* Check that other flow intro steps are not affected. E.g. `http://calypso.localhost:3000/setup/link-in-bio`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?