### PR TITLE
JP Manage: 87 - Disable the "Issue License" button if the partner cannot issue licenses

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -281,7 +281,7 @@ export default function SitesOverview() {
 						{ data?.sites && <SiteAddLicenseNotification /> }
 						<SiteContentHeader
 							content={
-								// render content only on large screens, The buttons for small scren have their own section
+								// render content only on large screens, The buttons for small screen have their own section
 								isLargeScreen &&
 								( selectedLicensesCount > 0 ? (
 									renderIssueLicenseButton()

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons/index.tsx
@@ -26,12 +26,7 @@ export default function SiteTopHeaderButtons() {
 	const partnerCanIssueLicense = Boolean( partner?.can_issue_licenses );
 
 	const onIssueNewLicenseClick = () => {
-		if ( partnerCanIssueLicense ) {
-			window.location.href = '/partner-portal/issue-license';
-			dispatch(
-				recordTracksEvent( 'calypso_jetpack_agency_dashboard_issue_license_button_click' )
-			);
-		}
+		dispatch( recordTracksEvent( 'calypso_jetpack_agency_dashboard_issue_license_button_click' ) );
 	};
 
 	return (
@@ -41,6 +36,7 @@ export default function SiteTopHeaderButtons() {
 			} ) }
 		>
 			<Button
+				href={ partnerCanIssueLicense ? '/partner-portal/issue-license' : undefined }
 				className="sites-overview__issue-license-button"
 				disabled={ ! partnerCanIssueLicense }
 				onClick={ onIssueNewLicenseClick }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons/index.tsx
@@ -5,14 +5,16 @@ import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useRef, useState } from 'react';
 import AddNewSiteButton from 'calypso/components/jetpack/add-new-site-button';
-import { useDispatch } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getCurrentPartner } from 'calypso/state/partner-portal/partner/selectors';
 import WPCOMHostingPopover from './wpcom-hosting-popover';
 
 export default function SiteTopHeaderButtons() {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const isMobile = useMobileBreakpoint();
+	const partner = useSelector( getCurrentPartner );
 
 	const isWPCOMAtomicSiteCreationEnabled = isEnabled(
 		'jetpack/pro-dashboard-wpcom-atomic-hosting'
@@ -20,6 +22,17 @@ export default function SiteTopHeaderButtons() {
 
 	const buttonRef = useRef< HTMLElement | null >( null );
 	const [ toggleIsOpen, setToggleIsOpen ] = useState( false );
+
+	const partnerCanIssueLicense = Boolean( partner?.can_issue_licenses );
+
+	const onIssueNewLicenseClick = () => {
+		if ( partnerCanIssueLicense ) {
+			window.location.href = '/partner-portal/issue-license';
+			dispatch(
+				recordTracksEvent( 'calypso_jetpack_agency_dashboard_issue_license_button_click' )
+			);
+		}
+	};
 
 	return (
 		<div
@@ -29,12 +42,8 @@ export default function SiteTopHeaderButtons() {
 		>
 			<Button
 				className="sites-overview__issue-license-button"
-				href="/partner-portal/issue-license"
-				onClick={ () =>
-					dispatch(
-						recordTracksEvent( 'calypso_jetpack_agency_dashboard_issue_license_button_click' )
-					)
-				}
+				disabled={ ! partnerCanIssueLicense }
+				onClick={ onIssueNewLicenseClick }
 			>
 				{ translate( 'Issue License', { context: 'button label' } ) }
 			</Button>

--- a/client/jetpack-cloud/sections/partner-portal/license-list/empty.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-list/empty.tsx
@@ -30,10 +30,7 @@ export default function LicenseListEmpty( { filter }: Props ) {
 	const licenseFilterStatusTitle = licenseFilterStatusTitleMap[ filter ] as string;
 
 	const onIssueNewLicense = () => {
-		if ( partnerCanIssueLicense ) {
-			window.location.href = '/partner-portal/issue-license';
-			dispatch( recordTracksEvent( 'calypso_partner_portal_issue_license_click_billing_page' ) );
-		}
+		dispatch( recordTracksEvent( 'calypso_partner_portal_issue_license_click_billing_page' ) );
 	};
 
 	return (
@@ -64,7 +61,11 @@ export default function LicenseListEmpty( { filter }: Props ) {
 				<p>{ translate( 'Every license you own is currently attached to a site.' ) }</p>
 			) }
 
-			<Button disabled={ ! partnerCanIssueLicense } onClick={ onIssueNewLicense }>
+			<Button
+				disabled={ ! partnerCanIssueLicense }
+				href={ partnerCanIssueLicense ? '/partner-portal/issue-license' : undefined }
+				onClick={ onIssueNewLicense }
+			>
 				{ translate( 'Issue New License' ) }
 			</Button>
 		</div>

--- a/client/jetpack-cloud/sections/partner-portal/license-list/empty.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-list/empty.tsx
@@ -5,6 +5,7 @@ import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getLicenseCounts } from 'calypso/state/partner-portal/licenses/selectors';
 import './style.scss';
+import { getCurrentPartner } from 'calypso/state/partner-portal/partner/selectors';
 
 interface Props {
 	filter: LicenseFilter;
@@ -15,6 +16,8 @@ export default function LicenseListEmpty( { filter }: Props ) {
 	const translate = useTranslate();
 	const counts = useSelector( getLicenseCounts );
 	const hasAssignedLicenses = counts[ LicenseFilter.Attached ] > 0;
+	const partner = useSelector( getCurrentPartner );
+	const partnerCanIssueLicense = Boolean( partner?.can_issue_licenses );
 
 	const licenseFilterStatusTitleMap = {
 		[ LicenseFilter.NotRevoked ]: translate( 'No active licenses' ),
@@ -27,9 +30,10 @@ export default function LicenseListEmpty( { filter }: Props ) {
 	const licenseFilterStatusTitle = licenseFilterStatusTitleMap[ filter ] as string;
 
 	const onIssueNewLicense = () => {
-		dispatch(
-			recordTracksEvent( 'calypso_partner_portal_license_list_empty_issue_license_click' )
-		);
+		if ( partnerCanIssueLicense ) {
+			window.location.href = '/partner-portal/issue-license';
+			dispatch( recordTracksEvent( 'calypso_partner_portal_issue_license_click_billing_page' ) );
+		}
 	};
 
 	return (
@@ -60,7 +64,7 @@ export default function LicenseListEmpty( { filter }: Props ) {
 				<p>{ translate( 'Every license you own is currently attached to a site.' ) }</p>
 			) }
 
-			<Button href="/partner-portal/issue-license" onClick={ onIssueNewLicense }>
+			<Button disabled={ ! partnerCanIssueLicense } onClick={ onIssueNewLicense }>
 				{ translate( 'Issue New License' ) }
 			</Button>
 		</div>

--- a/client/jetpack-cloud/sections/partner-portal/license-list/empty.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-list/empty.tsx
@@ -30,7 +30,9 @@ export default function LicenseListEmpty( { filter }: Props ) {
 	const licenseFilterStatusTitle = licenseFilterStatusTitleMap[ filter ] as string;
 
 	const onIssueNewLicense = () => {
-		dispatch( recordTracksEvent( 'calypso_partner_portal_issue_license_click_billing_page' ) );
+		dispatch(
+			recordTracksEvent( 'calypso_partner_portal_license_list_empty_issue_license_click' )
+		);
 	};
 
 	return (

--- a/client/jetpack-cloud/sections/partner-portal/primary/billing-dashboard/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/billing-dashboard/index.tsx
@@ -19,10 +19,7 @@ export default function BillingDashboard() {
 	const partnerCanIssueLicense = Boolean( partner?.can_issue_licenses );
 
 	const onIssueNewLicenseClick = () => {
-		if ( partnerCanIssueLicense ) {
-			window.location.href = '/partner-portal/issue-license';
-			dispatch( recordTracksEvent( 'calypso_partner_portal_issue_license_click_billing_page' ) );
-		}
+		dispatch( recordTracksEvent( 'calypso_partner_portal_issue_license_click_billing_page' ) );
 	};
 
 	return (
@@ -33,7 +30,12 @@ export default function BillingDashboard() {
 
 					<SelectPartnerKeyDropdown />
 
-					<Button disabled={ ! partnerCanIssueLicense } primary onClick={ onIssueNewLicenseClick }>
+					<Button
+						disabled={ ! partnerCanIssueLicense }
+						href={ partnerCanIssueLicense ? '/partner-portal/issue-license' : undefined }
+						primary
+						onClick={ onIssueNewLicenseClick }
+					>
 						{ translate( 'Issue New License' ) }
 					</Button>
 				</LayoutHeader>

--- a/client/jetpack-cloud/sections/partner-portal/primary/billing-dashboard/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/billing-dashboard/index.tsx
@@ -4,8 +4,9 @@ import CardHeading from 'calypso/components/card-heading';
 import BillingDetails from 'calypso/jetpack-cloud/sections/partner-portal/billing-details';
 import BillingSummary from 'calypso/jetpack-cloud/sections/partner-portal/billing-summary';
 import SelectPartnerKeyDropdown from 'calypso/jetpack-cloud/sections/partner-portal/select-partner-key-dropdown';
-import { useDispatch } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getCurrentPartner } from 'calypso/state/partner-portal/partner/selectors';
 import Layout from '../../layout';
 import LayoutBody from '../../layout/body';
 import LayoutHeader from '../../layout/header';
@@ -14,9 +15,14 @@ import LayoutTop from '../../layout/top';
 export default function BillingDashboard() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+	const partner = useSelector( getCurrentPartner );
+	const partnerCanIssueLicense = Boolean( partner?.can_issue_licenses );
 
 	const onIssueNewLicenseClick = () => {
-		dispatch( recordTracksEvent( 'calypso_partner_portal_issue_license_click_billing_page' ) );
+		if ( partnerCanIssueLicense ) {
+			window.location.href = '/partner-portal/issue-license';
+			dispatch( recordTracksEvent( 'calypso_partner_portal_issue_license_click_billing_page' ) );
+		}
 	};
 
 	return (
@@ -27,7 +33,7 @@ export default function BillingDashboard() {
 
 					<SelectPartnerKeyDropdown />
 
-					<Button primary href="/partner-portal/issue-license" onClick={ onIssueNewLicenseClick }>
+					<Button disabled={ ! partnerCanIssueLicense } primary onClick={ onIssueNewLicenseClick }>
 						{ translate( 'Issue New License' ) }
 					</Button>
 				</LayoutHeader>

--- a/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
@@ -83,10 +83,7 @@ export default function Licenses( {
 	};
 
 	const onIssueNewLicenseClick = () => {
-		if ( partnerCanIssueLicense ) {
-			window.location.href = '/partner-portal/issue-license';
-			dispatch( recordTracksEvent( 'calypso_partner_portal_license_list_issue_license_click' ) );
-		}
+		dispatch( recordTracksEvent( 'calypso_partner_portal_license_list_issue_license_click' ) );
 	};
 
 	const showEmptyStateContent = hasFetched && allLicensesCount === 0;
@@ -119,6 +116,7 @@ export default function Licenses( {
 
 						<Button
 							disabled={ ! partnerCanIssueLicense }
+							href={ partnerCanIssueLicense ? '/partner-portal/issue-license' : undefined }
 							onClick={ onIssueNewLicenseClick }
 							primary
 							style={ { marginLeft: 'auto' } }

--- a/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
@@ -23,7 +23,10 @@ import {
 	getLicenseCounts,
 	hasFetchedLicenseCounts,
 } from 'calypso/state/partner-portal/licenses/selectors';
-import { showAgencyDashboard } from 'calypso/state/partner-portal/partner/selectors';
+import {
+	getCurrentPartner,
+	showAgencyDashboard,
+} from 'calypso/state/partner-portal/partner/selectors';
 import Layout from '../../layout';
 import LayoutBody from '../../layout/body';
 import LayoutHeader from '../../layout/header';
@@ -55,6 +58,8 @@ export default function Licenses( {
 	const hasFetched = useSelector( hasFetchedLicenseCounts );
 	const allLicensesCount = counts[ 'all' ];
 	const provisioningSite = getQueryArg( window.location.href, 'provisioning' ) as string;
+	const partner = useSelector( getCurrentPartner );
+	const partnerCanIssueLicense = Boolean( partner?.can_issue_licenses );
 
 	useEffect( () => {
 		if ( 'true' === provisioningSite ) {
@@ -78,7 +83,10 @@ export default function Licenses( {
 	};
 
 	const onIssueNewLicenseClick = () => {
-		dispatch( recordTracksEvent( 'calypso_partner_portal_license_list_issue_license_click' ) );
+		if ( partnerCanIssueLicense ) {
+			window.location.href = '/partner-portal/issue-license';
+			dispatch( recordTracksEvent( 'calypso_partner_portal_license_list_issue_license_click' ) );
+		}
 	};
 
 	const showEmptyStateContent = hasFetched && allLicensesCount === 0;
@@ -110,7 +118,7 @@ export default function Licenses( {
 						<SelectPartnerKeyDropdown />
 
 						<Button
-							href="/partner-portal/issue-license"
+							disabled={ ! partnerCanIssueLicense }
 							onClick={ onIssueNewLicenseClick }
 							primary
 							style={ { marginLeft: 'auto' } }

--- a/client/jetpack-cloud/sections/partner-portal/primary/onboarding-widget/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/onboarding-widget/index.tsx
@@ -5,14 +5,16 @@ import { useState } from 'react';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { getCurrentPartner } from 'calypso/state/partner-portal/partner/selectors';
 import getSites from 'calypso/state/selectors/get-sites';
 import type { UserData } from 'calypso/lib/user/user';
-
 import './style.scss';
 
 export default function OnboardingWidget( { isLicensesPage }: { isLicensesPage?: boolean } ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+	const partner = useSelector( getCurrentPartner );
+	const partnerCanIssueLicense = Boolean( partner?.can_issue_licenses );
 
 	const [ isIframeLoaded, setIsIframeLoaded ] = useState( false );
 
@@ -20,13 +22,16 @@ export default function OnboardingWidget( { isLicensesPage }: { isLicensesPage?:
 	const sites = useSelector( getSites );
 
 	const onIssueNewLicenseClick = () => {
-		dispatch(
-			recordTracksEvent(
-				isLicensesPage
-					? 'calypso_partner_portal_empty_state_issue_license_click'
-					: 'calypso_jetpack_agency_dashboard_empty_state_issue_license_click'
-			)
-		);
+		if ( partnerCanIssueLicense ) {
+			window.location.href = '/partner-portal/issue-license';
+			dispatch(
+				recordTracksEvent(
+					isLicensesPage
+						? 'calypso_partner_portal_empty_state_issue_license_click'
+						: 'calypso_jetpack_agency_dashboard_empty_state_issue_license_click'
+				)
+			);
+		}
 	};
 
 	const onHowToAddNewSiteClick = () => {
@@ -82,7 +87,7 @@ export default function OnboardingWidget( { isLicensesPage }: { isLicensesPage?:
 				'https://video.wordpress.com/embed/nsqG1pBO?hd=1&amp;autoPlay=0&amp;permalink=1&amp;loop=0&amp;preloadContent=metadata&amp;muted=0&amp;playsinline=0&amp;controls=1&amp;cover=1',
 			extraContent: (
 				<Button
-					href="/partner-portal/issue-license"
+					disabled={ ! partnerCanIssueLicense }
 					onClick={ onIssueNewLicenseClick }
 					primary
 					style={ { marginLeft: 'auto' } }

--- a/client/jetpack-cloud/sections/partner-portal/primary/onboarding-widget/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/onboarding-widget/index.tsx
@@ -22,16 +22,13 @@ export default function OnboardingWidget( { isLicensesPage }: { isLicensesPage?:
 	const sites = useSelector( getSites );
 
 	const onIssueNewLicenseClick = () => {
-		if ( partnerCanIssueLicense ) {
-			window.location.href = '/partner-portal/issue-license';
-			dispatch(
-				recordTracksEvent(
-					isLicensesPage
-						? 'calypso_partner_portal_empty_state_issue_license_click'
-						: 'calypso_jetpack_agency_dashboard_empty_state_issue_license_click'
-				)
-			);
-		}
+		dispatch(
+			recordTracksEvent(
+				isLicensesPage
+					? 'calypso_partner_portal_empty_state_issue_license_click'
+					: 'calypso_jetpack_agency_dashboard_empty_state_issue_license_click'
+			)
+		);
 	};
 
 	const onHowToAddNewSiteClick = () => {
@@ -88,6 +85,7 @@ export default function OnboardingWidget( { isLicensesPage }: { isLicensesPage?:
 			extraContent: (
 				<Button
 					disabled={ ! partnerCanIssueLicense }
+					href={ partnerCanIssueLicense ? '/partner-portal/issue-license' : undefined }
 					onClick={ onIssueNewLicenseClick }
 					primary
 					style={ { marginLeft: 'auto' } }

--- a/client/state/partner-portal/types.ts
+++ b/client/state/partner-portal/types.ts
@@ -81,6 +81,7 @@ export interface APIPartner {
 	tos: string;
 	partner_type: string;
 	has_valid_payment_method: boolean;
+	can_issue_licenses: boolean;
 }
 
 // The API-returned license object is not quite consistent right now so we only define the properties we actively rely on.
@@ -200,6 +201,7 @@ export interface Partner {
 	tos: string;
 	partner_type: string;
 	has_valid_payment_method: boolean;
+	can_issue_licenses: boolean;
 }
 
 export interface PartnerStore {


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-manage/issues/87

## Proposed Changes

This PR disables the button "Issue License" on all the Partner Portal pages:

**/dashboard**
![image](https://github.com/Automattic/wp-calypso/assets/9832440/1a82f336-3bf9-4d5f-aeb1-ea58ab78064c)

**/partner-portal/licenses**
![image](https://github.com/Automattic/wp-calypso/assets/9832440/4381a84b-08ae-49cb-9a49-e6e0f9a1ed14)

**/partner-portal/billing**
![image](https://github.com/Automattic/wp-calypso/assets/9832440/82fe5559-b9bf-4854-94c1-861f29be78f3)

## Testing Instructions

- Apply this change.
- Ensure that you have in your sandbox the latest commits on the wpcom repo (trunk). In your `hosts`, point `public-api.wordpress.com` to your sandbox IP.
- You need a Partner account.
- Go to the following pages and check the "Add" button
   - /dashboard
   - /partner-portal/licenses
   - /partner-portal/billing
- If you, as a Partner, are allowed to issue licenses, you will see the button available and clickable.
- If you are not allowed to issue licenses, you will not see the button.
- **Note:** you can change your current value `can_issue_licenses` using the CLI in your sandbox:
   - `wp jetpack-start agency-can-issue-licenses {your_partner_id} --set-can-issue=yes`
   - `wp jetpack-start agency-can-issue-licenses {your_partner_id} --set-can-issue=no`
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?