### PR TITLE
Support: Expand chat closure message during closure

### DIFF
--- a/packages/components/src/gm-closure-notice/gm-closure-notice.tsx
+++ b/packages/components/src/gm-closure-notice/gm-closure-notice.tsx
@@ -73,7 +73,7 @@ export function GMClosureNotice( { displayAt, closesAt, reopensAt, enabled }: Pr
 
 	return (
 		<Panel className="a8c-components__gm-closure-notice">
-			<PanelBody initialOpen={ false } title={ heading }>
+			<PanelBody initialOpen={ period === 'during' } title={ heading }>
 				<PanelRow>{ MAIN_MESSAGES[ period ] }</PanelRow>
 			</PanelBody>
 		</Panel>


### PR DESCRIPTION
This should help customers that miss the collapsed notice - we're getting signals that they're missing the notice.

Props to @serabi for escalating this 🙇‍♂️ 

## Proposed Changes

* Expand the notice when we're in the chat closure period.

## Testing Instructions

- Open Help Center with a user that has chat support.
- Make sure the chat closure notice is expanded by default.

Before:
<img width="424" alt="Screenshot 2023-11-15 at 14 36 38" src="https://github.com/Automattic/wp-calypso/assets/3392497/1e2dbd36-d4e1-4edb-9f17-1fe3d183d939">

After:
<img width="429" alt="Screenshot 2023-11-15 at 14 36 48" src="https://github.com/Automattic/wp-calypso/assets/3392497/3c1242d6-1e25-4950-8b4d-009282c75ffd">
