### PR TITLE
Fix ETK video celebration modal always showing on save

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/lib/video-celebration-modal/use-should-show-video-celebration-modal.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/lib/video-celebration-modal/use-should-show-video-celebration-modal.ts
@@ -31,6 +31,8 @@ const useShouldShowVideoCelebrationModal = ( isEditorSaving: boolean ) => {
 
 		if ( 'videopress' === intent && ! hasSeenVideoCelebrationModal ) {
 			maybeRenderVideoCelebrationModal();
+		} else if ( hasSeenVideoCelebrationModal ) {
+			setShouldShowVideoCelebrationModal( false );
 		}
 	}, [
 		isEditorSaving, // included so that we check whether the video has been uploaded on save.

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/video-celebration-modal/index.jsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/video-celebration-modal/index.jsx
@@ -45,7 +45,7 @@ const VideoCelebrationModalInner = () => {
 			isEditorSaving: isSavingEntity,
 		};
 	} );
-	const shouldShowSellerCelebrationModal = useShouldShowVideoCelebrationModal( isEditorSaving );
+	const shouldShowVideoCelebrationModal = useShouldShowVideoCelebrationModal( isEditorSaving );
 
 	useEffect( () => {
 		// Conditions to show modal:
@@ -57,7 +57,7 @@ const VideoCelebrationModalInner = () => {
 			! isEditorSaving &&
 			previousIsEditorSaving.current &&
 			! hasDisplayedModal &&
-			shouldShowSellerCelebrationModal
+			shouldShowVideoCelebrationModal
 		) {
 			setIsModalOpen( true );
 			setHasDisplayedModal( true );
@@ -67,7 +67,7 @@ const VideoCelebrationModalInner = () => {
 	}, [
 		isEditorSaving,
 		hasDisplayedModal,
-		shouldShowSellerCelebrationModal,
+		shouldShowVideoCelebrationModal,
 		updateHasSeenVideoCelebrationModal,
 	] );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* prevent the video celebration modal from appearing more than once

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* pull pr
* from inside `apps/editing-toolkit` run `yarn dev --sync`
* create a new videopress motivated site (ex from `wordpress.com/setup/videopress` choose Portfolio site), OR reset an existing one from `wpsh` with `update_blog_option( [SITE_ID], 'has_seen_video_celebration_modal', false )`
* sandbox the site
* visit `/wp-admin/site-editor.php?calypso_origin=http%3A%2F%2Fcalypso.localhost%3A3000&canvas=edit`
* replace an existing video with a new upload
* press `Save` in the editor
* The Video Celebration modal SHOULD appear
* make a change on the page, press `Save` again.
* The Video celebration modal should NOT appear
* refresh the page, make a change and save.
* The Video celebration modal should NOT appear

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?