### PR TITLE
Reader: Allow media in compact posts to display full width if no excerpt is present

### DIFF
--- a/client/blocks/reader-excerpt/index.jsx
+++ b/client/blocks/reader-excerpt/index.jsx
@@ -121,7 +121,7 @@ const ReaderExcerpt = ( { post, setHasExcerpt } ) => {
 	const excerpt = chooseExcerpt( post );
 
 	useEffect( () => {
-		setHasExcerpt( !! excerpt );
+		setHasExcerpt?.( excerpt !== '' && excerpt !== null );
 	}, [ excerpt ] );
 
 	return (

--- a/client/blocks/reader-excerpt/index.jsx
+++ b/client/blocks/reader-excerpt/index.jsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import { trim, escapeRegExp } from 'lodash';
 import PropTypes from 'prop-types';
+import { useEffect } from 'react';
 import AutoDirection from 'calypso/components/auto-direction';
 import { domForHtml } from 'calypso/lib/post-normalizer/utils';
 
@@ -115,8 +116,13 @@ const chooseExcerpt = ( post ) => {
 	return null;
 };
 
-const ReaderExcerpt = ( { post } ) => {
+const ReaderExcerpt = ( { post, setHasExcerpt } ) => {
 	const isDailyPrompt = !! getDailyPromptText( post );
+	const excerpt = chooseExcerpt( post );
+
+	useEffect( () => {
+		setHasExcerpt( !! excerpt );
+	}, [ excerpt ] );
 
 	return (
 		<AutoDirection>
@@ -124,7 +130,7 @@ const ReaderExcerpt = ( { post } ) => {
 				className={ classNames( 'reader-excerpt__content reader-excerpt', {
 					'reader-excerpt__daily-prompt': isDailyPrompt,
 				} ) }
-				dangerouslySetInnerHTML={ { __html: chooseExcerpt( post ) } } // eslint-disable-line react/no-danger
+				dangerouslySetInnerHTML={ { __html: excerpt } } // eslint-disable-line react/no-danger
 			/>
 		</AutoDirection>
 	);

--- a/client/blocks/reader-featured-image/index.jsx
+++ b/client/blocks/reader-featured-image/index.jsx
@@ -22,6 +22,7 @@ const ReaderFeaturedImage = ( {
 	imageWidth,
 	imageHeight,
 	isCompactPost,
+	hasExcerpt,
 } ) => {
 	const featuredImageUrl = imageUrl || canonicalMedia?.src;
 	if ( featuredImageUrl === undefined ) {
@@ -38,7 +39,7 @@ const ReaderFeaturedImage = ( {
 	const safeCssUrl = cssSafeUrl( resizedUrl );
 	const newHeight =
 		imageHeight ||
-		( isCompactPost
+		( isCompactPost && hasExcerpt
 			? READER_COMPACT_POST_FEATURED_MAX_IMAGE_HEIGHT
 			: READER_FEATURED_MAX_IMAGE_HEIGHT );
 	let featuredImageStyle = { background: 'none' };

--- a/client/blocks/reader-featured-image/index.jsx
+++ b/client/blocks/reader-featured-image/index.jsx
@@ -30,7 +30,8 @@ const ReaderFeaturedImage = ( {
 	}
 	let resizedImageWidth = imageWidth;
 	if ( resizedImageWidth === undefined ) {
-		resizedImageWidth = isCompactPost ? READER_COMPACT_POST_FEATURED_MAX_IMAGE_WIDTH : 'auto';
+		resizedImageWidth =
+			isCompactPost && hasExcerpt ? READER_COMPACT_POST_FEATURED_MAX_IMAGE_WIDTH : 'auto';
 	}
 	// Don't resize image if it was already fetched.
 	const resizedUrl = fetched

--- a/client/blocks/reader-featured-video/index.jsx
+++ b/client/blocks/reader-featured-video/index.jsx
@@ -29,6 +29,7 @@ class ReaderFeaturedVideo extends Component {
 		isExpanded: PropTypes.bool,
 		isCompactPost: PropTypes.bool,
 		expandCard: PropTypes.func,
+		hasExcerpt: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -99,6 +100,7 @@ class ReaderFeaturedVideo extends Component {
 			href,
 			isExpanded,
 			isCompactPost,
+			hasExcerpt,
 		} = this.props;
 
 		const classNames = classnames( className, 'reader-featured-video' );
@@ -113,6 +115,7 @@ class ReaderFeaturedVideo extends Component {
 					href={ href }
 					fetched={ true }
 					isCompactPost={ isCompactPost }
+					hasExcerpt={ hasExcerpt }
 				>
 					{ allowPlaying && (
 						<img

--- a/client/blocks/reader-post-card/compact.jsx
+++ b/client/blocks/reader-post-card/compact.jsx
@@ -1,5 +1,7 @@
 import { useBreakpoint } from '@automattic/viewport-react';
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
+import { useState } from 'react';
 import ReaderExcerpt from 'calypso/blocks/reader-excerpt';
 import ReaderPostEllipsisMenu from 'calypso/blocks/reader-post-options-menu/reader-post-ellipsis-menu';
 import AutoDirection from 'calypso/components/auto-direction';
@@ -22,10 +24,15 @@ const CompactPost = ( {
 			: null;
 
 	const isSmallScreen = useBreakpoint( '<660px' );
+	const [ hasExcerpt, setHasExcerpt ] = useState( false );
 
 	return (
 		<div className="reader-post-card__post">
-			<div className="reader-post-card__post-content">
+			<div
+				className={ classNames( 'reader-post-card__post-content', {
+					'reader-post-card__no-excerpt': ! hasExcerpt,
+				} ) }
+			>
 				<div className="reader-post-card__post-details">
 					<div className="reader-post-card__post-heading">
 						<div className="reader-post-card__post-title-meta">
@@ -48,7 +55,7 @@ const CompactPost = ( {
 							/>
 						) }
 					</div>
-					<ReaderExcerpt post={ post } />
+					<ReaderExcerpt post={ post } setHasExcerpt={ setHasExcerpt } />
 				</div>
 				{ post.canonical_media && (
 					<div className="reader-post-card__post-media">

--- a/client/blocks/reader-post-card/compact.jsx
+++ b/client/blocks/reader-post-card/compact.jsx
@@ -25,6 +25,7 @@ const CompactPost = ( {
 
 	const isSmallScreen = useBreakpoint( '<660px' );
 	const [ hasExcerpt, setHasExcerpt ] = useState( false );
+	const imagePostWithoutExcerpt = post.canonical_media && ! hasExcerpt;
 
 	return (
 		<div className="reader-post-card__post">
@@ -45,7 +46,7 @@ const CompactPost = ( {
 							</AutoDirection>
 							{ postByline }
 						</div>
-						{ ( ! post.canonical_media || isSmallScreen ) && (
+						{ ( imagePostWithoutExcerpt || ! post.canonical_media || isSmallScreen ) && (
 							<ReaderPostEllipsisMenu
 								site={ site }
 								teams={ teams }
@@ -59,7 +60,7 @@ const CompactPost = ( {
 				</div>
 				{ post.canonical_media && (
 					<div className="reader-post-card__post-media">
-						{ ! isSmallScreen && (
+						{ ! isSmallScreen && hasExcerpt && (
 							<ReaderPostEllipsisMenu
 								site={ site }
 								teams={ teams }
@@ -75,6 +76,7 @@ const CompactPost = ( {
 							onVideoThumbnailClick={ onVideoThumbnailClick }
 							isVideoExpanded={ isExpanded }
 							isCompactPost={ true }
+							hasExcerpt={ hasExcerpt }
 						/>
 					</div>
 				) }

--- a/client/blocks/reader-post-card/compact.jsx
+++ b/client/blocks/reader-post-card/compact.jsx
@@ -24,7 +24,7 @@ const CompactPost = ( {
 			: null;
 
 	const isSmallScreen = useBreakpoint( '<660px' );
-	const [ hasExcerpt, setHasExcerpt ] = useState( false );
+	const [ hasExcerpt, setHasExcerpt ] = useState( true );
 	const imagePostWithoutExcerpt = post.canonical_media && ! hasExcerpt;
 
 	return (

--- a/client/blocks/reader-post-card/featured-asset.jsx
+++ b/client/blocks/reader-post-card/featured-asset.jsx
@@ -10,6 +10,7 @@ const FeaturedAsset = ( {
 	onVideoThumbnailClick,
 	isVideoExpanded,
 	isCompactPost,
+	hasExcerpt,
 } ) => {
 	if ( ! canonicalMedia ) {
 		return null;
@@ -34,6 +35,7 @@ const FeaturedAsset = ( {
 			postUrl={ postUrl }
 			canonicalMedia={ canonicalMedia }
 			isCompactPost={ isCompactPost }
+			hasExcerpt={ hasExcerpt }
 		/>
 	);
 };

--- a/client/blocks/reader-post-card/featured-asset.jsx
+++ b/client/blocks/reader-post-card/featured-asset.jsx
@@ -25,6 +25,7 @@ const FeaturedAsset = ( {
 				onThumbnailClick={ onVideoThumbnailClick }
 				isExpanded={ isVideoExpanded }
 				isCompactPost={ isCompactPost }
+				hasExcerpt={ hasExcerpt }
 			/>
 		);
 	}

--- a/client/blocks/reader-post-card/featured-images.jsx
+++ b/client/blocks/reader-post-card/featured-images.jsx
@@ -7,7 +7,7 @@ import {
 	READER_COMPACT_POST_FEATURED_MAX_IMAGE_HEIGHT,
 } from 'calypso/state/reader/posts/sizes';
 
-const ReaderFeaturedImages = ( { post, postUrl, canonicalMedia, isCompactPost } ) => {
+const ReaderFeaturedImages = ( { post, postUrl, canonicalMedia, isCompactPost, hasExcerpt } ) => {
 	const numImages = isCompactPost ? 1 : 4;
 	const imagesToDisplay = getImagesFromPostToDisplay( post, numImages );
 	if ( imagesToDisplay.length === 0 ) {
@@ -24,9 +24,10 @@ const ReaderFeaturedImages = ( { post, postUrl, canonicalMedia, isCompactPost } 
 	let classNames = 'reader-post-card__featured-images';
 	const listItems = imagesToDisplay.map( ( image, index, [ imageWidth, imageHeight ] ) => {
 		imageWidth = null;
-		imageHeight = isCompactPost
-			? READER_COMPACT_POST_FEATURED_MAX_IMAGE_HEIGHT
-			: READER_FEATURED_MAX_IMAGE_HEIGHT;
+		imageHeight =
+			isCompactPost && hasExcerpt
+				? READER_COMPACT_POST_FEATURED_MAX_IMAGE_HEIGHT
+				: READER_FEATURED_MAX_IMAGE_HEIGHT;
 
 		let width = '50%';
 

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -148,30 +148,6 @@
 	}
 
 	&.is-compact {
-		.reader-post-card__post-content:not(.reader-post-card__no-excerpt) {
-			.reader-featured-image {
-				width: 200px !important;
-
-				@include breakpoint-deprecated( "<660px" ) {
-					width: auto !important;
-					height: 300px !important;
-				}
-
-				@include breakpoint-deprecated( "<480px" ) {
-					height: 200px !important;
-				}
-			}
-		}
-
-		.reader-post-card__no-excerpt.reader-post-card__post-content {
-			flex-direction: column;
-			gap: 0;
-
-			.reader-post-card__post-details {
-				min-height: auto;
-			}
-		}
-
 		.reader-post-card__post {
 			display: inherit;
 			margin: 0;
@@ -189,6 +165,30 @@
 
 			@include breakpoint-deprecated( "<660px" ) {
 				flex-direction: column-reverse;
+			}
+
+			&.reader-post-card__no-excerpt {
+				flex-direction: column;
+				gap: 0;
+
+				.reader-post-card__post-details {
+					min-height: auto;
+				}
+			}
+
+			&:not(.reader-post-card__no-excerpt) {
+				.reader-featured-image {
+					width: 200px !important;
+
+					@include breakpoint-deprecated( "<660px" ) {
+						width: auto !important;
+						height: 300px !important;
+					}
+
+					@include breakpoint-deprecated( "<480px" ) {
+						height: 200px !important;
+					}
+				}
 			}
 		}
 

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -161,6 +161,24 @@
 			}
 		}
 
+		.reader-post-card__no-excerpt.reader-post-card__post-content {
+			flex-direction: column;
+			gap: 0;
+			.reader-featured-image {
+				width: 100% !important;
+				height: 400px !important;
+
+				@include breakpoint-deprecated( "<660px" ) {
+					width: 100% !important;
+					height: 300px !important;
+				}
+
+				@include breakpoint-deprecated( "<480px" ) {
+					height: 200px !important;
+				}
+			}
+		}
+
 		.reader-post-card__post {
 			display: inherit;
 			margin: 0;

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -148,37 +148,27 @@
 	}
 
 	&.is-compact {
-		.reader-featured-image {
-			width: 200px !important;
-
-			@include breakpoint-deprecated( "<660px" ) {
-				width: auto !important;
-				height: 300px !important;
-			}
-
-			@include breakpoint-deprecated( "<480px" ) {
-				height: 200px !important;
-			}
-		}
-
-		.reader-post-card__no-excerpt.reader-post-card__post-content {
-			flex-direction: column;
-			gap: 0;
-			.reader-post-card__post-details {
-				min-height: auto;
-			}
+		.reader-post-card__post-content:not(.reader-post-card__no-excerpt) {
 			.reader-featured-image {
-				width: 100% !important;
-				height: 300px !important;
+				width: 200px !important;
 
 				@include breakpoint-deprecated( "<660px" ) {
-					width: 100% !important;
+					width: auto !important;
 					height: 300px !important;
 				}
 
 				@include breakpoint-deprecated( "<480px" ) {
 					height: 200px !important;
 				}
+			}
+		}
+
+		.reader-post-card__no-excerpt.reader-post-card__post-content {
+			flex-direction: column;
+			gap: 0;
+
+			.reader-post-card__post-details {
+				min-height: auto;
 			}
 		}
 

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -164,9 +164,12 @@
 		.reader-post-card__no-excerpt.reader-post-card__post-content {
 			flex-direction: column;
 			gap: 0;
+			.reader-post-card__post-details {
+				min-height: auto;
+			}
 			.reader-featured-image {
 				width: 100% !important;
-				height: 400px !important;
+				height: 300px !important;
 
 				@include breakpoint-deprecated( "<660px" ) {
 					width: 100% !important;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

I worked on this during the DM during team time; no related diff, this is just a pet peeve I've had with the Reader since we started working on it. :) 

## Proposed Changes

<img width="617" alt="Screenshot 2023-11-27 at 3 10 27 PM" src="https://github.com/Automattic/wp-calypso/assets/2124984/71150551-7bc4-47cc-9c31-410273d00653">

The Reader uses a "compact" layout like the above for stream views; this works for most posts, but not very well for media-only posts (posts that have an image or video without an accompanying text excerpt). In such cases, a small image is shown to the right, with a large empty space to the left, like so:

<img width="619" alt="Screenshot 2023-11-27 at 3 10 02 PM" src="https://github.com/Automattic/wp-calypso/assets/2124984/5944a6df-9672-439e-bd16-d3a7f67e8c1f">

This diff checks to see if a media post includes an excerpt and styles the media full-width if not:

<img width="614" alt="Screenshot 2023-11-27 at 3 24 38 PM" src="https://github.com/Automattic/wp-calypso/assets/2124984/01c41d87-456d-43a6-a939-c60383877d43">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR
* Navigate to `/read`
* Browse the posts in a variety of streams (First Posts, Recommended, Tags, etc.)
* Posts with only a video or image should show full-width -- image examples are pretty common across all feeds, and I've found the `video` tag has some video examples.
* Videos should still be playable.
* You should still be able to access and interact with the three-dots menu at the top of posts with full-width media.
* Posts with both an excerpt/text and media should show the media smaller and to the right with the text to the left.
* Check the logged-out Reader, too.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?