### PR TITLE
Jetpack Manage: Add missing payment notification

### DIFF
--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -114,7 +114,8 @@
 		}
 	}
 
-	.notice__dismiss {
+	.notice__dismiss,
+	.notice__link {
 		overflow: hidden;
 		color: var(--color-neutral-20);
 
@@ -124,11 +125,17 @@
 		}
 	}
 
+	.notice__link {
+		// This matches the gridicon size, since we will not be using it with links
+		margin-right: 18px;
+	}
+
 	&.is-success,
 	&.is-error,
 	&.is-warning,
 	&.is-info {
-		.notice__dismiss {
+		.notice__dismiss,
+		.notice__link {
 			overflow: hidden;
 		}
 	}
@@ -220,7 +227,8 @@
 }
 
 // "X" for dismissing a notice
-.notice__dismiss {
+.notice__dismiss,
+.notice__link {
 	display: flex;
 	flex-shrink: 0;
 	padding: 12px;
@@ -323,7 +331,8 @@ a.notice__action {
 		height: 12px;
 	}
 
-	.notice__dismiss {
+	.notice__dismiss,
+	.notice__link {
 		position: relative;
 		align-self: center;
 		flex: none;
@@ -429,7 +438,8 @@ a.notice__action {
 	}
 
 	// "X" for dismissing a notice
-	.notice__dismiss {
+	.notice__dismiss,
+	.notice__link {
 		display: flex;
 		flex-shrink: 0;
 		padding: 16px;

--- a/client/jetpack-cloud/components/missing-payment-notification/index.tsx
+++ b/client/jetpack-cloud/components/missing-payment-notification/index.tsx
@@ -1,3 +1,4 @@
+import { useLocale } from '@automattic/i18n-utils';
 import { translate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import Notice from 'calypso/components/notice';
@@ -6,64 +7,15 @@ import { Invoice } from 'calypso/state/partner-portal/types';
 
 export default function MissingPaymentNotification() {
 	const partner = useSelector( getCurrentPartner );
+	const locale = useLocale();
 
 	if ( ! partner || ! partner.keys ) {
 		return null;
 	}
 
-	// Helper function to check if the date is greater than today
-	const isDateLowerThanToday = ( created: string ) => {
-		const today = new Date();
-		today.setHours( 0, 0, 0, 0 );
-		const createdDate = new Date( Number( created ) * 1000 );
-
-		return createdDate < today;
-	};
-
-	const getTranslatedMonth = ( date: Date ) => {
-		const monthIndex = date.getMonth();
-
-		switch ( monthIndex ) {
-			case 0:
-				return translate( 'January' );
-			case 1:
-				return translate( 'February' );
-			case 2:
-				return translate( 'March' );
-			case 3:
-				return translate( 'April' );
-			case 4:
-				return translate( 'May' );
-			case 5:
-				return translate( 'June' );
-			case 6:
-				return translate( 'July' );
-			case 7:
-				return translate( 'August' );
-			case 8:
-				return translate( 'September' );
-			case 9:
-				return translate( 'October' );
-			case 10:
-				return translate( 'November' );
-			case 11:
-				return translate( 'December' );
-			default:
-				throw new Error( 'Invalid month' );
-		}
-	};
-
 	const latestUnpaidInvoice = partner.keys.reduce< Invoice | null >( ( latestInvoice, key ) => {
-		if (
-			key.latestInvoice &&
-			key.latestInvoice.created &&
-			isDateLowerThanToday( key.latestInvoice.created ) &&
-			key.latestInvoice.status !== 'paid'
-		) {
-			const createdDate = new Date( Number( key.latestInvoice.created ) * 1000 );
-			if ( ! latestInvoice || createdDate > new Date( Number( latestInvoice.created ) * 1000 ) ) {
-				return key.latestInvoice;
-			}
+		if ( key.latestInvoice && key.latestInvoice.status !== 'paid' ) {
+			return key.latestInvoice;
 		}
 		return latestInvoice;
 	}, null );
@@ -72,14 +24,16 @@ export default function MissingPaymentNotification() {
 		const warningText = translate(
 			"The payment for your %s invoice didn't go through. Please take a moment to complete payment.",
 			{
-				args: getTranslatedMonth( new Date( Number( latestUnpaidInvoice.created ) * 1000 ) ),
+				args: new Date( Number( latestUnpaidInvoice.effectiveAt ) * 1000 ).toLocaleString( locale, {
+					month: 'long',
+				} ),
 			}
 		);
 
 		return (
 			<Notice className="is-warning" showDismiss={ false } text={ warningText }>
 				<a href="/partner-portal/invoices" className="notice__link">
-					View Invoice
+					{ translate( 'View Invoice' ) }
 				</a>
 			</Notice>
 		);

--- a/client/jetpack-cloud/components/missing-payment-notification/index.tsx
+++ b/client/jetpack-cloud/components/missing-payment-notification/index.tsx
@@ -58,7 +58,7 @@ export default function MissingPaymentNotification() {
 			key.latestInvoice &&
 			key.latestInvoice.created &&
 			isDateLowerThanToday( key.latestInvoice.created ) &&
-			key.latestInvoice.status === 'paid'
+			key.latestInvoice.status !== 'paid'
 		) {
 			const createdDate = new Date( Number( key.latestInvoice.created ) * 1000 );
 			if ( ! latestInvoice || createdDate > new Date( Number( latestInvoice.created ) * 1000 ) ) {

--- a/client/jetpack-cloud/components/missing-payment-notification/index.tsx
+++ b/client/jetpack-cloud/components/missing-payment-notification/index.tsx
@@ -1,0 +1,89 @@
+import { translate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import Notice from 'calypso/components/notice';
+import { getCurrentPartner } from 'calypso/state/partner-portal/partner/selectors';
+import { Invoice } from 'calypso/state/partner-portal/types';
+
+export default function MissingPaymentNotification() {
+	const partner = useSelector( getCurrentPartner );
+
+	if ( ! partner || ! partner.keys ) {
+		return null;
+	}
+
+	// Helper function to check if the date is greater than today
+	const isDateLowerThanToday = ( created: string ) => {
+		const today = new Date();
+		today.setHours( 0, 0, 0, 0 );
+		const createdDate = new Date( Number( created ) * 1000 );
+
+		return createdDate < today;
+	};
+
+	const getTranslatedMonth = ( date: Date ) => {
+		const monthIndex = date.getMonth();
+
+		switch ( monthIndex ) {
+			case 0:
+				return translate( 'January' );
+			case 1:
+				return translate( 'February' );
+			case 2:
+				return translate( 'March' );
+			case 3:
+				return translate( 'April' );
+			case 4:
+				return translate( 'May' );
+			case 5:
+				return translate( 'June' );
+			case 6:
+				return translate( 'July' );
+			case 7:
+				return translate( 'August' );
+			case 8:
+				return translate( 'September' );
+			case 9:
+				return translate( 'October' );
+			case 10:
+				return translate( 'November' );
+			case 11:
+				return translate( 'December' );
+			default:
+				throw new Error( 'Invalid month' );
+		}
+	};
+
+	const latestUnpaidInvoice = partner.keys.reduce< Invoice | null >( ( latestInvoice, key ) => {
+		if (
+			key.latestInvoice &&
+			key.latestInvoice.created &&
+			isDateLowerThanToday( key.latestInvoice.created ) &&
+			key.latestInvoice.status === 'paid'
+		) {
+			const createdDate = new Date( Number( key.latestInvoice.created ) * 1000 );
+			if ( ! latestInvoice || createdDate > new Date( Number( latestInvoice.created ) * 1000 ) ) {
+				return key.latestInvoice;
+			}
+		}
+		return latestInvoice;
+	}, null );
+
+	if ( latestUnpaidInvoice ) {
+		const warningText = translate(
+			"The payment for your %s invoice didn't go through. Please take a moment to complete payment.",
+			{
+				args: getTranslatedMonth( new Date( Number( latestUnpaidInvoice.created ) * 1000 ) ),
+			}
+		);
+
+		return (
+			<Notice className="is-warning" showDismiss={ false } text={ warningText }>
+				<a href="/partner-portal/invoices" className="notice__link">
+					View Invoice
+				</a>
+			</Notice>
+		);
+	}
+
+	return null;
+}

--- a/client/jetpack-cloud/components/missing-payment-notification/index.tsx
+++ b/client/jetpack-cloud/components/missing-payment-notification/index.tsx
@@ -1,5 +1,5 @@
 import { useLocale } from '@automattic/i18n-utils';
-import { translate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import Notice from 'calypso/components/notice';
 import { getCurrentPartner } from 'calypso/state/partner-portal/partner/selectors';
@@ -8,6 +8,7 @@ import { Invoice } from 'calypso/state/partner-portal/types';
 export default function MissingPaymentNotification() {
 	const partner = useSelector( getCurrentPartner );
 	const locale = useLocale();
+	const translate = useTranslate();
 
 	if ( ! partner || ! partner.keys ) {
 		return null;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content-header.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content-header.tsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
+import MissingPaymentNotification from 'calypso/jetpack-cloud/components/missing-payment-notification';
 import useDetectWindowBoundary from 'calypso/lib/detect-window-boundary';
 import type { ReactNode } from 'react';
 
@@ -18,21 +19,25 @@ export default function SiteContentHeader( { content, pageTitle, showStickyConte
 
 	const translate = useTranslate();
 	return (
-		<div className="sites-overview__viewport" { ...outerDivProps }>
-			<div
-				className={ classNames( 'sites-overview__page-title-container', {
-					'is-sticky': showStickyContent && hasCrossed,
-				} ) }
-			>
-				<div className="sites-overview__page-heading">
-					<h2 className="sites-overview__page-title">{ pageTitle }</h2>
-					<div className="sites-overview__page-subtitle">
-						{ translate( 'Manage all your Jetpack sites from one location' ) }
-					</div>
-				</div>
+		<>
+			<MissingPaymentNotification />
 
-				{ content }
+			<div className="sites-overview__viewport" { ...outerDivProps }>
+				<div
+					className={ classNames( 'sites-overview__page-title-container', {
+						'is-sticky': showStickyContent && hasCrossed,
+					} ) }
+				>
+					<div className="sites-overview__page-heading">
+						<h2 className="sites-overview__page-title">{ pageTitle }</h2>
+						<div className="sites-overview__page-subtitle">
+							{ translate( 'Manage all your Jetpack sites from one location' ) }
+						</div>
+					</div>
+
+					{ content }
+				</div>
 			</div>
-		</div>
+		</>
 	);
 }

--- a/client/jetpack-cloud/sections/partner-portal/invoices-list/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/invoices-list/index.tsx
@@ -95,6 +95,8 @@ export default function InvoicesList() {
 						id={ invoice.id }
 						number={ invoice.number }
 						dueDate={ invoice.dueDate }
+						created={ invoice.created }
+						effectiveAt={ invoice.effectiveAt }
 						status={ invoice.status }
 						total={ invoice.total }
 						currency={ invoice.currency }

--- a/client/jetpack-cloud/sections/partner-portal/lib/format-api-partner.ts
+++ b/client/jetpack-cloud/sections/partner-portal/lib/format-api-partner.ts
@@ -14,6 +14,19 @@ export default function formatApiPartner( partner: APIPartner ): Partner {
 			oAuth2Token: key.oauth2_token,
 			disabledOn: key.disabled_on,
 			hasLicenses: key.has_licenses,
+			latestInvoice: key.latest_invoice
+				? {
+						id: key.latest_invoice.id,
+						number: key.latest_invoice.number,
+						dueDate: key.latest_invoice.due_date,
+						created: key.latest_invoice.created,
+						effectiveAt: key.latest_invoice.effective_at,
+						status: key.latest_invoice.status,
+						total: key.latest_invoice.total,
+						currency: key.latest_invoice.currency,
+						pdfUrl: key.latest_invoice.invoice_pdf,
+				  }
+				: null,
 		} ) ),
 	};
 }

--- a/client/jetpack-cloud/sections/partner-portal/lib/test/format-api-partner.ts
+++ b/client/jetpack-cloud/sections/partner-portal/lib/test/format-api-partner.ts
@@ -22,11 +22,14 @@ const TEST_API_PARTNER: APIPartner = {
 			oauth2_token: 'secret-token-1234',
 			disabled_on: null,
 			has_licenses: true,
+			latest_invoice: null,
 		},
 	],
 	tos: 'my tos',
 	partner_type: 'my partner_type value',
 	has_valid_payment_method: false,
+	company_type: '',
+	managed_sites: '',
 };
 
 describe( 'formatApiPartner', () => {

--- a/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/licenses/index.tsx
@@ -5,6 +5,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import CardHeading from 'calypso/components/card-heading';
 import QueryJetpackPartnerPortalLicenseCounts from 'calypso/components/data/query-jetpack-partner-portal-license-counts';
+import MissingPaymentNotification from 'calypso/jetpack-cloud/components/missing-payment-notification';
 import SiteAddLicenseNotification from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-add-license-notification';
 import LicenseList from 'calypso/jetpack-cloud/sections/partner-portal/license-list';
 import LicenseListContext from 'calypso/jetpack-cloud/sections/partner-portal/license-list-context';
@@ -103,6 +104,8 @@ export default function Licenses( {
 				<LayoutTop>
 					{ isAgencyUser && <Banners /> }
 					<SiteAddLicenseNotification />
+
+					<MissingPaymentNotification />
 
 					<LayoutHeader>
 						<CardHeading size={ 36 }>{ translate( 'Licenses' ) }</CardHeading>

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -22,6 +22,7 @@ import Search from 'calypso/components/search';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
+import MissingPaymentNotification from 'calypso/jetpack-cloud/components/missing-payment-notification';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import urlSearch from 'calypso/lib/url-search';
 import { getVisibleSites, siteObjectsToSiteIds } from 'calypso/my-sites/plugins/utils';
@@ -505,6 +506,8 @@ export class PluginsMain extends Component {
 					} ) }
 				>
 					<div className="plugins__content-wrapper">
+						<MissingPaymentNotification />
+
 						{ isJetpackCloud && (
 							<div className="plugins__page-title-container">
 								<div className="plugins__header-left-content">

--- a/client/state/partner-portal/invoices/hooks/use-invoices-query.ts
+++ b/client/state/partner-portal/invoices/hooks/use-invoices-query.ts
@@ -36,6 +36,8 @@ function selectInvoices( api: APIInvoices ): Invoices {
 			id: apiInvoice.id,
 			number: apiInvoice.number,
 			dueDate: apiInvoice.due_date,
+			created: apiInvoice.created,
+			effectiveAt: apiInvoice.effective_at,
 			status: apiInvoice.status,
 			total: apiInvoice.total,
 			currency: apiInvoice.currency,

--- a/client/state/partner-portal/types.ts
+++ b/client/state/partner-portal/types.ts
@@ -57,6 +57,7 @@ export interface APIPartnerKey {
 	oauth2_token: string;
 	disabled_on: string | null;
 	has_licenses: boolean;
+	latest_invoice: APIInvoice | null;
 }
 
 export interface APIPartnerAddress {
@@ -122,6 +123,8 @@ export interface APIInvoice {
 	id: string;
 	number: string;
 	due_date: string | null;
+	created: string | null;
+	effective_at: string | null;
 	status: InvoiceStatus;
 	total: number;
 	currency: string;
@@ -140,6 +143,8 @@ export interface Invoice {
 	id: string;
 	number: string;
 	dueDate: string | null;
+	created: string | null;
+	effectiveAt: string | null;
 	status: InvoiceStatus;
 	total: number;
 	currency: string;
@@ -176,6 +181,7 @@ export interface PartnerKey {
 	oAuth2Token: string;
 	disabledOn: string | null;
 	hasLicenses: boolean;
+	latestInvoice: Invoice | null;
 }
 
 export interface PartnerAddress {


### PR DESCRIPTION
Related to https://github.com/Automattic/jetpack-manage/issues/86

## Proposed Changes

* This PR adds a notice informing the user about missing payments
* This PR adds two new properties to Invoices introduced by D128213-code : `created` and `effective_at`

## Testing Instructions

* If you know how to add an unpaid invoice to your user do it
  * Go to your Dashboard
  * The notice should be displayed alerting you about a missing payment, and a link pointing to invoices should be present
  * The same notice should be displayed in the Plugins page, and Licenses
 
![image](https://github.com/Automattic/wp-calypso/assets/37049295/8100e466-e7e4-42a5-95a2-27002a688545)

**Note**
Some helper functions, notably `isDateLowerThanToday` and `getTranslatedMonth`, could be relocated, but I'm unsure of the best place for them. If anyone considers this a blocker, please suggest an alternative location in the comments.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?