### PR TITLE
ActivityLog: Update filterbar styles, adding a compact variant to address most existing UI issues

### DIFF
--- a/client/components/activity-card-list/index.jsx
+++ b/client/components/activity-card-list/index.jsx
@@ -228,6 +228,8 @@ class ActivityCardList extends Component {
 					filter={ filter }
 					isLoading={ isLoading }
 					isVisible={ shouldShowFilter }
+					className="atelier-filterbar"
+					showFilterByLabel={ false }
 				/>
 			</div>
 		);

--- a/client/components/activity-card-list/index.jsx
+++ b/client/components/activity-card-list/index.jsx
@@ -228,8 +228,7 @@ class ActivityCardList extends Component {
 					filter={ filter }
 					isLoading={ isLoading }
 					isVisible={ shouldShowFilter }
-					className="atelier-filterbar"
-					showFilterByLabel={ false }
+					variant="compact"
 				/>
 			</div>
 		);

--- a/client/my-sites/activity/activity-log-v2/style.scss
+++ b/client/my-sites/activity/activity-log-v2/style.scss
@@ -9,29 +9,9 @@ main.activity-log-v2 {
 		}
 	}
 
-	.filterbar .filterbar__wrap.card {
-		display: flex;
-		flex-direction: row;
-
-		@include breakpoint-deprecated( "<660px" ) {
-			display: block;
-			height: auto;
-			margin-bottom: 1.5rem;
-
-			.filterbar__text-control,
-			.filterbar__label {
-				margin: 0;
-			}
-
-			.filterbar__text-control {
-				margin-bottom: 5px;
-			}
-
-			.filterbar__label,
-			.filterbar__control-list {
-				display: inline-flex;
-			}
-		}
+	.filterbar {
+		margin-left: 0;
+		margin-right: 0;
 	}
 
 	.activity-card-list__date-group-date {

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -585,6 +585,8 @@ class ActivityLog extends Component {
 					filter={ filter }
 					isLoading={ ! displayRulesLoaded || ! logsLoaded }
 					isVisible={ ! ( isEmpty( logs ) && isFilterEmpty ) }
+					className="atelier-filterbar"
+					showFilterByLabel={ false }
 				/>
 			</div>
 		);

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -585,8 +585,7 @@ class ActivityLog extends Component {
 					filter={ filter }
 					isLoading={ ! displayRulesLoaded || ! logsLoaded }
 					isVisible={ ! ( isEmpty( logs ) && isFilterEmpty ) }
-					className="atelier-filterbar"
-					showFilterByLabel={ false }
+					variant="compact"
 				/>
 			</div>
 		);

--- a/client/my-sites/activity/filterbar/date-range-selector.jsx
+++ b/client/my-sites/activity/filterbar/date-range-selector.jsx
@@ -1,4 +1,5 @@
 import { Button, Gridicon } from '@automattic/components';
+import { Icon, chevronDown } from '@wordpress/icons';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { isEmpty, flowRight as compose } from 'lodash';
@@ -97,7 +98,7 @@ export class DateRangeSelector extends Component {
 			return `${ toFormated }`;
 		}
 
-		return translate( 'Date Range' );
+		return translate( 'Date range' );
 	};
 
 	getFromDate = () => {
@@ -148,6 +149,7 @@ export class DateRangeSelector extends Component {
 							ref={ props.buttonRef }
 						>
 							{ customLabel ? customLabel : this.getFormattedDate( from, to ) }
+							<Icon icon={ chevronDown } size="16" fill="currentColor" />
 						</Button>
 						{ ( from || to ) && (
 							<Button

--- a/client/my-sites/activity/filterbar/date-range-selector.jsx
+++ b/client/my-sites/activity/filterbar/date-range-selector.jsx
@@ -13,6 +13,10 @@ import { recordTracksEvent, withAnalytics } from 'calypso/state/analytics/action
 const DATE_FORMAT = 'YYYY-MM-DD HH:mm:ss';
 
 export class DateRangeSelector extends Component {
+	static defaultProps = {
+		variant: 'default',
+	};
+
 	state = {
 		fromDate: null,
 		toDate: null,
@@ -123,7 +127,7 @@ export class DateRangeSelector extends Component {
 	};
 
 	render() {
-		const { customLabel, isVisible } = this.props;
+		const { customLabel, isVisible, variant } = this.props;
 		const from = this.getFromDate();
 		const to = this.getToDate();
 		const now = new Date();
@@ -132,6 +136,8 @@ export class DateRangeSelector extends Component {
 			'is-selected': from,
 			'is-active': isVisible && ! from,
 		} );
+
+		const isCompact = variant === 'compact';
 
 		return (
 			<DateRangePicker
@@ -149,7 +155,7 @@ export class DateRangeSelector extends Component {
 							ref={ props.buttonRef }
 						>
 							{ customLabel ? customLabel : this.getFormattedDate( from, to ) }
-							<Icon icon={ chevronDown } size="16" fill="currentColor" />
+							{ isCompact && <Icon icon={ chevronDown } size="16" fill="currentColor" /> }
 						</Button>
 						{ ( from || to ) && (
 							<Button

--- a/client/my-sites/activity/filterbar/index.jsx
+++ b/client/my-sites/activity/filterbar/index.jsx
@@ -1,5 +1,6 @@
 import { Button, Gridicon } from '@automattic/components';
 import { isWithinBreakpoint } from '@automattic/viewport';
+import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import { Component } from 'react';
@@ -18,6 +19,7 @@ import './style.scss';
 export class Filterbar extends Component {
 	static defaultProps = {
 		selectorTypes: { dateRange: true, actionType: true, text: true },
+		showFilterByLabel: true,
 	};
 
 	state = {
@@ -122,10 +124,13 @@ export class Filterbar extends Component {
 	};
 
 	render() {
-		const { translate, siteId, filter, isLoading, isVisible, selectorTypes } = this.props;
+		const { translate, siteId, filter, isLoading, isVisible, selectorTypes, showFilterByLabel } =
+			this.props;
+
+		const rootClassNames = classnames( 'filterbar', this.props.className );
 
 		if ( siteId && isLoading && this.isEmptyFilter( filter ) ) {
-			return <div className="filterbar is-loading" />;
+			return <div className={ `${ rootClassNames } is-loading` } />;
 		}
 
 		if ( ! isVisible ) {
@@ -134,7 +139,7 @@ export class Filterbar extends Component {
 
 		if ( filter.backButton ) {
 			return (
-				<div className="filterbar" id="filterbar">
+				<div className={ rootClassNames } id="filterbar">
 					<div className="filterbar__wrap card">
 						<BackButton onClick={ this.goBack } />
 					</div>
@@ -143,14 +148,16 @@ export class Filterbar extends Component {
 		}
 
 		return (
-			<div className="filterbar" id="filterbar">
+			<div className={ rootClassNames } id="filterbar">
 				<div className="filterbar__wrap card">
 					{ selectorTypes.text && (
 						<div className="filterbar__text-control">
 							<TextSelector filter={ filter } siteId={ siteId } />
 						</div>
 					) }
-					<span className="filterbar__label">{ translate( 'Filter by:' ) }</span>
+					{ showFilterByLabel && (
+						<span className="filterbar__label">{ translate( 'Filter by:' ) }</span>
+					) }
 					<ul className="filterbar__control-list">
 						{ selectorTypes.dateRange && (
 							<li>

--- a/client/my-sites/activity/filterbar/index.jsx
+++ b/client/my-sites/activity/filterbar/index.jsx
@@ -1,6 +1,5 @@
 import { Button, Gridicon } from '@automattic/components';
 import { isWithinBreakpoint } from '@automattic/viewport';
-import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import { Component } from 'react';
@@ -19,7 +18,7 @@ import './style.scss';
 export class Filterbar extends Component {
 	static defaultProps = {
 		selectorTypes: { dateRange: true, actionType: true, text: true },
-		showFilterByLabel: true,
+		variant: 'default',
 	};
 
 	state = {
@@ -123,11 +122,20 @@ export class Filterbar extends Component {
 		return true;
 	};
 
-	render() {
-		const { translate, siteId, filter, isLoading, isVisible, selectorTypes, showFilterByLabel } =
-			this.props;
+	VARIANT_STYLES = {
+		default: 'filterbar filterbar--default',
+		compact: 'filterbar filterbar--compact',
+	};
 
-		const rootClassNames = classnames( 'filterbar', this.props.className );
+	getStylesForVariant = ( variant ) => {
+		return this.VARIANT_STYLES[ variant ] || this.VARIANT_STYLES.default;
+	};
+
+	render() {
+		const { translate, siteId, filter, isLoading, isVisible, selectorTypes, variant } = this.props;
+
+		const isCompact = variant === 'compact';
+		const rootClassNames = this.getStylesForVariant( variant );
 
 		if ( siteId && isLoading && this.isEmptyFilter( filter ) ) {
 			return <div className={ `${ rootClassNames } is-loading` } />;
@@ -155,9 +163,7 @@ export class Filterbar extends Component {
 							<TextSelector filter={ filter } siteId={ siteId } />
 						</div>
 					) }
-					{ showFilterByLabel && (
-						<span className="filterbar__label">{ translate( 'Filter by:' ) }</span>
-					) }
+					{ ! isCompact && <span className="filterbar__label">{ translate( 'Filter by:' ) }</span> }
 					<ul className="filterbar__control-list">
 						{ selectorTypes.dateRange && (
 							<li>
@@ -167,6 +173,7 @@ export class Filterbar extends Component {
 									onClose={ this.closeDateRangeSelector }
 									filter={ filter }
 									siteId={ siteId }
+									variant={ variant }
 								/>
 							</li>
 						) }
@@ -178,6 +185,7 @@ export class Filterbar extends Component {
 									isVisible={ this.state.showActivityTypes }
 									onButtonClick={ this.toggleActivityTypesSelector }
 									onClose={ this.closeActivityTypes }
+									variant={ variant }
 								/>
 							</li>
 						) }
@@ -192,7 +200,7 @@ export class Filterbar extends Component {
 								/>
 							</li>
 						) }
-						<li>{ this.renderCloseButton() }</li>
+						{ ! isCompact && <li>{ this.renderCloseButton() }</li> }
 					</ul>
 				</div>
 				<div className="filterbar__mobile-wrap" />

--- a/client/my-sites/activity/filterbar/style.scss
+++ b/client/my-sites/activity/filterbar/style.scss
@@ -60,6 +60,7 @@
 		border-radius: 2px;
 		overflow: hidden;
 		white-space: nowrap;
+		background: #fff;
 	}
 
 	.filterbar__selection.is-selected,
@@ -341,5 +342,51 @@
 	margin-left: 0;
 	li {
 		list-style: none;
+	}
+}
+
+.atelier-filterbar .filterbar__wrap.card {
+	background-color: initial;
+	box-shadow: initial;
+	height: auto;
+
+	.filterbar__text-control {
+		flex-grow: initial;
+		margin: 0;
+
+		.search {
+			box-sizing: border-box;
+			width: 240px;
+		}
+
+		.search.is-compact .search__open-icon {
+			margin: 0 4px;
+			width: 24px;
+		}
+	}
+
+	.filterbar__control-list > li {
+		display: flex;
+		margin: 0 4px;
+	}
+
+	.filterbar__selection.button {
+		display: flex;
+		align-items: center;
+		padding: 8px 8px 8px 12px;
+	}
+
+	.filterbar__selection {
+		height: 36px;
+	}
+
+	.filterbar__selection-close {
+		height: 36px;
+	}
+
+	.filterbar__selection-expand-icon {
+		margin-left: 4px;
+		fill: currentColor;
+		color: var(--color-text-subtle);
 	}
 }

--- a/client/my-sites/activity/filterbar/style.scss
+++ b/client/my-sites/activity/filterbar/style.scss
@@ -11,6 +11,26 @@
 	animation: loading-fade 1.6s ease-in-out infinite;
 }
 
+.filterbar .filterbar__wrap.card {
+	display: flex;
+	flex-direction: row;
+
+	@include breakpoint-deprecated( "<660px" ) {
+		display: block;
+		height: auto;
+		margin-bottom: 1.5rem;
+
+		.filterbar__text-control,
+		.filterbar__label {
+			margin: 0;
+		}
+
+		.filterbar__text-control {
+			margin-bottom: 5px;
+		}
+	}
+}
+
 .filterbar__wrap.card {
 	position: relative;
 	display: flex;
@@ -345,29 +365,68 @@
 	}
 }
 
-.atelier-filterbar .filterbar__wrap.card {
+.filterbar {
+	margin: 0 16px;
+
+	@include break-xlarge {
+		margin: 0;
+	}
+}
+
+.filterbar--compact .filterbar__wrap.card {
 	background-color: initial;
 	box-shadow: initial;
 	height: auto;
 
 	.filterbar__text-control {
 		flex-grow: initial;
-		margin: 0;
+		margin: 0 0 5px 0;
 
 		.search {
 			box-sizing: border-box;
-			width: 240px;
+			width: 100%;
 		}
 
 		.search.is-compact .search__open-icon {
 			margin: 0 4px;
 			width: 24px;
 		}
+
+		@include break-xlarge {
+			margin-bottom: 0;
+			width: 240px;
+		}
+	}
+
+	.filterbar__control-list {
+		display: flex;
+		margin: 0;
+		gap: 5px;
+
+		@include break-xlarge {
+			margin: 0 0 0 4px;
+			gap: 0;
+		}
 	}
 
 	.filterbar__control-list > li {
 		display: flex;
-		margin: 0 4px;
+		margin: 0;
+		width: calc(50% - 2.5px);
+
+		@include break-xlarge {
+			margin: 0 4px;
+			flex-grow: 0;
+			width: auto;
+		}
+	}
+
+	.filterbar__control-list li .date-range {
+		width: 100%;
+
+		@include break-xlarge {
+			width: auto;
+		}
 	}
 
 	.filterbar__selection {
@@ -376,6 +435,17 @@
 		display: flex;
 		height: 36px;
 		padding: 8px 8px 8px 12px;
+		width: 100%;
+
+		@include break-xlarge {
+			width: auto;
+		}
+
+		span.button-label {
+			max-width: 180px;
+			overflow: hidden;
+			text-overflow: ellipsis;
+		}
 
 		&.is-active,
 		&.is-selected,

--- a/client/my-sites/activity/filterbar/style.scss
+++ b/client/my-sites/activity/filterbar/style.scss
@@ -370,14 +370,19 @@
 		margin: 0 4px;
 	}
 
-	.filterbar__selection.button {
-		display: flex;
-		align-items: center;
-		padding: 8px 8px 8px 12px;
-	}
-
 	.filterbar__selection {
+		align-items: center;
+		color: #000;
+		display: flex;
 		height: 36px;
+		padding: 8px 8px 8px 12px;
+
+		&.is-active,
+		&.is-selected,
+		&.is-selected:focus,
+		&.is-selected:hover {
+			color: var(--color-text-inverted);
+		}
 	}
 
 	.filterbar__selection-close {

--- a/client/my-sites/activity/filterbar/text-selector.tsx
+++ b/client/my-sites/activity/filterbar/text-selector.tsx
@@ -1,4 +1,3 @@
-import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
 import { useDispatch } from 'react-redux';
@@ -16,13 +15,7 @@ interface Props {
 
 const TextSelector: FunctionComponent< Props > = ( { siteId, filter } ) => {
 	const translate = useTranslate();
-	const isMobile = useMobileBreakpoint();
-
 	const dispatch = useDispatch() as CalypsoDispatch;
-
-	const placeholder = isMobile
-		? translate( 'Search posts' )
-		: translate( 'Search posts by ID, title or author' );
 
 	const handleSearchActivities = ( query: string ) => {
 		dispatch( updateFilter( siteId, { textSearch: query } ) );
@@ -37,7 +30,7 @@ const TextSelector: FunctionComponent< Props > = ( { siteId, filter } ) => {
 			initialValue={ filter.textSearch || null }
 			isOpen={ false }
 			onSearch={ handleSearchActivities }
-			placeholder={ placeholder }
+			placeholder={ translate( 'Search posts by ID, title or author' ) }
 		/>
 	);
 };

--- a/client/my-sites/activity/filterbar/type-selector/activity-type-selector.jsx
+++ b/client/my-sites/activity/filterbar/type-selector/activity-type-selector.jsx
@@ -9,14 +9,14 @@ import fromActivityTypeApi from 'calypso/state/data-layer/wpcom/sites/activity-t
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { TypeSelector } from './type-selector';
 
-const ActivityTypeSelector = ( props ) => {
-	const { translate } = props;
-
+const ActivityTypeSelector = ( { translate, variant = 'default', ...otherProps } ) => {
 	return (
 		<TypeSelector
-			{ ...props }
+			{ ...otherProps }
 			title={ translate( 'Activity type' ) }
 			showAppliedFiltersCount={ true }
+			variant={ variant }
+			translate={ translate }
 		/>
 	);
 };

--- a/client/my-sites/activity/filterbar/type-selector/type-selector.jsx
+++ b/client/my-sites/activity/filterbar/type-selector/type-selector.jsx
@@ -1,5 +1,6 @@
 import { Button, Card, Popover, Gridicon } from '@automattic/components';
 import { isWithinBreakpoint } from '@automattic/viewport';
+import { Icon, chevronDown } from '@wordpress/icons';
 import classnames from 'classnames';
 import { createRef, Component, Fragment } from 'react';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
@@ -310,8 +311,9 @@ export class TypeSelector extends Component {
 				ref={ this.typeButton }
 			>
 				{ shouldDisplayTitle && title }
-				{ shouldDisplayDelimiter && <span>: </span> }
+				{ shouldDisplayDelimiter && ': ' }
 				{ hasSelectedCheckboxes && selectedCheckboxesContent }
+				<Icon icon={ chevronDown } size="16" fill="currentColor" />
 			</Button>
 		);
 	};

--- a/client/my-sites/activity/filterbar/type-selector/type-selector.jsx
+++ b/client/my-sites/activity/filterbar/type-selector/type-selector.jsx
@@ -8,6 +8,10 @@ import FormLabel from 'calypso/components/forms/form-label';
 import MobileSelectPortal from '../mobile-select-portal';
 
 export class TypeSelector extends Component {
+	static defaultProps = {
+		variant: 'default',
+	};
+
 	state = {
 		userHasSelected: false,
 		selectedCheckboxes: [],
@@ -106,7 +110,6 @@ export class TypeSelector extends Component {
 	 * It searches the provided `key` through all `types` and its potential children recursively.
 	 * If the key is found, the corresponding name is returned.
 	 * If the key is not found, it returns the key itself as a fallback.k.
-	 *
 	 * @param {string} key - Activity Type key
 	 * @returns {string} - The resolved display name or the key itself if not found.
 	 */
@@ -274,7 +277,11 @@ export class TypeSelector extends Component {
 	hasSelectedCheckboxes = () => this.getSelectedCheckboxes().length > 0;
 
 	renderTypeSelectorButton = () => {
-		const { isNested, isVisible, showAppliedFiltersCount, title, translate } = this.props;
+		const { isNested, isVisible, showAppliedFiltersCount, title, translate, variant } = this.props;
+
+		const isCompact = variant === 'compact';
+		const isMobile = ! isWithinBreakpoint( '>660px' );
+
 		const selectedCheckboxes = this.getSelectedCheckboxes();
 		const hasSelectedCheckboxes = this.hasSelectedCheckboxes();
 
@@ -283,12 +290,13 @@ export class TypeSelector extends Component {
 			'is-active': isVisible && ! hasSelectedCheckboxes,
 		} );
 
-		// If the type selector is nested, we don't want to display the title
-		// unless there are no selected checkboxes.
-		const shouldDisplayTitle = ! isNested || ( isNested && ! hasSelectedCheckboxes );
+		// Hide the title when is nested with no selected checkboxes, or not nested, has selected checkboxes, and is mobile.
+		const shouldDisplayTitle =
+			( ! isNested || ( isNested && ! hasSelectedCheckboxes ) ) &&
+			! ( isMobile && hasSelectedCheckboxes );
 
-		// If the type selector is not nested and has selected checkboxes, we want to display a delimiter.
-		const shouldDisplayDelimiter = ! isNested && hasSelectedCheckboxes;
+		// Hide the delimiter when is not nested and has selected checkboxes, or is mobile.
+		const shouldDisplayDelimiter = ! isNested && hasSelectedCheckboxes && ! isMobile;
 
 		const activitiesSelectedText = translate( '%(selectedCount)s selected', {
 			args: {
@@ -310,10 +318,12 @@ export class TypeSelector extends Component {
 				onClick={ this.props.onButtonClick }
 				ref={ this.typeButton }
 			>
-				{ shouldDisplayTitle && title }
-				{ shouldDisplayDelimiter && ': ' }
-				{ hasSelectedCheckboxes && selectedCheckboxesContent }
-				<Icon icon={ chevronDown } size="16" fill="currentColor" />
+				<span className="button-label">
+					{ shouldDisplayTitle && title }
+					{ shouldDisplayDelimiter && ': ' }
+					{ hasSelectedCheckboxes && selectedCheckboxesContent }
+				</span>
+				{ isCompact && <Icon icon={ chevronDown } size="16" fill="currentColor" /> }
 			</Button>
 		);
 	};

--- a/client/my-sites/activity/filterbar/type-selector/type-selector.jsx
+++ b/client/my-sites/activity/filterbar/type-selector/type-selector.jsx
@@ -109,7 +109,7 @@ export class TypeSelector extends Component {
 	 *
 	 * It searches the provided `key` through all `types` and its potential children recursively.
 	 * If the key is found, the corresponding name is returned.
-	 * If the key is not found, it returns the key itself as a fallback.k.
+	 * If the key is not found, it returns the key itself as a fallback.
 	 * @param {string} key - Activity Type key
 	 * @returns {string} - The resolved display name or the key itself if not found.
 	 */


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/jetpack-backup-team/issues/217

This PR aims to address some UI existing issues in the Activity Log's filter bar available in Calypso Blue and Jetpack Cloud, providing a clean and smooth UI that also fits well for mobile resolutions.

## Proposed Changes

* Add `compact` variant to the filterbar. This way we are not going to impact the current usage of the filterbar on Jetpack Manage.
  * Hide `Activity type:` prefix on mobile resolutions
  * Improve filterbar UI on mobile resolutions in Calypso Blue and Jetpack Cloud
  * Hide `X` button to clear all filters at once
  * Remove `Filter By:`

### Screenshots
| Description | Before | After |
|---|---|---|
| Default state | ![CleanShot 2023-11-16 at 11 49 24@2x](https://github.com/Automattic/wp-calypso/assets/1488641/5fc14535-40c0-467a-90df-ea34901c2312) | ![CleanShot 2023-11-16 at 11 50 10@2x](https://github.com/Automattic/wp-calypso/assets/1488641/a130230a-877b-490a-ba75-37258c0e47b4) |
| Date range and 1 activity type selected | ![CleanShot 2023-11-16 at 11 51 18@2x](https://github.com/Automattic/wp-calypso/assets/1488641/d3c61c26-3ad2-46a9-8166-446d1869e1bc) | ![CleanShot 2023-11-16 at 11 52 05@2x](https://github.com/Automattic/wp-calypso/assets/1488641/07a12434-16a8-4199-b906-0a1e5eb979b2) |
| Date range and more than 1 activity type selected | ![CleanShot 2023-11-16 at 11 53 12@2x](https://github.com/Automattic/wp-calypso/assets/1488641/4f792d94-e36b-4a09-a9d6-2fc4f34d060c) | ![CleanShot 2023-11-16 at 11 52 45@2x](https://github.com/Automattic/wp-calypso/assets/1488641/e229ff9c-6ec6-4b21-a937-94370c5906f6) |
| Default state (Mobile) | ![CleanShot 2023-11-16 at 11 55 21@2x](https://github.com/Automattic/wp-calypso/assets/1488641/d7f08809-0768-43f5-ae30-e1db3c622b72) | ![CleanShot 2023-11-16 at 11 56 12@2x](https://github.com/Automattic/wp-calypso/assets/1488641/39ac4c42-f0d1-4920-9a16-7c023cc703da) |
| Date range and 1 activity type selected (Mobile) | ![CleanShot 2023-11-16 at 11 57 55@2x](https://github.com/Automattic/wp-calypso/assets/1488641/851bc60e-92ca-4222-ab7f-2a43170e506b) | ![CleanShot 2023-11-16 at 11 57 09@2x](https://github.com/Automattic/wp-calypso/assets/1488641/1ee4c3ba-ca4b-4991-9af9-a9308b1b52af) |
| Date range and more than 1 activity type selected (Mobile) | ![CleanShot 2023-11-16 at 11 58 08@2x](https://github.com/Automattic/wp-calypso/assets/1488641/fc7f3212-ecb6-41ff-ac5a-31f9467eb18a) | ![CleanShot 2023-11-16 at 11 57 25@2x](https://github.com/Automattic/wp-calypso/assets/1488641/05ff9aac-2dbb-479e-94e1-48215ee31a18) |

## Testing Instructions
* Spin up a Calypso and Jetpack Cloud live branch
* Navigate to the Activity Log.
* Play around with the filters and ensure it is not breaking UI when date range and activity types.
* Ensure the UI looks like the screenshots provided above in the `After` column

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
