### PR TITLE
Jetpack Manage: Fix issue with expandable block breaking for sites without boost data.

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
@@ -36,7 +36,7 @@ export default function BoostSitePerformance( { site, trackEvent, hasError }: Pr
 		has_pending_boost_one_time_score: hasPendingScore,
 	} = site;
 
-	const { overall: overallScore, mobile: mobileScore, desktop: desktopScore } = boostData;
+	const { overall: overallScore, mobile: mobileScore, desktop: desktopScore } = boostData ?? {};
 
 	const components = {
 		strong: <strong></strong>,


### PR DESCRIPTION


https://github.com/Automattic/wp-calypso/assets/56598660/972b14dd-3390-419f-9fdd-2686cda2f4ed



Closes https://github.com/Automattic/jetpack-manage/issues/105

## Proposed Changes

* Add handler for undefined boost data.

## Testing Instructions

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

* Use the Jetpack Cloud live link and go to `/partner-portal/create-site`
* Create a new atomic site and wait until it appears in the dashboard.
* Once the site appears, expand the row by clicking the chevron icon.
<img width="1533" alt="Screen Shot 2023-11-16 at 3 33 58 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/eca3fc02-673c-45b3-ae2a-d6f74c2ce602">
* Confirm that the screens do not crash.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?