### PR TITLE
WIP - add daily prompt block to the editor when using dailyprompts

### DIFF
--- a/apps/wpcom-block-editor/src/default/editor.js
+++ b/apps/wpcom-block-editor/src/default/editor.js
@@ -1,2 +1,3 @@
 import './features/rich-text';
 import './features/press-this';
+import './features/blogging-prompt';

--- a/apps/wpcom-block-editor/src/default/features/blogging-prompt.js
+++ b/apps/wpcom-block-editor/src/default/features/blogging-prompt.js
@@ -1,0 +1,18 @@
+import { createBlock } from '@wordpress/blocks';
+import { dispatch } from '@wordpress/data';
+import { getQueryArgs } from '@wordpress/url';
+import { isEditorReady } from '../../utils';
+
+const { answer_prompt, new_prompt } = getQueryArgs( window.location.href );
+
+if ( answer_prompt || new_prompt ) {
+	( async () => {
+		await isEditorReady();
+
+		const blockProps = answer_prompt ? { promptId: answer_prompt } : {};
+
+		dispatch( 'core/editor' ).resetEditorBlocks( [
+			createBlock( 'jetpack/blogging-prompt', blockProps ),
+		] );
+	} )();
+}

--- a/apps/wpcom-block-editor/src/default/features/press-this.js
+++ b/apps/wpcom-block-editor/src/default/features/press-this.js
@@ -3,7 +3,9 @@ import { dispatch } from '@wordpress/data';
 import { getQueryArgs } from '@wordpress/url';
 import { isEditorReady } from '../../utils';
 
-const { url, title, text, comment_content, comment_author } = getQueryArgs( window.location.href );
+const { url, title, text, comment_content, comment_author, answer_prompt } = getQueryArgs(
+	window.location.href
+);
 
 if ( url ) {
 	( async () => {
@@ -27,8 +29,18 @@ if ( url ) {
 				createBlock( 'core/quote', { value: comment_content, citation: comment_author } )
 			);
 		}
+
 		blocks.push( createBlock( 'core/embed', { url, type: 'wp-embed' } ) );
 
 		dispatch( 'core/editor' ).resetEditorBlocks( blocks );
+	} )();
+}
+
+if ( answer_prompt ) {
+	( async () => {
+		await isEditorReady();
+		dispatch( 'core/editor' ).resetEditorBlocks( [
+			createBlock( 'jetpack/blogging-prompt', { promptId: answer_prompt } ),
+		] );
 	} )();
 }

--- a/apps/wpcom-block-editor/src/default/features/press-this.js
+++ b/apps/wpcom-block-editor/src/default/features/press-this.js
@@ -3,9 +3,8 @@ import { dispatch } from '@wordpress/data';
 import { getQueryArgs } from '@wordpress/url';
 import { isEditorReady } from '../../utils';
 
-const { url, title, text, comment_content, comment_author, answer_prompt } = getQueryArgs(
-	window.location.href
-);
+const { url, title, text, comment_content, comment_author, answer_prompt, new_prompt } =
+	getQueryArgs( window.location.href );
 
 if ( url ) {
 	( async () => {
@@ -36,13 +35,11 @@ if ( url ) {
 	} )();
 }
 
-if ( answer_prompt ) {
+if ( answer_prompt || new_prompt ) {
 	( async () => {
 		await isEditorReady();
 
-		// If answer_prompt is strictly true, initiate the block with no promptId so it fetches the
-		// prompt for the day. Otherwise, if truthy we assume it as the promptId.
-		const blockProps = answer_prompt === true ? {} : { promptId: answer_prompt };
+		const blockProps = answer_prompt ? { promptId: answer_prompt } : {};
 
 		dispatch( 'core/editor' ).resetEditorBlocks( [
 			createBlock( 'jetpack/blogging-prompt', blockProps ),

--- a/apps/wpcom-block-editor/src/default/features/press-this.js
+++ b/apps/wpcom-block-editor/src/default/features/press-this.js
@@ -3,8 +3,7 @@ import { dispatch } from '@wordpress/data';
 import { getQueryArgs } from '@wordpress/url';
 import { isEditorReady } from '../../utils';
 
-const { url, title, text, comment_content, comment_author, answer_prompt, new_prompt } =
-	getQueryArgs( window.location.href );
+const { url, title, text, comment_content, comment_author } = getQueryArgs( window.location.href );
 
 if ( url ) {
 	( async () => {
@@ -32,17 +31,5 @@ if ( url ) {
 		blocks.push( createBlock( 'core/embed', { url, type: 'wp-embed' } ) );
 
 		dispatch( 'core/editor' ).resetEditorBlocks( blocks );
-	} )();
-}
-
-if ( answer_prompt || new_prompt ) {
-	( async () => {
-		await isEditorReady();
-
-		const blockProps = answer_prompt ? { promptId: answer_prompt } : {};
-
-		dispatch( 'core/editor' ).resetEditorBlocks( [
-			createBlock( 'jetpack/blogging-prompt', blockProps ),
-		] );
 	} )();
 }

--- a/apps/wpcom-block-editor/src/default/features/press-this.js
+++ b/apps/wpcom-block-editor/src/default/features/press-this.js
@@ -39,8 +39,13 @@ if ( url ) {
 if ( answer_prompt ) {
 	( async () => {
 		await isEditorReady();
+
+		// If answer_prompt is strictly true, initiate the block with no promptId so it fetches the
+		// prompt for the day. Otherwise, if truthy we assume it as the promptId.
+		const blockProps = answer_prompt === true ? {} : { promptId: answer_prompt };
+
 		dispatch( 'core/editor' ).resetEditorBlocks( [
-			createBlock( 'jetpack/blogging-prompt', { promptId: answer_prompt } ),
+			createBlock( 'jetpack/blogging-prompt', blockProps ),
 		] );
 	} )();
 }

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -61,6 +61,7 @@ interface Props {
 	postType: T.PostType;
 	editorType: 'site' | 'post'; // Note: a page or other CPT is a type of post.
 	pressThisData: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+	bloggingPromptData: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 	anchorFmData: {
 		anchor_podcast: string | undefined;
 		anchor_episode: string | undefined;
@@ -204,6 +205,7 @@ class CalypsoifyIframe extends Component< ComponentProps, State > {
 	 * this.
 	 *
 	 * Some historical work which has been combined into this timer:
+	 *
 	 * @see https://github.com/Automattic/wp-calypso/pull/43248
 	 * @see https://github.com/Automattic/wp-calypso/pull/36977
 	 * @see https://github.com/Automattic/wp-calypso/pull/41006
@@ -780,6 +782,7 @@ const mapStateToProps = (
 		anchorFmData,
 		showDraftPostModal,
 		pressThisData,
+		bloggingPromptData,
 		blockEditorSettings,
 	}: Props
 ) => {
@@ -806,7 +809,7 @@ const mapStateToProps = (
 		openSidebar: getQueryArg( window.location.href, 'openSidebar' ),
 		showDraftPostModal,
 		...pressThisData,
-		answer_prompt: getQueryArg( window.location.href, 'answer_prompt' ),
+		...bloggingPromptData,
 		assembler: getQueryArg( window.location.href, 'assembler' ), // Customize the first slide of Welcome Tour in the site editor
 		canvas: getQueryArg( window.location.href, 'canvas' ), // Site editor can initially load with or without nav sidebar (Gutenberg v15.0.0)
 	} );

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -227,11 +227,14 @@ export const redirect = async ( context, next ) => {
 };
 
 function getPressThisData( query ) {
-	const { url, text, title, comment_content, comment_author, answer_prompt, new_prompt } = query;
+	const { url, text, title, comment_content, comment_author } = query;
 
-	return url || answer_prompt || new_prompt
-		? { url, text, title, comment_content, comment_author, answer_prompt, new_prompt }
-		: null;
+	return url ? { url, text, title, comment_content, comment_author } : null;
+}
+
+function getBloggingPromptData( query ) {
+	const { answer_prompt, new_prompt } = query;
+	return answer_prompt || new_prompt ? { answer_prompt, new_prompt } : null;
 }
 
 function getAnchorFmData( query ) {
@@ -256,6 +259,7 @@ export const post = ( context, next ) => {
 	const state = context.store.getState();
 	const siteId = getSelectedSiteId( state );
 	const pressThisData = getPressThisData( context.query );
+	const bloggingPromptData = getBloggingPromptData( context.query );
 	const anchorFmData = getAnchorFmData( context.query );
 	const parentPostId = parseInt( context.query.parent_post, 10 ) || null;
 
@@ -272,6 +276,7 @@ export const post = ( context, next ) => {
 			postType={ postType }
 			duplicatePostId={ duplicatePostId }
 			pressThisData={ pressThisData }
+			bloggingPromptData={ bloggingPromptData }
 			anchorFmData={ anchorFmData }
 			parentPostId={ parentPostId }
 			creatingNewHomepage={ postType === 'page' && context.query.hasOwnProperty( 'new-homepage' ) }

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -107,6 +107,7 @@ function waitForPreferredEditorView( context ) {
  * auth cookies from being stored while embedding WP Admin in Calypso (i.e. if the browser is preventing cross-site
  * tracking), so we redirect the user to the WP Admin login page in order to store the auth cookie. Users will be
  * redirected back to Calypso when they are authenticated in WP Admin.
+ *
  * @param {Object} context Shared context in the route.
  * @param {Function} next  Next registered callback for the route.
  * @returns {*}            Whatever the next callback returns.
@@ -226,8 +227,11 @@ export const redirect = async ( context, next ) => {
 };
 
 function getPressThisData( query ) {
-	const { url, text, title, comment_content, comment_author } = query;
-	return url ? { url, text, title, comment_content, comment_author } : null;
+	const { url, text, title, comment_content, comment_author, answer_prompt } = query;
+
+	return url || answer_prompt
+		? { url, text, title, comment_content, comment_author, answer_prompt }
+		: null;
 }
 
 function getAnchorFmData( query ) {
@@ -292,6 +296,7 @@ export const exitPost = ( context, next ) => {
 
 /**
  * Redirects to the un-iframed Site Editor if the config is enabled.
+ *
  * @param {Object} context Shared context in the route.
  * @returns {*}            Whatever the next callback returns.
  */
@@ -304,6 +309,7 @@ export const redirectSiteEditor = async ( context ) => {
 };
 /**
  * Redirect the logged user to the permalink of the post, page, custom post type if the post is published.
+ *
  * @param {Object} context Shared context in the route.
  * @param {Function} next  Next registered callback for the route.
  * @returns undefined      Whatever the next callback returns.

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -227,10 +227,10 @@ export const redirect = async ( context, next ) => {
 };
 
 function getPressThisData( query ) {
-	const { url, text, title, comment_content, comment_author, answer_prompt } = query;
+	const { url, text, title, comment_content, comment_author, answer_prompt, new_prompt } = query;
 
-	return url || answer_prompt
-		? { url, text, title, comment_content, comment_author, answer_prompt }
+	return url || answer_prompt || new_prompt
+		? { url, text, title, comment_content, comment_author, answer_prompt, new_prompt }
 		: null;
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*  injects the daily prompt block when `answer_prompt` query arg is present in editor URL. this happens when users select a daily prompt from the daily prompt card in my home.
* also injects the daily prompt block when the `new_prompt` query arg is present. This defaults to the prompt of the day.

https://github.com/Automattic/wp-calypso/pull/84254 is a spin-off of this PR that instead surfaces a modal to allow the user to choose from a variety of prompts to add the block for, or choose not to add any at all.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
