### PR TITLE
Jetpack Manage: Fix the issue with the add site split button breaking on some screen sizes.

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -59,7 +59,11 @@
 
 
 .sites-overview__add-site-issue-license-buttons.is-with-split-button {
-	flex-direction: column;
+	flex-direction: row;
+
+	> a {
+		flex-grow: 1;
+	}
 
 	.split-button {
 		display: flex;
@@ -69,8 +73,10 @@
 		flex-grow: 1;
 	}
 
-	@include break-xlarge {
-		flex-direction: row;
+	@include break-small {
+		> a {
+			flex-grow: 0;
+		}
 	}
 }
 .sites-overview__add-new-site {
@@ -94,11 +100,11 @@
 
 	@include breakpoint-deprecated( ">660px" ) {
 		display: flex;
-		flex-direction: column;
 		justify-content: space-between;
+		flex-direction: column;
 	}
 
-	@include break-large {
+	@include break-xlarge {
 		flex-direction: row;
 	}
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -52,19 +52,27 @@
 		max-height: 40px;
 	}
 
-	&.is-with-split-button {
-		flex-direction: row;
-
-		.sites-overview__issue-license-button {
-			flex-grow: 1;
-		}
-	}
-
 	@include break-large {
 		flex-direction: row;
 	}
 }
 
+
+.sites-overview__add-site-issue-license-buttons.is-with-split-button {
+	flex-direction: column;
+
+	.split-button {
+		display: flex;
+	}
+
+	.split-button__main {
+		flex-grow: 1;
+	}
+
+	@include break-xlarge {
+		flex-direction: row;
+	}
+}
 .sites-overview__add-new-site {
 	white-space: nowrap;
 }
@@ -86,7 +94,12 @@
 
 	@include breakpoint-deprecated( ">660px" ) {
 		display: flex;
+		flex-direction: column;
 		justify-content: space-between;
+	}
+
+	@include break-large {
+		flex-direction: row;
 	}
 
 	&.is-sticky {


### PR DESCRIPTION
This pull request addresses a bug where the split button would break on certain screen sizes due to the header's element flow not collapsing at the correct breakpoint.

**Before**

https://github.com/Automattic/wp-calypso/assets/56598660/5311a18e-4d4f-4fd8-9c73-ed08f7c9009e

**After**

https://github.com/Automattic/wp-calypso/assets/56598660/20badbf9-0322-4de2-97aa-80af59a422cf



Closes https://github.com/Automattic/jetpack-manage/issues/122

## Proposed Changes

* This PR requires updating the styling to ensure that the header collapses at the natural breakpoints. 

## Testing Instructions

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

* Use the Jetpack Cloud live link and go to `/dashboard`
* Confirm that the split button and header flow collapse correctly after resizing the screens.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?