### PR TITLE
Minification: replace Terserplugin with SwcMinifyWebpackPlugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -200,6 +200,7 @@
 		"react-modal": "^3.16.1",
 		"redux": "^4.2.1",
 		"request": "^2.88.2",
+		"swc-minify-webpack-plugin": "^2.1.1",
 		"swiper": "^10.1.0",
 		"workspace": "^0.0.1-preview.1",
 		"wpcom": "workspace:^"
@@ -222,6 +223,7 @@
 		"@signal-noise/stylelint-scales": "^2.0.3",
 		"@storybook/cli": "^7.5.2",
 		"@storybook/react": "^7.5.2",
+		"@swc/core": "^1.3.96",
 		"@tanstack/eslint-plugin-query": "^4.29.8",
 		"@testing-library/jest-dom": "^6.1.4",
 		"@types/gradient-parser": "^0.1.4",

--- a/packages/calypso-build/webpack/minify.js
+++ b/packages/calypso-build/webpack/minify.js
@@ -2,8 +2,7 @@ const babelPlugins = require( '@babel/compat-data/plugins' );
 const browserslist = require( 'browserslist' );
 const CssMinimizerPlugin = require( 'css-minimizer-webpack-plugin' );
 const semver = require( 'semver' );
-const TerserPlugin = require( 'terser-webpack-plugin' );
-
+const { SwcMinifyWebpackPlugin } = require( 'swc-minify-webpack-plugin' );
 const supportedBrowsers = browserslist();
 
 // The list of browsers to check, that are supported by babel compat-data.
@@ -101,16 +100,10 @@ function chooseTerserEcmaVersion( browsers ) {
  * @param {Object} options Options
  * @param options.terserOptions Options for Terser plugin
  * @param options.cssMinimizerOptions Options for CSS Minimizer plugin
- * @param options.extractComments Whether to extract comments into a separate LICENSE file (defaults to true)
  * @param options.parallel Whether to run minifiers in parallel (defaults to true)
  * @returns {Object[]}     Terser plugin object to be used in Webpack minification.
  */
-module.exports = ( {
-	terserOptions = {},
-	cssMinimizerOptions = {},
-	parallel = true,
-	extractComments = true,
-} = {} ) => {
+module.exports = ( { terserOptions = {}, cssMinimizerOptions = {}, parallel = true } = {} ) => {
 	terserOptions = {
 		ecma: chooseTerserEcmaVersion( supportedBrowsers ),
 		ie8: false,
@@ -125,7 +118,7 @@ module.exports = ( {
 	};
 
 	return [
-		new TerserPlugin( { parallel, extractComments, terserOptions } ),
+		new SwcMinifyWebpackPlugin( terserOptions ),
 		new CssMinimizerPlugin( { parallel, minimizerOptions: cssMinimizerOptions } ),
 	];
 };

--- a/packages/calypso-build/webpack/minify.js
+++ b/packages/calypso-build/webpack/minify.js
@@ -105,12 +105,13 @@ function chooseTerserEcmaVersion( browsers ) {
  */
 module.exports = ( { terserOptions = {}, cssMinimizerOptions = {}, parallel = true } = {} ) => {
 	terserOptions = {
+		mangle: {
+			reserved: [ '__', '_n', '_nx', '_x' ],
+		},
 		ecma: chooseTerserEcmaVersion( supportedBrowsers ),
-		ie8: false,
 		safari10: supportedBrowsers.some(
 			( browser ) => browser.includes( 'safari 10' ) || browser.includes( 'ios_saf 10' )
 		),
-		...terserOptions,
 	};
 	cssMinimizerOptions = {
 		preset: 'default',

--- a/yarn.lock
+++ b/yarn.lock
@@ -7061,7 +7061,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swc/core@npm:^1.3.82":
+"@swc/core@npm:^1.3.82, @swc/core@npm:^1.3.96":
   version: 1.3.96
   resolution: "@swc/core@npm:1.3.96"
   dependencies:
@@ -29747,6 +29747,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"swc-minify-webpack-plugin@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "swc-minify-webpack-plugin@npm:2.1.1"
+  peerDependencies:
+    "@swc/core": ^1.0.0
+    webpack: ^5.0.0
+  checksum: a53c201758b02369ed417ee676c43084d6bb12d108dd7d5e86efc33628b686a154a12c23e7ba82d03f473fb73ba2a17e70290ea384cb3bad4fe9dfa54dc3224b
+  languageName: node
+  linkType: hard
+
 "swiper@npm:10.3.1, swiper@npm:^10.1.0":
   version: 10.3.1
   resolution: "swiper@npm:10.3.1"
@@ -32247,6 +32257,7 @@ __metadata:
     "@signal-noise/stylelint-scales": ^2.0.3
     "@storybook/cli": ^7.5.2
     "@storybook/react": ^7.5.2
+    "@swc/core": ^1.3.96
     "@tanstack/eslint-plugin-query": ^4.29.8
     "@testing-library/jest-dom": ^6.1.4
     "@types/cookie": ^0.4.1
@@ -32357,6 +32368,7 @@ __metadata:
     stackframe: ^1.1.1
     stacktrace-gps: ^3.0.3
     stylelint: ^14.16.1
+    swc-minify-webpack-plugin: ^2.1.1
     swiper: ^10.1.0
     tslib: ^2.3.0
     typescript: ^5.2.2


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* This PR is needed to be able to test TC builds

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* TBD

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?