### PR TITLE
Adds the Reader component to the customer home

### DIFF
--- a/client/my-sites/customer-home/cards/constants.js
+++ b/client/my-sites/customer-home/cards/constants.js
@@ -56,3 +56,4 @@ export const LAUNCHPAD_INTENT_FREE_NEWSLETTER = 'home-launchpad-intent-free-news
 export const LAUNCHPAD_INTENT_PAID_NEWSLETTER = 'home-launchpad-intent-paid-newsletter';
 export const LAUNCHPAD_PRE_LAUNCH = 'home-launchpad-pre-launch';
 export const NOTICE_HOME_LIMITED_TIME_OFFER_COUPON = 'home-limited-time-coupon';
+export const FEATURE_READER = 'home-feature-reader';

--- a/client/my-sites/customer-home/cards/features/reader/index.tsx
+++ b/client/my-sites/customer-home/cards/features/reader/index.tsx
@@ -1,0 +1,13 @@
+import { trackScrollPage } from 'calypso/reader/controller-helper';
+import Stream from 'calypso/reader/stream';
+
+const ReaderCard = () => {
+	return (
+		<Stream
+			streamKey="discover:recommended--dailyprompt"
+			trackScrollPage={ trackScrollPage.bind( null ) }
+		/>
+	);
+};
+
+export default ReaderCard;

--- a/client/my-sites/customer-home/locations/secondary/index.jsx
+++ b/client/my-sites/customer-home/locations/secondary/index.jsx
@@ -13,9 +13,11 @@ import {
 	LAUNCHPAD_INTENT_PAID_NEWSLETTER,
 	LAUNCHPAD_PRE_LAUNCH,
 	NOTICE_READER_FIRST_POSTS,
+	FEATURE_READER,
 } from 'calypso/my-sites/customer-home/cards/constants';
 import DomainUpsell from 'calypso/my-sites/customer-home/cards/features/domain-upsell';
 import HelpSearch from 'calypso/my-sites/customer-home/cards/features/help-search';
+import ReaderCard from 'calypso/my-sites/customer-home/cards/features/reader';
 import Stats from 'calypso/my-sites/customer-home/cards/features/stats';
 import LaunchpadIntentBuild from 'calypso/my-sites/customer-home/cards/launchpad/intent-build';
 import LaunchpadIntentHosting from 'calypso/my-sites/customer-home/cards/launchpad/intent-hosting';
@@ -41,6 +43,7 @@ const cardComponents = {
 	[ LAUNCHPAD_INTENT_FREE_NEWSLETTER ]: LaunchpadIntentFreeNewsletter,
 	[ LAUNCHPAD_INTENT_PAID_NEWSLETTER ]: LaunchpadIntentPaidNewsletter,
 	[ LAUNCHPAD_PRE_LAUNCH ]: LaunchpadPreLaunch,
+	[ FEATURE_READER ]: ReaderCard,
 };
 
 const Secondary = ( { cards, siteId } ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4546

## Proposed Changes

* Creates a new Reader component so we can use it on the Secondary area of the Customer Home page. This is part of our project to experiment with the Reader on the Customer Home to drive more engagements to the site.


More context:
* XdWiFk7W6Gxi57rzcAWHns-fi-0%3A1
* p1697830843894579-slack-C061Y2341JM

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?