### PR TITLE
Migrate subscribers: Calypso UI

### DIFF
--- a/client/my-sites/subscribers/components/migrate-subscribers-modal/index.ts
+++ b/client/my-sites/subscribers/components/migrate-subscribers-modal/index.ts
@@ -1,0 +1,1 @@
+export { default as MigrateSubscribersModal } from './migrate-subscribers-modal';

--- a/client/my-sites/subscribers/components/migrate-subscribers-modal/migrate-subscribers-modal.tsx
+++ b/client/my-sites/subscribers/components/migrate-subscribers-modal/migrate-subscribers-modal.tsx
@@ -114,7 +114,7 @@ const MigrateSubscribersModal = () => {
 			<div className="migrate-subscribers-modal__form--container">
 				<p className="migrate-subscribers-modal__form--disclaimer">
 					{ translate(
-						'This will move all of the subscribers from {{strong}}%(selectedSourceSiteName)s{{/strong}} to {{strong}}%(targetSiteName)s{{/strong}}. Are you sure?',
+						'This will {{strong}}move{{/strong}} all of the subscribers from {{strong}}%(selectedSourceSiteName)s{{/strong}} to {{strong}}%(targetSiteName)s{{/strong}}. Are you sure?',
 						{
 							args: { selectedSourceSiteName, targetSiteName },
 							components: { strong: <strong /> },

--- a/client/my-sites/subscribers/components/migrate-subscribers-modal/migrate-subscribers-modal.tsx
+++ b/client/my-sites/subscribers/components/migrate-subscribers-modal/migrate-subscribers-modal.tsx
@@ -63,7 +63,7 @@ const MigrateSubscribersModal = () => {
 			<div className="migrate-subscribers-modal__form--container">
 				<p className="migrate-subscribers-modal__form--disclaimer">
 					{ translate(
-						'This will migrate all of the subscribers from the site you select below to the current site, "{{strong}}%(targetSiteName)s{{/strong}}".',
+						'This will migrate all of the subscribers from the site you select below to the current site "{{strong}}%(targetSiteName)s{{/strong}}".',
 						{
 							args: { targetSiteName },
 							components: { strong: <strong /> },

--- a/client/my-sites/subscribers/components/migrate-subscribers-modal/migrate-subscribers-modal.tsx
+++ b/client/my-sites/subscribers/components/migrate-subscribers-modal/migrate-subscribers-modal.tsx
@@ -1,0 +1,116 @@
+import { localizeUrl } from '@automattic/i18n-utils';
+import { NextButton } from '@automattic/onboarding';
+import { Modal, Button } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
+import SitesDropdown from 'calypso/components/sites-dropdown';
+import { useSubscribersPage } from 'calypso/my-sites/subscribers/components/subscribers-page/subscribers-page-context';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+
+import './style.scss';
+
+const MigrateSubscribersModal = () => {
+	const translate = useTranslate();
+
+	const {
+		showMigrateSubscribersModal,
+		setShowMigrateSubscribersModal,
+		migrateSubscribersCallback,
+	} = useSubscribersPage();
+	const targetSite = useSelector( getSelectedSite );
+
+	const [ sourceSiteId, setSourceSiteId ] = useState();
+
+	useEffect( () => {
+		const handleHashChange = () => {
+			// Open "add subscribers" via URL hash
+			if ( window.location.hash === '#migrate-subscribers' ) {
+				setShowMigrateSubscribersModal( true );
+			}
+		};
+
+		// Listen to the hashchange event
+		window.addEventListener( 'hashchange', handleHashChange );
+
+		// Make it work on load as well
+		handleHashChange();
+
+		return () => {
+			window.removeEventListener( 'hashchange', handleHashChange );
+		};
+	}, [] );
+
+	const modalTitle = translate( 'Migrate subscribers to {{strong}}%(targetSiteName)s{{/strong}}', {
+		args: { targetSiteName: targetSite?.name || targetSite?.URL || '' },
+		components: { strong: <strong /> },
+	} );
+
+	if ( ! showMigrateSubscribersModal ) {
+		return null;
+	}
+
+	return (
+		<Modal
+			title={ modalTitle as string }
+			onRequestClose={ () => {
+				if ( window.location.hash === '#migrate-subscribers' ) {
+					// Doing this instead of window.location.hash = '' because window.location.hash keeps the # symbol
+					// Also this makes the back button show the modal again, which is neat
+					history.pushState(
+						'',
+						document.title,
+						window.location.pathname + window.location.search
+					);
+				}
+				setShowMigrateSubscribersModal( false );
+			} }
+			overlayClassName="migrate-subscribers-modal"
+		>
+			<div className="migrate-subscribers-modal__content">
+				<div className="migrate-subscribers-modal__form--container">
+					<label className="migrate-subscribers-modal__label">
+						{ translate( 'Migrate from' ) }
+					</label>
+					<SitesDropdown
+						key={ sourceSiteId }
+						isPlaceholder={ false }
+						selectedSiteId={ sourceSiteId }
+						onSiteSelect={ setSourceSiteId }
+					/>
+					<p className="migrate-subscribers-modal__form--disclaimer">
+						{ createInterpolateElement(
+							translate(
+								'For more details, take a look at our <Button>support document</Button>.'
+							),
+							{
+								Button: (
+									<Button
+										variant="link"
+										target="_blank"
+										href={ localizeUrl(
+											'https://jetpack.com/support/subscription-migration-tool/'
+										) }
+									/>
+								),
+							}
+						) }
+					</p>
+				</div>
+
+				<NextButton
+					type="submit"
+					className="migrate-subscriber__form-submit-btn"
+					// isBusy={ inProgress }
+					// disabled={ ! submitBtnReady }
+					onClick={ migrateSubscribersCallback }
+				>
+					{ translate( 'Migrate subscribers' ) }
+				</NextButton>
+			</div>
+		</Modal>
+	);
+};
+
+export default MigrateSubscribersModal;

--- a/client/my-sites/subscribers/components/migrate-subscribers-modal/migrate-subscribers-modal.tsx
+++ b/client/my-sites/subscribers/components/migrate-subscribers-modal/migrate-subscribers-modal.tsx
@@ -3,44 +3,23 @@ import { NextButton } from '@automattic/onboarding';
 import { Modal, Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useSelector } from 'react-redux';
 import SitesDropdown from 'calypso/components/sites-dropdown';
 import { useSubscribersPage } from 'calypso/my-sites/subscribers/components/subscribers-page/subscribers-page-context';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 
 const MigrateSubscribersModal = () => {
 	const translate = useTranslate();
 
-	const {
-		showMigrateSubscribersModal,
-		setShowMigrateSubscribersModal,
-		migrateSubscribersCallback,
-	} = useSubscribersPage();
+	const { showMigrateSubscribersModal, closeAllModals, migrateSubscribersCallback } =
+		useSubscribersPage();
 	const targetSite = useSelector( getSelectedSite );
+	const targetSiteId = useSelector( getSelectedSiteId );
 
 	const [ sourceSiteId, setSourceSiteId ] = useState();
-
-	useEffect( () => {
-		const handleHashChange = () => {
-			// Open "add subscribers" via URL hash
-			if ( window.location.hash === '#migrate-subscribers' ) {
-				setShowMigrateSubscribersModal( true );
-			}
-		};
-
-		// Listen to the hashchange event
-		window.addEventListener( 'hashchange', handleHashChange );
-
-		// Make it work on load as well
-		handleHashChange();
-
-		return () => {
-			window.removeEventListener( 'hashchange', handleHashChange );
-		};
-	}, [] );
 
 	const modalTitle = translate( 'Migrate subscribers to {{strong}}%(targetSiteName)s{{/strong}}', {
 		args: { targetSiteName: targetSite?.name || targetSite?.URL || '' },
@@ -54,18 +33,7 @@ const MigrateSubscribersModal = () => {
 	return (
 		<Modal
 			title={ modalTitle as string }
-			onRequestClose={ () => {
-				if ( window.location.hash === '#migrate-subscribers' ) {
-					// Doing this instead of window.location.hash = '' because window.location.hash keeps the # symbol
-					// Also this makes the back button show the modal again, which is neat
-					history.pushState(
-						'',
-						document.title,
-						window.location.pathname + window.location.search
-					);
-				}
-				setShowMigrateSubscribersModal( false );
-			} }
+			onRequestClose={ closeAllModals }
 			overlayClassName="migrate-subscribers-modal"
 		>
 			<div className="migrate-subscribers-modal__content">
@@ -104,7 +72,10 @@ const MigrateSubscribersModal = () => {
 					className="migrate-subscriber__form-submit-btn"
 					// isBusy={ inProgress }
 					// disabled={ ! submitBtnReady }
-					onClick={ migrateSubscribersCallback }
+					disabled={ ! sourceSiteId || ! targetSiteId }
+					onClick={ () =>
+						sourceSiteId && targetSiteId && migrateSubscribersCallback( sourceSiteId, targetSiteId )
+					}
 				>
 					{ translate( 'Migrate subscribers' ) }
 				</NextButton>

--- a/client/my-sites/subscribers/components/migrate-subscribers-modal/migrate-subscribers-modal.tsx
+++ b/client/my-sites/subscribers/components/migrate-subscribers-modal/migrate-subscribers-modal.tsx
@@ -138,11 +138,12 @@ const MigrateSubscribersModal = () => {
 						type="submit"
 						className="migrate-subscriber__form-submit-btn"
 						disabled={ ! selectedSourceSiteId }
-						onClick={ () =>
+						onClick={ () => {
+							setModalState( 'selection' );
 							selectedSourceSiteId &&
-							targetSiteId &&
-							migrateSubscribersCallback( selectedSourceSiteId, targetSiteId )
-						}
+								targetSiteId &&
+								migrateSubscribersCallback( selectedSourceSiteId, targetSiteId );
+						} }
 					>
 						{ translate( 'Confirm subscriber move' ) }
 					</NextButton>

--- a/client/my-sites/subscribers/components/migrate-subscribers-modal/migrate-subscribers-modal.tsx
+++ b/client/my-sites/subscribers/components/migrate-subscribers-modal/migrate-subscribers-modal.tsx
@@ -131,7 +131,7 @@ const MigrateSubscribersModal = () => {
 							setModalState( 'selection' );
 						} }
 					>
-						{ translate( 'Cancel' ) }
+						{ translate( 'Go back' ) }
 					</BackButton>
 
 					<NextButton

--- a/client/my-sites/subscribers/components/migrate-subscribers-modal/migrate-subscribers-modal.tsx
+++ b/client/my-sites/subscribers/components/migrate-subscribers-modal/migrate-subscribers-modal.tsx
@@ -14,7 +14,7 @@ import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 
-function useSelectedOtherSimpleSiteIDs() {
+function useOtherOwnedSiteIDs() {
 	const targetSiteId = useSelector( getSelectedSiteId );
 	const allSites = useSelector( getSites );
 	const currentUserId = useSelector( getCurrentUserId );
@@ -41,7 +41,7 @@ const MigrateSubscribersModal = () => {
 	const [ sourceSiteId, setSourceSiteId ] = useState();
 	const targetSiteName = targetSite?.name || targetSite?.URL || '';
 
-	const eligibleSiteIDs = useSelectedOtherSimpleSiteIDs();
+	const eligibleSiteIDs = useOtherOwnedSiteIDs();
 
 	const modalTitle = translate( 'Migrate subscribers to {{strong}}%(targetSiteName)s{{/strong}}', {
 		args: { targetSiteName: targetSite?.name || targetSite?.URL || '' },

--- a/client/my-sites/subscribers/components/migrate-subscribers-modal/migrate-subscribers-modal.tsx
+++ b/client/my-sites/subscribers/components/migrate-subscribers-modal/migrate-subscribers-modal.tsx
@@ -20,11 +20,15 @@ const MigrateSubscribersModal = () => {
 	const targetSiteId = useSelector( getSelectedSiteId );
 
 	const [ sourceSiteId, setSourceSiteId ] = useState();
+	const targetSiteName = targetSite?.name || targetSite?.URL || '';
 
-	const modalTitle = translate( 'Migrate subscribers to {{strong}}%(targetSiteName)s{{/strong}}', {
-		args: { targetSiteName: targetSite?.name || targetSite?.URL || '' },
-		components: { strong: <strong /> },
-	} );
+	const modalTitle = translate(
+		'Migrate subscribers to "{{strong}}%(targetSiteName)s{{/strong}}"',
+		{
+			args: { targetSiteName: targetSiteName },
+			components: { strong: <strong /> },
+		}
+	);
 
 	if ( ! showMigrateSubscribersModal ) {
 		return null;
@@ -38,6 +42,15 @@ const MigrateSubscribersModal = () => {
 		>
 			<div className="migrate-subscribers-modal__content">
 				<div className="migrate-subscribers-modal__form--container">
+					<p className="migrate-subscribers-modal__form--disclaimer">
+						{ translate(
+							'This will migrate all of the subscribers from the site you select below to the current site, "{{strong}}%(targetSiteName)s{{/strong}}".',
+							{
+								args: { targetSiteName },
+								components: { strong: <strong /> },
+							}
+						) }
+					</p>
 					<label className="migrate-subscribers-modal__label">
 						{ translate( 'Migrate from' ) }
 					</label>

--- a/client/my-sites/subscribers/components/migrate-subscribers-modal/migrate-subscribers-modal.tsx
+++ b/client/my-sites/subscribers/components/migrate-subscribers-modal/migrate-subscribers-modal.tsx
@@ -1,14 +1,15 @@
 import { localizeUrl } from '@automattic/i18n-utils';
-import { NextButton } from '@automattic/onboarding';
-import { Modal, Button } from '@wordpress/components';
+import { ActionButtons, BackButton, NextButton } from '@automattic/onboarding';
+import { Modal, Button, ButtonGroup } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
-import { useSelector } from 'react-redux';
 import SitesDropdown from 'calypso/components/sites-dropdown';
 import { useSubscribersPage } from 'calypso/my-sites/subscribers/components/subscribers-page/subscribers-page-context';
+import { useSelector } from 'calypso/state';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import getSites from 'calypso/state/selectors/get-sites';
+import { getSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './style.scss';
@@ -26,6 +27,8 @@ function useSelectedOtherSimpleSiteIDs() {
 		.filter( ( site ) => site?.ID !== targetSiteId && site?.site_owner === currentUserId )
 		.map( ( site ) => site?.ID );
 }
+
+type MigrateSubscribersModalState = 'selection' | 'confirmation';
 
 const MigrateSubscribersModal = () => {
 	const translate = useTranslate();
@@ -45,76 +48,121 @@ const MigrateSubscribersModal = () => {
 		components: { strong: <strong /> },
 	} );
 
+	const [ modalState, setModalState ] = useState< MigrateSubscribersModalState >( 'selection' );
+
+	const selectedSourceSiteId = sourceSiteId || eligibleSiteIDs[ 0 ];
+	const selectedSourceSite = useSelector( ( state ) => getSite( state, selectedSourceSiteId ) );
+	const selectedSourceSiteName = selectedSourceSite?.name || selectedSourceSite?.URL || '';
+
 	if ( ! showMigrateSubscribersModal ) {
 		return null;
 	}
 
-	const selectedSourceSiteId = sourceSiteId || eligibleSiteIDs[ 0 ];
+	const selectionRender = (
+		<div className="migrate-subscribers-modal__content">
+			<div className="migrate-subscribers-modal__form--container">
+				<p className="migrate-subscribers-modal__form--disclaimer">
+					{ translate(
+						'This will migrate all of the subscribers from the site you select below to the current site, "{{strong}}%(targetSiteName)s{{/strong}}".',
+						{
+							args: { targetSiteName },
+							components: { strong: <strong /> },
+						}
+					) }
+				</p>
+				<label className="migrate-subscribers-modal__label">{ translate( 'Migrate from' ) }</label>
+				<SitesDropdown
+					key={ sourceSiteId }
+					isPlaceholder={ false }
+					selectedSiteId={ selectedSourceSiteId }
+					onSiteSelect={ setSourceSiteId }
+					filter={ ( siteId ) => {
+						return eligibleSiteIDs.includes( siteId );
+					} }
+				/>
+				<p className="migrate-subscribers-modal__form--disclaimer">
+					{ createInterpolateElement(
+						translate( 'For more details, take a look at our <Button>support document</Button>.' ),
+						{
+							Button: (
+								<Button
+									variant="link"
+									target="_blank"
+									href={ localizeUrl( 'https://jetpack.com/support/subscription-migration-tool/' ) }
+								/>
+							),
+						}
+					) }
+				</p>
+			</div>
+
+			<NextButton
+				type="submit"
+				className="migrate-subscriber__form-submit-btn"
+				// isBusy={ inProgress }
+				// disabled={ ! submitBtnReady }
+				disabled={ ! selectedSourceSiteId }
+				onClick={ () => setModalState( 'confirmation' ) }
+			>
+				{ translate( 'Migrate subscribers' ) }
+			</NextButton>
+		</div>
+	);
+
+	const confirmationRender = (
+		<div className="migrate-subscribers-modal__content">
+			<div className="migrate-subscribers-modal__form--container">
+				<p className="migrate-subscribers-modal__form--disclaimer">
+					{ translate(
+						'This will move all of the subscribers from {{strong}}%(selectedSourceSiteName)s{{/strong}} to {{strong}}%(targetSiteName)s{{/strong}}. Are you sure?',
+						{
+							args: { selectedSourceSiteName, targetSiteName },
+							components: { strong: <strong /> },
+						}
+					) }
+				</p>
+			</div>
+
+			<ButtonGroup>
+				<ActionButtons>
+					<BackButton
+						className="migrate-subscriber__form-cancel-btn"
+						onClick={ () => {
+							setModalState( 'selection' );
+						} }
+					>
+						{ translate( 'Cancel' ) }
+					</BackButton>
+
+					<NextButton
+						type="submit"
+						className="migrate-subscriber__form-submit-btn"
+						disabled={ ! selectedSourceSiteId }
+						onClick={ () =>
+							selectedSourceSiteId &&
+							targetSiteId &&
+							migrateSubscribersCallback( selectedSourceSiteId, targetSiteId )
+						}
+					>
+						{ translate( 'Confirm subscriber move' ) }
+					</NextButton>
+				</ActionButtons>
+			</ButtonGroup>
+		</div>
+	);
 
 	return (
 		<Modal
 			title={ modalTitle as string }
-			onRequestClose={ closeAllModals }
+			onRequestClose={ () => {
+				closeAllModals();
+				//Setting a delay to prevent a flicker.
+				setTimeout( setModalState, 50, 'selection' );
+			} }
 			overlayClassName="migrate-subscribers-modal"
 		>
-			<div className="migrate-subscribers-modal__content">
-				<div className="migrate-subscribers-modal__form--container">
-					<p className="migrate-subscribers-modal__form--disclaimer">
-						{ translate(
-							'This will migrate all of the subscribers from the site you select below to the current site, "{{strong}}%(targetSiteName)s{{/strong}}".',
-							{
-								args: { targetSiteName },
-								components: { strong: <strong /> },
-							}
-						) }
-					</p>
-					<label className="migrate-subscribers-modal__label">
-						{ translate( 'Migrate from' ) }
-					</label>
-					<SitesDropdown
-						key={ sourceSiteId }
-						isPlaceholder={ false }
-						selectedSiteId={ selectedSourceSiteId }
-						onSiteSelect={ setSourceSiteId }
-						filter={ ( siteId ) => {
-							return eligibleSiteIDs.includes( siteId );
-						} }
-					/>
-					<p className="migrate-subscribers-modal__form--disclaimer">
-						{ createInterpolateElement(
-							translate(
-								'For more details, take a look at our <Button>support document</Button>.'
-							),
-							{
-								Button: (
-									<Button
-										variant="link"
-										target="_blank"
-										href={ localizeUrl(
-											'https://jetpack.com/support/subscription-migration-tool/'
-										) }
-									/>
-								),
-							}
-						) }
-					</p>
-				</div>
-
-				<NextButton
-					type="submit"
-					className="migrate-subscriber__form-submit-btn"
-					// isBusy={ inProgress }
-					// disabled={ ! submitBtnReady }
-					disabled={ ! selectedSourceSiteId }
-					onClick={ () =>
-						selectedSourceSiteId &&
-						targetSiteId &&
-						migrateSubscribersCallback( selectedSourceSiteId, targetSiteId )
-					}
-				>
-					{ translate( 'Migrate subscribers' ) }
-				</NextButton>
-			</div>
+			{ modalState === 'selection' && selectionRender }
+			{ modalState === 'confirmation' && confirmationRender }
 		</Modal>
 	);
 };

--- a/client/my-sites/subscribers/components/migrate-subscribers-modal/style.scss
+++ b/client/my-sites/subscribers/components/migrate-subscribers-modal/style.scss
@@ -16,6 +16,9 @@
 				text-overflow: ellipsis;
 				white-space: nowrap;
 				overflow: hidden;
+				@media ( max-width: $break-small ) {
+					max-width: 80vw;
+				}
 			}
 		}
 
@@ -46,6 +49,9 @@
 		line-height: 1.25;
 		color: var(--studio-gray-50);
 		margin-top: 16px;
+		strong {
+			white-space: nowrap;
+		}
 
 		a,
 		button {

--- a/client/my-sites/subscribers/components/migrate-subscribers-modal/style.scss
+++ b/client/my-sites/subscribers/components/migrate-subscribers-modal/style.scss
@@ -17,6 +17,7 @@
 				text-overflow: ellipsis;
 				white-space: nowrap;
 				overflow: hidden;
+				line-height: unset;
 				@media ( max-width: $break-small ) {
 					max-width: 80vw;
 				}

--- a/client/my-sites/subscribers/components/migrate-subscribers-modal/style.scss
+++ b/client/my-sites/subscribers/components/migrate-subscribers-modal/style.scss
@@ -1,0 +1,66 @@
+@import "@automattic/color-studio/dist/color-variables";
+@import "@automattic/typography/styles/variables";
+@import "@wordpress/base-styles/breakpoints";
+
+.migrate-subscribers-modal {
+	.components-modal__frame {
+		width: 560px;
+		// Allow site picker to expand beyond modal.
+		overflow: visible;
+
+		.components-modal__header {
+			padding: 0 24px;
+			h1 {
+				// limit the width so that the text-overflow kicks in.
+				max-width: 460px;
+				text-overflow: ellipsis;
+				white-space: nowrap;
+				overflow: hidden;
+			}
+		}
+
+		.components-modal__content {
+			padding: 0 24px 24px;
+			overflow: visible;
+		}
+
+		@media ( max-width: $break-small ) {
+			width: auto;
+		}
+	}
+
+	.migrate-subscribers-modal__content {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-end;
+		gap: 20px;
+	}
+
+	.migrate-subscribers-modal__form--container {
+		width: 100%;
+	}
+
+
+	.migrate-subscribers-modal__form--disclaimer {
+		font-size: $font-body-small;
+		line-height: 1.25;
+		color: var(--studio-gray-50);
+		margin-top: 16px;
+
+		a,
+		button {
+			font-size: $font-body-small;
+			color: var(--color-text);
+			text-decoration: underline;
+			height: unset;
+
+			&:hover {
+				color: var(--color-text-subtle);
+			}
+		}
+
+		.components-button {
+			padding: 0;
+		}
+	}
+}

--- a/client/my-sites/subscribers/components/migrate-subscribers-modal/style.scss
+++ b/client/my-sites/subscribers/components/migrate-subscribers-modal/style.scss
@@ -7,6 +7,7 @@
 		width: 560px;
 		// Allow site picker to expand beyond modal.
 		overflow: visible;
+		max-height: unset;
 
 		.components-modal__header {
 			padding: 0 24px;

--- a/client/my-sites/subscribers/components/migrate-subscribers-modal/style.scss
+++ b/client/my-sites/subscribers/components/migrate-subscribers-modal/style.scss
@@ -44,6 +44,10 @@
 		width: 100%;
 	}
 
+	.migrate-subscriber__form-cancel-btn {
+		box-shadow: unset;
+	}
+
 
 	.migrate-subscribers-modal__form--disclaimer {
 		font-size: $font-body-small;

--- a/client/my-sites/subscribers/components/subscribers-header-popover/subscribers-header-popover.tsx
+++ b/client/my-sites/subscribers/components/subscribers-header-popover/subscribers-header-popover.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
@@ -29,6 +30,9 @@ const SubscribersHeaderPopover = ( { siteId }: SubscribersHeaderPopoverProps ) =
 	const { grandTotal } = useSubscribersPage();
 	const recordExport = useRecordExport();
 	const currentUserSiteCount = useSelector( getCurrentUserSiteCount );
+	const migrationUrl = isEnabled( 'subscription-management/migrate-subscribers' )
+		? '#migrate-subscribers'
+		: `https://wordpress.com/manage/${ siteId }`;
 
 	const onDownloadCsvClick = () => {
 		dispatch(
@@ -74,7 +78,7 @@ const SubscribersHeaderPopover = ( { siteId }: SubscribersHeaderPopoverProps ) =
 					</PopoverMenuItem>
 				) }
 				{ hasMultipleSites && (
-					<PopoverMenuItem href={ `https://wordpress.com/manage/${ siteId }` }>
+					<PopoverMenuItem href={ migrationUrl }>
 						{ translate( 'Migrate subscribers from another WordPress.com site' ) }
 					</PopoverMenuItem>
 				) }

--- a/client/my-sites/subscribers/components/subscribers-page/migrate-subscribers-query.tsx
+++ b/client/my-sites/subscribers/components/subscribers-page/migrate-subscribers-query.tsx
@@ -1,0 +1,17 @@
+import wpcomRequest from 'wpcom-proxy-request';
+
+type Response = {
+	success: boolean;
+	message: string;
+};
+function migrateSubscribers( sourceSiteId: number, targetSiteId: number ) {
+	return wpcomRequest< Response >( {
+		path: `/jetpack-blogs/${ encodeURIComponent( targetSiteId ) }/source/${ encodeURIComponent(
+			sourceSiteId
+		) }/migrate?http_envelope=1`,
+		apiNamespace: 'rest/v1',
+		method: 'POST',
+	} );
+}
+
+export { migrateSubscribers };

--- a/client/my-sites/subscribers/components/subscribers-page/migrate-subscribers-query.tsx
+++ b/client/my-sites/subscribers/components/subscribers-page/migrate-subscribers-query.tsx
@@ -6,6 +6,7 @@ type Response = {
 };
 function migrateSubscribers( sourceSiteId: number, targetSiteId: number ) {
 	return wpcomRequest< Response >( {
+		// This endpoint is pretty old and needs the old variant of the envelope param.
 		path: `/jetpack-blogs/${ encodeURIComponent( targetSiteId ) }/source/${ encodeURIComponent(
 			sourceSiteId
 		) }/migrate?http_envelope=1`,

--- a/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
+++ b/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
@@ -41,8 +41,11 @@ type SubscribersPageContextProps = {
 	filterOption: SubscribersFilterBy;
 	setFilterOption: ( option: SubscribersFilterBy ) => void;
 	showAddSubscribersModal: boolean;
+	showMigrateSubscribersModal: boolean;
 	setShowAddSubscribersModal: ( show: boolean ) => void;
+	setShowMigrateSubscribersModal: ( show: boolean ) => void;
 	addSubscribersCallback: () => void;
+	migrateSubscribersCallback: () => void;
 	siteId: number | null;
 	isLoading: boolean;
 };
@@ -67,6 +70,7 @@ export const SubscribersPageProvider = ( {
 }: SubscribersPageProviderProps ) => {
 	const [ perPage, setPerPage ] = useState( DEFAULT_PER_PAGE );
 	const [ showAddSubscribersModal, setShowAddSubscribersModal ] = useState( false );
+	const [ showMigrateSubscribersModal, setShowMigrateSubscribersModal ] = useState( false );
 	const [ debouncedSearchTerm ] = useDebounce( searchTerm, 300 );
 	const { hasManySubscribers } = useManySubsSite( siteId );
 
@@ -120,6 +124,23 @@ export const SubscribersPageProvider = ( {
 		);
 	};
 
+	const migrateSubscribersCallback = () => {
+		setShowMigrateSubscribersModal( false );
+		console.log( 'make api call' );
+		// completeImportSubscribersTask();
+
+		// dispatch(
+		// 	successNotice(
+		// 		translate(
+		// 			"Your subscriber list is being processed. We'll send you an email when it's finished importing."
+		// 		),
+		// 		{
+		// 			duration: 5000,
+		// 		}
+		// 	)
+		// );
+	};
+
 	const handleSearch = useCallback( ( term: string ) => {
 		searchTermChanged( term );
 		pageChangeCallback( 1 );
@@ -155,8 +176,11 @@ export const SubscribersPageProvider = ( {
 				filterOption,
 				setFilterOption: filterOptionChanged,
 				showAddSubscribersModal,
+				showMigrateSubscribersModal,
 				setShowAddSubscribersModal,
+				setShowMigrateSubscribersModal,
 				addSubscribersCallback,
+				migrateSubscribersCallback,
 				siteId,
 				isLoading: subscribersQueryResult.isLoading,
 			} }

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -14,6 +14,7 @@ import {
 } from 'calypso/my-sites/subscribers/components/subscribers-page/subscribers-page-context';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { AddSubscribersModal } from './components/add-subscribers-modal';
+import { MigrateSubscribersModal } from './components/migrate-subscribers-modal';
 import { SubscribersHeaderPopover } from './components/subscribers-header-popover';
 import { UnsubscribeModal } from './components/unsubscribe-modal';
 import { SubscribersFilterBy, SubscribersSortBy } from './constants';
@@ -133,6 +134,7 @@ const SubscribersPage = ( {
 					onConfirm={ onConfirmModal }
 				/>
 				{ selectedSite && <AddSubscribersModal site={ selectedSite } /> }
+				{ selectedSite && <MigrateSubscribersModal /> }
 			</Main>
 		</SubscribersPageProvider>
 	);

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -135,6 +135,7 @@
 		"subscription-management-comments-view": true,
 		"subscription-management-pending-view": true,
 		"subscription-management/comments-list-controls": true,
+		"subscription-management/migrate-subscribers": true,
 		"subscription-management-redirect-following": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/block-theme-previews": true,

--- a/config/production.json
+++ b/config/production.json
@@ -162,6 +162,7 @@
 		"subscription-management-comments-view": true,
 		"subscription-management-pending-view": true,
 		"subscription-management/comments-list-controls": true,
+		"subscription-management/migrate-subscribers": true,
 		"subscription-management-redirect-following": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/block-theme-previews": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -157,6 +157,7 @@
 		"subscription-management-comments-view": true,
 		"subscription-management-pending-view": true,
 		"subscription-management/comments-list-controls": true,
+		"subscription-management/migrate-subscribers": true,
 		"subscription-management-redirect-following": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/block-theme-previews": true,


### PR DESCRIPTION
Related to the Hackathon project, see: Pf4ekF-3L-p2 

## Proposed Changes

Adds functionality to move migration from the older Atlas system to Calypso

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Users > Subscribers
* Click Migrate subscribers from another WordPress.com site
* Test the UI, make sure you get a confirmation.

![CleanShot 2023-11-16 at 16 15 51@2x](https://github.com/Automattic/wp-calypso/assets/533/985f64be-44aa-49f9-bc30-725dfaf5ce7d)

![CleanShot 2023-11-16 at 16 16 12@2x](https://github.com/Automattic/wp-calypso/assets/533/b985483c-c6dd-4cde-b637-492ab7f582c9)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
