### PR TITLE
happy-block: Use esbuild

### DIFF
--- a/apps/happy-blocks/block-library/education-header/style.scss
+++ b/apps/happy-blocks/block-library/education-header/style.scss
@@ -1,15 +1,15 @@
-@import "@automattic/calypso-color-schemes";
-@import "~@automattic/color-studio/dist/color-variables";
-@import "@automattic/onboarding/styles/mixins";
+@import '~@automattic/calypso-color-schemes';
+@import '~@automattic/color-studio/dist/color-variables';
+@import '@automattic/onboarding/styles/mixins';
 
 $breakpoint-mobile: 782px; //Mobile size.
 $breakpoint-tablet: 1224px; //Large tablet size.
 $breakpoint-desktop: 1440px; //Desktop size.
 
 $search-icon: 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none"%3E%3Cpath d="M9.16667 15.8333C12.8486 15.8333 15.8333 12.8486 15.8333 9.16667C15.8333 5.48477 12.8486 2.5 9.16667 2.5C5.48477 2.5 2.5 5.48477 2.5 9.16667C2.5 12.8486 5.48477 15.8333 9.16667 15.8333Z" stroke="%238C8F94" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/%3E%3Cpath d="M17.5 17.5L13.875 13.875" stroke="%238C8F94" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/%3E%3C/svg%3E';
-$recoleta-font-family: "Recoleta", sans-serif;
-$system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI", "Roboto",
-	"Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
+$recoleta-font-family: 'Recoleta', sans-serif;
+$system-font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Segoe UI', 'Roboto',
+	'Oxygen-Sans', 'Ubuntu', 'Cantarell', 'Helvetica Neue', sans-serif;
 
 // Only for categories page, tablet or bellow viewport, set the search box width to 100%.
 body.archive {
@@ -32,13 +32,12 @@ body.archive {
 		justify-content: flex-start !important;
 
 		div.happy-blocks-search__inside-wrapper {
-			width: var(--wp--style--global--content-size);
+			width: var( --wp--style--global--content-size );
 		}
 	}
 	@media only screen and ( max-width: $breakpoint-mobile ) {
 		margin: 16px 0 !important;
 	}
-
 }
 
 .happy-blocks-search {
@@ -67,16 +66,16 @@ body.archive {
 	margin-right: 22px;
 	font-size: 1rem;
 	text-decoration: none !important;
-	color: var(--studio-blue-50);
+	color: var( --studio-blue-50 );
 
 	&.active {
-		border-bottom: 2px solid var(--studio-gray-70);
-		color: var(--studio-gray-100);
+		border-bottom: 2px solid var( --studio-gray-70 );
+		color: var( --studio-gray-100 );
 	}
 
 	&:hover,
 	&:active {
-		border-bottom: 2px solid var(--studio-gray-70);
+		border-bottom: 2px solid var( --studio-gray-70 );
 	}
 }
 
@@ -87,19 +86,19 @@ body.archive {
 		margin-bottom: 0;
 	}
 	.screen-reader-text {
-		clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
-		clip: rect(1px, 1px, 1px, 1px);
+		clip: rect( 1px 1px 1px 1px ); /* IE6, IE7 */
+		clip: rect( 1px, 1px, 1px, 1px );
 		position: absolute !important;
 	}
 	// This applies to all search bars
 	.happy-blocks-search__inside-wrapper {
 		// width is 1/3 of the grid width minus 30px * 2 / 3 for the grid gap (gap is 30px, we need 2/3 of it)
-		width: calc(var(--wp--style--global--wide-size, 1224px) / 3 - 30px * 2 / 3);
+		width: calc( var( --wp--style--global--wide-size, 1224px ) / 3 - 30px * 2 / 3 );
 		max-width: 100%;
 		position: relative;
 		border-radius: 4px;
 		background-color: #fff;
-		box-shadow: 0 0 0 1px var(--color-neutral-5) inset;
+		box-shadow: 0 0 0 1px var( --color-neutral-5 ) inset;
 		display: flex;
 
 		@media only screen and ( max-width: $breakpoint-mobile ) {
@@ -122,17 +121,17 @@ body.archive {
 			&,
 			&::placeholder {
 				font-size: 1rem;
-				color: var(--color-neutral-50);
+				color: var( --color-neutral-50 );
 			}
 
 			font-size: 1rem;
-			color: var(--color-neutral-50);
+			color: var( --color-neutral-50 );
 		}
 
 		&::before {
 			z-index: 10;
-			content: "";
-			background: url($search-icon) 16px no-repeat;
+			content: '';
+			background: url( $search-icon ) 16px no-repeat;
 			background-position: center;
 			position: absolute;
 			top: 0;
@@ -144,7 +143,7 @@ body.archive {
 
 	.happy-blocks-search-container {
 		margin: 0 auto;
-		max-width: var(--wp--style--global--wide-size, 1224px);
+		max-width: var( --wp--style--global--wide-size, 1224px );
 
 		hr {
 			border-bottom-width: 0;
@@ -191,17 +190,17 @@ body.archive {
 				}
 
 				h1 {
-					font-size: rem(70px);
+					font-size: rem( 70px );
 					line-height: 76px;
 					@media ( max-width: $breakpoint-mobile ) {
-						font-size: rem(50px);
+						font-size: rem( 50px );
 						line-height: 57px;
 					}
 				}
 				// subtitle
 				p {
 					margin-top: 16px;
-					font-size: rem(18px);
+					font-size: rem( 18px );
 					line-height: 26px;
 					@media ( max-width: $breakpoint-mobile ) {
 						font-size: 1rem;
@@ -233,10 +232,9 @@ body.archive {
 			}
 		}
 
-
 		.happy-blocks-search__inside-wrapper {
 			input {
-				background-color: var(--studio-gray-0);
+				background-color: var( --studio-gray-0 );
 			}
 		}
 	}
@@ -262,7 +260,7 @@ body.archive {
 	}
 
 	p {
-		color: var(--color-neutral-60);
+		color: var( --color-neutral-60 );
 		font-family: $system-font-family;
 		font-size: 1rem;
 		margin-top: 0;

--- a/apps/happy-blocks/block-library/education-header/style.scss
+++ b/apps/happy-blocks/block-library/education-header/style.scss
@@ -1,15 +1,15 @@
-@import '~@automattic/calypso-color-schemes';
-@import '~@automattic/color-studio/dist/color-variables';
-@import '@automattic/onboarding/styles/mixins';
+@import "~@automattic/calypso-color-schemes";
+@import "~@automattic/color-studio/dist/color-variables";
+@import "@automattic/onboarding/styles/mixins";
 
 $breakpoint-mobile: 782px; //Mobile size.
 $breakpoint-tablet: 1224px; //Large tablet size.
 $breakpoint-desktop: 1440px; //Desktop size.
 
 $search-icon: 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none"%3E%3Cpath d="M9.16667 15.8333C12.8486 15.8333 15.8333 12.8486 15.8333 9.16667C15.8333 5.48477 12.8486 2.5 9.16667 2.5C5.48477 2.5 2.5 5.48477 2.5 9.16667C2.5 12.8486 5.48477 15.8333 9.16667 15.8333Z" stroke="%238C8F94" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/%3E%3Cpath d="M17.5 17.5L13.875 13.875" stroke="%238C8F94" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/%3E%3C/svg%3E';
-$recoleta-font-family: 'Recoleta', sans-serif;
-$system-font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Segoe UI', 'Roboto',
-	'Oxygen-Sans', 'Ubuntu', 'Cantarell', 'Helvetica Neue', sans-serif;
+$recoleta-font-family: "Recoleta", sans-serif;
+$system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI", "Roboto",
+	"Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
 
 // Only for categories page, tablet or bellow viewport, set the search box width to 100%.
 body.archive {
@@ -32,7 +32,7 @@ body.archive {
 		justify-content: flex-start !important;
 
 		div.happy-blocks-search__inside-wrapper {
-			width: var( --wp--style--global--content-size );
+			width: var(--wp--style--global--content-size);
 		}
 	}
 	@media only screen and ( max-width: $breakpoint-mobile ) {
@@ -66,16 +66,16 @@ body.archive {
 	margin-right: 22px;
 	font-size: 1rem;
 	text-decoration: none !important;
-	color: var( --studio-blue-50 );
+	color: var(--studio-blue-50);
 
 	&.active {
-		border-bottom: 2px solid var( --studio-gray-70 );
-		color: var( --studio-gray-100 );
+		border-bottom: 2px solid var(--studio-gray-70);
+		color: var(--studio-gray-100);
 	}
 
 	&:hover,
 	&:active {
-		border-bottom: 2px solid var( --studio-gray-70 );
+		border-bottom: 2px solid var(--studio-gray-70);
 	}
 }
 
@@ -86,19 +86,19 @@ body.archive {
 		margin-bottom: 0;
 	}
 	.screen-reader-text {
-		clip: rect( 1px 1px 1px 1px ); /* IE6, IE7 */
-		clip: rect( 1px, 1px, 1px, 1px );
+		clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
+		clip: rect(1px, 1px, 1px, 1px);
 		position: absolute !important;
 	}
 	// This applies to all search bars
 	.happy-blocks-search__inside-wrapper {
 		// width is 1/3 of the grid width minus 30px * 2 / 3 for the grid gap (gap is 30px, we need 2/3 of it)
-		width: calc( var( --wp--style--global--wide-size, 1224px ) / 3 - 30px * 2 / 3 );
+		width: calc(var(--wp--style--global--wide-size, 1224px) / 3 - 30px * 2 / 3);
 		max-width: 100%;
 		position: relative;
 		border-radius: 4px;
 		background-color: #fff;
-		box-shadow: 0 0 0 1px var( --color-neutral-5 ) inset;
+		box-shadow: 0 0 0 1px var(--color-neutral-5) inset;
 		display: flex;
 
 		@media only screen and ( max-width: $breakpoint-mobile ) {
@@ -121,17 +121,17 @@ body.archive {
 			&,
 			&::placeholder {
 				font-size: 1rem;
-				color: var( --color-neutral-50 );
+				color: var(--color-neutral-50);
 			}
 
 			font-size: 1rem;
-			color: var( --color-neutral-50 );
+			color: var(--color-neutral-50);
 		}
 
 		&::before {
 			z-index: 10;
-			content: '';
-			background: url( $search-icon ) 16px no-repeat;
+			content: "";
+			background: url($search-icon) 16px no-repeat;
 			background-position: center;
 			position: absolute;
 			top: 0;
@@ -143,7 +143,7 @@ body.archive {
 
 	.happy-blocks-search-container {
 		margin: 0 auto;
-		max-width: var( --wp--style--global--wide-size, 1224px );
+		max-width: var(--wp--style--global--wide-size, 1224px);
 
 		hr {
 			border-bottom-width: 0;
@@ -190,17 +190,17 @@ body.archive {
 				}
 
 				h1 {
-					font-size: rem( 70px );
+					font-size: rem(70px);
 					line-height: 76px;
 					@media ( max-width: $breakpoint-mobile ) {
-						font-size: rem( 50px );
+						font-size: rem(50px);
 						line-height: 57px;
 					}
 				}
 				// subtitle
 				p {
 					margin-top: 16px;
-					font-size: rem( 18px );
+					font-size: rem(18px);
 					line-height: 26px;
 					@media ( max-width: $breakpoint-mobile ) {
 						font-size: 1rem;
@@ -234,7 +234,7 @@ body.archive {
 
 		.happy-blocks-search__inside-wrapper {
 			input {
-				background-color: var( --studio-gray-0 );
+				background-color: var(--studio-gray-0);
 			}
 		}
 	}
@@ -260,7 +260,7 @@ body.archive {
 	}
 
 	p {
-		color: var( --color-neutral-60 );
+		color: var(--color-neutral-60);
 		font-family: $system-font-family;
 		font-size: 1rem;
 		margin-top: 0;

--- a/apps/happy-blocks/block-library/support-content-footer/style.scss
+++ b/apps/happy-blocks/block-library/support-content-footer/style.scss
@@ -1,11 +1,11 @@
-@import '~@automattic/calypso-color-schemes';
+@import "~@automattic/calypso-color-schemes";
 
 $breakpoint-mobile: 782px; //Mobile size.
 $breakpoint-tablet: 1224px; //Large tablet size.
 $breakpoint-desktop: 1440px; //Desktop size.
 $search-icon: 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none"%3E%3Cpath d="M9.16667 15.8333C12.8486 15.8333 15.8333 12.8486 15.8333 9.16667C15.8333 5.48477 12.8486 2.5 9.16667 2.5C5.48477 2.5 2.5 5.48477 2.5 9.16667C2.5 12.8486 5.48477 15.8333 9.16667 15.8333Z" stroke="%238C8F94" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/%3E%3Cpath d="M17.5 17.5L13.875 13.875" stroke="%238C8F94" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/%3E%3C/svg%3E';
-$system-font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Segoe UI', 'Roboto',
-	'Oxygen-Sans', 'Ubuntu', 'Cantarell', 'Helvetica Neue', sans-serif;
+$system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI", "Roboto",
+	"Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
 
 .happy-blocks-support-content-footer {
 	max-width: none !important;
@@ -27,11 +27,11 @@ $system-font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Segoe UI',
 	> * {
 		margin-left: auto !important;
 		margin-right: auto !important;
-		max-width: var( --wp--style--global--wide-size );
+		max-width: var(--wp--style--global--wide-size);
 	}
 
 	.support-content-cta {
-		border-bottom: 1px solid var( --studio-gray-0 );
+		border-bottom: 1px solid var(--studio-gray-0);
 		display: flex;
 		margin-bottom: 2rem;
 		font-size: 1.25rem;
@@ -46,7 +46,7 @@ $system-font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Segoe UI',
 			}
 
 			p {
-				color: var( --studio-gray-60 );
+				color: var(--studio-gray-60);
 				margin-top: 4px;
 				margin-bottom: 16px;
 			}
@@ -81,13 +81,13 @@ $system-font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Segoe UI',
 			min-width: 0;
 			overflow-wrap: break-word;
 			word-break: break-word;
-			border-bottom: 1px solid var( --studio-gray-0 );
+			border-bottom: 1px solid var(--studio-gray-0);
 			padding: 0 16px 32px 0;
 			font-size: 1.25rem;
 		}
 
 		p {
-			color: var( --studio-gray-60 );
+			color: var(--studio-gray-60);
 			margin-top: 16px;
 			margin-bottom: 28px;
 		}
@@ -99,7 +99,7 @@ $system-font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Segoe UI',
 
 	.support-content-resource__title {
 		margin-top: 0;
-		font-family: var( --wp--preset--font-family--system-font );
+		font-family: var(--wp--preset--font-family--system-font);
 	}
 
 	@media ( min-width: $breakpoint-mobile ) {
@@ -133,7 +133,7 @@ $system-font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Segoe UI',
 		}
 
 		.support-content-subscribe-disclaimer {
-			color: var( --studio-gray-60 );
+			color: var(--studio-gray-60);
 			font-size: 0.75rem;
 			line-height: 20px;
 
@@ -164,10 +164,10 @@ $system-font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Segoe UI',
 			}
 
 			button.support-content-subscribe-submit {
-				background-color: var( --color-primary );
+				background-color: var(--color-primary);
 				border-radius: 4px !important;
 				border: none;
-				color: var( --color-primary-0 );
+				color: var(--color-primary-0);
 				cursor: pointer;
 				font-size: 0.875rem;
 				line-height: 20px;

--- a/apps/happy-blocks/block-library/support-content-footer/style.scss
+++ b/apps/happy-blocks/block-library/support-content-footer/style.scss
@@ -1,11 +1,11 @@
-@import "@automattic/calypso-color-schemes";
+@import '~@automattic/calypso-color-schemes';
 
 $breakpoint-mobile: 782px; //Mobile size.
 $breakpoint-tablet: 1224px; //Large tablet size.
 $breakpoint-desktop: 1440px; //Desktop size.
 $search-icon: 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none"%3E%3Cpath d="M9.16667 15.8333C12.8486 15.8333 15.8333 12.8486 15.8333 9.16667C15.8333 5.48477 12.8486 2.5 9.16667 2.5C5.48477 2.5 2.5 5.48477 2.5 9.16667C2.5 12.8486 5.48477 15.8333 9.16667 15.8333Z" stroke="%238C8F94" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/%3E%3Cpath d="M17.5 17.5L13.875 13.875" stroke="%238C8F94" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/%3E%3C/svg%3E';
-$system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI", "Roboto",
-	"Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
+$system-font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Segoe UI', 'Roboto',
+	'Oxygen-Sans', 'Ubuntu', 'Cantarell', 'Helvetica Neue', sans-serif;
 
 .happy-blocks-support-content-footer {
 	max-width: none !important;
@@ -24,14 +24,14 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 		margin-bottom: 0;
 	}
 
-	>* {
+	> * {
 		margin-left: auto !important;
 		margin-right: auto !important;
-		max-width: var(--wp--style--global--wide-size);
+		max-width: var( --wp--style--global--wide-size );
 	}
 
 	.support-content-cta {
-		border-bottom: 1px solid var(--studio-gray-0);
+		border-bottom: 1px solid var( --studio-gray-0 );
 		display: flex;
 		margin-bottom: 2rem;
 		font-size: 1.25rem;
@@ -46,7 +46,7 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 			}
 
 			p {
-				color: var(--studio-gray-60);
+				color: var( --studio-gray-60 );
 				margin-top: 4px;
 				margin-bottom: 16px;
 			}
@@ -81,13 +81,13 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 			min-width: 0;
 			overflow-wrap: break-word;
 			word-break: break-word;
-			border-bottom: 1px solid var(--studio-gray-0);
+			border-bottom: 1px solid var( --studio-gray-0 );
 			padding: 0 16px 32px 0;
 			font-size: 1.25rem;
 		}
 
 		p {
-			color: var(--studio-gray-60);
+			color: var( --studio-gray-60 );
 			margin-top: 16px;
 			margin-bottom: 28px;
 		}
@@ -99,10 +99,10 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 
 	.support-content-resource__title {
 		margin-top: 0;
-		font-family: var(--wp--preset--font-family--system-font);
+		font-family: var( --wp--preset--font-family--system-font );
 	}
 
-	@media (min-width: $breakpoint-mobile) {
+	@media ( min-width: $breakpoint-mobile ) {
 		.support-content-resource {
 			flex-basis: 0;
 			flex-grow: 1;
@@ -132,9 +132,8 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 			margin-top: 0;
 		}
 
-
 		.support-content-subscribe-disclaimer {
-			color: var(--studio-gray-60);
+			color: var( --studio-gray-60 );
 			font-size: 0.75rem;
 			line-height: 20px;
 
@@ -165,10 +164,10 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 			}
 
 			button.support-content-subscribe-submit {
-				background-color: var(--color-primary);
+				background-color: var( --color-primary );
 				border-radius: 4px !important;
 				border: none;
-				color: var(--color-primary-0);
+				color: var( --color-primary-0 );
 				cursor: pointer;
 				font-size: 0.875rem;
 				line-height: 20px;
@@ -184,7 +183,7 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 		}
 	}
 
-	@media (max-width: $breakpoint-mobile) {
+	@media ( max-width: $breakpoint-mobile ) {
 		padding: 12px 24px !important;
 
 		h4 {
@@ -227,7 +226,6 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 				.resource-link {
 					line-height: 20px;
 				}
-
 
 				p {
 					margin-top: 4px;

--- a/apps/happy-blocks/block-library/universal-header/style.scss
+++ b/apps/happy-blocks/block-library/universal-header/style.scss
@@ -1,11 +1,11 @@
-@import '~@automattic/calypso-color-schemes';
+@import "~@automattic/calypso-color-schemes";
 
 $breakpoint-mobile: 782px; //Mobile size.
 $breakpoint-tablet: 1224px; //Large tablet size.
 $breakpoint-desktop: 1440px; //Desktop size.
-$recoleta-font-family: 'Recoleta', sans-serif;
-$system-font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Segoe UI', 'Roboto',
-	'Oxygen-Sans', 'Ubuntu', 'Cantarell', 'Helvetica Neue', sans-serif;
+$recoleta-font-family: "Recoleta", sans-serif;
+$system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI", "Roboto",
+	"Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
 
 .lpc-mobile-menu-mask {
 	position: fixed !important;
@@ -15,9 +15,9 @@ $system-font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Segoe UI',
 	height: 100vh !important;
 	background-image: none !important;
 	z-index: 2147483646;
-	background-color: rgba( 0, 0, 0, 0.5 );
+	background-color: rgba(0, 0, 0, 0.5);
 	animation-duration: 233ms;
-	animation-timing-function: cubic-bezier( 0, 0, 0.21, 1 );
+	animation-timing-function: cubic-bezier(0, 0, 0.21, 1);
 	animation-fill-mode: forwards;
 	display: none;
 	animation-name: i-amphtml-sidebar-mask-fade-in;
@@ -32,13 +32,13 @@ $system-font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Segoe UI',
 
 .x-menu,
 .x-link {
-	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
 	text-rendering: optimizeLegibility;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 }
 
-.x-root [role='menuitem']:focus {
+.x-root [role="menuitem"]:focus {
 	outline: 1px dotted Highlight;
 	outline: 5px auto -webkit-focus-ring-color;
 }
@@ -51,7 +51,7 @@ $system-font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Segoe UI',
 	background: none;
 	color: inherit;
 	font: inherit;
-	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
 	text-decoration: none;
 	cursor: pointer;
 	transition: 0.15s ease-out;
@@ -80,7 +80,7 @@ $system-font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Segoe UI',
 
 .x-hidden {
 	border: 0;
-	clip: rect( 0 0 0 0 );
+	clip: rect(0 0 0 0);
 	height: 1px;
 	margin: -1px;
 	overflow: hidden;
@@ -122,11 +122,11 @@ $system-font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Segoe UI',
 	left: 11px;
 	height: 2px;
 	width: 14px;
-	transform: rotate( 45deg );
+	transform: rotate(45deg);
 }
 
 .x-icon--close span + span {
-	transform: rotate( -45deg );
+	transform: rotate(-45deg);
 }
 
 .x-icon--menu {
@@ -192,7 +192,7 @@ $system-font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Segoe UI',
 	position: relative;
 	border-radius: 4px;
 	background: #fff;
-	box-shadow: 0 9px 48px rgba( 16, 21, 23, 0.25 );
+	box-shadow: 0 9px 48px rgba(16, 21, 23, 0.25);
 }
 
 .x-dropdown-top-fill {
@@ -200,7 +200,7 @@ $system-font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Segoe UI',
 }
 
 .x-dropdown-top-fill::before {
-	content: '';
+	content: "";
 	position: absolute;
 	top: 0;
 	left: 90px;
@@ -208,7 +208,7 @@ $system-font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Segoe UI',
 	background: inherit;
 	width: 36px;
 	height: 36px;
-	transform: rotate( 45deg );
+	transform: rotate(45deg);
 }
 
 .x-dropdown-bottom-fill {
@@ -226,7 +226,7 @@ $system-font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Segoe UI',
 	pointer-events: none;
 }
 
-.x-dropdown-content[aria-hidden='false'] {
+.x-dropdown-content[aria-hidden="false"] {
 	z-index: 1;
 	pointer-events: auto;
 }
@@ -270,7 +270,7 @@ $system-font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Segoe UI',
 	justify-content: space-between;
 	height: 57px;
 	padding: 0 24px;
-	color: rgb( var( --lp-color-primary, 255, 255, 255 ) );
+	color: rgb(var(--lp-color-primary, 255, 255, 255));
 }
 
 .x-nav-list {
@@ -287,7 +287,7 @@ $system-font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Segoe UI',
 .x-nav-list--right {
 	position: initial;
 	.x-nav-link--primary {
-		border: 1px solid var( --studio-gray-5 );
+		border: 1px solid var(--studio-gray-5);
 		background-color: transparent;
 		padding: 9px 12px 10px;
 		border-radius: 4px;
@@ -320,7 +320,7 @@ $system-font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Segoe UI',
 }
 
 .x-nav-link-chevron::before {
-	content: '▾';
+	content: "▾";
 }
 
 .x-nav-link--logo {
@@ -358,7 +358,7 @@ $system-font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Segoe UI',
 		padding-left: 18px;
 	}
 
-	.x-root .x-nav-link--primary[role='menuitem']:focus {
+	.x-root .x-nav-link--primary[role="menuitem"]:focus {
 		outline: none;
 	}
 
@@ -403,7 +403,7 @@ $system-font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Segoe UI',
 	right: 0;
 	bottom: 0;
 	left: 0;
-	background: rgba( 16, 21, 23, 0.85 );
+	background: rgba(16, 21, 23, 0.85);
 	opacity: 0;
 }
 
@@ -425,9 +425,9 @@ $system-font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Segoe UI',
 	background: #fff;
 	font-size: 0.875rem;
 	line-height: 19px;
-	transform: scale( 0 );
+	transform: scale(0);
 	transform-origin: 100% 0;
-	transform-origin: calc( 100% - 19px ) 15px;
+	transform-origin: calc(100% - 19px) 15px;
 	pointer-events: none;
 }
 
@@ -443,9 +443,9 @@ $system-font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Segoe UI',
 }
 
 .x-menu--open .x-menu-content {
-	transform: scale( 1 );
+	transform: scale(1);
 	transition-duration: 0.35s;
-	transition-timing-function: cubic-bezier( 0.1, 0.6, 0.2, 1 );
+	transition-timing-function: cubic-bezier(0.1, 0.6, 0.2, 1);
 	pointer-events: auto;
 }
 
@@ -511,12 +511,12 @@ $system-font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Segoe UI',
 }
 
 .x-menu-link-chevron::before {
-	content: '›';
+	content: "›";
 }
 
 .x-menu-link:hover .x-menu-link-chevron,
 .x-menu-link:active .x-menu-link-chevron {
-	transform: translate3d( 0.15em, 0, 0 );
+	transform: translate3d(0.15em, 0, 0);
 }
 
 .js-dynamic-type-on .x-menu-grid-item {

--- a/apps/happy-blocks/block-library/universal-header/style.scss
+++ b/apps/happy-blocks/block-library/universal-header/style.scss
@@ -1,11 +1,11 @@
-@import "@automattic/calypso-color-schemes";
+@import '~@automattic/calypso-color-schemes';
 
 $breakpoint-mobile: 782px; //Mobile size.
 $breakpoint-tablet: 1224px; //Large tablet size.
 $breakpoint-desktop: 1440px; //Desktop size.
-$recoleta-font-family: "Recoleta", sans-serif;
-$system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI", "Roboto",
-	"Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
+$recoleta-font-family: 'Recoleta', sans-serif;
+$system-font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans', 'Segoe UI', 'Roboto',
+	'Oxygen-Sans', 'Ubuntu', 'Cantarell', 'Helvetica Neue', sans-serif;
 
 .lpc-mobile-menu-mask {
 	position: fixed !important;
@@ -15,9 +15,9 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 	height: 100vh !important;
 	background-image: none !important;
 	z-index: 2147483646;
-	background-color: rgba(0, 0, 0, 0.5);
+	background-color: rgba( 0, 0, 0, 0.5 );
 	animation-duration: 233ms;
-	animation-timing-function: cubic-bezier(0, 0, 0.21, 1);
+	animation-timing-function: cubic-bezier( 0, 0, 0.21, 1 );
 	animation-fill-mode: forwards;
 	display: none;
 	animation-name: i-amphtml-sidebar-mask-fade-in;
@@ -32,13 +32,13 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 
 .x-menu,
 .x-link {
-	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
 	text-rendering: optimizeLegibility;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 }
 
-.x-root [role="menuitem"]:focus {
+.x-root [role='menuitem']:focus {
 	outline: 1px dotted Highlight;
 	outline: 5px auto -webkit-focus-ring-color;
 }
@@ -51,7 +51,7 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 	background: none;
 	color: inherit;
 	font: inherit;
-	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
 	text-decoration: none;
 	cursor: pointer;
 	transition: 0.15s ease-out;
@@ -80,7 +80,7 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 
 .x-hidden {
 	border: 0;
-	clip: rect(0 0 0 0);
+	clip: rect( 0 0 0 0 );
 	height: 1px;
 	margin: -1px;
 	overflow: hidden;
@@ -122,11 +122,11 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 	left: 11px;
 	height: 2px;
 	width: 14px;
-	transform: rotate(45deg);
+	transform: rotate( 45deg );
 }
 
 .x-icon--close span + span {
-	transform: rotate(-45deg);
+	transform: rotate( -45deg );
 }
 
 .x-icon--menu {
@@ -192,7 +192,7 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 	position: relative;
 	border-radius: 4px;
 	background: #fff;
-	box-shadow: 0 9px 48px rgba(16, 21, 23, 0.25);
+	box-shadow: 0 9px 48px rgba( 16, 21, 23, 0.25 );
 }
 
 .x-dropdown-top-fill {
@@ -200,7 +200,7 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 }
 
 .x-dropdown-top-fill::before {
-	content: "";
+	content: '';
 	position: absolute;
 	top: 0;
 	left: 90px;
@@ -208,7 +208,7 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 	background: inherit;
 	width: 36px;
 	height: 36px;
-	transform: rotate(45deg);
+	transform: rotate( 45deg );
 }
 
 .x-dropdown-bottom-fill {
@@ -226,7 +226,7 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 	pointer-events: none;
 }
 
-.x-dropdown-content[aria-hidden="false"] {
+.x-dropdown-content[aria-hidden='false'] {
 	z-index: 1;
 	pointer-events: auto;
 }
@@ -270,7 +270,7 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 	justify-content: space-between;
 	height: 57px;
 	padding: 0 24px;
-	color: rgb(var(--lp-color-primary, 255, 255, 255));
+	color: rgb( var( --lp-color-primary, 255, 255, 255 ) );
 }
 
 .x-nav-list {
@@ -287,7 +287,7 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 .x-nav-list--right {
 	position: initial;
 	.x-nav-link--primary {
-		border: 1px solid var(--studio-gray-5);
+		border: 1px solid var( --studio-gray-5 );
 		background-color: transparent;
 		padding: 9px 12px 10px;
 		border-radius: 4px;
@@ -320,7 +320,7 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 }
 
 .x-nav-link-chevron::before {
-	content: "▾";
+	content: '▾';
 }
 
 .x-nav-link--logo {
@@ -333,7 +333,6 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 }
 
 @media ( min-width: 768px ) {
-
 	.x-nav-link--menu {
 		padding: 0 9px 0 9px;
 		margin-right: 15px;
@@ -359,7 +358,7 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 		padding-left: 18px;
 	}
 
-	.x-root .x-nav-link--primary[role="menuitem"]:focus {
+	.x-root .x-nav-link--primary[role='menuitem']:focus {
 		outline: none;
 	}
 
@@ -370,7 +369,6 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 }
 
 @media ( min-width: 1056px ) {
-
 	.x-nav-link--primary {
 		padding: 9px 12px 10px;
 	}
@@ -405,7 +403,7 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 	right: 0;
 	bottom: 0;
 	left: 0;
-	background: rgba(16, 21, 23, 0.85);
+	background: rgba( 16, 21, 23, 0.85 );
 	opacity: 0;
 }
 
@@ -427,9 +425,9 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 	background: #fff;
 	font-size: 0.875rem;
 	line-height: 19px;
-	transform: scale(0);
+	transform: scale( 0 );
 	transform-origin: 100% 0;
-	transform-origin: calc(100% - 19px) 15px;
+	transform-origin: calc( 100% - 19px ) 15px;
 	pointer-events: none;
 }
 
@@ -445,9 +443,9 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 }
 
 .x-menu--open .x-menu-content {
-	transform: scale(1);
+	transform: scale( 1 );
 	transition-duration: 0.35s;
-	transition-timing-function: cubic-bezier(0.1, 0.6, 0.2, 1);
+	transition-timing-function: cubic-bezier( 0.1, 0.6, 0.2, 1 );
 	pointer-events: auto;
 }
 
@@ -513,12 +511,12 @@ $system-font-family: -apple-system, BlinkMacSystemFont, "Noto Sans", "Segoe UI",
 }
 
 .x-menu-link-chevron::before {
-	content: "›";
+	content: '›';
 }
 
 .x-menu-link:hover .x-menu-link-chevron,
 .x-menu-link:active .x-menu-link-chevron {
-	transform: translate3d(0.15em, 0, 0);
+	transform: translate3d( 0.15em, 0, 0 );
 }
 
 .js-dynamic-type-on .x-menu-grid-item {

--- a/apps/happy-blocks/build.mjs
+++ b/apps/happy-blocks/build.mjs
@@ -1,0 +1,122 @@
+import * as esbuild from 'esbuild';
+import { sassPlugin } from 'esbuild-sass-plugin';
+import rtlcss from 'rtlcss';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+async function scanDirectories( basePath, extensions ) {
+	return ( await fs.readdir( basePath, { withFileTypes: true } ) )
+		.filter( ( dirent ) => dirent.isDirectory() )
+		.map( ( dirent ) => dirent.name );
+}
+
+const rtlCSSPlugin = {
+	name: 'RTLCSSPlugin',
+	setup( build ) {
+		build.onEnd( ( result ) => {
+			Promise.all(
+				Object.keys( result.metafile.outputs ).map( async ( file ) => {
+					if ( /\.css$/.test( file ) ) {
+						const cssContent = await fs.readFile( file, 'utf8' );
+						const rtlContent = rtlcss.process( cssContent );
+						await fs.writeFile( file.replace( /\.css$/, '.rtl.css' ), rtlContent );
+					}
+				} )
+			);
+		} );
+	},
+};
+
+const copyFilesPlugin = ( filesToCopy ) => ( {
+	name: 'CopyFilesPlugin',
+	setup( build ) {
+		build.onEnd( async ( result ) => {
+			await Promise.all(
+				filesToCopy.map( async ( { src, dest, transform } ) => {
+					try {
+						await fs.cp( src, dest, { force: true, recursive: true } );
+
+						if ( transform ) {
+							await fs.writeFile( dest, transform( await fs.readFile( dest, 'utf8' ) ) );
+						}
+					} catch ( error ) {}
+				} )
+			);
+		} );
+	},
+} );
+
+const blocks = await scanDirectories( './block-library' );
+
+const result = blocks.map( async ( block ) => {
+	const blockPath = path.resolve( process.cwd(), 'block-library', block );
+	const entryPoints = ( await fs.readdir( blockPath ) )
+		.filter( ( filepath ) => {
+			return /(index|view)\.(j|t)sx?$/.test( filepath );
+		} )
+		.map( ( entryPoint ) => path.join( blockPath, entryPoint ) );
+
+	if ( entryPoints.length === 0 ) {
+		return;
+	}
+
+	const outdir = path.join( blockPath, 'build' );
+	const define = {
+		__i18n_text_domain__: JSON.stringify( 'happy-blocks' ),
+		'process.env.FORCE_REDUCED_MOTION': JSON.stringify(
+			!! process.env.FORCE_REDUCED_MOTION || false
+		),
+		global: 'window',
+	};
+
+	if ( process.env.NODE_ENV ) {
+		define[ 'process.env.NODE_ENV' ] = JSON.stringify( process.env.NODE_ENV );
+	}
+
+	const result = await esbuild.build( {
+		bundle: true,
+		minify: true,
+		metafile: true,
+		entryPoints,
+		outdir,
+		loader: { '.svg': 'file', '.png': 'file', '.js': 'jsx' },
+		mainFields: [ 'browser', 'calypso:src', 'module', 'main' ],
+		define,
+		plugins: [
+			sassPlugin( {
+				quietDeps: true,
+			} ),
+			rtlCSSPlugin,
+			copyFilesPlugin( [
+				{ src: path.join( blockPath, 'assets' ), dest: path.join( outdir, 'assets' ) },
+				{
+					src: path.join( blockPath, 'index.php' ),
+					dest: path.join( outdir, 'index.php' ),
+					transform( content ) {
+						return content.toString().replaceAll( '/build/rtl', '/rtl' ).replaceAll( '/build', '' );
+					},
+				},
+				{
+					src: path.join( blockPath, 'includes.php' ),
+					dest: path.join( outdir, 'includes.php' ),
+					transform( content ) {
+						return content.toString().replaceAll( '/build/rtl', '/rtl' ).replaceAll( '/build', '' );
+					},
+				},
+
+				{ src: path.join( blockPath, 'block.json' ), dest: path.join( outdir, 'block.json' ) },
+				{
+					src: path.join( blockPath, 'rtl', 'block.json' ),
+					dest: path.join( outdir, 'rtl', 'block.json' ),
+				},
+			] ),
+		],
+	} );
+
+	await fs.writeFile(
+		path.join( blockPath, 'build', 'meta.json' ),
+		JSON.stringify( result.metafile )
+	);
+} );
+
+await Promise.all( result );

--- a/apps/happy-blocks/package.json
+++ b/apps/happy-blocks/package.json
@@ -21,11 +21,12 @@
 		"build:support-content-links": "calypso-build --env block='support-content-links'",
 		"build-translations-manifest": "yarn run build-calypso-strings && node bin/build-translations-manifest.js",
 		"clean": "rm -r release-files block-library/*/build || true",
-		"dev": "yarn run calypso-apps-builder --localPath / --remotePath /home/wpcom/public_html/wp-content/a8c-plugins/happy-blocks"
+		"dev": "node build.mjs"
 	},
 	"dependencies": {
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/calypso-build": "workspace:^",
+		"@automattic/calypso-color-schemes": "workspace:^",
 		"@automattic/calypso-config": "workspace:^",
 		"@automattic/calypso-products": "workspace:^",
 		"@automattic/color-studio": "2.5.0",
@@ -46,7 +47,8 @@
 		"glob": "^7.1.6",
 		"i18n-calypso": "workspace:^",
 		"react": "^18.2.0",
-		"react-dom": "^18.2.0"
+		"react-dom": "^18.2.0",
+		"wpcom-proxy-request": "workspace:^"
 	},
 	"devDependencies": {
 		"@automattic/calypso-apps-builder": "workspace:^",
@@ -54,8 +56,11 @@
 		"@testing-library/react": "^14.0.0",
 		"@wordpress/readable-js-assets-webpack-plugin": "^2.21.0",
 		"copy-webpack-plugin": "^10.1.0",
+		"esbuild": "^0.19.5",
+		"esbuild-sass-plugin": "^2.16.0",
 		"glob": "^7.1.6",
 		"postcss": "^8.4.5",
+		"rtlcss": "^4.1.1",
 		"webpack": "^5.68.0"
 	}
 }

--- a/packages/components/src/pagination-control/style.scss
+++ b/packages/components/src/pagination-control/style.scss
@@ -1,4 +1,4 @@
-@import "@automattic/calypso-color-schemes";
+@import '~@automattic/calypso-color-schemes';
 
 .pagination-control {
 	margin: 0;
@@ -27,10 +27,10 @@
 		border-radius: 50%;
 		cursor: pointer;
 		transition: all 0.2s ease-in-out;
-		background-color: var(--color-neutral-10);
+		background-color: var( --color-neutral-10 );
 
 		&:hover {
-			background-color: var(--color-neutral-40);
+			background-color: var( --color-neutral-40 );
 		}
 
 		&:disabled {
@@ -38,8 +38,7 @@
 		}
 
 		&.is-current {
-			background-color: var(--wp-admin-theme-color);
+			background-color: var( --wp-admin-theme-color );
 		}
 	}
-
 }

--- a/packages/components/src/pagination-control/style.scss
+++ b/packages/components/src/pagination-control/style.scss
@@ -1,4 +1,4 @@
-@import '~@automattic/calypso-color-schemes';
+@import "~@automattic/calypso-color-schemes";
 
 .pagination-control {
 	margin: 0;
@@ -27,10 +27,10 @@
 		border-radius: 50%;
 		cursor: pointer;
 		transition: all 0.2s ease-in-out;
-		background-color: var( --color-neutral-10 );
+		background-color: var(--color-neutral-10);
 
 		&:hover {
-			background-color: var( --color-neutral-40 );
+			background-color: var(--color-neutral-40);
 		}
 
 		&:disabled {
@@ -38,7 +38,7 @@
 		}
 
 		&.is-current {
-			background-color: var( --wp-admin-theme-color );
+			background-color: var(--wp-admin-theme-color);
 		}
 	}
 }

--- a/packages/i18n-calypso/package.json
+++ b/packages/i18n-calypso/package.json
@@ -30,6 +30,7 @@
 		"use-subscription": "1.6.0"
 	},
 	"devDependencies": {
+		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",

--- a/packages/load-script/package.json
+++ b/packages/load-script/package.json
@@ -31,6 +31,7 @@
 		"prepack": "yarn run clean && yarn run build"
 	},
 	"devDependencies": {
+		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1136,6 +1136,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/load-script@workspace:packages/load-script"
   dependencies:
+    "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@babel/runtime": ^7.23.2
     debug: ^4.3.3
@@ -3947,9 +3948,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/android-arm64@npm:0.19.5":
+  version: 0.19.5
+  resolution: "@esbuild/android-arm64@npm:0.19.5"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/android-arm@npm:0.18.20":
   version: 0.18.20
   resolution: "@esbuild/android-arm@npm:0.18.20"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm@npm:0.19.5":
+  version: 0.19.5
+  resolution: "@esbuild/android-arm@npm:0.19.5"
   conditions: os=android & cpu=arm
   languageName: node
   linkType: hard
@@ -3961,9 +3976,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/android-x64@npm:0.19.5":
+  version: 0.19.5
+  resolution: "@esbuild/android-x64@npm:0.19.5"
+  conditions: os=android & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/darwin-arm64@npm:0.18.20":
   version: 0.18.20
   resolution: "@esbuild/darwin-arm64@npm:0.18.20"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-arm64@npm:0.19.5":
+  version: 0.19.5
+  resolution: "@esbuild/darwin-arm64@npm:0.19.5"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
@@ -3975,9 +4004,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/darwin-x64@npm:0.19.5":
+  version: 0.19.5
+  resolution: "@esbuild/darwin-x64@npm:0.19.5"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/freebsd-arm64@npm:0.18.20":
   version: 0.18.20
   resolution: "@esbuild/freebsd-arm64@npm:0.18.20"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-arm64@npm:0.19.5":
+  version: 0.19.5
+  resolution: "@esbuild/freebsd-arm64@npm:0.19.5"
   conditions: os=freebsd & cpu=arm64
   languageName: node
   linkType: hard
@@ -3989,9 +4032,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/freebsd-x64@npm:0.19.5":
+  version: 0.19.5
+  resolution: "@esbuild/freebsd-x64@npm:0.19.5"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-arm64@npm:0.18.20":
   version: 0.18.20
   resolution: "@esbuild/linux-arm64@npm:0.18.20"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm64@npm:0.19.5":
+  version: 0.19.5
+  resolution: "@esbuild/linux-arm64@npm:0.19.5"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
@@ -4003,9 +4060,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-arm@npm:0.19.5":
+  version: 0.19.5
+  resolution: "@esbuild/linux-arm@npm:0.19.5"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-ia32@npm:0.18.20":
   version: 0.18.20
   resolution: "@esbuild/linux-ia32@npm:0.18.20"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ia32@npm:0.19.5":
+  version: 0.19.5
+  resolution: "@esbuild/linux-ia32@npm:0.19.5"
   conditions: os=linux & cpu=ia32
   languageName: node
   linkType: hard
@@ -4017,9 +4088,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-loong64@npm:0.19.5":
+  version: 0.19.5
+  resolution: "@esbuild/linux-loong64@npm:0.19.5"
+  conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-mips64el@npm:0.18.20":
   version: 0.18.20
   resolution: "@esbuild/linux-mips64el@npm:0.18.20"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-mips64el@npm:0.19.5":
+  version: 0.19.5
+  resolution: "@esbuild/linux-mips64el@npm:0.19.5"
   conditions: os=linux & cpu=mips64el
   languageName: node
   linkType: hard
@@ -4031,9 +4116,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-ppc64@npm:0.19.5":
+  version: 0.19.5
+  resolution: "@esbuild/linux-ppc64@npm:0.19.5"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-riscv64@npm:0.18.20":
   version: 0.18.20
   resolution: "@esbuild/linux-riscv64@npm:0.18.20"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-riscv64@npm:0.19.5":
+  version: 0.19.5
+  resolution: "@esbuild/linux-riscv64@npm:0.19.5"
   conditions: os=linux & cpu=riscv64
   languageName: node
   linkType: hard
@@ -4045,9 +4144,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-s390x@npm:0.19.5":
+  version: 0.19.5
+  resolution: "@esbuild/linux-s390x@npm:0.19.5"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-x64@npm:0.18.20":
   version: 0.18.20
   resolution: "@esbuild/linux-x64@npm:0.18.20"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-x64@npm:0.19.5":
+  version: 0.19.5
+  resolution: "@esbuild/linux-x64@npm:0.19.5"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
@@ -4059,9 +4172,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/netbsd-x64@npm:0.19.5":
+  version: 0.19.5
+  resolution: "@esbuild/netbsd-x64@npm:0.19.5"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/openbsd-x64@npm:0.18.20":
   version: 0.18.20
   resolution: "@esbuild/openbsd-x64@npm:0.18.20"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-x64@npm:0.19.5":
+  version: 0.19.5
+  resolution: "@esbuild/openbsd-x64@npm:0.19.5"
   conditions: os=openbsd & cpu=x64
   languageName: node
   linkType: hard
@@ -4073,9 +4200,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/sunos-x64@npm:0.19.5":
+  version: 0.19.5
+  resolution: "@esbuild/sunos-x64@npm:0.19.5"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/win32-arm64@npm:0.18.20":
   version: 0.18.20
   resolution: "@esbuild/win32-arm64@npm:0.18.20"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-arm64@npm:0.19.5":
+  version: 0.19.5
+  resolution: "@esbuild/win32-arm64@npm:0.19.5"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -4087,9 +4228,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/win32-ia32@npm:0.19.5":
+  version: 0.19.5
+  resolution: "@esbuild/win32-ia32@npm:0.19.5"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@esbuild/win32-x64@npm:0.18.20":
   version: 0.18.20
   resolution: "@esbuild/win32-x64@npm:0.18.20"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-x64@npm:0.19.5":
+  version: 0.19.5
+  resolution: "@esbuild/win32-x64@npm:0.19.5"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -15691,6 +15846,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esbuild-sass-plugin@npm:^2.16.0":
+  version: 2.16.0
+  resolution: "esbuild-sass-plugin@npm:2.16.0"
+  dependencies:
+    resolve: ^1.22.6
+    sass: ^1.7.3
+  peerDependencies:
+    esbuild: ^0.19.4
+  checksum: ebaf1b3c4fafdf87f50fea3a53f0983820823458a5d2f7df37014a5f462e04ff9ec1c1746af41e2954b11a59acb4156d3bddaa54b8da673c27b29eb217aebf9e
+  languageName: node
+  linkType: hard
+
 "esbuild@npm:^0.18.0":
   version: 0.18.20
   resolution: "esbuild@npm:0.18.20"
@@ -15765,6 +15932,83 @@ __metadata:
   bin:
     esbuild: bin/esbuild
   checksum: 473b1d92842f50a303cf948a11ebd5f69581cd254d599dd9d62f9989858e0533f64e83b723b5e1398a5b488c0f5fd088795b4235f65ecaf4f007d4b79f04bc88
+  languageName: node
+  linkType: hard
+
+"esbuild@npm:^0.19.5":
+  version: 0.19.5
+  resolution: "esbuild@npm:0.19.5"
+  dependencies:
+    "@esbuild/android-arm": 0.19.5
+    "@esbuild/android-arm64": 0.19.5
+    "@esbuild/android-x64": 0.19.5
+    "@esbuild/darwin-arm64": 0.19.5
+    "@esbuild/darwin-x64": 0.19.5
+    "@esbuild/freebsd-arm64": 0.19.5
+    "@esbuild/freebsd-x64": 0.19.5
+    "@esbuild/linux-arm": 0.19.5
+    "@esbuild/linux-arm64": 0.19.5
+    "@esbuild/linux-ia32": 0.19.5
+    "@esbuild/linux-loong64": 0.19.5
+    "@esbuild/linux-mips64el": 0.19.5
+    "@esbuild/linux-ppc64": 0.19.5
+    "@esbuild/linux-riscv64": 0.19.5
+    "@esbuild/linux-s390x": 0.19.5
+    "@esbuild/linux-x64": 0.19.5
+    "@esbuild/netbsd-x64": 0.19.5
+    "@esbuild/openbsd-x64": 0.19.5
+    "@esbuild/sunos-x64": 0.19.5
+    "@esbuild/win32-arm64": 0.19.5
+    "@esbuild/win32-ia32": 0.19.5
+    "@esbuild/win32-x64": 0.19.5
+  dependenciesMeta:
+    "@esbuild/android-arm":
+      optional: true
+    "@esbuild/android-arm64":
+      optional: true
+    "@esbuild/android-x64":
+      optional: true
+    "@esbuild/darwin-arm64":
+      optional: true
+    "@esbuild/darwin-x64":
+      optional: true
+    "@esbuild/freebsd-arm64":
+      optional: true
+    "@esbuild/freebsd-x64":
+      optional: true
+    "@esbuild/linux-arm":
+      optional: true
+    "@esbuild/linux-arm64":
+      optional: true
+    "@esbuild/linux-ia32":
+      optional: true
+    "@esbuild/linux-loong64":
+      optional: true
+    "@esbuild/linux-mips64el":
+      optional: true
+    "@esbuild/linux-ppc64":
+      optional: true
+    "@esbuild/linux-riscv64":
+      optional: true
+    "@esbuild/linux-s390x":
+      optional: true
+    "@esbuild/linux-x64":
+      optional: true
+    "@esbuild/netbsd-x64":
+      optional: true
+    "@esbuild/openbsd-x64":
+      optional: true
+    "@esbuild/sunos-x64":
+      optional: true
+    "@esbuild/win32-arm64":
+      optional: true
+    "@esbuild/win32-ia32":
+      optional: true
+    "@esbuild/win32-x64":
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: 401e6da33bf6f2c4bbfa0aa8f37ddc6eb41c9d8ddf6b32c9922aabeef3f1886ed792eb03e778859e7e61467c765c78245f88216bc1a59050413ce7a513dd675f
   languageName: node
   linkType: hard
 
@@ -18240,6 +18484,7 @@ __metadata:
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-apps-builder": "workspace:^"
     "@automattic/calypso-build": "workspace:^"
+    "@automattic/calypso-color-schemes": "workspace:^"
     "@automattic/calypso-config": "workspace:^"
     "@automattic/calypso-products": "workspace:^"
     "@automattic/color-studio": 2.5.0
@@ -18261,12 +18506,16 @@ __metadata:
     "@wordpress/readable-js-assets-webpack-plugin": ^2.21.0
     classnames: ^2.3.2
     copy-webpack-plugin: ^10.1.0
+    esbuild: ^0.19.5
+    esbuild-sass-plugin: ^2.16.0
     glob: ^7.1.6
     i18n-calypso: "workspace:^"
     postcss: ^8.4.5
     react: ^18.2.0
     react-dom: ^18.2.0
+    rtlcss: ^4.1.1
     webpack: ^5.68.0
+    wpcom-proxy-request: "workspace:^"
   languageName: unknown
   linkType: soft
 
@@ -18912,6 +19161,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "i18n-calypso@workspace:packages/i18n-calypso"
   dependencies:
+    "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/interpolate-components": "workspace:^"
     "@babel/runtime": ^7.23.2
@@ -19019,6 +19269,13 @@ __metadata:
   version: 3.8.2
   resolution: "immutable@npm:3.8.2"
   checksum: fb6a2999ad3bda9e51741721e42547076dd492635ee4df9241224055fe953ec843583a700088cc4915f23dc326e5084f4e17f1bbd7388c3e872ef5a242e0ac5e
+  languageName: node
+  linkType: hard
+
+"immutable@npm:^4.0.0":
+  version: 4.3.4
+  resolution: "immutable@npm:4.3.4"
+  checksum: c15b9f0fa7b3c9315725cb00704fddad59f0e668a7379c39b9a528a8386140ee9effb015ae51a5b423e05c59d15fc0b38c970db6964ad6b3e05d0761db68441f
   languageName: node
   linkType: hard
 
@@ -27757,7 +28014,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@^1.10.0, resolve@^1.14.2, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.9.0, resolve@npm:^1.22.4":
+"resolve@^1.10.0, resolve@^1.14.2, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.9.0, resolve@npm:^1.22.4, resolve@npm:^1.22.6":
   version: 1.22.8
   resolution: "resolve@npm:1.22.8"
   dependencies:
@@ -27783,7 +28040,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@^1.10.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.14.2#~builtin<compat/resolve>, resolve@patch:resolve@^1.19.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.20.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.4#~builtin<compat/resolve>, resolve@patch:resolve@^1.9.0#~builtin<compat/resolve>":
+"resolve@patch:resolve@^1.10.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.14.2#~builtin<compat/resolve>, resolve@patch:resolve@^1.19.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.20.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.4#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.6#~builtin<compat/resolve>, resolve@patch:resolve@^1.9.0#~builtin<compat/resolve>":
   version: 1.22.8
   resolution: "resolve@patch:resolve@npm%3A1.22.8#~builtin<compat/resolve>::version=1.22.8&hash=07638b"
   dependencies:
@@ -27971,6 +28228,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rtlcss@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "rtlcss@npm:4.1.1"
+  dependencies:
+    escalade: ^3.1.1
+    picocolors: ^1.0.0
+    postcss: ^8.4.21
+    strip-json-comments: ^3.1.1
+  bin:
+    rtlcss: bin/rtlcss.js
+  checksum: 8667f09f683139abf1d5a58e284fa57c903f1f502a86cd1a7fa867777378f7f93a3c156ba27852b826299156451fbf8c6413710ab1cce8e6da87dd31a266c669
+  languageName: node
+  linkType: hard
+
 "run-applescript@npm:^5.0.0":
   version: 5.0.0
   resolution: "run-applescript@npm:5.0.0"
@@ -28152,6 +28423,19 @@ __metadata:
   bin:
     sass: sass.js
   checksum: 6513358db6101d3dee29222a0f9ef246f57a2e4b4fe3ca9aafdfbfd5a4c600fe9b9063d28776be3b8ef564f58547a9bacd1c802b89150a4f1cc44c014cf8d782
+  languageName: node
+  linkType: hard
+
+"sass@npm:^1.7.3":
+  version: 1.69.5
+  resolution: "sass@npm:1.69.5"
+  dependencies:
+    chokidar: ">=3.0.0 <4.0.0"
+    immutable: ^4.0.0
+    source-map-js: ">=0.6.2 <2.0.0"
+  bin:
+    sass: sass.js
+  checksum: a9003a9482f2e467fc412cfe58ba4fa14fb78bef7e1283ce5d64a065f8a31114ec3bbf5d4e724f94eb8512c32c768a6f91f228c7f16a26a300bbf4db293b5608
   languageName: node
   linkType: hard
 
@@ -28777,7 +29061,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map-js@npm:^1.0.2":
+"source-map-js@npm:>=0.6.2 <2.0.0, source-map-js@npm:^1.0.2":
   version: 1.0.2
   resolution: "source-map-js@npm:1.0.2"
   checksum: 32f2dfd1e9b7168f9a9715eb1b4e21905850f3b50cf02cf476e47e4eebe8e6b762b63a64357896aa29b37e24922b4282df0f492e0d2ace572b43d15525976ff8


### PR DESCRIPTION
## Proposed Changes

Experiment to bundle `apps/happy-blocks` with `esbuild` rather than `webpack`. It's still a work in progress but bundling works fine and seems to be a lot faster. We still need to evaluate a few things, namely:

- call the translations script (needs to be updated): build-translations-manifest.js
- copy or rewrite the script which creates a `build_meta.json` used on CI
- add postcss/autoprefixer to the bunde process
- set up remote syncing (as done in `packages/calypso-app-builder/index.js`)

You can find instructions for esbuild in `apps/happy-blocks/build.mjs`.

## Testing Instructions

* tbd