### PR TITLE
SMP: Add filter  by sites I own on `/sites`

### DIFF
--- a/client/sites-dashboard/components/sites-content-controls.tsx
+++ b/client/sites-dashboard/components/sites-content-controls.tsx
@@ -18,6 +18,7 @@ export interface SitesDashboardQueryParams {
 	showHidden?: boolean;
 	status?: GroupableSiteLaunchStatuses;
 	newSiteID?: number;
+	isFilterByOwner?: boolean;
 }
 
 const FilterBar = styled.div( {
@@ -67,8 +68,6 @@ const VisibilityControls = styled.div( {
 } );
 
 const ControlsSelectDropdown = styled( SelectDropdown )( {
-	width: '100%',
-
 	'.select-dropdown__container': {
 		minWidth: '100%',
 
@@ -84,6 +83,7 @@ type SitesContentControlsProps = {
 	initialSearch?: string;
 	onQueryParamChange?: ( params: Partial< SitesDashboardQueryParams > ) => void;
 	statuses: Statuses;
+	isFilterByOwner: boolean;
 	selectedStatus: Statuses[ number ];
 } & ComponentPropsWithoutRef< typeof SitesDisplayModeSwitcher > &
 	ComponentPropsWithoutRef< typeof SitesSortingDropdown >;
@@ -118,6 +118,7 @@ export const SitesContentControls = ( {
 	sitesSorting,
 	onSitesSortingChange,
 	hasSitesSortingPreferenceLoaded,
+	isFilterByOwner = false,
 }: SitesContentControlsProps ) => {
 	const { __ } = useI18n();
 	const searchRef = useRef< SearchImperativeHandle >( null );
@@ -175,6 +176,38 @@ export const SitesContentControls = ( {
 							{ title }
 						</SelectDropdown.Item>
 					) ) }
+				</ControlsSelectDropdown>
+				<ControlsSelectDropdown
+					// Translators: `siteOwner` is one of the site statuses specified in the Sites page.
+					selectedText={ isFilterByOwner ? __( 'Owner: Me' ) : __( 'Owner: Everyone' ) }
+					ariaLabel={
+						isFilterByOwner ? __( 'Displaying my sites.' ) : __( 'Displaying all sites' )
+					}
+				>
+					<SelectDropdown.Item
+						selected={ ! isFilterByOwner }
+						// Translators: `siteStatus` is one of the site statuses specified in the Sites page. `count` is a number of sites of given status.
+						onClick={ () =>
+							onQueryParamChange( {
+								isFilterByOwner: undefined,
+								page: undefined,
+							} )
+						}
+					>
+						{ __( 'Everyone' ) }
+					</SelectDropdown.Item>
+					<SelectDropdown.Item
+						selected={ isFilterByOwner }
+						// Translators: `siteStatus` is one of the site statuses specified in the Sites page. `count` is a number of sites of given status.
+						onClick={ () =>
+							onQueryParamChange( {
+								isFilterByOwner: true,
+								page: undefined,
+							} )
+						}
+					>
+						{ __( 'Me' ) }
+					</SelectDropdown.Item>
 				</ControlsSelectDropdown>
 				<VisibilityControls>
 					<SitesSortingDropdown

--- a/client/sites-dashboard/components/sites-content-controls.tsx
+++ b/client/sites-dashboard/components/sites-content-controls.tsx
@@ -1,5 +1,9 @@
 import { SearchIcon, type ImperativeHandle as SearchImperativeHandle } from '@automattic/search';
-import { GroupableSiteLaunchStatuses, useSitesListGrouping } from '@automattic/sites';
+import {
+	GroupableSiteLaunchStatuses,
+	useSitesListFiltering,
+	useSitesListGrouping,
+} from '@automattic/sites';
 import styled from '@emotion/styled';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
@@ -78,6 +82,7 @@ const ControlsSelectDropdown = styled( SelectDropdown )( {
 } );
 
 type Statuses = ReturnType< typeof useSitesListGrouping >[ 'statuses' ];
+type CountOwner = ReturnType< typeof useSitesListFiltering >[ 'countOwner' ];
 
 type SitesContentControlsProps = {
 	initialSearch?: string;
@@ -85,6 +90,7 @@ type SitesContentControlsProps = {
 	statuses: Statuses;
 	isFilterByOwner: boolean;
 	selectedStatus: Statuses[ number ];
+	countOwner: CountOwner;
 } & ComponentPropsWithoutRef< typeof SitesDisplayModeSwitcher > &
 	ComponentPropsWithoutRef< typeof SitesSortingDropdown >;
 
@@ -119,6 +125,7 @@ export const SitesContentControls = ( {
 	onSitesSortingChange,
 	hasSitesSortingPreferenceLoaded,
 	isFilterByOwner = false,
+	countOwner = { me: 0, all: 0 },
 }: SitesContentControlsProps ) => {
 	const { __ } = useI18n();
 	const searchRef = useRef< SearchImperativeHandle >( null );
@@ -185,8 +192,8 @@ export const SitesContentControls = ( {
 					}
 				>
 					<SelectDropdown.Item
+						count={ countOwner.all }
 						selected={ ! isFilterByOwner }
-						// Translators: `siteStatus` is one of the site statuses specified in the Sites page. `count` is a number of sites of given status.
 						onClick={ () =>
 							onQueryParamChange( {
 								isFilterByOwner: undefined,
@@ -197,8 +204,8 @@ export const SitesContentControls = ( {
 						{ __( 'Everyone' ) }
 					</SelectDropdown.Item>
 					<SelectDropdown.Item
+						count={ countOwner.me }
 						selected={ isFilterByOwner }
-						// Translators: `siteStatus` is one of the site statuses specified in the Sites page. `count` is a number of sites of given status.
 						onClick={ () =>
 							onQueryParamChange( {
 								isFilterByOwner: true,

--- a/client/sites-dashboard/components/sites-content-controls.tsx
+++ b/client/sites-dashboard/components/sites-content-controls.tsx
@@ -22,7 +22,7 @@ export interface SitesDashboardQueryParams {
 	showHidden?: boolean;
 	status?: GroupableSiteLaunchStatuses;
 	newSiteID?: number;
-	isFilterByOwner?: boolean;
+	owner?: string;
 }
 
 const FilterBar = styled.div( {
@@ -196,7 +196,7 @@ export const SitesContentControls = ( {
 						selected={ ! isFilterByOwner }
 						onClick={ () =>
 							onQueryParamChange( {
-								isFilterByOwner: undefined,
+								owner: undefined,
 								page: undefined,
 							} )
 						}
@@ -208,7 +208,7 @@ export const SitesContentControls = ( {
 						selected={ isFilterByOwner }
 						onClick={ () =>
 							onQueryParamChange( {
-								isFilterByOwner: true,
+								owner: 'me',
 								page: undefined,
 							} )
 						}

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -150,14 +150,7 @@ const ManageAllDomainsButton = styled( Button )`
 const SitesDashboardSitesList = createSitesListComponent();
 
 export function SitesDashboard( {
-	queryParams: {
-		page = 1,
-		perPage = 96,
-		search,
-		status = 'all',
-		isFilterByOwner = false,
-		newSiteID,
-	},
+	queryParams: { page = 1, perPage = 96, search, status = 'all', owner = '', newSiteID },
 }: SitesDashboardProps ) {
 	const createSiteUrl = useAddNewSiteUrl( {
 		source: TRACK_SOURCE_NAME,
@@ -172,6 +165,7 @@ export function SitesDashboard( {
 		[],
 		( site ) => ! site.options?.is_domain_only
 	);
+	const isFilterByOwner = owner === 'me';
 	const { hasSitesSortingPreferenceLoaded, sitesSorting, onSitesSortingChange } = useSitesSorting();
 	const [ displayMode, setDisplayMode ] = useSitesDisplayMode();
 	const userPreferencesLoaded = hasSitesSortingPreferenceLoaded && 'none' !== displayMode;

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -149,7 +149,14 @@ const ManageAllDomainsButton = styled( Button )`
 const SitesDashboardSitesList = createSitesListComponent();
 
 export function SitesDashboard( {
-	queryParams: { page = 1, perPage = 96, search, status = 'all', newSiteID },
+	queryParams: {
+		page = 1,
+		perPage = 96,
+		search,
+		status = 'all',
+		isFilterByOwner = false,
+		newSiteID,
+	},
 }: SitesDashboardProps ) {
 	const createSiteUrl = useAddNewSiteUrl( {
 		source: TRACK_SOURCE_NAME,
@@ -233,7 +240,6 @@ export function SitesDashboard( {
 			<PageBodyWrapper>
 				<SitesDashboardSitesList
 					sites={ allSites }
-					filtering={ { search } }
 					sorting={ sitesSorting }
 					grouping={ { status, showHidden: true } }
 				>
@@ -255,6 +261,7 @@ export function SitesDashboard( {
 										sitesSorting={ sitesSorting }
 										onSitesSortingChange={ onSitesSortingChange }
 										hasSitesSortingPreferenceLoaded={ hasSitesSortingPreferenceLoaded }
+										isFilterByOwner={ isFilterByOwner }
 									/>
 								) }
 								{ userPreferencesLoaded && (

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -246,7 +246,7 @@ export function SitesDashboard( {
 					sorting={ sitesSorting }
 					grouping={ { status, showHidden: true } }
 				>
-					{ ( { sites, statuses } ) => {
+					{ ( { sites, statuses, countOwner } ) => {
 						const paginatedSites = sites.slice( ( page - 1 ) * perPage, page * perPage );
 
 						const selectedStatus =
@@ -265,6 +265,7 @@ export function SitesDashboard( {
 										onSitesSortingChange={ onSitesSortingChange }
 										hasSitesSortingPreferenceLoaded={ hasSitesSortingPreferenceLoaded }
 										isFilterByOwner={ isFilterByOwner }
+										countOwner={ countOwner }
 									/>
 								) }
 								{ userPreferencesLoaded && (

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -18,7 +18,8 @@ import SplitButton from 'calypso/components/split-button';
 import { useSiteExcerptsQuery } from 'calypso/data/sites/use-site-excerpts-query';
 import { useAddNewSiteUrl } from 'calypso/lib/paths/use-add-new-site-url';
 import { withoutHttp } from 'calypso/lib/url';
-import { useDispatch } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { successNotice } from 'calypso/state/notices/actions';
 import { useSitesSorting } from 'calypso/state/sites/hooks/use-sites-sorting';
 import { useSitesDashboardImportSiteUrl } from '../hooks/use-sites-dashboard-import-site-url';
@@ -165,6 +166,7 @@ export function SitesDashboard( {
 	const importSiteUrl = useSitesDashboardImportSiteUrl( {
 		ref: 'topbar',
 	} );
+	const userId = useSelector( ( state ) => getCurrentUserId( state ) );
 	const { __, _n } = useI18n();
 	const { data: allSites = [], isLoading } = useSiteExcerptsQuery(
 		[],
@@ -240,6 +242,7 @@ export function SitesDashboard( {
 			<PageBodyWrapper>
 				<SitesDashboardSitesList
 					sites={ allSites }
+					filtering={ { search, userId, isFilterByOwner } }
 					sorting={ sitesSorting }
 					grouping={ { status, showHidden: true } }
 				>

--- a/client/sites-dashboard/controller.tsx
+++ b/client/sites-dashboard/controller.tsx
@@ -129,7 +129,7 @@ function sitesDashboard( context: PageJSContext, next: () => void ) {
 					search: context.query.search,
 					status: context.query.status,
 					newSiteID: parseInt( context.query[ 'new-site' ] ) || undefined,
-					isFilterByOwner: context.query.isFilterByOwner === 'true',
+					owner: context.query.owner,
 				} }
 			/>
 		</>

--- a/client/sites-dashboard/controller.tsx
+++ b/client/sites-dashboard/controller.tsx
@@ -129,6 +129,7 @@ function sitesDashboard( context: PageJSContext, next: () => void ) {
 					search: context.query.search,
 					status: context.query.status,
 					newSiteID: parseInt( context.query[ 'new-site' ] ) || undefined,
+					isFilterByOwner: context.query.isFilterByOwner === 'true',
 				} }
 			/>
 		</>

--- a/packages/sites/src/create-sites-list-component.ts
+++ b/packages/sites/src/create-sites-list-component.ts
@@ -28,10 +28,11 @@ type FilteringProps = { filtering?: SitesFilterOptions };
 const addFiltering = < T extends BaseProps >( enabled: boolean, baseProps: T ) => {
 	if ( enabled ) {
 		const props = baseProps as T & FilteringProps;
-
+		const { sites, countOwner } = useSitesListFiltering( props.sites, props.filtering ?? {} );
 		return {
 			...props,
-			sites: useSitesListFiltering( props.sites, props.filtering ?? {} ),
+			sites,
+			countOwner,
 		};
 	}
 
@@ -87,7 +88,9 @@ type ComponentFilteringProp< T extends boolean > = T extends true
 	: {};
 
 type RenderProp< TSite, TGrouping > = TGrouping extends true
-	? BaseProps< TSite > & { statuses: Status[] }
+	? BaseProps< TSite > & { statuses: Status[] } & {
+			countOwner: ReturnType< typeof useSitesListFiltering >[ 'countOwner' ];
+	  }
 	: BaseProps< TSite >;
 
 type CreatedComponentProps<
@@ -114,7 +117,6 @@ export const createSitesListComponent = <
 		const grouped = addGrouping( grouping ?? true, props );
 		const sorted = addSorting( sorting ?? true, grouped );
 		const filtered = addFiltering( filtering ?? true, sorted );
-
 		return children( filtered as unknown as RenderProp< TSite, TGrouping > );
 	};
 };

--- a/packages/sites/src/site-type.ts
+++ b/packages/sites/src/site-type.ts
@@ -10,6 +10,7 @@ export interface MinimumSite {
 	launch_status?: string;
 	user_interactions?: string[];
 	is_wpcom_staging_site?: boolean;
+	site_owner?: number | null;
 	options?: {
 		wpcom_production_blog_id?: number;
 		wpcom_staging_blog_ids?: number[];

--- a/packages/sites/src/use-sites-list-filtering.tsx
+++ b/packages/sites/src/use-sites-list-filtering.tsx
@@ -15,8 +15,9 @@ export function useSitesListFiltering< T extends SiteForFiltering >(
 	sites: T[],
 	{ search, userId, isFilterByOwner }: SitesFilterOptions
 ) {
-	if ( isFilterByOwner && userId ) {
-		sites = sites.filter( ( site ) => site.site_owner === userId );
+	let sitesOwnedByMe: T[] = [];
+	if ( userId ) {
+		sitesOwnedByMe = sites.filter( ( site ) => site.site_owner === userId );
 	}
 	const filteredSites = useFuzzySearch( {
 		data: sites,
@@ -24,5 +25,11 @@ export function useSitesListFiltering< T extends SiteForFiltering >(
 		query: search,
 	} );
 
-	return filteredSites;
+	return {
+		sites: isFilterByOwner ? sitesOwnedByMe : filteredSites,
+		countOwner: {
+			me: sitesOwnedByMe.length,
+			all: sites.length,
+		},
+	};
 }

--- a/packages/sites/src/use-sites-list-filtering.tsx
+++ b/packages/sites/src/use-sites-list-filtering.tsx
@@ -20,13 +20,13 @@ export function useSitesListFiltering< T extends SiteForFiltering >(
 		sitesOwnedByMe = sites.filter( ( site ) => site.site_owner === userId );
 	}
 	const filteredSites = useFuzzySearch( {
-		data: sites,
+		data: isFilterByOwner ? sitesOwnedByMe : sites,
 		keys: SITES_SEARCH_INDEX_KEYS,
 		query: search,
 	} );
 
 	return {
-		sites: isFilterByOwner ? sitesOwnedByMe : filteredSites,
+		sites: filteredSites,
 		countOwner: {
 			me: sitesOwnedByMe.length,
 			all: sites.length,

--- a/packages/sites/src/use-sites-list-filtering.tsx
+++ b/packages/sites/src/use-sites-list-filtering.tsx
@@ -5,14 +5,19 @@ export const SITES_SEARCH_INDEX_KEYS = [ 'name', 'slug', 'title', 'URL' ];
 
 export interface SitesFilterOptions {
 	search?: string;
+	userId?: number | null;
+	isFilterByOwner?: boolean;
 }
 
-type SiteForFiltering = Pick< MinimumSite, 'URL' | 'name' | 'slug' | 'title' >;
+type SiteForFiltering = Pick< MinimumSite, 'URL' | 'name' | 'slug' | 'title' | 'site_owner' >;
 
 export function useSitesListFiltering< T extends SiteForFiltering >(
 	sites: T[],
-	{ search }: SitesFilterOptions
+	{ search, userId, isFilterByOwner }: SitesFilterOptions
 ) {
+	if ( isFilterByOwner && userId ) {
+		sites = sites.filter( ( site ) => site.site_owner === userId );
+	}
 	const filteredSites = useFuzzySearch( {
 		data: sites,
 		keys: SITES_SEARCH_INDEX_KEYS,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Closes https://github.com/Automattic/dotcom-forge/issues/4542

## Proposed Changes

I still need to apply the same changes on `client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/site-picker.tsx`

* It adds a new dropdown on `/sites` to display the sites you own.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this branch locally or use calypso live link
* Navigate to `/sites`
* Click on `Owner: Everyone` and pick `Me`
* Observe you see only your sites
* Search something on the text input
* Observe the sites filter correctly
* Pick a different status, like Public
* Observe all the filters apply correctly


## Screencast

https://github.com/Automattic/wp-calypso/assets/779993/b981dd99-c7c6-4896-ad40-7412bfa7b2eb



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?