### PR TITLE
Domains: Add Glue Records management UI

### DIFF
--- a/client/components/domains/accordion/index.tsx
+++ b/client/components/domains/accordion/index.tsx
@@ -13,6 +13,7 @@ const Accordion = ( {
 	isDisabled,
 	expanded = false,
 	onClose,
+	onOpen,
 	className,
 }: AccordionProps ) => {
 	const classes = classNames( {
@@ -49,6 +50,7 @@ const Accordion = ( {
 					</button>
 				}
 				onClose={ onClose }
+				onOpen={ onOpen }
 			>
 				{ children }
 			</FoldableCard>

--- a/client/components/domains/accordion/types.ts
+++ b/client/components/domains/accordion/types.ts
@@ -6,6 +6,7 @@ export type AccordionProps = {
 	subtitle?: string | React.ReactNode;
 	expanded?: boolean;
 	onClose?: () => void;
+	onOpen?: () => void;
 
 	isPlaceholder?: boolean;
 	isDisabled?: boolean;

--- a/client/data/domains/glue-records/domain-glue-record-query-key.ts
+++ b/client/data/domains/glue-records/domain-glue-record-query-key.ts
@@ -1,0 +1,5 @@
+import { QueryKey } from '@tanstack/react-query';
+
+export function domainGlueRecordQueryKey( domainName: string ): QueryKey {
+	return [ 'glue-record', domainName ];
+}

--- a/client/data/domains/glue-records/use-delete-glue-record-mutation.ts
+++ b/client/data/domains/glue-records/use-delete-glue-record-mutation.ts
@@ -1,0 +1,42 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+import { domainGlueRecordQueryKey } from 'calypso/data/domains/glue-records/domain-glue-record-query-key';
+import { DomainsApiError } from 'calypso/lib/domains/types';
+import wp from 'calypso/lib/wp';
+
+export default function useDeleteGlueRecordMutation(
+	domainName: string,
+	queryOptions: {
+		onSuccess?: () => void;
+		onError?: ( error: DomainsApiError ) => void;
+	}
+) {
+	const queryClient = useQueryClient();
+	const mutation = useMutation( {
+		mutationFn: ( glueRecord: string ) =>
+			wp.req.post(
+				{
+					path: `/domains/glue-records/${ domainName }`,
+					apiNamespace: 'wpcom/v2',
+					method: 'DELETE',
+				},
+				{
+					name_server: glueRecord,
+				}
+			),
+		...queryOptions,
+		onSuccess() {
+			queryClient.removeQueries( domainGlueRecordQueryKey( domainName ) );
+			queryOptions.onSuccess?.();
+		},
+	} );
+
+	const { mutate } = mutation;
+
+	const deleteGlueRecord = useCallback(
+		( glueRecord: string ) => mutate( glueRecord ),
+		[ mutate ]
+	);
+
+	return { deleteGlueRecord, ...mutation };
+}

--- a/client/data/domains/glue-records/use-delete-glue-record-mutation.ts
+++ b/client/data/domains/glue-records/use-delete-glue-record-mutation.ts
@@ -1,6 +1,10 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
 import { domainGlueRecordQueryKey } from 'calypso/data/domains/glue-records/domain-glue-record-query-key';
+import {
+	GlueRecordObject,
+	GlueRecordQueryData,
+} from 'calypso/data/domains/glue-records/use-domain-glue-records-query';
 import { DomainsApiError } from 'calypso/lib/domains/types';
 import wp from 'calypso/lib/wp';
 
@@ -13,20 +17,28 @@ export default function useDeleteGlueRecordMutation(
 ) {
 	const queryClient = useQueryClient();
 	const mutation = useMutation( {
-		mutationFn: ( glueRecord: string ) =>
-			wp.req.post(
-				{
-					path: `/domains/glue-records/${ domainName }`,
-					apiNamespace: 'wpcom/v2',
-					method: 'DELETE',
-				},
-				{
-					name_server: glueRecord,
-				}
-			),
+		mutationFn: ( glueRecord: GlueRecordObject ) =>
+			wp.req
+				.post(
+					{
+						path: `/domains/glue-records/${ domainName }`,
+						apiNamespace: 'wpcom/v2',
+						method: 'DELETE',
+					},
+					{
+						name_server: glueRecord.record,
+					}
+				)
+				.then( () => glueRecord ),
 		...queryOptions,
-		onSuccess() {
-			queryClient.removeQueries( domainGlueRecordQueryKey( domainName ) );
+		onSuccess( glueRecord: GlueRecordObject ) {
+			const key = domainGlueRecordQueryKey( domainName );
+			queryClient.setQueryData( key, ( old: GlueRecordQueryData ) => {
+				if ( ! old ) {
+					return [];
+				}
+				return old.filter( ( item ) => item.nameserver !== glueRecord.record );
+			} );
 			queryOptions.onSuccess?.();
 		},
 	} );
@@ -34,7 +46,7 @@ export default function useDeleteGlueRecordMutation(
 	const { mutate } = mutation;
 
 	const deleteGlueRecord = useCallback(
-		( glueRecord: string ) => mutate( glueRecord ),
+		( glueRecord: GlueRecordObject ) => mutate( glueRecord ),
 		[ mutate ]
 	);
 

--- a/client/data/domains/glue-records/use-domain-glue-records-query.ts
+++ b/client/data/domains/glue-records/use-domain-glue-records-query.ts
@@ -38,8 +38,7 @@ const selectGlueRecords = ( response: GlueRecordApiObject[] | null ): GlueRecord
 };
 
 export default function useDomainGlueRecordsQuery(
-	domainName: string,
-	enabled: boolean
+	domainName: string
 ): UseQueryResult< GlueRecordResponse > {
 	return useQuery( {
 		queryKey: domainGlueRecordQueryKey( domainName ),
@@ -50,6 +49,8 @@ export default function useDomainGlueRecordsQuery(
 			} ),
 		refetchOnWindowFocus: false,
 		select: selectGlueRecords,
-		enabled,
+		enabled: false,
+		staleTime: 5 * 60 * 1000,
+		cacheTime: 5 * 60 * 1000,
 	} );
 }

--- a/client/data/domains/glue-records/use-domain-glue-records-query.ts
+++ b/client/data/domains/glue-records/use-domain-glue-records-query.ts
@@ -19,7 +19,7 @@ export type GlueRecordApiObject = {
 
 export const mapGlueRecordObjectToApiObject = ( record: GlueRecordObject ): GlueRecordApiObject => {
 	return {
-		nameserver: record.record,
+		nameserver: record.record.toLowerCase(),
 		ip_addresses: [ record.address ],
 	};
 };
@@ -31,7 +31,7 @@ const selectGlueRecords = ( response: GlueRecordApiObject[] | null ): GlueRecord
 
 	return response?.map( ( record: GlueRecordApiObject ) => {
 		return {
-			record: record.nameserver,
+			record: record.nameserver.toLowerCase(),
 			address: record.ip_addresses[ 0 ],
 		};
 	} );

--- a/client/data/domains/glue-records/use-domain-glue-records-query.ts
+++ b/client/data/domains/glue-records/use-domain-glue-records-query.ts
@@ -1,0 +1,43 @@
+import { UseQueryResult, useQuery } from '@tanstack/react-query';
+import wp from 'calypso/lib/wp';
+import { domainGlueRecordQueryKey } from './domain-glue-record-query-key';
+
+export type GlueRecordResponse = GlueRecordObject[] | null;
+
+export type GlueRecordObject = {
+	record: string;
+	address: string;
+};
+
+export type GlueRecordApiObject = {
+	nameserver: string;
+	ip_addresses: string[];
+};
+
+const selectGlueRecords = ( response: GlueRecordApiObject[] | null ): GlueRecordResponse => {
+	if ( ! response ) {
+		return null;
+	}
+
+	return response?.map( ( record: GlueRecordApiObject ) => {
+		return {
+			record: record.nameserver,
+			address: record.ip_addresses[ 0 ],
+		};
+	} );
+};
+
+export default function useDomainGlueRecordsQuery(
+	domainName: string
+): UseQueryResult< GlueRecordResponse > {
+	return useQuery( {
+		queryKey: domainGlueRecordQueryKey( domainName ),
+		queryFn: () =>
+			wp.req.get( {
+				path: `/domains/glue-records/${ domainName }`,
+				apiNamespace: 'wpcom/v2',
+			} ),
+		refetchOnWindowFocus: false,
+		select: selectGlueRecords,
+	} );
+}

--- a/client/data/domains/glue-records/use-domain-glue-records-query.ts
+++ b/client/data/domains/glue-records/use-domain-glue-records-query.ts
@@ -2,16 +2,26 @@ import { UseQueryResult, useQuery } from '@tanstack/react-query';
 import wp from 'calypso/lib/wp';
 import { domainGlueRecordQueryKey } from './domain-glue-record-query-key';
 
-export type GlueRecordResponse = GlueRecordObject[] | null;
+export type Maybe< T > = T | null | undefined;
+export type GlueRecordResponse = GlueRecordObject[] | null | undefined;
 
 export type GlueRecordObject = {
 	record: string;
 	address: string;
 };
 
+export type GlueRecordQueryData = Maybe< GlueRecordApiObject[] >;
+
 export type GlueRecordApiObject = {
 	nameserver: string;
 	ip_addresses: string[];
+};
+
+export const mapGlueRecordObjectToApiObject = ( record: GlueRecordObject ): GlueRecordApiObject => {
+	return {
+		nameserver: record.record,
+		ip_addresses: [ record.address ],
+	};
 };
 
 const selectGlueRecords = ( response: GlueRecordApiObject[] | null ): GlueRecordResponse => {

--- a/client/data/domains/glue-records/use-domain-glue-records-query.ts
+++ b/client/data/domains/glue-records/use-domain-glue-records-query.ts
@@ -38,7 +38,8 @@ const selectGlueRecords = ( response: GlueRecordApiObject[] | null ): GlueRecord
 };
 
 export default function useDomainGlueRecordsQuery(
-	domainName: string
+	domainName: string,
+	enabled: boolean
 ): UseQueryResult< GlueRecordResponse > {
 	return useQuery( {
 		queryKey: domainGlueRecordQueryKey( domainName ),
@@ -49,5 +50,6 @@ export default function useDomainGlueRecordsQuery(
 			} ),
 		refetchOnWindowFocus: false,
 		select: selectGlueRecords,
+		enabled,
 	} );
 }

--- a/client/data/domains/glue-records/use-update-glue-record-mutation.ts
+++ b/client/data/domains/glue-records/use-update-glue-record-mutation.ts
@@ -1,0 +1,48 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+import { domainGlueRecordQueryKey } from 'calypso/data/domains/glue-records/domain-glue-record-query-key';
+import { DomainsApiError } from 'calypso/lib/domains/types';
+import wp from 'calypso/lib/wp';
+import { GlueRecordObject } from './use-domain-glue-records-query';
+
+export default function useUpdateGlueRecordMutation(
+	domainName: string,
+	queryOptions: {
+		onSuccess?: () => void;
+		onError?: ( error: DomainsApiError ) => void;
+	}
+) {
+	const queryClient = useQueryClient();
+	const mutation = useMutation( {
+		mutationFn: ( glueRecord: GlueRecordObject ) => {
+			const data = {
+				name_server: glueRecord.record + '.' + domainName,
+				ip_addresses: [ glueRecord.address ],
+			};
+			return wp.req.post(
+				{
+					path: `/domains/glue-records`,
+					apiNamespace: 'wpcom/v2',
+				},
+				data
+			);
+		},
+		...queryOptions,
+		onSuccess() {
+			queryClient.invalidateQueries( domainGlueRecordQueryKey( domainName ) );
+			queryOptions.onSuccess?.();
+		},
+		onError( error: DomainsApiError ) {
+			queryOptions.onError?.( error );
+		},
+	} );
+
+	const { mutate } = mutation;
+
+	const updateGlueRecord = useCallback(
+		( glueRecord: GlueRecordObject ) => mutate( glueRecord ),
+		[ mutate ]
+	);
+
+	return { updateGlueRecord, ...mutation };
+}

--- a/client/data/domains/glue-records/use-update-glue-record-mutation.ts
+++ b/client/data/domains/glue-records/use-update-glue-record-mutation.ts
@@ -26,7 +26,7 @@ export default function useUpdateGlueRecordMutation(
 						apiNamespace: 'wpcom/v2',
 					},
 					{
-						name_server: glueRecord.record,
+						name_server: glueRecord.record.toLowerCase(),
 						ip_addresses: [ glueRecord.address ],
 					}
 				)

--- a/client/data/domains/glue-records/use-update-glue-record-mutation.ts
+++ b/client/data/domains/glue-records/use-update-glue-record-mutation.ts
@@ -3,7 +3,11 @@ import { useCallback } from 'react';
 import { domainGlueRecordQueryKey } from 'calypso/data/domains/glue-records/domain-glue-record-query-key';
 import { DomainsApiError } from 'calypso/lib/domains/types';
 import wp from 'calypso/lib/wp';
-import { GlueRecordObject } from './use-domain-glue-records-query';
+import {
+	GlueRecordObject,
+	GlueRecordQueryData,
+	mapGlueRecordObjectToApiObject,
+} from './use-domain-glue-records-query';
 
 export default function useUpdateGlueRecordMutation(
 	domainName: string,
@@ -14,22 +18,28 @@ export default function useUpdateGlueRecordMutation(
 ) {
 	const queryClient = useQueryClient();
 	const mutation = useMutation( {
-		mutationFn: ( glueRecord: GlueRecordObject ) => {
-			const data = {
-				name_server: glueRecord.record + '.' + domainName,
-				ip_addresses: [ glueRecord.address ],
-			};
-			return wp.req.post(
-				{
-					path: `/domains/glue-records`,
-					apiNamespace: 'wpcom/v2',
-				},
-				data
-			);
-		},
+		mutationFn: ( glueRecord: GlueRecordObject ) =>
+			wp.req
+				.post(
+					{
+						path: `/domains/glue-records`,
+						apiNamespace: 'wpcom/v2',
+					},
+					{
+						name_server: glueRecord.record,
+						ip_addresses: [ glueRecord.address ],
+					}
+				)
+				.then( () => glueRecord ),
 		...queryOptions,
-		onSuccess() {
-			queryClient.invalidateQueries( domainGlueRecordQueryKey( domainName ) );
+		onSuccess( glueRecord: GlueRecordObject ) {
+			const key = domainGlueRecordQueryKey( domainName );
+			queryClient.setQueryData( key, ( old: GlueRecordQueryData ) => {
+				if ( ! old ) {
+					return [ mapGlueRecordObjectToApiObject( glueRecord ) ];
+				}
+				return [ ...old, mapGlueRecordObjectToApiObject( glueRecord ) ];
+			} );
 			queryOptions.onSuccess?.();
 		},
 		onError( error: DomainsApiError ) {

--- a/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
@@ -133,7 +133,7 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 				<div className="domain-forwarding-card__fields-column glue-record-data">
 					<div className="domain-forwarding-card__fields-row addresses">
 						<div className="domain-forwarding-card__fields-column source">
-							{ translate( 'Record' ) }:
+							{ translate( 'Name server' ) }:
 						</div>
 						<div className="domain-forwarding-card__fields-column destination">
 							<strong>{ child.record }</strong>
@@ -167,7 +167,7 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 	const FormRowEditable = ( { child }: { child: GlueRecordObject } ) => (
 		<>
 			<FormFieldset className="domain-forwarding-card__fields" key={ `edit-${ child.record }` }>
-				<FormLabel>{ translate( 'Record' ) }</FormLabel>
+				<FormLabel>{ translate( 'Name server' ) }</FormLabel>
 				<div className="glue-record-input-wrapper">
 					<FormTextInputWithAffixes
 						placeholder={ translate( 'Enter subdomain (e.g. ns1)' ) }
@@ -179,7 +179,7 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 						suffix={ <FormLabel>.{ domain.domain }</FormLabel> }
 					/>
 				</div>
-				<FormLabel>{ translate( 'IP Address' ) }</FormLabel>
+				<FormLabel>{ translate( 'IP address' ) }</FormLabel>
 				<div className="ip-address">
 					<FormTextInputWithAffixes
 						disabled={ isLoadingData || isSaving }

--- a/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
@@ -26,7 +26,6 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
-	// Manage local state for target url and protocol as we split forwarding target into host, path and protocol when we store it
 	const [ isExpanded, setIsExpanded ] = useState( false );
 	const [ isSaving, setIsSaving ] = useState( false );
 	const [ isRemoving, setIsRemoving ] = useState( false );
@@ -62,7 +61,7 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 		},
 	} );
 
-	// Display success notices when the forwarding is deleted
+	// Display success notices when the glue record is deleted
 	const { deleteGlueRecord } = useDeleteGlueRecordMutation( domain.name, {
 		onSuccess() {
 			dispatch( successNotice( translate( 'Glue record deleted successfully.' ), noticeOptions ) );

--- a/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
@@ -29,6 +29,7 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 
 	// Manage local state for target url and protocol as we split forwarding target into host, path and protocol when we store it
 	const [ isSaving, setIsSaving ] = useState( false );
+	const [ isRemoving, setIsRemoving ] = useState( false );
 	const [ isEditing, setIsEditing ] = useState( false );
 	const [ record, setRecord ] = useState( '' );
 	const [ ipAddress, setIpAddress ] = useState( '' );
@@ -38,6 +39,7 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 		setRecord( '' );
 		setIpAddress( '' );
 		setIsSaving( false );
+		setIsRemoving( false );
 	};
 
 	// Display success notices when the glue record is updated
@@ -48,6 +50,7 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 		},
 		onError( error ) {
 			dispatch( errorNotice( error.message, noticeOptions ) );
+			clearState();
 		},
 	} );
 
@@ -55,6 +58,7 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 	const { deleteGlueRecord } = useDeleteGlueRecordMutation( domain.name, {
 		onSuccess() {
 			dispatch( successNotice( translate( 'Glue record deleted successfully.' ), noticeOptions ) );
+			clearState();
 		},
 		onError() {
 			dispatch(
@@ -63,6 +67,7 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 					noticeOptions
 				)
 			);
+			clearState();
 		},
 	} );
 
@@ -110,6 +115,7 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 	};
 
 	const handleDelete = ( record: string ) => {
+		setIsRemoving( true );
 		deleteGlueRecord( record );
 	};
 
@@ -146,7 +152,7 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 				<div className="domain-forwarding-card__fields-column">
 					<Button
 						scary
-						busy={ isSaving }
+						disabled={ isSaving || isRemoving }
 						className="edit-redirect-button"
 						onClick={ () => handleDelete( child.record ) }
 					>

--- a/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
@@ -241,13 +241,15 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 					} ) }
 			</form>
 
-			<Button
-				borderless
-				className="add-forward-button  link-button"
-				onClick={ () => handleAddGlueRecord() }
-			>
-				{ translate( '+ Add Glue Record' ) }
-			</Button>
+			{ data && data.length < 3 && (
+				<Button
+					borderless
+					className="add-forward-button  link-button"
+					onClick={ () => handleAddGlueRecord() }
+				>
+					{ translate( '+ Add Glue Record' ) }
+				</Button>
+			) }
 		</>
 	);
 }

--- a/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
@@ -32,6 +32,8 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 	const [ isEditing, setIsEditing ] = useState( false );
 	const [ record, setRecord ] = useState( '' );
 	const [ ipAddress, setIpAddress ] = useState( '' );
+	const [ isValidRecord, setIsValidRecord ] = useState( true );
+	const [ isValidIpAddress, setIsValidIpAddress ] = useState( true );
 
 	const {
 		data,
@@ -47,6 +49,8 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 		setIpAddress( '' );
 		setIsSaving( false );
 		setIsRemoving( false );
+		setIsValidRecord( true );
+		setIsValidIpAddress( true );
 	};
 
 	// Display success notices when the glue record is updated
@@ -117,10 +121,6 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 		setIpAddress( ipAddress );
 	};
 
-	const glueRecordValidation = () => {
-		return true;
-	};
-
 	const handleRecordChange = ( event: React.ChangeEvent< HTMLInputElement > ) => {
 		const record = event.target.value;
 
@@ -132,7 +132,43 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 		deleteGlueRecord( record );
 	};
 
+	const validateRecord = () => {
+		if ( ! record ) {
+			return false;
+		}
+		if ( ! record.match( /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$/ ) ) {
+			return false;
+		}
+		return true;
+	};
+
+	const validateIpAddress = () => {
+		if ( ! ipAddress ) {
+			return false;
+		}
+		if ( ! ipAddress.match( /^(\d{1,3}\.){3}\d{1,3}$/ ) ) {
+			return false;
+		}
+		return true;
+	};
+
+	const validateGlueRecord = () => {
+		const recordIsValid = validateRecord();
+		const ipAddressIsValid = validateIpAddress();
+		setIsValidRecord( recordIsValid );
+		setIsValidIpAddress( ipAddressIsValid );
+
+		if ( ! recordIsValid || ! ipAddressIsValid ) {
+			return false;
+		}
+		return true;
+	};
+
 	const handleSubmit = () => {
+		if ( ! validateGlueRecord() ) {
+			return;
+		}
+
 		setIsSaving( true );
 		updateGlueRecord( {
 			record: `${ record }.${ domain.domain }`,
@@ -198,6 +234,7 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 						value={ record }
 						maxLength={ 1000 }
 						suffix={ <FormLabel>.{ domain.domain }</FormLabel> }
+						isError={ ! isValidRecord }
 					/>
 				</div>
 				<FormLabel>{ translate( 'IP address' ) }</FormLabel>
@@ -212,15 +249,9 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 						name="ip-address"
 						noWrap
 						onChange={ handleIpAddressChange }
-						onBlur={ glueRecordValidation }
 						value={ ipAddress }
-						// className={ classNames( { 'is-error': ! isValidUrl } ) }
 						maxLength={ 1000 }
-						/* suffix={
-							<Button className="forwarding__clear" onClick={ cleanGlueRecordInput }>
-								<Gridicon icon="cross" />
-							</Button>
-						} */
+						isError={ ! isValidIpAddress }
 					/>
 				</div>
 				<div className="glue-records__action-buttons">

--- a/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
@@ -278,6 +278,13 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 		</>
 	);
 
+	const expandCard = () => {
+		setIsExpanded( true );
+		// We want to always fetch the latest glue record when the card is expanded
+		// otherwise the user might see stale data if they made an update and refreshed the page
+		refetchGlueRecordsData();
+	};
+
 	const renderGlueRecords = () => {
 		if ( isLoadingData || ! data ) {
 			return (
@@ -320,7 +327,7 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 			title={ translate( 'Glue Records' ) }
 			subtitle={ translate( 'Edit your private name servers (glue records)' ) }
 			expanded={ isExpanded }
-			onOpen={ () => setIsExpanded( true ) }
+			onOpen={ expandCard }
 			onClose={ () => setIsExpanded( false ) }
 		>
 			{ renderGlueRecords() }

--- a/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
@@ -94,7 +94,7 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 		}
 	}, [ isError, dispatch, translate ] );
 
-	const handleAddGlueRecord = () => {
+	const showGlueRecordForm = () => {
 		setIsEditing( true );
 	};
 
@@ -111,7 +111,7 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 
 		// By default, the interface already opens with domain forwarding addition
 		if ( data?.length === 0 ) {
-			handleAddGlueRecord();
+			showGlueRecordForm();
 		}
 	}, [ isLoadingData, data, isExpanded ] );
 
@@ -306,7 +306,7 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 					<Button
 						borderless
 						className="add-forward-button  link-button"
-						onClick={ () => handleAddGlueRecord() }
+						onClick={ () => showGlueRecordForm() }
 					>
 						{ translate( '+ Add Glue Record' ) }
 					</Button>

--- a/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
@@ -26,8 +26,6 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
-	const { data, isLoading: isLoadingData, isError } = useDomainGlueRecordsQuery( domain.name );
-
 	// Manage local state for target url and protocol as we split forwarding target into host, path and protocol when we store it
 	const [ isExpanded, setIsExpanded ] = useState( false );
 	const [ isSaving, setIsSaving ] = useState( false );
@@ -35,6 +33,12 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 	const [ isEditing, setIsEditing ] = useState( false );
 	const [ record, setRecord ] = useState( '' );
 	const [ ipAddress, setIpAddress ] = useState( '' );
+
+	const {
+		data,
+		isLoading: isLoadingData,
+		isError,
+	} = useDomainGlueRecordsQuery( domain.name, isExpanded );
 
 	const clearState = () => {
 		setIsEditing( false );

--- a/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
@@ -36,9 +36,11 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 
 	const {
 		data,
-		isLoading: isLoadingData,
+		isFetching: isLoadingData,
 		isError,
-	} = useDomainGlueRecordsQuery( domain.name, isExpanded );
+		isStale,
+		refetch: refetchGlueRecordsData,
+	} = useDomainGlueRecordsQuery( domain.name );
 
 	const clearState = () => {
 		setIsEditing( false );
@@ -92,6 +94,12 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 	const handleAddGlueRecord = () => {
 		setIsEditing( true );
 	};
+
+	useEffect( () => {
+		if ( isExpanded && isStale ) {
+			refetchGlueRecordsData();
+		}
+	}, [ isExpanded, isStale ] );
 
 	useEffect( () => {
 		if ( isLoadingData || ! data ) {
@@ -237,23 +245,16 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 		</>
 	);
 
-	if ( ! data || isLoadingData ) {
-		return (
-			<>
-				<div className="domain-glue-records is-placeholder"></div>
-			</>
-		);
-	}
+	const renderGlueRecords = () => {
+		if ( isLoadingData || ! data ) {
+			return (
+				<div className="domain-glue-records">
+					<div className="domain-glue-records is-placeholder"></div>
+				</div>
+			);
+		}
 
-	return (
-		<Accordion
-			className="domain-forwarding-card__accordion"
-			title={ translate( 'Glue Records' ) }
-			subtitle={ translate( 'Edit your private name servers (glue records)' ) }
-			expanded={ isExpanded }
-			onOpen={ () => setIsExpanded( true ) }
-			onClose={ () => setIsExpanded( false ) }
-		>
+		return (
 			<div className="domain-glue-records">
 				<form
 					onSubmit={ ( e ) => {
@@ -281,6 +282,19 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 					</Button>
 				) }
 			</div>
+		);
+	};
+
+	return (
+		<Accordion
+			className="domain-forwarding-card__accordion"
+			title={ translate( 'Glue Records' ) }
+			subtitle={ translate( 'Edit your private name servers (glue records)' ) }
+			expanded={ isExpanded }
+			onOpen={ () => setIsExpanded( true ) }
+			onClose={ () => setIsExpanded( false ) }
+		>
+			{ renderGlueRecords() }
 		</Accordion>
 	);
 }

--- a/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
@@ -1,4 +1,4 @@
-import { Badge, Button } from '@automattic/components';
+import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
@@ -121,8 +121,24 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 	const FormViewRow = ( { child: child }: { child: GlueRecordObject } ) => (
 		<FormFieldset className="domain-forwarding-card__fields" key={ `view-${ child.record }` }>
 			<div className="domain-forwarding-card__fields-row">
-				<div className="domain-forwarding-card__fields-column">
-					<Badge type="info">{ translate( 'Glue record' ) }</Badge>
+				<div className="domain-forwarding-card__fields-column glue-record-data">
+					<div className="domain-forwarding-card__fields-row addresses">
+						<div className="domain-forwarding-card__fields-column source">
+							{ translate( 'Record' ) }:
+						</div>
+						<div className="domain-forwarding-card__fields-column destination">
+							<strong>{ child.record }</strong>
+						</div>
+					</div>
+
+					<div className="domain-forwarding-card__fields-row addresses">
+						<div className="domain-forwarding-card__fields-column source">
+							{ translate( 'IP address' ) }:
+						</div>
+						<div className="domain-forwarding-card__fields-column destination">
+							<strong>{ child.address }</strong>
+						</div>
+					</div>
 				</div>
 				<div className="domain-forwarding-card__fields-column">
 					<Button
@@ -134,24 +150,6 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 					</Button>
 				</div>
 			</div>
-
-			<div className="domain-forwarding-card__fields-row addresses">
-				<div className="domain-forwarding-card__fields-column source">
-					{ translate( 'Record' ) }:
-				</div>
-				<div className="domain-forwarding-card__fields-column destination">
-					<strong>{ child.record }</strong>
-				</div>
-			</div>
-
-			<div className="domain-forwarding-card__fields-row addresses">
-				<div className="domain-forwarding-card__fields-column source">
-					{ translate( 'IP address' ) }:
-				</div>
-				<div className="domain-forwarding-card__fields-column destination">
-					<strong>{ child.address }</strong>
-				</div>
-			</div>
 		</FormFieldset>
 	);
 
@@ -161,7 +159,7 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 				<FormLabel>{ translate( 'Record' ) }</FormLabel>
 				<div className="glue-record-input-wrapper">
 					<FormTextInputWithAffixes
-						placeholder="ns1"
+						placeholder={ translate( 'Ex: ns1' ) }
 						disabled={ isLoading }
 						name="record"
 						onChange={ handleRecordChange }
@@ -189,14 +187,7 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 						} */
 					/>
 				</div>
-				{ /*// TODO: validate glue record*/ }
-				{ /*{ ! isValidUrl && (
-					<div className="domain-forwarding-card__error-field">
-						<FormInputValidation isError={ true } text={ errorMessage } />
-					</div>
-				) }*/ }
-
-				<div>
+				<div className="glue-records__action-buttons">
 					<FormButton onClick={ handleSubmit } disabled={ isLoading }>
 						{ translate( 'Save' ) }
 					</FormButton>

--- a/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
@@ -1,0 +1,238 @@
+import { Badge, Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect, useState } from 'react';
+import { useDispatch } from 'react-redux';
+import FormButton from 'calypso/components/forms/form-button';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-with-affixes';
+import useDeleteGlueRecordMutation from 'calypso/data/domains/glue-records/use-delete-glue-record-mutation';
+import useDomainGlueRecordsQuery, {
+	GlueRecordObject,
+} from 'calypso/data/domains/glue-records/use-domain-glue-records-query';
+import useUpdateGlueRecordMutation from 'calypso/data/domains/glue-records/use-update-glue-record-mutation';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import type { ResponseDomain } from 'calypso/lib/domains/types';
+
+import './style.scss';
+
+const noticeOptions = {
+	duration: 5000,
+	id: `domain-forwarding-notification`,
+};
+
+export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } ) {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+
+	const { data, isLoading, isError } = useDomainGlueRecordsQuery( domain.name );
+
+	// Manage local state for target url and protocol as we split forwarding target into host, path and protocol when we store it
+	const [ isEditing, setIsEditing ] = useState( false );
+	const [ record, setRecord ] = useState( '' );
+	const [ ipAddress, setIpAddress ] = useState( '' );
+
+	const clearState = () => {
+		setIsEditing( false );
+		setRecord( '' );
+		setIpAddress( '' );
+	};
+
+	// Display success notices when the glue record is updated
+	const { updateGlueRecord } = useUpdateGlueRecordMutation( domain.name, {
+		onSuccess() {
+			dispatch( successNotice( translate( 'Glue record updated and enabled.' ), noticeOptions ) );
+			clearState();
+		},
+		onError( error ) {
+			dispatch( errorNotice( error.message, noticeOptions ) );
+		},
+	} );
+
+	// Display success notices when the forwarding is deleted
+	const { deleteGlueRecord } = useDeleteGlueRecordMutation( domain.name, {
+		onSuccess() {
+			dispatch( successNotice( translate( 'Glue record deleted successfully.' ), noticeOptions ) );
+		},
+		onError() {
+			dispatch(
+				errorNotice(
+					translate( 'An error occurred while deleting the glue record.' ),
+					noticeOptions
+				)
+			);
+		},
+	} );
+
+	// Render an error if the glue record fails to load
+	useEffect( () => {
+		if ( isError ) {
+			dispatch(
+				errorNotice(
+					translate( 'An error occurred while fetching your glue record.' ),
+					noticeOptions
+				)
+			);
+		}
+	}, [ isError, dispatch, translate ] );
+
+	const handleAddGlueRecord = () => {
+		setIsEditing( true );
+	};
+
+	useEffect( () => {
+		if ( isLoading || ! data ) {
+			return;
+		}
+
+		// By default, the interface already opens with domain forwarding addition
+		if ( data?.length === 0 ) {
+			handleAddGlueRecord();
+		}
+	}, [ isLoading, data ] );
+
+	const handleIpAddressChange = ( event: React.ChangeEvent< HTMLInputElement > ) => {
+		const ipAddress = event.target.value;
+
+		setIpAddress( ipAddress );
+	};
+
+	const glueRecordValidation = () => {
+		return true;
+	};
+
+	const handleRecordChange = ( event: React.ChangeEvent< HTMLInputElement > ) => {
+		const record = event.target.value;
+
+		setRecord( record );
+	};
+
+	const handleDelete = ( record: string ) => {
+		deleteGlueRecord( record );
+	};
+
+	const handleSubmit = () => {
+		updateGlueRecord( {
+			record: record,
+			address: ipAddress,
+		} );
+	};
+
+	const FormViewRow = ( { child: child }: { child: GlueRecordObject } ) => (
+		<FormFieldset className="domain-forwarding-card__fields" key={ `view-${ child.record }` }>
+			<div className="domain-forwarding-card__fields-row">
+				<div className="domain-forwarding-card__fields-column">
+					<Badge type="info">{ translate( 'Glue record' ) }</Badge>
+				</div>
+				<div className="domain-forwarding-card__fields-column">
+					<Button
+						borderless
+						className="edit-redirect-button link-button"
+						onClick={ () => handleDelete( child.record ) }
+					>
+						{ translate( 'Remove' ) }
+					</Button>
+				</div>
+			</div>
+
+			<div className="domain-forwarding-card__fields-row addresses">
+				<div className="domain-forwarding-card__fields-column source">
+					{ translate( 'Record' ) }:
+				</div>
+				<div className="domain-forwarding-card__fields-column destination">
+					<strong>{ child.record }</strong>
+				</div>
+			</div>
+
+			<div className="domain-forwarding-card__fields-row addresses">
+				<div className="domain-forwarding-card__fields-column source">
+					{ translate( 'IP address' ) }:
+				</div>
+				<div className="domain-forwarding-card__fields-column destination">
+					<strong>{ child.address }</strong>
+				</div>
+			</div>
+		</FormFieldset>
+	);
+
+	const FormRowEditable = ( { child }: { child: GlueRecordObject } ) => (
+		<>
+			<FormFieldset className="domain-forwarding-card__fields" key={ `edit-${ child.record }` }>
+				<FormLabel>{ translate( 'Record' ) }</FormLabel>
+				<div className="glue-record-input-wrapper">
+					<FormTextInputWithAffixes
+						placeholder="ns1"
+						disabled={ isLoading }
+						name="record"
+						onChange={ handleRecordChange }
+						value={ record }
+						// className={ classNames( { 'is-error': ! isValidUrl } ) }
+						maxLength={ 1000 }
+						suffix={ <FormLabel>.{ domain.domain }</FormLabel> }
+					/>
+				</div>
+				<FormLabel>{ translate( 'IP Address' ) }</FormLabel>
+				<div className="ip-address">
+					<FormTextInputWithAffixes
+						disabled={ isLoading }
+						name="ip-address"
+						noWrap
+						onChange={ handleIpAddressChange }
+						onBlur={ glueRecordValidation }
+						value={ ipAddress }
+						// className={ classNames( { 'is-error': ! isValidUrl } ) }
+						maxLength={ 1000 }
+						/* suffix={
+							<Button className="forwarding__clear" onClick={ cleanGlueRecordInput }>
+								<Gridicon icon="cross" />
+							</Button>
+						} */
+					/>
+				</div>
+				{ /*// TODO: validate glue record*/ }
+				{ /*{ ! isValidUrl && (
+					<div className="domain-forwarding-card__error-field">
+						<FormInputValidation isError={ true } text={ errorMessage } />
+					</div>
+				) }*/ }
+
+				<div>
+					<FormButton onClick={ handleSubmit } disabled={ isLoading }>
+						{ translate( 'Save' ) }
+					</FormButton>
+					<FormButton onClick={ () => clearState() } type="button" isPrimary={ false }>
+						{ translate( 'Cancel' ) }
+					</FormButton>
+				</div>
+			</FormFieldset>
+		</>
+	);
+
+	return (
+		<>
+			<form
+				onSubmit={ ( e ) => {
+					e.preventDefault();
+					return false;
+				} }
+			>
+				{ data?.map( ( item ) => FormViewRow( { child: item } ) ) }
+				{ isEditing &&
+					FormRowEditable( {
+						child: {
+							record: '',
+							address: '',
+						},
+					} ) }
+			</form>
+
+			<Button
+				borderless
+				className="add-forward-button  link-button"
+				onClick={ () => handleAddGlueRecord() }
+			>
+				{ translate( '+ Add Glue Record' ) }
+			</Button>
+		</>
+	);
+}

--- a/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
@@ -111,7 +111,7 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 	const handleRecordChange = ( event: React.ChangeEvent< HTMLInputElement > ) => {
 		const record = event.target.value;
 
-		setRecord( record );
+		setRecord( record.toLowerCase() );
 	};
 
 	const handleDelete = ( record: GlueRecordObject ) => {

--- a/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
@@ -223,8 +223,16 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 		</>
 	);
 
+	if ( ! data || isLoadingData ) {
+		return (
+			<>
+				<div className="domain-glue-records is-placeholder"></div>
+			</>
+		);
+	}
+
 	return (
-		<>
+		<div className="domain-glue-records">
 			<form
 				onSubmit={ ( e ) => {
 					e.preventDefault();
@@ -250,6 +258,6 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 					{ translate( '+ Add Glue Record' ) }
 				</Button>
 			) }
-		</>
+		</div>
 	);
 }

--- a/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
@@ -249,7 +249,7 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 					} ) }
 			</form>
 
-			{ data && data.length < 3 && (
+			{ ! isEditing && data && data.length < 3 && (
 				<Button
 					borderless
 					className="add-forward-button  link-button"

--- a/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
@@ -114,7 +114,7 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 		setRecord( record );
 	};
 
-	const handleDelete = ( record: string ) => {
+	const handleDelete = ( record: GlueRecordObject ) => {
 		setIsRemoving( true );
 		deleteGlueRecord( record );
 	};
@@ -122,7 +122,7 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 	const handleSubmit = () => {
 		setIsSaving( true );
 		updateGlueRecord( {
-			record: record,
+			record: `${ record }.${ domain.domain }`,
 			address: ipAddress,
 		} );
 	};
@@ -154,7 +154,7 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 						scary
 						disabled={ isSaving || isRemoving }
 						className="edit-redirect-button"
-						onClick={ () => handleDelete( child.record ) }
+						onClick={ () => handleDelete( child ) }
 					>
 						<Gridicon icon="trash" />
 						{ translate( 'Remove' ) }

--- a/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@automattic/components';
+import { Button, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
@@ -145,10 +145,12 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 				</div>
 				<div className="domain-forwarding-card__fields-column">
 					<Button
-						borderless
-						className="edit-redirect-button link-button"
+						scary
+						busy={ isSaving }
+						className="edit-redirect-button"
 						onClick={ () => handleDelete( child.record ) }
 					>
+						<Gridicon icon="trash" />
 						{ translate( 'Remove' ) }
 					</Button>
 				</div>

--- a/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
@@ -158,10 +158,7 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 		setIsValidRecord( recordIsValid );
 		setIsValidIpAddress( ipAddressIsValid );
 
-		if ( ! recordIsValid || ! ipAddressIsValid ) {
-			return false;
-		}
-		return true;
+		return recordIsValid && ipAddressIsValid;
 	};
 
 	const handleSubmit = () => {

--- a/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
@@ -19,7 +19,7 @@ import './style.scss';
 
 const noticeOptions = {
 	duration: 5000,
-	id: `domain-forwarding-notification`,
+	id: `glue-records-notification`,
 };
 
 export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } ) {
@@ -182,28 +182,24 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 	};
 
 	const FormViewRow = ( { child: child }: { child: GlueRecordObject } ) => (
-		<FormFieldset className="domain-forwarding-card__fields" key={ `view-${ child.record }` }>
-			<div className="domain-forwarding-card__fields-row">
-				<div className="domain-forwarding-card__fields-column glue-record-data">
-					<div className="domain-forwarding-card__fields-row addresses">
-						<div className="domain-forwarding-card__fields-column source">
-							{ translate( 'Name server' ) }:
-						</div>
-						<div className="domain-forwarding-card__fields-column destination">
+		<FormFieldset key={ `view-${ child.record }` }>
+			<div className="domain-glue-records-card__fields">
+				<div className="glue-record-data">
+					<div className="domain-glue-records-card__fields-row">
+						<div className="label">{ translate( 'Name server' ) }:</div>
+						<div className="value">
 							<strong>{ child.record }</strong>
 						</div>
 					</div>
 
-					<div className="domain-forwarding-card__fields-row addresses">
-						<div className="domain-forwarding-card__fields-column source">
-							{ translate( 'IP address' ) }:
-						</div>
-						<div className="domain-forwarding-card__fields-column destination">
+					<div className="domain-glue-records-card__fields-row">
+						<div className="label">{ translate( 'IP address' ) }:</div>
+						<div className="value">
 							<strong>{ child.address }</strong>
 						</div>
 					</div>
 				</div>
-				<div className="domain-forwarding-card__fields-column">
+				<div>
 					<Button
 						scary
 						disabled={ isSaving || isRemoving }
@@ -220,9 +216,9 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 
 	const FormRowEditable = ( { child }: { child: GlueRecordObject } ) => (
 		<>
-			<FormFieldset className="domain-forwarding-card__fields" key={ `edit-${ child.record }` }>
+			<FormFieldset key={ `edit-${ child.record }` }>
 				<FormLabel>{ translate( 'Name server' ) }</FormLabel>
-				<div className="glue-record-input-wrapper">
+				<div>
 					<FormTextInputWithAffixes
 						placeholder={ translate( 'Enter subdomain (e.g. ns1)' ) }
 						disabled={ isLoadingData || isSaving }
@@ -234,7 +230,7 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 						isError={ ! isValidRecord }
 					/>
 					{ ! isValidRecord && (
-						<div className="domain-forwarding-card__error-field">
+						<div className="domain-glue-records-card__error-field">
 							<FormInputValidation isError text={ translate( 'Invalid subdomain' ) } />
 						</div>
 					) }
@@ -256,7 +252,7 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 						isError={ ! isValidIpAddress }
 					/>
 					{ ! isValidIpAddress && (
-						<div className="domain-forwarding-card__error-field">
+						<div className="domain-glue-records-card__error-field">
 							<FormInputValidation isError text={ translate( 'Invalid IP address' ) } />
 						</div>
 					) }
@@ -285,14 +281,14 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 	const renderGlueRecords = () => {
 		if ( isLoadingData || ! data ) {
 			return (
-				<div className="domain-glue-records">
-					<div className="domain-glue-records is-placeholder"></div>
+				<div className="domain-glue-records-card">
+					<div className="domain-glue-records-card is-placeholder"></div>
 				</div>
 			);
 		}
 
 		return (
-			<div className="domain-glue-records">
+			<div className="domain-glue-records-card">
 				<form
 					onSubmit={ ( e ) => {
 						e.preventDefault();
@@ -310,11 +306,7 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 				</form>
 
 				{ ! isEditing && data && data.length < 3 && (
-					<Button
-						borderless
-						className="add-forward-button  link-button"
-						onClick={ () => showGlueRecordForm() }
-					>
+					<Button borderless className="link-button" onClick={ () => showGlueRecordForm() }>
 						{ translate( '+ Add Glue Record' ) }
 					</Button>
 				) }
@@ -324,7 +316,7 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 
 	return (
 		<Accordion
-			className="domain-forwarding-card__accordion"
+			className="domain-glue-records-card__accordion"
 			title={ translate( 'Glue Records' ) }
 			subtitle={ translate( 'Edit your private name servers (glue records)' ) }
 			expanded={ isExpanded }

--- a/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
@@ -170,7 +170,7 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 				<FormLabel>{ translate( 'Record' ) }</FormLabel>
 				<div className="glue-record-input-wrapper">
 					<FormTextInputWithAffixes
-						placeholder={ translate( 'Ex: ns1' ) }
+						placeholder={ translate( 'Enter subdomain (e.g. ns1)' ) }
 						disabled={ isLoadingData || isSaving }
 						name="record"
 						onChange={ handleRecordChange }
@@ -183,6 +183,11 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 				<div className="ip-address">
 					<FormTextInputWithAffixes
 						disabled={ isLoadingData || isSaving }
+						placeholder={ translate( 'e.g. %(example)s', {
+							args: {
+								example: '123.45.78.9',
+							},
+						} ) }
 						name="ip-address"
 						noWrap
 						onChange={ handleIpAddressChange }

--- a/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
@@ -109,7 +109,7 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 			return;
 		}
 
-		// By default, the interface already opens with domain forwarding addition
+		// If there are no glue records, start with the form to add one open
 		if ( data?.length === 0 ) {
 			showGlueRecordForm();
 		}

--- a/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
@@ -2,6 +2,7 @@ import { Button, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
+import Accordion from 'calypso/components/domains/accordion';
 import FormButton from 'calypso/components/forms/form-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
@@ -28,6 +29,7 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 	const { data, isLoading: isLoadingData, isError } = useDomainGlueRecordsQuery( domain.name );
 
 	// Manage local state for target url and protocol as we split forwarding target into host, path and protocol when we store it
+	const [ isExpanded, setIsExpanded ] = useState( false );
 	const [ isSaving, setIsSaving ] = useState( false );
 	const [ isRemoving, setIsRemoving ] = useState( false );
 	const [ isEditing, setIsEditing ] = useState( false );
@@ -96,7 +98,7 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 		if ( data?.length === 0 ) {
 			handleAddGlueRecord();
 		}
-	}, [ isLoadingData, data ] );
+	}, [ isLoadingData, data, isExpanded ] );
 
 	const handleIpAddressChange = ( event: React.ChangeEvent< HTMLInputElement > ) => {
 		const ipAddress = event.target.value;
@@ -125,6 +127,14 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 			record: `${ record }.${ domain.domain }`,
 			address: ipAddress,
 		} );
+	};
+
+	const handleCancel = () => {
+		clearState();
+
+		if ( data && data.length === 0 ) {
+			setIsExpanded( false );
+		}
 	};
 
 	const FormViewRow = ( { child: child }: { child: GlueRecordObject } ) => (
@@ -212,7 +222,7 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 					</FormButton>
 					<FormButton
 						disabled={ isSaving }
-						onClick={ () => clearState() }
+						onClick={ handleCancel }
 						type="button"
 						isPrimary={ false }
 					>
@@ -232,32 +242,41 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 	}
 
 	return (
-		<div className="domain-glue-records">
-			<form
-				onSubmit={ ( e ) => {
-					e.preventDefault();
-					return false;
-				} }
-			>
-				{ data?.map( ( item ) => FormViewRow( { child: item } ) ) }
-				{ isEditing &&
-					FormRowEditable( {
-						child: {
-							record: '',
-							address: '',
-						},
-					} ) }
-			</form>
-
-			{ ! isEditing && data && data.length < 3 && (
-				<Button
-					borderless
-					className="add-forward-button  link-button"
-					onClick={ () => handleAddGlueRecord() }
+		<Accordion
+			className="domain-forwarding-card__accordion"
+			title={ translate( 'Glue Records' ) }
+			subtitle={ translate( 'Edit your private name servers (glue records)' ) }
+			expanded={ isExpanded }
+			onOpen={ () => setIsExpanded( true ) }
+			onClose={ () => setIsExpanded( false ) }
+		>
+			<div className="domain-glue-records">
+				<form
+					onSubmit={ ( e ) => {
+						e.preventDefault();
+						return false;
+					} }
 				>
-					{ translate( '+ Add Glue Record' ) }
-				</Button>
-			) }
-		</div>
+					{ data?.map( ( item ) => FormViewRow( { child: item } ) ) }
+					{ isEditing &&
+						FormRowEditable( {
+							child: {
+								record: '',
+								address: '',
+							},
+						} ) }
+				</form>
+
+				{ ! isEditing && data && data.length < 3 && (
+					<Button
+						borderless
+						className="add-forward-button  link-button"
+						onClick={ () => handleAddGlueRecord() }
+					>
+						{ translate( '+ Add Glue Record' ) }
+					</Button>
+				) }
+			</div>
+		</Accordion>
 	);
 }

--- a/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
@@ -25,9 +25,10 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
-	const { data, isLoading, isError } = useDomainGlueRecordsQuery( domain.name );
+	const { data, isLoading: isLoadingData, isError } = useDomainGlueRecordsQuery( domain.name );
 
 	// Manage local state for target url and protocol as we split forwarding target into host, path and protocol when we store it
+	const [ isSaving, setIsSaving ] = useState( false );
 	const [ isEditing, setIsEditing ] = useState( false );
 	const [ record, setRecord ] = useState( '' );
 	const [ ipAddress, setIpAddress ] = useState( '' );
@@ -36,6 +37,7 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 		setIsEditing( false );
 		setRecord( '' );
 		setIpAddress( '' );
+		setIsSaving( false );
 	};
 
 	// Display success notices when the glue record is updated
@@ -81,7 +83,7 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 	};
 
 	useEffect( () => {
-		if ( isLoading || ! data ) {
+		if ( isLoadingData || ! data ) {
 			return;
 		}
 
@@ -89,7 +91,7 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 		if ( data?.length === 0 ) {
 			handleAddGlueRecord();
 		}
-	}, [ isLoading, data ] );
+	}, [ isLoadingData, data ] );
 
 	const handleIpAddressChange = ( event: React.ChangeEvent< HTMLInputElement > ) => {
 		const ipAddress = event.target.value;
@@ -112,6 +114,7 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 	};
 
 	const handleSubmit = () => {
+		setIsSaving( true );
 		updateGlueRecord( {
 			record: record,
 			address: ipAddress,
@@ -160,11 +163,10 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 				<div className="glue-record-input-wrapper">
 					<FormTextInputWithAffixes
 						placeholder={ translate( 'Ex: ns1' ) }
-						disabled={ isLoading }
+						disabled={ isLoadingData || isSaving }
 						name="record"
 						onChange={ handleRecordChange }
 						value={ record }
-						// className={ classNames( { 'is-error': ! isValidUrl } ) }
 						maxLength={ 1000 }
 						suffix={ <FormLabel>.{ domain.domain }</FormLabel> }
 					/>
@@ -172,7 +174,7 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 				<FormLabel>{ translate( 'IP Address' ) }</FormLabel>
 				<div className="ip-address">
 					<FormTextInputWithAffixes
-						disabled={ isLoading }
+						disabled={ isLoadingData || isSaving }
 						name="ip-address"
 						noWrap
 						onChange={ handleIpAddressChange }
@@ -188,10 +190,19 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 					/>
 				</div>
 				<div className="glue-records__action-buttons">
-					<FormButton onClick={ handleSubmit } disabled={ isLoading }>
+					<FormButton
+						busy={ isSaving }
+						onClick={ handleSubmit }
+						disabled={ isLoadingData || isSaving }
+					>
 						{ translate( 'Save' ) }
 					</FormButton>
-					<FormButton onClick={ () => clearState() } type="button" isPrimary={ false }>
+					<FormButton
+						disabled={ isSaving }
+						onClick={ () => clearState() }
+						type="button"
+						isPrimary={ false }
+					>
 						{ translate( 'Cancel' ) }
 					</FormButton>
 				</div>

--- a/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
@@ -1,4 +1,4 @@
-import { Button, Gridicon } from '@automattic/components';
+import { Button, FormInputValidation, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
@@ -233,6 +233,11 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 						suffix={ <FormLabel>.{ domain.domain }</FormLabel> }
 						isError={ ! isValidRecord }
 					/>
+					{ ! isValidRecord && (
+						<div className="domain-forwarding-card__error-field">
+							<FormInputValidation isError text={ translate( 'Invalid subdomain' ) } />
+						</div>
+					) }
 				</div>
 				<FormLabel>{ translate( 'IP address' ) }</FormLabel>
 				<div className="ip-address">
@@ -250,6 +255,11 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 						maxLength={ 1000 }
 						isError={ ! isValidIpAddress }
 					/>
+					{ ! isValidIpAddress && (
+						<div className="domain-forwarding-card__error-field">
+							<FormInputValidation isError text={ translate( 'Invalid IP address' ) } />
+						</div>
+					) }
 				</div>
 				<div className="glue-records__action-buttons">
 					<FormButton

--- a/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
@@ -102,7 +102,7 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 		if ( isExpanded && isStale ) {
 			refetchGlueRecordsData();
 		}
-	}, [ isExpanded, isStale ] );
+	}, [ isExpanded, isStale, refetchGlueRecordsData ] );
 
 	useEffect( () => {
 		if ( isLoadingData || ! data ) {

--- a/client/my-sites/domains/domain-management/settings/cards/style.scss
+++ b/client/my-sites/domains/domain-management/settings/cards/style.scss
@@ -425,3 +425,10 @@
 	}
 }
 
+.glue-record-data {
+	flex-grow: 1;
+}
+
+.glue-records__action-buttons {
+	margin-top: 15px;
+}

--- a/client/my-sites/domains/domain-management/settings/cards/style.scss
+++ b/client/my-sites/domains/domain-management/settings/cards/style.scss
@@ -132,7 +132,8 @@
 	}
 }
 
-.domain-forwarding-card__accordion {
+.domain-forwarding-card__accordion,
+.domain-glue-records-card__accordion {
 	color: var(--studio-gray-50);
 	margin-bottom: 0 !important;
 
@@ -425,7 +426,7 @@
 	}
 }
 
-.domain-glue-records {
+.domain-glue-records-card {
 	.glue-record-data {
 		flex-grow: 1;
 	}
@@ -437,5 +438,31 @@
 	.is-placeholder {
 		height: 100px;
 		@include placeholder();
+	}
+}
+
+.domain-glue-records-card__accordion {
+	.domain-glue-records-card__error-field {
+		height: 20px;
+	}
+
+	.domain-glue-records-card__fields {
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+		gap: 1rem;
+	}
+
+	.domain-glue-records-card__fields-row {
+		display: flex;
+		flex-direction: row;
+
+		.label {
+			width: 25%;
+		}
+
+		.value {
+			overflow-wrap: anywhere;
+		}
 	}
 }

--- a/client/my-sites/domains/domain-management/settings/cards/style.scss
+++ b/client/my-sites/domains/domain-management/settings/cards/style.scss
@@ -425,10 +425,17 @@
 	}
 }
 
-.glue-record-data {
-	flex-grow: 1;
-}
+.domain-glue-records {
+	.glue-record-data {
+		flex-grow: 1;
+	}
 
-.glue-records__action-buttons {
-	margin-top: 15px;
+	.glue-records__action-buttons {
+		margin-top: 15px;
+	}
+
+	.is-placeholder {
+		height: 100px;
+		@include placeholder();
+	}
 }

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -634,11 +634,11 @@ const Settings = ( {
 	};
 
 	const renderDomainGlueRecordsSection = () => {
+		// We can only create glue records for domains registered with us
 		if (
 			! config.isEnabled( 'domains/glue-records' ) ||
 			! domain ||
-			domain.type === domainTypes.SITE_REDIRECT ||
-			domain.transferStatus === transferStatus.PENDING_ASYNC ||
+			domain.type !== domainTypes.REGISTERED ||
 			! domain.canManageDnsRecords
 		) {
 			return null;

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -26,6 +26,7 @@ import DomainMainPlaceholder from 'calypso/my-sites/domains/domain-management/co
 import DomainHeader from 'calypso/my-sites/domains/domain-management/components/domain-header';
 import { WPCOM_DEFAULT_NAMESERVERS_REGEX } from 'calypso/my-sites/domains/domain-management/name-servers/constants';
 import withDomainNameservers from 'calypso/my-sites/domains/domain-management/name-servers/with-domain-nameservers';
+import GlueRecordsCard from 'calypso/my-sites/domains/domain-management/settings/cards/glue-records-card';
 import {
 	domainManagementEdit,
 	domainManagementEditContactInfo,
@@ -631,6 +632,27 @@ const Settings = ( {
 		);
 	};
 
+	const renderDomainGlueRecordsSection = () => {
+		if (
+			! domain ||
+			domain.type === domainTypes.SITE_REDIRECT ||
+			domain.transferStatus === transferStatus.PENDING_ASYNC ||
+			! domain.canManageDnsRecords
+		) {
+			return null;
+		}
+
+		return (
+			<Accordion
+				className="domain-forwarding-card__accordion"
+				title={ translate( 'Glue Records' ) }
+				subtitle={ translate( 'Edit your private name servers (glue records)' ) }
+			>
+				<GlueRecordsCard domain={ domain } />
+			</Accordion>
+		);
+	};
+
 	const renderMainContent = () => {
 		// TODO: If it's a registered domain or transfer and the domain's registrar is in maintenance, show maintenance card
 		if ( ! domain ) {
@@ -657,6 +679,7 @@ const Settings = ( {
 				{ renderContactInformationSecion() }
 				{ renderContactVerificationSection() }
 				{ renderDomainSecuritySection() }
+				{ renderDomainGlueRecordsSection() }
 			</>
 		);
 	};

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
 import { englishLocales } from '@automattic/i18n-utils';
@@ -634,6 +635,7 @@ const Settings = ( {
 
 	const renderDomainGlueRecordsSection = () => {
 		if (
+			! config.isEnabled( 'domains/glue-records' ) ||
 			! domain ||
 			domain.type === domainTypes.SITE_REDIRECT ||
 			domain.transferStatus === transferStatus.PENDING_ASYNC ||

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -634,11 +634,12 @@ const Settings = ( {
 	};
 
 	const renderDomainGlueRecordsSection = () => {
-		// We can only create glue records for domains registered with us
+		// We can only create glue records for domains registered with us through KS_RAM
 		if (
 			! config.isEnabled( 'domains/glue-records' ) ||
 			! domain ||
 			domain.type !== domainTypes.REGISTERED ||
+			domain.registrar !== 'KS_RAM' ||
 			! domain.canManageDnsRecords
 		) {
 			return null;

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -644,15 +644,7 @@ const Settings = ( {
 			return null;
 		}
 
-		return (
-			<Accordion
-				className="domain-forwarding-card__accordion"
-				title={ translate( 'Glue Records' ) }
-				subtitle={ translate( 'Edit your private name servers (glue records)' ) }
-			>
-				<GlueRecordsCard domain={ domain } />
-			</Accordion>
-		);
+		return <GlueRecordsCard domain={ domain } />;
 	};
 
 	const renderMainContent = () => {

--- a/config/client.json
+++ b/config/client.json
@@ -3,6 +3,7 @@
 	"boom_analytics_key",
 	"client_slug",
 	"daily_post_blog_id",
+	"domains/glue-records",
 	"env",
 	"env_id",
 	"facebook_api_key",

--- a/config/development.json
+++ b/config/development.json
@@ -61,6 +61,7 @@
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
+		"domains/glue-records": true,
 		"email-accounts/enabled": true,
 		"external-media": true,
 		"external-media/free-photo-library": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -33,6 +33,7 @@
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
 		"domains/transfer-to-any-user": true,
+		"domains/glue-records": true,
 		"external-media": true,
 		"external-media/free-photo-library": true,
 		"external-media/google-photos": true,

--- a/config/production.json
+++ b/config/production.json
@@ -41,6 +41,7 @@
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
+		"domains/glue-records": false,
 		"external-media": true,
 		"external-media/free-photo-library": true,
 		"external-media/google-photos": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -38,6 +38,7 @@
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
+		"domains/glue-records": true,
 		"domains/premium-domain-purchases": true,
 		"external-media": true,
 		"external-media/free-photo-library": true,

--- a/config/test.json
+++ b/config/test.json
@@ -38,6 +38,7 @@
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": true,
 		"difm/allow-extra-pages": false,
+		"domains/glue-records": true,
 		"domains/transfer-to-any-user": true,
 		"cookie-banner": false,
 		"google-my-business": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -40,6 +40,7 @@
 		"devdocs/color-scheme-picker": true,
 		"devdocs/redirect-loggedout-homepage": true,
 		"domains/gdpr-consent-page": true,
+		"domains/glue-records": true,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This PR creates a card to manage glue records in the domain management page. Glue records can be added for domains that are registered with us through Key-Systems. It's currently behind a feature flag (`domains/glue-records`).

### Screenshots

- The card is initially closed

![Markup on 2023-12-06 at 20:47:39](https://github.com/Automattic/wp-calypso/assets/5324818/f022d671-362c-4418-be8a-19f4cd98801a)

- Open card

![Markup on 2023-12-06 at 20:47:15](https://github.com/Automattic/wp-calypso/assets/5324818/9c8dabc9-5339-43a5-9a76-5c364addc820)

- Open card with glue record added

<img width="892" alt="Screenshot 2023-12-07 at 10 29 20" src="https://github.com/Automattic/wp-calypso/assets/5324818/2a92b8af-d5e4-473f-9288-d99c89ef73e3">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Open the live Calypso link or build this branch locally
- Go to the domain management page for a domain that's registered with us via Key-Systems
- Append `?flags=domains/glue-records` to your URL
- Ensure the card is shown correctly
- Try adding and removing glue records and ensure it works correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?