### PR TITLE
Checkout: add subtotal and credits to sidebar

### DIFF
--- a/client/my-sites/checkout/src/components/payment-method-step.tsx
+++ b/client/my-sites/checkout/src/components/payment-method-step.tsx
@@ -1,13 +1,16 @@
+import { formatCurrency } from '@automattic/format-currency';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import {
 	getTotalLineItemFromCart,
 	getTaxBreakdownLineItemsFromCart,
 	getCreditsLineItemFromCart,
-	getSubtotalLineItemFromCart,
 	NonProductLineItem,
 	hasCheckoutVersion,
+	LineItemType,
+	getCouponLineItemFromCart,
 } from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
+import { useTranslate } from 'i18n-calypso';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import CheckoutTerms from '../components/checkout-terms';
 import { useShouldCollapseLastStep } from '../hooks/use-should-collapse-last-step';
@@ -59,7 +62,21 @@ export default function BeforeSubmitCheckoutHeader() {
 	const { responseCart } = useShoppingCart( cartKey );
 	const taxLineItems = getTaxBreakdownLineItemsFromCart( responseCart );
 	const creditsLineItem = getCreditsLineItemFromCart( responseCart );
+	const couponLineItem = getCouponLineItemFromCart( responseCart );
 	const shouldCollapseLastStep = useShouldCollapseLastStep();
+	const translate = useTranslate();
+	const subtotalWithoutCoupon =
+		responseCart.sub_total_integer + responseCart.coupon_savings_total_integer;
+	const subTotalLineItemWithoutCoupon: LineItemType = {
+		id: 'subtotal-without-coupon',
+		type: 'subtotal',
+		label: translate( 'Subtotal' ),
+		formattedAmount: formatCurrency( subtotalWithoutCoupon, responseCart.currency, {
+			isSmallestUnit: true,
+			stripZeros: true,
+		} ),
+	};
+
 	return (
 		<>
 			<CheckoutTermsWrapper shouldCollapseLastStep={ shouldCollapseLastStep }>
@@ -69,7 +86,8 @@ export default function BeforeSubmitCheckoutHeader() {
 			{ ! hasCheckoutVersion( '2' ) && (
 				<WPOrderReviewSection>
 					<NonTotalPrices>
-						<NonProductLineItem subtotal lineItem={ getSubtotalLineItemFromCart( responseCart ) } />
+						<NonProductLineItem subtotal lineItem={ subTotalLineItemWithoutCoupon } />
+						<NonProductLineItem subtotal lineItem={ couponLineItem } />
 						{ taxLineItems.map( ( taxLineItem ) => (
 							<NonProductLineItem key={ taxLineItem.id } tax lineItem={ taxLineItem } />
 						) ) }

--- a/client/my-sites/checkout/src/components/payment-method-step.tsx
+++ b/client/my-sites/checkout/src/components/payment-method-step.tsx
@@ -87,7 +87,7 @@ export default function BeforeSubmitCheckoutHeader() {
 				<WPOrderReviewSection>
 					<NonTotalPrices>
 						<NonProductLineItem subtotal lineItem={ subTotalLineItemWithoutCoupon } />
-						<NonProductLineItem subtotal lineItem={ couponLineItem } />
+						{ couponLineItem && <NonProductLineItem subtotal lineItem={ couponLineItem } /> }
 						{ taxLineItems.map( ( taxLineItem ) => (
 							<NonProductLineItem key={ taxLineItem.id } tax lineItem={ taxLineItem } />
 						) ) }

--- a/client/my-sites/checkout/src/components/payment-method-step.tsx
+++ b/client/my-sites/checkout/src/components/payment-method-step.tsx
@@ -8,6 +8,7 @@ import {
 	hasCheckoutVersion,
 	LineItemType,
 	getCouponLineItemFromCart,
+	getSubtotalWithoutCoupon,
 } from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
@@ -65,8 +66,7 @@ export default function BeforeSubmitCheckoutHeader() {
 	const couponLineItem = getCouponLineItemFromCart( responseCart );
 	const shouldCollapseLastStep = useShouldCollapseLastStep();
 	const translate = useTranslate();
-	const subtotalWithoutCoupon =
-		responseCart.sub_total_integer + responseCart.coupon_savings_total_integer;
+	const subtotalWithoutCoupon = getSubtotalWithoutCoupon( responseCart );
 	const subTotalLineItemWithoutCoupon: LineItemType = {
 		id: 'subtotal-without-coupon',
 		type: 'subtotal',

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -22,13 +22,13 @@ import {
 } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
+import { formatCurrency } from '@automattic/format-currency';
 import { isNewsletterOrLinkInBioFlow, isAnyHostingFlow } from '@automattic/onboarding';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import {
 	getCouponLineItemFromCart,
 	getTaxBreakdownLineItemsFromCart,
 	getTotalLineItemFromCart,
-	getSubtotalLineItemFromCart,
 	hasCheckoutVersion,
 	getCreditsLineItemFromCart,
 } from '@automattic/wpcom-checkout';
@@ -117,19 +117,25 @@ export default function WPCheckoutOrderSummary( {
 function CheckoutSummaryPriceList() {
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
-	const subtotalLineItem = getSubtotalLineItemFromCart( responseCart );
 	const couponLineItem = getCouponLineItemFromCart( responseCart );
 	const creditsLineItem = getCreditsLineItemFromCart( responseCart );
 	const taxLineItems = getTaxBreakdownLineItemsFromCart( responseCart );
 	const totalLineItem = getTotalLineItemFromCart( responseCart );
 	const translate = useTranslate();
+	const subtotalWithoutCoupon =
+		responseCart.sub_total_integer + responseCart.coupon_savings_total_integer;
 
 	return (
 		<>
 			<CheckoutSummaryAmountWrapper>
-				<CheckoutSummaryLineItem key={ 'checkout-summary-line-item-' + subtotalLineItem.id }>
-					<span>{ subtotalLineItem.label }</span>
-					<span>{ subtotalLineItem.formattedAmount }</span>
+				<CheckoutSummaryLineItem key="checkout-summary-line-item-subtotal">
+					<span>{ translate( 'Subtotal' ) }</span>
+					<span>
+						{ formatCurrency( subtotalWithoutCoupon, responseCart.currency, {
+							isSmallestUnit: true,
+							stripZeros: true,
+						} ) }
+					</span>
 				</CheckoutSummaryLineItem>
 				{ ! hasCheckoutVersion( '2' ) && couponLineItem && (
 					<CheckoutSummaryLineItem key={ 'checkout-summary-line-item-' + couponLineItem.id }>

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -31,6 +31,7 @@ import {
 	getTotalLineItemFromCart,
 	hasCheckoutVersion,
 	getCreditsLineItemFromCart,
+	getSubtotalWithoutCoupon,
 } from '@automattic/wpcom-checkout';
 import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
@@ -122,8 +123,7 @@ function CheckoutSummaryPriceList() {
 	const taxLineItems = getTaxBreakdownLineItemsFromCart( responseCart );
 	const totalLineItem = getTotalLineItemFromCart( responseCart );
 	const translate = useTranslate();
-	const subtotalWithoutCoupon =
-		responseCart.sub_total_integer + responseCart.coupon_savings_total_integer;
+	const subtotalWithoutCoupon = getSubtotalWithoutCoupon( responseCart );
 
 	return (
 		<>

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -30,6 +30,7 @@ import {
 	getTotalLineItemFromCart,
 	getSubtotalLineItemFromCart,
 	hasCheckoutVersion,
+	getCreditsLineItemFromCart,
 } from '@automattic/wpcom-checkout';
 import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
@@ -118,6 +119,7 @@ function CheckoutSummaryPriceList() {
 	const { responseCart } = useShoppingCart( cartKey );
 	const subtotalLineItem = getSubtotalLineItemFromCart( responseCart );
 	const couponLineItem = getCouponLineItemFromCart( responseCart );
+	const creditsLineItem = getCreditsLineItemFromCart( responseCart );
 	const taxLineItems = getTaxBreakdownLineItemsFromCart( responseCart );
 	const totalLineItem = getTotalLineItemFromCart( responseCart );
 	const translate = useTranslate();
@@ -141,6 +143,12 @@ function CheckoutSummaryPriceList() {
 						<span>{ taxLineItem.formattedAmount }</span>
 					</CheckoutSummaryLineItem>
 				) ) }
+				{ ! hasCheckoutVersion( '2' ) && creditsLineItem && responseCart.sub_total_integer > 0 && (
+					<CheckoutSummaryLineItem key={ 'checkout-summary-line-item-' + creditsLineItem.id }>
+						<span>{ creditsLineItem.label }</span>
+						<span>{ creditsLineItem.formattedAmount }</span>
+					</CheckoutSummaryLineItem>
+				) }
 
 				<CheckoutSummaryTotal>
 					<span>{ translate( 'Total' ) }</span>

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -125,12 +125,10 @@ function CheckoutSummaryPriceList() {
 	return (
 		<>
 			<CheckoutSummaryAmountWrapper>
-				{ hasCheckoutVersion( '2' ) && (
-					<CheckoutSummaryLineItem key={ 'checkout-summary-line-item-' + subtotalLineItem.id }>
-						<span>{ subtotalLineItem.label }</span>
-						<span>{ subtotalLineItem.formattedAmount }</span>
-					</CheckoutSummaryLineItem>
-				) }
+				<CheckoutSummaryLineItem key={ 'checkout-summary-line-item-' + subtotalLineItem.id }>
+					<span>{ subtotalLineItem.label }</span>
+					<span>{ subtotalLineItem.formattedAmount }</span>
+				</CheckoutSummaryLineItem>
 				{ ! hasCheckoutVersion( '2' ) && couponLineItem && (
 					<CheckoutSummaryLineItem key={ 'checkout-summary-line-item-' + couponLineItem.id }>
 						<span>{ couponLineItem.label }</span>

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -267,11 +267,17 @@ export interface ResponseCart< P = ResponseCartProduct > {
 
 	/**
 	 * The subtotal with taxes included in the currency's smallest unit.
+	 *
+	 * This is the sum of each item's price with all discounts (including
+	 * coupons), but without taxes. This does not include credits!
 	 */
 	sub_total_with_taxes_integer: number;
 
 	/**
 	 * The subtotal without taxes included in the currency's smallest unit.
+	 *
+	 * This is the sum of each item's price with all discounts (including
+	 * coupons), but without taxes. This does not include credits!
 	 */
 	sub_total_integer: number;
 
@@ -390,6 +396,9 @@ export interface ResponseCartProduct {
 
 	/**
 	 * The cart item's subtotal in the currency's smallest unit.
+	 *
+	 * This is the cost of the item with all discounts (including coupons),
+	 * but without taxes.
 	 */
 	item_subtotal_integer: number;
 
@@ -419,16 +428,13 @@ export interface ResponseCartProduct {
 	 *
 	 * Note that the difference may be caused by many factors, not just coupons.
 	 * It's best not to rely on it.
-	 *
 	 * @deprecated This is a float and is unreliable. Use coupon_savings_integer
 	 */
 	coupon_savings?: number;
 
 	/**
-	 * The difference between `cost_before_coupon` and the actual price in the currency's smallest unit.
-	 *
-	 * Note that the difference may be caused by many factors, not just coupons.
-	 * It's best not to rely on it.
+	 * The amount of the local currency deducted by an applied coupon, if any.
+	 * This is in the currency's smallest unit.
 	 */
 	coupon_savings_integer?: number;
 

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -42,19 +42,6 @@ export function getCouponLineItemFromCart( responseCart: ResponseCart ): LineIte
 	};
 }
 
-export function getSubtotalLineItemFromCart( responseCart: ResponseCart ): LineItemType {
-	return {
-		id: 'subtotal',
-		type: 'subtotal',
-		// translators: The label of the subtotal line item in checkout
-		label: String( translate( 'Subtotal' ) ),
-		formattedAmount: formatCurrency( responseCart.sub_total_integer, responseCart.currency, {
-			isSmallestUnit: true,
-			stripZeros: true,
-		} ),
-	};
-}
-
 export function getTaxLineItemFromCart( responseCart: ResponseCart ): LineItemType | null {
 	if ( ! responseCart.tax.display_taxes ) {
 		return null;

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -120,6 +120,17 @@ export function getCreditsLineItemFromCart( responseCart: ResponseCart ): LineIt
 	};
 }
 
+/*
+ * Coupon discounts are applied (or not, as appropriate) to each line item's
+ * total, so the cart's subtotal includes them. However, because it's nice to
+ * be able to display the coupon discount as a discount separately from the
+ * subtotal, this function returns the cart's subtotal with the coupon savings
+ * removed.
+ */
+export function getSubtotalWithoutCoupon( responseCart: ResponseCart ): number {
+	return responseCart.sub_total_integer + responseCart.coupon_savings_total_integer;
+}
+
 export function doesPurchaseHaveFullCredits( cart: ResponseCart ): boolean {
 	const credits = cart.credits_integer;
 	const subtotal = cart.sub_total_integer;

--- a/packages/wpcom-checkout/test/transformations.ts
+++ b/packages/wpcom-checkout/test/transformations.ts
@@ -3,7 +3,6 @@ import {
 	getCreditsLineItemFromCart,
 	getTaxLineItemFromCart,
 	getTaxBreakdownLineItemsFromCart,
-	getSubtotalLineItemFromCart,
 	getCouponLineItemFromCart,
 	getTotalLineItemFromCart,
 	LineItemType,
@@ -114,19 +113,6 @@ describe( 'getCouponLineItemFromCart', function () {
 		};
 
 		expect( getCouponLineItemFromCart( cartWithCoupon ) ).toStrictEqual( expected );
-	} );
-} );
-
-describe( 'getSubtotalLineItemFromCart', function () {
-	it( 'returns line item for subtotal', () => {
-		const expected: LineItemType = {
-			id: 'subtotal',
-			type: 'subtotal',
-			label: 'Subtotal',
-			formattedAmount: '¥75,000',
-		};
-
-		expect( getSubtotalLineItemFromCart( cart ) ).toStrictEqual( expected );
 	} );
 } );
 


### PR DESCRIPTION
## Proposed Changes

This PR adds the subtotal and credits line items to the sidebar. These are already displayed in the price tally at the bottom of checkout, but this way they will make the sidebar summary more clear.

> [!Note]
> This changes the meaning of the "Subtotal" displayed in both the sidebar and the bottom of the page. It no longer includes coupon discounts.

Before             |  After
:-------------------------:|:-------------------------:
 <img width="254" alt="Screenshot 2023-11-16 at 12 13 57 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/eac3aecb-410d-4af5-8c34-3a0ac0e3e607"> | <img width="269" alt="Screenshot 2023-11-16 at 1 15 28 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/b8379d71-ba48-45ae-a6bb-43af2adec7af">


Fixes https://github.com/Automattic/payments-shilling/issues/2173

## Testing Instructions

- Add credits to your account if you want to see the credits changes.
- Add a product to your cart and visit checkout.
- View the checkout sidebar at desktop width (it's collapsed at the top at mobile width).
- Verify that the sidebar contains the subtotal and credits line items.
