### PR TITLE
Adds the tags header to the customer home reader component

### DIFF
--- a/client/my-sites/customer-home/cards/features/reader/index.tsx
+++ b/client/my-sites/customer-home/cards/features/reader/index.tsx
@@ -43,6 +43,14 @@ const ReaderCard = ( props: ReaderCardProps ) => {
 		},
 	} );
 
+	// Add dailyprompt to the front of interestTags if not present.
+	const hasDailyPrompt = interestTags.filter(
+		( tag: { slug: string } ) => tag.slug === 'dailyprompt'
+	).length;
+	if ( ! hasDailyPrompt ) {
+		interestTags.unshift( { title: translate( 'Daily prompts' ), slug: 'dailyprompt' } );
+	}
+
 	const queryParams = new URLSearchParams( window.location.search );
 	const selectedTab = queryParams.get( 'selectedTab' ) || DEFAULT_TAB;
 

--- a/client/my-sites/customer-home/cards/features/reader/index.tsx
+++ b/client/my-sites/customer-home/cards/features/reader/index.tsx
@@ -6,15 +6,8 @@ import withDimensions from 'calypso/lib/with-dimensions';
 import wpcom from 'calypso/lib/wp';
 import { trackScrollPage } from 'calypso/reader/controller-helper';
 import DiscoverNavigation from 'calypso/reader/discover/discover-navigation';
-import {
-	DEFAULT_TAB,
-	buildDiscoverStreamKey,
-	getDiscoverStreamTags,
-} from 'calypso/reader/discover/helper';
+import { DEFAULT_TAB, buildDiscoverStreamKey } from 'calypso/reader/discover/helper';
 import Stream from 'calypso/reader/stream';
-import { useSelector } from 'calypso/state';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import { getReaderFollowedTags } from 'calypso/state/reader/tags/selectors';
 
 import './style.scss';
 
@@ -43,25 +36,10 @@ const ReaderCard = ( props: ReaderCardProps ) => {
 		},
 	} );
 
-	// Add dailyprompt to the front of interestTags if not present.
-	const hasDailyPrompt = interestTags.filter(
-		( tag: { slug: string } ) => tag.slug === 'dailyprompt'
-	).length;
-	if ( ! hasDailyPrompt ) {
-		interestTags.unshift( { title: translate( 'Daily prompts' ), slug: 'dailyprompt' } );
-	}
-
 	const queryParams = new URLSearchParams( window.location.search );
 	const selectedTab = queryParams.get( 'selectedTab' ) || DEFAULT_TAB;
 
-	const followedTags = useSelector( getReaderFollowedTags );
-	const isLoggedIn = useSelector( isUserLoggedIn );
-	// Do not supply a fallback empty array as null is good data for getDiscoverStreamTags.
-	const recommendedStreamTags = getDiscoverStreamTags(
-		followedTags && followedTags.map( ( tag ) => tag.slug ),
-		isLoggedIn
-	);
-	const streamKey = buildDiscoverStreamKey( selectedTab, recommendedStreamTags );
+	const streamKey = buildDiscoverStreamKey( selectedTab, [ 'dailyprompt' ] );
 
 	return (
 		<>

--- a/client/my-sites/customer-home/cards/features/reader/index.tsx
+++ b/client/my-sites/customer-home/cards/features/reader/index.tsx
@@ -1,12 +1,40 @@
+import { useLocale } from '@automattic/i18n-utils';
+import { useQuery } from '@tanstack/react-query';
 import { useTranslate } from 'i18n-calypso';
 import iconReaderLightbulb from 'calypso/assets/images/customer-home/reader-lightbulb.svg';
+import withDimensions from 'calypso/lib/with-dimensions';
+import wpcom from 'calypso/lib/wp';
 import { trackScrollPage } from 'calypso/reader/controller-helper';
+import DiscoverNavigation from 'calypso/reader/discover/discover-navigation';
+import { DEFAULT_TAB } from 'calypso/reader/discover/helper';
 import Stream from 'calypso/reader/stream';
 
 import './style.scss';
 
-const ReaderCard = () => {
+interface ReaderCardProps {
+	width: number;
+}
+
+const ReaderCard = ( props: ReaderCardProps ) => {
 	const translate = useTranslate();
+	const locale = useLocale();
+
+	const { data: interestTags = [] } = useQuery( {
+		queryKey: [ 'read/interests', locale ],
+		queryFn: () =>
+			wpcom.req.get(
+				{
+					path: `/read/interests`,
+					apiNamespace: 'wpcom/v2',
+				},
+				{
+					_locale: locale,
+				}
+			),
+		select: ( data ) => {
+			return data.interests;
+		},
+	} );
 
 	return (
 		<>
@@ -24,6 +52,11 @@ const ReaderCard = () => {
 						) }
 					</span>
 				</div>
+				<DiscoverNavigation
+					width={ props.width }
+					selectedTab={ DEFAULT_TAB }
+					recommendedTags={ interestTags }
+				/>
 				<Stream
 					streamKey="discover:recommended--dailyprompt"
 					trackScrollPage={ trackScrollPage.bind( null ) }
@@ -36,4 +69,4 @@ const ReaderCard = () => {
 	);
 };
 
-export default ReaderCard;
+export default withDimensions( ReaderCard );

--- a/client/my-sites/customer-home/cards/features/reader/index.tsx
+++ b/client/my-sites/customer-home/cards/features/reader/index.tsx
@@ -6,8 +6,15 @@ import withDimensions from 'calypso/lib/with-dimensions';
 import wpcom from 'calypso/lib/wp';
 import { trackScrollPage } from 'calypso/reader/controller-helper';
 import DiscoverNavigation from 'calypso/reader/discover/discover-navigation';
-import { DEFAULT_TAB } from 'calypso/reader/discover/helper';
+import {
+	DEFAULT_TAB,
+	buildDiscoverStreamKey,
+	getDiscoverStreamTags,
+} from 'calypso/reader/discover/helper';
 import Stream from 'calypso/reader/stream';
+import { useSelector } from 'calypso/state';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { getReaderFollowedTags } from 'calypso/state/reader/tags/selectors';
 
 import './style.scss';
 
@@ -36,6 +43,18 @@ const ReaderCard = ( props: ReaderCardProps ) => {
 		},
 	} );
 
+	const queryParams = new URLSearchParams( window.location.search );
+	const selectedTab = queryParams.get( 'selectedTab' ) || DEFAULT_TAB;
+
+	const followedTags = useSelector( getReaderFollowedTags );
+	const isLoggedIn = useSelector( isUserLoggedIn );
+	// Do not supply a fallback empty array as null is good data for getDiscoverStreamTags.
+	const recommendedStreamTags = getDiscoverStreamTags(
+		followedTags && followedTags.map( ( tag ) => tag.slug ),
+		isLoggedIn
+	);
+	const streamKey = buildDiscoverStreamKey( selectedTab, recommendedStreamTags );
+
 	return (
 		<>
 			<div className="reader-card customer-home__card">
@@ -54,11 +73,11 @@ const ReaderCard = ( props: ReaderCardProps ) => {
 				</div>
 				<DiscoverNavigation
 					width={ props.width }
-					selectedTab={ DEFAULT_TAB }
+					selectedTab={ selectedTab }
 					recommendedTags={ interestTags }
 				/>
 				<Stream
-					streamKey="discover:recommended--dailyprompt"
+					streamKey={ streamKey }
 					trackScrollPage={ trackScrollPage.bind( null ) }
 					useCompactCards={ true }
 					isDiscoverStream={ true }

--- a/client/my-sites/customer-home/cards/features/reader/style.scss
+++ b/client/my-sites/customer-home/cards/features/reader/style.scss
@@ -50,6 +50,15 @@
 		letter-spacing: -0.15px;
 	}
 
+	.discover-stream-navigation {
+		max-width: none;
+
+		.discover-stream-navigation__right-button-wrapper,
+		.discover-stream-navigation__left-button-wrapper {
+			background: none;
+		}
+	}
+
 	.following.main {
 		max-width: none !important;
 		padding-bottom: 0 !important;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4546

## Proposed Changes

* Adds the Tags header to the Customer Home reader component. This will allow the users to navigate in different tags.
* This is part of our experiment to add the Reader on the customer home after the setup.

<img width="1196" alt="Screen Shot 2023-11-17 at 16 00 23" src="https://github.com/Automattic/wp-calypso/assets/1234758/9e080f4c-8289-418b-8688-b64b1030e4d4">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure you are sandboxed
* Add the following filter to your 0-sandbox.php file:
```
add_filter( 'reader_experiment_enabled', '__return_true', 10, 2 );
```
* Create a new by navigating to `/setup/start-writing`
* Go through the setup follow, until you reach on the Customer Home page
* Hide all the banners displayed on the Customer Home page
* It should show the Reader in the Customer Home page and it should contain the tab navigator, with many tags.
* Play around and make sure clicking on the tags updates the views.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?