### PR TITLE
VideoMaker: add support for setting variation for light / dark theme in chooser

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videomaker-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videomaker-setup/index.tsx
@@ -38,7 +38,7 @@ const VideomakerSetup: Step = function VideomakerSetup( { navigation } ) {
 		setSelectedDesign( {
 			slug: 'videomaker',
 			theme: slug,
-			is_premium: config.isEnabled( 'videomaker-trial' ) ? false : true,
+			is_premium: ! config.isEnabled( 'videomaker-trial' ),
 			title: 'Videomaker',
 			categories: [],
 			features: [],

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videomaker-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videomaker-setup/index.tsx
@@ -60,7 +60,11 @@ const VideomakerSetup: Step = function VideomakerSetup( { navigation } ) {
 			<div className="videomaker-setup__theme-picker">
 				<button
 					className="videomaker-setup__dark-button"
-					onClick={ () => onSelectTheme( 'pub/videomaker' ) }
+					onClick={ () =>
+						onSelectTheme(
+							config.isEnabled( 'videomaker-trial' ) ? 'pub/videomaker' : 'premium/videomaker'
+						)
+					}
 				>
 					<img
 						src="https://videopress2.files.wordpress.com/2022/12/videomaker-dark.jpg"
@@ -71,7 +75,7 @@ const VideomakerSetup: Step = function VideomakerSetup( { navigation } ) {
 					className="videomaker-setup__light-button"
 					onClick={ () =>
 						onSelectTheme(
-							'pub/videomaker',
+							config.isEnabled( 'videomaker-trial' ) ? 'pub/videomaker' : 'premium/videomaker',
 							styles.find( ( style ) => 'white' === style.name )
 						)
 					}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videomaker-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videomaker-setup/index.tsx
@@ -1,5 +1,7 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
+import config from '@automattic/calypso-config';
+import { StyleVariation } from '@automattic/design-picker';
 import { StepContainer } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
@@ -11,21 +13,44 @@ import type { Step } from 'calypso/landing/stepper/declarative-flow/internals/ty
 
 import './styles.scss';
 
+type ThemeStyle = {
+	name: string;
+	title: string;
+};
+
+const styles: ThemeStyle[] = [
+	{ name: 'charcoal', title: 'Charcoal' },
+	{ name: 'rainforest', title: 'Rainforest' },
+	{ name: 'ruby-wine', title: 'Ruby Wine' },
+	{ name: 'blue-yellow', title: 'Blue/Yellow' },
+	{ name: 'grey-bordeaux', title: 'Light Grey/Bordeaux' },
+	{ name: 'grey-mint', title: 'Grey/Mint Green' },
+	{ name: 'olive-pink', title: 'Olive Green/Light Pink' },
+	{ name: 'white', title: 'White' },
+];
+
 const VideomakerSetup: Step = function VideomakerSetup( { navigation } ) {
 	const { submit } = navigation;
 	const { __ } = useI18n();
-	const { setSelectedDesign } = useDispatch( ONBOARD_STORE );
+	const { setSelectedDesign, setSelectedStyleVariation } = useDispatch( ONBOARD_STORE );
 
-	const onSelectTheme = ( slug: string ) => {
+	const onSelectTheme = ( slug: string, styleVariation?: ThemeStyle ) => {
 		setSelectedDesign( {
 			slug: 'videomaker',
 			theme: slug,
-			is_premium: true,
+			is_premium: config.isEnabled( 'videomaker-trial' ) ? false : true,
 			title: 'Videomaker',
 			categories: [],
 			features: [],
-			template: '',
+			template: styleVariation?.name ?? '',
 		} );
+
+		if ( config.isEnabled( 'videomaker-trial' ) && styleVariation ) {
+			setSelectedStyleVariation( {
+				slug: styleVariation.name,
+				title: styleVariation.title,
+			} as StyleVariation );
+		}
 
 		submit?.();
 	};
@@ -35,7 +60,7 @@ const VideomakerSetup: Step = function VideomakerSetup( { navigation } ) {
 			<div className="videomaker-setup__theme-picker">
 				<button
 					className="videomaker-setup__dark-button"
-					onClick={ () => onSelectTheme( 'premium/videomaker' ) }
+					onClick={ () => onSelectTheme( 'pub/videomaker' ) }
 				>
 					<img
 						src="https://videopress2.files.wordpress.com/2022/12/videomaker-dark.jpg"
@@ -44,7 +69,12 @@ const VideomakerSetup: Step = function VideomakerSetup( { navigation } ) {
 				</button>
 				<button
 					className="videomaker-setup__light-button"
-					onClick={ () => onSelectTheme( 'premium/videomaker-white' ) }
+					onClick={ () =>
+						onSelectTheme(
+							'pub/videomaker',
+							styles.find( ( style ) => 'white' === style.name )
+						)
+					}
 				>
 					<img
 						src="https://videopress2.files.wordpress.com/2022/12/videomaker-light.jpg"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/videomaker-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/videomaker-setup/index.tsx
@@ -75,7 +75,9 @@ const VideomakerSetup: Step = function VideomakerSetup( { navigation } ) {
 					className="videomaker-setup__light-button"
 					onClick={ () =>
 						onSelectTheme(
-							config.isEnabled( 'videomaker-trial' ) ? 'pub/videomaker' : 'premium/videomaker',
+							config.isEnabled( 'videomaker-trial' )
+								? 'pub/videomaker'
+								: 'premium/videomaker-white',
 							styles.find( ( style ) => 'white' === style.name )
 						)
 					}

--- a/client/landing/stepper/declarative-flow/videopress.ts
+++ b/client/landing/stepper/declarative-flow/videopress.ts
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import { LaunchpadNavigator, PlansSelect, SiteSelect } from '@automattic/data-stores';
+import { StyleVariation } from '@automattic/design-picker';
 import { useLocale } from '@automattic/i18n-utils';
 import { useFlowProgress, VIDEOPRESS_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -9,6 +10,7 @@ import { useSupportedPlans } from 'calypso/../packages/plans-grid/src/hooks';
 import { useNewSiteVisibility } from 'calypso/landing/stepper/hooks/use-selected-plan';
 import { skipLaunchpad } from 'calypso/landing/stepper/utils/skip-launchpad';
 import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
+import wpcom from 'calypso/lib/wp';
 import { cartManagerClient } from 'calypso/my-sites/checkout/cart-manager-client';
 import { useSiteIdParam } from '../hooks/use-site-id-param';
 import { useSiteSlug } from '../hooks/use-site-slug';
@@ -67,6 +69,10 @@ const videopress: Flow = {
 		}
 
 		const name = this.name;
+		const { getSelectedStyleVariation } = useSelect(
+			( select ) => select( ONBOARD_STORE ) as OnboardSelect,
+			[]
+		);
 		const { setDomain, setSelectedDesign, setSiteDescription, setSiteTitle, setStepProgress } =
 			useDispatch( ONBOARD_STORE );
 		const flowProgress = useFlowProgress( { stepName: _currentStep, flowName: name } );
@@ -139,6 +145,53 @@ const videopress: Flow = {
 			return true;
 		};
 
+		const updateSelectedTheme = async ( siteId: number ) => {
+			const getStyleVariations = (): Promise< StyleVariation[] > => {
+				return wpcom.req.get( {
+					path: `/sites/${ siteId }/global-styles/themes/pub/videomaker/variations`,
+					apiNamespace: 'wp/v2',
+				} );
+			};
+
+			type Theme = {
+				_links: {
+					'wp:user-global-styles': { href: string }[];
+				};
+			};
+
+			const getSiteTheme = (): Promise< Theme > => {
+				return wpcom.req.get( {
+					path: `/sites/${ siteId }/themes/pub/videomaker`,
+					apiNamespace: 'wp/v2',
+				} );
+			};
+
+			const updateGlobalStyles = ( globalStylesId: number, styleVariation: StyleVariation ) => {
+				return wpcom.req.post( {
+					path: `/sites/${ siteId }/global-styles/${ globalStylesId }`,
+					apiNamespace: 'wp/v2',
+					body: styleVariation,
+				} );
+			};
+
+			const selectedStyleVariationTitle = getSelectedStyleVariation()?.title;
+			const [ styleVariations, theme ]: [ StyleVariation[], Theme ] = await Promise.all( [
+				getStyleVariations(),
+				getSiteTheme(),
+			] );
+
+			const userGlobalStylesLink: string =
+				theme?._links?.[ 'wp:user-global-styles' ]?.[ 0 ]?.href || '';
+			const userGlobalStylesId = parseInt( userGlobalStylesLink.split( '/' ).pop() || '', 10 );
+			const styleVariation = styleVariations.find(
+				( variation ) => variation.title === selectedStyleVariationTitle
+			);
+
+			if ( styleVariation && userGlobalStylesId ) {
+				await updateGlobalStyles( userGlobalStylesId, styleVariation );
+			}
+		};
+
 		const addVideoPressPendingAction = () => {
 			// if the supported plans haven't been received yet, wait for next rerender to try again.
 			if ( 0 === supportedPlans.length ) {
@@ -177,6 +230,13 @@ const videopress: Flow = {
 						launchpad_screen: 'off',
 						blogdescription: siteDescription,
 					} );
+
+					setProgress( 0.75 );
+
+					await updateSelectedTheme( newSite.blogid );
+
+					setProgress( 1.0 );
+
 					clearOnboardingSiteOptions();
 					return window.location.assign( `/site-editor/${ newSite.site_slug }` );
 				}

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -53,9 +53,11 @@ export function* createVideoPressSite( {
 
 	const siteUrl = domain?.domain_name || siteTitle || username;
 	const lang_id = ( getLanguage( languageSlug ) as Language )?.value;
-	const siteVertical = 'videomaker';
-	const blogTitle = siteTitle.trim() === '' ? __( 'Site Title' ) : siteTitle;
 	const isVideomakerTrial = config.isEnabled( 'videomaker-trial' );
+	const defaultTheme = selectedDesign?.theme || 'premium/videomaker';
+	const legacyVertical = 'premium/videomaker' === defaultTheme ? 'videomaker' : 'videomaker-white';
+	const siteVertical = isVideomakerTrial ? 'videomaker' : legacyVertical;
+	const blogTitle = siteTitle.trim() === '' ? __( 'Site Title' ) : siteTitle;
 	const themeSlug = isVideomakerTrial ? 'pub/videomaker' : 'pub/twentytwentytwo'; // NOTE: keep this a consistent, free theme so post ids during headstart re-run after premium theme switch remain consistent
 
 	const params: CreateSiteParams = {

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -53,8 +53,7 @@ export function* createVideoPressSite( {
 
 	const siteUrl = domain?.domain_name || siteTitle || username;
 	const lang_id = ( getLanguage( languageSlug ) as Language )?.value;
-	const defaultTheme = selectedDesign?.theme || 'premium/videomaker';
-	const siteVertical = 'premium/videomaker' === defaultTheme ? 'videomaker' : 'videomaker-white';
+	const siteVertical = 'videomaker';
 	const blogTitle = siteTitle.trim() === '' ? __( 'Site Title' ) : siteTitle;
 	const isVideomakerTrial = config.isEnabled( 'videomaker-trial' );
 	const themeSlug = isVideomakerTrial ? 'pub/videomaker' : 'pub/twentytwentytwo'; // NOTE: keep this a consistent, free theme so post ids during headstart re-run after premium theme switch remain consistent


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes  https://github.com/Automattic/greenhouse/issues/1893
This PR is a replacement for https://github.com/Automattic/wp-calypso/pull/83098

## Proposed Changes

* set the correct style variation in the theme for the selected variation
* only support the 2 variations we currently support. We can add in more later if we think it is necessary now that we have the support for it.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `yarn && yarn start`
* `/setup/videopress` 
* choose "Showcase your work"
* select the white theme
* complete site creation
* You should arrive in the editor with the white variation
* repeat site creation but choose the dark theme
* Now test the NON-dev version (use the `Calypso live`) link below
* repeat the above steps, the correct styled site should be created

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?