### PR TITLE
Media Library: update Thumbnail to Poster to make consistent with video block copy

### DIFF
--- a/client/blocks/video-editor/index.jsx
+++ b/client/blocks/video-editor/index.jsx
@@ -179,7 +179,7 @@ class VideoEditor extends Component {
 							/>
 						) }
 						<span className="video-editor__text">
-							{ translate( 'Select a frame to use as the thumbnail image or upload your own.' ) }
+							{ translate( 'Select a frame to use as the poster image or upload your own.' ) }
 						</span>
 						<VideoEditorControls
 							isPosterUpdating={ isSelectingFrame || ( uploadProgress && ! error ) }

--- a/client/post-editor/media-modal/detail/detail-item.jsx
+++ b/client/post-editor/media-modal/detail/detail-item.jsx
@@ -110,7 +110,7 @@ export class EditorMediaModalDetailItem extends Component {
 		}
 
 		const isVideoMime = 'video' === mimePrefix;
-		const editText = isVideoMime ? translate( 'Edit Thumbnail' ) : translate( 'Edit Image' );
+		const editText = isVideoMime ? translate( 'Edit Poster' ) : translate( 'Edit Image' );
 
 		return (
 			<Button


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/greenhouse/issues/1965

## Proposed Changes

* update the labels in the media library for Videos that refer to "thumbnails" to "Poster" which is how it is referred to in the video block. This will make documentation more consistent as well.

| before | after |
| --- | --- |

| <img width="444" alt="SCR-20231116-nsoc" src="https://github.com/Automattic/wp-calypso/assets/4081020/b83c9e20-5e2e-4873-8d74-d7f78647e0b3"> | <img width="375" alt="SCR-20231116-nvlu" src="https://github.com/Automattic/wp-calypso/assets/4081020/ddfe017c-fae7-4bcd-a035-6845ec026701"> |
| --- | --- |
| <img width="600" alt="SCR-20231116-nsql" src="https://github.com/Automattic/wp-calypso/assets/4081020/23c51af5-d7f2-4d66-81dc-36308df4b8fb"> | <img width="628" alt="SCR-20231116-nvnc" src="https://github.com/Automattic/wp-calypso/assets/4081020/8c32751b-dc2b-447f-b81d-5ec3d3709196"> |
| --- | --- |


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `yarn && yarn start`
* visit the media library for a site with videos
* open a video (select + click Edit)
* The button in the upper right of the video should say "Edit Poster"
* click the button
* The instructions under the video should refer to "poster" not "thumbnail"

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?