### PR TITLE
Checkout: Adjust spacing of plan upsell text to avoid line wrapping

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/style.scss
+++ b/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/style.scss
@@ -18,7 +18,7 @@
 .checkout-sidebar-plan-upsell__plan-grid {
 	display: grid;
 	grid-template-rows: 1fr 1fr;
-	grid-template-columns: 1fr 3fr;
+	grid-template-columns: 2fr 3fr;
 }
 
 .checkout-sidebar-plan-upsell__plan-grid > div:nth-child(even) {


### PR DESCRIPTION
The plan upsell css grid appears to wrap the text onto two lines. This [may have been introduced](https://github.com/Automattic/wp-calypso/commit/1a2bfa67b4731bb783cd8288390cc667fa4107cc) when we wrapped the upsell card with a conditional for the checkout redesign...but since we only conditionally call the code I don't think the styling should have been affected.

Related to https://github.com/Automattic/payments-shilling/issues/2174

## Proposed Changes

* This PR changes the grid ratio for the upsell card's columns from `1fr 3fr` to `2fr 3fr`, which should provide a more equitable share of the available space and avoid text wrapping.

## Testing Instructions

* Add a one year plan to your cart
* Go to checkout and look at the sidebar plan upsell card, make sure the `One year...two years` text is on one line each

**Before**

![image](https://github.com/Automattic/wp-calypso/assets/16580129/def46f02-6277-41a6-ac6e-12c5dcb3257a)

**After**

![image](https://github.com/Automattic/wp-calypso/assets/16580129/1b922667-51cd-4e43-b0ad-e3c44789183a)


