### PR TITLE
ActivityLog: Fix activity type count indicator for nested filters

### DIFF
--- a/client/my-sites/activity/filterbar/type-selector/type-selector.jsx
+++ b/client/my-sites/activity/filterbar/type-selector/type-selector.jsx
@@ -66,24 +66,24 @@ export class TypeSelector extends Component {
 				selectedCheckboxes: updatedSelection,
 			} );
 		} else {
-			let updatedSelection = [ ...selectedCheckboxes ];
+			let updatedSelection = new Set( selectedCheckboxes );
 
 			// If it's a parent type, we simply use the parentTypeKey
 			if ( isParentType ) {
-				updatedSelection = [ parentTypeKey ];
+				updatedSelection = new Set( [ parentTypeKey ] );
 			} else {
 				// Find the type object and add its children if it has any
 				const currentType = this.props.types.find( ( typeItem ) => typeItem.key === type );
 				if ( currentType && currentType.children ) {
-					currentType.children.forEach( ( child ) => updatedSelection.push( child.key ) );
+					currentType.children.forEach( ( child ) => updatedSelection.add( child.key ) );
 				}
 				// Always add the type itself to the selection
-				updatedSelection.push( type );
+				updatedSelection.add( type );
 			}
 
 			this.setState( {
 				userHasSelected: true,
-				selectedCheckboxes: updatedSelection,
+				selectedCheckboxes: [ ...updatedSelection ],
 			} );
 		}
 	};


### PR DESCRIPTION
This PR aims to fix the count of activity type filters selected when a user tries to select children filters and then it parents.

In the following video, you can see how the count indicator when from 4 to 8. This is because the array of activity types checkboxes is allowing duplicate values.

https://github.com/Automattic/wp-calypso/assets/1488641/f6ca3ae6-4145-4c71-a40b-277379f79e7b

## Proposed Changes

* Prevent duplicate activity types selected using [Set()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set) instead of just pushing elements into an array.

## Testing Instructions
* Spin up a Calypso or Jetpack Cloud live branch
* Navigate to Activity Log with a site that has posts published, deleted, trashed or updated.
* Try to reproduce the same scenario described in the video shared above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
