### PR TITLE
Re-enable subscription portal

### DIFF
--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -815,9 +815,14 @@ function wpcomPages( app ) {
 			} );
 	} );
 
-	app.get( [ '/subscriptions', '/subscriptions/*' ], function ( req, res ) {
-		// For users on subkey or not logged in, redirect to the email login link page.
-		if ( req.cookies.subkey || ! req.context.isLoggedIn ) {
+	app.get( [ '/subscriptions', '/subscriptions/*' ], function ( req, res, next ) {
+		if ( ( req.cookies.subkey || calypsoEnv !== 'production' ) && ! req.context.isLoggedIn ) {
+			// If the user is not logged in but has a subkey cookie, they are authorized to view old portal
+			return next();
+		}
+
+		// For users not logged in, redirect to the email login link page.
+		if ( ! req.context.isLoggedIn ) {
 			return res.redirect( 'https://wordpress.com/email-subscriptions' );
 		}
 


### PR DESCRIPTION
This PR should redirect users to the subscription portal if they have the subkey cookie set & are not logged in.

I kept the logic in that checks for being on local env, but I think that can be removed.

<img width="1661" alt="CleanShot 2023-11-17 at 07 25 27@2x" src="https://github.com/Automattic/wp-calypso/assets/528287/73f58bb0-4591-428c-884c-35172c8c80e9">

## Testing Instructions

1. Apply this PR & run Calypso
2. In an incognito window open http://calypso.localhost:3000/
3. Set a subkey cookie: 328a7-pb
4. Visit http://calypso.localhost:3000/subscriptions

You should be able to view the subscription portal.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?