### PR TITLE
Partner Portal: Remove the feature flag check to show the total cost for the selected licenses

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import CardHeading from 'calypso/components/card-heading';
@@ -32,7 +31,7 @@ export default function IssueLicense( { selectedSite, suggestedProduct }: Assign
 			<LayoutTop>
 				<div className="issue-license__step-progress">
 					<AssignLicenseStepProgress currentStep="issueLicense" selectedSite={ selectedSite } />
-					{ isEnabled( 'jetpack/partner-portal-issue-multiple-licenses' ) && <TotalCost /> }
+					<TotalCost />
 				</div>
 
 				<LayoutHeader>


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-manage/issues/126

## Proposed Changes

This PR fixes the issue of the total cost for the selected licenses not being shown because of a feature flag that was removed. 

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Open the Jetpack Cloud live link
2. Click `Licenses` > Click the `Issue New License` button > Verify that the Total Cost is shown on top right as shown below

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="1426" alt="Screenshot 2023-11-17 at 1 42 23 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/f5232e61-a1aa-4df2-a10f-16956ca1ea72">
</td>
<td>
<img width="1426" alt="Screenshot 2023-11-17 at 1 42 32 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/ae59e5bf-9054-4b4b-8a09-0e82ae7e6bf8"></td>
</tr>
</table>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?