### PR TITLE
Assembler: Fix the width of the large preview changed when adding or replacing patterns

### DIFF
--- a/packages/components/src/device-switcher/device-switcher.tsx
+++ b/packages/components/src/device-switcher/device-switcher.tsx
@@ -4,7 +4,7 @@ import { search } from '@wordpress/icons';
 import classnames from 'classnames';
 import { useState, useEffect, useRef } from 'react';
 import { DEVICE_TYPES } from './constants';
-import FixedViewport, { useViewportScale } from './fixed-viewport';
+import FixedViewport from './fixed-viewport';
 import DeviceSwitcherToolbar from './toolbar';
 import useZoomOut from './use-zoom-out';
 import type { Device } from './types';
@@ -47,9 +47,6 @@ const DeviceSwitcher = ( {
 	const [ device, setDevice ] = useState< Device >( defaultDevice );
 	const [ containerResizeListener, { width, height } ] = useResizeObserver();
 	const timerRef = useRef< null | ReturnType< typeof setTimeout > >( null );
-	const viewportElement = frameRef?.current?.parentElement;
-	const viewportWidth = viewportElement?.clientWidth as number;
-	const viewportScale = useViewportScale( device, viewportWidth );
 	const { zoomOutScale, zoomOutStyles, handleZoomOutScaleChange } =
 		useZoomOut( onZoomOutScaleChange );
 
@@ -76,7 +73,7 @@ const DeviceSwitcher = ( {
 		}, ANIMATION_DURATION );
 
 		return clearAnimationEndTimer;
-	}, [ width, height, viewportScale, isFixedViewport ] );
+	}, [ width, height, isFixedViewport ] );
 
 	let frame = (
 		<div className="device-switcher__frame" ref={ frameRef }>
@@ -90,7 +87,7 @@ const DeviceSwitcher = ( {
 
 	if ( isFixedViewport ) {
 		frame = (
-			<FixedViewport device={ device } frameRef={ frameRef }>
+			<FixedViewport device={ device } viewportWidth={ width ?? 0 }>
 				{ frame }
 			</FixedViewport>
 		);

--- a/packages/components/src/device-switcher/fixed-viewport.tsx
+++ b/packages/components/src/device-switcher/fixed-viewport.tsx
@@ -30,12 +30,11 @@ export const useViewportScale = ( device: string, viewportWidth: number ) => {
 
 interface Props {
 	children: React.ReactNode;
-	frameRef?: React.MutableRefObject< HTMLDivElement | null >;
+	viewportWidth: number;
 	device: string;
 }
 
-const FixedViewport = ( { children, frameRef, device }: Props ) => {
-	const viewportWidth = frameRef?.current?.parentElement?.clientWidth as number;
+const FixedViewport = ( { children, viewportWidth, device }: Props ) => {
 	const viewportScale = useViewportScale( device, viewportWidth );
 
 	return (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1700146432328239-slack-CRWCHQGUB

## Proposed Changes

* This PR focuses on the weird behavior that the container width of the large preview frame becomes 0 when you select a pattern. Instead of using the container width, I switched to using the width from the resized container. The result looks good but I'm unsure whether there is any side effect or not.

https://github.com/Automattic/wp-calypso/assets/13596067/3c6858b1-e4a6-44ff-8bc1-8ea2e209ab78

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Assembler
* Select a header
* Select another header
* Ensure the weird behavior won't happen anymore
* Resize your window and ensure the large preview works as before
* Zoom out the large preview and ensure it works as before

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?