### PR TITLE
ReaderJoinConversation: fix window references in SSR

### DIFF
--- a/client/blocks/reader-join-conversation/dialog.jsx
+++ b/client/blocks/reader-join-conversation/dialog.jsx
@@ -41,7 +41,7 @@ const ReaderJoinConversationDialog = ( { onClose, isVisible, loggedInAction, onL
 		}
 	}, [ isVisible ] );
 
-	const { login, createAccount, loginWindow } = useLoginWindow( {
+	const { login, createAccount, close } = useLoginWindow( {
 		onLoginSuccess: handleLoginSuccess,
 		onWindowClose: () => setIsLoginPopupOpen( false ),
 	} );
@@ -61,13 +61,13 @@ const ReaderJoinConversationDialog = ( { onClose, isVisible, loggedInAction, onL
 	const onCancelClick = () => {
 		setIsLoginPopupOpen( false );
 		trackEvent( 'calypso_reader_dialog_cancel_clicked' );
-		loginWindow?.close();
+		close();
 	};
 
 	const onCloseClick = () => {
 		setIsLoginPopupOpen( false );
 		trackEvent( 'calypso_reader_dialog_close_clicked' );
-		loginWindow?.close();
+		close();
 		onClose();
 	};
 

--- a/client/data/reader/use-login-window.ts
+++ b/client/data/reader/use-login-window.ts
@@ -10,7 +10,7 @@ interface UseLoginWindowProps {
 interface UseLoginWindowReturn {
 	login: () => void;
 	createAccount: () => void;
-	loginWindow: Window | null;
+	close: () => void;
 }
 
 export default function useLoginWindow( {
@@ -19,6 +19,15 @@ export default function useLoginWindow( {
 }: UseLoginWindowProps ): UseLoginWindowReturn {
 	const [ loginWindow, setLoginWindow ] = useState< Window | null >( null );
 	const isBrowser: boolean = typeof window !== 'undefined';
+
+	if ( ! isBrowser ) {
+		return {
+			login: () => {},
+			createAccount: () => {},
+			close: () => {},
+		};
+	}
+
 	const environment = config( 'env_id' );
 	const args = {
 		action: 'verify',
@@ -51,10 +60,6 @@ export default function useLoginWindow( {
 	};
 
 	const openWindow = ( url: string ) => {
-		if ( ! isBrowser ) {
-			return;
-		}
-
 		const popupWindow = window.open( url, windowName, windowFeatures );
 
 		// Listen for logged in confirmation from the login window.
@@ -80,5 +85,9 @@ export default function useLoginWindow( {
 		openWindow( createAccountURL );
 	};
 
-	return { login, createAccount, loginWindow };
+	const close = () => {
+		loginWindow?.close();
+	};
+
+	return { login, createAccount, close };
 }


### PR DESCRIPTION
Run Calypso locally in dev mode (`yarn start`) and go to the login page (`calypso.localhost:3000/log-in`). The server tries to server-render the login page, but as you can see in the terminal that runs the server, it fails:

<img width="1185" alt="Screenshot 2023-11-16 at 17 49 16" src="https://github.com/Automattic/wp-calypso/assets/664258/8004481e-899d-43be-94d6-b74667114c88">

It crashes when rendering the logged-out layout, which uses `ReaderJoinConversation`, which uses `useLoginWindow`, which looks at `window.location`, but `window` is not there.

This PR fixes that by returning a set of empty callback in server mode. They won't be called anyway, because they're used only in UI's `onClick` handlers. I also modified the `useLoginWindow` hook to return a `close` method instead of the `loginWindow` object.

**Side note:** it's not optimal that the `ReaderJoinConversation` component is included on every logged out page. It's active only on handful of Reader pages, these that call `registerLastActionRequiresLogin`, is that right? It would be better to move it to these specific pages. The ICFY stats for say that it adds 34k to the login entrypoint:
```
name                   parsed_size           gzip_size
entry-login               +37032 B  (+2.8%)    +9208 B  (+2.4%)
entry-main                +11390 B  (+0.6%)    +3262 B  (+0.7%)
entry-stepper             +10656 B  (+0.6%)    +3118 B  (+0.6%)
```