### PR TITLE
Jetpack Manage: Add bundle licensing size menu in the new issue license page.

### DIFF
--- a/client/jetpack-cloud/components/layout/body.tsx
+++ b/client/jetpack-cloud/components/layout/body.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from 'react';
+
+type Props = {
+	children: ReactNode;
+};
+
+export default function LayoutBody( { children }: Props ) {
+	return (
+		<div className="jetpack-cloud-layout__body">
+			<div className="jetpack-cloud-layout__body-wrapper">{ children }</div>
+		</div>
+	);
+}

--- a/client/jetpack-cloud/components/layout/header.tsx
+++ b/client/jetpack-cloud/components/layout/header.tsx
@@ -1,0 +1,45 @@
+import { Children, ReactNode } from 'react';
+
+type Props = {
+	children: ReactNode;
+};
+
+export function LayoutHeaderTitle( { children }: Props ) {
+	return <h1 className="jetpack-cloud-layout__header-title">{ children }</h1>;
+}
+
+export function LayoutHeaderSubtitle( { children }: Props ) {
+	return <h2 className="jetpack-cloud-layout__header-subtitle">{ children }</h2>;
+}
+
+export function LayoutHeaderActions( { children }: Props ) {
+	return <h2 className="jetpack-cloud-layout__header-actions">{ children }</h2>;
+}
+
+export default function LayoutHeader( { children }: Props ) {
+	const headerTitle = Children.toArray( children ).find(
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		( child: any ) => child.type === LayoutHeaderTitle
+	);
+
+	const headerSubtitle = Children.toArray( children ).find(
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		( child: any ) => child.type === LayoutHeaderSubtitle
+	);
+
+	const headerActions = Children.toArray( children ).find(
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		( child: any ) => child.type === LayoutHeaderActions
+	);
+
+	return (
+		<div className="jetpack-cloud-layout__header">
+			<div className="jetpack-cloud-layout__header-main">
+				{ headerTitle }
+				{ headerSubtitle }
+			</div>
+
+			{ headerActions }
+		</div>
+	);
+}

--- a/client/jetpack-cloud/components/layout/index.tsx
+++ b/client/jetpack-cloud/components/layout/index.tsx
@@ -1,0 +1,36 @@
+import classNames from 'classnames';
+import { ReactNode } from 'react';
+import DocumentHead from 'calypso/components/data/document-head';
+import Main from 'calypso/components/main';
+
+import './style.scss';
+
+type Props = {
+	children: ReactNode;
+	className?: string;
+	title: ReactNode;
+	wide?: boolean;
+	withBorder?: boolean;
+};
+
+export default function Layout( {
+	children,
+	className,
+	title,
+	wide = false,
+	withBorder = false,
+}: Props ) {
+	return (
+		<Main
+			className={ classNames( 'jetpack-cloud-layout', className, {
+				'is-with-border': withBorder,
+			} ) }
+			fullWidthLayout={ wide }
+			wideLayout={ ! wide } // When we set to full width, we want to set this to false.
+		>
+			<DocumentHead title={ title } />
+
+			<div className="jetpack-cloud-layout__container">{ children }</div>
+		</Main>
+	);
+}

--- a/client/jetpack-cloud/components/layout/nav.tsx
+++ b/client/jetpack-cloud/components/layout/nav.tsx
@@ -9,7 +9,7 @@ type LayoutNavigationProps = {
 	className?: string;
 	children: ReactNode;
 	selectedText: string;
-	selectedCount: number;
+	selectedCount?: number;
 };
 
 type LayoutNavigationItemProps = {

--- a/client/jetpack-cloud/components/layout/nav.tsx
+++ b/client/jetpack-cloud/components/layout/nav.tsx
@@ -1,0 +1,67 @@
+import { Count } from '@automattic/components';
+import classNames from 'classnames';
+import { ReactNode } from 'react';
+import SectionNav from 'calypso/components/section-nav';
+import NavItem from 'calypso/components/section-nav/item';
+import NavTabs from 'calypso/components/section-nav/tabs';
+
+type LayoutNavigationProps = {
+	className?: string;
+	children: ReactNode;
+	selectedText: string;
+	selectedCount: number;
+};
+
+type LayoutNavigationItemProps = {
+	label: string;
+	compactCount?: boolean;
+	onClick?: () => void;
+	path?: string;
+	count?: number;
+	selected?: boolean;
+};
+
+export function LayoutNavigationItem( {
+	label,
+	onClick,
+	path,
+	count,
+	selected,
+	compactCount = true,
+}: LayoutNavigationItemProps ) {
+	return (
+		<NavItem
+			compactCount={ compactCount }
+			count={ count }
+			path={ path }
+			onClick={ onClick }
+			selected={ selected }
+		>
+			{ label }
+		</NavItem>
+	);
+}
+
+export default function LayoutNavigation( {
+	className,
+	children,
+	selectedText,
+	selectedCount,
+}: LayoutNavigationProps ) {
+	return (
+		<SectionNav
+			className={ classNames( 'jetpack-cloud-layout__navigation', className ) }
+			applyUpdatedStyles
+			selectedText={
+				<span>
+					{ selectedText }
+					<Count count={ selectedCount } compact={ true } />
+				</span>
+			}
+		>
+			<NavTabs selectedText={ selectedText } selectedCount={ selectedCount }>
+				{ children }
+			</NavTabs>
+		</SectionNav>
+	);
+}

--- a/client/jetpack-cloud/components/layout/style.scss
+++ b/client/jetpack-cloud/components/layout/style.scss
@@ -101,14 +101,15 @@
 .jetpack-cloud-layout__header-subtitle {
 	font-size: 1rem;
 	color: var(--studio-gray-60);
-	margin-bottom: 8px;
+	margin: 0;
 	font-weight: 400;
 	line-height: 1.2;
 }
 
-.jetpack-cloud-layout__navigation {
+.section-nav.jetpack-cloud-layout__navigation {
+	margin-block-start: 32px;
 	.section-nav__mobile-header-text .count {
-		margin-left: 8px;
+		margin-inline-start: 8px;
 	}
 
 	.select-dropdown__item.is-selected .count {

--- a/client/jetpack-cloud/components/layout/style.scss
+++ b/client/jetpack-cloud/components/layout/style.scss
@@ -1,0 +1,107 @@
+.is-jetpack-new-navigation {
+	.jetpack-cloud-layout__header h1 {
+		font-weight: 600;
+	}
+}
+
+.main.jetpack-cloud-layout {
+	padding-inline: 0;
+
+	header.current-section {
+		padding: 0 16px;
+
+		button {
+			padding: 20px 8px;
+		}
+	}
+}
+
+.jetpack-cloud-layout__container {
+	max-width: 100%;
+	min-height: calc(100vh - 123px);
+	display: flex;
+	flex-direction: column;
+	margin: auto;
+	padding: 0;
+}
+
+.jetpack-cloud-layout__body {
+	margin-block-end: -32px;
+	flex: 1 1 100%;
+}
+
+.jetpack-cloud-layout__top,
+.jetpack-cloud-layout__body {
+	width: 100%;
+
+	&-wrapper {
+		margin-inline: 0;
+	}
+
+	&-wrapper > * {
+		max-width: 1500px;
+		margin-inline: auto !important;
+	}
+
+	@include breakpoint-deprecated( ">660px" ) {
+		// We need these negative margin values because we want to make the container full-width,
+		// but our element is inside a limited-width parent.
+		margin-inline-start: -73px;
+		padding-inline: 73px;
+	}
+}
+
+.main.jetpack-cloud-layout.is-with-border {
+	.jetpack-cloud-layout__body {
+		padding-block: 16px;
+	}
+
+	@include breakpoint-deprecated( ">660px" ) {
+		.jetpack-cloud-layout__top {
+			border-block-end: 1px solid var(--color-primary-5);
+		}
+
+		.jetpack-cloud-layout__body {
+			background: rgba(255, 255, 255, 0.5);
+		}
+	}
+}
+
+
+.jetpack-cloud-layout__header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+
+	> * + * {
+		margin-inline-start: 24px;
+	}
+
+	@include breakpoint-deprecated( "<960px" ) {
+		flex-wrap: wrap;
+
+		> * {
+			width: 100%;
+			margin-block-end: 16px;
+		}
+
+		> * + * {
+			margin-inline-start: 0;
+		}
+	}
+}
+
+.jetpack-cloud-layout__header-title {
+	font-size: 2.25rem;
+	margin-block-end: 8px;
+	font-weight: 600;
+	line-height: 1.2;
+}
+
+.jetpack-cloud-layout__header-subtitle {
+	font-size: 1rem;
+	color: var(--studio-gray-60);
+	margin-bottom: 8px;
+	font-weight: 400;
+	line-height: 1.2;
+}

--- a/client/jetpack-cloud/components/layout/style.scss
+++ b/client/jetpack-cloud/components/layout/style.scss
@@ -105,3 +105,49 @@
 	font-weight: 400;
 	line-height: 1.2;
 }
+
+.jetpack-cloud-layout__navigation {
+	.section-nav__mobile-header-text .count {
+		margin-left: 8px;
+	}
+
+	.select-dropdown__item.is-selected .count {
+		color: var(--color-text);
+	}
+
+	.select-dropdown__header {
+		border-width: 0;
+
+		.count {
+			top: 12.5px;
+		}
+
+		@include breakpoint-deprecated( ">660px" ) {
+			border-width: 1px;
+		}
+	}
+
+	.section-nav-tabs.is-dropdown {
+		width: 100%;
+		margin: 0 0 1px 0;
+
+		@include breakpoint-deprecated( ">660px" ) {
+			margin-block-end: 12px;
+		}
+	}
+
+	.select-dropdown__options {
+		margin-inline: -1px;
+	}
+
+	.section-nav-tabs__dropdown .select-dropdown__container {
+		max-width: unset;
+		width: 100%;
+	}
+
+	.section-nav-tabs__dropdown {
+		// Since the search below the dropdown has z-index: 22,
+		// we need to make sure the dropdown is above it
+		z-index: 23;
+	}
+}

--- a/client/jetpack-cloud/components/layout/top.tsx
+++ b/client/jetpack-cloud/components/layout/top.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from 'react';
+
+type Props = {
+	children: ReactNode;
+};
+
+export default function LayoutTop( { children }: Props ) {
+	return (
+		<div className="jetpack-cloud-layout__top">
+			<div className="jetpack-cloud-layout__top-wrapper">{ children }</div>
+		</div>
+	);
+}

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/hooks/use-product-bundle-size.ts
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/hooks/use-product-bundle-size.ts
@@ -1,0 +1,42 @@
+import { useCallback, useState } from 'react';
+import { useURLQueryParams } from '../../hooks';
+
+const AVAILABLE_SIZES = [ 1, 5, 10, 20, 50, 75, 100 ]; //TO-DO: We will need to get this from the API
+
+const BUNDLE_SIZE_PARAM_KEY = 'bundle_size';
+
+// Parse the location hash to get the selected product bundle size
+// If the hash is not found, return the default size (1)
+const parseLocationHash = ( value: string ) => {
+	return AVAILABLE_SIZES.find( ( size ) => value === `${ size }` ) || 1;
+};
+
+export function useProductBundleSize() {
+	const { setParams, resetParams, getParamValue } = useURLQueryParams();
+	const [ selectedSize, setSelectedSize ] = useState(
+		parseLocationHash( getParamValue( BUNDLE_SIZE_PARAM_KEY ) )
+	);
+
+	const setSelectedSizeAndLocationHash = useCallback(
+		( size: number ) => {
+			if ( size === 1 ) {
+				resetParams( [ BUNDLE_SIZE_PARAM_KEY ] );
+			} else {
+				setParams( [
+					{
+						key: BUNDLE_SIZE_PARAM_KEY,
+						value: `${ size }`,
+					},
+				] );
+			}
+			setSelectedSize( size );
+		},
+		[ resetParams, setParams ]
+	);
+
+	return {
+		selectedSize,
+		setSelectedSize: setSelectedSizeAndLocationHash,
+		availableSizes: AVAILABLE_SIZES,
+	};
+}

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/index.tsx
@@ -7,10 +7,16 @@ import LayoutHeader, {
 	LayoutHeaderSubtitle as Subtitle,
 	LayoutHeaderTitle as Title,
 } from 'calypso/jetpack-cloud/components/layout/header';
+import LayoutNavigation, {
+	LayoutNavigationItem,
+} from 'calypso/jetpack-cloud/components/layout/nav';
 import LayoutTop from 'calypso/jetpack-cloud/components/layout/top';
+import { useProductBundleSize } from './hooks/use-product-bundle-size';
 
 export default function IssueLicenseV2() {
+	const { selectedSize, setSelectedSize, availableSizes } = useProductBundleSize();
 	const translate = useTranslate();
+
 	return (
 		<Layout
 			className="issue-license-v2"
@@ -29,6 +35,26 @@ export default function IssueLicenseV2() {
 						<Button primary>Issue license </Button>
 					</LayoutHeaderActions>
 				</LayoutHeader>
+
+				<LayoutNavigation
+					selectedText={
+						selectedSize === 1
+							? translate( 'Single license' )
+							: ( translate( '%(size)d licenses', { args: { selectedSize } } ) as string )
+					}
+				>
+					{ availableSizes.map( ( size ) => (
+						<LayoutNavigationItem
+							label={
+								size === 1
+									? translate( 'Single license' )
+									: ( translate( '%(size)d licenses', { args: { size } } ) as string )
+							}
+							selected={ selectedSize === size }
+							onClick={ () => setSelectedSize( size ) }
+						/>
+					) ) }
+				</LayoutNavigation>
 			</LayoutTop>
 
 			<LayoutBody>

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/index.tsx
@@ -1,7 +1,39 @@
+import { Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import Layout from 'calypso/jetpack-cloud/components/layout';
+import LayoutBody from 'calypso/jetpack-cloud/components/layout/body';
+import LayoutHeader, {
+	LayoutHeaderActions,
+	LayoutHeaderSubtitle as Subtitle,
+	LayoutHeaderTitle as Title,
+} from 'calypso/jetpack-cloud/components/layout/header';
+import LayoutTop from 'calypso/jetpack-cloud/components/layout/top';
+
 export default function IssueLicenseV2() {
+	const translate = useTranslate();
 	return (
-		<div>
-			<h1>Issue License</h1>
-		</div>
+		<Layout
+			className="issue-license-v2"
+			title={ translate( 'Issue a new License' ) }
+			wide
+			withBorder
+		>
+			<LayoutTop>
+				<LayoutHeader>
+					<Title>{ translate( 'Issue product licenses' ) } </Title>
+					<Subtitle>
+						{ translate( 'Select single product licenses or save when you issue in bulk' ) }
+					</Subtitle>
+
+					<LayoutHeaderActions>
+						<Button primary>Issue license </Button>
+					</LayoutHeaderActions>
+				</LayoutHeader>
+			</LayoutTop>
+
+			<LayoutBody>
+				<div>body here</div>
+			</LayoutBody>
+		</Layout>
 	);
 }

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/index.tsx
@@ -3,12 +3,12 @@ import { useTranslate } from 'i18n-calypso';
 import Layout from 'calypso/jetpack-cloud/components/layout';
 import LayoutBody from 'calypso/jetpack-cloud/components/layout/body';
 import LayoutHeader, {
-	LayoutHeaderActions,
+	LayoutHeaderActions as Actions,
 	LayoutHeaderSubtitle as Subtitle,
 	LayoutHeaderTitle as Title,
 } from 'calypso/jetpack-cloud/components/layout/header';
 import LayoutNavigation, {
-	LayoutNavigationItem,
+	LayoutNavigationItem as NavigationItem,
 } from 'calypso/jetpack-cloud/components/layout/nav';
 import LayoutTop from 'calypso/jetpack-cloud/components/layout/top';
 import { useProductBundleSize } from './hooks/use-product-bundle-size';
@@ -31,20 +31,20 @@ export default function IssueLicenseV2() {
 						{ translate( 'Select single product licenses or save when you issue in bulk' ) }
 					</Subtitle>
 
-					<LayoutHeaderActions>
+					<Actions>
 						<Button primary>Issue license </Button>
-					</LayoutHeaderActions>
+					</Actions>
 				</LayoutHeader>
 
 				<LayoutNavigation
 					selectedText={
 						selectedSize === 1
 							? translate( 'Single license' )
-							: ( translate( '%(size)d licenses', { args: { selectedSize } } ) as string )
+							: ( translate( '%(size)d licenses', { args: { size: selectedSize } } ) as string )
 					}
 				>
 					{ availableSizes.map( ( size ) => (
-						<LayoutNavigationItem
+						<NavigationItem
 							label={
 								size === 1
 									? translate( 'Single license' )


### PR DESCRIPTION
This pull request adds a bundle-size menu to the new page. Currently, the available sizes are hardcoded for simplicity, but ideally, they should be fetched from an API.

Moreover, this pull request includes the addition of a reusable layout that we can employ for future pages. The layout component is primarily replicated from the current `/partner-portal/layout` component, albeit with a minor enhancement and a difference in styling. I opted to create a new layout component to avoid disrupting any existing pages that rely on it.

**NOTE THAT THE NAVIGATION HEADER HAS SOME MOBILE VIEW ISSUES WHICH WILL BE ADDRESSED ON A SEPARATE TICKET.**

<img width="1175" alt="Screen Shot 2023-11-17 at 6 01 47 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/581817fb-7373-4b17-935a-67d023c708b2">


Closes https://github.com/Automattic/jetpack-genesis/issues/91

## Proposed Changes

* Add a new layout component based on `/partner-portal/layout`, with a reusable navigation menu.
* Add the Bundle size menu component using the new layout component. The menu is also designed to be URL accessible.

## Testing Instructions
 Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.
 
 * Use the Jetpack cloud live link below and go to `/partner-portal/issue-license?flags=jetpack/bundle-licensing`
 * Confirm that the bundle size menu is working and is updating the URL correctly.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?