### PR TITLE
fix: sass error in `jetpack-plans/product-store/style.scss`

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/style.scss
+++ b/client/my-sites/plans/jetpack-plans/product-store/style.scss
@@ -1,3 +1,4 @@
+@use "sass:math";
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
@@ -18,7 +19,7 @@
 
 			// tablets
 			@media ( max-width: 900px ) {
-				margin-top: 8.5rem + $sale-banner-height + $mobile-offset / 3;
+				margin-top: 8.5rem + $sale-banner-height + math.div($mobile-offset, 3);
 			}
 			// mobiles
 			@media ( max-width: 560px ) {


### PR DESCRIPTION
## Proposed Changes

PR fixes a SASS deprecation warning that currently appears when you run calypso locally via `yarn start`.

<img width="710" alt="Screenshot 2023-11-17 at 11 21 56" src="https://github.com/Automattic/wp-calypso/assets/9202899/f38f9101-82de-4ed9-83c5-dc37e5d6945b">

## Testing Instructions

* Run calypso locally and verify you don't see this warning anymore


