### PR TITLE
Try/add buttons to reader card

### DIFF
--- a/client/my-sites/customer-home/cards/features/reader/index.tsx
+++ b/client/my-sites/customer-home/cards/features/reader/index.tsx
@@ -1,5 +1,6 @@
 import { useLocale } from '@automattic/i18n-utils';
 import { useQuery } from '@tanstack/react-query';
+import { useState } from 'react';
 import withDimensions from 'calypso/lib/with-dimensions';
 import wpcom from 'calypso/lib/wp';
 import { trackScrollPage } from 'calypso/reader/controller-helper';
@@ -9,12 +10,15 @@ import Stream from 'calypso/reader/stream';
 
 import './style.scss';
 
+type TabType = string;
+
 interface ReaderCardProps {
 	width: number;
 }
 
 const ReaderCard = ( props: ReaderCardProps ) => {
 	const locale = useLocale();
+	const [ selectedTab, setSelectedTab ] = useState( DEFAULT_TAB );
 
 	const { data: interestTags = [] } = useQuery( {
 		queryKey: [ 'read/interests', locale ],
@@ -33,17 +37,21 @@ const ReaderCard = ( props: ReaderCardProps ) => {
 		},
 	} );
 
+	const handleTabChange = ( newTab: TabType ) => {
+		setSelectedTab( newTab );
+	};
+
+	const streamKey = `discover:recommended--${ selectedTab }`;
+
 	return (
 		<div className="customer-home-reader-card">
 			<DiscoverNavigation
 				width={ props.width }
 				selectedTab={ DEFAULT_TAB }
 				recommendedTags={ interestTags }
+				onTabChange={ handleTabChange }
 			/>
-			<Stream
-				streamKey="discover:recommended--dailyprompt"
-				trackScrollPage={ trackScrollPage.bind( null ) }
-			/>
+			<Stream streamKey={ streamKey } trackScrollPage={ trackScrollPage.bind( null ) } />
 		</div>
 	);
 };

--- a/client/my-sites/customer-home/cards/features/reader/index.tsx
+++ b/client/my-sites/customer-home/cards/features/reader/index.tsx
@@ -1,13 +1,51 @@
+import { useLocale } from '@automattic/i18n-utils';
+import { useQuery } from '@tanstack/react-query';
+import withDimensions from 'calypso/lib/with-dimensions';
+import wpcom from 'calypso/lib/wp';
 import { trackScrollPage } from 'calypso/reader/controller-helper';
+import DiscoverNavigation from 'calypso/reader/discover/discover-navigation';
+import { DEFAULT_TAB } from 'calypso/reader/discover/helper';
 import Stream from 'calypso/reader/stream';
 
-const ReaderCard = () => {
+import './style.scss';
+
+interface ReaderCardProps {
+	width: number;
+}
+
+const ReaderCard = ( props: ReaderCardProps ) => {
+	const locale = useLocale();
+
+	const { data: interestTags = [] } = useQuery( {
+		queryKey: [ 'read/interests', locale ],
+		queryFn: () =>
+			wpcom.req.get(
+				{
+					path: `/read/interests`,
+					apiNamespace: 'wpcom/v2',
+				},
+				{
+					_locale: locale,
+				}
+			),
+		select: ( data ) => {
+			return data.interests;
+		},
+	} );
+
 	return (
-		<Stream
-			streamKey="discover:recommended--dailyprompt"
-			trackScrollPage={ trackScrollPage.bind( null ) }
-		/>
+		<div className="customer-home-reader-card">
+			<DiscoverNavigation
+				width={ props.width }
+				selectedTab={ DEFAULT_TAB }
+				recommendedTags={ interestTags }
+			/>
+			<Stream
+				streamKey="discover:recommended--dailyprompt"
+				trackScrollPage={ trackScrollPage.bind( null ) }
+			/>
+		</div>
 	);
 };
 
-export default ReaderCard;
+export default withDimensions( ReaderCard );

--- a/client/my-sites/customer-home/cards/features/reader/style.scss
+++ b/client/my-sites/customer-home/cards/features/reader/style.scss
@@ -1,0 +1,8 @@
+.customer-home-reader-card {
+	.discover-stream-navigation {
+		.discover-stream-navigation__right-button-wrapper,
+		.discover-stream-navigation__left-button-wrapper {
+			background: none;
+		}
+	}
+}

--- a/client/reader/discover/discover-navigation.js
+++ b/client/reader/discover/discover-navigation.js
@@ -18,7 +18,12 @@ const DEFAULT_CLASS = 'discover-stream-navigation';
 const showElement = ( element ) => element && element.classList.remove( 'display-none' );
 const hideElement = ( element ) => element && element.classList.add( 'display-none' );
 
-const DiscoverNavigation = ( { recommendedTags, selectedTab, width } ) => {
+const DiscoverNavigation = ( {
+	recommendedTags,
+	selectedTab,
+	width,
+	onTabChange = ( tab ) => {},
+} ) => {
 	const scrollRef = useRef();
 
 	const recordTabClick = () => {
@@ -27,9 +32,14 @@ const DiscoverNavigation = ( { recommendedTags, selectedTab, width } ) => {
 	};
 
 	const menuTabClick = ( tab ) => {
-		page.replace(
-			addQueryArgs( { selectedTab: tab }, window.location.pathname + window.location.search )
-		);
+		if ( onTabChange ) {
+			onTabChange( tab ); // Invoke the onTabChange callback with the new tab value
+		} else {
+			// Fallback behavior if onTabChange is not provided
+			page.replace(
+				addQueryArgs( { selectedTab: tab }, window.location.pathname + window.location.search )
+			);
+		}
 		recordTabClick();
 	};
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* This kind of works, but has an ESLint error and needs a little more tweaking.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?