### PR TITLE
Reader Tags: fix issues with alphabetic tags sticky header

### DIFF
--- a/client/components/sticky-panel/style.scss
+++ b/client/components/sticky-panel/style.scss
@@ -10,6 +10,9 @@
 
 .sticky-panel__content {
 	position: relative;
+	// Makes the bottom margin of the inner element contribute to its height
+	// so that the `StickyPanel` component can determine the height correctly.
+	display: flow-root;
 }
 
 .sticky-panel.is-sticky .sticky-panel__content {

--- a/client/reader/tags/alphabetic-tags.tsx
+++ b/client/reader/tags/alphabetic-tags.tsx
@@ -114,18 +114,20 @@ export default function AlphabeticTags( { alphabeticTags }: AlphabeticTagsProps 
 		<>
 			<div className="sticky-container">
 				<StickyPanel minLimit={ 0 }>
-					<div className="alphabetic-tags__header">
-						<h2>{ translate( 'Tags from A — Z' ) }</h2>
-						<div className="alphabetic-tags__tag-links">
-							{ Object.keys( tagTables ).map( ( letter: string ) => (
-								<Button
-									variant="link"
-									key={ 'alphabetic-tags-link-' + letter }
-									onClick={ () => scrollToLetter( letter ) }
-								>
-									{ letter }
-								</Button>
-							) ) }
+					<div className="alphabetic-tags__header-wrap">
+						<div className="alphabetic-tags__header">
+							<h2>{ translate( 'Tags from A — Z' ) }</h2>
+							<div className="alphabetic-tags__tag-links">
+								{ Object.keys( tagTables ).map( ( letter: string ) => (
+									<Button
+										variant="link"
+										key={ 'alphabetic-tags-link-' + letter }
+										onClick={ () => scrollToLetter( letter ) }
+									>
+										{ letter }
+									</Button>
+								) ) }
+							</div>
 						</div>
 					</div>
 				</StickyPanel>

--- a/client/reader/tags/alphabetic-tags.tsx
+++ b/client/reader/tags/alphabetic-tags.tsx
@@ -114,20 +114,18 @@ export default function AlphabeticTags( { alphabeticTags }: AlphabeticTagsProps 
 		<>
 			<div className="sticky-container">
 				<StickyPanel minLimit={ 0 }>
-					<div className="alphabetic-tags__header-wrap">
-						<div className="alphabetic-tags__header">
-							<h2>{ translate( 'Tags from A — Z' ) }</h2>
-							<div className="alphabetic-tags__tag-links">
-								{ Object.keys( tagTables ).map( ( letter: string ) => (
-									<Button
-										variant="link"
-										key={ 'alphabetic-tags-link-' + letter }
-										onClick={ () => scrollToLetter( letter ) }
-									>
-										{ letter }
-									</Button>
-								) ) }
-							</div>
+					<div className="alphabetic-tags__header">
+						<h2>{ translate( 'Tags from A — Z' ) }</h2>
+						<div className="alphabetic-tags__tag-links">
+							{ Object.keys( tagTables ).map( ( letter: string ) => (
+								<Button
+									variant="link"
+									key={ 'alphabetic-tags-link-' + letter }
+									onClick={ () => scrollToLetter( letter ) }
+								>
+									{ letter }
+								</Button>
+							) ) }
 						</div>
 					</div>
 				</StickyPanel>

--- a/client/reader/tags/style.scss
+++ b/client/reader/tags/style.scss
@@ -131,12 +131,6 @@
 	}
 }
 
-.alphabetic-tags__header-wrap {
-	// Makes the bottom margin of the inner element contribute to its height
-	// so that the `StickyPanel` component can determine the height correctly.
-	display: flow-root;
-}
-
 .alphabetic-tags__header {
 	background-color: var(--color-neutral-0);
 	padding-top: 20px;

--- a/client/reader/tags/style.scss
+++ b/client/reader/tags/style.scss
@@ -130,8 +130,15 @@
 		}
 	}
 }
+
+.alphabetic-tags__header-wrap {
+	// Makes the bottom margin of the inner element contribute to its height
+	// so that the `StickyPanel` component can determine the height correctly.
+	display: flow-root;
+}
+
 .alphabetic-tags__header {
-	background: inherit;
+	background-color: var(--color-neutral-0);
 	padding-top: 20px;
 	padding-bottom: 10px;
 	border-bottom: 1px solid var(--studio-gray-5);


### PR DESCRIPTION
Fixes two issues when scrolling on the `/tags` and activating the "Tags from A-Z" sticky header:

https://github.com/Automattic/wp-calypso/assets/664258/e1a68bef-6dea-4a29-bc3d-3783c6151675

1. The header background is transparent, the text of the header and the list is rendered on top of each other.
2. The scrolling is not smooth, when you scroll down, the content jumps up a few pixels when the sticky header gets activated.

The first issue is fixed by adding an explicit `background-color` to the header element, overriding the inherited transparent one.

The second issue is caused by a `margin-bottom` on the `alphabetic-tags__header`.

<img width="326" alt="Screenshot 2023-11-17 at 11 21 12" src="https://github.com/Automattic/wp-calypso/assets/664258/ed06e2e5-1d26-4b5d-9e04-307dd07dbdde">

That margin is used in the layout, but is not accounted for by the `StickyPanel` component when measuring the height of the element. Then the `sticky-panel__spacer` element, which replaces the `sticky-panel__content` element in the layout flow, won't have correct height.

This is fixed by adding a wrapper element, `alphabetic-tags__header`, and setting a `display: flow-root` style on it so that the child element's margin is part of its height.
