### PR TITLE
Storage Add-On: Fix spotlight plan CTA upgrade behavior

### DIFF
--- a/client/my-sites/plans-grid/components/actions.tsx
+++ b/client/my-sites/plans-grid/components/actions.tsx
@@ -262,7 +262,7 @@ const LoggedInPlansFeatureActionButton = ( {
 			selectedStorageOptionForPlan && addOn?.featureSlugs?.includes( selectedStorageOptionForPlan )
 	)?.checkoutLink;
 	const nonDefaultStorageOptionSelected =
-		selectedStorageOptionForPlan !== undefined ||
+		selectedStorageOptionForPlan !== undefined &&
 		selectedStorageOptionForPlan !== defaultStorageOption;
 
 	if (

--- a/client/my-sites/plans-grid/components/actions.tsx
+++ b/client/my-sites/plans-grid/components/actions.tsx
@@ -261,7 +261,9 @@ const LoggedInPlansFeatureActionButton = ( {
 		( addOn ) =>
 			selectedStorageOptionForPlan && addOn?.featureSlugs?.includes( selectedStorageOptionForPlan )
 	)?.checkoutLink;
-	const nonDefaultStorageOptionSelected = defaultStorageOption !== selectedStorageOptionForPlan;
+	const nonDefaultStorageOptionSelected =
+		selectedStorageOptionForPlan !== undefined ||
+		selectedStorageOptionForPlan !== defaultStorageOption;
 
 	if (
 		freePlan ||

--- a/client/my-sites/plans-grid/components/storage-add-on-dropdown.tsx
+++ b/client/my-sites/plans-grid/components/storage-add-on-dropdown.tsx
@@ -101,7 +101,13 @@ export const StorageAddOnDropdown = ( {
 		if ( storageAddOnsForPlan && defaultStorageOption && ! selectedStorageOptionForPlan ) {
 			setSelectedStorageOptionForPlan( { addOnSlug: defaultStorageOption, planSlug } );
 		}
-	}, [] );
+	}, [
+		storageAddOnsForPlan,
+		defaultStorageOption,
+		selectedStorageOptionForPlan,
+		setSelectedStorageOptionForPlan,
+		planSlug,
+	] );
 
 	const selectControlOptions = storageOptions.map( ( storageOption ) => {
 		const title = getStorageStringFromFeature( storageOption.slug ) || '';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/2418

## Proposed Changes

* Adds an undefined value check for a given selected storage option when the page is first initialized

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

I spent quite a bit of time attempting to replicate [the original bug ]( https://github.com/Automattic/martech/issues/2418 ) ( different browsers, throttled connections, mobile vs. desktop etc. ). I wasn't able to successfully reproduce it which means that I can't 100% confirm that the issue is fixed. Given the reported behavior though, I do believe that the problem should be addressed with this PR.

With that in mind, we can still smoke test intended behavior to ensure that storage add-on dropdown functionality is still correct.

* Check out this branch
* Visit `/start/plans`
* Ensure that the storage add-on dropdown continues to behave properly
  * Add-on prices are still displayed in the dropdown
  * A storage add-on upgrade can be selected
  * Storage add-on is correctly added to the cart at checkout

![2023-11-18 10 18 05](https://github.com/Automattic/wp-calypso/assets/5414230/61457db0-79c2-4555-b1de-32a74d232d36)

* Visit Calypso admin `/plans`
* Confirm, again, that the storage add-on dropdown continues to behave properly ( but don't purchase the storage add-on upgrade )

![2023-11-18 10 22 30](https://github.com/Automattic/wp-calypso/assets/5414230/6a326426-cc3d-409f-8725-1e39e13d642f)

* Upgrade site plan to either business or commerce
* Confirm that the add-on upgrade CTA in the spotlight plan behaves as expected

![2023-11-18 10 20 49](https://github.com/Automattic/wp-calypso/assets/5414230/f533a859-333c-45a3-bbbd-461fe3e8312e)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?