### PR TITLE
Plans 2023: Add term toggle to sticky bar in comparison grid

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -806,7 +806,11 @@ const PlansFeaturesMain = ( {
 				{ ! isPlansGridReady && <Spinner size={ 30 } /> }
 				{ isPlansGridReady && (
 					<>
-						{ ! hidePlanSelector && <PlanTypeSelector { ...planTypeSelectorProps } /> }
+						{ ! hidePlanSelector && (
+							<div className="plans-features-main__plan-type-selector">
+								<PlanTypeSelector { ...planTypeSelectorProps } />
+							</div>
+						) }
 						<div
 							className={ classNames(
 								'plans-features-main__group',
@@ -877,7 +881,9 @@ const PlansFeaturesMain = ( {
 												{ translate( 'Compare our plans and find yours' ) }
 											</PlanComparisonHeader>
 											{ ! hidePlanSelector && showPlansComparisonGrid && (
-												<PlanTypeSelector { ...planTypeSelectorProps } />
+												<div className="plans-features-main__plan-type-selector">
+													<PlanTypeSelector { ...planTypeSelectorProps } />
+												</div>
 											) }
 											<ComparisonGrid
 												gridPlans={ gridPlansForComparisonGrid }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -535,25 +535,42 @@ const PlansFeaturesMain = ( {
 		_customerType = 'business';
 	}
 
-	// These never reach the grid-components. Little/no need to memoize.
-	const planTypeSelectorProps = {
+	const planTypeSelectorProps = useMemo( () => {
+		return {
+			basePlansPath,
+			isStepperUpgradeFlow,
+			isInSignup,
+			eligibleForWpcomMonthlyPlans,
+			isPlansInsideStepper,
+			intervalType,
+			customerType: _customerType,
+			siteSlug,
+			selectedPlan,
+			selectedFeature,
+			showBiennialToggle,
+			kind: planTypeSelector,
+			plans: gridPlansForFeaturesGrid.map( ( gridPlan ) => gridPlan.planSlug ),
+			currentSitePlanSlug: sitePlanSlug,
+			usePricingMetaForGridPlans,
+			recordTracksEvent,
+		};
+	}, [
+		_customerType,
 		basePlansPath,
-		isStepperUpgradeFlow,
-		isInSignup,
-		eligibleForWpcomMonthlyPlans,
-		isPlansInsideStepper,
+		gridPlansForFeaturesGrid,
 		intervalType,
-		customerType: _customerType,
-		siteSlug,
-		selectedPlan,
+		planTypeSelector,
 		selectedFeature,
+		selectedPlan,
+		sitePlanSlug,
+		siteSlug,
+		isInSignup,
+		isPlansInsideStepper,
+		isStepperUpgradeFlow,
 		showBiennialToggle,
-		kind: planTypeSelector,
-		plans: gridPlansForFeaturesGrid.map( ( gridPlan ) => gridPlan.planSlug ),
-		currentSitePlanSlug: sitePlanSlug,
-		usePricingMetaForGridPlans,
-		recordTracksEvent,
-	};
+		eligibleForWpcomMonthlyPlans,
+	] );
+
 	/**
 	 * The effects on /plans page need to be checked if this variable is initialized
 	 */
@@ -909,7 +926,9 @@ const PlansFeaturesMain = ( {
 												allFeaturesList={ FEATURES_LIST }
 												onStorageAddOnClick={ handleStorageAddOnClick }
 												showRefundPeriod={ isAnyHostingFlow( flowName ) }
-												planTypeSelectorProps={ planTypeSelectorProps }
+												planTypeSelectorProps={
+													! hidePlanSelector ? planTypeSelectorProps : undefined
+												}
 											/>
 											<ComparisonGridToggle
 												onClick={ toggleShowPlansComparisonGrid }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -903,6 +903,7 @@ const PlansFeaturesMain = ( {
 												allFeaturesList={ FEATURES_LIST }
 												onStorageAddOnClick={ handleStorageAddOnClick }
 												showRefundPeriod={ isAnyHostingFlow( flowName ) }
+												planTypeSelectorProps={ planTypeSelectorProps }
 											/>
 											<ComparisonGridToggle
 												onClick={ toggleShowPlansComparisonGrid }

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -388,3 +388,16 @@ body.is-section-signup.is-white-signup {
 		}
 	}
 }
+
+.plans-features-main__plan-type-selector {
+	display: flex;
+	align-content: space-between;
+	justify-content: center;
+	margin: 0 20px 24px;
+	.segmented-control.price-toggle {
+		.is-section-signup &,
+		.is-section-stepper & {
+			border: solid 1px var(--studio-gray-5);
+		}
+	}
+}

--- a/client/my-sites/plans-grid/components/comparison-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/comparison-grid/index.tsx
@@ -530,6 +530,7 @@ const ComparisonGridHeader = forwardRef< HTMLDivElement, ComparisonGridHeaderPro
 			siteId ?? 0,
 			displayedGridPlans.map( ( { planSlug } ) => planSlug )
 		);
+
 		return (
 			<PlanRow isHiddenInMobile={ isHiddenInMobile } ref={ ref }>
 				<RowTitleCell
@@ -538,8 +539,11 @@ const ComparisonGridHeader = forwardRef< HTMLDivElement, ComparisonGridHeaderPro
 				>
 					{ isStuck && planTypeSelectorProps && (
 						<PlanTypeSelectorWrapper>
-							<p>{ translate( 'Billing Cycle' ) }</p>
-							<PlanTypeSelector { ...planTypeSelectorProps } hideDiscountLabel={ true } />
+							<PlanTypeSelector
+								{ ...planTypeSelectorProps }
+								title={ translate( 'Billing Cycle' ) }
+								hideDiscountLabel={ true }
+							/>
 						</PlanTypeSelectorWrapper>
 					) }
 				</RowTitleCell>

--- a/client/my-sites/plans-grid/components/comparison-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/comparison-grid/index.tsx
@@ -40,6 +40,7 @@ import { getStorageStringFromFeature, usePricingBreakpoint } from '../../util';
 import PlanFeatures2023GridActions from '../actions';
 import PlanFeatures2023GridBillingTimeframe from '../billing-timeframe';
 import PlanFeatures2023GridHeaderPrice from '../header-price';
+import PlanTypeSelector, { type PlanTypeSelectorProps } from '../plan-type-selector';
 import { Plans2023Tooltip } from '../plans-2023-tooltip';
 import PopularBadge from '../popular-badge';
 import { StickyContainer } from '../sticky-container';
@@ -338,6 +339,7 @@ type ComparisonGridProps = {
 	stickyRowOffset: number;
 	onStorageAddOnClick?: ( addOnSlug: WPComStorageAddOnSlug ) => void;
 	showRefundPeriod?: boolean;
+	planTypeSelectorProps: PlanTypeSelectorProps;
 };
 
 type ComparisonGridHeaderProps = {
@@ -355,9 +357,10 @@ type ComparisonGridHeaderProps = {
 	showRefundPeriod?: boolean;
 	isStuck: boolean;
 	isHiddenInMobile?: boolean;
+	planTypeSelectorProps: PlanTypeSelectorProps;
 };
 
-type ComparisonGridHeaderCellProps = ComparisonGridHeaderProps & {
+type ComparisonGridHeaderCellProps = Omit< ComparisonGridHeaderProps, 'planTypeSelectorProps' > & {
 	allVisible: boolean;
 	isLastInRow: boolean;
 	isLargeCurrency: boolean;
@@ -502,6 +505,7 @@ const ComparisonGridHeader = forwardRef< HTMLDivElement, ComparisonGridHeaderPro
 			isHiddenInMobile,
 			showRefundPeriod,
 			isStuck,
+			planTypeSelectorProps,
 		},
 		ref
 	) => {
@@ -523,7 +527,9 @@ const ComparisonGridHeader = forwardRef< HTMLDivElement, ComparisonGridHeaderPro
 				<RowTitleCell
 					key="feature-name"
 					className="plan-comparison-grid__header-cell plan-comparison-grid__interval-toggle is-placeholder-header-cell"
-				/>
+				>
+					{ isStuck && <PlanTypeSelector { ...planTypeSelectorProps } /> }
+				</RowTitleCell>
 				{ visibleGridPlans.map( ( { planSlug }, index ) => (
 					<ComparisonGridHeaderCell
 						planSlug={ planSlug }
@@ -965,6 +971,7 @@ const ComparisonGrid = ( {
 	stickyRowOffset,
 	onStorageAddOnClick,
 	showRefundPeriod,
+	planTypeSelectorProps,
 }: ComparisonGridProps ) => {
 	const { gridPlans } = usePlansGridContext();
 	const [ activeTooltipId, setActiveTooltipId ] = useManageTooltipToggle();
@@ -1110,6 +1117,7 @@ const ComparisonGrid = ( {
 							selectedPlan={ selectedPlan }
 							showRefundPeriod={ showRefundPeriod }
 							isStuck={ isStuck }
+							planTypeSelectorProps={ planTypeSelectorProps }
 						/>
 					) }
 				</StickyContainer>
@@ -1144,6 +1152,7 @@ const ComparisonGrid = ( {
 					isStuck={ false }
 					isHiddenInMobile={ true }
 					ref={ bottomHeaderRef }
+					planTypeSelectorProps={ planTypeSelectorProps }
 				/>
 			</Grid>
 

--- a/client/my-sites/plans-grid/components/comparison-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/comparison-grid/index.tsx
@@ -339,7 +339,7 @@ type ComparisonGridProps = {
 	stickyRowOffset: number;
 	onStorageAddOnClick?: ( addOnSlug: WPComStorageAddOnSlug ) => void;
 	showRefundPeriod?: boolean;
-	planTypeSelectorProps: PlanTypeSelectorProps;
+	planTypeSelectorProps?: PlanTypeSelectorProps;
 };
 
 type ComparisonGridHeaderProps = {
@@ -357,7 +357,7 @@ type ComparisonGridHeaderProps = {
 	showRefundPeriod?: boolean;
 	isStuck: boolean;
 	isHiddenInMobile?: boolean;
-	planTypeSelectorProps: PlanTypeSelectorProps;
+	planTypeSelectorProps?: PlanTypeSelectorProps;
 };
 
 type ComparisonGridHeaderCellProps = Omit< ComparisonGridHeaderProps, 'planTypeSelectorProps' > & {
@@ -509,6 +509,7 @@ const ComparisonGridHeader = forwardRef< HTMLDivElement, ComparisonGridHeaderPro
 		},
 		ref
 	) => {
+		const translate = useTranslate();
 		const allVisible = visibleGridPlans.length === displayedGridPlans.length;
 		const { prices, currencyCode } = usePlanPricingInfoFromGridPlans( {
 			gridPlans: displayedGridPlans,
@@ -528,7 +529,12 @@ const ComparisonGridHeader = forwardRef< HTMLDivElement, ComparisonGridHeaderPro
 					key="feature-name"
 					className="plan-comparison-grid__header-cell plan-comparison-grid__interval-toggle is-placeholder-header-cell"
 				>
-					{ isStuck && <PlanTypeSelector { ...planTypeSelectorProps } /> }
+					{ isStuck && planTypeSelectorProps && (
+						<>
+							<p>{ translate( 'Billing Cycle' ) }</p>
+							<PlanTypeSelector { ...planTypeSelectorProps } />{ ' ' }
+						</>
+					) }
 				</RowTitleCell>
 				{ visibleGridPlans.map( ( { planSlug }, index ) => (
 					<ComparisonGridHeaderCell

--- a/client/my-sites/plans-grid/components/comparison-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/comparison-grid/index.tsx
@@ -488,6 +488,13 @@ const ComparisonGridHeaderCell = ( {
 	);
 };
 
+const PlanTypeSelectorWrapper = styled.div`
+	display: none;
+	${ plansBreakSmall( css`
+		display: block;
+	` ) }
+`;
+
 const ComparisonGridHeader = forwardRef< HTMLDivElement, ComparisonGridHeaderProps >(
 	(
 		{
@@ -527,13 +534,13 @@ const ComparisonGridHeader = forwardRef< HTMLDivElement, ComparisonGridHeaderPro
 			<PlanRow isHiddenInMobile={ isHiddenInMobile } ref={ ref }>
 				<RowTitleCell
 					key="feature-name"
-					className="plan-comparison-grid__header-cell plan-comparison-grid__interval-toggle is-placeholder-header-cell"
+					className="plan-comparison-grid__header-cell is-placeholder-header-cell"
 				>
 					{ isStuck && planTypeSelectorProps && (
-						<>
+						<PlanTypeSelectorWrapper>
 							<p>{ translate( 'Billing Cycle' ) }</p>
-							<PlanTypeSelector { ...planTypeSelectorProps } />{ ' ' }
-						</>
+							<PlanTypeSelector { ...planTypeSelectorProps } hideDiscountLabel={ true } />
+						</PlanTypeSelectorWrapper>
 					) }
 				</RowTitleCell>
 				{ visibleGridPlans.map( ( { planSlug }, index ) => (

--- a/client/my-sites/plans-grid/components/plan-type-selector/index.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/index.tsx
@@ -38,6 +38,10 @@ export type PlanTypeSelectorProps = {
 	currentSitePlanSlug?: PlanSlug | null;
 	usePricingMetaForGridPlans: UsePricingMetaForGridPlans;
 	recordTracksEvent?: ( eventName: string, eventProperties: Record< string, unknown > ) => void;
+	/**
+	 * Whether to render the selector along with a title if passed.
+	 */
+	title?: string;
 };
 
 interface PathArgs {
@@ -225,6 +229,7 @@ type IntervalTypeProps = Pick<
 	| 'selectedFeature'
 	| 'currentSitePlanSlug'
 	| 'usePricingMetaForGridPlans'
+	| 'title'
 >;
 
 export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = ( props ) => {
@@ -237,6 +242,7 @@ export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = 
 		showBiennialToggle,
 		currentSitePlanSlug,
 		usePricingMetaForGridPlans,
+		title,
 	} = props;
 	const [ spanRef, setSpanRef ] = useState< HTMLSpanElement >();
 	const segmentClasses = classNames( 'price-toggle', {
@@ -283,75 +289,85 @@ export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = 
 	const intervalTabs = showBiennialToggle ? [ 'yearly', '2yearly' ] : [ 'monthly', 'yearly' ];
 
 	return (
-		<div className="plan-type-selector__interval-type">
-			<SegmentedControl compact className={ segmentClasses } primary={ true }>
-				{ intervalTabs.map( ( interval ) => (
-					<SegmentedControl.Item
-						key={ interval }
-						selected={ intervalType === interval }
-						path={ generatePath( props, {
-							intervalType: interval,
-							domain: isDomainUpsellFlow,
-							domainAndPlanPackage: isDomainAndPlanPackageFlow,
-							jetpackAppPlans: isJetpackAppFlow,
-							...additionalPathProps,
-						} ) }
-						isPlansInsideStepper={ props.isPlansInsideStepper }
-					>
-						<span
-							ref={
-								intervalType === 'monthly' ? ( ref ) => ref && ! spanRef && setSpanRef( ref ) : null
-							}
+		<>
+			{ title && <div className="plan-type-selector__title">{ title }</div> }
+			<div className="plan-type-selector__interval-type">
+				<SegmentedControl compact className={ segmentClasses } primary={ true }>
+					{ intervalTabs.map( ( interval ) => (
+						<SegmentedControl.Item
+							key={ interval }
+							selected={ intervalType === interval }
+							path={ generatePath( props, {
+								intervalType: interval,
+								domain: isDomainUpsellFlow,
+								domainAndPlanPackage: isDomainAndPlanPackageFlow,
+								jetpackAppPlans: isJetpackAppFlow,
+								...additionalPathProps,
+							} ) }
+							isPlansInsideStepper={ props.isPlansInsideStepper }
 						>
-							{ interval === 'monthly' ? translate( 'Pay monthly' ) : null }
-							{ interval === 'yearly' && ! showBiennialToggle ? translate( 'Pay annually' ) : null }
-							{ interval === 'yearly' && showBiennialToggle ? translate( 'Pay 1 year' ) : null }
-							{ interval === '2yearly' ? translate( 'Pay 2 years' ) : null }
-						</span>
-						{ ! showBiennialToggle && hideDiscountLabel ? null : (
-							<PopupMessages context={ spanRef } isVisible={ popupIsVisible }>
-								{ translate(
-									'Save up to %(maxDiscount)d%% by paying annually and get a free domain for one year',
-									{
-										args: { maxDiscount },
-										comment: 'Will be like "Save up to 30% by paying annually..."',
-									}
-								) }
-							</PopupMessages>
-						) }
-					</SegmentedControl.Item>
-				) ) }
-			</SegmentedControl>
-		</div>
+							<span
+								ref={
+									intervalType === 'monthly'
+										? ( ref ) => ref && ! spanRef && setSpanRef( ref )
+										: null
+								}
+							>
+								{ interval === 'monthly' ? translate( 'Pay monthly' ) : null }
+								{ interval === 'yearly' && ! showBiennialToggle
+									? translate( 'Pay annually' )
+									: null }
+								{ interval === 'yearly' && showBiennialToggle ? translate( 'Pay 1 year' ) : null }
+								{ interval === '2yearly' ? translate( 'Pay 2 years' ) : null }
+							</span>
+							{ ! showBiennialToggle && hideDiscountLabel ? null : (
+								<PopupMessages context={ spanRef } isVisible={ popupIsVisible }>
+									{ translate(
+										'Save up to %(maxDiscount)d%% by paying annually and get a free domain for one year',
+										{
+											args: { maxDiscount },
+											comment: 'Will be like "Save up to 30% by paying annually..."',
+										}
+									) }
+								</PopupMessages>
+							) }
+						</SegmentedControl.Item>
+					) ) }
+				</SegmentedControl>
+			</div>
+		</>
 	);
 };
 
-type CustomerTypeProps = Pick< PlanTypeSelectorProps, 'customerType' | 'isInSignup' >;
+type CustomerTypeProps = Pick< PlanTypeSelectorProps, 'customerType' | 'isInSignup' | 'title' >;
 
 export const CustomerTypeToggle: React.FunctionComponent< CustomerTypeProps > = ( props ) => {
 	const translate = useTranslate();
-	const { customerType } = props;
+	const { customerType, title } = props;
 	const segmentClasses = classNames(
 		'plan-type-selector__interval-type',
 		'is-customer-type-toggle'
 	);
 
 	return (
-		<SegmentedControl className={ segmentClasses } primary={ true }>
-			<SegmentedControl.Item
-				selected={ customerType === 'personal' }
-				path={ generatePath( props, { customerType: 'personal' } ) }
-			>
-				{ translate( 'Blogs and personal sites' ) }
-			</SegmentedControl.Item>
+		<>
+			{ title && <div className="plan-type-selector__title">{ title }</div> }
+			<SegmentedControl className={ segmentClasses } primary={ true }>
+				<SegmentedControl.Item
+					selected={ customerType === 'personal' }
+					path={ generatePath( props, { customerType: 'personal' } ) }
+				>
+					{ translate( 'Blogs and personal sites' ) }
+				</SegmentedControl.Item>
 
-			<SegmentedControl.Item
-				selected={ customerType === 'business' }
-				path={ generatePath( props, { customerType: 'business' } ) }
-			>
-				{ translate( 'Business sites and online stores' ) }
-			</SegmentedControl.Item>
-		</SegmentedControl>
+				<SegmentedControl.Item
+					selected={ customerType === 'business' }
+					path={ generatePath( props, { customerType: 'business' } ) }
+				>
+					{ translate( 'Business sites and online stores' ) }
+				</SegmentedControl.Item>
+			</SegmentedControl>
+		</>
 	);
 };
 

--- a/client/my-sites/plans-grid/components/plan-type-selector/index.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/index.tsx
@@ -12,7 +12,7 @@ import styled from '@emotion/styled';
 import { useEffect, useState } from '@wordpress/element';
 import { addQueryArgs } from '@wordpress/url';
 import classNames from 'classnames';
-import { useTranslate } from 'i18n-calypso';
+import { type TranslateResult, useTranslate } from 'i18n-calypso';
 import * as React from 'react';
 import CSSTransition from 'react-transition-group/CSSTransition';
 import type { UsePricingMetaForGridPlans } from '../../hooks/npm-ready/data-store/use-grid-plans';
@@ -41,7 +41,7 @@ export type PlanTypeSelectorProps = {
 	/**
 	 * Whether to render the selector along with a title if passed.
 	 */
-	title?: string;
+	title?: TranslateResult;
 };
 
 interface PathArgs {

--- a/client/my-sites/plans-grid/components/plan-type-selector/index.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/index.tsx
@@ -46,13 +46,6 @@ interface PathArgs {
 
 type GeneratePathFunction = ( props: Partial< PlanTypeSelectorProps >, args: PathArgs ) => string;
 
-const IntervalTypeToggleWrapper = styled.div< { showingMonthly: boolean } >`
-	display: flex;
-	align-content: space-between;
-	justify-content: center;
-	margin: 0 20px 24px;
-`;
-
 const StyledPopover = styled( Popover )`
 	&.popover {
 		display: none;
@@ -246,7 +239,7 @@ export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = 
 		usePricingMetaForGridPlans,
 	} = props;
 	const [ spanRef, setSpanRef ] = useState< HTMLSpanElement >();
-	const segmentClasses = classNames( 'plan-type-selector__interval-type', 'price-toggle', {
+	const segmentClasses = classNames( 'price-toggle', {
 		'is-signup': isInSignup,
 	} );
 	const popupIsVisible = Boolean( intervalType === 'monthly' && isInSignup && props.plans.length );
@@ -290,7 +283,7 @@ export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = 
 	const intervalTabs = showBiennialToggle ? [ 'yearly', '2yearly' ] : [ 'monthly', 'yearly' ];
 
 	return (
-		<IntervalTypeToggleWrapper showingMonthly={ intervalType === 'monthly' }>
+		<div className="plan-type-selector__interval-type">
 			<SegmentedControl compact className={ segmentClasses } primary={ true }>
 				{ intervalTabs.map( ( interval ) => (
 					<SegmentedControl.Item
@@ -329,7 +322,7 @@ export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = 
 					</SegmentedControl.Item>
 				) ) }
 			</SegmentedControl>
-		</IntervalTypeToggleWrapper>
+		</div>
 	);
 };
 
@@ -373,11 +366,19 @@ const PlanTypeSelector: React.FunctionComponent< PlanTypeSelectorProps > = ( {
 	}, [] );
 
 	if ( kind === 'interval' ) {
-		return <IntervalTypeToggle { ...props } />;
+		return (
+			<div className="plan-type-selector">
+				<IntervalTypeToggle { ...props } />
+			</div>
+		);
 	}
 
 	if ( kind === 'customer' ) {
-		return <CustomerTypeToggle { ...props } />;
+		return (
+			<div className="plan-type-selector">
+				<CustomerTypeToggle { ...props } />
+			</div>
+		);
 	}
 
 	return null;

--- a/client/my-sites/plans-grid/components/plan-type-selector/style.scss
+++ b/client/my-sites/plans-grid/components/plan-type-selector/style.scss
@@ -1,7 +1,9 @@
 
-body.is-section-signup.is-white-signup .signup__step .segmented-control.price-toggle,
-body.is-section-plans.is-section-plans .plans .segmented-control.price-toggle,
-body.is-group-stepper .plans .segmented-control.price-toggle {
+.plan-type-selector {
+	max-width: fit-content;
+}
+
+.plan-type-selector .plan-type-selector__interval-type .segmented-control.price-toggle {
 	background-color: #f2f2f2;
 	border-radius: 6px; /* stylelint-disable-line scales/radii */
 	margin-top: 16px;
@@ -10,6 +12,14 @@ body.is-group-stepper .plans .segmented-control.price-toggle {
 	.segmented-control__item {
 		border: 6px;
 		padding: 2px;
+
+		&.is-selected + .segmented-control__item .segmented-control__link {
+			border-left-color: #f2f2f2;
+			&:hover {
+				border-left-color: var(--studio-gray-10);
+			}
+		}
+
 		.segmented-control__link {
 			color: var(--studio-gray-90);
 			font-weight: 500;
@@ -44,13 +54,4 @@ body.is-group-stepper .plans .segmented-control.price-toggle {
 			white-space: initial;
 		}
 	}
-}
-
-.notouch body.is-section-signup.is-white-signup .signup__step .segmented-control.price-toggle {
-	border: solid 1px var(--studio-gray-5);
-}
-
-.notouch body.is-section-plans.is-section-plans .plans .segmented-control.price-toggle {
-	margin: 8px auto 16px;
-	max-width: fit-content;
 }

--- a/client/my-sites/plans-grid/components/plan-type-selector/style.scss
+++ b/client/my-sites/plans-grid/components/plan-type-selector/style.scss
@@ -3,6 +3,10 @@
 	max-width: fit-content;
 }
 
+.plan-type-selector__title {
+	margin-bottom: 20px;
+}
+
 .plan-type-selector .plan-type-selector__interval-type .segmented-control.price-toggle {
 	background-color: #f2f2f2;
 	border-radius: 6px; /* stylelint-disable-line scales/radii */

--- a/client/my-sites/plans-grid/index.tsx
+++ b/client/my-sites/plans-grid/index.tsx
@@ -1,7 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
 import ComparisonGrid from './components/comparison-grid';
 import FeaturesGrid from './components/features-grid';
-import PlanTypeSelector from './components/plan-type-selector';
+import PlanTypeSelector, { type PlanTypeSelectorProps } from './components/plan-type-selector';
 import PlansGridContextProvider from './grid-context';
 import useIsLargeCurrency from './hooks/npm-ready/use-is-large-currency';
 import useUpgradeClickHandler from './hooks/npm-ready/use-upgrade-click-handler';
@@ -59,6 +59,7 @@ export interface PlansGridProps {
 	stickyRowOffset: number;
 	usePricingMetaForGridPlans: UsePricingMetaForGridPlans;
 	showRefundPeriod?: boolean;
+	planTypeSelectorProps: PlanTypeSelectorProps;
 }
 
 const WrappedComparisonGrid = ( {

--- a/client/my-sites/plans-grid/index.tsx
+++ b/client/my-sites/plans-grid/index.tsx
@@ -59,7 +59,8 @@ export interface PlansGridProps {
 	stickyRowOffset: number;
 	usePricingMetaForGridPlans: UsePricingMetaForGridPlans;
 	showRefundPeriod?: boolean;
-	planTypeSelectorProps: PlanTypeSelectorProps;
+	// only used for comparison grid
+	planTypeSelectorProps?: PlanTypeSelectorProps;
 }
 
 const WrappedComparisonGrid = ( {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/martech/issues/2403
Branched from https://github.com/Automattic/wp-calypso/pull/84162

## Proposed Changes

- Adds the term toggle to the comparison grid header when stuck
- Applies to > mobile
- Some general cleanup of styles to separate some styling as non-default (margins and borders for signup/stepper moved to consuming end)

### Media

<img width="400" alt="Screenshot 2023-11-17 at 3 20 17 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/590cdcf4-be31-49e9-a0b8-9a7557083891">

**Concerning toggle borders:**

- No border in `/plans` or when in sticky header

  <img width="245" alt="Screenshot 2023-11-17 at 3 30 42 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/ea2e535c-7cf6-4132-9795-abca89d6dd9c">

- Border in `/start/plans`

  <img width="400" alt="Screenshot 2023-11-17 at 3 30 27 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/3e007270-0259-47df-8eb4-5bcef256d9bc">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Confirm in `/plans/[ free ]`, `/start/plans`, `/setup/newsletter/plans`
    * term toggle works as before top/bottom of page
    * scroll in comparison grid to get the header stuck and confirm term toggle appears as in media
        * confirm not visible in mobile view (two plans full width) - some small misalignment may be present between header & body on mobile, but it's unrelated
    * Confirm term toggle borders appear as expected (no border around it on `/plans`, border on `/start/plans`, no border when in sticky header)



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?