### PR TITLE
Sort email verification task to first if not verified

### DIFF
--- a/client/lib/checklist/index.js
+++ b/client/lib/checklist/index.js
@@ -9,6 +9,10 @@ class WpcomTaskList {
 		return this.tasks;
 	}
 
+	getAllSorted( comparator ) {
+		return [ ...this.tasks ].sort( comparator );
+	}
+
 	get( taskId ) {
 		return this.tasks.find( ( task ) => task.id === taskId );
 	}

--- a/client/lib/checklist/index.js
+++ b/client/lib/checklist/index.js
@@ -9,7 +9,9 @@ class WpcomTaskList {
 		return this.tasks;
 	}
 
-	getAllSorted = memoize( ( comparator ) => [ ...this.tasks ].sort( comparator ) );
+	getAllSorted( comparator ) {
+		return [ ...this.tasks ].sort( comparator );
+	}
 
 	get( taskId ) {
 		return this.tasks.find( ( task ) => task.id === taskId );

--- a/client/lib/checklist/index.js
+++ b/client/lib/checklist/index.js
@@ -9,9 +9,7 @@ class WpcomTaskList {
 		return this.tasks;
 	}
 
-	getAllSorted( comparator ) {
-		return [ ...this.tasks ].sort( comparator );
-	}
+	getAllSorted = memoize( ( comparator ) => [ ...this.tasks ].sort( comparator ) );
 
 	get( taskId ) {
 		return this.tasks.find( ( task ) => task.id === taskId );

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 import { Card, Spinner } from '@automattic/components';
 import { isDesktop, isWithinBreakpoint, subscribeIsWithinBreakpoint } from '@automattic/viewport';
 import classnames from 'classnames';
@@ -366,19 +367,18 @@ const ConnectedSiteSetupList = connect( ( state, props ) => {
 	} );
 	// Existing usage didn't have a global selector, we can tidy this in a follow up.
 	const emailVerificationStatus = state?.currentUser?.emailVerification?.status;
+	const isEmailUnverified = ! isCurrentUserEmailVerified( state );
 
 	return {
 		emailVerificationStatus,
 		firstIncompleteTask: taskList.getFirstIncompleteTask(),
-		isEmailUnverified: ! isCurrentUserEmailVerified( state ),
+		isEmailUnverified,
 		isFSEActive,
 		isPodcastingSite: !! getSiteOption( state, siteId, 'anchor_podcast' ),
 		menusUrl: getCustomizerUrl( state, siteId, null, null, 'add-menu' ),
 		siteId,
 		siteSlug: getSiteSlug( state, siteId ),
-		tasks: taskList.getAllSorted(
-			unverifiedEmailTaskComparator( ! isCurrentUserEmailVerified( state ) )
-		),
+		tasks: taskList.getAllSorted( unverifiedEmailTaskComparator( isEmailUnverified ) ),
 		taskUrls: getChecklistTaskUrls( state, siteId ),
 		userEmail: user?.email,
 		siteCount,

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -2,6 +2,7 @@ import { Card, Spinner } from '@automattic/components';
 import { isDesktop, isWithinBreakpoint, subscribeIsWithinBreakpoint } from '@automattic/viewport';
 import classnames from 'classnames';
 import { translate, useRtl } from 'i18n-calypso';
+import { memoize } from 'lodash';
 import { useEffect, useState } from 'react';
 import { connect, useDispatch } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
@@ -25,7 +26,6 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import CurrentTaskItem from './current-task-item';
 import { getTask } from './get-task';
 import NavItem from './nav-item';
-
 /**
  * Import Styles
  */
@@ -60,8 +60,10 @@ const startTask = ( dispatch, task, siteId, advanceToNextIncompleteTask, isPodca
 	}
 };
 
-const unverifiedEmailTaskComparator = ( isEmailUnverified ) => ( task ) =>
-	isEmailUnverified && CHECKLIST_KNOWN_TASKS.EMAIL_VERIFIED === task.id ? -1 : 0;
+const unverifiedEmailTaskComparator = memoize(
+	( isEmailUnverified ) => ( task ) =>
+		isEmailUnverified && CHECKLIST_KNOWN_TASKS.EMAIL_VERIFIED === task.id ? -1 : 0
+);
 
 const skipTask = (
 	dispatch,

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -131,6 +131,10 @@ const SiteSetupList = ( {
 			( task ) => task.id === CHECKLIST_KNOWN_TASKS.DOMAIN_VERIFIED && ! task.isCompleted
 		).length > 0;
 
+	tasks = tasks.sort( ( task ) =>
+		isEmailUnverified && CHECKLIST_KNOWN_TASKS.EMAIL_VERIFIED === task.id ? -1 : 0
+	);
+
 	const siteIntent = useSiteOption( 'site_intent' );
 	const isBlogger = siteIntent === 'write';
 	const isRtl = useRtl();

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -2,7 +2,6 @@ import { Card, Spinner } from '@automattic/components';
 import { isDesktop, isWithinBreakpoint, subscribeIsWithinBreakpoint } from '@automattic/viewport';
 import classnames from 'classnames';
 import { translate, useRtl } from 'i18n-calypso';
-import { memoize } from 'lodash';
 import { useEffect, useState } from 'react';
 import { connect, useDispatch } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
@@ -26,6 +25,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import CurrentTaskItem from './current-task-item';
 import { getTask } from './get-task';
 import NavItem from './nav-item';
+
 /**
  * Import Styles
  */
@@ -60,10 +60,8 @@ const startTask = ( dispatch, task, siteId, advanceToNextIncompleteTask, isPodca
 	}
 };
 
-const unverifiedEmailTaskComparator = memoize(
-	( isEmailUnverified ) => ( task ) =>
-		isEmailUnverified && CHECKLIST_KNOWN_TASKS.EMAIL_VERIFIED === task.id ? -1 : 0
-);
+const unverifiedEmailTaskComparator = ( isEmailUnverified ) => ( task ) =>
+	isEmailUnverified && CHECKLIST_KNOWN_TASKS.EMAIL_VERIFIED === task.id ? -1 : 0;
 
 const skipTask = (
 	dispatch,

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -123,6 +123,8 @@ const SiteSetupList = ( {
 	const [ useAccordionLayout, setUseAccordionLayout ] = useState( false );
 	const [ showAccordionSelectedTask, setShowAccordionSelectedTask ] = useState( false );
 	const [ isLoading, setIsLoading ] = useState( false );
+	const [ sortedTaskList, setSortedTaskList ] = useState( tasks );
+
 	const dispatch = useDispatch();
 	const { skipCurrentView } = useSkipCurrentViewMutation( siteId );
 
@@ -132,8 +134,10 @@ const SiteSetupList = ( {
 		).length > 0;
 
 	useEffect( () => {
-		tasks.sort( ( task ) =>
-			isEmailUnverified && CHECKLIST_KNOWN_TASKS.EMAIL_VERIFIED === task.id ? -1 : 0
+		setSortedTaskList(
+			[ ...tasks ].sort( ( task ) =>
+				isEmailUnverified && CHECKLIST_KNOWN_TASKS.EMAIL_VERIFIED === task.id ? -1 : 0
+			)
 		);
 	}, [ isEmailUnverified, tasks ] );
 
@@ -143,13 +147,13 @@ const SiteSetupList = ( {
 
 	// Move to first incomplete task on first load.
 	useEffect( () => {
-		if ( ! currentTaskId && tasks.length ) {
-			const initialTask = tasks.find( ( task ) => ! task.isCompleted );
+		if ( ! currentTaskId && sortedTaskList.length ) {
+			const initialTask = sortedTaskList.find( ( task ) => ! task.isCompleted );
 			if ( initialTask ) {
 				setCurrentTaskId( initialTask.id );
 			}
 		}
-	}, [ currentTaskId, dispatch, tasks ] );
+	}, [ currentTaskId, dispatch, sortedTaskList ] );
 
 	// If specified, then automatically complete the current task when viewed
 	// if it is not already complete.
@@ -279,7 +283,7 @@ const SiteSetupList = ( {
 					aria-label="Site setup"
 					aria-orientation="vertical"
 				>
-					{ tasks.map( ( task ) => {
+					{ sortedTaskList.map( ( task ) => {
 						const enhancedTask = getTask( task, { isBlogger, isFSEActive, userEmail } );
 						const isCurrent = task.id === currentTask.id;
 						const isCompleted = task.isCompleted;

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -131,9 +131,11 @@ const SiteSetupList = ( {
 			( task ) => task.id === CHECKLIST_KNOWN_TASKS.DOMAIN_VERIFIED && ! task.isCompleted
 		).length > 0;
 
-	tasks = tasks.sort( ( task ) =>
-		isEmailUnverified && CHECKLIST_KNOWN_TASKS.EMAIL_VERIFIED === task.id ? -1 : 0
-	);
+	useEffect( () => {
+		tasks.sort( ( task ) =>
+			isEmailUnverified && CHECKLIST_KNOWN_TASKS.EMAIL_VERIFIED === task.id ? -1 : 0
+		);
+	}, [ isEmailUnverified, tasks ] );
 
 	const siteIntent = useSiteOption( 'site_intent' );
 	const isBlogger = siteIntent === 'write';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/84163

## Proposed Changes

* Pushed email verification step to the top of tasklist if the email is not verified.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. In an incognito window, move through the Sensei onboarding flow.
2. When you get to the account step, enter a dummy email address.
3. On the domain page, select a .blog domain.
4. When checking out, first search for the email address you used in Store Admin and give yourself the appropriate number of free credits.
5. Continue the checkout process. For payment, choose the "Assign a payment method later" option.
6. Eventually you should end up on the My Home page.
7. Check that the verify email step is on the top
8. Now try accessing the My Home Page as a user with a verified email, maybe your current account
9. Check that the email verification step hasn't changed its place

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?