### PR TITLE
Change Password: report failed validation REST request in the UI

### DIFF
--- a/client/me/account-password/index.jsx
+++ b/client/me/account-password/index.jsx
@@ -58,13 +58,23 @@ class AccountPassword extends Component {
 			return;
 		}
 
-		try {
-			const validation = await wp.req.post( '/me/settings/password/validate', { password } );
+		const validation = await wp.req
+			.post( '/me/settings/password/validate', { password } )
+			.catch( () => ( {
+				passed: false,
+				test_results: {
+					failed: [
+						{
+							test_name: 'network_error',
+							explanation: this.props.translate(
+								'The password could not be vaiidated. Please check your network connection and try again.'
+							),
+						},
+					],
+				},
+			} ) );
 
-			this.setState( { pendingValidation: false, validation } );
-		} catch ( err ) {
-			this.setState( { pendingValidation: false } );
-		}
+		this.setState( { pendingValidation: false, validation } );
 	}, 300 );
 
 	handlePasswordChange = ( event ) => {

--- a/client/me/account-password/index.jsx
+++ b/client/me/account-password/index.jsx
@@ -67,7 +67,7 @@ class AccountPassword extends Component {
 						{
 							test_name: 'network_error',
 							explanation: this.props.translate(
-								'The password could not be vaiidated. Please check your network connection and try again.'
+								'The password could not be validated. Please check your network connection and try again.'
 							),
 						},
 					],


### PR DESCRIPTION
Sometimes our users need to urgently change their password, and do it from a crowded place with unreliable Wi-Fi. Then they can get stuck in a situation that looks like this:

<img width="919" alt="Screenshot 2023-11-17 at 15 47 32" src="https://github.com/Automattic/wp-calypso/assets/664258/7787585f-04d0-4512-ba90-22e10389ea68">

The new password is there, but the "Save password" button is disabled and nobody tells you why.

That can happen when the REST request to `/me/settings/password/validate` fails. That leads to component state where `this.state.validation.passed` is not `true`, but there are no errors to display.

This PR fixes that by setting a synthetic `this.state.validation` response that contains info about network error.

The resulting UI:

<img width="924" alt="Screenshot 2023-11-17 at 15 25 24" src="https://github.com/Automattic/wp-calypso/assets/664258/a632dfc8-b81e-41b2-a6d1-da2e9ffda31a">

**How to test:**
I tested this by setting network offline in Chrome devtools.
