### PR TITLE
Reader in home: Update copy and CSS in treatment

### DIFF
--- a/client/my-sites/customer-home/cards/actions/quick-post/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-post/index.jsx
@@ -24,7 +24,7 @@ export const QuickPost = () => {
 		<div className="quick-post customer-home__card">
 			<div className="quick-post__title">
 				{ translate(
-					'{{strong}}Hey there!{{/strong}}{{br}}{{/br}} Did you know people that post more get more traffic?',
+					'{{strong}}Hey there!{{/strong}}{{br}}{{/br}} Did you know sites with more posts get more traffic?',
 					{
 						args: [ currentUser.first_name ],
 						components: {

--- a/client/my-sites/customer-home/cards/actions/quick-post/style.scss
+++ b/client/my-sites/customer-home/cards/actions/quick-post/style.scss
@@ -1,7 +1,7 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-.quick-post {
+.layout__primary .customer-home__layout-col .quick-post {
 	box-shadow: none !important;
 	border: 0 !important;
 	background: var(--studio-white) !important;
@@ -9,6 +9,7 @@
 	gap: 17px;
 	padding: 0 !important;
 	align-items: center;
+	margin-top: 17px;
 
 	@media (max-width: $break-small) {
 		padding: 16px !important;
@@ -25,18 +26,5 @@
 		flex: 1;
 	}
 
-	&__action-button {
-		border-radius: 40px; /* stylelint-disable-line scales/radii */
-		display: inline-flex;
-		padding: 10px 24px;
-		justify-content: center;
-		align-items: center;
-		color: var(--p-2-white, #fff);
-		text-align: center;
-		font-size: $font-body-small;
-		font-style: normal;
-		font-weight: 400;
-		line-height: 21px;
-		letter-spacing: -0.09px;
-	}
+
 }

--- a/client/my-sites/customer-home/cards/features/reader/index.tsx
+++ b/client/my-sites/customer-home/cards/features/reader/index.tsx
@@ -49,11 +49,11 @@ const ReaderCard = ( props: ReaderCardProps ) => {
 						<div className="reader-card__title-icon">
 							<img src={ iconReaderLightbulb } alt="" />
 						</div>
-						<span>{ translate( 'Increase Views by Engaging with Others' ) }</span>
+						<span>{ translate( 'Increase views by engaging with others' ) }</span>
 					</h2>
 					<span className="reader-card__subtitle">
 						{ translate(
-							'You have more chances to pomp up your views when joining new conversations.'
+							'Thoughtfully commenting on other sites is a great way to grow your audience.'
 						) }
 					</span>
 				</div>

--- a/client/my-sites/customer-home/cards/features/reader/style.scss
+++ b/client/my-sites/customer-home/cards/features/reader/style.scss
@@ -1,7 +1,7 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-.reader-card {
+.layout__primary .customer-home__layout-col .reader-card {
 	box-shadow: none !important;
 	border: 0 !important;
 	background: var(--studio-white) !important;
@@ -52,6 +52,7 @@
 
 	.discover-stream-navigation {
 		max-width: none;
+		margin-left: 0;
 
 		.discover-stream-navigation__right-button-wrapper,
 		.discover-stream-navigation__left-button-wrapper {

--- a/client/my-sites/customer-home/cards/features/stats/style.scss
+++ b/client/my-sites/customer-home/cards/features/stats/style.scss
@@ -168,3 +168,24 @@
 		color: var(--color-text-inverted);
 	}
 }
+
+.layout__primary .customer-home__layout-col-right {
+	.stats__data-item {
+		width: 50%;
+		text-align: left;
+		font-size: rem(14px);
+		padding: 14px;
+
+		&:nth-child(1),
+		&:nth-child(2) {
+			border-bottom: none;
+		}
+		&:nth-child(2) {
+			border-right: 1px solid var(--color-neutral-5);
+		}
+	}
+
+	.stats__all-link {
+		padding: 14px;
+	}
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4546

## Proposed Changes

* Copy and style changes to the treatment.


Before | After
--|--
<img width="1718" alt="Screenshot 2023-11-17 at 10 22 19 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/ed237ef8-50ca-47f7-8632-32129931a9c1">  | <img width="1721" alt="Screenshot 2023-11-17 at 10 21 57 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/326879b1-fbc5-42b6-ac79-79b8a6f88243">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?