### PR TITLE
Jetpack Manage: Hide "Add" button when the partner cannot issue licenses

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/backup-storage.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/backup-storage.tsx
@@ -8,6 +8,7 @@ import { isSuccessfulRealtimeBackup } from 'calypso/lib/jetpack/backup-utils';
 import useDateOffsetForSite from 'calypso/lib/jetpack/hooks/use-date-offset-for-site';
 import { urlToSlug } from 'calypso/lib/url';
 import { useSelector } from 'calypso/state';
+import { getCurrentPartner } from 'calypso/state/partner-portal/partner/selectors';
 import { isJetpackSiteMultiSite } from 'calypso/state/sites/selectors';
 import ExpandedCard from './expanded-card';
 import useDashboardAddRemoveLicense from './hooks/use-dashboard-add-remove-license';
@@ -121,6 +122,9 @@ export default function BackupStorage( { site, trackEvent, hasError }: Props ) {
 
 	const translate = useTranslate();
 
+	const partner = useSelector( getCurrentPartner );
+	const partnerCanIssueLicense = Boolean( partner?.can_issue_licenses );
+
 	const hasBackupError = BACKUP_ERROR_STATUSES.includes( backupStatus );
 
 	const components = {
@@ -180,6 +184,11 @@ export default function BackupStorage( { site, trackEvent, hasError }: Props ) {
 				emptyContent={ translate( 'Backup not supported on multisite' ) }
 			/>
 		);
+	}
+
+	// If the user cannot issue licenses, and doesn't already have one, we have nothing to show
+	if ( ! isLicenseSelected && ! partnerCanIssueLicense ) {
+		return null;
 	}
 
 	return (

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/boost-site-performance.tsx
@@ -4,6 +4,8 @@ import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useRef, useState, useMemo } from 'react';
 import Tooltip from 'calypso/components/tooltip';
+import { useSelector } from 'calypso/state';
+import { getCurrentPartner } from 'calypso/state/partner-portal/partner/selectors';
 import { jetpackBoostDesktopIcon, jetpackBoostMobileIcon } from '../../icons';
 import { getBoostRating, getBoostRatingClass } from '../lib/boost';
 import BoostLicenseInfoModal from '../site-status-content/site-boost-column/boost-license-info-modal';
@@ -19,6 +21,9 @@ interface Props {
 
 export default function BoostSitePerformance( { site, trackEvent, hasError }: Props ) {
 	const translate = useTranslate();
+
+	const partner = useSelector( getCurrentPartner );
+	const partnerCanIssueLicense = Boolean( partner?.can_issue_licenses );
 
 	const helpIconRef = useRef< HTMLElement | null >( null );
 	const [ showTooltip, setShowTooltip ] = useState( false );
@@ -94,6 +99,10 @@ export default function BoostSitePerformance( { site, trackEvent, hasError }: Pr
 			},
 		];
 	}, [ isAtomicSite, hasBoost, ScoreRating, translate, siteUrlWithScheme, trackEvent ] );
+
+	if ( ! isEnabled && ! partnerCanIssueLicense ) {
+		return null;
+	}
 
 	return (
 		<>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/test/backup-storage.test.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/test/backup-storage.test.tsx
@@ -38,6 +38,13 @@ describe( 'BackupStorage component', () => {
 			},
 		},
 		siteSettings: { items: {} },
+		partnerPortal: {
+			partner: {
+				current: {
+					can_issue_licenses: true,
+				},
+			},
+		},
 	};
 
 	const mockTrackEvent = jest.fn();

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/test/boost-site-performance.test.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/test/boost-site-performance.test.tsx
@@ -2,17 +2,43 @@
  * @jest-environment jsdom
  */
 
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
 import { site } from '../../test/test-utils/constants';
 import BoostSitePerformance from '../boost-site-performance';
 
 describe( 'BoostSitePerformance', () => {
 	const trackEventMock = jest.fn();
 
+	const initialState = {
+		partnerPortal: {
+			partner: {
+				current: {
+					can_issue_licenses: true,
+				},
+			},
+		},
+	};
+
+	const mockStore = configureStore();
+	const store = mockStore( initialState );
+	const queryClient = new QueryClient();
+
+	const Wrapper = ( { children } ) => (
+		<Provider store={ store }>
+			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+		</Provider>
+	);
+
 	test( 'renders the overall score and tooltip', () => {
 		render(
-			<BoostSitePerformance site={ site } trackEvent={ trackEventMock } hasError={ false } />
+			<BoostSitePerformance site={ site } trackEvent={ trackEventMock } hasError={ false } />,
+			{
+				wrapper: Wrapper,
+			}
 		);
 
 		const overallRating = screen.getByText( 'B' );
@@ -35,7 +61,9 @@ describe( 'BoostSitePerformance', () => {
 			trackEvent: trackEventMock,
 			hasError: false,
 		};
-		render( <BoostSitePerformance { ...props } /> );
+		render( <BoostSitePerformance { ...props } />, {
+			wrapper: Wrapper,
+		} );
 
 		const emptyContent = screen.getByText( /see your site performance scores/i );
 		expect( emptyContent ).toBeInTheDocument();
@@ -54,7 +82,9 @@ describe( 'BoostSitePerformance', () => {
 			hasError: false,
 		};
 
-		render( <BoostSitePerformance { ...props } /> );
+		render( <BoostSitePerformance { ...props } />, {
+			wrapper: Wrapper,
+		} );
 
 		const autoOptimizeButton = screen.getByText( /Auto-optimize/i );
 		expect( autoOptimizeButton ).toBeInTheDocument();
@@ -80,7 +110,9 @@ describe( 'BoostSitePerformance', () => {
 			trackEvent: trackEventMock,
 			hasError: false,
 		};
-		render( <BoostSitePerformance { ...props } /> );
+		render( <BoostSitePerformance { ...props } />, {
+			wrapper: Wrapper,
+		} );
 
 		const button = screen.getByRole( 'link', { name: /boost settings/i } );
 		expect( button ).toBeInTheDocument();
@@ -103,7 +135,9 @@ describe( 'BoostSitePerformance', () => {
 			trackEvent: trackEventMock,
 			hasError: false,
 		};
-		render( <BoostSitePerformance { ...props } /> );
+		render( <BoostSitePerformance { ...props } />, {
+			wrapper: Wrapper,
+		} );
 
 		const button = screen.getByRole( 'link', { name: /optimize performance/i } );
 		expect( button ).toBeInTheDocument();

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-status-column.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-status-column.tsx
@@ -8,6 +8,7 @@ import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { selectLicense, unselectLicense } from 'calypso/state/jetpack-agency-dashboard/actions';
 import { hasSelectedLicensesOfType } from 'calypso/state/jetpack-agency-dashboard/selectors';
+import { getCurrentPartner } from 'calypso/state/partner-portal/partner/selectors';
 import { DASHBOARD_PRODUCT_SLUGS_BY_TYPE } from '../lib/constants';
 import { AllowedTypes, RowMetaData, SiteData } from '../types';
 
@@ -37,6 +38,9 @@ export default function SiteStatsColumn( { type, rows, metadata, disabled }: Pro
 	const isLicenseSelected = useSelector( ( state ) =>
 		hasSelectedLicensesOfType( state, siteId, type )
 	);
+
+	const partner = useSelector( getCurrentPartner );
+	const partnerCanIssueLicense = Boolean( partner?.can_issue_licenses );
 
 	const issueLicenseRedirectUrl = useMemo( () => {
 		return addQueryArgs( `/partner-portal/issue-license/`, {
@@ -98,6 +102,9 @@ export default function SiteStatsColumn( { type, rows, metadata, disabled }: Pro
 				return <Gridicon icon="time" size={ 18 } className="sites-overview__grey-icon" />;
 			}
 			case 'inactive': {
+				if ( ! partnerCanIssueLicense ) {
+					return null;
+				}
 				return ! isLicenseSelected ? (
 					<button
 						className="sites-overview__column-action-button"
@@ -120,6 +127,7 @@ export default function SiteStatsColumn( { type, rows, metadata, disabled }: Pro
 	}, [
 		handleDeselectLicenseAction,
 		handleSelectLicenseAction,
+		partnerCanIssueLicense,
 		isLicenseSelected,
 		isSupported,
 		status,


### PR DESCRIPTION
This PR hides the `Add` button from the Site Dashboard when the partner cannot issue licenses.

Related to https://github.com/Automattic/jetpack-manage/issues/127

## Proposed Changes

* This PR hides the `Add` button from the Site Dashboard when the partner cannot issue licenses.

## Testing Instructions

- Ensure that you have in your sandbox the latest commits on the wpcom repo (trunk). In your `hosts`, point `public-api.wordpress.com` to your sandbox IP.
- You need a Partner account.
- Go to the following pages and check the "Add" button
   - /dashboard
![image](https://github.com/Automattic/wp-calypso/assets/37049295/f4623882-99c1-47e6-bec4-2170ff542483)

- If you, as a Partner, are allowed to issue licenses, you will see the button available and clickable.
- If you are not allowed to issue licenses, you will not see the button.

- Additionally, the 'Get Score' and 'Add Backup' divs in the site details will be unavailable if the partner is unable to issue licenses.:
![image](https://github.com/Automattic/wp-calypso/assets/37049295/c71e2e16-ad7c-4d1a-aa1b-8401c5b01ad3)
 

- **Note:** you can change your current value `can_issue_licenses` using the CLI in your sandbox:
   - `wp jetpack-start agency-can-issue-licenses {your_partner_id} --set-can-issue=yes`
   - `wp jetpack-start agency-can-issue-licenses {your_partner_id} --set-can-issue=no`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?