### PR TITLE
Checkout: Explicitly set font-size for checkout modal p tags

### DIFF
--- a/packages/composite-checkout/src/components/checkout-modal.tsx
+++ b/packages/composite-checkout/src/components/checkout-modal.tsx
@@ -177,6 +177,7 @@ const CheckoutModalTitle = styled.h1`
 const CheckoutModalCopy = styled.p`
 	margin: 0;
 	color: ${ ( props ) => props.theme.colors.textColor };
+	font-size: 16px;
 `;
 
 const CheckoutModalActions = styled.div`


### PR DESCRIPTION
This is a follow up to this PR https://github.com/Automattic/wp-calypso/pull/84274

While the base font-size for the checkout 'remove from cart' modal is set to 16px, this size is inherited from higher in the tree and just happens to be what we want. But, if you click on the checkout 'back button' you'll see the same modal load where the base paragraph font is 13px:

![image](https://github.com/Automattic/wp-calypso/assets/16580129/b6d06db5-800b-43b2-a899-e512122f7368)

## Proposed Changes

Setting the font-size for the `CheckoutModalCopy` p tags to 16px will resolve this issue for all instances of the modal.

## Testing Instructions

* Go to Checkout and click on the 'Back' arrow in the upper left corner
* The 'remove from cart' modal will pop up and you should now see the paragraph text set to 16px
