### PR TITLE
Add Back to Home for domain checkout with siteId

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/domains/domain-only-thank-you-redesign-v2.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/domain-only-thank-you-redesign-v2.tsx
@@ -1,6 +1,8 @@
 import { translate } from 'i18n-calypso';
 import emailImage from 'calypso/assets/images/thank-you-upsell/email.svg';
 import { emailManagement } from 'calypso/my-sites/email/paths';
+import { useSelector } from 'calypso/state';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import ThankYouLayout from '../redesign-v2/ThankYouLayout';
 import DomainOnlyFooter from '../redesign-v2/sections/footer/DomainOnlyFooter';
 import DefaultThankYouHeader from '../redesign-v2/sections/header/Default';
@@ -13,9 +15,12 @@ interface DomainOnlyThankYouContainerProps {
 }
 
 const DomainOnlyThankYou: React.FC< DomainOnlyThankYouContainerProps > = ( { domains } ) => {
+	const siteId = useSelector( getSelectedSiteId );
+	const siteSlug = useSelector( getSelectedSiteSlug );
+	const backText = translate( 'Back to Home' );
 	const firstDomain = domains[ 0 ];
 	return (
-		<ThankYouLayout>
+		<ThankYouLayout masterbarProps={ { siteId, siteSlug, backText } }>
 			<DefaultThankYouHeader>{ translate( 'Your own corner of the web' ) }</DefaultThankYouHeader>
 			<DefaultSubHeader>
 				{ translate(

--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -699,13 +699,16 @@ export class CheckoutThankYou extends Component<
 			>
 				<PageViewTracker { ...this.getAnalyticsProperties() } title="Checkout Thank You" />
 				{ this.isDataLoaded() && isRedesignV2( this.props ) && (
-					<ConfettiAnimation delay={ 1000 } />
-				) }
-				{ isRedesignV2( this.props ) && (
-					<CheckoutMasterbar
-						siteId={ this.props.selectedSite?.ID }
-						siteSlug={ this.props.selectedSiteSlug }
-					/>
+					<>
+						<ConfettiAnimation delay={ 1000 } />
+						<CheckoutMasterbar
+							siteId={ this.props.selectedSite?.ID }
+							siteSlug={ this.props.selectedSiteSlug }
+							backText={
+								this.props.selectedSiteSlug ? translate( 'Back to dashboard' ) : undefined
+							}
+						/>
+					</>
 				) }
 				<Card className="checkout-thank-you__content">{ this.productRelatedMessages() }</Card>
 				{ showHappinessSupport && (

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/ThankYouLayout.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/ThankYouLayout.tsx
@@ -5,7 +5,7 @@ import './style.scss';
 
 interface ThankYouLayoutContainerProps {
 	children: React.ReactNode;
-	masterbarProps: CheckoutMasterbarProps;
+	masterbarProps?: CheckoutMasterbarProps;
 }
 
 const ThankYouLayout: React.FC< ThankYouLayoutContainerProps > = ( {

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/ThankYouLayout.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/ThankYouLayout.tsx
@@ -1,16 +1,20 @@
 import Main from 'calypso/components/main';
-import CheckoutMasterbar from './sections/CheckoutMasterbar';
+import CheckoutMasterbar, { CheckoutMasterbarProps } from './sections/CheckoutMasterbar';
 
 import './style.scss';
 
 interface ThankYouLayoutContainerProps {
 	children: React.ReactNode;
+	masterbarProps: CheckoutMasterbarProps;
 }
 
-const ThankYouLayout: React.FC< ThankYouLayoutContainerProps > = ( { children } ) => {
+const ThankYouLayout: React.FC< ThankYouLayoutContainerProps > = ( {
+	children,
+	masterbarProps,
+} ) => {
 	return (
 		<Main className="is-redesign-v2">
-			<CheckoutMasterbar />
+			<CheckoutMasterbar { ...masterbarProps } />
 			{ children }
 		</Main>
 	);

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/CheckoutMasterbar.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/CheckoutMasterbar.tsx
@@ -1,16 +1,14 @@
-import { useI18n } from '@wordpress/react-i18n';
 import page from 'page';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import MasterbarStyled from '../masterbar-styled';
 
-type HeaderProps = {
-	siteId?: number;
+export type CheckoutMasterbarProps = {
+	siteId?: number | null;
 	siteSlug?: string | null;
+	backText?: string;
 };
 
-const CheckoutMasterbar = ( { siteId, siteSlug }: HeaderProps ) => {
-	const { __ } = useI18n();
-
+const CheckoutMasterbar = ( { siteId, siteSlug, backText }: CheckoutMasterbarProps ) => {
 	if ( ! siteId ) {
 		return (
 			<MasterbarStyled
@@ -27,7 +25,7 @@ const CheckoutMasterbar = ( { siteId, siteSlug }: HeaderProps ) => {
 			<QuerySitePurchases siteId={ siteId } />
 			<MasterbarStyled
 				onClick={ () => page( `/home/${ siteSlug ?? '' }` ) }
-				backText={ __( 'Back to dashboard' ) }
+				backText={ backText ?? '' }
 				canGoBack={ true }
 				showContact={ true }
 			/>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/4552

## Proposed Changes

Add "Back to Home" button when domain is connected to site.

| Before  | After |
| :-------------: | :-------------: |
| <img src="https://github.com/Automattic/wp-calypso/assets/6586048/63168fa5-743d-474f-bd2a-7defb1fc9d6d">  | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/b8d8ec86-4f01-40a0-af7d-e6579ddc1331">|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Test the claim free domain flow**
* Store sandbox
* Have a Personal plan and above without domain claimed
* Go through the claim domain process
* Make sure the Congrats page have "Back to Home" button and works

**Test the original domain only flow**
* Go to `/start/domain/domain-only`
* Go through the flow, and the Congrats page should not have any errors or back button

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?