### PR TITLE
Fix dockerfile node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG use_cache=false
-ARG node_version=18.17.0
+ARG node_version=20.8.1
 ARG base_image=registry.a8c.com/calypso/base:latest
 
 ###################


### PR DESCRIPTION
In #83585, one Node version string was missed. Thankfully, this doesn't have a real impact on builds -- the string is only used when the cache image is _not_ used. And since we always use the cache/base image in CI, it wasn't applicable. Still good to update though :)