### PR TITLE
Checkout: Adjust spacing between override list items and area behind flag

### DIFF
--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -61,6 +61,10 @@ const CostOverridesListStyle = styled.div`
 		margin-top: 16px;
 	}
 
+	& .cost-overrides-list-item:nth-of-type( 1 ) {
+		margin-top: 0;
+	}
+
 	& .cost-overrides-list-item__actions {
 		grid-column: 1 / span 2;
 		display: flex;

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -58,11 +58,10 @@ const CostOverridesListStyle = styled.div`
 		display: grid;
 		justify-content: space-between;
 		grid-template-columns: auto auto;
-		margin-top: 16px;
 	}
 
-	& .cost-overrides-list-item:nth-of-type( 1 ) {
-		margin-top: 0;
+	& .cost-overrides-list-item--coupon {
+		margin-top: 16px;
 	}
 
 	& .cost-overrides-list-item__actions {
@@ -176,7 +175,10 @@ function CostOverridesList( {
 			) }
 			{ couponOverrides.map( ( costOverride ) => {
 				return (
-					<div className="cost-overrides-list-item" key={ costOverride.humanReadableReason }>
+					<div
+						className="cost-overrides-list-item cost-overrides-list-item--coupon"
+						key={ costOverride.humanReadableReason }
+					>
 						<span className="cost-overrides-list-item__reason">
 							{ couponCode.length > 0
 								? translate( 'Coupon: %(couponCode)s', { args: { couponCode } } )

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -35,7 +35,7 @@ import type { PropsWithChildren } from 'react';
 
 const WPOrderReviewList = styled.ul< { theme?: Theme } >`
 	box-sizing: border-box;
-	margin: 20px 0;
+	margin: 24px 0;
 	padding: 0;
 `;
 
@@ -52,12 +52,13 @@ const CostOverridesListStyle = styled.div`
 	justify-content: space-between;
 	font-size: 12px;
 	font-weight: 400;
+	margin-top: 10px;
 
 	& .cost-overrides-list-item {
 		display: grid;
 		justify-content: space-between;
 		grid-template-columns: auto auto;
-		padding: 2px 0px;
+		margin-top: 16px;
 	}
 
 	& .cost-overrides-list-item__actions {

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -58,10 +58,15 @@ const CostOverridesListStyle = styled.div`
 		display: grid;
 		justify-content: space-between;
 		grid-template-columns: auto auto;
+		margin-top: 4px;
 	}
 
 	& .cost-overrides-list-item--coupon {
 		margin-top: 16px;
+	}
+
+	& .cost-overrides-list-item:nth-of-type( 1 ) {
+		margin-top: 0;
 	}
 
 	& .cost-overrides-list-item__actions {


### PR DESCRIPTION
## Proposed Changes

This is a follow-up to https://github.com/Automattic/wp-calypso/pull/83890. This PR adjusts the styles of the list of cost overrides so that they match the design.

The annotations in the first screenshot below show the requested design changes that this PR implements (this is a screenshot _without_ the changes; screenshots with the changes are below):

![283992714-4b38c3a7-1935-4b13-a361-c0be2cf26e40](https://github.com/Automattic/wp-calypso/assets/2036909/b0dfc0a0-f616-4b6d-932e-0c6923ec2019)

> [!NOTE] 
> The redesigned checkout remains hidden behind both a feature flag and a query string parameter. It is only available currently in development (`calypso.localhost`) and on `wpcalypso` which is used by the `calypso.live` branches below.

Before             |  After
:-------------------------:|:-------------------------:
<img width="262" alt="Screenshot 2023-11-19 at 1 42 21 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/c810a8d1-a7cf-49ca-b3bf-1e4cd7a9f099"> | <img width="256" alt="Screenshot 2023-11-20 at 11 03 34 AM" src="https://github.com/Automattic/wp-calypso/assets/2036909/d678f2c7-7141-49af-aa40-c78bd1dd6802">

This is part of the project to implement a redesign of checkout: https://github.com/Automattic/payments-shilling/issues/1969

## Testing Instructions

- Use a site with an existing plan.
- Add a plan upgrade (a higher level plan) to your cart and visit checkout.
- Add `?checkoutVersion=2` to the end of the checkout URL and reload checkout.
- Verify that the sidebar spacing matches the design instruction shown above.