### PR TITLE
Ensure replace happens inline allowing error handling to remove domains effectively

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -615,7 +615,7 @@ export class RenderDomainsStep extends Component {
 			const sortedProducts = this.sortProductsByPriceDescending( productsInCart );
 
 			// Replace the products in the cart with the freshly sorted products.
-			this.props.shoppingCartManager.replaceProductsInCart( sortedProducts );
+			await this.props.shoppingCartManager.replaceProductsInCart( sortedProducts );
 		} else {
 			await this.props.shoppingCartManager.addProductsToCart( registration );
 		}


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/4554

We made this call async to speed up execution of the interface in https://github.com/Automattic/wp-calypso/pull/84269/

The remove-on-error code https://github.com/Automattic/wp-calypso/blob/trunk/client/components/domains/register-domain-step/index.jsx#L1416 was executing after we added the domain but before the replace cart had fully executed. The result is that the domain was being removed but then added back by the complete replacement cart call.

## Proposed Changes

* Awaits for the full add domain process to complete before allowing the remove-on-error code to execute.

## Testing Instructions

* See https://github.com/Automattic/dotcom-forge/issues/4554 for backend code to add to trigger this case
* Enter a matching domains search
* Try to add one of the matching domains
* The domain should be added to the cart and then removed when the error is shown.

Note it might be better off just reverting the change see: https://github.com/Automattic/wp-calypso/pull/84328