### PR TITLE
Revert "Multi-Domain: Allowing instant insertion of domains into the mini-cart"

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -200,11 +200,8 @@ class DomainRegistrationSuggestion extends Component {
 			buttonStyles = { ...buttonStyles, disabled: true };
 		}
 
-		if (
-			shouldUseMultipleDomainsInCart( flowName ) &&
-			( getDomainRegistrations( cart ).length > 0 || temporaryCart?.length > 0 )
-		) {
-			buttonStyles = { ...buttonStyles, primary: false, disabled: false, busy: false };
+		if ( shouldUseMultipleDomainsInCart( flowName ) && getDomainRegistrations( cart ).length > 0 ) {
+			buttonStyles = { ...buttonStyles, primary: false };
 		}
 
 		return {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -601,8 +601,6 @@ export class RenderDomainsStep extends Component {
 				} ) );
 			}
 
-			await this.props.shoppingCartManager.addProductsToCart( [ registration ] );
-
 			// We add a plan to cart on Multi Domains to show the proper discount on the mini-cart.
 			const productsToAdd = ! hasPlan( this.props.cart )
 				? [ registration, this.props.multiDomainDefaultPlan ]
@@ -615,7 +613,7 @@ export class RenderDomainsStep extends Component {
 			const sortedProducts = this.sortProductsByPriceDescending( productsInCart );
 
 			// Replace the products in the cart with the freshly sorted products.
-			this.props.shoppingCartManager.replaceProductsInCart( sortedProducts );
+			await this.props.shoppingCartManager.replaceProductsInCart( sortedProducts );
 		} else {
 			await this.props.shoppingCartManager.addProductsToCart( registration );
 		}


### PR DESCRIPTION
Reverts Automattic/wp-calypso#84272 (originally https://github.com/Automattic/wp-calypso/pull/84269)
Fixes https://github.com/Automattic/dotcom-forge/issues/4554