### PR TITLE
Hosting flow: Refresh copy in signup step for hosting flow

### DIFF
--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { isNewsletterFlow } from '@automattic/onboarding';
+import { isNewsletterFlow, isHostingSignupFlow } from '@automattic/onboarding';
 import { isMobile } from '@automattic/viewport';
 import { Button } from '@wordpress/components';
 import classNames from 'classnames';
@@ -270,6 +270,13 @@ export class UserStep extends Component {
 					subHeaderText = translate( 'Already have a WordPress.com account? {{a}}Log in{{/a}}', {
 						components: { a: <a href={ loginUrl } rel="noopener noreferrer" /> },
 					} );
+				} else if ( isHostingSignupFlow( flowName ) ) {
+					subHeaderText = translate(
+						'The most reliable WordPress platform awaits you. Have an account? {{a}}Log in{{/a}}',
+						{
+							components: { a: <a href={ loginUrl } rel="noopener noreferrer" /> },
+						}
+					);
 				} else {
 					subHeaderText = translate(
 						'First, create your WordPress.com account. Have an account? {{a}}Log in{{/a}}',
@@ -464,7 +471,7 @@ export class UserStep extends Component {
 		}
 
 		const params = new URLSearchParams( window.location.search );
-		if ( isNewsletterFlow( params.get( 'variationName' ) ) ) {
+		if ( isNewsletterFlow( params.get( 'variationName' ) ) || isHostingSignupFlow( flowName ) ) {
 			return translate( 'Let’s get you signed up.' );
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Makes requested (pet6gk-Kj-p2) changes to the copy on the signup step for the hosting flow.

We don't want untranslated text appearing before it's available. Because this PR only contains copy changes we can keep things simple rather than using the `i18n.hasTranslation()` function and use the `[Status] String freeze` label instead.

We'll only apply that label once the PR is reviewed and we're definitely happy with the new copy.

**Before**

![CleanShot 2023-11-20 at 16 00 09@2x](https://github.com/Automattic/wp-calypso/assets/1500769/e9c01450-e6bc-4484-ba13-5acdd44011e0)


**After**

![CleanShot 2023-11-21 at 13 48 39@2x](https://github.com/Automattic/wp-calypso/assets/1500769/22e635ef-9b65-434f-b6ca-932c21e8c396)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `/start/hosting/user-hosting?ref=hosting-lp&section=hero&flow=new-hosted-site` will show the new strings
* Try another language by appending a slug fragment to the URL
   * e.g. `/start/hosting/user-hosting/es?ref=hosting-lp&section=hero&flow=new-hosted-site`
* The `user` step on other signup flows should be unchanged.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] ~Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?~
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~