### PR TITLE
Jetpack Manage: Fix issue with split button chevron icon misalignment

### DIFF
--- a/client/jetpack-cloud/style.scss
+++ b/client/jetpack-cloud/style.scss
@@ -471,7 +471,7 @@ body.is-section-jetpack-cloud-pricing.is-group-jetpack-cloud .mini-cart {
 		}
 	}
 
-	.gridicon {
+	.button .gridicon {
 		width: 20px;
 		height: 20px;
 		fill: var(--studio-white);


### PR DESCRIPTION
The main PR goal is to fix conflicting rules between GridIcon and SplitButton, causing misalignment when `.button .gridicon` takes precedence over `.split-button .gridicon`.


**Before**
<img width="299" alt="Screen Shot 2023-11-20 at 3 23 01 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/d9255dd6-deff-438a-8bae-c87a8facd567">

**After**
<img width="334" alt="Screen Shot 2023-11-20 at 3 31 39 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/aa3d6539-bcb9-446d-97a4-fddc37ff75dd">


Closes https://github.com/Automattic/jetpack-manage/issues/58

## Proposed Changes

* Raise split-button gridicon specificity to avoid incorrect rules taking precedence.

## Testing Instructions

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

* Use the live link below and go to `/plugins/manage` **(This is an important step to test if the new rule is working as expected)**
* Go to Dashboard by clicking the Sites menu item in the sidebar.
* Confirm that the chevron icon is no longer misaligned.

## Pre-merge Checklist



- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?