### PR TITLE
chore: remove `@types/highlight-words-core` & `@types/gradient-parser`

### DIFF
--- a/package.json
+++ b/package.json
@@ -225,7 +225,6 @@
 		"@tanstack/eslint-plugin-query": "^4.29.8",
 		"@testing-library/jest-dom": "^6.1.4",
 		"@types/gtag.js": "^0.0.10",
-		"@types/highlight-words-core": "^1.2.1",
 		"@types/superagent": "^4.1.15",
 		"@typescript-eslint/eslint-plugin": "^6.10.0",
 		"@typescript-eslint/parser": "^6.10.0",

--- a/package.json
+++ b/package.json
@@ -224,7 +224,6 @@
 		"@storybook/react": "^7.5.3",
 		"@tanstack/eslint-plugin-query": "^4.29.8",
 		"@testing-library/jest-dom": "^6.1.4",
-		"@types/gradient-parser": "^0.1.5",
 		"@types/gtag.js": "^0.0.10",
 		"@types/highlight-words-core": "^1.2.1",
 		"@types/superagent": "^4.1.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7732,7 +7732,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/highlight-words-core@npm:1.2.1, @types/highlight-words-core@npm:^1.2.1":
+"@types/highlight-words-core@npm:1.2.1":
   version: 1.2.1
   resolution: "@types/highlight-words-core@npm:1.2.1"
   checksum: f3795656cbe4215e849faa2e53c74a9c6a7b2e148f54267c6a7f25a4f3cd55374f3e4d2e2618740c96fafabdb36b855f7cec27cab207957d566d0500a10e2312
@@ -32275,7 +32275,6 @@ __metadata:
     "@types/debug": "npm:^4.1.7"
     "@types/fast-json-stable-stringify": "npm:^2.0.0"
     "@types/gtag.js": "npm:^0.0.10"
-    "@types/highlight-words-core": "npm:^1.2.1"
     "@types/jest": "npm:^29.5.8"
     "@types/lodash": "npm:^4.14.199"
     "@types/node": "npm:^20.8.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7716,13 +7716,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/gradient-parser@npm:^0.1.5":
-  version: 0.1.5
-  resolution: "@types/gradient-parser@npm:0.1.5"
-  checksum: 8347fb24885aeb133421baec58d0eab4e8ec43d17f337bc4f1d23bde99ca5e87b82b44834eb00d71fd820503c530d4c75e4d9a98652e09b2f04b08fbc1057762
-  languageName: node
-  linkType: hard
-
 "@types/gtag.js@npm:^0.0.10":
   version: 0.0.10
   resolution: "@types/gtag.js@npm:0.0.10"
@@ -32281,7 +32274,6 @@ __metadata:
     "@types/cookie": "npm:^0.4.1"
     "@types/debug": "npm:^4.1.7"
     "@types/fast-json-stable-stringify": "npm:^2.0.0"
-    "@types/gradient-parser": "npm:^0.1.5"
     "@types/gtag.js": "npm:^0.0.10"
     "@types/highlight-words-core": "npm:^1.2.1"
     "@types/jest": "npm:^29.5.8"


### PR DESCRIPTION
We added those packages to compensate `@wordpress/components` not shipping with those types. After https://github.com/WordPress/gutenberg/pull/50231 this should be fixed.

## Proposed Changes

* remove `@types/gradient-parser`
* remove `@types/highlight-words-core `

## Testing Instructions

* There shouldn't be any type errors
