### PR TITLE
chore: migration to RQ v5 (major)

### DIFF
--- a/client/blocks/importer/wordpress/import-everything/pre-migration/credentials-form.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/credentials-form.tsx
@@ -87,7 +87,7 @@ export const CredentialsForm: React.FunctionComponent< Props > = ( props ) => {
 		dispatch( updateCredentials( sourceSite.ID, credentials, true, false ) );
 	};
 
-	const { migrateProvision, isLoading, isError, error } =
+	const { migrateProvision, isPending, isError, error } =
 		useMigrateProvisionMutation( handleUpdateCredentials );
 
 	const submitCredentials = useCallback(
@@ -187,7 +187,7 @@ export const CredentialsForm: React.FunctionComponent< Props > = ( props ) => {
 			) }
 			<form onSubmit={ submitCredentials }>
 				<CredentialsFormAdvanced
-					disabled={ isFormSubmissionPending || isLoading }
+					disabled={ isFormSubmissionPending || isPending }
 					formErrors={ formErrors }
 					formMode={ formMode }
 					formState={ formState }
@@ -220,8 +220,8 @@ export const CredentialsForm: React.FunctionComponent< Props > = ( props ) => {
 				) }
 
 				<div className="pre-migration__content pre-migration__proceed import__footer-button-container">
-					<NextButton type="submit" isBusy={ isFormSubmissionPending || isLoading }>
-						{ isFormSubmissionPending || isLoading
+					<NextButton type="submit" isBusy={ isFormSubmissionPending || isPending }>
+						{ isFormSubmissionPending || isPending
 							? translate( 'Testing credentials' )
 							: translate( 'Start migration' ) }
 					</NextButton>

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
@@ -97,7 +97,7 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 		isRequestingSitePlans( state, targetSite.ID )
 	);
 
-	const { isLoading: isAddingTrial } = useAddHostingTrialMutation( {
+	const { isPending: isAddingTrial } = useAddHostingTrialMutation( {
 		onSuccess: () => {
 			setQueryTargetSitePlanStatus( 'fetching' );
 		},

--- a/client/blocks/importer/wordpress/upgrade-plan/index.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/index.tsx
@@ -45,7 +45,7 @@ export const UpgradePlan: React.FunctionComponent< Props > = ( props: Props ) =>
 		// If the user's email is unverified, we still want to show the trial plan option
 		migrationTrialEligibility?.error_code === 'email-unverified';
 
-	const { addHostingTrial, isLoading: isAddingTrial } = useAddHostingTrialMutation( {
+	const { addHostingTrial, isPending: isAddingTrial } = useAddHostingTrialMutation( {
 		onSuccess: () => {
 			// After the trial is added, we need to request the site again to get the updated plan
 			site && dispatch( requestSite( site.ID ) );

--- a/client/blocks/reader-site-subscription/details.tsx
+++ b/client/blocks/reader-site-subscription/details.tsx
@@ -42,13 +42,13 @@ const SiteSubscriptionDetails = ( {
 
 	const {
 		mutate: subscribe,
-		isLoading: subscribing,
+		isPending: subscribing,
 		isSuccess: subscribed,
 		error: subscribeError,
 	} = SubscriptionManager.useSiteSubscribeMutation();
 	const {
 		mutate: unsubscribe,
-		isLoading: unsubscribing,
+		isPending: unsubscribing,
 		isSuccess: unsubscribed,
 		error: unsubscribeError,
 	} = SubscriptionManager.useSiteUnsubscribeMutation();

--- a/client/blocks/reader-site-subscription/settings.tsx
+++ b/client/blocks/reader-site-subscription/settings.tsx
@@ -21,13 +21,13 @@ const SiteSubscriptionSettings = ( {
 }: SiteSubscriptionSettingsProps ) => {
 	const translate = useTranslate();
 
-	const { mutate: updateNotifyMeOfNewPosts, isLoading: updatingNotifyMeOfNewPosts } =
+	const { mutate: updateNotifyMeOfNewPosts, isPending: updatingNotifyMeOfNewPosts } =
 		SubscriptionManager.useSiteNotifyMeOfNewPostsMutation();
-	const { mutate: updateEmailMeNewPosts, isLoading: updatingEmailMeNewPosts } =
+	const { mutate: updateEmailMeNewPosts, isPending: updatingEmailMeNewPosts } =
 		SubscriptionManager.useSiteEmailMeNewPostsMutation();
-	const { mutate: updateDeliveryFrequency, isLoading: updatingFrequency } =
+	const { mutate: updateDeliveryFrequency, isPending: updatingFrequency } =
 		SubscriptionManager.useSiteDeliveryFrequencyMutation();
-	const { mutate: updateEmailMeNewComments, isLoading: updatingEmailMeNewComments } =
+	const { mutate: updateEmailMeNewComments, isPending: updatingEmailMeNewComments } =
 		SubscriptionManager.useSiteEmailMeNewCommentsMutation();
 
 	return (

--- a/client/blocks/reader-site-subscription/subscribe-to-newsletter-categories.tsx
+++ b/client/blocks/reader-site-subscription/subscribe-to-newsletter-categories.tsx
@@ -16,7 +16,7 @@ const SubscribeToNewsletterCategories = ( { siteId }: SubscribeToNewsletterCateg
 	const { data: subscribedNewsletterCategoriesData, isLoading } = useSubscribedNewsletterCategories(
 		{ siteId }
 	);
-	const { mutate, isLoading: isSaving } = useNewsletterCategorySubscriptionMutation( siteId );
+	const { mutate, isPending: isSaving } = useNewsletterCategorySubscriptionMutation( siteId );
 
 	const subscribedCategoryIds = useMemo(
 		() =>

--- a/client/blocks/reader-unsubscribed-feeds-search-list/reader-unsubscribed-non-wpcom-feed-item.tsx
+++ b/client/blocks/reader-unsubscribed-feeds-search-list/reader-unsubscribed-non-wpcom-feed-item.tsx
@@ -75,7 +75,7 @@ const ReaderUnsubscribedNonWpcomFeedItem = ( {
 			isExternalLink
 			hasSubscribed={ feedQuery.data?.is_following || subscribe.isSuccess }
 			iconUrl={ feedQuery.data?.image }
-			isSubscribing={ subscribe.isLoading }
+			isSubscribing={ subscribe.isPending }
 			onSubscribeClick={ () => {
 				subscribe.mutate( {
 					feed_id: feedId,
@@ -108,7 +108,7 @@ const ReaderUnsubscribedNonWpcomFeedItem = ( {
 				}
 			} }
 			subscribeDisabled={
-				feedQuery.data?.is_following || subscribe.isLoading || subscribe.isSuccess
+				feedQuery.data?.is_following || subscribe.isPending || subscribe.isSuccess
 			}
 			title={ feedQuery.data?.name ?? filterURLForDisplay( subscribeUrl ) }
 			onTitleClick={ () => {

--- a/client/blocks/reader-unsubscribed-feeds-search-list/reader-unsubscribed-wpcom-feed-item.tsx
+++ b/client/blocks/reader-unsubscribed-feeds-search-list/reader-unsubscribed-wpcom-feed-item.tsx
@@ -27,7 +27,7 @@ const ReaderUnsubscribedWpcomFeedItem = ( {
 }: ReaderUnsubscribedWpcomFeedItemProps ) => {
 	const {
 		mutate: subscribe,
-		isLoading: subscribing,
+		isPending: subscribing,
 		isSuccess: subscribed,
 	} = SubscriptionManager.useSiteSubscribeMutation();
 	const dispatch = useDispatch();

--- a/client/components/site-preview-link/index.tsx
+++ b/client/components/site-preview-link/index.tsx
@@ -75,7 +75,7 @@ export default function SitePreviewLink( {
 		}
 	}, [ checked, shouldBeChecked ] );
 
-	const { createLink, isLoading: isCreating } = useCreateSitePreviewLink( {
+	const { createLink, isPending: isCreating } = useCreateSitePreviewLink( {
 		siteId,
 		onSuccess: () => {
 			showSuccessNotice( translate( 'Preview link enabled.' ) );
@@ -87,7 +87,7 @@ export default function SitePreviewLink( {
 		},
 	} );
 
-	const { deleteLink, isLoading: isDeleting } = useDeleteSitePreviewLink( {
+	const { deleteLink, isPending: isDeleting } = useDeleteSitePreviewLink( {
 		siteId,
 		onSuccess: () => {
 			showSuccessNotice( translate( 'Preview link disabled.' ) );

--- a/client/data/domains/glue-records/use-domain-glue-records-query.ts
+++ b/client/data/domains/glue-records/use-domain-glue-records-query.ts
@@ -51,6 +51,6 @@ export default function useDomainGlueRecordsQuery(
 		select: selectGlueRecords,
 		enabled: false,
 		staleTime: 5 * 60 * 1000,
-		cacheTime: 5 * 60 * 1000,
+		gcTime: 5 * 60 * 1000,
 	} );
 }

--- a/client/data/followers/use-followers-query.js
+++ b/client/data/followers/use-followers-query.js
@@ -29,7 +29,7 @@ const useFollowersQuery = ( siteId, type = 'wpcom', fetchOptions = {}, queryOpti
 
 	return useInfiniteQuery( {
 		queryKey: [ 'followers', siteId, type, search ],
-		queryFn: async ( { pageParam = 1 } ) =>
+		queryFn: async ( { pageParam } ) =>
 			wpcom.req.get( `/sites/${ siteId }/followers`, {
 				...defaults,
 				...fetchOptions,
@@ -37,6 +37,7 @@ const useFollowersQuery = ( siteId, type = 'wpcom', fetchOptions = {}, queryOpti
 				page: pageParam,
 			} ),
 		...queryOptions,
+		initialPageParam: 1,
 		getNextPageParam: ( lastPage, allPages ) => {
 			if ( lastPage.pages <= allPages.length || allPages.length >= MAX_FOLLOWERS ) {
 				return;

--- a/client/data/hosting/use-site-logs-query.ts
+++ b/client/data/hosting/use-site-logs-query.ts
@@ -1,4 +1,4 @@
-import { UseQueryOptions, useQuery, useQueryClient } from '@tanstack/react-query';
+import { UseQueryOptions, keepPreviousData, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import wpcom from 'calypso/lib/wp';
 
@@ -78,7 +78,7 @@ export function useSiteLogsQuery(
 				}
 			);
 		},
-		keepPreviousData: true,
+		placeholderData: keepPreviousData,
 		enabled: !! siteId && params.start <= params.end,
 		staleTime: Infinity, // The logs within a specified time range never change.
 		select( { data } ) {

--- a/client/data/marketplace/use-es-query.ts
+++ b/client/data/marketplace/use-es-query.ts
@@ -103,7 +103,11 @@ const ONE_DAY_IN_MS = 1000 * 60 * 60 * 24;
 export const useESPlugin = (
 	slug: string,
 	fields?: Array< string >,
-	{ enabled = true, staleTime = ONE_DAY_IN_MS, refetchOnMount = true }: UseQueryOptions< any > = {}
+	{
+		enabled = true,
+		staleTime = ONE_DAY_IN_MS,
+		refetchOnMount = true,
+	}: Omit< UseQueryOptions< any >, 'queryKey' > = {}
 ): UseQueryResult => {
 	const locale = useSelector( getCurrentUserLocale );
 
@@ -115,15 +119,21 @@ export const useESPlugin = (
 	} );
 };
 
+type PageParam = string | number;
+
 export const getESPluginsInfiniteQueryParams = (
 	options: PluginQueryOptions,
 	locale: string
-): { queryKey: QueryKey; queryFn: QueryFunction< ESResponse, QueryKey > } => {
+): {
+	queryKey: QueryKey;
+	queryFn: QueryFunction< ESResponse, QueryKey, PageParam >;
+	initialPageParam: PageParam;
+} => {
 	const [ searchTerm, author ] = extractSearchInformation( options.searchTerm );
 	const pageSize = options.pageSize ?? DEFAULT_PAGE_SIZE;
 	const queryKey = getPluginsListKey( [ 'DEBUG-new-site-seach' ], options, true );
 	const groupId = options.category !== 'popular' ? 'marketplace' : 'wporg';
-	const queryFn = ( { pageParam = 1 } ) =>
+	const queryFn: QueryFunction< ESResponse, QueryKey, PageParam > = ( { pageParam } ) =>
 		search( {
 			query: searchTerm,
 			author,
@@ -133,17 +143,27 @@ export const getESPluginsInfiniteQueryParams = (
 			pageSize,
 			locale: getWpLocaleBySlug( ( options.locale || locale ) as LanguageSlug ),
 		} );
-	return { queryKey, queryFn };
+	return { queryKey, queryFn, initialPageParam: 1 };
 };
 
 export const useESPluginsInfinite = (
 	options: PluginQueryOptions,
-	{ enabled = true, staleTime = 10000, refetchOnMount = true }: UseQueryOptions< any > = {}
-): UseQueryResult => {
+	{
+		enabled = true,
+		staleTime = 10000,
+		refetchOnMount = true,
+	}: Omit< UseQueryOptions< any >, 'queryKey' > = {}
+) => {
 	const locale = useSelector( getCurrentUserLocale );
 
+	const { queryKey, queryFn, initialPageParam } = getESPluginsInfiniteQueryParams(
+		options,
+		locale
+	);
+
 	return useInfiniteQuery( {
-		...getESPluginsInfiniteQueryParams( options, locale ),
+		queryKey,
+		queryFn,
 		select: ( data: InfiniteData< ESResponse > ) => {
 			return {
 				...data,
@@ -155,6 +175,7 @@ export const useESPluginsInfinite = (
 				},
 			};
 		},
+		initialPageParam,
 		getNextPageParam: ( lastPage ) => {
 			return lastPage?.data?.page_handle;
 		},

--- a/client/data/marketplace/use-marketplace-reviews.ts
+++ b/client/data/marketplace/use-marketplace-reviews.ts
@@ -280,7 +280,7 @@ export const useInfiniteMarketplaceReviewsQuery = (
 		perPage,
 		'infinite',
 	];
-	const queryFn = ( { pageParam = 1 } ) =>
+	const queryFn = ( { pageParam } ) =>
 		fetchMarketplaceReviews( productType, slug, pageParam, perPage, author, author_exclude );
 
 	return useInfiniteQuery< MarketplaceReviewsQueryResponse >( {
@@ -292,6 +292,7 @@ export const useInfiniteMarketplaceReviewsQuery = (
 			}
 			return allPages.length + 1;
 		},
+		initialPageParam: 1,
 		enabled,
 		staleTime,
 	} );

--- a/client/data/marketplace/use-marketplace-reviews.ts
+++ b/client/data/marketplace/use-marketplace-reviews.ts
@@ -280,12 +280,18 @@ export const useInfiniteMarketplaceReviewsQuery = (
 		perPage,
 		'infinite',
 	];
-	const queryFn = ( { pageParam } ) =>
-		fetchMarketplaceReviews( productType, slug, pageParam, perPage, author, author_exclude );
 
 	return useInfiniteQuery< MarketplaceReviewsQueryResponse >( {
 		queryKey,
-		queryFn,
+		queryFn: ( { pageParam } ) =>
+			fetchMarketplaceReviews(
+				productType,
+				slug,
+				pageParam as number,
+				perPage,
+				author,
+				author_exclude
+			),
 		getNextPageParam: ( lastPage, allPages ) => {
 			if ( lastPage.headers[ 'X-WP-TotalPages' ] <= allPages.length ) {
 				return;

--- a/client/data/marketplace/use-wporg-plugin-query.ts
+++ b/client/data/marketplace/use-wporg-plugin-query.ts
@@ -77,14 +77,14 @@ export const useWPORGInfinitePlugins = (
 		enabled = true,
 		staleTime = BASE_STALE_TIME,
 		refetchOnMount = true,
-	}: UseQueryOptions< any > = {}
+	}: Omit< UseQueryOptions< any >, 'queryKey' > = {}
 ): UseInfiniteQueryResult => {
 	const [ search, author ] = extractSearchInformation( options.searchTerm );
 	const locale = useSelector( getCurrentUserLocale );
 
 	return useInfiniteQuery( {
 		queryKey: getPluginsListKey( [ WPORG_CACHE_KEY ], options, true ),
-		queryFn: ( { pageParam = 1 } ) =>
+		queryFn: ( { pageParam } ) =>
 			fetchPluginsList( {
 				pageSize: options.pageSize,
 				page: pageParam,
@@ -103,6 +103,7 @@ export const useWPORGInfinitePlugins = (
 				pagination: extractPagination( data.pages ),
 			};
 		},
+		initialPageParam: 1,
 		getNextPageParam: ( lastPage: { info: { page: number; pages: number } } ) => {
 			// When on last page, the next page is undefined, according to docs.
 			// @see: https://tanstack.com/query/v4/docs/reference/useInfiniteQuery

--- a/client/data/promote-post/types.ts
+++ b/client/data/promote-post/types.ts
@@ -85,6 +85,8 @@ export type PostQueryResult = {
 	total_items: number;
 	total_pages: number;
 	page: number;
+	pages: [];
+	pageParams: [];
 };
 
 export type CampaignQueryResult = {

--- a/client/data/promote-post/use-promote-post-campaigns-query-paged.ts
+++ b/client/data/promote-post/use-promote-post-campaigns-query-paged.ts
@@ -1,4 +1,4 @@
-import { useInfiniteQuery } from '@tanstack/react-query';
+import { keepPreviousData, useInfiniteQuery } from '@tanstack/react-query';
 import { requestDSPHandleErrors } from 'calypso/lib/promote-post';
 import { SearchOptions } from 'calypso/my-sites/promote-post-i2/components/search-bar';
 import { CampaignQueryResult } from './types';
@@ -52,7 +52,7 @@ const useCampaignsQueryPaged = (
 		...queryOptions,
 		enabled: !! siteId,
 		retryDelay: 3000,
-		keepPreviousData: true,
+		placeholderData: keepPreviousData,
 		refetchOnWindowFocus: false,
 		meta: {
 			persist: false,

--- a/client/data/promote-post/use-promote-post-campaigns-query-paged.ts
+++ b/client/data/promote-post/use-promote-post-campaigns-query-paged.ts
@@ -31,7 +31,7 @@ const useCampaignsQueryPaged = (
 
 	return useInfiniteQuery( {
 		queryKey: [ 'promote-post-campaigns', siteId, searchQueryParams ],
-		queryFn: async ( { pageParam = 1 } ) => {
+		queryFn: async ( { pageParam } ) => {
 			const searchCampaignsUrl = `/search/campaigns/site/${ siteId }?order=asc&order_by=post_date&page=${ pageParam }${ searchQueryParams }`;
 			const resultQuery = await requestDSPHandleErrors< CampaignQueryResult >(
 				siteId,
@@ -57,6 +57,7 @@ const useCampaignsQueryPaged = (
 		meta: {
 			persist: false,
 		},
+		initialPageParam: 1,
 		getNextPageParam: ( lastPage ) => {
 			if ( lastPage.has_more_pages ) {
 				return lastPage.page + 1;

--- a/client/data/promote-post/use-promote-post-posts-query-paged.ts
+++ b/client/data/promote-post/use-promote-post-posts-query-paged.ts
@@ -51,7 +51,7 @@ const usePostsQueryPaged = (
 	const searchQueryParams = getSearchOptionsQueryParams( searchOptions );
 	return useInfiniteQuery( {
 		queryKey: [ 'promote-post-posts', siteId, searchQueryParams ],
-		queryFn: async ( { pageParam = 1 } ) => {
+		queryFn: async ( { pageParam } ) => {
 			// Fetch blazable posts
 			const postsResponse = await queryPosts( siteId, `page=${ pageParam }${ searchQueryParams }` );
 
@@ -74,6 +74,7 @@ const usePostsQueryPaged = (
 		meta: {
 			persist: false,
 		},
+		initialPageParam: 1,
 		getNextPageParam: ( lastPage ) => {
 			if ( lastPage.has_more_pages ) {
 				return lastPage.page + 1;

--- a/client/data/promote-post/use-promote-post-posts-query-paged.ts
+++ b/client/data/promote-post/use-promote-post-posts-query-paged.ts
@@ -1,5 +1,9 @@
 import config from '@automattic/calypso-config';
-import { InfiniteQueryObserverResult, useInfiniteQuery } from '@tanstack/react-query';
+import {
+	InfiniteQueryObserverResult,
+	keepPreviousData,
+	useInfiniteQuery,
+} from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 import { SearchOptions } from 'calypso/my-sites/promote-post-i2/components/search-bar';
 import { PostQueryResult } from './types';
@@ -65,7 +69,7 @@ const usePostsQueryPaged = (
 		...queryOptions,
 		enabled: !! siteId,
 		retryDelay: 3000,
-		keepPreviousData: true,
+		placeholderData: keepPreviousData,
 		refetchOnWindowFocus: false,
 		meta: {
 			persist: false,

--- a/client/data/users/use-users-query.js
+++ b/client/data/users/use-users-query.js
@@ -16,13 +16,14 @@ const useUsersQuery = ( siteId, fetchOptions = {}, queryOptions = {} ) => {
 
 	return useInfiniteQuery( {
 		queryKey: [ 'users', siteId, search ],
-		queryFn: ( { pageParam = 0 } ) =>
+		queryFn: ( { pageParam } ) =>
 			wpcom.req.get( `/sites/${ siteId }/users`, {
 				...defaults,
 				...fetchOptions,
 				offset: pageParam,
 			} ),
 		enabled: !! siteId,
+		initialPageParam: 0,
 		getNextPageParam: ( lastPage, allPages ) => {
 			const n = fetchOptions.number ?? defaults.number;
 			if ( lastPage.found <= allPages.length * n ) {

--- a/client/data/viewers/use-viewers-query.js
+++ b/client/data/viewers/use-viewers-query.js
@@ -10,9 +10,10 @@ const DEFAULT_PER_PAGE = 100;
 const useViewersQuery = ( siteId, { number = DEFAULT_PER_PAGE } = {}, queryOptions = {} ) => {
 	return useInfiniteQuery( {
 		queryKey: [ 'viewers', siteId ],
-		queryFn: ( { pageParam = 1 } ) =>
+		queryFn: ( { pageParam } ) =>
 			wpcom.req.get( `/sites/${ siteId }/viewers`, { number, page: pageParam } ),
 		...queryOptions,
+		initialPageParam: 1,
 		getNextPageParam: ( lastPage, allPages ) => {
 			if ( lastPage.found <= allPages.length * number ) {
 				return;

--- a/client/jetpack-cloud/components/user-feedback-modal-form/use-submit-product-feedback.ts
+++ b/client/jetpack-cloud/components/user-feedback-modal-form/use-submit-product-feedback.ts
@@ -17,7 +17,7 @@ export default function useSubmitProductFeedback(): {
 		isError,
 		isSuccess,
 		mutate,
-		isLoading: isSubmittingFeedback,
+		isPending: isSubmittingFeedback,
 	} = useSubmitProductFeedbackMutation();
 
 	useEffect( () => {

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-editor/verify.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/contact-editor/verify.tsx
@@ -83,14 +83,14 @@ export default function VerifyContactForm( {
 	);
 
 	const {
-		isLoading: isSubmittingVerificationCode,
+		isPending: isSubmittingVerificationCode,
 		isVerified: isSubmittingVerificationCodeSuccess,
 		isError: isSubmittingVerificationCodeFailed,
 		errorMessage: submitVerificationCodeErrorMessage,
 		mutate: submitVerificationCode,
 	} = useValidateVerificationCode();
 	const {
-		isLoading: isRequestingVerificationCode,
+		isPending: isRequestingVerificationCode,
 		isSuccess: isRequestingVerificationCodeSuccess,
 		isError: isRequestingVerificationCodeFailed,
 		isVerified: isRequestingVerificationCodeAlreadyVerified,
@@ -98,7 +98,7 @@ export default function VerifyContactForm( {
 	} = useRequestVerificationCode();
 
 	const {
-		isLoading: isResendingVerificationCode,
+		isPending: isResendingVerificationCode,
 		isSuccess: isResendingVerificationCodeSuccess,
 		isError: isResendingVerificationCodeFailed,
 		mutate: resendVerificationCode,

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/hooks/use-request-verification-code.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/hooks/use-request-verification-code.ts
@@ -5,7 +5,7 @@ import type { RequestVerificationCodeParams } from '../../sites-overview/types';
 export default function useRequestVerificationCode(): {
 	mutate: ( params: RequestVerificationCodeParams ) => void;
 	isError: boolean;
-	isLoading: boolean;
+	isPending: boolean;
 	isSuccess: boolean;
 	isVerified: boolean;
 	data: any;

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/hooks/use-resend-verification-code.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/hooks/use-resend-verification-code.ts
@@ -3,7 +3,7 @@ import type { ResendVerificationCodeParams } from '../../sites-overview/types';
 
 export default function useResendVerificationCode(): {
 	mutate: ( params: ResendVerificationCodeParams ) => void;
-	isLoading: boolean;
+	isPending: boolean;
 	isSuccess: boolean;
 	isError: boolean;
 	data: any;

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/hooks/use-validate-verification-code.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/hooks/use-validate-verification-code.ts
@@ -6,7 +6,7 @@ import type { ValidateVerificationCodeParams } from '../../sites-overview/types'
 
 export default function useValidateVerificationCode(): {
 	mutate: ( params: ValidateVerificationCodeParams ) => void;
-	isLoading: boolean;
+	isPending: boolean;
 	isSuccess: boolean;
 	isError: boolean;
 	errorMessage?: string;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-set-favorite/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-set-favorite/index.tsx
@@ -132,7 +132,7 @@ export default function SiteSetFavorite( { isFavorite, siteId, siteUrl }: Props 
 		};
 	};
 
-	const { isLoading, mutate } = useToggleFavoriteSiteMutation( handleMutation() );
+	const { isPending, mutate } = useToggleFavoriteSiteMutation( handleMutation() );
 
 	const handleFavoriteChange = () => {
 		mutate( { siteId, isFavorite } );
@@ -149,7 +149,7 @@ export default function SiteSetFavorite( { isFavorite, siteId, siteUrl }: Props 
 		<Button
 			borderless
 			compact
-			disabled={ isLoading }
+			disabled={ isPending }
 			onClick={ handleFavoriteChange }
 			className={ classNames(
 				'site-set-favorite__favorite-icon',

--- a/client/jetpack-cloud/sections/agency-signup/agency-signup-form/index.tsx
+++ b/client/jetpack-cloud/sections/agency-signup/agency-signup-form/index.tsx
@@ -126,7 +126,7 @@ export default function AgencySignupForm() {
 			{ hasFetched && ! partner && (
 				<CompanyDetailsForm
 					includeTermsOfService={ true }
-					isLoading={ createPartner.isLoading }
+					isLoading={ createPartner.isPending }
 					onSubmit={ onSubmit }
 					submitLabel={ translate( 'Continue' ) }
 					showSignupFields={ true }

--- a/client/jetpack-cloud/sections/partner-portal/download-products-form/woo-product-download.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/download-products-form/woo-product-download.tsx
@@ -55,7 +55,7 @@ export default function WooProductDownload( { licenseKey, allProducts }: WooProd
 				}
 				buttonText={ translate( 'Download' ) }
 				buttonOnClick={ download }
-				buttonDisabled={ downloadUrl.isLoading }
+				buttonDisabled={ downloadUrl.isPending }
 			/>
 		</div>
 	);

--- a/client/jetpack-cloud/sections/partner-portal/invoices-list-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/invoices-list-card/index.tsx
@@ -68,7 +68,7 @@ function InvoicesListCard( { id, number, dueDate, status, total, currency, pdfUr
 
 			<div className="invoices-list-card__actions">
 				{ status === 'open' && (
-					<Button compact primary busy={ payInvoice.isLoading } onClick={ pay }>
+					<Button compact primary busy={ payInvoice.isPending } onClick={ pay }>
 						{ translate( 'Pay' ) }
 					</Button>
 				) }

--- a/client/jetpack-cloud/sections/partner-portal/license-details/actions.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/actions.tsx
@@ -67,7 +67,7 @@ export default function LicenseDetailsActions( {
 				licenseType === LicenseType.Partner && (
 					<Button
 						compact
-						{ ...( downloadUrl.isLoading ? { busy: true } : {} ) }
+						{ ...( downloadUrl.isPending ? { busy: true } : {} ) }
 						onClick={ download }
 					>
 						{ translate( 'Download' ) }

--- a/client/jetpack-cloud/sections/partner-portal/primary/terms-of-service-consent/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/terms-of-service-consent/index.tsx
@@ -100,7 +100,7 @@ export default function TermsOfServiceConsent() {
 							className="terms-of-service-consent__proceed"
 							onClick={ agreeToTOS }
 							disabled={ ! checkedTOS }
-							busy={ consent.isLoading }
+							busy={ consent.isPending }
 							primary
 						>
 							{ translate( 'Proceed' ) }

--- a/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/index.tsx
@@ -45,10 +45,10 @@ export default function RevokeLicenseDialog( {
 	} );
 
 	close = useCallback( () => {
-		if ( ! mutation.isLoading ) {
+		if ( ! mutation.isPending ) {
 			onClose();
 		}
-	}, [ onClose, mutation.isLoading ] );
+	}, [ onClose, mutation.isPending ] );
 
 	const revoke = useCallback( () => {
 		dispatch(
@@ -67,8 +67,9 @@ export default function RevokeLicenseDialog( {
 			{ translate( 'Go back' ) }
 		</Button>,
 
-		<Button primary scary busy={ mutation.isLoading } onClick={ revoke }>
+		<Button primary scary busy={ mutation.isPending } onClick={ revoke }>
 			{ isParentLicense ? translate( 'Revoke bundle' ) : translate( 'Revoke License' ) }
+			{ translate( 'Revoke License' ) }
 		</Button>,
 	];
 

--- a/client/jetpack-cloud/sections/partner-portal/unassign-license-dialog/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/unassign-license-dialog/index.tsx
@@ -39,10 +39,10 @@ export default function UnassignLicenseDialog( {
 	} );
 
 	close = useCallback( () => {
-		if ( ! mutation.isLoading ) {
+		if ( ! mutation.isPending ) {
 			onClose();
 		}
-	}, [ onClose, mutation.isLoading ] );
+	}, [ onClose, mutation.isPending ] );
 
 	const unassign = useCallback( () => {
 		dispatch( recordTracksEvent( 'calypso_partner_portal_license_list_unassign_dialog_unassign' ) );
@@ -54,7 +54,7 @@ export default function UnassignLicenseDialog( {
 			{ translate( 'Go back' ) }
 		</Button>,
 
-		<Button primary scary busy={ mutation.isLoading } onClick={ unassign }>
+		<Button primary scary busy={ mutation.isPending } onClick={ unassign }>
 			{ translate( 'Unassign License' ) }
 		</Button>,
 	];

--- a/client/jetpack-cloud/sections/partner-portal/update-company-details-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/update-company-details-form/index.tsx
@@ -92,7 +92,7 @@ export default function UpdateCompanyDetailsForm() {
 				postalCode,
 				state,
 			} }
-			isLoading={ updateCompanyDetails.isLoading }
+			isLoading={ updateCompanyDetails.isPending }
 			onSubmit={ onSubmit }
 			submitLabel={ translate( 'Update details' ) }
 		/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/lib/fixtures.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/lib/fixtures.ts
@@ -311,7 +311,6 @@ export const MOCK_USE_QUERY_RESULT = {
 	isLoading: false,
 	isLoadingError: false,
 	isPlaceholderData: false,
-	isPreviousData: false,
 	isRefetchError: false,
 	isRefetching: false,
 	isStale: false,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/migration-trial-acknowledge.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/migration-trial-acknowledge.tsx
@@ -43,7 +43,7 @@ const MigrationTrialAcknowledgeInternal = function ( props: Props ) {
 	const isEligibleForTrialPlan = migrationTrialEligibility?.eligible;
 	const eligibilityErrorCode = migrationTrialEligibility?.error_code;
 	const plan = getPlan( PLAN_BUSINESS );
-	const { addHostingTrial, isLoading: isAddingTrial } = useAddHostingTrialMutation( {
+	const { addHostingTrial, isPending: isAddingTrial } = useAddHostingTrialMutation( {
 		onSuccess: () => {
 			navigateToImporterStep();
 		},

--- a/client/landing/stepper/hooks/use-get-site-suggestions-query.ts
+++ b/client/landing/stepper/hooks/use-get-site-suggestions-query.ts
@@ -32,7 +32,7 @@ export const useGetSiteSuggestionsQuery = ( {
 	refetchOnWindowFocus?: boolean;
 } ) =>
 	useQuery( {
-		cacheTime: 0,
+		gcTime: 0,
 		queryFn: () => getSiteSuggestions( params ),
 		refetchOnWindowFocus,
 		enabled,

--- a/client/landing/stepper/hooks/use-is-domain-code-valid.ts
+++ b/client/landing/stepper/hooks/use-is-domain-code-valid.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import sha256 from 'hash.js/lib/hash/sha/256';
 import wpcomRequest from 'wpcom-proxy-request';
 import { domainAvailability } from 'calypso/lib/domains/constants';
@@ -100,7 +100,7 @@ export function useIsDomainCodeValid( pair: DomainCodePair, queryOptions = {} ) 
 		},
 		staleTime: 5 * 60 * 1000,
 		cacheTime: 5 * 60 * 1000,
-		keepPreviousData: true,
+		placeholderData: keepPreviousData,
 		refetchOnWindowFocus: false,
 		refetchOnMount: false,
 		...queryOptions,

--- a/client/landing/stepper/hooks/use-is-domain-code-valid.ts
+++ b/client/landing/stepper/hooks/use-is-domain-code-valid.ts
@@ -99,7 +99,7 @@ export function useIsDomainCodeValid( pair: DomainCodePair, queryOptions = {} ) 
 			}
 		},
 		staleTime: 5 * 60 * 1000,
-		cacheTime: 5 * 60 * 1000,
+		gcTime: 5 * 60 * 1000,
 		placeholderData: keepPreviousData,
 		refetchOnWindowFocus: false,
 		refetchOnMount: false,

--- a/client/landing/stepper/hooks/use-site-preview-share-code.ts
+++ b/client/landing/stepper/hooks/use-site-preview-share-code.ts
@@ -24,7 +24,7 @@ export function useSitePreviewShareCode() {
 	} );
 
 	// Provides createLink() function used to generate a new site preview share code
-	const { createLink, isLoading: isCreatingSitePreviewLinks } = useCreateSitePreviewLink( {
+	const { createLink, isPending: isCreatingSitePreviewLinks } = useCreateSitePreviewLink( {
 		siteId: Number( site?.ID ),
 	} );
 

--- a/client/landing/subscriptions/components/add-sites-form/add-sites-form.tsx
+++ b/client/landing/subscriptions/components/add-sites-form/add-sites-form.tsx
@@ -22,7 +22,7 @@ const AddSitesForm = ( { onAddFinished }: AddSitesFormProps ) => {
 	const { showErrorNotice, showWarningNotice, showSuccessNotice } = useAddSitesModalNotices();
 	const recordSiteSubscribed = useRecordSiteSubscribed();
 
-	const { mutate: subscribe, isLoading: subscribing } =
+	const { mutate: subscribe, isPending: subscribing } =
 		SubscriptionManager.useSiteSubscribeMutation();
 
 	const validateInputValue = useCallback(

--- a/client/landing/subscriptions/components/comment-list/comment-row.tsx
+++ b/client/landing/subscriptions/components/comment-list/comment-row.tsx
@@ -32,10 +32,10 @@ const CommentRow = ( {
 	const translate = useTranslate();
 	const hostname = useMemo( () => new URL( site_url ).hostname, [ site_url ] );
 
-	const { mutate: notifyMeOfNewComments, isLoading: notifyingMeOfNewComments } =
+	const { mutate: notifyMeOfNewComments, isPending: notifyingMeOfNewComments } =
 		SubscriptionManager.usePostNotifyMeOfNewCommentsMutation();
 
-	const { mutate: unsubscribe, isLoading: unsubscribing } =
+	const { mutate: unsubscribe, isPending: unsubscribing } =
 		SubscriptionManager.usePostUnsubscribeMutation();
 
 	const recordCommentNotificationsToggle = useRecordCommentNotificationsToggle();

--- a/client/landing/subscriptions/components/pending-list/pending-post-list/pending-post-row.tsx
+++ b/client/landing/subscriptions/components/pending-list/pending-post-list/pending-post-row.tsx
@@ -16,9 +16,9 @@ export default function PendingPostRow( {
 }: Reader.PendingPostSubscription ) {
 	const hostname = useMemo( () => new URL( post_url ).hostname, [ post_url ] );
 
-	const { mutate: confirmPendingSubscription, isLoading: confirmingPendingSubscription } =
+	const { mutate: confirmPendingSubscription, isPending: confirmingPendingSubscription } =
 		SubscriptionManager.usePendingPostConfirmMutation();
-	const { mutate: deletePendingSubscription, isLoading: deletingPendingSubscription } =
+	const { mutate: deletePendingSubscription, isPending: deletingPendingSubscription } =
 		SubscriptionManager.usePendingPostDeleteMutation();
 
 	return (

--- a/client/landing/subscriptions/components/pending-list/pending-site-list/pending-site-row.tsx
+++ b/client/landing/subscriptions/components/pending-list/pending-site-list/pending-site-row.tsx
@@ -14,9 +14,9 @@ export default function PendingSiteRow( {
 }: Reader.PendingSiteSubscription ) {
 	const hostname = useMemo( () => new URL( site_url ).hostname, [ site_url ] );
 
-	const { mutate: confirmPendingSubscription, isLoading: confirmingPendingSubscription } =
+	const { mutate: confirmPendingSubscription, isPending: confirmingPendingSubscription } =
 		SubscriptionManager.usePendingSiteConfirmMutation();
-	const { mutate: deletePendingSubscription, isLoading: deletingPendingSubscription } =
+	const { mutate: deletePendingSubscription, isPending: deletingPendingSubscription } =
 		SubscriptionManager.usePendingSiteDeleteMutation();
 
 	return (

--- a/client/landing/subscriptions/components/site-subscriptions-list/site-subscription-row.tsx
+++ b/client/landing/subscriptions/components/site-subscriptions-list/site-subscription-row.tsx
@@ -112,15 +112,15 @@ const SiteSubscriptionRow = ( {
 	);
 	const sanitizedBlogId = Reader.isValidId( blog_id ) ? Number( blog_id ) : undefined;
 
-	const { mutate: updateNotifyMeOfNewPosts, isLoading: updatingNotifyMeOfNewPosts } =
+	const { mutate: updateNotifyMeOfNewPosts, isPending: updatingNotifyMeOfNewPosts } =
 		SubscriptionManager.useSiteNotifyMeOfNewPostsMutation();
-	const { mutate: updateEmailMeNewPosts, isLoading: updatingEmailMeNewPosts } =
+	const { mutate: updateEmailMeNewPosts, isPending: updatingEmailMeNewPosts } =
 		SubscriptionManager.useSiteEmailMeNewPostsMutation();
-	const { mutate: updateDeliveryFrequency, isLoading: updatingFrequency } =
+	const { mutate: updateDeliveryFrequency, isPending: updatingFrequency } =
 		SubscriptionManager.useSiteDeliveryFrequencyMutation();
-	const { mutate: updateEmailMeNewComments, isLoading: updatingEmailMeNewComments } =
+	const { mutate: updateEmailMeNewComments, isPending: updatingEmailMeNewComments } =
 		SubscriptionManager.useSiteEmailMeNewCommentsMutation();
-	const { mutate: unsubscribe, isLoading: unsubscribing } =
+	const { mutate: unsubscribe, isPending: unsubscribing } =
 		SubscriptionManager.useSiteUnsubscribeMutation();
 	const { mutate: resubscribe } = SubscriptionManager.useSiteSubscribeMutation();
 

--- a/client/landing/subscriptions/components/user-settings/user-settings.tsx
+++ b/client/landing/subscriptions/components/user-settings/user-settings.tsx
@@ -25,7 +25,7 @@ const DEFAULT_VALUE = {};
 
 const UserSettings = ( { value = DEFAULT_VALUE }: UserSettingsProps ) => {
 	const [ formState, setFormState ] = useState( value );
-	const { mutate, isLoading, isSuccess, error } = SubscriptionManager.useUserSettingsMutation();
+	const { mutate, isPending, isSuccess, error } = SubscriptionManager.useUserSettingsMutation();
 	const [ notice, setNotice ] = useState< NoticeState | null >( null );
 
 	useEffect( () => {
@@ -82,7 +82,7 @@ const UserSettings = ( { value = DEFAULT_VALUE }: UserSettingsProps ) => {
 				value={ formState.blocked ?? false }
 				onChange={ ( value ) => onChange?.( { blocked: value.target.checked } ) }
 			/>
-			<Button className="user-settings__submit-button" disabled={ isLoading } onClick={ onSubmit }>
+			<Button className="user-settings__submit-button" disabled={ isPending } onClick={ onSubmit }>
 				{ translate( 'Save changes', {
 					context: 'Save the subscription management user changes',
 				} ) }

--- a/client/me/purchases/vat-info/use-vat-details.ts
+++ b/client/me/purchases/vat-info/use-vat-details.ts
@@ -88,7 +88,7 @@ export default function useVatDetails(): VatDetailsManager {
 		() => ( {
 			vatDetails: query.data ?? emptyVatDetails,
 			isLoading: query.isLoading,
-			isUpdating: mutation.isLoading,
+			isUpdating: mutation.isPending,
 			isUpdateSuccessful: mutation.isSuccess,
 			fetchError: query.error,
 			updateError: mutation.error,

--- a/client/me/security-ssh-key/security-ssh-key.tsx
+++ b/client/me/security-ssh-key/security-ssh-key.tsx
@@ -81,7 +81,7 @@ export const SecuritySSHKey = ( { queryParams }: SecuritySSHKeyProps ) => {
 	const [ showDialog, setShowDialog ] = useState( false );
 	const { __ } = useI18n();
 
-	const { addSSHKey, isLoading: isAdding } = useAddSSHKeyMutation( {
+	const { addSSHKey, isPending: isAdding } = useAddSSHKeyMutation( {
 		onMutate: () => {
 			dispatch( removeNotice( sshKeySaveFailureNoticeId ) );
 		},
@@ -129,7 +129,7 @@ export const SecuritySSHKey = ( { queryParams }: SecuritySSHKeyProps ) => {
 		},
 	} );
 
-	const { updateSSHKey, isLoading: keyBeingUpdated } = useUpdateSSHKeyMutation( {
+	const { updateSSHKey, isPending: keyBeingUpdated } = useUpdateSSHKeyMutation( {
 		onMutate: () => {
 			dispatch( removeNotice( sshKeyUpdateFailureNoticeId ) );
 		},

--- a/client/me/security-ssh-key/use-add-ssh-key-mutation.ts
+++ b/client/me/security-ssh-key/use-add-ssh-key-mutation.ts
@@ -37,9 +37,9 @@ export const useAddSSHKeyMutation = (
 		},
 	} );
 
-	const { mutate, isLoading } = mutation;
+	const { mutate, isPending } = mutation;
 
 	const addSSHKey = useCallback( ( args: MutationVariables ) => mutate( args ), [ mutate ] );
 
-	return { addSSHKey, isLoading };
+	return { addSSHKey, isPending };
 };

--- a/client/me/security-ssh-key/use-delete-ssh-key-mutation.ts
+++ b/client/me/security-ssh-key/use-delete-ssh-key-mutation.ts
@@ -41,6 +41,6 @@ export const useDeleteSSHKeyMutation = (
 	return {
 		deleteSSHKey,
 		keyBeingDeleted:
-			mutation.isLoading && mutation.variables ? mutation.variables.sshKeyName : null,
+			mutation.isPending && mutation.variables ? mutation.variables.sshKeyName : null,
 	};
 };

--- a/client/me/security-ssh-key/use-update-ssh-key-mutation.ts
+++ b/client/me/security-ssh-key/use-update-ssh-key-mutation.ts
@@ -45,9 +45,9 @@ export const useUpdateSSHKeyMutation = (
 		},
 	} );
 
-	const { mutate, isLoading } = mutation;
+	const { mutate, isPending } = mutation;
 
 	const updateSSHKey = useCallback( ( args: MutationVariables ) => mutate( args ), [ mutate ] );
 
-	return { updateSSHKey, isLoading };
+	return { updateSSHKey, isPending };
 };

--- a/client/my-sites/checkout/src/hooks/use-purchase-order.tsx
+++ b/client/my-sites/checkout/src/hooks/use-purchase-order.tsx
@@ -140,7 +140,7 @@ export default function usePurchaseOrder(
 			return rawOrder ? transformRawOrderToOrderTransaction( rawOrder ) : undefined;
 		},
 		enabled: shouldFetch,
-		refetchInterval: ( data ) => ( isOrderComplete( data ) ? false : pollInterval ),
+		refetchInterval: ( query ) => ( isOrderComplete( query.state.data ) ? false : pollInterval ),
 	} );
 
 	const output = { isLoading: shouldFetch ? isLoading : false, order };

--- a/client/my-sites/checkout/src/hooks/use-stored-payment-methods.tsx
+++ b/client/my-sites/checkout/src/hooks/use-stored-payment-methods.tsx
@@ -130,7 +130,7 @@ export function useStoredPaymentMethods( {
 	return {
 		paymentMethods,
 		isLoading: isLoggedOut ? false : isLoading,
-		isDeleting: mutation.isLoading,
+		isDeleting: mutation.isPending,
 		error: errorMessage,
 		deletePaymentMethod,
 	};

--- a/client/my-sites/email/email-forwarding/email-forwarding-add-new-compact-list.tsx
+++ b/client/my-sites/email/email-forwarding/email-forwarding-add-new-compact-list.tsx
@@ -34,7 +34,7 @@ const EmailForwardingAddNewCompactList = ( {
 	);
 	const existingEmailForwards = emailAccounts[ 0 ]?.emails ?? [];
 
-	const { mutate: addEmailForward, isLoading: isAddingEmailForward } =
+	const { mutate: addEmailForward, isPending: isAddingEmailForward } =
 		useAddEmailForwardMutation( selectedDomainName );
 
 	const hasValidEmailForwards = () => {

--- a/client/my-sites/hosting/github/deployment-card/index.tsx
+++ b/client/my-sites/hosting/github/deployment-card/index.tsx
@@ -30,7 +30,7 @@ export const DeploymentCard = ( { repo, branch, connectionId }: DeploymentCardPr
 
 	const dispatch = useDispatch();
 
-	const { disconnectRepo, isLoading: isDisconnecting } = useGithubDisconnectRepoMutation(
+	const { disconnectRepo, isPending: isDisconnecting } = useGithubDisconnectRepoMutation(
 		siteId,
 		connectionId,
 		{

--- a/client/my-sites/hosting/github/deployment-card/use-disconnect-repo.ts
+++ b/client/my-sites/hosting/github/deployment-card/use-disconnect-repo.ts
@@ -36,9 +36,9 @@ export const useGithubDisconnectRepoMutation = (
 		},
 	} );
 
-	const { mutate, isLoading } = mutation;
+	const { mutate, isPending } = mutation;
 
 	const disconnectRepo = useCallback( ( siteId: number | null ) => mutate( siteId ), [ mutate ] );
 
-	return { disconnectRepo, isLoading };
+	return { disconnectRepo, isPending };
 };

--- a/client/my-sites/hosting/github/disconnect-github-button/index.tsx
+++ b/client/my-sites/hosting/github/disconnect-github-button/index.tsx
@@ -30,7 +30,7 @@ export function DisconnectGitHubButton( { connection }: DisconnectGitHubButtonPr
 			} );
 		},
 	} );
-	const { mutate: disconnect, isLoading: isDisconnecting } = mutation;
+	const { mutate: disconnect, isPending: isDisconnecting } = mutation;
 
 	return (
 		<Button

--- a/client/my-sites/hosting/github/github-authorize-card/index.tsx
+++ b/client/my-sites/hosting/github/github-authorize-card/index.tsx
@@ -24,7 +24,7 @@ export const GithubAuthorizeCard = () => {
 		getKeyringServiceByName( state, 'github-deploy' )
 	) as Service;
 
-	const { mutate: authorize, isLoading: isAuthorizing } = useMutation< void, unknown, string >( {
+	const { mutate: authorize, isPending: isAuthorizing } = useMutation< void, unknown, string >( {
 		mutationFn: async ( connectURL ) => {
 			dispatch( recordTracksEvent( 'calypso_hosting_github_authorize_click' ) );
 			await new Promise( ( resolve ) => requestExternalAccess( connectURL, resolve ) );

--- a/client/my-sites/hosting/github/github-connect-card/index.tsx
+++ b/client/my-sites/hosting/github/github-connect-card/index.tsx
@@ -33,7 +33,7 @@ export const GithubConnectCard = ( { connection }: GithubConnectCardProps ) => {
 	const [ selectedRepo, setSelectedRepo ] = useState< string >( '' );
 	const [ selectedBranch, setSelectedBranch ] = useState< string >( '' );
 
-	const { connectBranch, isLoading: isConnecting } = useGithubConnectMutation( siteId, {
+	const { connectBranch, isPending: isConnecting } = useGithubConnectMutation( siteId, {
 		onSuccess: () => {
 			dispatch( successNotice( __( 'Repository connected.' ), noticeOptions ) );
 		},

--- a/client/my-sites/hosting/github/github-connect-card/use-github-branches-query.ts
+++ b/client/my-sites/hosting/github/github-connect-card/use-github-branches-query.ts
@@ -32,6 +32,6 @@ export const useGithubBranchesQuery = (
 			persist: false,
 		},
 		...options,
-		cacheTime: CACHE_TIME,
+		gcTime: CACHE_TIME,
 	} );
 };

--- a/client/my-sites/hosting/github/github-connect-card/use-github-connect-mutation.ts
+++ b/client/my-sites/hosting/github/github-connect-card/use-github-connect-mutation.ts
@@ -43,9 +43,9 @@ export const useGithubConnectMutation = (
 		},
 	} );
 
-	const { mutate, isLoading } = mutation;
+	const { mutate, isPending } = mutation;
 
 	const connectBranch = useCallback( ( args: MutationVariables ) => mutate( args ), [ mutate ] );
 
-	return { connectBranch, isLoading };
+	return { connectBranch, isPending };
 };

--- a/client/my-sites/hosting/sftp-card/ssh-key-card.tsx
+++ b/client/my-sites/hosting/sftp-card/ssh-key-card.tsx
@@ -37,7 +37,7 @@ const sshKeyDetachFailureNoticeId = 'ssh-key-detach-failure';
 function SshKeyCard( { deleteText, siteId, sshKey, disabled = false }: SshKeyCardProps ) {
 	const { __ } = useI18n();
 	const dispatch = useDispatch();
-	const { detachSshKey, isLoading: isDetaching } = useDetachSshKeyMutation(
+	const { detachSshKey, isPending: isDetaching } = useDetachSshKeyMutation(
 		{ siteId },
 		{
 			onMutate: () => {

--- a/client/my-sites/hosting/sftp-card/ssh-keys.tsx
+++ b/client/my-sites/hosting/sftp-card/ssh-keys.tsx
@@ -42,7 +42,7 @@ function SshKeys( { siteId, siteSlug, username, disabled }: SshKeysProps ) {
 		enabled: ! disabled,
 	} );
 	const { data: userKeys, isLoading: isLoadingUserKeys } = useSSHKeyQuery();
-	const { attachSshKey, isLoading: attachingKey } = useAttachSshKeyMutation( siteId, {
+	const { attachSshKey, isPending: attachingKey } = useAttachSshKeyMutation( siteId, {
 		onMutate: () => {
 			dispatch( removeNotice( sshKeyAttachFailureNoticeId ) );
 		},

--- a/client/my-sites/hosting/sftp-card/use-attach-ssh-key.ts
+++ b/client/my-sites/hosting/sftp-card/use-attach-ssh-key.ts
@@ -37,9 +37,9 @@ export const useAttachSshKeyMutation = (
 		},
 	} );
 
-	const { mutate, isLoading } = mutation;
+	const { mutate, isPending } = mutation;
 
 	const attachSshKey = useCallback( ( args: MutationVariables ) => mutate( args ), [ mutate ] );
 
-	return { attachSshKey, isLoading };
+	return { attachSshKey, isPending };
 };

--- a/client/my-sites/hosting/sftp-card/use-detach-ssh-key.ts
+++ b/client/my-sites/hosting/sftp-card/use-detach-ssh-key.ts
@@ -38,9 +38,9 @@ export const useDetachSshKeyMutation = (
 			options.onSuccess?.( ...args );
 		},
 	} );
-	const { mutate, isLoading } = mutation;
+	const { mutate, isPending } = mutation;
 
 	const detachSshKey = useCallback( ( args: MutationVariables ) => mutate( args ), [ mutate ] );
 
-	return { detachSshKey, isLoading };
+	return { detachSshKey, isPending };
 };

--- a/client/my-sites/hosting/site-admin-interface-card/use-select-interface-mutation.ts
+++ b/client/my-sites/hosting/site-admin-interface-card/use-select-interface-mutation.ts
@@ -92,6 +92,6 @@ export const useSiteInterfaceMutation = (
 	return {
 		...mutation,
 		setSiteInterface: mutate,
-		isLoading: mutation.isLoading || isRequestingMenu,
+		isLoading: mutation.isPending || isRequestingMenu,
 	};
 };

--- a/client/my-sites/marketplace/components/review-modal/index.tsx
+++ b/client/my-sites/marketplace/components/review-modal/index.tsx
@@ -6,7 +6,6 @@ import CardHeading from 'calypso/components/card-heading';
 import ReviewsRatingsStars from 'calypso/components/reviews-rating-stars/reviews-ratings-stars';
 import {
 	ProductType,
-	ErrorResponse,
 	useCreateMarketplaceReviewMutation,
 } from 'calypso/data/marketplace/use-marketplace-reviews';
 
@@ -85,18 +84,16 @@ export const ReviewModal = ( { isVisible, onClose, slug, productName, productTyp
 							className="marketplace-review-modal__button-submit"
 							primary
 							type="submit"
-							disabled={ createReview.isLoading }
+							disabled={ createReview.isPending }
 						>
-							{ createReview.isLoading && <Spinner className="card__icon" /> }
+							{ createReview.isPending && <Spinner className="card__icon" /> }
 							<span>{ translate( 'Submit' ) }</span>
 						</Button>
 						<Button onClick={ onClose }>{ translate( 'Cancel' ) }</Button>
 					</div>
 				</form>
 				{ createReview.isError && (
-					<span className="marketplace-review-modal__error">
-						{ ( createReview.error as ErrorResponse ).message }
-					</span>
+					<span className="marketplace-review-modal__error">{ createReview.error.message }</span>
 				) }
 			</Card>
 		</Dialog>

--- a/client/my-sites/site-settings/site-owner-transfer/site-owner-user-search.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/site-owner-user-search.tsx
@@ -79,7 +79,7 @@ const SiteOwnerTransferEligibility = ( {
 	const [ tempSiteOwner, setTempSiteOwner ] = useState< User >();
 	const [ siteTransferEligibilityError, setSiteTransferEligibilityError ] = useState( '' );
 
-	const { checkSiteTransferEligibility, isLoading: isCheckingSiteTransferEligibility } =
+	const { checkSiteTransferEligibility, isPending: isCheckingSiteTransferEligibility } =
 		useCheckSiteTransferEligibility( siteId, {
 			onMutate: () => {
 				setSiteTransferEligibilityError( '' );

--- a/client/my-sites/site-settings/site-owner-transfer/start-site-owner-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/start-site-owner-transfer.tsx
@@ -260,7 +260,7 @@ const StartSiteOwnerTransfer = ( {
 
 	const purchases = useSelector( ( state ) => getSitePurchases( state, selectedSiteId ) );
 
-	const { startSiteOwnerTransfer, isLoading: isStartingSiteTransfer } = useStartSiteOwnerTransfer(
+	const { startSiteOwnerTransfer, isPending: isStartingSiteTransfer } = useStartSiteOwnerTransfer(
 		selectedSiteId,
 		{
 			onMutate: () => {

--- a/client/my-sites/site-settings/site-owner-transfer/use-check-site-transfer-eligibility.ts
+++ b/client/my-sites/site-settings/site-owner-transfer/use-check-site-transfer-eligibility.ts
@@ -31,12 +31,12 @@ export const useCheckSiteTransferEligibility = (
 			),
 	} );
 
-	const { mutate, isLoading } = mutation;
+	const { mutate, isPending } = mutation;
 
 	const checkSiteTransferEligibility = useCallback(
 		( args: MutationVariables ) => mutate( args ),
 		[ mutate ]
 	);
 
-	return { checkSiteTransferEligibility, isLoading };
+	return { checkSiteTransferEligibility, isPending };
 };

--- a/client/my-sites/site-settings/site-owner-transfer/use-start-site-owner-transfer.ts
+++ b/client/my-sites/site-settings/site-owner-transfer/use-start-site-owner-transfer.ts
@@ -32,12 +32,12 @@ export const useStartSiteOwnerTransfer = (
 		},
 	} );
 
-	const { mutate, isLoading } = mutation;
+	const { mutate, isPending } = mutation;
 
 	const startSiteOwnerTransfer = useCallback(
 		( args: MutationVariables ) => mutate( args ),
 		[ mutate ]
 	);
 
-	return { startSiteOwnerTransfer, isLoading };
+	return { startSiteOwnerTransfer, isPending };
 };

--- a/client/my-sites/stats/hooks/use-notice-visibility-query.ts
+++ b/client/my-sites/stats/hooks/use-notice-visibility-query.ts
@@ -14,7 +14,7 @@ const DEFAULT_CLIENT_NOTICES_VISIBILITY = {
 	client_paid_plan_purchase_success: true,
 	client_free_plan_purchase_success: true,
 };
-const DEFAULT_NOTICES_VISIBILITY = {
+export const DEFAULT_NOTICES_VISIBILITY = {
 	...DEFAULT_CLIENT_NOTICES_VISIBILITY,
 	...DEFAULT_SERVER_NOTICES_VISIBILITY,
 };

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect } from 'react';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import version_compare from 'calypso/lib/version-compare';
 import {
+	DEFAULT_NOTICES_VISIBILITY,
 	Notices,
 	useNoticesVisibilityQuery,
 	processConflictNotices,
@@ -125,7 +126,7 @@ const NewStatsNotices = ( { siteId, isOdysseyStats, statsPurchaseSuccess }: Stat
 	}
 
 	const calculatedNoticesVisibility = ensureOnlyOneNoticeVisible(
-		serverNoticesVisibility,
+		serverNoticesVisibility ?? DEFAULT_NOTICES_VISIBILITY,
 		noticeOptions
 	);
 

--- a/client/my-sites/subscribers/queries/use-subscriber-count-query.ts
+++ b/client/my-sites/subscribers/queries/use-subscriber-count-query.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 
 export interface SubscribersTotals {
@@ -29,6 +29,6 @@ export default function useSubscriberCountQuery( siteId: number | null ) {
 			} );
 		},
 		enabled: !! siteId,
-		keepPreviousData: true,
+		placeholderData: keepPreviousData,
 	} );
 }

--- a/client/my-sites/subscribers/queries/use-subscriber-details-query.tsx
+++ b/client/my-sites/subscribers/queries/use-subscriber-details-query.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 import { getSubscriberDetailsCacheKey, getSubscriberDetailsType } from '../helpers';
 import type { Subscriber } from '../types';
@@ -20,7 +20,7 @@ const useSubscriberDetailsQuery = (
 				apiNamespace: 'wpcom/v2',
 			} ),
 		enabled: !! siteId,
-		keepPreviousData: true,
+		placeholderData: keepPreviousData,
 	} );
 };
 

--- a/client/my-sites/subscribers/queries/use-subscriber-stats-query.ts
+++ b/client/my-sites/subscribers/queries/use-subscriber-stats-query.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 import type { SubscriberStats } from '../types';
 
@@ -39,7 +39,7 @@ const useSubscriberStatsQuery = (
 			}
 		},
 		enabled: !! siteId,
-		keepPreviousData: true,
+		placeholderData: keepPreviousData,
 	} );
 };
 

--- a/client/my-sites/subscribers/queries/use-subscribers-query.tsx
+++ b/client/my-sites/subscribers/queries/use-subscribers-query.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 import { DEFAULT_PER_PAGE, SubscribersFilterBy, SubscribersSortBy } from '../constants';
 import { getSubscribersCacheKey } from '../helpers';
@@ -45,7 +45,7 @@ const useSubscribersQuery = ( {
 			} );
 		},
 		enabled: !! siteId && shouldFetch,
-		keepPreviousData: true,
+		placeholderData: keepPreviousData,
 	} );
 };
 

--- a/client/signup/steps/website-content/index.tsx
+++ b/client/signup/steps/website-content/index.tsx
@@ -113,7 +113,7 @@ function WebsiteContentStep( {
 		? BBE_STORE_WEBSITE_CONTENT_FILLING_STEP
 		: BBE_WEBSITE_CONTENT_FILLING_STEP;
 
-	const { isLoading: isSaving, mutateAsync } = useSaveWebsiteContentMutation(
+	const { isPending: isSaving, mutateAsync } = useSaveWebsiteContentMutation(
 		siteId,
 		websiteContent
 	);

--- a/client/state/activitypub/use-activitypub-status.js
+++ b/client/state/activitypub/use-activitypub-status.js
@@ -9,7 +9,7 @@ export const useActivityPubStatus = ( blogId, onUpdate = () => {} ) => {
 	const { data, isInitialLoading, isError } = useQuery( {
 		queryKey,
 		staleTime: 0, // refetches are important here, lots of stuff in play while doing upgrades, activation, etc
-		cacheTime: 5 * 60 * 1000, // 5 mins
+		gcTime: 5 * 60 * 1000, // 5 mins
 		queryFn: () => wpcom.req.get( { path, apiNamespace } ),
 	} );
 	const queryClient = useQueryClient();

--- a/client/state/partner-portal/invoices/test/hooks.js
+++ b/client/state/partner-portal/invoices/test/hooks.js
@@ -15,10 +15,7 @@ jest.mock( 'react-redux', () => ( {
 } ) );
 
 function createQueryClient() {
-	const logger = {
-		error: jest.fn(),
-	};
-	return new QueryClient( { logger } );
+	return new QueryClient();
 }
 
 describe( 'useInvoicesQuery', () => {

--- a/client/state/partner-portal/licenses/test/hooks.js
+++ b/client/state/partner-portal/licenses/test/hooks.js
@@ -402,10 +402,7 @@ describe( 'useTOSConsentMutation', () => {
 
 describe( 'useBillingDashboardQuery', () => {
 	function createQueryClient() {
-		const logger = {
-			error: jest.fn(),
-		};
-		return new QueryClient( { logger } );
+		return new QueryClient();
 	}
 
 	it( 'returns transformed request data', async () => {

--- a/client/state/query-client-ssr.ts
+++ b/client/state/query-client-ssr.ts
@@ -35,7 +35,7 @@ const sharedCache = new QueryCacheSSR();
 
 export function createQueryClientSSR() {
 	const queryClient = new QueryClient( {
-		defaultOptions: { queries: { cacheTime: MAX_AGE, staleTime: BASE_STALE_TIME } },
+		defaultOptions: { queries: { gcTime: MAX_AGE, staleTime: BASE_STALE_TIME } },
 		queryCache: sharedCache,
 	} );
 

--- a/client/state/query-client.ts
+++ b/client/state/query-client.ts
@@ -13,7 +13,7 @@ import { shouldDehydrateQuery } from './should-dehydrate-query';
 export async function createQueryClient( userId?: number ): Promise< QueryClient > {
 	await loadPersistedState();
 	const queryClient = new QueryClient( {
-		defaultOptions: { queries: { cacheTime: MAX_AGE } },
+		defaultOptions: { queries: { gcTime: MAX_AGE } },
 	} );
 	await hydrateBrowserState( queryClient, userId );
 	return queryClient;

--- a/client/state/test/data-fetching-persistence.tsx
+++ b/client/state/test/data-fetching-persistence.tsx
@@ -7,17 +7,7 @@ import { persistQueryClient } from '@tanstack/react-query-persist-client';
 import { render, waitFor } from '@testing-library/react';
 import { shouldDehydrateQuery } from '../should-dehydrate-query';
 
-// eslint-disable-next-line @typescript-eslint/no-empty-function
-const noop = () => {};
-
-// https://github.com/tannerlinsley/react-query/blob/2771a15403cb2e7c70022b850e8c54c6d2b3d8a0/docs/src/pages/guides/testing.md#turn-off-network-error-logging
-const logger = {
-	error: noop,
-	log: noop,
-	warn: noop,
-};
-
-const queryClient = new QueryClient( { logger } );
+const queryClient = new QueryClient();
 
 const PERSISTENCE_KEY = 'REACT_QUERY_OFFLINE_CACHE';
 
@@ -144,14 +134,14 @@ describe( 'shouldDehydrateQuery', () => {
 				expect.objectContaining( {
 					clientState: expect.objectContaining( {
 						queries: [
-							{
+							expect.objectContaining( {
 								state: expect.objectContaining( {
 									data,
 									status: 'success',
 								} ),
 								queryKey: [ queryKey ],
 								queryHash: `["${ queryKey }"]`,
-							},
+							} ),
 						],
 					} ),
 				} )
@@ -198,14 +188,14 @@ describe( 'shouldDehydrateQuery', () => {
 				expect.objectContaining( {
 					clientState: expect.objectContaining( {
 						queries: [
-							{
+							expect.objectContaining( {
 								state: expect.objectContaining( {
 									data,
 									status: 'success',
 								} ),
 								queryKey: [ queryKey ],
 								queryHash: `["${ queryKey }"]`,
-							},
+							} ),
 						],
 					} ),
 				} )

--- a/packages/data-stores/src/queries/use-bulk-domain-update-status-query.ts
+++ b/packages/data-stores/src/queries/use-bulk-domain-update-status-query.ts
@@ -54,10 +54,9 @@ export interface BulkDomainUpdateStatusResult {
 
 export function useBulkDomainUpdateStatusQuery< TError = unknown >(
 	pollingInterval: number,
-	options: UseQueryOptions<
-		BulkDomainUpdateStatusQueryFnData,
-		TError,
-		BulkDomainUpdateStatusResult
+	options: Omit<
+		UseQueryOptions< BulkDomainUpdateStatusQueryFnData, TError, BulkDomainUpdateStatusResult >,
+		'queryKey'
 	> = {}
 ) {
 	return useQuery( {
@@ -120,7 +119,7 @@ export function useBulkDomainUpdateStatusQuery< TError = unknown >(
 			return { domainResults, completedJobs };
 		},
 		refetchInterval: pollingInterval,
-		queryKey: getBulkDomainUpdateStatusQueryKey(),
 		...options,
+		queryKey: getBulkDomainUpdateStatusQueryKey(),
 	} );
 }

--- a/packages/data-stores/src/queries/use-site-query.ts
+++ b/packages/data-stores/src/queries/use-site-query.ts
@@ -4,10 +4,9 @@ import wpcomRequest from 'wpcom-proxy-request';
 
 export function useSiteQuery< TError = unknown, TData = SiteDetails >(
 	sourceSiteSlug: string | number | null | undefined,
-	options: UseQueryOptions< SiteDetails, TError, TData > = {}
+	options: Omit< UseQueryOptions< SiteDetails, TError, TData >, 'queryKey' > = {}
 ) {
 	return useQuery( {
-		queryKey: getSiteQueryKey( sourceSiteSlug ),
 		queryFn: () =>
 			wpcomRequest< SiteDetails >( {
 				path: '/sites/' + encodeURIComponent( sourceSiteSlug ?? '' ),
@@ -16,6 +15,7 @@ export function useSiteQuery< TError = unknown, TData = SiteDetails >(
 			persist: false,
 		},
 		...options,
+		queryKey: getSiteQueryKey( sourceSiteSlug ),
 		enabled: Boolean( sourceSiteSlug ) && options.enabled,
 	} );
 }

--- a/packages/data-stores/src/reader/queries/use-read-feed-search-query.ts
+++ b/packages/data-stores/src/reader/queries/use-read-feed-search-query.ts
@@ -63,6 +63,7 @@ const useReadFeedSearchQuery = ( {
 			} );
 		},
 		enabled: Boolean( query ),
+		initialPageParam: '',
 		getNextPageParam: ( lastPage ) => lastPage?.next_page,
 		refetchOnWindowFocus: false,
 	} );

--- a/packages/data-stores/src/reader/queries/use-site-subscriptions-query.ts
+++ b/packages/data-stores/src/reader/queries/use-site-subscriptions-query.ts
@@ -58,7 +58,7 @@ const useSiteSubscriptionsQuery = ( {
 	const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isFetching, ...rest } =
 		useInfiniteQuery< SubscriptionManagerSiteSubscriptions >( {
 			queryKey: cacheKey,
-			queryFn: async ( { pageParam = 1 } ) => {
+			queryFn: async ( { pageParam } ) => {
 				const data = await callApi< SubscriptionManagerSiteSubscriptions >( {
 					path: `/read/following/mine?number=${ number }&page=${ pageParam }`,
 					isLoggedIn,
@@ -77,6 +77,7 @@ const useSiteSubscriptionsQuery = ( {
 				};
 			},
 			enabled,
+			initialPageParam: 1,
 			getNextPageParam: ( lastPage, pages ) => {
 				return lastPage.page * number < lastPage.total_subscriptions ? pages.length + 1 : undefined;
 			},

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -94,8 +94,8 @@ export const HelpCenterContactForm = () => {
 	const [ hideSiteInfo, setHideSiteInfo ] = useState( false );
 	const [ hasSubmittingError, setHasSubmittingError ] = useState< boolean >( false );
 	const locale = useLocale();
-	const { isLoading: submittingTicket, mutateAsync: submitTicket } = useSubmitTicketMutation();
-	const { isLoading: submittingTopic, mutateAsync: submitTopic } = useSubmitForumsMutation();
+	const { isPending: submittingTicket, mutateAsync: submitTicket } = useSubmitTicketMutation();
+	const { isPending: submittingTopic, mutateAsync: submitTopic } = useSubmitForumsMutation();
 	const userId = useSelector( getCurrentUserId );
 	const { data: userSites } = useUserSites( userId );
 	const userWithNoSites = userSites?.sites.length === 0;

--- a/packages/help-center/src/data/use-jetpack-search-ai.ts
+++ b/packages/help-center/src/data/use-jetpack-search-ai.ts
@@ -46,7 +46,6 @@ export function useJetpackSearchAIQuery( config: JetpackSearchAIConfig ) {
 						}&query=${ encodeURIComponent( config.query ) }&stop_at=${ config.stopAt }`,
 				  } as APIFetchOptions ),
 		refetchOnWindowFocus: false,
-		keepPreviousData: false,
 		enabled: config.enabled && !! config.query,
 		retry: false,
 		select: ( data ) => {

--- a/packages/help-center/src/data/use-support-activity.ts
+++ b/packages/help-center/src/data/use-support-activity.ts
@@ -20,7 +20,6 @@ export function useSupportActivity( enabled = true ) {
 						global: true,
 				  } as APIFetchOptions ),
 		refetchOnWindowFocus: false,
-		keepPreviousData: false,
 		refetchOnMount: true,
 		enabled,
 		select: ( activities ) => {

--- a/packages/help-center/src/data/use-support-availability.ts
+++ b/packages/help-center/src/data/use-support-availability.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import apiFetch from '@wordpress/api-fetch';
 import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
 import { OtherSupportAvailability, ChatAvailability } from '../types';
@@ -31,7 +31,7 @@ export function useSupportAvailability< SUPPORT_TYPE extends 'CHAT' | 'OTHER' >(
 				  } as APIFetchOptions ),
 		enabled,
 		refetchOnWindowFocus: false,
-		keepPreviousData: true,
+		placeholderData: keepPreviousData,
 		staleTime: 6 * 60 * 60 * 1000, // 6 hours
 	} );
 }

--- a/packages/help-center/src/hooks/use-chat-widget.ts
+++ b/packages/help-center/src/hooks/use-chat-widget.ts
@@ -25,7 +25,7 @@ export default function useChatWidget(
 	enabled = true
 ) {
 	const sectionName = useSelector( getSectionName );
-	const { isLoading: isSubmittingZendeskUserFields, mutateAsync: submitZendeskUserFields } =
+	const { isPending: isSubmittingZendeskUserFields, mutateAsync: submitZendeskUserFields } =
 		useUpdateZendeskUserFieldsMutation();
 	const { setShowHelpCenter, resetStore } = useDispatch( HELP_CENTER_STORE );
 

--- a/packages/launchpad/src/test/lib/fixtures.ts
+++ b/packages/launchpad/src/test/lib/fixtures.ts
@@ -311,7 +311,6 @@ export const MOCK_USE_QUERY_RESULT = {
 	isLoading: false,
 	isLoadingError: false,
 	isPlaceholderData: false,
-	isPreviousData: false,
 	isRefetchError: false,
 	isRefetching: false,
 	isStale: false,


### PR DESCRIPTION
Related to #84413

⚠️ This PR should merge into #84413 and **not** into `trunk`.

See the official migration guide for React Query v5: https://tanstack.com/query/latest/docs/react/guides/migrating-to-v5

## Upgrade path: breaking changes

- [x] Always use object format for `useQuery` and friends ([link](https://tanstack.com/query/latest/docs/react/guides/migrating-to-v5#supports-a-single-signature-one-object))
  - https://github.com/Automattic/wp-calypso/pull/84378
  - https://github.com/Automattic/wp-calypso/pull/84380
  - https://github.com/Automattic/wp-calypso/pull/84416
  - #84471
  - https://github.com/Automattic/wp-calypso/pull/86114
- [x] Dont use `onSuccess`, `onError` and `onSettled` with `useQuery` ([link](https://tanstack.com/query/latest/docs/react/guides/migrating-to-v5#callbacks-on-usequery-and-queryobserver-have-been-removed))
  - #84415
  - #84464
  -  #86118
  - #86149
  - see https://github.com/Automattic/wp-calypso/pull/84338#issuecomment-1824525840
- [x] ~~`refetchInterval`: use `query.state.data` to retrieve `data` ([link](https://tanstack.com/query/latest/docs/react/guides/migrating-to-v5#the-refetchinterval-callback-function-only-gets-query-passed))~~ no usage found where we pass a function
- [x] Remove any usages of the deprecated logger ([link](https://tanstack.com/query/latest/docs/react/guides/migrating-to-v5#callbacks-on-usequery-and-queryobserver-have-been-removed))
- [x] Rename `cacheTime` to `gcTime` ([link](https://tanstack.com/query/latest/docs/react/guides/migrating-to-v5#rename-cachetime-to-gctime))
- [x] Replace `keepPreviousData` with `placeholderData: keepPreviousData` ([link](https://tanstack.com/query/latest/docs/react/guides/migrating-to-v5#removed-keeppreviousdata-in-favor-of-placeholderdata-identity-function))
- [x] Infinite queries need `initialPageParam` ([link](https://tanstack.com/query/latest/docs/react/guides/migrating-to-v5#infinite-queries-now-need-a-initialpageparam))
- [x] Fix type errors related to `queryKey` not being excluded from `UserQueryOptions` on custom query hooks
  - #84472
  - #84600
- [x] Fix type errors related to `TError` generic changing to `Error` instead of `unknown`
  -  #84474
  - #84599
- [ ] Rename `isLoading` to `isPending` ([link](https://tanstack.com/query/latest/docs/react/guides/migrating-to-v5#status-loading-has-been-changed-to-status-pending-and-isloading-has-been-changed-to-ispending-and-isinitialloading-has-now-been-renamed-to-isloading))
	- [x] `isLoading` usages on mutations
	- [ ] `isLoading` usages on queries
	- note: `isInitialLoading` is deprecated and being renamed to `isLoading` which is the same as `isPending && isFetching` – we'll keep this for now and follow up
- [x] Fix broken tests
  - #84465

## Testing Instructions

- Smoke test Calypso and thoroughly test important flows like login, signup, etc – everything should behave exactly the same as on prod
- Verify there are no type errors and no eslint failures
- Verify all tests are passing and failing tests are fixed in a reasonable way

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
