### PR TITLE
Jetpack Manage: remove extra spacing in Company Details page

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/company-details-form/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/company-details-form/style.scss
@@ -1,10 +1,5 @@
 .company-details-form {
 
-	// We have to add some "invisible" spacing below the form so
-	// our country and state dropdown have enough space to fold out
-	// and be visible (using position: relative/absolute).
-	margin-bottom: 100px;
-
 	&__controls {
 		margin-top: 2rem;
 	}


### PR DESCRIPTION
## Proposed Changes

* Remove the extra spacing (`margin-bottom`) at the end of the Company Details.

Before | After
--|--
![image](https://github.com/Automattic/wp-calypso/assets/390760/b796ef84-e586-4a9a-85b0-31bfe588f79c) | ![image](https://github.com/Automattic/wp-calypso/assets/390760/838bf43f-fbcf-42c1-807f-2ed735b2e0e8)

Don't know if anything has changed since, but despite the comments in the initial code (see: https://github.com/Automattic/wp-calypso/pull/63100/files#diff-3afcd6996453456701701d347997beaf5563b458200dfba57749e1c65311db37R2) all fields work fine without the extra `margin-bottom`. Both fields that were mentioned there — country and state — seem to push the content down so they work as expected without the hack, as evidenced below:

https://github.com/Automattic/wp-calypso/assets/390760/d611d22b-0010-4783-bb56-43560352065f

## Testing Instructions

* Fire up this branch.
* In Manage, go to `Purchases > Company Details`.
* Ensure there's no empty space in the card and that all fields work correctly.