### PR TITLE
Plans 2023: Fix large-currency logic issues. More consistent application in comparison grid.

### DIFF
--- a/client/my-sites/plans-grid/components/comparison-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/comparison-grid/index.tsx
@@ -519,7 +519,7 @@ const ComparisonGridHeader = forwardRef< HTMLDivElement, ComparisonGridHeaderPro
 		const translate = useTranslate();
 		const allVisible = visibleGridPlans.length === displayedGridPlans.length;
 		const { prices, currencyCode } = usePlanPricingInfoFromGridPlans( {
-			gridPlans: displayedGridPlans,
+			gridPlans: visibleGridPlans,
 		} );
 
 		const isLargeCurrency = useIsLargeCurrency( {

--- a/client/my-sites/plans-grid/components/header-price.tsx
+++ b/client/my-sites/plans-grid/components/header-price.tsx
@@ -62,6 +62,10 @@ const HeaderPriceContainer = styled.div`
 		font-family: Recoleta, sans-serif;
 	}
 
+	.plan-price.is-placeholder-price {
+		visibility: hidden;
+	}
+
 	.plan-price__currency-symbol,
 	.plan-price.is-discounted .plan-price__currency-symbol {
 		font-size: 14px;
@@ -205,14 +209,38 @@ const PlanFeatures2023GridHeaderPrice = ( {
 					{ isAnyVisibleGridPlanDiscounted && (
 						<Badge className="plan-features-2023-grid__badge" isHidden={ true }></Badge>
 					) }
-					<PlanPrice
-						currencyCode={ currencyCode }
-						rawPrice={ originalPrice.monthly }
-						displayPerMonthNotation={ false }
-						isLargeCurrency={ isLargeCurrency }
-						isSmallestUnit={ true }
-						priceDisplayWrapperClassName="plans-grid-2023__html-price-display-wrapper"
-					/>
+					{ isLargeCurrency ? (
+						<PricesGroup isLargeCurrency={ isLargeCurrency }>
+							<PlanPrice
+								currencyCode={ currencyCode }
+								rawPrice={ 0 }
+								displayPerMonthNotation={ false }
+								isLargeCurrency={ isLargeCurrency }
+								isSmallestUnit={ true }
+								priceDisplayWrapperClassName="plans-grid-2023__html-price-display-wrapper"
+								className="is-placeholder-price"
+								original
+							/>
+							<PlanPrice
+								currencyCode={ currencyCode }
+								rawPrice={ originalPrice.monthly }
+								displayPerMonthNotation={ false }
+								isLargeCurrency={ isLargeCurrency }
+								isSmallestUnit={ true }
+								priceDisplayWrapperClassName="plans-grid-2023__html-price-display-wrapper"
+								discounted
+							/>
+						</PricesGroup>
+					) : (
+						<PlanPrice
+							currencyCode={ currencyCode }
+							rawPrice={ originalPrice.monthly }
+							displayPerMonthNotation={ false }
+							isLargeCurrency={ isLargeCurrency }
+							isSmallestUnit={ true }
+							priceDisplayWrapperClassName="plans-grid-2023__html-price-display-wrapper"
+						/>
+					) }
 				</>
 			) }
 		</HeaderPriceContainer>

--- a/client/my-sites/plans-grid/components/header-price.tsx
+++ b/client/my-sites/plans-grid/components/header-price.tsx
@@ -143,7 +143,7 @@ const PlanFeatures2023GridHeaderPrice = ( {
 		current,
 		pricing: { currencyCode, originalPrice, discountedPrice, introOffer },
 	} = gridPlansIndex[ planSlug ];
-	const shouldShowDiscountedPrice = Boolean( discountedPrice.monthly );
+	const isGridPlanDiscounted = Boolean( discountedPrice.monthly );
 	const isAnyVisibleGridPlanDiscounted = visibleGridPlans.some(
 		( { pricing } ) => pricing.discountedPrice.monthly
 	);
@@ -176,7 +176,7 @@ const PlanFeatures2023GridHeaderPrice = ( {
 
 	return (
 		<HeaderPriceContainer>
-			{ shouldShowDiscountedPrice ? (
+			{ isGridPlanDiscounted ? (
 				<>
 					<Badge className="plan-features-2023-grid__badge">
 						{ isPlanUpgradeCreditEligible

--- a/client/my-sites/plans-grid/components/header-price.tsx
+++ b/client/my-sites/plans-grid/components/header-price.tsx
@@ -209,7 +209,7 @@ const PlanFeatures2023GridHeaderPrice = ( {
 					{ isAnyVisibleGridPlanDiscounted && (
 						<Badge className="plan-features-2023-grid__badge" isHidden={ true }></Badge>
 					) }
-					{ isLargeCurrency ? (
+					{ isLargeCurrency && isAnyVisibleGridPlanDiscounted ? (
 						<PricesGroup isLargeCurrency={ isLargeCurrency }>
 							<PlanPrice
 								currencyCode={ currencyCode }

--- a/client/my-sites/plans-grid/hooks/npm-ready/use-is-large-currency.ts
+++ b/client/my-sites/plans-grid/hooks/npm-ready/use-is-large-currency.ts
@@ -42,7 +42,7 @@ function hasExceededPriceThreshold( displayPrices?: string[], isAddOn = false ) 
  */
 function hasExceededCombinedPriceThreshold( displayPrices?: string[] ) {
 	if ( ! displayPrices || displayPrices.length < 2 ) {
-		return;
+		return false;
 	}
 
 	for ( let i = 0; i < displayPrices.length - 1; i++ ) {

--- a/client/my-sites/plans-grid/hooks/npm-ready/use-is-large-currency.ts
+++ b/client/my-sites/plans-grid/hooks/npm-ready/use-is-large-currency.ts
@@ -35,27 +35,26 @@ function hasExceededPriceThreshold( displayPrices?: string[], isAddOn = false ) 
 	return !! displayPrices?.some( ( price ) => price.length > threshold );
 }
 
+/**
+ * Returns true if the combined length of the display prices exceeds the threshold.
+ * Checks the adjacent pairs in the displayPrices array,
+ * which correspnd to the original-price and discounted-price for each plan.
+ */
 function hasExceededCombinedPriceThreshold( displayPrices?: string[] ) {
-	let planPrices: string[] = [];
-	let exceedsThreshold = false;
+	if ( ! displayPrices || displayPrices.length < 2 ) {
+		return;
+	}
 
-	displayPrices?.forEach( ( price ) => {
-		const [ originalPrice, discountedPrice ] = planPrices;
+	for ( let i = 0; i < displayPrices.length - 1; i++ ) {
+		const originalPrice = displayPrices[ i ];
+		const discountedPrice = displayPrices[ i + 1 ];
 
-		// pushes until a pair of original and discounted prices can be evaluated
-		if ( ! originalPrice || ! discountedPrice ) {
-			planPrices.push( price );
-			return;
+		if ( originalPrice.length + discountedPrice.length > LARGE_CURRENCY_COMBINED_CHAR_THRESHOLD ) {
+			return true;
 		}
+	}
 
-		exceedsThreshold =
-			originalPrice.length + discountedPrice.length > LARGE_CURRENCY_COMBINED_CHAR_THRESHOLD;
-
-		// reset to evaluate the next pair of prices
-		planPrices = [];
-	} );
-
-	return !! exceedsThreshold;
+	return false;
 }
 
 /**

--- a/client/my-sites/plans-grid/hooks/use-plan-pricing-info-from-grid-plans.ts
+++ b/client/my-sites/plans-grid/hooks/use-plan-pricing-info-from-grid-plans.ts
@@ -26,10 +26,10 @@ export function usePlanPricingInfoFromGridPlans( {
 
 					return {
 						prices: [ ...acc.prices, originalPriceForTerm, discountedPriceForTerm ],
-						...( currencyCode && { currencyCode } ),
+						currencyCode: currencyCode ?? acc.currencyCode,
 					};
 				},
-				{ prices: [], currencyCode: 'USD' }
+				{ prices: [], currencyCode: 'USD' } as PricingInfo
 			),
 		[ gridPlans, returnMonthly ]
 	);

--- a/client/my-sites/plans-grid/hooks/use-plan-pricing-info-from-grid-plans.ts
+++ b/client/my-sites/plans-grid/hooks/use-plan-pricing-info-from-grid-plans.ts
@@ -29,7 +29,7 @@ export function usePlanPricingInfoFromGridPlans( {
 						currencyCode: currencyCode ?? acc.currencyCode,
 					};
 				},
-				{ prices: [], currencyCode: 'USD' } as PricingInfo
+				{ prices: [], currencyCode: 'USD' }
 			),
 		[ gridPlans, returnMonthly ]
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/79220

## Proposed Changes

- Fixes some large-currency-related issues in code, and may or may not fix https://github.com/Automattic/wp-calypso/issues/79220
- The current method was not working consistently for the comparison grid
- A few more issues with how we'd condition around the thresholds for the combined pricing (original + discount). I think this was more accidentally working so far.
- Fixes/aligns prices in the grid when discounted

## Media

### Comparison Grid

- **Before**
  <img width="400" alt="Screenshot 2023-11-21 at 1 32 23 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/afa61070-c10a-4680-bb94-176d124b6cb9"> 

- **After (is-large-currency conditions properly applied)**
  <img width="400" alt="Screenshot 2023-11-21 at 1 32 15 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/df520c2c-74f3-43c7-9c3c-ea6ccc39cb0d">

### Features Grid & Comparison Grid

- **Before**

<img width="400" alt="Screenshot 2023-11-21 at 1 33 13 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/00bbe088-40ee-404d-8241-198ba77b638a">

- **After (prices aligned - better?)**

<img width="400" alt="Screenshot 2023-11-21 at 1 33 06 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/94c1c57f-16c3-4768-8b9b-17198dc55829">

### Signup

- **Before (looks like incorrect is-large-currency conditioning)**

<img width="400" alt="Screenshot 2023-11-21 at 2 29 41 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/a85db649-48d2-4d74-b320-b255e98a0b99">

- **After** 

<img width="400" alt="Screenshot 2023-11-21 at 2 29 56 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/0a26d8d4-89aa-4a36-bd3c-e689e6c4fec6">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/plans` and `/start/plans` with currency & plan combinations that will force discounts
- Ensure prices render as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?