### PR TITLE
Domains: Use sentence case for all domain type labels

### DIFF
--- a/packages/domains-table/src/utils/get-domain-type-text.tsx
+++ b/packages/domains-table/src/utils/get-domain-type-text.tsx
@@ -12,30 +12,30 @@ export function getDomainTypeText(
 		switch ( domain.type ) {
 			case domainTypes.MAPPED:
 				if ( context === domainInfoContext.PAGE_TITLE ) {
-					return __( 'Connected Domain', __i18n_text_domain__ );
+					return __( 'Connected domain', __i18n_text_domain__ );
 				}
 
 				return __( 'Registered with an external provider', __i18n_text_domain__ );
 
 			case domainTypes.REGISTERED:
 				if ( domain?.isPremium ) {
-					return __( 'Premium Domain', __i18n_text_domain__ );
+					return __( 'Premium domain', __i18n_text_domain__ );
 				}
 
 				// Registered domains don't show any type text in the domain row component
 				if ( context === domainInfoContext.DOMAIN_ROW ) {
 					return null;
 				}
-				return __( 'Registered Domain', __i18n_text_domain__ );
+				return __( 'Registered domain', __i18n_text_domain__ );
 
 			case domainTypes.SITE_REDIRECT:
-				return __( 'Site Redirect', __i18n_text_domain__ );
+				return __( 'Site redirect', __i18n_text_domain__ );
 
 			case domainTypes.WPCOM:
-				return __( 'Default Site Domain', __i18n_text_domain__ );
+				return __( 'Default site domain', __i18n_text_domain__ );
 
 			case domainTypes.TRANSFER:
-				return __( 'Domain Transfer', __i18n_text_domain__ );
+				return __( 'Domain transfer', __i18n_text_domain__ );
 
 			default:
 				return '';


### PR DESCRIPTION
See p1700489143887079-slack-C9EJ7KSGH

## Proposed Changes

Switches all domain type labels to sentence case.

**Before**

![image](https://github.com/Automattic/wp-calypso/assets/36432/13467cb6-d9ef-4ab0-bb62-6913840583a4)

**After**

![CleanShot 2023-11-20 at 07 53 11@2x](https://github.com/Automattic/wp-calypso/assets/36432/04299e17-b0e6-4551-b780-5d8ec45f473a)

## Testing Instructions

1. Navigate to the Domain management screen.
2. Verify all of the domain type labels are lowercase as expected.