### PR TITLE
Me/Security: Use sentence case for 'Security key' heading

### DIFF
--- a/client/me/security-2fa-key/index.jsx
+++ b/client/me/security-2fa-key/index.jsx
@@ -89,7 +89,7 @@ class Security2faKey extends Component {
 
 		return (
 			<div className="security-2fa-key">
-				<SectionHeader label={ translate( 'Security Key' ) }>
+				<SectionHeader label={ translate( 'Security key' ) }>
 					{ ! addingKey && isBrowserSupported && (
 						<Button
 							compact


### PR DESCRIPTION
Follow up from https://github.com/Automattic/wp-calypso/pull/84151

## Proposed Changes

Switches the 'Security key' heading from title case to sentence case

**Before**

![CleanShot 2023-11-20 at 08 02 05@2x](https://github.com/Automattic/wp-calypso/assets/36432/0d6ac8ee-ce89-47c3-a826-6f16e67b262a)

**After**

![CleanShot 2023-11-20 at 08 01 30@2x](https://github.com/Automattic/wp-calypso/assets/36432/72d74bb5-98e9-4418-9373-a3575b500253)

## Testing Instructions

N/A