### PR TITLE
Checkout: Include credits in subtotal for checkout sidebar behind redesign flag

### DIFF
--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -32,6 +32,7 @@ import {
 	hasCheckoutVersion,
 	getCreditsLineItemFromCart,
 	getSubtotalWithoutCoupon,
+	getSubtotalWithCredits,
 } from '@automattic/wpcom-checkout';
 import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
@@ -124,6 +125,7 @@ function CheckoutSummaryPriceList() {
 	const totalLineItem = getTotalLineItemFromCart( responseCart );
 	const translate = useTranslate();
 	const subtotalWithoutCoupon = getSubtotalWithoutCoupon( responseCart );
+	const subtotalWithCredits = getSubtotalWithCredits( responseCart );
 
 	return (
 		<>
@@ -131,10 +133,14 @@ function CheckoutSummaryPriceList() {
 				<CheckoutSummaryLineItem key="checkout-summary-line-item-subtotal">
 					<span>{ translate( 'Subtotal' ) }</span>
 					<span>
-						{ formatCurrency( subtotalWithoutCoupon, responseCart.currency, {
-							isSmallestUnit: true,
-							stripZeros: true,
-						} ) }
+						{ formatCurrency(
+							hasCheckoutVersion( '2' ) ? subtotalWithCredits : subtotalWithoutCoupon,
+							responseCart.currency,
+							{
+								isSmallestUnit: true,
+								stripZeros: true,
+							}
+						) }
 					</span>
 				</CheckoutSummaryLineItem>
 				{ ! hasCheckoutVersion( '2' ) && couponLineItem && (


### PR DESCRIPTION
## Proposed Changes

In the checkout redesign, all prices are shown in the sidebar as a sort of tally sheet. However, the "Subtotal" line of this sheet is confusing. It comes from the cart's subtotal, which is a sum of all the cart items. This includes all item discounts. However, it does not include credits, because credits are not like other discounts; they apply to the cart as a whole rather than to the cart items.

In the updated design, all cart discounts, including credits, are displayed together above the subtotal. Because of this, it appears that the subtotal is wrong when there are credits. This was made worse by https://github.com/Automattic/wp-calypso/pull/84263 which also removes coupons from the subtotal.

In this PR we alter the subtotal line to use the total of all line items (including coupon discounts), minus credits. That way the math makes sense.

> [!NOTE] 
> The redesigned checkout remains hidden behind both a feature flag and a query string parameter. It is only available currently in development (`calypso.localhost`) and on `wpcalypso` which is used by the `calypso.live` branches below.

Before             |  After
:-------------------------:|:-------------------------:
<img width="251" alt="Screenshot 2023-11-20 at 3 07 42 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/1ff5a4bc-91b4-4501-a49d-d2e7e4766002">  |<img width="255" alt="Screenshot 2023-11-20 at 3 07 12 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/f1eb2351-1d82-4a46-8db2-33efdbf2bd23">

This is part of the project to redesign checkout: https://github.com/Automattic/payments-shilling/issues/1969

## Testing Instructions

- Use an account with some free credits.
- Add a product to your cart and visit checkout.
- Verify that the subtotal is unchanged by this PR from production.
- Add `?checkoutVersion=2` to the end of the checkout URL and reload checkout.
- Verify that the subtotal in the sidebar math adds up correctly.