### PR TITLE
wp-admin Site Default: Clean up feature flag

### DIFF
--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -95,7 +95,6 @@ const MainCards = ( {
 	isWpcomStagingSite,
 	isMigrationTrial,
 	siteId,
-	isYoloWpAdminFeatureDevelopment,
 } ) => {
 	const mainCards = [
 		{
@@ -146,13 +145,11 @@ const MainCards = ( {
 			content: <CacheCard disabled={ isBasicHostingDisabled } />,
 			type: 'basic',
 		},
-		isYoloWpAdminFeatureDevelopment
-			? {
-					feature: 'wp-admin',
-					content: <SiteAdminInterfaceCard />,
-					type: 'basic',
-			  }
-			: null,
+		{
+			feature: 'wp-admin',
+			content: <SiteAdminInterfaceCard />,
+			type: 'basic',
+		},
 	].filter( ( card ) => card !== null );
 
 	const availableTypes = [
@@ -318,8 +315,6 @@ class Hosting extends Component {
 			const isGithubIntegrationEnabled =
 				isEnabled( 'github-integration-i1' ) && isAutomatticTeamMember( teams );
 
-			const isYoloWpAdminFeatureDevelopment = isEnabled( 'yolo/wp-admin-site-default' );
-
 			return (
 				<>
 					{ isJetpack && <QueryJetpackModules siteId={ siteId } /> }
@@ -339,7 +334,6 @@ class Hosting extends Component {
 								isWpcomStagingSite={ isWpcomStagingSite }
 								isMigrationTrial={ isMigrationTrial }
 								siteId={ siteId }
-								isYoloWpAdminFeatureDevelopment={ isYoloWpAdminFeatureDevelopment }
 							/>
 						</Column>
 						<Column type="sidebar">

--- a/config/development.json
+++ b/config/development.json
@@ -219,8 +219,6 @@
 		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": false,
-		"yolo/hosting-metrics-i1": true,
-		"yolo/wp-admin-site-default": true,
 		"yolo/command-pallette": true
 	}
 }

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -157,8 +157,6 @@
 		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,
-		"yolo/hosting-metrics-i1": false,
-		"yolo/wp-admin-site-default": true,
 		"yolo/command-pallette": false
 	},
 	"siftscience_key": "a4f69f6759",

--- a/config/production.json
+++ b/config/production.json
@@ -185,8 +185,6 @@
 		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,
-		"yolo/hosting-metrics-i1": true,
-		"yolo/wp-admin-site-default": true,
 		"yolo/command-pallette": false
 	},
 	"siftscience_key": "a4f69f6759",

--- a/config/stage.json
+++ b/config/stage.json
@@ -179,8 +179,6 @@
 		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,
-		"yolo/hosting-metrics-i1": true,
-		"yolo/wp-admin-site-default": true,
 		"yolo/command-pallette": false
 	},
 	"siftscience_key": "e00e878351",

--- a/config/test.json
+++ b/config/test.json
@@ -114,8 +114,6 @@
 		"videomaker-trial": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": false,
-		"yolo/hosting-metrics-i1": true,
-		"yolo/wp-admin-site-default": true,
 		"yolo/command-pallette": true
 	}
 }

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -187,8 +187,6 @@
 		"woop": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,
-		"yolo/hosting-metrics-i1": true,
-		"yolo/wp-admin-site-default": true,
 		"yolo/command-pallette": true
 	},
 	"siftscience_key": "e00e878351",


### PR DESCRIPTION
See https://github.com/Automattic/dotcom-forge/issues/4444

## Proposed Changes

Cleans up the `yolo/wp-admin-site-default` feature flag from the codebase.

## Testing Instructions

Feature should still be present in the UI.