### PR TITLE
Jetpack Manage: Add background image to bundle cards

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/license-bundle-card/gradient.svg
+++ b/client/jetpack-cloud/sections/partner-portal/license-bundle-card/gradient.svg
@@ -1,0 +1,31 @@
+<svg width="528" height="217" viewBox="0 0 528 217" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g opacity="0.5">
+<rect width="731.153" height="617.74" transform="translate(299.808 -341.522) rotate(54.5376)" fill="white"/>
+<g filter="url(#filter0_f_5108_1987)">
+<ellipse cx="632.737" cy="235.156" rx="239.921" ry="170.691" transform="rotate(88.126 632.737 235.156)" fill="#069E08" fill-opacity="0.15"/>
+</g>
+<g filter="url(#filter1_f_5108_1987)">
+<ellipse cx="171.351" cy="98.3923" rx="171.351" ry="98.3923" transform="matrix(0.999987 -0.00516973 0.074387 0.997229 82 -190.331)" fill="#F5E6B3"/>
+</g>
+<g opacity="0.7" filter="url(#filter2_f_5108_1987)">
+<ellipse cx="-16.5" cy="272.5" rx="151.5" ry="125.5" transform="rotate(90 -16.5 272.5)" fill="#CED9F2"/>
+</g>
+</g>
+<defs>
+<filter id="filter0_f_5108_1987" x="281.953" y="-184.703" width="701.569" height="839.719" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="90.0002" result="effect1_foregroundBlur_5108_1987"/>
+</filter>
+<filter id="filter1_f_5108_1987" x="-90.8406" y="-371.222" width="703.017" height="556.249" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="90.0002" result="effect1_foregroundBlur_5108_1987"/>
+</filter>
+<filter id="filter2_f_5108_1987" x="-328.646" y="-65.6465" width="624.293" height="676.293" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="93.3232" result="effect1_foregroundBlur_5108_1987"/>
+</filter>
+</defs>
+</svg>

--- a/client/jetpack-cloud/sections/partner-portal/license-bundle-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-bundle-card/index.tsx
@@ -17,7 +17,7 @@ import './style.scss';
 type Props = {
 	isBusy: boolean;
 	isDisabled: boolean;
-	withBackground: boolean;
+	withBackground?: boolean;
 	tabIndex: number;
 	product: APIProductFamilyProduct;
 	onSelectProduct?: ( value: APIProductFamilyProduct ) => void;

--- a/client/jetpack-cloud/sections/partner-portal/license-bundle-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-bundle-card/index.tsx
@@ -1,9 +1,11 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
+import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { APIProductFamilyProduct } from '../../../../state/partner-portal/types';
+import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import { useProductDescription, useURLQueryParams } from '../hooks';
 import { getProductTitle, LICENSE_INFO_MODAL_ID } from '../lib';
 import LicenseLightbox from '../license-lightbox';
@@ -15,6 +17,7 @@ import './style.scss';
 type Props = {
 	isBusy: boolean;
 	isDisabled: boolean;
+	withBackground: boolean;
 	tabIndex: number;
 	product: APIProductFamilyProduct;
 	onSelectProduct?: ( value: APIProductFamilyProduct ) => void;
@@ -23,6 +26,7 @@ type Props = {
 const LicenseBundleCard = ( {
 	isBusy = false,
 	isDisabled = false,
+	withBackground = isEnabled( 'jetpack/bundle-licensing' ),
 	tabIndex,
 	product,
 	onSelectProduct,
@@ -68,7 +72,11 @@ const LicenseBundleCard = ( {
 
 	return (
 		<>
-			<div className="license-bundle-card">
+			<div
+				className={ classNames( 'license-bundle-card', {
+					'license-bundle-card--with-background': withBackground,
+				} ) }
+			>
 				<div className="license-bundle-card__details">
 					<h3 className="license-bundle-card__title">{ productTitle }</h3>
 

--- a/client/jetpack-cloud/sections/partner-portal/license-bundle-card/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-bundle-card/style.scss
@@ -7,11 +7,6 @@
 	justify-content: space-between;
 	box-sizing: border-box;
 
-	&--with-background {
-		background-image: url(./gradient.svg);
-		background-size: 100% 100%;
-	}
-
 	width: 100%;
 
 	margin: 0.5rem 0;
@@ -33,6 +28,11 @@
 	@include break-wide {
 		width: calc(33.33% - 1rem);
 	}
+}
+
+.license-bundle-card--with-background {
+	background-image: url(./gradient.svg);
+	background-size: 100% 100%;
 }
 
 .license-bundle-card__title {

--- a/client/jetpack-cloud/sections/partner-portal/license-bundle-card/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-bundle-card/style.scss
@@ -7,6 +7,11 @@
 	justify-content: space-between;
 	box-sizing: border-box;
 
+	&--with-background {
+		background-image: url(./gradient.svg);
+		background-size: 100% 100%;
+	}
+
 	width: 100%;
 
 	margin: 0.5rem 0;


### PR DESCRIPTION
This pull request adds a background image to product cards showing a bundle on the Issue License page.

Resolves https://github.com/Automattic/jetpack-genesis/issues/109.

## Proposed Changes

* Add a new background asset, `gradient.svg`, to display the background.
* Add a new `withBackground` property to `LicenseBundleCard`, set to default-true if the bundle licensing feature flag is enabled.
* Add styling rules for `.license-bundle-card--with-background` to display the gradient background when applied.

## Testing Instructions

* In your Jetpack Cloud test environment, ensure the bundle licensing feature flag is enabled by adding it to your browser's URL: `?flags=jetpack/bundle-licensing`
* If necessary, you can brute-force enable the new backgrounds by changing line 29 in `client/jetpack-cloud/sections/partner-portal/license-bundle-card/index.tsx` to be `withBackground = true,`.
* Visit the Issue License page and scroll to find the list of bundles available for purchase.
* Verify you see the appropriate background image, per designs. Also verify this background is not present on any other product cards.
* Disable the bundle licensing feature flag, and verify the background is no longer present on bundles.

## Reference screenshots

<img height="300" src="https://github.com/Automattic/wp-calypso/assets/670067/fcec05b2-22fe-4738-a811-1599f06e021b"> <img height="300" src="https://github.com/Automattic/wp-calypso/assets/670067/cb1fa452-c956-410d-94e2-3f3a74ee1fac">