### PR TITLE
Monetize: Update supporters list

### DIFF
--- a/client/my-sites/earn/customers/index.tsx
+++ b/client/my-sites/earn/customers/index.tsx
@@ -15,7 +15,6 @@ import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import Notice from 'calypso/components/notice';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
-import SectionHeader from 'calypso/components/section-header';
 import { decodeEntities } from 'calypso/lib/formatting';
 import { useDispatch, useSelector } from 'calypso/state';
 import {
@@ -149,7 +148,6 @@ function CustomerSection() {
 		const wording = getIntervalDependantWording( cancelledSubscriber );
 		return (
 			<div>
-				<SectionHeader label={ translate( 'Customers and Subscribers' ) } />
 				{ Object.values( subscribers ).length === 0 && (
 					<Card>
 						{ translate( "You haven't added any customers. {{a}}Learn more{{/a}} about payments.", {
@@ -168,7 +166,7 @@ function CustomerSection() {
 					</Card>
 				) }
 				{ Object.values( subscribers ).length > 0 && (
-					<Card>
+					<>
 						<ul className="supporters-list" role="table">
 							<li className="row header" role="row">
 								<span className="supporters-list__profile-column" role="columnheader">
@@ -214,7 +212,7 @@ function CustomerSection() {
 								{ translate( 'Download list as CSV' ) }
 							</Button>
 						</div>
-					</Card>
+					</>
 				) }
 			</div>
 		);

--- a/client/my-sites/earn/customers/index.tsx
+++ b/client/my-sites/earn/customers/index.tsx
@@ -1,337 +1,42 @@
-import { Card, Button, Dialog, Gridicon } from '@automattic/components';
-import formatCurrency from '@automattic/format-currency';
-import { localizeUrl } from '@automattic/i18n-utils';
-import { saveAs } from 'browser-filesaver';
-import { useTranslate } from 'i18n-calypso';
-import { orderBy } from 'lodash';
-import { useState, useEffect, useCallback, MouseEvent } from 'react';
-import { shallowEqual } from 'react-redux';
+import { addQueryArgs, removeQueryArgs } from '@wordpress/url';
 import QueryMembershipsEarnings from 'calypso/components/data/query-memberships-earnings';
 import QueryMembershipsSettings from 'calypso/components/data/query-memberships-settings';
-import EllipsisMenu from 'calypso/components/ellipsis-menu';
-import Gravatar from 'calypso/components/gravatar';
-import InfiniteScroll from 'calypso/components/infinite-scroll';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
-import { useLocalizedMoment } from 'calypso/components/localized-moment';
-import Notice from 'calypso/components/notice';
-import PopoverMenuItem from 'calypso/components/popover-menu/item';
-import SectionHeader from 'calypso/components/section-header';
-import { decodeEntities } from 'calypso/lib/formatting';
-import { useDispatch, useSelector } from 'calypso/state';
-import {
-	requestSubscribers,
-	requestSubscriptionStop,
-} from 'calypso/state/memberships/subscribers/actions';
-import {
-	getTotalSubscribersForSiteId,
-	getOwnershipsForSiteId,
-} from 'calypso/state/memberships/subscribers/selectors';
+import { SubscribersFilterBy, SubscribersSortBy } from 'calypso/my-sites/subscribers/constants';
+import { useSelector } from 'calypso/state';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import {
-	PLAN_YEARLY_FREQUENCY,
-	PLAN_MONTHLY_FREQUENCY,
-	PLAN_ONE_TIME_FREQUENCY,
-} from '../memberships/constants';
+import { sanitizeInt } from '../../subscribers/helpers';
+import SubscribersPage from '../../subscribers/main';
+import { Query } from '../types';
 
-type Subscriber = {
-	id: string;
-	status: string;
-	start_date: string;
-	end_date: string;
-	// appears as both subscriber.user_email & subscriber.user.user_email in this file
-	user_email: string;
-	user: {
-		ID: string;
-		name: string;
-		user_email: string;
-	};
-	plan: {
-		connected_account_product_id: string;
-		title: string;
-		renewal_price: number;
-		currency: string;
-		renew_interval: string;
-	};
-	renew_interval: string;
-	all_time_total: number;
+const FILTER_KEY = 'f';
+const PAGE_KEY = 'page';
+const SEARCH_KEY = 's';
+const SORT_KEY = 'sort';
+const scrollToTop = () => window?.scrollTo( 0, 0 );
+
+type MembersProductsSectionProps = {
+	query: Query;
 };
 
-function CustomerSection() {
-	const translate = useTranslate();
-	const dispatch = useDispatch();
-	const moment = useLocalizedMoment();
-	const [ cancelledSubscriber, setCancelledSubscriber ] = useState< Subscriber | null >( null );
+const queryStringChanged = ( key: string | number ) => ( value: string | number ) => {
+	const path = window.location.pathname + window.location.search;
 
+	scrollToTop();
+
+	if ( ! value ) {
+		return page.show( removeQueryArgs( path, key as string ) );
+	}
+
+	return page.show( addQueryArgs( path, { [ key ]: value } ) );
+};
+
+function CustomerSection( { query }: MembersProductsSectionProps ) {
 	const site = useSelector( ( state ) => getSelectedSite( state ) );
-
-	const subscribers = useSelector(
-		( state ) => getOwnershipsForSiteId( state, site?.ID ),
-		shallowEqual
-	);
-
-	const totalSubscribers = useSelector( ( state ) =>
-		getTotalSubscribersForSiteId( state, site?.ID )
-	);
-
-	const fetchNextSubscriberPage = useCallback(
-		( force: boolean ) => {
-			const fetched = Object.keys( subscribers ).length;
-			if ( fetched < totalSubscribers || force ) {
-				dispatch( requestSubscribers( site?.ID, fetched ) );
-			}
-		},
-		[ dispatch, site, subscribers, totalSubscribers ]
-	);
-
-	function onCloseCancelSubscription( reason: string | undefined ) {
-		if ( reason === 'cancel' ) {
-			dispatch(
-				requestSubscriptionStop(
-					site?.ID,
-					cancelledSubscriber,
-					getIntervalDependantWording( cancelledSubscriber ).success
-				)
-			);
-		}
-		setCancelledSubscriber( null );
-	}
-
-	function downloadSubscriberList( event: MouseEvent< HTMLButtonElement > ) {
-		event.preventDefault();
-		const fileName = [ site?.slug, 'memberships', 'subscribers' ].join( '_' ) + '.csv';
-
-		const csvData = [
-			[
-				'ID',
-				'status',
-				'start_date',
-				'end_date',
-				'user_name',
-				'user_email',
-				'plan_id',
-				'plan_title',
-				'renewal_price',
-				'currency',
-				'renew_interval',
-				'All time total',
-			]
-				.map( ( field ) => '"' + field + '"' )
-				.join( ',' ),
-		]
-			.concat(
-				Object.values( subscribers ).map( ( row ) =>
-					[
-						row.id,
-						row.status,
-						row.start_date,
-						row.end_date,
-						row.user.name,
-						row.user.user_email,
-						row.plan.connected_account_product_id,
-						row.plan.title,
-						row.plan.renewal_price,
-						row.plan.currency,
-						row.renew_interval,
-						row.all_time_total,
-					]
-						.map( ( field ) => ( field ? '"' + field + '"' : '""' ) )
-						.join( ',' )
-				)
-			)
-			.join( '\n' );
-
-		const blob = new window.Blob( [ csvData ], { type: 'text/csv;charset=utf-8' } );
-
-		saveAs( blob, fileName );
-	}
-
-	function renderSubscriberList() {
-		const wording = getIntervalDependantWording( cancelledSubscriber );
-		return (
-			<div>
-				<SectionHeader label={ translate( 'Customers and Subscribers' ) } />
-				{ Object.values( subscribers ).length === 0 && (
-					<Card>
-						{ translate( "You haven't added any customers. {{a}}Learn more{{/a}} about payments.", {
-							components: {
-								a: (
-									<a
-										href={ localizeUrl(
-											'https://wordpress.com/support/wordpress-editor/blocks/payments/'
-										) }
-										target="_blank"
-										rel="noreferrer noopener"
-									/>
-								),
-							},
-						} ) }
-					</Card>
-				) }
-				{ Object.values( subscribers ).length > 0 && (
-					<Card>
-						<div className="memberships__module-content module-content">
-							<div>
-								{ orderBy( Object.values( subscribers ), [ 'id' ], [ 'desc' ] ).map( ( sub ) =>
-									renderSubscriber( sub )
-								) }
-							</div>
-							<InfiniteScroll nextPageMethod={ () => fetchNextSubscriberPage( false ) } />
-						</div>
-						<Dialog
-							isVisible={ !! cancelledSubscriber }
-							buttons={ [
-								{
-									label: translate( 'Back' ),
-									action: 'back',
-								},
-								{
-									label: wording.button,
-									isPrimary: true,
-									action: 'cancel',
-								},
-							] }
-							onClose={ onCloseCancelSubscription }
-						>
-							<h1>{ translate( 'Confirmation' ) }</h1>
-							<p>{ wording.confirmation_subheading }</p>
-							<Notice text={ wording.confirmation_info } showDismiss={ false } />
-						</Dialog>
-						<div className="memberships__module-footer">
-							<Button onClick={ downloadSubscriberList }>
-								{ translate( 'Download list as CSV' ) }
-							</Button>
-						</div>
-					</Card>
-				) }
-			</div>
-		);
-	}
-
-	function getIntervalDependantWording( subscriber: Subscriber | null ) {
-		const subscriber_email = subscriber?.user.user_email ?? '';
-		const plan_name = subscriber?.plan.title ?? '';
-
-		if ( subscriber?.plan?.renew_interval === 'one-time' ) {
-			return {
-				button: translate( 'Remove payment' ),
-				confirmation_subheading: translate( 'Do you want to remove this payment?' ),
-				confirmation_info: translate(
-					'Removing this payment means that the user %(subscriber_email)s will no longer have access to any service granted by the %(plan_name)s plan. The payment will not be refunded.',
-					{ args: { subscriber_email, plan_name } }
-				),
-				success: translate( 'Payment removed for %(subscriber_email)s.', {
-					args: { subscriber_email },
-				} ),
-			};
-		}
-		return {
-			button: translate( 'Cancel payment' ),
-			confirmation_subheading: translate( 'Do you want to cancel this payment?' ),
-			confirmation_info: translate(
-				'Cancelling this payment means that the user %(subscriber_email)s will no longer have access to any service granted by the %(plan_name)s plan. Payments already made will not be refunded but any scheduled future payments will not be made.',
-				{ args: { subscriber_email, plan_name } }
-			),
-			success: translate( 'Payment cancelled for %(subscriber_email)s.', {
-				args: { subscriber_email },
-			} ),
-		};
-	}
-
-	function renderSubscriberSubscriptionSummary( subscriber: Subscriber ) {
-		const title = subscriber.plan.title ? ` (${ subscriber.plan.title }) ` : ' ';
-		if ( subscriber.plan.renew_interval === PLAN_ONE_TIME_FREQUENCY ) {
-			/* translators: Information about a one-time payment made by a subscriber to a site owner.
-				%(amount)s - the amount paid,
-				%(formattedDate) - the date it was paid
-				%(title) - description of the payment plan, or a blank space if no description available. */
-			return translate( 'Paid %(amount)s once on %(formattedDate)s%(title)s', {
-				args: {
-					amount: formatCurrency( subscriber.plan.renewal_price, subscriber.plan.currency ),
-					formattedDate: moment( subscriber.start_date ).format( 'll' ),
-					title,
-				},
-			} );
-		} else if ( subscriber.plan.renew_interval === PLAN_YEARLY_FREQUENCY ) {
-			/* translators: Information about a recurring yearly payment made by a subscriber to a site owner.
-				%(amount)s - the amount paid,
-				%(formattedDate)s - the date it was first paid
-				%(title)s - description of the payment plan, or a blank space if no description available
-				%(total)s - the total amount subscriber has paid thus far */
-			return translate(
-				'Paying %(amount)s/year%(title)ssince %(formattedDate)s. Total of %(total)s.',
-				{
-					args: {
-						amount: formatCurrency( subscriber.plan.renewal_price, subscriber.plan.currency ),
-						formattedDate: moment( subscriber.start_date ).format( 'll' ),
-						total: formatCurrency( subscriber.all_time_total, subscriber.plan.currency ),
-						title,
-					},
-				}
-			);
-		} else if ( subscriber.plan.renew_interval === PLAN_MONTHLY_FREQUENCY ) {
-			/* translators: Information about a recurring monthly payment made by a subscriber to a site owner.
-				%(amount)s - the amount paid,
-				%(formattedDate)s - the date it was first paid
-				%(title)s - description of the payment plan, or a blank space if no description available
-				%(total)s - the total amount subscriber has paid thus far */
-			return translate(
-				'Paying %(amount)s/month%(title)ssince %(formattedDate)s. Total of %(total)s.',
-				{
-					args: {
-						amount: formatCurrency( subscriber.plan.renewal_price, subscriber.plan.currency ),
-						formattedDate: moment( subscriber.start_date ).format( 'll' ),
-						total: formatCurrency( subscriber.all_time_total, subscriber.plan.currency ),
-						title,
-					},
-				}
-			);
-		}
-	}
-
-	function renderSubscriberActions( subscriber: Subscriber ) {
-		return (
-			<EllipsisMenu position="bottom left" className="memberships__subscriber-actions">
-				<PopoverMenuItem
-					target="_blank"
-					rel="noopener norefferer"
-					href={ `https://dashboard.stripe.com/search?query=metadata%3A${ subscriber.user.ID }` }
-				>
-					<Gridicon size={ 18 } icon="external" />
-					{ translate( 'See transactions in Stripe Dashboard' ) }
-				</PopoverMenuItem>
-				<PopoverMenuItem onClick={ () => setCancelledSubscriber( subscriber ) }>
-					<Gridicon size={ 18 } icon="cross" />
-					{ getIntervalDependantWording( subscriber ).button }
-				</PopoverMenuItem>
-			</EllipsisMenu>
-		);
-	}
-
-	function renderSubscriber( subscriber: Subscriber ) {
-		return (
-			<Card className="memberships__subscriber-profile is-compact" key={ subscriber.id }>
-				{ renderSubscriberActions( subscriber ) }
-				<div className="memberships__subscriber-gravatar">
-					<Gravatar user={ subscriber.user } size={ 72 } />
-				</div>
-				<div className="memberships__subscriber-detail">
-					<div className="memberships__subscriber-username">
-						{ decodeEntities( subscriber.user.name ) }
-					</div>
-					<div className="memberships__subscriber-email" data-e2e-login={ subscriber.user_email }>
-						<span>{ subscriber.user.user_email }</span>
-					</div>
-					<div className="memberships__subscriber-subscribed">
-						{ renderSubscriberSubscriptionSummary( subscriber ) }
-					</div>
-				</div>
-			</Card>
-		);
-	}
-
-	useEffect( () => {
-		fetchNextSubscriberPage( true );
-	}, [ fetchNextSubscriberPage ] );
+	const searchTerm = query?.[ SEARCH_KEY ] ?? '';
+	const filterOption = query?.[ FILTER_KEY ] ?? 'all';
+	const sortTerm = query?.[ SORT_KEY ] ?? 'date_subscribed';
+	const pageNumber = query?.[ PAGE_KEY ] ? ( sanitizeInt( query[ PAGE_KEY ] ) as number ) : 1;
 
 	if ( ! site ) {
 		return <LoadingEllipsis />;
@@ -339,9 +44,18 @@ function CustomerSection() {
 
 	return (
 		<div>
-			<QueryMembershipsEarnings siteId={ site.ID } />
-			<QueryMembershipsSettings siteId={ site.ID } />
-			<div>{ renderSubscriberList() }</div>
+			<QueryMembershipsEarnings siteId={ site?.ID } />
+			<QueryMembershipsSettings siteId={ site?.ID } />
+			<SubscribersPage
+				filterOption={ filterOption as SubscribersFilterBy }
+				pageNumber={ pageNumber }
+				searchTerm={ searchTerm }
+				sortTerm={ sortTerm as SubscribersSortBy }
+				filterOptionChanged={ queryStringChanged( FILTER_KEY ) }
+				pageChanged={ queryStringChanged( PAGE_KEY ) }
+				searchTermChanged={ queryStringChanged( SEARCH_KEY ) }
+				sortTermChanged={ queryStringChanged( SORT_KEY ) }
+			/>
 		</div>
 	);
 }

--- a/client/my-sites/earn/customers/index.tsx
+++ b/client/my-sites/earn/customers/index.tsx
@@ -1,42 +1,352 @@
-import { addQueryArgs, removeQueryArgs } from '@wordpress/url';
+import { Card, Button, Dialog, Gridicon } from '@automattic/components';
+import formatCurrency from '@automattic/format-currency';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { saveAs } from 'browser-filesaver';
+import { useTranslate } from 'i18n-calypso';
+import { orderBy } from 'lodash';
+import { useState, useEffect, useCallback, MouseEvent } from 'react';
+import { shallowEqual } from 'react-redux';
 import QueryMembershipsEarnings from 'calypso/components/data/query-memberships-earnings';
 import QueryMembershipsSettings from 'calypso/components/data/query-memberships-settings';
+import EllipsisMenu from 'calypso/components/ellipsis-menu';
+import Gravatar from 'calypso/components/gravatar';
+import InfiniteScroll from 'calypso/components/infinite-scroll';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
-import { SubscribersFilterBy, SubscribersSortBy } from 'calypso/my-sites/subscribers/constants';
-import { useSelector } from 'calypso/state';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import Notice from 'calypso/components/notice';
+import PopoverMenuItem from 'calypso/components/popover-menu/item';
+import SectionHeader from 'calypso/components/section-header';
+import { decodeEntities } from 'calypso/lib/formatting';
+import { useDispatch, useSelector } from 'calypso/state';
+import {
+	requestSubscribers,
+	requestSubscriptionStop,
+} from 'calypso/state/memberships/subscribers/actions';
+import {
+	getTotalSubscribersForSiteId,
+	getOwnershipsForSiteId,
+} from 'calypso/state/memberships/subscribers/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import { sanitizeInt } from '../../subscribers/helpers';
-import SubscribersPage from '../../subscribers/main';
-import { Query } from '../types';
+import {
+	PLAN_YEARLY_FREQUENCY,
+	PLAN_MONTHLY_FREQUENCY,
+	PLAN_ONE_TIME_FREQUENCY,
+} from '../memberships/constants';
 
-const FILTER_KEY = 'f';
-const PAGE_KEY = 'page';
-const SEARCH_KEY = 's';
-const SORT_KEY = 'sort';
-const scrollToTop = () => window?.scrollTo( 0, 0 );
-
-type MembersProductsSectionProps = {
-	query: Query;
+type Subscriber = {
+	id: string;
+	status: string;
+	start_date: string;
+	end_date: string;
+	// appears as both subscriber.user_email & subscriber.user.user_email in this file
+	user_email: string;
+	user: {
+		ID: string;
+		name: string;
+		user_email: string;
+	};
+	plan: {
+		connected_account_product_id: string;
+		title: string;
+		renewal_price: number;
+		currency: string;
+		renew_interval: string;
+	};
+	renew_interval: string;
+	all_time_total: number;
 };
 
-const queryStringChanged = ( key: string | number ) => ( value: string | number ) => {
-	const path = window.location.pathname + window.location.search;
+function CustomerSection() {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const moment = useLocalizedMoment();
+	const [ cancelledSubscriber, setCancelledSubscriber ] = useState< Subscriber | null >( null );
 
-	scrollToTop();
+	const site = useSelector( ( state ) => getSelectedSite( state ) );
 
-	if ( ! value ) {
-		return page.show( removeQueryArgs( path, key as string ) );
+	const subscribers = useSelector(
+		( state ) => getOwnershipsForSiteId( state, site?.ID ),
+		shallowEqual
+	);
+
+	const totalSubscribers = useSelector( ( state ) =>
+		getTotalSubscribersForSiteId( state, site?.ID )
+	);
+
+	const fetchNextSubscriberPage = useCallback(
+		( force: boolean ) => {
+			const fetched = Object.keys( subscribers ).length;
+			if ( fetched < totalSubscribers || force ) {
+				dispatch( requestSubscribers( site?.ID, fetched ) );
+			}
+		},
+		[ dispatch, site, subscribers, totalSubscribers ]
+	);
+
+	function onCloseCancelSubscription( reason: string | undefined ) {
+		if ( reason === 'cancel' ) {
+			dispatch(
+				requestSubscriptionStop(
+					site?.ID,
+					cancelledSubscriber,
+					getIntervalDependantWording( cancelledSubscriber ).success
+				)
+			);
+		}
+		setCancelledSubscriber( null );
 	}
 
-	return page.show( addQueryArgs( path, { [ key ]: value } ) );
-};
+	function downloadSubscriberList( event: MouseEvent< HTMLButtonElement > ) {
+		event.preventDefault();
+		const fileName = [ site?.slug, 'memberships', 'subscribers' ].join( '_' ) + '.csv';
 
-function CustomerSection( { query }: MembersProductsSectionProps ) {
-	const site = useSelector( ( state ) => getSelectedSite( state ) );
-	const searchTerm = query?.[ SEARCH_KEY ] ?? '';
-	const filterOption = query?.[ FILTER_KEY ] ?? 'all';
-	const sortTerm = query?.[ SORT_KEY ] ?? 'date_subscribed';
-	const pageNumber = query?.[ PAGE_KEY ] ? ( sanitizeInt( query[ PAGE_KEY ] ) as number ) : 1;
+		const csvData = [
+			[
+				'ID',
+				'status',
+				'start_date',
+				'end_date',
+				'user_name',
+				'user_email',
+				'plan_id',
+				'plan_title',
+				'renewal_price',
+				'currency',
+				'renew_interval',
+				'All time total',
+			]
+				.map( ( field ) => '"' + field + '"' )
+				.join( ',' ),
+		]
+			.concat(
+				Object.values( subscribers ).map( ( row ) =>
+					[
+						row.id,
+						row.status,
+						row.start_date,
+						row.end_date,
+						row.user.name,
+						row.user.user_email,
+						row.plan.connected_account_product_id,
+						row.plan.title,
+						row.plan.renewal_price,
+						row.plan.currency,
+						row.renew_interval,
+						row.all_time_total,
+					]
+						.map( ( field ) => ( field ? '"' + field + '"' : '""' ) )
+						.join( ',' )
+				)
+			)
+			.join( '\n' );
+
+		const blob = new window.Blob( [ csvData ], { type: 'text/csv;charset=utf-8' } );
+
+		saveAs( blob, fileName );
+	}
+
+	function renderSubscriberList() {
+		const wording = getIntervalDependantWording( cancelledSubscriber );
+		return (
+			<div>
+				<SectionHeader label={ translate( 'Customers and Subscribers' ) } />
+				{ Object.values( subscribers ).length === 0 && (
+					<Card>
+						{ translate( "You haven't added any customers. {{a}}Learn more{{/a}} about payments.", {
+							components: {
+								a: (
+									<a
+										href={ localizeUrl(
+											'https://wordpress.com/support/wordpress-editor/blocks/payments/'
+										) }
+										target="_blank"
+										rel="noreferrer noopener"
+									/>
+								),
+							},
+						} ) }
+					</Card>
+				) }
+				{ Object.values( subscribers ).length > 0 && (
+					<Card>
+						<ul className="supporters-list" role="table">
+							<li className="row header" role="row">
+								<span className="supporters-list__profile-column" role="columnheader">
+									{ translate( 'Name' ) }
+								</span>
+								<span className="supporters-list__offer-type-column" role="columnheader">
+									{ translate( 'Offer Type' ) }
+								</span>
+								<span className="supporters-list__total-column" role="columnheader">
+									{ translate( 'Total' ) }
+								</span>
+								<span className="supporters-list__since-column" role="columnheader">
+									{ translate( 'Since' ) }
+								</span>
+								<span className="supporters-list__menu-column" role="columnheader"></span>
+							</li>
+							{ orderBy( Object.values( subscribers ), [ 'id' ], [ 'desc' ] ).map( ( sub ) =>
+								renderSubscriber( sub )
+							) }
+							<InfiniteScroll nextPageMethod={ () => fetchNextSubscriberPage( false ) } />
+						</ul>
+						<Dialog
+							isVisible={ !! cancelledSubscriber }
+							buttons={ [
+								{
+									label: translate( 'Back' ),
+									action: 'back',
+								},
+								{
+									label: wording.button,
+									isPrimary: true,
+									action: 'cancel',
+								},
+							] }
+							onClose={ onCloseCancelSubscription }
+						>
+							<h1>{ translate( 'Confirmation' ) }</h1>
+							<p>{ wording.confirmation_subheading }</p>
+							<Notice text={ wording.confirmation_info } showDismiss={ false } />
+						</Dialog>
+						<div className="memberships__module-footer">
+							<Button onClick={ downloadSubscriberList }>
+								{ translate( 'Download list as CSV' ) }
+							</Button>
+						</div>
+					</Card>
+				) }
+			</div>
+		);
+	}
+
+	function getIntervalDependantWording( subscriber: Subscriber | null ) {
+		const subscriber_email = subscriber?.user.user_email ?? '';
+		const plan_name = subscriber?.plan.title ?? '';
+
+		if ( subscriber?.plan?.renew_interval === 'one-time' ) {
+			return {
+				button: translate( 'Remove payment' ),
+				confirmation_subheading: translate( 'Do you want to remove this payment?' ),
+				confirmation_info: translate(
+					'Removing this payment means that the user %(subscriber_email)s will no longer have access to any service granted by the %(plan_name)s plan. The payment will not be refunded.',
+					{ args: { subscriber_email, plan_name } }
+				),
+				success: translate( 'Payment removed for %(subscriber_email)s.', {
+					args: { subscriber_email },
+				} ),
+			};
+		}
+		return {
+			button: translate( 'Cancel payment' ),
+			confirmation_subheading: translate( 'Do you want to cancel this payment?' ),
+			confirmation_info: translate(
+				'Cancelling this payment means that the user %(subscriber_email)s will no longer have access to any service granted by the %(plan_name)s plan. Payments already made will not be refunded but any scheduled future payments will not be made.',
+				{ args: { subscriber_email, plan_name } }
+			),
+			success: translate( 'Payment cancelled for %(subscriber_email)s.', {
+				args: { subscriber_email },
+			} ),
+		};
+	}
+
+	function renderSubscriberSubscriptionSummary( subscriber: Subscriber ) {
+		if ( subscriber.plan.renew_interval === PLAN_ONE_TIME_FREQUENCY ) {
+			/* translators: Information about a one-time payment made by a subscriber to a site owner.
+				%(amount)s - the amount paid,
+				%(formattedDate) - the date it was paid
+				%(title) - description of the payment plan, or a blank space if no description available. */
+			return translate( '%(amount)s once', {
+				args: {
+					amount: formatCurrency( subscriber.plan.renewal_price, subscriber.plan.currency ),
+				},
+			} );
+		} else if ( subscriber.plan.renew_interval === PLAN_YEARLY_FREQUENCY ) {
+			/* translators: Information about a recurring yearly payment made by a subscriber to a site owner.
+				%(amount)s - the amount paid,
+				%(formattedDate)s - the date it was first paid
+				%(title)s - description of the payment plan, or a blank space if no description available
+				%(total)s - the total amount subscriber has paid thus far */
+			return translate( '%(amount)s/year%', {
+				args: {
+					amount: formatCurrency( subscriber.plan.renewal_price, subscriber.plan.currency ),
+				},
+			} );
+		} else if ( subscriber.plan.renew_interval === PLAN_MONTHLY_FREQUENCY ) {
+			/* translators: Information about a recurring monthly payment made by a subscriber to a site owner.
+				%(amount)s - the amount paid,
+				%(formattedDate)s - the date it was first paid
+				%(title)s - description of the payment plan, or a blank space if no description available
+				%(total)s - the total amount subscriber has paid thus far */
+			return translate( '%(amount)s/month', {
+				args: {
+					amount: formatCurrency( subscriber.plan.renewal_price, subscriber.plan.currency ),
+				},
+			} );
+		}
+	}
+
+	function renderSubscriberActions( subscriber: Subscriber ) {
+		return (
+			<EllipsisMenu position="bottom left" className="memberships__subscriber-actions">
+				<PopoverMenuItem
+					target="_blank"
+					rel="noopener norefferer"
+					href={ `https://dashboard.stripe.com/search?query=metadata%3A${ subscriber.user.ID }` }
+				>
+					<Gridicon size={ 18 } icon="external" />
+					{ translate( 'See transactions in Stripe Dashboard' ) }
+				</PopoverMenuItem>
+				<PopoverMenuItem onClick={ () => setCancelledSubscriber( subscriber ) }>
+					<Gridicon size={ 18 } icon="cross" />
+					{ getIntervalDependantWording( subscriber ).button }
+				</PopoverMenuItem>
+			</EllipsisMenu>
+		);
+	}
+
+	function renderSubscriber( subscriber: Subscriber ) {
+		return (
+			<li className="supporter-row row" role="row">
+				<span className="supporters-list__profile-column" role="cell">
+					<div className="supporters-list__user-profile">
+						<Gravatar
+							user={ subscriber.user }
+							size={ 40 }
+							className="supporters-list__user-image"
+						/>
+						<div className="supporters-list__user-details">
+							<span className="supporters-list__user-name">
+								{ decodeEntities( subscriber.user.name ) }
+							</span>
+							<span className="supporters-list__user-email">{ subscriber.user.user_email }</span>
+						</div>
+					</div>
+				</span>
+				<span className="supporters-list__offer-type-column" role="cell">
+					<div className="supporters-list__offer-type-title">
+						{ subscriber.plan.title ? `${ subscriber.plan.title }` : ' ' }
+					</div>
+					<div className="supporters-list__offer-type-price">
+						{ renderSubscriberSubscriptionSummary( subscriber ) }
+					</div>
+				</span>
+				<span className="supporters-list__total-column" role="cell">
+					{ formatCurrency( subscriber.all_time_total, subscriber.plan.currency ) }
+				</span>
+				<span className="supporters-list__since-column" role="cell">
+					{ moment( subscriber.start_date ).format( 'll' ) }
+				</span>
+				<span className="supporters-list__menu-column" role="cell">
+					{ renderSubscriberActions( subscriber ) }
+				</span>
+			</li>
+		);
+	}
+
+	useEffect( () => {
+		fetchNextSubscriberPage( true );
+	}, [ fetchNextSubscriberPage ] );
 
 	if ( ! site ) {
 		return <LoadingEllipsis />;
@@ -44,18 +354,9 @@ function CustomerSection( { query }: MembersProductsSectionProps ) {
 
 	return (
 		<div>
-			<QueryMembershipsEarnings siteId={ site?.ID } />
-			<QueryMembershipsSettings siteId={ site?.ID } />
-			<SubscribersPage
-				filterOption={ filterOption as SubscribersFilterBy }
-				pageNumber={ pageNumber }
-				searchTerm={ searchTerm }
-				sortTerm={ sortTerm as SubscribersSortBy }
-				filterOptionChanged={ queryStringChanged( FILTER_KEY ) }
-				pageChanged={ queryStringChanged( PAGE_KEY ) }
-				searchTermChanged={ queryStringChanged( SEARCH_KEY ) }
-				sortTermChanged={ queryStringChanged( SORT_KEY ) }
-			/>
+			<QueryMembershipsEarnings siteId={ site.ID } />
+			<QueryMembershipsSettings siteId={ site.ID } />
+			<div>{ renderSubscriberList() }</div>
 		</div>
 	);
 }

--- a/client/my-sites/earn/customers/index.tsx
+++ b/client/my-sites/earn/customers/index.tsx
@@ -252,33 +252,19 @@ function CustomerSection() {
 
 	function renderSubscriberSubscriptionSummary( subscriber: Subscriber ) {
 		if ( subscriber.plan.renew_interval === PLAN_ONE_TIME_FREQUENCY ) {
-			/* translators: Information about a one-time payment made by a subscriber to a site owner.
-				%(amount)s - the amount paid,
-				%(formattedDate) - the date it was paid
-				%(title) - description of the payment plan, or a blank space if no description available. */
-			return translate( '%(amount)s once', {
+			return translate( 'One Time (%(amount)s)', {
 				args: {
 					amount: formatCurrency( subscriber.plan.renewal_price, subscriber.plan.currency ),
 				},
 			} );
 		} else if ( subscriber.plan.renew_interval === PLAN_YEARLY_FREQUENCY ) {
-			/* translators: Information about a recurring yearly payment made by a subscriber to a site owner.
-				%(amount)s - the amount paid,
-				%(formattedDate)s - the date it was first paid
-				%(title)s - description of the payment plan, or a blank space if no description available
-				%(total)s - the total amount subscriber has paid thus far */
-			return translate( '%(amount)s/year%', {
+			return translate( 'Yearly (%(amount)s)', {
 				args: {
 					amount: formatCurrency( subscriber.plan.renewal_price, subscriber.plan.currency ),
 				},
 			} );
 		} else if ( subscriber.plan.renew_interval === PLAN_MONTHLY_FREQUENCY ) {
-			/* translators: Information about a recurring monthly payment made by a subscriber to a site owner.
-				%(amount)s - the amount paid,
-				%(formattedDate)s - the date it was first paid
-				%(title)s - description of the payment plan, or a blank space if no description available
-				%(total)s - the total amount subscriber has paid thus far */
-			return translate( '%(amount)s/month', {
+			return translate( 'Monthly (%(amount)s)', {
 				args: {
 					amount: formatCurrency( subscriber.plan.renewal_price, subscriber.plan.currency ),
 				},

--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -1,5 +1,7 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "@automattic/color-studio/dist/color-variables";
+@import "@automattic/typography/styles/variables";
 
 body.is-section-earn.theme-default.color-scheme {
 	--color-surface-backdrop: var(--studio-white);
@@ -351,5 +353,148 @@ body.is-section-earn.theme-default.color-scheme {
 	.wpcom__loading-ellipsis {
 		display: block;
 		margin: auto;
+	}
+}
+
+
+.supporters-list {
+	margin: 0;
+
+	.row {
+		border-block-end: 1px solid $studio-gray-5;
+		display: flex;
+		align-items: center;
+		flex-direction: row;
+		padding-top: 20px;
+		padding-bottom: 20px;
+
+		> * {
+			flex: 1;
+		}
+
+		.supporters-list__checkbox-column,
+		.supporters-list__profile-column,
+		.supporters-list__offer-type-column,
+		.supporters-list__total-column,
+		.supporters-list__since-column,
+		.supporters-list__menu-column {
+			font-weight: 400;
+			font-size: $font-body-small;
+			line-height: 20px;
+			letter-spacing: -0.15px;
+			color: $studio-gray-60;
+		}
+
+		.supporters-list__profile-column {
+			display: flex;
+			align-items: center;
+			flex: 2;
+			min-width: 0;
+		}
+
+		.supporters-list__offer-type-column {
+			flex: 2;
+			.supporters-list__offer-type-title {
+				font-weight: 600;
+			}
+			.supporters-list__offer-type-price {
+				font-size: $font-body-extra-small;
+				color: $studio-gray-40;
+			}
+		}
+
+		.supporters-list__menu-column {
+			flex-basis: 48px;
+			flex-grow: initial;
+
+			.gridicon {
+				fill: $studio-gray-50;
+			}
+		}
+
+		.hidden {
+			display: none;
+		}
+
+		&:last-child {
+			border-bottom: none;
+		}
+
+		&.header {
+			padding-bottom: $font-code;
+			padding-top: 8px;
+
+			span {
+				font-weight: 500;
+			}
+
+			@media (max-width: $break-small) {
+				display: none;
+			}
+		}
+	}
+
+	.supporters-list__user-profile {
+		display: flex;
+		align-items: center;
+		min-width: 0;
+
+		.supporters-list__user-image {
+			height: 40px;
+			width: 40px;
+			border-radius: 50%;
+			margin-right: 12px;
+			flex: 0;
+		}
+
+		.supporters-list__user-details {
+			display: flex;
+			flex-direction: column;
+			justify-content: center;
+			max-width: 100%;
+			overflow: hidden;
+			min-width: 0;
+
+			.supporters-list__user-name {
+				overflow: hidden;
+				text-overflow: ellipsis;
+				white-space: nowrap;
+				font-weight: 600;
+				font-size: $font-code;
+				min-width: 0;
+			}
+
+			.supporters-list__user-email {
+				overflow: hidden;
+				text-overflow: ellipsis;
+				white-space: nowrap;
+				font-weight: 400;
+				font-size: $font-body-extra-small;
+				color: $studio-gray-40;
+				min-width: 0;
+			}
+		}
+	}
+}
+
+@media ( max-width: $break-large ) {
+	.supporters-list {
+		padding-left: 16px;
+		padding-right: 16px;
+
+		.supporters-list__since-column {
+			display: none;
+		}
+	}
+}
+
+@media ( max-width: $break-medium ) {
+	.supporters-list {
+		padding-left: 16px;
+		padding-right: 16px;
+
+		.supporters-list__offer-type-column {
+			display: none;
+		}
 	}
 }

--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -153,209 +153,6 @@ body.is-section-earn.theme-default.color-scheme {
 	}
 }
 
-.memberships__subscriber-profile {
-	position: relative;
-	@include clear-fix;
-	border-bottom: 1px solid var(--color-neutral-0);
-	box-shadow: none;
-
-	&.is-placeholder {
-		.memberships__subscriber-username,
-		.memberships__subscriber-email,
-		.gravatar.is-placeholder {
-			color: transparent;
-			background-color: var(--color-neutral-0);
-			animation: loading-fade 1.6s ease-in-out infinite;
-		}
-
-		.memberships__subscriber-username {
-			width: 36%;
-		}
-	}
-}
-
-.memberships__subscriber-gravatar {
-	float: left;
-}
-
-.memberships__subscriber-gravatar .gravatar {
-	width: 56px !important;
-	height: 56px !important;
-
-	@include breakpoint-deprecated( ">480px" ) {
-		width: 72px !important;
-		height: 72px !important;
-	}
-}
-
-.memberships__subscriber-detail {
-	margin-left: 80px;
-
-	@include breakpoint-deprecated( ">480px" ) {
-		margin-left: 96px;
-	}
-}
-
-.memberships__subscriber-username {
-	color: var(--color-neutral-70);
-	font-size: $font-body;
-	font-weight: 600;
-	white-space: pre;
-	text-overflow: clip;
-	overflow: hidden;
-	position: relative;
-
-	@include breakpoint-deprecated( ">480px" ) {
-		font-size: $font-title-small;
-	}
-
-	&::before {
-		@include long-content-fade();
-	}
-}
-
-.memberships__subscriber-email {
-	color: var(--color-text-subtle);
-	font-size: $font-body-small;
-
-	@include breakpoint-deprecated( ">480px" ) {
-		font-size: $font-body;
-		margin-top: -3px;
-	}
-}
-
-.memberships__subscriber-subscribed {
-	color: var(--color-text-subtle);
-	font-size: $font-body-extra-small;
-	margin-top: 4px;
-}
-
-.memberships__module-footer {
-	margin-top: 20px;
-}
-
-.memberships__module-plans-title {
-	color: var(--color-neutral-100);
-}
-
-.memberships__module-settings-title {
-	color: var(--color-neutral-100);
-	display: flex;
-	align-items: center;
-}
-
-.memberships__loading {
-	text-align: center;
-	padding: 3em 0;
-}
-
-.memberships__module-settings-description {
-	color: var(--color-neutral-100);
-	font-size: $font-body-small;
-}
-
-.memberships__module-plans-description {
-	color: var(--color-neutral-100);
-	font-size: $font-body-small;
-}
-
-.memberships__module-plans-content {
-	display: flex;
-	flex-direction: row;
-}
-
-.memberships__module-plans-icon {
-	padding-right: 24px;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	color: var(--color-neutral-60);
-}
-
-.memberships__module-products-list-icon {
-	margin-right: 6px;
-}
-
-.memberships__products-product-card {
-	display: flex;
-}
-.memberships__products-product-details {
-	flex-grow: 1;
-}
-.memberships__products-product-price {
-	color: var(--color-text-subtle);
-	font-size: $font-body-small;
-	line-height: 1.5;
-}
-.memberships__products-product-title {
-	color: var(--color-text);
-	font-size: $font-body;
-	font-weight: bold;
-}
-.memberships__products-product-badge {
-	margin-top: 10px;
-	margin-left: -5px;
-}
-.memberships__earnings-breakdown-notes {
-	display: block;
-	clear: both;
-	color: var(--color-neutral-30);
-	padding-bottom: 12px;
-	padding-top: 24px;
-	font-size: $font-body-extra-small;
-	line-height: 1.6;
-	font-style: italic;
-	text-align: center;
-	em {
-		font-weight: 600;
-	}
-}
-.memberships__subscriber-actions {
-	float: right;
-}
-
-/**
- * Delete Site Options
- */
-
-.memberships__settings-section-title {
-	margin-bottom: 4px;
-	font-size: $font-body-small;
-	line-height: 18px;
-	color: var(--color-neutral-70);
-
-	&.is-warning {
-		color: var(--color-error);
-	}
-}
-
-.memberships__settings-section-desc {
-	margin-bottom: 0;
-	font-size: $font-body-small;
-	color: var(--color-text-subtle);
-	font-style: italic;
-}
-
-.memberships__settings-content {
-	flex: 0 1 auto;
-}
-
-.memberships__settings-link,
-.memberships__settings-link:hover,
-.memberships__settings-link:active,
-.memberships__settings-link:visited {
-	color: inherit;
-}
-
-.earn__payments-loading {
-	margin-top: 25px;
-
-	.wpcom__loading-ellipsis {
-		display: block;
-		margin: auto;
-	}
-}
-
 
 .supporters-list {
 	margin: 0;
@@ -501,5 +298,131 @@ body.is-section-earn.theme-default.color-scheme {
 		.supporters-list__offer-type-column {
 			display: none;
 		}
+	}
+}
+
+.memberships__module-footer {
+	margin-top: 20px;
+}
+
+.memberships__module-plans-title {
+	color: var(--color-neutral-100);
+}
+
+.memberships__module-settings-title {
+	color: var(--color-neutral-100);
+	display: flex;
+	align-items: center;
+}
+
+.memberships__loading {
+	text-align: center;
+	padding: 3em 0;
+}
+
+.memberships__module-settings-description {
+	color: var(--color-neutral-100);
+	font-size: $font-body-small;
+}
+
+.memberships__module-plans-description {
+	color: var(--color-neutral-100);
+	font-size: $font-body-small;
+}
+
+.memberships__module-plans-content {
+	display: flex;
+	flex-direction: row;
+}
+
+.memberships__module-plans-icon {
+	padding-right: 24px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	color: var(--color-neutral-60);
+}
+
+.memberships__module-products-list-icon {
+	margin-right: 6px;
+}
+
+.memberships__products-product-card {
+	display: flex;
+}
+.memberships__products-product-details {
+	flex-grow: 1;
+}
+.memberships__products-product-price {
+	color: var(--color-text-subtle);
+	font-size: $font-body-small;
+	line-height: 1.5;
+}
+.memberships__products-product-title {
+	color: var(--color-text);
+	font-size: $font-body;
+	font-weight: bold;
+}
+.memberships__products-product-badge {
+	margin-top: 10px;
+	margin-left: -5px;
+}
+.memberships__earnings-breakdown-notes {
+	display: block;
+	clear: both;
+	color: var(--color-neutral-30);
+	padding-bottom: 12px;
+	padding-top: 24px;
+	font-size: $font-body-extra-small;
+	line-height: 1.6;
+	font-style: italic;
+	text-align: center;
+	em {
+		font-weight: 600;
+	}
+}
+.memberships__subscriber-actions {
+	float: right;
+}
+
+/**
+ * Delete Site Options
+ */
+
+.memberships__settings-section-title {
+	margin-bottom: 4px;
+	font-size: $font-body-small;
+	line-height: 18px;
+	color: var(--color-neutral-70);
+
+	&.is-warning {
+		color: var(--color-error);
+	}
+}
+
+.memberships__settings-section-desc {
+	margin-bottom: 0;
+	font-size: $font-body-small;
+	color: var(--color-text-subtle);
+	font-style: italic;
+}
+
+.memberships__settings-content {
+	flex: 0 1 auto;
+}
+
+.memberships__settings-link,
+.memberships__settings-link:hover,
+.memberships__settings-link:active,
+.memberships__settings-link:visited {
+	color: inherit;
+}
+
+.earn__payments-loading {
+	margin-top: 25px;
+
+	.wpcom__loading-ellipsis {
+		display: block;
+		margin: auto;
 	}
 }

--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -396,6 +396,11 @@ body.is-section-earn.theme-default.color-scheme {
 			flex: 2;
 			.supporters-list__offer-type-title {
 				font-weight: 600;
+				/* stylelint-disable-next-line unit-allowed-list */
+				max-width: 28ch;
+				overflow: hidden;
+				white-space: nowrap;
+				text-overflow: ellipsis;
 			}
 			.supporters-list__offer-type-price {
 				font-size: $font-body-extra-small;

--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -155,7 +155,7 @@ body.is-section-earn.theme-default.color-scheme {
 
 
 .supporters-list {
-	margin: 0;
+	margin: 20px 0 0;
 
 	.row {
 		border-block-end: 1px solid $studio-gray-5;

--- a/client/my-sites/earn/style.scss
+++ b/client/my-sites/earn/style.scss
@@ -2,6 +2,15 @@
 @import "@automattic/components/src/styles/typography";
 @import "@wordpress/base-styles/mixins";
 
+#earn-navigation {
+	margin-bottom: 30px;
+}
+
+// Small override for card component headers
+.is-section-earn .section-header__label {
+	font-weight: 600;
+}
+
 .earn__launchpad {
 	padding: 4px 20px;
 	box-shadow: 0 0 0 1px var(--color-border-subtle);

--- a/client/my-sites/earn/types.ts
+++ b/client/my-sites/earn/types.ts
@@ -1,5 +1,3 @@
-import { SubscribersFilterBy, SubscribersSortBy } from '../subscribers/constants';
-
 export type Product = {
 	ID?: number;
 	currency?: string;
@@ -14,11 +12,8 @@ export type Product = {
 	type?: string;
 	is_editable?: boolean;
 	tier?: number;
-	f?: SubscribersFilterBy;
 };
 
 export type Query = {
-	f: SubscribersFilterBy | undefined;
-	sort: SubscribersSortBy | undefined;
-	[ key: string ]: string | undefined;
+	[ key: string ]: string;
 };

--- a/client/my-sites/earn/types.ts
+++ b/client/my-sites/earn/types.ts
@@ -1,3 +1,5 @@
+import { SubscribersFilterBy, SubscribersSortBy } from '../subscribers/constants';
+
 export type Product = {
 	ID?: number;
 	currency?: string;
@@ -12,8 +14,11 @@ export type Product = {
 	type?: string;
 	is_editable?: boolean;
 	tier?: number;
+	f?: SubscribersFilterBy;
 };
 
 export type Query = {
-	[ key: string ]: string;
+	f: SubscribersFilterBy | undefined;
+	sort: SubscribersSortBy | undefined;
+	[ key: string ]: string | undefined;
 };


### PR DESCRIPTION
## Proposed Changes

* Updates the Monetizes > Supporters list table. It now has several new columns which collectively show product title, product price and period, total paid, and date of first purchase. 
* This PR starts moving the Supporters screen toward the new Figma designs here: DqXCQr1dEWpF3P2dIEwiwd-fi-791_88014

**Before**
<img width="1091" alt="supporters-before" src="https://github.com/Automattic/wp-calypso/assets/21228350/91209cad-72b9-4639-8e3e-d8cda2767ca1">

**After**
<img width="1110" alt="supporters-after-2" src="https://github.com/Automattic/wp-calypso/assets/21228350/ea16d5c0-7226-412b-9b99-cf5d7f9e324d">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. You will need a WordPress simple site with stripe connected, some paid plans, and some actual paid purchases. The table in this list only shows paid customers. 
2. Go to http://calypso.localhost:3000/earn/supporters/YOURSITESLUG, and confirm the new table looks like the new screenshot above. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?