### PR TITLE
Free trial upgrade on purchases should go directly to checkout

### DIFF
--- a/client/me/purchases/manage-purchase/notices.tsx
+++ b/client/me/purchases/manage-purchase/notices.tsx
@@ -11,7 +11,6 @@ import {
 	PLAN_MIGRATION_TRIAL_MONTHLY,
 	PLAN_HOSTING_TRIAL_MONTHLY,
 	is100Year,
-	PLAN_ECOMMERCE,
 	getPlanPath,
 } from '@automattic/calypso-products';
 import { localize } from 'i18n-calypso';
@@ -1066,24 +1065,28 @@ class PurchaseNotice extends Component<
 	renderTrialNotice( productSlug: string ) {
 		const { moment, purchase, selectedSite, translate } = this.props;
 		const onClick = () => {
-			const upgradePlanSlug =
-				productSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY
-					? getPlan( PLAN_ECOMMERCE )?.getStoreSlug()
-					: getPlan( PLAN_BUSINESS )?.getStoreSlug();
+			const selectedSiteSlug = selectedSite?.slug;
+			const isEcommerceTrialMonthly = productSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY;
 
-			this.props.recordTracksEvent( 'calypso_business_expired_trial_upgrade_cta_clicked', {
-				location: 'purchases',
+			if ( isEcommerceTrialMonthly ) {
+				return page( `/plans/${ selectedSiteSlug }` );
+			}
+
+			const upgradePlanSlug = getPlan( PLAN_BUSINESS )?.getStoreSlug();
+
+			this.props.recordTracksEvent( 'calypso_subscription_trial_notice_cta_clicked', {
 				plan_slug: upgradePlanSlug,
 			} );
 
 			const planPath = getPlanPath( upgradePlanSlug ?? '' ) ?? '';
 			const checkoutUrl = getTrialCheckoutUrl( {
 				productSlug: planPath,
-				siteSlug: selectedSite?.slug ?? '',
+				siteSlug: selectedSiteSlug ?? '',
 			} );
 
 			return page( checkoutUrl );
 		};
+
 		const expiry = moment.utc( purchase.expiryDate );
 		const daysToExpiry = isExpired( purchase )
 			? 0

--- a/client/me/purchases/manage-purchase/notices.tsx
+++ b/client/me/purchases/manage-purchase/notices.tsx
@@ -1069,13 +1069,20 @@ class PurchaseNotice extends Component<
 			const isEcommerceTrialMonthly = productSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY;
 
 			if ( isEcommerceTrialMonthly ) {
+				this.props.recordTracksEvent( 'calypso_subscription_trial_notice_cta_clicked', {
+					current_plan_slug: productSlug,
+					to_checkout: false,
+				} );
+
 				return page( `/plans/${ selectedSiteSlug }` );
 			}
 
 			const upgradePlanSlug = getPlan( PLAN_BUSINESS )?.getStoreSlug();
 
 			this.props.recordTracksEvent( 'calypso_subscription_trial_notice_cta_clicked', {
-				plan_slug: upgradePlanSlug,
+				current_plan_slug: productSlug,
+				to_checkout: true,
+				upgrade_plan_slug: upgradePlanSlug,
 			} );
 
 			const planPath = getPlanPath( upgradePlanSlug ?? '' ) ?? '';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/4544

## Proposed Changes

At the moment when we go to `me/purchases` and select a free trail plan that is expired, we are shown a notice with a CTA to upgrade the plan. clicking the `Upgrade now` button redirects user to plans step to upgrade again. This PR removes that step and goes straight to checkout since we know the free trial plan is either business or commerce.

* Go straight to checkout when upgrade plan is clicked

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/me/purchases`
* Select an expired free trial plan an you will see a notice with CTA to upgrade now
* Click the CTA and verify that you go directly to checkout with the business plan selected
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?