### PR TITLE
Jetpack Manage: make the "Issue x licenses" button along with the header sticky when scrolled below the viewport

### DIFF
--- a/client/jetpack-cloud/components/layout/header.tsx
+++ b/client/jetpack-cloud/components/layout/header.tsx
@@ -1,6 +1,8 @@
+import classNames from 'classnames';
 import { Children, ReactNode } from 'react';
 
 type Props = {
+	className?: string;
 	children: ReactNode;
 };
 
@@ -16,7 +18,7 @@ export function LayoutHeaderActions( { children }: Props ) {
 	return <h2 className="jetpack-cloud-layout__header-actions">{ children }</h2>;
 }
 
-export default function LayoutHeader( { children }: Props ) {
+export default function LayoutHeader( { className, children }: Props ) {
 	const headerTitle = Children.toArray( children ).find(
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		( child: any ) => child.type === LayoutHeaderTitle
@@ -33,7 +35,7 @@ export default function LayoutHeader( { children }: Props ) {
 	);
 
 	return (
-		<div className="jetpack-cloud-layout__header">
+		<div className={ classNames( 'jetpack-cloud-layout__header', className ) }>
 			<div className="jetpack-cloud-layout__header-main">
 				{ headerTitle }
 				{ headerSubtitle }

--- a/client/jetpack-cloud/components/layout/header.tsx
+++ b/client/jetpack-cloud/components/layout/header.tsx
@@ -1,8 +1,9 @@
 import classNames from 'classnames';
 import { Children, ReactNode } from 'react';
+import useDetectWindowBoundary from 'calypso/lib/detect-window-boundary';
 
 type Props = {
-	className?: string;
+	showStickyContent?: boolean;
 	children: ReactNode;
 };
 
@@ -18,7 +19,7 @@ export function LayoutHeaderActions( { children }: Props ) {
 	return <h2 className="jetpack-cloud-layout__header-actions">{ children }</h2>;
 }
 
-export default function LayoutHeader( { className, children }: Props ) {
+export default function LayoutHeader( { showStickyContent, children }: Props ) {
 	const headerTitle = Children.toArray( children ).find(
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		( child: any ) => child.type === LayoutHeaderTitle
@@ -34,14 +35,26 @@ export default function LayoutHeader( { className, children }: Props ) {
 		( child: any ) => child.type === LayoutHeaderActions
 	);
 
-	return (
-		<div className={ classNames( 'jetpack-cloud-layout__header', className ) }>
-			<div className="jetpack-cloud-layout__header-main">
-				{ headerTitle }
-				{ headerSubtitle }
-			</div>
+	const [ divRef, hasCrossed ] = useDetectWindowBoundary();
 
-			{ headerActions }
+	const outerDivProps = divRef ? { ref: divRef as React.RefObject< HTMLDivElement > } : {};
+
+	return (
+		<div className="jetpack-cloud-layout__viewport" { ...outerDivProps }>
+			<div
+				className={ classNames( {
+					'jetpack-cloud-layout__sticky-header': showStickyContent && hasCrossed,
+				} ) }
+			>
+				<div className={ classNames( 'jetpack-cloud-layout__header' ) }>
+					<div className="jetpack-cloud-layout__header-main">
+						{ headerTitle }
+						{ headerSubtitle }
+					</div>
+
+					{ headerActions }
+				</div>
+			</div>
 		</div>
 	);
 }

--- a/client/jetpack-cloud/components/layout/style.scss
+++ b/client/jetpack-cloud/components/layout/style.scss
@@ -68,6 +68,8 @@
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
+	margin: auto;
+	height: 100%;
 
 	> * + * {
 		margin-inline-start: 24px;
@@ -85,6 +87,18 @@
 			margin-inline-start: 0;
 		}
 	}
+}
+
+.jetpack-cloud-layout__sticky-header {
+	position: fixed;
+	width: calc(100% - var(--sidebar-width-max));
+	left: var(--sidebar-width-max);
+	top: var(--masterbar-height);
+	background-color: rgba(246, 247, 247, 0.95);
+	box-shadow: 2px 2px 2px 0 rgb(0 0 0 / 8%);
+	z-index: 1001;
+	height: 74px;
+
 }
 
 .jetpack-cloud-layout__header-title {
@@ -147,4 +161,8 @@
 		// we need to make sure the dropdown is above it
 		z-index: 23;
 	}
+}
+
+.jetpack-cloud-layout__viewport {
+	margin-inline-start: 0;
 }

--- a/client/jetpack-cloud/components/layout/style.scss
+++ b/client/jetpack-cloud/components/layout/style.scss
@@ -26,28 +26,25 @@
 }
 
 .jetpack-cloud-layout__body {
+	width: 100%;
 	margin-block-end: -32px;
 	flex: 1 1 100%;
-}
-
-.jetpack-cloud-layout__top,
-.jetpack-cloud-layout__body {
-	width: 100%;
-
-	&-wrapper {
-		margin-inline: 0;
-	}
-
-	&-wrapper > * {
-		max-width: 1500px;
-		margin-inline: auto !important;
-	}
 
 	@include breakpoint-deprecated( ">660px" ) {
 		// We need these negative margin values because we want to make the container full-width,
 		// but our element is inside a limited-width parent.
 		margin-inline-start: -73px;
 		padding-inline: 73px;
+	}
+}
+
+.jetpack-cloud-layout__top-wrapper,
+.jetpack-cloud-layout__body-wrapper {
+	margin-inline: 0;
+
+	> * {
+		max-width: 1500px;
+		margin-inline: auto !important;
 	}
 }
 
@@ -66,7 +63,6 @@
 		}
 	}
 }
-
 
 .jetpack-cloud-layout__header {
 	display: flex;

--- a/client/jetpack-cloud/components/layout/top.tsx
+++ b/client/jetpack-cloud/components/layout/top.tsx
@@ -5,9 +5,5 @@ type Props = {
 };
 
 export default function LayoutTop( { children }: Props ) {
-	return (
-		<div className="jetpack-cloud-layout__top">
-			<div className="jetpack-cloud-layout__top-wrapper">{ children }</div>
-		</div>
-	);
+	return <div className="jetpack-cloud-layout__top-wrapper">{ children }</div>;
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content-header.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content-header.tsx
@@ -4,8 +4,6 @@ import MissingPaymentNotification from 'calypso/jetpack-cloud/components/missing
 import useDetectWindowBoundary from 'calypso/lib/detect-window-boundary';
 import type { ReactNode } from 'react';
 
-const CALYPSO_MASTERBAR_HEIGHT = 47;
-
 interface Props {
 	pageTitle: string;
 	showStickyContent: boolean;
@@ -13,7 +11,7 @@ interface Props {
 }
 
 export default function SiteContentHeader( { content, pageTitle, showStickyContent }: Props ) {
-	const [ divRef, hasCrossed ] = useDetectWindowBoundary( CALYPSO_MASTERBAR_HEIGHT );
+	const [ divRef, hasCrossed ] = useDetectWindowBoundary();
 
 	const outerDivProps = divRef ? { ref: divRef as React.RefObject< HTMLDivElement > } : {};
 

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/index.tsx
@@ -1,6 +1,9 @@
 import { Button } from '@automattic/components';
+import { isWithinBreakpoint } from '@automattic/viewport';
+import { getQueryArg } from '@wordpress/url';
+import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import Layout from 'calypso/jetpack-cloud/components/layout';
 import LayoutBody from 'calypso/jetpack-cloud/components/layout/body';
 import LayoutHeader, {
@@ -12,17 +15,49 @@ import LayoutNavigation, {
 	LayoutNavigationItem as NavigationItem,
 } from 'calypso/jetpack-cloud/components/layout/nav';
 import LayoutTop from 'calypso/jetpack-cloud/components/layout/top';
+import useDetectWindowBoundary from 'calypso/lib/detect-window-boundary';
 import IssueLicenseContext from './context';
 import { useProductBundleSize } from './hooks/use-product-bundle-size';
+import useSubmitForm from './hooks/use-submit-form';
 import LicensesForm from './licenses-form';
 import type { SelectedLicenseProp } from './types';
 import type { AssignLicenceProps } from '../types';
+
+import './style.scss';
 
 export default function IssueLicenseV2( { selectedSite, suggestedProduct }: AssignLicenceProps ) {
 	const translate = useTranslate();
 
 	const { selectedSize, setSelectedSize, availableSizes } = useProductBundleSize();
+
+	// We need the suggested products (i.e., the products chosen from the dashboard) to properly
+	// track if the user purchases a different set of products.
+	const suggestedProductSlugs = getQueryArg( window.location.href, 'product_slug' )
+		?.toString()
+		.split( ',' );
+
+	const { isReady } = useSubmitForm( selectedSite, suggestedProductSlugs );
+
 	const [ selectedLicenses, setSelectedLicenses ] = useState< SelectedLicenseProp[] >( [] );
+
+	const [ divRef, hasCrossed ] = useDetectWindowBoundary();
+
+	const outerDivProps = divRef ? { ref: divRef as React.RefObject< HTMLDivElement > } : {};
+
+	const selectedLicenseCount = selectedLicenses
+		.map( ( license ) => license.quantity )
+		.reduce( ( a, b ) => a + b, 0 );
+
+	const handleShowLicenseOverview = useCallback( () => {
+		// Handle showing the license overview modal here
+	}, [] );
+
+	const onClickIssueLicenses = useCallback( () => {
+		handleShowLicenseOverview();
+	}, [ handleShowLicenseOverview ] );
+
+	const showStickyContent =
+		isWithinBreakpoint( '>960px' ) && selectedLicenses.length > 0 && hasCrossed;
 
 	return (
 		<Layout
@@ -32,16 +67,36 @@ export default function IssueLicenseV2( { selectedSite, suggestedProduct }: Assi
 			withBorder
 		>
 			<LayoutTop>
-				<LayoutHeader>
-					<Title>{ translate( 'Issue product licenses' ) } </Title>
-					<Subtitle>
-						{ translate( 'Select single product licenses or save when you issue in bulk' ) }
-					</Subtitle>
-
-					<Actions>
-						<Button primary>Issue license </Button>
-					</Actions>
-				</LayoutHeader>
+				<div className="issue-license-v2__viewport" { ...outerDivProps }>
+					<LayoutHeader
+						className={ classNames( {
+							'issue-license-v2__sticky-header': showStickyContent,
+						} ) }
+					>
+						<Title>{ translate( 'Issue product licenses' ) } </Title>
+						<Subtitle>
+							{ translate( 'Select single product licenses or save when you issue in bulk' ) }
+						</Subtitle>
+						<Actions>
+							{ selectedLicenses.length > 0 && (
+								<Button
+									primary
+									className="issue-license-v2__select-license"
+									busy={ ! isReady }
+									onClick={ onClickIssueLicenses }
+								>
+									{ translate( 'Issue %(numLicenses)d license', 'Issue %(numLicenses)d licenses', {
+										context: 'button label',
+										count: selectedLicenseCount,
+										args: {
+											numLicenses: selectedLicenseCount,
+										},
+									} ) }
+								</Button>
+							) }
+						</Actions>
+					</LayoutHeader>
+				</div>
 
 				<LayoutNavigation
 					selectedText={
@@ -52,6 +107,7 @@ export default function IssueLicenseV2( { selectedSite, suggestedProduct }: Assi
 				>
 					{ availableSizes.map( ( size ) => (
 						<NavigationItem
+							key={ size }
 							label={
 								size === 1
 									? translate( 'Single license' )

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/index.tsx
@@ -1,7 +1,6 @@
 import { Button } from '@automattic/components';
 import { isWithinBreakpoint } from '@automattic/viewport';
 import { getQueryArg } from '@wordpress/url';
-import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
 import Layout from 'calypso/jetpack-cloud/components/layout';
@@ -15,7 +14,6 @@ import LayoutNavigation, {
 	LayoutNavigationItem as NavigationItem,
 } from 'calypso/jetpack-cloud/components/layout/nav';
 import LayoutTop from 'calypso/jetpack-cloud/components/layout/top';
-import useDetectWindowBoundary from 'calypso/lib/detect-window-boundary';
 import IssueLicenseContext from './context';
 import { useProductBundleSize } from './hooks/use-product-bundle-size';
 import useSubmitForm from './hooks/use-submit-form';
@@ -40,10 +38,6 @@ export default function IssueLicenseV2( { selectedSite, suggestedProduct }: Assi
 
 	const [ selectedLicenses, setSelectedLicenses ] = useState< SelectedLicenseProp[] >( [] );
 
-	const [ divRef, hasCrossed ] = useDetectWindowBoundary();
-
-	const outerDivProps = divRef ? { ref: divRef as React.RefObject< HTMLDivElement > } : {};
-
 	const selectedLicenseCount = selectedLicenses
 		.map( ( license ) => license.quantity )
 		.reduce( ( a, b ) => a + b, 0 );
@@ -56,8 +50,7 @@ export default function IssueLicenseV2( { selectedSite, suggestedProduct }: Assi
 		handleShowLicenseOverview();
 	}, [ handleShowLicenseOverview ] );
 
-	const showStickyContent =
-		isWithinBreakpoint( '>960px' ) && selectedLicenses.length > 0 && hasCrossed;
+	const showStickyContent = isWithinBreakpoint( '>960px' ) && selectedLicenses.length > 0;
 
 	return (
 		<Layout
@@ -67,36 +60,30 @@ export default function IssueLicenseV2( { selectedSite, suggestedProduct }: Assi
 			withBorder
 		>
 			<LayoutTop>
-				<div className="issue-license-v2__viewport" { ...outerDivProps }>
-					<LayoutHeader
-						className={ classNames( {
-							'issue-license-v2__sticky-header': showStickyContent,
-						} ) }
-					>
-						<Title>{ translate( 'Issue product licenses' ) } </Title>
-						<Subtitle>
-							{ translate( 'Select single product licenses or save when you issue in bulk' ) }
-						</Subtitle>
-						<Actions>
-							{ selectedLicenses.length > 0 && (
-								<Button
-									primary
-									className="issue-license-v2__select-license"
-									busy={ ! isReady }
-									onClick={ onClickIssueLicenses }
-								>
-									{ translate( 'Issue %(numLicenses)d license', 'Issue %(numLicenses)d licenses', {
-										context: 'button label',
-										count: selectedLicenseCount,
-										args: {
-											numLicenses: selectedLicenseCount,
-										},
-									} ) }
-								</Button>
-							) }
-						</Actions>
-					</LayoutHeader>
-				</div>
+				<LayoutHeader showStickyContent={ showStickyContent }>
+					<Title>{ translate( 'Issue product licenses' ) } </Title>
+					<Subtitle>
+						{ translate( 'Select single product licenses or save when you issue in bulk' ) }
+					</Subtitle>
+					<Actions>
+						{ selectedLicenses.length > 0 && (
+							<Button
+								primary
+								className="issue-license-v2__select-license"
+								busy={ ! isReady }
+								onClick={ onClickIssueLicenses }
+							>
+								{ translate( 'Issue %(numLicenses)d license', 'Issue %(numLicenses)d licenses', {
+									context: 'button label',
+									count: selectedLicenseCount,
+									args: {
+										numLicenses: selectedLicenseCount,
+									},
+								} ) }
+							</Button>
+						) }
+					</Actions>
+				</LayoutHeader>
 
 				<LayoutNavigation
 					selectedText={

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
@@ -1,4 +1,3 @@
-import { Button } from '@automattic/components';
 import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useMemo, useContext } from 'react';
@@ -129,10 +128,6 @@ export default function LicensesForm( {
 		[ quantity, selectedLicenses, setSelectedLicenses ]
 	);
 
-	const handleShowLicenseOverview = useCallback( () => {
-		// Handle showing the license overview modal here
-	}, [] );
-
 	const onSelectProduct = useCallback(
 		( product: APIProductFamilyProduct ) => {
 			handleSelectBundleLicense( product );
@@ -149,10 +144,6 @@ export default function LicensesForm( {
 		[ handleSelectBundleLicense ]
 	);
 
-	const onClickIssueLicenses = useCallback( () => {
-		handleShowLicenseOverview();
-	}, [ handleShowLicenseOverview ] );
-
 	if ( isLoadingProducts ) {
 		return (
 			<div className="licenses-form">
@@ -162,10 +153,6 @@ export default function LicensesForm( {
 	}
 
 	const selectedSiteDomain = selectedSite?.domain;
-
-	const selectedLicenseCount = selectedLicenses
-		.map( ( license ) => license.quantity )
-		.reduce( ( a, b ) => a + b, 0 );
 
 	const isSelected = ( slug: string ) =>
 		selectedLicenses.findIndex(
@@ -191,22 +178,6 @@ export default function LicensesForm( {
 				</p>
 				<div className="licenses-form__controls">
 					<TotalCost />
-					{ selectedLicenseCount > 0 && (
-						<Button
-							primary
-							className="licenses-form__select-license"
-							busy={ ! isReady }
-							onClick={ onClickIssueLicenses }
-						>
-							{ translate( 'Issue %(numLicenses)d license', 'Issue %(numLicenses)d licenses', {
-								context: 'button label',
-								count: selectedLicenseCount,
-								args: {
-									numLicenses: selectedLicenseCount,
-								},
-							} ) }
-						</Button>
-					) }
 				</div>
 			</div>
 			<div className="licenses-form__bottom">

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/style.scss
@@ -34,11 +34,6 @@
 	@include breakpoint-deprecated("<660px") {
 		display: flex;
 
-		.licenses-form__select-license {
-			width: auto;
-			flex-grow: 1;
-		}
-
 		.total-cost {
 			margin-right: 8px;
 		}
@@ -80,10 +75,4 @@ p.licenses-form__description {
 
 .licenses-form__separator {
 	margin: 2rem 0;
-}
-
-.licenses-form__select-license {
-	// :active introduces a 1px border but :focus introduces a 1.5px border which causes the button to move around.
-	border-width: 1.5px !important;
-	border-color: transparent;
 }

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/style.scss
@@ -1,0 +1,41 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+issue-license-v2__viewport {
+	margin-inline-start: 0;
+}
+
+.issue-license-v2__sticky-header {
+	position: fixed;
+	width: calc(100% - var(--sidebar-width-max));
+	left: var(--sidebar-width-max);
+	top: var(--masterbar-height);
+	background-color: rgba(246, 247, 247, 0.95);
+	box-shadow: 2px 2px 2px 0 rgb(0 0 0 / 8%);
+	z-index: 1001;
+	height: 74px;
+
+	.jetpack-cloud-layout__header-subtitle {
+		display: none;
+	}
+
+	.jetpack-cloud-layout__header-title {
+		margin-left: 73px;
+		font-size: rem(24px);
+	}
+
+	.jetpack-cloud-layout__header-actions {
+		margin-right: 73px;
+	}
+}
+
+.issue-license-v2__select-license {
+	// :active introduces a 1px border but :focus introduces a 1.5px border which causes the button to move around.
+	border-width: 1.5px !important;
+	border-color: transparent;
+
+	@include breakpoint-deprecated("<660px") {
+		width: auto;
+		flex-grow: 1;
+	}
+}

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/style.scss
@@ -1,31 +1,20 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-issue-license-v2__viewport {
-	margin-inline-start: 0;
-}
-
-.issue-license-v2__sticky-header {
-	position: fixed;
-	width: calc(100% - var(--sidebar-width-max));
-	left: var(--sidebar-width-max);
-	top: var(--masterbar-height);
-	background-color: rgba(246, 247, 247, 0.95);
-	box-shadow: 2px 2px 2px 0 rgb(0 0 0 / 8%);
-	z-index: 1001;
-	height: 74px;
+.jetpack-cloud-layout__sticky-header {
 
 	.jetpack-cloud-layout__header-subtitle {
 		display: none;
 	}
 
 	.jetpack-cloud-layout__header-title {
-		margin-left: 73px;
+		margin-inline-start: 48px;
 		font-size: rem(24px);
+		margin-block-end: 0;
 	}
 
 	.jetpack-cloud-layout__header-actions {
-		margin-right: 73px;
+		margin-inline-end: 48px;
 	}
 }
 


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/116

## Proposed Changes

This PR

- Makes the "Issue x licenses" button along with the header sticky when scrolled below the viewport
- Fixes the dashboard sticky header

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Visit the Jetpack Cloud link > Replace `dashboard` in the URL with `/partner-portal/issue-license?flags=jetpack/bundle-licensing`.
2. Verify that the Issue License button doesn't appear without selecting a license.
3. Select licenses & scroll through the page > Verify that the sticky header appears when scrolled below the viewport.
4. Verify that the sticky header doesn't appear when no license is selected.
5. The "total cost" area will be added in another PR.
6. Also, visit the dashboard & verify that the sticky header when a license appears when scrolled below the viewport.

https://github.com/Automattic/wp-calypso/assets/10586875/cca92238-370c-4230-a33e-1bb7bd5fd618

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?