### PR TITLE
Jetpack Manage: Rearrange products and plans listing in the Issue License page based on the new design.

### DIFF
--- a/client/jetpack-cloud/components/layout/nav.tsx
+++ b/client/jetpack-cloud/components/layout/nav.tsx
@@ -55,7 +55,7 @@ export default function LayoutNavigation( {
 			selectedText={
 				<span>
 					{ selectedText }
-					{ selectedCount !== undefined && <Count count={ selectedCount } compact={ true } /> }
+					{ Number.isInteger( selectedCount ) && <Count count={ selectedCount } compact /> }
 				</span>
 			}
 		>

--- a/client/jetpack-cloud/components/layout/nav.tsx
+++ b/client/jetpack-cloud/components/layout/nav.tsx
@@ -55,7 +55,7 @@ export default function LayoutNavigation( {
 			selectedText={
 				<span>
 					{ selectedText }
-					<Count count={ selectedCount } compact={ true } />
+					{ selectedCount !== undefined && <Count count={ selectedCount } compact={ true } /> }
 				</span>
 			}
 		>

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/index.tsx
@@ -94,7 +94,7 @@ export default function IssueLicenseV2( { selectedSite, suggestedProduct }: Assi
 				>
 					{ availableSizes.map( ( size ) => (
 						<NavigationItem
-							key={ size }
+							key={ `bundle-size-${ size }` }
 							label={
 								size === 1
 									? translate( 'Single license' )

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/hooks/use-product-and-plans.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/hooks/use-product-and-plans.tsx
@@ -22,13 +22,12 @@ export default function useProductAndPlans( { selectedSite }: Props ) {
 	const { data, isLoading: isLoadingProducts } = useProductsQuery();
 	const dispatch = useDispatch();
 
-	// If the user comes from the flow for adding a new payment method during an attempt to issue a license
-	// after the payment method is added, we will make an attempt to issue the chosen license automatically.
-	const defaultProductSlugs = getQueryArg( window.location.href, 'products' )
-		?.toString()
-		.split( ',' );
-
 	useEffect( () => {
+		// If the user comes from the flow for adding a new payment method during an attempt to issue a license
+		// after the payment method is added, we will make an attempt to issue the chosen license automatically.
+		const defaultProductSlugs = getQueryArg( window.location.href, 'products' )
+			?.toString()
+			.split( ',' );
 		// Select the slugs included in the URL
 		defaultProductSlugs &&
 			dispatch(
@@ -42,21 +41,22 @@ export default function useProductAndPlans( { selectedSite }: Props ) {
 		return () => {
 			dispatch( clearSelectedProductSlugs() );
 		};
-	}, [ dispatch, defaultProductSlugs ] );
+	}, [ dispatch ] );
 
-	let allProductsAndBundles = data;
 	const addedPlanAndProducts = useSelector( ( state ) =>
 		selectedSite ? getAssignedPlanAndProductIDsForSite( state, selectedSite.ID ) : null
 	);
 
-	// Filter products & plan that are already assigned to a site
-	if ( selectedSite && addedPlanAndProducts && allProductsAndBundles ) {
-		allProductsAndBundles = allProductsAndBundles.filter(
-			( product ) => ! addedPlanAndProducts.includes( product.product_id )
-		);
-	}
-
 	return useMemo( () => {
+		let allProductsAndBundles = data;
+
+		// Filter products & plan that are already assigned to a site
+		if ( selectedSite && addedPlanAndProducts && allProductsAndBundles ) {
+			allProductsAndBundles = allProductsAndBundles.filter(
+				( product ) => ! addedPlanAndProducts.includes( product.product_id )
+			);
+		}
+
 		const bundles =
 			allProductsAndBundles?.filter(
 				( { family_slug }: { family_slug: string } ) => family_slug === 'jetpack-packs'
@@ -95,5 +95,5 @@ export default function useProductAndPlans( { selectedSite }: Props ) {
 			wooExtensions,
 			suggestedProductSlugs,
 		};
-	}, [ allProductsAndBundles, isLoadingProducts ] );
+	}, [ addedPlanAndProducts, data, isLoadingProducts, selectedSite ] );
 }

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/hooks/use-product-and-plans.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/hooks/use-product-and-plans.tsx
@@ -1,0 +1,99 @@
+import { getQueryArg } from '@wordpress/url';
+import { useEffect, useMemo } from 'react';
+import {
+	isJetpackBundle,
+	isWooCommerceProduct,
+	isWpcomHostingProduct,
+} from 'calypso/jetpack-cloud/sections/partner-portal/lib';
+import { useDispatch, useSelector } from 'calypso/state';
+import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
+import { getAssignedPlanAndProductIDsForSite } from 'calypso/state/partner-portal/licenses/selectors';
+import {
+	addSelectedProductSlugs,
+	clearSelectedProductSlugs,
+} from 'calypso/state/partner-portal/products/actions';
+import type { SiteDetails } from '@automattic/data-stores';
+
+type Props = {
+	selectedSite?: SiteDetails | null;
+};
+
+export default function useProductAndPlans( { selectedSite }: Props ) {
+	const { data, isLoading: isLoadingProducts } = useProductsQuery();
+	const dispatch = useDispatch();
+
+	// If the user comes from the flow for adding a new payment method during an attempt to issue a license
+	// after the payment method is added, we will make an attempt to issue the chosen license automatically.
+	const defaultProductSlugs = getQueryArg( window.location.href, 'products' )
+		?.toString()
+		.split( ',' );
+
+	useEffect( () => {
+		// Select the slugs included in the URL
+		defaultProductSlugs &&
+			dispatch(
+				addSelectedProductSlugs(
+					// Filter the bundles and select only individual products
+					defaultProductSlugs.filter( ( slug ) => ! isJetpackBundle( slug ) )
+				)
+			);
+
+		// Clear all selected slugs when navigating away from the page to avoid persisting the data.
+		return () => {
+			dispatch( clearSelectedProductSlugs() );
+		};
+	}, [ dispatch, defaultProductSlugs ] );
+
+	let allProductsAndBundles = data;
+	const addedPlanAndProducts = useSelector( ( state ) =>
+		selectedSite ? getAssignedPlanAndProductIDsForSite( state, selectedSite.ID ) : null
+	);
+
+	// Filter products & plan that are already assigned to a site
+	if ( selectedSite && addedPlanAndProducts && allProductsAndBundles ) {
+		allProductsAndBundles = allProductsAndBundles.filter(
+			( product ) => ! addedPlanAndProducts.includes( product.product_id )
+		);
+	}
+
+	return useMemo( () => {
+		const bundles =
+			allProductsAndBundles?.filter(
+				( { family_slug }: { family_slug: string } ) => family_slug === 'jetpack-packs'
+			) || [];
+		const backupAddons =
+			allProductsAndBundles
+				?.filter(
+					( { family_slug }: { family_slug: string } ) => family_slug === 'jetpack-backup-storage'
+				)
+				.sort( ( a, b ) => a.product_id - b.product_id ) || [];
+		const products =
+			allProductsAndBundles?.filter(
+				( { family_slug }: { family_slug: string } ) =>
+					family_slug !== 'jetpack-packs' &&
+					family_slug !== 'jetpack-backup-storage' &&
+					! isWooCommerceProduct( family_slug ) &&
+					! isWpcomHostingProduct( family_slug )
+			) || [];
+		const wooExtensions =
+			allProductsAndBundles?.filter( ( { family_slug }: { family_slug: string } ) =>
+				isWooCommerceProduct( family_slug )
+			) || [];
+
+		// We need the suggested products (i.e., the products chosen from the dashboard) to properly
+		// track if the user purchases a different set of products.
+		const suggestedProductSlugs = getQueryArg( window.location.href, 'product_slug' )
+			?.toString()
+			.split( ',' );
+
+		return {
+			isLoadingProducts,
+			allProductsAndBundles,
+			bundles,
+			backupAddons,
+			products,
+			wooExtensions,
+			suggestedProductSlugs,
+		};
+	}, [ allProductsAndBundles, isLoadingProducts ] );
+}

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
@@ -84,6 +84,8 @@ export default function LicensesForm( {
 		[ quantity, selectedLicenses ]
 	);
 
+	const isSingleLicenseView = quantity === 1;
+
 	if ( isLoadingProducts ) {
 		return (
 			<div className="licenses-form">
@@ -138,7 +140,7 @@ export default function LicensesForm( {
 				</LicensesFormSection>
 			) }
 
-			{ wooExtensions.length > 0 && (
+			{ isSingleLicenseView && wooExtensions.length > 0 && (
 				<LicensesFormSection
 					title={ translate( 'WooCommerce Extensions' ) }
 					description={ translate(
@@ -160,7 +162,7 @@ export default function LicensesForm( {
 				</LicensesFormSection>
 			) }
 
-			{ backupAddons.length > 0 && (
+			{ isSingleLicenseView && backupAddons.length > 0 && (
 				<LicensesFormSection
 					title={ translate( 'VaultPress Backup Add-ons' ) }
 					description={ translate(

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
@@ -1,24 +1,13 @@
-import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useEffect, useMemo, useContext } from 'react';
+import { useCallback, useContext } from 'react';
 import QueryProductsList from 'calypso/components/data/query-products-list';
-import {
-	isJetpackBundle,
-	isWooCommerceProduct,
-	isWpcomHostingProduct,
-} from 'calypso/jetpack-cloud/sections/partner-portal/lib';
 import LicenseBundleCard from 'calypso/jetpack-cloud/sections/partner-portal/license-bundle-card';
 import LicenseProductCard from 'calypso/jetpack-cloud/sections/partner-portal/license-product-card';
-import { useDispatch, useSelector } from 'calypso/state';
-import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
-import { getAssignedPlanAndProductIDsForSite } from 'calypso/state/partner-portal/licenses/selectors';
-import {
-	addSelectedProductSlugs,
-	clearSelectedProductSlugs,
-} from 'calypso/state/partner-portal/products/actions';
+import { useSelector } from 'calypso/state';
 import { getDisabledProductSlugs } from 'calypso/state/partner-portal/products/selectors';
 import IssueLicenseContext from '../context';
 import useSubmitForm from '../hooks/use-submit-form';
+import useProductAndPlans from './hooks/use-product-and-plans';
 import LicensesFormSection from './sections';
 import type { AssignLicenceProps } from '../../types';
 import type {
@@ -34,79 +23,22 @@ export default function LicensesForm( {
 	quantity = 1,
 }: AssignLicenceProps ) {
 	const translate = useTranslate();
-	const dispatch = useDispatch();
-
-	const { data, isLoading: isLoadingProducts } = useProductsQuery();
 
 	const { selectedLicenses, setSelectedLicenses } = useContext( IssueLicenseContext );
 
-	let allProducts = data;
-	const addedPlanAndProducts = useSelector( ( state ) =>
-		selectedSite ? getAssignedPlanAndProductIDsForSite( state, selectedSite.ID ) : null
-	);
-
-	// Filter products & plan that are already assigned to a site
-	if ( selectedSite && addedPlanAndProducts && allProducts ) {
-		allProducts = allProducts.filter(
-			( product ) => ! addedPlanAndProducts.includes( product.product_id )
-		);
-	}
-
-	const bundles =
-		allProducts?.filter(
-			( { family_slug }: { family_slug: string } ) => family_slug === 'jetpack-packs'
-		) || [];
-	const backupAddons =
-		allProducts
-			?.filter(
-				( { family_slug }: { family_slug: string } ) => family_slug === 'jetpack-backup-storage'
-			)
-			.sort( ( a, b ) => a.product_id - b.product_id ) || [];
-	const products =
-		allProducts?.filter(
-			( { family_slug }: { family_slug: string } ) =>
-				family_slug !== 'jetpack-packs' &&
-				family_slug !== 'jetpack-backup-storage' &&
-				! isWooCommerceProduct( family_slug ) &&
-				! isWpcomHostingProduct( family_slug )
-		) || [];
-	const wooExtensions =
-		allProducts?.filter( ( { family_slug }: { family_slug: string } ) =>
-			isWooCommerceProduct( family_slug )
-		) || [];
-
-	// If the user comes from the flow for adding a new payment method during an attempt to issue a license
-	// after the payment method is added, we will make an attempt to issue the chosen license automatically.
-	const defaultProductSlugs = useMemo(
-		() => getQueryArg( window.location.href, 'products' )?.toString().split( ',' ),
-		[]
-	);
-
-	useEffect( () => {
-		// Select the slugs included in the URL
-		defaultProductSlugs &&
-			dispatch(
-				addSelectedProductSlugs(
-					// Filter the bundles and select only individual products
-					defaultProductSlugs.filter( ( slug ) => ! isJetpackBundle( slug ) )
-				)
-			);
-
-		// Clear all selected slugs when navigating away from the page to avoid persisting the data.
-		return () => {
-			dispatch( clearSelectedProductSlugs() );
-		};
-	}, [ dispatch, defaultProductSlugs ] );
+	const {
+		allProductsAndBundles,
+		isLoadingProducts,
+		bundles,
+		backupAddons,
+		products,
+		wooExtensions,
+		suggestedProductSlugs,
+	} = useProductAndPlans( { selectedSite } );
 
 	const disabledProductSlugs = useSelector< PartnerPortalStore, string[] >( ( state ) =>
-		getDisabledProductSlugs( state, allProducts ?? [] )
+		getDisabledProductSlugs( state, allProductsAndBundles ?? [] )
 	);
-
-	// We need the suggested products (i.e., the products chosen from the dashboard) to properly
-	// track if the user purchases a different set of products.
-	const suggestedProductSlugs = getQueryArg( window.location.href, 'product_slug' )
-		?.toString()
-		.split( ',' );
 
 	const handleSelectBundleLicense = useCallback(
 		( product: APIProductFamilyProduct ) => {

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
@@ -78,9 +78,9 @@ export default function LicensesForm( {
 
 	const isSelected = useCallback(
 		( slug: string ) =>
-			selectedLicenses.findIndex(
+			selectedLicenses.some(
 				( license ) => license.slug === slug && license.quantity === quantity
-			) !== -1,
+			),
 		[ quantity, selectedLicenses ]
 	);
 

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/sections.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/sections.tsx
@@ -1,0 +1,21 @@
+import { ReactNode } from 'react';
+
+type Props = {
+	title: string;
+	description: string;
+	children: ReactNode;
+};
+
+export default function LicensesFormSection( { title, description, children }: Props ) {
+	return (
+		<div className="licenses-form__section">
+			<h2 className="licenses-form__section-title">
+				<span>{ title }</span>
+				<hr />
+			</h2>
+			<p className="licenses-form__section-description">{ description }</p>
+
+			<div className="licenses-form__section-content">{ children }</div>
+		</div>
+	);
+}

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/style.scss
@@ -2,62 +2,51 @@
 @import "@wordpress/base-styles/mixins";
 @import "../../mixins.scss";
 
-.licenses-form {
-
-	p {
-		font-size: 1rem;
-	}
-
-	.select-dropdown__container {
-		width: 100%;
-	}
-}
-
 .licenses-form__placeholder {
 	@include placeholder( --color-neutral-10 );
 	height: 43px;
 }
 
-.licenses-form__actions {
-	display: flex;
-	justify-content: flex-end;
-	margin: 42px -10px 0;
+.licenses-form__section {
+	margin-block-end: 32px;
+}
 
-	> * {
-		margin: 0 10px;
+h2.licenses-form__section-title {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	gap: 18px;
+	margin-block-end: 10px;
+	font-size: rem(20px);
+	font-weight: 600;
+	line-height: 1.2;
+
+	hr {
+		color: var(--color-gray-5);
+		width: 1px;
+		flex-grow: 1;
+		margin: 0;
 	}
 }
 
-.licenses-form__controls {
-	@include licensing-portal-bottom-action-bar;
-
-	@include breakpoint-deprecated("<660px") {
-		display: flex;
-
-		.total-cost {
-			margin-right: 8px;
-		}
-	}
-
-	@include breakpoint-deprecated( ">660px" ) {
-		.total-cost {
-			display: none;
-		}
-	}
+p.licenses-form__section-description {
+	font-size: rem(14px);
+	font-weight: 400;
+	line-height: 1.2;
+	margin-block-end: 32px;
 }
 
-.licenses-form__top {
-	display: flex;
-	justify-content: space-between;
-}
-
-.licenses-form__bottom {
-	display: flex;
-	flex-wrap: wrap;
+.licenses-form__section-content {
+	display: grid;
+	gap: 16px;
+	grid-template-columns: 1fr;
 
 	@include break-xlarge {
-		margin-left: -0.5rem;
-		margin-right: -0.5rem;
+		grid-template-columns: repeat(2, 1fr);
+	}
+
+	@include break-wide {
+		grid-template-columns: repeat(3, 1fr);
 	}
 }
 
@@ -73,6 +62,8 @@ p.licenses-form__description {
 	}
 }
 
-.licenses-form__separator {
-	margin: 2rem 0;
+.licenses-form__select-license {
+	// :active introduces a 1px border but :focus introduces a 1.5px border which causes the button to move around.
+	border-width: 1.5px !important;
+	border-color: transparent;
 }

--- a/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/style.scss
@@ -58,12 +58,16 @@
 }
 
 .issue-multiple-licenses-form__bottom {
-	display: flex;
-	flex-wrap: wrap;
+	display: grid;
+	gap: 16px;
+	grid-template-columns: 1fr;
 
 	@include break-xlarge {
-		margin-left: -0.5rem;
-		margin-right: -0.5rem;
+		grid-template-columns: repeat(2, 1fr);
+	}
+
+	@include break-wide {
+		grid-template-columns: repeat(3, 1fr);
 	}
 }
 

--- a/client/jetpack-cloud/sections/partner-portal/license-bundle-card/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-bundle-card/style.scss
@@ -7,9 +7,7 @@
 	justify-content: space-between;
 	box-sizing: border-box;
 
-	width: 100%;
-
-	margin: 0.5rem 0;
+	margin: 0;
 	padding: 1.5rem;
 
 	border: 1px solid var(--studio-gray-10);
@@ -18,15 +16,7 @@
 	user-select: none;
 
 	@include break-xlarge {
-
-		width: calc(50% - 1rem);
-
-		margin: 0.5rem;
 		padding: 1.75rem;
-	}
-
-	@include break-wide {
-		width: calc(33.33% - 1rem);
 	}
 }
 

--- a/client/jetpack-cloud/sections/partner-portal/license-product-card/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-product-card/style.scss
@@ -4,7 +4,6 @@
 .license-product-card {
 	display: flex;
 	justify-content: stretch;
-	width: 100%;
 
 	&.disabled {
 		opacity: 0.5;
@@ -13,19 +12,11 @@
 			cursor: not-allowed;
 		}
 	}
-
-	@include break-xlarge {
-		width: 50%;
-	}
-
-	@include break-wide {
-		width: 33.33%;
-	}
 }
 
 .license-product-card__inner {
 	flex-grow: 1;
-	margin: 0.5rem 0;
+	margin: 0;
 	padding: 1.5rem;
 	border: 1px solid var(--studio-gray-10);
 	border-radius: 4px;
@@ -33,7 +24,6 @@
 	cursor: pointer;
 
 	@include break-xlarge {
-		margin: 0.5rem;
 		padding: 1.75rem;
 	}
 }


### PR DESCRIPTION
The objective of this pull request is to reorganize the display of products and bundles in the Issue License page in accordance with the new design. 

**Please note that the items listed in the Plans section are tentative. A separate task will be assigned to consolidate the two Security plan variations into a single card. At present, the discussion regarding this is ongoing.**

https://github.com/Automattic/wp-calypso/assets/56598660/d1fc8538-ff1d-48f9-a81a-d72c1685b690


Closes https://github.com/Automattic/jetpack-genesis/issues/104

## Proposed Changes
* I have made some changes to the CSS rules of the product and bundle cards in order to reuse them with our new spacing. I removed unnecessary margins and switched from a Flexbox to a Gridbox, which simplified the CSS rules.
* I added a form section component to create a reusable template for our updated product and plan listing, along with updating the copies to match the new design.
* Products and plans-related logic were moved within a hook to declutter the license form component.

## Testing Instructions
Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

* Use the Jetpack cloud live link below and go to the Licenses page (`/partner-portal/issue-license?flags=jetpack/bundle-licensing`)
* Confirm that the items are grouped and arranged based on the new design (Except the Plans list)
* Confirm that when selecting bundle sizes, it will hide both the Woo extensions and VaultPress Backup Addons.


## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?