### PR TITLE
Assembler: Hide the back button if user is from LoTS

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -668,6 +668,7 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 			goNext={ goNext }
 			isHorizontalLayout={ false }
 			isFullLayout={ true }
+			hideBack={ isSiteAssemblerFlow( flow ) && isNewSite }
 			hideSkip={ true }
 			stepContent={
 				<PatternAssemblerContainer


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/84362

## Proposed Changes

* The current flow of the LoTS is as follows, so the back button should not point to the Theme Showcase. Hence, this PR made a change to hide the back button, “Back to themes” if users are from the LoTS
  * LoTS > Sign in/Sign up > Domains > Plans > Assembler

| Before | After (LoTS) | After (LiTS) |
| - | - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/81b69559-9956-420b-8499-1328ee791045) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/23cd8422-7fb7-4d19-91ca-dcc8d5ef6419) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/e7c5ce7a-2b9d-4be6-ab72-6be29e9e0ef3) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Existing site

* Go to /themes from your existing site
* Select the Assembler CTA
* When you land on the Assembler, you should see the back button

## New site

* Go to /themes without logged-in
* Select the Assembler CTA
* Sign in/Signup, and pick domains & plans
* When you land on the Assembler, you should **NOT** see the back button

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?