### PR TITLE
Assembler: Fix the warning when rendering svg-filters

### DIFF
--- a/packages/block-renderer/src/components/block-renderer-container.tsx
+++ b/packages/block-renderer/src/components/block-renderer-container.tsx
@@ -143,6 +143,7 @@ const ScaledBlockRendererContainer = ( {
 					/* Filters need to be rendered before children to avoid Safari rendering issues. */
 					svgFilters.map( ( preset ) => (
 						<div
+							key={ preset.slug }
 							// eslint-disable-next-line react/no-danger
 							dangerouslySetInnerHTML={ {
 								__html: getDuotoneFilter( `wp-duotone-${ preset.slug }`, preset.colors ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Use the `preset.slug` as the key to avoid the following error
  ![image](https://github.com/Automattic/wp-calypso/assets/13596067/70116534-a639-42de-954f-f68ca450709b)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Assembler
* You should not see the error below
  ![image](https://github.com/Automattic/wp-calypso/assets/13596067/70116534-a639-42de-954f-f68ca450709b)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?