### PR TITLE
Black Friday: support coupon URL param on hosting flows

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import/index.tsx
@@ -10,6 +10,8 @@ import DocumentHead from 'calypso/components/data/document-head';
 import { useCurrentRoute } from 'calypso/landing/stepper/hooks/use-current-route';
 import useMigrationConfirmation from 'calypso/landing/stepper/hooks/use-migration-confirmation';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { getQueryArgs } from 'calypso/lib/query-args/index';
+import { addQueryArgs } from 'calypso/lib/url/index';
 import { BASE_ROUTE } from './config';
 import { generateStepPath } from './helper';
 import type { Step } from '../../types';
@@ -38,8 +40,14 @@ export const ImportWrapper: Step = function ( props ) {
 	const getGoNext = () => {
 		switch ( flow ) {
 			case IMPORT_HOSTED_SITE_FLOW:
-				return () => window.location.assign( '/setup/new-hosted-site' );
-
+				return () => {
+					const { coupon } = getQueryArgs();
+					const url =
+						typeof coupon === 'string'
+							? addQueryArgs( { coupon }, '/setup/new-hosted-site' )
+							: '/setup/new-hosted-site';
+					window.location.assign( url );
+				};
 			default:
 				return navigation.goNext;
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/new-hosted-site-options.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/new-hosted-site-options.tsx
@@ -15,6 +15,8 @@ import FormSettingExplanation from 'calypso/components/forms/form-setting-explan
 import FormInput from 'calypso/components/forms/form-text-input';
 import { useGetSiteSuggestionsQuery } from 'calypso/landing/stepper/hooks/use-get-site-suggestions-query';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { getQueryArgs } from 'calypso/lib/query-args/index';
+import { addQueryArgs } from 'calypso/lib/url/index';
 import { tip } from 'calypso/signup/icons';
 import { ONBOARD_STORE } from '../../../../stores';
 import type { StepProps } from '../../types';
@@ -168,7 +170,14 @@ export const NewHostedSiteOptions = ( { navigation }: Pick< StepProps, 'navigati
 				backLabelText={ __( 'Back' ) }
 				goBack={ goBack }
 				skipLabelText={ __( 'Migrate a site' ) }
-				goNext={ () => window.location.assign( '/setup/import-hosted-site' ) }
+				goNext={ () => {
+					const { coupon } = getQueryArgs();
+					const url =
+						typeof coupon === 'string'
+							? addQueryArgs( { coupon }, '/setup/import-hosted-site' )
+							: '/setup/import-hosted-site';
+					window.location.assign( url );
+				} }
 				isHorizontalLayout
 				formattedHeader={
 					<FormattedHeader id="site-options-header" headerText={ headerText } align="left" />

--- a/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
@@ -3,6 +3,7 @@ import { NEW_HOSTED_SITE_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { useEffect, useLayoutEffect } from 'react';
+import { getQueryArgs } from 'calypso/lib/query-args';
 import {
 	setSignupCompleteSlug,
 	persistSignupDestination,
@@ -135,12 +136,14 @@ const hosting: Flow = {
 					setSignupCompleteFlowName( flowName );
 
 					if ( providedDependencies.goToCheckout ) {
+						const { coupon } = getQueryArgs();
+
 						return window.location.assign(
 							addQueryArgs(
 								`/checkout/${ encodeURIComponent(
 									( providedDependencies?.siteSlug as string ) ?? ''
 								) }`,
-								{ redirect_to: destination }
+								{ redirect_to: destination, coupon }
 							)
 						);
 					}

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -238,17 +238,23 @@ function getDIFMSiteContentCollectionDestination( { siteSlug } ) {
 }
 
 function getHostingFlowDestination() {
-	const queryArgs = getQueryArgs();
+	const { flow, coupon } = getQueryArgs();
 
-	if ( queryArgs.flow === 'new-hosted-site' ) {
-		return '/setup/new-hosted-site';
+	if ( flow === 'new-hosted-site' ) {
+		return typeof coupon === 'string'
+			? addQueryArgs( { coupon }, '/setup/new-hosted-site' )
+			: '/setup/new-hosted-site';
 	}
 
-	if ( queryArgs.flow === 'import-hosted-site' ) {
-		return '/setup/import-hosted-site';
+	if ( flow === 'import-hosted-site' ) {
+		return typeof coupon === 'string'
+			? addQueryArgs( { coupon }, '/setup/import-hosted-site' )
+			: '/setup/import-hosted-site';
 	}
 
-	return '/sites?hosting-flow=true';
+	return typeof coupon === 'string'
+		? addQueryArgs( { coupon }, '/sites?hosting-flow=true' )
+		: '/sites?hosting-flow=true';
 }
 
 const flows = generateFlows( {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4567

## Proposed Changes

* Support Black Friday coupon on hosting flows. In practice, this means checking for a `coupon` URL param and passing it through the flows. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch
* Use a start URL like `/start/hosting/user-hosting?ref=hosting-lp&section=hero&flow=new-hosted-site&coupon=test`. Note the `coupon` param, which can be anything for this test. 
* Go through the flow until the checkout. If the coupon name you used is nonexistent, you will see an error as shown below - that's fine. We are just interested in the `coupon` param handling at this stage. 
    * Try with a new user
    * Try with a logged-in user
    * Try with a logged-out user
    * Try switching to "Migrate a site" via the options step
    * Try switching back to "Create a site"
    * In all scenarios, `coupon` should persist until checkout. 
* Try with other URL params, e.g. `shouldNotPersist=true` and ensure they are stripped
* Try the regular flow with no param, i.e. current prod behaviour and make sure it still works
* There is no validation in this PR. Should there be? Need to test it with a temp coupon with a date range outside the current date and ensure the server validation handles that. I don't think we want client-side date validation, which can be hacked easily. 

**Note**: The code feels a bit longwinded thanks to the type of `QueryArgParsed` and that it can be `undefined`. But I kept it simple as this code will probably get removed on the 31st. 

![image](https://github.com/Automattic/wp-calypso/assets/6851384/03be916f-291d-4fac-82e2-5c7f9f5e2489)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?