### PR TITLE
wp-admin Site Default: Add ellipsis menu item

### DIFF
--- a/client/my-sites/hosting/site-admin-interface-card/index.js
+++ b/client/my-sites/hosting/site-admin-interface-card/index.js
@@ -76,9 +76,9 @@ const SiteAdminInterfaceCard = ( { siteId, adminInterface } ) => {
 	}, [ adminInterface ] );
 
 	return (
-		<Card className="sitewpadmin-card">
+		<Card>
 			<MaterialIcon icon="display_settings" style="filled" size={ 32 } />
-			<CardHeading id="sitewpadmin-card" size={ 20 }>
+			<CardHeading id="admin-interface-style" size={ 20 }>
 				{ translate( 'Admin interface style' ) }
 			</CardHeading>
 			<p>

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -301,6 +301,11 @@ function useSubmenuItems( site: SiteExcerptData ) {
 				href: `/hosting-config/${ siteSlug }#cache`,
 				sectionName: 'cache',
 			},
+			{
+				label: __( 'Admin interface style' ),
+				href: `/hosting-config/${ siteSlug }#admin-interface-style`,
+				sectionName: 'admin-interface-style',
+			},
 		].filter( ( { condition } ) => condition ?? true );
 	}, [ __, siteSlug, hasStagingSitesFeature, isA12n ] );
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/4444

## Proposed Changes

Adds "Admin interface style" as an option to the ellipsis menu:

![CleanShot 2023-11-21 at 04 07 02@2x](https://github.com/Automattic/wp-calypso/assets/36432/4917f1a3-1bcf-4419-b40e-61136be21e08)


## Testing Instructions

1. Navigate to the Sites page.
2. Verify "Admin interface style" appears as an ellipsis menu option for a WoA site.
3. Verify clicking on the link takes you to the expected card.
4. Verify "Admin interface style" doesn't appear as an ellipsis menu option for other sites.