### PR TITLE
Show notice only for 'open' invoices

### DIFF
--- a/client/jetpack-cloud/components/missing-payment-notification/index.tsx
+++ b/client/jetpack-cloud/components/missing-payment-notification/index.tsx
@@ -15,7 +15,7 @@ export default function MissingPaymentNotification() {
 	}
 
 	const latestUnpaidInvoice = partner.keys.reduce< Invoice | null >( ( latestInvoice, key ) => {
-		if ( key.latestInvoice && key.latestInvoice.status !== 'paid' ) {
+		if ( key.latestInvoice && key.latestInvoice.status === 'open' ) {
 			return key.latestInvoice;
 		}
 		return latestInvoice;

--- a/client/jetpack-cloud/components/missing-payment-notification/index.tsx
+++ b/client/jetpack-cloud/components/missing-payment-notification/index.tsx
@@ -3,7 +3,6 @@ import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import Notice from 'calypso/components/notice';
 import { getCurrentPartner } from 'calypso/state/partner-portal/partner/selectors';
-import { Invoice } from 'calypso/state/partner-portal/types';
 
 export default function MissingPaymentNotification() {
 	const partner = useSelector( getCurrentPartner );
@@ -14,18 +13,15 @@ export default function MissingPaymentNotification() {
 		return null;
 	}
 
-	const latestUnpaidInvoice = partner.keys.reduce< Invoice | null >( ( latestInvoice, key ) => {
-		if ( key.latestInvoice && key.latestInvoice.status === 'open' ) {
-			return key.latestInvoice;
-		}
-		return latestInvoice;
-	}, null );
+	const firstUnpaidInvoice = partner.keys.find(
+		( key ) => key.latestInvoice && key.latestInvoice.status === 'open'
+	)?.latestInvoice;
 
-	if ( latestUnpaidInvoice ) {
+	if ( firstUnpaidInvoice ) {
 		const warningText = translate(
 			"The payment for your %s invoice didn't go through. Please take a moment to complete payment.",
 			{
-				args: new Date( Number( latestUnpaidInvoice.effectiveAt ) * 1000 ).toLocaleString( locale, {
+				args: new Date( Number( firstUnpaidInvoice.effectiveAt ) * 1000 ).toLocaleString( locale, {
 					month: 'long',
 				} ),
 			}


### PR DESCRIPTION
Related to https://github.com/Automattic/jetpack-manage/issues/131

## Proposed Changes

* This PR fixes the unpaid invoice notice show condition to show only for invoices with the 'open' status. More information: p1700576374498969-slack-C02C312V9

## Testing Instructions

* If you know how to add an unpaid invoice to your user do it, else there is information here on an easy way to do this: p1700148938480389/1700110298.551569-slack-CTXBP902X
  * Go to your Dashboard
  * The notice should be displayed alerting you about a missing payment, and a link pointing to invoices should be present
  * The same notice should be displayed in the Plugins page, and Licenses
  * The notice should only be shown for 'open' status invoices.


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?