### PR TITLE
refactor some `useInfiniteQuery` to use object syntax

### DIFF
--- a/client/data/followers/use-followers-query.js
+++ b/client/data/followers/use-followers-query.js
@@ -27,33 +27,31 @@ const compareUnique = ( a, b ) => a.ID === b.ID;
 const useFollowersQuery = ( siteId, type = 'wpcom', fetchOptions = {}, queryOptions = {} ) => {
 	const { search } = fetchOptions;
 
-	return useInfiniteQuery(
-		[ 'followers', siteId, type, search ],
-		async ( { pageParam = 1 } ) =>
+	return useInfiniteQuery( {
+		queryKey: [ 'followers', siteId, type, search ],
+		queryFn: async ( { pageParam = 1 } ) =>
 			wpcom.req.get( `/sites/${ siteId }/followers`, {
 				...defaults,
 				...fetchOptions,
 				type,
 				page: pageParam,
 			} ),
-		{
-			...queryOptions,
-			getNextPageParam: ( lastPage, allPages ) => {
-				if ( lastPage.pages <= allPages.length || allPages.length >= MAX_FOLLOWERS ) {
-					return;
-				}
-				return allPages.length + 1;
-			},
-			select: ( data ) => {
-				return {
-					/* @TODO: `uniqueBy` is necessary, because the API can return duplicates */
-					followers: uniqueBy( extractPages( data.pages ), compareUnique ),
-					total: data.pages[ 0 ].total,
-					...data,
-				};
-			},
-		}
-	);
+		...queryOptions,
+		getNextPageParam: ( lastPage, allPages ) => {
+			if ( lastPage.pages <= allPages.length || allPages.length >= MAX_FOLLOWERS ) {
+				return;
+			}
+			return allPages.length + 1;
+		},
+		select: ( data ) => {
+			return {
+				/* @TODO: `uniqueBy` is necessary, because the API can return duplicates */
+				followers: uniqueBy( extractPages( data.pages ), compareUnique ),
+				total: data.pages[ 0 ].total,
+				...data,
+			};
+		},
+	} );
 };
 
 export default useFollowersQuery;

--- a/client/data/promote-post/use-promote-post-campaigns-query-paged.ts
+++ b/client/data/promote-post/use-promote-post-campaigns-query-paged.ts
@@ -29,9 +29,9 @@ const useCampaignsQueryPaged = (
 ) => {
 	const searchQueryParams = getSearchOptionsQueryParams( searchOptions );
 
-	return useInfiniteQuery(
-		[ 'promote-post-campaigns', siteId, searchQueryParams ],
-		async ( { pageParam = 1 } ) => {
+	return useInfiniteQuery( {
+		queryKey: [ 'promote-post-campaigns', siteId, searchQueryParams ],
+		queryFn: async ( { pageParam = 1 } ) => {
 			const searchCampaignsUrl = `/search/campaigns/site/${ siteId }?order=asc&order_by=post_date&page=${ pageParam }${ searchQueryParams }`;
 			const resultQuery = await requestDSPHandleErrors< CampaignQueryResult >(
 				siteId,
@@ -49,23 +49,21 @@ const useCampaignsQueryPaged = (
 				page,
 			};
 		},
-		{
-			...queryOptions,
-			enabled: !! siteId,
-			retryDelay: 3000,
-			keepPreviousData: true,
-			refetchOnWindowFocus: false,
-			meta: {
-				persist: false,
-			},
-			getNextPageParam: ( lastPage ) => {
-				if ( lastPage.has_more_pages ) {
-					return lastPage.page + 1;
-				}
-				return undefined;
-			},
-		}
-	);
+		...queryOptions,
+		enabled: !! siteId,
+		retryDelay: 3000,
+		keepPreviousData: true,
+		refetchOnWindowFocus: false,
+		meta: {
+			persist: false,
+		},
+		getNextPageParam: ( lastPage ) => {
+			if ( lastPage.has_more_pages ) {
+				return lastPage.page + 1;
+			}
+			return undefined;
+		},
+	} );
 };
 
 export default useCampaignsQueryPaged;

--- a/client/data/promote-post/use-promote-post-posts-query-paged.ts
+++ b/client/data/promote-post/use-promote-post-posts-query-paged.ts
@@ -45,9 +45,9 @@ const usePostsQueryPaged = (
 	queryOptions: BlazablePostsQueryOptions = {}
 ): InfiniteQueryObserverResult< PostQueryResult > => {
 	const searchQueryParams = getSearchOptionsQueryParams( searchOptions );
-	return useInfiniteQuery(
-		[ 'promote-post-posts', siteId, searchQueryParams ],
-		async ( { pageParam = 1 } ) => {
+	return useInfiniteQuery( {
+		queryKey: [ 'promote-post-posts', siteId, searchQueryParams ],
+		queryFn: async ( { pageParam = 1 } ) => {
 			// Fetch blazable posts
 			const postsResponse = await queryPosts( siteId, `page=${ pageParam }${ searchQueryParams }` );
 
@@ -62,23 +62,21 @@ const usePostsQueryPaged = (
 				page,
 			};
 		},
-		{
-			...queryOptions,
-			enabled: !! siteId,
-			retryDelay: 3000,
-			keepPreviousData: true,
-			refetchOnWindowFocus: false,
-			meta: {
-				persist: false,
-			},
-			getNextPageParam: ( lastPage ) => {
-				if ( lastPage.has_more_pages ) {
-					return lastPage.page + 1;
-				}
-				return undefined;
-			},
-		}
-	);
+		...queryOptions,
+		enabled: !! siteId,
+		retryDelay: 3000,
+		keepPreviousData: true,
+		refetchOnWindowFocus: false,
+		meta: {
+			persist: false,
+		},
+		getNextPageParam: ( lastPage ) => {
+			if ( lastPage.has_more_pages ) {
+				return lastPage.page + 1;
+			}
+			return undefined;
+		},
+	} );
 };
 
 export default usePostsQueryPaged;

--- a/client/data/users/use-users-query.js
+++ b/client/data/users/use-users-query.js
@@ -14,34 +14,32 @@ const compareUnique = ( a, b ) => a.ID === b.ID;
 const useUsersQuery = ( siteId, fetchOptions = {}, queryOptions = {} ) => {
 	const { search } = fetchOptions;
 
-	return useInfiniteQuery(
-		[ 'users', siteId, search ],
-		( { pageParam = 0 } ) =>
+	return useInfiniteQuery( {
+		queryKey: [ 'users', siteId, search ],
+		queryFn: ( { pageParam = 0 } ) =>
 			wpcom.req.get( `/sites/${ siteId }/users`, {
 				...defaults,
 				...fetchOptions,
 				offset: pageParam,
 			} ),
-		{
-			enabled: !! siteId,
-			getNextPageParam: ( lastPage, allPages ) => {
-				const n = fetchOptions.number ?? defaults.number;
-				if ( lastPage.found <= allPages.length * n ) {
-					return;
-				}
-				return allPages.length * n;
-			},
-			select: ( data ) => {
-				return {
-					/* @TODO: `uniqueBy` is necessary, because the API can return duplicates */
-					users: uniqueBy( extractPages( data.pages ), compareUnique ),
-					total: data.pages[ 0 ].found,
-					...data,
-				};
-			},
-			...queryOptions,
-		}
-	);
+		enabled: !! siteId,
+		getNextPageParam: ( lastPage, allPages ) => {
+			const n = fetchOptions.number ?? defaults.number;
+			if ( lastPage.found <= allPages.length * n ) {
+				return;
+			}
+			return allPages.length * n;
+		},
+		select: ( data ) => {
+			return {
+				/* @TODO: `uniqueBy` is necessary, because the API can return duplicates */
+				users: uniqueBy( extractPages( data.pages ), compareUnique ),
+				total: data.pages[ 0 ].found,
+				...data,
+			};
+		},
+		...queryOptions,
+	} );
 };
 
 export default useUsersQuery;

--- a/client/data/viewers/use-viewers-query.js
+++ b/client/data/viewers/use-viewers-query.js
@@ -8,28 +8,26 @@ const compareUnique = ( a, b ) => a.ID === b.ID;
 const DEFAULT_PER_PAGE = 100;
 
 const useViewersQuery = ( siteId, { number = DEFAULT_PER_PAGE } = {}, queryOptions = {} ) => {
-	return useInfiniteQuery(
-		[ 'viewers', siteId ],
-		( { pageParam = 1 } ) =>
+	return useInfiniteQuery( {
+		queryKey: [ 'viewers', siteId ],
+		queryFn: ( { pageParam = 1 } ) =>
 			wpcom.req.get( `/sites/${ siteId }/viewers`, { number, page: pageParam } ),
-		{
-			...queryOptions,
-			getNextPageParam: ( lastPage, allPages ) => {
-				if ( lastPage.found <= allPages.length * number ) {
-					return;
-				}
-				return allPages.length + 1;
-			},
-			select: ( data ) => {
-				return {
-					/* @TODO: `uniqueBy` is necessary, because the API can return duplicates */
-					viewers: uniqueBy( extractPages( data.pages ), compareUnique ),
-					total: data.pages[ 0 ].found,
-					...data,
-				};
-			},
-		}
-	);
+		...queryOptions,
+		getNextPageParam: ( lastPage, allPages ) => {
+			if ( lastPage.found <= allPages.length * number ) {
+				return;
+			}
+			return allPages.length + 1;
+		},
+		select: ( data ) => {
+			return {
+				/* @TODO: `uniqueBy` is necessary, because the API can return duplicates */
+				viewers: uniqueBy( extractPages( data.pages ), compareUnique ),
+				total: data.pages[ 0 ].found,
+				...data,
+			};
+		},
+	} );
 };
 
 export default useViewersQuery;

--- a/packages/data-stores/src/reader/queries/use-post-subscriptions-query.ts
+++ b/packages/data-stores/src/reader/queries/use-post-subscriptions-query.ts
@@ -46,9 +46,9 @@ const usePostSubscriptionsQuery = ( {
 	const cacheKey = useCacheKey( postSubscriptionsQueryKeyPrefix );
 
 	const { data, isFetching, isFetchingNextPage, fetchNextPage, hasNextPage, ...rest } =
-		useInfiniteQuery< SubscriptionManagerPostSubscriptions >(
-			cacheKey,
-			async ( { pageParam = 1 } ) => {
+		useInfiniteQuery< SubscriptionManagerPostSubscriptions >( {
+			queryKey: cacheKey,
+			queryFn: async ( { pageParam = 1 } ) => {
 				const result = await callApi< SubscriptionManagerPostSubscriptions >( {
 					path: `/post-comment-subscriptions?per_page=${ number }&page=${ pageParam }`,
 					isLoggedIn,
@@ -58,15 +58,13 @@ const usePostSubscriptionsQuery = ( {
 
 				return result;
 			},
-			{
-				enabled,
-				getNextPageParam: ( lastPage, pages ) =>
-					pages.length * number >= lastPage.total_comment_subscriptions_count
-						? undefined
-						: pages.length + 1,
-				refetchOnWindowFocus: false,
-			}
-		);
+			enabled,
+			getNextPageParam: ( lastPage, pages ) =>
+				pages.length * number >= lastPage.total_comment_subscriptions_count
+					? undefined
+					: pages.length + 1,
+			refetchOnWindowFocus: false,
+		} );
 
 	useEffect( () => {
 		if ( hasNextPage && ! isFetchingNextPage && ! isFetching ) {

--- a/packages/data-stores/src/reader/queries/use-read-feed-search-query.ts
+++ b/packages/data-stores/src/reader/queries/use-read-feed-search-query.ts
@@ -42,9 +42,9 @@ const useReadFeedSearchQuery = ( {
 	excludeFollowed = false,
 	sort = FeedSort.Relevance,
 }: ReadFeedSearchQueryProps ) => {
-	return useInfiniteQuery(
-		[ 'read', 'feed', 'search', query, excludeFollowed, sort ],
-		async ( { pageParam: pageParamQueryString } ) => {
+	return useInfiniteQuery( {
+		queryKey: [ 'read', 'feed', 'search', query, excludeFollowed, sort ],
+		queryFn: async ( { pageParam: pageParamQueryString } ) => {
 			if ( query === undefined ) {
 				return;
 			}
@@ -62,12 +62,10 @@ const useReadFeedSearchQuery = ( {
 				query: urlQuery,
 			} );
 		},
-		{
-			enabled: Boolean( query ),
-			getNextPageParam: ( lastPage ) => lastPage?.next_page,
-			refetchOnWindowFocus: false,
-		}
-	);
+		enabled: Boolean( query ),
+		getNextPageParam: ( lastPage ) => lastPage?.next_page,
+		refetchOnWindowFocus: false,
+	} );
 };
 
 export default useReadFeedSearchQuery;

--- a/packages/data-stores/src/reader/queries/use-site-subscriptions-query.ts
+++ b/packages/data-stores/src/reader/queries/use-site-subscriptions-query.ts
@@ -56,9 +56,9 @@ const useSiteSubscriptionsQuery = ( {
 	const { searchTerm, filterOption, sortTerm } = useSiteSubscriptionsQueryProps();
 
 	const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isFetching, ...rest } =
-		useInfiniteQuery< SubscriptionManagerSiteSubscriptions >(
-			cacheKey,
-			async ( { pageParam = 1 } ) => {
+		useInfiniteQuery< SubscriptionManagerSiteSubscriptions >( {
+			queryKey: cacheKey,
+			queryFn: async ( { pageParam = 1 } ) => {
 				const data = await callApi< SubscriptionManagerSiteSubscriptions >( {
 					path: `/read/following/mine?number=${ number }&page=${ pageParam }`,
 					isLoggedIn,
@@ -76,16 +76,12 @@ const useSiteSubscriptionsQuery = ( {
 						: [],
 				};
 			},
-			{
-				enabled,
-				getNextPageParam: ( lastPage, pages ) => {
-					return lastPage.page * number < lastPage.total_subscriptions
-						? pages.length + 1
-						: undefined;
-				},
-				refetchOnWindowFocus: false,
-			}
-		);
+			enabled,
+			getNextPageParam: ( lastPage, pages ) => {
+				return lastPage.page * number < lastPage.total_subscriptions ? pages.length + 1 : undefined;
+			},
+			refetchOnWindowFocus: false,
+		} );
 
 	const nextPage = hasNextPage && ! isFetching && data ? data.pages.length + 1 : null;
 


### PR DESCRIPTION
Part of #84338 

## Proposed Changes

This PR changes all instances of `useInfiniteQuery` to use object syntax as other signatures are removed in v5 of RQ.

## Testing Instructions

This is a mere refactoring without real changes to running code. I think a thorough code review should suffice but smoke testing the Reader, the people section and Advertising (`/advertising/campaigns`) won't hurt.