### PR TITLE
chore: run `remove-overloads` codemod on query files

### DIFF
--- a/client/blocks/blog-stickers/use-add-blog-sticker-mutation.js
+++ b/client/blocks/blog-stickers/use-add-blog-sticker-mutation.js
@@ -17,7 +17,9 @@ export const useAddBlogStickerMutation = ( options = {} ) => {
 		...options,
 		onSuccess( ...args ) {
 			const [ , { blogId } ] = args;
-			queryClient.invalidateQueries( [ `blog-stickers`, blogId ] );
+			queryClient.invalidateQueries( {
+				queryKey: [ `blog-stickers`, blogId ],
+			} );
 			options.onSuccess?.( ...args );
 		},
 	} );

--- a/client/blocks/blog-stickers/use-remove-blog-sticker-mutation.js
+++ b/client/blocks/blog-stickers/use-remove-blog-sticker-mutation.js
@@ -19,7 +19,9 @@ export const useRemoveBlogStickerMutation = ( options = {} ) => {
 		...options,
 		onSuccess( ...args ) {
 			const [ , { blogId } ] = args;
-			queryClient.invalidateQueries( [ `blog-stickers`, blogId ] );
+			queryClient.invalidateQueries( {
+				queryKey: [ `blog-stickers`, blogId ],
+			} );
 			options.onSuccess?.( ...args );
 		},
 	} );

--- a/client/components/blazepress-widget/index.tsx
+++ b/client/components/blazepress-widget/index.tsx
@@ -66,11 +66,16 @@ const BlazePressWidget = ( props: BlazePressPromotionProps ) => {
 	};
 
 	const onClose = ( goToCampaigns?: boolean ) => {
-		queryClient.invalidateQueries( [ 'promote-post-campaigns', siteId ] );
+		queryClient.invalidateQueries( {
+			queryKey: [ 'promote-post-campaigns', siteId ],
+		} );
 		if ( goToCampaigns ) {
 			page( getAdvertisingDashboardPath( `/campaigns/${ siteSlug }` ) );
 		} else {
-			queryClient && queryClient.invalidateQueries( [ 'promote-post-campaigns', siteId ] );
+			queryClient &&
+				queryClient.invalidateQueries( {
+					queryKey: [ 'promote-post-campaigns', siteId ],
+				} );
 			if ( previousRoute ) {
 				closeModal();
 			} else {

--- a/client/components/site-preview-link/use-create-site-preview-link.ts
+++ b/client/components/site-preview-link/use-create-site-preview-link.ts
@@ -31,7 +31,9 @@ export const useCreateSitePreviewLink = ( options: UseCreateSitePreviewLinkOptio
 			onError?.();
 		},
 		onMutate: async () => {
-			await queryClient.cancelQueries( queryKey );
+			await queryClient.cancelQueries( {
+				queryKey: queryKey,
+			} );
 			const cachedData = queryClient.getQueryData( queryKey );
 			queryClient.setQueryData< PreviewLinksResponse >( queryKey, ( old ) => [
 				...( old ?? [] ),
@@ -47,7 +49,9 @@ export const useCreateSitePreviewLink = ( options: UseCreateSitePreviewLinkOptio
 			if ( data?.code ) {
 				queryClient.setQueryData( queryKey, () => [ data ] );
 			}
-			queryClient.invalidateQueries( queryKey );
+			queryClient.invalidateQueries( {
+				queryKey: queryKey,
+			} );
 		},
 	} );
 

--- a/client/components/site-preview-link/use-create-site-preview-link.ts
+++ b/client/components/site-preview-link/use-create-site-preview-link.ts
@@ -32,7 +32,7 @@ export const useCreateSitePreviewLink = ( options: UseCreateSitePreviewLinkOptio
 		},
 		onMutate: async () => {
 			await queryClient.cancelQueries( {
-				queryKey: queryKey,
+				queryKey,
 			} );
 			const cachedData = queryClient.getQueryData( queryKey );
 			queryClient.setQueryData< PreviewLinksResponse >( queryKey, ( old ) => [
@@ -50,7 +50,7 @@ export const useCreateSitePreviewLink = ( options: UseCreateSitePreviewLinkOptio
 				queryClient.setQueryData( queryKey, () => [ data ] );
 			}
 			queryClient.invalidateQueries( {
-				queryKey: queryKey,
+				queryKey,
 			} );
 		},
 	} );

--- a/client/components/site-preview-link/use-delete-site-preview-link.ts
+++ b/client/components/site-preview-link/use-delete-site-preview-link.ts
@@ -28,7 +28,9 @@ export const useDeleteSitePreviewLink = ( options: UseDeleteSitePreviewLinkOptio
 			onSuccess?.();
 		},
 		onMutate: async ( code: string ) => {
-			await queryClient.cancelQueries( queryKey );
+			await queryClient.cancelQueries( {
+				queryKey: queryKey,
+			} );
 			const cachedData = queryClient.getQueryData< PreviewLinksResponse >( queryKey );
 			queryClient.setQueryData< PreviewLinksResponse >( queryKey, ( old ) => {
 				const previewLinks = old ?? [];
@@ -56,7 +58,9 @@ export const useDeleteSitePreviewLink = ( options: UseDeleteSitePreviewLinkOptio
 					() => cachedData?.filter( ( previewLink ) => ! previewLink.isRemoving )
 				);
 			}
-			queryClient.invalidateQueries( queryKey );
+			queryClient.invalidateQueries( {
+				queryKey: queryKey,
+			} );
 		},
 	} );
 

--- a/client/components/site-preview-link/use-delete-site-preview-link.ts
+++ b/client/components/site-preview-link/use-delete-site-preview-link.ts
@@ -29,7 +29,7 @@ export const useDeleteSitePreviewLink = ( options: UseDeleteSitePreviewLinkOptio
 		},
 		onMutate: async ( code: string ) => {
 			await queryClient.cancelQueries( {
-				queryKey: queryKey,
+				queryKey,
 			} );
 			const cachedData = queryClient.getQueryData< PreviewLinksResponse >( queryKey );
 			queryClient.setQueryData< PreviewLinksResponse >( queryKey, ( old ) => {
@@ -59,7 +59,7 @@ export const useDeleteSitePreviewLink = ( options: UseDeleteSitePreviewLinkOptio
 				);
 			}
 			queryClient.invalidateQueries( {
-				queryKey: queryKey,
+				queryKey,
 			} );
 		},
 	} );

--- a/client/data/application-passwords/use-create-app-password-mutation.js
+++ b/client/data/application-passwords/use-create-app-password-mutation.js
@@ -11,7 +11,9 @@ const useCreateAppPasswordMutation = ( queryOptions = {} ) => {
 			} ),
 		...queryOptions,
 		onSuccess( ...args ) {
-			queryClient.invalidateQueries( [ 'application-passwords' ] );
+			queryClient.invalidateQueries( {
+				queryKey: [ 'application-passwords' ],
+			} );
 			queryOptions.onSuccess?.( ...args );
 		},
 	} );

--- a/client/data/application-passwords/use-delete-app-password-mutation.js
+++ b/client/data/application-passwords/use-delete-app-password-mutation.js
@@ -9,7 +9,9 @@ const useDeleteAppPasswordMutation = ( queryOptions = {} ) => {
 			wp.req.post( `/me/two-step/application-passwords/${ appPasswordId }/delete` ),
 		...queryOptions,
 		onSuccess( ...args ) {
-			queryClient.invalidateQueries( [ 'application-passwords' ] );
+			queryClient.invalidateQueries( {
+				queryKey: [ 'application-passwords' ],
+			} );
 			queryOptions.onSuccess?.( ...args );
 		},
 	} );

--- a/client/data/courses/use-update-user-course-progression-mutation.js
+++ b/client/data/courses/use-update-user-course-progression-mutation.js
@@ -18,7 +18,9 @@ function useUpdateUserCourseProgressionMutation( queryOptions = {} ) {
 			),
 		...queryOptions,
 		onSuccess( data, variables, context ) {
-			queryClient.invalidateQueries( [ 'courses', variables.courseSlug ] );
+			queryClient.invalidateQueries( {
+				queryKey: [ 'courses', variables.courseSlug ],
+			} );
 			queryOptions.onSuccess?.( data, variables, context );
 		},
 	} );

--- a/client/data/domains/forwarding/use-delete-domain-forwarding-mutation.ts
+++ b/client/data/domains/forwarding/use-delete-domain-forwarding-mutation.ts
@@ -19,7 +19,7 @@ export default function useDeleteDomainForwardingMutation(
 			} ),
 		...queryOptions,
 		onSuccess() {
-			queryClient.removeQueries( domainForwardingQueryKey( domainName ) );
+			queryClient.removeQueries( { queryKey: domainForwardingQueryKey( domainName ) } );
 			queryOptions.onSuccess?.();
 		},
 	} );

--- a/client/data/domains/forwarding/use-update-domain-forwarding-mutation.ts
+++ b/client/data/domains/forwarding/use-update-domain-forwarding-mutation.ts
@@ -18,7 +18,7 @@ export default function useUpdateDomainForwardingMutation(
 			wp.req.post( `/sites/all/domain/${ domainName }/redirects`, forwarding ),
 		...queryOptions,
 		onSuccess() {
-			queryClient.invalidateQueries( domainForwardingQueryKey( domainName ) );
+			queryClient.invalidateQueries( { queryKey: domainForwardingQueryKey( domainName ) } );
 			queryOptions.onSuccess?.();
 		},
 		onError( error: DomainsApiError ) {

--- a/client/data/domains/nameservers/use-update-nameservers-mutation.js
+++ b/client/data/domains/nameservers/use-update-nameservers-mutation.js
@@ -11,7 +11,9 @@ function useUpdateNameserversMutation( domainName, queryOptions = {} ) {
 			} ),
 		...queryOptions,
 		onSuccess( ...args ) {
-			queryClient.invalidateQueries( [ 'domain-nameservers', domainName ] );
+			queryClient.invalidateQueries( {
+				queryKey: [ 'domain-nameservers', domainName ],
+			} );
 			queryOptions.onSuccess?.( ...args );
 		},
 	} );

--- a/client/data/domains/transfers/use-domain-transfer-request-delete.ts
+++ b/client/data/domains/transfers/use-domain-transfer-request-delete.ts
@@ -18,7 +18,9 @@ export default function useDomainTransferRequestDelete(
 			wp.req.post( `/sites/${ siteSlug }/domains/${ domainName }/transfer-to-any-user/delete` ),
 		...queryOptions,
 		onSuccess() {
-			queryClient.removeQueries( domainTransferRequestQueryKey( siteSlug, domainName ) );
+			queryClient.removeQueries( {
+				queryKey: domainTransferRequestQueryKey( siteSlug, domainName ),
+			} );
 			queryOptions.onSuccess?.();
 		},
 	} );

--- a/client/data/domains/transfers/use-domain-transfer-request-update.ts
+++ b/client/data/domains/transfers/use-domain-transfer-request-update.ts
@@ -20,7 +20,9 @@ export default function useDomainTransferRequestUpdate(
 			} ),
 		...queryOptions,
 		onSuccess() {
-			queryClient.invalidateQueries( domainTransferRequestQueryKey( siteSlug, domainName ) );
+			queryClient.invalidateQueries( {
+				queryKey: domainTransferRequestQueryKey( siteSlug, domainName ),
+			} );
 			queryOptions.onSuccess?.();
 		},
 	} );

--- a/client/data/emails/use-add-email-forward-mutation.tsx
+++ b/client/data/emails/use-add-email-forward-mutation.tsx
@@ -22,7 +22,9 @@ type Context = {
 const MUTATION_KEY = 'addEmailForward';
 
 export function useIsLoading() {
-	const activeCount = useIsMutating( [ MUTATION_KEY ] );
+	const activeCount = useIsMutating( {
+		mutationKey: [ MUTATION_KEY ],
+	} );
 
 	return Boolean( activeCount );
 }

--- a/client/data/emails/use-add-email-forward-mutation.tsx
+++ b/client/data/emails/use-add-email-forward-mutation.tsx
@@ -60,16 +60,16 @@ export default function useAddEmailForwardMutation(
 	mutationOptions.onSettled = ( data, error, variables, context ) => {
 		suppliedOnSettled?.( data, error, variables, context );
 
-		queryClient.invalidateQueries( emailAccountsQueryKey );
-		queryClient.invalidateQueries( domainsQueryKey );
+		queryClient.invalidateQueries( { queryKey: emailAccountsQueryKey } );
+		queryClient.invalidateQueries( { queryKey: domainsQueryKey } );
 	};
 
 	mutationOptions.onMutate = async ( variables ) => {
 		const { mailbox, destination } = variables;
 		suppliedOnMutate?.( variables );
 
-		await queryClient.cancelQueries( emailAccountsQueryKey );
-		await queryClient.cancelQueries( domainsQueryKey );
+		await queryClient.cancelQueries( { queryKey: emailAccountsQueryKey } );
+		await queryClient.cancelQueries( { queryKey: domainsQueryKey } );
 
 		const previousEmailAccountsQueryData = queryClient.getQueryData< any >( emailAccountsQueryKey );
 		const emailForwards = previousEmailAccountsQueryData?.accounts?.[ 0 ]?.emails;

--- a/client/data/emails/use-remove-email-forward-mutation.tsx
+++ b/client/data/emails/use-remove-email-forward-mutation.tsx
@@ -48,15 +48,15 @@ export default function useRemoveEmailForwardMutation(
 	mutationOptions.onSettled = ( data, error, variables, context ) => {
 		suppliedOnSettled?.( data, error, variables, context );
 
-		queryClient.invalidateQueries( emailAccountsQueryKey );
-		queryClient.invalidateQueries( domainsQueryKey );
+		queryClient.invalidateQueries( { queryKey: emailAccountsQueryKey } );
+		queryClient.invalidateQueries( { queryKey: domainsQueryKey } );
 	};
 
 	mutationOptions.onMutate = async ( emailForward ) => {
 		suppliedOnMutate?.( emailForward );
 
-		await queryClient.cancelQueries( emailAccountsQueryKey );
-		await queryClient.cancelQueries( domainsQueryKey );
+		await queryClient.cancelQueries( { queryKey: emailAccountsQueryKey } );
+		await queryClient.cancelQueries( { queryKey: domainsQueryKey } );
 
 		const previousEmailAccountsQueryData = queryClient.getQueryData< any >( emailAccountsQueryKey );
 

--- a/client/data/emails/use-remove-titan-mailbox-mutation.ts
+++ b/client/data/emails/use-remove-titan-mailbox-mutation.ts
@@ -47,7 +47,7 @@ export function useRemoveTitanMailboxMutation(
 
 	// Setup actions to happen before the mutation
 	mutationOptions.onMutate = async () => {
-		await queryClient.cancelQueries( queryKey );
+		await queryClient.cancelQueries( { queryKey } );
 
 		const previousNumberOfMailboxes = getNumberOfMailboxes( queryClient, queryKey );
 
@@ -61,7 +61,7 @@ export function useRemoveTitanMailboxMutation(
 		suppliedOnSettled?.( data, error, variables, context );
 
 		// Always invalidate attendant queries
-		queryClient.invalidateQueries( queryKey ).then( () => {
+		queryClient.invalidateQueries( { queryKey } ).then( () => {
 			const numberOfMailboxes = getNumberOfMailboxes( queryClient, queryKey );
 
 			// Determine if we already have updated data, since the removal job is not synchronous
@@ -70,7 +70,7 @@ export function useRemoveTitanMailboxMutation(
 			}
 
 			setTimeout( () => {
-				queryClient.invalidateQueries( queryKey );
+				queryClient.invalidateQueries( { queryKey } );
 			}, invalidationDelayTimeout );
 		} );
 	};

--- a/client/data/followers/use-remove-follower-mutation.js
+++ b/client/data/followers/use-remove-follower-mutation.js
@@ -11,7 +11,9 @@ function useRemoveFollowerMutation() {
 		},
 		onSuccess( data, variables ) {
 			const { siteId, type } = variables;
-			queryClient.invalidateQueries( [ 'followers', siteId, type ] );
+			queryClient.invalidateQueries( {
+				queryKey: [ 'followers', siteId, type ],
+			} );
 		},
 	} );
 	const { mutate } = mutation;

--- a/client/data/media/use-upload-media-mutation.js
+++ b/client/data/media/use-upload-media-mutation.js
@@ -23,7 +23,9 @@ export const useUploadMediaMutation = ( queryOptions = {} ) => {
 			dispatch( successMediaItemRequest( siteId, transientMedia.ID ) );
 			dispatch( receiveMedia( siteId, uploadedMediaWithTransientId, found ) );
 
-			queryClient.invalidateQueries( [ 'media-storage', siteId ] );
+			queryClient.invalidateQueries( {
+				queryKey: [ 'media-storage', siteId ],
+			} );
 		},
 		onError( error, { siteId, transientMedia } ) {
 			dispatch( failMediaItemRequest( siteId, transientMedia.ID, error ) );

--- a/client/data/media/with-delete-media.js
+++ b/client/data/media/with-delete-media.js
@@ -37,7 +37,9 @@ export const withDeleteMedia = createHigherOrderComponent(
 				}
 
 				if ( promises.some( ( p ) => p.status === 'fulfilled' ) ) {
-					queryClient.invalidateQueries( [ 'media-storage', siteId ] );
+					queryClient.invalidateQueries( {
+						queryKey: [ 'media-storage', siteId ],
+					} );
 				}
 			},
 			[ mutateAsync, dispatch, queryClient, translate ]

--- a/client/data/newsletter-categories/test/use-mark-as-newsletter-category-mutation.test.tsx
+++ b/client/data/newsletter-categories/test/use-mark-as-newsletter-category-mutation.test.tsx
@@ -73,7 +73,9 @@ describe( 'useMarkAsNewsletterCategoryMutation', () => {
 			await result.current.mutateAsync( categoryId );
 		} );
 
-		expect( invalidateQueriesSpy ).toHaveBeenCalledWith( [ 'newsletter-categories', 123 ] );
+		expect( invalidateQueriesSpy ).toHaveBeenCalledWith( {
+			queryKey: [ 'newsletter-categories', 123 ],
+		} );
 	} );
 
 	it( 'should throw an error when ID is missing', async () => {

--- a/client/data/newsletter-categories/test/use-unmark-as-newsletter-category-mutation.test.tsx
+++ b/client/data/newsletter-categories/test/use-unmark-as-newsletter-category-mutation.test.tsx
@@ -73,7 +73,9 @@ describe( 'useUnmarkAsNewsletterCategoryMutation', () => {
 			await result.current.mutateAsync( categoryId );
 		} );
 
-		expect( invalidateQueriesSpy ).toHaveBeenCalledWith( [ 'newsletter-categories', 123 ] );
+		expect( invalidateQueriesSpy ).toHaveBeenCalledWith( {
+			queryKey: [ 'newsletter-categories', 123 ],
+		} );
 	} );
 
 	it( 'should throw an error when ID is missing', async () => {

--- a/client/data/newsletter-categories/use-mark-as-newsletter-category-mutation.tsx
+++ b/client/data/newsletter-categories/use-mark-as-newsletter-category-mutation.tsx
@@ -30,7 +30,7 @@ const useMarkAsNewsletterCategoryMutation = ( siteId: string | number ) => {
 			return response;
 		},
 		onMutate: async ( categoryId: number ) => {
-			await queryClient.cancelQueries( cacheKey );
+			await queryClient.cancelQueries( { queryKey: cacheKey } );
 
 			const previousData = queryClient.getQueryData< NewsletterCategories >( cacheKey );
 			const categories = queryClient.getQueryData< Category[] >( [ 'categories', siteId ] );
@@ -61,7 +61,7 @@ const useMarkAsNewsletterCategoryMutation = ( siteId: string | number ) => {
 			queryClient.setQueryData( cacheKey, context?.previousData );
 		},
 		onSettled: async () => {
-			await queryClient.invalidateQueries( cacheKey );
+			await queryClient.invalidateQueries( { queryKey: cacheKey } );
 		},
 	} );
 };

--- a/client/data/newsletter-categories/use-newsletter-category-subscription-mutation.tsx
+++ b/client/data/newsletter-categories/use-newsletter-category-subscription-mutation.tsx
@@ -23,7 +23,7 @@ const useNewsletterCategorySubscriptionMutation = ( siteId: string | number ) =>
 			);
 		},
 		onMutate: async ( categorySubscriptions: NewsletterCategorySubscription[] ) => {
-			await queryClient.cancelQueries( subscribedCategoriesCacheKey );
+			await queryClient.cancelQueries( { queryKey: subscribedCategoriesCacheKey } );
 
 			const previousData = queryClient.getQueryData< NewsletterCategories >(
 				subscribedCategoriesCacheKey
@@ -64,7 +64,7 @@ const useNewsletterCategorySubscriptionMutation = ( siteId: string | number ) =>
 			queryClient.setQueryData( subscribedCategoriesCacheKey, context?.previousData );
 		},
 		onSettled: async () => {
-			await queryClient.invalidateQueries( subscribedCategoriesCacheKey );
+			await queryClient.invalidateQueries( { queryKey: subscribedCategoriesCacheKey } );
 		},
 	} );
 };

--- a/client/data/newsletter-categories/use-unmark-as-newsletter-category-mutation.tsx
+++ b/client/data/newsletter-categories/use-unmark-as-newsletter-category-mutation.tsx
@@ -31,7 +31,7 @@ const useUnmarkAsNewsletterCategoryMutation = ( siteId: string | number ) => {
 			return response;
 		},
 		onMutate: async ( categoryId: number ) => {
-			await queryClient.cancelQueries( cacheKey );
+			await queryClient.cancelQueries( { queryKey: cacheKey } );
 
 			const previousData = queryClient.getQueryData< NewsletterCategories >( cacheKey );
 
@@ -53,7 +53,7 @@ const useUnmarkAsNewsletterCategoryMutation = ( siteId: string | number ) => {
 			queryClient.setQueryData( cacheKey, context?.previousData );
 		},
 		onSettled: async () => {
-			await queryClient.invalidateQueries( cacheKey );
+			await queryClient.invalidateQueries( { queryKey: cacheKey } );
 		},
 	} );
 };

--- a/client/data/promote-post/use-promote-post-cancel-campaign-mutation.ts
+++ b/client/data/promote-post/use-promote-post-cancel-campaign-mutation.ts
@@ -9,7 +9,9 @@ export const useCancelCampaignMutation = ( onError: () => void ) => {
 		mutationFn: async ( { siteId, campaignId }: { siteId: number; campaignId: number } ) =>
 			await requestDSP< { results: Campaign[] } >( siteId, `/campaigns/${ campaignId }/stop` ),
 		onSuccess( data, { siteId } ) {
-			queryClient.invalidateQueries( [ 'promote-post-campaigns', siteId ] );
+			queryClient.invalidateQueries( {
+				queryKey: [ 'promote-post-campaigns', siteId ],
+			} );
 		},
 		onError,
 	} );

--- a/client/data/site-monitor/use-update-site-monitor-settings-mutation.js
+++ b/client/data/site-monitor/use-update-site-monitor-settings-mutation.js
@@ -8,7 +8,9 @@ function useUpdateSiteMonitorSettingsMutation( siteId, queryOptions = {} ) {
 		mutationFn: ( { settings } ) => wp.req.post( `/jetpack-blogs/${ siteId }`, settings ),
 		...queryOptions,
 		onSuccess( ...args ) {
-			queryClient.invalidateQueries( [ 'site-monitor-settings', siteId ] );
+			queryClient.invalidateQueries( {
+				queryKey: [ 'site-monitor-settings', siteId ],
+			} );
 			queryOptions.onSuccess?.( ...args );
 		},
 	} );

--- a/client/data/site-monitor/with-site-monitor-settings.js
+++ b/client/data/site-monitor/with-site-monitor-settings.js
@@ -25,7 +25,9 @@ const withSiteMonitorSettings = createHigherOrderComponent( ( Wrapped ) => {
 					const queryKey = [ 'site-monitor-settings', siteId ];
 
 					// Cancel any current refetches, so they don't overwrite our optimistic update
-					await queryClient.cancelQueries( queryKey );
+					await queryClient.cancelQueries( {
+						queryKey: queryKey,
+					} );
 
 					// Snapshot the previous value
 					const previousSettings = queryClient.getQueryData( queryKey );
@@ -54,7 +56,9 @@ const withSiteMonitorSettings = createHigherOrderComponent( ( Wrapped ) => {
 				},
 				onSettled: () => {
 					// Refetch settings regardless
-					queryClient.invalidateQueries( [ 'site-monitor-settings', siteId ] );
+					queryClient.invalidateQueries( {
+						queryKey: [ 'site-monitor-settings', siteId ],
+					} );
 				},
 			} );
 

--- a/client/data/site-monitor/with-site-monitor-settings.js
+++ b/client/data/site-monitor/with-site-monitor-settings.js
@@ -26,7 +26,7 @@ const withSiteMonitorSettings = createHigherOrderComponent( ( Wrapped ) => {
 
 					// Cancel any current refetches, so they don't overwrite our optimistic update
 					await queryClient.cancelQueries( {
-						queryKey: queryKey,
+						queryKey,
 					} );
 
 					// Snapshot the previous value

--- a/client/data/users/use-delete-user-mutation.js
+++ b/client/data/users/use-delete-user-mutation.js
@@ -9,7 +9,9 @@ function useDeleteUserMutation( siteId, queryOptions = {} ) {
 			wp.req.post( `/sites/${ siteId }/users/${ userId }/delete`, variables ),
 		...queryOptions,
 		onSuccess( ...args ) {
-			queryClient.invalidateQueries( [ 'users', siteId ] );
+			queryClient.invalidateQueries( {
+				queryKey: [ 'users', siteId ],
+			} );
 			queryOptions.onSuccess?.( ...args );
 		},
 	} );

--- a/client/data/viewers/use-remove-viewer-mutation.js
+++ b/client/data/viewers/use-remove-viewer-mutation.js
@@ -10,7 +10,9 @@ function useRemoveViewer() {
 		},
 		onSuccess( data, variables ) {
 			const { siteId } = variables;
-			queryClient.invalidateQueries( [ 'viewers', siteId ] );
+			queryClient.invalidateQueries( {
+				queryKey: [ 'viewers', siteId ],
+			} );
 		},
 	} );
 

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/hooks/use-validate-verification-code.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/hooks/use-validate-verification-code.ts
@@ -30,7 +30,9 @@ export default function useValidateVerificationCode(): {
 		const queryKey = [ 'monitor_notification_contacts' ];
 
 		// Cancel any current refetches, so they don't overwrite our optimistic update
-		await queryClient.cancelQueries( queryKey );
+		await queryClient.cancelQueries( {
+			queryKey: queryKey,
+		} );
 
 		// Optimistically update the contacts
 		queryClient.setQueryData( queryKey, ( oldContacts: any ) => {

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/hooks/use-validate-verification-code.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/hooks/use-validate-verification-code.ts
@@ -31,7 +31,7 @@ export default function useValidateVerificationCode(): {
 
 		// Cancel any current refetches, so they don't overwrite our optimistic update
 		await queryClient.cancelQueries( {
-			queryKey: queryKey,
+			queryKey,
 		} );
 
 		// Optimistically update the contacts

--- a/client/jetpack-cloud/sections/agency-dashboard/hooks/use-toggle-activate-monitor.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/hooks/use-toggle-activate-monitor.tsx
@@ -27,7 +27,9 @@ export default function useToggleActivateMonitor(
 		},
 		onSuccess: async ( _data, { siteId, params } ) => {
 			// Cancel any current refetches, so they don't overwrite our update
-			await queryClient.cancelQueries( queryKey );
+			await queryClient.cancelQueries( {
+				queryKey: queryKey,
+			} );
 
 			// Update to the new value
 			queryClient.setQueryData( queryKey, ( oldSites: any ) => {

--- a/client/jetpack-cloud/sections/agency-dashboard/hooks/use-toggle-activate-monitor.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/hooks/use-toggle-activate-monitor.tsx
@@ -28,7 +28,7 @@ export default function useToggleActivateMonitor(
 		onSuccess: async ( _data, { siteId, params } ) => {
 			// Cancel any current refetches, so they don't overwrite our update
 			await queryClient.cancelQueries( {
-				queryKey: queryKey,
+				queryKey,
 			} );
 
 			// Update to the new value

--- a/client/jetpack-cloud/sections/agency-dashboard/hooks/use-update-monitor-settings.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/hooks/use-update-monitor-settings.tsx
@@ -30,7 +30,9 @@ export default function useUpdateMonitorSettings(
 	const updateMonitorSettings = useUpdateMonitorSettingsMutation( {
 		onSuccess: async ( data, { siteId } ) => {
 			// Cancel any current refetches, so they don't overwrite our optimistic update
-			await queryClient.cancelQueries( queryKey );
+			await queryClient.cancelQueries( {
+				queryKey: queryKey,
+			} );
 
 			// Optimistically update to the new value
 			queryClient.setQueryData( queryKey, ( oldSites: any ) => {

--- a/client/jetpack-cloud/sections/agency-dashboard/hooks/use-update-monitor-settings.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/hooks/use-update-monitor-settings.tsx
@@ -31,7 +31,7 @@ export default function useUpdateMonitorSettings(
 		onSuccess: async ( data, { siteId } ) => {
 			// Cancel any current refetches, so they don't overwrite our optimistic update
 			await queryClient.cancelQueries( {
-				queryKey: queryKey,
+				queryKey,
 			} );
 
 			// Optimistically update to the new value

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/hooks/use-install-boost.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/hooks/use-install-boost.tsx
@@ -20,7 +20,7 @@ export default function useInstallBoost(
 
 	const handleUpdateSites = useCallback( async () => {
 		// Cancel any current refetches, so they don't overwrite our update
-		await queryClient.cancelQueries( queryKey );
+		await queryClient.cancelQueries( { queryKey } );
 
 		// Update to the new value
 		queryClient.setQueryData( queryKey, ( oldSites: any ) => {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-set-favorite/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-set-favorite/index.tsx
@@ -79,7 +79,7 @@ export default function SiteSetFavorite( { isFavorite, siteId, siteUrl }: Props 
 			onMutate: async ( { siteId, isFavorite }: { siteId: number; isFavorite: boolean } ) => {
 				// Cancel any current refetches, so they don't overwrite our optimistic update
 				await queryClient.cancelQueries( {
-					queryKey: queryKey,
+					queryKey,
 				} );
 
 				// Snapshot the previous value
@@ -126,7 +126,7 @@ export default function SiteSetFavorite( { isFavorite, siteId, siteUrl }: Props 
 			},
 			onSettled: () => {
 				queryClient.invalidateQueries( {
-					queryKey: queryKey,
+					queryKey,
 				} );
 			},
 		};

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-set-favorite/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-set-favorite/index.tsx
@@ -78,7 +78,9 @@ export default function SiteSetFavorite( { isFavorite, siteId, siteUrl }: Props 
 		return {
 			onMutate: async ( { siteId, isFavorite }: { siteId: number; isFavorite: boolean } ) => {
 				// Cancel any current refetches, so they don't overwrite our optimistic update
-				await queryClient.cancelQueries( queryKey );
+				await queryClient.cancelQueries( {
+					queryKey: queryKey,
+				} );
 
 				// Snapshot the previous value
 				const previousSites = queryClient.getQueryData( queryKey );
@@ -123,7 +125,9 @@ export default function SiteSetFavorite( { isFavorite, siteId, siteUrl }: Props 
 				dispatch( errorNotice( errorMessage ) );
 			},
 			onSettled: () => {
-				queryClient.invalidateQueries( queryKey );
+				queryClient.invalidateQueries( {
+					queryKey: queryKey,
+				} );
 			},
 		};
 	};

--- a/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
@@ -140,7 +140,6 @@ export default function LicenseProductCard( props: Props ) {
 					</div>
 				</div>
 			</div>
-
 			{ showLightbox && (
 				<LicenseLightbox
 					product={ product }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -122,7 +122,7 @@ export function getEnhancedTasks(
 			await updateLaunchpadSettings( siteSlug, {
 				checklist_statuses: { newsletter_plan_created: true },
 			} );
-			queryClient?.invalidateQueries( [ 'launchpad' ] );
+			queryClient?.invalidateQueries( { queryKey: [ 'launchpad' ] } );
 		}
 	};
 

--- a/client/me/purchases/payment-methods/payment-method-backup-toggle.tsx
+++ b/client/me/purchases/payment-methods/payment-method-backup-toggle.tsx
@@ -46,7 +46,9 @@ export default function PaymentMethodBackupToggle( { card }: { card: StoredPayme
 			queryClient.setQueryData( [ 'payment-method-backup-toggle', storedDetailsId ], data );
 
 			// Invalidate queries made by `useStoredPaymentMethods`.
-			queryClient.invalidateQueries( [ storedPaymentMethodsQueryKey ] );
+			queryClient.invalidateQueries( {
+				queryKey: [ storedPaymentMethodsQueryKey ],
+			} );
 		},
 	} );
 	const toggleIsBackup = useCallback(

--- a/client/me/security-ssh-key/use-add-ssh-key-mutation.ts
+++ b/client/me/security-ssh-key/use-add-ssh-key-mutation.ts
@@ -32,7 +32,7 @@ export const useAddSSHKeyMutation = (
 			),
 		...options,
 		onSuccess: async ( ...args ) => {
-			await queryClient.invalidateQueries( SSH_KEY_QUERY_KEY );
+			await queryClient.invalidateQueries( { queryKey: SSH_KEY_QUERY_KEY } );
 			options.onSuccess?.( ...args );
 		},
 	} );

--- a/client/me/security-ssh-key/use-delete-ssh-key-mutation.ts
+++ b/client/me/security-ssh-key/use-delete-ssh-key-mutation.ts
@@ -29,7 +29,7 @@ export const useDeleteSSHKeyMutation = (
 			} ),
 		...options,
 		onSuccess: async ( ...args ) => {
-			await queryClient.invalidateQueries( SSH_KEY_QUERY_KEY );
+			await queryClient.invalidateQueries( { queryKey: SSH_KEY_QUERY_KEY } );
 			options.onSuccess?.( ...args );
 		},
 	} );

--- a/client/me/security-ssh-key/use-update-ssh-key-mutation.ts
+++ b/client/me/security-ssh-key/use-update-ssh-key-mutation.ts
@@ -37,7 +37,7 @@ export const useUpdateSSHKeyMutation = (
 			),
 		...options,
 		onSuccess: async ( ...args ) => {
-			await queryClient.invalidateQueries( SSH_KEY_QUERY_KEY );
+			await queryClient.invalidateQueries( { queryKey: SSH_KEY_QUERY_KEY } );
 			await queryClient.invalidateQueries( {
 				queryKey: [ USE_ATOMIC_SSH_KEYS_QUERY_KEY ],
 			} );

--- a/client/me/security-ssh-key/use-update-ssh-key-mutation.ts
+++ b/client/me/security-ssh-key/use-update-ssh-key-mutation.ts
@@ -38,7 +38,9 @@ export const useUpdateSSHKeyMutation = (
 		...options,
 		onSuccess: async ( ...args ) => {
 			await queryClient.invalidateQueries( SSH_KEY_QUERY_KEY );
-			await queryClient.invalidateQueries( [ USE_ATOMIC_SSH_KEYS_QUERY_KEY ] );
+			await queryClient.invalidateQueries( {
+				queryKey: [ USE_ATOMIC_SSH_KEYS_QUERY_KEY ],
+			} );
 			options.onSuccess?.( ...args );
 		},
 	} );

--- a/client/my-sites/checkout/src/hooks/use-stored-payment-methods.tsx
+++ b/client/my-sites/checkout/src/hooks/use-stored-payment-methods.tsx
@@ -94,7 +94,9 @@ export function useStoredPaymentMethods( {
 	>( {
 		mutationFn: ( id ) => requestPaymentMethodDeletion( id ),
 		onSuccess: () => {
-			queryClient.invalidateQueries( [ storedPaymentMethodsQueryKey ] );
+			queryClient.invalidateQueries( {
+				queryKey: [ storedPaymentMethodsQueryKey ],
+			} );
 		},
 	} );
 

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -115,7 +115,7 @@ const Home = ( {
 
 	useEffect( () => {
 		if ( ! isSiteLaunching && launchedSiteId === siteId ) {
-			queryClient.invalidateQueries( getCacheKey( siteId ) );
+			queryClient.invalidateQueries( { queryKey: getCacheKey( siteId ) } );
 			setLaunchedSiteId( null );
 		}
 	}, [ isSiteLaunching, launchedSiteId, queryClient, siteId ] );

--- a/client/my-sites/email/mailboxes/mailbox-selection-list/index.tsx
+++ b/client/my-sites/email/mailboxes/mailbox-selection-list/index.tsx
@@ -183,7 +183,7 @@ const MailboxLoaderError = ( {
 	const queryClient = useQueryClient();
 
 	const reloadMailboxes = () => {
-		queryClient.removeQueries( getMailboxesQueryKey( siteId ) );
+		queryClient.removeQueries( { queryKey: getMailboxesQueryKey( siteId ) } );
 		reFetchMailboxes();
 	};
 

--- a/client/my-sites/hosting/cache-card/use-toggle-edge-cache.ts
+++ b/client/my-sites/hosting/cache-card/use-toggle-edge-cache.ts
@@ -32,7 +32,9 @@ export const useToggleEdgeCacheMutation = (
 		},
 		mutationKey: [ TOGGLE_EDGE_CACHE_MUTATION_KEY, siteId ],
 		onMutate: async ( active ) => {
-			await queryClient.cancelQueries( [ USE_EDGE_CACHE_QUERY_KEY, siteId ] );
+			await queryClient.cancelQueries( {
+				queryKey: [ USE_EDGE_CACHE_QUERY_KEY, siteId ],
+			} );
 			const previousData = queryClient.getQueryData( [ USE_EDGE_CACHE_QUERY_KEY, siteId ] );
 			queryClient.setQueryData( [ USE_EDGE_CACHE_QUERY_KEY, siteId ], active );
 			return previousData;
@@ -43,7 +45,9 @@ export const useToggleEdgeCacheMutation = (
 		},
 		onSettled: ( ...args ) => {
 			// Refetch settings regardless
-			queryClient.invalidateQueries( [ USE_EDGE_CACHE_QUERY_KEY, siteId ] );
+			queryClient.invalidateQueries( {
+				queryKey: [ USE_EDGE_CACHE_QUERY_KEY, siteId ],
+			} );
 			options?.onSettled?.( ...args );
 		},
 	} );

--- a/client/my-sites/hosting/github/deployment-card/use-disconnect-repo.ts
+++ b/client/my-sites/hosting/github/deployment-card/use-disconnect-repo.ts
@@ -25,12 +25,12 @@ export const useGithubDisconnectRepoMutation = (
 		...options,
 		onSuccess: async ( ...args ) => {
 			await Promise.all( [
-				queryClient.invalidateQueries( [ GITHUB_INTEGRATION_QUERY_KEY, siteId, connectionId ] ),
-				queryClient.invalidateQueries( [
-					GITHUB_INTEGRATION_QUERY_KEY,
-					siteId,
-					GITHUB_CONNECTION_QUERY_KEY,
-				] ),
+				queryClient.invalidateQueries( {
+					queryKey: [ GITHUB_INTEGRATION_QUERY_KEY, siteId, connectionId ],
+				} ),
+				queryClient.invalidateQueries( {
+					queryKey: [ GITHUB_INTEGRATION_QUERY_KEY, siteId, GITHUB_CONNECTION_QUERY_KEY ],
+				} ),
 			] );
 			options.onSuccess?.( ...args );
 		},

--- a/client/my-sites/hosting/github/disconnect-github-button/index.tsx
+++ b/client/my-sites/hosting/github/disconnect-github-button/index.tsx
@@ -25,11 +25,9 @@ export function DisconnectGitHubButton( { connection }: DisconnectGitHubButtonPr
 		mutationFn: async ( c ) => {
 			dispatch( recordTracksEvent( 'calypso_hosting_github_unauthorize_click' ) );
 			await dispatch( deleteStoredKeyringConnection( c ) );
-			await queryClient.invalidateQueries( [
-				GITHUB_INTEGRATION_QUERY_KEY,
-				siteId,
-				GITHUB_CONNECTION_QUERY_KEY,
-			] );
+			await queryClient.invalidateQueries( {
+				queryKey: [ GITHUB_INTEGRATION_QUERY_KEY, siteId, GITHUB_CONNECTION_QUERY_KEY ],
+			} );
 		},
 	} );
 	const { mutate: disconnect, isLoading: isDisconnecting } = mutation;

--- a/client/my-sites/hosting/github/github-authorize-card/index.tsx
+++ b/client/my-sites/hosting/github/github-authorize-card/index.tsx
@@ -32,7 +32,9 @@ export const GithubAuthorizeCard = () => {
 		},
 		onSuccess: async () => {
 			const connectionKey = [ GITHUB_INTEGRATION_QUERY_KEY, siteId, GITHUB_CONNECTION_QUERY_KEY ];
-			await queryClient.invalidateQueries( connectionKey );
+			await queryClient.invalidateQueries( {
+				queryKey: connectionKey,
+			} );
 
 			const authorized =
 				queryClient.getQueryData< GithubConnectionData >( connectionKey )?.connected;

--- a/client/my-sites/hosting/github/github-connect-card/use-github-connect-mutation.ts
+++ b/client/my-sites/hosting/github/github-connect-card/use-github-connect-mutation.ts
@@ -36,11 +36,9 @@ export const useGithubConnectMutation = (
 			),
 		...options,
 		onSuccess: async ( ...args ) => {
-			await queryClient.invalidateQueries( [
-				GITHUB_INTEGRATION_QUERY_KEY,
-				siteId,
-				GITHUB_CONNECTION_QUERY_KEY,
-			] );
+			await queryClient.invalidateQueries( {
+				queryKey: [ GITHUB_INTEGRATION_QUERY_KEY, siteId, GITHUB_CONNECTION_QUERY_KEY ],
+			} );
 			options.onSuccess?.( ...args );
 		},
 	} );

--- a/client/my-sites/hosting/sftp-card/use-attach-ssh-key.ts
+++ b/client/my-sites/hosting/sftp-card/use-attach-ssh-key.ts
@@ -30,7 +30,9 @@ export const useAttachSshKeyMutation = (
 			} ),
 		...options,
 		onSuccess: async ( ...args ) => {
-			await queryClient.invalidateQueries( [ USE_ATOMIC_SSH_KEYS_QUERY_KEY, siteId ] );
+			await queryClient.invalidateQueries( {
+				queryKey: [ USE_ATOMIC_SSH_KEYS_QUERY_KEY, siteId ],
+			} );
 			options.onSuccess?.( ...args );
 		},
 	} );

--- a/client/my-sites/hosting/sftp-card/use-detach-ssh-key.ts
+++ b/client/my-sites/hosting/sftp-card/use-detach-ssh-key.ts
@@ -32,7 +32,9 @@ export const useDetachSshKeyMutation = (
 		},
 		...options,
 		onSuccess: async ( ...args ) => {
-			await queryClient.invalidateQueries( [ USE_ATOMIC_SSH_KEYS_QUERY_KEY, siteId ] );
+			await queryClient.invalidateQueries( {
+				queryKey: [ USE_ATOMIC_SSH_KEYS_QUERY_KEY, siteId ],
+			} );
 			options.onSuccess?.( ...args );
 		},
 	} );

--- a/client/my-sites/hosting/staging-site-card/index.js
+++ b/client/my-sites/hosting/staging-site-card/index.js
@@ -125,7 +125,9 @@ export const StagingSiteCard = ( {
 	const isStagingSiteTransferComplete = transferStatus === transferStates.COMPLETE;
 	useEffect( () => {
 		if ( wasCreating && isStagingSiteTransferComplete ) {
-			queryClient.invalidateQueries( [ USE_SITE_EXCERPTS_QUERY_KEY ] );
+			queryClient.invalidateQueries( {
+				queryKey: [ USE_SITE_EXCERPTS_QUERY_KEY ],
+			} );
 			dispatch(
 				successNotice( __( 'Staging site added.' ), { id: stagingSiteAddSuccessNoticeId } )
 			);

--- a/client/my-sites/hosting/staging-site-card/use-add-staging-site.ts
+++ b/client/my-sites/hosting/staging-site-card/use-add-staging-site.ts
@@ -37,7 +37,9 @@ export const useAddStagingSiteMutation = (
 		...options,
 		mutationKey: [ ADD_STAGING_SITE_MUTATION_KEY, siteId ],
 		onSuccess: async ( ...args ) => {
-			await queryClient.invalidateQueries( [ USE_STAGING_SITE_QUERY_KEY, siteId ] );
+			await queryClient.invalidateQueries( {
+				queryKey: [ USE_STAGING_SITE_QUERY_KEY, siteId ],
+			} );
 			options.onSuccess?.( ...args );
 		},
 	} );

--- a/client/my-sites/hosting/staging-site-card/use-delete-staging-site.ts
+++ b/client/my-sites/hosting/staging-site-card/use-delete-staging-site.ts
@@ -30,7 +30,9 @@ export const useDeleteStagingSite = ( options: UseDeleteStagingSiteOptions ) => 
 	const dispatch = useDispatch();
 	const [ isDeletingInitiated, setIsDeletingInitiated ] = useState( false );
 	const onReverted = useCallback( () => {
-		queryClient.invalidateQueries( [ USE_STAGING_SITE_QUERY_KEY ] );
+		queryClient.invalidateQueries( {
+			queryKey: [ USE_STAGING_SITE_QUERY_KEY ],
+		} );
 		setIsDeletingInitiated( false );
 		onSuccess?.();
 	}, [ onSuccess, queryClient ] );
@@ -42,7 +44,9 @@ export const useDeleteStagingSite = ( options: UseDeleteStagingSiteOptions ) => 
 		if ( isDeletingInitiated ) {
 			if ( stagingSiteId ) {
 				timeoutId = setInterval( () => {
-					queryClient.invalidateQueries( [ USE_STAGING_SITE_QUERY_KEY ] );
+					queryClient.invalidateQueries( {
+						queryKey: [ USE_STAGING_SITE_QUERY_KEY ],
+					} );
 				}, 3000 );
 			} else {
 				onReverted();

--- a/client/my-sites/plugins/controller-logged-out.js
+++ b/client/my-sites/plugins/controller-logged-out.js
@@ -64,7 +64,10 @@ const prefetchProductList = ( queryClient, store ) => {
 	const type = 'all';
 
 	return queryClient
-		.fetchQuery( [ 'products-list', type ], () => wpcom.req.get( '/products', { type } ) )
+		.fetchQuery( {
+			queryKey: [ 'products-list', type ],
+			queryFn: () => wpcom.req.get( '/products', { type } ),
+		} )
 		.then( ( productsList ) => {
 			return store.dispatch( receiveProductsList( productsList, type ) );
 		} );

--- a/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
+++ b/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
@@ -60,7 +60,7 @@ const useSubscriberRemoveMutation = (
 			return true;
 		},
 		onMutate: async ( subscriber ) => {
-			await queryClient.cancelQueries( subscribersCacheKey );
+			await queryClient.cancelQueries( { queryKey: subscribersCacheKey } );
 			let page = currentPage;
 
 			const previousData =
@@ -125,7 +125,7 @@ const useSubscriberRemoveMutation = (
 					getSubscriberDetailsType( subscriber.user_id )
 				);
 
-				await queryClient.cancelQueries( cacheKey );
+				await queryClient.cancelQueries( { queryKey: cacheKey } );
 
 				previousDetailsData = queryClient.getQueryData< Subscriber >( cacheKey );
 			}
@@ -164,7 +164,7 @@ const useSubscriberRemoveMutation = (
 			} );
 		},
 		onSettled: ( data, error, subscriber ) => {
-			queryClient.invalidateQueries( subscribersCacheKey );
+			queryClient.invalidateQueries( { queryKey: subscribersCacheKey } );
 
 			if ( invalidateDetailsCache ) {
 				const detailsCacheKey = getSubscriberDetailsCacheKey(
@@ -174,7 +174,7 @@ const useSubscriberRemoveMutation = (
 					getSubscriberDetailsType( subscriber.user_id )
 				);
 
-				queryClient.invalidateQueries( detailsCacheKey );
+				queryClient.invalidateQueries( { queryKey: detailsCacheKey } );
 			}
 		},
 	} );

--- a/client/reader/recommended-sites/recommended-site.tsx
+++ b/client/reader/recommended-sites/recommended-site.tsx
@@ -60,7 +60,7 @@ const useInvalidateSiteSubscriptionsCache = ( isSubscribeLoading: boolean ) => {
 	const queryClient = useQueryClient();
 	useEffect( () => {
 		if ( wasSubscribeLoading && ! isSubscribeLoading ) {
-			queryClient.invalidateQueries( siteSubscriptionsCacheKey );
+			queryClient.invalidateQueries( { queryKey: siteSubscriptionsCacheKey } );
 		}
 	}, [ isSubscribeLoading, wasSubscribeLoading, queryClient, siteSubscriptionsCacheKey ] );
 };

--- a/client/state/partner-portal/invoices/hooks/pay-invoice-mutation.ts
+++ b/client/state/partner-portal/invoices/hooks/pay-invoice-mutation.ts
@@ -32,11 +32,9 @@ export default function usePayInvoiceMutation< TContext = unknown >(
 	return useMutation< APIInvoice, Error, PayInvoiceMutationVariables, TContext >( {
 		mutationFn: payInvoiceMutation,
 		onSuccess: ( invoice: APIInvoice ) => {
-			const invoicePages = queryClient.getQueriesData( [
-				'partner-portal',
-				'invoices',
-				activeKeyId,
-			] );
+			const invoicePages = queryClient.getQueriesData( {
+				queryKey: [ 'partner-portal', 'invoices', activeKeyId ],
+			} );
 
 			invoicePages.forEach( ( query ) => {
 				const data = query[ 1 ] as APIInvoices;

--- a/packages/data-stores/src/domain-suggestions/queries.ts
+++ b/packages/data-stores/src/domain-suggestions/queries.ts
@@ -52,7 +52,9 @@ export function useGetDomainSuggestions(
 	return {
 		...result,
 		invalidateCache: () =>
-			queryClient.invalidateQueries( [ 'domain-suggestions', search, searchOptions ] ),
+			queryClient.invalidateQueries( {
+				queryKey: [ 'domain-suggestions', search, searchOptions ],
+			} ),
 	};
 }
 

--- a/packages/data-stores/src/reader/helpers/optimistic-update.ts
+++ b/packages/data-stores/src/reader/helpers/optimistic-update.ts
@@ -49,7 +49,7 @@ const alterSiteSubscriptionDetails = async (
 	keys.push( [ 'read', 'subscriptions', subscriptionId, isLoggedIn, id ] );
 
 	for ( const key of keys ) {
-		await queryClient.cancelQueries( key );
+		await queryClient.cancelQueries( { queryKey: key } );
 
 		const previousDataForKey = queryClient.getQueryData< SiteSubscriptionDetails >( key );
 		if ( previousDataForKey ) {
@@ -66,7 +66,7 @@ const invalidateSiteSubscriptionDetails = (
 	queryClient: QueryClient,
 	{ blogId, subscriptionId, isLoggedIn, id }: SiteSubScriptionDetailsParameters
 ) => {
-	queryClient.invalidateQueries( [ 'read', 'site-subscriptions' ] );
+	queryClient.invalidateQueries( { queryKey: [ 'read', 'site-subscriptions' ] } );
 	queryClient.invalidateQueries(
 		buildQueryKey( [ 'read', 'site-subscription-details', blogId ], isLoggedIn, id )
 	);

--- a/packages/data-stores/src/reader/mutations/use-pending-post-confirm-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-pending-post-confirm-mutation.ts
@@ -48,8 +48,8 @@ const usePendingPostConfirmMutation = () => {
 			await queryClient.cancelQueries( {
 				queryKey: [ 'read', 'pending-post-subscriptions', isLoggedIn ],
 			} );
-			await queryClient.cancelQueries( subscriptionsCacheKey );
-			await queryClient.cancelQueries( countCacheKey );
+			await queryClient.cancelQueries( { queryKey: subscriptionsCacheKey } );
+			await queryClient.cancelQueries( { queryKey: countCacheKey } );
 
 			const previousPendingPostSubscriptions =
 				queryClient.getQueryData< PendingPostSubscriptionsResult >( [
@@ -107,8 +107,8 @@ const usePendingPostConfirmMutation = () => {
 			queryClient.invalidateQueries( {
 				queryKey: [ 'read', 'pending-post-subscriptions', isLoggedIn ],
 			} );
-			queryClient.invalidateQueries( subscriptionsCacheKey );
-			queryClient.invalidateQueries( countCacheKey );
+			queryClient.invalidateQueries( { queryKey: subscriptionsCacheKey } );
+			queryClient.invalidateQueries( { queryKey: countCacheKey } );
 		},
 	} );
 };

--- a/packages/data-stores/src/reader/mutations/use-pending-post-confirm-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-pending-post-confirm-mutation.ts
@@ -45,7 +45,9 @@ const usePendingPostConfirmMutation = () => {
 			return response;
 		},
 		onMutate: async ( { id } ) => {
-			await queryClient.cancelQueries( [ 'read', 'pending-post-subscriptions', isLoggedIn ] );
+			await queryClient.cancelQueries( {
+				queryKey: [ 'read', 'pending-post-subscriptions', isLoggedIn ],
+			} );
 			await queryClient.cancelQueries( subscriptionsCacheKey );
 			await queryClient.cancelQueries( countCacheKey );
 
@@ -102,7 +104,9 @@ const usePendingPostConfirmMutation = () => {
 			}
 		},
 		onSettled: () => {
-			queryClient.invalidateQueries( [ 'read', 'pending-post-subscriptions', isLoggedIn ] );
+			queryClient.invalidateQueries( {
+				queryKey: [ 'read', 'pending-post-subscriptions', isLoggedIn ],
+			} );
 			queryClient.invalidateQueries( subscriptionsCacheKey );
 			queryClient.invalidateQueries( countCacheKey );
 		},

--- a/packages/data-stores/src/reader/mutations/use-pending-post-delete-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-pending-post-delete-mutation.ts
@@ -46,7 +46,7 @@ const usePendingPostDeleteMutation = () => {
 			await queryClient.cancelQueries( {
 				queryKey: [ 'read', 'pending-post-subscriptions', isLoggedIn ],
 			} );
-			await queryClient.cancelQueries( countCacheKey );
+			await queryClient.cancelQueries( { queryKey: countCacheKey } );
 
 			const previousPendingPostSubscriptions =
 				queryClient.getQueryData< PendingPostSubscriptionsResult >( [
@@ -101,7 +101,7 @@ const usePendingPostDeleteMutation = () => {
 			queryClient.invalidateQueries( {
 				queryKey: [ 'read', 'pending-post-subscriptions', isLoggedIn ],
 			} );
-			queryClient.invalidateQueries( countCacheKey );
+			queryClient.invalidateQueries( { queryKey: countCacheKey } );
 		},
 	} );
 };

--- a/packages/data-stores/src/reader/mutations/use-pending-post-delete-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-pending-post-delete-mutation.ts
@@ -43,7 +43,9 @@ const usePendingPostDeleteMutation = () => {
 			return response;
 		},
 		onMutate: async ( params ) => {
-			await queryClient.cancelQueries( [ 'read', 'pending-post-subscriptions', isLoggedIn ] );
+			await queryClient.cancelQueries( {
+				queryKey: [ 'read', 'pending-post-subscriptions', isLoggedIn ],
+			} );
 			await queryClient.cancelQueries( countCacheKey );
 
 			const previousPendingPostSubscriptions =
@@ -96,7 +98,9 @@ const usePendingPostDeleteMutation = () => {
 			}
 		},
 		onSettled: () => {
-			queryClient.invalidateQueries( [ 'read', 'pending-post-subscriptions', isLoggedIn ] );
+			queryClient.invalidateQueries( {
+				queryKey: [ 'read', 'pending-post-subscriptions', isLoggedIn ],
+			} );
 			queryClient.invalidateQueries( countCacheKey );
 		},
 	} );

--- a/packages/data-stores/src/reader/mutations/use-pending-site-confirm-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-pending-site-confirm-mutation.ts
@@ -49,8 +49,8 @@ const usePendingSiteConfirmMutation = () => {
 			await queryClient.cancelQueries( {
 				queryKey: [ 'read', 'pending-site-subscriptions', isLoggedIn ],
 			} );
-			await queryClient.cancelQueries( subscriptionsCacheKey );
-			await queryClient.cancelQueries( countCacheKey );
+			await queryClient.cancelQueries( { queryKey: subscriptionsCacheKey } );
+			await queryClient.cancelQueries( { queryKey: countCacheKey } );
 
 			const previousPendingSiteSubscriptions =
 				queryClient.getQueryData< PendingSiteSubscriptionsResult >( [
@@ -106,8 +106,8 @@ const usePendingSiteConfirmMutation = () => {
 			queryClient.invalidateQueries( {
 				queryKey: [ 'read', 'pending-site-subscriptions', isLoggedIn ],
 			} );
-			queryClient.invalidateQueries( subscriptionsCacheKey );
-			queryClient.invalidateQueries( countCacheKey );
+			queryClient.invalidateQueries( { queryKey: subscriptionsCacheKey } );
+			queryClient.invalidateQueries( { queryKey: countCacheKey } );
 		},
 	} );
 };

--- a/packages/data-stores/src/reader/mutations/use-pending-site-confirm-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-pending-site-confirm-mutation.ts
@@ -46,7 +46,9 @@ const usePendingSiteConfirmMutation = () => {
 			return response;
 		},
 		onMutate: async ( params ) => {
-			await queryClient.cancelQueries( [ 'read', 'pending-site-subscriptions', isLoggedIn ] );
+			await queryClient.cancelQueries( {
+				queryKey: [ 'read', 'pending-site-subscriptions', isLoggedIn ],
+			} );
 			await queryClient.cancelQueries( subscriptionsCacheKey );
 			await queryClient.cancelQueries( countCacheKey );
 
@@ -101,7 +103,9 @@ const usePendingSiteConfirmMutation = () => {
 			}
 		},
 		onSettled: () => {
-			queryClient.invalidateQueries( [ 'read', 'pending-site-subscriptions', isLoggedIn ] );
+			queryClient.invalidateQueries( {
+				queryKey: [ 'read', 'pending-site-subscriptions', isLoggedIn ],
+			} );
 			queryClient.invalidateQueries( subscriptionsCacheKey );
 			queryClient.invalidateQueries( countCacheKey );
 		},

--- a/packages/data-stores/src/reader/mutations/use-pending-site-delete-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-pending-site-delete-mutation.ts
@@ -43,7 +43,9 @@ const usePendingSiteDeleteMutation = () => {
 			return response;
 		},
 		onMutate: async ( params ) => {
-			await queryClient.cancelQueries( [ 'read', 'pending-site-subscriptions', isLoggedIn ] );
+			await queryClient.cancelQueries( {
+				queryKey: [ 'read', 'pending-site-subscriptions', isLoggedIn ],
+			} );
 			await queryClient.cancelQueries( countCacheKey );
 
 			const previousPendingSiteSubscriptions =
@@ -96,7 +98,9 @@ const usePendingSiteDeleteMutation = () => {
 			}
 		},
 		onSettled: () => {
-			queryClient.invalidateQueries( [ 'read', 'pending-site-subscriptions', isLoggedIn ] );
+			queryClient.invalidateQueries( {
+				queryKey: [ 'read', 'pending-site-subscriptions', isLoggedIn ],
+			} );
 			queryClient.invalidateQueries( countCacheKey );
 		},
 	} );

--- a/packages/data-stores/src/reader/mutations/use-pending-site-delete-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-pending-site-delete-mutation.ts
@@ -46,7 +46,7 @@ const usePendingSiteDeleteMutation = () => {
 			await queryClient.cancelQueries( {
 				queryKey: [ 'read', 'pending-site-subscriptions', isLoggedIn ],
 			} );
-			await queryClient.cancelQueries( countCacheKey );
+			await queryClient.cancelQueries( { queryKey: countCacheKey } );
 
 			const previousPendingSiteSubscriptions =
 				queryClient.getQueryData< PendingSiteSubscriptionsResult >( [
@@ -101,7 +101,7 @@ const usePendingSiteDeleteMutation = () => {
 			queryClient.invalidateQueries( {
 				queryKey: [ 'read', 'pending-site-subscriptions', isLoggedIn ],
 			} );
-			queryClient.invalidateQueries( countCacheKey );
+			queryClient.invalidateQueries( { queryKey: countCacheKey } );
 		},
 	} );
 };

--- a/packages/data-stores/src/reader/mutations/use-post-unsubscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-post-unsubscribe-mutation.ts
@@ -57,7 +57,7 @@ const usePostUnsubscribeMutation = () => {
 			return response;
 		},
 		onMutate: async ( params ) => {
-			await queryClient.cancelQueries( postSubscriptionsCacheKey );
+			await queryClient.cancelQueries( { queryKey: postSubscriptionsCacheKey } );
 			await queryClient.cancelQueries( {
 				queryKey: [ 'read', 'subscriptions-count', isLoggedIn ],
 			} );
@@ -114,8 +114,8 @@ const usePostUnsubscribeMutation = () => {
 			}
 		},
 		onSettled: () => {
-			queryClient.invalidateQueries( postSubscriptionsCacheKey );
-			queryClient.invalidateQueries( subscriptionsCountCacheKey );
+			queryClient.invalidateQueries( { queryKey: postSubscriptionsCacheKey } );
+			queryClient.invalidateQueries( { queryKey: subscriptionsCountCacheKey } );
 		},
 	} );
 };

--- a/packages/data-stores/src/reader/mutations/use-post-unsubscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-post-unsubscribe-mutation.ts
@@ -58,7 +58,9 @@ const usePostUnsubscribeMutation = () => {
 		},
 		onMutate: async ( params ) => {
 			await queryClient.cancelQueries( postSubscriptionsCacheKey );
-			await queryClient.cancelQueries( [ 'read', 'subscriptions-count', isLoggedIn ] );
+			await queryClient.cancelQueries( {
+				queryKey: [ 'read', 'subscriptions-count', isLoggedIn ],
+			} );
 
 			const previousPostSubscriptions =
 				queryClient.getQueryData< PostSubscriptionsPages >( postSubscriptionsCacheKey );

--- a/packages/data-stores/src/reader/mutations/use-site-delivery-frequency-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-delivery-frequency-mutation.ts
@@ -69,7 +69,7 @@ const useSiteDeliveryFrequencyMutation = () => {
 				id
 			);
 
-			await queryClient.cancelQueries( siteSubscriptionsCacheKey );
+			await queryClient.cancelQueries( { queryKey: siteSubscriptionsCacheKey } );
 
 			const previousSiteSubscriptions =
 				queryClient.getQueryData<

--- a/packages/data-stores/src/reader/mutations/use-site-delivery-frequency-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-delivery-frequency-mutation.ts
@@ -138,7 +138,9 @@ const useSiteDeliveryFrequencyMutation = () => {
 				isLoggedIn,
 				id,
 			} );
-			queryClient.invalidateQueries( [ 'read', 'subscriptions', subscriptionId, isLoggedIn, id ] );
+			queryClient.invalidateQueries( {
+				queryKey: [ 'read', 'subscriptions', subscriptionId, isLoggedIn, id ],
+			} );
 		},
 	} );
 };

--- a/packages/data-stores/src/reader/mutations/use-site-email-me-new-comments-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-email-me-new-comments-mutation.ts
@@ -56,7 +56,7 @@ const useSiteEmailMeNewCommentsMutation = () => {
 				id
 			);
 
-			await queryClient.cancelQueries( siteSubscriptionsQueryKey );
+			await queryClient.cancelQueries( { queryKey: siteSubscriptionsQueryKey } );
 
 			const previousSiteSubscriptions =
 				queryClient.getQueryData< SiteSubscriptionsPages >( siteSubscriptionsQueryKey );

--- a/packages/data-stores/src/reader/mutations/use-site-email-me-new-comments-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-email-me-new-comments-mutation.ts
@@ -130,7 +130,9 @@ const useSiteEmailMeNewCommentsMutation = () => {
 				isLoggedIn,
 				id,
 			} );
-			queryClient.invalidateQueries( [ 'read', 'subscriptions', subscriptionId, isLoggedIn, id ] );
+			queryClient.invalidateQueries( {
+				queryKey: [ 'read', 'subscriptions', subscriptionId, isLoggedIn, id ],
+			} );
 		},
 	} );
 };

--- a/packages/data-stores/src/reader/mutations/use-site-email-me-new-posts-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-email-me-new-posts-mutation.ts
@@ -133,7 +133,9 @@ const useSiteEmailMeNewPostsMutation = () => {
 				isLoggedIn,
 				id,
 			} );
-			queryClient.invalidateQueries( [ 'read', 'subscriptions', subscriptionId, isLoggedIn, id ] );
+			queryClient.invalidateQueries( {
+				queryKey: [ 'read', 'subscriptions', subscriptionId, isLoggedIn, id ],
+			} );
 		},
 	} );
 };

--- a/packages/data-stores/src/reader/mutations/use-site-email-me-new-posts-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-email-me-new-posts-mutation.ts
@@ -56,7 +56,7 @@ const useSiteEmailMeNewPostsMutation = () => {
 				id
 			);
 
-			await queryClient.cancelQueries( siteSubscriptionsQueryKey );
+			await queryClient.cancelQueries( { queryKey: siteSubscriptionsQueryKey } );
 
 			const previousSiteSubscriptions =
 				queryClient.getQueryData< SiteSubscriptionsPages >( siteSubscriptionsQueryKey );

--- a/packages/data-stores/src/reader/mutations/use-site-notify-me-of-new-posts-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-notify-me-of-new-posts-mutation.ts
@@ -57,7 +57,7 @@ const useSiteNotifyMeOfNewPostsMutation = () => {
 				id
 			);
 
-			await queryClient.cancelQueries( siteSubscriptionsQueryKey );
+			await queryClient.cancelQueries( { queryKey: siteSubscriptionsQueryKey } );
 
 			const previousSiteSubscriptions =
 				queryClient.getQueryData< SiteSubscriptionsPages >( siteSubscriptionsQueryKey );

--- a/packages/data-stores/src/reader/mutations/use-site-notify-me-of-new-posts-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-notify-me-of-new-posts-mutation.ts
@@ -135,7 +135,9 @@ const useSiteNotifyMeOfNewPostsMutation = () => {
 				isLoggedIn,
 				id,
 			} );
-			queryClient.invalidateQueries( [ 'read', 'subscriptions', subscriptionId, isLoggedIn, id ] );
+			queryClient.invalidateQueries( {
+				queryKey: [ 'read', 'subscriptions', subscriptionId, isLoggedIn, id ],
+			} );
 		},
 	} );
 };

--- a/packages/data-stores/src/reader/mutations/use-site-subscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-subscribe-mutation.ts
@@ -83,7 +83,7 @@ const useSiteSubscribeMutation = () => {
 					isLoggedIn,
 					userId
 				);
-				await queryClient.cancelQueries( siteSubscriptionDetailsCacheKey );
+				await queryClient.cancelQueries( { queryKey: siteSubscriptionDetailsCacheKey } );
 
 				previousSiteSubscriptionDetailsByBlogId =
 					queryClient.getQueryData< SiteSubscriptionDetails >( siteSubscriptionDetailsCacheKey );
@@ -145,7 +145,7 @@ const useSiteSubscribeMutation = () => {
 		},
 		onSettled: ( _data, _error, params: SubscribeParams ) => {
 			if ( params.doNotInvalidateSiteSubscriptions !== true ) {
-				queryClient.invalidateQueries( siteSubscriptionsCacheKey );
+				queryClient.invalidateQueries( { queryKey: siteSubscriptionsCacheKey } );
 			}
 
 			if ( isValidId( params.blog_id ) ) {
@@ -154,7 +154,7 @@ const useSiteSubscribeMutation = () => {
 					isLoggedIn,
 					userId
 				);
-				queryClient.invalidateQueries( siteSubscriptionDetailsCacheKey );
+				queryClient.invalidateQueries( { queryKey: siteSubscriptionDetailsCacheKey } );
 				queryClient.invalidateQueries( {
 					queryKey: [ 'read', 'sites', Number( params.blog_id ) ],
 				} );
@@ -167,7 +167,7 @@ const useSiteSubscribeMutation = () => {
 				} );
 			}
 
-			queryClient.invalidateQueries( subscriptionsCountCacheKey );
+			queryClient.invalidateQueries( { queryKey: subscriptionsCountCacheKey } );
 		},
 		onSuccess: ( data, params ) => {
 			params.onSuccess?.();

--- a/packages/data-stores/src/reader/mutations/use-site-subscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-subscribe-mutation.ts
@@ -155,12 +155,16 @@ const useSiteSubscribeMutation = () => {
 					userId
 				);
 				queryClient.invalidateQueries( siteSubscriptionDetailsCacheKey );
-				queryClient.invalidateQueries( [ 'read', 'sites', Number( params.blog_id ) ] );
+				queryClient.invalidateQueries( {
+					queryKey: [ 'read', 'sites', Number( params.blog_id ) ],
+				} );
 			}
 
 			if ( isValidId( params.feed_id ) ) {
 				const feedCacheKey = [ 'read', 'feeds', Number( params.feed_id ) ];
-				queryClient.invalidateQueries( feedCacheKey );
+				queryClient.invalidateQueries( {
+					queryKey: feedCacheKey,
+				} );
 			}
 
 			queryClient.invalidateQueries( subscriptionsCountCacheKey );

--- a/packages/data-stores/src/reader/mutations/use-site-unsubscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-unsubscribe-mutation.ts
@@ -85,9 +85,9 @@ const useSiteUnsubscribeMutation = () => {
 				userId
 			);
 
-			await queryClient.cancelQueries( siteSubscriptionsQueryKey );
-			await queryClient.cancelQueries( subscriptionsCountQueryKey );
-			await queryClient.cancelQueries( siteSubscriptionDetailsQueryKey );
+			await queryClient.cancelQueries( { queryKey: siteSubscriptionsQueryKey } );
+			await queryClient.cancelQueries( { queryKey: subscriptionsCountQueryKey } );
+			await queryClient.cancelQueries( { queryKey: siteSubscriptionDetailsQueryKey } );
 
 			const previousSiteSubscriptions =
 				queryClient.getQueryData< SiteSubscriptionsPages >( siteSubscriptionsQueryKey );
@@ -146,7 +146,7 @@ const useSiteUnsubscribeMutation = () => {
 					userId
 				);
 
-				await queryClient.cancelQueries( siteSubscriptionDetailsCacheKey );
+				await queryClient.cancelQueries( { queryKey: siteSubscriptionDetailsCacheKey } );
 
 				previousSiteSubscriptionDetailsByBlogId = queryClient.getQueryData(
 					siteSubscriptionDetailsCacheKey
@@ -200,7 +200,7 @@ const useSiteUnsubscribeMutation = () => {
 		},
 		onSettled: ( _data, _error, params ) => {
 			if ( params.doNotInvalidateSiteSubscriptions !== true ) {
-				queryClient.invalidateQueries( siteSubscriptionsQueryKey );
+				queryClient.invalidateQueries( { queryKey: siteSubscriptionsQueryKey } );
 			}
 
 			if ( isValidId( params.blog_id ) ) {
@@ -214,7 +214,7 @@ const useSiteUnsubscribeMutation = () => {
 				} );
 			}
 
-			queryClient.invalidateQueries( subscriptionsCountQueryKey );
+			queryClient.invalidateQueries( { queryKey: subscriptionsCountQueryKey } );
 			queryClient.invalidateQueries( {
 				queryKey: [ 'read', 'feed', 'search' ],
 			} );

--- a/packages/data-stores/src/reader/mutations/use-site-unsubscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-unsubscribe-mutation.ts
@@ -209,11 +209,15 @@ const useSiteUnsubscribeMutation = () => {
 				queryClient.invalidateQueries( siteSubscriptionDetailsByBlogIdQueryKey, {
 					refetchType: 'none',
 				} );
-				queryClient.invalidateQueries( [ 'read', 'sites', Number( params.blog_id ) ] );
+				queryClient.invalidateQueries( {
+					queryKey: [ 'read', 'sites', Number( params.blog_id ) ],
+				} );
 			}
 
 			queryClient.invalidateQueries( subscriptionsCountQueryKey );
-			queryClient.invalidateQueries( [ 'read', 'feed', 'search' ] );
+			queryClient.invalidateQueries( {
+				queryKey: [ 'read', 'feed', 'search' ],
+			} );
 			queryClient.invalidateQueries(
 				buildSiteSubscriptionDetailsQueryKey( params.subscriptionId, isLoggedIn, userId )
 			);

--- a/packages/data-stores/src/reader/mutations/use-user-settings-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-user-settings-mutation.ts
@@ -34,7 +34,7 @@ const useUserSettingsMutation = () => {
 			return settings;
 		},
 		onMutate: async ( data ) => {
-			await queryClient.cancelQueries( emailSettingsCacheKey );
+			await queryClient.cancelQueries( { queryKey: emailSettingsCacheKey } );
 			const previousSettings =
 				queryClient.getQueryData< SubscriptionManagerUserSettings >( emailSettingsCacheKey );
 

--- a/packages/data-stores/src/reader/mutations/use-user-settings-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-user-settings-mutation.ts
@@ -56,7 +56,9 @@ const useUserSettingsMutation = () => {
 		},
 		onSettled: () => {
 			// pass in a more minimal key, everything to the right will be invalidated
-			queryClient.invalidateQueries( [ 'read', 'email-settings' ] );
+			queryClient.invalidateQueries( {
+				queryKey: [ 'read', 'email-settings' ],
+			} );
 		},
 	} );
 };

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -367,7 +367,9 @@ export const HelpCenterContactForm = () => {
 							setTimeout( () => {
 								// wait 30 seconds until support-history endpoint actually updates
 								// yup, it takes that long (tried 5, and 10)
-								queryClient.invalidateQueries( [ 'help-support-history', 'ticket', email ] );
+								queryClient.invalidateQueries( {
+									queryKey: [ 'help-support-history', 'ticket', email ],
+								} );
 							}, 30000 );
 						} )
 						.catch( () => {


### PR DESCRIPTION
Part of #84338 

## Proposed Changes

This PR runs the [`remove-overloads` codemod](https://tanstack.com/query/v5/docs/react/guides/migrating-to-v5#codemod) on all files in `/packages`, `/apps` and `/client`. RQ v5 only supports object syntax for most of the query methods which is why we need those changes in order to be able to update.

Please note, there are a few occurrences left after this PR because the codemod only touches methods which are given literal arrays as a parameter. The codemod can't know whether a variable passed to e.g. `cancelQueries( myVar );` contains a valid object or an array. We have to update these manually.

## Testing Instructions

For one verify Calypso builds well, all tests are passing, there are no linting issues. Smoke testing Calypso won't hurt. Also, verify there are only changes which change query methods to using object syntax (compare the relevant part in the [migration guide for RQ v5](https://tanstack.com/query/v5/docs/react/guides/migrating-to-v5#supports-a-single-signature-one-object)).