### PR TITLE
Marketplace: fix the saas selector to check against the billing_product_slug

### DIFF
--- a/client/state/products-list/selectors/is-saas-product.js
+++ b/client/state/products-list/selectors/is-saas-product.js
@@ -6,10 +6,15 @@ export const isSaasProduct = ( state, productSlug ) => {
 		return false;
 	}
 
-	// Note: Converting the slug and accessing the productsList by key
-	// is more than 10 times faster than traversing the list
-	const snakeCaseSlug = productSlug.replace( /-/g, '_' );
 	const productsList = getProductsList( state );
 
-	return productsList[ snakeCaseSlug ]?.product_type === 'saas_plugin';
+	// storeProductSlug is from the legacy store_products system, billing_product_slug is from
+	// the non-legacy billing system and for marketplace plugins will match the slug of the plugin
+	// by convention.
+	return Object.entries( productsList ).some(
+		( [ storeProductSlug, { product_type, billing_product_slug } ] ) =>
+			( productSlug === storeProductSlug || productSlug === billing_product_slug ) &&
+			typeof product_type === 'string' &&
+			product_type === 'saas_plugin'
+	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

*  The code checked against the `key` of the `product_list` which is usually containing the billing variation suffix `_yearly`, `_monthly` while it should check against the `billing_product_slug` which is the same for all variations.
* It worked OK for Mailpoet cause it seems it doesn't have the variation in one of the keys
* It became a problem for `nelio-ab-testing` cause it has the suffixes

![CleanShot 2023-11-21 at 20 23 50@2x](https://github.com/Automattic/wp-calypso/assets/12430020/9863d950-1271-4f58-b625-a16ef74afda9)

![CleanShot 2023-11-21 at 20 24 17@2x](https://github.com/Automattic/wp-calypso/assets/12430020/36220242-bec4-4735-b0bb-08b4b6637637)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure that loading `http://calypso.localhost:3000/plugins/mailpoet-business` still shows "Get Started"
* Load `http://calypso.localhost:3000/plugins/nelio-ab-testing-wpcom` make sure it shows "Get Started"

![CleanShot 2023-11-21 at 20 26 45@2x](https://github.com/Automattic/wp-calypso/assets/12430020/fb8b6acc-dc11-4d12-b731-8e376557d9e6)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?