### PR TITLE
add context to user message

### DIFF
--- a/client/odie/context/index.tsx
+++ b/client/odie/context/index.tsx
@@ -44,7 +44,7 @@ const defaultContextInterfaceValues = {
 	addMessage: noop,
 	botName: 'Wapuu',
 	botNameSlug: null,
-	chat: { context: { section_name: '', site_id: null }, messages: [] },
+	chat: { context: { section_name: '', blog_id: null }, messages: [] },
 	clearChat: noop,
 	initialUserMessage: null,
 	isLoadingChat: false,

--- a/client/odie/query/index.ts
+++ b/client/odie/query/index.ts
@@ -38,7 +38,7 @@ function odieWpcomSendSupportMessage( message: Message, path: string ) {
 	return wpcom.req.post( {
 		path,
 		apiNamespace: 'wpcom/v2',
-		body: { message: message.content },
+		body: { message: message.content, context: message.context },
 	} );
 }
 

--- a/client/odie/send-message-input/index.tsx
+++ b/client/odie/send-message-input/index.tsx
@@ -5,7 +5,6 @@ import TextareaAutosize from 'calypso/components/textarea-autosize';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
-import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSiteDomain } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { WAPUU_ERROR_MESSAGE } from '..';
@@ -35,17 +34,15 @@ export const OdieSendMessageButton = ( {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
-	const { siteId, siteDomain, currentRoute, currentPlan } = useSelector( ( state ) => {
+	const { siteId, siteDomain, currentRoute } = useSelector( ( state ) => {
 		const siteId = getSelectedSiteId( state ) as number;
 		const siteDomain = getSiteDomain( state, siteId ) as string;
 		const currentRoute = getCurrentRoute( state );
-		const currentPlan = getCurrentPlan( state, siteId );
 
 		return {
 			siteId,
 			siteDomain,
 			currentRoute,
-			currentPlan,
 		};
 	} );
 
@@ -76,7 +73,6 @@ export const OdieSendMessageButton = ( {
 			blog_id: siteId,
 			route: route,
 			route_params: routeParams,
-			site_plan_id: currentPlan?.id ?? null,
 		};
 	};
 

--- a/client/odie/send-message-input/index.tsx
+++ b/client/odie/send-message-input/index.tsx
@@ -4,7 +4,7 @@ import ArrowUp from 'calypso/assets/images/odie/arrow-up.svg';
 import TextareaAutosize from 'calypso/components/textarea-autosize';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSiteDomain } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -35,13 +35,18 @@ export const OdieSendMessageButton = ( {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
-	const siteId = useSelector( getSelectedSiteId ) as number;
-	const currentSiteDomain = useSelector( ( state ) => {
-		return getSiteDomain( state, siteId );
-	} );
-	const currentRoute = useSelector( getCurrentRoute );
-	const currentPlan = useSelector( ( state ) => {
-		return getCurrentPlan( state, siteId );
+	const { siteId, siteDomain, currentRoute, currentPlan } = useSelector( ( state ) => {
+		const siteId = getSelectedSiteId( state );
+		const siteDomain = getSiteDomain( state, siteId as number ) as string;
+		const currentRoute = getCurrentRoute( state );
+		const currentPlan = getCurrentPlan( state, siteId );
+
+		return {
+			siteId,
+			siteDomain,
+			currentRoute,
+			currentPlan,
+		};
 	} );
 
 	useEffect( () => {
@@ -51,7 +56,7 @@ export const OdieSendMessageButton = ( {
 	}, [ initialUserMessage, chat.chat_id ] );
 
 	const replaceRouteParams = ( route: string ) => {
-		route = route.replace( currentSiteDomain as string, ':site' );
+		route = route.replace( siteDomain, ':site' );
 
 		return route;
 	};

--- a/client/odie/send-message-input/index.tsx
+++ b/client/odie/send-message-input/index.tsx
@@ -36,8 +36,8 @@ export const OdieSendMessageButton = ( {
 	const translate = useTranslate();
 
 	const { siteId, siteDomain, currentRoute, currentPlan } = useSelector( ( state ) => {
-		const siteId = getSelectedSiteId( state );
-		const siteDomain = getSiteDomain( state, siteId as number ) as string;
+		const siteId = getSelectedSiteId( state ) as number;
+		const siteDomain = getSiteDomain( state, siteId ) as string;
 		const currentRoute = getCurrentRoute( state );
 		const currentPlan = getCurrentPlan( state, siteId );
 
@@ -55,16 +55,27 @@ export const OdieSendMessageButton = ( {
 		}
 	}, [ initialUserMessage, chat.chat_id ] );
 
-	const replaceRouteParams = ( route: string ) => {
-		route = route.replace( siteDomain, ':site' );
+	/**
+	 * Replaces route param values with placeholders, and returns the modified route path and route params.
+	 * @param  {string}  route The route path
+	 * @returns {string, Object} Object containing the modified route path and route params
+	 */
+	const replaceRouteParamsWithPlaceholders = ( route: string ) => {
+		const routeParams = {} as Record< string, string >;
 
-		return route;
+		route = route.replace( siteDomain, ':site' );
+		routeParams.site = siteDomain;
+
+		return { route, routeParams };
 	};
 
 	const buildContext = () => {
+		const { route, routeParams } = replaceRouteParamsWithPlaceholders( currentRoute );
+
 		return {
 			site_id: siteId,
-			route: replaceRouteParams( currentRoute ),
+			route: route,
+			route_params: routeParams,
 			plan: currentPlan,
 		};
 	};

--- a/client/odie/send-message-input/index.tsx
+++ b/client/odie/send-message-input/index.tsx
@@ -73,10 +73,10 @@ export const OdieSendMessageButton = ( {
 		const { route, routeParams } = replaceRouteParamsWithPlaceholders( currentRoute );
 
 		return {
-			site_id: siteId,
+			blog_id: siteId,
 			route: route,
 			route_params: routeParams,
-			plan: currentPlan,
+			site_plan_id: currentPlan?.id ?? null,
 		};
 	};
 

--- a/client/odie/types/index.ts
+++ b/client/odie/types/index.ts
@@ -33,7 +33,7 @@ export type Context = {
 	nudge_id?: string | undefined;
 	section_name?: string;
 	session_id?: string;
-	site_id: number | null;
+	blog_id?: number;
 	user_tracking?: OdieUserTracking[];
 	sources?: Source[];
 	prompt_tags?: {
@@ -46,6 +46,9 @@ export type Context = {
 		forward_to_human_support?: boolean;
 		canned_response?: boolean;
 	};
+	route?: string;
+	route_params?: Record< string, string >;
+	site_plan_id?: number;
 };
 
 export type Nudge = {

--- a/client/odie/types/index.ts
+++ b/client/odie/types/index.ts
@@ -48,7 +48,6 @@ export type Context = {
 	};
 	route?: string;
 	route_params?: Record< string, string >;
-	site_plan_id?: number;
 };
 
 export type Nudge = {

--- a/packages/help-center/src/components/index.d.ts
+++ b/packages/help-center/src/components/index.d.ts
@@ -63,6 +63,10 @@ declare module 'calypso/state/purchases/selectors' {
 	export const getUserPurchases: ( state: unknown ) => { productSlug: string }[];
 }
 
+declare module 'calypso/state/selectors/get-current-route' {
+	export const getCurrentRoute: ( state: unknown ) => string;
+}
+
 declare module 'calypso/state/ui/selectors' {
 	export const getSelectedSiteId: ( state: unknown ) => number;
 	export const getSectionName: ( state: unknown ) => SectionName;
@@ -70,8 +74,13 @@ declare module 'calypso/state/ui/selectors' {
 
 declare module 'calypso/state/sites/selectors' {
 	export const getSite: ( state: unknown, siteId: number ) => { is_wpcom_atomic: boolean };
+	export const getSiteDomain: ( state: unknown, siteId: number ) => string;
 	export const getIsSimpleSite: ( state: unknown ) => boolean;
 	export const isJetpackSite: ( state: unknown, siteId: number ) => boolean | null;
+}
+
+declare module 'calypso/state/sites/selectors/get-site-domain' {
+	export const getSiteDomain: ( state: unknown, siteId: number ) => string;
 }
 
 declare module 'calypso/state/sites/selectors/is-simple-site' {
@@ -82,6 +91,13 @@ declare module 'calypso/state/sites/selectors/is-simple-site' {
 declare module 'calypso/state/sites/selectors/is-jetpack-site' {
 	const isJetpackSite: ( state: unknown, siteId?: number ) => boolean;
 	export default isJetpackSite;
+}
+
+declare module 'calypso/state/sites/plans/selectors' {
+	export const getCurrentPlan: (
+		state: unknown,
+		siteId: number | null
+	) => Record< string, unknown >;
 }
 
 declare module 'calypso/state/sites/hooks' {


### PR DESCRIPTION
## Proposed Changes

Add context to Wapuu bot
- blog_id
- route
- route params
- ~~site_plan_id~~

## Testing Instructions

1. http://calypso.localhost:3000/stats/day/:site?flags=wapuu
2. Open the Wapuu chat through the Help Center.
3. Submit a message.
4. Verify the context in the db.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?