### PR TITLE
Domain picker: Remove self-align rule to keep badges at the top.

### DIFF
--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -124,10 +124,6 @@
 		font-size: $font-body-extra-small;
 		order: 2;
 
-		@include break-mobile {
-			align-self: center;
-		}
-
 		.progress-bar {
 			width: 25%;
 			margin-right: 1em;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

* I noticed the badges in the two top domains in the picker look misaligned, so I removed the `align-self` vertical center rule.

Before | After
------ | -----
<img width="705" alt="Screen Shot 2023-11-21 at 2 24 16 PM" src="https://github.com/Automattic/wp-calypso/assets/1689238/f5b72946-30c9-4cbf-90b8-66ee082e165d"> | <img width="705" alt="Screen Shot 2023-11-21 at 2 24 21 PM" src="https://github.com/Automattic/wp-calypso/assets/1689238/c5939a32-c114-4265-85d9-1327c0e92ed6">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /start/domains
* Type in a long domain search term
* Check that the badges in the top two results are aligned
* Regression: check other domains flows.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?