### PR TITLE
Reader/Tags: Update the Reader Tags page to use the new stream-builder endpoint

### DIFF
--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -369,7 +369,9 @@ export function requestPage( action ) {
 
 function get_page_handle( streamType, action, data ) {
 	const { date_range, meta, next_page, next_page_handle } = data;
-	if ( includes( streamType, 'rec' ) ) {
+	if ( next_page_handle ) {
+		return { page_handle: next_page_handle };
+	} else if ( includes( streamType, 'rec' ) ) {
 		const offset = get( action, 'payload.pageHandle.offset', 0 ) + PER_FETCH;
 		return { offset };
 	} else if ( next_page || ( meta && meta.next_page ) ) {
@@ -381,8 +383,6 @@ function get_page_handle( streamType, action, data ) {
 		// and offsets must be used
 		const { after } = date_range;
 		return { before: after };
-	} else if ( next_page_handle ) {
-		return { page_handle: next_page_handle };
 	}
 	return null;
 }

--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -297,7 +297,8 @@ const streamApis = {
 			getQueryStringForPoll( extraFields, { ...extraQueryParams, number: 10 } ),
 	},
 	tag: {
-		path: ( { streamKey } ) => `/read/tags/${ streamKeySuffix( streamKey ) }/posts`,
+		path: ( { streamKey } ) => `/read/streams/tag/${ streamKeySuffix( streamKey ) }`,
+		apiNamespace: 'wpcom/v2',
 		dateProperty: 'date',
 	},
 	tag_popular: {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #84142

## Proposed Changes

This updates Calypso to use the new `/wpcom/v2/read/streams/tags/:tag` endpoint being added in D129617-code.

This new endpoint is used on the `/tags` page of the Reader.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D129617-code to your sandbox and sandbox public-api.wordpress.com
* Use this branch or the calypso.live link.
* Make sure you are subscribed to at least one tag.
* Click on the `# Tags` sidebar in the Reader and click on one of the tags you're subscribed to.
<img width="324" alt="CleanShot 2023-11-21 at 14 46 10@2x" src="https://github.com/Automattic/wp-calypso/assets/917632/656e8c55-be09-45d0-8d36-915f3714a21a">

* Scroll down the page and verify that new posts for that tag are loaded as you scroll.
* Now click on "See all tags" and click on a different tag that you aren't subscribed to.
* Scroll down the page and verify that new posts for that tag are loaded as you scroll.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
