### PR TITLE
Checkout: ToS Experiment - Load the experiment in the useToSFoldableCard hook

### DIFF
--- a/client/my-sites/checkout/src/components/accept-terms-of-service-checkbox.tsx
+++ b/client/my-sites/checkout/src/components/accept-terms-of-service-checkbox.tsx
@@ -73,7 +73,7 @@ function AcceptTermsOfServiceCheckbox( {
 		onChange( event.target.checked );
 	};
 
-	const showToSFoldableCard = useToSFoldableCard();
+	const showToSFoldableCard = useToSFoldableCard() === 'treatment';
 
 	return (
 		<FormLabel>

--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -548,7 +548,7 @@ export default function CheckoutMain( {
 			isLoading: responseCart.products.length < 1,
 		},
 		{ name: translate( 'Loading countries list' ), isLoading: countriesList.length < 1 },
-		{ name: translate( 'Loading site' ), isLoading: isToSExperimentLoading },
+		{ name: translate( 'Loading Site' ), isLoading: isToSExperimentLoading },
 	];
 	const isCheckoutPageLoading: boolean = checkoutLoadingConditions.some(
 		( condition ) => condition.isLoading

--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -43,6 +43,7 @@ import useRecordCartLoaded from '../hooks/use-record-cart-loaded';
 import useRecordCheckoutLoaded from '../hooks/use-record-checkout-loaded';
 import useRemoveFromCartAndRedirect from '../hooks/use-remove-from-cart-and-redirect';
 import { useStoredPaymentMethods } from '../hooks/use-stored-payment-methods';
+import { useToSFoldableCard } from '../hooks/use-tos-foldable-card';
 import { logStashLoadErrorEvent, logStashEvent, convertErrorToString } from '../lib/analytics';
 import existingCardProcessor from '../lib/existing-card-processor';
 import filterAppropriatePaymentMethods from '../lib/filter-appropriate-payment-methods';
@@ -522,6 +523,8 @@ export default function CheckoutMain( {
 		: {};
 	const theme = { ...checkoutTheme, colors: { ...checkoutTheme.colors, ...jetpackColors } };
 
+	const isToSExperimentLoading = useToSFoldableCard() === 'loading';
+
 	// This variable determines if we see the loading page or if checkout can
 	// render its steps.
 	//
@@ -545,6 +548,7 @@ export default function CheckoutMain( {
 			isLoading: responseCart.products.length < 1,
 		},
 		{ name: translate( 'Loading countries list' ), isLoading: countriesList.length < 1 },
+		{ name: translate( 'Loading site' ), isLoading: isToSExperimentLoading },
 	];
 	const isCheckoutPageLoading: boolean = checkoutLoadingConditions.some(
 		( condition ) => condition.isLoading

--- a/client/my-sites/checkout/src/components/checkout-terms-item.tsx
+++ b/client/my-sites/checkout/src/components/checkout-terms-item.tsx
@@ -40,7 +40,7 @@ const CheckoutTermsItem = ( {
 	onClick?: MouseEventHandler< HTMLDivElement >;
 	isPrewrappedChildren?: boolean;
 } > ) => {
-	const showToSFoldableCard = useToSFoldableCard();
+	const showToSFoldableCard = useToSFoldableCard() === 'treatment';
 
 	return (
 		<Wrapper

--- a/client/my-sites/checkout/src/components/checkout-terms.tsx
+++ b/client/my-sites/checkout/src/components/checkout-terms.tsx
@@ -60,7 +60,7 @@ export default function CheckoutTerms( { cart }: { cart: ResponseCart } ) {
 		}
 	`;
 
-	const showToSFoldableCard = useToSFoldableCard();
+	const showToSFoldableCard = useToSFoldableCard() === 'treatment';
 
 	const shouldShowBundledDomainNotice = showBundledDomainNotice( cart );
 	const shouldShowRefundPolicy = isNotJetpackOrAkismetCheckout;

--- a/client/my-sites/checkout/src/components/payment-method-step.tsx
+++ b/client/my-sites/checkout/src/components/payment-method-step.tsx
@@ -103,7 +103,7 @@ export default function BeforeSubmitCheckoutHeader() {
 		} ),
 	};
 
-	const showToSFoldableCard = useToSFoldableCard();
+	const showToSFoldableCard = useToSFoldableCard() === 'treatment';
 
 	return (
 		<>

--- a/client/my-sites/checkout/src/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout.tsx
@@ -331,7 +331,7 @@ export default function WPCheckout( {
 	const { transactionStatus } = useTransactionStatus();
 	const paymentMethod = usePaymentMethod();
 	const shouldCollapseLastStep = useShouldCollapseLastStep();
-	const showToSFoldableCard = useToSFoldableCard();
+	const showToSFoldableCard = useToSFoldableCard() === 'treatment';
 
 	const hasMarketplaceProduct = useSelector( ( state ) => {
 		return responseCart?.products?.some( ( p ) => isMarketplaceProduct( state, p.product_slug ) );

--- a/client/my-sites/checkout/src/hooks/use-tos-foldable-card.tsx
+++ b/client/my-sites/checkout/src/hooks/use-tos-foldable-card.tsx
@@ -1,7 +1,15 @@
-import { hasCheckoutVersion } from '@automattic/wpcom-checkout';
+import { useExperiment } from 'calypso/lib/explat';
 
 export function useToSFoldableCard(): boolean {
-	if ( hasCheckoutVersion( 'tos-foldable-card' ) ) {
+	const [ isLoadingExperimentAssignment, experimentAssignment ] = useExperiment(
+		'wp_web_checkout_tos_foldable_card_v1'
+	);
+
+	if ( ! isLoadingExperimentAssignment ) {
+		return false;
+	}
+
+	if ( experimentAssignment?.variationName === 'treatment' ) {
 		return true;
 	}
 	return false;

--- a/client/my-sites/checkout/src/hooks/use-tos-foldable-card.tsx
+++ b/client/my-sites/checkout/src/hooks/use-tos-foldable-card.tsx
@@ -1,8 +1,22 @@
+import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
 import { useExperiment } from 'calypso/lib/explat';
+import isJetpackCheckout from 'calypso/lib/jetpack/is-jetpack-checkout';
+import { useSelector } from 'calypso/state';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 export function useToSFoldableCard(): boolean {
+	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+
+	const isJetpackNotAtomic = useSelector(
+		( state ) => isJetpackSite( state, siteId ) && ! isSiteAutomatedTransfer( state, siteId )
+	);
+
+	const isWPcomCheckout = ! isJetpackCheckout() && ! isAkismetCheckout() && ! isJetpackNotAtomic;
 	const [ isLoadingExperimentAssignment, experimentAssignment ] = useExperiment(
-		'wp_web_checkout_tos_foldable_card_v1'
+		'wp_web_checkout_tos_foldable_card_v1',
+		{ isEligible: isWPcomCheckout }
 	);
 
 	if ( ! isLoadingExperimentAssignment ) {

--- a/client/my-sites/checkout/src/hooks/use-tos-foldable-card.tsx
+++ b/client/my-sites/checkout/src/hooks/use-tos-foldable-card.tsx
@@ -6,7 +6,7 @@ import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-t
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
-export function useToSFoldableCard(): boolean {
+export function useToSFoldableCard(): 'loading' | 'treatment' | 'control' {
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 
 	const isJetpackNotAtomic = useSelector(
@@ -14,17 +14,20 @@ export function useToSFoldableCard(): boolean {
 	);
 
 	const isWPcomCheckout = ! isJetpackCheckout() && ! isAkismetCheckout() && ! isJetpackNotAtomic;
+
 	const [ isLoadingExperimentAssignment, experimentAssignment ] = useExperiment(
 		'wp_web_checkout_tos_foldable_card_v1',
 		{ isEligible: isWPcomCheckout }
 	);
 
-	if ( ! isLoadingExperimentAssignment ) {
-		return false;
+	// Is loading experiment assignment
+	if ( isLoadingExperimentAssignment ) {
+		return 'loading';
 	}
-
+	// Done loading experiment assignment, and treatment assignment found
 	if ( experimentAssignment?.variationName === 'treatment' ) {
-		return true;
+		return 'treatment';
 	}
-	return false;
+	// Done loading experiment assignment, and control or null assignment found
+	return 'control';
 }

--- a/client/my-sites/checkout/src/test/util/index.ts
+++ b/client/my-sites/checkout/src/test/util/index.ts
@@ -9,6 +9,7 @@ import { prettyDOM } from '@testing-library/react';
 import nock from 'nock';
 import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
+import { useExperiment } from 'calypso/lib/explat';
 import domainManagementReducer from 'calypso/state/domains/management/reducer';
 import noticesReducer from 'calypso/state/notices/reducer';
 import type { PricedAPIPlan, StorePlanSlug } from '@automattic/data-stores';
@@ -25,6 +26,9 @@ import type {
 	PossiblyCompleteDomainContactDetails,
 	ContactDetailsType,
 } from '@automattic/wpcom-checkout';
+
+jest.mock( 'calypso/lib/explat' );
+( useExperiment as jest.Mock ).mockImplementation( () => [ false, undefined ] );
 
 export const normalAllowedPaymentMethods = [
 	'WPCOM_Billing_PayPal_Express',


### PR DESCRIPTION
This PR implements the experimentation platform code for 21525-explat-experiment

Related to #84031 

## Proposed Changes

* Update the useToSFoldableCard hook to filter based on the experiment control or treatment.
* This hook will load either the control 'original' ToS placement in checkout, or, the treatment variant of the ToS which includes loading part of the ToS in a foldable card:

Control             |  Treatment
:-------------------------:|:-------------------------:
<img src="https://github.com/Automattic/wp-calypso/assets/16580129/c21ff9fa-729c-4533-8ff8-7c23145cc671" width="400"> | <img src="https://github.com/Automattic/wp-calypso/assets/16580129/a188a111-90eb-442b-ad49-67caeba3204d" width=400>


## Testing Instructions
See testing instructions here PCYsg-SwK-p2
