### PR TITLE
Jetpack Manage: Create review licenses modal

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/index.tsx
@@ -18,6 +18,7 @@ import IssueLicenseContext from './context';
 import { useProductBundleSize } from './hooks/use-product-bundle-size';
 import useSubmitForm from './hooks/use-submit-form';
 import LicensesForm from './licenses-form';
+import ReviewLicenses from './review-licenses';
 import type { SelectedLicenseProp } from './types';
 import type { AssignLicenceProps } from '../types';
 
@@ -37,13 +38,14 @@ export default function IssueLicenseV2( { selectedSite, suggestedProduct }: Assi
 	const { isReady } = useSubmitForm( selectedSite, suggestedProductSlugs );
 
 	const [ selectedLicenses, setSelectedLicenses ] = useState< SelectedLicenseProp[] >( [] );
+	const [ showReviewLicenses, setShowReviewLicenses ] = useState< boolean >( false );
 
 	const selectedLicenseCount = selectedLicenses
 		.map( ( license ) => license.quantity )
 		.reduce( ( a, b ) => a + b, 0 );
 
 	const handleShowLicenseOverview = useCallback( () => {
-		// Handle showing the license overview modal here
+		setShowReviewLicenses( true );
 	}, [] );
 
 	const onClickIssueLicenses = useCallback( () => {
@@ -53,69 +55,81 @@ export default function IssueLicenseV2( { selectedSite, suggestedProduct }: Assi
 	const showStickyContent = isWithinBreakpoint( '>960px' ) && selectedLicenses.length > 0;
 
 	return (
-		<Layout
-			className="issue-license-v2"
-			title={ translate( 'Issue a new License' ) }
-			wide
-			withBorder
-		>
-			<LayoutTop>
-				<LayoutHeader showStickyContent={ showStickyContent }>
-					<Title>{ translate( 'Issue product licenses' ) } </Title>
-					<Subtitle>
-						{ translate( 'Select single product licenses or save when you issue in bulk' ) }
-					</Subtitle>
-					<Actions>
-						{ selectedLicenses.length > 0 && (
-							<Button
-								primary
-								className="issue-license-v2__select-license"
-								busy={ ! isReady }
-								onClick={ onClickIssueLicenses }
-							>
-								{ translate( 'Issue %(numLicenses)d license', 'Issue %(numLicenses)d licenses', {
-									context: 'button label',
-									count: selectedLicenseCount,
-									args: {
-										numLicenses: selectedLicenseCount,
-									},
-								} ) }
-							</Button>
-						) }
-					</Actions>
-				</LayoutHeader>
+		<>
+			<Layout
+				className="issue-license-v2"
+				title={ translate( 'Issue a new License' ) }
+				wide
+				withBorder
+			>
+				<LayoutTop>
+					<LayoutHeader showStickyContent={ showStickyContent }>
+						<Title>{ translate( 'Issue product licenses' ) } </Title>
+						<Subtitle>
+							{ translate( 'Select single product licenses or save when you issue in bulk' ) }
+						</Subtitle>
+						<Actions>
+							{ selectedLicenses.length > 0 && (
+								<Button
+									primary
+									className="issue-license-v2__select-license"
+									busy={ ! isReady }
+									onClick={ onClickIssueLicenses }
+								>
+									{ translate(
+										'Review %(numLicenses)d license',
+										'Review %(numLicenses)d licenses',
+										{
+											context: 'button label',
+											count: selectedLicenseCount,
+											args: {
+												numLicenses: selectedLicenseCount,
+											},
+										}
+									) }
+								</Button>
+							) }
+						</Actions>
+					</LayoutHeader>
 
-				<LayoutNavigation
-					selectedText={
-						selectedSize === 1
-							? translate( 'Single license' )
-							: ( translate( '%(size)d licenses', { args: { size: selectedSize } } ) as string )
-					}
-				>
-					{ availableSizes.map( ( size ) => (
-						<NavigationItem
-							key={ `bundle-size-${ size }` }
-							label={
-								size === 1
-									? translate( 'Single license' )
-									: ( translate( '%(size)d licenses', { args: { size } } ) as string )
-							}
-							selected={ selectedSize === size }
-							onClick={ () => setSelectedSize( size ) }
+					<LayoutNavigation
+						selectedText={
+							selectedSize === 1
+								? translate( 'Single license' )
+								: ( translate( '%(size)d licenses', { args: { size: selectedSize } } ) as string )
+						}
+					>
+						{ availableSizes.map( ( size ) => (
+							<NavigationItem
+								key={ `bundle-size-${ size }` }
+								label={
+									size === 1
+										? translate( 'Single license' )
+										: ( translate( '%(size)d licenses', { args: { size } } ) as string )
+								}
+								selected={ selectedSize === size }
+								onClick={ () => setSelectedSize( size ) }
+							/>
+						) ) }
+					</LayoutNavigation>
+				</LayoutTop>
+
+				<LayoutBody>
+					<IssueLicenseContext.Provider value={ { setSelectedLicenses, selectedLicenses } }>
+						<LicensesForm
+							selectedSite={ selectedSite }
+							suggestedProduct={ suggestedProduct }
+							quantity={ selectedSize }
 						/>
-					) ) }
-				</LayoutNavigation>
-			</LayoutTop>
-
-			<LayoutBody>
-				<IssueLicenseContext.Provider value={ { setSelectedLicenses, selectedLicenses } }>
-					<LicensesForm
-						selectedSite={ selectedSite }
-						suggestedProduct={ suggestedProduct }
-						quantity={ selectedSize }
-					/>
-				</IssueLicenseContext.Provider>
-			</LayoutBody>
-		</Layout>
+					</IssueLicenseContext.Provider>
+				</LayoutBody>
+			</Layout>
+			{ showReviewLicenses && (
+				<ReviewLicenses
+					onClose={ () => setShowReviewLicenses( false ) }
+					selectedLicenses={ selectedLicenses }
+				/>
+			) }
+		</>
 	);
 }

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/index.tsx
@@ -1,0 +1,22 @@
+import { useTranslate } from 'i18n-calypso';
+import DashboardModal from 'calypso/jetpack-cloud/sections/agency-dashboard/dashboard-modal';
+import type { SelectedLicenseProp } from '../types';
+
+interface Props {
+	onClose: () => void;
+	selectedLicenses: SelectedLicenseProp[];
+}
+
+export default function ReviewLicenses( { onClose, selectedLicenses }: Props ) {
+	const translate = useTranslate();
+
+	return (
+		<DashboardModal
+			title={ translate( 'Review license selection' ) }
+			subtitle={ translate( 'You’re about to issue the following licenses:' ) }
+			onClose={ onClose }
+		>
+			{ selectedLicenses.length }
+		</DashboardModal>
+	);
+}


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/95 
Resolves https://github.com/Automattic/jetpack-genesis/issues/96

## Proposed Changes

This PR creates a review licenses modal.

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Visit the Jetpack Cloud link > Replace `dashboard` in the URL with `/partner-portal/issue-license?flags=jetpack/bundle-licensing`.
2. Select a license and verify that the button now says `Review 1 license` > Select more than 1 license and verify that the button now says `Review 2 licenses`.

<img width="1631" alt="Screenshot 2023-11-22 at 9 46 02 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/c505894a-925d-4bf0-bdd7-de51ff103217">

<img width="1589" alt="Screenshot 2023-11-22 at 9 46 52 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/b7a94ce9-fed8-4cb8-ab85-c84841c451a1">

3. Now click the `Review x license` button and verify that a modal opens up as shown below

<img width="454" alt="Screenshot 2023-11-21 at 11 14 13 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/45adde9f-1299-4866-8233-24c777e48d43">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?