### PR TITLE
GF Signup: Implement experiment for free domain explainer copy

### DIFF
--- a/client/components/domains/choose-domain-later/index.tsx
+++ b/client/components/domains/choose-domain-later/index.tsx
@@ -61,7 +61,7 @@ export default function ChooseDomainLater( props: Props ) {
 	}
 
 	if (
-		[ 'treatment_search', 'treatment_type' ].includes( escapeHatchVariant ) &&
+		[ 'treatment_search', 'treatment_type' ].includes( escapeHatchVariant ?? '' ) &&
 		( domainForm.loadingResults ||
 			! Array.isArray( domainForm?.searchResults ) ||
 			domainForm?.searchResults?.length === 0 )

--- a/client/components/domains/choose-domain-later/index.tsx
+++ b/client/components/domains/choose-domain-later/index.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { useExperiment } from 'calypso/lib/explat';
+import ReskinSideExplainer from '../reskin-side-explainer';
+
+type Props = {
+	step: {
+		domainForm: {
+			loadingResults: boolean;
+			searchResults?: Array< any > | null;
+		};
+	};
+	handleDomainExplainerClick: () => void;
+	flowName: string;
+};
+
+export default function ChooseDomainLater( props: Props ) {
+	const [ isLoading, experimentAssignment ] = useExperiment(
+		'calypso_gf_signup_onboarding_escape_hatch',
+		{
+			isEligible: props.flowName === 'onboarding',
+		}
+	);
+
+	if ( isLoading ) {
+		return null;
+	}
+	const escapeHatchVariant = experimentAssignment?.variationName;
+
+	const { step, handleDomainExplainerClick, flowName } = props;
+	const domainForm = step?.domainForm ?? {};
+	if (
+		escapeHatchVariant === 'treatment_search' &&
+		! domainForm.loadingResults &&
+		Array.isArray( domainForm?.searchResults ) &&
+		domainForm?.searchResults?.length > 0
+	) {
+		return (
+			<div className="domains__domain-side-content domains__free-domain">
+				<ReskinSideExplainer
+					onClick={ handleDomainExplainerClick }
+					type="free-domain-explainer-treatment-search"
+					flowName={ flowName }
+				/>
+			</div>
+		);
+	} else if (
+		escapeHatchVariant === 'treatment_type' &&
+		! domainForm.loadingResults &&
+		Array.isArray( domainForm?.searchResults ) &&
+		domainForm?.searchResults?.length > 0
+	) {
+		return (
+			<div className="domains__domain-side-content domains__free-domain">
+				<ReskinSideExplainer
+					onClick={ handleDomainExplainerClick }
+					type="free-domain-explainer-treatment-type"
+					flowName={ flowName }
+				/>
+			</div>
+		);
+	}
+
+	if (
+		[ 'treatment_search', 'treatment_type' ].includes( escapeHatchVariant ) &&
+		( domainForm.loadingResults ||
+			! Array.isArray( domainForm?.searchResults ) ||
+			domainForm?.searchResults?.length === 0 )
+	) {
+		/**
+		 * We do not show the free domain explainer until there is at least one search query
+		 */
+		return null;
+	}
+
+	// The default behavior is the control variant
+	return (
+		<div className="domains__domain-side-content domains__free-domain">
+			<ReskinSideExplainer
+				onClick={ handleDomainExplainerClick }
+				type="free-domain-explainer"
+				flowName={ flowName }
+			/>
+		</div>
+	);
+}

--- a/client/components/domains/choose-domain-later/index.tsx
+++ b/client/components/domains/choose-domain-later/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useExperiment } from 'calypso/lib/explat';
 import ReskinSideExplainer from '../reskin-side-explainer';
 
@@ -14,6 +14,7 @@ type Props = {
 };
 
 export default function ChooseDomainLater( props: Props ) {
+	const [ isEscapeHatchShownOnce, setisEscapeHatchShownOnce ] = useState( false );
 	const [ isLoading, experimentAssignment ] = useExperiment(
 		'calypso_gf_signup_onboarding_escape_hatch',
 		{
@@ -25,15 +26,21 @@ export default function ChooseDomainLater( props: Props ) {
 		return null;
 	}
 	const escapeHatchVariant = experimentAssignment?.variationName;
-
 	const { step, handleDomainExplainerClick, flowName } = props;
 	const domainForm = step?.domainForm ?? {};
-	if (
-		escapeHatchVariant === 'treatment_search' &&
+
+	const isDomainResultsLoaded =
 		! domainForm.loadingResults &&
 		Array.isArray( domainForm?.searchResults ) &&
-		domainForm?.searchResults?.length > 0
+		domainForm?.searchResults?.length > 0;
+
+	if (
+		escapeHatchVariant === 'treatment_search' &&
+		( isEscapeHatchShownOnce || isDomainResultsLoaded )
 	) {
+		if ( ! isEscapeHatchShownOnce ) {
+			setisEscapeHatchShownOnce( true );
+		}
 		return (
 			<div className="domains__domain-side-content domains__free-domain">
 				<ReskinSideExplainer
@@ -45,10 +52,11 @@ export default function ChooseDomainLater( props: Props ) {
 		);
 	} else if (
 		escapeHatchVariant === 'treatment_type' &&
-		! domainForm.loadingResults &&
-		Array.isArray( domainForm?.searchResults ) &&
-		domainForm?.searchResults?.length > 0
+		( isEscapeHatchShownOnce || isDomainResultsLoaded )
 	) {
+		if ( ! isEscapeHatchShownOnce ) {
+			setisEscapeHatchShownOnce( true );
+		}
 		return (
 			<div className="domains__domain-side-content domains__free-domain">
 				<ReskinSideExplainer

--- a/client/components/domains/choose-domain-later/test/choose-domain-later.test.tsx
+++ b/client/components/domains/choose-domain-later/test/choose-domain-later.test.tsx
@@ -1,0 +1,129 @@
+/** @jest-environment jsdom */
+
+import React from 'react';
+import { useExperiment } from 'calypso/lib/explat';
+import { reducer as ui } from 'calypso/state/ui/reducer';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import ChooseDomainLater from '../index';
+
+const render = ( el, options? ) => renderWithProvider( el, { ...options, reducers: { ui } } );
+
+jest.mock( 'calypso/lib/explat', () => ( {
+	useExperiment: jest.fn(),
+} ) );
+
+describe( 'ChooseDomainLater', () => {
+	test( 'Renders treatment_search when that treatment is active', () => {
+		useExperiment.mockImplementation( () => [ false, { variationName: 'treatment_search' } ] );
+
+		const { getByText } = render(
+			<ChooseDomainLater
+				flowName="onboarding"
+				step={ {
+					domainForm: {
+						loadingResults: false,
+						searchResults: Array( 5 ).fill( {} ),
+					},
+				} }
+				handleDomainExplainerClick={ () => {} }
+			/>
+		);
+
+		expect( getByText( 'Not ready to choose a domain just yet?' ) ).toBeTruthy();
+	} );
+
+	test( 'Renders treatment_type when that treatment is active', () => {
+		useExperiment.mockImplementation( () => [ false, { variationName: 'treatment_type' } ] );
+
+		const { getByText } = render(
+			<ChooseDomainLater
+				flowName="onboarding"
+				step={ {
+					domainForm: {
+						loadingResults: false,
+						searchResults: Array( 5 ).fill( {} ),
+					},
+				} }
+				handleDomainExplainerClick={ () => {} }
+			/>
+		);
+
+		expect( getByText( 'Get a free domain with select paid plans' ) ).toBeTruthy();
+	} );
+
+	test( 'Renders control when that control is active', () => {
+		useExperiment.mockImplementation( () => [ false, { variationName: 'control' } ] );
+
+		const { container } = render(
+			<ChooseDomainLater
+				flowName="onboarding"
+				step={ {
+					domainForm: {
+						loadingResults: false,
+						searchResults: Array( 5 ).fill( {} ),
+					},
+				} }
+				handleDomainExplainerClick={ () => {} }
+			/>
+		);
+
+		expect( container.innerHTML ).toContain(
+			'Get a <strong>free</strong> one-year domain registration with any paid annual plan.'
+		);
+	} );
+
+	test( 'Does not render if treatment_type and domain results not loaded', () => {
+		useExperiment.mockImplementation( () => [ false, { variationName: 'treatment_type' } ] );
+
+		const { queryByText } = render(
+			<ChooseDomainLater
+				flowName="onboarding"
+				step={ {
+					domainForm: {
+						loadingResults: true,
+						searchResults: [],
+					},
+				} }
+				handleDomainExplainerClick={ () => {} }
+			/>
+		);
+
+		expect( queryByText( 'Get a free domain with select paid plans' ) ).toBeFalsy();
+	} );
+
+	test( 'Does not render if treatment_search and domain results not loaded', () => {
+		useExperiment.mockImplementation( () => [ false, { variationName: 'treatment_search' } ] );
+
+		const { queryByText } = render(
+			<ChooseDomainLater
+				flowName="onboarding"
+				step={ {
+					domainForm: {
+						loadingResults: true,
+						searchResults: [],
+					},
+				} }
+				handleDomainExplainerClick={ () => {} }
+			/>
+		);
+
+		expect( queryByText( 'Not ready to choose a domain just yet?' ) ).toBeFalsy();
+	} );
+
+	test( 'Does not render anything if experiment is still loading', () => {
+		useExperiment.mockImplementation( () => [ true, null ] );
+		const { container } = render(
+			<ChooseDomainLater
+				flowName="onboarding"
+				step={ {
+					domainForm: {
+						loadingResults: false,
+						searchResults: [],
+					},
+				} }
+				handleDomainExplainerClick={ () => {} }
+			/>
+		);
+		expect( container.innerHTML ).toBeFalsy();
+	} );
+} );

--- a/client/components/domains/choose-domain-later/test/choose-domain-later.test.tsx
+++ b/client/components/domains/choose-domain-later/test/choose-domain-later.test.tsx
@@ -14,8 +14,8 @@ jest.mock( 'calypso/lib/explat', () => ( {
 } ) );
 
 describe( 'ChooseDomainLater', () => {
-	test( 'Renders treatment_search when that treatment is active', () => {
-		useExperimentMock.mockImplementation( () => [ false, { variationName: 'treatment_search' } ] );
+	test( 'Renders treatment_type when that treatment is active', () => {
+		useExperimentMock.mockImplementation( () => [ false, { variationName: 'treatment_type' } ] );
 
 		const { getByText } = render(
 			<ChooseDomainLater
@@ -33,8 +33,8 @@ describe( 'ChooseDomainLater', () => {
 		expect( getByText( 'Not ready to choose a domain just yet?' ) ).toBeTruthy();
 	} );
 
-	test( 'Renders treatment_type when that treatment is active', () => {
-		useExperimentMock.mockImplementation( () => [ false, { variationName: 'treatment_type' } ] );
+	test( 'Renders treatment_search when that treatment is active', () => {
+		useExperimentMock.mockImplementation( () => [ false, { variationName: 'treatment_search' } ] );
 
 		const { getByText } = render(
 			<ChooseDomainLater
@@ -73,8 +73,8 @@ describe( 'ChooseDomainLater', () => {
 		);
 	} );
 
-	test( 'Does not render if treatment_type and domain results not loaded', () => {
-		useExperimentMock.mockImplementation( () => [ false, { variationName: 'treatment_type' } ] );
+	test( 'Does not render if treatment_search and domain results not loaded', () => {
+		useExperimentMock.mockImplementation( () => [ false, { variationName: 'treatment_search' } ] );
 
 		const { queryByText } = render(
 			<ChooseDomainLater
@@ -92,8 +92,8 @@ describe( 'ChooseDomainLater', () => {
 		expect( queryByText( 'Get a free domain with select paid plans' ) ).toBeFalsy();
 	} );
 
-	test( 'Does not render if treatment_search and domain results not loaded', () => {
-		useExperimentMock.mockImplementation( () => [ false, { variationName: 'treatment_search' } ] );
+	test( 'Does not render if treatment_type and domain results not loaded', () => {
+		useExperimentMock.mockImplementation( () => [ false, { variationName: 'treatment_type' } ] );
 
 		const { queryByText } = render(
 			<ChooseDomainLater

--- a/client/components/domains/choose-domain-later/test/choose-domain-later.test.tsx
+++ b/client/components/domains/choose-domain-later/test/choose-domain-later.test.tsx
@@ -6,6 +6,7 @@ import { reducer as ui } from 'calypso/state/ui/reducer';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import ChooseDomainLater from '../index';
 
+const useExperimentMock = useExperiment as jest.MockedFunction< any >;
 const render = ( el, options? ) => renderWithProvider( el, { ...options, reducers: { ui } } );
 
 jest.mock( 'calypso/lib/explat', () => ( {
@@ -14,7 +15,7 @@ jest.mock( 'calypso/lib/explat', () => ( {
 
 describe( 'ChooseDomainLater', () => {
 	test( 'Renders treatment_search when that treatment is active', () => {
-		useExperiment.mockImplementation( () => [ false, { variationName: 'treatment_search' } ] );
+		useExperimentMock.mockImplementation( () => [ false, { variationName: 'treatment_search' } ] );
 
 		const { getByText } = render(
 			<ChooseDomainLater
@@ -33,7 +34,7 @@ describe( 'ChooseDomainLater', () => {
 	} );
 
 	test( 'Renders treatment_type when that treatment is active', () => {
-		useExperiment.mockImplementation( () => [ false, { variationName: 'treatment_type' } ] );
+		useExperimentMock.mockImplementation( () => [ false, { variationName: 'treatment_type' } ] );
 
 		const { getByText } = render(
 			<ChooseDomainLater
@@ -52,7 +53,7 @@ describe( 'ChooseDomainLater', () => {
 	} );
 
 	test( 'Renders control when that control is active', () => {
-		useExperiment.mockImplementation( () => [ false, { variationName: 'control' } ] );
+		useExperimentMock.mockImplementation( () => [ false, { variationName: 'control' } ] );
 
 		const { container } = render(
 			<ChooseDomainLater
@@ -73,7 +74,7 @@ describe( 'ChooseDomainLater', () => {
 	} );
 
 	test( 'Does not render if treatment_type and domain results not loaded', () => {
-		useExperiment.mockImplementation( () => [ false, { variationName: 'treatment_type' } ] );
+		useExperimentMock.mockImplementation( () => [ false, { variationName: 'treatment_type' } ] );
 
 		const { queryByText } = render(
 			<ChooseDomainLater
@@ -92,7 +93,7 @@ describe( 'ChooseDomainLater', () => {
 	} );
 
 	test( 'Does not render if treatment_search and domain results not loaded', () => {
-		useExperiment.mockImplementation( () => [ false, { variationName: 'treatment_search' } ] );
+		useExperimentMock.mockImplementation( () => [ false, { variationName: 'treatment_search' } ] );
 
 		const { queryByText } = render(
 			<ChooseDomainLater
@@ -111,7 +112,7 @@ describe( 'ChooseDomainLater', () => {
 	} );
 
 	test( 'Does not render anything if experiment is still loading', () => {
-		useExperiment.mockImplementation( () => [ true, null ] );
+		useExperimentMock.mockImplementation( () => [ true, null ] );
 		const { container } = render(
 			<ChooseDomainLater
 				flowName="onboarding"

--- a/client/components/domains/reskin-side-explainer/index.jsx
+++ b/client/components/domains/reskin-side-explainer/index.jsx
@@ -73,7 +73,7 @@ class ReskinSideExplainer extends Component {
 					<span>{ translate( 'Choose my domain later' ) }</span>
 				);
 				break;
-			case 'free-domain-explainer-treatment-search':
+			case 'free-domain-explainer-treatment-type':
 				title = translate( 'Not ready to choose a domain just yet?' );
 				subtitle = translate(
 					'Select any annual paid plan and we’ll pay the first year’s domain registration fees for you.'
@@ -82,7 +82,7 @@ class ReskinSideExplainer extends Component {
 				ctaText = translate( 'Check paid plans »' );
 				break;
 
-			case 'free-domain-explainer-treatment-type':
+			case 'free-domain-explainer-treatment-search':
 				title = translate( 'Get a free domain with select paid plans' );
 				subtitle = translate(
 					'Select any annual paid plan and we’ll pay the first year’s domain registration fees for you.'

--- a/client/components/domains/reskin-side-explainer/index.jsx
+++ b/client/components/domains/reskin-side-explainer/index.jsx
@@ -73,6 +73,25 @@ class ReskinSideExplainer extends Component {
 					<span>{ translate( 'Choose my domain later' ) }</span>
 				);
 				break;
+			case 'free-domain-explainer-treatment-search':
+				title = translate( 'Not ready to choose a domain just yet?' );
+				subtitle = translate(
+					'Select any annual paid plan and we’ll pay the first year’s domain registration fees for you.'
+				);
+				subtitle2 = translate( 'You can claim your custom domain name later when you’re ready.' );
+				ctaText = translate( 'Check paid plans »' );
+				break;
+
+			case 'free-domain-explainer-treatment-type':
+				title = translate( 'Get a free domain with select paid plans' );
+				subtitle = translate(
+					'Select any annual paid plan and we’ll pay the first year’s domain registration fees for you.'
+				);
+				subtitle2 = translate(
+					'Not ready to choose domain yet? Get your plan now and claim your domain later!'
+				);
+				ctaText = translate( 'Check paid plans »' );
+				break;
 
 			case 'use-your-domain':
 				title = translate( 'Already own a domain?' );

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -984,7 +984,7 @@ export class RenderDomainsStep extends Component {
 							<ChooseDomainLater
 								step={ this.props.step }
 								flowName={ this.props.flowName }
-								handleDomainExplainerClick={ this.props.handleDomainExplainerClick }
+								handleDomainExplainerClick={ this.handleDomainExplainerClick }
 							/>
 					  ) }
 				{ useYourDomain }

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -15,6 +15,7 @@ import { parse } from 'qs';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import QueryProductsList from 'calypso/components/data/query-products-list';
+import ChooseDomainLater from 'calypso/components/domains/choose-domain-later';
 import { useMyDomainInputMode as inputMode } from 'calypso/components/domains/connect-domain-step/constants';
 import RegisterDomainStep from 'calypso/components/domains/register-domain-step';
 import { recordUseYourDomainButtonClick } from 'calypso/components/domains/register-domain-step/analytics';
@@ -980,13 +981,11 @@ export class RenderDomainsStep extends Component {
 					? DomainsInCart()
 					: ! this.shouldHideDomainExplainer() &&
 					  this.props.isPlanSelectionAvailableLaterInFlow && (
-							<div className="domains__domain-side-content domains__free-domain">
-								<ReskinSideExplainer
-									onClick={ this.handleDomainExplainerClick }
-									type="free-domain-explainer"
-									flowName={ this.props.flowName }
-								/>
-							</div>
+							<ChooseDomainLater
+								step={ this.props.step }
+								flowName={ this.props.flowName }
+								handleDomainExplainerClick={ this.props.handleDomainExplainerClick }
+							/>
 					  ) }
 				{ useYourDomain }
 				{ this.shouldDisplayDomainOnlyExplainer() && (

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1,6 +1,6 @@
 import { PLAN_PERSONAL, isFreeWordPressComDomain } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
-import { Button, FoldableCard } from '@automattic/components';
+import { Button, FoldableCard, Spinner } from '@automattic/components';
 import { formatCurrency } from '@automattic/format-currency';
 import { VIDEOPRESS_FLOW, isWithThemeFlow, isHostingSignupFlow } from '@automattic/onboarding';
 import { isTailoredSignupFlow } from '@automattic/onboarding/src';
@@ -40,7 +40,7 @@ import {
 	getFixedDomainSearch,
 } from 'calypso/lib/domains';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
-import { ProvideExperimentData } from 'calypso/lib/explat';
+import { ProvideExperimentData, useExperiment } from 'calypso/lib/explat';
 import { logToLogstash } from 'calypso/lib/logstash';
 import { getSitePropertyDefaults } from 'calypso/lib/signup/site-properties';
 import { maybeExcludeEmailsStep } from 'calypso/lib/signup/step-actions';
@@ -1302,8 +1302,14 @@ export class RenderDomainsStep extends Component {
 				key={ this.props.step + this.props.stepSectionName }
 				className="domains__step-content domains__step-content-domain-step"
 			>
-				{ content }
-				{ sideContent }
+				{ this.props.isSideContentExperimentLoading ? (
+					<Spinner width="100" />
+				) : (
+					<>
+						{ content }
+						{ sideContent }
+					</>
+				) }
 			</div>
 		);
 	}
@@ -1523,9 +1529,18 @@ const RenderDomainsStepConnect = connect(
 )( withCartKey( withShoppingCart( localize( RenderDomainsStep ) ) ) );
 
 export default function DomainsStep( props ) {
+	const [ isSideContentExperimentLoading ] = useExperiment(
+		'calypso_gf_signup_onboarding_escape_hatch',
+		{
+			isEligible: props.flowName === 'onboarding',
+		}
+	);
 	return (
 		<CalypsoShoppingCartProvider>
-			<RenderDomainsStepConnect { ...props } />
+			<RenderDomainsStepConnect
+				{ ...props }
+				isSideContentExperimentLoading={ isSideContentExperimentLoading }
+			/>
 		</CalypsoShoppingCartProvider>
 	);
 }

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -38,6 +38,9 @@
 
 	&.domains__step-content-domain-step {
 		margin-bottom: 20px;
+		.spinner {
+			width: 100%;
+		}
 	}
 
 	.search-component .search-component__icon-navigation {

--- a/packages/calypso-e2e/src/lib/pages/signup/signup-domain-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup/signup-domain-page.ts
@@ -20,10 +20,9 @@ export class SignupDomainPage {
 	 * Skips the domain selection screen.
 	 */
 	async skipDomainSelection(): Promise< void > {
-		console.log( 'async skipDomainSelection(): Promise< void > {' );
-		console.log( this.page.getByRole( 'button', { name: 'Choose my domain later', exact: true } ) );
-		console.log( this.page.getByRole( 'button', { name: 'Skip Purchase', exact: true } ) );
-		// await this.page.getByRole( 'button', { name: 'Skip Purchase', exact: true } ).click();
-		await this.page.getByRole( 'button', { name: 'Choose my domain later', exact: true } ).click();
+		await Promise.race( [
+			this.page.getByRole( 'button', { name: 'Skip Purchase', exact: true } ).click(),
+			this.page.getByRole( 'button', { name: 'Choose my domain later', exact: true } ).click(),
+		] );
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/signup/signup-domain-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup/signup-domain-page.ts
@@ -20,9 +20,10 @@ export class SignupDomainPage {
 	 * Skips the domain selection screen.
 	 */
 	async skipDomainSelection(): Promise< void > {
-		await Promise.race( [
-			this.page.getByRole( 'button', { name: 'Skip Purchase', exact: true } ).click(),
-			this.page.getByRole( 'button', { name: 'Choose my domain later', exact: true } ).click(),
-		] );
+		console.log( 'async skipDomainSelection(): Promise< void > {' );
+		console.log( this.page.getByRole( 'button', { name: 'Choose my domain later', exact: true } ) );
+		console.log( this.page.getByRole( 'button', { name: 'Skip Purchase', exact: true } ) );
+		// await this.page.getByRole( 'button', { name: 'Skip Purchase', exact: true } ).click();
+		await this.page.getByRole( 'button', { name: 'Choose my domain later', exact: true } ).click();
 	}
 }


### PR DESCRIPTION
Experiment: pbxNRc-3hQ-p2
Abacus: 21526-explat-experiment

Fixes: Automattic/growth-foundations#263

## Proposed Changes
Implements an experiment to show variants of the free domain explainer and hide it until domain search results are shown.

#### Shows loader until experiment is loaded.
<img width="250" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3422709/3317aec3-8d22-4825-8d4a-e786e91b87a0">

### Cases Grid
| stage | ```control``` | Variant ```treatment_type```  | Variant ```treatment_search``` |
| - | - | - | - |
| Description | Original copy | Contextually relevant copy  | Best of both worlds – Mixed approach |
| Pre Results  | Current Layout: ```Get a free one-year domain registration with any paid annual plan.``` | (same in both variants) Only section ```Already own a domain?``` | (same in both variants) Only section ```Already own a domain?```|
| Post Results  |  Current Layout: ```Get a free one-year domain registration with any paid annual plan.``` | ```Not ready to choose a domain just yet?``` |  ```Get a free domain with select paid plans``` |

| stage | Control | Variant treatment_type  | Variant treatment_search |
| - | - | - | - |
| Pre Results  | <img width="250" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3422709/efc473fd-d284-4bf2-88bb-201784567e6c"> | (same in both variants) <img width="250" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3422709/d434329a-4250-43d6-b0af-db284c08e344"> | (same in both variants) <img width="250" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3422709/d434329a-4250-43d6-b0af-db284c08e344"> |
| Post Results  | Same as above | <img width="250" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3422709/7f688e8f-8b45-426b-bf34-0bca8ed2e252"> |  <img width="250" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3422709/8e638464-eeec-4114-ae22-60236754a023"> |


https://github.com/Automattic/wp-calypso/assets/3422709/31e1d946-fa5e-4fe1-ae49-715eafe81c41


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Assign yourself for various variants and make sure the above variant outcomes are matched
* Make sure a loader is shown until the experiment is loaded
* When in variants, Make sure the free domain explained does not appear until after the domain results are fully loaded
*  When in variants, make sure the free domain explainer does not disappear once appeared (when searching for domains with different queries)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?