### PR TITLE
Jetpack Manage: Add product filtering capabilities in the new issue license page.

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/constants.ts
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/constants.ts
@@ -1,0 +1,5 @@
+export const PRODUCT_FILTER_ALL = null;
+export const PRODUCT_FILTER_PLANS = 'plans';
+export const PRODUCT_FILTER_PRODUCTS = 'products';
+export const PRODUCT_FILTER_WOOCOMMERCE_EXTENSIONS = 'woocommerce-extensions';
+export const PRODUCT_FILTER_VAULTPRESS_BACKUP_ADDONS = 'vaultpress-backup-addons';

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/hooks/use-product-and-plans.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/hooks/use-product-and-plans.tsx
@@ -12,13 +12,67 @@ import {
 	addSelectedProductSlugs,
 	clearSelectedProductSlugs,
 } from 'calypso/state/partner-portal/products/actions';
+import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+import {
+	PRODUCT_FILTER_ALL,
+	PRODUCT_FILTER_PLANS,
+	PRODUCT_FILTER_PRODUCTS,
+	PRODUCT_FILTER_VAULTPRESS_BACKUP_ADDONS,
+	PRODUCT_FILTER_WOOCOMMERCE_EXTENSIONS,
+} from '../../constants';
 import type { SiteDetails } from '@automattic/data-stores';
 
 type Props = {
 	selectedSite?: SiteDetails | null;
+	selectedProductFilter?: string | null;
 };
 
-export default function useProductAndPlans( { selectedSite }: Props ) {
+const getProductsAndPlansByFilter = (
+	filter: string | null,
+	allProductsAndPlans?: APIProductFamilyProduct[]
+) => {
+	switch ( filter ) {
+		case PRODUCT_FILTER_PRODUCTS:
+			return (
+				allProductsAndPlans?.filter(
+					( { family_slug }: { family_slug: string } ) =>
+						family_slug !== 'jetpack-packs' &&
+						family_slug !== 'jetpack-backup-storage' &&
+						! isWooCommerceProduct( family_slug ) &&
+						! isWpcomHostingProduct( family_slug )
+				) || []
+			);
+		case PRODUCT_FILTER_PLANS:
+			return (
+				allProductsAndPlans?.filter(
+					( { family_slug }: { family_slug: string } ) => family_slug === 'jetpack-packs'
+				) || []
+			);
+
+		case PRODUCT_FILTER_VAULTPRESS_BACKUP_ADDONS:
+			return (
+				allProductsAndPlans
+					?.filter(
+						( { family_slug }: { family_slug: string } ) => family_slug === 'jetpack-backup-storage'
+					)
+					.sort( ( a, b ) => a.product_id - b.product_id ) || []
+			);
+
+		case PRODUCT_FILTER_WOOCOMMERCE_EXTENSIONS:
+			return (
+				allProductsAndPlans?.filter( ( { family_slug }: { family_slug: string } ) =>
+					isWooCommerceProduct( family_slug )
+				) || []
+			);
+	}
+
+	return allProductsAndPlans || [];
+};
+
+export default function useProductAndPlans( {
+	selectedSite,
+	selectedProductFilter = PRODUCT_FILTER_ALL,
+}: Props ) {
 	const { data, isLoading: isLoadingProducts } = useProductsQuery();
 	const dispatch = useDispatch();
 
@@ -48,37 +102,15 @@ export default function useProductAndPlans( { selectedSite }: Props ) {
 	);
 
 	return useMemo( () => {
-		let allProductsAndBundles = data;
+		// We pre-filter the list by current selected filter
+		let filteredProductsAndBundles = getProductsAndPlansByFilter( selectedProductFilter, data );
 
 		// Filter products & plan that are already assigned to a site
-		if ( selectedSite && addedPlanAndProducts && allProductsAndBundles ) {
-			allProductsAndBundles = allProductsAndBundles.filter(
+		if ( selectedSite && addedPlanAndProducts && filteredProductsAndBundles ) {
+			filteredProductsAndBundles = filteredProductsAndBundles.filter(
 				( product ) => ! addedPlanAndProducts.includes( product.product_id )
 			);
 		}
-
-		const bundles =
-			allProductsAndBundles?.filter(
-				( { family_slug }: { family_slug: string } ) => family_slug === 'jetpack-packs'
-			) || [];
-		const backupAddons =
-			allProductsAndBundles
-				?.filter(
-					( { family_slug }: { family_slug: string } ) => family_slug === 'jetpack-backup-storage'
-				)
-				.sort( ( a, b ) => a.product_id - b.product_id ) || [];
-		const products =
-			allProductsAndBundles?.filter(
-				( { family_slug }: { family_slug: string } ) =>
-					family_slug !== 'jetpack-packs' &&
-					family_slug !== 'jetpack-backup-storage' &&
-					! isWooCommerceProduct( family_slug ) &&
-					! isWpcomHostingProduct( family_slug )
-			) || [];
-		const wooExtensions =
-			allProductsAndBundles?.filter( ( { family_slug }: { family_slug: string } ) =>
-				isWooCommerceProduct( family_slug )
-			) || [];
 
 		// We need the suggested products (i.e., the products chosen from the dashboard) to properly
 		// track if the user purchases a different set of products.
@@ -88,12 +120,18 @@ export default function useProductAndPlans( { selectedSite }: Props ) {
 
 		return {
 			isLoadingProducts,
-			allProductsAndBundles,
-			bundles,
-			backupAddons,
-			products,
-			wooExtensions,
+			filteredProductsAndBundles,
+			plans: getProductsAndPlansByFilter( PRODUCT_FILTER_PLANS, filteredProductsAndBundles ),
+			products: getProductsAndPlansByFilter( PRODUCT_FILTER_PRODUCTS, filteredProductsAndBundles ),
+			backupAddons: getProductsAndPlansByFilter(
+				PRODUCT_FILTER_VAULTPRESS_BACKUP_ADDONS,
+				filteredProductsAndBundles
+			),
+			wooExtensions: getProductsAndPlansByFilter(
+				PRODUCT_FILTER_WOOCOMMERCE_EXTENSIONS,
+				filteredProductsAndBundles
+			),
 			suggestedProductSlugs,
 		};
-	}, [ addedPlanAndProducts, data, isLoadingProducts, selectedSite ] );
+	}, [ addedPlanAndProducts, data, isLoadingProducts, selectedProductFilter, selectedSite ] );
 }

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/hooks/use-product-and-plans.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/hooks/use-product-and-plans.tsx
@@ -35,7 +35,7 @@ const getProductsAndPlansByFilter = (
 		case PRODUCT_FILTER_PRODUCTS:
 			return (
 				allProductsAndPlans?.filter(
-					( { family_slug }: { family_slug: string } ) =>
+					( { family_slug } ) =>
 						family_slug !== 'jetpack-packs' &&
 						family_slug !== 'jetpack-backup-storage' &&
 						! isWooCommerceProduct( family_slug ) &&
@@ -44,25 +44,20 @@ const getProductsAndPlansByFilter = (
 			);
 		case PRODUCT_FILTER_PLANS:
 			return (
-				allProductsAndPlans?.filter(
-					( { family_slug }: { family_slug: string } ) => family_slug === 'jetpack-packs'
-				) || []
+				allProductsAndPlans?.filter( ( { family_slug } ) => family_slug === 'jetpack-packs' ) || []
 			);
 
 		case PRODUCT_FILTER_VAULTPRESS_BACKUP_ADDONS:
 			return (
 				allProductsAndPlans
-					?.filter(
-						( { family_slug }: { family_slug: string } ) => family_slug === 'jetpack-backup-storage'
-					)
+					?.filter( ( { family_slug } ) => family_slug === 'jetpack-backup-storage' )
 					.sort( ( a, b ) => a.product_id - b.product_id ) || []
 			);
 
 		case PRODUCT_FILTER_WOOCOMMERCE_EXTENSIONS:
 			return (
-				allProductsAndPlans?.filter( ( { family_slug }: { family_slug: string } ) =>
-					isWooCommerceProduct( family_slug )
-				) || []
+				allProductsAndPlans?.filter( ( { family_slug } ) => isWooCommerceProduct( family_slug ) ) ||
+				[]
 			);
 	}
 

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
@@ -1,13 +1,15 @@
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useContext } from 'react';
+import { useCallback, useContext, useState } from 'react';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import LicenseBundleCard from 'calypso/jetpack-cloud/sections/partner-portal/license-bundle-card';
 import LicenseProductCard from 'calypso/jetpack-cloud/sections/partner-portal/license-product-card';
 import { useSelector } from 'calypso/state';
 import { getDisabledProductSlugs } from 'calypso/state/partner-portal/products/selectors';
+import { PRODUCT_FILTER_ALL } from '../constants';
 import IssueLicenseContext from '../context';
 import useSubmitForm from '../hooks/use-submit-form';
 import useProductAndPlans from './hooks/use-product-and-plans';
+import ProductFilterSelect from './product-filter-select';
 import LicensesFormSection from './sections';
 import type { AssignLicenceProps } from '../../types';
 import type {
@@ -26,18 +28,22 @@ export default function LicensesForm( {
 
 	const { selectedLicenses, setSelectedLicenses } = useContext( IssueLicenseContext );
 
+	const [ selectedProductFilter, setSelectedProductFilter ] = useState< string | null >(
+		PRODUCT_FILTER_ALL
+	);
+
 	const {
-		allProductsAndBundles,
+		filteredProductsAndBundles,
 		isLoadingProducts,
-		bundles,
+		plans,
 		backupAddons,
 		products,
 		wooExtensions,
 		suggestedProductSlugs,
-	} = useProductAndPlans( { selectedSite } );
+	} = useProductAndPlans( { selectedSite, selectedProductFilter } );
 
 	const disabledProductSlugs = useSelector< PartnerPortalStore, string[] >( ( state ) =>
-		getDisabledProductSlugs( state, allProductsAndBundles ?? [] )
+		getDisabledProductSlugs( state, filteredProductsAndBundles ?? [] )
 	);
 
 	const handleSelectBundleLicense = useCallback(
@@ -84,6 +90,13 @@ export default function LicensesForm( {
 		[ quantity, selectedLicenses ]
 	);
 
+	const onProductFilterSelect = useCallback(
+		( value: string | null ) => {
+			setSelectedProductFilter( value );
+		},
+		[ setSelectedProductFilter ]
+	);
+
 	const isSingleLicenseView = quantity === 1;
 
 	if ( isLoadingProducts ) {
@@ -98,14 +111,22 @@ export default function LicensesForm( {
 		<div className="licenses-form">
 			<QueryProductsList type="jetpack" currency="USD" />
 
-			{ bundles && (
+			<div className="licenses-form__actions">
+				<ProductFilterSelect
+					selectedProductFilter={ selectedProductFilter }
+					onProductFilterSelect={ onProductFilterSelect }
+					isSingleLicense={ isSingleLicenseView }
+				/>
+			</div>
+
+			{ plans.length > 0 && (
 				<LicensesFormSection
 					title={ translate( 'Plans' ) }
 					description={ translate(
 						'Save big with comprehensive bundles of Jetpack security, performance, and growth tools.'
 					) }
 				>
-					{ bundles.map( ( productOption, i ) => (
+					{ plans.map( ( productOption, i ) => (
 						<LicenseBundleCard
 							key={ productOption.slug }
 							product={ productOption }
@@ -119,7 +140,7 @@ export default function LicensesForm( {
 				</LicensesFormSection>
 			) }
 
-			{ products && (
+			{ products.length > 0 && (
 				<LicensesFormSection
 					title={ translate( 'Products' ) }
 					description={ translate(

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/product-filter-select.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/product-filter-select.tsx
@@ -1,0 +1,96 @@
+import { SelectDropdown } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect, useMemo } from 'react';
+import {
+	PRODUCT_FILTER_ALL,
+	PRODUCT_FILTER_PLANS,
+	PRODUCT_FILTER_PRODUCTS,
+	PRODUCT_FILTER_VAULTPRESS_BACKUP_ADDONS,
+	PRODUCT_FILTER_WOOCOMMERCE_EXTENSIONS,
+} from '../constants';
+
+type Props = {
+	selectedProductFilter: string | null;
+	onProductFilterSelect: ( value: string | null ) => void;
+	isSingleLicense?: boolean;
+};
+
+type Option = {
+	value?: string | null;
+	label: string;
+};
+
+const getOptionByFuction = ( options: Option[], value: string | null ): Option => {
+	return options.find( ( option ) => option.value === value ) ?? options[ 0 ];
+};
+
+export default function ProductFilterSelect( {
+	selectedProductFilter,
+	onProductFilterSelect,
+	isSingleLicense,
+}: Props ) {
+	const translate = useTranslate();
+
+	const productFilterOptions = useMemo< Option[] >( () => {
+		const options = [
+			{
+				value: PRODUCT_FILTER_ALL,
+				label: translate( 'All' ),
+			},
+			{
+				value: PRODUCT_FILTER_PLANS,
+				label: translate( 'Plans' ),
+			},
+			{
+				value: PRODUCT_FILTER_PRODUCTS,
+				label: translate( 'Products' ),
+			},
+		];
+
+		if ( isSingleLicense ) {
+			options.push(
+				{
+					value: PRODUCT_FILTER_WOOCOMMERCE_EXTENSIONS,
+					label: translate( 'WooCommerce Extensions' ),
+				},
+				{
+					value: PRODUCT_FILTER_VAULTPRESS_BACKUP_ADDONS,
+					label: translate( 'VaultPress Backup Add-ons' ),
+				}
+			);
+		}
+
+		return options;
+	}, [ isSingleLicense, translate ] );
+
+	const currentSelectedOption = getOptionByFuction( productFilterOptions, selectedProductFilter );
+
+	const selectedText = translate( '{{b}}Products{{/b}} : %(productFilter)s', {
+		args: {
+			productFilter: currentSelectedOption.label as string,
+		},
+		components: {
+			b: <b />,
+		},
+	} );
+
+	useEffect( () => {
+		if (
+			! isSingleLicense &&
+			( selectedProductFilter === PRODUCT_FILTER_WOOCOMMERCE_EXTENSIONS ||
+				selectedProductFilter === PRODUCT_FILTER_VAULTPRESS_BACKUP_ADDONS )
+		) {
+			onProductFilterSelect( PRODUCT_FILTER_ALL );
+		}
+	}, [ isSingleLicense, onProductFilterSelect, selectedProductFilter ] );
+
+	return (
+		<SelectDropdown
+			className="licenses-form__product-filter-select"
+			selectedText={ selectedText }
+			options={ productFilterOptions }
+			onSelect={ ( option: { value: string | null } ) => onProductFilterSelect( option.value ) }
+			compact
+		/>
+	);
+}

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/product-filter-select.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/product-filter-select.tsx
@@ -72,6 +72,7 @@ export default function ProductFilterSelect( {
 		components: {
 			b: <b />,
 		},
+		comment: 'productFilter is the selected filter type.',
 	} );
 
 	useEffect( () => {

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/style.scss
@@ -77,6 +77,7 @@ p.licenses-form__description {
 		font-size: rem(13px);
 		font-weight: 400;
 		color: var(--studio-grey-5);
+		padding-inline-end: 8px;
 	}
 
 	.select-dropdown__header-text b {

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/style.scss
@@ -67,3 +67,19 @@ p.licenses-form__description {
 	border-width: 1.5px !important;
 	border-color: transparent;
 }
+
+.licenses-form__actions {
+	margin: 16px 0 32px;
+}
+
+.licenses-form__product-filter-select {
+	.select-dropdown__header-text {
+		font-size: rem(13px);
+		font-weight: 400;
+		color: var(--studio-grey-5);
+	}
+
+	.select-dropdown__header-text b {
+		color: var(--studio-black);
+	}
+}


### PR DESCRIPTION
This pull request aims to incorporate the ability to filter by product type on the new issue license page.

https://github.com/Automattic/wp-calypso/assets/56598660/520a014f-8604-4426-b2b1-bdc5028eb95c


Closes https://github.com/Automattic/jetpack-genesis/issues/115


## Proposed Changes

* Add a product filter select component to the Issue license page to show only the filtered product type.

## Testing Instructions

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

* Use the Jetpack cloud live link below and go to the Licenses page (`/partner-portal/issue-license?flags=jetpack/bundle-licensing`)
* Confirm that the filtering works as expected. Please test the filter by switching to different bundle size tab.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?