### PR TITLE
Adds products as an allowed post type filter

### DIFF
--- a/client/my-sites/promote-post-i2/components/search-bar/index.tsx
+++ b/client/my-sites/promote-post-i2/components/search-bar/index.tsx
@@ -86,6 +86,10 @@ export default function SearchBar( props: Props ) {
 			label: translate( 'Pages' ),
 			value: 'page',
 		},
+		{
+			label: translate( 'Products' ),
+			value: 'product',
+		},
 	];
 
 	const [ searchInput, setSearchInput ] = React.useState< string | undefined >( '' );


### PR DESCRIPTION
Related to #SELFSERVE-832

## Proposed Changes

* Add Products to post type filter in advertising dashboard

## Testing Instructions

- [ ] Visit the advertising dashboard for your site /advertising/posts using the PR testing [(link)](https://container-epic-kepler.calypso.live/advertising/posts )
- [ ] See that products is an option in the dropdown
- [ ] Confirm that you only see products when using that filter

https://github.com/Automattic/wp-calypso/assets/6440498/582dc4c3-28d6-48e7-a624-debe129949bf


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?