### PR TITLE
Theme Detail: Add tracks event when the preview button is shown

### DIFF
--- a/client/my-sites/theme/live-preview-button/index.tsx
+++ b/client/my-sites/theme/live-preview-button/index.tsx
@@ -28,7 +28,7 @@ export const LivePreviewButton: FC< Props > = ( { themeId, siteId } ) => {
 
 	return (
 		<>
-			<TrackComponentView eventName="calypso_live_preview_button_impression" />
+			<TrackComponentView eventName="calypso_block_theme_live_preview_impression" />
 			<Button onClick={ () => dispatch( livePreview( themeId, siteId, 'detail' ) ) }>
 				{ translate( 'Preview & Customize' ) }
 			</Button>

--- a/client/my-sites/theme/live-preview-button/index.tsx
+++ b/client/my-sites/theme/live-preview-button/index.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { FC } from 'react';
+import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { useDispatch, useSelector } from 'calypso/state';
 import { livePreview } from 'calypso/state/themes/actions';
 import { getIsLivePreviewSupported } from 'calypso/state/themes/selectors';
@@ -26,8 +27,11 @@ export const LivePreviewButton: FC< Props > = ( { themeId, siteId } ) => {
 	}
 
 	return (
-		<Button onClick={ () => dispatch( livePreview( themeId, siteId, 'detail' ) ) }>
-			{ translate( 'Preview & Customize' ) }
-		</Button>
+		<>
+			<TrackComponentView eventName="calypso_live_preview_button_impression" />
+			<Button onClick={ () => dispatch( livePreview( themeId, siteId, 'detail' ) ) }>
+				{ translate( 'Preview & Customize' ) }
+			</Button>
+		</>
 	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
- https://github.com/Automattic/dotcom-forge/issues/4579

## Proposed Changes

* Added an event when the `Live Preview` button is displayed.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using the Calypso Live link
* Open the Theme Details page
* You should see a `calypso_live_preview_button_impression` being recorded

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?