### PR TITLE
Customizer redirect to wp-admin: don't use page.js which leads to security error

### DIFF
--- a/client/my-sites/customize/main.jsx
+++ b/client/my-sites/customize/main.jsx
@@ -93,7 +93,8 @@ class Customize extends Component {
 			page( menusUrl );
 		}
 		if ( isJetpack ) {
-			page( customizerUrl );
+			// Always an external non-Calypso wp-admin URL, so no `page()`, but a full-page navigation.
+			window.location = customizerUrl;
 		}
 	};
 


### PR DESCRIPTION
This fixes a crash reported in Sentry that looks like:
```
Failed to execute 'pushState' on 'History': A history state object with URL 'https://example.blog/wp-admin/customize.php?return=https%3A%2F%2Fwordpress.com%2Fcustomize%2Fexample.blog%3Ffrom%3Dtheme-info' cannot be created in a documen...
```
It happens because there is a `page( customizerUrl )` call, where `customizerUrl` is a wp-admin URL, in a different origin, and page.js is internally calling `window.history.pushState` with that URL. That fails with a security error when the pushed URL is in a different origin.

I'm changing this to `window.location =` as it's going to be a full-page navigation anyway.

See also: #15998