### PR TITLE
Simplify bots logic

### DIFF
--- a/client/odie/context/get-odie-initial-message.ts
+++ b/client/odie/context/get-odie-initial-message.ts
@@ -2,7 +2,7 @@ import { __ } from '@wordpress/i18n';
 import { preventWidows } from 'calypso/lib/formatting';
 import { Message, OdieAllowedBots } from '../types';
 
-const getOdieInitialPrompt = ( botNameSlug: OdieAllowedBots = 'wpcom-support-chat' ): string => {
+const getOdieInitialPrompt = ( botNameSlug: OdieAllowedBots ): string => {
 	switch ( botNameSlug ) {
 		case 'wpcom-support-chat':
 			return preventWidows(
@@ -10,14 +10,10 @@ const getOdieInitialPrompt = ( botNameSlug: OdieAllowedBots = 'wpcom-support-cha
 					'Hi there 👋 I’m Wapuu, WordPress.com’s AI assistant! Having an issue with your site or account? Tell me all about it and I’ll be happy to help.'
 				)
 			);
-		default:
-			return 'Hello, I am your personal assistant.';
 	}
 };
 
-export const getOdieInitialMessage = (
-	botNameSlug: OdieAllowedBots = 'wpcom-support-chat'
-): Message => {
+export const getOdieInitialMessage = ( botNameSlug: OdieAllowedBots ): Message => {
 	return {
 		content: getOdieInitialPrompt( botNameSlug ),
 		role: 'bot',

--- a/client/odie/context/index.tsx
+++ b/client/odie/context/index.tsx
@@ -43,7 +43,7 @@ interface OdieAssistantContextInterface {
 const defaultContextInterfaceValues = {
 	addMessage: noop,
 	botName: 'Wapuu',
-	botNameSlug: null,
+	botNameSlug: 'wpcom-support-chat' as OdieAllowedBots,
 	chat: { context: { section_name: '', site_id: null }, messages: [] },
 	clearChat: noop,
 	initialUserMessage: null,
@@ -74,7 +74,7 @@ const useOdieAssistantContext = () => useContext( OdieAssistantContext );
 // Create a provider component for the context
 const OdieAssistantProvider = ( {
 	botName = 'Wapuu assistant',
-	botNameSlug = null,
+	botNameSlug = 'wpcom-support-chat',
 	botSetting = 'wapuu',
 	initialUserMessage,
 	extraContactOptions,

--- a/client/odie/message/jump-to-recent.tsx
+++ b/client/odie/message/jump-to-recent.tsx
@@ -46,7 +46,7 @@ export const JumpToRecent = ( {
 		};
 	}, [] );
 
-	if ( isMinimized && botNameSlug === 'wpcom-support-chat' ) {
+	if ( isMinimized ) {
 		return null;
 	}
 

--- a/client/odie/types/index.ts
+++ b/client/odie/types/index.ts
@@ -92,4 +92,4 @@ export type OdieAllowedSectionNames =
 	| 'checkout'
 	| 'help-center';
 
-export type OdieAllowedBots = 'wpcom-support-chat' | null;
+export type OdieAllowedBots = 'wpcom-support-chat';

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -360,9 +360,9 @@ export const HelpCenterContactForm = () => {
 								section: sectionName,
 							} );
 							navigate( '/success' );
-							if ( ! wapuuFlow ) {
-								resetStore();
-							}
+
+							resetStore();
+
 							// reset support-history cache
 							setTimeout( () => {
 								// wait 30 seconds until support-history endpoint actually updates
@@ -475,7 +475,7 @@ export const HelpCenterContactForm = () => {
 
 		// We're prefetching the GPT response,
 		// so only disabling the button while fetching if we're on the response screen
-		if ( showingGPTResponse && isFetchingGPTResponse && ! wapuuFlow ) {
+		if ( showingGPTResponse && isFetchingGPTResponse ) {
 			return true;
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/84129 and Issue 715 (Odie Board)

## Proposed Changes

We are still relying on some old code that we wanted to maintain for the initial PoC launched 5 months ago. Cleaning code and adding unit tests in the subsequent developments now.

## Testing Instructions

Please, assert that Wapuu is still working and replying to questions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?