### PR TITLE
Fix the Add new site button in the site selector

### DIFF
--- a/client/components/site-selector/add-site.tsx
+++ b/client/components/site-selector/add-site.tsx
@@ -3,15 +3,13 @@ import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent, useCallback } from 'react';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { useAddNewSiteUrl } from 'calypso/lib/paths/use-add-new-site-url';
-import { useDispatch, useSelector } from 'calypso/state';
+import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 const SiteSelectorAddSite: FunctionComponent = () => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const siteSlug = useSelector( getSelectedSiteSlug );
 	const recordAddNewSite = useCallback( () => {
 		const event = isJetpackCloud()
 			? 'calypso_add_new_jetpack_click'
@@ -23,7 +21,6 @@ const SiteSelectorAddSite: FunctionComponent = () => {
 	const addNewSiteUrl = useAddNewSiteUrl( {
 		ref: 'site-selector',
 		source: isJetpackCloud() ? 'jetpack-cloud' : 'my-home',
-		siteSlug,
 	} );
 
 	return (


### PR DESCRIPTION
The site slug should not break this button but should also not be there. The site slug in the context of a signup is the new site, not the old one.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Reported at p1700649163403089-slack-C02FMH4G8

Slug was added in https://github.com/Automattic/wp-calypso/pull/77691

## Proposed Changes

Remove siteSlug from the Add new site button as it confuses the signup and it sometimes breaks

## Testing Instructions

1. On a user with multiple sites
2. Click Switch Site -> Add new site
3. Try to skip the domain. It should work
4. Repeat and try to search for a domain and select a paid plan. It should work

https://github.com/Automattic/wp-calypso/assets/82778/e12df2db-a9f0-4aeb-b218-3751ec837122

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?