### PR TITLE
Hosting Command Palette: fix active descendant id for reserved characters

### DIFF
--- a/client/components/command-pallette/wpcom-command-pallette.tsx
+++ b/client/components/command-pallette/wpcom-command-pallette.tsx
@@ -4,7 +4,7 @@ import { Icon, search as inputIcon } from '@wordpress/icons';
 import { cleanForSlug } from '@wordpress/url';
 import classnames from 'classnames';
 import { Command, useCommandState } from 'cmdk';
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useState, useRef, useMemo } from 'react';
 import { useCommandPallette } from './use-command-pallette';
 
 import '@wordpress/commands/build-style/style.css';
@@ -71,7 +71,7 @@ interface CommandInputProps {
 function CommandInput( { isOpen, search, setSearch }: CommandInputProps ) {
 	const commandMenuInput = useRef< HTMLInputElement >( null );
 	const itemValue = useCommandState( ( state ) => state.value );
-	const itemId = cleanForSlug( itemValue );
+	const itemId = useMemo( () => cleanForSlug( itemValue ), [ itemValue ] );
 
 	useEffect( () => {
 		// Focus the command palette input when mounting the modal.

--- a/client/components/command-pallette/wpcom-command-pallette.tsx
+++ b/client/components/command-pallette/wpcom-command-pallette.tsx
@@ -1,9 +1,10 @@
 import { Modal, TextHighlight, __experimentalHStack as HStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Icon, search as inputIcon } from '@wordpress/icons';
+import { cleanForSlug } from '@wordpress/url';
 import classnames from 'classnames';
-import { useCommandState, Command } from 'cmdk';
-import { useEffect, useMemo, useState, useRef } from 'react';
+import { Command, useCommandState } from 'cmdk';
+import { useEffect, useState, useRef } from 'react';
 import { useCommandPallette } from './use-command-pallette';
 
 import '@wordpress/commands/build-style/style.css';
@@ -34,12 +35,13 @@ export function CommandMenuGroup( {
 	return (
 		<Command.Group about="WPCOM">
 			{ commands.map( ( command ) => {
+				const itemValue = command.searchLabel ?? command.label;
 				return (
 					<Command.Item
 						key={ command.name }
-						value={ command.searchLabel ?? command.label }
+						value={ itemValue }
 						onSelect={ () => command.callback( { close, setSearch } ) }
-						id={ command.name }
+						id={ cleanForSlug( itemValue ) }
 					>
 						<HStack
 							alignment="left"
@@ -68,16 +70,8 @@ interface CommandInputProps {
 
 function CommandInput( { isOpen, search, setSearch }: CommandInputProps ) {
 	const commandMenuInput = useRef< HTMLInputElement >( null );
-	const _value = useCommandState( ( state ) => state.value );
-	const sanitizedValue = useMemo( () => {
-		const removedQuotesValue = _value.replace( /"/g, '' ); // Remove double quotes from any selected items before processing input
-		return removedQuotesValue;
-	}, [ _value ] );
-
-	const selectedItemId = useMemo( () => {
-		const item = document.querySelector( `[cmdk-item=""][data-value="${ sanitizedValue }"]` );
-		return item?.getAttribute( 'id' );
-	}, [ sanitizedValue ] );
+	const itemValue = useCommandState( ( state ) => state.value );
+	const itemId = cleanForSlug( itemValue );
 
 	useEffect( () => {
 		// Focus the command palette input when mounting the modal.
@@ -92,7 +86,7 @@ function CommandInput( { isOpen, search, setSearch }: CommandInputProps ) {
 			value={ search }
 			onValueChange={ setSearch }
 			placeholder={ __( 'Search for commands' ) }
-			aria-activedescendant={ `${ selectedItemId }` }
+			aria-activedescendant={ itemId }
 		/>
 	);
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Related to https://github.com/Automattic/wp-calypso/pull/84373

## Proposed Changes

* Avoid accessing the DOM and just calculate the same ID for item and active descendant.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* See https://github.com/Automattic/wp-calypso/pull/84373

## Screencast



https://github.com/Automattic/wp-calypso/assets/779993/f2cba3b5-b4cd-46cb-865b-694803a5b887




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?