### PR TITLE
getFilteredAndSortedPlugins: avoid structuredClone

### DIFF
--- a/client/state/plugins/installed/selectors-ts.ts
+++ b/client/state/plugins/installed/selectors-ts.ts
@@ -199,17 +199,13 @@ export const getFilteredAndSortedPlugins = createSelector(
 		}
 
 		// Filter the plugins using the pluginFilter if it is set
-		const pluginList =
-			pluginFilter && _filters[ pluginFilter ]
-				? Object.fromEntries(
-						Object.entries( allPluginsForSites ).filter( ( [ , plugin ] ) =>
-							_filters[ pluginFilter ]( plugin )
-						)
-				  )
-				: allPluginsForSites;
+		let pluginList = Object.values( allPluginsForSites );
+		if ( pluginFilter && _filters[ pluginFilter ] ) {
+			pluginList = pluginList.filter( ( plugin ) => _filters[ pluginFilter ]( plugin ) );
+		}
 
 		// Sort the plugins alphabetically by slug
-		const sortedPluginListEntries = Object.values( pluginList ).sort( ( pluginA, pluginB ) => {
+		const sortedPluginListEntries = pluginList.sort( ( pluginA, pluginB ) => {
 			const pluginSlugALower = pluginA.slug.toLowerCase();
 			const pluginSlugBLower = pluginB.slug.toLowerCase();
 			return getSortCompareNumber( pluginSlugALower, pluginSlugBLower );


### PR DESCRIPTION
I got a Sentry notification about a crash because `structuredClone` is undefined. It was Chrome 91, almost 2 years old version, which didn't have `structuredClone` yet. We officially don't support browsers like this, but anyway, it's not hard to avoid `structuredClone`.

This proposed PR rewrites `getFilteredAndSortedPlugins` to avoid unwanted mutation by creating a shallow clone of an object with `{ ...plugin, sites }`. And also replaces two `.reduce` calls with a more elegant `Object.fromEntries`.

For reference, the original code was added in #73206.

**How to test:**
This is well covered by unit tests and they are passing.