### PR TITLE
`useGetSiteSuggestionsQuery`: remove `onSuccess`

### DIFF
--- a/client/landing/stepper/hooks/use-get-site-suggestions-query.ts
+++ b/client/landing/stepper/hooks/use-get-site-suggestions-query.ts
@@ -25,12 +25,10 @@ export const getSiteSuggestions = (
 export const useGetSiteSuggestionsQuery = ( {
 	params,
 	enabled,
-	onSuccess,
 	refetchOnWindowFocus,
 }: {
 	params?: Record< string, unknown >;
 	enabled: boolean;
-	onSuccess?: ( response: SuggestionsResponse ) => void;
 	refetchOnWindowFocus?: boolean;
 } ) =>
 	useQuery( {
@@ -38,7 +36,6 @@ export const useGetSiteSuggestionsQuery = ( {
 		queryFn: () => getSiteSuggestions( params ),
 		refetchOnWindowFocus,
 		enabled,
-		onSuccess,
 		queryKey: [ 'site-suggestions', params ],
 		meta: {
 			persist: false,


### PR DESCRIPTION
Related to #84338

## Proposed Changes

* Remove `onSuccess` callback from `useGetSiteSuggestionsQuery` in preparation for the v5 update

## Testing Instructions

This hook is not in use so there's nothing to test. Verify the code change make sense, there are no type errors or eslint failures and all tests still pass.

@mpkelly @zaguiini do we still need this hook or can it be removed? It's not referenced from anywhere within the Calypso repo.