### PR TITLE
chore: fix more RQ usages to use object syntax

### DIFF
--- a/client/data/domains/forwarding/use-delete-domain-forwarding-mutation.ts
+++ b/client/data/domains/forwarding/use-delete-domain-forwarding-mutation.ts
@@ -19,7 +19,7 @@ export default function useDeleteDomainForwardingMutation(
 			} ),
 		...queryOptions,
 		onSuccess() {
-			queryClient.removeQueries( domainForwardingQueryKey( domainName ) );
+			queryClient.removeQueries( { queryKey: domainForwardingQueryKey( domainName ) } );
 			queryOptions.onSuccess?.();
 		},
 	} );

--- a/client/data/domains/forwarding/use-update-domain-forwarding-mutation.ts
+++ b/client/data/domains/forwarding/use-update-domain-forwarding-mutation.ts
@@ -18,7 +18,7 @@ export default function useUpdateDomainForwardingMutation(
 			wp.req.post( `/sites/all/domain/${ domainName }/redirects`, forwarding ),
 		...queryOptions,
 		onSuccess() {
-			queryClient.invalidateQueries( domainForwardingQueryKey( domainName ) );
+			queryClient.invalidateQueries( { queryKey: domainForwardingQueryKey( domainName ) } );
 			queryOptions.onSuccess?.();
 		},
 		onError( error: DomainsApiError ) {

--- a/client/data/domains/transfers/use-domain-transfer-request-delete.ts
+++ b/client/data/domains/transfers/use-domain-transfer-request-delete.ts
@@ -18,7 +18,9 @@ export default function useDomainTransferRequestDelete(
 			wp.req.post( `/sites/${ siteSlug }/domains/${ domainName }/transfer-to-any-user/delete` ),
 		...queryOptions,
 		onSuccess() {
-			queryClient.removeQueries( domainTransferRequestQueryKey( siteSlug, domainName ) );
+			queryClient.removeQueries( {
+				queryKey: domainTransferRequestQueryKey( siteSlug, domainName ),
+			} );
 			queryOptions.onSuccess?.();
 		},
 	} );

--- a/client/data/domains/transfers/use-domain-transfer-request-update.ts
+++ b/client/data/domains/transfers/use-domain-transfer-request-update.ts
@@ -20,7 +20,9 @@ export default function useDomainTransferRequestUpdate(
 			} ),
 		...queryOptions,
 		onSuccess() {
-			queryClient.invalidateQueries( domainTransferRequestQueryKey( siteSlug, domainName ) );
+			queryClient.invalidateQueries( {
+				queryKey: domainTransferRequestQueryKey( siteSlug, domainName ),
+			} );
 			queryOptions.onSuccess?.();
 		},
 	} );

--- a/client/data/emails/use-add-email-forward-mutation.tsx
+++ b/client/data/emails/use-add-email-forward-mutation.tsx
@@ -60,8 +60,8 @@ export default function useAddEmailForwardMutation(
 	mutationOptions.onSettled = ( data, error, variables, context ) => {
 		suppliedOnSettled?.( data, error, variables, context );
 
-		queryClient.invalidateQueries( emailAccountsQueryKey );
-		queryClient.invalidateQueries( domainsQueryKey );
+		queryClient.invalidateQueries( { queryKey: emailAccountsQueryKey } );
+		queryClient.invalidateQueries( { queryKey: domainsQueryKey } );
 	};
 
 	mutationOptions.onMutate = async ( variables ) => {

--- a/client/data/emails/use-add-email-forward-mutation.tsx
+++ b/client/data/emails/use-add-email-forward-mutation.tsx
@@ -68,8 +68,8 @@ export default function useAddEmailForwardMutation(
 		const { mailbox, destination } = variables;
 		suppliedOnMutate?.( variables );
 
-		await queryClient.cancelQueries( emailAccountsQueryKey );
-		await queryClient.cancelQueries( domainsQueryKey );
+		await queryClient.cancelQueries( { queryKey: emailAccountsQueryKey } );
+		await queryClient.cancelQueries( { queryKey: domainsQueryKey } );
 
 		const previousEmailAccountsQueryData = queryClient.getQueryData< any >( emailAccountsQueryKey );
 		const emailForwards = previousEmailAccountsQueryData?.accounts?.[ 0 ]?.emails;

--- a/client/data/emails/use-remove-email-forward-mutation.tsx
+++ b/client/data/emails/use-remove-email-forward-mutation.tsx
@@ -55,8 +55,8 @@ export default function useRemoveEmailForwardMutation(
 	mutationOptions.onMutate = async ( emailForward ) => {
 		suppliedOnMutate?.( emailForward );
 
-		await queryClient.cancelQueries( emailAccountsQueryKey );
-		await queryClient.cancelQueries( domainsQueryKey );
+		await queryClient.cancelQueries( { queryKey: emailAccountsQueryKey } );
+		await queryClient.cancelQueries( { queryKey: domainsQueryKey } );
 
 		const previousEmailAccountsQueryData = queryClient.getQueryData< any >( emailAccountsQueryKey );
 

--- a/client/data/emails/use-remove-email-forward-mutation.tsx
+++ b/client/data/emails/use-remove-email-forward-mutation.tsx
@@ -48,8 +48,8 @@ export default function useRemoveEmailForwardMutation(
 	mutationOptions.onSettled = ( data, error, variables, context ) => {
 		suppliedOnSettled?.( data, error, variables, context );
 
-		queryClient.invalidateQueries( emailAccountsQueryKey );
-		queryClient.invalidateQueries( domainsQueryKey );
+		queryClient.invalidateQueries( { queryKey: emailAccountsQueryKey } );
+		queryClient.invalidateQueries( { queryKey: domainsQueryKey } );
 	};
 
 	mutationOptions.onMutate = async ( emailForward ) => {

--- a/client/data/emails/use-remove-titan-mailbox-mutation.ts
+++ b/client/data/emails/use-remove-titan-mailbox-mutation.ts
@@ -61,7 +61,7 @@ export function useRemoveTitanMailboxMutation(
 		suppliedOnSettled?.( data, error, variables, context );
 
 		// Always invalidate attendant queries
-		queryClient.invalidateQueries( queryKey ).then( () => {
+		queryClient.invalidateQueries( { queryKey } ).then( () => {
 			const numberOfMailboxes = getNumberOfMailboxes( queryClient, queryKey );
 
 			// Determine if we already have updated data, since the removal job is not synchronous
@@ -70,7 +70,7 @@ export function useRemoveTitanMailboxMutation(
 			}
 
 			setTimeout( () => {
-				queryClient.invalidateQueries( queryKey );
+				queryClient.invalidateQueries( { queryKey } );
 			}, invalidationDelayTimeout );
 		} );
 	};

--- a/client/data/emails/use-remove-titan-mailbox-mutation.ts
+++ b/client/data/emails/use-remove-titan-mailbox-mutation.ts
@@ -47,7 +47,7 @@ export function useRemoveTitanMailboxMutation(
 
 	// Setup actions to happen before the mutation
 	mutationOptions.onMutate = async () => {
-		await queryClient.cancelQueries( queryKey );
+		await queryClient.cancelQueries( { queryKey } );
 
 		const previousNumberOfMailboxes = getNumberOfMailboxes( queryClient, queryKey );
 

--- a/client/data/newsletter-categories/test/use-mark-as-newsletter-category-mutation.test.tsx
+++ b/client/data/newsletter-categories/test/use-mark-as-newsletter-category-mutation.test.tsx
@@ -73,7 +73,9 @@ describe( 'useMarkAsNewsletterCategoryMutation', () => {
 			await result.current.mutateAsync( categoryId );
 		} );
 
-		expect( invalidateQueriesSpy ).toHaveBeenCalledWith( [ 'newsletter-categories', 123 ] );
+		expect( invalidateQueriesSpy ).toHaveBeenCalledWith( {
+			queryKey: [ 'newsletter-categories', 123 ],
+		} );
 	} );
 
 	it( 'should throw an error when ID is missing', async () => {

--- a/client/data/newsletter-categories/test/use-unmark-as-newsletter-category-mutation.test.tsx
+++ b/client/data/newsletter-categories/test/use-unmark-as-newsletter-category-mutation.test.tsx
@@ -73,7 +73,9 @@ describe( 'useUnmarkAsNewsletterCategoryMutation', () => {
 			await result.current.mutateAsync( categoryId );
 		} );
 
-		expect( invalidateQueriesSpy ).toHaveBeenCalledWith( [ 'newsletter-categories', 123 ] );
+		expect( invalidateQueriesSpy ).toHaveBeenCalledWith( {
+			queryKey: [ 'newsletter-categories', 123 ],
+		} );
 	} );
 
 	it( 'should throw an error when ID is missing', async () => {

--- a/client/data/newsletter-categories/use-mark-as-newsletter-category-mutation.tsx
+++ b/client/data/newsletter-categories/use-mark-as-newsletter-category-mutation.tsx
@@ -30,7 +30,7 @@ const useMarkAsNewsletterCategoryMutation = ( siteId: string | number ) => {
 			return response;
 		},
 		onMutate: async ( categoryId: number ) => {
-			await queryClient.cancelQueries( cacheKey );
+			await queryClient.cancelQueries( { queryKey: cacheKey } );
 
 			const previousData = queryClient.getQueryData< NewsletterCategories >( cacheKey );
 			const categories = queryClient.getQueryData< Category[] >( [ 'categories', siteId ] );

--- a/client/data/newsletter-categories/use-mark-as-newsletter-category-mutation.tsx
+++ b/client/data/newsletter-categories/use-mark-as-newsletter-category-mutation.tsx
@@ -61,7 +61,7 @@ const useMarkAsNewsletterCategoryMutation = ( siteId: string | number ) => {
 			queryClient.setQueryData( cacheKey, context?.previousData );
 		},
 		onSettled: async () => {
-			await queryClient.invalidateQueries( cacheKey );
+			await queryClient.invalidateQueries( { queryKey: cacheKey } );
 		},
 	} );
 };

--- a/client/data/newsletter-categories/use-newsletter-category-subscription-mutation.tsx
+++ b/client/data/newsletter-categories/use-newsletter-category-subscription-mutation.tsx
@@ -64,7 +64,7 @@ const useNewsletterCategorySubscriptionMutation = ( siteId: string | number ) =>
 			queryClient.setQueryData( subscribedCategoriesCacheKey, context?.previousData );
 		},
 		onSettled: async () => {
-			await queryClient.invalidateQueries( subscribedCategoriesCacheKey );
+			await queryClient.invalidateQueries( { queryKey: subscribedCategoriesCacheKey } );
 		},
 	} );
 };

--- a/client/data/newsletter-categories/use-newsletter-category-subscription-mutation.tsx
+++ b/client/data/newsletter-categories/use-newsletter-category-subscription-mutation.tsx
@@ -23,7 +23,7 @@ const useNewsletterCategorySubscriptionMutation = ( siteId: string | number ) =>
 			);
 		},
 		onMutate: async ( categorySubscriptions: NewsletterCategorySubscription[] ) => {
-			await queryClient.cancelQueries( subscribedCategoriesCacheKey );
+			await queryClient.cancelQueries( { queryKey: subscribedCategoriesCacheKey } );
 
 			const previousData = queryClient.getQueryData< NewsletterCategories >(
 				subscribedCategoriesCacheKey

--- a/client/data/newsletter-categories/use-unmark-as-newsletter-category-mutation.tsx
+++ b/client/data/newsletter-categories/use-unmark-as-newsletter-category-mutation.tsx
@@ -31,7 +31,7 @@ const useUnmarkAsNewsletterCategoryMutation = ( siteId: string | number ) => {
 			return response;
 		},
 		onMutate: async ( categoryId: number ) => {
-			await queryClient.cancelQueries( cacheKey );
+			await queryClient.cancelQueries( { queryKey: cacheKey } );
 
 			const previousData = queryClient.getQueryData< NewsletterCategories >( cacheKey );
 

--- a/client/data/newsletter-categories/use-unmark-as-newsletter-category-mutation.tsx
+++ b/client/data/newsletter-categories/use-unmark-as-newsletter-category-mutation.tsx
@@ -53,7 +53,7 @@ const useUnmarkAsNewsletterCategoryMutation = ( siteId: string | number ) => {
 			queryClient.setQueryData( cacheKey, context?.previousData );
 		},
 		onSettled: async () => {
-			await queryClient.invalidateQueries( cacheKey );
+			await queryClient.invalidateQueries( { queryKey: cacheKey } );
 		},
 	} );
 };

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/hooks/use-install-boost.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/hooks/use-install-boost.tsx
@@ -20,7 +20,7 @@ export default function useInstallBoost(
 
 	const handleUpdateSites = useCallback( async () => {
 		// Cancel any current refetches, so they don't overwrite our update
-		await queryClient.cancelQueries( { queryKey: queryKey } );
+		await queryClient.cancelQueries( { queryKey } );
 
 		// Update to the new value
 		queryClient.setQueryData( queryKey, ( oldSites: any ) => {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/hooks/use-install-boost.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/hooks/use-install-boost.tsx
@@ -20,7 +20,7 @@ export default function useInstallBoost(
 
 	const handleUpdateSites = useCallback( async () => {
 		// Cancel any current refetches, so they don't overwrite our update
-		await queryClient.cancelQueries( queryKey );
+		await queryClient.cancelQueries( { queryKey: queryKey } );
 
 		// Update to the new value
 		queryClient.setQueryData( queryKey, ( oldSites: any ) => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -122,7 +122,7 @@ export function getEnhancedTasks(
 			await updateLaunchpadSettings( siteSlug, {
 				checklist_statuses: { newsletter_plan_created: true },
 			} );
-			queryClient?.invalidateQueries( [ 'launchpad' ] );
+			queryClient?.invalidateQueries( { queryKey: [ 'launchpad' ] } );
 		}
 	};
 

--- a/client/me/security-ssh-key/use-add-ssh-key-mutation.ts
+++ b/client/me/security-ssh-key/use-add-ssh-key-mutation.ts
@@ -32,7 +32,7 @@ export const useAddSSHKeyMutation = (
 			),
 		...options,
 		onSuccess: async ( ...args ) => {
-			await queryClient.invalidateQueries( SSH_KEY_QUERY_KEY );
+			await queryClient.invalidateQueries( { queryKey: SSH_KEY_QUERY_KEY } );
 			options.onSuccess?.( ...args );
 		},
 	} );

--- a/client/me/security-ssh-key/use-delete-ssh-key-mutation.ts
+++ b/client/me/security-ssh-key/use-delete-ssh-key-mutation.ts
@@ -29,7 +29,7 @@ export const useDeleteSSHKeyMutation = (
 			} ),
 		...options,
 		onSuccess: async ( ...args ) => {
-			await queryClient.invalidateQueries( SSH_KEY_QUERY_KEY );
+			await queryClient.invalidateQueries( { queryKey: SSH_KEY_QUERY_KEY } );
 			options.onSuccess?.( ...args );
 		},
 	} );

--- a/client/me/security-ssh-key/use-update-ssh-key-mutation.ts
+++ b/client/me/security-ssh-key/use-update-ssh-key-mutation.ts
@@ -37,7 +37,7 @@ export const useUpdateSSHKeyMutation = (
 			),
 		...options,
 		onSuccess: async ( ...args ) => {
-			await queryClient.invalidateQueries( SSH_KEY_QUERY_KEY );
+			await queryClient.invalidateQueries( { queryKey: SSH_KEY_QUERY_KEY } );
 			await queryClient.invalidateQueries( {
 				queryKey: [ USE_ATOMIC_SSH_KEYS_QUERY_KEY ],
 			} );

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -115,7 +115,7 @@ const Home = ( {
 
 	useEffect( () => {
 		if ( ! isSiteLaunching && launchedSiteId === siteId ) {
-			queryClient.invalidateQueries( getCacheKey( siteId ) );
+			queryClient.invalidateQueries( { queryKey: getCacheKey( siteId ) } );
 			setLaunchedSiteId( null );
 		}
 	}, [ isSiteLaunching, launchedSiteId, queryClient, siteId ] );

--- a/client/my-sites/email/mailboxes/mailbox-selection-list/index.tsx
+++ b/client/my-sites/email/mailboxes/mailbox-selection-list/index.tsx
@@ -183,7 +183,7 @@ const MailboxLoaderError = ( {
 	const queryClient = useQueryClient();
 
 	const reloadMailboxes = () => {
-		queryClient.removeQueries( getMailboxesQueryKey( siteId ) );
+		queryClient.removeQueries( { queryKey: getMailboxesQueryKey( siteId ) } );
 		reFetchMailboxes();
 	};
 

--- a/client/my-sites/plugins/controller-logged-out.js
+++ b/client/my-sites/plugins/controller-logged-out.js
@@ -64,7 +64,10 @@ const prefetchProductList = ( queryClient, store ) => {
 	const type = 'all';
 
 	return queryClient
-		.fetchQuery( [ 'products-list', type ], () => wpcom.req.get( '/products', { type } ) )
+		.fetchQuery( {
+			queryKey: [ 'products-list', type ],
+			queryFn: () => wpcom.req.get( '/products', { type } ),
+		} )
 		.then( ( productsList ) => {
 			return store.dispatch( receiveProductsList( productsList, type ) );
 		} );

--- a/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
+++ b/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
@@ -60,7 +60,7 @@ const useSubscriberRemoveMutation = (
 			return true;
 		},
 		onMutate: async ( subscriber ) => {
-			await queryClient.cancelQueries( subscribersCacheKey );
+			await queryClient.cancelQueries( { queryKey: subscribersCacheKey } );
 			let page = currentPage;
 
 			const previousData =
@@ -125,7 +125,7 @@ const useSubscriberRemoveMutation = (
 					getSubscriberDetailsType( subscriber.user_id )
 				);
 
-				await queryClient.cancelQueries( cacheKey );
+				await queryClient.cancelQueries( { queryKey: cacheKey } );
 
 				previousDetailsData = queryClient.getQueryData< Subscriber >( cacheKey );
 			}

--- a/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
+++ b/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
@@ -164,7 +164,7 @@ const useSubscriberRemoveMutation = (
 			} );
 		},
 		onSettled: ( data, error, subscriber ) => {
-			queryClient.invalidateQueries( subscribersCacheKey );
+			queryClient.invalidateQueries( { queryKey: subscribersCacheKey } );
 
 			if ( invalidateDetailsCache ) {
 				const detailsCacheKey = getSubscriberDetailsCacheKey(
@@ -174,7 +174,7 @@ const useSubscriberRemoveMutation = (
 					getSubscriberDetailsType( subscriber.user_id )
 				);
 
-				queryClient.invalidateQueries( detailsCacheKey );
+				queryClient.invalidateQueries( { queryKey: detailsCacheKey } );
 			}
 		},
 	} );

--- a/client/reader/recommended-sites/recommended-site.tsx
+++ b/client/reader/recommended-sites/recommended-site.tsx
@@ -60,7 +60,7 @@ const useInvalidateSiteSubscriptionsCache = ( isSubscribeLoading: boolean ) => {
 	const queryClient = useQueryClient();
 	useEffect( () => {
 		if ( wasSubscribeLoading && ! isSubscribeLoading ) {
-			queryClient.invalidateQueries( siteSubscriptionsCacheKey );
+			queryClient.invalidateQueries( { queryKey: siteSubscriptionsCacheKey } );
 		}
 	}, [ isSubscribeLoading, wasSubscribeLoading, queryClient, siteSubscriptionsCacheKey ] );
 };

--- a/packages/data-stores/src/reader/helpers/optimistic-update.ts
+++ b/packages/data-stores/src/reader/helpers/optimistic-update.ts
@@ -66,7 +66,7 @@ const invalidateSiteSubscriptionDetails = (
 	queryClient: QueryClient,
 	{ blogId, subscriptionId, isLoggedIn, id }: SiteSubScriptionDetailsParameters
 ) => {
-	queryClient.invalidateQueries( [ 'read', 'site-subscriptions' ] );
+	queryClient.invalidateQueries( { queryKey: [ 'read', 'site-subscriptions' ] } );
 	queryClient.invalidateQueries(
 		buildQueryKey( [ 'read', 'site-subscription-details', blogId ], isLoggedIn, id )
 	);

--- a/packages/data-stores/src/reader/helpers/optimistic-update.ts
+++ b/packages/data-stores/src/reader/helpers/optimistic-update.ts
@@ -49,7 +49,7 @@ const alterSiteSubscriptionDetails = async (
 	keys.push( [ 'read', 'subscriptions', subscriptionId, isLoggedIn, id ] );
 
 	for ( const key of keys ) {
-		await queryClient.cancelQueries( key );
+		await queryClient.cancelQueries( { queryKey: key } );
 
 		const previousDataForKey = queryClient.getQueryData< SiteSubscriptionDetails >( key );
 		if ( previousDataForKey ) {

--- a/packages/data-stores/src/reader/mutations/use-pending-post-confirm-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-pending-post-confirm-mutation.ts
@@ -107,8 +107,8 @@ const usePendingPostConfirmMutation = () => {
 			queryClient.invalidateQueries( {
 				queryKey: [ 'read', 'pending-post-subscriptions', isLoggedIn ],
 			} );
-			queryClient.invalidateQueries( subscriptionsCacheKey );
-			queryClient.invalidateQueries( countCacheKey );
+			queryClient.invalidateQueries( { queryKey: subscriptionsCacheKey } );
+			queryClient.invalidateQueries( { queryKey: countCacheKey } );
 		},
 	} );
 };

--- a/packages/data-stores/src/reader/mutations/use-pending-post-confirm-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-pending-post-confirm-mutation.ts
@@ -48,8 +48,8 @@ const usePendingPostConfirmMutation = () => {
 			await queryClient.cancelQueries( {
 				queryKey: [ 'read', 'pending-post-subscriptions', isLoggedIn ],
 			} );
-			await queryClient.cancelQueries( subscriptionsCacheKey );
-			await queryClient.cancelQueries( countCacheKey );
+			await queryClient.cancelQueries( { queryKey: subscriptionsCacheKey } );
+			await queryClient.cancelQueries( { queryKey: countCacheKey } );
 
 			const previousPendingPostSubscriptions =
 				queryClient.getQueryData< PendingPostSubscriptionsResult >( [

--- a/packages/data-stores/src/reader/mutations/use-pending-post-delete-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-pending-post-delete-mutation.ts
@@ -46,7 +46,7 @@ const usePendingPostDeleteMutation = () => {
 			await queryClient.cancelQueries( {
 				queryKey: [ 'read', 'pending-post-subscriptions', isLoggedIn ],
 			} );
-			await queryClient.cancelQueries( countCacheKey );
+			await queryClient.cancelQueries( { queryKey: countCacheKey } );
 
 			const previousPendingPostSubscriptions =
 				queryClient.getQueryData< PendingPostSubscriptionsResult >( [

--- a/packages/data-stores/src/reader/mutations/use-pending-post-delete-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-pending-post-delete-mutation.ts
@@ -101,7 +101,7 @@ const usePendingPostDeleteMutation = () => {
 			queryClient.invalidateQueries( {
 				queryKey: [ 'read', 'pending-post-subscriptions', isLoggedIn ],
 			} );
-			queryClient.invalidateQueries( countCacheKey );
+			queryClient.invalidateQueries( { queryKey: countCacheKey } );
 		},
 	} );
 };

--- a/packages/data-stores/src/reader/mutations/use-pending-site-confirm-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-pending-site-confirm-mutation.ts
@@ -106,8 +106,8 @@ const usePendingSiteConfirmMutation = () => {
 			queryClient.invalidateQueries( {
 				queryKey: [ 'read', 'pending-site-subscriptions', isLoggedIn ],
 			} );
-			queryClient.invalidateQueries( subscriptionsCacheKey );
-			queryClient.invalidateQueries( countCacheKey );
+			queryClient.invalidateQueries( { queryKey: subscriptionsCacheKey } );
+			queryClient.invalidateQueries( { queryKey: countCacheKey } );
 		},
 	} );
 };

--- a/packages/data-stores/src/reader/mutations/use-pending-site-confirm-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-pending-site-confirm-mutation.ts
@@ -49,8 +49,8 @@ const usePendingSiteConfirmMutation = () => {
 			await queryClient.cancelQueries( {
 				queryKey: [ 'read', 'pending-site-subscriptions', isLoggedIn ],
 			} );
-			await queryClient.cancelQueries( subscriptionsCacheKey );
-			await queryClient.cancelQueries( countCacheKey );
+			await queryClient.cancelQueries( { queryKey: subscriptionsCacheKey } );
+			await queryClient.cancelQueries( { queryKey: countCacheKey } );
 
 			const previousPendingSiteSubscriptions =
 				queryClient.getQueryData< PendingSiteSubscriptionsResult >( [

--- a/packages/data-stores/src/reader/mutations/use-pending-site-delete-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-pending-site-delete-mutation.ts
@@ -46,7 +46,7 @@ const usePendingSiteDeleteMutation = () => {
 			await queryClient.cancelQueries( {
 				queryKey: [ 'read', 'pending-site-subscriptions', isLoggedIn ],
 			} );
-			await queryClient.cancelQueries( countCacheKey );
+			await queryClient.cancelQueries( { queryKey: countCacheKey } );
 
 			const previousPendingSiteSubscriptions =
 				queryClient.getQueryData< PendingSiteSubscriptionsResult >( [

--- a/packages/data-stores/src/reader/mutations/use-pending-site-delete-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-pending-site-delete-mutation.ts
@@ -101,7 +101,7 @@ const usePendingSiteDeleteMutation = () => {
 			queryClient.invalidateQueries( {
 				queryKey: [ 'read', 'pending-site-subscriptions', isLoggedIn ],
 			} );
-			queryClient.invalidateQueries( countCacheKey );
+			queryClient.invalidateQueries( { queryKey: countCacheKey } );
 		},
 	} );
 };

--- a/packages/data-stores/src/reader/mutations/use-post-unsubscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-post-unsubscribe-mutation.ts
@@ -114,8 +114,8 @@ const usePostUnsubscribeMutation = () => {
 			}
 		},
 		onSettled: () => {
-			queryClient.invalidateQueries( postSubscriptionsCacheKey );
-			queryClient.invalidateQueries( subscriptionsCountCacheKey );
+			queryClient.invalidateQueries( { queryKey: postSubscriptionsCacheKey } );
+			queryClient.invalidateQueries( { queryKey: subscriptionsCountCacheKey } );
 		},
 	} );
 };

--- a/packages/data-stores/src/reader/mutations/use-post-unsubscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-post-unsubscribe-mutation.ts
@@ -57,7 +57,7 @@ const usePostUnsubscribeMutation = () => {
 			return response;
 		},
 		onMutate: async ( params ) => {
-			await queryClient.cancelQueries( postSubscriptionsCacheKey );
+			await queryClient.cancelQueries( { queryKey: postSubscriptionsCacheKey } );
 			await queryClient.cancelQueries( {
 				queryKey: [ 'read', 'subscriptions-count', isLoggedIn ],
 			} );

--- a/packages/data-stores/src/reader/mutations/use-site-delivery-frequency-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-delivery-frequency-mutation.ts
@@ -69,7 +69,7 @@ const useSiteDeliveryFrequencyMutation = () => {
 				id
 			);
 
-			await queryClient.cancelQueries( siteSubscriptionsCacheKey );
+			await queryClient.cancelQueries( { queryKey: siteSubscriptionsCacheKey } );
 
 			const previousSiteSubscriptions =
 				queryClient.getQueryData<

--- a/packages/data-stores/src/reader/mutations/use-site-email-me-new-comments-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-email-me-new-comments-mutation.ts
@@ -56,7 +56,7 @@ const useSiteEmailMeNewCommentsMutation = () => {
 				id
 			);
 
-			await queryClient.cancelQueries( siteSubscriptionsQueryKey );
+			await queryClient.cancelQueries( { queryKey: siteSubscriptionsQueryKey } );
 
 			const previousSiteSubscriptions =
 				queryClient.getQueryData< SiteSubscriptionsPages >( siteSubscriptionsQueryKey );

--- a/packages/data-stores/src/reader/mutations/use-site-email-me-new-posts-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-email-me-new-posts-mutation.ts
@@ -56,7 +56,7 @@ const useSiteEmailMeNewPostsMutation = () => {
 				id
 			);
 
-			await queryClient.cancelQueries( siteSubscriptionsQueryKey );
+			await queryClient.cancelQueries( { queryKey: siteSubscriptionsQueryKey } );
 
 			const previousSiteSubscriptions =
 				queryClient.getQueryData< SiteSubscriptionsPages >( siteSubscriptionsQueryKey );

--- a/packages/data-stores/src/reader/mutations/use-site-notify-me-of-new-posts-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-notify-me-of-new-posts-mutation.ts
@@ -57,7 +57,7 @@ const useSiteNotifyMeOfNewPostsMutation = () => {
 				id
 			);
 
-			await queryClient.cancelQueries( siteSubscriptionsQueryKey );
+			await queryClient.cancelQueries( { queryKey: siteSubscriptionsQueryKey } );
 
 			const previousSiteSubscriptions =
 				queryClient.getQueryData< SiteSubscriptionsPages >( siteSubscriptionsQueryKey );

--- a/packages/data-stores/src/reader/mutations/use-site-subscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-subscribe-mutation.ts
@@ -145,7 +145,7 @@ const useSiteSubscribeMutation = () => {
 		},
 		onSettled: ( _data, _error, params: SubscribeParams ) => {
 			if ( params.doNotInvalidateSiteSubscriptions !== true ) {
-				queryClient.invalidateQueries( siteSubscriptionsCacheKey );
+				queryClient.invalidateQueries( { queryKey: siteSubscriptionsCacheKey } );
 			}
 
 			if ( isValidId( params.blog_id ) ) {
@@ -154,7 +154,7 @@ const useSiteSubscribeMutation = () => {
 					isLoggedIn,
 					userId
 				);
-				queryClient.invalidateQueries( siteSubscriptionDetailsCacheKey );
+				queryClient.invalidateQueries( { queryKey: siteSubscriptionDetailsCacheKey } );
 				queryClient.invalidateQueries( {
 					queryKey: [ 'read', 'sites', Number( params.blog_id ) ],
 				} );
@@ -167,7 +167,7 @@ const useSiteSubscribeMutation = () => {
 				} );
 			}
 
-			queryClient.invalidateQueries( subscriptionsCountCacheKey );
+			queryClient.invalidateQueries( { queryKey: subscriptionsCountCacheKey } );
 		},
 		onSuccess: ( data, params ) => {
 			params.onSuccess?.();

--- a/packages/data-stores/src/reader/mutations/use-site-subscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-subscribe-mutation.ts
@@ -83,7 +83,7 @@ const useSiteSubscribeMutation = () => {
 					isLoggedIn,
 					userId
 				);
-				await queryClient.cancelQueries( siteSubscriptionDetailsCacheKey );
+				await queryClient.cancelQueries( { queryKey: siteSubscriptionDetailsCacheKey } );
 
 				previousSiteSubscriptionDetailsByBlogId =
 					queryClient.getQueryData< SiteSubscriptionDetails >( siteSubscriptionDetailsCacheKey );

--- a/packages/data-stores/src/reader/mutations/use-site-unsubscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-unsubscribe-mutation.ts
@@ -85,9 +85,9 @@ const useSiteUnsubscribeMutation = () => {
 				userId
 			);
 
-			await queryClient.cancelQueries( siteSubscriptionsQueryKey );
-			await queryClient.cancelQueries( subscriptionsCountQueryKey );
-			await queryClient.cancelQueries( siteSubscriptionDetailsQueryKey );
+			await queryClient.cancelQueries( { queryKey: siteSubscriptionsQueryKey } );
+			await queryClient.cancelQueries( { queryKey: subscriptionsCountQueryKey } );
+			await queryClient.cancelQueries( { queryKey: siteSubscriptionDetailsQueryKey } );
 
 			const previousSiteSubscriptions =
 				queryClient.getQueryData< SiteSubscriptionsPages >( siteSubscriptionsQueryKey );
@@ -146,7 +146,7 @@ const useSiteUnsubscribeMutation = () => {
 					userId
 				);
 
-				await queryClient.cancelQueries( siteSubscriptionDetailsCacheKey );
+				await queryClient.cancelQueries( { queryKey: siteSubscriptionDetailsCacheKey } );
 
 				previousSiteSubscriptionDetailsByBlogId = queryClient.getQueryData(
 					siteSubscriptionDetailsCacheKey

--- a/packages/data-stores/src/reader/mutations/use-site-unsubscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-unsubscribe-mutation.ts
@@ -200,7 +200,7 @@ const useSiteUnsubscribeMutation = () => {
 		},
 		onSettled: ( _data, _error, params ) => {
 			if ( params.doNotInvalidateSiteSubscriptions !== true ) {
-				queryClient.invalidateQueries( siteSubscriptionsQueryKey );
+				queryClient.invalidateQueries( { queryKey: siteSubscriptionsQueryKey } );
 			}
 
 			if ( isValidId( params.blog_id ) ) {
@@ -214,7 +214,7 @@ const useSiteUnsubscribeMutation = () => {
 				} );
 			}
 
-			queryClient.invalidateQueries( subscriptionsCountQueryKey );
+			queryClient.invalidateQueries( { queryKey: subscriptionsCountQueryKey } );
 			queryClient.invalidateQueries( {
 				queryKey: [ 'read', 'feed', 'search' ],
 			} );

--- a/packages/data-stores/src/reader/mutations/use-user-settings-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-user-settings-mutation.ts
@@ -34,7 +34,7 @@ const useUserSettingsMutation = () => {
 			return settings;
 		},
 		onMutate: async ( data ) => {
-			await queryClient.cancelQueries( emailSettingsCacheKey );
+			await queryClient.cancelQueries( { queryKey: emailSettingsCacheKey } );
 			const previousSettings =
 				queryClient.getQueryData< SubscriptionManagerUserSettings >( emailSettingsCacheKey );
 


### PR DESCRIPTION
Related to #84338

⚠️ Is based on and will merge into #84380

## Proposed Changes

After I ran the codemod in #84380 I noticed there are quite a few instances which could not be automatically migrated because they're using variables and the codemod doesn't have a way to analyze whether those variables aren't already valid query option objects.

This PR migrates remaining usages of `useQuery` and friends to use object syntax.

## Testing Instructions

In theory you'd need to go through all usages and verify those variables aren't already valid object arguments. However, if that was the case TypeScript would complain about that because

```ts
queryClient.invalidateQueries( { queryKey: { queryKey: [ 'arbitrary-query-key' ] } } )`
```

is not a valid overload and thus a type error. There is one file which is not a `.tsx?` file though so this needs to be checked manually: [client/my-sites/plugins/controller-logged-out.js](https://github.com/Automattic/wp-calypso/compare/update/run-remove-overloads-codemod...update/fix-more-query-overloads?expand=1#diff-b4e8533bd35c0ed97c4d6960f21e96e6987d8c8e1cb611130945ca757ed0508a).

I think it should be sufficient to check whether the above is true. Also Calypso should build just fine, there shouldn't be any type errors nor eslint failures.

I grouped commits by method for an easier review.