### PR TITLE
Add dynamic titles to task lists

### DIFF
--- a/client/my-sites/customer-home/cards/launchpad/index.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/index.tsx
@@ -45,7 +45,9 @@ const CustomerHomeLaunchpad = ( {
 	return (
 		<div className="customer-home-launchpad">
 			<div className="customer-home-launchpad__header">
-				<h2 className="customer-home-launchpad__title">{ title }</h2>
+				<h2 className="customer-home-launchpad__title">
+					{ title ?? translate( 'Next steps for your site' ) }
+				</h2>
 				{ numberOfSteps > completedSteps ? (
 					<div className="customer-home-launchpad__progress-bar-container">
 						<CircularProgressBar

--- a/client/my-sites/customer-home/cards/launchpad/index.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/index.tsx
@@ -27,7 +27,7 @@ const CustomerHomeLaunchpad = ( {
 	const translate = useTranslate();
 	const [ isDismissed, setIsDismissed ] = useState( false );
 	const {
-		data: { checklist, is_dismissed: initialIsChecklistDismissed },
+		data: { checklist, is_dismissed: initialIsChecklistDismissed, title },
 	} = useSortedLaunchpadTasks( siteSlug, checklistSlug );
 
 	useEffect( () => {
@@ -45,9 +45,7 @@ const CustomerHomeLaunchpad = ( {
 	return (
 		<div className="customer-home-launchpad">
 			<div className="customer-home-launchpad__header">
-				<h2 className="customer-home-launchpad__title">
-					{ translate( 'Next steps for your site' ) }
-				</h2>
+				<h2 className="customer-home-launchpad__title">{ title }</h2>
 				{ numberOfSteps > completedSteps ? (
 					<div className="customer-home-launchpad__progress-bar-container">
 						<CircularProgressBar

--- a/packages/data-stores/src/queries/use-launchpad.ts
+++ b/packages/data-stores/src/queries/use-launchpad.ts
@@ -40,6 +40,7 @@ interface LaunchpadResponse {
 	checklist_statuses?: ChecklistStatuses;
 	is_enabled: boolean;
 	is_dismissed: boolean;
+	title?: string | null;
 }
 
 type LaunchpadUpdateSettings = {
@@ -115,6 +116,7 @@ export const useLaunchpad = (
 			checklist: null,
 			is_enabled: false,
 			is_dismissed: false,
+			title: null,
 		},
 	} );
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #83880

## Proposed Changes

* The task list title is currently hardcoded on the CustomerHome launchpad component. Meaning that all the task lists has the same name across different intents.
* The task lists should now render the title that comes from the back end, instead of the hardcoded `Next steps for your site`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply https://github.com/Automattic/jetpack/pull/34244 to your sandbox
* Use the calypso live link below, or apply this PR to your local environment
* Use an exiting site that displays the Launchpad on the Customer Home, or create a new on `/start` path, selecting the "Promote myself or business` on the Goal step.
* On the Customer Home `/home/:siteSlug`, make sure you see the title of the Launchpad

<img width="765" alt="Screen Shot 2023-11-22 at 10 39 13" src="https://github.com/Automattic/wp-calypso/assets/1234758/f2e8b635-fcf5-4ee7-86a4-cd5327406e06">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?