### PR TITLE
Several followups for the page.js fork

### DIFF
--- a/client/blocks/announcement-modal/index.jsx
+++ b/client/blocks/announcement-modal/index.jsx
@@ -1,4 +1,4 @@
-import { default as pageRouter } from '@automattic/calypso-router';
+import pageRouter from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
 import { Guide } from '@wordpress/components';
 import { useSelector, useDispatch } from 'react-redux';

--- a/client/my-sites/earn/controller.ts
+++ b/client/my-sites/earn/controller.ts
@@ -1,30 +1,25 @@
-import page from '@automattic/calypso-router';
-import { createElement, FC } from 'react';
+import page, { type Callback } from '@automattic/calypso-router';
+import { createElement } from 'react';
 import Main from './main';
-import { Query } from './types';
-import type { Context as PageJSContext } from '@automattic/calypso-router';
 
-export default {
-	redirectToAdsEarnings: function ( context: PageJSContext ) {
-		page.redirect( '/earn/ads-earnings/' + context.params.site_id );
-	},
-	redirectToAdsSettings: function ( context: PageJSContext ) {
-		page.redirect( '/earn/ads-settings/' + context.params.site_id );
-	},
-	layout: function ( context: PageJSContext, next: () => void ) {
-		// Scroll to the top
-		if ( typeof window !== 'undefined' ) {
-			window.scrollTo( 0, 0 );
-		}
+export const redirectToAdsEarnings: Callback = ( context ) => {
+	page.redirect( '/earn/ads-earnings/' + context.params.site_id );
+};
 
-		context.primary = createElement(
-			Main as FC< { section: string; path: string; query: Query } >,
-			{
-				section: context.params.section,
-				path: context.path,
-				query: context.query,
-			}
-		);
-		next();
-	},
+export const redirectToAdsSettings: Callback = ( context ) => {
+	page.redirect( '/earn/ads-settings/' + context.params.site_id );
+};
+
+export const layout: Callback = ( context, next ) => {
+	// Scroll to the top
+	if ( typeof window !== 'undefined' ) {
+		window.scrollTo( 0, 0 );
+	}
+
+	context.primary = createElement( Main, {
+		section: context.params.section,
+		path: context.path,
+		query: context.query,
+	} );
+	next();
 };

--- a/client/my-sites/earn/index.ts
+++ b/client/my-sites/earn/index.ts
@@ -1,7 +1,7 @@
 import page from '@automattic/calypso-router';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
-import earnController from './controller';
+import { redirectToAdsEarnings, redirectToAdsSettings, layout } from './controller';
 
 export default function () {
 	page( '/earn', siteSelection, sites, makeLayout, clientRender );
@@ -22,27 +22,13 @@ export default function () {
 	page( '/earn/refer-a-friend', siteSelection, sites, makeLayout, clientRender );
 
 	// These are legacy URLs to redirect if they are present anywhere on the web.
-	page( '/ads/earnings/:site_id', earnController.redirectToAdsEarnings, makeLayout, clientRender );
-	page( '/ads/settings/:site_id', earnController.redirectToAdsSettings, makeLayout, clientRender );
-	page( '/ads/:site_id', earnController.redirectToAdsEarnings, makeLayout, clientRender );
+	page( '/ads/earnings/:site_id', redirectToAdsEarnings, makeLayout, clientRender );
+	page( '/ads/settings/:site_id', redirectToAdsSettings, makeLayout, clientRender );
+	page( '/ads/:site_id', redirectToAdsEarnings, makeLayout, clientRender );
 	page( '/ads', '/earn' );
 	page( '/ads/*', '/earn' );
 
-	page(
-		'/earn/:site_id',
-		siteSelection,
-		navigation,
-		earnController.layout,
-		makeLayout,
-		clientRender
-	);
+	page( '/earn/:site_id', siteSelection, navigation, layout, makeLayout, clientRender );
 
-	page(
-		'/earn/:section/:site_id',
-		siteSelection,
-		navigation,
-		earnController.layout,
-		makeLayout,
-		clientRender
-	);
+	page( '/earn/:section/:site_id', siteSelection, navigation, layout, makeLayout, clientRender );
 }

--- a/client/my-sites/themes/collections/showcase-theme-collection.tsx
+++ b/client/my-sites/themes/collections/showcase-theme-collection.tsx
@@ -1,4 +1,4 @@
-import { default as pageRouter } from '@automattic/calypso-router';
+import page from '@automattic/calypso-router';
 import { ReactElement } from 'react';
 import { useQueryThemes } from 'calypso/components/data/query-themes';
 import ThemeCollection from 'calypso/components/theme-collection';
@@ -77,7 +77,7 @@ export default function ShowcaseThemeCollection( {
 		} else {
 			recordThemesStyleVariationMoreClick( themeId, resultsRank );
 			const themeDetailsUrl = getThemeDetailsUrl( themeId );
-			themeDetailsUrl && pageRouter( themeDetailsUrl );
+			themeDetailsUrl && page( themeDetailsUrl );
 		}
 	};
 

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -2,7 +2,7 @@ import {
 	FEATURE_INSTALL_THEMES,
 	WPCOM_FEATURES_PREMIUM_THEMES,
 } from '@automattic/calypso-products';
-import { default as pageRouter } from '@automattic/calypso-router';
+import pageRouter from '@automattic/calypso-router';
 import { compact } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';

--- a/packages/calypso-router/src/index.js
+++ b/packages/calypso-router/src/index.js
@@ -1162,13 +1162,7 @@ function Route( path, options, pageInstance ) {
  */
 Route.prototype.middleware = function ( fn ) {
 	const handler = ( ctx, next ) => fn( ctx, next );
-	handler.match = ( ctx ) => {
-		if ( this.match( ctx.path, ctx.params ) ) {
-			ctx.routePath = this.path;
-			return true;
-		}
-		return false;
-	};
+	handler.match = ( ctx ) => this.match( ctx.path, ctx.params );
 	return handler;
 };
 


### PR DESCRIPTION
A few cleanup we didn't do in the main PR, #84096.
- remove the unused `ctx.routePath` field, as discussed in https://github.com/Automattic/wp-calypso/pull/84096#discussion_r1400580512
- fixup some router imports, changing `import { default as X } from` to `import X from`
- cleanup the Earn controller: export individual handlers instead of an object, use the `Callback` type, remove the unnecessary `FC` types for the `Main` component, whose types are already good enough.