### PR TITLE
[Odie] Initial Odie client tests and utils

### DIFF
--- a/client/odie/context/index.tsx
+++ b/client/odie/context/index.tsx
@@ -15,7 +15,7 @@ export const noop = () => {};
  * available to the components that are wrapped in the provider.
  *
  */
-interface OdieAssistantContextInterface {
+export interface OdieAssistantContextInterface {
 	addMessage: ( message: Message | Message[] ) => void;
 	botName?: string;
 	botNameSlug: OdieAllowedBots;

--- a/client/odie/message/test/custom-a-link.tsx
+++ b/client/odie/message/test/custom-a-link.tsx
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment jsdom
+ */
+import { fireEvent } from '@testing-library/react';
+import React from 'react';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { renderWithOdieContext } from '../.././test-utils/mock-odie';
+import CustomALink from './../custom-a-link';
+
+jest.mock( 'calypso/state/analytics/actions', () => ( {
+	recordTracksEvent: jest.fn( () => ( {
+		type: 'ANALYTICS_EVENT_RECORD',
+	} ) ),
+} ) );
+
+describe( 'CustomALink', () => {
+	it( 'calls recordTracksEvent on click', () => {
+		const { getByText } = renderWithOdieContext(
+			<CustomALink href="https://example.com">Test Link</CustomALink>
+		);
+
+		fireEvent.click( getByText( 'Test Link' ) );
+
+		expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_odie_chat_message_action_click', {
+			bot_name_slug: 'wpcom-support-chat',
+			action: 'link',
+			href: 'https://example.com',
+		} );
+	} );
+
+	it( 'applies correct classes when inline prop is true', () => {
+		const { container } = renderWithOdieContext(
+			<CustomALink href="https://example.com" inline={ true }>
+				Test Link
+			</CustomALink>
+		);
+
+		expect( container.firstChild ).toHaveClass( 'odie-sources' );
+		expect( container.firstChild ).toHaveClass( 'odie-sources-inline' );
+	} );
+
+	it( 'does not apply inline class when inline prop is false', () => {
+		const { container } = renderWithOdieContext(
+			<CustomALink href="https://example.com" inline={ false }>
+				Test Link
+			</CustomALink>
+		);
+
+		expect( container.firstChild ).toHaveClass( 'odie-sources' );
+		expect( container.firstChild ).not.toHaveClass( 'odie-sources-inline' );
+	} );
+} );

--- a/client/odie/message/test/custom-a-link.tsx
+++ b/client/odie/message/test/custom-a-link.tsx
@@ -4,7 +4,7 @@
 import { fireEvent } from '@testing-library/react';
 import React from 'react';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { renderWithOdieContext } from '../.././test-utils/mock-odie';
+import { renderWithOdieContext } from '../../test-utils/mock-odie';
 import CustomALink from './../custom-a-link';
 
 jest.mock( 'calypso/state/analytics/actions', () => ( {

--- a/client/odie/message/test/jump-to-recent.tsx
+++ b/client/odie/message/test/jump-to-recent.tsx
@@ -1,0 +1,63 @@
+/**
+ * @jest-environment jsdom
+ */
+import { fireEvent } from '@testing-library/react';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { renderWithOdieContext } from '../../test-utils/mock-odie';
+import { JumpToRecent } from '../jump-to-recent';
+
+jest.mock( 'calypso/state/analytics/actions', () => ( {
+	recordTracksEvent: jest.fn( () => ( {
+		type: 'ANALYTICS_EVENT_RECORD',
+	} ) ),
+} ) );
+
+describe( 'JumpToRecent', () => {
+	const scrollToBottom = jest.fn();
+
+	it( 'calls scrollToBottom and recordTracksEvent on button click', () => {
+		const { getByText } = renderWithOdieContext(
+			<JumpToRecent
+				scrollToBottom={ scrollToBottom }
+				enableJumpToRecent={ true }
+				bottomOffset={ 0 }
+			/>,
+			{},
+			{ botSetting: 'Wapuu' }
+		);
+
+		fireEvent.click( getByText( 'Jump to recent' ) );
+
+		expect( scrollToBottom ).toHaveBeenCalled();
+		expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_odie_chat_jump_to_recent_click', {
+			bot_name_slug: 'wpcom-support-chat',
+			bot_setting: 'Wapuu',
+		} );
+	} );
+
+	it( 'renders correctly when enableJumpToRecent is true', () => {
+		const { container } = renderWithOdieContext(
+			<JumpToRecent
+				scrollToBottom={ scrollToBottom }
+				enableJumpToRecent={ true }
+				bottomOffset={ 0 }
+			/>
+		);
+
+		expect( container.firstChild ).toHaveClass( 'odie-gradient-to-white' );
+		expect( container.firstChild ).toHaveClass( 'is-visible' );
+	} );
+
+	it( 'does not render visible class when enableJumpToRecent is false', () => {
+		const { container } = renderWithOdieContext(
+			<JumpToRecent
+				scrollToBottom={ scrollToBottom }
+				enableJumpToRecent={ false }
+				bottomOffset={ 0 }
+			/>
+		);
+
+		expect( container.firstChild ).toHaveClass( 'odie-gradient-to-white' );
+		expect( container.firstChild ).not.toHaveClass( 'is-visible' );
+	} );
+} );

--- a/client/odie/test-utils/mock-odie.tsx
+++ b/client/odie/test-utils/mock-odie.tsx
@@ -1,0 +1,63 @@
+/**
+ * @jest-environment jsdom
+ */
+import { RenderOptions, render } from '@testing-library/react';
+import { Provider as ReduxProvider } from 'react-redux';
+import { createStore, applyMiddleware } from 'redux';
+import thunk from 'redux-thunk';
+import { OdieAssistantContext, OdieAssistantContextInterface, noop } from '../context';
+
+type TestState = object;
+
+const initialState: TestState = {};
+
+const dummyReducer = ( state: TestState = initialState ): TestState => {
+	return state;
+};
+
+const createTestStore = () => {
+	return createStore( dummyReducer, {}, applyMiddleware( thunk ) );
+};
+
+export const renderWithOdieContext = (
+	ui: React.ReactElement,
+	options: RenderOptions = {},
+	context: Partial< OdieAssistantContextInterface > = {}
+) => {
+	const store = createTestStore();
+
+	const mockContextValue: OdieAssistantContextInterface = {
+		botNameSlug: 'wpcom-support-chat',
+		addMessage: noop,
+		chat: {
+			chat_id: undefined,
+			messages: [],
+		},
+		clearChat: noop,
+		initialUserMessage: undefined,
+		isLoadingChat: false,
+		isLoading: false,
+		isNudging: false,
+		isVisible: false,
+		lastNudge: null,
+		sendNudge: noop,
+		setChat: noop,
+		setIsLoadingChat: noop,
+		setMessageLikedStatus: noop,
+		setContext: noop,
+		setIsNudging: noop,
+		setIsVisible: noop,
+		setIsLoading: noop,
+		trackEvent: noop,
+		...context,
+	};
+
+	return render(
+		<ReduxProvider store={ store }>
+			<OdieAssistantContext.Provider value={ mockContextValue }>
+				{ ui }
+			</OdieAssistantContext.Provider>
+		</ReduxProvider>,
+		options
+	);
+};


### PR DESCRIPTION
## Proposed Changes

Start adding tests for Odie Client

## Testing Instructions

Checkout this branch locally and run:
yarn test-client client/odie/message/test/custom-a-link.tsx

All the test should pass.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?