### PR TITLE
WIP: Add cart items to Parsely conversion tag

### DIFF
--- a/client/lib/analytics/ad-tracking/record-order.ts
+++ b/client/lib/analytics/ad-tracking/record-order.ts
@@ -732,8 +732,11 @@ function recordOrderInParsely( cart: ResponseCart, orderId: number | null | unde
 				return;
 			}
 
+			// Get all the products in the cart.
+			const cartProducts = cart.products.map( ( product ) => product.product_name ).join( ', ' );
+
 			// Record Parsely purchase
-			window.PARSELY.conversions.trackPurchase( `Order Id ${ orderId }` );
+			window.PARSELY.conversions.trackPurchase( cartProducts );
 
 			debug( `recordOrderInParsely: Record Parsely purchase`, orderId );
 		} )


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Adds the cart items as a string instead of using the order ID
* I'm investigating whether this tag allows for more complex objects, like an array or JSON object, which will be more useful than a concatenated string).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enable `ad-tracking` and `cookie-banner` flag(s)
* Sandbox the API, and enable store debug, then purchase any valid set of items (bundle, domain, plan)
* In Parsely, you should see your new conversion under WordPress.com > conversions, where unlike the existing orders where you see "Order id", you'll see the cart contents.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
