### PR TITLE
Checkout: Fix bi-yearly sidebar upsell for Akismet black-friday discounts.

### DIFF
--- a/client/my-sites/checkout/src/components/item-variation-picker/util.ts
+++ b/client/my-sites/checkout/src/components/item-variation-picker/util.ts
@@ -1,3 +1,4 @@
+import { isJetpackPlan, isJetpackProduct, isAkismetProduct } from '@automattic/calypso-products';
 import type { WPCOMProductVariant } from './types';
 
 export function getItemVariantCompareToPrice(
@@ -23,12 +24,11 @@ export function getItemVariantCompareToPrice(
 		return compareTo.priceBeforeDiscounts * 2;
 	}
 
-	// CompareTo price with introductory offers (For Jetpack)
+	// CompareTo price with introductory offers and wihtout (For Jetpack and Akismet)
 	if (
-		compareTo.introductoryInterval === 1 &&
-		compareTo.introductoryTerm === 'year' &&
-		variant.introductoryInterval === 2 &&
-		variant.introductoryTerm === 'year'
+		isJetpackPlan( { product_slug: compareTo.productSlug } ) ||
+		isJetpackProduct( { product_slug: compareTo.productSlug } ) ||
+		isAkismetProduct( { product_slug: compareTo.productSlug } )
 	) {
 		return compareTo.priceInteger + compareTo.priceBeforeDiscounts;
 	}

--- a/client/my-sites/checkout/src/components/item-variation-picker/util.ts
+++ b/client/my-sites/checkout/src/components/item-variation-picker/util.ts
@@ -24,13 +24,15 @@ export function getItemVariantCompareToPrice(
 		return compareTo.priceBeforeDiscounts * 2;
 	}
 
-	// CompareTo price with introductory offers and wihtout (For Jetpack and Akismet)
+	// CompareTo price with introductory offers and without (For Jetpack and Akismet)
 	if (
 		isJetpackPlan( { product_slug: compareTo.productSlug } ) ||
 		isJetpackProduct( { product_slug: compareTo.productSlug } ) ||
 		isAkismetProduct( { product_slug: compareTo.productSlug } )
 	) {
-		return compareTo.priceInteger + compareTo.priceBeforeDiscounts;
+		if ( compareTo.termIntervalInMonths === 12 && variant.termIntervalInMonths === 24 ) {
+			return compareTo.priceInteger + compareTo.priceBeforeDiscounts;
+		}
 	}
 
 	// CompareTo price without intro offers (For WPCOM)

--- a/client/my-sites/checkout/src/components/jetpack-akismet-checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/src/components/jetpack-akismet-checkout-sidebar-plan-upsell/index.tsx
@@ -126,6 +126,9 @@ const JetpackAkismetCheckoutSidebarPlanUpsell: FC = () => {
 		biennialVariant.introductoryTerm === 'year' &&
 		currentVariant.introductoryInterval === 1 &&
 		currentVariant.introductoryTerm === 'year';
+	const isDiscounted =
+		! isComparisonWithIntroOffer &&
+		currentVariant.priceInteger < currentVariant.priceBeforeDiscounts;
 	const currencyConfig = {
 		stripZeros: true,
 		isSmallestUnit: true,
@@ -140,15 +143,16 @@ const JetpackAkismetCheckoutSidebarPlanUpsell: FC = () => {
 		{ strong: <strong /> }
 	);
 
-	const yearOnePrice = isComparisonWithIntroOffer
-		? currentVariant.priceInteger
-		: currentVariant.priceBeforeDiscounts;
+	const yearOnePrice =
+		isComparisonWithIntroOffer || isDiscounted
+			? currentVariant.priceInteger
+			: currentVariant.priceBeforeDiscounts;
 
 	const yearTwoPrice = currentVariant.priceBeforeDiscounts;
 
 	const twoYearTotal =
 		currentVariant.priceBeforeDiscounts +
-		( isComparisonWithIntroOffer
+		( isComparisonWithIntroOffer || isDiscounted
 			? currentVariant.priceInteger
 			: currentVariant.priceBeforeDiscounts );
 


### PR DESCRIPTION
I noticed that with the Black Friday discounts applied, Akismet checkout was not displaying the prices/discounts correctly in the bi-yearly upsell box in the sidebar of checkout.  This PR fixes the discount price and percentage for the bi-yearly upsell box in Akismet checkout.  (See before & after images below)

**BEFORE** | **AFTER**
--- | ---
![Markup 2023-11-22 at 10 11 40](https://github.com/Automattic/wp-calypso/assets/11078128/8dd86947-fef1-4ab3-9edd-b514e54e4f28) |![Markup 2023-11-22 at 10 13 22](https://github.com/Automattic/wp-calypso/assets/11078128/4510f8d4-9872-47dc-a406-8ab077799e5e)


## Testing Instructions

- Checkout this PR branch and `yarn start` or click the Calypso Lice (direct link) below.
- Go to `/checkout/akismet/ak_pro5h_yearly`
- You can compare with wordpress.com and with the before and after images above, and verify the following:
- In the sidebar, bi-yearly upsell box, verify that the "Year One" price is now correct (reflecting the Black Friday discount).
- In the upsell box, verify the Yearly plan "Total" is now correct.
- In the upsell box, verify the % savings is now correct.
- Check it with a Jetpack product in the cart and verify nothing has changed and it still behaves the same.
- Check it with a WPCOM product and verify nothing has changed and it still behaves the same.
- Also check the billing-term variation picker, and verify that the "Save x%" looks correct.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?