### PR TITLE
Jetpack Manage: Update post-purchase notification text

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/hooks/use-issue-and-assign-licenses.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/hooks/use-issue-and-assign-licenses.tsx
@@ -1,6 +1,7 @@
+import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { getQueryArg } from '@wordpress/url';
-import { useTranslate } from 'i18n-calypso';
+import { type TranslateResult, useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo } from 'react';
 import { partnerPortalBasePath } from 'calypso/lib/jetpack/paths';
 import { addQueryArgs } from 'calypso/lib/url';
@@ -9,79 +10,121 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { setPurchasedLicense, resetSite } from 'calypso/state/jetpack-agency-dashboard/actions';
 import { successNotice } from 'calypso/state/notices/actions';
 import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
-import { APIError } from 'calypso/state/partner-portal/types';
+import { type APIError } from 'calypso/state/partner-portal/types';
 import getSites from 'calypso/state/selectors/get-sites';
 import useAssignLicensesToSite from './use-assign-licenses-to-site';
-import useIssueLicenses, { FulfilledIssueLicenseResult } from './use-issue-licenses';
+import useIssueLicenses, { type FulfilledIssueLicenseResult } from './use-issue-licenses';
 
 const NO_OP = () => {
 	/* Do nothing */
 };
 
-const useGetLicenseIssuedMessage = () => {
-	const translate = useTranslate();
-	const products = useProductsQuery();
+// TODO: Rewrite this hook as a const once the feature flag is removed
+let useGetLicenseIssuedMessage: () => (
+	licenses: FulfilledIssueLicenseResult[]
+) => TranslateResult | undefined;
+if ( isEnabled( 'jetpack/bundle-licensing' ) ) {
+	useGetLicenseIssuedMessage = () => {
+		const translate = useTranslate();
+		const products = useProductsQuery();
 
-	return useCallback(
-		( licenses: FulfilledIssueLicenseResult[] ) => {
-			if ( licenses.length === 0 ) {
-				return;
-			}
+		return useCallback(
+			( licenses: FulfilledIssueLicenseResult[] ) => {
+				if ( licenses.length === 0 ) {
+					return;
+				}
 
-			const productNames: string[] = licenses
-				.map( ( { slug } ) => products?.data?.find?.( ( p ) => p.slug === slug )?.name )
-				.filter( ( name ): name is string => Boolean( name ) );
-			const components = {
-				strong: <strong />,
-			};
+				// Only one individual license; let's be more specific
+				if ( licenses.length === 1 && ( licenses[ 0 ].quantity ?? 1 ) === 1 ) {
+					const productName =
+						products?.data?.find?.( ( p ) => p.slug === licenses[ 0 ].slug )?.name ?? '';
+					return translate(
+						'Thanks for your purchase! Below you can view and assign your new {{strong}}%(productName)s{{/strong}} license to a website.',
+						{
+							args: {
+								productName,
+							},
+							components: {
+								strong: <strong />,
+							},
+						}
+					);
+				}
 
-			if ( productNames.length === 1 ) {
-				return translate( '{{strong}}%(productName)s{{/strong}} was successfully issued.', {
-					args: {
-						productName: productNames[ 0 ],
-					},
-					components,
-				} );
-			}
-
-			if ( productNames.length === 2 ) {
+				// Multiple licenses and/or bundles? A generic thanks will suffice.
 				return translate(
-					'{{strong}}%(first)s{{/strong}} and {{strong}}%(second)s{{/strong}} were successfully issued.',
+					'Thanks for your purchase! Below you can view and assign your new Jetpack product licenses to your websites.'
+				);
+			},
+			[ products?.data, translate ]
+		);
+	};
+} else {
+	useGetLicenseIssuedMessage = () => {
+		const translate = useTranslate();
+		const products = useProductsQuery();
+
+		return useCallback(
+			( licenses: FulfilledIssueLicenseResult[] ) => {
+				if ( licenses.length === 0 ) {
+					return;
+				}
+
+				const productNames: string[] = licenses
+					.map( ( { slug } ) => products?.data?.find?.( ( p ) => p.slug === slug )?.name )
+					.filter( ( name ): name is string => Boolean( name ) );
+				const components = {
+					strong: <strong />,
+				};
+
+				if ( productNames.length === 1 ) {
+					return translate( '{{strong}}%(productName)s{{/strong}} was successfully issued.', {
+						args: {
+							productName: productNames[ 0 ],
+						},
+						components,
+					} );
+				}
+
+				if ( productNames.length === 2 ) {
+					return translate(
+						'{{strong}}%(first)s{{/strong}} and {{strong}}%(second)s{{/strong}} were successfully issued.',
+						{
+							args: {
+								first: productNames[ 0 ],
+								second: productNames[ 1 ],
+							},
+							comment:
+								'%(first)s and %(second)s are each product names (e.g., "Jetpack Backup," "Jetpack Scan," etc.)',
+							components,
+						}
+					);
+				}
+
+				const initialSeparator = translate( ', ', {
+					comment:
+						'Characters used to separate all but the final item in a list of 3 or more (e.g., the comma and trailing space in "Jetpack Backup, Jetpack Scan, and Jetpack Boost").',
+				} ) as string;
+				const initialProducts = productNames.slice( 0, -1 ).join( initialSeparator );
+				const finalProduct = productNames.at( -1 ) as string;
+
+				return translate(
+					'{{strong}}%(initialProducts)s{{/strong}}, and {{strong}}%(finalProduct)s{{/strong}} were successfully issued.',
 					{
 						args: {
-							first: productNames[ 0 ],
-							second: productNames[ 1 ],
+							initialProducts,
+							finalProduct,
 						},
 						comment:
-							'%(first)s and %(second)s are each product names (e.g., "Jetpack Backup," "Jetpack Scan," etc.)',
+							'%(initialProducts)s is a list of 2+ product names, each separated by list item separator character(s) (e.g., in English, a comma and a trailing space); %(finalProduct)s is the final product name in the list.',
 						components,
 					}
 				);
-			}
-
-			const initialSeparator = translate( ', ', {
-				comment:
-					'Characters used to separate all but the final item in a list of 3 or more (e.g., the comma and trailing space in "Jetpack Backup, Jetpack Scan, and Jetpack Boost").',
-			} ) as string;
-			const initialProducts = productNames.slice( 0, -1 ).join( initialSeparator );
-			const finalProduct = productNames.at( -1 ) as string;
-
-			return translate(
-				'{{strong}}%(initialProducts)s{{/strong}}, and {{strong}}%(finalProduct)s{{/strong}} were successfully issued.',
-				{
-					args: {
-						initialProducts,
-						finalProduct,
-					},
-					comment:
-						'%(initialProducts)s is a list of 2+ product names, each separated by list item separator character(s) (e.g., in English, a comma and a trailing space); %(finalProduct)s is the final product name in the list.',
-					components,
-				}
-			);
-		},
-		[ products?.data, translate ]
-	);
-};
+			},
+			[ products?.data, translate ]
+		);
+	};
+}
 
 type UseIssueAndAssignLicensesOptions = {
 	onIssueError?: ( ( error: APIError ) => void ) | ( () => void );

--- a/client/state/partner-portal/types.ts
+++ b/client/state/partner-portal/types.ts
@@ -87,7 +87,10 @@ export interface APIPartner {
 
 // The API-returned license object is not quite consistent right now so we only define the properties we actively rely on.
 export interface APILicense {
+	license_id: number;
 	license_key: string;
+	quantity: number | null;
+	parent_jetpack_license_id: string | null;
 	issued_at: string;
 	revoked_at: string | null;
 }


### PR DESCRIPTION
This PR updates the notification customers receive after purchasing one or more Jetpack product licenses, to keep the text concise in the event of several different product and/or bundle license purchases.

Resolves https://github.com/Automattic/jetpack-genesis/issues/102.

## Proposed Changes

* Add a second implementation of the `useGetLicenseIssuedMessage` hook that is less specific but more concise.
* Choose the active implementation of the hook based on whether the `jetpack/bundle-licensing` flag is enabled.
* Add `type` to some imports to specify that we're importing a type and not JavaScript code.

## Testing Instructions

* In your Jetpack Cloud test environment, open Jetpack Manage with the bundle license feature flag enabled (add `?flags=jetpack/bundle-licensing`) to your browser's URL).
* If necessary, you can force-enable this functionality without the feature flag by altering line 26 of `client/jetpack-cloud/sections/partner-portal/hooks/use-issue-and-assign-licenses.tsx` to read `if ( true ) {`.

**Scenario A (one license):**

* Visit the Issue Licenses page and issue an individual license for exactly one product.
* Verify after the license is issued, you see the following notification message at the top of the viewport: `Thanks for your purchase! Below you can view and assign your new <product name> license to a website.`.

<img height="80" alt="image" src="https://github.com/Automattic/wp-calypso/assets/670067/28ee6faf-0187-481f-aae9-7c383e2af7ed"> <img height="80" alt="image" src="https://github.com/Automattic/wp-calypso/assets/670067/2cb30908-d6f7-48b8-96b9-a296011332a7">

**Scenario B+C (multiple individual licenses, and/or 1+ bundle licenses):**

* Visit the Issue Licenses page and issue an individual license for more than one product; OR, issue one bundle license; OR, a combination of both.
* Verify after the licenses are issued, you see the following notification message at the top of the viewport: `Thanks for your purchase! Below you can view and assign your new Jetpack product licenses to your websites.`.

<img height="80" alt="image" src="https://github.com/Automattic/wp-calypso/assets/670067/1240dd9a-04a3-4838-b111-c0af15a7ad41"> <img height="80" alt="image" src="https://github.com/Automattic/wp-calypso/assets/670067/3e011472-7cd1-4e73-aee7-32ddf565b891">
