### PR TITLE
Jetpack Manage: Registering a new "Overview" page

### DIFF
--- a/client/jetpack-cloud/sections/agency-signup/agency-signup-form/index.tsx
+++ b/client/jetpack-cloud/sections/agency-signup/agency-signup-form/index.tsx
@@ -7,7 +7,7 @@ import QueryJetpackPartnerPortalPartner from 'calypso/components/data/query-jetp
 import CompanyDetailsForm from 'calypso/jetpack-cloud/sections/partner-portal/company-details-form';
 import formatApiPartner from 'calypso/jetpack-cloud/sections/partner-portal/lib/format-api-partner';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
-import { dashboardPath, overviewPath } from 'calypso/lib/jetpack/paths';
+import { dashboardPath } from 'calypso/lib/jetpack/paths';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, removeNotice } from 'calypso/state/notices/actions';
@@ -79,7 +79,9 @@ export default function AgencySignupForm() {
 	// or the overview page if the form was submitted successfully.
 	useEffect( () => {
 		if ( createPartner.isSuccess ) {
-			page.redirect( overviewPath() );
+			// Redirect to dashboard until Overview page is built.
+			// page.redirect( overviewPath() );
+			page.redirect( dashboardPath() );
 		} else if ( partner ) {
 			page.redirect( dashboardPath() );
 		}

--- a/client/jetpack-cloud/sections/agency-signup/agency-signup-form/index.tsx
+++ b/client/jetpack-cloud/sections/agency-signup/agency-signup-form/index.tsx
@@ -7,7 +7,7 @@ import QueryJetpackPartnerPortalPartner from 'calypso/components/data/query-jetp
 import CompanyDetailsForm from 'calypso/jetpack-cloud/sections/partner-portal/company-details-form';
 import formatApiPartner from 'calypso/jetpack-cloud/sections/partner-portal/lib/format-api-partner';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
-import { dashboardPath } from 'calypso/lib/jetpack/paths';
+import { dashboardPath, overviewPath } from 'calypso/lib/jetpack/paths';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, removeNotice } from 'calypso/state/notices/actions';
@@ -75,9 +75,12 @@ export default function AgencySignupForm() {
 		[ notificationId, partner?.id, createPartner.mutate, dispatch ]
 	);
 
-	// Redirect the user if they are already a partner or the form was submitted successfully.
+	// Redirect the user to the dashboard if they are already a partner,
+	// or the overview page if the form was submitted successfully.
 	useEffect( () => {
-		if ( partner ) {
+		if ( createPartner.isSuccess ) {
+			page.redirect( overviewPath() );
+		} else if ( partner ) {
 			page.redirect( dashboardPath() );
 		}
 	} );

--- a/client/jetpack-cloud/sections/overview/controller.tsx
+++ b/client/jetpack-cloud/sections/overview/controller.tsx
@@ -1,0 +1,13 @@
+import { type Callback, type Context } from '@automattic/calypso-router';
+import Overview from 'calypso/jetpack-cloud/sections/overview/primary/overview';
+import JetpackManageSidebar from 'calypso/jetpack-cloud/sections/sidebar-navigation/jetpack-manage';
+
+const setSidebar = ( context: Context ): void => {
+	context.secondary = <JetpackManageSidebar path={ context.path } />;
+};
+
+export const overviewContext: Callback = ( context, next ) => {
+	setSidebar( context );
+	context.primary = <Overview />;
+	next();
+};

--- a/client/jetpack-cloud/sections/overview/index.ts
+++ b/client/jetpack-cloud/sections/overview/index.ts
@@ -1,0 +1,9 @@
+import page from '@automattic/calypso-router';
+import { makeLayout, render as clientRender } from 'calypso/controller';
+import { overviewPath } from 'calypso/lib/jetpack/paths';
+import { navigation } from 'calypso/my-sites/controller';
+import * as controller from './controller';
+
+export default function () {
+	page( overviewPath(), navigation, controller.overviewContext, makeLayout, clientRender );
+}

--- a/client/jetpack-cloud/sections/overview/primary/overview/index.tsx
+++ b/client/jetpack-cloud/sections/overview/primary/overview/index.tsx
@@ -1,0 +1,13 @@
+import { useTranslate } from 'i18n-calypso';
+import DocumentHead from 'calypso/components/data/document-head';
+import Main from 'calypso/components/main';
+
+export default function Overview() {
+	const translate = useTranslate();
+
+	return (
+		<Main className="manage-overview">
+			<DocumentHead title={ translate( 'Overview' ) } />
+		</Main>
+	);
+}

--- a/client/jetpack-cloud/sections/sidebar-navigation/jetpack-manage.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/jetpack-manage.tsx
@@ -1,4 +1,4 @@
-import { plugins, currencyDollar, category } from '@wordpress/icons';
+import { plugins, currencyDollar, category, home } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import JetpackIcons from 'calypso/components/jetpack/sidebar/menu-items/jetpack-icons';
 import GuidedTour from 'calypso/jetpack-cloud/components/guided-tour';
@@ -9,6 +9,7 @@ import {
 	JETPACK_MANAGE_PLUGINS_LINK,
 	JETPACK_MANAGE_LICENCES_LINK,
 	JETPACK_MANAGE_BILLING_LINK,
+	JETPACK_MANAGE_OVERVIEW_LINK,
 } from './lib/constants';
 import type { MenuItemProps } from './types';
 
@@ -24,6 +25,15 @@ const JetpackManageSidebar = ( { path }: { path: string } ) => {
 	} );
 
 	const menuItems = [
+		createItem( {
+			icon: home,
+			path: '/',
+			link: JETPACK_MANAGE_OVERVIEW_LINK,
+			title: translate( 'Overview' ),
+			trackEventProps: {
+				menu_item: 'Jetpack Cloud / Overview',
+			},
+		} ),
 		createItem( {
 			icon: category,
 			path: '/',

--- a/client/jetpack-cloud/sections/sidebar-navigation/lib/constants.ts
+++ b/client/jetpack-cloud/sections/sidebar-navigation/lib/constants.ts
@@ -3,6 +3,7 @@ export const JETPACK_MANAGE_PLUGINS_LINK = '/plugins/manage';
 export const JETPACK_CLOUD_ACTIVITY_LOG_LINK = '/activity-log';
 export const JETPACK_CLOUD_SEARCH_LINK = '/jetpack-search';
 export const JETPACK_CLOUD_SOCIAL_LINK = '/jetpack-social';
+export const JETPACK_MANAGE_OVERVIEW_LINK = '/overview';
 export const JETPACK_MANAGE_PARTNER_PORTAL_LINK = '/partner-portal';
 export const JETPACK_MANAGE_LICENCES_LINK = `${ JETPACK_MANAGE_PARTNER_PORTAL_LINK }/licenses`;
 export const JETPACK_MANAGE_BILLING_LINK = `${ JETPACK_MANAGE_PARTNER_PORTAL_LINK }/billing`;

--- a/client/lib/jetpack/paths.ts
+++ b/client/lib/jetpack/paths.ts
@@ -41,6 +41,8 @@ export const partnerPortalBasePath = ( path = '' ) => `/partner-portal${ path }`
 export const agencySignupBasePath = () => '/manage/signup';
 export const agencySignupLegacyPath = () => '/agency/signup';
 
+export const overviewPath = () => '/overview';
+
 const pluginsBasePath = '/plugins/manage';
 
 export const pluginsPath = ( siteSlug?: string | null, query = {} ): string => {

--- a/client/sections.js
+++ b/client/sections.js
@@ -598,6 +598,12 @@ const sections = [
 		group: 'sites',
 	},
 	{
+		name: 'jetpack-cloud-overview',
+		paths: [ '/overview' ],
+		module: 'calypso/jetpack-cloud/sections/overview',
+		group: 'jetpack-cloud',
+	},
+	{
 		name: 'jetpack-cloud-partner-portal',
 		paths: [ '/partner-portal' ],
 		module: 'calypso/jetpack-cloud/sections/partner-portal',

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -155,6 +155,7 @@
 	"enable_all_sections": true,
 	"sections": {
 		"jetpack-cloud": false,
+		"jetpack-cloud-overview": false,
 		"jetpack-cloud-agency-dashboard": false,
 		"jetpack-cloud-features-comparison": false,
 		"jetpack-cloud-plugin-management": false,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -77,6 +77,7 @@
 		"activity": true,
 		"backup": true,
 		"jetpack-cloud": true,
+		"jetpack-cloud-overview": true,
 		"jetpack-cloud-agency-dashboard": true,
 		"jetpack-cloud-agency-signup": true,
 		"jetpack-cloud-auth": true,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -70,6 +70,7 @@
 		"activity": true,
 		"backup": true,
 		"jetpack-cloud": true,
+		"jetpack-cloud-overview": false,
 		"jetpack-cloud-agency-dashboard": true,
 		"jetpack-cloud-agency-signup": true,
 		"jetpack-cloud-auth": false,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -73,6 +73,7 @@
 		"activity": true,
 		"backup": true,
 		"jetpack-cloud": true,
+		"jetpack-cloud-overview": false,
 		"jetpack-cloud-agency-dashboard": true,
 		"jetpack-cloud-agency-signup": true,
 		"jetpack-cloud-auth": true,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -74,6 +74,7 @@
 		"activity": true,
 		"backup": true,
 		"jetpack-cloud": true,
+		"jetpack-cloud-overview": true,
 		"jetpack-cloud-agency-dashboard": true,
 		"jetpack-cloud-agency-signup": true,
 		"jetpack-cloud-auth": true,


### PR DESCRIPTION
Related to https://github.com/Automattic/jetpack-manage/issues/132

## Proposed Changes

* This PR adds an empty 'Overview' page at /overview.
* The page includes the main Jetpack Manage sidebar navigation, and the Overview page is the top item in that menu:

<img width="212" alt="Screenshot 2023-11-22 at 16 26 18" src="https://github.com/Automattic/wp-calypso/assets/16754605/9441a1b7-17e6-4dce-85f9-411956b91bd0">

* The overview page is the landing page only immediately after filling in the Manage sign up form - any subsequent visits to the Manage sign up form if you are already a partner should redirect you to the dashboard. P2 comment about this here: pf36In-mf-p2#comment-504 
* The page is also available in staging.

## Testing Instructions

* Apply this branch, and visit `http://jetpack.cloud.localhost:3000/overview`
* Verify the page loads with no errors, and that the navigation matches that in the screenshot above
* The page should also match the technical specifications and screenshots included in this post: pf36In-mf-p2#new-page-1 (minus tracking, for later follow-ups).
* To test the page redirect, in an incognito window visit the Manage signup form - `http://jetpack.cloud.localhost:3000/manage/signup` - and with a new user sign in and fill out the form.
* You should only be redirected to the overview page on successful form submission (not after filling a field out incorrectly, for example not entering a website URL).
* Once logged in, visit the Manage signup form once again. You should be redirected to the dashboard, not the overview page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?