### PR TITLE
Display contact info even when the update is forbidden

### DIFF
--- a/client/my-sites/domains/domain-management/settings/cards/contact-information/contacts-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/contact-information/contacts-card.tsx
@@ -156,7 +156,7 @@ const ContactsPrivacyCard = ( props: ContactsCardProps ) => {
 		);
 	};
 
-	const { selectedDomainName, canManageConsent, currentRoute } = props;
+	const { selectedDomainName, canManageConsent, currentRoute, readOnly } = props;
 
 	return (
 		<div>
@@ -165,9 +165,9 @@ const ContactsPrivacyCard = ( props: ContactsCardProps ) => {
 					<ContactDisplay selectedDomainName={ selectedDomainName } />
 					<div className="contact-information__button-container">
 						<Button
-							disabled={ disableEdit }
+							disabled={ disableEdit || readOnly }
 							href={
-								disableEdit
+								disableEdit || readOnly
 									? ''
 									: domainManagementEditContactInfo(
 											props.selectedSite.slug,
@@ -191,7 +191,7 @@ const ContactsPrivacyCard = ( props: ContactsCardProps ) => {
 							</Button>
 						) }
 					</div>
-					{ disableEdit && (
+					{ disableEdit && ! readOnly && (
 						<p className="contact-information__transfer-warn">
 							{ translate(
 								'Contact modifications are disabled while domain transfers are pending.'

--- a/client/my-sites/domains/domain-management/settings/cards/contact-information/contacts-privacy-info.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/contact-information/contacts-privacy-info.tsx
@@ -12,7 +12,7 @@ import type { ContactsInfoPassedProps, ContactsInfoProps } from './types';
 import './style.scss';
 
 const ContactsPrivacy = ( props: ContactsInfoProps ): null | JSX.Element => {
-	const renderForOwner = () => {
+	const renderForOwner = ( readonly = false ) => {
 		const domain = getSelectedDomain( props );
 		if ( ! domain ) {
 			return null;
@@ -38,6 +38,7 @@ const ContactsPrivacy = ( props: ContactsInfoProps ): null | JSX.Element => {
 				contactInfoDisclosed={ contactInfoDisclosed }
 				contactInfoDisclosureAvailable={ contactInfoDisclosureAvailable }
 				isPendingIcannVerification={ isPendingIcannVerification }
+				readOnly={ readonly }
 			/>
 		);
 	};
@@ -51,7 +52,13 @@ const ContactsPrivacy = ( props: ContactsInfoProps ): null | JSX.Element => {
 
 	const domain = getSelectedDomain( props );
 	if ( domain && ! domain.canUpdateContactInfo ) {
-		return <InfoNotice redesigned={ true } text={ domain.cannotUpdateContactInfoReason } />;
+		return (
+			<>
+				<InfoNotice redesigned={ true } text={ domain.cannotUpdateContactInfoReason } />
+				<br />
+				{ renderForOwner( true ) }
+			</>
+		);
 	}
 	return domain?.currentUserCanManage ? renderForOwner() : renderForOthers();
 };

--- a/client/my-sites/domains/domain-management/settings/cards/contact-information/types.ts
+++ b/client/my-sites/domains/domain-management/settings/cards/contact-information/types.ts
@@ -31,6 +31,7 @@ export type ContactsCardPassedProps = {
 	contactInfoDisclosureAvailable: boolean;
 	contactInfoDisclosed: boolean;
 	isPendingIcannVerification: boolean;
+	readOnly: boolean | undefined;
 };
 
 export type ContactsCardConnectedProps = {


### PR DESCRIPTION
## Proposed Changes

This PR updates the Domain Management card _Contact Information_ to show contact details data even if the update is not allowed (the Edit button is disabled).

## Testing Instructions

Apply this PR locally or use the build link and test it with a domain whose contact information cannot be updated. Verify that the contact information is displayed and the Edit button is not enabled.

![contact-info-before](https://github.com/Automattic/wp-calypso/assets/2797601/47bdcbad-615a-4762-9bc4-a8c59278f416)

![contact-info-after](https://github.com/Automattic/wp-calypso/assets/2797601/68f02237-a32a-46e3-b9fb-82c76bb41866)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?