### PR TITLE
Added new Jetpack Manage Onboarding mailing list category

### DIFF
--- a/client/mailing-lists/main.jsx
+++ b/client/mailing-lists/main.jsx
@@ -114,6 +114,8 @@ class MainComponent extends Component {
 			return this.props.translate( 'Jetpack Newsletter' );
 		} else if ( 'jetpack_reports' === category ) {
 			return this.props.translate( 'Jetpack Reports' );
+		} else if ( 'jetpack_manage_onboarding' === category ) {
+			return this.props.translate( 'Jetpack Manage Onboarding' );
 		} else if ( 'akismet_marketing' === category ) {
 			return this.props.translate( 'Akismet Marketing' );
 		} else if ( 'woopay_marketing' === category ) {
@@ -159,6 +161,8 @@ class MainComponent extends Component {
 			return this.props.translate( 'Jetpack news, announcements, and product spotlights.' );
 		} else if ( 'jetpack_reports' === category ) {
 			return this.props.translate( 'Jetpack security and performance reports.' );
+		} else if ( 'jetpack_manage_onboarding' === category ) {
+			return this.props.translate( 'Jetpack Manage program setup and onboarding.' );
 		} else if ( 'akismet_marketing' === category ) {
 			return this.props.translate(
 				'Relevant tips and new features to get the most out of Akismet'


### PR DESCRIPTION
This change adds proper Calypso (UI) support for a new mailing list category used for Jetpack Manage onboarding notifications.

## Testing Instructions

The backend work on adding the new mailing list category for Jetpack Agency Pro Onboarding was completed via D128564.

* Visit [this unsubscribe URL](http://calypso.localhost:3000/mailing-lists/unsubscribe?category=jetpack_manage_onboarding&email=codefourcomics%40gmail.com&hmac=78f77ecac1158b52fd5180806a7fc282). Confirm that the subscribe and resubscribe actions work, and that the title and description of the message are correctly displayed. 

![CleanShot 2023-11-22 at 12 23 22@2x](https://github.com/Automattic/wp-calypso/assets/135139690/d5cf0b06-34e1-4d8d-a1c1-e145af917a23)

Note: This new mailing list category will not be displayed in the public Notifications Update page, since this is a unique mailing list category for a specific audience. This was discussed here in the [previous PR](https://github.com/Automattic/wp-calypso/pull/79087#issuecomment-1625223337).
