### PR TITLE
Update: home - get the mobile app

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -125,7 +125,7 @@ export const getTask = (
 			break;
 		case CHECKLIST_KNOWN_TASKS.MOBILE_APP_INSTALLED:
 			taskData = {
-				title: translate( 'Try the Jetpack app' ),
+				title: translate( 'Get the mobile app' ),
 				subtitle: translate( 'Put your site in your pocket' ),
 				icon: (
 					<AnimatedIcon


### PR DESCRIPTION
Updates the copy on the task list from "Try the Jetpack app" => "Get the mobile app"

See p58i-fXA-p2

Before:
![Screenshot_2023-11-22_at_9_55_38 AM](https://github.com/Automattic/wp-calypso/assets/115071/030e9b3e-8407-49e4-9439-223b6bb1727e)
![Screenshot_2023-11-22_at_9_42_48 AM](https://github.com/Automattic/wp-calypso/assets/115071/a34f756b-3caa-482f-8fce-0adb884f8af1)



After:

![Screenshot_2023-11-22_at_9_56_05 AM](https://github.com/Automattic/wp-calypso/assets/115071/e9cf3091-19ae-4cc2-9ec4-f6bbbd5f16f3)

![Screenshot_2023-11-22_at_9_42_31 AM](https://github.com/Automattic/wp-calypso/assets/115071/a42c5133-adb7-4e87-8218-8b56f35ab300)


## Proposed Changes
This PR updates the copy from "Try the jetpack app" to "Get the mobile app"


## Testing Instructions

* On a site that has the the "Site setup" a site that is not launched yet. Notice that the copy has been updated to invite the user to get the mobile app. 

Notice that on mobile the "Get the app" banner only shows up if the user has NOT completed this task. 
In our case clicked on the "Download button"

In my testing I displayed the task by updating the `display: block;` of the task in the inspector. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?