### PR TITLE
Marketplace: Create methods to verify if the user can publish reviews

### DIFF
--- a/client/data/marketplace/test/use-can-publish-plugin-reviews.test.ts
+++ b/client/data/marketplace/test/use-can-publish-plugin-reviews.test.ts
@@ -1,0 +1,78 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { renderHook } from '@testing-library/react';
+import { useSelector } from 'react-redux';
+import { useCanPublishPluginReview } from '../use-can-publish-plugin-reviews';
+
+jest.mock( 'react-redux', () => ( {
+	useSelector: jest.fn(),
+} ) );
+
+describe( 'useCanPublishPluginReview', () => {
+	it( 'returns true if the user is logged in and the plugin is not a marketplace product', () => {
+		useSelector.mockImplementation( ( selector ) =>
+			selector( {
+				currentUser: { id: 1 },
+				purchases: {},
+			} )
+		);
+		const { result } = renderHook( () =>
+			useCanPublishPluginReview( { isMarketplaceProduct: false } )
+		);
+
+		expect( result.current ).toBe( true );
+	} );
+
+	it( 'returns false if the user is not logged in', () => {
+		useSelector.mockImplementation( ( selector ) =>
+			selector( {
+				currentUser: { id: null },
+				purchases: {},
+			} )
+		);
+
+		const { result } = renderHook( () =>
+			useCanPublishPluginReview( { isMarketplaceProduct: false } )
+		);
+
+		expect( result.current ).toBe( false );
+	} );
+
+	it( 'returns true if the user is logged in and has an active subscription for a marketplace product', () => {
+		useSelector.mockImplementation( ( selector ) =>
+			selector( {
+				currentUser: { id: 1 },
+				purchases: {
+					hasLoadedUserPurchasesFromServer: true,
+					data: [ { product_id: 2, user_id: 1 } ],
+				},
+			} )
+		);
+
+		const { result } = renderHook( () =>
+			useCanPublishPluginReview( { isMarketplaceProduct: true, variations: [ { product_id: 2 } ] } )
+		);
+
+		expect( result.current ).toBe( true );
+	} );
+
+	it( 'returns false if the user is logged in but does not have an active subscription for a marketplace product', () => {
+		useSelector.mockImplementation( ( selector ) =>
+			selector( {
+				currentUser: { id: 1 },
+				purchases: {
+					hasLoadedUserPurchasesFromServer: true,
+					data: [],
+				},
+			} )
+		);
+
+		const { result } = renderHook( () =>
+			useCanPublishPluginReview( { isMarketplaceProduct: true, variations: [ { product_id: 2 } ] } )
+		);
+
+		expect( result.current ).toBe( false );
+	} );
+} );

--- a/client/data/marketplace/use-can-publish-plugin-reviews.ts
+++ b/client/data/marketplace/use-can-publish-plugin-reviews.ts
@@ -9,7 +9,7 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
  * @param {{}} plugin the given plugin with its variations
  * @returns {boolean} true if the user is logged in and has purchased the plugin.
  */
-export function useCanUserPostReviews( plugin ) {
+export function useCanPublishPluginReview( plugin = {} ) {
 	const isLoggedIn = useSelector( isUserLoggedIn );
 
 	const selectedSite = useSelector( getSelectedSite );

--- a/client/data/marketplace/use-can-publish-plugin-reviews.ts
+++ b/client/data/marketplace/use-can-publish-plugin-reviews.ts
@@ -1,8 +1,7 @@
 import { useSelector } from 'react-redux';
 import { getPluginPurchased } from 'calypso/lib/plugins/utils';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import { getSitePurchases } from 'calypso/state/purchases/selectors';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { getUserPurchases } from 'calypso/state/purchases/selectors';
 
 /**
  * Checks if the current user can post reviews for a given plugin.
@@ -13,9 +12,8 @@ export function useCanPublishPluginReview( plugin = { isMarketplaceProduct: fals
 	const { isMarketplaceProduct } = plugin;
 	const isLoggedIn = useSelector( isUserLoggedIn );
 
-	const selectedSite = useSelector( getSelectedSite );
-	const purchases = useSelector( ( state ) => getSitePurchases( state, selectedSite?.ID ) );
-	const purchasedPlugin = getPluginPurchased( plugin, purchases );
+	const purchases = useSelector( ( state ) => getUserPurchases( state ) );
+	const purchasedPlugin = getPluginPurchased( plugin, purchases || [] );
 	const hasActiveSubscription = !! purchasedPlugin;
 
 	return isLoggedIn && ( ! isMarketplaceProduct || hasActiveSubscription );

--- a/client/data/marketplace/use-can-publish-plugin-reviews.ts
+++ b/client/data/marketplace/use-can-publish-plugin-reviews.ts
@@ -9,12 +9,14 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
  * @param {{}} plugin the given plugin with its variations
  * @returns {boolean} true if the user is logged in and has purchased the plugin.
  */
-export function useCanPublishPluginReview( plugin = {} ) {
+export function useCanPublishPluginReview( plugin = { isMarketplaceProduct: false } ) {
+	const { isMarketplaceProduct } = plugin;
 	const isLoggedIn = useSelector( isUserLoggedIn );
 
 	const selectedSite = useSelector( getSelectedSite );
 	const purchases = useSelector( ( state ) => getSitePurchases( state, selectedSite?.ID ) );
 	const purchasedPlugin = getPluginPurchased( plugin, purchases );
+	const hasActiveSubscription = !! purchasedPlugin;
 
-	return isLoggedIn && !! purchasedPlugin;
+	return isLoggedIn && ( ! isMarketplaceProduct || hasActiveSubscription );
 }

--- a/client/my-sites/plugins/use-can-user-post-reviews/index.js
+++ b/client/my-sites/plugins/use-can-user-post-reviews/index.js
@@ -1,0 +1,20 @@
+import { useSelector } from 'react-redux';
+import { getPluginPurchased } from 'calypso/lib/plugins/utils';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { getSitePurchases } from 'calypso/state/purchases/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+
+/**
+ * Checks if the current user can post reviews for a given plugin.
+ * @param {{}} plugin the given plugin with its variations
+ * @returns {boolean} true if the user is logged in and has purchased the plugin.
+ */
+export function useCanUserPostReviews( plugin ) {
+	const isLoggedIn = useSelector( isUserLoggedIn );
+
+	const selectedSite = useSelector( getSelectedSite );
+	const purchases = useSelector( ( state ) => getSitePurchases( state, selectedSite?.ID ) );
+	const purchasedPlugin = getPluginPurchased( plugin, purchases );
+
+	return isLoggedIn && !! purchasedPlugin;
+}

--- a/client/state/themes/selectors/can-publish-theme-review.ts
+++ b/client/state/themes/selectors/can-publish-theme-review.ts
@@ -1,0 +1,19 @@
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import {
+	isExternallyManagedTheme as getIsExternallyManagedTheme,
+	isMarketplaceThemeSubscribed as getIsMarketplaceThemeSubscribed,
+} from 'calypso/state/themes/selectors';
+import { AppState } from 'calypso/types';
+
+export function canPublishThemeReview(
+	state: AppState,
+	themeId: string | undefined,
+	siteId: number | undefined
+) {
+	const isLoggedIn = isUserLoggedIn( state );
+	const isExternallyManagedTheme = themeId && getIsExternallyManagedTheme( state, themeId );
+	const isMarketplaceThemeSubscribed =
+		siteId && isExternallyManagedTheme && getIsMarketplaceThemeSubscribed( state, themeId, siteId );
+
+	return isLoggedIn && isMarketplaceThemeSubscribed;
+}

--- a/client/state/themes/selectors/can-publish-theme-review.ts
+++ b/client/state/themes/selectors/can-publish-theme-review.ts
@@ -1,19 +1,15 @@
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import {
 	isExternallyManagedTheme as getIsExternallyManagedTheme,
-	isMarketplaceThemeSubscribed as getIsMarketplaceThemeSubscribed,
+	isMarketplaceThemeSubscribedByUser as getIsMarketplaceThemeSubscribed,
 } from 'calypso/state/themes/selectors';
 import { AppState } from 'calypso/types';
 
-export function canPublishThemeReview(
-	state: AppState,
-	themeId: string | undefined,
-	siteId: number | undefined
-) {
+export function canPublishThemeReview( state: AppState, themeId: string | undefined ) {
 	const isLoggedIn = isUserLoggedIn( state );
 	const isExternallyManagedTheme = themeId && getIsExternallyManagedTheme( state, themeId );
 	const isMarketplaceThemeSubscribed =
-		siteId && isExternallyManagedTheme && getIsMarketplaceThemeSubscribed( state, themeId, siteId );
+		isExternallyManagedTheme && getIsMarketplaceThemeSubscribed( state, themeId );
 
 	return isLoggedIn && ( ! isExternallyManagedTheme || isMarketplaceThemeSubscribed );
 }

--- a/client/state/themes/selectors/can-publish-theme-review.ts
+++ b/client/state/themes/selectors/can-publish-theme-review.ts
@@ -15,5 +15,5 @@ export function canPublishThemeReview(
 	const isMarketplaceThemeSubscribed =
 		siteId && isExternallyManagedTheme && getIsMarketplaceThemeSubscribed( state, themeId, siteId );
 
-	return isLoggedIn && isMarketplaceThemeSubscribed;
+	return isLoggedIn && ( ! isExternallyManagedTheme || isMarketplaceThemeSubscribed );
 }

--- a/client/state/themes/selectors/index.js
+++ b/client/state/themes/selectors/index.js
@@ -81,3 +81,4 @@ export {
 } from 'calypso/state/themes/selectors/theme-activation-modal';
 export { themePreviewVisibility } from 'calypso/state/themes/selectors/theme-preview-visibility';
 export { getThemeFiltersRequestError } from 'calypso/state/themes/selectors/get-theme-filters-request-error';
+export { canPublishThemeReview } from 'calypso/state/themes/selectors/can-publish-theme-review';

--- a/client/state/themes/selectors/index.js
+++ b/client/state/themes/selectors/index.js
@@ -54,6 +54,7 @@ export { isFulfilledThemesForQuery } from 'calypso/state/themes/selectors/is-ful
 export { isFullSiteEditingTheme } from 'calypso/state/themes/selectors/is-full-site-editing-theme';
 export { isInstallingTheme } from 'calypso/state/themes/selectors/is-installing-theme';
 export { isMarketplaceThemeSubscribed } from 'calypso/state/themes/selectors/is-marketplace-theme-subscribed';
+export { isMarketplaceThemeSubscribedByUser } from 'calypso/state/themes/selectors/is-marketplace-theme-subscribed-by-user';
 export { isPremiumThemeAvailable } from 'calypso/state/themes/selectors/is-premium-theme-available';
 export { isRequestingActiveTheme } from 'calypso/state/themes/selectors/is-requesting-active-theme';
 export { isRequestingTheme } from 'calypso/state/themes/selectors/is-requesting-theme';

--- a/client/state/themes/selectors/is-marketplace-theme-subscribed-by-user.ts
+++ b/client/state/themes/selectors/is-marketplace-theme-subscribed-by-user.ts
@@ -1,0 +1,23 @@
+import { marketplaceThemeBillingProductSlug } from 'calypso/my-sites/themes/helpers';
+import { getProductsByBillingSlug } from 'calypso/state/products-list/selectors';
+import { getUserPurchases } from 'calypso/state/purchases/selectors';
+
+/**
+ * Checks if the user has a subscription to the theme on any site.
+ * @param {Object} state global state
+ * @param {string} themeId theme id
+ * @returns {boolean} true if the site subscribed to the theme
+ */
+export function isMarketplaceThemeSubscribedByUser( state = {}, themeId: string ) {
+	const products = getProductsByBillingSlug( state, marketplaceThemeBillingProductSlug( themeId ) );
+	const userPurchases = getUserPurchases( state );
+
+	return !! (
+		userPurchases &&
+		userPurchases.find( ( purchase ) => {
+			return (
+				products && products.find( ( product ) => purchase.productSlug === product.product_slug )
+			);
+		} )
+	);
+}

--- a/client/state/themes/selectors/test/can-publish-theme-review.test.ts
+++ b/client/state/themes/selectors/test/can-publish-theme-review.test.ts
@@ -1,0 +1,45 @@
+import * as userSelectors from 'calypso/state/current-user/selectors';
+import * as themeSelectors from 'calypso/state/themes/selectors';
+import { canPublishThemeReview } from '../can-publish-theme-review';
+
+jest.mock( 'calypso/state/current-user/selectors' );
+jest.mock( 'calypso/state/themes/selectors' );
+
+describe( 'canPublishThemeReview', () => {
+	it( 'returns true if the user is logged in and the theme is not externally managed', () => {
+		userSelectors.isUserLoggedIn.mockReturnValue( true );
+		themeSelectors.isExternallyManagedTheme.mockReturnValue( false );
+
+		const result = canPublishThemeReview( {}, 'theme1' );
+
+		expect( result ).toBe( true );
+	} );
+
+	it( 'returns false if the user is not logged in', () => {
+		userSelectors.isUserLoggedIn.mockReturnValue( false );
+
+		const result = canPublishThemeReview( {}, 'theme1' );
+
+		expect( result ).toBe( false );
+	} );
+
+	it( 'returns true if the user is logged in and has a subscription for an externally managed theme', () => {
+		userSelectors.isUserLoggedIn.mockReturnValue( true );
+		themeSelectors.isExternallyManagedTheme.mockReturnValue( true );
+		themeSelectors.isMarketplaceThemeSubscribedByUser.mockReturnValue( true );
+
+		const result = canPublishThemeReview( {}, 'theme1' );
+
+		expect( result ).toBe( true );
+	} );
+
+	it( 'returns false if the user is logged in but does not have a subscription for an externally managed theme', () => {
+		userSelectors.isUserLoggedIn.mockReturnValue( true );
+		themeSelectors.isExternallyManagedTheme.mockReturnValue( true );
+		themeSelectors.isMarketplaceThemeSubscribedByUser.mockReturnValue( false );
+
+		const result = canPublishThemeReview( {}, 'theme1' );
+
+		expect( result ).toBe( false );
+	} );
+} );


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/3920

## Proposed Changes

* Add the hook `useCanPublishPluginReview`
* Add the selector `canPublishThemeReview`

Both should tells whether a user can publish a review or not, the hook requiring less input (only plugin), but the Themes area is still composed by Class components which don't accept hooks.

## Testing Instructions

* Go to `plugin-details.jsx` file
* On the imports sections add the following lines
```js
import { useCanPublishPluginReview } from 'calypso/data/marketplace/use-can-publish-plugin-reviews';
import QueryUserPurchases from 'calypso/components/data/query-user-purchases';

````

* On line `192` add the following piece:
```js
const canPublishReview = useCanPublishPluginReview( fullPlugin );
console.log( { canPublishReview } );
```

* On line `350` add the following line:
```js
<QueryUserPurchases />
```

* Go to `my-sites/theme/main.jsx` file

* On the line `92` add
```js

canPublishThemeReview as canPublishThemeReviewSelector,
````

* On line `1395` add the following piece:
```js
const { canPublishThemeReview } = this.props;
console.log( { canPublishThemeReview } );
```

On the line `1542` add the following piece
```js
canPublishThemeReview: canPublishThemeReviewSelector( state, theme?.id ),
```

**Plugins**
* Go to the `/plugins/:plugin_slug/:site` with a plugin slug with an active subscription and logged in user 
* On the console you should see `true`
* Select a paid plugin without a subscription
* You should see `false`
* Select a free plugin
* You should see `true`
* Go to the `/plugins/:plugin_slug` on a incognito window
* You should see `false` on every plugin


**Themes**
* Go to the `/theme/:theme_slug/:site` with a plugin slug with an active subscription and logged in user 
* On the console you should see `true`
* Select a paid theme without a subscription
* You should see `false`
* Select a free or premium theme
* You should see `true`
* Go to the `/theme/:theme_slug` on a incognito window
* You should see `false` on every theme

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
