### PR TITLE
Subscription Management: Fix invalid redirect when external portal URL has a locale

### DIFF
--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -841,11 +841,16 @@ function wpcomPages( app ) {
 			return res.redirect( 'https://wordpress.com/read/site/subscription/' + siteFragment[ 1 ] );
 		}
 
-		// If user enters /subscriptions/(comments|pending)(.*),
-		// redirect to /read/subscriptions/(comments\pending)(.*)
-		const commentsOrPendingFragment = req.path.match( /(comments(.*)|pending(.*))/gi );
-		if ( commentsOrPendingFragment ) {
-			return res.redirect( basePath + '/' + commentsOrPendingFragment[ 0 ] );
+		// If user enters /subscriptions/comments(.*),
+		// redirect to /read/subscriptions/comments.
+		if ( req.path.match( '/subscriptions/comments' ) ) {
+			return res.redirect( basePath + '/comments' );
+		}
+
+		// If user enters /subscriptions/pending(.*),
+		// redirect to /read/subscriptions/pending.
+		if ( req.path.match( '/subscriptions/pending' ) ) {
+			return res.redirect( basePath + '/pending' );
 		}
 
 		// If user enters /subscriptions/settings,


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/84444

## Proposed Changes

* Fix invalid redirect when external portal URL has a locale

## Testing Instructions

* Apply this PR to your local
* To make it easier to test on local, comment lines 819 to 827
* Run `yarn start` (after applying this PR)
* Go to http://calypso.localhost:3000/subscriptions/comments/en
* You should be redirected to https://wordpress.com/read/subscriptions/comments
* Go to http://calypso.localhost:3000/subscriptions/comments
* You should be redirected to https://wordpress.com/read/subscriptions/comments
* Go to http://calypso.localhost:3000/subscriptions/pending/en
* You should be redirected to https://wordpress.com/read/subscriptions/pending
* Go to http://calypso.localhost:3000/subscriptions/pending/en
* You should be redirected to https://wordpress.com/read/subscriptions/pending
* Note that the reader should be displayed with the user locale (not the initial URL locale)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?