### PR TITLE
try: type safe queries with `zod`

### DIFF
--- a/client/data/site-roles/schema.ts
+++ b/client/data/site-roles/schema.ts
@@ -1,0 +1,9 @@
+import z from 'zod';
+
+const RoleSchema = z.object( {
+	name: z.string(),
+	display_name: z.string(),
+	capabilities: z.record( z.boolean() ),
+} );
+
+export const SiteRolesResponseSchema = z.object( { roles: z.array( RoleSchema ) } );

--- a/client/data/site-roles/use-site-roles-query.ts
+++ b/client/data/site-roles/use-site-roles-query.ts
@@ -1,10 +1,14 @@
 import { useQuery } from '@tanstack/react-query';
 import wp from 'calypso/lib/wp';
+import { SiteRolesResponseSchema } from './schema';
 
-function useSiteRolesQuery( siteId, queryOptions = {} ) {
+function useSiteRolesQuery( siteId: string | number, queryOptions = {} ) {
 	return useQuery( {
 		queryKey: [ 'site-roles', siteId ],
-		queryFn: () => wp.req.get( `/sites/${ siteId }/roles` ),
+		queryFn: async () => {
+			const response = await wp.req.get( `/sites/${ siteId }/roles` );
+			return SiteRolesResponseSchema.parse( response );
+		},
 		...queryOptions,
 		select: ( { roles } ) => {
 			return roles.map( ( role ) =>
@@ -12,6 +16,7 @@ function useSiteRolesQuery( siteId, queryOptions = {} ) {
 			);
 		},
 		enabled: !! siteId,
+		staleTime: 60 * 1000,
 	} );
 }
 

--- a/client/package.json
+++ b/client/package.json
@@ -213,7 +213,8 @@
 		"webpack-node-externals": "^3.0.0",
 		"wpcom": "workspace:^",
 		"wpcom-proxy-request": "workspace:^",
-		"wpcom-xhr-request": "workspace:^"
+		"wpcom-xhr-request": "workspace:^",
+		"zod": "^3.22.4"
 	},
 	"devDependencies": {
 		"@automattic/calypso-eslint-overrides": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12233,6 +12233,7 @@ __metadata:
     wpcom: "workspace:^"
     wpcom-proxy-request: "workspace:^"
     wpcom-xhr-request: "workspace:^"
+    zod: "npm:^3.22.4"
   languageName: unknown
   linkType: soft
 
@@ -32983,5 +32984,12 @@ __metadata:
     compress-commons: "npm:^4.1.0"
     readable-stream: "npm:^3.6.0"
   checksum: ed9eb9387953576c43bdf7678705e8b0ff4e9149cf92b39fa845ddd5413b08daf68655b1ee8311e2dd7c88ddeb95908a785e8e48473016b2595870b0adf588d4
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.22.4":
+  version: 3.22.4
+  resolution: "zod@npm:3.22.4"
+  checksum: 7578ab283dac0eee66a0ad0fc4a7f28c43e6745aadb3a529f59a4b851aa10872b3890398b3160f257f4b6817b4ce643debdda4fb21a2c040adda7862cab0a587
   languageName: node
   linkType: hard


### PR DESCRIPTION
⚠️ This is an experiment and should not be merged.

## Proposed Changes

Introduce `zod` for type safe validation. – In case of RQ we may want to use it to validate server responses on runtime. We currently don't have a recommended approach (I think we used to with our legacy data layer).`zod` plays nicely with RQ in terms of type inference.

```ts
// simple example
import { useQuery } from '@tanstack/react-query';
import { z } from 'zod';

const SomeEntitySchema = z.object( {
    ID: z.number(),
    title: z.string(),
    description: z.string().optional(),
} );

const ResponseSchema = z.array( SomeEntitySchema );

export type SomeEntity = z.infer< typeof SomeEntitySchema >;
// is equivalent to:
// type SomeEntity = {
//     ID: number;
//     title: string;
//     descrription?: string | undefined;
// }

export const useMyExampleQuery = ( siteId: number ) => {
    return useQuery( {
        queryKey: [ 'my-example-query', siteId ],
        queryFn: async () => {
            const response = await wp.req.get( `/sites/${ siteId }/example` );
            return ResponseSchema.parse( response );
        },
    } );
};
```

## Testing Instructions

* tbd