### PR TITLE
Promote subscription: Add setting to toggle Subscription modal

### DIFF
--- a/client/my-sites/site-settings/form-discussion.jsx
+++ b/client/my-sites/site-settings/form-discussion.jsx
@@ -169,9 +169,9 @@ class SiteSettingsFormDiscussion extends Component {
 				/>
 				{ ! this.props.isJetpack && 1 === fields.lang_id && (
 					<ToggleControl
-						checked={ !! fields.verbum_subscription_modal }
+						checked={ !! fields.jetpack_verbum_subscription_modal }
 						disabled={ isRequestingSettings || isSavingSettings }
-						onChange={ handleAutosavingToggle( 'verbum_subscription_modal' ) }
+						onChange={ handleAutosavingToggle( 'jetpack_verbum_subscription_modal' ) }
 						label={ translate( 'Display subscription suggestion after comment' ) }
 					/>
 				) }
@@ -660,7 +660,7 @@ export const getFormSettings = ( settings ) => {
 		'stb_enabled',
 		'stc_enabled',
 		'wpcom_publish_comments_with_markdown',
-		'verbum_subscription_modal',
+		'jetpack_verbum_subscription_modal',
 		'lang_id',
 	] );
 };

--- a/client/my-sites/site-settings/form-discussion.jsx
+++ b/client/my-sites/site-settings/form-discussion.jsx
@@ -1,4 +1,5 @@
 import { Card } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { ToggleControl } from '@wordpress/components';
 import { flowRight, pick } from 'lodash';
 import { Component } from 'react';
@@ -166,12 +167,20 @@ class SiteSettingsFormDiscussion extends Component {
 						'Comments should be displayed with the older comments at the top of each page'
 					) }
 				/>
+				{ ! this.props.isJetpack && (
+					<ToggleControl
+						checked={ !! fields.verbum_subscription_modal }
+						disabled={ isRequestingSettings || isSavingSettings }
+						onChange={ handleAutosavingToggle( 'verbum_subscription_modal' ) }
+						label={ translate( 'Display subscription suggestion after comment.' ) }
+					/>
+				) }
 				<SupportInfo
 					text={ translate( 'Allow readers to use markdown in comments.' ) }
 					link={
 						isJetpack && ! isAtomic
 							? 'https://jetpack.com/support/markdown/'
-							: 'https://wordpress.com/support/markdown-quick-reference/'
+							: localizeUrl( 'https://wordpress.com/support/markdown-quick-reference/' )
 					}
 				/>
 				<ToggleControl
@@ -651,6 +660,7 @@ export const getFormSettings = ( settings ) => {
 		'stb_enabled',
 		'stc_enabled',
 		'wpcom_publish_comments_with_markdown',
+		'verbum_subscription_modal',
 	] );
 };
 

--- a/client/my-sites/site-settings/form-discussion.jsx
+++ b/client/my-sites/site-settings/form-discussion.jsx
@@ -167,16 +167,16 @@ class SiteSettingsFormDiscussion extends Component {
 						'Comments should be displayed with the older comments at the top of each page'
 					) }
 				/>
-				{ ! this.props.isJetpack && (
+				{ ! this.props.isJetpack && 1 === fields.lang_id && (
 					<ToggleControl
 						checked={ !! fields.verbum_subscription_modal }
 						disabled={ isRequestingSettings || isSavingSettings }
 						onChange={ handleAutosavingToggle( 'verbum_subscription_modal' ) }
-						label={ translate( 'Display subscription suggestion after comment.' ) }
+						label={ translate( 'Display subscription suggestion after comment' ) }
 					/>
 				) }
 				<SupportInfo
-					text={ translate( 'Allow readers to use markdown in comments.' ) }
+					text={ translate( 'Allow readers to use markdown in comments' ) }
 					link={
 						isJetpack && ! isAtomic
 							? 'https://jetpack.com/support/markdown/'
@@ -661,6 +661,7 @@ export const getFormSettings = ( settings ) => {
 		'stc_enabled',
 		'wpcom_publish_comments_with_markdown',
 		'verbum_subscription_modal',
+		'lang_id',
 	] );
 };
 

--- a/client/my-sites/site-settings/form-discussion.jsx
+++ b/client/my-sites/site-settings/form-discussion.jsx
@@ -167,14 +167,6 @@ class SiteSettingsFormDiscussion extends Component {
 						'Comments should be displayed with the older comments at the top of each page'
 					) }
 				/>
-				{ ! this.props.isJetpack && 1 === fields.lang_id && (
-					<ToggleControl
-						checked={ !! fields.jetpack_verbum_subscription_modal }
-						disabled={ isRequestingSettings || isSavingSettings }
-						onChange={ handleAutosavingToggle( 'jetpack_verbum_subscription_modal' ) }
-						label={ translate( 'Display subscription suggestion after comment' ) }
-					/>
-				) }
 				<SupportInfo
 					text={ translate( 'Allow readers to use markdown in comments' ) }
 					link={
@@ -660,8 +652,6 @@ export const getFormSettings = ( settings ) => {
 		'stb_enabled',
 		'stc_enabled',
 		'wpcom_publish_comments_with_markdown',
-		'jetpack_verbum_subscription_modal',
-		'lang_id',
 	] );
 };
 

--- a/client/my-sites/site-settings/settings-newsletter/SubscribeModalOnCommentSetting.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/SubscribeModalOnCommentSetting.tsx
@@ -1,0 +1,28 @@
+import { ToggleControl } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+export const SUBSCRIBE_MODAL_ON_COMMENT_OPTION = 'jetpack_verbum_subscription_modal';
+
+type SubscribeModalOnCommentSettingProps = {
+	value?: boolean;
+	handleToggle: ( field: string ) => ( value: boolean ) => void;
+	disabled?: boolean;
+};
+
+export const SubscribeModalOnCommentSetting = ( {
+	value = false,
+	handleToggle,
+	disabled,
+}: SubscribeModalOnCommentSettingProps ) => {
+	const translate = useTranslate();
+
+	return (
+		<>
+			<ToggleControl
+				checked={ !! value }
+				onChange={ handleToggle( SUBSCRIBE_MODAL_ON_COMMENT_OPTION ) }
+				disabled={ disabled }
+				label={ translate( 'Display subscription suggestion after comment' ) }
+			/>
+		</>
+	);
+};

--- a/client/my-sites/site-settings/settings-newsletter/main.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/main.tsx
@@ -16,6 +16,7 @@ import wrapSettingsForm from '../wrap-settings-form';
 import { EmailsTextSetting } from './EmailsTextSetting';
 import { ExcerptSetting } from './ExcerptSetting';
 import { FeaturedImageEmailSetting } from './FeaturedImageEmailSetting';
+import { SubscribeModalOnCommentSetting } from './SubscribeModalOnCommentSetting';
 import { SubscribeModalSetting } from './SubscribeModalSetting';
 import { NewsletterCategoriesSection } from './newsletter-categories-section';
 
@@ -34,6 +35,8 @@ type Fields = {
 	wpcom_newsletter_categories_enabled?: boolean;
 	wpcom_subscription_emails_use_excerpt?: boolean;
 	sm_enabled?: boolean;
+	jetpack_verbum_subscription_modal?: boolean;
+	lang_id?: number;
 };
 
 const getFormSettings = ( settings?: Fields ) => {
@@ -48,6 +51,8 @@ const getFormSettings = ( settings?: Fields ) => {
 		wpcom_newsletter_categories_enabled,
 		wpcom_subscription_emails_use_excerpt,
 		sm_enabled,
+		jetpack_verbum_subscription_modal,
+		lang_id,
 	} = settings;
 
 	return {
@@ -57,6 +62,8 @@ const getFormSettings = ( settings?: Fields ) => {
 		wpcom_newsletter_categories_enabled: !! wpcom_newsletter_categories_enabled,
 		wpcom_subscription_emails_use_excerpt: !! wpcom_subscription_emails_use_excerpt,
 		sm_enabled: !! sm_enabled,
+		jetpack_verbum_subscription_modal: !! jetpack_verbum_subscription_modal,
+		lang_id: lang_id || 1,
 	};
 };
 
@@ -87,6 +94,8 @@ const NewsletterSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 		wpcom_subscription_emails_use_excerpt,
 		subscription_options,
 		sm_enabled,
+		jetpack_verbum_subscription_modal,
+		lang_id,
 	} = fields;
 
 	const isSubscriptionModuleInactive = useSelector( ( state ) => {
@@ -101,6 +110,14 @@ const NewsletterSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 		return (
 			Boolean( isJetpackSite ) && isJetpackModuleActive( state, siteId, 'subscriptions' ) === false
 		);
+	} );
+
+	const isSubscriptionOnCommentModuleInactive = useSelector( ( state ) => {
+		const isJetpackSite = isJetpackSiteSelector( state, siteId, {
+			treatAtomicAsJetpackSite: true,
+		} );
+
+		return Boolean( isJetpackSite );
 	} );
 
 	const disabled = isSubscriptionModuleInactive || isRequestingSettings || isSavingSettings;
@@ -134,6 +151,15 @@ const NewsletterSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 					value={ sm_enabled }
 				/>
 			</Card>
+			{ ! isSubscriptionOnCommentModuleInactive && 1 === lang_id && (
+				<Card className="site-settings__card">
+					<SubscribeModalOnCommentSetting
+						disabled={ disabled }
+						handleToggle={ handleToggle }
+						value={ jetpack_verbum_subscription_modal }
+					/>
+				</Card>
+			) }
 
 			{ /* @ts-expect-error SettingsSectionHeader is not typed and is causing errors */ }
 			<SettingsSectionHeader


### PR DESCRIPTION
Related to https://github.com/Automattic/verbum/issues/34

## Proposed Changes

* Add an option to enable/disable the subscription modal on Verbum on the `Subscriptions` section of `/settings/newsletter/` page

PT: pb5gDS-3tB-p2

![image](https://github.com/Automattic/wp-calypso/assets/402286/967f9afa-1a42-484d-8604-83b4cb68f349)


## Testing Instructions

* Go to `/settings/newsletter/` using a Simple site
* You should see the toggle.
* Try changing the site language
* Try using an Atomic site