### PR TITLE
Update account deletion webpage to reference apps

### DIFF
--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -204,7 +204,7 @@ class AccountSettingsClose extends Component {
 								</p>
 								<p className="account-close__body-copy">
 									{ translate(
-										'You will not be able to log in to any other Automattic Services that use your WordPress.com account as a login. This includes WooCommerce.com, Crowdsignal.com, IntenseDebate.com and Gravatar.com. Once your WordPress.com account is closed, these services will also be closed and you will lose access to any orders or support history you may have.'
+										'You will not be able to log in to any other Automattic Services that use your WordPress.com account as a login. This includes WooCommerce.com, Crowdsignal.com, IntenseDebate.com, Gravatar.com, the Jetpack mobile app and the WordPress mobile app. Once your WordPress.com account is closed, these services will also be closed and you will lose access to any orders or support history you may have.'
 									) }
 								</p>
 								<p className="account-close__body-copy">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

To comply with Google Play policies, the app's Play Store listing now includes an account deletion section that points users to https://wordpress.com/me/account/close (see this discussion, https://wp.me/pcdRpT-4y0#comment-7486)

This link must "...reference the app or developer name (that is, as it appears on your store listing in Google Play)". This PR adds the apps' names to the highlighted portion of this webpage:

| Before | After |
| - | - |
| <img width="783" alt="Screenshot 2023-11-22 at 19 29 06" src="https://github.com/Automattic/wp-calypso/assets/1898325/9d6e589a-1081-481d-9049-a8e794897314"> | <img width="790" alt="Screenshot 2023-11-22 at 20 19 43" src="https://github.com/Automattic/wp-calypso/assets/1898325/5d916b47-307a-4468-97f6-b03aff02bba4"> |


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Navigate to the account closure webpage using the Calypso live build and verify it mentions both the WordPress and Jetpack mobile apps. Tip: don't use an Incognito browser session to test, use a normal one instead, otherwise it keeps asking you to log in.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

> [!CAUTION]
> I left the above checklist unchecked because I don't think any apply. Let me know if you think otherwise 🙇 