### PR TITLE
Show FAQ after plans grid has been loaded to prevent unsightly layout shifts

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -1,4 +1,4 @@
-import { getPlan, PLAN_FREE, PRODUCT_1GB_SPACE } from '@automattic/calypso-products';
+import { PRODUCT_1GB_SPACE } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import {
 	START_WRITING_FLOW,
@@ -20,8 +20,6 @@ import classNames from 'classnames';
 import { localize, useTranslate } from 'i18n-calypso';
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
-import QueryPlans from 'calypso/components/data/query-plans';
-import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { getPlanCartItem } from 'calypso/lib/cart-values/cart-items';
 import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
@@ -29,7 +27,6 @@ import PlanFAQ from 'calypso/my-sites/plans-features-main/components/plan-faq';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { getIntervalType } from 'calypso/signup/steps/plans/util';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getPlanSlug } from 'calypso/state/plans/selectors';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { ONBOARD_STORE } from '../../../../stores';
@@ -41,7 +38,6 @@ interface Props {
 	shouldIncludeFAQ?: boolean;
 	flowName: string | null;
 	onSubmit: ( planCartItem: MinimalRequestCartProduct | null ) => void;
-	plansLoaded: boolean;
 	selectedSiteId: number | null;
 	setSelectedSiteId: ( siteId: number ) => void;
 }
@@ -133,14 +129,6 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 		props.onSubmit( null );
 	};
 
-	const renderLoading = () => {
-		return (
-			<div className="plans__loading">
-				<LoadingEllipsis className="active" />
-			</div>
-		);
-	};
-
 	const removePaidDomain = () => {
 		setDomainCartItem( null );
 	};
@@ -150,10 +138,6 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 	};
 
 	const plansFeaturesList = () => {
-		if ( ! props.plansLoaded ) {
-			return renderLoading();
-		}
-
 		return (
 			<div>
 				<PlansFeaturesMain
@@ -173,8 +157,8 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 					intent={ plansIntent }
 					removePaidDomain={ removePaidDomain }
 					setSiteUrlAsFreeDomainSuggestion={ setSiteUrlAsFreeDomainSuggestion }
+					renderSiblingWhenLoaded={ () => props.shouldIncludeFAQ && <PlanFAQ /> }
 				/>
-				{ props.shouldIncludeFAQ && <PlanFAQ /> }
 			</div>
 		);
 	};
@@ -264,7 +248,6 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 
 	return (
 		<div className="stepper-plans">
-			<QueryPlans />
 			<div className={ classes }>{ plansFeaturesSelection() }</div>
 		</div>
 	);
@@ -273,7 +256,6 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 export default connect(
 	( state ) => {
 		return {
-			plansLoaded: Boolean( getPlanSlug( state, getPlan( PLAN_FREE )?.getProductId() || 0 ) ),
 			selectedSiteId: getSelectedSiteId( state ),
 		};
 	},

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -683,92 +683,97 @@ const PlansFeaturesMain = ( {
 		}
 	);
 
+	const isPlansGridReady =
+		! isLoadingGridPlans && ! resolvedSubdomainName.isLoading && ! isLoadingHostingTrialExperiment;
+
 	return (
-		<div
-			className={ classNames( 'plans-features-main', 'is-pricing-grid-2023-plans-features-main' ) }
-		>
-			<QueryPlans />
-			<QuerySites siteId={ siteId } />
-			<QuerySitePlans siteId={ siteId } />
-			<QueryActivePromotions />
-			<QueryProductsList />
-			<PlanUpsellModal
-				isModalOpen={ isModalOpen }
-				paidDomainName={ paidDomainName }
-				modalType={ resolveModal( lastClickedPlan ) }
-				generatedWPComSubdomain={ resolvedSubdomainName }
-				onClose={ () => setIsModalOpen( false ) }
-				onFreePlanSelected={ ( isDomainRetained ) => {
-					if ( ! isDomainRetained ) {
-						removePaidDomain?.();
-					}
-					// Since this domain will not be available after it is selected, invalidate the cache.
-					invalidateDomainSuggestionCache();
-					if ( resolvedSubdomainName.result?.domain_name ) {
-						setSiteUrlAsFreeDomainSuggestion?.( resolvedSubdomainName.result );
-					}
-					onUpgradeClick?.( null );
-				} }
-				onPlanSelected={ ( planSlug ) => {
-					if ( resolvedSubdomainName.result?.domain_name ) {
-						setSiteUrlAsFreeDomainSuggestion?.( resolvedSubdomainName.result );
-					}
-					invalidateDomainSuggestionCache();
-					const cartItemForPlan = getCartItemForPlan( planSlug );
-					const cartItems = cartItemForPlan ? [ cartItemForPlan ] : null;
-					onUpgradeClick?.( cartItems );
-				} }
-			/>
-			{ siteId && (
-				<PlanNotice
-					visiblePlans={ gridPlansForFeaturesGrid.map( ( gridPlan ) => gridPlan.planSlug ) }
-					siteId={ siteId }
-					isInSignup={ isInSignup }
-					{ ...( withDiscount &&
-						discountEndDate && {
-							discountInformation: {
-								withDiscount,
-								discountEndDate,
-							},
-						} ) }
+		<>
+			<div
+				className={ classNames(
+					'plans-features-main',
+					'is-pricing-grid-2023-plans-features-main'
+				) }
+			>
+				<QueryPlans />
+				<QuerySites siteId={ siteId } />
+				<QuerySitePlans siteId={ siteId } />
+				<QueryActivePromotions />
+				<QueryProductsList />
+				<PlanUpsellModal
+					isModalOpen={ isModalOpen }
+					paidDomainName={ paidDomainName }
+					modalType={ resolveModal( lastClickedPlan ) }
+					generatedWPComSubdomain={ resolvedSubdomainName }
+					onClose={ () => setIsModalOpen( false ) }
+					onFreePlanSelected={ ( isDomainRetained ) => {
+						if ( ! isDomainRetained ) {
+							removePaidDomain?.();
+						}
+						// Since this domain will not be available after it is selected, invalidate the cache.
+						invalidateDomainSuggestionCache();
+						if ( resolvedSubdomainName.result?.domain_name ) {
+							setSiteUrlAsFreeDomainSuggestion?.( resolvedSubdomainName.result );
+						}
+						onUpgradeClick?.( null );
+					} }
+					onPlanSelected={ ( planSlug ) => {
+						if ( resolvedSubdomainName.result?.domain_name ) {
+							setSiteUrlAsFreeDomainSuggestion?.( resolvedSubdomainName.result );
+						}
+						invalidateDomainSuggestionCache();
+						const cartItemForPlan = getCartItemForPlan( planSlug );
+						const cartItems = cartItemForPlan ? [ cartItemForPlan ] : null;
+						onUpgradeClick?.( cartItems );
+					} }
 				/>
-			) }
-			{ intent === 'plans-paid-media' &&
-				( isPlanUpsellEnabledOnFreeDomain.isLoading ? (
-					<FreePlanSubHeader>
-						{ translate( `Unlock a powerful bundle of features. Or {{loader}}{{/loader}}`, {
-							components: {
-								loader: (
-									<LoadingPlaceholder
-										display="inline-block"
-										width="155px"
-										minHeight="0px"
-										height="15px"
-										borderRadius="2px"
-									/>
-								),
-							},
-						} ) }
-					</FreePlanSubHeader>
-				) : (
-					<FreePlanSubHeader>
-						{ translate(
-							`Unlock a powerful bundle of features. Or {{link}}start with a free plan{{/link}}.`,
-							{
-								components: {
-									link: <Button onClick={ () => handleUpgradeClick() } borderless />,
+				{ siteId && (
+					<PlanNotice
+						visiblePlans={ gridPlansForFeaturesGrid.map( ( gridPlan ) => gridPlan.planSlug ) }
+						siteId={ siteId }
+						isInSignup={ isInSignup }
+						{ ...( withDiscount &&
+							discountEndDate && {
+								discountInformation: {
+									withDiscount,
+									discountEndDate,
 								},
-							}
-						) }
-					</FreePlanSubHeader>
-				) ) }
-			{ isDisplayingPlansNeededForFeature() && <SecondaryFormattedHeader siteSlug={ siteSlug } /> }
-			{ ( isLoadingGridPlans ||
-				resolvedSubdomainName.isLoading ||
-				isLoadingHostingTrialExperiment ) && <Spinner size={ 30 } /> }
-			{ ! isLoadingGridPlans &&
-				! resolvedSubdomainName.isLoading &&
-				! isLoadingHostingTrialExperiment && (
+							} ) }
+					/>
+				) }
+				{ intent === 'plans-paid-media' &&
+					( isPlanUpsellEnabledOnFreeDomain.isLoading ? (
+						<FreePlanSubHeader>
+							{ translate( `Unlock a powerful bundle of features. Or {{loader}}{{/loader}}`, {
+								components: {
+									loader: (
+										<LoadingPlaceholder
+											display="inline-block"
+											width="155px"
+											minHeight="0px"
+											height="15px"
+											borderRadius="2px"
+										/>
+									),
+								},
+							} ) }
+						</FreePlanSubHeader>
+					) : (
+						<FreePlanSubHeader>
+							{ translate(
+								`Unlock a powerful bundle of features. Or {{link}}start with a free plan{{/link}}.`,
+								{
+									components: {
+										link: <Button onClick={ () => handleUpgradeClick() } borderless />,
+									},
+								}
+							) }
+						</FreePlanSubHeader>
+					) ) }
+				{ isDisplayingPlansNeededForFeature() && (
+					<SecondaryFormattedHeader siteSlug={ siteSlug } />
+				) }
+				{ ! isPlansGridReady && <Spinner size={ 30 } /> }
+				{ isPlansGridReady && (
 					<>
 						{ ! hidePlanSelector && <PlanTypeSelector { ...planTypeSelectorProps } /> }
 						<div
@@ -890,10 +895,11 @@ const PlansFeaturesMain = ( {
 								) }
 							</div>
 						</div>
-						{ renderSiblingWhenLoaded?.() }
 					</>
 				) }
-		</div>
+			</div>
+			{ isPlansGridReady && renderSiblingWhenLoaded?.() }
+		</>
 	);
 };
 

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -31,6 +31,7 @@ import {
 } from '@wordpress/element';
 import classNames from 'classnames';
 import { localize, useTranslate } from 'i18n-calypso';
+import { ReactNode } from 'react';
 import { useSelector } from 'react-redux';
 import QueryActivePromotions from 'calypso/components/data/query-active-promotions';
 import QueryPlans from 'calypso/components/data/query-plans';
@@ -178,6 +179,7 @@ export interface PlansFeaturesMainProps {
 	hideUnavailableFeatures?: boolean; // used to hide features that are not available, instead of strike-through as explained in #76206
 	showLegacyStorageFeature?: boolean;
 	isSpotlightOnCurrentPlan?: boolean;
+	renderSiblingWhenLoaded?: () => ReactNode; // renders additional components as last dom node when plans grid dependecies are fully loaded
 }
 
 const SecondaryFormattedHeader = ( { siteSlug }: { siteSlug?: string | null } ) => {
@@ -236,6 +238,7 @@ const PlansFeaturesMain = ( {
 	isLaunchPage = false,
 	showLegacyStorageFeature = false,
 	isSpotlightOnCurrentPlan,
+	renderSiblingWhenLoaded,
 }: PlansFeaturesMainProps ) => {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const [ lastClickedPlan, setLastClickedPlan ] = useState< string | null >( null );
@@ -887,6 +890,7 @@ const PlansFeaturesMain = ( {
 								) }
 							</div>
 						</div>
+						{ renderSiblingWhenLoaded?.() }
 					</>
 				) }
 		</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/4587
 
## Proposed Changes

Currently the FAQ section on the plans grid is shown while the plan grid is being loaded, this results in a jarring layout shift when the grid loads. This PR fixes that by showing the FAQ after the grid has been loaded

* Remove redundant `<QueryPlans/>` which was showing two different loader types.
* Add function `renderSiblingWhenLoaded` to `PlansFeaturesMain` so that it can render a component after it has done loading it's dependencies.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to `/setup/new-hosted-site/plans` 
* Verify the FAQ sections loads after the plans has being loaded and that you now see a single loading spinner.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?