### PR TITLE
Plans: fix the tooltip flashing.

### DIFF
--- a/client/my-sites/plans-grid/components/plans-2023-tooltip.tsx
+++ b/client/my-sites/plans-grid/components/plans-2023-tooltip.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import { TranslateResult } from 'i18n-calypso';
-import { Dispatch, PropsWithChildren, SetStateAction, useEffect, useRef, useState } from 'react';
+import { Dispatch, PropsWithChildren, SetStateAction, useRef } from 'react';
 import Tooltip from 'calypso/components/tooltip';
 import { hasTouch } from '../lib/touch-detect';
 
@@ -35,14 +35,9 @@ export const Plans2023Tooltip = ( {
 	id: string;
 	showOnMobile?: boolean;
 } > ) => {
-	const [ isVisible, setIsVisible ] = useState( false );
 	const { activeTooltipId, setActiveTooltipId, id } = props;
 	const tooltipRef = useRef< HTMLDivElement >( null );
 	const isTouch = hasTouch();
-
-	useEffect( () => {
-		activeTooltipId === id ? setIsVisible( true ) : setIsVisible( false );
-	}, [ activeTooltipId, id ] );
 
 	if ( ! props.text ) {
 		return <>{ props.children }</>;
@@ -56,6 +51,8 @@ export const Plans2023Tooltip = ( {
 
 		return id;
 	};
+
+	const isVisible = activeTooltipId === id;
 
 	return (
 		<>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

When moving the cursor onto the edge of the tooltip, it starts flashing. e.g. on the downgrading button:

https://github.com/Automattic/wp-calypso/assets/1842898/d0bc605f-4526-4c88-8719-38b1a8fc1955

On a feature tooltip:

https://github.com/Automattic/wp-calypso/assets/1842898/a385109e-4c83-47c7-8827-7ee17bf4cb77


It is because we have two state values controlling the visibility: the active id that's managed by the parent component, and the visibility flag value mananged by the tooltip component. This PR fixes the issue by deriving the visibility value directly from the id and the active id.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Doing the same thing as the screencasts above shown, the tooltip should just disappear normally and won't flash.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
