### PR TITLE
Jetpack Manage: Display the selected licenses in the review licenses modal

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/index.tsx
@@ -54,6 +54,20 @@ export default function IssueLicenseV2( { selectedSite, suggestedProduct }: Assi
 
 	const showStickyContent = isWithinBreakpoint( '>960px' ) && selectedLicenses.length > 0;
 
+	// Group licenses by slug and sort them by quantity
+	const getGroupedLicenses = useCallback( () => {
+		return Object.values(
+			selectedLicenses.reduce(
+				( acc: Record< string, SelectedLicenseProp[] >, license ) => (
+					( acc[ license.slug ] = ( acc[ license.slug ] || [] ).concat( license ) ), acc
+				),
+				{}
+			)
+		)
+			.map( ( group ) => group.sort( ( a, b ) => a.quantity - b.quantity ) )
+			.flat();
+	}, [ selectedLicenses ] );
+
 	return (
 		<>
 			<Layout
@@ -127,7 +141,7 @@ export default function IssueLicenseV2( { selectedSite, suggestedProduct }: Assi
 			{ showReviewLicenses && (
 				<ReviewLicenses
 					onClose={ () => setShowReviewLicenses( false ) }
-					selectedLicenses={ selectedLicenses }
+					selectedLicenses={ getGroupedLicenses() }
 				/>
 			) }
 		</>

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/index.tsx
@@ -1,6 +1,13 @@
 import { useTranslate } from 'i18n-calypso';
-import DashboardModal from 'calypso/jetpack-cloud/sections/agency-dashboard/dashboard-modal';
+import JetpackLightbox, {
+	JetpackLightboxAside,
+	JetpackLightboxMain,
+} from 'calypso/components/jetpack/jetpack-lightbox';
+import useMobileSidebar from 'calypso/components/jetpack/jetpack-lightbox/hooks/use-mobile-sidebar';
+import LicenseInfo from './license-info';
 import type { SelectedLicenseProp } from '../types';
+
+import './style.scss';
 
 interface Props {
 	onClose: () => void;
@@ -10,13 +17,25 @@ interface Props {
 export default function ReviewLicenses( { onClose, selectedLicenses }: Props ) {
 	const translate = useTranslate();
 
+	const { sidebarRef, mainRef, initMobileSidebar } = useMobileSidebar();
+
 	return (
-		<DashboardModal
-			title={ translate( 'Review license selection' ) }
-			subtitle={ translate( 'You’re about to issue the following licenses:' ) }
-			onClose={ onClose }
-		>
-			{ selectedLicenses.length }
-		</DashboardModal>
+		<JetpackLightbox isOpen={ true } onClose={ onClose } onAfterOpen={ initMobileSidebar }>
+			<JetpackLightboxMain ref={ mainRef }>
+				<div className="review-licenses__header">
+					<div className="review-licenses__title">{ translate( 'Review license selection' ) }</div>
+					<div className="review-licenses__subtitle">
+						{ translate( 'You’re about to issue the following licenses:' ) }
+					</div>
+					<div className="review-licenses__selected-licenses">
+						{ selectedLicenses.map( ( license ) => (
+							<LicenseInfo product={ license } />
+						) ) }
+					</div>
+				</div>
+			</JetpackLightboxMain>
+
+			<JetpackLightboxAside ref={ sidebarRef }>Content</JetpackLightboxAside>
+		</JetpackLightbox>
 	);
 }

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/license-info.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/license-info.tsx
@@ -14,16 +14,16 @@ export default function LicenseInfo( { product }: { product: SelectedLicenseProp
 
 	return (
 		<div className="review-licenses__selected-license">
-			<div className="review-licenses__details">
-				<div className="review-licenses__icon">
+			<div className="review-licenses__license-details">
+				<div className="review-licenses__license-icon">
 					<img src={ getProductIcon( { productSlug: productInfo.productSlug } ) } alt={ title } />
 				</div>
-				<div className="review-licenses__text-content">
-					<div className="review-licenses__header">
-						<label htmlFor={ title } className="review-licenses__label">
+				<div className="review-licenses__license-text-content">
+					<div className="review-licenses__license-header">
+						<label htmlFor={ title } className="review-licenses__license-label">
 							{ title }
 						</label>
-						<span className="review-licenses__count">
+						<span className="review-licenses__license-count">
 							{ translate( '%(numLicenses)d license', '%(numLicenses)d licenses', {
 								context: 'button label',
 								count: product.quantity,
@@ -33,7 +33,9 @@ export default function LicenseInfo( { product }: { product: SelectedLicenseProp
 							} ) }
 						</span>
 					</div>
-					<p className="review-licenses__info">{ productInfo.lightboxDescription }</p>
+					<p className="review-licenses__license-description">
+						{ productInfo.lightboxDescription }
+					</p>
 				</div>
 			</div>
 		</div>

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/license-info.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/license-info.tsx
@@ -1,0 +1,41 @@
+import { useTranslate } from 'i18n-calypso';
+import getProductIcon from 'calypso/my-sites/plans/jetpack-plans/product-store/utils/get-product-icon';
+import { useLicenseLightboxData } from '../../license-lightbox/hooks/use-license-lightbox-data';
+import type { SelectedLicenseProp } from '../types';
+
+export default function LicenseInfo( { product }: { product: SelectedLicenseProp } ) {
+	const translate = useTranslate();
+
+	const { title, product: productInfo } = useLicenseLightboxData( product );
+
+	if ( ! productInfo ) {
+		return null;
+	}
+
+	return (
+		<div className="review-licenses__selected-license">
+			<div className="review-licenses__details">
+				<div className="review-licenses__icon">
+					<img src={ getProductIcon( { productSlug: productInfo.productSlug } ) } alt={ title } />
+				</div>
+				<div className="review-licenses__text-content">
+					<div className="review-licenses__header">
+						<label htmlFor={ title } className="review-licenses__label">
+							{ title }
+						</label>
+						<span className="review-licenses__count">
+							{ translate( '%(numLicenses)d license', '%(numLicenses)d licenses', {
+								context: 'button label',
+								count: product.quantity,
+								args: {
+									numLicenses: product.quantity,
+								},
+							} ) }
+						</span>
+					</div>
+					<p className="review-licenses__info">{ productInfo.lightboxDescription }</p>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/style.scss
@@ -17,11 +17,11 @@
 .review-licenses__selected-license {
 	margin-block-end: 24px;
 
-	.review-licenses__details {
+	.review-licenses__license-details {
 		display: flex;
 		gap: 14px;
 
-		.review-licenses__icon {
+		.review-licenses__license-icon {
 			display: none;
 			box-sizing: border-box;
 			width: 48px;
@@ -36,28 +36,28 @@
 			}
 		}
 
-		.review-licenses__icon > img {
+		.review-licenses__license-icon > img {
 			width: 22px;
 			height: auto;
 		}
 
 
-		.review-licenses__text-content {
+		.review-licenses__license-text-content {
 			width: 100%;
 		}
 
-		.review-licenses__header {
+		.review-licenses__license-header {
 			display: flex;
 			justify-content: space-between;
 			align-items: center;
 		}
 
-		.review-licenses__label {
+		.review-licenses__license-label {
 			font-size: rem(16px);
 			font-weight: 700;
 		}
 
-		.review-licenses__count {
+		.review-licenses__license-count {
 			background-color: var(--studio-gray-0);
 			padding: 5px 15px;
 			border-radius: 4px;
@@ -65,7 +65,7 @@
 
 		}
 
-		.review-licenses__info {
+		.review-licenses__license-description {
 			color: var(--studio-gray-70);
 			font-size: rem(16px);
 			font-weight: 400;

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/style.scss
@@ -1,0 +1,75 @@
+.review-licenses__title {
+	color: var(--studio-gray-100);
+	font-size: rem(24px);
+	font-weight: 700;
+}
+
+.review-licenses__subtitle {
+	color: var(--studio-gray-80);
+	font-size: rem(16px);
+	font-weight: 400;
+}
+
+.review-licenses__selected-licenses {
+	margin-block-start: 24px;
+}
+
+.review-licenses__selected-license {
+	margin-block-end: 24px;
+
+	.review-licenses__details {
+		display: flex;
+		gap: 14px;
+
+		.review-licenses__icon {
+			display: none;
+			box-sizing: border-box;
+			width: 48px;
+			height: 48px;
+			background: linear-gradient(159.87deg, #f6f6f4 7.24%, #f7f4ea 64.73%, #ddedd5 116.53%);
+			border-radius: 4px;
+
+			@media only screen and ( min-width: 821px ) {
+				display: flex;
+				align-items: center;
+				justify-content: center;
+			}
+		}
+
+		.review-licenses__icon > img {
+			width: 22px;
+			height: auto;
+		}
+
+
+		.review-licenses__text-content {
+			width: 100%;
+		}
+
+		.review-licenses__header {
+			display: flex;
+			justify-content: space-between;
+			align-items: center;
+		}
+
+		.review-licenses__label {
+			font-size: rem(16px);
+			font-weight: 700;
+		}
+
+		.review-licenses__count {
+			background-color: var(--studio-gray-0);
+			padding: 5px 15px;
+			border-radius: 4px;
+			font-weight: 500;
+
+		}
+
+		.review-licenses__info {
+			color: var(--studio-gray-70);
+			font-size: rem(16px);
+			font-weight: 400;
+			margin-block: 4px 0;
+		}
+	}
+}


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/97

## Proposed Changes

This PR displays the selected licenses in the review licenses modal.

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Visit the Jetpack Cloud link > Replace `dashboard` in the URL with `/partner-portal/issue-license?flags=jetpack/bundle-licensing`.
2. Select a few licenses and click the `Review X licenses` button > Verify that the selected licenses are displayed as shown below. Verify it displays well on all screen sizes.

Large screen view:

<img width="1123" alt="Screenshot 2023-11-23 at 9 22 37 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/52cb3276-2c86-4cbb-aa9a-fced9a809e5e">

Mobile view:

![mobile (43)](https://github.com/Automattic/wp-calypso/assets/10586875/98627c4a-3e4f-46fb-a630-6a48cd7f013b)

Tablet view:

![mobile (44)](https://github.com/Automattic/wp-calypso/assets/10586875/f42af07c-f0ae-40fa-b366-32413664c56b)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?