### PR TITLE
Fix double logo seen in Link in Bio Launchpad header

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -365,6 +365,14 @@
 	}
 }
 
+// Link in Bio flow
+.link-in-bio-tld.launchpad {
+	padding: 0;
+	.signup-header {
+		display: none;
+	}
+}
+
 // Write and Build flow
 .write.launchpad,
 .build.launchpad {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->



## Proposed Changes

This fixes an issue with the header in the Launchpad for the Link in Bio flow showing the logo twice. This bug came with the CSS changes introduced in https://github.com/Automattic/wp-calypso/pull/84318.

### BEFORE

<img width="1718" alt="Screenshot 2023-11-23 at 12 22 45 PM" src="https://github.com/Automattic/wp-calypso/assets/1269602/13b81ef2-9da5-428a-be2f-eff0274dd49a">


### AFTER

<img width="1678" alt="Screenshot 2023-11-23 at 12 22 35 PM" src="https://github.com/Automattic/wp-calypso/assets/1269602/2e25078d-0373-49a6-82fd-125d14192263">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* First verify that the testing instructions in https://github.com/Automattic/wp-calypso/pull/84318 work well.
* Next, complete all steps in the link in bio flow till you reach the Launcpage and verify that the Launchpad does not show two logos.

