### PR TITLE
Jetpack Manage: Add stepper and fix sticky header responsive issue.

### DIFF
--- a/client/jetpack-cloud/components/layout/style.scss
+++ b/client/jetpack-cloud/components/layout/style.scss
@@ -71,6 +71,7 @@
 	margin: auto;
 	height: 100%;
 
+
 	> * + * {
 		margin-inline-start: 24px;
 	}
@@ -91,14 +92,47 @@
 
 .jetpack-cloud-layout__sticky-header {
 	position: fixed;
-	width: calc(100% - var(--sidebar-width-max));
-	left: var(--sidebar-width-max);
+	width: calc(100%);
+	left: 0;
 	top: var(--masterbar-height);
 	background-color: rgba(246, 247, 247, 0.95);
 	box-shadow: 2px 2px 2px 0 rgb(0 0 0 / 8%);
 	z-index: 1001;
 	height: 74px;
 
+	.jetpack-cloud-layout__header {
+		flex-wrap: nowrap;
+		max-width: 1500px;
+		padding-inline: 48px;
+
+		> * {
+			width: auto;
+		}
+	}
+
+	.jetpack-cloud-layout__header-main,
+	.jetpack-cloud-layout__header-actions {
+		margin: 0;
+	}
+
+	.jetpack-cloud-layout__header-subtitle {
+		display: none;
+	}
+
+	.jetpack-cloud-layout__header-title {
+		font-size: rem(24px);
+		margin-block-end: 0;
+	}
+
+	@include breakpoint-deprecated( ">660px" ) {
+		width: calc(100% - var(--sidebar-width-min));
+		left: var(--sidebar-width-min);
+	}
+
+	@include breakpoint-deprecated( ">960px" ) {
+		width: calc(100% - var(--sidebar-width-max));
+		left: var(--sidebar-width-max);
+	}
 }
 
 .jetpack-cloud-layout__header-title {

--- a/client/jetpack-cloud/sections/partner-portal/assign-license-step-progress/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-step-progress/index.tsx
@@ -33,7 +33,12 @@ function CheckMarkOrNumber( { currentStep, step }: { currentStep: number; step: 
 	);
 }
 
-type StepKey = 'issueLicense' | 'addPaymentMethod' | 'assignLicense' | 'downloadProducts';
+type StepKey =
+	| 'issueLicense'
+	| 'reviewLicense'
+	| 'addPaymentMethod'
+	| 'assignLicense'
+	| 'downloadProducts';
 
 interface Step {
 	key: StepKey;
@@ -44,21 +49,42 @@ interface Props {
 	currentStep: StepKey;
 	selectedSite?: SiteDetails | null;
 	showDownloadStep?: boolean;
+	isBundleLicensing?: boolean;
 }
 
-const AssignLicenseStepProgress = ( { currentStep, selectedSite, showDownloadStep }: Props ) => {
+const AssignLicenseStepProgress = ( {
+	currentStep,
+	selectedSite,
+	showDownloadStep,
+	isBundleLicensing,
+}: Props ) => {
 	const translate = useTranslate();
 	const paymentMethodRequired = useSelector( doesPartnerRequireAPaymentMethod );
 	const sites = useSelector( getSites ).length;
 
-	const steps: Step[] = [ { key: 'issueLicense', label: translate( 'Issue new license' ) } ];
+	const steps: Step[] = [
+		{
+			key: 'issueLicense',
+			label: isBundleLicensing ? translate( 'Select licenses' ) : translate( 'Issue new license' ),
+		},
+	];
+
+	if ( isBundleLicensing ) {
+		steps.push( {
+			key: 'reviewLicense',
+			label: translate( 'Review selections' ),
+		} );
+	}
 
 	if ( paymentMethodRequired ) {
 		steps.push( { key: 'addPaymentMethod', label: translate( 'Add Payment Method' ) } );
 	}
 
 	if ( sites > 0 && ! selectedSite ) {
-		steps.push( { key: 'assignLicense', label: translate( 'Assign license' ) } );
+		steps.push( {
+			key: 'assignLicense',
+			label: isBundleLicensing ? translate( 'Assign licenses' ) : translate( 'Assign license' ),
+		} );
 	}
 
 	if ( showDownloadStep ) {

--- a/client/jetpack-cloud/sections/partner-portal/assign-license-step-progress/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-step-progress/index.tsx
@@ -83,7 +83,7 @@ const AssignLicenseStepProgress = ( {
 	if ( sites > 0 && ! selectedSite ) {
 		steps.push( {
 			key: 'assignLicense',
-			label: isBundleLicensing ? translate( 'Assign licenses' ) : translate( 'Assign license' ),
+			label: translate( 'Assign licenses' ),
 		} );
 	}
 

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/index.tsx
@@ -14,6 +14,7 @@ import LayoutNavigation, {
 	LayoutNavigationItem as NavigationItem,
 } from 'calypso/jetpack-cloud/components/layout/nav';
 import LayoutTop from 'calypso/jetpack-cloud/components/layout/top';
+import AssignLicenseStepProgress from '../assign-license-step-progress';
 import IssueLicenseContext from './context';
 import { useProductBundleSize } from './hooks/use-product-bundle-size';
 import useSubmitForm from './hooks/use-submit-form';
@@ -68,6 +69,8 @@ export default function IssueLicenseV2( { selectedSite, suggestedProduct }: Assi
 			.flat();
 	}, [ selectedLicenses ] );
 
+	const currentStep = showReviewLicenses ? 'reviewLicense' : 'issueLicense';
+
 	return (
 		<>
 			<Layout
@@ -77,6 +80,8 @@ export default function IssueLicenseV2( { selectedSite, suggestedProduct }: Assi
 				withBorder
 			>
 				<LayoutTop>
+					<AssignLicenseStepProgress currentStep={ currentStep } isBundleLicensing />
+
 					<LayoutHeader showStickyContent={ showStickyContent }>
 						<Title>{ translate( 'Issue product licenses' ) } </Title>
 						<Subtitle>

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/index.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@automattic/components';
-import { isWithinBreakpoint } from '@automattic/viewport';
 import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
@@ -53,7 +52,7 @@ export default function IssueLicenseV2( { selectedSite, suggestedProduct }: Assi
 		handleShowLicenseOverview();
 	}, [ handleShowLicenseOverview ] );
 
-	const showStickyContent = isWithinBreakpoint( '>960px' ) && selectedLicenses.length > 0;
+	const showStickyContent = selectedLicenses.length > 0;
 
 	// Group licenses by slug and sort them by quantity
 	const getGroupedLicenses = useCallback( () => {

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/style.scss
@@ -28,3 +28,14 @@
 		flex-grow: 1;
 	}
 }
+
+.issue-license-v2 .assign-license-step-progress {
+	margin-block-start: 16px;
+	margin-block-end: 32px;
+
+	.step-current .assign-license-step-progress__step-circle {
+		background-color: var(--studio-jetpack-green-50);
+		border: 2px solid var(--studio-jetpack-green-50);
+		color: var(--studio-white);
+	}
+}

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/style.scss
@@ -1,23 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-.jetpack-cloud-layout__sticky-header {
-
-	.jetpack-cloud-layout__header-subtitle {
-		display: none;
-	}
-
-	.jetpack-cloud-layout__header-title {
-		margin-inline-start: 48px;
-		font-size: rem(24px);
-		margin-block-end: 0;
-	}
-
-	.jetpack-cloud-layout__header-actions {
-		margin-inline-end: 48px;
-	}
-}
-
 .issue-license-v2__select-license {
 	// :active introduces a 1px border but :focus introduces a 1.5px border which causes the button to move around.
 	border-width: 1.5px !important;


### PR DESCRIPTION
This pull request updates the header to include a stepper, which was previously missing. Additionally, the pull request addresses the issue with the sticky header breaking on certain screen sizes and updates some styling rules to fix this.

**Before**

https://github.com/Automattic/wp-calypso/assets/56598660/cebd7c29-67b2-4b9c-9764-38b837b869df


**After**

https://github.com/Automattic/wp-calypso/assets/56598660/40ce1138-a365-4c83-85c5-830b6d8d9599



Closes https://github.com/Automattic/jetpack-genesis/issues/105

## Proposed Changes

* Update the `AssignLicenseStepProgress` component to handle the copies and new review steps from the new design.
* Update the Issue license page to reuse `AssignLicenseStepProgress` and override specific styling.
* Update styling rules for the sticky header to address issues with some screen sizes.

## Testing Instructions

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

* Use the Jetpack cloud live link below and go to the Licenses page (`/partner-portal/issue-license?flags=jetpack/bundle-licensing`)
* Confirm that the stepper is now visible in the header section.
* Select some licenses and press the review licenses button. Confirm that the stepper moves to the next step.
* Finally, confirm that the sticky header works with any screen size.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?