### PR TITLE
SegmentedControl to packages (Step 3): Update references to use new package component

### DIFF
--- a/apps/odyssey-stats/src/widget/highlights.tsx
+++ b/apps/odyssey-stats/src/widget/highlights.tsx
@@ -1,10 +1,9 @@
-import { formattedNumber } from '@automattic/components';
+import { formattedNumber, SegmentedControl } from '@automattic/components';
 import { Icon, external } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import moment from 'moment';
 import { useState, FunctionComponent } from 'react';
-import SegmentedControl from 'calypso/components/segmented-control';
 import useReferrersQuery from '../hooks/use-referrers-query';
 import useTopPostsQuery from '../hooks/use-top-posts-query';
 import { HighLightItem } from '../typings';

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -1,4 +1,4 @@
-import { Button, Gridicon } from '@automattic/components';
+import { Button, Gridicon, SegmentedControl } from '@automattic/components';
 import classnames from 'classnames';
 import { translate } from 'i18n-calypso';
 import { get, size, delay, pickBy } from 'lodash';
@@ -7,7 +7,6 @@ import { Component, createRef } from 'react';
 import { connect } from 'react-redux';
 import ConversationFollowButton from 'calypso/blocks/conversation-follow-button';
 import { shouldShowConversationFollowButton } from 'calypso/blocks/conversation-follow-button/helper';
-import SegmentedControl from 'calypso/components/segmented-control';
 import ReaderFollowConversationIcon from 'calypso/reader/components/icons/follow-conversation-icon';
 import ReaderFollowingConversationIcon from 'calypso/reader/components/icons/following-conversation-icon';
 import { recordAction, recordGaEvent, recordTrackForPost } from 'calypso/reader/stats';

--- a/client/blocks/jetpack-review-prompt/docs/example.tsx
+++ b/client/blocks/jetpack-review-prompt/docs/example.tsx
@@ -1,8 +1,7 @@
-import { Button, Card } from '@automattic/components';
+import { Button, Card, SegmentedControl } from '@automattic/components';
 import { FunctionComponent, useState } from 'react';
 import JetpackReviewPrompt from 'calypso/blocks/jetpack-review-prompt';
 import CardHeading from 'calypso/components/card-heading';
-import SegmentedControl from 'calypso/components/segmented-control';
 import { useSelector, useDispatch } from 'calypso/state';
 import { setValidFrom } from 'calypso/state/jetpack-review-prompt/actions';
 import { PREFERENCE_NAME } from 'calypso/state/jetpack-review-prompt/constants';

--- a/client/blocks/reader-site-notification-settings/index.jsx
+++ b/client/blocks/reader-site-notification-settings/index.jsx
@@ -1,3 +1,4 @@
+import { SegmentedControl } from '@automattic/components';
 import { Button, ToggleControl } from '@wordpress/components';
 import { Icon, settings } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
@@ -7,7 +8,6 @@ import { createRef, Component } from 'react';
 import { connect } from 'react-redux';
 import Settings from 'calypso/assets/images/icons/settings.svg';
 import QueryUserSettings from 'calypso/components/data/query-user-settings';
-import SegmentedControl from 'calypso/components/segmented-control';
 import SVGIcon from 'calypso/components/svg-icon';
 import ReaderPopover from 'calypso/reader/components/reader-popover';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';

--- a/client/blocks/stats-navigation/intervals.js
+++ b/client/blocks/stats-navigation/intervals.js
@@ -1,8 +1,8 @@
+import { SegmentedControl } from '@automattic/components';
 import { Icon } from '@wordpress/icons';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import SegmentedControl from 'calypso/components/segmented-control';
 import { intervals } from './constants';
 
 import './intervals.scss';

--- a/client/components/advanced-credentials/credentials-form/index.tsx
+++ b/client/components/advanced-credentials/credentials-form/index.tsx
@@ -1,4 +1,4 @@
-import { Button, FormInputValidation, Gridicon } from '@automattic/components';
+import { Button, FormInputValidation, Gridicon, SegmentedControl } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent, useState, FormEventHandler } from 'react';
 import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
@@ -10,7 +10,6 @@ import FormSettingExplanation from 'calypso/components/forms/form-setting-explan
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import FormTextArea from 'calypso/components/forms/form-textarea';
 import InfoPopover from 'calypso/components/info-popover';
-import SegmentedControl from 'calypso/components/segmented-control';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { FormState, FormMode, FormErrors, INITIAL_FORM_INTERACTION } from '../form';

--- a/client/components/jetpack/threat-history-list/threat-status-filter.tsx
+++ b/client/components/jetpack/threat-history-list/threat-status-filter.tsx
@@ -1,5 +1,5 @@
+import { SimplifiedSegmentedControl } from '@automattic/components';
 import * as React from 'react';
-import SimplifiedSegmentedControl from 'calypso/components/segmented-control/simplified';
 
 import './style.scss';
 

--- a/client/components/post-schedule/clock.jsx
+++ b/client/components/post-schedule/clock.jsx
@@ -1,3 +1,4 @@
+import { SegmentedControl } from '@automattic/components';
 import { isMobile } from '@automattic/viewport';
 import { localize } from 'i18n-calypso';
 import { flowRight as compose } from 'lodash';
@@ -7,7 +8,6 @@ import { connect } from 'react-redux';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import InfoPopover from 'calypso/components/info-popover';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
-import SegmentedControl from 'calypso/components/segmented-control';
 import getSiteSetting from 'calypso/state/selectors/get-site-setting';
 import {
 	is12hr,

--- a/client/components/section-nav/segmented.jsx
+++ b/client/components/section-nav/segmented.jsx
@@ -1,7 +1,7 @@
+import { SegmentedControl } from '@automattic/components';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import { Children, Component } from 'react';
-import SegmentedControl from 'calypso/components/segmented-control';
 
 import './segmented.scss';
 
@@ -27,7 +27,6 @@ class NavSegmented extends Component {
 
 				<SegmentedControl>{ this.getControlItems() }</SegmentedControl>
 			</div>
-			/* eslint-enable wpcalyspo/jsx-classname-namespace */
 		);
 	}
 

--- a/client/landing/subscriptions/components/settings/site-settings/delivery-frequency-input.tsx
+++ b/client/landing/subscriptions/components/settings/site-settings/delivery-frequency-input.tsx
@@ -1,8 +1,8 @@
+import { SegmentedControl } from '@automattic/components';
 import { Reader, SubscriptionManager } from '@automattic/data-stores';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
-import SegmentedControl from 'calypso/components/segmented-control';
 
 type DeliveryFrequencyOptionProps = {
 	children: React.ReactNode;

--- a/client/my-sites/comments/comment-navigation/index.jsx
+++ b/client/my-sites/comments/comment-navigation/index.jsx
@@ -1,4 +1,4 @@
-import { Button, Count, Gridicon } from '@automattic/components';
+import { Button, Count, Gridicon, SegmentedControl } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { get, includes, isEqual, map } from 'lodash';
 import { Component } from 'react';
@@ -9,7 +9,6 @@ import Search from 'calypso/components/search';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
-import SegmentedControl from 'calypso/components/segmented-control';
 import UrlSearch from 'calypso/lib/url-search';
 import {
 	bumpStat,

--- a/client/my-sites/email/email-providers-comparison/billing-interval-toggle/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/billing-interval-toggle/index.tsx
@@ -1,7 +1,6 @@
-import { Popover } from '@automattic/components';
+import { Popover, SegmentedControl } from '@automattic/components';
 import { useState } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
-import SegmentedControl from 'calypso/components/segmented-control';
 import { IntervalLength } from 'calypso/my-sites/email/email-providers-comparison/interval-length';
 
 import './style.scss';

--- a/client/my-sites/media-library/scale.jsx
+++ b/client/my-sites/media-library/scale.jsx
@@ -1,11 +1,10 @@
-import { Gridicon } from '@automattic/components';
+import { Gridicon, SegmentedControl } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { debounce } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import FormRange from 'calypso/components/forms/range';
-import SegmentedControl from 'calypso/components/segmented-control';
 import { SCALE_CHOICES, SCALE_TOUCH_GRID } from 'calypso/lib/media/constants';
 import { setPreference, savePreference } from 'calypso/state/preferences/actions';
 

--- a/client/my-sites/plans-features-main/components/plan-interval-selector/index.tsx
+++ b/client/my-sites/plans-features-main/components/plan-interval-selector/index.tsx
@@ -1,5 +1,5 @@
+import { SegmentedControl } from '@automattic/components';
 import classNames from 'classnames';
-import SegmentedControl from 'calypso/components/segmented-control';
 import type { ReactNode } from 'react';
 
 import './style.scss';

--- a/client/my-sites/promote-post-i2/components/campaigns-filter/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaigns-filter/index.tsx
@@ -1,6 +1,6 @@
+import { SegmentedControl } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useRef } from 'react';
-import SegmentedControl from 'calypso/components/segmented-control';
 
 export type CampaignsFilterType = '' | 'active' | 'created' | 'finished' | 'rejected';
 

--- a/client/my-sites/site-monitoring/components/time-range-picker/index.jsx
+++ b/client/my-sites/site-monitoring/components/time-range-picker/index.jsx
@@ -1,7 +1,7 @@
+import { SegmentedControl } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import moment from 'moment';
 import { useState } from 'react';
-import SegmentedControl from 'calypso/components/segmented-control';
 
 import './style.scss';
 

--- a/client/my-sites/stats/all-time-views-section/index.tsx
+++ b/client/my-sites/stats/all-time-views-section/index.tsx
@@ -1,9 +1,8 @@
-import { Card } from '@automattic/components';
+import { Card, SimplifiedSegmentedControl } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo, useState } from 'react';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
-import SimplifiedSegmentedControl from 'calypso/components/segmented-control/simplified';
 import { useSelector } from 'calypso/state';
 import { getSiteStatsViewSummary } from 'calypso/state/stats/lists/selectors';
 import StatsHeatMapLegend from '../stats-heap-map/legend';

--- a/client/my-sites/stats/post-detail-table-section/index.tsx
+++ b/client/my-sites/stats/post-detail-table-section/index.tsx
@@ -1,7 +1,6 @@
-import { Card } from '@automattic/components';
+import { Card, SimplifiedSegmentedControl } from '@automattic/components';
 import { translate } from 'i18n-calypso';
 import { useState } from 'react';
-import SimplifiedSegmentedControl from 'calypso/components/segmented-control/simplified';
 import PostMonths from '../stats-detail-months';
 import PostWeeks from '../stats-detail-weeks';
 import StatsHeatMapLegend from '../stats-heap-map/legend';

--- a/client/my-sites/stats/stats-comments/index.jsx
+++ b/client/my-sites/stats/stats-comments/index.jsx
@@ -1,3 +1,4 @@
+import { SimplifiedSegmentedControl } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
 import { get, flowRight } from 'lodash';
@@ -5,7 +6,6 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
-import SimplifiedSegmentedControl from 'calypso/components/segmented-control/simplified';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import {

--- a/client/my-sites/stats/stats-followers/index.jsx
+++ b/client/my-sites/stats/stats-followers/index.jsx
@@ -1,11 +1,11 @@
 import config from '@automattic/calypso-config';
+import { SimplifiedSegmentedControl } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
 import { flowRight, get } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
-import SimplifiedSegmentedControl from 'calypso/components/segmented-control/simplified';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import {

--- a/client/my-sites/stats/stats-module/all-time-nav.jsx
+++ b/client/my-sites/stats/stats-module/all-time-nav.jsx
@@ -1,11 +1,10 @@
-import { ComponentSwapper } from '@automattic/components';
+import { ComponentSwapper, SegmentedControl } from '@automattic/components';
 import { Icon, lock } from '@wordpress/icons';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { flowRight, find, get } from 'lodash';
 import moment from 'moment';
 import { connect, useDispatch } from 'react-redux';
-import SegmentedControl from 'calypso/components/segmented-control';
 import SelectDropdown from 'calypso/components/select-dropdown';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { getSiteSlug } from 'calypso/state/sites/selectors';

--- a/client/my-sites/stats/stats-post-summary/index.jsx
+++ b/client/my-sites/stats/stats-post-summary/index.jsx
@@ -1,3 +1,4 @@
+import { SegmentedControl } from '@automattic/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -5,7 +6,6 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import QueryPostStats from 'calypso/components/data/query-post-stats';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
-import SegmentedControl from 'calypso/components/segmented-control';
 import { getPostStats, isRequestingPostStats } from 'calypso/state/stats/posts/selectors';
 import DatePicker from '../stats-date-picker';
 import StatsPeriodHeader from '../stats-period-header';

--- a/client/post-editor/editor-revisions-list/view-buttons.jsx
+++ b/client/post-editor/editor-revisions-list/view-buttons.jsx
@@ -1,7 +1,7 @@
+import { SegmentedControl } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import SegmentedControl from 'calypso/components/segmented-control';
 import {
 	splitPostRevisionsDiffView,
 	unifyPostRevisionsDiffView,

--- a/client/post-editor/media-modal/gallery/preview.jsx
+++ b/client/post-editor/media-modal/gallery/preview.jsx
@@ -1,8 +1,8 @@
+import { SegmentedControl } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import Notice from 'calypso/components/notice';
-import SegmentedControl from 'calypso/components/segmented-control';
 import EditorMediaModalGalleryEdit from './edit';
 import EditorMediaModalGalleryPreviewIndividual from './preview-individual';
 import EditorMediaModalGalleryPreviewShortcode from './preview-shortcode';

--- a/client/reader/discover/discover-navigation.js
+++ b/client/reader/discover/discover-navigation.js
@@ -1,11 +1,10 @@
 import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
-import { Button, Gridicon } from '@automattic/components';
+import { Button, Gridicon, SegmentedControl } from '@automattic/components';
 import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
 import { throttle } from 'lodash';
 import { useRef } from 'react';
-import SegmentedControl from 'calypso/components/segmented-control';
 import { addQueryArgs } from 'calypso/lib/url';
 import { recordAction, recordGaEvent } from 'calypso/reader/stats';
 import { WIDE_DISPLAY_CUTOFF } from 'calypso/reader/stream';

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -1,5 +1,5 @@
 import page from '@automattic/calypso-router';
-import { CompactCard } from '@automattic/components';
+import { CompactCard, SegmentedControl } from '@automattic/components';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { trim, flatMap } from 'lodash';
@@ -9,7 +9,6 @@ import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import NavigationHeader from 'calypso/components/navigation-header';
 import SearchInput from 'calypso/components/search';
-import SegmentedControl from 'calypso/components/segmented-control';
 import { addQueryArgs } from 'calypso/lib/url';
 import withDimensions from 'calypso/lib/with-dimensions';
 import BlankSuggestions from 'calypso/reader/components/reader-blank-suggestions';

--- a/client/reader/tag-stream/header.jsx
+++ b/client/reader/tag-stream/header.jsx
@@ -1,4 +1,5 @@
 import page from '@automattic/calypso-router';
+import { SegmentedControl } from '@automattic/components';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -7,7 +8,6 @@ import { connect } from 'react-redux';
 import FollowButton from 'calypso/blocks/follow-button/button';
 import BloganuaryHeader from 'calypso/components/bloganuary-header';
 import NavigationHeader from 'calypso/components/navigation-header';
-import SegmentedControl from 'calypso/components/segmented-control';
 import { addQueryArgs } from 'calypso/lib/url';
 import ReaderFollowFeedIcon from 'calypso/reader/components/icons/follow-feed-icon';
 import ReaderFollowingFeedIcon from 'calypso/reader/components/icons/following-feed-icon';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/81117

We should wait for https://github.com/Automattic/wp-calypso/pull/83646 to sit in production for several days before merging this PR. It will allow us to see if there were any problems with our migration.

## Proposed Changes

- Repoints any references to `SegmentedControl` from Calypso components to `@automattic/components`
- This is a change that touches many files. We effectively made this change in the background with https://github.com/Automattic/wp-calypso/pull/84100, so all `SegmentedControl` components are running the new/relocated code already. This PR repoints the reference from the wrapper to the "real" code, so I don't expect this to cause any issues.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Make sure tests pass.
- Do a spot-check of `SegmentedControl` instances to ensure they still look/work as expected. See https://github.com/Automattic/wp-calypso/pull/84100 for some examples.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?