### PR TITLE
SegmentedControl to packages (Step 4): Remove SegmentedControl component shim

### DIFF
--- a/client/components/button-group/README.md
+++ b/client/components/button-group/README.md
@@ -22,13 +22,13 @@ function render() {
 ### General guidelines
 
 - Follow the same guidelines as the [Button](./buttons) component.
-- To manipulate or switch visible content, use the [SegmentedControl](./segmented-control) component instead.
+- To manipulate or switch visible content, use the [SegmentedControl](/packages/components/segmented-control) component instead.
 - Group together actions that have a relationship.
 - Be thoughtful about how multiple horizontally placed buttons will look and work on small screens.
 
 ## Related components
 
 - See the [Button](./buttons) component for more detail.
-- Use the [SegmentedControl](./segmented-control) component to switch content.
+- Use the [SegmentedControl](/packages/components/segmented-control) component to switch content.
 - To use a button with a secondary popover menu, use the [SplitButton](./split-button) component.
 - To display a loading spinner with a button, use the [SpinnerButton](../design/spinner-button) component.

--- a/client/components/pagination/README.md
+++ b/client/components/pagination/README.md
@@ -33,4 +33,4 @@ function render() {
 ## Related components
 
 - To group buttons together, use the [ButtonGroup](./button-group) component.
-- To use show/hide certain content, use the [SegmentedControl](./segmented-control) component.
+- To use show/hide certain content, use the [SegmentedControl](/packages/components/segmented-control) component.

--- a/client/components/section-nav/README.md
+++ b/client/components/section-nav/README.md
@@ -118,7 +118,7 @@ Text displayed above tabs group when:
 
 ## Nav Segmented
 
-The segmented sub component utilizes [`SegmentedControl`](/client/components/segmented-control) to display `NavItems` inline.
+The segmented sub component utilizes [`SegmentedControl`](/packages/components/segmented-control) to display `NavItems` inline.
 
 ![Nav Segmented Example](https://cldup.com/tPEfoQ78pR.png)
 

--- a/client/components/segmented-control/index.jsx
+++ b/client/components/segmented-control/index.jsx
@@ -1,7 +1,0 @@
-import { SegmentedControl } from '@automattic/components';
-
-// We're in the process of migrating to @automattic/components. Because of this, we're using this wrapper
-// component to point references to the old SegmentedControl component to the new one in @automattic/components.
-// This allows us to transition in smaller pieces and without risking updates to the old Calypso component in the interim.
-
-export default SegmentedControl;

--- a/client/components/segmented-control/simplified.jsx
+++ b/client/components/segmented-control/simplified.jsx
@@ -1,7 +1,0 @@
-import { SimplifiedSegmentedControl } from '@automattic/components';
-
-// We're in the process of migrating to @automattic/components. Because of this, we're using this wrapper
-// component to point references to the old SimplifiedSegmentedControl component to the new one in @automattic/components.
-// This allows us to transition in smaller pieces and without risking updates to the old Calypso component in the interim.
-
-export default SimplifiedSegmentedControl;

--- a/client/my-sites/promote-post-i2/components/search-bar/index.tsx
+++ b/client/my-sites/promote-post-i2/components/search-bar/index.tsx
@@ -1,10 +1,9 @@
 import config from '@automattic/calypso-config';
-import { SelectDropdown } from '@automattic/components';
+import { SelectDropdown, SegmentedControl } from '@automattic/components';
 import Search, { SearchIcon } from '@automattic/search';
 import { useMediaQuery } from '@wordpress/compose';
 import { translate } from 'i18n-calypso';
 import React, { useEffect, useRef } from 'react';
-import SegmentedControl from 'calypso/components/segmented-control';
 import CampaignsFilter, { CampaignsFilterType } from '../campaigns-filter';
 import './style.scss';
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/81117

## Proposed Changes

Following up on https://github.com/Automattic/wp-calypso/pull/84461, there are no more `client/components/segmented-control` or `client/components/segmented-control/simplified` references in Calypso. All instances of the SegmentedControl component are now imported from @automattic/components.

Because of this, we remove the unused `client/components/segmented-control` directory and contents.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Smoke test instances of the SegmentedControl component (see https://github.com/Automattic/wp-calypso/pull/84100)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?