### PR TITLE
jcl/partner-portal: remove `onError` from query hook

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/invoices-list/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/invoices-list/index.tsx
@@ -1,11 +1,13 @@
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { memo, useCallback, useState } from 'react';
+import { memo, useCallback, useEffect, useState } from 'react';
 import Pagination from 'calypso/components/pagination';
 import { useCursorPagination } from 'calypso/jetpack-cloud/sections/partner-portal/hooks';
 import InvoicesListCard from 'calypso/jetpack-cloud/sections/partner-portal/invoices-list-card';
 import InvoicesListRow from 'calypso/jetpack-cloud/sections/partner-portal/invoices-list-row';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
+import { useDispatch } from 'calypso/state';
+import { errorNotice } from 'calypso/state/notices/actions';
 import useInvoicesQuery from 'calypso/state/partner-portal/invoices/hooks/use-invoices-query';
 
 import './style.scss';
@@ -38,8 +40,20 @@ const InvoicePlaceholderCard = memo( () => {
 
 export default function InvoicesList() {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 	const [ pagination, setPagination ] = useState( { starting_after: '', ending_before: '' } );
 	const invoices = useInvoicesQuery( pagination );
+
+	useEffect( () => {
+		if ( invoices.isError ) {
+			dispatch(
+				errorNotice( translate( 'We were unable to retrieve your invoices.' ), {
+					id: 'partner-portal-invoices-failure',
+				} )
+			);
+		}
+	}, [ dispatch, translate, invoices.isError ] );
+
 	const hasMore = invoices.isSuccess ? invoices.data.hasMore : false;
 	const onNavigateCallback = useCallback(
 		( page: number, direction: 'next' | 'prev' ) => {

--- a/client/jetpack-cloud/sections/partner-portal/invoices-list/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/invoices-list/index.tsx
@@ -49,6 +49,7 @@ export default function InvoicesList() {
 			dispatch(
 				errorNotice( translate( 'We were unable to retrieve your invoices.' ), {
 					id: 'partner-portal-invoices-failure',
+					duration: 5000,
 				} )
 			);
 		}

--- a/client/state/partner-portal/invoices/hooks/use-invoices-query.ts
+++ b/client/state/partner-portal/invoices/hooks/use-invoices-query.ts
@@ -4,11 +4,9 @@ import {
 	UseQueryResult,
 	QueryFunctionContext,
 } from '@tanstack/react-query';
-import { useTranslate } from 'i18n-calypso';
 import { addQueryArgs } from 'calypso/lib/url';
 import { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
-import { useDispatch, useSelector } from 'calypso/state';
-import { errorNotice } from 'calypso/state/notices/actions';
+import { useSelector } from 'calypso/state';
 import { getActivePartnerKeyId } from 'calypso/state/partner-portal/partner/selectors';
 import type { APIInvoices, Invoices } from 'calypso/state/partner-portal/types';
 
@@ -51,8 +49,6 @@ export default function useInvoicesQuery(
 	pagination: Pagination,
 	options?: UseQueryOptions< APIInvoices, QueryError, Invoices >
 ): UseQueryResult< Invoices, QueryError > {
-	const translate = useTranslate();
-	const dispatch = useDispatch();
 	const activeKeyId = useSelector( getActivePartnerKeyId );
 
 	return useQuery< APIInvoices, QueryError, Invoices >( {
@@ -60,13 +56,6 @@ export default function useInvoicesQuery(
 		queryFn: queryInvoices,
 		refetchOnWindowFocus: false,
 		select: selectInvoices,
-		onError: () => {
-			dispatch(
-				errorNotice( translate( 'We were unable to retrieve your invoices.' ), {
-					id: 'partner-portal-invoices-failure',
-				} )
-			);
-		},
 		...options,
 	} );
 }

--- a/client/state/partner-portal/invoices/test/hooks.js
+++ b/client/state/partner-portal/invoices/test/hooks.js
@@ -70,42 +70,6 @@ describe( 'useInvoicesQuery', () => {
 
 		expect( result.current.data ).toEqual( formattedStub );
 	} );
-
-	it( 'dispatches notice on error', async () => {
-		const queryClient = createQueryClient();
-		const wrapper = ( { children } ) => (
-			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
-		);
-
-		nock( 'https://public-api.wordpress.com' )
-			.get( '/wpcom/v2/jetpack-licensing/partner/invoices?starting_after=&ending_before=' )
-			.reply( 403 );
-
-		const dispatch = jest.fn();
-		useDispatch.mockReturnValue( dispatch );
-
-		const { result } = renderHook(
-			() =>
-				useInvoicesQuery(
-					{
-						starting_after: '',
-						ending_before: '',
-					},
-					{ retry: false }
-				),
-			{
-				wrapper,
-			}
-		);
-
-		await waitFor( () => expect( result.current.isError ).toBe( true ) );
-
-		expect( dispatch.mock.calls[ 0 ][ 0 ].type ).toBe( 'NOTICE_CREATE' );
-		expect( dispatch.mock.calls[ 0 ][ 0 ].notice.noticeId ).toBe(
-			'partner-portal-invoices-failure'
-		);
-		expect( dispatch.mock.calls[ 0 ][ 0 ].notice.status ).toBe( 'is-error' );
-	} );
 } );
 
 describe( 'usePayInvoiceMutation', () => {


### PR DESCRIPTION
Related to #84338

## Proposed Changes

* Remove `onError` callback from `useQuery` as they're removed with the v5 update

## Testing Instructions

**Note**: You need a partner account for this to work.

Run `yarn start-jetpack-cloud` locally or use the JCL calypso.live link below:

1. Block network requests to `/jetpack-licensing/partner/invoices` (via Browser devtools)
2. Go to `/partner-portal/invoices`
3. Verify after the 3rd retry you see an error notice