### PR TITLE
tests: fix `launchpad` tests to avoid mocking `useQuery`

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/index.tsx
@@ -2,8 +2,7 @@
  * @jest-environment jsdom
  */
 import config from '@automattic/calypso-config';
-import { Site } from '@automattic/data-stores';
-import * as ReactQuery from '@tanstack/react-query';
+import { Site, useLaunchpad } from '@automattic/data-stores';
 import { useDispatch } from '@wordpress/data';
 import nock from 'nock';
 import React from 'react';
@@ -37,6 +36,13 @@ jest.mock( 'calypso/state/sites/hooks/use-site-global-styles-status', () => ( {
 	useSiteGlobalStylesStatus: () => ( {
 		shouldLimitGlobalStyles: false,
 		globalStylesInUse: false,
+	} ),
+} ) );
+
+jest.mock( '@automattic/data-stores', () => ( {
+	...jest.requireActual( '@automattic/data-stores' ),
+	useLaunchpad: jest.fn( () => {
+		return jest.requireActual( '@automattic/data-stores' ).useLaunchpad();
 	} ),
 } ) );
 
@@ -134,13 +140,10 @@ describe( 'Launchpad', () => {
 	describe( 'when loading the Launchpad view', () => {
 		describe( 'and the site is launchpad enabled', () => {
 			it( 'does not redirect', () => {
-				jest
-					.spyOn( ReactQuery, 'useQuery' )
-					.mockImplementation(
-						jest
-							.fn()
-							.mockReturnValue( { ...MOCK_USE_QUERY_RESULT, data: { launchpad_screen: 'full' } } )
-					);
+				( useLaunchpad as jest.Mock ).mockReturnValueOnce( {
+					...MOCK_USE_QUERY_RESULT,
+					data: { launchpad_screen: 'full' },
+				} );
 				const initialReduxState = { currentUser: { id: user.ID } };
 				renderLaunchpad( props, defaultSiteDetails, initialReduxState, siteSlug );
 				expect( replaceMock ).not.toHaveBeenCalled();
@@ -149,13 +152,10 @@ describe( 'Launchpad', () => {
 
 		describe( 'and the site is not launchpad enabled', () => {
 			it( 'redirects to Calypso My Home', () => {
-				jest
-					.spyOn( ReactQuery, 'useQuery' )
-					.mockImplementation(
-						jest
-							.fn()
-							.mockReturnValue( { ...MOCK_USE_QUERY_RESULT, data: { launchpad_screen: 'off' } } )
-					);
+				( useLaunchpad as jest.Mock ).mockReturnValueOnce( {
+					...MOCK_USE_QUERY_RESULT,
+					data: { launchpad_screen: 'off' },
+				} );
 				const initialReduxState = { currentUser: { id: user.ID } };
 				renderLaunchpad(
 					props,


### PR DESCRIPTION
Related to #84338

These tests will fail with the update RQ v5 PR linked above: `TypeError: Cannot redefine property: useQuery`

## Proposed Changes

PR removes the `spyOn` on `useQuery` which also mocked the return value and instead mock the `useLaunchpad` custom query hook. Ideally I think we wouldn't mock at all and use [`nock`](https://www.npmjs.com/package/nock) or [`msw`](https://www.npmjs.com/package/msw) to respond the request.

## Testing Instructions

Verify the changes don't change the test conditions and they still pass.
