### PR TITLE
Plans grid: Change Excl Taxes to sentence casing

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.tsx
@@ -58,7 +58,7 @@ const ScreenUpsell = ( { numOfSelectedGlobalStyles = 1, onCheckout, onTryStyle }
 						<LoadingPlaceholder style={ { height: '48px' } } />
 					) }
 					<div className="screen-upsell__plan-billing-time-frame">
-						{ translate( 'per month, {{span}}%(rawPrice)s{{/span}} billed annually, Excl. Taxes', {
+						{ translate( 'per month, {{span}}%(rawPrice)s{{/span}} billed annually, excl. taxes', {
 							args: {
 								rawPrice: isPricingLoaded
 									? formatCurrency( pricing?.originalPrice.full ?? 0, pricing?.currencyCode ?? '', {
@@ -67,7 +67,7 @@ const ScreenUpsell = ( { numOfSelectedGlobalStyles = 1, onCheckout, onTryStyle }
 									  } )
 									: '',
 							},
-							comment: 'Excl. Taxes is short for excluding taxes',
+							comment: 'excl. taxes is short for excluding taxes',
 							components: {
 								span: isPricingLoaded ? (
 									<span />

--- a/client/my-sites/plans-grid/components/billing-timeframe.tsx
+++ b/client/my-sites/plans-grid/components/billing-timeframe.tsx
@@ -228,7 +228,7 @@ function usePerMonthDescription( { planSlug }: { planSlug: PlanSlug } ) {
 	if ( discountedPriceFullTermText ) {
 		if ( PLAN_ANNUAL_PERIOD === billingPeriod ) {
 			return translate(
-				'per month, %(fullTermDiscountedPriceText)s for the first year, Excl. Taxes',
+				'per month, %(fullTermDiscountedPriceText)s for the first year, excl. taxes',
 				{
 					args: { fullTermDiscountedPriceText: discountedPriceFullTermText },
 					comment: 'Excl. Taxes is short for excluding taxes',
@@ -238,7 +238,7 @@ function usePerMonthDescription( { planSlug }: { planSlug: PlanSlug } ) {
 
 		if ( PLAN_BIENNIAL_PERIOD === billingPeriod ) {
 			return translate(
-				'per month, %(fullTermDiscountedPriceText)s for the first two years, Excl. Taxes',
+				'per month, %(fullTermDiscountedPriceText)s for the first two years, excl. taxes',
 				{
 					args: { fullTermDiscountedPriceText: discountedPriceFullTermText },
 					comment: 'Excl. Taxes is short for excluding taxes',
@@ -248,7 +248,7 @@ function usePerMonthDescription( { planSlug }: { planSlug: PlanSlug } ) {
 
 		if ( PLAN_TRIENNIAL_PERIOD === billingPeriod ) {
 			return translate(
-				'per month, %(fullTermDiscountedPriceText)s for the first three years, Excl. Taxes',
+				'per month, %(fullTermDiscountedPriceText)s for the first three years, excl. taxes',
 				{
 					args: { fullTermDiscountedPriceText: discountedPriceFullTermText },
 					comment: 'Excl. Taxes is short for excluding taxes',
@@ -257,21 +257,21 @@ function usePerMonthDescription( { planSlug }: { planSlug: PlanSlug } ) {
 		}
 	} else if ( originalPriceFullTermText ) {
 		if ( PLAN_ANNUAL_PERIOD === billingPeriod ) {
-			return translate( 'per month, %(rawPrice)s billed annually, Excl. Taxes', {
+			return translate( 'per month, %(rawPrice)s billed annually, excl. taxes', {
 				args: { rawPrice: originalPriceFullTermText },
 				comment: 'Excl. Taxes is short for excluding taxes',
 			} );
 		}
 
 		if ( PLAN_BIENNIAL_PERIOD === billingPeriod ) {
-			return translate( 'per month, %(rawPrice)s billed every two years, Excl. Taxes', {
+			return translate( 'per month, %(rawPrice)s billed every two years, excl. taxes', {
 				args: { rawPrice: originalPriceFullTermText },
 				comment: 'Excl. Taxes is short for excluding taxes',
 			} );
 		}
 
 		if ( PLAN_TRIENNIAL_PERIOD === billingPeriod ) {
-			return translate( 'per month, %(rawPrice)s billed every three years, Excl. Taxes', {
+			return translate( 'per month, %(rawPrice)s billed every three years, excl. taxes', {
 				args: { rawPrice: originalPriceFullTermText },
 				comment: 'Excl. Taxes is short for excluding taxes',
 			} );

--- a/client/my-sites/plans-grid/components/test/billing-timeframe.tsx
+++ b/client/my-sites/plans-grid/components/test/billing-timeframe.tsx
@@ -199,7 +199,7 @@ describe( 'PlanFeatures2023GridBillingTimeframe', () => {
 			isSmallestUnit: true,
 		} );
 		expect( container ).toHaveTextContent(
-			`per month, ${ originalPrice } billed annually, Excl. Taxes`
+			`per month, ${ originalPrice } billed annually, excl. taxes`
 		);
 	} );
 
@@ -231,7 +231,7 @@ describe( 'PlanFeatures2023GridBillingTimeframe', () => {
 			isSmallestUnit: true,
 		} );
 		expect( container ).toHaveTextContent(
-			`per month, ${ originalPrice } billed every two years, Excl. Taxes`
+			`per month, ${ originalPrice } billed every two years, excl. taxes`
 		);
 	} );
 
@@ -263,7 +263,7 @@ describe( 'PlanFeatures2023GridBillingTimeframe', () => {
 			isSmallestUnit: true,
 		} );
 		expect( container ).toHaveTextContent(
-			`per month, ${ originalPrice } billed every three years, Excl. Taxes`
+			`per month, ${ originalPrice } billed every three years, excl. taxes`
 		);
 	} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Change "Excl. Taxes" to sentence casing "excl. taxes". This was requested in https://github.com/Automattic/wp-calypso/issues/78296#issuecomment-1823407067.

### BEFORE

#### /start/plans
<img width="474" alt="Screenshot 2023-11-23 at 3 56 39 PM" src="https://github.com/Automattic/wp-calypso/assets/1269602/34d46f5a-47b3-4487-8e3d-112e417ac05b">

#### Stepper upsell
<img width="336" alt="Screenshot 2023-11-23 at 4 19 47 PM" src="https://github.com/Automattic/wp-calypso/assets/1269602/67f03252-1bf0-4914-961e-d77369c8dfc7">



### AFTER

#### /start/plans
<img width="471" alt="Screenshot 2023-11-23 at 3 56 54 PM" src="https://github.com/Automattic/wp-calypso/assets/1269602/77fac283-e09f-4fa6-a87d-fcd7b586f2c1">


#### Stepper upsell
<img width="343" alt="Screenshot 2023-11-23 at 4 19 43 PM" src="https://github.com/Automattic/wp-calypso/assets/1269602/d5307c39-56ca-4340-9a5e-904fb0962232">



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify "excl. taxes" is visible in `/start/plans` and `/plans/yearly/{SITE_SLUG}`.
<img width="507" alt="Screenshot 2023-11-23 at 3 54 53 PM" src="https://github.com/Automattic/wp-calypso/assets/1269602/d04c0e16-daa8-4bef-a2b1-1fe6c79e0b89">

* Next signup via the free site signup flow (from wordpress.com/free), and in the "Pick a design" step, click on "Design your own", then pick a pattern and style. In the upsell that shows, verify that you see excl. taxes in lower case.



