### PR TITLE
Hosting Command Palette: improve the UX for nested command 

### DIFF
--- a/client/components/command-pallette/use-command-pallette.tsx
+++ b/client/components/command-pallette/use-command-pallette.tsx
@@ -22,17 +22,17 @@ interface SiteFunctions {
 	onClick: ( { site, close }: { site: SiteExcerptData; close: CloseFunction } ) => void;
 	filter?: ( site: SiteExcerptData ) => boolean | undefined | null;
 }
+export interface CommandCallBackParams {
+	close: CloseFunction;
+	setSearch: ( search: string ) => void;
+	setPlaceholderOverride: ( placeholder: string ) => void;
+}
+
 interface Command {
 	name: string;
 	label: string;
 	searchLabel: string;
-	callback: ( {
-		close,
-		setSearch,
-	}: {
-		close: CloseFunction;
-		setSearch: ( search: string ) => void;
-	} ) => void;
+	callback: ( params: CommandCallBackParams ) => void;
 	context?: string;
 	icon?: JSX.Element;
 	image?: JSX.Element;

--- a/client/components/command-pallette/wpcom-command-pallette.tsx
+++ b/client/components/command-pallette/wpcom-command-pallette.tsx
@@ -13,6 +13,8 @@ interface CommandMenuGroupProps
 	extends Pick< CommandCallBackParams, 'close' | 'setSearch' | 'setPlaceholderOverride' > {
 	isContextual?: boolean;
 	search: string;
+	selectedCommandName: string;
+	setSelectedCommandName: ( name: string ) => void;
 }
 
 export function CommandMenuGroup( {
@@ -21,8 +23,9 @@ export function CommandMenuGroup( {
 	close,
 	setSearch,
 	setPlaceholderOverride,
+	selectedCommandName,
+	setSelectedCommandName,
 }: CommandMenuGroupProps ) {
-	const [ selectedCommandName, setSelectedCommandName ] = useState( '' );
 	const { commands: smpDefaultCommands } = useCommandPallette( {
 		selectedCommandName,
 		setSelectedCommandName,
@@ -95,6 +98,7 @@ function CommandInput( { isOpen, search, setSearch, placeholder }: CommandInputP
 export const WpcomCommandPalette = () => {
 	const [ placeHolderOverride, setPlaceholderOverride ] = useState( '' );
 	const [ search, setSearch ] = useState( '' );
+	const [ selectedCommandName, setSelectedCommandName ] = useState( '' );
 	const [ isOpen, setIsOpen ] = useState( false );
 	const { close, toggle } = {
 		close: () => setIsOpen( false ),
@@ -117,6 +121,7 @@ export const WpcomCommandPalette = () => {
 	const reset = () => {
 		setPlaceholderOverride( '' );
 		setSearch( '' );
+		setSelectedCommandName( '' );
 	};
 	const closeAndReset = () => {
 		reset();
@@ -137,6 +142,10 @@ export const WpcomCommandPalette = () => {
 			event.keyCode === 229
 		) {
 			event.preventDefault();
+		}
+		if ( event.key === 'Escape' && selectedCommandName ) {
+			event.preventDefault();
+			reset();
 		}
 	};
 
@@ -170,6 +179,8 @@ export const WpcomCommandPalette = () => {
 							isContextual
 							setSearch={ setSearch }
 							setPlaceholderOverride={ setPlaceholderOverride }
+							selectedCommandName={ selectedCommandName }
+							setSelectedCommandName={ setSelectedCommandName }
 						/>
 						{ search && (
 							<CommandMenuGroup
@@ -177,6 +188,8 @@ export const WpcomCommandPalette = () => {
 								close={ closeAndReset }
 								setSearch={ setSearch }
 								setPlaceholderOverride={ setPlaceholderOverride }
+								selectedCommandName={ selectedCommandName }
+								setSelectedCommandName={ setSelectedCommandName }
 							/>
 						) }
 					</Command.List>

--- a/client/components/command-pallette/wpcom-command-pallette.tsx
+++ b/client/components/command-pallette/wpcom-command-pallette.tsx
@@ -189,7 +189,10 @@ export const WpcomCommandPalette = () => {
 		) {
 			event.preventDefault();
 		}
-		if ( event.key === 'Escape' && selectedCommandName ) {
+		if (
+			( event.key === 'Escape' && selectedCommandName ) ||
+			( event.key === 'Backspace' && ! search )
+		) {
 			event.preventDefault();
 			reset();
 		}

--- a/client/sites-dashboard/components/wpcom-smp-commands.tsx
+++ b/client/sites-dashboard/components/wpcom-smp-commands.tsx
@@ -4,6 +4,8 @@ import {
 	commentAuthorAvatar as profileIcon,
 } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
+import { useTranslate } from 'i18n-calypso';
+import { CommandCallBackParams } from 'calypso/components/command-pallette/use-command-pallette';
 import MaterialIcon from 'calypso/components/material-icon';
 import { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
 import { navigate } from 'calypso/lib/navigate';
@@ -13,16 +15,20 @@ import { useDispatch } from 'calypso/state';
 import { successNotice } from 'calypso/state/notices/actions';
 import { isCustomDomain, isNotAtomicJetpack } from '../utils';
 
+interface useCommandsArrayWpcomOptions {
+	setSelectedCommandName: ( name: string ) => void;
+}
+
 export const useCommandsArrayWpcom = ( {
 	setSelectedCommandName,
-}: {
-	setSelectedCommandName: ( actionName: string ) => void;
-} ) => {
+}: useCommandsArrayWpcomOptions ) => {
+	const translate = useTranslate();
 	const setStateCallback =
 		( actionName: string ) =>
-		( { setSearch }: { setSearch: ( search: string ) => void } ) => {
+		( { setSearch, setPlaceholderOverride }: CommandCallBackParams ) => {
 			setSearch( '' );
 			setSelectedCommandName( actionName );
+			setPlaceholderOverride( translate( 'Search for a site' ) );
 		};
 
 	const { __ } = useI18n();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Related to https://github.com/Automattic/dotcom-forge/issues/4531

## Proposed Changes

* Change the placeholder when pickcing a site
* Go back to the parent command when pressing `Esc`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch locally or use calypso live
* Access `/sites`
* Press `cmd+k` on mac or `ctrl+k` on Windows
* Pick any of the SSH commands
* Observe the place holder has changed from `Search for commands` to `Search for sites`
* Press `esc`
* Observe the commands are the root commands and the placeholder is `Search for commands`.
* Press `esc` again
* Observe the command palette closes.

## Screencast



https://github.com/Automattic/wp-calypso/assets/779993/23c69500-d31a-4b7b-934e-4e0a29b858eb


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?