### PR TITLE
`useSkipCurrentViewMutation`: use `fetchQuery` object syntax

### DIFF
--- a/client/data/home/use-skip-current-view-mutation.ts
+++ b/client/data/home/use-skip-current-view-mutation.ts
@@ -22,11 +22,11 @@ function useSkipCurrentViewMutation< TData, TError >( siteId: number ): Result< 
 
 	const mutation = useMutation< TData, TError, Variables >( {
 		mutationFn: async ( { reminder, card } ) => {
-			const data = await queryClient.fetchQuery(
-				getCacheKey( siteId ),
-				() => fetchHomeLayout( siteId, query ),
-				{ staleTime: Infinity }
-			);
+			const data = await queryClient.fetchQuery( {
+				queryKey: getCacheKey( siteId ),
+				queryFn: () => fetchHomeLayout( siteId, query ),
+				staleTime: Infinity,
+			} );
 
 			const view_name = ( data as any ).view_name;
 			const multipleCardViews = [ 'VIEW_POST_LAUNCH', 'VIEW_SITE_SETUP' ];


### PR DESCRIPTION
Related to #84338

## Proposed Changes

PR refactors `useSkipCurrentViewMutation` to use object syntax for `queryClient.fetchQuery`. 

## Testing Instructions

Review code changes, verify tests are passing and there are no type errors.