### PR TITLE
omit `queryKey` if we expose `UseQueryOptions`

### DIFF
--- a/client/data/domains/use-get-domains-query.ts
+++ b/client/data/domains/use-get-domains-query.ts
@@ -9,7 +9,7 @@ type UseGetDomainsQueryData = ResponseDomain[];
 
 export const useGetDomainsQuery = (
 	siteId: number | null,
-	queryOptions?: UseQueryOptions< any, unknown, UseGetDomainsQueryData >
+	queryOptions?: Omit< UseQueryOptions< any, unknown, UseGetDomainsQueryData >, 'queryKey' >
 ) => {
 	const enabled = queryOptions?.enabled ?? true;
 

--- a/client/data/emails/use-get-email-accounts-query.ts
+++ b/client/data/emails/use-get-email-accounts-query.ts
@@ -24,7 +24,7 @@ export const getCacheKey = ( siteId: number | null, domain: string ) => [
 export const useGetEmailAccountsQuery = (
 	siteId: number | null,
 	domain: string,
-	queryOptions?: UseQueryOptions< any, unknown, UseGetEmailAccountsQueryData >
+	queryOptions?: Omit< UseQueryOptions< any, unknown, UseGetEmailAccountsQueryData >, 'queryKey' >
 ) => {
 	return useQuery< any, unknown, UseGetEmailAccountsQueryData >( {
 		queryKey: getCacheKey( siteId, domain ),

--- a/client/data/emails/use-get-mailboxes.ts
+++ b/client/data/emails/use-get-mailboxes.ts
@@ -15,7 +15,7 @@ export const getCacheKey = ( siteId: number | null ) => [ 'sites', siteId, 'emai
  */
 export const useGetMailboxes = (
 	siteId: number,
-	queryOptions?: UseQueryOptions< any, unknown, UseGetMailboxesQueryData >
+	queryOptions?: Omit< UseQueryOptions< any, unknown, UseGetMailboxesQueryData >, 'queryKey' >
 ) => {
 	return useQuery< any, unknown, UseGetMailboxesQueryData >( {
 		queryKey: getCacheKey( siteId ),

--- a/client/data/emails/use-get-titan-mailbox-availability.ts
+++ b/client/data/emails/use-get-titan-mailbox-availability.ts
@@ -23,7 +23,7 @@ const finalErrorStatuses = [ 400, 401, 403, 409 ];
 export const useGetTitanMailboxAvailability = (
 	domainName: string,
 	mailboxName: string,
-	queryOptions: UseQueryOptions< any, any > = {}
+	queryOptions: Omit< UseQueryOptions< any, any >, 'queryKey' > = {}
 ) => {
 	return useQuery< any, any >( {
 		queryKey: getCacheKey( domainName, mailboxName ),

--- a/client/data/hosting/use-site-logs-query.ts
+++ b/client/data/hosting/use-site-logs-query.ts
@@ -32,7 +32,10 @@ export interface SiteLogsParams {
 export function useSiteLogsQuery(
 	siteId: number | null | undefined,
 	params: SiteLogsParams,
-	queryOptions: UseQueryOptions< SiteLogsAPIResponse, unknown, SiteLogsData > = {}
+	queryOptions: Omit<
+		UseQueryOptions< SiteLogsAPIResponse, unknown, SiteLogsData >,
+		'queryKey'
+	> = {}
 ) {
 	const queryClient = useQueryClient();
 	const [ scrollId, setScrollId ] = useState< string | undefined >();

--- a/client/data/marketplace/use-get-related-plugins.ts
+++ b/client/data/marketplace/use-get-related-plugins.ts
@@ -46,7 +46,11 @@ const getRelatedPluginsQueryParams = (
 export const useGetRelatedPlugins = (
 	pluginSlug: string,
 	size = 4,
-	{ enabled = true, staleTime = BASE_STALE_TIME, refetchOnMount = true }: UseQueryOptions = {}
+	{
+		enabled = true,
+		staleTime = BASE_STALE_TIME,
+		refetchOnMount = true,
+	}: Omit< UseQueryOptions, 'queryKey' > = {}
 ): UseQueryResult => {
 	return useQuery( {
 		...getRelatedPluginsQueryParams( pluginSlug, size ),

--- a/client/data/marketplace/use-wpcom-plugins-query.ts
+++ b/client/data/marketplace/use-wpcom-plugins-query.ts
@@ -73,7 +73,7 @@ export const useWPCOMPluginsList = (
 		enabled = true,
 		staleTime = BASE_STALE_TIME,
 		refetchOnMount = true,
-	}: UseQueryOptions< any > = {}
+	}: Omit< UseQueryOptions< any >, 'queryKey' > = {}
 ): UseQueryResult => {
 	return useQuery( {
 		...getWPCOMPluginsQueryParams( type, searchTerm, tag ),
@@ -109,7 +109,11 @@ export const getWPCOMPluginQueryParams = (
  */
 export const useWPCOMPlugin = (
 	slug: string,
-	{ enabled = true, staleTime = BASE_STALE_TIME, refetchOnMount = true }: UseQueryOptions = {}
+	{
+		enabled = true,
+		staleTime = BASE_STALE_TIME,
+		refetchOnMount = true,
+	}: Omit< UseQueryOptions, 'queryKey' > = {}
 ): UseQueryResult< any > => {
 	return useQuery( {
 		...getWPCOMPluginQueryParams( slug ),
@@ -151,7 +155,7 @@ export const useWPCOMFeaturedPlugins = ( {
 	enabled = true,
 	staleTime = BASE_STALE_TIME,
 	refetchOnMount = true,
-}: UseQueryOptions = {} ): UseQueryResult => {
+}: Omit< UseQueryOptions, 'queryKey' > = {} ): UseQueryResult => {
 	return useQuery( {
 		...getWPCOMFeaturedPluginsQueryParams(),
 		enabled,

--- a/client/data/marketplace/use-wporg-plugin-query.ts
+++ b/client/data/marketplace/use-wporg-plugin-query.ts
@@ -53,7 +53,7 @@ export const useWPORGPlugins = (
 		enabled = true,
 		staleTime = BASE_STALE_TIME,
 		refetchOnMount = true,
-	}: UseQueryOptions< any > = {}
+	}: Omit< UseQueryOptions< any >, 'queryKey' > = {}
 ): UseQueryResult => {
 	const locale = useSelector( getCurrentUserLocale );
 

--- a/client/jetpack-cloud/sections/partner-portal/hooks/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/hooks/index.tsx
@@ -31,7 +31,9 @@ export function useReturnUrl( redirect: boolean ): void {
  * Returns the recent payment methods from the Jetpack Stripe account.
  *
  */
-export function useRecentPaymentMethodsQuery( { enabled = true }: UseQueryOptions = {} ) {
+export function useRecentPaymentMethodsQuery( {
+	enabled = true,
+}: Omit< UseQueryOptions, 'queryKey' > = {} ) {
 	return useQuery( {
 		queryKey: [ 'jetpack-cloud', 'partner-portal', 'recent-cards' ],
 		queryFn: () =>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-dotcom-patterns.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-dotcom-patterns.ts
@@ -5,7 +5,7 @@ import type { Pattern } from '../types';
 
 const useDotcomPatterns = (
 	lang?: string,
-	queryOptions: UseQueryOptions< any, unknown, Pattern[] > = {}
+	queryOptions: Omit< UseQueryOptions< any, unknown, Pattern[] >, 'queryKey' > = {}
 ): Pattern[] => {
 	const { data } = useQuery< any, unknown, Pattern[] >( {
 		queryKey: [ lang, 'patterns' ],

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-categories.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-categories.ts
@@ -4,7 +4,7 @@ import type { Category } from '../types';
 
 const usePatternCategories = (
 	siteId: undefined | number = 0,
-	queryOptions: UseQueryOptions< any, unknown, Category[] > = {}
+	queryOptions: Omit< UseQueryOptions< any, unknown, Category[] >, 'queryKey' > = {}
 ): Category[] => {
 	const { data } = useQuery< any, unknown, Category[] >( {
 		queryKey: [ siteId, 'block-patterns', 'categories' ],

--- a/client/landing/stepper/hooks/use-countries.ts
+++ b/client/landing/stepper/hooks/use-countries.ts
@@ -4,7 +4,7 @@ import wpcom from 'calypso/lib/wp';
 type WooCountries = Record< string, string >;
 
 export function useCountries(
-	queryOptions: UseQueryOptions< any, unknown, WooCountries > = {}
+	queryOptions: Omit< UseQueryOptions< any, unknown, WooCountries >, 'queryKey' > = {}
 ): UseQueryResult< WooCountries > {
 	return useQuery< any, unknown, WooCountries >( {
 		queryKey: [ 'countries' ],

--- a/client/my-sites/hosting/sftp-card/use-atomic-ssh-keys.ts
+++ b/client/my-sites/hosting/sftp-card/use-atomic-ssh-keys.ts
@@ -10,7 +10,10 @@ export interface AtomicKey {
 	attached_at: string;
 }
 
-export const useAtomicSshKeys = ( siteId: number, options: UseQueryOptions ) => {
+export const useAtomicSshKeys = (
+	siteId: number,
+	options: Omit< UseQueryOptions, 'queryKey' >
+) => {
 	return useQuery< { ssh_keys: Array< AtomicKey > }, unknown, Array< AtomicKey > >( {
 		queryKey: [ USE_ATOMIC_SSH_KEYS_QUERY_KEY, siteId ],
 		queryFn: () =>

--- a/packages/block-renderer/src/hooks/use-block-renderer-settings.ts
+++ b/packages/block-renderer/src/hooks/use-block-renderer-settings.ts
@@ -6,7 +6,7 @@ const useBlockRendererSettings = (
 	siteId: number | string,
 	stylesheet: string,
 	useInlineStyles = false,
-	queryOptions: UseQueryOptions< unknown, Error, BlockRendererSettings > = {}
+	queryOptions: Omit< UseQueryOptions< unknown, Error, BlockRendererSettings >, 'queryKey' > = {}
 ): UseQueryResult< BlockRendererSettings > => {
 	const params = new URLSearchParams( {
 		stylesheet,

--- a/packages/data-stores/src/queries/use-all-domains-query.ts
+++ b/packages/data-stores/src/queries/use-all-domains-query.ts
@@ -33,9 +33,9 @@ export interface AllDomainsQueryArgs {
 
 export function useAllDomainsQuery< TError = unknown, TData = AllDomainsQueryFnData >(
 	queryArgs: AllDomainsQueryArgs = {},
-	options: UseQueryOptions< AllDomainsQueryFnData, TError, TData > = {}
+	options: Omit< UseQueryOptions< AllDomainsQueryFnData, TError, TData >, 'queryKey' > = {}
 ) {
-	return useQuery( {
+	return useQuery< AllDomainsQueryFnData, TError, TData >( {
 		queryKey: [ 'all-domains', queryArgs ],
 		queryFn: () =>
 			wpcomRequest< AllDomainsQueryFnData >( {

--- a/packages/data-stores/src/templates/use-template.ts
+++ b/packages/data-stores/src/templates/use-template.ts
@@ -9,7 +9,7 @@ interface Options extends QueryOptions< Template > {
 const useTemplate = (
 	siteId: string | number,
 	templateId: string,
-	queryOptions: Options = {}
+	queryOptions: Omit< Options, 'queryKey' > = {}
 ): UseQueryResult< Template > => {
 	return useQuery< Template >( {
 		queryKey: [ siteId, 'templates', templateId ],

--- a/packages/design-picker/src/hooks/use-theme-designs-query.ts
+++ b/packages/design-picker/src/hooks/use-theme-designs-query.ts
@@ -22,7 +22,7 @@ export interface UseThemeDesignsQueryOptions {
 
 export function useThemeDesignsQuery(
 	{ filter = 'auto-loading-homepage', tier = 'all' }: UseThemeDesignsQueryOptions = {},
-	queryOptions: UseQueryOptions< unknown, Error, Design[] > = {}
+	queryOptions: Omit< UseQueryOptions< unknown, Error, Design[] >, 'queryKey' > = {}
 ): UseQueryResult< Design[], Error > {
 	return useQuery< any, Error, Design[] >( {
 		queryKey: [ 'themes', filter, tier ],


### PR DESCRIPTION
Cherry picked from and related to #84338.

## Proposed Changes

With RQv5 we have to omit the `queryKey` from `UseQueryOptions` if we expose them from our custom query hooks. Otherwise this will result in a type error (in RQv5).

## Testing Instructions

There souldn't be any runtime changes. Verify tests are passing and there aren't any type errors.