### PR TITLE
fix `unknown` > `Error` type

### DIFF
--- a/packages/block-renderer/src/hooks/use-block-renderer-settings.ts
+++ b/packages/block-renderer/src/hooks/use-block-renderer-settings.ts
@@ -6,14 +6,14 @@ const useBlockRendererSettings = (
 	siteId: number | string,
 	stylesheet: string,
 	useInlineStyles = false,
-	queryOptions: UseQueryOptions< unknown, unknown, BlockRendererSettings > = {}
+	queryOptions: UseQueryOptions< unknown, Error, BlockRendererSettings > = {}
 ): UseQueryResult< BlockRendererSettings > => {
 	const params = new URLSearchParams( {
 		stylesheet,
 		use_inline_styles: useInlineStyles.toString(),
 	} );
 
-	return useQuery< any, unknown, BlockRendererSettings >( {
+	return useQuery< any, Error, BlockRendererSettings >( {
 		queryKey: [ siteId, 'block-renderer', stylesheet, useInlineStyles ],
 		queryFn: () =>
 			wpcomRequest( {

--- a/packages/data-stores/src/starter-designs-queries/use-starter-design-by-slug.ts
+++ b/packages/data-stores/src/starter-designs-queries/use-starter-design-by-slug.ts
@@ -2,7 +2,7 @@ import { useQuery, UseQueryResult, QueryOptions } from '@tanstack/react-query';
 import wpcomRequest from 'wpcom-proxy-request';
 import type { Design } from '@automattic/design-picker/src/types';
 
-interface Options extends QueryOptions< Design, unknown > {
+interface Options extends QueryOptions< Design > {
 	enabled?: boolean;
 	select?: ( response: Design ) => Design;
 }

--- a/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
+++ b/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
@@ -17,7 +17,7 @@ interface StarterDesignsQueryParams {
 	_locale: string;
 }
 
-interface Options extends QueryOptions< StarterDesignsResponse, unknown > {
+interface Options extends QueryOptions< StarterDesignsResponse > {
 	enabled?: boolean;
 	select?: ( response: StarterDesigns ) => StarterDesigns;
 }

--- a/packages/data-stores/src/templates/use-template.ts
+++ b/packages/data-stores/src/templates/use-template.ts
@@ -2,7 +2,7 @@ import { useQuery, UseQueryResult, QueryOptions } from '@tanstack/react-query';
 import wpcomRequest from 'wpcom-proxy-request';
 import type { Template } from './types';
 
-interface Options extends QueryOptions< Template, unknown > {
+interface Options extends QueryOptions< Template > {
 	enabled?: boolean;
 }
 

--- a/packages/design-picker/src/hooks/use-theme-designs-query.ts
+++ b/packages/design-picker/src/hooks/use-theme-designs-query.ts
@@ -22,9 +22,9 @@ export interface UseThemeDesignsQueryOptions {
 
 export function useThemeDesignsQuery(
 	{ filter = 'auto-loading-homepage', tier = 'all' }: UseThemeDesignsQueryOptions = {},
-	queryOptions: UseQueryOptions< unknown, unknown, Design[] > = {}
-): UseQueryResult< Design[] > {
-	return useQuery< any, unknown, Design[] >( {
+	queryOptions: UseQueryOptions< unknown, Error, Design[] > = {}
+): UseQueryResult< Design[], Error > {
+	return useQuery< any, Error, Design[] >( {
 		queryKey: [ 'themes', filter, tier ],
 		queryFn: () =>
 			wpcom.req.get( '/themes', {


### PR DESCRIPTION
Cherry picked from and related to #84338.

## Proposed Changes

With RQv5 the default for `TError` generic will change from `unknown` instead to `Error`. In order to be compliant with the update we have to use either the one or the other. Omitting the generic means defaulting to `unknown` in v4 or `Error` in v5.

## Testing Instructions

There souldn't be any runtime changes. Verify tests are passing and there aren't any type errors.