### PR TITLE
Fix interval toggle width on domain upsell flow

### DIFF
--- a/client/my-sites/plans-grid/components/plan-type-selector/index.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/index.tsx
@@ -46,8 +46,8 @@ interface PathArgs {
 
 type GeneratePathFunction = ( props: Partial< PlanTypeSelectorProps >, args: PathArgs ) => string;
 
-const IntervalTypeToggleWrapper = styled.div< { showingMonthly: boolean; isInSignup: boolean } >`
-	display: ${ ( { isInSignup } ) => ( isInSignup ? 'flex' : 'block' ) };
+const IntervalTypeToggleWrapper = styled.div< { showingMonthly: boolean } >`
+	display: flex;
 	align-content: space-between;
 	justify-content: center;
 	margin: 0 20px 24px;
@@ -290,10 +290,7 @@ export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = 
 	const intervalTabs = showBiennialToggle ? [ 'yearly', '2yearly' ] : [ 'monthly', 'yearly' ];
 
 	return (
-		<IntervalTypeToggleWrapper
-			showingMonthly={ intervalType === 'monthly' }
-			isInSignup={ isInSignup }
-		>
+		<IntervalTypeToggleWrapper showingMonthly={ intervalType === 'monthly' }>
 			<SegmentedControl compact className={ segmentClasses } primary={ true }>
 				{ intervalTabs.map( ( interval ) => (
 					<SegmentedControl.Item


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Removes the unnecessary isInSignup flag for the interval toggle. The interval toggle width will always behave similarly in all flows.
<img width="962" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3422709/9dd5cc0a-031f-47e5-beef-49819e71cd7a">

## Testing Instructions

* Go through several signup flows specifically launch-site, domain-upsell to make sure the interval toggle is not broken.
     * `/setup/domain-upsell/plans` Plans page


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?