### PR TITLE
Checkout: include volume in original price and cost overrides (behind flag)

### DIFF
--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -115,7 +115,11 @@ function filterAndGroupCostOverridesForDisplay(
 				return;
 			}
 			const discountAmount = grouped[ costOverride.override_code ]?.discountAmount ?? 0;
-			const newDiscountAmount = costOverride.old_price - costOverride.new_price;
+			// Cost overrides do not account for volume; they are always for the
+			// single volume amount. Therefore they must be multiplied by volume the
+			// same way we do for the cost.
+			const newDiscountAmount =
+				costOverride.old_price * product.volume - costOverride.new_price * product.volume;
 			grouped[ costOverride.override_code ] = {
 				humanReadableReason: costOverride.human_readable_reason,
 				overrideCode: costOverride.override_code,

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -564,12 +564,18 @@ export interface ResponseCartCostOverride {
 	/**
 	 * This is the price after this override was applied. It is in the
 	 * currency's standard unit as a floating point number.
+	 *
+	 * Note that this does not account for volume! Make sure to multiply this
+	 * value by the volume before displaying it.
 	 */
 	new_price: number;
 
 	/**
 	 * This is the price before this override was applied. It is in the
 	 * currency's standard unit as a floating point number.
+	 *
+	 * Note that this does not account for volume! Make sure to multiply this
+	 * value by the volume before displaying it.
 	 */
 	old_price: number;
 

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -442,10 +442,15 @@ export interface ResponseCartProduct {
 	price_tier_maximum_units?: number | null;
 
 	/**
-	 * A cost override is a change to the price of a product. The new price and the old (original) price are both provided.
+	 * A cost override is a change to the price of a product. The new price and
+	 * the old (original) price are both provided.
 	 *
 	 * The override_code is a string that identifies the reason for the override.
 	 * When displaying the reason to the customer, use the human_readable_reason.
+	 *
+	 * Note that cost overrides do not include volume! You should always
+	 * multiply the numbers by volume if you want to know what prices are being
+	 * used.
 	 */
 	cost_overrides?: ResponseCartCostOverride[];
 
@@ -551,11 +556,42 @@ export interface ResponseCartProductVariant {
 }
 
 export interface ResponseCartCostOverride {
+	/**
+	 * The reason for this cost override, translated to the user's locale.
+	 */
 	human_readable_reason: string;
+
+	/**
+	 * This is the price after this override was applied. It is in the
+	 * currency's standard unit as a floating point number.
+	 */
 	new_price: number;
+
+	/**
+	 * This is the price before this override was applied. It is in the
+	 * currency's standard unit as a floating point number.
+	 */
 	old_price: number;
+
+	/**
+	 * A code to identify the override. Even if the translated
+	 * `human_readable_reason` changes, this will remain the same. While it
+	 * should be unique for a collection of overrides in a product, there's
+	 * nothing that requires that so don't rely on it being true.
+	 */
 	override_code: string;
+
+	/**
+	 * If true, the override changes the product's original price and is not a
+	 * discount. This is used by products which have dynamic pricing like
+	 * Domain Transfers.
+	 */
 	does_override_original_cost: boolean;
+
+	/**
+	 * The reason for this discount.
+	 * @deprecated use human_readable_reason instead
+	 */
 	reason: string;
 }
 

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -1055,16 +1055,16 @@ function getCostBeforeDiscounts( product: ResponseCartProduct ): number {
 	if ( originalCostOverrides.length > 0 ) {
 		const lastOriginalCostOverride = originalCostOverrides.pop();
 		if ( lastOriginalCostOverride ) {
-			return lastOriginalCostOverride.new_price;
+			return lastOriginalCostOverride.new_price * product.volume;
 		}
 	}
 	if ( product.cost_overrides && product.cost_overrides.length > 0 ) {
 		const firstOverride = product.cost_overrides[ 0 ];
 		if ( firstOverride ) {
-			return firstOverride.old_price;
+			return firstOverride.old_price * product.volume;
 		}
 	}
-	return product.cost;
+	return product.cost * product.volume;
 }
 
 function CheckoutLineItem( {


### PR DESCRIPTION
## Proposed Changes

Since https://github.com/Automattic/wp-calypso/pull/83890, we display each line item's "original cost" in the checkout sidebar so that the discounts listed below it will appear more like an invoice: one price adjusted by several discounts. 

However, this does not work for cart items with a volume greater than 1 (eg: multi-year domains).

This PR fixes the calculation of the original price and all of the discounts by multiplying them by the volume.

> [!NOTE] 
> The redesigned checkout remains hidden behind both a feature flag and a query string parameter. It is only available currently in development (`calypso.localhost`) and on `wpcalypso` which is used by the `calypso.live` branches below.

Before             |  After
:-------------------------:|:-------------------------:
<img width="260" alt="Screenshot 2023-11-23 at 11 22 33 AM" src="https://github.com/Automattic/wp-calypso/assets/2036909/77b0108e-67d1-41e5-a638-aa6c46c8064b"> | <img width="252" alt="Screenshot 2023-11-23 at 11 22 52 AM" src="https://github.com/Automattic/wp-calypso/assets/2036909/e888f444-edd6-492b-8823-230de69fde76">

This is part of the project to move the checkout line items to the sidebar: https://github.com/Automattic/payments-shilling/issues/1969

## Testing Instructions

- Add a domain registration to your cart and visit checkout.
- Add `?checkoutVersion=2` to the URL and reload the page to see the new design.
- Use the variant dropdown (yes, its wording is incorrect – that's a separate issue) to change the volume to 2 years.
- Verify that the item's price now shows the correct cost (you can compare it to the total to be sure).
- Verify that the first year of the item is free and that the discounted amount is one year only. This is easier to see with D129725-code applied.