### PR TITLE
Tweak e2e test timeouts on flaky VideoPress trial test.

### DIFF
--- a/test/e2e/specs/onboarding/signup__videopress-tailored.ts
+++ b/test/e2e/specs/onboarding/signup__videopress-tailored.ts
@@ -37,6 +37,7 @@ describe( DataHelper.createSuiteTitle( 'Signup: Tailored VideoPress' ), () => {
 		} );
 
 		it( 'Click Get Started', async function () {
+			page.setDefaultTimeout( 60 * 1000 );
 			// Return a button "key" for the button that is found on page.
 			// See diff in https://github.com/Automattic/wp-calypso/pull/84189 for what to revert in case we disable trial.
 			const startButtonText = 'Start a free trial';
@@ -49,6 +50,7 @@ describe( DataHelper.createSuiteTitle( 'Signup: Tailored VideoPress' ), () => {
 		} );
 
 		it( 'Enter account details', async function () {
+			page.setDefaultTimeout( 60 * 1000 );
 			await page.waitForURL( /.*videopress-account.*/ );
 			const userSignupPage = new UserSignupPage( page );
 			newUserDetails = await userSignupPage.signup(
@@ -83,10 +85,10 @@ describe( DataHelper.createSuiteTitle( 'Signup: Tailored VideoPress' ), () => {
 		} );
 
 		it( 'Land in processing', async function () {
-			await page.waitForURL( /.*processing.*/, { timeout: 20 * 1000 } );
+			await page.waitForURL( /.*processing.*/, { timeout: 60 * 1000 } );
 		} );
 		it( 'Navigate to site editor', async function () {
-			await page.waitForURL( /.*site-editor.*/, { timeout: 20 * 1000 } );
+			await page.waitForURL( /.*site-editor.*/, { timeout: 60 * 1000 } );
 		} );
 		// This happens after we finish signup.
 		it( 'Get activation link', async function () {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* fix flaky e2e test

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run tests locally with `CALYPSO_BASE_URL=http://calypso.localhost:3000 yarn workspace wp-e2e-tests test -- specs/onboarding/signup__videopress-tailored.ts`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?