### PR TITLE
Jetpack Manage: Disabling and hiding the issue license buttons from dashboard - site menu dropdowns and lightbox

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/license-info-modal/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/license-info-modal/index.tsx
@@ -4,6 +4,8 @@ import { useTranslate } from 'i18n-calypso';
 import { useContext, useMemo } from 'react';
 import LicenseLightbox from 'calypso/jetpack-cloud/sections/partner-portal/license-lightbox';
 import { addQueryArgs } from 'calypso/lib/url';
+import { useSelector } from 'calypso/state';
+import { getCurrentPartner } from 'calypso/state/partner-portal/partner/selectors';
 import useJetpackAgencyDashboardRecordTrackEvent from '../../hooks/use-jetpack-agency-dashboard-record-track-event';
 import SitesOverviewContext from '../context';
 import DashboardDataContext from '../dashboard-data-context';
@@ -32,6 +34,8 @@ export default function LicenseInfoModal( {
 }: Props ) {
 	const isMobile = useMobileBreakpoint();
 	const translate = useTranslate();
+	const partner = useSelector( getCurrentPartner );
+	const partnerCanIssueLicense = Boolean( partner?.can_issue_licenses );
 
 	const { hideLicenseInfo } = useContext( SitesOverviewContext );
 
@@ -80,7 +84,7 @@ export default function LicenseInfoModal( {
 				className={ className }
 				product={ currentLicenseProduct }
 				ctaLabel={ label ?? translate( 'Issue License' ) }
-				isDisabled={ isDisabled }
+				isDisabled={ ! partnerCanIssueLicense || isDisabled }
 				onActivate={ onIssueLicense }
 				onClose={ onHideLicenseInfo }
 				extraAsideContent={ extraAsideContent }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/test/site-actions.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/test/site-actions.tsx
@@ -1,58 +1,130 @@
 /**
  * @jest-environment jsdom
  */
-
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, fireEvent } from '@testing-library/react';
+import React from 'react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import SiteActions from '../index';
 import type { SiteNode } from '../../types';
 
 describe( '<SiteActions>', () => {
-	test( 'should render correctly and have href for all the actions', () => {
-		const siteObj = {
-			blog_id: 1234,
-			url: 'test.jurassic.ninja',
-			url_with_scheme: 'https://test.jurassic.ninja/',
-			monitor_active: false,
-			monitor_site_status: false,
-			has_scan: true,
-			has_backup: false,
-			latest_scan_threats_found: [],
-			latest_backup_status: '',
-			is_connection_healthy: true,
-			awaiting_plugin_updates: [],
-			is_favorite: false,
+	const siteObj = {
+		blog_id: 1234,
+		url: 'test.jurassic.ninja',
+		url_with_scheme: 'https://test.jurassic.ninja/',
+		monitor_active: false,
+		monitor_site_status: false,
+		has_scan: true,
+		has_backup: false,
+		latest_scan_threats_found: [],
+		latest_backup_status: '',
+		is_connection_healthy: true,
+		awaiting_plugin_updates: [],
+		is_favorite: false,
+	};
+	const site: SiteNode = {
+		value: siteObj,
+		error: false,
+		type: 'site',
+		status: 'active',
+	};
+	const mockStore = configureStore();
+	const queryClient = new QueryClient();
+	let issueLicense: Element | null = null;
+	let viewActivity: Element | null = null;
+	let viewSite: Element | null = null;
+	let visitWPAdmin: Element | null = null;
+
+	test( 'should render correctly and have href for all four available actions', () => {
+		const initialState = {
+			partnerPortal: {
+				partner: {
+					current: {
+						can_issue_licenses: true,
+					},
+				},
+			},
 		};
-		const site: SiteNode = {
-			value: siteObj,
-			error: false,
-			type: 'site',
-			status: '',
-		};
-		const initialState = {};
-		const mockStore = configureStore();
 		const store = mockStore( initialState );
 
 		const { container } = render(
 			<Provider store={ store }>
-				<SiteActions site={ site } siteError={ false } />
+				<QueryClientProvider client={ queryClient }>
+					<SiteActions site={ site } siteError={ false } />
+				</QueryClientProvider>
 			</Provider>
 		);
 
 		const [ button ] = container.getElementsByTagName( 'button' );
 		fireEvent.click( button );
 
-		const [ popoverMenu ] = container.parentElement.getElementsByClassName( 'popover__menu' );
+		const popoverMenu = container.parentElement?.getElementsByClassName(
+			'popover__menu'
+		)[ 0 ] as Element | null;
+
 		expect( popoverMenu ).toBeInTheDocument();
 
-		const [ issueLicense, viewActivity, viewSite, visitWPAdmin ] =
-			popoverMenu.getElementsByClassName( 'site-actions__menu-item' );
+		if ( popoverMenu ) {
+			const menuItems = popoverMenu.getElementsByClassName( 'site-actions__menu-item' );
+			if ( menuItems.length === 4 ) {
+				[ issueLicense, viewActivity, viewSite, visitWPAdmin ] = menuItems;
+			}
+		}
 
 		expect( issueLicense ).toHaveProperty(
 			'href',
 			`https://example.com/partner-portal/issue-license/?site_id=${ site.value.blog_id }&source=dashboard`
 		);
+
+		expect( viewActivity ).toHaveProperty(
+			'href',
+			`https://example.com/activity-log/${ site.value.url }`
+		);
+		expect( viewSite ).toHaveProperty( 'href', site.value.url_with_scheme );
+		expect( visitWPAdmin ).toHaveProperty(
+			'href',
+			`${ site.value.url_with_scheme }/wp-admin/admin.php?page=jetpack#/dashboard`
+		);
+	} );
+
+	test( 'should render correctly and have href for all the actions except issuing licenses, if partner cannot issue new licenses', () => {
+		const initialState = {
+			partnerPortal: {
+				partner: {
+					current: {
+						can_issue_licenses: false,
+					},
+				},
+			},
+		};
+		const store = mockStore( initialState );
+
+		const { container } = render(
+			<Provider store={ store }>
+				<QueryClientProvider client={ queryClient }>
+					<SiteActions site={ site } siteError={ false } />
+				</QueryClientProvider>
+			</Provider>
+		);
+
+		const [ button ] = container.getElementsByTagName( 'button' );
+		fireEvent.click( button );
+
+		const popoverMenu = container.parentElement?.getElementsByClassName(
+			'popover__menu'
+		)[ 0 ] as Element | null;
+
+		expect( popoverMenu ).toBeInTheDocument();
+
+		if ( popoverMenu ) {
+			const menuItems = popoverMenu.getElementsByClassName( 'site-actions__menu-item' );
+			if ( menuItems.length === 3 ) {
+				[ viewActivity, viewSite, visitWPAdmin ] = menuItems;
+			}
+		}
+
 		expect( viewActivity ).toHaveProperty(
 			'href',
 			`https://example.com/activity-log/${ site.value.url }`

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/use-site-actions.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/use-site-actions.ts
@@ -2,8 +2,9 @@ import { isEnabled } from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { urlToSlug } from 'calypso/lib/url/http-utils';
-import { useDispatch } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getCurrentPartner } from 'calypso/state/partner-portal/partner/selectors';
 import getActionEventName from './get-action-event-name';
 import type { SiteNode, AllowedActionTypes } from '../types';
 
@@ -14,6 +15,8 @@ export default function useSiteActions(
 ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+	const partner = useSelector( getCurrentPartner );
+	const partnerCanIssueLicense = Boolean( partner?.can_issue_licenses );
 
 	const siteValue = site?.value;
 
@@ -58,10 +61,12 @@ export default function useSiteActions(
 			},
 			{
 				name: translate( 'Issue new license' ),
-				href: `/partner-portal/issue-license/?site_id=${ blog_id }&source=dashboard`,
+				href: partnerCanIssueLicense
+					? `/partner-portal/issue-license/?site_id=${ blog_id }&source=dashboard`
+					: undefined,
 				onClick: () => handleClickMenuItem( 'issue_license' ),
 				isExternalLink: false,
-				isEnabled: ! siteError,
+				isEnabled: partnerCanIssueLicense && ! siteError,
 			},
 			{
 				name: translate( 'View activity' ),


### PR DESCRIPTION
Related to https://github.com/Automattic/jetpack-manage/issues/135

## Proposed Changes

* This PR hides the "Issue new license" menu item from the dashboard individual site menu:

<img width="309" alt="Screenshot 2023-11-23 at 16 47 26" src="https://github.com/Automattic/wp-calypso/assets/16754605/ce0b5a51-dc4d-477d-90d9-ef1a72ec3353">


* This PR also disables the button to issue licenses on product lightboxes that display via the dashboard:

<img width="1073" alt="Screenshot 2023-11-23 at 16 47 39" src="https://github.com/Automattic/wp-calypso/assets/16754605/311448c4-2220-416a-bc57-ddf0e4c2a49e">

* This PR also modifies one test and adds another, to make sure the dashboard 'site actions' menu behaves as expected when a partner can or can't issue licenses.


## Testing Instructions

- Apply this change.
- Ensure that you have in your sandbox the latest commits on the wpcom repo (trunk). In your `hosts` file, point `public-api.wordpress.com` to your sandbox IP.
- You need a Partner account.
- Go to the dashboard (`http://jetpack.cloud.localhost:3000/dashboard`) and click on the menu icon next to any site in the table:

![image](https://github.com/Automattic/wp-calypso/assets/16754605/b863c51a-038b-4f79-b073-7dedb23121bb)

- Additionally, click on any of the info icons in the main table menu header (eg. next to Boost Score, Backup, Scan):

![image (1)](https://github.com/Automattic/wp-calypso/assets/16754605/21c7d06b-3c74-4761-a6cc-f91da42d717d)

- Additionally, if you have any sites showing 'Get Score' in the Boost Score column, click on that.

- If you, as a Partner, are allowed to issue licenses, you will see the issue license button available and clickable in the lightboxes, and you will see the 'Issue new license' menu option from the menu for any site in the table.
- If you are not allowed to issue licenses, the button to issues licenses will not be clickable in the lightboxes, and the menu option for sites in the table will not show the 'Issue new license' option at all.
- **Note:** you can change your current value `can_issue_licenses` using the CLI in your sandbox:
   - `wp jetpack-start agency-can-issue-licenses {your_partner_id} --set-can-issue=yes`
   - `wp jetpack-start agency-can-issue-licenses {your_partner_id} --set-can-issue=no`

* You can also test the test by running `yarn run test-client client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/test` locally, however the Github actions tests should also pass.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?