### PR TITLE
Disables the like popover for mobile versions

### DIFF
--- a/client/reader/like-button/index.jsx
+++ b/client/reader/like-button/index.jsx
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import { getUrlParts } from '@automattic/calypso-url';
+import { isMobile } from '@automattic/viewport';
 import { createRef, Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import LikeButtonContainer from 'calypso/blocks/like-button';
@@ -64,11 +65,17 @@ class ReaderLikeButton extends Component {
 	};
 
 	showLikesPopover = () => {
+		if ( isMobile() ) {
+			return;
+		}
 		clearTimeout( this.hidePopoverTimeout );
 		this.setState( { showLikesPopover: true } );
 	};
 
 	hideLikesPopover = () => {
+		if ( isMobile() ) {
+			return;
+		}
 		this.hidePopoverTimeout = setTimeout( () => {
 			this.setState( { showLikesPopover: false } );
 		}, 200 );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

More context: paYKcK-3F0-p2#comment-2583

## Proposed Changes

* We agreed that showing the Likes in a popover for the mobile version upon clicking on the Star is not the best case. This deviates from the target action, which is to Like the post.
* This is the first step to work out the best UX for showing the Likes on a post.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso Live link below, or apply this PR to your local environment
* Navigate to `/discover` and hover a Star button, making sure the popover with the Likes still shows up for the web version.
* Now, switch to the mobile version(By using the dev tools) and click on the Star. The popover should no longer be shown.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?