### PR TITLE
Use site specific manage domains link on thank you page

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/domains/domain-only-thank-you-redesign-v2.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/domain-only-thank-you-redesign-v2.tsx
@@ -32,7 +32,7 @@ const DomainOnlyThankYou: React.FC< DomainOnlyThankYouContainerProps > = ( { dom
 				) }
 			</DefaultSubHeader>
 			{ domains.map( ( domain ) => (
-				<ProductDomain shareSite key={ domain } domain={ domain } />
+				<ProductDomain shareSite key={ domain } domain={ domain } siteSlug={ siteSlug } />
 			) ) }
 			<DomainOnlyFooter />
 			<DefaultUpsell

--- a/client/my-sites/checkout/checkout-thank-you/domains/domain-only-thank-you-redesign-v2.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/domain-only-thank-you-redesign-v2.tsx
@@ -19,6 +19,7 @@ const DomainOnlyThankYou: React.FC< DomainOnlyThankYouContainerProps > = ( { dom
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const backText = translate( 'Back to Home' );
 	const firstDomain = domains[ 0 ];
+
 	return (
 		<ThankYouLayout masterbarProps={ { siteId, siteSlug, backText } }>
 			<DefaultThankYouHeader>{ translate( 'Your own corner of the web' ) }</DefaultThankYouHeader>

--- a/client/my-sites/checkout/checkout-thank-you/domains/domain-only-thank-you-redesign-v2.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domains/domain-only-thank-you-redesign-v2.tsx
@@ -43,7 +43,7 @@ const DomainOnlyThankYou: React.FC< DomainOnlyThankYouContainerProps > = ( { dom
 				) }
 				meshColor="blue"
 				icon={ emailImage }
-				href={ emailManagement( firstDomain, firstDomain ) }
+				href={ emailManagement( siteSlug ?? firstDomain, firstDomain ) }
 				buttonText={ translate( 'Add email' ) }
 				trackEvent="calypso_domain_only_thank_you_professional_email_click"
 			/>

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/product/ProductDomain.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/product/ProductDomain.tsx
@@ -8,7 +8,7 @@ import './style.scss';
 type ProductDomainProps = {
 	domain: string;
 	shareSite?: boolean;
-	siteSlug?: string;
+	siteSlug?: string | null;
 };
 
 const ProductDomain = ( { domain, shareSite, siteSlug }: ProductDomainProps ) => {

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/product/ProductDomain.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/product/ProductDomain.tsx
@@ -1,16 +1,17 @@
 import { Button, ClipboardButton } from '@wordpress/components';
 import { translate } from 'i18n-calypso';
 import { useState } from 'react';
-import { domainManagementRoot } from 'calypso/my-sites/domains/paths';
+import { domainManagementList, domainManagementRoot } from 'calypso/my-sites/domains/paths';
 
 import './style.scss';
 
 type ProductDomainProps = {
 	domain: string;
 	shareSite?: boolean;
+	siteSlug?: string;
 };
 
-const ProductDomain = ( { domain, shareSite }: ProductDomainProps ) => {
+const ProductDomain = ( { domain, shareSite, siteSlug }: ProductDomainProps ) => {
 	const [ isCopying, setIsCopying ] = useState( false );
 	const handleShareSite = ( processing: boolean ) => () => {
 		setIsCopying( processing );
@@ -34,7 +35,10 @@ const ProductDomain = ( { domain, shareSite }: ProductDomainProps ) => {
 						{ isCopying ? translate( 'Site copied' ) : translate( 'Share site' ) }
 					</ClipboardButton>
 				) }
-				<Button variant={ shareSite ? 'secondary' : 'primary' } href={ domainManagementRoot() }>
+				<Button
+					variant={ shareSite ? 'secondary' : 'primary' }
+					href={ siteSlug ? domainManagementList( siteSlug ) : domainManagementRoot() }
+				>
 					{ translate( 'Manage domains' ) }
 				</Button>
 			</div>


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/4565

## Proposed Changes

* Use site specific "manage domain" link on thank you page
* Use site/domain specific "add email" link on thank you page 

## Testing Instructions

* Purchase a .blog domain for a site, save the thank you page url for reloading/testing
* e.g. http://calypso.localhost:3000/checkout/thank-you/tests635.wordpress.com/87090385
* Check: the manage domains link takes you to the domains management list for that site not the manage all domains page.
* Check: the add email link takes you to the site specific email setup `/email/tests635.blog/manage/tests635.wordpress.com`

Next:

* Purchase a .blog domain for no site via the domains page flow: wordpress.com/domains
* e.g. http://calypso.localhost:3000/start/domain/domain-only?new=test153433.blog&search=yes
* Save the checkout thank you page url for reloading/testing
* e.g. http://calypso.localhost:3000/checkout/thank-you/no-site/pending/:orderId?redirectTo=%2Fcheckout%2Foffer-professional-email%2Ftest153433.blog%2F87090736%2Fno-site&receiptId=87090736
* or if the redirect works: http://calypso.localhost:3000/checkout/offer-professional-email/test153433.blog/87090736/no-site
* Check: The manage domains link should point to the manage all domains page: `/domains/manage`
* Check: the add email link takes you to the domain only specific email setup `/email/test153433.blog/manage/test153433.blog`

Next:

Confirm other thank you pages with domain products still load the `/domains/mange` url, e.g. http://calypso.localhost:3000/checkout/domain-transfer-to-any-user/thank-you/test153433.blog
