### PR TITLE
Hosting Command Palette: display contextual commands by default based on the current path

### DIFF
--- a/client/components/command-pallette/use-command-pallette.tsx
+++ b/client/components/command-pallette/use-command-pallette.tsx
@@ -35,7 +35,7 @@ interface Command {
 	subLabel?: string;
 	searchLabel: string;
 	callback: ( params: CommandCallBackParams ) => void;
-	context?: string;
+	context?: string | string[];
 	icon?: JSX.Element;
 	image?: JSX.Element;
 	siteFunctions?: SiteFunctions;

--- a/client/components/command-pallette/use-command-pallette.tsx
+++ b/client/components/command-pallette/use-command-pallette.tsx
@@ -35,7 +35,7 @@ interface Command {
 	subLabel?: string;
 	searchLabel: string;
 	callback: ( params: CommandCallBackParams ) => void;
-	context?: string | string[];
+	context?: string[];
 	icon?: JSX.Element;
 	image?: JSX.Element;
 	siteFunctions?: SiteFunctions;

--- a/client/components/command-pallette/use-command-pallette.tsx
+++ b/client/components/command-pallette/use-command-pallette.tsx
@@ -44,6 +44,7 @@ interface Command {
 interface useCommandPalletteOptions {
 	selectedCommandName: string;
 	setSelectedCommandName: ( name: string ) => void;
+	filter?: ( command: Command ) => boolean | undefined;
 }
 
 const siteToAction =
@@ -70,6 +71,7 @@ const siteToAction =
 export const useCommandPallette = ( {
 	selectedCommandName,
 	setSelectedCommandName,
+	filter,
 }: useCommandPalletteOptions ): { commands: Command[] } => {
 	const { data: allSites = [] } = useSiteExcerptsQuery(
 		[],
@@ -77,7 +79,11 @@ export const useCommandPallette = ( {
 	);
 
 	// Call the generateCommandsArray function to get the commands array
-	const commands = useCommandsArrayWpcom( { setSelectedCommandName } );
+	let commands = useCommandsArrayWpcom( { setSelectedCommandName } );
+
+	if ( 'function' === typeof filter ) {
+		commands = commands.filter( filter );
+	}
 
 	const selectedCommand = commands.find( ( c ) => c.name === selectedCommandName );
 	let sitesToPick = null;

--- a/client/components/command-pallette/wpcom-command-pallette.tsx
+++ b/client/components/command-pallette/wpcom-command-pallette.tsx
@@ -68,13 +68,12 @@ export function CommandMenuGroup( {
 	setSelectedCommandName,
 }: CommandMenuGroupProps ) {
 	const currentPath = useSelector( ( state ) => getCurrentRoute( state ) );
-	const { commands: smpDefaultCommands } = useCommandPallette( {
+	const { commands } = useCommandPallette( {
 		selectedCommandName,
 		setSelectedCommandName,
+		filter: isContextual ? ( command ) => command.context?.includes( currentPath ) : undefined,
 	} );
-	const commands = isContextual
-		? smpDefaultCommands.filter( ( command ) => command.context?.includes( currentPath ) )
-		: smpDefaultCommands;
+
 	if ( ! commands.length ) {
 		return null;
 	}

--- a/client/components/command-pallette/wpcom-command-pallette.tsx
+++ b/client/components/command-pallette/wpcom-command-pallette.tsx
@@ -6,6 +6,8 @@ import { cleanForSlug } from '@wordpress/url';
 import classnames from 'classnames';
 import { Command, useCommandState } from 'cmdk';
 import { useEffect, useState, useRef, useMemo } from 'react';
+import { useSelector } from 'calypso/state';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { CommandCallBackParams, useCommandPallette } from './use-command-pallette';
 
 import '@wordpress/commands/build-style/style.css';
@@ -65,11 +67,14 @@ export function CommandMenuGroup( {
 	selectedCommandName,
 	setSelectedCommandName,
 }: CommandMenuGroupProps ) {
+	const currentPath = useSelector( ( state ) => getCurrentRoute( state ) );
 	const { commands: smpDefaultCommands } = useCommandPallette( {
 		selectedCommandName,
 		setSelectedCommandName,
 	} );
-	const commands = isContextual ? smpDefaultCommands : [];
+	const commands = isContextual
+		? smpDefaultCommands.filter( ( command ) => command.context?.includes( currentPath ) )
+		: smpDefaultCommands;
 	if ( ! commands.length ) {
 		return null;
 	}
@@ -223,24 +228,14 @@ export const WpcomCommandPalette = () => {
 							<Command.Empty>{ __( 'No results found.' ) }</Command.Empty>
 						) }
 						<CommandMenuGroup
+							isContextual={ ! search && ! selectedCommandName }
 							search={ search }
 							close={ closeAndReset }
-							isContextual
 							setSearch={ setSearch }
 							setPlaceholderOverride={ setPlaceholderOverride }
 							selectedCommandName={ selectedCommandName }
 							setSelectedCommandName={ setSelectedCommandName }
 						/>
-						{ search && (
-							<CommandMenuGroup
-								search={ search }
-								close={ closeAndReset }
-								setSearch={ setSearch }
-								setPlaceholderOverride={ setPlaceholderOverride }
-								selectedCommandName={ selectedCommandName }
-								setSelectedCommandName={ setSelectedCommandName }
-							/>
-						) }
 					</Command.List>
 				</Command>
 			</StyledCommandsMenuContainer>

--- a/client/sites-dashboard/components/wpcom-smp-commands.tsx
+++ b/client/sites-dashboard/components/wpcom-smp-commands.tsx
@@ -179,7 +179,6 @@ export const useCommandsArrayWpcom = ( {
 			name: 'openAccountSettings',
 			label: __( 'Open account settings' ),
 			searchLabel: __( 'open account settings' ),
-			context: 'Openining account settings',
 			callback: ( { close }: { close: () => void } ) => {
 				close();
 				navigate( `/me/account` );

--- a/client/sites-dashboard/components/wpcom-smp-commands.tsx
+++ b/client/sites-dashboard/components/wpcom-smp-commands.tsx
@@ -124,7 +124,7 @@ export const useCommandsArrayWpcom = ( {
 			name: 'addNewSite',
 			label: __( 'Add new site' ),
 			searchLabel: __( 'add new site' ),
-			context: 'Adding a new website',
+			context: [ '/sites' ],
 			callback: ( { close }: { close: () => void } ) => {
 				close();
 				navigate( createSiteUrl );
@@ -135,7 +135,7 @@ export const useCommandsArrayWpcom = ( {
 			name: 'openProfile',
 			label: __( 'Open my profile' ),
 			searchLabel: __( 'open my profile' ),
-			context: 'Opening my profile',
+			context: [ '/sites' ],
 			callback: ( { close }: { close: () => void } ) => {
 				close();
 				navigate( `/me` );
@@ -157,7 +157,7 @@ export const useCommandsArrayWpcom = ( {
 			name: 'acessPurchases',
 			label: __( 'Open my purchases' ),
 			searchLabel: __( 'open my purchases' ),
-			context: 'Openining my purchases',
+			context: [ '/sites' ],
 			callback: ( { close }: { close: () => void } ) => {
 				close();
 				navigate( `me/purchases` );
@@ -168,7 +168,7 @@ export const useCommandsArrayWpcom = ( {
 			name: 'manageDomains',
 			label: __( 'Manage domains' ),
 			searchLabel: __( 'manage domains' ),
-			context: 'Managing domains',
+			context: [ '/sites' ],
 			callback: ( { close }: { close: () => void } ) => {
 				close();
 				navigate( `domains/manage` );
@@ -179,7 +179,7 @@ export const useCommandsArrayWpcom = ( {
 			name: 'manageDns',
 			label: __( 'Manage DNS records' ),
 			searchLabel: __( 'manage dns records' ),
-			context: 'Managing DNS records',
+			context: [ '/sites' ],
 			callback: setStateCallback( 'manageDns' ),
 			siteFunctions: {
 				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
@@ -195,7 +195,6 @@ export const useCommandsArrayWpcom = ( {
 			name: 'copySshConnectionString',
 			label: __( 'Copy SSH connection string' ),
 			searchLabel: __( 'copy ssh connection string' ),
-			context: 'Copying SSH connection string',
 			callback: setStateCallback( 'copySshConnectionString' ),
 			siteFunctions: {
 				onClick: async ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
@@ -210,7 +209,6 @@ export const useCommandsArrayWpcom = ( {
 			name: 'openSshCredentials',
 			label: __( 'Open SFTP/SSH credentials' ),
 			searchLabel: __( 'open SFTP/SSH credentials' ),
-			context: 'Opening SFTP/SSH credentials',
 			callback: setStateCallback( 'openSshCredentials' ),
 			siteFunctions: {
 				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
@@ -225,7 +223,6 @@ export const useCommandsArrayWpcom = ( {
 			name: 'resetSshSftpPassword',
 			label: __( 'Reset SSH/SFTP password' ),
 			searchLabel: __( 'reset ssh/sftp password' ),
-			context: 'Resetting SSH/SFTP password',
 			callback: setStateCallback( 'resetSshSftpPassword' ),
 			siteFunctions: {
 				onClick: async ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
@@ -240,7 +237,7 @@ export const useCommandsArrayWpcom = ( {
 			name: 'openSiteDashboard',
 			label: __( 'Open site dashboard' ),
 			searchLabel: __( 'open site dashboard' ),
-			context: 'Opening site dashboard',
+			context: [ '/sites' ],
 			callback: setStateCallback( 'openSiteDashboard' ),
 			siteFunctions: {
 				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
@@ -254,7 +251,6 @@ export const useCommandsArrayWpcom = ( {
 			name: 'openSiteStats',
 			label: __( 'Open site stats' ),
 			searchLabel: __( 'open site stats' ),
-			context: 'Opening site stats',
 			callback: setStateCallback( 'openSiteStats' ),
 			siteFunctions: {
 				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
@@ -268,7 +264,7 @@ export const useCommandsArrayWpcom = ( {
 			name: 'registerDomain',
 			label: __( 'Register domain' ),
 			searchLabel: __( 'register domain' ),
-			context: 'Registering domain',
+			context: [ '/sites' ],
 			callback: ( { close }: { close: () => void } ) => {
 				close();
 				navigate( `/start/domain/domain-only` );
@@ -279,7 +275,6 @@ export const useCommandsArrayWpcom = ( {
 			name: 'openActivityLog',
 			label: __( 'Open activity log' ),
 			searchLabel: __( 'open activity log' ),
-			context: 'Opening activity log',
 			callback: setStateCallback( 'openActivityLog' ),
 			siteFunctions: {
 				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
@@ -294,7 +289,6 @@ export const useCommandsArrayWpcom = ( {
 			name: 'openBackups',
 			label: __( 'Open backups' ),
 			searchLabel: __( 'open backups' ),
-			context: 'Opening backups',
 			callback: setStateCallback( 'openBackups' ),
 			siteFunctions: {
 				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
@@ -309,7 +303,6 @@ export const useCommandsArrayWpcom = ( {
 			name: 'viewSiteMetrics',
 			label: __( 'View site metrics' ),
 			searchLabel: __( 'view site metrics' ),
-			context: 'Viewing site metrics',
 			callback: setStateCallback( 'viewSiteMetrics' ),
 			siteFunctions: {
 				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
@@ -324,7 +317,6 @@ export const useCommandsArrayWpcom = ( {
 			name: 'openPHPLogs',
 			label: __( 'Open PHP logs' ),
 			searchLabel: __( 'open PHP logs' ),
-			context: 'Opening PHP logs',
 			callback: setStateCallback( 'openPHPLogs' ),
 			siteFunctions: {
 				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
@@ -339,7 +331,6 @@ export const useCommandsArrayWpcom = ( {
 			name: 'openWebServerLogs',
 			label: __( 'Open web server logs' ),
 			searchLabel: __( 'open web server logs' ),
-			context: 'Opening web server logs',
 			callback: setStateCallback( 'openWebServerLogs' ),
 			siteFunctions: {
 				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
@@ -354,7 +345,7 @@ export const useCommandsArrayWpcom = ( {
 			name: 'openHostingConfiguration',
 			label: __( 'Open hosting configuration' ),
 			searchLabel: __( 'open hosting configuration' ),
-			context: 'Opening hosting configuration',
+			context: [ '/sites' ],
 			callback: setStateCallback( 'openHostingConfiguration' ),
 			siteFunctions: {
 				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
@@ -369,7 +360,7 @@ export const useCommandsArrayWpcom = ( {
 			name: 'openPHPmyAdmin',
 			label: __( 'Open database in phpMyAdmin' ),
 			searchLabel: __( 'open database in phpMyAdmin' ),
-			context: 'Opening phpMyAdmin',
+			context: [ '/sites' ],
 			callback: setStateCallback( 'openPHPmyAdmin' ),
 			siteFunctions: {
 				onClick: async ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
@@ -384,7 +375,6 @@ export const useCommandsArrayWpcom = ( {
 			name: 'manageStagingSites',
 			label: __( 'Manage staging sites' ),
 			searchLabel: __( 'manage staging sites' ),
-			context: 'Managing staging sites',
 			callback: setStateCallback( 'manageStagingSites' ),
 			siteFunctions: {
 				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
@@ -399,7 +389,6 @@ export const useCommandsArrayWpcom = ( {
 			name: 'managePHPVersion',
 			label: __( 'Manage PHP version' ),
 			searchLabel: __( 'manage PHP issue' ),
-			context: 'Managing PHP version',
 			callback: setStateCallback( 'managePHPVersion' ),
 			siteFunctions: {
 				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
@@ -414,7 +403,6 @@ export const useCommandsArrayWpcom = ( {
 			name: 'manageCacheSettings',
 			label: __( 'Manage cache settings' ),
 			searchLabel: __( 'manage cache settings' ),
-			context: 'Managing cache settings',
 			callback: setStateCallback( 'manageCacheSettings' ),
 			siteFunctions: {
 				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
@@ -429,7 +417,6 @@ export const useCommandsArrayWpcom = ( {
 			name: 'manageAdminInterfaceStyle',
 			label: __( 'Manage admin interface style' ),
 			searchLabel: __( 'manage admin interface style' ),
-			context: 'Managing admin interface style',
 			callback: setStateCallback( 'manageAdminInterfaceStyle' ),
 			siteFunctions: {
 				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {

--- a/client/sites-dashboard/components/wpcom-smp-commands.tsx
+++ b/client/sites-dashboard/components/wpcom-smp-commands.tsx
@@ -121,15 +121,48 @@ export const useCommandsArrayWpcom = ( {
 
 	const commands = [
 		{
-			name: 'addNewSite',
-			label: __( 'Add new site' ),
-			searchLabel: __( 'add new site' ),
+			name: 'openSiteDashboard',
+			label: __( 'Open site dashboard' ),
+			searchLabel: __( 'open site dashboard' ),
 			context: [ '/sites' ],
-			callback: ( { close }: { close: () => void } ) => {
-				close();
-				navigate( createSiteUrl );
+			callback: setStateCallback( 'openSiteDashboard' ),
+			siteFunctions: {
+				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
+					close();
+					navigate( `/home/${ site.slug }` );
+				},
 			},
-			icon: addNewSiteIcon,
+			icon: dashboardIcon,
+		},
+		{
+			name: 'openHostingConfiguration',
+			label: __( 'Open hosting configuration' ),
+			searchLabel: __( 'open hosting configuration' ),
+			context: [ '/sites' ],
+			callback: setStateCallback( 'openHostingConfiguration' ),
+			siteFunctions: {
+				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
+					close();
+					navigate( `/hosting-config/${ site.slug }#sftp-credentials` );
+				},
+				filter: ( site: SiteExcerptData ) => ! isP2Site( site ) && ! isNotAtomicJetpack( site ),
+			},
+			icon: hostingConfigIcon,
+		},
+		{
+			name: 'openPHPmyAdmin',
+			label: __( 'Open database in phpMyAdmin' ),
+			searchLabel: __( 'open database in phpMyAdmin' ),
+			context: [ '/sites' ],
+			callback: setStateCallback( 'openPHPmyAdmin' ),
+			siteFunctions: {
+				onClick: async ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
+					close();
+					await openPHPmyAdmin( site.ID );
+				},
+				filter: ( site: SiteExcerptData ) => site?.is_wpcom_atomic,
+			},
+			icon: pageIcon,
 		},
 		{
 			name: 'openProfile',
@@ -234,20 +267,6 @@ export const useCommandsArrayWpcom = ( {
 			icon: keyIcon,
 		},
 		{
-			name: 'openSiteDashboard',
-			label: __( 'Open site dashboard' ),
-			searchLabel: __( 'open site dashboard' ),
-			context: [ '/sites' ],
-			callback: setStateCallback( 'openSiteDashboard' ),
-			siteFunctions: {
-				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
-					close();
-					navigate( `/home/${ site.slug }` );
-				},
-			},
-			icon: dashboardIcon,
-		},
-		{
 			name: 'openSiteStats',
 			label: __( 'Open site stats' ),
 			searchLabel: __( 'open site stats' ),
@@ -342,36 +361,6 @@ export const useCommandsArrayWpcom = ( {
 			icon: acitvityLogIcon,
 		},
 		{
-			name: 'openHostingConfiguration',
-			label: __( 'Open hosting configuration' ),
-			searchLabel: __( 'open hosting configuration' ),
-			context: [ '/sites' ],
-			callback: setStateCallback( 'openHostingConfiguration' ),
-			siteFunctions: {
-				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
-					close();
-					navigate( `/hosting-config/${ site.slug }#sftp-credentials` );
-				},
-				filter: ( site: SiteExcerptData ) => ! isP2Site( site ) && ! isNotAtomicJetpack( site ),
-			},
-			icon: hostingConfigIcon,
-		},
-		{
-			name: 'openPHPmyAdmin',
-			label: __( 'Open database in phpMyAdmin' ),
-			searchLabel: __( 'open database in phpMyAdmin' ),
-			context: [ '/sites' ],
-			callback: setStateCallback( 'openPHPmyAdmin' ),
-			siteFunctions: {
-				onClick: async ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
-					close();
-					await openPHPmyAdmin( site.ID );
-				},
-				filter: ( site: SiteExcerptData ) => site?.is_wpcom_atomic,
-			},
-			icon: pageIcon,
-		},
-		{
 			name: 'manageStagingSites',
 			label: __( 'Manage staging sites' ),
 			searchLabel: __( 'manage staging sites' ),
@@ -426,6 +415,17 @@ export const useCommandsArrayWpcom = ( {
 				filter: ( site: SiteExcerptData ) => site?.is_wpcom_atomic,
 			},
 			icon: pageIcon,
+		},
+		{
+			name: 'addNewSite',
+			label: __( 'Add new site' ),
+			searchLabel: __( 'add new site' ),
+			context: [ '/sites' ],
+			callback: ( { close }: { close: () => void } ) => {
+				close();
+				navigate( createSiteUrl );
+			},
+			icon: addNewSiteIcon,
 		},
 	];
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Related to https://github.com/Automattic/dotcom-forge/issues/4531

## Proposed Changes

* Limit the commands displayed by default and those are based on the current path

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch locally or use calypso live
* Access `/sites`
* Press `cmd+k` on mac or `ctrl+k` on Windows
* Observe that the list of commands is limited and there is no scroll in the palette
* Type a letter , like `s`
* Observe the list of commands is displaying all the commands with `s` and the palette has scroll.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?