### PR TITLE
Plans: Fix left border of the plans spotlight element on plans page

### DIFF
--- a/client/my-sites/plans-grid/style.scss
+++ b/client/my-sites/plans-grid/style.scss
@@ -409,7 +409,11 @@ $mobile-card-max-width: 440px;
 	}
 
 	@include plans-2023-break-small {
-		border-left: solid 1px #e0e0e0;
+		// The .plan-features-2023-grid__table-item is used to render the plan spotlight which doesn't
+		// use a table layout, but borders are only appropriate in table layout.
+		&:is(td) {
+			border-left: solid 1px #e0e0e0;
+		}
 	}
 }
 
@@ -630,7 +634,9 @@ body.is-section-signup.is-white-signup,
 		border-right: none;
 		background-color: transparent;
 
-		&:first-of-type {
+		// The extra `:is(td)` is needed so this rule is at the same specificity as the rule
+		// which originally added the border-left, which uses an `:is` selector.
+		&:first-of-type:is(td) {
 			border-left: none;
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

The current plan spotlight on `/plans/{{ site slug }}` has an extra border on the left hand side, making it appear twice as thick. It makes me cry when I see it 😫

![CleanShot 2023-11-24 at 17 55 31@2x](https://github.com/Automattic/wp-calypso/assets/1500769/70ee6180-4c4a-41e1-beb8-a6e412269c10)

The border comes from `.plan-features-2023-grid__table-item`. This is the rule used to style the table elements in the plans grid below the spotlight and the `border-left` is what draws the border between the different plan columns. However this class is also used on the plan spotlight, presumably to make sure the text looks nice and consistent with the table below.

The problem is that `:first-of-type` is used to disable the `border-left` for the first column. That's fine for the grid because they're all `td` elements and are laid out in a row. But the plan spotlight doesn't use a table and so `:first-of-type` doesn't work. The extra border isn't removed.

Potential solutions:
- Use a `<table>` for the plan spotlight too. That doesn't seem semantically correct.
- Ensure the `border-left` rules are only used when it's _actually_ a table. That's what this PR does. It's sort of like how the `border-left` rules are disabled for mobile layout too.
- Refactor `.plan-features-2023-grid__table-item` into two classes, one for the bits needed for table layout and the other for styling. The plan spotlight would only use the styling class. This'd be a bigger change than what I'm proposing here but it would be a good option here.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test on Chromium, Safari, FF
* Test mobile and desktop, and sizes in between
* Test when there's no plan spotlight too, like in `/start/plans`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] ~https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?~
- [ ] ~Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?~
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] ~Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)~
- [ ] ~Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?~
- [ ] ~For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?~