### PR TITLE
Jetpack Manage: Hide discount information for products that have bundle equivalents in a single-size view.

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
@@ -113,6 +113,7 @@ export default function LicensesForm( {
 							isDisabled={ ! isReady }
 							onSelectProduct={ onSelectBundle }
 							tabIndex={ 100 + ( products?.length || 0 ) + i }
+							hideDiscount={ isSingleLicenseView }
 						/>
 					) ) }
 				</LicensesFormSection>
@@ -135,6 +136,7 @@ export default function LicensesForm( {
 							isDisabled={ disabledProductSlugs.includes( productOption.slug ) }
 							tabIndex={ 100 + i }
 							suggestedProduct={ suggestedProduct }
+							hideDiscount={ isSingleLicenseView }
 						/>
 					) ) }
 				</LicensesFormSection>

--- a/client/jetpack-cloud/sections/partner-portal/license-bundle-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-bundle-card/index.tsx
@@ -21,6 +21,7 @@ type Props = {
 	tabIndex: number;
 	product: APIProductFamilyProduct;
 	onSelectProduct?: ( value: APIProductFamilyProduct ) => void;
+	hideDiscount?: boolean;
 };
 
 const LicenseBundleCard = ( {
@@ -30,6 +31,7 @@ const LicenseBundleCard = ( {
 	tabIndex,
 	product,
 	onSelectProduct,
+	hideDiscount,
 }: Props ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -87,7 +89,7 @@ const LicenseBundleCard = ( {
 
 				<div className="license-bundle-card__footer">
 					<div className="license-bundle-card__pricing">
-						<ProductPriceWithDiscount product={ product } />
+						<ProductPriceWithDiscount product={ product } hideDiscount={ hideDiscount } />
 					</div>
 					<Button
 						primary

--- a/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
@@ -21,6 +21,7 @@ interface Props {
 	onSelectProduct: ( value: APIProductFamilyProduct ) => void | null;
 	suggestedProduct?: string | null;
 	isMultiSelect?: boolean;
+	hideDiscount?: boolean;
 }
 
 export default function LicenseProductCard( props: Props ) {
@@ -32,6 +33,7 @@ export default function LicenseProductCard( props: Props ) {
 		onSelectProduct,
 		suggestedProduct,
 		isMultiSelect,
+		hideDiscount,
 	} = props;
 	const { setParams, resetParams, getParamValue } = useURLQueryParams();
 	const modalParamValue = getParamValue( LICENSE_INFO_MODAL_ID );
@@ -135,7 +137,7 @@ export default function LicenseProductCard( props: Props ) {
 						</div>
 
 						<div className="license-product-card__pricing">
-							<ProductPriceWithDiscount product={ product } />
+							<ProductPriceWithDiscount product={ product } hideDiscount={ hideDiscount } />
 						</div>
 					</div>
 				</div>

--- a/client/jetpack-cloud/sections/partner-portal/primary/product-price-with-discount-info/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/product-price-with-discount-info/index.tsx
@@ -8,9 +8,10 @@ import './style.scss';
 
 interface Props {
 	product: APIProductFamilyProduct;
+	hideDiscount?: boolean;
 }
 
-export default function ProductPriceWithDiscount( { product }: Props ) {
+export default function ProductPriceWithDiscount( { product, hideDiscount }: Props ) {
 	const translate = useTranslate();
 
 	const userProducts = useSelector( ( state ) => getProductsList( state ) );
@@ -54,7 +55,7 @@ export default function ProductPriceWithDiscount( { product }: Props ) {
 				{ discountInfo.discountedCost }
 				{
 					// Display discount info only if there is a discount
-					discountInfo.discountPercentage > 0 && (
+					discountInfo.discountPercentage > 0 && ! hideDiscount && (
 						<>
 							<span className="product-price-with-discount__price-discount">
 								{ translate( 'Save %(discountPercentage)s%', {


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack-genesis/issues/106

## Proposed Changes

* Update the Bundle and Product cards component to include hideDiscount props.
* Update the Issue license page to hide discounts for products with equivalent bundles when in the Single bundle size view.

## Testing Instructions

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

* Use the Jetpack cloud live link below and go to the Licenses page (`/partner-portal/issue-license?flags=jetpack/bundle-licensing`)
* Confirm that when selecting the Single license tab, the discounts are not visible for both plans and products. **Note that the Woo extensions and Backup addons will still display discounts as these do not have equivalent bundles.**

<img width="1571" alt="Screen Shot 2023-11-24 at 1 23 27 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/b23abe38-f061-47c2-aec2-5ca905f68042">

* Confirm that when selecting a non-single license tab, the discounts are visible.
<img width="1557" alt="Screen Shot 2023-11-24 at 1 25 05 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/729b20b6-7e5f-4fca-83da-a2f225a15eef">

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?