### PR TITLE
Stats: Update to useTranslate for slider strings

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.tsx
@@ -1,6 +1,6 @@
 import { PricingSlider } from '@automattic/components';
 import classNames from 'classnames';
-import { translate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import React, { useState } from 'react';
 import useAvailableUpgradeTiers from './stats-purchase-tier-upgrade-slider-utils';
 
@@ -10,7 +10,8 @@ type TierUpgradeSliderProps = {
 	className?: string;
 };
 
-function getLocalizedStrings() {
+function useTranslatedStrings() {
+	const translate = useTranslate();
 	const limits = translate( 'Monthly site views limit', {
 		comment: 'Heading for Stats Upgrade slider. The monthly views limit.',
 	} );
@@ -43,17 +44,17 @@ function TierUpgradeSlider( { className }: TierUpgradeSliderProps ) {
 		setCurrentPlanIndex( value );
 	};
 
-	const localizedStrings = getLocalizedStrings();
+	const translatedStrings = useTranslatedStrings();
 
 	return (
 		<div className={ componentClassNames }>
 			<div className="stats-tier-upgrade-slider__plan-callouts">
 				<div className="stats-tier-upgrade-slider__plan-callout">
-					<h2>{ localizedStrings.limits }</h2>
+					<h2>{ translatedStrings.limits }</h2>
 					<p>{ plans[ currentPlanIndex ].views }</p>
 				</div>
 				<div className="stats-tier-upgrade-slider__plan-callout">
-					<h2>{ localizedStrings.price }</h2>
+					<h2>{ translatedStrings.price }</h2>
 					<p className="right-aligned">{ plans[ currentPlanIndex ].price }</p>
 				</div>
 			</div>
@@ -65,7 +66,7 @@ function TierUpgradeSlider( { className }: TierUpgradeSliderProps ) {
 				onChange={ handleSliderChange }
 				marks
 			/>
-			<p className="stats-tier-upgrade-slider__info-message">{ localizedStrings.strategy }</p>
+			<p className="stats-tier-upgrade-slider__info-message">{ translatedStrings.strategy }</p>
 		</div>
 	);
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #83898

## Proposed Changes

Update code to hooks pattern and `useTranslate()` when setting up strings.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Launch the Calypso Live link.
2. Navigate to **Stats → Traffic**.
3. Update URL to: `http://calypso.localhost:3000/stats/purchase/SITE_SLUG?productType=commercial&flags=stats/type-detection,stats/tier-upgrade-slider`
4. Confirm slider with strings are visible.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?