### PR TITLE
Jetpack Manage: Implement pricing summary in the review licenses modal

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/lib/pricing.ts
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/lib/pricing.ts
@@ -37,9 +37,9 @@ export const getProductPricingInfo = (
 		if ( monthlyProduct ) {
 			const actualCost = isDailyPricing ? monthlyProduct.cost / 365 : monthlyProduct.cost;
 			const discountedCost = actualCost - productCost;
-			discountInfo.discountPercentage = ! productCost
-				? 100
-				: Math.round( ( discountedCost / actualCost ) * 100 );
+			discountInfo.discountPercentage = productCost
+				? Math.round( ( discountedCost / actualCost ) * 100 )
+				: 100;
 			discountInfo.actualCost = actualCost * product.quantity;
 		}
 	}

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/lib/pricing.ts
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/lib/pricing.ts
@@ -1,0 +1,74 @@
+import type { SelectedLicenseProp } from '../types';
+import type { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
+
+// This function calculates the pricing information for a given product.
+export const getProductPricingInfo = (
+	userProducts: Record< string, ProductListItem >,
+	product: SelectedLicenseProp
+) => {
+	const productCost = product?.amount || 0;
+
+	const isDailyPricing = product.price_interval === 'day';
+
+	const discountInfo: {
+		actualCost: number;
+		discountedCost: number;
+		discountPercentage: number;
+	} = {
+		actualCost: 0,
+		discountedCost: productCost * product.quantity, // This is the discounted cost based on the product quantity
+		discountPercentage: 0,
+	};
+	if ( Object.keys( userProducts ).length && product ) {
+		// Find the yearly version of the product in userProducts
+		const yearlyProduct = Object.values( userProducts ).find(
+			( prod ) => prod.product_id === product.product_id
+		);
+
+		// If a yearly product is found, find the monthly version of the product
+		const monthlyProduct =
+			yearlyProduct &&
+			Object.values( userProducts ).find(
+				( p ) =>
+					p.billing_product_slug === yearlyProduct.billing_product_slug &&
+					p.product_term === 'month'
+			);
+		// If a monthly product is found, calculate the actual cost and discount percentage
+		if ( monthlyProduct ) {
+			const actualCost = isDailyPricing ? monthlyProduct.cost / 365 : monthlyProduct.cost;
+			const discountedCost = actualCost - productCost;
+			discountInfo.discountPercentage = ! productCost
+				? 100
+				: Math.round( ( discountedCost / actualCost ) * 100 );
+			discountInfo.actualCost = actualCost * product.quantity;
+		}
+	}
+	return discountInfo;
+};
+
+// Calculate the actual cost based on the product quantity
+export const getTotalInvoiceValue = (
+	userProducts: Record< string, ProductListItem >,
+	selectedLicenses: SelectedLicenseProp[]
+) => {
+	// Use the reduce function to calculate the total invoice value
+	return selectedLicenses.reduce(
+		( acc, license ) => {
+			// Get the pricing information for the current license
+			const { actualCost, discountedCost, discountPercentage } = getProductPricingInfo(
+				userProducts,
+				license
+			);
+			// Add the actual cost, discounted cost, and discount percentage to the accumulator
+			acc.actualCost += actualCost;
+			acc.discountedCost += discountedCost;
+			acc.discountPercentage += discountPercentage;
+			return acc;
+		},
+		{
+			actualCost: 0,
+			discountedCost: 0,
+			discountPercentage: 0,
+		}
+	);
+};

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/index.tsx
@@ -5,6 +5,7 @@ import JetpackLightbox, {
 } from 'calypso/components/jetpack/jetpack-lightbox';
 import useMobileSidebar from 'calypso/components/jetpack/jetpack-lightbox/hooks/use-mobile-sidebar';
 import LicenseInfo from './license-info';
+import PricingSummary from './pricing-summary';
 import type { SelectedLicenseProp } from '../types';
 
 import './style.scss';
@@ -20,7 +21,12 @@ export default function ReviewLicenses( { onClose, selectedLicenses }: Props ) {
 	const { sidebarRef, mainRef, initMobileSidebar } = useMobileSidebar();
 
 	return (
-		<JetpackLightbox isOpen={ true } onClose={ onClose } onAfterOpen={ initMobileSidebar }>
+		<JetpackLightbox
+			className="review-licenses__lightbox"
+			isOpen={ true }
+			onClose={ onClose }
+			onAfterOpen={ initMobileSidebar }
+		>
 			<JetpackLightboxMain ref={ mainRef }>
 				<div className="review-licenses__header">
 					<div className="review-licenses__title">{ translate( 'Review license selection' ) }</div>
@@ -35,7 +41,9 @@ export default function ReviewLicenses( { onClose, selectedLicenses }: Props ) {
 				</div>
 			</JetpackLightboxMain>
 
-			<JetpackLightboxAside ref={ sidebarRef }>Content</JetpackLightboxAside>
+			<JetpackLightboxAside ref={ sidebarRef }>
+				<PricingSummary selectedLicenses={ selectedLicenses } />
+			</JetpackLightboxAside>
 		</JetpackLightbox>
 	);
 }

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/pricing-summary.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/pricing-summary.tsx
@@ -33,13 +33,13 @@ export default function PricingSummary( {
 	return (
 		<>
 			<div className="review-licenses__pricing">
-				<span className="review-licenses__price">
+				<span className="review-licenses__pricing-discounted">
 					{ formatCurrency( discountedCost, currency ) }
 				</span>
-				<span className="review-licenses__price-old">
+				<span className="review-licenses__pricing-original">
 					{ formatCurrency( actualCost, currency ) }
 				</span>
-				<div className="review-licenses__price-interval">{ translate( '/per month' ) }</div>
+				<div className="review-licenses__pricing-interval">{ translate( '/per month' ) }</div>
 			</div>
 			<Button primary className="review-licenses__cta-button" onClick={ handleCTAClick }>
 				{ translate( 'Issue %(numLicenses)d license', 'Issue %(numLicenses)d licenses', {

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/pricing-summary.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/pricing-summary.tsx
@@ -1,0 +1,65 @@
+import { Button } from '@automattic/components';
+import formatCurrency from '@automattic/format-currency';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
+import { useSelector } from 'calypso/state';
+import { getProductsList } from 'calypso/state/products-list/selectors';
+import { getTotalInvoiceValue } from '../lib/pricing';
+import type { SelectedLicenseProp } from '../types';
+
+export default function PricingSummary( {
+	selectedLicenses,
+}: {
+	selectedLicenses: SelectedLicenseProp[];
+} ) {
+	const translate = useTranslate();
+
+	const userProducts = useSelector( getProductsList );
+	const { discountedCost, actualCost } = getTotalInvoiceValue( userProducts, selectedLicenses );
+
+	const selectedLicenseCount = selectedLicenses
+		.map( ( license ) => license.quantity )
+		.reduce( ( a, b ) => a + b, 0 );
+
+	const handleCTAClick = useCallback( () => {
+		// TODO: Add tracking
+		// TODO: Handle onclick
+	}, [] );
+
+	const link = '#link'; // TODO: Add link
+
+	const currency = selectedLicenses[ 0 ].currency; // FIXME: Fix if multiple currencies are supported
+
+	return (
+		<>
+			<div className="review-licenses__pricing">
+				<span className="review-licenses__price">
+					{ formatCurrency( discountedCost, currency ) }
+				</span>
+				<span className="review-licenses__price-old">
+					{ formatCurrency( actualCost, currency ) }
+				</span>
+				<div className="review-licenses__price-interval">{ translate( '/per month' ) }</div>
+			</div>
+			<Button primary className="review-licenses__cta-button" onClick={ handleCTAClick }>
+				{ translate( 'Issue %(numLicenses)d license', 'Issue %(numLicenses)d licenses', {
+					context: 'button label',
+					count: selectedLicenseCount,
+					args: {
+						numLicenses: selectedLicenseCount,
+					},
+				} ) }
+			</Button>
+			<div className="review-licenses__notice">
+				{ translate(
+					'You will be billed at the end of every month. Your first month may be less than the above amount. {{a}}Learn more{{/a}}',
+					{
+						components: {
+							a: <a href={ link } target="_blank" rel="noopener noreferrer" />,
+						},
+					}
+				) }
+			</div>
+		</>
+	);
+}

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/style.scss
@@ -87,7 +87,15 @@
 	border: 1px solid var(--studio-jetpack-green-50);
 	padding: 1rem;
 
-	.review-licenses__price {
+	@media only screen and ( min-width: 782px ) {
+		margin-block-start: 24px;
+	}
+
+	@include break-large {
+		margin-block-start: 8px;
+	}
+
+	.review-licenses__pricing-discounted {
 		font-size: 1.25rem;
 		font-weight: 600;
 		color: var(--studio-gray-80);
@@ -100,22 +108,14 @@
 		}
 	}
 
-	@media only screen and ( min-width: 782px ) {
-		margin-block-start: 24px;
-	}
-
-	@include break-large {
-		margin-block-start: 8px;
-	}
-
-	.review-licenses__price-old {
+	.review-licenses__pricing-original {
 		text-decoration: line-through;
 		font-weight: 400;
 		font-size: 1rem;
 		margin-inline-start: 8px;
 	}
 
-	.review-licenses__price-interval {
+	.review-licenses__pricing-interval {
 		font-size: 0.75rem;
 		font-weight: 400;
 		color: var(--studio-gray-60);

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/style.scss
@@ -1,3 +1,10 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.review-licenses__lightbox {
+	min-height: 300px;
+}
+
 .review-licenses__title {
 	color: var(--studio-gray-100);
 	font-size: rem(24px);
@@ -71,5 +78,63 @@
 			font-weight: 400;
 			margin-block: 4px 0;
 		}
+	}
+}
+
+.review-licenses__pricing {
+	background-color: var(--studio-white);
+	border-radius: 8px; /* stylelint-disable-line scales/radii */
+	border: 1px solid var(--studio-jetpack-green-50);
+	padding: 1rem;
+
+	.review-licenses__price {
+		font-size: 1.25rem;
+		font-weight: 600;
+		color: var(--studio-gray-80);
+		line-height: 1;
+
+		@include break-xlarge {
+			font-size: 1.5rem;
+			font-weight: 700;
+			color: var(--studio-black);
+		}
+	}
+
+	@media only screen and ( min-width: 782px ) {
+		margin-block-start: 24px;
+	}
+
+	@include break-large {
+		margin-block-start: 8px;
+	}
+
+	.review-licenses__price-old {
+		text-decoration: line-through;
+		font-weight: 400;
+		font-size: 1rem;
+		margin-inline-start: 8px;
+	}
+
+	.review-licenses__price-interval {
+		font-size: 0.75rem;
+		font-weight: 400;
+		color: var(--studio-gray-60);
+		line-height: 2;
+	}
+}
+
+.review-licenses__cta-button {
+	margin-block: 16px 8px;
+	width: 100%;
+}
+
+.review-licenses__notice {
+	color: var(--studio-gray-50);
+	font-size: rem(12px);
+	margin-block-end: 16px;
+
+	a {
+		text-decoration: underline;
+		color: var(--studio-black);
 	}
 }


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/98

## Proposed Changes

This PR displays the pricing summary in the review licenses modal.

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Visit the Jetpack Cloud link > Replace `dashboard` in the URL with `/partner-portal/issue-license?flags=jetpack/bundle-licensing`.
2. Select a few licenses and click the `Review X licenses` button > Verify that the total price is shown along with the `Issue X license` button on the right side of the modal. Please note the CTA & Learn more link doesn't do anything. It will be updated in upcoming PRs. The pricing breakdown will the done in another PR. The discounted price needs to be updated based on the selected bundle(TODO)

Large screen:

<img width="1154" alt="Screenshot 2023-11-24 at 11 11 06 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/2cb5314b-d138-45a4-88e1-a527ea01c213">

Tablet view:

<img width="591" alt="Screenshot 2023-11-24 at 11 24 21 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/8a52a3d0-90a9-480a-86ee-82276f5c280a">

Mobile view:

<img width="395" alt="Screenshot 2023-11-24 at 11 12 01 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/d7499fbf-74d8-4d79-8582-31f9a57954ea">




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?