### PR TITLE
Jetpack Manage: Fix UI shifting issue when rendering the sticky header in the Issue license page.

### DIFF
--- a/client/jetpack-cloud/components/layout/header.tsx
+++ b/client/jetpack-cloud/components/layout/header.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import { Children, ReactNode, useEffect, useState } from 'react';
+import { Children, ReactNode, useLayoutEffect, useState } from 'react';
 import useDetectWindowBoundary from 'calypso/lib/detect-window-boundary';
 
 type Props = {
@@ -43,7 +43,7 @@ export default function LayoutHeader( { showStickyContent, children }: Props ) {
 
 	// To avoid shifting the layout when displaying sticky content,  we will need to
 	// keep track of our Header height and set it as the minimum viewport height.
-	useEffect(
+	useLayoutEffect(
 		() => {
 			const headerRef = outerDivProps?.ref?.current;
 

--- a/client/jetpack-cloud/components/layout/header.tsx
+++ b/client/jetpack-cloud/components/layout/header.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import { Children, ReactNode } from 'react';
+import { Children, ReactNode, useEffect, useState } from 'react';
 import useDetectWindowBoundary from 'calypso/lib/detect-window-boundary';
 
 type Props = {
@@ -39,8 +39,36 @@ export default function LayoutHeader( { showStickyContent, children }: Props ) {
 
 	const outerDivProps = divRef ? { ref: divRef as React.RefObject< HTMLDivElement > } : {};
 
+	const [ minHeaderHeight, setMinHeaderHeight ] = useState( 0 );
+
+	// To avoid shifting the layout when displaying sticky content,  we will need to
+	// keep track of our Header height and set it as the minimum viewport height.
+	useEffect(
+		() => {
+			const headerRef = outerDivProps?.ref?.current;
+
+			const updateMinHeaderHeight = () => {
+				setMinHeaderHeight( headerRef?.clientHeight ?? 0 );
+			};
+
+			window.addEventListener( 'resize', updateMinHeaderHeight );
+
+			updateMinHeaderHeight();
+
+			return () => {
+				window.removeEventListener( 'resize', updateMinHeaderHeight );
+			};
+		},
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[]
+	);
+
 	return (
-		<div className="jetpack-cloud-layout__viewport" { ...outerDivProps }>
+		<div
+			className="jetpack-cloud-layout__viewport"
+			{ ...outerDivProps }
+			style={ showStickyContent ? { minHeight: `${ minHeaderHeight }px` } : {} }
+		>
 			<div
 				className={ classNames( {
 					'jetpack-cloud-layout__sticky-header': showStickyContent && hasCrossed,


### PR DESCRIPTION
This pull request aims to resolve the issue of UI shift that occurs when the sticky header is rendered or hidden, by introducing a minimum height. This fix ensures a smoother user experience and a more consistent visual appearance.

**Before**

https://github.com/Automattic/wp-calypso/assets/56598660/1aea1981-85de-42ec-9f07-fb1fd0cd2e3c

**After**

https://github.com/Automattic/wp-calypso/assets/56598660/7182c157-374d-4c51-b04f-4d50ca5afc70



## Proposed Changes

* When rendering the sticky header, use the viewport height as a minimum height for the header. This prevents the UI from shifting as the header container will occupy the space.


## Testing Instructions

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

* Use the Jetpack cloud live link below and go to the Licenses page (`/partner-portal/issue-license?flags=jetpack/bundle-licensing`)
* Scroll down and select a product (Make sure you select the products below where header is already outside the viewport).
* Confirm that there is no UI shift.


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?