### PR TITLE
Checkout: fix yoast coupon starting with numbers

### DIFF
--- a/client/my-sites/checkout/src/hooks/use-coupon-field-state.ts
+++ b/client/my-sites/checkout/src/hooks/use-coupon-field-state.ts
@@ -67,6 +67,12 @@ export default function useCouponFieldState(
 }
 
 function isCouponValid( coupon: string ) {
+	// Quick fix for Yoast coupon code. See: https://a8c.slack.com/archives/CFFF01Q4V/p1700817298317919?thread_ts=1700816348.184029&cid=CFFF01Q4V
+	// Will follow up with proper fix OR remove this code after the coupon code is expired.
+	if ( coupon === '30YOAST2023' ) {
+		return true;
+	}
+
 	// Coupon code is case-insensitive and started with an alphabet.
 	// Underscores and hyphens can be included in the coupon code.
 	// Per-user coupons can have a dot followed by 5-6 letter checksum for verification.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1700817298317919/1700816348.184029-slack-CFFF01Q4V

## Proposed Changes

Quick fix for Yoast coupon code.
Will follow up with proper fix OR remove this code after the coupon code is expired.
Coupon regex was changed in  https://github.com/Automattic/wp-calypso/pull/49181/files but we haven't yet figured out why it doesn't allow numbers in the start.

## Testing Instructions

* add `https://wordpress.com/plugins/wordpress-seo-premium` to your cart
* add `30YOAST2023` coupon
* make sure you get a discount

![CleanShot 2023-11-24 at 11 09 37@2x](https://github.com/Automattic/wp-calypso/assets/12430020/e7d98d1a-8d44-4405-8ce8-e7406699c91e)

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?