### PR TITLE
Checkout: fix coupons starting with numbers

### DIFF
--- a/client/my-sites/checkout/src/hooks/use-coupon-field-state.ts
+++ b/client/my-sites/checkout/src/hooks/use-coupon-field-state.ts
@@ -70,5 +70,5 @@ function isCouponValid( coupon: string ) {
 	// Coupon code is case-insensitive and starts with an alphanumeric.
 	// Underscores and hyphens can be included in the coupon code.
 	// Per-user coupons can have a dot followed by 5-6 letter checksum for verification.
-	return coupon.match( /^[a-z0-9][a-z\d_-]+(\.[a-z\d]+)?$/i );
+	return coupon.match( /^[a-z\d][a-z\d_-]+(\.[a-z\d]+)?$/i );
 }

--- a/client/my-sites/checkout/src/hooks/use-coupon-field-state.ts
+++ b/client/my-sites/checkout/src/hooks/use-coupon-field-state.ts
@@ -67,14 +67,8 @@ export default function useCouponFieldState(
 }
 
 function isCouponValid( coupon: string ) {
-	// Quick fix for Yoast coupon code. See: https://a8c.slack.com/archives/CFFF01Q4V/p1700817298317919?thread_ts=1700816348.184029&cid=CFFF01Q4V
-	// Will follow up with proper fix OR remove this code after the coupon code is expired.
-	if ( coupon === '30YOAST2023' ) {
-		return true;
-	}
-
-	// Coupon code is case-insensitive and started with an alphabet.
+	// Coupon code is case-insensitive and starts with an alphanumeric.
 	// Underscores and hyphens can be included in the coupon code.
 	// Per-user coupons can have a dot followed by 5-6 letter checksum for verification.
-	return coupon.match( /^[a-z][a-z\d_-]+(\.[a-z\d]+)?$/i );
+	return coupon.match( /^[a-z0-9][a-z\d_-]+(\.[a-z\d]+)?$/i );
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

This is a follow up of https://github.com/Automattic/wp-calypso/pull/84499
Related slack: p1700816348184029-slack-CFFF01Q4V

## Proposed Changes

* allow coupons starting with a number

## Testing Instructions

**Scenario 1 - coupons starting with numbers**

* add `https://wordpress.com/plugins/wordpress-seo-premium` to your cart
* add `30YOAST2023` coupon
* make sure you get a discount

![CleanShot 2023-11-24 at 11 09 37@2x](https://github.com/Automattic/wp-calypso/assets/12430020/e7d98d1a-8d44-4405-8ce8-e7406699c91e)

**Scenario 2 - coupons not starting numbers**
Use a coupon that already exists and test

**Scenario 3 - per user coupons**

Generate a coupon and test pau2Xa-2Cr-p2

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?