### PR TITLE
Assembler: Refactor: simplify shufflePosts logic

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pages/page-preview-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pages/page-preview-list.tsx
@@ -78,7 +78,6 @@ const PagePreviewList = ( {
 					style={ pagePreviewStyle }
 					patterns={ homepage }
 					transformPatternHtml={ transformPatternHtml }
-					shouldShufflePosts={ isNewSite }
 					onFullscreenEnter={ handleFullscreenEnter }
 					onFullscreenLeave={ handleFullscreenLeave }
 				/>
@@ -95,7 +94,6 @@ const PagePreviewList = ( {
 							...( selectedFooter ? [ selectedFooter ] : [] ),
 						] }
 						transformPatternHtml={ transformPatternHtml }
-						shouldShufflePosts={ isNewSite }
 						onFullscreenEnter={ handleFullscreenEnter }
 						onFullscreenLeave={ handleFullscreenLeave }
 					/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pages/page-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pages/page-preview.tsx
@@ -14,7 +14,6 @@ interface BasePageProps {
 	style: CSSProperties;
 	patterns: Pattern[];
 	transformPatternHtml: ( patternHtml: string ) => string;
-	shouldShufflePosts: boolean;
 }
 
 interface PageProps extends BasePageProps {
@@ -32,13 +31,7 @@ interface PagePreviewProps extends BasePageProps {
 const PATTERN_PAGE_PREVIEW_ITEM_VIEWPORT_HEIGHT = 500;
 const PATTERN_PAGE_PREVIEW_ITEM_VIEWPORT_WIDTH = 1080;
 
-const Page = ( {
-	className,
-	style,
-	patterns,
-	transformPatternHtml,
-	shouldShufflePosts,
-}: PageProps ) => {
+const Page = ( { className, style, patterns, transformPatternHtml }: PageProps ) => {
 	const pageTitle = useMemo( () => {
 		return patterns.find( isPagePattern )?.title ?? '';
 	}, [ patterns ] );
@@ -62,7 +55,6 @@ const Page = ( {
 					transformHtml={
 						isPagePattern( pattern ) ? transformPagePatternHtml : transformPatternHtml
 					}
-					shouldShufflePosts={ shouldShufflePosts }
 				/>
 			) ) }
 		</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-container.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-container.tsx
@@ -12,7 +12,7 @@ interface Props {
 	patternsMapByCategory: Record< string, Pattern[] >;
 	children: JSX.Element;
 	siteInfo: SiteInfo;
-	isNewSite?: boolean;
+	isNewSite: boolean;
 }
 
 const PatternAssemblerContainer = ( {
@@ -51,6 +51,7 @@ const PatternAssemblerContainer = ( {
 				patternIdsByCategory={ patternIdsByCategory }
 				// Use siteInfo to overwrite site-related things such as title, and tagline.
 				siteInfo={ siteInfo }
+				isNewSite={ isNewSite }
 			>
 				{ children }
 			</PatternsRendererProvider>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-container.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-container.tsx
@@ -51,7 +51,7 @@ const PatternAssemblerContainer = ( {
 				patternIdsByCategory={ patternIdsByCategory }
 				// Use siteInfo to overwrite site-related things such as title, and tagline.
 				siteInfo={ siteInfo }
-				isNewSite={ isNewSite }
+				shouldShufflePosts={ isNewSite }
 			>
 				{ children }
 			</PatternsRendererProvider>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -158,7 +158,6 @@ const PatternLargePreview = ( {
 						// Disable default max-height
 						maxHeight="none"
 						transformHtml={ transformPatternHtml }
-						shouldShufflePosts={ isNewSite }
 					/>
 				) }
 				{ isActive && (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.tsx
@@ -18,7 +18,6 @@ type PatternListPanelProps = {
 	label?: string;
 	description?: string;
 	recordTracksEvent: ( name: string, eventProperties?: any ) => void;
-	isNewSite: boolean;
 };
 
 const PatternListPanel = ( {
@@ -31,7 +30,6 @@ const PatternListPanel = ( {
 	description,
 	onSelect,
 	recordTracksEvent,
-	isNewSite,
 }: PatternListPanelProps ) => {
 	const translate = useTranslate();
 	const [ isShowMorePatterns, setIsShowMorePatterns ] = useState( false );
@@ -61,7 +59,6 @@ const PatternListPanel = ( {
 				selectedPattern={ selectedPattern }
 				selectedPatterns={ selectedPatterns }
 				isShowMorePatterns={ isShowMorePatterns }
-				isNewSite={ isNewSite }
 			/>
 			{ ! isShowMorePatterns && hasNonPriorityPatterns && (
 				<div className="pattern-list-panel__show-more">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-renderer.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-renderer.tsx
@@ -15,7 +15,6 @@ interface PatternListItemProps {
 	isSelected?: boolean;
 	composite?: Record< string, unknown >;
 	onSelect: ( selectedPattern: Pattern | null ) => void;
-	isNewSite: boolean;
 }
 
 interface PatternListRendererProps {
@@ -27,7 +26,6 @@ interface PatternListRendererProps {
 	composite?: Record< string, unknown >;
 	onSelect: ( selectedPattern: Pattern | null ) => void;
 	isShowMorePatterns?: boolean;
-	isNewSite: boolean;
 }
 
 const DEFAULT_VIEWPORT_WIDTH = 1060;
@@ -42,7 +40,6 @@ const PatternListItem = ( {
 	isSelected,
 	composite,
 	onSelect,
-	isNewSite,
 }: PatternListItemProps ) => {
 	const ref = useRef< HTMLButtonElement >();
 	const { ref: inViewRef, inView: inViewOnce } = useInView( {
@@ -85,7 +82,6 @@ const PatternListItem = ( {
 						viewportWidth={ DEFAULT_VIEWPORT_WIDTH }
 						viewportHeight={ DEFAULT_VIEWPORT_HEIGHT }
 						minHeight={ PLACEHOLDER_HEIGHT }
-						shouldShufflePosts={ isNewSite }
 					/>
 				) : (
 					<div key={ pattern.ID } style={ { height: PLACEHOLDER_HEIGHT } } />
@@ -104,7 +100,6 @@ const PatternListRenderer = ( {
 	composite,
 	onSelect,
 	isShowMorePatterns,
-	isNewSite,
 }: PatternListRendererProps ) => {
 	const filterPriorityPatterns = ( pattern: Pattern ) =>
 		isShowMorePatterns || isPriorityPattern( pattern );
@@ -125,7 +120,6 @@ const PatternListRenderer = ( {
 					isSelected={ pattern.ID === selectedPattern?.ID }
 					composite={ composite }
 					onSelect={ onSelect }
-					isNewSite={ isNewSite }
 				/>
 			) ) }
 		</>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
@@ -13,7 +13,6 @@ type PatternSelectorProps = {
 	selectedPattern: Pattern | null;
 	selectedPatterns?: Pattern[];
 	isShowMorePatterns?: boolean;
-	isNewSite: boolean;
 };
 
 const PatternSelector = ( {
@@ -22,7 +21,6 @@ const PatternSelector = ( {
 	selectedPattern,
 	selectedPatterns,
 	isShowMorePatterns,
-	isNewSite,
 }: PatternSelectorProps ) => {
 	const translate = useTranslate();
 	const shownPatterns = useAsyncList( patterns );
@@ -46,7 +44,6 @@ const PatternSelector = ( {
 						composite={ composite }
 						onSelect={ onSelect }
 						isShowMorePatterns={ isShowMorePatterns }
-						isNewSite={ isNewSite }
 					/>
 				</Composite>
 			</div>

--- a/packages/block-renderer/src/components/block-renderer-container.tsx
+++ b/packages/block-renderer/src/components/block-renderer-container.tsx
@@ -26,7 +26,6 @@ interface BlockRendererContainerProps {
 	children: ReactNode;
 	styles?: RenderedStyle[];
 	scripts?: string;
-	inlineCss?: string;
 	viewportWidth?: number;
 	maxHeight?: 'none' | number;
 	minHeight?: number;
@@ -40,7 +39,6 @@ const ScaledBlockRendererContainer = ( {
 	children,
 	styles: customStyles,
 	scripts: customScripts,
-	inlineCss = '',
 	viewportWidth = 1200,
 	containerWidth,
 	maxHeight = BLOCK_MAX_HEIGHT,
@@ -66,12 +64,8 @@ const ScaledBlockRendererContainer = ( {
 			// Ignore svgs since the current version of EditorStyles doesn't support it
 			.filter( ( style: RenderedStyle ) => style.__unstableType !== 'svgs' );
 
-		if ( ! inlineCss ) {
-			return mergedStyles;
-		}
-
-		return [ ...mergedStyles, { css: inlineCss } ];
-	}, [ styles, customStyles, inlineCss ] );
+		return mergedStyles;
+	}, [ styles, customStyles ] );
 
 	const scripts = useMemo( () => {
 		return [ assets?.scripts, customScripts ].filter( Boolean ).join( '' );

--- a/packages/block-renderer/src/components/pattern-renderer.tsx
+++ b/packages/block-renderer/src/components/pattern-renderer.tsx
@@ -22,7 +22,7 @@ const PatternRenderer = ( {
 	maxHeight,
 	transformHtml,
 }: Props ) => {
-	const { renderedPatterns, isNewSite } = usePatternsRendererContext();
+	const { renderedPatterns, shouldShufflePosts } = usePatternsRendererContext();
 	const pattern = renderedPatterns[ patternId ];
 
 	let patternHtml = pattern?.html ?? '';
@@ -34,8 +34,8 @@ const PatternRenderer = ( {
 	}
 
 	let patternStyles = pattern?.styles ?? [];
-	if ( isNewSite ) {
-		const css = shufflePosts( patternId, pattern.html );
+	if ( shouldShufflePosts ) {
+		const css = shufflePosts( patternId, patternHtml );
 		patternStyles = [ ...patternStyles, { css } as RenderedStyle ];
 	}
 

--- a/packages/block-renderer/src/components/pattern-renderer.tsx
+++ b/packages/block-renderer/src/components/pattern-renderer.tsx
@@ -1,8 +1,9 @@
 import { memo } from 'react';
 import { normalizeMinHeight } from '../html-transformers';
-import shufflePosts from '../styles-transformers/shuffle-posts';
+import { shufflePosts } from '../styles-transformers';
 import BlockRendererContainer from './block-renderer-container';
 import { usePatternsRendererContext } from './patterns-renderer-context';
+import type { RenderedStyle } from '../types';
 
 interface Props {
 	patternId: string;
@@ -11,7 +12,6 @@ interface Props {
 	minHeight?: number;
 	maxHeight?: 'none' | number;
 	transformHtml?: ( patternHtml: string ) => string;
-	shouldShufflePosts: boolean;
 }
 
 const PatternRenderer = ( {
@@ -21,9 +21,8 @@ const PatternRenderer = ( {
 	minHeight,
 	maxHeight,
 	transformHtml,
-	shouldShufflePosts,
 }: Props ) => {
-	const renderedPatterns = usePatternsRendererContext();
+	const { renderedPatterns, isNewSite } = usePatternsRendererContext();
 	const pattern = renderedPatterns[ patternId ];
 
 	let patternHtml = pattern?.html ?? '';
@@ -34,18 +33,20 @@ const PatternRenderer = ( {
 		patternHtml = transformHtml( patternHtml );
 	}
 
-	// TODO(fushar): refactor this similar to how we refactor html transformations above.
-	const inlineCss = shufflePosts( patternId, patternHtml, shouldShufflePosts );
+	let patternStyles = pattern?.styles ?? [];
+	if ( isNewSite ) {
+		const css = shufflePosts( patternId, pattern.html );
+		patternStyles = [ ...patternStyles, { css } as RenderedStyle ];
+	}
 
 	return (
 		<BlockRendererContainer
 			key={ pattern?.ID }
-			styles={ pattern?.styles ?? [] }
+			styles={ patternStyles }
 			scripts={ pattern?.scripts ?? '' }
 			viewportWidth={ viewportWidth }
 			maxHeight={ maxHeight }
 			minHeight={ minHeight }
-			inlineCss={ inlineCss }
 		>
 			<div
 				// eslint-disable-next-line react/no-danger

--- a/packages/block-renderer/src/components/patterns-renderer-context.tsx
+++ b/packages/block-renderer/src/components/patterns-renderer-context.tsx
@@ -3,12 +3,13 @@ import type { RenderedPattern } from '../types';
 
 export interface PatternsRendererContextValue {
 	renderedPatterns: { [ key: string ]: RenderedPattern };
-	isNewSite: boolean;
+	shouldShufflePosts: boolean;
 }
 
-const PatternsRendererContext = createContext< PatternsRendererContextValue >(
-	{} as PatternsRendererContextValue
-);
+const PatternsRendererContext = createContext< PatternsRendererContextValue >( {
+	renderedPatterns: {},
+	shouldShufflePosts: false,
+} as PatternsRendererContextValue );
 
 export const usePatternsRendererContext = (): PatternsRendererContextValue =>
 	useContext( PatternsRendererContext );

--- a/packages/block-renderer/src/components/patterns-renderer-context.tsx
+++ b/packages/block-renderer/src/components/patterns-renderer-context.tsx
@@ -2,7 +2,8 @@ import { createContext, useContext } from '@wordpress/element';
 import type { RenderedPattern } from '../types';
 
 export interface PatternsRendererContextValue {
-	[ key: string ]: RenderedPattern;
+	renderedPatterns: { [ key: string ]: RenderedPattern };
+	isNewSite: boolean;
 }
 
 const PatternsRendererContext = createContext< PatternsRendererContextValue >(

--- a/packages/block-renderer/src/components/patterns-renderer-provider.tsx
+++ b/packages/block-renderer/src/components/patterns-renderer-provider.tsx
@@ -9,6 +9,7 @@ interface Props {
 	patternIdsByCategory: Record< string, string[] >;
 	children: JSX.Element;
 	siteInfo: SiteInfo;
+	isNewSite: boolean;
 }
 
 const PatternsRendererProvider = ( {
@@ -17,6 +18,7 @@ const PatternsRendererProvider = ( {
 	patternIdsByCategory,
 	children,
 	siteInfo = {},
+	isNewSite,
 }: Props ) => {
 	const renderedPatterns = useRenderedPatterns(
 		siteId,
@@ -26,7 +28,7 @@ const PatternsRendererProvider = ( {
 	);
 
 	return (
-		<PatternsRendererContext.Provider value={ renderedPatterns }>
+		<PatternsRendererContext.Provider value={ { renderedPatterns, isNewSite } }>
 			{ children }
 		</PatternsRendererContext.Provider>
 	);

--- a/packages/block-renderer/src/components/patterns-renderer-provider.tsx
+++ b/packages/block-renderer/src/components/patterns-renderer-provider.tsx
@@ -9,7 +9,7 @@ interface Props {
 	patternIdsByCategory: Record< string, string[] >;
 	children: JSX.Element;
 	siteInfo: SiteInfo;
-	isNewSite: boolean;
+	shouldShufflePosts: boolean;
 }
 
 const PatternsRendererProvider = ( {
@@ -18,7 +18,7 @@ const PatternsRendererProvider = ( {
 	patternIdsByCategory,
 	children,
 	siteInfo = {},
-	isNewSite,
+	shouldShufflePosts,
 }: Props ) => {
 	const renderedPatterns = useRenderedPatterns(
 		siteId,
@@ -28,7 +28,7 @@ const PatternsRendererProvider = ( {
 	);
 
 	return (
-		<PatternsRendererContext.Provider value={ { renderedPatterns, isNewSite } }>
+		<PatternsRendererContext.Provider value={ { renderedPatterns, shouldShufflePosts } }>
 			{ children }
 		</PatternsRendererContext.Provider>
 	);

--- a/packages/block-renderer/src/components/patterns-renderer-provider.tsx
+++ b/packages/block-renderer/src/components/patterns-renderer-provider.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import useRenderedPatterns from '../hooks/use-rendered-patterns';
 import PatternsRendererContext from './patterns-renderer-context';
 import type { SiteInfo } from '../types';
@@ -27,8 +27,16 @@ const PatternsRendererProvider = ( {
 		siteInfo
 	);
 
+	const contextValue = useMemo(
+		() => ( {
+			renderedPatterns,
+			shouldShufflePosts,
+		} ),
+		[ renderedPatterns, shouldShufflePosts ]
+	);
+
 	return (
-		<PatternsRendererContext.Provider value={ { renderedPatterns, shouldShufflePosts } }>
+		<PatternsRendererContext.Provider value={ contextValue }>
 			{ children }
 		</PatternsRendererContext.Provider>
 	);

--- a/packages/block-renderer/src/styles-transformers/index.ts
+++ b/packages/block-renderer/src/styles-transformers/index.ts
@@ -1,0 +1,1 @@
+export { default as shufflePosts } from './shuffle-posts';

--- a/packages/block-renderer/src/styles-transformers/shuffle-posts.ts
+++ b/packages/block-renderer/src/styles-transformers/shuffle-posts.ts
@@ -4,12 +4,14 @@ const inlineCssByPatternId: { [ key: string ]: string } = {};
 // Memoize last offset
 let lastOffset = 0;
 
-const shufflePosts = ( patternId: string, patternHtml: string, shouldShufflePosts: boolean ) => {
+// Shuffles the order of posts so that the featured images don't look too repetitive between patterns
+// when multiple "blog" patterns are shown in a list.
+const shufflePosts = ( patternId: string, patternHtml: string ) => {
 	const hasGrid = patternHtml?.includes( 'is-layout-grid' );
 	const blogPostCount = patternHtml?.match( /wp-block-post /g )?.length ?? 0;
 
 	// Only for patterns with a grid of posts in newly created sites
-	if ( ! shouldShufflePosts || ! hasGrid || blogPostCount <= 1 ) {
+	if ( ! hasGrid || blogPostCount <= 1 ) {
 		return undefined;
 	}
 
@@ -22,7 +24,6 @@ const shufflePosts = ( patternId: string, patternHtml: string, shouldShufflePost
 	// Create CSS rules
 	[ ...Array( blogPostCount ).keys() ].forEach( ( order, index ) => {
 		const childIndex = index + 1;
-		// Offset order of blog posts to avoid repetition in previews
 		const offset = lastOffset % blogPostCount;
 		const orderWithOffset = ( order - offset + blogPostCount ) % blogPostCount;
 		inlineCss += `.is-layout-grid > .wp-block-post:nth-child(${ childIndex }) { order: ${ orderWithOffset }; }`;


### PR DESCRIPTION
## Proposed Changes

This PR simplifies the `shufflePosts` logic so that we don't have to pass around `shouldShufflePosts` every time we use `<PatternRenderer />`:

- Put `isNewSite` to `<PatternRenderedContext />`
   - We already are using this to to determine which source site to use anyway, see: https://github.com/Automattic/wp-calypso/blob/5dc6cfdb59d9245967c8311d1b596c744a6803fd/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-container.tsx#L45-L49
- Use this in the `<PatternRenderer />` to determine whether to shuffle posts.
- Remove `inlineCss` and simplify the logic in `<BlockRenderer />` because we can just append the new css to the `styles` props.

## Testing Instructions

Do the same tests in:

- https://github.com/Automattic/wp-calypso/pull/82475

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?