### PR TITLE
Command palette: add settings relevant for bloggers

### DIFF
--- a/client/sites-dashboard/components/wpcom-smp-commands.tsx
+++ b/client/sites-dashboard/components/wpcom-smp-commands.tsx
@@ -478,7 +478,7 @@ export const useCommandsArrayWpcom = ( {
 		{
 			name: 'manageSettingsWriting',
 			label: __( 'Manage writing settings' ),
-			context: 'Managing settings for writing the blog',
+			context: [ '/settings' ],
 			callback: setStateCallback( 'manageSettingsWriting' ),
 			siteFunctions: {
 				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
@@ -491,7 +491,7 @@ export const useCommandsArrayWpcom = ( {
 		{
 			name: 'manageSettingsReading',
 			label: __( 'Manage reading settings' ),
-			context: 'Managing settings for reading the blog',
+			context: [ '/settings' ],
 			callback: setStateCallback( 'manageSettingsReading' ),
 			siteFunctions: {
 				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
@@ -504,7 +504,7 @@ export const useCommandsArrayWpcom = ( {
 		{
 			name: 'manageSettingsDiscussion',
 			label: __( 'Manage discussion settings' ),
-			context: 'Managing settings for discussions on the blog',
+			context: [ '/settings' ],
 			callback: setStateCallback( 'manageSettingsDiscussion' ),
 			siteFunctions: {
 				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
@@ -517,7 +517,7 @@ export const useCommandsArrayWpcom = ( {
 		{
 			name: 'manageSettingsNewsletter',
 			label: __( 'Manage newsletter settings' ),
-			context: 'Managing settings for the built-in newsletter',
+			context: [ '/settings' ],
 			callback: setStateCallback( 'manageSettingsNewsletter' ),
 			siteFunctions: {
 				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
@@ -530,7 +530,7 @@ export const useCommandsArrayWpcom = ( {
 		{
 			name: 'manageSettingsPodcast',
 			label: __( 'Manage podcast settings' ),
-			context: 'Managing settings for the built-in podcast',
+			context: [ '/settings' ],
 			callback: setStateCallback( 'manageSettingsPodcast' ),
 			siteFunctions: {
 				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {

--- a/client/sites-dashboard/components/wpcom-smp-commands.tsx
+++ b/client/sites-dashboard/components/wpcom-smp-commands.tsx
@@ -45,7 +45,7 @@ export const useCommandsArrayWpcom = ( {
 			setPlaceholderOverride( translate( 'Select a site' ) );
 		};
 
-	const { __, _x } = useI18n();
+	const { __ } = useI18n();
 	const dispatch = useDispatch();
 	const displaySuccessNotice = ( message: string ) =>
 		dispatch( successNotice( message, { duration: 5000 } ) );
@@ -478,7 +478,6 @@ export const useCommandsArrayWpcom = ( {
 		{
 			name: 'manageSettingsWriting',
 			label: __( 'Manage writing settings' ),
-			searchLabel: _x( 'Manage blog writing settings', 'search label for command palette' ),
 			context: 'Managing settings for writing the blog',
 			callback: setStateCallback( 'manageSettingsWriting' ),
 			siteFunctions: {
@@ -492,7 +491,6 @@ export const useCommandsArrayWpcom = ( {
 		{
 			name: 'manageSettingsReading',
 			label: __( 'Manage reading settings' ),
-			searchLabel: _x( 'Manage blog reading settings', 'search label for command palette' ),
 			context: 'Managing settings for reading the blog',
 			callback: setStateCallback( 'manageSettingsReading' ),
 			siteFunctions: {
@@ -506,7 +504,6 @@ export const useCommandsArrayWpcom = ( {
 		{
 			name: 'manageSettingsDiscussion',
 			label: __( 'Manage discussion settings' ),
-			searchLabel: _x( 'Manage blog discussion settings', 'search label for command palette' ),
 			context: 'Managing settings for discussions on the blog',
 			callback: setStateCallback( 'manageSettingsDiscussion' ),
 			siteFunctions: {
@@ -520,7 +517,6 @@ export const useCommandsArrayWpcom = ( {
 		{
 			name: 'manageSettingsNewsletter',
 			label: __( 'Manage newsletter settings' ),
-			searchLabel: _x( 'Manage newsletter settings', 'search label for command palette' ),
 			context: 'Managing settings for the built-in newsletter',
 			callback: setStateCallback( 'manageSettingsNewsletter' ),
 			siteFunctions: {
@@ -534,7 +530,6 @@ export const useCommandsArrayWpcom = ( {
 		{
 			name: 'manageSettingsPodcast',
 			label: __( 'Manage podcast settings' ),
-			searchLabel: _x( 'Manage podcast settings', 'search label for command palette' ),
 			context: 'Managing settings for the built-in podcast',
 			callback: setStateCallback( 'manageSettingsPodcast' ),
 			siteFunctions: {

--- a/client/sites-dashboard/components/wpcom-smp-commands.tsx
+++ b/client/sites-dashboard/components/wpcom-smp-commands.tsx
@@ -2,11 +2,10 @@ import {
 	alignJustify as acitvityLogIcon,
 	backup as backupIcon,
 	chartBar as statsIcon,
-	cog as hostingConfigIcon,
+	cog as settingsIcon,
 	commentAuthorAvatar as profileIcon,
 	commentAuthorName as subscriberIcon,
 	download as downloadIcon,
-	upload as uploadIcon,
 	globe as domainsIcon,
 	home as dashboardIcon,
 	key as keyIcon,
@@ -16,6 +15,7 @@ import {
 	postComments as postCommentsIcon,
 	settings as accountSettingsIcon,
 	tool as toolIcon,
+	upload as uploadIcon,
 } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useTranslate } from 'i18n-calypso';
@@ -45,7 +45,7 @@ export const useCommandsArrayWpcom = ( {
 			setPlaceholderOverride( translate( 'Select a site' ) );
 		};
 
-	const { __ } = useI18n();
+	const { __, _x } = useI18n();
 	const dispatch = useDispatch();
 	const displaySuccessNotice = ( message: string ) =>
 		dispatch( successNotice( message, { duration: 5000 } ) );
@@ -137,7 +137,7 @@ export const useCommandsArrayWpcom = ( {
 				},
 				filter: ( site: SiteExcerptData ) => ! isP2Site( site ) && ! isNotAtomicJetpack( site ),
 			},
-			icon: hostingConfigIcon,
+			icon: settingsIcon,
 		},
 		{
 			name: 'openPHPmyAdmin',
@@ -474,6 +474,76 @@ export const useCommandsArrayWpcom = ( {
 				},
 			},
 			icon: uploadIcon,
+		},
+		{
+			name: 'manageSettingsWriting',
+			label: __( 'Manage writing settings' ),
+			searchLabel: _x( 'Manage blog writing settings', 'search label for command palette' ),
+			context: 'Managing settings for writing the blog',
+			callback: setStateCallback( 'manageSettingsWriting' ),
+			siteFunctions: {
+				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
+					close();
+					navigate( `/settings/writing/${ site.slug }` );
+				},
+			},
+			icon: settingsIcon,
+		},
+		{
+			name: 'manageSettingsReading',
+			label: __( 'Manage reading settings' ),
+			searchLabel: _x( 'Manage blog reading settings', 'search label for command palette' ),
+			context: 'Managing settings for reading the blog',
+			callback: setStateCallback( 'manageSettingsReading' ),
+			siteFunctions: {
+				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
+					close();
+					navigate( `/settings/reading/${ site.slug }` );
+				},
+			},
+			icon: settingsIcon,
+		},
+		{
+			name: 'manageSettingsDiscussion',
+			label: __( 'Manage discussion settings' ),
+			searchLabel: _x( 'Manage blog discussion settings', 'search label for command palette' ),
+			context: 'Managing settings for discussions on the blog',
+			callback: setStateCallback( 'manageSettingsDiscussion' ),
+			siteFunctions: {
+				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
+					close();
+					navigate( `/settings/discussion/${ site.slug }` );
+				},
+			},
+			icon: settingsIcon,
+		},
+		{
+			name: 'manageSettingsNewsletter',
+			label: __( 'Manage newsletter settings' ),
+			searchLabel: _x( 'Manage newsletter settings', 'search label for command palette' ),
+			context: 'Managing settings for the built-in newsletter',
+			callback: setStateCallback( 'manageSettingsNewsletter' ),
+			siteFunctions: {
+				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
+					close();
+					navigate( `/settings/newsletter/${ site.slug }` );
+				},
+			},
+			icon: settingsIcon,
+		},
+		{
+			name: 'manageSettingsPodcast',
+			label: __( 'Manage podcast settings' ),
+			searchLabel: _x( 'Manage podcast settings', 'search label for command palette' ),
+			context: 'Managing settings for the built-in podcast',
+			callback: setStateCallback( 'manageSettingsPodcast' ),
+			siteFunctions: {
+				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
+					close();
+					navigate( `/settings/podcasting/${ site.slug }` );
+				},
+			},
+			icon: settingsIcon,
 		},
 	];
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Similar to other PR which adds more blogger commands https://github.com/Automattic/wp-calypso/pull/84505

Note that I'm exploring the API, so just lemme know if I'm doing something unintended.

<img width="470" alt="Screenshot 2023-11-24 at 11 55 57" src="https://github.com/Automattic/wp-calypso/assets/87168/fcc04894-5744-4487-8f80-c7ca35497c5a">


## Proposed Changes

* Adds settings pages (`settings/*`) relevant for bloggers; reading, writing, discussion, newsletter, podcasting

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch locally or use calypso live
* Access `/sites`
* Press `cmd+k` on mac or `ctrl+k` on Windows
* Search for "settings"
* Choosing settings will make you pick a site, and then land at correct settings page


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?