### PR TITLE
Command palette: add various commands useful for bloggers

### DIFF
--- a/client/sites-dashboard/components/wpcom-smp-commands.tsx
+++ b/client/sites-dashboard/components/wpcom-smp-commands.tsx
@@ -398,6 +398,7 @@ export const useCommandsArrayWpcom = ( {
 		{
 			name: 'addNewPost',
 			label: __( 'Add new post' ),
+			searchLabel: __( 'Write new post' ),
 			context: [ '/posts' ],
 			callback: setStateCallback( 'addNewPost' ),
 			siteFunctions: {

--- a/client/sites-dashboard/components/wpcom-smp-commands.tsx
+++ b/client/sites-dashboard/components/wpcom-smp-commands.tsx
@@ -112,19 +112,6 @@ export const useCommandsArrayWpcom = ( {
 
 	const { openPhpMyAdmin } = useOpenPhpMyAdmin();
 
-	const downloadSubscribersForSite = async ( slug: string, siteId: number ) => {
-		const url = `https://dashboard.wordpress.com/wp-admin/index.php?page=subscribers&blog=${ siteId }&blog_subscribers=csv&type=all`;
-		window.open( url );
-		const link = document.createElement( 'a' );
-		link.href = url;
-		link.setAttribute(
-			'download',
-			`subscribers-${ slug.replace( '.', '-' ) }-${ new Date().toJSON().slice( 0, 10 ) }.csv`
-		);
-		link.click();
-		window.URL.revokeObjectURL( url );
-	};
-
 	const commands = [
 		{
 			name: 'openSiteDashboard',
@@ -412,7 +399,7 @@ export const useCommandsArrayWpcom = ( {
 		{
 			name: 'addNewPost',
 			label: __( 'Add new post' ),
-			searchLabel: __( 'add new post' ),
+			context: [ '/posts' ],
 			callback: setStateCallback( 'addNewPost' ),
 			siteFunctions: {
 				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
@@ -423,35 +410,8 @@ export const useCommandsArrayWpcom = ( {
 			icon: postIcon,
 		},
 		{
-			name: 'addNewPostAccessSubscribers',
-			label: __( 'Add new subscribers-only post' ),
-			searchLabel: __( 'add new subscribers-only post' ),
-			callback: setStateCallback( 'addNewPostAccessSubscribers' ),
-			siteFunctions: {
-				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
-					close();
-					navigate( `/post/${ site.slug }?jetpack_access=subscribers` ); // @TODO: `?jetpack_access=` requires Jetpack PR
-				},
-			},
-			icon: postIcon,
-		},
-		{
-			name: 'addNewPostAccessPaidSubscribers',
-			label: __( 'Add new paid subscribers-only post' ),
-			searchLabel: __( 'add new paid subscribers-only post' ),
-			callback: setStateCallback( 'addNewPostAccessPaidSubscribers' ),
-			siteFunctions: {
-				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
-					close();
-					navigate( `/post/${ site.slug }?jetpack_access=paid-subscribers` ); // @TODO: `?jetpack_access=` requires Jetpack PR
-				},
-			},
-			icon: postIcon, // TODO: paywall icon
-		},
-		{
 			name: 'manageComments',
 			label: __( 'Manage comments' ),
-			searchLabel: __( 'manage comments' ),
 			callback: setStateCallback( 'manageComments' ),
 			siteFunctions: {
 				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
@@ -464,7 +424,7 @@ export const useCommandsArrayWpcom = ( {
 		{
 			name: 'addSubscribers',
 			label: __( 'Add subscribers' ),
-			searchLabel: __( 'add subscribers' ),
+			context: [ '/subscribers' ],
 			callback: setStateCallback( 'addSubscribers' ),
 			siteFunctions: {
 				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
@@ -472,12 +432,11 @@ export const useCommandsArrayWpcom = ( {
 					navigate( `/subscribers/${ site.slug }#add-subscribers` );
 				},
 			},
-			icon: subscriberIcon, // TODO: subscribers icon, currently using icon for comments
+			icon: subscriberIcon,
 		},
 		{
 			name: 'manageSubscribers',
 			label: __( 'Manage subscribers' ),
-			searchLabel: __( 'manage subscribers' ),
 			callback: setStateCallback( 'manageSubscribers' ),
 			siteFunctions: {
 				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
@@ -485,17 +444,19 @@ export const useCommandsArrayWpcom = ( {
 					navigate( `/subscribers/${ site.slug }` );
 				},
 			},
-			icon: subscriberIcon, // TODO: subscribers icon, currently using icon for comments
+			icon: subscriberIcon,
 		},
 		{
 			name: 'downloadSubscribers',
 			label: __( 'Download subscribers as CSV' ),
-			searchLabel: __( 'download subscribers as csv' ),
+			context: [ '/subscribers' ],
 			callback: setStateCallback( 'downloadSubscribers' ),
 			siteFunctions: {
 				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
 					close();
-					downloadSubscribersForSite( site.slug, site.ID );
+					window.location.assign(
+						`https://dashboard.wordpress.com/wp-admin/index.php?page=subscribers&blog=${ site.ID }&blog_subscribers=csv&type=all`
+					);
 				},
 			},
 			icon: downloadIcon,
@@ -503,7 +464,7 @@ export const useCommandsArrayWpcom = ( {
 		{
 			name: 'import',
 			label: __( 'Import content to the site' ),
-			searchLabel: __( 'import content to the site' ),
+			context: [ '/posts' ],
 			callback: setStateCallback( 'import' ),
 			siteFunctions: {
 				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {

--- a/client/sites-dashboard/components/wpcom-smp-commands.tsx
+++ b/client/sites-dashboard/components/wpcom-smp-commands.tsx
@@ -12,8 +12,7 @@ import {
 	key as keyIcon,
 	page as pageIcon,
 	payment as creditCardIcon,
-	plus as addNewSiteIcon,
-	post as postIcon,
+	plus as plusIcon,
 	postComments as postCommentsIcon,
 	settings as accountSettingsIcon,
 	tool as toolIcon,
@@ -394,7 +393,7 @@ export const useCommandsArrayWpcom = ( {
 				close();
 				navigate( createSiteUrl );
 			},
-			icon: addNewSiteIcon,
+			icon: plusIcon,
 		},
 		{
 			name: 'addNewPost',
@@ -407,7 +406,7 @@ export const useCommandsArrayWpcom = ( {
 					navigate( `/post/${ site.slug }` );
 				},
 			},
-			icon: postIcon,
+			icon: plusIcon,
 		},
 		{
 			name: 'manageComments',

--- a/client/sites-dashboard/components/wpcom-smp-commands.tsx
+++ b/client/sites-dashboard/components/wpcom-smp-commands.tsx
@@ -1,17 +1,21 @@
 import {
-	plus as addNewSiteIcon,
-	globe as domainsIcon,
-	commentAuthorAvatar as profileIcon,
-	settings as accountSettingsIcon,
-	payment as creditCardIcon,
-	home as dashboardIcon,
-	chartBar as statsIcon,
 	alignJustify as acitvityLogIcon,
 	backup as backupIcon,
+	chartBar as statsIcon,
 	cog as hostingConfigIcon,
-	tool as toolIcon,
-	page as pageIcon,
+	commentAuthorAvatar as profileIcon,
+	commentAuthorName as subscriberIcon,
+	download as downloadIcon,
+	globe as domainsIcon,
+	home as dashboardIcon,
 	key as keyIcon,
+	page as pageIcon,
+	payment as creditCardIcon,
+	plus as addNewSiteIcon,
+	post as postIcon,
+	postComments as postCommentsIcon,
+	settings as accountSettingsIcon,
+	tool as toolIcon,
 } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useTranslate } from 'i18n-calypso';
@@ -106,6 +110,19 @@ export const useCommandsArrayWpcom = ( {
 	};
 
 	const { openPhpMyAdmin } = useOpenPhpMyAdmin();
+
+	const downloadSubscribersForSite = async ( slug: string, siteId: number ) => {
+		const url = `https://dashboard.wordpress.com/wp-admin/index.php?page=subscribers&blog=${ siteId }&blog_subscribers=csv&type=all`;
+		window.open( url );
+		const link = document.createElement( 'a' );
+		link.href = url;
+		link.setAttribute(
+			'download',
+			`subscribers-${ slug.replace( '.', '-' ) }-${ new Date().toJSON().slice( 0, 10 ) }.csv`
+		);
+		link.click();
+		window.URL.revokeObjectURL( url );
+	};
 
 	const commands = [
 		{
@@ -390,6 +407,97 @@ export const useCommandsArrayWpcom = ( {
 				navigate( createSiteUrl );
 			},
 			icon: addNewSiteIcon,
+		},
+		{
+			name: 'addNewPost',
+			label: __( 'Add new post' ),
+			searchLabel: __( 'add new post' ),
+			callback: setStateCallback( 'addNewPost' ),
+			siteFunctions: {
+				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
+					close();
+					navigate( `/post/${ site.slug }` );
+				},
+			},
+			icon: postIcon,
+		},
+		{
+			name: 'addNewPostAccessSubscribers',
+			label: __( 'Add new subscribers-only post' ),
+			searchLabel: __( 'add new subscribers-only post' ),
+			callback: setStateCallback( 'addNewPostAccessSubscribers' ),
+			siteFunctions: {
+				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
+					close();
+					navigate( `/post/${ site.slug }?jetpack_access=subscribers` ); // @TODO: `?jetpack_access=` requires Jetpack PR
+				},
+			},
+			icon: postIcon,
+		},
+		{
+			name: 'addNewPostAccessPaidSubscribers',
+			label: __( 'Add new paid subscribers-only post' ),
+			searchLabel: __( 'add new paid subscribers-only post' ),
+			callback: setStateCallback( 'addNewPostAccessPaidSubscribers' ),
+			siteFunctions: {
+				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
+					close();
+					navigate( `/post/${ site.slug }?jetpack_access=paid-subscribers` ); // @TODO: `?jetpack_access=` requires Jetpack PR
+				},
+			},
+			icon: postIcon, // TODO: paywall icon
+		},
+		{
+			name: 'manageComments',
+			label: __( 'Manage comments' ),
+			searchLabel: __( 'manage comments' ),
+			callback: setStateCallback( 'manageComments' ),
+			siteFunctions: {
+				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
+					close();
+					navigate( `/comments/${ site.slug }` );
+				},
+			},
+			icon: postCommentsIcon,
+		},
+		{
+			name: 'addSubscribers',
+			label: __( 'Add subscribers' ),
+			searchLabel: __( 'add subscribers' ),
+			callback: setStateCallback( 'addSubscribers' ),
+			siteFunctions: {
+				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
+					close();
+					navigate( `/subscribers/${ site.slug }#add-subscribers` );
+				},
+			},
+			icon: subscriberIcon, // TODO: subscribers icon, currently using icon for comments
+		},
+		{
+			name: 'manageSubscribers',
+			label: __( 'Manage subscribers' ),
+			searchLabel: __( 'manage subscribers' ),
+			callback: setStateCallback( 'manageSubscribers' ),
+			siteFunctions: {
+				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
+					close();
+					navigate( `/subscribers/${ site.slug }` );
+				},
+			},
+			icon: subscriberIcon, // TODO: subscribers icon, currently using icon for comments
+		},
+		{
+			name: 'downloadSubscribers',
+			label: __( 'Download subscribers as CSV' ),
+			searchLabel: __( 'download subscribers as csv' ),
+			callback: setStateCallback( 'downloadSubscribers' ),
+			siteFunctions: {
+				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
+					close();
+					downloadSubscribersForSite( site.slug, site.ID );
+				},
+			},
+			icon: downloadIcon,
 		},
 	];
 

--- a/client/sites-dashboard/components/wpcom-smp-commands.tsx
+++ b/client/sites-dashboard/components/wpcom-smp-commands.tsx
@@ -424,6 +424,7 @@ export const useCommandsArrayWpcom = ( {
 		{
 			name: 'addSubscribers',
 			label: __( 'Add subscribers' ),
+			searchLabel: __( 'Import subscribers' ),
 			context: [ '/subscribers' ],
 			callback: setStateCallback( 'addSubscribers' ),
 			siteFunctions: {

--- a/client/sites-dashboard/components/wpcom-smp-commands.tsx
+++ b/client/sites-dashboard/components/wpcom-smp-commands.tsx
@@ -6,6 +6,7 @@ import {
 	commentAuthorAvatar as profileIcon,
 	commentAuthorName as subscriberIcon,
 	download as downloadIcon,
+	upload as uploadIcon,
 	globe as domainsIcon,
 	home as dashboardIcon,
 	key as keyIcon,
@@ -498,6 +499,19 @@ export const useCommandsArrayWpcom = ( {
 				},
 			},
 			icon: downloadIcon,
+		},
+		{
+			name: 'import',
+			label: __( 'Import content to the site' ),
+			searchLabel: __( 'import content to the site' ),
+			callback: setStateCallback( 'import' ),
+			siteFunctions: {
+				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
+					close();
+					navigate( `/import/${ site.slug }` );
+				},
+			},
+			icon: uploadIcon,
 		},
 	];
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Similar to other PR which adds settings pages https://github.com/Automattic/wp-calypso/pull/84502

## Proposed Changes

Adds new commands to command palette:

* Add new post
* Manage comments
* Add subscribers / Import subscribers
* Manage subscribers
* Download subscribers as CSV
* Import content to the site

Adds "context" to commands which will help to prioritize commands in right screens, but the command palette isn't available yet on those pages so there's no way to test.

<img width="441" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/624e88f8-a381-433e-903c-541c049f7d34">
<img width="450" alt="Screenshot 2023-11-28 at 13 14 53" src="https://github.com/Automattic/wp-calypso/assets/87168/f44617fd-ad1e-4452-be85-7941eca319cd">
<img width="450" alt="Screenshot 2023-11-28 at 13 14 58" src="https://github.com/Automattic/wp-calypso/assets/87168/7c7493fd-d24b-43f7-a17a-20849af92b61">
<img width="448" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/2551bd23-cdee-4abf-bf1c-241aad4ce2d6">

Alias works:
<img width="449" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/dcc96f55-635d-42d1-996e-8741116b2c7a">



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/sites`
* Type commands to reveal all above commands, and test them all.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
