### PR TITLE
Show placeholder content for site preview card

### DIFF
--- a/client/my-sites/customer-home/cards/features/site-preview/index.tsx
+++ b/client/my-sites/customer-home/cards/features/site-preview/index.tsx
@@ -66,17 +66,26 @@ const SitePreview = ( {
 	const isMobile = useMobileBreakpoint();
 	const wpcomDomain = useSelector( ( state ) => getWpComDomainBySiteId( state, selectedSite?.ID ) );
 
-	if ( isMobile || ! selectedSite || ! wpcomDomain ) {
+	if ( isMobile ) {
 		return <></>;
 	}
 
-	const shouldShowEditSite = isFSEActive && showEditSite && canManageSite;
+	const shouldShowEditSite =
+		Boolean( selectedSite ) && isFSEActive && showEditSite && canManageSite;
 
-	const editSiteURL = addQueryArgs( `/site-editor/${ selectedSite.slug }`, {
-		canvas: 'edit',
-	} );
+	const editSiteURL = selectedSite
+		? addQueryArgs( `/site-editor/${ selectedSite.slug }`, {
+				canvas: 'edit',
+		  } )
+		: '#';
 
-	const iframeSrcKeepHomepage = `//${ wpcomDomain.domain }/?hide_banners=true&preview_overlay=true&preview=true`;
+	const iframeSrcKeepHomepage = wpcomDomain
+		? `//${ wpcomDomain.domain }/?hide_banners=true&preview_overlay=true&preview=true`
+		: '#';
+
+	const selectedSiteURL = selectedSite ? selectedSite.URL : '#';
+	const selectedSiteSlug = selectedSite ? selectedSite.slug : '...';
+	const selectedSiteName = selectedSite ? selectedSite.name : '&nbsp;';
 
 	return (
 		<div className="home-site-preview">
@@ -87,20 +96,24 @@ const SitePreview = ( {
 					</Button>
 				) }
 				<div className="home-site-preview__thumbnail">
-					<iframe
-						scrolling="no"
-						loading="lazy"
-						title={ __( 'Site Preview' ) }
-						src={ iframeSrcKeepHomepage }
-					/>
+					{ wpcomDomain ? (
+						<iframe
+							scrolling="no"
+							loading="lazy"
+							title={ __( 'Site Preview' ) }
+							src={ iframeSrcKeepHomepage }
+						/>
+					) : (
+						<div className="home-site-preview__thumbnail-placeholder" />
+					) }
 				</div>
 			</ThumbnailWrapper>
 			{ showSiteDetails && (
 				<div className="home-site-preview__action-bar">
 					<div className="home-site-preview__site-info">
-						<h2 className="home-site-preview__info-title">{ selectedSite.name }</h2>
-						<SiteUrl href={ selectedSite.URL } title={ selectedSite.URL }>
-							<Truncated>{ selectedSite.slug }</Truncated>
+						<h2 className="home-site-preview__info-title">{ selectedSiteName }</h2>
+						<SiteUrl href={ selectedSiteURL } title={ selectedSiteURL }>
+							<Truncated>{ selectedSiteSlug }</Truncated>
 						</SiteUrl>
 					</div>
 					<SitePreviewEllipsisMenu />

--- a/client/my-sites/customer-home/cards/features/site-preview/style.scss
+++ b/client/my-sites/customer-home/cards/features/site-preview/style.scss
@@ -43,6 +43,11 @@
 				transform-origin: top left;
 				translate: 0 -10px;
 			}
+
+			.home-site-preview__thumbnail-placeholder {
+				height: 100%;
+				@include placeholder();
+			}
 		}
 
 		.home-site-preview__thumbnail-label {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
* https://github.com/Automattic/wp-calypso/issues/83465
* D128092-code
* D127655-code

## Proposed Changes

* This change ensures that the Site Preview card we use in My Home shows placeholder content while we're loading the relevant data from the server.
* This should reduce unexpected vertical shifts that occur in My Home when we receive the data we need to show the preview, as I noticed multiple situations where the initial render didn't show any content, but the content was then pushed into the screen once it was available.

### Short screen capture

https://github.com/Automattic/wp-calypso/assets/3376401/bfeee651-9cfe-4d1d-8f6f-4360171300d8

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Find a site where you have a launchpad already being shown in My Home
* Run this branch locally or via Calypso.live
* Use your browser tools to throttle your network connection as a way to extend the loading period for the site
* Navigate to My Home for your chosen site
* Verify that you see a pulsing light grey box instead of the site preview until the site preview can be rendered correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?