### PR TITLE
Plans 2023: Add usePlans hook in data-store and initial use for grid-plans

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -67,7 +67,6 @@ import { getSitePlanSlug, getSiteSlug, isCurrentPlanPaid } from 'calypso/state/s
 import ComparisonGridToggle from './components/comparison-grid-toggle';
 import PlanUpsellModal from './components/plan-upsell-modal';
 import { useModalResolutionCallback } from './components/plan-upsell-modal/hooks/use-modal-resolution-callback';
-import usePricedAPIPlans from './hooks/data-store/use-priced-api-plans';
 import usePricingMetaForGridPlans from './hooks/data-store/use-pricing-meta-for-grid-plans';
 import useCurrentPlanManageHref from './hooks/use-current-plan-manage-href';
 import useFilterPlansForPlanFeatures from './hooks/use-filter-plans-for-plan-features';
@@ -414,7 +413,6 @@ const PlansFeaturesMain = ( {
 
 	const gridPlans = useGridPlans( {
 		allFeaturesList: FEATURES_LIST,
-		usePricedAPIPlans,
 		usePricingMetaForGridPlans,
 		useFreeTrialPlanSlugs,
 		selectedFeature,

--- a/client/my-sites/plans-features-main/test/index.jsx
+++ b/client/my-sites/plans-features-main/test/index.jsx
@@ -43,6 +43,14 @@ jest.mock(
 jest.mock( 'calypso/my-sites/plans-features-main/hooks/data-store/use-priced-api-plans', () =>
 	jest.fn()
 );
+jest.mock( '@automattic/data-stores', () => ( {
+	...jest.requireActual( '@automattic/data-stores' ),
+	Plans: {
+		...jest.requireActual( '@automattic/data-stores' ).Plans,
+		usePlans: jest.fn(),
+	},
+} ) );
+
 jest.mock( 'calypso/components/data/query-active-promotions', () => jest.fn() );
 jest.mock( 'calypso/components/data/query-products-list', () => jest.fn() );
 jest.mock( 'calypso/my-sites/plans-features-main/hooks/use-free-hosting-trial-assignment', () => ( {
@@ -68,6 +76,7 @@ import {
 	PLAN_PERSONAL_2_YEARS,
 	PLAN_ENTERPRISE_GRID_WPCOM,
 } from '@automattic/calypso-products';
+import { Plans } from '@automattic/data-stores';
 import { screen } from '@testing-library/react';
 import usePricedAPIPlans from 'calypso/my-sites/plans-features-main/hooks/data-store/use-priced-api-plans';
 import usePricingMetaForGridPlans from 'calypso/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans';
@@ -103,6 +112,10 @@ describe( 'PlansFeaturesMain', () => {
 		} ) );
 		getSelectedSiteId.mockImplementation( () => 123 );
 		usePricedAPIPlans.mockImplementation( () => emptyPlansIndexForMockedFeatures );
+		Plans.usePlans.mockImplementation( () => ( {
+			isFetching: false,
+			data: emptyPlansIndexForMockedFeatures,
+		} ) );
 		usePricingMetaForGridPlans.mockImplementation( () => emptyPlansIndexForMockedFeatures );
 		usePlanFeaturesForGridPlans.mockImplementation( () => emptyPlansIndexForMockedFeatures );
 		useRestructuredPlanFeaturesForComparisonGrid.mockImplementation(

--- a/packages/data-stores/src/plans/index.ts
+++ b/packages/data-stores/src/plans/index.ts
@@ -19,6 +19,7 @@ export type {
 	PlanSimplifiedFeature,
 } from './types';
 
+export { default as usePlans } from './queries/use-plans';
 export { default as useSitePlans } from './queries/use-site-plans';
 export { default as useIntroOffers } from './hooks/use-intro-offers';
 export { default as useIntroOffersForWooExpress } from './hooks/use-intro-offers-for-woo-express';

--- a/packages/data-stores/src/plans/queries/lib/use-query-keys-factory.ts
+++ b/packages/data-stores/src/plans/queries/lib/use-query-keys-factory.ts
@@ -1,5 +1,6 @@
 const useQueryKeysFactory = () => ( {
 	sitePlans: ( siteId?: string | number | null ) => [ 'site-plans', siteId ],
+	plans: () => [ 'plans' ],
 } );
 
 export default useQueryKeysFactory;

--- a/packages/data-stores/src/plans/queries/use-plans.ts
+++ b/packages/data-stores/src/plans/queries/use-plans.ts
@@ -1,0 +1,40 @@
+import { useQuery } from '@tanstack/react-query';
+import { useCallback } from '@wordpress/element';
+import wpcomRequest from 'wpcom-proxy-request';
+import useQueryKeysFactory from './lib/use-query-keys-factory';
+import type { PricedAPIPlan, PlanNext } from '../types';
+
+interface PlansIndex {
+	[ planSlug: string ]: PlanNext;
+}
+
+function usePlans() {
+	const queryKeys = useQueryKeysFactory();
+
+	return useQuery< PricedAPIPlan[], Error, PlansIndex >( {
+		queryKey: queryKeys.plans(),
+		queryFn: async () =>
+			await wpcomRequest( {
+				path: `/plans`,
+				apiVersion: '1.5',
+			} ),
+		select: useCallback( ( data: PricedAPIPlan[] ) => {
+			return data.reduce< PlansIndex >( ( acc, plan ) => {
+				return {
+					...acc,
+					[ plan.product_slug ]: {
+						planSlug: plan.product_slug,
+						productId: plan.product_id,
+						productNameShort: plan.product_name_short,
+						billPeriod: plan.bill_period,
+						currencyCode: plan.currency_code,
+					},
+				};
+			}, {} );
+		}, [] ),
+		refetchOnWindowFocus: false,
+		staleTime: 1000 * 60 * 5, // 5 minutes
+	} );
+}
+
+export default usePlans;

--- a/packages/data-stores/src/plans/queries/use-site-plans.ts
+++ b/packages/data-stores/src/plans/queries/use-site-plans.ts
@@ -15,26 +15,23 @@ interface Props {
 	siteId?: string | number | null;
 }
 
-const unpackIntroOffer = ( sitePlan: PricedAPISitePlan ): PlanIntroductoryOffer | null => {
+const unpackIntroOffer = ( plan: PricedAPISitePlan ): PlanIntroductoryOffer | null => {
 	// these aren't grouped or separated. so no introductory offer if no cost or interval
-	if (
-		! sitePlan.introductory_offer_interval_unit &&
-		! sitePlan.introductory_offer_interval_count
-	) {
+	if ( ! plan.introductory_offer_interval_unit && ! plan.introductory_offer_interval_count ) {
 		return null;
 	}
 
 	const isOfferComplete = Boolean(
-		sitePlan.expiry &&
-			sitePlan.introductory_offer_end_date &&
-			new Date( sitePlan.expiry ) > new Date( sitePlan.introductory_offer_end_date )
+		plan.expiry &&
+			plan.introductory_offer_end_date &&
+			new Date( plan.expiry ) > new Date( plan.introductory_offer_end_date )
 	);
 
 	return {
-		formattedPrice: sitePlan.introductory_offer_formatted_price as string,
-		rawPrice: sitePlan.introductory_offer_raw_price as number,
-		intervalUnit: sitePlan.introductory_offer_interval_unit as string,
-		intervalCount: sitePlan.introductory_offer_interval_count as number,
+		formattedPrice: plan.introductory_offer_formatted_price as string,
+		rawPrice: plan.introductory_offer_raw_price as number,
+		intervalUnit: plan.introductory_offer_interval_unit as string,
+		intervalCount: plan.introductory_offer_interval_count as number,
 		isOfferComplete,
 	};
 };

--- a/packages/data-stores/src/plans/types.ts
+++ b/packages/data-stores/src/plans/types.ts
@@ -67,6 +67,18 @@ export interface SitePlan {
 	expiry?: string;
 }
 
+/*
+ * This is the new interface for API Plans that will replace the existing Plan interface above.
+ * The existing Plan interface will be removed once this interface is fully implemented.
+ */
+export interface PlanNext {
+	planSlug: PlanSlugFromProducts;
+	productId: number;
+	productNameShort: string;
+	billPeriod: -1 | ( typeof PERIOD_LIST )[ number ];
+	currencyCode: string;
+}
+
 export interface PricedAPIPlanIntroductoryOffer {
 	introductory_offer_formatted_price?: string;
 	introductory_offer_raw_price?: number;
@@ -95,7 +107,6 @@ export interface PricedAPIPlan {
 
 	/**
 	 * The product price as a float.
-	 *
 	 * @deprecated use raw_price_integer as using floats for currency is not safe.
 	 */
 	raw_price: number;
@@ -109,7 +120,6 @@ export interface PricedAPIPlan {
 
 	/**
 	 * The orig cost as a float.
-	 *
 	 * @deprecated use orig_cost_integer as using floats for currency is not safe.
 	 */
 	orig_cost?: number | null;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to a couple of issues that expect store-based access to plans: 
- wpcom introductory offers: https://github.com/Automattic/dotcom-forge/issues/4570
- porting plans data/pricing to data store: https://github.com/Automattic/wp-calypso/issues/79005

## Proposed Changes

- Adds a `usePlans` hook to plans data-store and uses it to derive the `product_name_short` variable used for grid-plans (as an initial usage instance). Gradually more `PricedAPIPlan` data will be derived from here, until the entire data layer is effectively replaced.
- A `PlanNext` type is introduced, which will evolve to include relevant properties needed to eventually replace the previous `Plan` interface. This is not meant to be a more general refactoring of the data-store. That will happen at a later time. There are several types being defined that we are gradually extending and redefining. 

### Media

<img width="400" alt="Screenshot 2023-11-24 at 2 35 22 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/d38ff935-4368-418d-ab45-2b8cba28e803">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/plans` and ensure the previous/inherited plan's name is displayed as expected (per media above).
* General sanity checks on plans pages (flows and admin)
* Wait a while 5-10+ minutes and ensure the page doesn't go blank (~5 minutes data would become stale and might trigger a refetch). This is possibly subject to being refactored, similarly to https://github.com/Automattic/wp-calypso/pull/82995 (reverted, but will resurface).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?