### PR TITLE
Plans Grid Refactor: Revert "Refactor: Move action override related props to the relevant data structure"

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -552,34 +552,25 @@ const PlansFeaturesMain = ( {
 			};
 		}
 
-		if ( sitePlanSlug && intentFromProps !== 'plans-p2' ) {
-			if ( isFreePlan( sitePlanSlug ) ) {
-				actionOverrides = {
-					loggedInFreePlan: {
-						status:
-							isPlanUpsellEnabledOnFreeDomain.isLoading || resolvedSubdomainName.isLoading
-								? 'blocked'
-								: 'enabled',
-						callback: () => {
-							page.redirect( `/add-ons/${ siteSlug }` );
-						},
-						text: translate( 'Manage add-ons', { context: 'verb' } ),
+		if ( sitePlanSlug && isFreePlan( sitePlanSlug ) && intentFromProps !== 'plans-p2' ) {
+			actionOverrides = {
+				loggedInFreePlan: {
+					status:
+						isPlanUpsellEnabledOnFreeDomain.isLoading || resolvedSubdomainName.isLoading
+							? 'blocked'
+							: 'enabled',
+					callback: () => {
+						page.redirect( `/add-ons/${ siteSlug }` );
 					},
-				};
+					text: translate( 'Manage add-ons', { context: 'verb' } ),
+				},
+			};
 
-				if ( domainFromHomeUpsellFlow ) {
-					actionOverrides.loggedInFreePlan = {
-						...actionOverrides.loggedInFreePlan,
-						callback: showDomainUpsellDialog,
-						text: translate( 'Keep my plan', { context: 'verb' } ),
-					};
-				}
-			} else {
-				actionOverrides = {
-					currentPlan: {
-						text: canUserManageCurrentPlan ? translate( 'Manage plan' ) : translate( 'View plan' ),
-						callback: () => page( currentPlanManageHref ),
-					},
+			if ( domainFromHomeUpsellFlow ) {
+				actionOverrides.loggedInFreePlan = {
+					...actionOverrides.loggedInFreePlan,
+					callback: showDomainUpsellDialog,
+					text: translate( 'Keep my plan', { context: 'verb' } ),
 				};
 			}
 		}
@@ -588,15 +579,12 @@ const PlansFeaturesMain = ( {
 	}, [
 		isInSignup,
 		sitePlanSlug,
-		intentFromProps,
 		isPlanUpsellEnabledOnFreeDomain.isLoading,
 		resolvedSubdomainName.isLoading,
 		translate,
 		domainFromHomeUpsellFlow,
 		siteSlug,
 		showDomainUpsellDialog,
-		canUserManageCurrentPlan,
-		currentPlanManageHref,
 	] );
 
 	/**
@@ -824,6 +812,8 @@ const PlansFeaturesMain = ( {
 									usePricingMetaForGridPlans={ usePricingMetaForGridPlans }
 									allFeaturesList={ FEATURES_LIST }
 									onStorageAddOnClick={ handleStorageAddOnClick }
+									currentPlanManageHref={ currentPlanManageHref }
+									canUserManageCurrentPlan={ canUserManageCurrentPlan }
 									showRefundPeriod={ isAnyHostingFlow( flowName ) }
 								/>
 								{ showEscapeHatch && hidePlansFeatureComparison && (
@@ -885,6 +875,8 @@ const PlansFeaturesMain = ( {
 												usePricingMetaForGridPlans={ usePricingMetaForGridPlans }
 												allFeaturesList={ FEATURES_LIST }
 												onStorageAddOnClick={ handleStorageAddOnClick }
+												currentPlanManageHref={ currentPlanManageHref }
+												canUserManageCurrentPlan={ canUserManageCurrentPlan }
 												showRefundPeriod={ isAnyHostingFlow( flowName ) }
 											/>
 											<ComparisonGridToggle

--- a/client/my-sites/plans-grid/components/actions.tsx
+++ b/client/my-sites/plans-grid/components/actions.tsx
@@ -31,9 +31,11 @@ import type { PlanActionOverrides } from '../types';
 
 type PlanFeaturesActionsButtonProps = {
 	availableForPurchase: boolean;
+	canUserManageCurrentPlan?: boolean | null;
 	className: string;
 	currentSitePlanSlug?: string | null;
 	freePlan: boolean;
+	currentPlanManageHref?: string;
 	isPopular?: boolean;
 	isInSignup?: boolean;
 	isLaunchPage?: boolean | null;
@@ -215,6 +217,8 @@ const LoggedInPlansFeatureActionButton = ( {
 	planTitle,
 	handleUpgradeButtonClick,
 	planSlug,
+	currentPlanManageHref,
+	canUserManageCurrentPlan,
 	currentSitePlanSlug,
 	buttonText,
 	planActionOverrides,
@@ -230,6 +234,8 @@ const LoggedInPlansFeatureActionButton = ( {
 	planTitle: TranslateResult;
 	handleUpgradeButtonClick: () => void;
 	planSlug: PlanSlug;
+	currentPlanManageHref?: string;
+	canUserManageCurrentPlan?: boolean | null;
 	currentSitePlanSlug?: string | null;
 	buttonText?: string;
 	planActionOverrides?: PlanActionOverrides;
@@ -269,7 +275,11 @@ const LoggedInPlansFeatureActionButton = ( {
 	) {
 		if ( planActionOverrides?.loggedInFreePlan ) {
 			return (
-				<Button className={ classes } onClick={ planActionOverrides.loggedInFreePlan.callback }>
+				<Button
+					className={ classes }
+					onClick={ planActionOverrides.loggedInFreePlan.callback }
+					disabled={ ! currentPlanManageHref } // not sure why this is here
+				>
 					{ planActionOverrides.loggedInFreePlan.text }
 				</Button>
 			);
@@ -296,17 +306,15 @@ const LoggedInPlansFeatureActionButton = ( {
 					{ translate( 'Upgrade' ) }
 				</Button>
 			);
-		} else if ( planActionOverrides?.currentPlan ) {
-			const { callback, text } = planActionOverrides.currentPlan;
-			return (
-				<Button className={ classes } disabled={ ! callback } onClick={ callback }>
-					{ text }
-				</Button>
-			);
 		}
+
 		return (
-			<Button className={ classes } disabled>
-				{ translate( 'Active Plan' ) }
+			<Button
+				className={ classes }
+				href={ currentPlanManageHref }
+				disabled={ ! currentPlanManageHref }
+			>
+				{ canUserManageCurrentPlan ? translate( 'Manage plan' ) : translate( 'View plan' ) }
 			</Button>
 		);
 	}
@@ -424,9 +432,11 @@ const LoggedInPlansFeatureActionButton = ( {
 
 const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( {
 	availableForPurchase = true,
+	canUserManageCurrentPlan,
 	className,
 	currentSitePlanSlug,
 	freePlan = false,
+	currentPlanManageHref,
 	isInSignup,
 	isLaunchPage,
 	onUpgradeClick,
@@ -556,6 +566,8 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 			availableForPurchase={ availableForPurchase }
 			classes={ classes }
 			handleUpgradeButtonClick={ handleUpgradeButtonClick }
+			currentPlanManageHref={ currentPlanManageHref }
+			canUserManageCurrentPlan={ canUserManageCurrentPlan }
 			currentSitePlanSlug={ currentSitePlanSlug }
 			buttonText={ buttonText }
 			planActionOverrides={ planActionOverrides }

--- a/client/my-sites/plans-grid/components/comparison-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/comparison-grid/index.tsx
@@ -328,6 +328,8 @@ type ComparisonGridProps = {
 	isLaunchPage?: boolean | null;
 	flowName?: string | null;
 	currentSitePlanSlug?: string | null;
+	currentPlanManageHref?: string;
+	canUserManageCurrentPlan?: boolean | null;
 	onUpgradeClick: ( planSlug: PlanSlug ) => void;
 	siteId?: number | null;
 	planActionOverrides?: PlanActionOverrides;
@@ -349,6 +351,8 @@ type ComparisonGridHeaderProps = {
 	flowName?: string | null;
 	onPlanChange: ( currentPlan: PlanSlug, event: ChangeEvent< HTMLSelectElement > ) => void;
 	currentSitePlanSlug?: string | null;
+	currentPlanManageHref?: string;
+	canUserManageCurrentPlan?: boolean | null;
 	onUpgradeClick: ( planSlug: PlanSlug ) => void;
 	siteId?: number | null;
 	planActionOverrides?: PlanActionOverrides;
@@ -381,6 +385,8 @@ const ComparisonGridHeaderCell = ( {
 	onPlanChange,
 	displayedGridPlans,
 	currentSitePlanSlug,
+	currentPlanManageHref,
+	canUserManageCurrentPlan,
 	isLaunchPage,
 	flowName,
 	isLargeCurrency,
@@ -471,6 +477,8 @@ const ComparisonGridHeaderCell = ( {
 			</div>
 			<PlanFeatures2023GridActions
 				currentSitePlanSlug={ currentSitePlanSlug }
+				currentPlanManageHref={ currentPlanManageHref }
+				canUserManageCurrentPlan={ canUserManageCurrentPlan }
 				availableForPurchase={ gridPlan.availableForPurchase }
 				className={ getPlanClass( planSlug ) }
 				freePlan={ isFreePlan( planSlug ) }
@@ -499,6 +507,8 @@ const ComparisonGridHeader = forwardRef< HTMLDivElement, ComparisonGridHeaderPro
 			isFooter,
 			onPlanChange,
 			currentSitePlanSlug,
+			currentPlanManageHref,
+			canUserManageCurrentPlan,
 			onUpgradeClick,
 			siteId,
 			planActionOverrides,
@@ -541,6 +551,8 @@ const ComparisonGridHeader = forwardRef< HTMLDivElement, ComparisonGridHeaderPro
 						onPlanChange={ onPlanChange }
 						displayedGridPlans={ displayedGridPlans }
 						currentSitePlanSlug={ currentSitePlanSlug }
+						currentPlanManageHref={ currentPlanManageHref }
+						canUserManageCurrentPlan={ canUserManageCurrentPlan }
 						flowName={ flowName }
 						onUpgradeClick={ onUpgradeClick }
 						isLaunchPage={ isLaunchPage }
@@ -954,6 +966,8 @@ const ComparisonGrid = ( {
 	isLaunchPage,
 	flowName,
 	currentSitePlanSlug,
+	currentPlanManageHref,
+	canUserManageCurrentPlan,
 	onUpgradeClick,
 	siteId,
 	planActionOverrides,
@@ -1104,6 +1118,8 @@ const ComparisonGrid = ( {
 							flowName={ flowName }
 							onPlanChange={ onPlanChange }
 							currentSitePlanSlug={ currentSitePlanSlug }
+							currentPlanManageHref={ currentPlanManageHref }
+							canUserManageCurrentPlan={ canUserManageCurrentPlan }
 							onUpgradeClick={ onUpgradeClick }
 							planActionOverrides={ planActionOverrides }
 							selectedPlan={ selectedPlan }
@@ -1136,6 +1152,8 @@ const ComparisonGrid = ( {
 					isFooter={ true }
 					onPlanChange={ onPlanChange }
 					currentSitePlanSlug={ currentSitePlanSlug }
+					currentPlanManageHref={ currentPlanManageHref }
+					canUserManageCurrentPlan={ canUserManageCurrentPlan }
 					onUpgradeClick={ onUpgradeClick }
 					siteId={ siteId }
 					planActionOverrides={ planActionOverrides }

--- a/client/my-sites/plans-grid/components/features-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/features-grid/index.tsx
@@ -47,6 +47,7 @@ type PlanRowOptions = {
 interface FeaturesGridType extends PlansGridProps {
 	isLargeCurrency: boolean;
 	translate: LocalizeProps[ 'translate' ];
+	canUserManageCurrentPlan?: boolean | null;
 	currentPlanManageHref?: string;
 	isPlanUpgradeCreditEligible: boolean;
 	handleUpgradeClick: ( planSlug: PlanSlug ) => void;
@@ -358,6 +359,8 @@ class FeaturesGrid extends Component< FeaturesGridType > {
 			isInSignup,
 			isLaunchPage,
 			flowName,
+			canUserManageCurrentPlan,
+			currentPlanManageHref,
 			currentSitePlanSlug,
 			translate,
 			planActionOverrides,
@@ -394,6 +397,8 @@ class FeaturesGrid extends Component< FeaturesGridType > {
 						isTableCell={ options?.isTableCell }
 					>
 						<PlanFeatures2023GridActions
+							currentPlanManageHref={ currentPlanManageHref }
+							canUserManageCurrentPlan={ canUserManageCurrentPlan }
 							availableForPurchase={ availableForPurchase }
 							className={ getPlanClass( planSlug ) }
 							freePlan={ isFreePlan( planSlug ) }

--- a/client/my-sites/plans-grid/components/test/actions.tsx
+++ b/client/my-sites/plans-grid/components/test/actions.tsx
@@ -68,6 +68,7 @@ describe( 'PlanFeatures2023GridActions', () => {
 		const contactSupport = 'Contact support';
 		const defaultProps = {
 			availableForPurchase: true,
+			canUserManageCurrentPlan: true,
 			className: '',
 			current: false,
 			freePlan: false,

--- a/client/my-sites/plans-grid/index.tsx
+++ b/client/my-sites/plans-grid/index.tsx
@@ -56,6 +56,8 @@ export interface PlansGridProps {
 	showUpgradeableStorage: boolean; // feature flag used to show the storage add-on dropdown
 	stickyRowOffset: number;
 	usePricingMetaForGridPlans: UsePricingMetaForGridPlans;
+	currentPlanManageHref?: string;
+	canUserManageCurrentPlan?: boolean | null;
 	showRefundPeriod?: boolean;
 }
 
@@ -76,6 +78,8 @@ const WrappedComparisonGrid = ( {
 	showLegacyStorageFeature,
 	showUpgradeableStorage,
 	onStorageAddOnClick,
+	currentPlanManageHref,
+	canUserManageCurrentPlan,
 	stickyRowOffset,
 	...otherProps
 }: PlansGridProps ) => {
@@ -97,6 +101,8 @@ const WrappedComparisonGrid = ( {
 				isLaunchPage={ isLaunchPage }
 				flowName={ flowName }
 				currentSitePlanSlug={ currentSitePlanSlug }
+				currentPlanManageHref={ currentPlanManageHref }
+				canUserManageCurrentPlan={ canUserManageCurrentPlan }
 				onUpgradeClick={ handleUpgradeClick }
 				siteId={ siteId }
 				selectedPlan={ selectedPlan }
@@ -112,8 +118,16 @@ const WrappedComparisonGrid = ( {
 };
 
 const WrappedFeaturesGrid = ( props: PlansGridProps ) => {
-	const { siteId, intent, gridPlans, usePricingMetaForGridPlans, allFeaturesList, onUpgradeClick } =
-		props;
+	const {
+		siteId,
+		intent,
+		gridPlans,
+		usePricingMetaForGridPlans,
+		allFeaturesList,
+		onUpgradeClick,
+		currentPlanManageHref,
+		canUserManageCurrentPlan,
+	} = props;
 	const translate = useTranslate();
 	const isPlanUpgradeCreditEligible = useIsPlanUpgradeCreditVisible(
 		siteId,
@@ -143,6 +157,8 @@ const WrappedFeaturesGrid = ( props: PlansGridProps ) => {
 				{ ...props }
 				isPlanUpgradeCreditEligible={ isPlanUpgradeCreditEligible }
 				isLargeCurrency={ isLargeCurrency }
+				canUserManageCurrentPlan={ canUserManageCurrentPlan }
+				currentPlanManageHref={ currentPlanManageHref }
 				translate={ translate }
 				handleUpgradeClick={ handleUpgradeClick }
 			/>

--- a/client/my-sites/plans-grid/types.ts
+++ b/client/my-sites/plans-grid/types.ts
@@ -9,13 +9,9 @@ export type TransformedFeatureObject = FeatureObject & {
 
 export interface PlanActionOverrides {
 	loggedInFreePlan?: {
+		callback?: () => void;
 		text?: TranslateResult;
 		status?: 'blocked' | 'enabled';
-		callback?: () => void;
-	};
-	currentPlan?: {
-		text?: TranslateResult;
-		callback?: () => void;
 	};
 }
 


### PR DESCRIPTION
Reverts Automattic/wp-calypso#83976