### PR TITLE
Plans Grid Refactor: Attempt - 2 - Plans Grid Refactor: Move action override related props to the relevant data structure

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -540,10 +540,8 @@ const PlansFeaturesMain = ( {
 	 */
 	const planActionOverrides = useMemo( () => {
 		let actionOverrides: PlanActionOverrides | undefined;
-		const commonProps = { canUserManageCurrentPlan, currentPlanManageHref };
 		if ( isInSignup ) {
 			actionOverrides = {
-				...commonProps,
 				loggedInFreePlan: {
 					status:
 						isPlanUpsellEnabledOnFreeDomain.isLoading || resolvedSubdomainName.isLoading
@@ -553,42 +551,50 @@ const PlansFeaturesMain = ( {
 			};
 		}
 
-		if ( sitePlanSlug && isFreePlan( sitePlanSlug ) && intentFromProps !== 'plans-p2' ) {
-			actionOverrides = {
-				...commonProps,
-				loggedInFreePlan: {
-					status:
-						isPlanUpsellEnabledOnFreeDomain.isLoading || resolvedSubdomainName.isLoading
-							? 'blocked'
-							: 'enabled',
-					callback: () => {
-						page.redirect( `/add-ons/${ siteSlug }` );
+		if ( sitePlanSlug && intentFromProps !== 'plans-p2' ) {
+			if ( isFreePlan( sitePlanSlug ) ) {
+				actionOverrides = {
+					loggedInFreePlan: {
+						status:
+							isPlanUpsellEnabledOnFreeDomain.isLoading || resolvedSubdomainName.isLoading
+								? 'blocked'
+								: 'enabled',
+						callback: () => {
+							page.redirect( `/add-ons/${ siteSlug }` );
+						},
 					},
-					text: translate( 'Manage add-ons', { context: 'verb' } ),
-				},
-			};
+				};
 
-			if ( domainFromHomeUpsellFlow ) {
-				actionOverrides.loggedInFreePlan = {
-					...actionOverrides.loggedInFreePlan,
-					callback: showDomainUpsellDialog,
-					text: translate( 'Keep my plan', { context: 'verb' } ),
+				if ( domainFromHomeUpsellFlow ) {
+					actionOverrides.loggedInFreePlan = {
+						...actionOverrides?.loggedInFreePlan,
+						callback: showDomainUpsellDialog,
+						text: translate( 'Keep my plan', { context: 'verb' } ),
+					};
+				}
+			} else {
+				actionOverrides = {
+					currentPlan: {
+						text: canUserManageCurrentPlan ? translate( 'Manage plan' ) : translate( 'View plan' ),
+						callback: () => page( currentPlanManageHref ),
+					},
 				};
 			}
 		}
 
 		return actionOverrides;
 	}, [
-		canUserManageCurrentPlan,
-		currentPlanManageHref,
 		isInSignup,
 		sitePlanSlug,
+		intentFromProps,
 		isPlanUpsellEnabledOnFreeDomain.isLoading,
 		resolvedSubdomainName.isLoading,
-		translate,
 		domainFromHomeUpsellFlow,
 		siteSlug,
 		showDomainUpsellDialog,
+		translate,
+		canUserManageCurrentPlan,
+		currentPlanManageHref,
 	] );
 
 	/**

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -540,6 +540,7 @@ const PlansFeaturesMain = ( {
 	 */
 	const planActionOverrides = useMemo( () => {
 		let actionOverrides: PlanActionOverrides | undefined;
+
 		if ( isInSignup ) {
 			actionOverrides = {
 				loggedInFreePlan: {
@@ -562,12 +563,13 @@ const PlansFeaturesMain = ( {
 						callback: () => {
 							page.redirect( `/add-ons/${ siteSlug }` );
 						},
+						text: translate( 'Manage add-ons', { context: 'verb' } ),
 					},
 				};
 
 				if ( domainFromHomeUpsellFlow ) {
 					actionOverrides.loggedInFreePlan = {
-						...actionOverrides?.loggedInFreePlan,
+						...actionOverrides.loggedInFreePlan,
 						callback: showDomainUpsellDialog,
 						text: translate( 'Keep my plan', { context: 'verb' } ),
 					};
@@ -589,10 +591,10 @@ const PlansFeaturesMain = ( {
 		intentFromProps,
 		isPlanUpsellEnabledOnFreeDomain.isLoading,
 		resolvedSubdomainName.isLoading,
+		translate,
 		domainFromHomeUpsellFlow,
 		siteSlug,
 		showDomainUpsellDialog,
-		translate,
 		canUserManageCurrentPlan,
 		currentPlanManageHref,
 	] );

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -540,9 +540,10 @@ const PlansFeaturesMain = ( {
 	 */
 	const planActionOverrides = useMemo( () => {
 		let actionOverrides: PlanActionOverrides | undefined;
-
+		const commonProps = { canUserManageCurrentPlan, currentPlanManageHref };
 		if ( isInSignup ) {
 			actionOverrides = {
+				...commonProps,
 				loggedInFreePlan: {
 					status:
 						isPlanUpsellEnabledOnFreeDomain.isLoading || resolvedSubdomainName.isLoading
@@ -554,6 +555,7 @@ const PlansFeaturesMain = ( {
 
 		if ( sitePlanSlug && isFreePlan( sitePlanSlug ) && intentFromProps !== 'plans-p2' ) {
 			actionOverrides = {
+				...commonProps,
 				loggedInFreePlan: {
 					status:
 						isPlanUpsellEnabledOnFreeDomain.isLoading || resolvedSubdomainName.isLoading
@@ -577,6 +579,8 @@ const PlansFeaturesMain = ( {
 
 		return actionOverrides;
 	}, [
+		canUserManageCurrentPlan,
+		currentPlanManageHref,
 		isInSignup,
 		sitePlanSlug,
 		isPlanUpsellEnabledOnFreeDomain.isLoading,
@@ -812,8 +816,6 @@ const PlansFeaturesMain = ( {
 									usePricingMetaForGridPlans={ usePricingMetaForGridPlans }
 									allFeaturesList={ FEATURES_LIST }
 									onStorageAddOnClick={ handleStorageAddOnClick }
-									currentPlanManageHref={ currentPlanManageHref }
-									canUserManageCurrentPlan={ canUserManageCurrentPlan }
 									showRefundPeriod={ isAnyHostingFlow( flowName ) }
 								/>
 								{ showEscapeHatch && hidePlansFeatureComparison && (
@@ -875,8 +877,6 @@ const PlansFeaturesMain = ( {
 												usePricingMetaForGridPlans={ usePricingMetaForGridPlans }
 												allFeaturesList={ FEATURES_LIST }
 												onStorageAddOnClick={ handleStorageAddOnClick }
-												currentPlanManageHref={ currentPlanManageHref }
-												canUserManageCurrentPlan={ canUserManageCurrentPlan }
 												showRefundPeriod={ isAnyHostingFlow( flowName ) }
 											/>
 											<ComparisonGridToggle

--- a/client/my-sites/plans-grid/components/actions.tsx
+++ b/client/my-sites/plans-grid/components/actions.tsx
@@ -299,7 +299,11 @@ const LoggedInPlansFeatureActionButton = ( {
 		}
 
 		return (
-			<Button className={ classes } disabled={ ! planActionOverrides?.currentPlan?.callback }>
+			<Button
+				className={ classes }
+				disabled={ ! planActionOverrides?.currentPlan?.callback }
+				onClick={ planActionOverrides?.currentPlan?.callback }
+			>
 				{ planActionOverrides?.currentPlan?.text }
 			</Button>
 		);

--- a/client/my-sites/plans-grid/components/actions.tsx
+++ b/client/my-sites/plans-grid/components/actions.tsx
@@ -299,14 +299,8 @@ const LoggedInPlansFeatureActionButton = ( {
 		}
 
 		return (
-			<Button
-				className={ classes }
-				href={ planActionOverrides?.currentPlanManageHref ?? '' }
-				disabled={ ! planActionOverrides?.currentPlanManageHref }
-			>
-				{ planActionOverrides?.canUserManageCurrentPlan
-					? translate( 'Manage plan' )
-					: translate( 'View plan' ) }
+			<Button className={ classes } disabled={ ! planActionOverrides?.currentPlan?.callback }>
+				{ planActionOverrides?.currentPlan?.text }
 			</Button>
 		);
 	}

--- a/client/my-sites/plans-grid/components/actions.tsx
+++ b/client/my-sites/plans-grid/components/actions.tsx
@@ -31,11 +31,9 @@ import type { PlanActionOverrides } from '../types';
 
 type PlanFeaturesActionsButtonProps = {
 	availableForPurchase: boolean;
-	canUserManageCurrentPlan?: boolean | null;
 	className: string;
 	currentSitePlanSlug?: string | null;
 	freePlan: boolean;
-	currentPlanManageHref?: string;
 	isPopular?: boolean;
 	isInSignup?: boolean;
 	isLaunchPage?: boolean | null;
@@ -217,8 +215,6 @@ const LoggedInPlansFeatureActionButton = ( {
 	planTitle,
 	handleUpgradeButtonClick,
 	planSlug,
-	currentPlanManageHref,
-	canUserManageCurrentPlan,
 	currentSitePlanSlug,
 	buttonText,
 	planActionOverrides,
@@ -234,8 +230,6 @@ const LoggedInPlansFeatureActionButton = ( {
 	planTitle: TranslateResult;
 	handleUpgradeButtonClick: () => void;
 	planSlug: PlanSlug;
-	currentPlanManageHref?: string;
-	canUserManageCurrentPlan?: boolean | null;
 	currentSitePlanSlug?: string | null;
 	buttonText?: string;
 	planActionOverrides?: PlanActionOverrides;
@@ -275,11 +269,7 @@ const LoggedInPlansFeatureActionButton = ( {
 	) {
 		if ( planActionOverrides?.loggedInFreePlan ) {
 			return (
-				<Button
-					className={ classes }
-					onClick={ planActionOverrides.loggedInFreePlan.callback }
-					disabled={ ! currentPlanManageHref } // not sure why this is here
-				>
+				<Button className={ classes } onClick={ planActionOverrides.loggedInFreePlan.callback }>
 					{ planActionOverrides.loggedInFreePlan.text }
 				</Button>
 			);
@@ -311,10 +301,12 @@ const LoggedInPlansFeatureActionButton = ( {
 		return (
 			<Button
 				className={ classes }
-				href={ currentPlanManageHref }
-				disabled={ ! currentPlanManageHref }
+				href={ planActionOverrides?.currentPlanManageHref ?? '' }
+				disabled={ ! planActionOverrides?.currentPlanManageHref }
 			>
-				{ canUserManageCurrentPlan ? translate( 'Manage plan' ) : translate( 'View plan' ) }
+				{ planActionOverrides?.canUserManageCurrentPlan
+					? translate( 'Manage plan' )
+					: translate( 'View plan' ) }
 			</Button>
 		);
 	}
@@ -432,11 +424,9 @@ const LoggedInPlansFeatureActionButton = ( {
 
 const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( {
 	availableForPurchase = true,
-	canUserManageCurrentPlan,
 	className,
 	currentSitePlanSlug,
 	freePlan = false,
-	currentPlanManageHref,
 	isInSignup,
 	isLaunchPage,
 	onUpgradeClick,
@@ -566,8 +556,6 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 			availableForPurchase={ availableForPurchase }
 			classes={ classes }
 			handleUpgradeButtonClick={ handleUpgradeButtonClick }
-			currentPlanManageHref={ currentPlanManageHref }
-			canUserManageCurrentPlan={ canUserManageCurrentPlan }
 			currentSitePlanSlug={ currentSitePlanSlug }
 			buttonText={ buttonText }
 			planActionOverrides={ planActionOverrides }

--- a/client/my-sites/plans-grid/components/actions.tsx
+++ b/client/my-sites/plans-grid/components/actions.tsx
@@ -296,15 +296,17 @@ const LoggedInPlansFeatureActionButton = ( {
 					{ translate( 'Upgrade' ) }
 				</Button>
 			);
+		} else if ( planActionOverrides?.currentPlan ) {
+			const { callback, text } = planActionOverrides.currentPlan;
+			return (
+				<Button className={ classes } disabled={ ! callback } onClick={ callback }>
+					{ text }
+				</Button>
+			);
 		}
-
 		return (
-			<Button
-				className={ classes }
-				disabled={ ! planActionOverrides?.currentPlan?.callback }
-				onClick={ planActionOverrides?.currentPlan?.callback }
-			>
-				{ planActionOverrides?.currentPlan?.text }
+			<Button className={ classes } disabled>
+				{ translate( 'Active Plan' ) }
 			</Button>
 		);
 	}

--- a/client/my-sites/plans-grid/components/comparison-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/comparison-grid/index.tsx
@@ -328,8 +328,6 @@ type ComparisonGridProps = {
 	isLaunchPage?: boolean | null;
 	flowName?: string | null;
 	currentSitePlanSlug?: string | null;
-	currentPlanManageHref?: string;
-	canUserManageCurrentPlan?: boolean | null;
 	onUpgradeClick: ( planSlug: PlanSlug ) => void;
 	siteId?: number | null;
 	planActionOverrides?: PlanActionOverrides;
@@ -351,8 +349,6 @@ type ComparisonGridHeaderProps = {
 	flowName?: string | null;
 	onPlanChange: ( currentPlan: PlanSlug, event: ChangeEvent< HTMLSelectElement > ) => void;
 	currentSitePlanSlug?: string | null;
-	currentPlanManageHref?: string;
-	canUserManageCurrentPlan?: boolean | null;
 	onUpgradeClick: ( planSlug: PlanSlug ) => void;
 	siteId?: number | null;
 	planActionOverrides?: PlanActionOverrides;
@@ -385,8 +381,6 @@ const ComparisonGridHeaderCell = ( {
 	onPlanChange,
 	displayedGridPlans,
 	currentSitePlanSlug,
-	currentPlanManageHref,
-	canUserManageCurrentPlan,
 	isLaunchPage,
 	flowName,
 	isLargeCurrency,
@@ -477,8 +471,6 @@ const ComparisonGridHeaderCell = ( {
 			</div>
 			<PlanFeatures2023GridActions
 				currentSitePlanSlug={ currentSitePlanSlug }
-				currentPlanManageHref={ currentPlanManageHref }
-				canUserManageCurrentPlan={ canUserManageCurrentPlan }
 				availableForPurchase={ gridPlan.availableForPurchase }
 				className={ getPlanClass( planSlug ) }
 				freePlan={ isFreePlan( planSlug ) }
@@ -507,8 +499,6 @@ const ComparisonGridHeader = forwardRef< HTMLDivElement, ComparisonGridHeaderPro
 			isFooter,
 			onPlanChange,
 			currentSitePlanSlug,
-			currentPlanManageHref,
-			canUserManageCurrentPlan,
 			onUpgradeClick,
 			siteId,
 			planActionOverrides,
@@ -551,8 +541,6 @@ const ComparisonGridHeader = forwardRef< HTMLDivElement, ComparisonGridHeaderPro
 						onPlanChange={ onPlanChange }
 						displayedGridPlans={ displayedGridPlans }
 						currentSitePlanSlug={ currentSitePlanSlug }
-						currentPlanManageHref={ currentPlanManageHref }
-						canUserManageCurrentPlan={ canUserManageCurrentPlan }
 						flowName={ flowName }
 						onUpgradeClick={ onUpgradeClick }
 						isLaunchPage={ isLaunchPage }
@@ -966,8 +954,6 @@ const ComparisonGrid = ( {
 	isLaunchPage,
 	flowName,
 	currentSitePlanSlug,
-	currentPlanManageHref,
-	canUserManageCurrentPlan,
 	onUpgradeClick,
 	siteId,
 	planActionOverrides,
@@ -1118,8 +1104,6 @@ const ComparisonGrid = ( {
 							flowName={ flowName }
 							onPlanChange={ onPlanChange }
 							currentSitePlanSlug={ currentSitePlanSlug }
-							currentPlanManageHref={ currentPlanManageHref }
-							canUserManageCurrentPlan={ canUserManageCurrentPlan }
 							onUpgradeClick={ onUpgradeClick }
 							planActionOverrides={ planActionOverrides }
 							selectedPlan={ selectedPlan }
@@ -1152,8 +1136,6 @@ const ComparisonGrid = ( {
 					isFooter={ true }
 					onPlanChange={ onPlanChange }
 					currentSitePlanSlug={ currentSitePlanSlug }
-					currentPlanManageHref={ currentPlanManageHref }
-					canUserManageCurrentPlan={ canUserManageCurrentPlan }
 					onUpgradeClick={ onUpgradeClick }
 					siteId={ siteId }
 					planActionOverrides={ planActionOverrides }

--- a/client/my-sites/plans-grid/components/features-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/features-grid/index.tsx
@@ -47,7 +47,6 @@ type PlanRowOptions = {
 interface FeaturesGridType extends PlansGridProps {
 	isLargeCurrency: boolean;
 	translate: LocalizeProps[ 'translate' ];
-	canUserManageCurrentPlan?: boolean | null;
 	currentPlanManageHref?: string;
 	isPlanUpgradeCreditEligible: boolean;
 	handleUpgradeClick: ( planSlug: PlanSlug ) => void;
@@ -359,8 +358,6 @@ class FeaturesGrid extends Component< FeaturesGridType > {
 			isInSignup,
 			isLaunchPage,
 			flowName,
-			canUserManageCurrentPlan,
-			currentPlanManageHref,
 			currentSitePlanSlug,
 			translate,
 			planActionOverrides,
@@ -397,8 +394,6 @@ class FeaturesGrid extends Component< FeaturesGridType > {
 						isTableCell={ options?.isTableCell }
 					>
 						<PlanFeatures2023GridActions
-							currentPlanManageHref={ currentPlanManageHref }
-							canUserManageCurrentPlan={ canUserManageCurrentPlan }
 							availableForPurchase={ availableForPurchase }
 							className={ getPlanClass( planSlug ) }
 							freePlan={ isFreePlan( planSlug ) }

--- a/client/my-sites/plans-grid/components/test/actions.tsx
+++ b/client/my-sites/plans-grid/components/test/actions.tsx
@@ -68,7 +68,6 @@ describe( 'PlanFeatures2023GridActions', () => {
 		const contactSupport = 'Contact support';
 		const defaultProps = {
 			availableForPurchase: true,
-			canUserManageCurrentPlan: true,
 			className: '',
 			current: false,
 			freePlan: false,

--- a/client/my-sites/plans-grid/index.tsx
+++ b/client/my-sites/plans-grid/index.tsx
@@ -56,8 +56,6 @@ export interface PlansGridProps {
 	showUpgradeableStorage: boolean; // feature flag used to show the storage add-on dropdown
 	stickyRowOffset: number;
 	usePricingMetaForGridPlans: UsePricingMetaForGridPlans;
-	currentPlanManageHref?: string;
-	canUserManageCurrentPlan?: boolean | null;
 	showRefundPeriod?: boolean;
 }
 
@@ -78,8 +76,6 @@ const WrappedComparisonGrid = ( {
 	showLegacyStorageFeature,
 	showUpgradeableStorage,
 	onStorageAddOnClick,
-	currentPlanManageHref,
-	canUserManageCurrentPlan,
 	stickyRowOffset,
 	...otherProps
 }: PlansGridProps ) => {
@@ -101,8 +97,6 @@ const WrappedComparisonGrid = ( {
 				isLaunchPage={ isLaunchPage }
 				flowName={ flowName }
 				currentSitePlanSlug={ currentSitePlanSlug }
-				currentPlanManageHref={ currentPlanManageHref }
-				canUserManageCurrentPlan={ canUserManageCurrentPlan }
 				onUpgradeClick={ handleUpgradeClick }
 				siteId={ siteId }
 				selectedPlan={ selectedPlan }
@@ -118,16 +112,8 @@ const WrappedComparisonGrid = ( {
 };
 
 const WrappedFeaturesGrid = ( props: PlansGridProps ) => {
-	const {
-		siteId,
-		intent,
-		gridPlans,
-		usePricingMetaForGridPlans,
-		allFeaturesList,
-		onUpgradeClick,
-		currentPlanManageHref,
-		canUserManageCurrentPlan,
-	} = props;
+	const { siteId, intent, gridPlans, usePricingMetaForGridPlans, allFeaturesList, onUpgradeClick } =
+		props;
 	const translate = useTranslate();
 	const isPlanUpgradeCreditEligible = useIsPlanUpgradeCreditVisible(
 		siteId,
@@ -157,8 +143,6 @@ const WrappedFeaturesGrid = ( props: PlansGridProps ) => {
 				{ ...props }
 				isPlanUpgradeCreditEligible={ isPlanUpgradeCreditEligible }
 				isLargeCurrency={ isLargeCurrency }
-				canUserManageCurrentPlan={ canUserManageCurrentPlan }
-				currentPlanManageHref={ currentPlanManageHref }
 				translate={ translate }
 				handleUpgradeClick={ handleUpgradeClick }
 			/>

--- a/client/my-sites/plans-grid/types.ts
+++ b/client/my-sites/plans-grid/types.ts
@@ -8,12 +8,14 @@ export type TransformedFeatureObject = FeatureObject & {
 };
 
 export interface PlanActionOverrides {
-	canUserManageCurrentPlan: boolean | null;
-	currentPlanManageHref: string | null;
 	loggedInFreePlan?: {
-		callback?: () => void;
 		text?: TranslateResult;
 		status?: 'blocked' | 'enabled';
+		callback?: () => void;
+	};
+	currentPlan?: {
+		text?: TranslateResult;
+		callback?: () => void;
 	};
 }
 

--- a/client/my-sites/plans-grid/types.ts
+++ b/client/my-sites/plans-grid/types.ts
@@ -8,6 +8,8 @@ export type TransformedFeatureObject = FeatureObject & {
 };
 
 export interface PlanActionOverrides {
+	canUserManageCurrentPlan: boolean | null;
+	currentPlanManageHref: string | null;
 	loggedInFreePlan?: {
 		callback?: () => void;
 		text?: TranslateResult;

--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -40,7 +40,7 @@ const selectors = {
 		return `.plan-features__${ viewportSuffix } >> .plan-features__actions-button.is-${ plan.toLowerCase() }-plan:has-text("${ buttonText }")`;
 	},
 	activePlan: ( plan: Plans ) => `a.is-${ plan.toLowerCase() }-plan.is-current-plan:visible`,
-
+	spotlightPlan: '.plan-features-2023-grid__plan-spotlight',
 	// My Plans tab
 	myPlanTitle: ( planName: Plans ) => `.my-plan-card__title:has-text("${ planName }")`,
 };
@@ -123,13 +123,7 @@ export class PlansPage {
 	 * @throws If the expected plan title is not found in the timeout period.
 	 */
 	async validateActivePlan( expectedPlan: Plans ): Promise< void > {
-		await Promise.race( [
-			this.page.locator( selectors.myPlanTitle( expectedPlan ) ).waitFor(),
-			// There can be lots of these link buttons for different viewports.
-			// We only need one to be there! We must use strict selection.
-			// Any of these link buttons means the right plan is selected.
-			this.page.locator( selectors.activePlan( expectedPlan ) ).first().waitFor(),
-		] );
+		await this.page.locator( selectors.spotlightPlan ).getByText( expectedPlan ).waitFor();
 	}
 
 	/**
@@ -138,7 +132,6 @@ export class PlansPage {
 	async clickManagePlan(): Promise< void > {
 		await this.page.click( selectors.managePlanButton );
 	}
-
 	/**
 	 * Validates that the provided tab name is the the currently active tab in the wrapper Plans page. Throws if it isn't.
 	 *


### PR DESCRIPTION
- Initial: https://github.com/Automattic/wp-calypso/pull/83976 
- Revert: https://github.com/Automattic/wp-calypso/pull/84512

## Proposed Changes

* Pre release tests were failing this change fixes those issues.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* See https://github.com/Automattic/wp-calypso/pull/83976
* Make sure pre release tests are running

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?