### PR TITLE
Checkout: prevent calling a payment processor function if checkout disabled

### DIFF
--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/content.tsx
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/content.tsx
@@ -179,13 +179,14 @@ function PayButton( {
 			? translate( 'Complete Checkout' )
 			: sprintf( translate( 'Pay %s' ), totalCostDisplay );
 	const processingText = translate( 'Processing…' );
+	const noop = () => {};
 
 	return (
 		<Button
 			primary={ ! busy }
 			busy={ busy }
 			disabled={ busy }
-			onClick={ onClick }
+			onClick={ busy ? noop : onClick }
 			className="purchase-modal__pay-button"
 		>
 			{ busy ? processingText : payText }

--- a/packages/composite-checkout/src/components/checkout-submit-button.tsx
+++ b/packages/composite-checkout/src/components/checkout-submit-button.tsx
@@ -67,7 +67,13 @@ function CheckoutSubmitButtonForPaymentMethod( {
 	const onClickWithValidation: ProcessPayment = async (
 		processorData: PaymentProcessorSubmitData
 	) => {
-		if ( ! isActive ) {
+		if ( formStatus === FormStatus.SUBMITTING ) {
+			return Promise.resolve(
+				makeErrorResponse( __( 'A transaction is currently pending. Please wait.' ) )
+			);
+		}
+
+		if ( isDisabled ) {
 			return Promise.resolve(
 				makeErrorResponse( __( 'This payment method is not currently available.' ) )
 			);


### PR DESCRIPTION
## Proposed Changes

We have several pieces of evidence (for example, 3DS challenges: https://github.com/Automattic/payments-shilling/issues/1910#issuecomment-1729918046) that show that some users are able to submit checkout more than once within a single second on the same page. That shouldn't be possible since we disable the submit button in that case and I've never been able to reproduce it. Nevertheless, it may be a good idea to just prevent it from ever happening.

This PR modifies the checkout submit button function and the one for the one-click checkout modal so that if the transaction has been submitted, the button will no longer work even if it becomes enabled.

This should help solve the same issue that I was trying to solve with https://github.com/Automattic/wp-calypso/issues/82067 although that's still a useful improvement.

## Testing Instructions

- Add an item to your cart and load checkout.
- Complete the required steps and verify that the submit button is enabled. You may want to select a payment method that will fail (eg: the test card `4000000000000002`) or that can easily fail (eg: a 3DS test card) so you can test this without needing to make a real purchase.
- Click to submit a payment and verify that the transaction is submitted.