### PR TITLE
Checkout: Call useExperiment for collapse payment method step test

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -42,6 +42,7 @@ import usePrepareProductsForCart from '../hooks/use-prepare-products-for-cart';
 import useRecordCartLoaded from '../hooks/use-record-cart-loaded';
 import useRecordCheckoutLoaded from '../hooks/use-record-checkout-loaded';
 import useRemoveFromCartAndRedirect from '../hooks/use-remove-from-cart-and-redirect';
+import { useShouldCollapseLastStep } from '../hooks/use-should-collapse-last-step';
 import { useStoredPaymentMethods } from '../hooks/use-stored-payment-methods';
 import { useToSFoldableCard } from '../hooks/use-tos-foldable-card';
 import { logStashLoadErrorEvent, logStashEvent, convertErrorToString } from '../lib/analytics';
@@ -524,6 +525,7 @@ export default function CheckoutMain( {
 	const theme = { ...checkoutTheme, colors: { ...checkoutTheme.colors, ...jetpackColors } };
 
 	const isToSExperimentLoading = useToSFoldableCard() === 'loading';
+	const isCollapseExperimentLoading = useShouldCollapseLastStep() === 'loading';
 
 	// This variable determines if we see the loading page or if checkout can
 	// render its steps.
@@ -549,6 +551,7 @@ export default function CheckoutMain( {
 		},
 		{ name: translate( 'Loading countries list' ), isLoading: countriesList.length < 1 },
 		{ name: translate( 'Loading Site' ), isLoading: isToSExperimentLoading },
+		{ name: translate( 'Loading Site' ), isLoading: isCollapseExperimentLoading },
 	];
 	const isCheckoutPageLoading: boolean = checkoutLoadingConditions.some(
 		( condition ) => condition.isLoading

--- a/client/my-sites/checkout/src/components/payment-method-step.tsx
+++ b/client/my-sites/checkout/src/components/payment-method-step.tsx
@@ -90,7 +90,7 @@ export default function BeforeSubmitCheckoutHeader() {
 	const taxLineItems = getTaxBreakdownLineItemsFromCart( responseCart );
 	const creditsLineItem = getCreditsLineItemFromCart( responseCart );
 	const couponLineItem = getCouponLineItemFromCart( responseCart );
-	const shouldCollapseLastStep = useShouldCollapseLastStep();
+	const shouldCollapseLastStep = useShouldCollapseLastStep() === 'collapse';
 	const translate = useTranslate();
 	const subtotalWithoutCoupon = getSubtotalWithoutCoupon( responseCart );
 	const subTotalLineItemWithoutCoupon: LineItemType = {

--- a/client/my-sites/checkout/src/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout.tsx
@@ -330,7 +330,6 @@ export default function WPCheckout( {
 
 	const { transactionStatus } = useTransactionStatus();
 	const paymentMethod = usePaymentMethod();
-	const shouldCollapseLastStep = useShouldCollapseLastStep();
 	const showToSFoldableCard = useToSFoldableCard() === 'treatment';
 
 	const hasMarketplaceProduct = useSelector( ( state ) => {
@@ -841,7 +840,7 @@ function CheckoutTermsAndCheckboxes( {
 	} );
 
 	const translate = useTranslate();
-	const shouldCollapseLastStep = useShouldCollapseLastStep();
+	const shouldCollapseLastStep = useShouldCollapseLastStep() === 'collapse';
 
 	if ( ! shouldCollapseLastStep ) {
 		return null;

--- a/client/my-sites/checkout/src/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout.tsx
@@ -331,6 +331,7 @@ export default function WPCheckout( {
 	const { transactionStatus } = useTransactionStatus();
 	const paymentMethod = usePaymentMethod();
 	const showToSFoldableCard = useToSFoldableCard() === 'treatment';
+	const shouldCollapseLastStep = useShouldCollapseLastStep() === 'collapse';
 
 	const hasMarketplaceProduct = useSelector( ( state ) => {
 		return responseCart?.products?.some( ( p ) => isMarketplaceProduct( state, p.product_slug ) );

--- a/client/my-sites/checkout/src/hooks/use-cached-domain-contact-details.ts
+++ b/client/my-sites/checkout/src/hooks/use-cached-domain-contact-details.ts
@@ -18,7 +18,7 @@ import type {
 	CountryListItem,
 } from '@automattic/wpcom-checkout';
 
-const debug = debugFactory( 'calypso:composite-checkout:use-cached-domain-contact-details' );
+const debug = debugFactory( 'calypso:use-cached-domain-contact-details' );
 
 function useCachedContactDetails(): PossiblyCompleteDomainContactDetails | null {
 	const reduxDispatch = useReduxDispatch();
@@ -62,7 +62,7 @@ function useCachedContactDetailsForCheckoutForm(
 	}
 	const { loadDomainContactDetailsFromCache } = checkoutStoreActions;
 
-	const shouldCollapseLastStep = useShouldCollapseLastStep() === 'collapse';
+	const collapseLastStepStatus = useShouldCollapseLastStep();
 
 	const isMounted = useRef( true );
 	useEffect( () => {
@@ -77,6 +77,10 @@ function useCachedContactDetailsForCheckoutForm(
 	useEffect( () => {
 		// Once this activates, do not do it again.
 		if ( didFillForm.current ) {
+			return;
+		}
+		if ( collapseLastStepStatus === 'loading' ) {
+			debug( 'prepopulating cached contact details waiting on Explat' );
 			return;
 		}
 		// Do nothing if the contact details are loading, or the countries are loading.
@@ -101,7 +105,8 @@ function useCachedContactDetailsForCheckoutForm(
 				if ( cachedContactDetails.countryCode ) {
 					setShouldShowContactDetailsValidationErrors( false );
 					debug( 'Contact details are populated; attempting to skip to payment method step' );
-					if ( shouldCollapseLastStep ) {
+					if ( collapseLastStepStatus === 'collapse' ) {
+						debug( 'also attempting to skip payment method step' );
 						return setStepCompleteStatus( 'payment-method-step' );
 					}
 					return setStepCompleteStatus( 'contact-form' );
@@ -135,7 +140,7 @@ function useCachedContactDetailsForCheckoutForm(
 				} );
 			} );
 	}, [
-		shouldCollapseLastStep,
+		collapseLastStepStatus,
 		setShouldShowContactDetailsValidationErrors,
 		reduxDispatch,
 		setStepCompleteStatus,

--- a/client/my-sites/checkout/src/hooks/use-cached-domain-contact-details.ts
+++ b/client/my-sites/checkout/src/hooks/use-cached-domain-contact-details.ts
@@ -62,7 +62,7 @@ function useCachedContactDetailsForCheckoutForm(
 	}
 	const { loadDomainContactDetailsFromCache } = checkoutStoreActions;
 
-	const shouldCollapseLastStep = useShouldCollapseLastStep();
+	const shouldCollapseLastStep = useShouldCollapseLastStep() === 'collapse';
 
 	const isMounted = useRef( true );
 	useEffect( () => {

--- a/client/my-sites/checkout/src/hooks/use-should-collapse-last-step.tsx
+++ b/client/my-sites/checkout/src/hooks/use-should-collapse-last-step.tsx
@@ -19,7 +19,7 @@ export function useShouldCollapseLastStep(): boolean {
 		{ isEligible: isWPcomCheckout }
 	);
 
-	if ( ! isLoadingExperimentAssignment ) {
+	if ( isLoadingExperimentAssignment ) {
 		return false;
 	}
 

--- a/client/my-sites/checkout/src/hooks/use-should-collapse-last-step.tsx
+++ b/client/my-sites/checkout/src/hooks/use-should-collapse-last-step.tsx
@@ -6,7 +6,7 @@ import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-t
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
-export function useShouldCollapseLastStep(): boolean {
+export function useShouldCollapseLastStep(): 'loading' | 'collapse' | 'no-collapse' {
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 
 	const isJetpackNotAtomic = useSelector(
@@ -20,11 +20,11 @@ export function useShouldCollapseLastStep(): boolean {
 	);
 
 	if ( isLoadingExperimentAssignment ) {
-		return false;
+		return 'loading';
 	}
 
 	if ( experimentAssignment?.variationName === 'treatment' ) {
-		return true;
+		return 'collapse';
 	}
-	return false;
+	return 'no-collapse';
 }

--- a/client/my-sites/checkout/src/hooks/use-should-collapse-last-step.tsx
+++ b/client/my-sites/checkout/src/hooks/use-should-collapse-last-step.tsx
@@ -1,7 +1,29 @@
-import { hasCheckoutVersion } from '@automattic/wpcom-checkout';
+import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
+import { useExperiment } from 'calypso/lib/explat';
+import isJetpackCheckout from 'calypso/lib/jetpack/is-jetpack-checkout';
+import { useSelector } from 'calypso/state';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 export function useShouldCollapseLastStep(): boolean {
-	if ( hasCheckoutVersion( 'collapse-steps' ) ) {
+	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+
+	const isJetpackNotAtomic = useSelector(
+		( state ) => isJetpackSite( state, siteId ) && ! isSiteAutomatedTransfer( state, siteId )
+	);
+
+	const isWPcomCheckout = ! isJetpackCheckout() && ! isAkismetCheckout() && ! isJetpackNotAtomic;
+	const [ isLoadingExperimentAssignment, experimentAssignment ] = useExperiment(
+		'wp_web_checkout_collapse_payment_method',
+		{ isEligible: isWPcomCheckout }
+	);
+
+	if ( ! isLoadingExperimentAssignment ) {
+		return false;
+	}
+
+	if ( experimentAssignment?.variationName === 'treatment' ) {
 		return true;
 	}
 	return false;

--- a/client/my-sites/checkout/src/test/use-cached-domain-contact-details.tsx
+++ b/client/my-sites/checkout/src/test/use-cached-domain-contact-details.tsx
@@ -12,6 +12,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { useSelect } from '@wordpress/data';
 import { useState } from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
+import { useExperiment } from 'calypso/lib/explat';
 import useCachedDomainContactDetails from 'calypso/my-sites/checkout/src/hooks/use-cached-domain-contact-details';
 import { CHECKOUT_STORE } from 'calypso/my-sites/checkout/src/lib/wpcom-store';
 import {
@@ -21,6 +22,9 @@ import {
 	mockCachedContactDetailsEndpoint,
 } from './util';
 import type { CountryListItem } from '@automattic/wpcom-checkout';
+
+jest.mock( 'calypso/lib/explat' );
+( useExperiment as jest.Mock ).mockImplementation( () => [ false, undefined ] );
 
 const initialCart = getEmptyResponseCart();
 const { getCart, setCart } = mockCartEndpoint( initialCart, 'USD', 'US' );

--- a/packages/composite-checkout/src/components/checkout-payment-methods.tsx
+++ b/packages/composite-checkout/src/components/checkout-payment-methods.tsx
@@ -25,10 +25,6 @@ const CheckoutPaymentMethodsWrapper = styled.div`
 	padding-top: 4px;
 `;
 
-export const RadioButtons = styled.div`
-	margin-bottom: 16px;
-`;
-
 export default function CheckoutPaymentMethods( {
 	summary,
 	isComplete,
@@ -93,7 +89,7 @@ export default function CheckoutPaymentMethods( {
 		<CheckoutPaymentMethodsWrapper
 			className={ joinClasses( [ className, 'checkout-payment-methods' ] ) }
 		>
-			<RadioButtons>
+			<div>
 				{ paymentMethods.map( ( method ) => (
 					<CheckoutErrorBoundary
 						key={ method.id }
@@ -115,7 +111,7 @@ export default function CheckoutPaymentMethods( {
 						/>
 					</CheckoutErrorBoundary>
 				) ) }
-			</RadioButtons>
+			</div>
 		</CheckoutPaymentMethodsWrapper>
 	);
 }


### PR DESCRIPTION
## Proposed Changes

This PR creates an ExPlat experiment for the feature added by https://github.com/Automattic/wp-calypso/pull/83985. The experiment p2 post is here: pbxNRc-3le-p2

To quote the original PR:

There are currently two steps in checkout: the billing info step (sometimes even that does not exist for certain free purchases) and the payment method step. Each `CheckoutStep` as defined by the `@automattic/composite-checkout` package has the ability to be rendered in an "active" and an "inactive" state. For example, when you enter your billing info into the first step and press "Continue", the step is changed to its "inactive" state which displays the billing info without the editable fields.

We have a feature which attempts to auto-complete the billing info step using cached contact details when checkout loads, but there is no way to complete the payment method step because a `CheckoutStep` will not display the "Continue" button for the last step. This is so it doesn't conflict with the `CheckoutFormSubmit` which is the page's primary call-to-action.

In this experiment, we modify the auto-complete feature to also attempt to complete the payment method step when checkout loads. Since this is done programmatically, it allows marking the step as inactive even though there's no manual way to do so. 

Doing this required also moving the Terms of Service and checkboxes section from the bottom of the payment method step to a component between the payment method step and the submit button so that they will be visible even if the step is collapsed. One side effect of this is that the Terms of Service are no longer hidden when the billing step is active, but I don't know if that will be a problem.

The motivation for this change is to reduce visual noise on the checkout page for returning customers who want to continue using a saved payment method.

This is part of the project to update checkout's UI: https://github.com/Automattic/payments-shilling/issues/1969

## Screenshots

Control             |  Treatment
:-------------------------:|:-------------------------:
<img width="835" alt="before-83985" src="https://github.com/Automattic/wp-calypso/assets/2036909/9c7b2248-32a6-44f4-aec7-393121b435bc">  | <img width="840" alt="Screenshot 2023-11-08 at 6 40 57 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/d4a844fc-31a3-4612-9439-4dd678e00d75">

## Testing Instructions

See PCYsg-SwK-p2