### PR TITLE
Checkout: Add chat launcher to checkout masterbar - attempt 2

### DIFF
--- a/client/components/chat-button/index.tsx
+++ b/client/components/chat-button/index.tsx
@@ -71,6 +71,16 @@ function getMessagingGroupForIntent( chatIntent: ChatIntent, keyType: KeyType ):
 	}
 }
 
+/**
+ * ChatButton - A button that opens a chat widget when clicked.
+ * If the user is not eligible for chat, it will open the help center instead.
+ *
+ * This component currently needs to be wrapped in a ShoppingCartProvider to work
+ * properly. See client/my-sites/checkout/calypso-shopping-cart-provider.tsx
+ */
+
+// TODO - decouple this component from the shopping cart
+
 const ChatButton: FC< Props > = ( {
 	borderless = true,
 	chatIntent = 'SUPPORT',

--- a/client/components/chat-button/index.tsx
+++ b/client/components/chat-button/index.tsx
@@ -83,6 +83,8 @@ const ChatButton: FC< Props > = ( {
 		if ( isEligibleForChat && isChatAvailable ) {
 			return true;
 		}
+
+		return false;
 	}
 
 	const { isOpeningChatWidget, openChatWidget } = useChatWidget();

--- a/client/components/marketing-survey/cancel-purchase-form/precancellation-chat-button/index.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/precancellation-chat-button/index.tsx
@@ -5,6 +5,7 @@ import classNames from 'classnames';
 import ChatButton from 'calypso/components/chat-button';
 import MaterialIcon from 'calypso/components/material-icon';
 import { hasIncludedDomain } from 'calypso/lib/purchases';
+import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import { useSelector } from 'calypso/state';
 import { getSiteUrl } from 'calypso/state/sites/selectors';
 import type { Purchase } from 'calypso/lib/purchases/types';
@@ -51,16 +52,18 @@ const PrecancellationChatButton: FC< Props > = ( {
 		`${ purchase.productName } (slug: ${ purchase.productSlug }, ${ purchaseDomain })`;
 
 	return (
-		<ChatButton
-			chatIntent="PRECANCELLATION"
-			initialMessage={ initialMessage }
-			siteUrl={ siteUrl }
-			className={ classNames( 'precancellation-chat-button__main-button', className ) }
-			onClick={ handleClick }
-		>
-			{ icon && <MaterialIcon icon={ icon } /> }
-			{ __( 'Need help? Chat with us' ) }
-		</ChatButton>
+		<CalypsoShoppingCartProvider>
+			<ChatButton
+				chatIntent="PRECANCELLATION"
+				initialMessage={ initialMessage }
+				siteUrl={ siteUrl }
+				className={ classNames( 'precancellation-chat-button__main-button', className ) }
+				onClick={ handleClick }
+			>
+				{ icon && <MaterialIcon icon={ icon } /> }
+				{ __( 'Need help? Chat with us' ) }
+			</ChatButton>
+		</CalypsoShoppingCartProvider>
 	);
 };
 

--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -91,11 +91,7 @@ const CheckoutMasterbar = ( {
 		responseCart.products.map( ( product ) => product.product_name ).join( ', ' );
 
 	const handleClick = () => {
-		reduxDispatch(
-			recordTracksEvent( 'calypso_checkout_masterbar_support_click', {
-				cart: JSON.stringify( responseCart ),
-			} )
-		);
+		reduxDispatch( recordTracksEvent( 'calypso_checkout_masterbar_support_click' ) );
 	};
 
 	return (

--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -6,12 +6,16 @@ import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import AkismetLogo from 'calypso/components/akismet-logo';
+import ChatButton from 'calypso/components/chat-button';
 import JetpackLogo from 'calypso/components/jetpack-logo';
+import MaterialIcon from 'calypso/components/material-icon';
+import { reduxDispatch } from 'calypso/lib/redux-bridge';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import { DefaultMasterbarContact } from 'calypso/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/default-contact';
 import useValidCheckoutBackUrl from 'calypso/my-sites/checkout/src/hooks/use-valid-checkout-back-url';
 import { leaveCheckout } from 'calypso/my-sites/checkout/src/lib/leave-checkout';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import Item from './item';
 import Masterbar from './masterbar';
 
@@ -81,6 +85,19 @@ const CheckoutMasterbar = ( {
 
 	const showCloseButton = isLeavingAllowed && checkoutType === 'wpcom';
 
+	const initialMessage =
+		'Customer is contacting us from the checkout pre-sales flow.\n' +
+		`Product${ responseCart.products.length > 1 && 's' } they're attempting to purchase: ` +
+		responseCart.products.map( ( product ) => product.product_name ).join( ', ' );
+
+	const handleClick = () => {
+		reduxDispatch(
+			recordTracksEvent( 'calypso_checkout_masterbar_support_click', {
+				cart: JSON.stringify( responseCart ),
+			} )
+		);
+	};
+
 	return (
 		<Masterbar
 			className={ classnames( 'masterbar--is-checkout', {
@@ -108,6 +125,15 @@ const CheckoutMasterbar = ( {
 				<span className="masterbar__secure-checkout-text">{ translate( 'Secure checkout' ) }</span>
 			</div>
 			{ title && <Item className="masterbar__item-title">{ title }</Item> }
+			<ChatButton
+				chatIntent="PRESALES"
+				initialMessage={ initialMessage }
+				siteUrl={ siteSlug }
+				className="masterbar__item"
+				onClick={ handleClick }
+			>
+				<MaterialIcon icon="chat_bubble" />
+			</ChatButton>
 			{ loadHelpCenterIcon && <DefaultMasterbarContact /> }
 			<CheckoutModal
 				title={ modalTitleText }

--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -125,16 +125,18 @@ const CheckoutMasterbar = ( {
 				<span className="masterbar__secure-checkout-text">{ translate( 'Secure checkout' ) }</span>
 			</div>
 			{ title && <Item className="masterbar__item-title">{ title }</Item> }
-			<ChatButton
-				chatIntent="PRESALES"
-				initialMessage={ initialMessage }
-				siteUrl={ siteSlug }
-				className="masterbar__item"
-				onClick={ handleClick }
-			>
-				<MaterialIcon icon="chat_bubble" />
-			</ChatButton>
-			{ loadHelpCenterIcon && <DefaultMasterbarContact /> }
+			<div className="masterbar__support-icons">
+				<ChatButton
+					chatIntent="PRESALES"
+					initialMessage={ initialMessage }
+					siteUrl={ siteSlug }
+					className="masterbar__item"
+					onClick={ handleClick }
+				>
+					<MaterialIcon icon="chat_bubble" />
+				</ChatButton>
+				{ loadHelpCenterIcon && <DefaultMasterbarContact /> }
+			</div>
 			<CheckoutModal
 				title={ modalTitleText }
 				copy={ modalBodyText }

--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -87,7 +87,7 @@ const CheckoutMasterbar = ( {
 
 	const initialMessage =
 		'Customer is contacting us from the checkout pre-sales flow.\n' +
-		`Product${ responseCart.products.length > 1 && 's' } they're attempting to purchase: ` +
+		`Product${ responseCart.products?.length > 1 ? 's' : '' } they're attempting to purchase: ` +
 		responseCart.products.map( ( product ) => product.product_name ).join( ', ' );
 
 	const handleClick = () => {

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -892,6 +892,18 @@ a.masterbar__quick-language-switcher {
 	pointer-events: none;
 }
 
+.masterbar__support-icons {
+	display: flex;
+	justify-content: flex-end;
+
+	& .chat-button {
+		position: relative;
+		top: 1px;
+		left: 10px;
+		flex: 1;
+	}
+}
+
 .masterbar__secure-checkout {
 	display: flex;
 	align-items: center;
@@ -928,11 +940,13 @@ a.masterbar__quick-language-switcher {
 		line-height: 1.2em;
 		font-size: 0.75rem;
 		margin-left: 5px;
+		display: none;
 
 		@include breakpoint-deprecated( ">480px" ) {
 			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 			font-size: 100%;
 			margin-left: 0;
+			display: block;
 		}
 
 		.masterbar--is-jetpack & {

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -278,6 +278,13 @@ body.is-mobile-app-view {
 		padding: 0 0 0 6px;
 	}
 
+	.masterbar--is-checkout &.chat-button {
+
+		@include breakpoint-deprecated( ">480px" ) {
+			display: none;
+		}
+	}
+
 	&:hover {
 		@include breakpoint-deprecated( ">480px" ) {
 			background: var(--color-masterbar-item-hover-background);

--- a/client/lib/presales-chat/index.ts
+++ b/client/lib/presales-chat/index.ts
@@ -89,7 +89,12 @@ export function usePresalesChat( keyType: KeyType, enabled = true, skipAvailabil
 	useEffect( () => {
 		// presales chat is always shown by default
 		if ( enabled && isPresalesChatAvailable && isMessagingScriptLoaded ) {
-			! isMobile() ? window.zE( 'messenger', 'show' ) : window.zE( 'messenger', 'hide' );
+			if ( ! isMobile() ) {
+				window.zE( 'messenger', 'show' );
+			} else {
+				window.zE( 'messenger', 'close' );
+				window.zE( 'messenger', 'hide' );
+			}
 		}
 	}, [ enabled, isMessagingScriptLoaded, isPresalesChatAvailable, renderCount ] );
 

--- a/client/lib/presales-chat/index.ts
+++ b/client/lib/presales-chat/index.ts
@@ -89,11 +89,7 @@ export function usePresalesChat( keyType: KeyType, enabled = true, skipAvailabil
 	useEffect( () => {
 		// presales chat is always shown by default
 		if ( enabled && isPresalesChatAvailable && isMessagingScriptLoaded ) {
-			window.zE( 'messenger', 'show' );
-		}
-
-		if ( isMobile() ) {
-			window.zE( 'messenger', 'hide' );
+			! isMobile() ? window.zE( 'messenger', 'show' ) : window.zE( 'messenger', 'hide' );
 		}
 	}, [ enabled, isMessagingScriptLoaded, isPresalesChatAvailable, renderCount ] );
 

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/masterbar-styled/default-contact.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/masterbar-styled/default-contact.tsx
@@ -13,6 +13,7 @@ const HELP_CENTER_STORE = HelpCenter.register();
 
 const ContactContainer = styled.div`
 	display: flex;
+	flex: 1;
 	align-items: center;
 	column-gap: 8px;
 	padding-right: 24px;

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -106,7 +106,7 @@ const HelpCenter: React.FC< Container > = ( { handleClose, hidden } ) => {
 	const { hasActiveChats, isEligibleForChat } = useChatStatus( 'wpcom_messaging', false );
 	const { isMessagingScriptLoaded } = useZendeskMessaging(
 		'zendesk_support_chat_key',
-		( isHelpCenterShown && isEligibleForChat ) || hasActiveChats,
+		isHelpCenterShown || isEligibleForChat || hasActiveChats,
 		isEligibleForChat && hasActiveChats
 	);
 


### PR DESCRIPTION
This is a follow up to the reverted PR https://github.com/Automattic/wp-calypso/pull/80724

The original deployment of this ChatButton update (p58i-fyj-p2) failed because the code added to the ChatButton component included `useShoppingCart` which needs to be wrapped in a shopping cart provider. 

Related to #79018 

## Proposed Changes

This PR will add a chat launcher icon to the checkout masterbar on tablet and mobile sized devices and will hide the 'fancy action button' that typically loads in the bottom right corner of the page. This should free up the footer space on smaller devices for the checkout payment button

Additionally, the ChatButton found in the precancellation modal is now wrapped in `CalypsoShoppingCartProvider` which should guard against the incident that reverted the last attempted deployment.

## Testing Instructions

- Open up this PR locally or use the Calypso live link below
- Add a product to your cart and proceed to checkout
- While in checkout with a desktop viewport you should see the fancy chat button in the bottom right corner (Note: you may need to refresh the page a few times as the launcher only seems to appears if chat is available, though that may have changed recently. *See note below
- Shrink the window to a mobile size, under 480px should work 
- In a mobile viewport the bottom right chat launcher should be hidden and a new chat icon should appear in the checkout masterbar
- Click on the new chat icon, it should load the chat messaging widget
- Close the widget, ensure that the bottom right fancy chat button doesn't reappear in mobile view
- Load the help center by clicking on the ? symbol, loading the help center should minimize the chat, and vice versa
- Look for any functional or visual inconsistencies or degraded UX

**Skip the availability checks - you can set the third parameter of usePresalesChat() in wp-checkout.tsx to true which will skip the availability check for the regular launcher icon on desktop. You'll also need to remove the second condition in the ChatButton component definition where it says if ( isEligibleForChat && isChatAvailable ) {, this will skip the availability check for the mobile icon.)


## Testing the incident issue

- Go to `/me/purchases` and open a purchase
- Click on 'Cancel Plan' > 'Cancel Subscription' (wording may differ depending on the product)
- This should then successfully open the 'Share your feedback' modal
- If you see an error at this step, please report it here
![image](https://github.com/Automattic/wp-calypso/assets/16580129/5c70cc91-6091-4dcc-b713-0eda262d1cfb)