### PR TITLE
Marketplace: add the marketplace-reviews-show flag

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -122,6 +122,7 @@
 		"marketplace-domain-bundle": true,
 		"marketplace-fetch-all-dynamic-products": true,
 		"marketplace-personal-premium": false,
+		"marketplace-reviews-show": true,
 		"marketplace-test": true,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -78,6 +78,7 @@
 		"marketplace-domain-bundle": false,
 		"marketplace-fetch-all-dynamic-products": true,
 		"marketplace-personal-premium": false,
+		"marketplace-reviews-show": false,
 		"marketplace-test": false,
 		"me/account/color-scheme-picker": true,
 		"me/vat-details": true,

--- a/config/production.json
+++ b/config/production.json
@@ -92,6 +92,7 @@
 		"marketplace-domain-bundle": false,
 		"marketplace-fetch-all-dynamic-products": false,
 		"marketplace-personal-premium": false,
+		"marketplace-reviews-show": false,
 		"marketplace-test": false,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -88,6 +88,7 @@
 		"marketplace-domain-bundle": true,
 		"marketplace-fetch-all-dynamic-products": true,
 		"marketplace-personal-premium": false,
+		"marketplace-reviews-show": false,
 		"marketplace-test": true,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -96,6 +96,7 @@
 		"marketplace-domain-bundle": true,
 		"marketplace-fetch-all-dynamic-products": true,
 		"marketplace-personal-premium": false,
+		"marketplace-reviews-show": true,
 		"marketplace-test": true,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,


### PR DESCRIPTION
## Proposed Changes

Add the `marketplace-reviews-show` flag.

## Testing Instructions

All the test and CI should pass.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
