### PR TITLE
Checkout: removes coupon frontend validation

### DIFF
--- a/client/my-sites/checkout/src/hooks/use-coupon-field-state.ts
+++ b/client/my-sites/checkout/src/hooks/use-coupon-field-state.ts
@@ -35,25 +35,17 @@ export default function useCouponFieldState(
 	const handleCouponSubmit = useCallback( () => {
 		const trimmedValue = couponFieldValue.trim();
 
-		if ( isCouponValid( trimmedValue ) ) {
-			reduxDispatch(
-				recordTracksEvent( 'calypso_checkout_composite_coupon_add_submit', {
-					coupon: trimmedValue,
-				} )
-			);
-
-			applyCoupon( trimmedValue ).catch( () => {
-				// Nothing needs to be done here. CartMessages will display the error to the user.
-			} );
-
-			return;
-		}
-
 		reduxDispatch(
-			recordTracksEvent( 'calypso_checkout_composite_coupon_add_error', {
-				error_type: 'Invalid code',
+			recordTracksEvent( 'calypso_checkout_composite_coupon_add_submit', {
+				coupon: trimmedValue,
 			} )
 		);
+
+		applyCoupon( trimmedValue ).catch( () => {
+			// Nothing needs to be done here. CartMessages will display the error to the user.
+		} );
+
+		return;
 	}, [ couponFieldValue, reduxDispatch, applyCoupon ] );
 
 	return {
@@ -64,11 +56,4 @@ export default function useCouponFieldState(
 		setIsFreshOrEdited,
 		handleCouponSubmit,
 	};
-}
-
-function isCouponValid( coupon: string ) {
-	// Coupon code is case-insensitive and starts with an alphanumeric.
-	// Underscores and hyphens can be included in the coupon code.
-	// Per-user coupons can have a dot followed by 5-6 letter checksum for verification.
-	return coupon.match( /^[a-z\d][a-z\d_-]+(\.[a-z\d]+)?$/i );
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Following the discussions in https://github.com/Automattic/wp-calypso/pull/84500#discussion_r1404447138, this PR removes the frontend coupon validation `The user will still see a perfectly satisfactory error message with an invalid coupon` which comes from the backend. 
* Previously, bad formatted coupons wouldn't return any visual cue for the user
* Removes tracking of `calypso_checkout_composite_coupon_add_error`. Should we also do this in the backend?

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Add Yoast SEO Premium `https://wordpress.com/plugins/wordpress-seo-premium` in your cart
* Try a random ( invalid ) coupon
* You should get an explanatory error message

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?