### PR TITLE
Add-ons: display zero dollars per month if applicable

### DIFF
--- a/client/my-sites/add-ons/hooks/use-add-on-prices.ts
+++ b/client/my-sites/add-ons/hooks/use-add-on-prices.ts
@@ -9,7 +9,7 @@ const useAddOnPrices = ( productSlug: string, quantity?: number ) => {
 
 	return useMemo( () => {
 		let cost = product?.cost_smallest_unit;
-		if ( ! cost || ! currencyCode ) {
+		if ( cost == null || ! currencyCode ) {
 			return null;
 		}
 


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/4633.

## Proposed Changes

Fixes a problem where the add-ons did not include any pricing information.

Add-ons page:

| Before | After |
| ------ | ----- |
| <img width="509" alt="image" src="https://github.com/Automattic/wp-calypso/assets/26530524/fd0d273d-2ee6-4d76-9ca9-52f9e804a33f"> | <img width="529" alt="image" src="https://github.com/Automattic/wp-calypso/assets/26530524/9489ba0b-d10d-4e85-8f14-bdfcdac0c01c"> |

Plans grid:

| Before | After |
| ------ | ----- |
| <img width="321" alt="image" src="https://github.com/Automattic/wp-calypso/assets/26530524/ff9b8f6a-2d97-4546-b951-e23dcb7be0c4"> | <img width="333" alt="image" src="https://github.com/Automattic/wp-calypso/assets/26530524/e14328c0-f9fa-4e8e-a3f0-3e0378389563"> |


## Testing Instructions

Apply D129558-code to your sandbox and proxy the API; navigate to the pages referred in the screenshots and verify that the pricing information is displayed instead of absent.