### PR TITLE
Domains page: fix infinite loading in domains page

### DIFF
--- a/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
@@ -53,6 +53,7 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 	const hasDomainCredit = useSelector( ( state ) => hasDomainCreditSelector( state, site?.ID ) );
 	const { data, isLoading, refetch } = useSiteDomainsQuery( site?.ID, {
 		queryFn: () => fetchSiteDomains( site?.ID ),
+		enabled: !! site?.ID,
 	} );
 	const translate = useTranslate();
 	const { sendNudge } = useOdieAssistantContext();


### PR DESCRIPTION
1. This prevents issuing a request to `/undefined/domains` and only fetches when the ID is available. 
2. It may also prevent an infinite loading state when the site ID flips from `undefined` to `defined.


## Testing Instructions
1. Go to /manage/domains
2. Page should load fine.
