### PR TITLE
Provide ways for agencies to create or import a site using their introductory offer

### DIFF
--- a/client/landing/stepper/declarative-flow/agency-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/agency-hosted-site-flow.ts
@@ -1,0 +1,84 @@
+import { AGENCY_HOSTED_SITE_FLOW, AGENCY_OFFER_BUNDLE } from '@automattic/onboarding';
+import { useDispatch } from '@wordpress/data';
+import { addQueryArgs } from '@wordpress/url';
+import { useEffect } from 'react';
+import {
+	setSignupCompleteSlug,
+	persistSignupDestination,
+	setSignupCompleteFlowName,
+} from 'calypso/signup/storageUtils';
+import { ONBOARD_STORE } from '../stores';
+import { recordSubmitStep } from './internals/analytics/record-submit-step';
+import { Flow, ProvidedDependencies } from './internals/types';
+
+const hosting: Flow = {
+	name: AGENCY_HOSTED_SITE_FLOW,
+	useSteps() {
+		return [
+			{
+				slug: 'siteCreationStep',
+				asyncComponent: () => import( './internals/steps-repository/site-creation-step' ),
+			},
+			{
+				slug: 'processing',
+				asyncComponent: () => import( './internals/steps-repository/processing-step' ),
+			},
+		];
+	},
+	useStepNavigation( _currentStepSlug, navigate ) {
+		const flowName = this.name;
+
+		const submit = ( providedDependencies: ProvidedDependencies = {} ) => {
+			recordSubmitStep( providedDependencies, '', flowName, _currentStepSlug );
+
+			switch ( _currentStepSlug ) {
+				case 'siteCreationStep':
+					return navigate( 'processing' );
+
+				case 'processing': {
+					// Purchasing Business or Commerce plans will trigger an atomic transfer, so go to stepper flow where we wait for it to complete.
+					const destination = addQueryArgs( '/setup/transferring-hosted-site', {
+						siteId: providedDependencies.siteId,
+					} );
+
+					persistSignupDestination( destination );
+					setSignupCompleteSlug( providedDependencies?.siteSlug );
+					setSignupCompleteFlowName( flowName );
+
+					if ( providedDependencies.goToCheckout ) {
+						return window.location.assign(
+							addQueryArgs(
+								`/checkout/${ encodeURIComponent(
+									( providedDependencies?.siteSlug as string ) ?? ''
+								) }`,
+								{ redirect_to: destination }
+							)
+						);
+					}
+
+					return window.location.assign( destination );
+				}
+			}
+		};
+
+		return {
+			submit,
+		};
+	},
+	useSideEffect( currentStepSlug ) {
+		const { setProductCartItems } = useDispatch( ONBOARD_STORE );
+
+		useEffect(
+			() => {
+				if ( currentStepSlug === undefined ) {
+					setProductCartItems( AGENCY_OFFER_BUNDLE );
+				}
+			},
+			// We only need to reset the store when the flow is mounted.
+			// eslint-disable-next-line react-hooks/exhaustive-deps
+			[]
+		);
+	},
+};
+
+export default hosting;

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -12,6 +12,7 @@ import {
 	VIDEOPRESS_TV_FLOW,
 	VIDEOPRESS_TV_PURCHASE_FLOW,
 	GOOGLE_TRANSFER,
+	AGENCY_HOSTED_SITE_FLOW,
 } from '@automattic/onboarding';
 import type { Flow } from '../declarative-flow/internals/types';
 
@@ -93,6 +94,9 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 
 	[ CONNECT_DOMAIN_FLOW ]: () =>
 		import( /* webpackChunkName: "connect-domain" */ '../declarative-flow/connect-domain' ),
+
+	[ AGENCY_HOSTED_SITE_FLOW ]: () =>
+		import( /* webpackChunkName: "agency-hosted-site-flow" */ './agency-hosted-site-flow' ),
 
 	[ NEW_HOSTED_SITE_FLOW ]: () =>
 		import( /* webpackChunkName: "new-hosted-site-flow" */ './new-hosted-site-flow' ),

--- a/client/my-sites/plans/components/plans-header/index.tsx
+++ b/client/my-sites/plans/components/plans-header/index.tsx
@@ -1,6 +1,6 @@
-import { PLAN_BUSINESS, PRODUCT_1GB_SPACE } from '@automattic/calypso-products';
 import { Button, Gridicon } from '@automattic/components';
 import { WpcomPlansUI } from '@automattic/data-stores';
+import { AGENCY_OFFER_BUNDLE } from '@automattic/onboarding';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { useDispatch } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
@@ -79,17 +79,7 @@ const PlansHeader: React.FunctionComponent< {
 	}
 
 	async function handleAddCart() {
-		await cart.addProductsToCart( [
-			{
-				product_slug: PLAN_BUSINESS,
-				meta: 'agency-offer',
-			},
-			{
-				product_slug: PRODUCT_1GB_SPACE,
-				quantity: 50,
-				meta: 'agency-offer',
-			},
-		] );
+		await cart.addProductsToCart( AGENCY_OFFER_BUNDLE );
 
 		window.location.href = `/checkout/${ selectedSiteSlug }`;
 	}

--- a/packages/onboarding/src/utils/bundles.ts
+++ b/packages/onboarding/src/utils/bundles.ts
@@ -1,0 +1,13 @@
+import { PLAN_BUSINESS, PRODUCT_1GB_SPACE } from '@automattic/calypso-products';
+
+export const AGENCY_OFFER_BUNDLE = [
+	{
+		product_slug: PLAN_BUSINESS,
+		meta: 'agency-offer',
+	},
+	{
+		product_slug: PRODUCT_1GB_SPACE,
+		quantity: 50,
+		meta: 'agency-offer',
+	},
+];

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -2,6 +2,7 @@ export const AI_ASSEMBLER_FLOW = 'ai-assembler';
 export const NEWSLETTER_FLOW = 'newsletter';
 export const NEWSLETTER_POST_SETUP_FLOW = 'newsletter-post-setup';
 export const HOSTING_LP_FLOW = 'hosting';
+export const AGENCY_HOSTED_SITE_FLOW = 'agency-hosted-site';
 export const NEW_HOSTED_SITE_FLOW = 'new-hosted-site';
 export const TRANSFERRING_HOSTED_SITE_FLOW = 'transferring-hosted-site';
 export const LINK_IN_BIO_FLOW = 'link-in-bio';

--- a/packages/onboarding/src/utils/index.ts
+++ b/packages/onboarding/src/utils/index.ts
@@ -1,5 +1,6 @@
 export * from './contrastChecker';
 export * from './flows';
 export * from './use-data-loss-warning';
+export * from './bundles';
 export { doesStringResembleDomain } from './is-domain';
 export { suggestEmailCorrection } from './domain-suggester';


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/4633.

## Proposed Changes

Adds a way to agencies to create a new site based on the agency offering.

TODO:
- [ ] Expose the link `/sites`
- [ ] Tell them how to use the offer when importing a site (maybe a customized import flow that adds the agency bundle to the cart directly)

## Testing Instructions

Apply D129558-code to your sandbox and navigate to `/setup/agency-hosted-site`. Verify that you get a new site and get redirected to checkout with the special offer.