### PR TITLE
Use site id for launchpad within the start writing flow

### DIFF
--- a/client/landing/stepper/declarative-flow/design-first.ts
+++ b/client/landing/stepper/declarative-flow/design-first.ts
@@ -214,11 +214,7 @@ const designFirst: Flow = {
 							)( dispatch, state );
 						}
 
-						const currentSiteSlug = String( providedDependencies?.domainName ?? siteSlug );
-
-						return window.location.assign(
-							`/setup/design-first/launchpad?siteSlug=${ currentSiteSlug }`
-						);
+						return window.location.assign( `/setup/design-first/launchpad?siteId=${ site?.ID }` );
 					}
 
 					return navigate( 'plans' );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/celebration-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/celebration-step/index.tsx
@@ -5,9 +5,9 @@ import { useSelect } from '@wordpress/data';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
-import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { urlToSlug } from 'calypso/lib/url';
 import SitePreview from '../../components/site-preview';
 import useCelebrationData from './use-celebration-data';
 import type { Step } from '../../types';
@@ -16,9 +16,10 @@ import type { OnboardSelect } from '@automattic/data-stores';
 import './styles.scss';
 
 const CelebrationStep: Step = ( { flow, navigation } ) => {
-	const siteSlug = useSiteSlugParam() ?? '';
-	const site = useSite();
 	const { submit } = navigation;
+
+	const site = useSite();
+	const siteSlug = urlToSlug( site?.URL ?? '' );
 
 	const selectedDomain = useSelect(
 		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedDomain(),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -22,7 +22,7 @@ import type { SiteSelect } from '@automattic/data-stores';
 
 import './style.scss';
 
-// Offloads whether to use siteSlug or siteId to useSite() enabling the launchpad to use either query param
+// This wrapper offloads whether to use siteSlug or siteId to useSite()
 const LaunchpadSiteWrapper: Step = ( {
 	navigation,
 	flow,
@@ -32,6 +32,7 @@ const LaunchpadSiteWrapper: Step = ( {
 } ) => {
 	const site = useSite();
 
+	// Return null while sites are loaded
 	if ( ! site || ! flow ) {
 		return null;
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -48,7 +48,7 @@ const LaunchpadSiteWrapper: Step = ( {
 	);
 };
 
-function Launchpad( {
+export function Launchpad( {
 	siteSlug,
 	siteId,
 	site,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -8,9 +8,9 @@ import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
-import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
 import { SITE_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { urlToSlug } from 'calypso/lib/url';
 import { useSelector, useDispatch } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { successNotice } from 'calypso/state/notices/actions';
@@ -22,6 +22,7 @@ import type { SiteSelect } from '@automattic/data-stores';
 
 import './style.scss';
 
+// Offloads whether to use siteSlug or siteId to useSite() enabling the launchpad to use either query param
 const LaunchpadSiteWrapper: Step = ( {
 	navigation,
 	flow,
@@ -30,17 +31,16 @@ const LaunchpadSiteWrapper: Step = ( {
 	flow: string | null;
 } ) => {
 	const site = useSite();
+
 	if ( ! site || ! flow ) {
 		return null;
 	}
 
-	const siteSlug = site.URL.replace( /^https?:\/\//i, '' );
-	const siteId = site.ID;
 	return (
 		<Launchpad
 			site={ site }
-			siteId={ siteId }
-			siteSlug={ siteSlug }
+			siteId={ site.ID }
+			siteSlug={ urlToSlug( site.URL ) }
 			navigation={ navigation }
 			flow={ flow }
 		/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -24,30 +24,26 @@ import type { SiteSelect } from '@automattic/data-stores';
 
 import './style.scss';
 
-const Launchpad: Step = ( {
-	navigation,
-	flow,
-}: {
+type LaunchpadProps = {
 	navigation: NavigationControls;
-	flow: string;
-} ) => {
-	const site = useSite();
-	const siteSlugParam = useSiteSlugParam();
-	const siteIdParam = useSiteIdParam();
-	const siteKey = siteIdParam || site?.ID || siteSlugParam || '';
-	const siteSlug = urlToSlug( site?.URL ?? '' ) || siteSlugParam || '';
+	flow: string | null;
+};
 
+const Launchpad: Step = ( { navigation, flow }: LaunchpadProps ) => {
 	const translate = useTranslate();
 	const almostReadyToLaunchText = translate( 'Almost ready to launch' );
-
 	const verifiedParam = useQuery().get( 'verified' );
-
+	const site = useSite();
+	const siteIdParam = useSiteIdParam();
+	const siteSlugParam = useSiteSlugParam();
+	const siteSlug = urlToSlug( site?.URL ?? '' ) || siteSlugParam || '';
+	const launchpadKey = siteIdParam || site?.ID || siteSlugParam || '';
 	const siteIntentOption = site?.options?.site_intent;
 	const isSiteLaunched = site?.launch_status === 'launched' || false;
 	const {
 		isError: launchpadFetchError,
 		data: { launchpad_screen: launchpadScreenOption, checklist: launchpadChecklist } = {},
-	} = useLaunchpad( siteKey.toString(), siteIntentOption );
+	} = useLaunchpad( launchpadKey.toString(), siteIntentOption );
 
 	const dispatch = useDispatch();
 	const { saveSiteSettings } = useWPDispatch( SITE_STORE );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -145,9 +145,10 @@ export function getEnhancedTasks(
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							window.location.assign(
-								addQueryArgs( `/setup/${ flow }/setup-blog`, {
-									...{ siteSlug: siteSlug },
-								} )
+								addQueryArgs(
+									`/setup/${ flow }/setup-blog`,
+									isBlogOnboardingFlow( flow ) ? { siteId: site?.ID } : { siteSlug: siteSlug }
+								)
 							);
 						},
 						disabled: task.completed && ! isBlogOnboardingFlow( flow ),
@@ -239,9 +240,10 @@ export function getEnhancedTasks(
 					taskData = {
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
-							const plansUrl = addQueryArgs( `/setup/${ flow }/plans`, {
-								...{ siteSlug: siteSlug },
-							} );
+							const plansUrl = addQueryArgs(
+								`/setup/${ flow }/plans`,
+								isBlogOnboardingFlow( flow ) ? { siteId: site?.ID } : { siteSlug: siteSlug }
+							);
 
 							window.location.assign( plansUrl );
 						},

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -493,7 +493,7 @@ export function getEnhancedTasks(
 							if ( isBlogOnboardingFlow( flow ) ) {
 								window.location.assign(
 									addQueryArgs( `/setup/${ flow }/domains`, {
-										siteSlug,
+										siteId: site?.ID,
 										flowToReturnTo: flow,
 										new: site?.name,
 										domainAndPlanPackage: true,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/index.tsx
@@ -13,7 +13,7 @@ import { getInitialState, getStateFromCache } from 'calypso/state/initial-state'
 import initialReducer from 'calypso/state/reducer';
 import { setStore } from 'calypso/state/redux-store';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
-import Launchpad from '../index';
+import { Launchpad } from '../index';
 import { buildSiteDetails, defaultSiteDetails, MOCK_USE_QUERY_RESULT } from './lib/fixtures';
 
 jest.mock( '../launchpad-site-preview', () => () => {
@@ -86,7 +86,12 @@ function renderLaunchpad(
 		return (
 			<Provider store={ reduxStore }>
 				<MemoryRouter initialEntries={ [ `/setup/link-in-bio/launchpad?siteSlug=${ siteSlug }` ] }>
-					<Launchpad { ...props } />
+					<Launchpad
+						siteId={ siteDetails.ID }
+						siteSlug={ siteSlug }
+						site={ siteDetails }
+						{ ...props }
+					/>
 				</MemoryRouter>
 			</Provider>
 		);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/index.tsx
@@ -13,7 +13,7 @@ import { getInitialState, getStateFromCache } from 'calypso/state/initial-state'
 import initialReducer from 'calypso/state/reducer';
 import { setStore } from 'calypso/state/redux-store';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
-import { Launchpad } from '../index';
+import Launchpad from '../index';
 import { buildSiteDetails, defaultSiteDetails, MOCK_USE_QUERY_RESULT } from './lib/fixtures';
 
 jest.mock( '../launchpad-site-preview', () => () => {
@@ -86,12 +86,7 @@ function renderLaunchpad(
 		return (
 			<Provider store={ reduxStore }>
 				<MemoryRouter initialEntries={ [ `/setup/link-in-bio/launchpad?siteSlug=${ siteSlug }` ] }>
-					<Launchpad
-						siteId={ siteDetails.ID }
-						siteSlug={ siteSlug }
-						site={ siteDetails }
-						{ ...props }
-					/>
+					<Launchpad { ...props } />
 				</MemoryRouter>
 			</Provider>
 		);
@@ -103,7 +98,6 @@ function renderLaunchpad(
 describe( 'Launchpad', () => {
 	let savedLocation;
 	const props = {
-		siteSlug,
 		/* eslint-disable @typescript-eslint/no-empty-function */
 		navigation: {
 			submit: () => {},

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/index.tsx
@@ -66,7 +66,7 @@ function renderLaunchpad(
 	props = {},
 	siteDetails = defaultSiteDetails,
 	initialReduxState = {},
-	siteSlug = ''
+	route = '/setup/link-in-bio/launchpad?siteSlug=testlinkinbio.wordpress.com'
 ): void {
 	function TestLaunchpad( props ) {
 		window.initialReduxState = initialReduxState;
@@ -85,7 +85,7 @@ function renderLaunchpad(
 
 		return (
 			<Provider store={ reduxStore }>
-				<MemoryRouter initialEntries={ [ `/setup/link-in-bio/launchpad?siteSlug=${ siteSlug }` ] }>
+				<MemoryRouter initialEntries={ [ route ] }>
 					<Launchpad { ...props } />
 				</MemoryRouter>
 			</Provider>
@@ -144,7 +144,27 @@ describe( 'Launchpad', () => {
 					data: { launchpad_screen: 'full' },
 				} );
 				const initialReduxState = { currentUser: { id: user.ID } };
-				renderLaunchpad( props, defaultSiteDetails, initialReduxState, siteSlug );
+				renderLaunchpad(
+					props,
+					defaultSiteDetails,
+					initialReduxState,
+					`/setup/link-in-bio/launchpad?siteSlug=${ siteSlug }`
+				);
+				expect( replaceMock ).not.toHaveBeenCalled();
+			} );
+
+			it( 'does not redirect when site id is used', () => {
+				( useLaunchpad as jest.Mock ).mockReturnValueOnce( {
+					...MOCK_USE_QUERY_RESULT,
+					data: { launchpad_screen: 'full' },
+				} );
+				const initialReduxState = { currentUser: { id: user.ID } };
+				renderLaunchpad(
+					props,
+					defaultSiteDetails,
+					initialReduxState,
+					`/setup/link-in-bio/launchpad?siteId=${ defaultSiteDetails.ID }`
+				);
 				expect( replaceMock ).not.toHaveBeenCalled();
 			} );
 		} );
@@ -165,7 +185,7 @@ describe( 'Launchpad', () => {
 						},
 					} ),
 					initialReduxState,
-					siteSlug
+					`/setup/link-in-bio/launchpad?siteSlug=${ siteSlug }`
 				);
 				expect( replaceMock ).toHaveBeenCalledTimes( 1 );
 				expect( replaceMock ).toHaveBeenCalledWith( `/home/${ siteSlug }` );
@@ -183,7 +203,7 @@ describe( 'Launchpad', () => {
 						},
 					} ),
 					{},
-					siteSlug
+					`/setup/link-in-bio/launchpad?siteSlug=${ siteSlug }`
 				);
 				expect( replaceMock ).toHaveBeenCalledWith( `/home/${ siteSlug }` );
 			} );
@@ -201,7 +221,7 @@ describe( 'Launchpad', () => {
 						},
 					} ),
 					initialReduxState,
-					''
+					'/setup/link-in-bio/launchpad'
 				);
 				expect( replaceMock ).toHaveBeenCalledWith( `/home` );
 			} );

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -190,12 +190,7 @@ const startWriting: Flow = {
 								false
 							)( dispatch, state );
 						}
-
-						const currentSiteSlug = String( providedDependencies?.domainName ?? siteSlug );
-
-						return window.location.assign(
-							`/setup/start-writing/launchpad?siteSlug=${ currentSiteSlug }`
-						);
+						return window.location.assign( `/setup/start-writing/launchpad?siteId=${ site?.ID }` );
 					}
 
 					return navigate( 'plans' );

--- a/client/landing/stepper/hooks/use-site.ts
+++ b/client/landing/stepper/hooks/use-site.ts
@@ -7,7 +7,6 @@ import type { SiteSelect } from '@automattic/data-stores';
 export function useSite() {
 	const siteSlug = useSiteSlugParam();
 	const siteIdParam = useSiteIdParam();
-	console.log( { siteSlug, siteIdParam } );
 
 	const site = useSelect(
 		( select ) => {

--- a/client/landing/stepper/hooks/use-site.ts
+++ b/client/landing/stepper/hooks/use-site.ts
@@ -7,6 +7,7 @@ import type { SiteSelect } from '@automattic/data-stores';
 export function useSite() {
 	const siteSlug = useSiteSlugParam();
 	const siteIdParam = useSiteIdParam();
+	console.log( { siteSlug, siteIdParam } );
 
 	const site = useSelect(
 		( select ) => {


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/4582

The siteSlug query param used after hitting the back button is invalid once the site slug is changed in the domain step of the start-writing onboarding flow. This PR makes the launchpad and domain steps in the start writing flow use site id instead of site slug query params.

## Proposed Changes

* Enables the launchpad step to load with either a siteSlug or siteId query param given.
* Modifies blog onboarding launchpad steps to use siteId slugs when modifying the site slug in the start writing flow.

Todo: 
- [x] Decide what to do about the failing tests, I'm not sure if the behavior under test is what we want or just testing current behavior. The redirects might no longer make sense as we now support using site picker in these flows, it might make more sense to redirect to the intent step instead.
Decide if this approach makes sense, it's a little hacky but the alternative options proved excessive to support this single use case. eg https://github.com/Automattic/wp-calypso/pull/84490
- [x] If this approach makes sense update the sitename / plans steps to support site id in a similar manner as the user could technically wind up on a no longer valid screen if they use the back button enough. (current PR only fixes the domain step to and back)

## Testing Instructions

- Work your way up to the launchpad onboarding step with new account through blog start writing flow on the LOHP https://wordpress.com/setup/blog/
- Your current site slug will be shown in the url the first time you enter the launch pad
- All subsequent steps in the launchpad should be using siteId
- Search for a new domain name
- Select the free domain option and return to the launchpad step
- Hitting browser back button to return to the domain step, this step should now let you choose a domain
- Hitting browser back enough times to return to the initial launchpad step you should be redirected to the new site slug 
    - [ ] Something tofix?


Also test the launchpad while entering from other onboarding flows. Site slug should still be used in those flows.