### PR TITLE
Jetpack Manage: Fix The WPCOM Business & Commerce plan card's feature tooltip not displaying correctly.

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/card-content.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/card-content.tsx
@@ -113,12 +113,12 @@ export default function CardContent( {
 			price: formatCurrency( agencyProduct?.amount || 0, 'USD', { stripZeros: true } ),
 			interval: 'month',
 			wpcomFeatures: planFeaturesObject.map( ( feature ) => ( {
-				text: feature?.getTitle?.()?.toString() || '',
-				tooltipText: feature?.getDescription?.()?.toString() || '',
+				text: ( feature?.getTitle?.() as string ) || '',
+				tooltipText: ( feature?.getDescription?.() as string ) || '',
 			} ) ),
 			jetpackFeatures: jetpackFeaturesObject.map( ( feature ) => ( {
-				text: feature?.getTitle?.()?.toString() || '',
-				tooltipText: feature?.getDescription?.()?.toString() || '',
+				text: ( feature?.getTitle?.() as string ) || '',
+				tooltipText: ( feature?.getDescription?.() as string ) || '',
 			} ) ),
 			storage: '50GB',
 			logo: getLogo( planSlug ),

--- a/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/feature-item.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/feature-item.tsx
@@ -23,7 +23,11 @@ export default function FeatureItem( { feature, tooltipText }: Props ) {
 			>
 				{ feature }
 			</div>
-			<Tooltip context={ tooltipRef.current } isVisible={ showPopover } position="top">
+			<Tooltip
+				context={ tooltipRef.current }
+				isVisible={ showPopover && !! tooltipText }
+				position="top"
+			>
 				{ tooltipText }
 			</Tooltip>
 		</>


### PR DESCRIPTION
When hovering over the feature list on the WPCOM Atomic site creation plan cards, some items display incorrect tooltips. This pull request addresses the following issues.

While hovering the free domain, the tooltip shows "[object Object]" and the commission fees tooltip is empty.

<img width="202" alt="Screen Shot 2023-11-27 at 2 48 17 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/acfd8dda-5a57-4a46-a6bf-c7bcd09f751b">


<img width="615" alt="Screen Shot 2023-11-27 at 2 48 34 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/0e347be7-8ff4-4b11-9d31-1768640c760d">


Closes https://github.com/Automattic/jetpack-manage/issues/136

## Proposed Changes

* Remove the `toString` function call and use regular `as` type casting when extracting the feature texts. 
* Update the feature item component to ensure the tooltip is only rendered when there is a tooltip text.

## Testing Instructions
Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

* Use the Jetpack cloud live link below and go to the Licenses page (/partner-portal/create-site)
* Confirm that hovering the feature lists shows the correct tooltips.
<img width="475" alt="Screen Shot 2023-11-27 at 2 54 20 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/ea6d1c69-bbe8-4dde-a5b5-82fb8f5d0bf0">

<img width="612" alt="Screen Shot 2023-11-27 at 2 54 27 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/113453bc-b359-42a5-a995-437973d1fe07">


## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
