### PR TITLE
Jetpack Manage: Fallback to default check interval for downtime monitoring

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/hooks/use-toggle-activate-monitor.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/hooks/use-toggle-activate-monitor.tsx
@@ -10,6 +10,7 @@ import getRejectedAndFulfilledRequests from './get-rejected-and-fulfilled-reques
 import type { Site } from '../sites-overview/types';
 
 const NOTIFICATION_DURATION = 3000;
+const DEFAULT_CHECK_INTERVAL = 5;
 
 export default function useToggleActivateMonitor(
 	sites: Array< { blog_id: number; url: string } >
@@ -42,6 +43,7 @@ export default function useToggleActivateMonitor(
 								monitor_settings: {
 									...site.monitor_settings,
 									monitor_active: params.monitor_active,
+									check_interval: site.monitor_settings?.check_interval ?? DEFAULT_CHECK_INTERVAL,
 									// As we rely primarily on the monitor_site_status field to determine the status of the monitor,
 									// we need to update it when the monitor_active field is updated.
 									monitor_site_status: params.monitor_active,


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-manage/issues/137

## Proposed Changes

This PR fixes the issue where the label for toggle monitor doesn't appear when the monitor is enabled for the first time.

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Visit the Jetpack Cloud link > Add a couple of new JN sites > Enable monitor for the newly created site > Verify that the `5m` label appears next to the toggle as soon as the monitor is enabled
2. Click the 5m label and change the `Monitor my site every:` value to 10 min
3. Disable the monitor > Enable the monitor again > Verify that the label now shows `10m`
4. Verify the same for a couple of more sites 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?