### PR TITLE
Remove needsLikers prop from QueryPostLikes component

### DIFF
--- a/client/components/data/query-post-likes/index.jsx
+++ b/client/components/data/query-post-likes/index.jsx
@@ -4,38 +4,32 @@ import { useDispatch } from 'react-redux';
 import { useInterval } from 'calypso/lib/interval';
 import { requestPostLikes } from 'calypso/state/posts/likes/actions';
 import { getPostLikeLastUpdated } from 'calypso/state/posts/selectors/get-post-like-last-updated';
-import { getPostLikes } from 'calypso/state/posts/selectors/get-post-likes';
 
 const MAX_AGE_MS = 120 * 1000;
 
-const request = ( siteId, postId, needsLikers ) => ( dispatch, getState ) => {
+const request = ( siteId, postId ) => ( dispatch, getState ) => {
 	const state = getState();
 	const lastUpdated = getPostLikeLastUpdated( state, siteId, postId );
-	const hasPostLikes = getPostLikes( state, siteId, postId ) !== null;
 
-	if (
-		! lastUpdated ||
-		Date.now() - lastUpdated > MAX_AGE_MS ||
-		( needsLikers && ! hasPostLikes )
-	) {
+	if ( ! lastUpdated || Date.now() - lastUpdated > MAX_AGE_MS ) {
 		dispatch( requestPostLikes( siteId, postId ) );
 	}
 };
 
-function QueryPostLikes( { siteId, postId, needsLikers = false } ) {
+function QueryPostLikes( { siteId, postId } ) {
 	const dispatch = useDispatch();
 
 	useInterval( () => {
 		if ( siteId && postId ) {
-			dispatch( request( siteId, postId, needsLikers ) );
+			dispatch( request( siteId, postId ) );
 		}
 	}, MAX_AGE_MS + 1 );
 
 	useEffect( () => {
 		if ( siteId && postId ) {
-			dispatch( request( siteId, postId, needsLikers ) );
+			dispatch( request( siteId, postId ) );
 		}
-	}, [ dispatch, siteId, postId, needsLikers ] );
+	}, [ dispatch, siteId, postId ] );
 
 	return null;
 }
@@ -43,7 +37,6 @@ function QueryPostLikes( { siteId, postId, needsLikers = false } ) {
 QueryPostLikes.propTypes = {
 	siteId: PropTypes.number.isRequired,
 	postId: PropTypes.number.isRequired,
-	needsLikers: PropTypes.bool,
 };
 
 export default QueryPostLikes;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #84288

## Proposed Changes

* This PR removes the `needsLikers` prop from the `QueryPostLikes` component as a follow-up to #84288, which moved the logic to fetch liker data into a new, dedicated `QueryPostLikers` component.

## Testing Instructions

* Run this branch locally or via Calypso.live
* Open your browser developer tools to keep an eye on network traffic, particularly XMLHttp API calls
* Navigate to `/read/`
* Wait two minutes (or slightly longer)
* Verify that there are multiple `GET` API calls to the `/rest/v1.1/sites/:blogId/posts/:postId/likes` endpoint
* Check the browser console, and verify that there aren't any errors or warnings due to unexpected prop types or the component in question

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [N/A] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
