### PR TITLE
Comment subscription list: Fix e is undefined

### DIFF
--- a/packages/data-stores/src/reader/queries/use-post-subscriptions-query.ts
+++ b/packages/data-stores/src/reader/queries/use-post-subscriptions-query.ts
@@ -93,7 +93,7 @@ const usePostSubscriptionsQuery = ( {
 
 		// TODO: Temporary fix for https://github.com/Automattic/wp-calypso/issues/76678, remove once fixed
 		const filteredData = flattenedData?.filter(
-			( comment_subscription ) => typeof comment_subscription.post_url === 'string'
+			( comment_subscription ) => typeof comment_subscription?.post_url === 'string'
 		);
 
 		// Transform the dates into Date objects


### PR DESCRIPTION
Related to p1701044340856779-slack-C04U5A26MJB 

## Proposed Changes

* Just adds a ?, so this won't break when `comment_subscription` is undefined.

## Testing Instructions

Code review should be good

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?