### PR TITLE
Jetpack Manage: Remove unnecessary spacing in Select text to optimize translations.

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/product-filter-select.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/product-filter-select.tsx
@@ -65,7 +65,7 @@ export default function ProductFilterSelect( {
 
 	const currentSelectedOption = getOptionByFuction( productFilterOptions, selectedProductFilter );
 
-	const selectedText = translate( '{{b}}Products{{/b}} : %(productFilter)s', {
+	const selectedText = translate( '{{b}}Products{{/b}}: %(productFilter)s', {
 		args: {
 			productFilter: currentSelectedOption.label as string,
 		},


### PR DESCRIPTION
This was raised by the i18n team, but to make it clear and consistent, this PR removes unnecessary spacing in the Select component's placeholder text.

With this PR, the spacing before the colon in the placeholder text has been removed.

**Before**
<img width="295" alt="Screen Shot 2023-11-27 at 4 01 03 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/da9000dc-22ed-4c9d-96f0-be57c7d45921">


**After**
<img width="296" alt="Screen Shot 2023-11-27 at 4 00 41 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/5bcbf5ef-5482-4e26-bb2c-04c6832c7a0c">

## Proposed Changes

* Remove unnecessary spacing in Select text to optimize translations.

## Testing Instructions

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

* Use the Jetpack cloud live link below and go to the Licenses page (/partner-portal/issue-license?flags=jetpack/bundle-licensing)
* Confirm that there is no more spacing before the colon in the `Select` component.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?