### PR TITLE
Jetpack Manage: Display the pricing breakdown in the review licenses modal

### DIFF
--- a/client/components/jetpack/jetpack-lightbox/style.scss
+++ b/client/components/jetpack/jetpack-lightbox/style.scss
@@ -78,6 +78,8 @@
 	background-color: var(--studio-gray-0);
 	border-radius: 0 8px 8px 0; /* stylelint-disable-line scales/radii */
 	box-shadow: 0 4px 8px rgb(0 0 0 / 30%);
+	overflow-y: auto;
+	max-height: 85vh;
 
 	@include break-medium {
 		box-shadow: none;
@@ -135,6 +137,7 @@
 		box-sizing: border-box;
 		transition: transform 0.2s;
 		transform: translateY(100%);
+		max-height: 100%;
 
 		&.is-expanded {
 			transform: translateY(0);

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/pricing-breakdown.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/pricing-breakdown.tsx
@@ -1,0 +1,60 @@
+import formatCurrency from '@automattic/format-currency';
+import { Icon, check } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { useLicenseLightboxData } from '../../license-lightbox/hooks/use-license-lightbox-data';
+import { getProductPricingInfo, getTotalInvoiceValue } from '../lib/pricing';
+import type { SelectedLicenseProp } from '../types';
+import type { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
+
+const LicenseItem = ( {
+	license,
+	userProducts,
+}: {
+	license: SelectedLicenseProp;
+	userProducts: Record< string, ProductListItem >;
+} ) => {
+	const { actualCost, discountedCost } = getProductPricingInfo( userProducts, license );
+
+	const { title } = useLicenseLightboxData( license );
+
+	return (
+		<div className="review-licenses__license-item">
+			<span className="review-licenses__license-item-column">
+				<Icon size={ 24 } icon={ check } />
+				{ title } x{ license.quantity }
+			</span>
+			<span className="review-licenses__license-item-column">
+				{ formatCurrency( discountedCost, license.currency ) }
+				<span className="review-licenses__license-item-actual-cost">
+					{ formatCurrency( actualCost, license.currency ) }
+				</span>
+			</span>
+		</div>
+	);
+};
+
+export default function PricingBreakdown( {
+	selectedLicenses,
+	userProducts,
+}: {
+	selectedLicenses: SelectedLicenseProp[];
+	userProducts: Record< string, ProductListItem >;
+} ) {
+	const translate = useTranslate();
+
+	const { discountedCost } = getTotalInvoiceValue( userProducts, selectedLicenses );
+
+	return (
+		<>
+			<div className="review-licenses__pricing-breakdown">
+				{ selectedLicenses.map( ( license ) => (
+					<LicenseItem license={ license } userProducts={ userProducts } />
+				) ) }
+			</div>
+			<div className="review-licenses__pricing-breakdown-total">
+				<span>{ translate( 'Total:' ) }</span>
+				<span>{ formatCurrency( discountedCost, selectedLicenses[ 0 ].currency ) }</span>
+			</div>
+		</>
+	);
+}

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/pricing-summary.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/pricing-summary.tsx
@@ -5,6 +5,7 @@ import { useCallback } from 'react';
 import { useSelector } from 'calypso/state';
 import { getProductsList } from 'calypso/state/products-list/selectors';
 import { getTotalInvoiceValue } from '../lib/pricing';
+import PricingBreakdown from './pricing-breakdown';
 import type { SelectedLicenseProp } from '../types';
 
 export default function PricingSummary( {
@@ -60,6 +61,7 @@ export default function PricingSummary( {
 					}
 				) }
 			</div>
+			<PricingBreakdown userProducts={ userProducts } selectedLicenses={ selectedLicenses } />
 		</>
 	);
 }

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/style.scss
@@ -1,8 +1,22 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-.review-licenses__lightbox {
+.review-licenses__lightbox.jetpack-lightbox__modal {
 	min-height: 300px;
+	width: 95%;
+
+	.jetpack-lightbox__content-main,
+	.jetpack-lightbox__content-aside {
+		padding: 24px;
+
+		@media only screen and ( min-width: 782px ) {
+			padding: 16px;
+		}
+
+		@include break-xlarge {
+			padding: 32px;
+		}
+	}
 }
 
 .review-licenses__title {
@@ -88,11 +102,11 @@
 	padding: 1rem;
 
 	@media only screen and ( min-width: 782px ) {
-		margin-block-start: 24px;
+		margin-block-start: 32px;
 	}
 
-	@include break-large {
-		margin-block-start: 8px;
+	@include break-xlarge {
+		margin-block-start: 24px;
 	}
 
 	.review-licenses__pricing-discounted {
@@ -138,3 +152,47 @@
 		color: var(--studio-black);
 	}
 }
+
+.review-licenses__pricing-breakdown {
+	display: flex;
+	flex-direction: column;
+	overflow-y: auto;
+	max-height: 55vh;
+
+	.review-licenses__license-item {
+		display: flex;
+		gap: 12px;
+		align-items: center;
+		font-size: rem(14px);
+		color: var(--studio-gray-70);
+		justify-content: space-between;
+		margin-block-end: 4px;
+
+		.review-licenses__license-item-column {
+			display: flex;
+			align-items: center;
+
+			svg {
+				min-width: 22px;
+			}
+		}
+
+		.review-licenses__license-item-actual-cost {
+			text-decoration: line-through;
+			margin-inline-start: 8px;
+		}
+	}
+}
+
+
+.review-licenses__pricing-breakdown-total {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	margin-block-start: 20px;
+	padding-block-start: 20px;
+	color: var(--studio-gray-70);
+	font-weight: 500;
+	border-block-start: 1px solid var(--studio-gray-10);
+}
+


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/118

## Proposed Changes

This PR displays the pricing breakdown for the review license modal.

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Visit the Jetpack Cloud link > Replace `dashboard` in the URL with `/partner-portal/issue-license?flags=jetpack/bundle-licensing`.
2. Select a few licenses and click the `Review X licenses` button > Verify that the pricing breakdown along with the total is displayed as shown in the screenshot below. Also, select a lot of licenses and verify that the overflow is handled well on different screen sizes

Note:

- Please note the CTA & Learn more link doesn't do anything.
- The discounted price needs to be updated based on the selected bundle(TODO)


<img width="1074" alt="Screenshot 2023-11-27 at 2 40 08 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/5011c4a0-0abf-441c-8b14-bd5fcad2857b">

More screenshots of different screen sizes:

Large screen:

<img width="1115" alt="Screenshot 2023-11-27 at 9 33 09 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/626518f5-3c39-48f7-a156-214ede77ca13">

Tablet view:

<img width="816" alt="Screenshot 2023-11-27 at 9 33 27 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/d3dee710-b556-43c1-bff0-b3ff84f79cb5">

Mobile view:

<img width="353" alt="Screenshot 2023-11-27 at 9 33 49 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/3b338e0e-ea40-4aff-b19c-349a501f5d20">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?