### PR TITLE
Assembler: Show a tooltip telling users that patterns are not editable when they click on them

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -138,8 +138,12 @@ const PatternLargePreview = ( {
 				return;
 			}
 
-			const { clientX: x, clientY: y } = event;
 			if ( tooltipRef.current ) {
+				const { clientX, clientY } = event;
+				const { height, width } = tooltipRef.current.getBoundingClientRect();
+				const x = Math.min( clientX, window.innerWidth - ( width + 32 ) );
+				const y = Math.min( clientY, window.innerHeight - ( height + 32 ) );
+
 				tooltipRef.current.style.transform = `translate( ${ x }px, ${ y }px )`;
 				setShouldShowTooltip( true );
 			}
@@ -298,10 +302,16 @@ const PatternLargePreview = ( {
 	// Tooltip follows the mouse cursor.
 	useEffect( () => {
 		const handleMouseMove = ( event: MouseEvent ) => {
-			const { clientX: x, clientY: y } = event;
-			if ( tooltipRef.current && shouldShowTooltip ) {
-				tooltipRef.current.style.transform = `translate( ${ x }px, ${ y }px )`;
+			if ( ! tooltipRef.current || ! shouldShowTooltip ) {
+				return;
 			}
+
+			const { clientX, clientY } = event;
+			const { height, width } = tooltipRef.current.getBoundingClientRect();
+			const x = Math.min( clientX, window.innerWidth - ( width + 32 ) );
+			const y = Math.min( clientY, window.innerHeight - ( height + 32 ) );
+
+			tooltipRef.current.style.transform = `translate( ${ x }px, ${ y }px )`;
 		};
 
 		frameRef.current?.addEventListener( 'mousemove', handleMouseMove );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -349,24 +349,26 @@ const PatternLargePreview = ( {
 					</ul>
 				</div>
 			) }
-			<Popover
-				className="pattern-assembler__tooltip"
-				animate={ false }
-				focusOnMount={ false }
-				resize={ false }
-				anchor={ tooltipAnchor }
-				placement="bottom-end"
-				variant="unstyled"
-			>
-				<div
-					className={ classnames( 'pattern-assembler__tooltip-content', {
-						'pattern-assembler__tooltip-content--visible': shouldShowTooltip,
-					} ) }
-					ref={ tooltipRef }
+			{ activeElement && (
+				<Popover
+					className="pattern-assembler__tooltip"
+					animate={ false }
+					focusOnMount={ false }
+					resize={ false }
+					anchor={ tooltipAnchor }
+					placement="bottom-end"
+					variant="unstyled"
 				>
-					{ translate( 'You can edit your content later in the Site Editor' ) }
-				</div>
-			</Popover>
+					<div
+						className={ classnames( 'pattern-assembler__tooltip-content', {
+							'pattern-assembler__tooltip-content--visible': shouldShowTooltip,
+						} ) }
+						ref={ tooltipRef }
+					>
+						{ translate( 'You can edit your content later in the Site Editor' ) }
+					</div>
+				</Popover>
+			) }
 		</DeviceSwitcher>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -261,3 +261,27 @@ $font-family: "SF Pro Text", $sans;
 		box-shadow: 0 0 0 2px var(--color-primary-light);
 	}
 }
+
+.pattern-assembler__tooltip {
+	pointer-events: none;
+	position: fixed !important;
+
+	&-content {
+		background: var(--studio-gray-100);
+		border-radius: 4px;
+		box-shadow: 0 4px 4px 0 rgba(0, 0, 0, 0.1);
+		color: #fff;
+		font-size: $font-body-extra-small;
+		left: 16px;
+		opacity: 0;
+		padding: 8px 10px;
+		position: relative;
+		top: 16px;
+		transition: opacity 0.2s;
+		white-space: nowrap;
+
+		&--visible {
+			opacity: 1;
+		}
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -269,6 +269,7 @@ $font-family: "SF Pro Text", $sans;
 	&-content {
 		background: var(--studio-gray-100);
 		border-radius: 4px;
+		box-sizing: border-box;
 		box-shadow: 0 4px 4px 0 rgba(0, 0, 0, 0.1);
 		color: #fff;
 		font-size: $font-body-extra-small;
@@ -277,7 +278,6 @@ $font-family: "SF Pro Text", $sans;
 		padding: 8px 10px;
 		position: relative;
 		top: 16px;
-		transition: opacity 0.2s;
 		white-space: nowrap;
 
 		&--visible {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #82782

## Proposed Changes

This PR implements a tooltip that is shown to users when they click on patterns in the large preview. The tooltip tells users that they can edit patterns later in the Site Editor. We can implement the same tooltip in the Pages screen in a later PR.

See the following recording for reference:

https://github.com/Automattic/wp-calypso/assets/797888/0c1bd7d1-eda6-4725-82c2-66cac64c9228

![Screenshot 2023-11-27 at 5 59 34 PM](https://github.com/Automattic/wp-calypso/assets/797888/d238c159-73b3-40de-8f8a-44a632389db3)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Assembler.
* Select any pattern(s).
* Click on the pattern in the large preview.
* Ensure that you see the tooltip.
* Ensure that the tooltip disappears when (1) the cursor leaves the large preview or (2) the cursor hovers the action bar.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?