### PR TITLE
Promote Subscription: Enable setting for all languages

### DIFF
--- a/client/my-sites/site-settings/settings-newsletter/main.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/main.tsx
@@ -36,7 +36,6 @@ type Fields = {
 	wpcom_subscription_emails_use_excerpt?: boolean;
 	sm_enabled?: boolean;
 	jetpack_verbum_subscription_modal?: boolean;
-	lang_id?: number;
 };
 
 const getFormSettings = ( settings?: Fields ) => {
@@ -52,7 +51,6 @@ const getFormSettings = ( settings?: Fields ) => {
 		wpcom_subscription_emails_use_excerpt,
 		sm_enabled,
 		jetpack_verbum_subscription_modal,
-		lang_id,
 	} = settings;
 
 	return {
@@ -63,7 +61,6 @@ const getFormSettings = ( settings?: Fields ) => {
 		wpcom_subscription_emails_use_excerpt: !! wpcom_subscription_emails_use_excerpt,
 		sm_enabled: !! sm_enabled,
 		jetpack_verbum_subscription_modal: !! jetpack_verbum_subscription_modal,
-		lang_id: lang_id || 1,
 	};
 };
 
@@ -95,7 +92,6 @@ const NewsletterSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 		subscription_options,
 		sm_enabled,
 		jetpack_verbum_subscription_modal,
-		lang_id,
 	} = fields;
 
 	const isSubscriptionModuleInactive = useSelector( ( state ) => {

--- a/client/my-sites/site-settings/settings-newsletter/main.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/main.tsx
@@ -112,12 +112,12 @@ const NewsletterSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 		);
 	} );
 
-	const isSubscriptionOnCommentModuleInactive = useSelector( ( state ) => {
+	const shouldShowSubscriptionOnCommentModule = useSelector( ( state ) => {
 		const isJetpackSite = isJetpackSiteSelector( state, siteId, {
 			treatAtomicAsJetpackSite: true,
 		} );
 
-		return Boolean( isJetpackSite );
+		return ! isJetpackSite && 1 === lang_id;
 	} );
 
 	const disabled = isSubscriptionModuleInactive || isRequestingSettings || isSavingSettings;
@@ -151,7 +151,7 @@ const NewsletterSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 					value={ sm_enabled }
 				/>
 			</Card>
-			{ ! isSubscriptionOnCommentModuleInactive && 1 === lang_id && (
+			{ shouldShowSubscriptionOnCommentModule && (
 				<Card className="site-settings__card">
 					<SubscribeModalOnCommentSetting
 						disabled={ disabled }

--- a/client/my-sites/site-settings/settings-newsletter/main.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/main.tsx
@@ -117,7 +117,7 @@ const NewsletterSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 			treatAtomicAsJetpackSite: true,
 		} );
 
-		return ! isJetpackSite && 1 === lang_id;
+		return ! isJetpackSite;
 	} );
 
 	const disabled = isSubscriptionModuleInactive || isRequestingSettings || isSavingSettings;


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/4639

## Proposed Changes

Show Subscription modal setting for all site's languages (Simple Sites only).

> [!CAUTION]
> Do not merge until https://translate.wordpress.com/projects/wpcom/-all-translated/905313 and https://translate.wordpress.com/projects/wpcom/-all-translated/905384 translations are done.

## Testing Instructions

* Use a simple site
* Go to `/settings/newsletter`
* Check if the option is showing.
* Change the site language on `/settings/general`
* Check again (it should show)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?