### PR TITLE
Sharing: show Twitter/X username field for both button variations

### DIFF
--- a/client/my-sites/marketing/buttons/options.jsx
+++ b/client/my-sites/marketing/buttons/options.jsx
@@ -1,3 +1,4 @@
+import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
 import { filter, flowRight, get, some, values, xor } from 'lodash';
 import PropTypes from 'prop-types';
@@ -147,18 +148,28 @@ class SharingButtonsOptions extends Component {
 		return some( this.props.buttons, { ID: 'twitter', enabled: true } );
 	}
 
+	isXButtonEnabled() {
+		return some( this.props.buttons, { ID: 'x', enabled: true } );
+	}
+
 	getTwitterViaOptionElement() {
 		const { isJetpack, initialized, settings, translate } = this.props;
-		if ( ! this.isTwitterButtonEnabled() ) {
+
+		const isTwitterButtonEnabled = this.isTwitterButtonEnabled();
+		const isXButtonEnabled = this.isXButtonEnabled();
+		if ( ! isTwitterButtonEnabled && ! isXButtonEnabled ) {
 			return;
 		}
 
 		const option = isJetpack ? 'jetpack-twitter-cards-site-tag' : 'twitter_via';
+		const serviceName = isTwitterButtonEnabled ? 'Twitter' : 'X';
 
 		return (
 			<FormFieldset className="sharing-buttons__fieldset">
 				<legend className="sharing-buttons__fieldset-heading">
-					{ translate( 'Twitter username' ) }
+					{ translate( '%(service)s username', {
+						args: { service: serviceName },
+					} ) }
 				</legend>
 				<FormTextInput
 					name={ option }
@@ -170,7 +181,10 @@ class SharingButtonsOptions extends Component {
 				/>
 				<p className="sharing-buttons__fieldset-detail">
 					{ translate(
-						'This will be included in tweets when people share using the Twitter button.'
+						'This will be included in tweets when people share using the %(service)s button.',
+						{
+							args: { service: serviceName },
+						}
 					) }
 				</p>
 			</FormFieldset>
@@ -205,7 +219,7 @@ class SharingButtonsOptions extends Component {
 						text={ translate(
 							"Encourage your community by giving readers the ability to show appreciation for one another's comments."
 						) }
-						link="https://wordpress.com/support/comment-likes/"
+						link={ localizeUrl( 'https://wordpress.com/support/comment-likes/' ) }
 						privacyLink={ false }
 						position="bottom left"
 					/>


### PR DESCRIPTION
Related to #81835

## Proposed Changes

We now offer 2 variations of the Twitter button: the old "Twitter" button as well as the new "X" button. Both have the same behavior, and still support the "via" username option. Let's offer that field regardless of the button variation you use.

## Testing Instructions

* In Calypso, go to Tools > Marketing > Sharing Buttons
* Add a Twitter button
    * See the Twitter username field in the top right.
* Add an X button
    * The field should remain there.
* Remove the Twitter button
    * The field should remain (and be renamed).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

## Related conversation

p1701071766038209-slack-C9EJ7KSGH

## Screenshots

<img width="1070" alt="Screenshot 2023-11-27 at 11 50 32" src="https://github.com/Automattic/wp-calypso/assets/426388/346ba91f-da7d-4137-97a4-2428a9b32a5e">
<img width="1088" alt="Screenshot 2023-11-27 at 11 50 37" src="https://github.com/Automattic/wp-calypso/assets/426388/f6b08cb2-d137-4d80-bb58-aca3eb1c74f8">

