### PR TITLE
Stats: Update thumb styles in upgrade slider

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.scss
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.scss
@@ -6,7 +6,7 @@
 	--gray-gray-5: #dcdcde;
 	margin-top: 42px;
 
-	.jp-components-pricing-slider__thumb {
+	.jp-components-pricing-slider__thumb.upgrade-thumb {
 		width: 40px;
 		height: 40px;
 		border-radius: 50%;

--- a/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.scss
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.scss
@@ -1,19 +1,33 @@
+$slider-height: 40px;
+$slider-bg-color: var(--studio-white);
+$thumb-width: 40px;
+$mark-diameter: 8px;
+$mark-border-width: 2px;
+$track-extra-width: ($thumb-width - $mark-diameter - $mark-border-width * 2) / 2;
 
+// The trick is to cover the extra slider track with blocks with the same background color as the slider.
+@mixin slider-track-extra-cover() {
+	content: "";
+	position: absolute;
+	width: $track-extra-width;
+	height: $slider-height;
+	background-color: $slider-bg-color;
+}
 
 .stats-tier-upgrade-slider {
 	--jp-white: #fff;
 	--jp-green-50: #008710;
 	--gray-gray-5: #dcdcde;
 	margin-top: 42px;
+	background-color: $slider-bg-color;
 
 	.jp-components-pricing-slider__thumb.upgrade-thumb {
-		width: 40px;
-		height: 40px;
+		width: $thumb-width;
+		height: $slider-height;
 		border-radius: 50%;
 		border-color: var(--jp-green-50);
 		background-color: var(--jp-green-50);
 		color: var(--jp-white);
-		transform: translate(-50%, 0);
 	}
 
 	.jp-components-pricing-slider__track {
@@ -23,14 +37,29 @@
 	}
 
 	.jp-components-pricing-slider__control {
+		width: calc(100% + $track-extra-width * 2);
+		margin-left: -($track-extra-width);
+
+		&::before {
+			@include slider-track-extra-cover();
+			left: 0;
+			z-index: 1;
+		}
+
+		&::after {
+			@include slider-track-extra-cover();
+			right: 0;
+		}
+
 		.mark {
-			position: absolute;
-			height: 10px;
-			width: 10px;
+			height: $mark-diameter;
+			width: $mark-diameter;
+			border: $mark-border-width solid var(--gray-gray-5);
 			background-color: var(--gray-gray-5);
 			border-radius: 50%;
-			top: 50%;
-			transform: translate(-50%, -50%);
+			cursor: pointer;
+			margin: 0 $track-extra-width;
+			bottom: calc(50% - ($mark-diameter / 2 + $mark-border-width));
 		}
 	}
 }

--- a/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.scss
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.scss
@@ -45,6 +45,9 @@ $track-extra-width: ($thumb-width - $mark-diameter - $mark-border-width * 2) / 2
 	}
 
 	.jp-components-pricing-slider__control {
+		// TODO: Determine control alignment.
+		// Do we want the slider full-width or do we align based on thumb?
+		// Alternatively, we could use some CSS to reposition the thumbs if either end-cap is selected.
 		// width: calc(100% + $track-extra-width * 2);
 		// margin-left: -($track-extra-width);
 

--- a/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.scss
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.scss
@@ -19,6 +19,10 @@ $track-extra-width: ($thumb-width - $mark-diameter - $mark-border-width * 2) / 2
 	--jp-green-50: #008710;
 	--gray-gray-5: #dcdcde;
 	--studio-gray-40: #787c82;
+	// TODO: Determine correct colors.
+	// Theme or Jetpack? The following are theme colors.
+	--color-accent: #008763;
+	--color-primary: #0675c4;
 	margin-top: 42px;
 	background-color: $slider-bg-color;
 
@@ -30,8 +34,8 @@ $track-extra-width: ($thumb-width - $mark-diameter - $mark-border-width * 2) / 2
 		width: $thumb-width;
 		height: $slider-height;
 		border-radius: 50%;
-		border-color: var(--jp-green-50);
-		background-color: var(--jp-green-50);
+		border-color: var(--color-primary);
+		background-color: var(--color-primary);
 		color: var(--jp-white);
 	}
 

--- a/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.scss
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.scss
@@ -4,6 +4,7 @@ $thumb-width: 40px;
 $mark-diameter: 8px;
 $mark-border-width: 2px;
 $track-extra-width: ($thumb-width - $mark-diameter - $mark-border-width * 2) / 2;
+$track-height: 4px;
 
 // The trick is to cover the extra slider track with blocks with the same background color as the slider.
 @mixin slider-track-extra-cover() {
@@ -35,9 +36,9 @@ $track-extra-width: ($thumb-width - $mark-diameter - $mark-border-width * 2) / 2
 	}
 
 	.jp-components-pricing-slider__track {
-		// Assuming 40px tall container.
-		height: 4px;
-		top: 18px;
+		// Based on slider height of 40px & track height of 4px.
+		height: $track-height;
+		top: $slider-height / 2 - $track-height / 2;
 	}
 
 	.jp-components-pricing-slider__control {

--- a/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.scss
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.scss
@@ -30,12 +30,11 @@ $track-extra-width: ($thumb-width - $mark-diameter - $mark-border-width * 2) / 2
 	border-radius: 5px; // stylelint-disable-line scales/radii
 	padding: 12px;
 
-	.jp-components-pricing-slider__thumb.upgrade-thumb {
+	.jp-components-pricing-slider__thumb.stats-tier-upgrade-slider__thumb {
 		width: $thumb-width;
 		height: $slider-height;
 		border-radius: 50%;
-		border-color: var(--color-primary);
-		background-color: var(--color-primary);
+		background-color: var(--jp-green-50);
 		color: var(--jp-white);
 	}
 
@@ -70,6 +69,13 @@ $track-extra-width: ($thumb-width - $mark-diameter - $mark-border-width * 2) / 2
 			margin: 0 $track-extra-width;
 			bottom: calc(50% - ($mark-diameter / 2 + $mark-border-width));
 		}
+	}
+}
+
+// Override colors for WPCOM context.
+.stats-purchase-page--is-wpcom {
+	.jp-components-pricing-slider__thumb.stats-tier-upgrade-slider__thumb {
+		background-color: var(--color-primary);
 	}
 }
 

--- a/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.scss
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.scss
@@ -28,7 +28,6 @@
 			border-radius: 50%;
 			top: 50%;
 			transform: translate(-50%, -50%);
-			z-index: 10;
 		}
 	}
 }

--- a/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.scss
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.scss
@@ -14,7 +14,9 @@
 	}
 
 	.jp-components-pricing-slider__track {
+		// Assuming 40px tall container.
 		height: 4px;
+		top: 18px;
 	}
 
 	.jp-components-pricing-slider__control {

--- a/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.scss
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.scss
@@ -21,6 +21,10 @@ $track-extra-width: ($thumb-width - $mark-diameter - $mark-border-width * 2) / 2
 	margin-top: 42px;
 	background-color: $slider-bg-color;
 
+	border: 1px solid var(--gray-gray-5);
+	border-radius: 5px; // stylelint-disable-line scales/radii
+	padding: 12px;
+
 	.jp-components-pricing-slider__thumb.upgrade-thumb {
 		width: $thumb-width;
 		height: $slider-height;

--- a/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.scss
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.scss
@@ -18,6 +18,7 @@ $track-extra-width: ($thumb-width - $mark-diameter - $mark-border-width * 2) / 2
 	--jp-white: #fff;
 	--jp-green-50: #008710;
 	--gray-gray-5: #dcdcde;
+	--studio-gray-40: #787c82;
 	margin-top: 42px;
 	background-color: $slider-bg-color;
 
@@ -69,7 +70,7 @@ $track-extra-width: ($thumb-width - $mark-diameter - $mark-border-width * 2) / 2
 }
 
 .stats-tier-upgrade-slider__info-message {
-	color: var(--jp-green-50);
+	color: var(--studio-gray-40);
 	margin: 12px 0;
 	text-align: center;
 }

--- a/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.scss
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.scss
@@ -7,10 +7,13 @@
 	margin-top: 42px;
 
 	.jp-components-pricing-slider__thumb {
-		border-radius: 4px;
+		width: 40px;
+		height: 40px;
+		border-radius: 50%;
 		border-color: var(--jp-green-50);
 		background-color: var(--jp-green-50);
 		color: var(--jp-white);
+		transform: translate(-50%, 0);
 	}
 
 	.jp-components-pricing-slider__track {

--- a/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.scss
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.scss
@@ -18,11 +18,7 @@ $track-extra-width: ($thumb-width - $mark-diameter - $mark-border-width * 2) / 2
 	--jp-white: #fff;
 	--jp-green-50: #008710;
 	--gray-gray-5: #dcdcde;
-	--studio-gray-40: #787c82;
-	// TODO: Determine correct colors.
-	// Theme or Jetpack? The following are theme colors.
-	--color-accent: #008763;
-	--color-primary: #0675c4;
+
 	margin-top: 42px;
 	background-color: $slider-bg-color;
 

--- a/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.scss
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.scss
@@ -41,8 +41,8 @@ $track-extra-width: ($thumb-width - $mark-diameter - $mark-border-width * 2) / 2
 	}
 
 	.jp-components-pricing-slider__control {
-		width: calc(100% + $track-extra-width * 2);
-		margin-left: -($track-extra-width);
+		// width: calc(100% + $track-extra-width * 2);
+		// margin-left: -($track-extra-width);
 
 		&::before {
 			@include slider-track-extra-cover();

--- a/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.tsx
@@ -53,9 +53,9 @@ function TierUpgradeSlider( { className }: TierUpgradeSliderProps ) {
 					<h2>{ translatedStrings.limits }</h2>
 					<p>{ plans[ currentPlanIndex ].views }</p>
 				</div>
-				<div className="stats-tier-upgrade-slider__plan-callout">
+				<div className="stats-tier-upgrade-slider__plan-callout right-aligned">
 					<h2>{ translatedStrings.price }</h2>
-					<p className="right-aligned">{ plans[ currentPlanIndex ].price }</p>
+					<p>{ plans[ currentPlanIndex ].price }</p>
 				</div>
 			</div>
 			<PricingSlider

--- a/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.tsx
@@ -60,6 +60,7 @@ function TierUpgradeSlider( { className }: TierUpgradeSliderProps ) {
 			</div>
 			<PricingSlider
 				className="stats-tier-upgrade-slider__slider"
+				thumbClassName="upgrade-thumb"
 				value={ currentPlanIndex }
 				minValue={ sliderMin }
 				maxValue={ sliderMax }

--- a/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.tsx
@@ -60,7 +60,7 @@ function TierUpgradeSlider( { className }: TierUpgradeSliderProps ) {
 			</div>
 			<PricingSlider
 				className="stats-tier-upgrade-slider__slider"
-				thumbClassName="upgrade-thumb"
+				thumbClassName="stats-tier-upgrade-slider__thumb"
 				value={ currentPlanIndex }
 				minValue={ sliderMin }
 				maxValue={ sliderMax }

--- a/packages/components/src/pricing-slider/index.tsx
+++ b/packages/components/src/pricing-slider/index.tsx
@@ -20,6 +20,7 @@ const PricingSlider: React.FC< PricingSliderProps > = ( {
 	onBeforeChange,
 	onAfterChange,
 	renderThumb,
+	thumbClassName,
 	marks = false,
 } ) => {
 	const [ isThumbHolding, setIsThumbHolding ] = React.useState( false );
@@ -27,6 +28,7 @@ const PricingSlider: React.FC< PricingSliderProps > = ( {
 	const componentClassName = classNames( 'jp-components-pricing-slider', className, {
 		'jp-components-pricing-slider--is-holding': isThumbHolding,
 	} );
+	const thumbClassNames = classNames( 'jp-components-pricing-slider__thumb', thumbClassName );
 
 	const onBeforeChangeCallback = ( beforeValue: number ) => {
 		setIsThumbHolding( true );
@@ -54,7 +56,7 @@ const PricingSlider: React.FC< PricingSliderProps > = ( {
 		<div className={ componentClassName } data-testid="pricing-slider">
 			<ReactSlider
 				className="jp-components-pricing-slider__control"
-				thumbClassName="jp-components-pricing-slider__thumb"
+				thumbClassName={ thumbClassNames }
 				thumbActiveClassName="jp-components-pricing-slider__thumb--is-active"
 				trackClassName="jp-components-pricing-slider__track"
 				marks={ marks }

--- a/packages/components/src/pricing-slider/types.ts
+++ b/packages/components/src/pricing-slider/types.ts
@@ -56,6 +56,11 @@ export type PricingSliderProps = {
 	renderThumb?: RenderThumbFunction;
 
 	/**
+	 * Additional classname to be applied to the slider thumb.
+	 */
+	thumbClassName?: string;
+
+	/**
 	 * The marks on the slider, represented as an array of numbers or true.
 	 * Passing true will enable marks for every step on the slider.
 	 */


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #83898.

## Proposed Changes

Some tweaks to get the slider/thumb closer to our target designs.

## Before

1. Fixes track positioning.
2. Fixes mark positioning.
3. Puts mark behind slider thumb.
4. Updates thumb styles (border, shape).

<img width="573" alt="SCR-20231127-qolg" src="https://github.com/Automattic/wp-calypso/assets/40267301/fe39abec-8c8d-49d0-8639-f5a50f7d126a">

## After

Of note:

1. Left-hand track should use the same color as the thumb.
2. Left-hand marks should use same color as thumb.
3. Need the little "<>" icon for the thumb.
4. Does not address the thumb layout strategy noted here: p1701058599878429-slack-C82FZ5T4G

<img width="584" alt="SCR-20231127-qpax" src="https://github.com/Automattic/wp-calypso/assets/40267301/bc9153b6-0cf8-4ec7-b870-49d28fa58e6e">

## Update 2

This update incorporates fixes provided by @dognose24 to handle the thumb and mark layout. Thanks, Dognose! 🙇 

1. This button uses the theme's accent color.
2. The thumb and track are now using the theme's primary color. Do we want to this or should we use the accent color here too?
3. Note the slight indenting of the slider's left and right bounds. This is to keep everything inside the container so that selecting min or max allows the thumb to line up correctly with the adjacent controls. 

<img width="615" alt="SCR-20231128-rvgj" src="https://github.com/Automattic/wp-calypso/assets/40267301/c06312f8-37af-4a1d-97f3-9f3ecbd853d3">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Launch the **Calypso Live** link.
4. Navigate to **Stats → Traffic**.
5. Update URL to: `http://calypso.localhost:3000/stats/purchase/SITE_SLUG?productType=commercial&flags=stats/type-detection,stats/tier-upgrade-slider`
6. Confirm appearance matches After screencap.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?