### PR TITLE
[Odie] Tracks Events enhancements, reduce external package dependencies

### DIFF
--- a/client/odie/context/index.tsx
+++ b/client/odie/context/index.tsx
@@ -25,6 +25,7 @@ interface OdieAssistantContextInterface {
 	initialUserMessage: string | null | undefined;
 	isLoadingChat: boolean;
 	isLoading: boolean;
+	isMinimized?: boolean;
 	isNudging: boolean;
 	isVisible: boolean;
 	extraContactOptions?: ReactNode;
@@ -49,6 +50,7 @@ const defaultContextInterfaceValues = {
 	initialUserMessage: null,
 	isLoadingChat: false,
 	isLoading: false,
+	isMinimized: false,
 	isNudging: false,
 	isVisible: false,
 	lastNudge: null,
@@ -77,6 +79,7 @@ const OdieAssistantProvider = ( {
 	botNameSlug = 'wpcom-support-chat',
 	botSetting = 'wapuu',
 	initialUserMessage,
+	isMinimized = false,
 	extraContactOptions,
 	enabled = true,
 	children,
@@ -86,6 +89,7 @@ const OdieAssistantProvider = ( {
 	botSetting?: string;
 	enabled?: boolean;
 	initialUserMessage?: string | null | undefined;
+	isMinimized?: boolean;
 	extraContactOptions?: ReactNode;
 	children?: ReactNode;
 } ) => {
@@ -114,6 +118,7 @@ const OdieAssistantProvider = ( {
 			chat_id: null,
 			messages: [ getOdieInitialMessage( botNameSlug ) ],
 		} );
+		recordTracksEvent( 'calypso_odie_chat_cleared' );
 	}, [ botNameSlug ] );
 
 	const trackEvent = ( event: string, properties?: Record< string, unknown > ) => {
@@ -196,6 +201,7 @@ const OdieAssistantProvider = ( {
 				initialUserMessage,
 				isLoadingChat: false,
 				isLoading: isLoading,
+				isMinimized,
 				isNudging,
 				isVisible,
 				lastNudge,

--- a/client/odie/context/index.tsx
+++ b/client/odie/context/index.tsx
@@ -118,7 +118,7 @@ const OdieAssistantProvider = ( {
 			chat_id: null,
 			messages: [ getOdieInitialMessage( botNameSlug ) ],
 		} );
-		recordTracksEvent( 'calypso_odie_chat_cleared' );
+		recordTracksEvent( 'calypso_odie_chat_cleared', {} );
 	}, [ botNameSlug ] );
 
 	const trackEvent = ( event: string, properties?: Record< string, unknown > ) => {

--- a/client/odie/context/index.tsx
+++ b/client/odie/context/index.tsx
@@ -112,18 +112,21 @@ const OdieAssistantProvider = ( {
 		}
 	}, [ existingChat, existingChat.chat_id ] );
 
+	const trackEvent = useCallback(
+		( event: string, properties?: Record< string, unknown > ) => {
+			dispatch( recordTracksEvent( event, properties ) );
+		},
+		[ dispatch ]
+	);
+
 	const clearChat = useCallback( () => {
 		clearOdieStorage( 'chat_id' );
 		setChat( {
 			chat_id: null,
 			messages: [ getOdieInitialMessage( botNameSlug ) ],
 		} );
-		recordTracksEvent( 'calypso_odie_chat_cleared', {} );
-	}, [ botNameSlug ] );
-
-	const trackEvent = ( event: string, properties?: Record< string, unknown > ) => {
-		dispatch( recordTracksEvent( event, properties ) );
-	};
+		trackEvent( 'calypso_odie_chat_cleared', {} );
+	}, [ botNameSlug, trackEvent ] );
 
 	const setMessageLikedStatus = ( message: Message, liked: boolean ) => {
 		setChat( ( prevChat ) => {

--- a/client/odie/message/custom-a-link.tsx
+++ b/client/odie/message/custom-a-link.tsx
@@ -1,6 +1,4 @@
 import classnames from 'classnames';
-import { useDispatch } from 'calypso/state';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { useOdieAssistantContext } from '../context';
 
 import './style.scss';
@@ -20,8 +18,7 @@ const CustomALink = ( {
 	children: React.ReactNode;
 	inline?: boolean;
 } ) => {
-	const dispatch = useDispatch();
-	const { botNameSlug } = useOdieAssistantContext();
+	const { botNameSlug, trackEvent } = useOdieAssistantContext();
 
 	const classNames = classnames( 'odie-sources', {
 		'odie-sources-inline': inline,
@@ -35,13 +32,11 @@ const CustomALink = ( {
 				target="_blank"
 				rel="noopener noreferrer"
 				onClick={ () => {
-					dispatch(
-						recordTracksEvent( 'calypso_odie_chat_message_action_click', {
-							bot_name_slug: botNameSlug,
-							action: 'link',
-							href: href,
-						} )
-					);
+					trackEvent( 'calypso_odie_chat_message_action_click', {
+						bot_name_slug: botNameSlug,
+						action: 'link',
+						href: href,
+					} );
 				} }
 			>
 				{ children }

--- a/client/odie/message/index.tsx
+++ b/client/odie/message/index.tsx
@@ -43,7 +43,7 @@ const ChatMessage = (
 	ref: React.Ref< HTMLDivElement >
 ) => {
 	const isUser = message.role === 'user';
-	const { botName, extraContactOptions, addMessage } = useOdieAssistantContext();
+	const { botName, extraContactOptions, addMessage, trackEvent } = useOdieAssistantContext();
 	const [ scrolledToBottom, setScrolledToBottom ] = useState( false );
 	const [ isFullscreen, setIsFullscreen ] = useState( false );
 	const currentUser = useSelector( getCurrentUser );
@@ -284,6 +284,20 @@ const ChatMessage = (
 							'Below this text are links to sources for the current message received from the bot.',
 						textOnly: true,
 					} ) }
+					onClose={ () =>
+						trackEvent( 'calypso_odie_chat_message_action_sources', {
+							bot_name_slug: botName,
+							action: 'close',
+							message_id: message.message_id,
+						} )
+					}
+					onOpen={ () =>
+						trackEvent( 'calypso_odie_chat_message_action_sources', {
+							bot_name_slug: botName,
+							action: 'open',
+							message_id: message.message_id,
+						} )
+					}
 					screenReaderText="More"
 				>
 					<div className="odie-chatbox-message-sources">

--- a/client/odie/message/jump-to-recent.tsx
+++ b/client/odie/message/jump-to-recent.tsx
@@ -1,12 +1,7 @@
-import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
-import { useSelect } from '@wordpress/data';
 import { Icon, chevronDown } from '@wordpress/icons';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useDispatch } from 'calypso/state';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { useOdieAssistantContext } from '../context';
-import type { HelpCenterSelect } from '@automattic/data-stores';
 
 /**
  * This might be synced with CSS in client/odie/message/style.scss, which is half of the height for the gradient.
@@ -24,27 +19,15 @@ export const JumpToRecent = ( {
 	enableJumpToRecent: boolean;
 	bottomOffset: number;
 } ) => {
-	const { botSetting, botNameSlug } = useOdieAssistantContext();
+	const { botSetting, botNameSlug, trackEvent, isMinimized } = useOdieAssistantContext();
 	const translate = useTranslate();
-	const dispatch = useDispatch();
 	const jumpToRecent = () => {
 		scrollToBottom();
-		dispatch(
-			recordTracksEvent( 'calypso_odie_chat_jump_to_recent_click', {
-				bot_name_slug: botNameSlug,
-				bot_setting: botSetting,
-			} )
-		);
+		trackEvent( 'calypso_odie_chat_jump_to_recent_click', {
+			bot_name_slug: botNameSlug,
+			bot_setting: botSetting,
+		} );
 	};
-
-	const { isMinimized } = useSelect( ( select ) => {
-		const store = select( HELP_CENTER_STORE ) as HelpCenterSelect;
-		return {
-			show: store.isHelpCenterShown(),
-			isMinimized: store.getIsMinimized(),
-			initialRoute: store.getInitialRoute(),
-		};
-	}, [] );
 
 	if ( isMinimized ) {
 		return null;

--- a/client/odie/message/was-this-helpful-buttons.tsx
+++ b/client/odie/message/was-this-helpful-buttons.tsx
@@ -18,7 +18,7 @@ const WasThisHelpfulButtons = ( {
 	const THUMBS_UP_RATING_VALUE = 4;
 
 	const translate = useTranslate();
-	const { setMessageLikedStatus } = useOdieAssistantContext();
+	const { setMessageLikedStatus, botNameSlug, trackEvent } = useOdieAssistantContext();
 	const { mutateAsync: sendOdieMessageFeedback } = useOdieSendMessageFeedback();
 
 	const liked = message.liked === true;
@@ -30,10 +30,18 @@ const WasThisHelpfulButtons = ( {
 			message,
 			rating_value: isHelpful ? THUMBS_UP_RATING_VALUE : THUMBS_DOWN_RATING_VALUE,
 		} );
+
 		setMessageLikedStatus( message, isHelpful );
 		if ( ! isHelpful ) {
 			onDislike();
 		}
+
+		trackEvent( 'calypso_odie_chat_message_action_feedback', {
+			bot_name_slug: botNameSlug,
+			action: 'feedback',
+			is_helpful: isHelpful,
+			message_id: message.message_id,
+		} );
 	};
 
 	const thumbsUpClasses = classnames( {

--- a/client/odie/send-message-input/index.tsx
+++ b/client/odie/send-message-input/index.tsx
@@ -2,8 +2,6 @@ import { useTranslate } from 'i18n-calypso';
 import React, { useState, KeyboardEvent, FormEvent, useRef, useEffect } from 'react';
 import ArrowUp from 'calypso/assets/images/odie/arrow-up.svg';
 import TextareaAutosize from 'calypso/components/textarea-autosize';
-import { useDispatch } from 'calypso/state';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { WAPUU_ERROR_MESSAGE } from '..';
 import { useOdieAssistantContext } from '../context';
 import { JumpToRecent } from '../message/jump-to-recent';
@@ -25,10 +23,9 @@ export const OdieSendMessageButton = ( {
 } ) => {
 	const [ messageString, setMessageString ] = useState< string >( '' );
 	const divContainerRef = useRef< HTMLDivElement >( null );
-	const { addMessage, setIsLoading, botNameSlug, initialUserMessage, chat, isLoading } =
+	const { addMessage, setIsLoading, botNameSlug, initialUserMessage, chat, isLoading, trackEvent } =
 		useOdieAssistantContext();
 	const { mutateAsync: sendOdieMessage } = useOdieSendMessage();
-	const dispatch = useDispatch();
 	const translate = useTranslate();
 
 	useEffect( () => {
@@ -41,11 +38,9 @@ export const OdieSendMessageButton = ( {
 		try {
 			setIsLoading( true );
 
-			dispatch(
-				recordTracksEvent( 'calypso_odie_chat_message_action_send', {
-					bot_name_slug: botNameSlug,
-				} )
-			);
+			trackEvent( 'calypso_odie_chat_message_action_send', {
+				bot_name_slug: botNameSlug,
+			} );
 
 			const message = {
 				content: messageString,
@@ -63,11 +58,9 @@ export const OdieSendMessageButton = ( {
 			] );
 
 			const receivedMessage = await sendOdieMessage( { message } );
-			dispatch(
-				recordTracksEvent( 'calypso_odie_chat_message_action_receive', {
-					bot_name_slug: botNameSlug,
-				} )
-			);
+			trackEvent( 'calypso_odie_chat_message_action_receive', {
+				bot_name_slug: botNameSlug,
+			} );
 
 			addMessage( {
 				content: receivedMessage.messages[ 0 ].content,

--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -31,6 +31,12 @@ const HelpCenterContent: React.FC< { isRelative?: boolean } > = () => {
 	const containerRef = useRef< HTMLDivElement >( null );
 	const section = useSelector( getSectionName );
 	const isWapuuEnabled = useIsWapuuEnabled();
+	const { isMinimized } = useSelect( ( select ) => {
+		const store = select( HELP_CENTER_STORE ) as HelpCenterSelect;
+		return {
+			isMinimized: store.getIsMinimized(),
+		};
+	}, [] );
 
 	useEffect( () => {
 		recordTracksEvent( 'calypso_helpcenter_page_open', {
@@ -79,6 +85,7 @@ const HelpCenterContent: React.FC< { isRelative?: boolean } > = () => {
 							botSetting="supportDocs"
 							botName="Wapuu"
 							enabled={ isWapuuEnabled }
+							isMinimized={ isMinimized }
 							initialUserMessage={ searchTerm }
 							extraContactOptions={ <HelpCenterContactPage hideHeaders /> }
 						>


### PR DESCRIPTION
Related to #

## Proposed Changes

Improved Tracks Events usage in Odie Client.

The following events have been added:

- Clearing a chat
- Liking a message
- Disliking a message
- Opening sources
- Closing sources

There has been a bit of rework in the sense of how tracks are being sent, now we use the Odie Context to centralise the effort. Also, I've removed an external dependency to an external store (Help Center) that was checking if the Help Center was minimised or not. Now it's injected via props, extending functionality and reducing package dependency.

## Testing Instructions

This is optional, but ensure you have Installed Tracks Vigilante so you can easily track the events fired.

1. Test that like and dislikes events are sent: `calypso_odie_chat_message_action_feedback` with a prop being `is_helpful` being set either to `true` or `false`.
2. Test that the event for opening the sources is sent: `calypso_odie_chat_message_action_sources`, with extra prop: `action` to be either `open` or `close`.
3. Test that the event is sent when clearing the chat using the three dots button in the top right corner of the chat: `calypso_odie_chat_cleared`

Assert that the Chat can still be hidden using the hide icon in the Help Center, and no remaining of it is still shown.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
