### PR TITLE
Router: remove unused decodeURLComponents option

### DIFF
--- a/apps/blaze-dashboard/src/page-middleware/setup-context.jsx
+++ b/apps/blaze-dashboard/src/page-middleware/setup-context.jsx
@@ -6,7 +6,6 @@ const debug = debugFactory( 'calypso' );
 
 export const setupContextMiddleware = ( reduxStore, reactQueryClient ) => {
 	page( '*', ( context, next ) => {
-		// page.js url parsing is broken so we had to disable it with `decodeURLComponents: false`
 		const parsed = getUrlParts( context.path );
 		const path = parsed.pathname + parsed.search || null;
 

--- a/apps/odyssey-stats/src/page-middleware/setup-context.ts
+++ b/apps/odyssey-stats/src/page-middleware/setup-context.ts
@@ -8,7 +8,6 @@ const debug = debugFactory( 'calypso' );
 
 export const setupContextMiddleware = ( reduxStore: Store, reactQueryClient: QueryClient ) => {
 	page( '*', ( context, next ) => {
-		// page.js url parsing is broken so we had to disable it with `decodeURLComponents: false`
 		const parsed = getUrlParts( context.path );
 		const path = parsed.pathname + parsed.search || null;
 

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -53,7 +53,6 @@ const debug = debugFactory( 'calypso' );
 
 const setupContextMiddleware = ( reduxStore, reactQueryClient ) => {
 	page( '*', ( context, next ) => {
-		// page.js url parsing is broken so we had to disable it with `decodeURLComponents: false`
 		const parsed = getUrlParts( context.canonicalPath );
 		const path = parsed.pathname + parsed.search || null;
 		context.prevPath = path === context.path ? false : path;
@@ -431,7 +430,7 @@ const boot = async ( currentUser, registerRoutes ) => {
 		renderLayout( reduxStore, queryClient );
 	}
 
-	page.start( { decodeURLComponents: false } );
+	page.start();
 };
 
 export const bootApp = async ( appName, registerRoutes ) => {

--- a/client/landing/login/common.js
+++ b/client/landing/login/common.js
@@ -12,7 +12,6 @@ const debug = debugFactory( 'calypso' );
 
 export function setupContextMiddleware() {
 	page( '*', ( context, next ) => {
-		// page.js url parsing is broken so we had to disable it with `decodeURLComponents: false`
 		const parsed = getUrlParts( context.canonicalPath );
 		const path = parsed.pathname + parsed.search || null;
 		context.prevPath = path === context.path ? false : path;

--- a/client/landing/login/index.js
+++ b/client/landing/login/index.js
@@ -35,7 +35,7 @@ const boot = ( currentUser ) => {
 	} );
 
 	initLoginSection( ( route, ...handlers ) => page( route, ...handlers, render ) );
-	page.start( { decodeURLComponents: false } );
+	page.start();
 };
 
 window.AppBoot = async () => {

--- a/packages/calypso-router/CHANGELOG.md
+++ b/packages/calypso-router/CHANGELOG.md
@@ -1,3 +1,4 @@
 ## 0.7.0
 
 - Initial fork of page.js with conversion to ES module and ES syntax.
+- Removed the `decodeURLComponents` option that was leading to buggy `ctx.querystring` values.

--- a/packages/calypso-router/src/index.js
+++ b/packages/calypso-router/src/index.js
@@ -421,7 +421,6 @@ function Page() {
 	this.len = 0;
 
 	// private things
-	this._decodeURLComponents = true;
 	this._base = '';
 	this._strict = false;
 	this._running = false;
@@ -441,7 +440,6 @@ Page.prototype.configure = function ( options ) {
 	const opts = options || {};
 
 	this._window = opts.window || ( hasWindow && window );
-	this._decodeURLComponents = opts.decodeURLComponents !== false;
 	this._popstate = opts.popstate !== false && hasWindow;
 	this._click = opts.click !== false && hasDocument;
 	this._hashbang = !! opts.hashbang;
@@ -923,19 +921,6 @@ Page.prototype._samePath = function ( url ) {
 };
 
 /**
- * Remove URL encoding from the given `str`.
- * Accommodates whitespace in both x-www-form-urlencoded
- * and regular percent-encoded form.
- * @param {string} val URL component to decode
- */
-Page.prototype._decodeURLEncodedURIComponent = function ( val ) {
-	if ( typeof val !== 'string' ) {
-		return val;
-	}
-	return this._decodeURLComponents ? decodeURIComponent( val.replace( /\+/g, ' ' ) ) : val;
-};
-
-/**
  * Create a new `page` instance and function
  */
 function createPage() {
@@ -1088,8 +1073,8 @@ function Context( path, state, pageInstance ) {
 	this.title = hasDocument && window.document.title;
 	this.state = state || {};
 	this.state.path = path;
-	this.querystring = i !== -1 ? this.page._decodeURLEncodedURIComponent( path.slice( i + 1 ) ) : '';
-	this.pathname = this.page._decodeURLEncodedURIComponent( i !== -1 ? path.slice( 0, i ) : path );
+	this.querystring = i !== -1 ? path.slice( i + 1 ) : '';
+	this.pathname = i !== -1 ? path.slice( 0, i ) : path;
 	this.params = {};
 
 	// fragment
@@ -1100,7 +1085,7 @@ function Context( path, state, pageInstance ) {
 		}
 		const parts = this.path.split( '#' );
 		this.path = this.pathname = parts[ 0 ];
-		this.hash = this.page._decodeURLEncodedURIComponent( parts[ 1 ] ) || '';
+		this.hash = parts[ 1 ] || '';
 		this.querystring = this.querystring.split( '#' )[ 0 ];
 	}
 }
@@ -1185,7 +1170,7 @@ Route.prototype.match = function ( path, params ) {
 
 	for ( let i = 1, len = m.length; i < len; ++i ) {
 		const key = keys[ i - 1 ];
-		const val = this.page._decodeURLEncodedURIComponent( m[ i ] );
+		const val = m[ i ];
 		if ( val !== undefined || ! hasOwnProperty.call( params, key.name ) ) {
 			params[ key.name ] = val;
 		}

--- a/packages/calypso-router/src/index.js
+++ b/packages/calypso-router/src/index.js
@@ -532,7 +532,7 @@ Page.prototype.start = function ( options ) {
 		const window = this._window;
 		const loc = window.location;
 
-		if ( this._hashbang && ~loc.hash.indexOf( '#!' ) ) {
+		if ( this._hashbang && loc.hash.indexOf( '#!' ) !== -1 ) {
 			url = loc.hash.substr( 2 ) + loc.search;
 		} else if ( this._hashbang ) {
 			url = loc.search + loc.hash;
@@ -1088,14 +1088,14 @@ function Context( path, state, pageInstance ) {
 	this.title = hasDocument && window.document.title;
 	this.state = state || {};
 	this.state.path = path;
-	this.querystring = ~i ? this.page._decodeURLEncodedURIComponent( path.slice( i + 1 ) ) : '';
-	this.pathname = this.page._decodeURLEncodedURIComponent( ~i ? path.slice( 0, i ) : path );
+	this.querystring = i !== -1 ? this.page._decodeURLEncodedURIComponent( path.slice( i + 1 ) ) : '';
+	this.pathname = this.page._decodeURLEncodedURIComponent( i !== -1 ? path.slice( 0, i ) : path );
 	this.params = {};
 
 	// fragment
 	this.hash = '';
 	if ( ! hashbang ) {
-		if ( ! ~this.path.indexOf( '#' ) ) {
+		if ( this.path.indexOf( '#' ) === -1 ) {
 			return;
 		}
 		const parts = this.path.split( '#' );
@@ -1176,7 +1176,7 @@ Route.prototype.middleware = function ( fn ) {
 Route.prototype.match = function ( path, params ) {
 	const keys = this.keys;
 	const qsIndex = path.indexOf( '?' );
-	const pathname = ~qsIndex ? path.slice( 0, qsIndex ) : path;
+	const pathname = qsIndex !== -1 ? path.slice( 0, qsIndex ) : path;
 	const m = this.regexp.exec( decodeURIComponent( pathname ) );
 
 	if ( ! m ) {

--- a/packages/calypso-router/types/index.d.ts
+++ b/packages/calypso-router/types/index.d.ts
@@ -222,10 +222,6 @@ interface Options {
 	 */
 	hashbang: boolean;
 	/**
-	 * remove URL encoding from path components
-	 */
-	decodeURLComponents: boolean;
-	/**
 	 * provide a window to control (by default it will control the main window)
 	 */
 	window: Window;


### PR DESCRIPTION
This PR removes the `decodeURLComponents` option from the Calypso Router (former page.js). We were always (since #17526) explicitly disabling that option, because it led to incorrect value in `context.querystring`. Consider, for example a query string like `?p=a%26b`. When calling `new URLSearchParams( qs )`, we want to get one param: `{ p: 'a&b' }`. But when page.js was decoding the query string first, it became `?p=a&b` and there were two params: `{ p: 'a', b: '' }`. That's bad.

One of simplifications we can do now we've forked page.js in our monorepo.