### PR TITLE
Jetpack Backup: Added info popover to remember credentials check

### DIFF
--- a/client/components/advanced-credentials/credentials-form/index.tsx
+++ b/client/components/advanced-credentials/credentials-form/index.tsx
@@ -555,7 +555,18 @@ const ServerCredentialsForm: FunctionComponent< Props > = ( {
 							onChange={ handleFormChange }
 							value="true"
 						/>
-						<span>{ translate( 'Remember credentials' ) }</span>
+						<span>
+							{ translate( 'Remember credentials' ) }
+							<InfoPopover
+								className="credentials-form__remember-credentials-info-popover"
+								position="right"
+								showOnHover={ true }
+							>
+								{ translate(
+									'Save this configuration so you can easily access it the next time you copy a site to staging.'
+								) }
+							</InfoPopover>
+						</span>
 					</FormLabel>
 				</FormFieldset>
 			) }

--- a/client/components/advanced-credentials/credentials-form/style.scss
+++ b/client/components/advanced-credentials/credentials-form/style.scss
@@ -32,6 +32,11 @@
 			font-size: $font-body;
 		}
 	}
+
+	&__remember-credentials-info-popover {
+		vertical-align: middle;
+		margin-inline-start: 2px;
+	}
 }
 
 .credentials-form__buttons .credentials-form__buttons-flex {
@@ -74,7 +79,6 @@
 		}
 	}
 }
-
 
 .credentials-form__row {
 	display: flex;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/83035#issuecomment-1775318890

## Proposed Changes

* As per the suggestion on the [linked comment](https://github.com/Automattic/wp-calypso/pull/83035#issuecomment-1775318890), adding a more verbose explanation to the right of the 'Remember credentials' checkbox.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

| Before  | After |
| ------------- | ------------- |
| <img width="315" alt="Screenshot 2023-11-27 at 5 50 47 PM" src="https://github.com/Automattic/wp-calypso/assets/13975226/dc431785-0f2a-4f84-8ad1-c875ff4deb93"> |  <img width="525" alt="Screenshot 2023-11-27 at 5 51 03 PM" src="https://github.com/Automattic/wp-calypso/assets/13975226/107578a2-5e6f-4211-809c-6abe65f376d3"> |

* Spin up Calypso Blue and Jetpack Cloud live branches
* Visit a site's activity log and click on Copy this site button
* On Set a destination site screen, click on _Enter credentials for a new destination site_ + link
* Inside the form, hover over the _Remember credentials_ checkbox and see the info popover is displayed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
