### PR TITLE
Plans 2023: Use useIntroOffers hook for the Woo intro offers

### DIFF
--- a/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
+++ b/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
@@ -62,7 +62,8 @@ const usePricingMetaForGridPlans: UsePricingMetaForGridPlans = ( {
 	);
 	const currentSitePlanSlug = currentPlan?.productSlug;
 	const pricedAPIPlans = usePricedAPIPlans( { planSlugs: planSlugs } );
-	const sitePlans = Plans.useSitePlans( { siteId: selectedSiteId } );
+	const pricedAPISitePlans = Plans.useSitePlans( { siteId: selectedSiteId } );
+	const introOffers = Plans.useIntroOffers( { siteId: selectedSiteId } );
 	const selectedStorageOptions = useSelect( ( select ) => {
 		return select( WpcomPlansUI.store ).getSelectedStorageOptions();
 	}, [] );
@@ -194,7 +195,7 @@ const usePricingMetaForGridPlans: UsePricingMetaForGridPlans = ( {
 	 * - For now a simple loader is shown until these are resolved
 	 * - We can optimise Error states in the UI / when everything gets ported into data-stores
 	 */
-	if ( sitePlans.isFetching || ! pricedAPIPlans ) {
+	if ( pricedAPISitePlans.isFetching || ! pricedAPIPlans ) {
 		return null;
 	}
 
@@ -203,7 +204,7 @@ const usePricingMetaForGridPlans: UsePricingMetaForGridPlans = ( {
 			// pricedAPIPlans - should have a definition for all plans, being the main source of API data
 			const pricedAPIPlan = pricedAPIPlans[ planSlug ];
 			// pricedAPISitePlans - unclear if all plans are included
-			const sitePlan = sitePlans.data?.[ planSlug ];
+			const pricedAPISitePlan = pricedAPISitePlans.data?.[ planSlug ];
 
 			return {
 				...acc,
@@ -212,8 +213,8 @@ const usePricingMetaForGridPlans: UsePricingMetaForGridPlans = ( {
 					discountedPrice: planPrices[ planSlug ]?.discountedPrice,
 					billingPeriod: pricedAPIPlan?.bill_period,
 					currencyCode: pricedAPIPlan?.currency_code,
-					introOffer: sitePlan?.introOffer,
-					expiry: sitePlan?.expiry,
+					introOffer: introOffers?.[ planSlug ],
+					expiry: pricedAPISitePlan?.expiry,
 				},
 			};
 		},

--- a/client/my-sites/plans-features-main/hooks/test/use-pricing-meta-for-grid-plans.ts
+++ b/client/my-sites/plans-features-main/hooks/test/use-pricing-meta-for-grid-plans.ts
@@ -29,6 +29,7 @@ jest.mock( 'calypso/state/purchases/selectors', () => ( {
 jest.mock( '@automattic/data-stores', () => ( {
 	Plans: {
 		useSitePlans: jest.fn(),
+		useIntroOffers: jest.fn(),
 	},
 } ) );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4570

## Proposed Changes

Updates introductory offers to be derived off respective `useIntroOffers` hook - as these are subject to be conditionally compiled from both `plans` and `site plans` endpoints next.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure `/plans/[ site ]` and `/start/plans` render pricing correctly
* Ensure `/plans[ woo trial ]` renders the introductory offers fine (can get a Woo Site by visiting `/setup/wooexpress`)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?