### PR TITLE
Site Checklist: fix crash when checklist is empty object

### DIFF
--- a/client/data/site-checklist/use-site-checklist-task.ts
+++ b/client/data/site-checklist/use-site-checklist-task.ts
@@ -1,4 +1,3 @@
-import { useMemo } from 'react';
 import { Task } from 'calypso/state/checklist/types';
 import { CHECKLIST_KNOWN_TASKS } from 'calypso/state/data-layer/wpcom/checklist/index.js';
 import useSiteChecklist from './use-site-checklist';
@@ -13,12 +12,7 @@ const useSiteChecklistTask = (
 	taskId: ( typeof CHECKLIST_KNOWN_TASKS )[ keyof typeof CHECKLIST_KNOWN_TASKS ]
 ): Task | undefined => {
 	const siteChecklist = useSiteChecklist( siteId );
-	const task = useMemo(
-		() => siteChecklist?.tasks.find( ( { id } ) => id === taskId ),
-		[ siteChecklist, taskId ]
-	);
-
-	return task;
+	return siteChecklist?.tasks?.find( ( { id } ) => id === taskId );
 };
 
 export default useSiteChecklistTask;

--- a/client/data/site-checklist/use-site-checklist.ts
+++ b/client/data/site-checklist/use-site-checklist.ts
@@ -6,9 +6,7 @@ import getSiteChecklist from 'calypso/state/selectors/get-site-checklist';
 
 const useSiteChecklist = ( siteId: string ): Checklist | null => {
 	const dispatch = useDispatch();
-	const { siteChecklist } = useSelector( ( state ) => ( {
-		siteChecklist: getSiteChecklist( state, Number( siteId ) ),
-	} ) );
+	const siteChecklist = useSelector( ( state ) => getSiteChecklist( state, Number( siteId ) ) );
 
 	useEffect( () => {
 		if ( siteId && ! siteChecklist ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-launch/use-atomic-site-checklist.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-launch/use-atomic-site-checklist.ts
@@ -10,9 +10,7 @@ import getSiteChecklist from 'calypso/state/selectors/get-site-checklist';
 export function useAtomicSiteChecklist() {
 	const dispatch = useRootDispatch();
 	const siteId = useSite()?.ID || '';
-	const { siteChecklist } = useSelector( ( state ) => ( {
-		siteChecklist: getSiteChecklist( state, Number( siteId ) ),
-	} ) );
+	const siteChecklist = useSelector( ( state ) => getSiteChecklist( state, Number( siteId ) ) );
 
 	const requestChecklist = useCallback(
 		() => dispatch( requestSiteChecklist( siteId.toString() ) ),

--- a/client/state/checklist/reducer.js
+++ b/client/state/checklist/reducer.js
@@ -26,7 +26,7 @@ const moduleTaskMap = {
 	videopress: CHECKLIST_KNOWN_TASKS.JETPACK_VIDEO_HOSTING,
 };
 
-const items = withSchemaValidation( itemSchemas, ( state = {}, action ) => {
+const items = withSchemaValidation( itemSchemas, ( state = null, action ) => {
 	switch ( action.type ) {
 		case SITE_CHECKLIST_RECEIVE:
 			return action.checklist;

--- a/client/state/selectors/get-site-task-list.js
+++ b/client/state/selectors/get-site-task-list.js
@@ -1,4 +1,3 @@
-import { get } from 'lodash';
 import { getTaskList } from 'calypso/lib/checklist';
 import getChecklistTaskUrls from './get-checklist-task-urls';
 import getSiteChecklist from './get-site-checklist';
@@ -12,8 +11,8 @@ import getSiteChecklist from './get-site-checklist';
 export default function getSiteTaskList( state, siteId ) {
 	const siteChecklist = getSiteChecklist( state, siteId );
 	const taskList = getTaskList( {
-		taskStatuses: get( siteChecklist, 'tasks' ),
-		siteSegment: get( siteChecklist, 'siteSegment' ),
+		taskStatuses: siteChecklist?.tasks,
+		siteSegment: siteChecklist?.siteSegment,
 	} );
 	const taskUrls = getChecklistTaskUrls( state, siteId );
 	taskList.removeTasksWithoutUrls( taskUrls );


### PR DESCRIPTION
Fixes a crash reported in Sentry where `sitesChecklist.tasks` is `undefined` and `.find` can't be executed on it:

<img width="988" alt="Screenshot 2023-11-27 at 14 27 18" src="https://github.com/Automattic/wp-calypso/assets/664258/44210579-9029-40dc-861e-4acfa655e658">

I wasn't able to reproduce it locally, because it requires a precise race condition, but here is how it can happen:
- some action with `action.siteId` field equal to current site is dispatched. That's enough to initialize the `state.checklist[ siteId].items` with an empty `{}` object because that's the initial state of the reducer. The action doesn't need to be related to site checklist at all.
- the REST request to fetch site checklist for site `siteId` didn't yet finish, otherwise it would update the state with a full valid checklist object.
- the `useRequestSiteChecklistTaskUpdate` hook is mounted. Many UI screens, like Themes, do this when they are displayed, marking a task as finished.
- this hook calls `useSiteCheckListTask`, which calls `siteChecklist?.tasks.find`. Because `siteChecklist` is an object, the first optional chaining returns `undefined`, and then the non-optional `.find` crashes.

Fixed by:
1. adding one more `?.` before `find`
2. changing initial state of the `state.checklist` reducer to `null`, which is better than empty object. I verified that all usages of `getSiteChecklist` can work with `null` return value.

I also:
- removed call of `useMemo` because the `find` doesn't need to be memoized. There are 10-ish items in the task list, the `useMemo` overhead is possibly bigger than saving a `.find` call.
- fixes several "Selector returned a different result when called with the same parameters." warnings on usages of `getSiteChecklist`. Redux selectors are not the same as `@wordpress/data`, returning an object is not a good idea there!

