### PR TITLE
Promote Post: fix infinite loop switching tab and site

### DIFF
--- a/client/my-sites/promote-post-i2/controller.js
+++ b/client/my-sites/promote-post-i2/controller.js
@@ -9,7 +9,7 @@ import { getAdvertisingDashboardPath } from './utils';
 // Compatibility: Checks that the order of the tab and site are correct, redirects the user if they are switched
 export const checkValidTabInNavigation = ( context, next ) => {
 	const { site, tab } = context.params;
-	if ( site && tab && ! TAB_OPTIONS.includes( tab ) ) {
+	if ( site && tab && ! TAB_OPTIONS.includes( tab ) && TAB_OPTIONS.includes( site ) ) {
 		return page.redirect( getAdvertisingDashboardPath( `/${ site }/${ tab }` ) );
 	}
 

--- a/client/my-sites/promote-post-i2/main.tsx
+++ b/client/my-sites/promote-post-i2/main.tsx
@@ -75,7 +75,7 @@ const POST_DEFAULT_SEARCH_OPTIONS: SearchOptions = {
 
 export default function PromotedPosts( { tab }: Props ) {
 	const isRunningInJetpack = config.isEnabled( 'is_running_in_jetpack_site' );
-	const selectedTab = tab && [ 'campaigns', 'posts', 'credits' ].includes( tab ) ? tab : 'posts';
+	const selectedTab = tab && TAB_OPTIONS.includes( tab ) ? tab : 'posts';
 	const selectedSite = useSelector( getSelectedSite );
 	const selectedSiteId = selectedSite?.ID || 0;
 	const translate = useTranslate();


### PR DESCRIPTION
Fixes another infinite loop (after #84104) in the `/advertising` route! Just go to `/advertising/foo/bar` and watch an infinite redirect between `foo/bar` and `bar/foo`. There is a handler that tries to detect a semi-invalid route where `tab` and `site` are swapped and redirects to a route with the "correct" order. But it loops when neither parameter is a valid tab. I added a check where `site` must be a valid tab name.

As a drive-by, I'm replacing an array literal with a `TAB_OPTIONS` constant that has the same value.