### PR TITLE
Hosting Command Palette: Remove redundant search labels

### DIFF
--- a/client/components/command-pallette/use-command-pallette.tsx
+++ b/client/components/command-pallette/use-command-pallette.tsx
@@ -33,7 +33,7 @@ interface Command {
 	name: string;
 	label: string;
 	subLabel?: string;
-	searchLabel: string;
+	searchLabel?: string;
 	callback: ( params: CommandCallBackParams ) => void;
 	context?: string[];
 	icon?: JSX.Element;

--- a/client/sites-dashboard/components/wpcom-smp-commands.tsx
+++ b/client/sites-dashboard/components/wpcom-smp-commands.tsx
@@ -123,7 +123,6 @@ export const useCommandsArrayWpcom = ( {
 		{
 			name: 'openSiteDashboard',
 			label: __( 'Open site dashboard' ),
-			searchLabel: __( 'open site dashboard' ),
 			context: [ '/sites' ],
 			callback: setStateCallback( 'openSiteDashboard' ),
 			siteFunctions: {
@@ -137,7 +136,6 @@ export const useCommandsArrayWpcom = ( {
 		{
 			name: 'openHostingConfiguration',
 			label: __( 'Open hosting configuration' ),
-			searchLabel: __( 'open hosting configuration' ),
 			context: [ '/sites' ],
 			callback: setStateCallback( 'openHostingConfiguration' ),
 			siteFunctions: {
@@ -152,7 +150,6 @@ export const useCommandsArrayWpcom = ( {
 		{
 			name: 'openPHPmyAdmin',
 			label: __( 'Open database in phpMyAdmin' ),
-			searchLabel: __( 'open database in phpMyAdmin' ),
 			context: [ '/sites' ],
 			callback: setStateCallback( 'openPHPmyAdmin' ),
 			siteFunctions: {
@@ -167,7 +164,6 @@ export const useCommandsArrayWpcom = ( {
 		{
 			name: 'openProfile',
 			label: __( 'Open my profile' ),
-			searchLabel: __( 'open my profile' ),
 			context: [ '/sites' ],
 			callback: ( { close }: { close: () => void } ) => {
 				close();
@@ -178,7 +174,6 @@ export const useCommandsArrayWpcom = ( {
 		{
 			name: 'openAccountSettings',
 			label: __( 'Open account settings' ),
-			searchLabel: __( 'open account settings' ),
 			callback: ( { close }: { close: () => void } ) => {
 				close();
 				navigate( `/me/account` );
@@ -188,7 +183,6 @@ export const useCommandsArrayWpcom = ( {
 		{
 			name: 'acessPurchases',
 			label: __( 'Open my purchases' ),
-			searchLabel: __( 'open my purchases' ),
 			context: [ '/sites' ],
 			callback: ( { close }: { close: () => void } ) => {
 				close();
@@ -199,7 +193,6 @@ export const useCommandsArrayWpcom = ( {
 		{
 			name: 'manageDomains',
 			label: __( 'Manage domains' ),
-			searchLabel: __( 'manage domains' ),
 			context: [ '/sites' ],
 			callback: ( { close }: { close: () => void } ) => {
 				close();
@@ -210,7 +203,6 @@ export const useCommandsArrayWpcom = ( {
 		{
 			name: 'manageDns',
 			label: __( 'Manage DNS records' ),
-			searchLabel: __( 'manage dns records' ),
 			context: [ '/sites' ],
 			callback: setStateCallback( 'manageDns' ),
 			siteFunctions: {
@@ -226,7 +218,6 @@ export const useCommandsArrayWpcom = ( {
 		{
 			name: 'copySshConnectionString',
 			label: __( 'Copy SSH connection string' ),
-			searchLabel: __( 'copy ssh connection string' ),
 			callback: setStateCallback( 'copySshConnectionString' ),
 			siteFunctions: {
 				onClick: async ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
@@ -240,7 +231,6 @@ export const useCommandsArrayWpcom = ( {
 		{
 			name: 'openSshCredentials',
 			label: __( 'Open SFTP/SSH credentials' ),
-			searchLabel: __( 'open SFTP/SSH credentials' ),
 			callback: setStateCallback( 'openSshCredentials' ),
 			siteFunctions: {
 				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
@@ -254,7 +244,6 @@ export const useCommandsArrayWpcom = ( {
 		{
 			name: 'resetSshSftpPassword',
 			label: __( 'Reset SSH/SFTP password' ),
-			searchLabel: __( 'reset ssh/sftp password' ),
 			callback: setStateCallback( 'resetSshSftpPassword' ),
 			siteFunctions: {
 				onClick: async ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
@@ -268,7 +257,6 @@ export const useCommandsArrayWpcom = ( {
 		{
 			name: 'openSiteStats',
 			label: __( 'Open site stats' ),
-			searchLabel: __( 'open site stats' ),
 			callback: setStateCallback( 'openSiteStats' ),
 			siteFunctions: {
 				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
@@ -281,7 +269,6 @@ export const useCommandsArrayWpcom = ( {
 		{
 			name: 'registerDomain',
 			label: __( 'Register domain' ),
-			searchLabel: __( 'register domain' ),
 			context: [ '/sites' ],
 			callback: ( { close }: { close: () => void } ) => {
 				close();
@@ -292,7 +279,6 @@ export const useCommandsArrayWpcom = ( {
 		{
 			name: 'openActivityLog',
 			label: __( 'Open activity log' ),
-			searchLabel: __( 'open activity log' ),
 			callback: setStateCallback( 'openActivityLog' ),
 			siteFunctions: {
 				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
@@ -306,7 +292,6 @@ export const useCommandsArrayWpcom = ( {
 		{
 			name: 'openBackups',
 			label: __( 'Open backups' ),
-			searchLabel: __( 'open backups' ),
 			callback: setStateCallback( 'openBackups' ),
 			siteFunctions: {
 				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
@@ -320,7 +305,6 @@ export const useCommandsArrayWpcom = ( {
 		{
 			name: 'viewSiteMetrics',
 			label: __( 'View site metrics' ),
-			searchLabel: __( 'view site metrics' ),
 			callback: setStateCallback( 'viewSiteMetrics' ),
 			siteFunctions: {
 				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
@@ -334,7 +318,6 @@ export const useCommandsArrayWpcom = ( {
 		{
 			name: 'openPHPLogs',
 			label: __( 'Open PHP logs' ),
-			searchLabel: __( 'open PHP logs' ),
 			callback: setStateCallback( 'openPHPLogs' ),
 			siteFunctions: {
 				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
@@ -348,7 +331,6 @@ export const useCommandsArrayWpcom = ( {
 		{
 			name: 'openWebServerLogs',
 			label: __( 'Open web server logs' ),
-			searchLabel: __( 'open web server logs' ),
 			callback: setStateCallback( 'openWebServerLogs' ),
 			siteFunctions: {
 				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
@@ -362,7 +344,6 @@ export const useCommandsArrayWpcom = ( {
 		{
 			name: 'manageStagingSites',
 			label: __( 'Manage staging sites' ),
-			searchLabel: __( 'manage staging sites' ),
 			callback: setStateCallback( 'manageStagingSites' ),
 			siteFunctions: {
 				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
@@ -376,7 +357,6 @@ export const useCommandsArrayWpcom = ( {
 		{
 			name: 'managePHPVersion',
 			label: __( 'Manage PHP version' ),
-			searchLabel: __( 'manage PHP issue' ),
 			callback: setStateCallback( 'managePHPVersion' ),
 			siteFunctions: {
 				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
@@ -390,7 +370,6 @@ export const useCommandsArrayWpcom = ( {
 		{
 			name: 'manageCacheSettings',
 			label: __( 'Manage cache settings' ),
-			searchLabel: __( 'manage cache settings' ),
 			callback: setStateCallback( 'manageCacheSettings' ),
 			siteFunctions: {
 				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
@@ -404,7 +383,6 @@ export const useCommandsArrayWpcom = ( {
 		{
 			name: 'manageAdminInterfaceStyle',
 			label: __( 'Manage admin interface style' ),
-			searchLabel: __( 'manage admin interface style' ),
 			callback: setStateCallback( 'manageAdminInterfaceStyle' ),
 			siteFunctions: {
 				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
@@ -418,7 +396,6 @@ export const useCommandsArrayWpcom = ( {
 		{
 			name: 'addNewSite',
 			label: __( 'Add new site' ),
-			searchLabel: __( 'add new site' ),
 			context: [ '/sites' ],
 			callback: ( { close }: { close: () => void } ) => {
 				close();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4629

## Proposed Changes

In this PR, I propose to remove `searchLabel` property for commands that have it set to the same value as `label`. `searchLabel` should be defined only if we want to provide other search keywords for a given command.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run this branch locally or use Calypso Live
2. Access `/sites`
3. Press cmd+k on mac or ctrl+k on Windows
4. Search for different keywords e.g. "Manage" and confirm that proper commands are shown

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?