### PR TITLE
Hosting trial: track paid offer click

### DIFF
--- a/client/my-sites/plans-grid/components/actions.tsx
+++ b/client/my-sites/plans-grid/components/actions.tsx
@@ -464,6 +464,7 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 				recordTracksEvent( 'calypso_plan_features_upgrade_click', {
 					current_plan: currentSitePlanSlug,
 					upgrading_to: upgradePlan,
+					saw_free_trial_offer: !! freeTrialPlanSlug,
 				} );
 			}
 


### PR DESCRIPTION
## Proposed Changes

Let's track if the trial was offered when the user clicks the plans grid button.

## Testing Instructions

1. Enable logging by inputting `localStorage.setItem('debug', 'calypso:analytics')` in the dev console
2. Open `/setup/new-hosted-site?flags=+plans/hosting-trial` 
3. Click the secondary "Get Business" button and verify that `calypso_plan_features_upgrade_click` was dispatched with `saw_free_trial_offer: true`

<img width="615" alt="image" src="https://github.com/Automattic/wp-calypso/assets/26530524/37ba0767-16aa-48d1-a857-f4111f018f79">

4. In turn, clicking the primary "Get Business" button in an environment where you're not in the treatment group, should track `saw_free_trial_offer: false`

<img width="613" alt="image" src="https://github.com/Automattic/wp-calypso/assets/26530524/b75808b0-8fea-4681-a7cd-ea8be7da544b">