### PR TITLE
Add tracks location prop to Reader on the Customer Home

### DIFF
--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -99,6 +99,9 @@ function getLocation( path ) {
 	if ( path.indexOf( '/read/conversations' ) === 0 ) {
 		return 'conversations';
 	}
+	if ( path.indexOf( '/home' ) === 0 ) {
+		return 'home';
+	}
 	return 'unknown';
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

More context:
* p1700123535422679-slack-C064GPHRVHC

## Proposed Changes

* Dale noticed that we were not able to identify users who were seeing the post through the experiment we worked on the Munich meetup: p4lB9U-YY-p2
* I added the `/home` path to the allow list so the `ui_algo` can be populated on the Customer Home. With this change we'll be able to identify the experiment if the `ui_algo` is equals to `home`.

![Screen Shot 2023-11-27 at 13 11 42](https://github.com/Automattic/wp-calypso/assets/1234758/e50c8a73-8804-484f-ada9-73c9bed61c66)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso Live link or apply this PR to your local environment
* Make sure you are sandboxed
* Edit this(fbhepr%2Skers%2Sjcpbz%2Sjc%2Qpbagrag%2Syvo%2Subzr%2Sivrjf.cuc%3Se%3Q0o594289%23408-og) condition to always return true so you can fall into the experiment.
* Create a site through `/setup/start-writing`
* Go through the flow until you reach the Customer Home, dismiss or complete actions on the main banners
* You should then see the Reader on the Customer Home
* Make sure that the tracks events have the `ui_algo`, and the value is `home`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?