### PR TITLE
remove `onSuccess` from `useGithubBranchesQuery` usage

### DIFF
--- a/client/my-sites/hosting/github/github-connect-card/search-branches.tsx
+++ b/client/my-sites/hosting/github/github-connect-card/search-branches.tsx
@@ -1,6 +1,6 @@
 import { Spinner } from '@automattic/components';
 import { useI18n } from '@wordpress/react-i18n';
-import { ChangeEvent } from 'react';
+import { ChangeEvent, useEffect } from 'react';
 import FormSelect from 'calypso/components/forms/form-select';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import { useGithubBranchesQuery } from './use-github-branches-query';
@@ -26,17 +26,18 @@ export const SearchBranches = ( {
 }: SearchBranchesProps ) => {
 	const { __ } = useI18n();
 
-	const { data: branches, isFetching } = useGithubBranchesQuery( siteId, repoName, connectionId, {
-		onSuccess( branches ) {
-			if (
-				branches.length > 0 &&
-				branches.length < SEARCH_BRANCHES_LIMIT &&
-				( ! selectedBranch || ! branches.includes( selectedBranch ) )
-			) {
-				onSelect( branches[ 0 ] );
-			}
-		},
-	} );
+	const { data: branches, isFetching } = useGithubBranchesQuery( siteId, repoName, connectionId );
+
+	useEffect( () => {
+		if (
+			branches &&
+			branches.length > 0 &&
+			branches.length < SEARCH_BRANCHES_LIMIT &&
+			( ! selectedBranch || ! branches.includes( selectedBranch ) )
+		) {
+			onSelect( branches[ 0 ] );
+		}
+	}, [ branches, onSelect, selectedBranch ] );
 
 	if ( ! repoName || ! branches ) {
 		return (


### PR DESCRIPTION
Related to #84338

## Proposed Changes

Migrage `onSuccess` usage of `useGithubBranchesQuery` to `useEffect` as those handlers are removed from the `useQuery` API in v5 of RQ.

## Testing Instructions

* On a AT site go to `/hosting-config`
* append `?flags=github-integration-i1` to URL
* You will see the github deploy card, connect to github then search for repositories and branches to see if it works.
* Main thing to look at is whether a branch gets autoselected after selecting a repo


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
