### PR TITLE
ResponsiveToolbarGroup: Fix the popover loading in a fallback container

### DIFF
--- a/packages/components/src/responsive-toolbar-group/dropdown-group.tsx
+++ b/packages/components/src/responsive-toolbar-group/dropdown-group.tsx
@@ -91,6 +91,7 @@ export default function DropdownGroup( {
 		if ( containGroupedIndexes || always ) {
 			return (
 				<SlotFillProvider>
+					{ /* @ts-expect-error-ignore  */ }
 					<Popover.Slot />
 					<Dropdown
 						renderToggle={ ( { onToggle } ) => (

--- a/packages/components/src/responsive-toolbar-group/dropdown-group.tsx
+++ b/packages/components/src/responsive-toolbar-group/dropdown-group.tsx
@@ -1,4 +1,12 @@
-import { ToolbarGroup, ToolbarButton, Dropdown, MenuItem, MenuGroup } from '@wordpress/components';
+import {
+	ToolbarGroup,
+	ToolbarButton,
+	Dropdown,
+	MenuItem,
+	MenuGroup,
+	SlotFillProvider,
+	Popover,
+} from '@wordpress/components';
 import { Icon, chevronDown } from '@wordpress/icons';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -82,45 +90,48 @@ export default function DropdownGroup( {
 
 		if ( containGroupedIndexes || always ) {
 			return (
-				<Dropdown
-					renderToggle={ ( { onToggle } ) => (
-						<ToolbarButton
-							className={ classnames(
-								'responsive-toolbar-group__more-item',
-								'responsive-toolbar-group__button-item'
-							) }
-							isActive={ groupedIndexes[ activeIndex ] }
-							onClick={ () => {
-								onToggle();
-							} }
-						>
-							{ translate( 'More' ) }
-							<Icon icon={ chevronDown } />
-						</ToolbarButton>
-					) }
-					renderContent={ ( { onClose } ) => (
-						<MenuGroup>
-							{ getChildrenToRender()
-								.filter( ( { grouped } ) => grouped )
-								.map( ( { index, child } ) => (
-									<MenuItem
-										key={ `menu-item-${ index }` }
-										onClick={ () => {
-											setActiveIndex( parseInt( index ) );
-											onClick( parseInt( index ) );
-											onClose();
-										} }
-										className={ classnames(
-											'responsive-toolbar-group__menu-item',
-											activeIndex === parseInt( index ) ? 'is-selected' : ''
-										) }
-									>
-										{ child }
-									</MenuItem>
-								) ) }
-						</MenuGroup>
-					) }
-				/>
+				<SlotFillProvider>
+					<Popover.Slot />
+					<Dropdown
+						renderToggle={ ( { onToggle } ) => (
+							<ToolbarButton
+								className={ classnames(
+									'responsive-toolbar-group__more-item',
+									'responsive-toolbar-group__button-item'
+								) }
+								isActive={ groupedIndexes[ activeIndex ] }
+								onClick={ () => {
+									onToggle();
+								} }
+							>
+								{ translate( 'More' ) }
+								<Icon icon={ chevronDown } />
+							</ToolbarButton>
+						) }
+						renderContent={ ( { onClose } ) => (
+							<MenuGroup>
+								{ getChildrenToRender()
+									.filter( ( { grouped } ) => grouped )
+									.map( ( { index, child } ) => (
+										<MenuItem
+											key={ `menu-item-${ index }` }
+											onClick={ () => {
+												setActiveIndex( parseInt( index ) );
+												onClick( parseInt( index ) );
+												onClose();
+											} }
+											className={ classnames(
+												'responsive-toolbar-group__menu-item',
+												activeIndex === parseInt( index ) ? 'is-selected' : ''
+											) }
+										>
+											{ child }
+										</MenuItem>
+									) ) }
+							</MenuGroup>
+						) }
+					/>
+				</SlotFillProvider>
 			);
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

The DropdownGroup we use in the ResponsiveToolbarGroup component uses the Popover component (core WordPress Components). The Popover component uses a Slot to render the elements. When the slot is not defined, a fallback container is added automatically at the end of the page.

In order to apply the custom styles we have for Themes/Plugins/Design Picker, we need to load the slot inside of the Responsive Toolbar.

Related to https://github.com/Automattic/wp-calypso/issues/82389

## Proposed Changes

* Load the Popover WordPress Component in a Slot part of the dropdown. This way, the CSS we have for LoTS/LiTS/Plugins/DP is applied correctly.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso live link
* Go to LoTS/LiTS and click a category in the `More` dropdown
* Notice that the category clicked is now highlighted in the More dropdown
* Go to Plugins and DesignPicker and repeat the same steps
* Notice that the category is now selected in the dropdown

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?