### PR TITLE
Fullscreen Launchpad: better loading placeholder

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -186,21 +186,21 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goToStep, flow }: SidebarPr
 		);
 	}
 
-	if ( ! site ) {
-		return null;
-	}
-
+	// If there is no site yet then we set 1 as numberOfSteps so the CircularProgressBar gets rendered in
+	// an empty state. If site is here then we default to the previous behaviour: show it if enhancedTasks.length > 0.
+	const numberOfSteps = site === null ? 1 : enhancedTasks?.length || null;
 	return (
 		<>
-			<QueryMembershipsSettings siteId={ site.ID } source="launchpad" />
+			{ site && <QueryMembershipsSettings siteId={ site.ID } source="launchpad" /> }
 			<div className="launchpad__sidebar">
 				<div className="launchpad__sidebar-content-container">
 					<div className="launchpad__progress-bar-container">
 						<CircularProgressBar
 							size={ 40 }
 							enableDesktopScaling
-							currentStep={ currentTask || null }
-							numberOfSteps={ enhancedTasks?.length || null }
+							currentStep={ currentTask || 0 }
+							numberOfSteps={ numberOfSteps }
+							showProgressText={ site !== null }
 						/>
 					</div>
 					{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace*/ }

--- a/packages/launchpad/src/checklist-item/style.scss
+++ b/packages/launchpad/src/checklist-item/style.scss
@@ -71,6 +71,12 @@
 	}
 }
 
+.checklist-item__task-content {
+	&.is-placeholder {
+		padding: 5px 0 5px 0;
+	}
+}
+
 .checklist-item__task-content.components-button:hover:not([disabled]),
 .checklist-item__task-content.components-button:focus:not([disabled]) {
 	fill: var(--studio-blue-50);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/84509

## Proposed Changes

Shows the sidebar even if `site` isn't loaded. After applying this change the sidebar will be shown in a placeholder state preventing layout shifts when `site` finally loads.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this patch to your local env or go to the calypso.live link below
* Open network tools and throttle your connection (Fast 3G should be sufficient)
* Open the fullscreen launchpad on an existing site or create a new one (free flow works)
* Verify when the screen is loading you see a placeholder in the sidebar and no layout shift occurs

This is the placeholder:
<img width="484" alt="image" src="https://github.com/Automattic/wp-calypso/assets/375980/0a481096-c635-426c-824f-3725f647edc5">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?