### PR TITLE
Layout: Fix masterbar flicker in sign up

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -367,7 +367,9 @@ export default withCurrentRoute(
 			isDomainAndPlanPackageFlow ||
 			isReaderTagEmbedPage( window?.location );
 		const noMasterbarForSection =
-			! isWooCoreProfilerFlow && [ 'signup', 'jetpack-connect' ].includes( sectionName );
+			// hide the masterBar until the section is loaded. To flicker the masterBar in, is better than to flicker it out.
+			! sectionName ||
+			( ! isWooCoreProfilerFlow && [ 'signup', 'jetpack-connect' ].includes( sectionName ) );
 		const masterbarIsHidden =
 			! masterbarIsVisible( state ) ||
 			noMasterbarForSection ||


### PR DESCRIPTION
This fixes the master bar flicker in sign up by only showing the master bar after the section name is determined; the section name is the main factor in deciding if the MB should be shown.

This is a win-win because when the section name is loaded, the section would also be loaded, and this means the master bar and the section (the UI underneath it) will render together at once! Removing the flicker in all cases (with or without master bar).

Fixes:  https://github.com/Automattic/wp-calypso/issues/83712

## Proposed Changes

* Don't render the masterbar unless the section name is defined. [**Every section has a name.** ](https://github.com/Automattic/wp-calypso/blob/trunk/client/sections.js)

## Testing Instructions

1. While logged in, go to /start.
2. The master bar shouldn't flicker in and out. 
3. Visit another section that has the masterbar (like my home). The master bar should render together with everything.
