### PR TITLE
`useCheckJetpackConnectionHealth`: remove `on*` handlers

### DIFF
--- a/client/components/jetpack/connection-health/index.tsx
+++ b/client/components/jetpack/connection-health/index.tsx
@@ -1,6 +1,5 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
 import { useSelector } from 'react-redux';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import {
@@ -30,15 +29,11 @@ export const JetpackConnectionHealthBanner = ( { siteId }: Props ) => {
 		( state ) => !! isSiteAutomatedTransfer( state, siteId )
 	);
 
-	const [ isErrorCheckJetpackConnectionHealth, setIsErrorCheckJetpackConnectionHealth ] =
-		useState( false );
-
-	const { data: jetpackConnectionHealth, isLoading: isLoadingJetpackConnectionHealth } =
-		useCheckJetpackConnectionHealth( siteId, {
-			onError: () => {
-				setIsErrorCheckJetpackConnectionHealth( true );
-			},
-		} );
+	const {
+		data: jetpackConnectionHealth,
+		isLoading: isLoadingJetpackConnectionHealth,
+		isError: isErrorCheckJetpackConnectionHealth,
+	} = useCheckJetpackConnectionHealth( siteId );
 
 	if (
 		isLoadingJetpackConnectionHealth ||

--- a/client/components/jetpack/connection-health/use-check-jetpack-connection-health.ts
+++ b/client/components/jetpack/connection-health/use-check-jetpack-connection-health.ts
@@ -34,19 +34,21 @@ export const useCheckJetpackConnectionHealth = ( siteId: number ) => {
 		staleTime: 10 * 1000,
 	} );
 
-	const data = query.data;
+	const { data, isSuccess } = query;
+	const isHealthy = data?.is_healthy;
+	const error = data?.error;
 
 	useEffect( () => {
-		if ( ! data ) {
+		if ( ! isSuccess ) {
 			return;
 		}
-		if ( data.is_healthy && reduxIsUnhealthy ) {
+		if ( isHealthy && reduxIsUnhealthy ) {
 			dispatch( setJetpackConnectionHealthy( siteId ) );
 		}
-		if ( ! data.is_healthy && ! reduxIsUnhealthy ) {
-			dispatch( setJetpackConnectionUnhealthy( siteId, data.error ?? '' ) );
+		if ( ! isHealthy && ! reduxIsUnhealthy ) {
+			dispatch( setJetpackConnectionUnhealthy( siteId, error ?? '' ) );
 		}
-	}, [ dispatch, reduxIsUnhealthy, data, siteId ] );
+	}, [ dispatch, reduxIsUnhealthy, isSuccess, isHealthy, error, siteId ] );
 
 	return query;
 };

--- a/client/components/jetpack/connection-health/use-check-jetpack-connection-health.ts
+++ b/client/components/jetpack/connection-health/use-check-jetpack-connection-health.ts
@@ -1,10 +1,12 @@
 import { useQuery } from '@tanstack/react-query';
+import { useEffect } from 'react';
 import wp from 'calypso/lib/wp';
-import { useDispatch } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
 import {
 	setJetpackConnectionHealthy,
 	setJetpackConnectionUnhealthy,
 } from 'calypso/state/jetpack-connection-health/actions';
+import isJetpackConnectionUnhealthy from 'calypso/state/jetpack-connection-health/selectors/is-jetpack-connection-unhealthy';
 
 export const JETPACK_CONNECTION_HEALTH_QUERY_KEY = 'jetpack-connection-health';
 
@@ -13,17 +15,13 @@ export interface JetpackConnectionHealth {
 	error: string;
 }
 
-interface UseCheckJetpackConnectionHealthOptions {
-	onError?: () => void;
-	onSuccess?: ( data: JetpackConnectionHealth | undefined ) => void;
-}
-
-export const useCheckJetpackConnectionHealth = (
-	siteId: number,
-	options: UseCheckJetpackConnectionHealthOptions
-) => {
+export const useCheckJetpackConnectionHealth = ( siteId: number ) => {
 	const dispatch = useDispatch();
-	return useQuery< JetpackConnectionHealth, unknown, JetpackConnectionHealth >( {
+	const reduxIsUnhealthy = useSelector( ( state ) =>
+		isJetpackConnectionUnhealthy( state, siteId )
+	);
+
+	const query = useQuery< JetpackConnectionHealth, unknown, JetpackConnectionHealth >( {
 		queryKey: [ JETPACK_CONNECTION_HEALTH_QUERY_KEY, siteId ],
 		queryFn: () =>
 			wp.req.get( {
@@ -34,13 +32,21 @@ export const useCheckJetpackConnectionHealth = (
 			persist: false,
 		},
 		staleTime: 10 * 1000,
-		onError: options?.onError,
-		onSuccess: ( data ) => {
-			if ( data?.is_healthy ) {
-				dispatch( setJetpackConnectionHealthy( siteId ) );
-			} else {
-				dispatch( setJetpackConnectionUnhealthy( siteId, data?.error ?? '' ) );
-			}
-		},
 	} );
+
+	const data = query.data;
+
+	useEffect( () => {
+		if ( ! data ) {
+			return;
+		}
+		if ( data.is_healthy && reduxIsUnhealthy ) {
+			dispatch( setJetpackConnectionHealthy( siteId ) );
+		}
+		if ( ! data.is_healthy && ! reduxIsUnhealthy ) {
+			dispatch( setJetpackConnectionUnhealthy( siteId, data.error ?? '' ) );
+		}
+	}, [ dispatch, reduxIsUnhealthy, data, siteId ] );
+
+	return query;
 };


### PR DESCRIPTION
Related to #84338 

## Proposed Changes

PR removes `on*` handlers from `useCheckJetpackConnectionHealth`. This solution is not ideal though because we're syncing state from a `useQuery` hook to Redux which should be avoided if possible. The purpose of this PR is merely to unblock the v5 update and we'd ideally follow up to unmangle the `useCheckJetpackConnectionHealth` from Redux state.

## Testing Instructions

Follow testing instructions from https://github.com/Automattic/wp-calypso/pull/79965. I don't think it's necessary to apply the mentioned patch but block network requests to `/jetpack-connection-health` via browser devtools.