### PR TITLE
Import flow: Redesign the capture screen

### DIFF
--- a/client/blocks/import/capture/capture-input.tsx
+++ b/client/blocks/import/capture/capture-input.tsx
@@ -2,7 +2,6 @@
 import { Button } from '@automattic/components';
 import { NextButton } from '@automattic/onboarding';
 import { createElement, createInterpolateElement } from '@wordpress/element';
-import { sprintf } from '@wordpress/i18n';
 import { Icon, info } from '@wordpress/icons';
 import classnames from 'classnames';
 import { localize, translate } from 'i18n-calypso';
@@ -13,7 +12,6 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextInput from 'calypso/components/forms/form-text-input';
-import { bulb } from 'calypso/signup/icons';
 import type { OnInputChange, OnInputEnter } from './types';
 import type { FunctionComponent } from 'react';
 
@@ -30,7 +28,7 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 	const [ urlValue, setUrlValue ] = useState( '' );
 	const [ isValid, setIsValid ] = useState( false );
 	const [ submitted, setSubmitted ] = useState( false );
-	const exampleInputWebsite = 'www.artfulbaker.blog';
+	const exampleInputWebsite = 'artfulbaker.blog';
 	const showValidationMsg = hasError || ( submitted && ! isValid );
 	const { search } = useLocation();
 
@@ -69,11 +67,7 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 	return (
 		<form className={ classnames( 'import-light__capture' ) } onSubmit={ onFormSubmit }>
 			<FormFieldset>
-				<FormLabel>
-					{ createInterpolateElement( translate( 'Existing site address' ).toString(), {
-						span: createElement( 'span' ),
-					} ) }
-				</FormLabel>
+				<FormLabel>{ translate( 'Enter the URL of the site:' ) }</FormLabel>
 				<FormTextInput
 					type="text"
 					className={ classnames( { 'is-error': showValidationMsg } ) }
@@ -83,32 +77,12 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 					autoCorrect="off"
 					spellCheck="false"
 					value={ urlValue }
-					placeholder={ sprintf(
-						/* translators: the exampleSite is a URL, eg: www.artfulbaker.blog */
-						translate( 'Ex. %(exampleSite)s' ).toString(),
-						{
-							exampleSite: exampleInputWebsite,
-						}
-					) }
+					placeholder={ exampleInputWebsite }
 					onChange={ onChange }
 				/>
-				{ onDontHaveSiteAddressClick && (
-					<Button
-						borderless={ true }
-						className="action-buttons__importer-list"
-						onClick={ onDontHaveSiteAddressClick }
-					>
-						{ translate( "Don't have a site address?" ) }
-					</Button>
-				) }
 
 				<FormSettingExplanation>
 					<span className={ classnames( { 'is-error': showValidationMsg } ) }>
-						{ ! showValidationMsg && (
-							<>
-								<Icon icon={ bulb } size={ 20 } /> { translate( 'You must own this website.' ) }
-							</>
-						) }
 						{ showValidationMsg && (
 							<>
 								<Icon icon={ info } size={ 20 } />{ ' ' }
@@ -120,6 +94,16 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 			</FormFieldset>
 
 			<NextButton type="submit">{ translate( 'Continue' ) }</NextButton>
+
+			<div className="action-buttons__importer-list">
+				{ onDontHaveSiteAddressClick &&
+					createInterpolateElement( translate( 'Or <button>choose a content platform</button>' ), {
+						button: createElement( Button, {
+							borderless: true,
+							onClick: onDontHaveSiteAddressClick,
+						} ),
+					} ) }
+			</div>
 		</form>
 	);
 };

--- a/client/blocks/import/capture/index.tsx
+++ b/client/blocks/import/capture/index.tsx
@@ -1,8 +1,7 @@
+import { Title } from '@automattic/onboarding';
 import { localize, translate } from 'i18n-calypso';
 import React, { useEffect, useRef } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
-import illustrationImg from 'calypso/assets/images/onboarding/import-1.svg';
-import FormattedHeader from 'calypso/components/formatted-header';
 import { triggerMigrationStartingEvent } from 'calypso/my-sites/migrate/helpers';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
@@ -27,32 +26,19 @@ const Capture: FunctionComponent< Props > = ( props ) => {
 	const { translate, onInputEnter, onInputChange, onDontHaveSiteAddressClick, hasError } = props;
 
 	return (
-		<div className="import-layout__center">
-			<div className="import-layout">
-				<div className="import-layout__column">
-					<div className="import__heading">
-						<FormattedHeader
-							align="left"
-							headerText={ translate( 'Where will you import from?' ) }
-							subHeaderText={ translate(
-								'After a brief scan, we’ll prompt with what we can import from your website.'
-							) }
-						/>
-						<div className="step-wrapper__header-image">
-							<img alt="Light import" src={ illustrationImg } aria-hidden="true" />
-						</div>
-					</div>
-				</div>
-				<div className="import-layout__column">
-					<CaptureInput
-						onInputEnter={ onInputEnter }
-						onInputChange={ onInputChange }
-						onDontHaveSiteAddressClick={ onDontHaveSiteAddressClick }
-						hasError={ hasError }
-					/>
-				</div>
+		<>
+			<div className="import__header">
+				<Title>{ translate( 'Where will you import from?' ) }</Title>
 			</div>
-		</div>
+			<div className="import__capture-container">
+				<CaptureInput
+					onInputEnter={ onInputEnter }
+					onInputChange={ onInputChange }
+					onDontHaveSiteAddressClick={ onDontHaveSiteAddressClick }
+					hasError={ hasError }
+				/>
+			</div>
+		</>
 	);
 };
 

--- a/client/blocks/import/capture/style.scss
+++ b/client/blocks/import/capture/style.scss
@@ -1,8 +1,14 @@
+.import__capture-container {
+	max-width: 368px;
+	margin: 0 auto;
+}
+
 .import-light__capture {
 	.form-label {
-		font-size: 1em; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		font-size: 0.875rem;
 		font-weight: 500;
 		color: var(--studio-gray-60);
+		margin-bottom: 0.5rem;
 
 		span {
 			font-weight: normal;
@@ -11,7 +17,7 @@
 	}
 
 	.form-fieldset {
-		margin-bottom: 2em;
+		margin-bottom: 1em;
 	}
 
 	input[type="text"].form-text-input {
@@ -20,11 +26,15 @@
 		line-height: 2rem;
 		color: var(--studio-gray-90);
 		border-radius: 4px;
-		border-color: var(--studio-gray-50);
+		border-color: var(--studio-gray-10);
 	}
 
 	input[type="text"].form-text-input::placeholder {
 		color: var(--studio-gray-30);
+	}
+
+	button[type="submit"] {
+		width: 100%;
 	}
 
 	.form-setting-explanation {
@@ -46,9 +56,16 @@
 	}
 
 	.action-buttons__importer-list {
-		font-weight: 500;
-		text-decoration: underline;
-		color: var(--studio-gray-100);
-		margin-top: 1em;
+		font-size: 0.875rem;
+		text-align: center;
+		color: var(--studio-gray-90);
+		margin-top: 1rem;
+
+		button {
+			text-decoration: underline;
+			color: inherit;
+			margin: 0;
+			padding: 0;
+		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import/index.tsx
@@ -48,8 +48,6 @@ export const ImportWrapper: Step = function ( props ) {
 	const shouldHideSkipBtn = () => {
 		switch ( flow ) {
 			case IMPORT_FOCUSED_FLOW:
-				return currentRoute !== `${ flow }/${ BASE_ROUTE }`;
-
 			case IMPORT_HOSTED_SITE_FLOW:
 				return currentRoute !== `${ flow }/${ BASE_ROUTE }`;
 

--- a/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
@@ -5,7 +5,7 @@ const selectors = {
 	// Generic
 	button: ( text: string ) => `button:text("${ text }")`,
 	backLink: '.navigation-link:text("Back")',
-	dontHaveASiteButton: 'button:text-matches("don\'t have a site address", "i")',
+	dontHaveASiteButton: 'button:text-matches("choose a content platform", "i")',
 
 	// Inputs
 	urlInput: 'input.capture__input',


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/84569

## Proposed Changes

* Redesign the Capture step following [the Figma design](https://www.figma.com/file/Qk6oQI6SxPhh7FyngXVnAV/Migrate-from-Site-Backups?type=design&node-id=1950%3A12164&mode=design&t=xyHdYqzVOKuKF7Hq-1)

## Testing Instructions

* Go to `/setup/import-focused?siteSlug={SLUG}`
* Check if the capture screen is matched with Figma design

<img width="682" alt="Screenshot 2023-11-27 at 19 49 01" src="https://github.com/Automattic/wp-calypso/assets/1241413/a922d422-6d49-4a7e-8473-0a0f3776e0c2">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
