### PR TITLE
Plans Grid Refactor: Unify and restructure plan grid props

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -849,7 +849,6 @@ const PlansFeaturesMain = ( {
 									isLaunchPage={ isLaunchPage }
 									onUpgradeClick={ handleUpgradeClick }
 									selectedFeature={ selectedFeature }
-									selectedPlan={ selectedPlan }
 									siteId={ siteId }
 									intervalType={ intervalType }
 									hideUnavailableFeatures={ hideUnavailableFeatures }
@@ -903,10 +902,6 @@ const PlansFeaturesMain = ( {
 											) }
 											<ComparisonGrid
 												gridPlans={ gridPlansForComparisonGrid }
-												gridPlanForSpotlight={ gridPlanForSpotlight }
-												paidDomainName={ paidDomainName }
-												generatedWPComSubdomain={ resolvedSubdomainName }
-												isCustomDomainAllowedOnFreePlan={ isCustomDomainAllowedOnFreePlan }
 												isInSignup={ isInSignup }
 												isLaunchPage={ isLaunchPage }
 												onUpgradeClick={ handleUpgradeClick }
@@ -918,7 +913,6 @@ const PlansFeaturesMain = ( {
 												currentSitePlanSlug={ sitePlanSlug }
 												planActionOverrides={ planActionOverrides }
 												intent={ intent }
-												showLegacyStorageFeature={ showLegacyStorageFeature }
 												showUpgradeableStorage={ showUpgradeableStorage }
 												stickyRowOffset={ masterbarHeight }
 												usePricingMetaForGridPlans={ usePricingMetaForGridPlans }

--- a/client/my-sites/plans-grid/components/actions.tsx
+++ b/client/my-sites/plans-grid/components/actions.tsx
@@ -43,6 +43,9 @@ type PlanFeaturesActionsButtonProps = {
 	isWpcomEnterpriseGridPlan: boolean;
 	planActionOverrides?: PlanActionOverrides;
 	showMonthlyPrice: boolean;
+	/**
+	 * @deprecated Site id is not used here to be cleaned up
+	 */
 	siteId?: number | null;
 	isStuck: boolean;
 	isLargeCurrency?: boolean;

--- a/client/my-sites/plans-grid/components/comparison-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/comparison-grid/index.tsx
@@ -45,6 +45,7 @@ import { Plans2023Tooltip } from '../plans-2023-tooltip';
 import PopularBadge from '../popular-badge';
 import { StickyContainer } from '../sticky-container';
 import StorageAddOnDropdown from '../storage-add-on-dropdown';
+import type { PlansGridProps } from '../..';
 import type {
 	GridPlan,
 	TransformedFeatureObject,
@@ -324,23 +325,9 @@ const FeatureFootnote = styled.span`
 	}
 `;
 
-type ComparisonGridProps = {
-	intervalType: string;
-	isInSignup: boolean;
-	isLaunchPage?: boolean | null;
-	currentSitePlanSlug?: string | null;
+interface ComparisonGridProps extends Omit< PlansGridProps, 'onUpgradeClick' > {
 	onUpgradeClick: ( planSlug: PlanSlug ) => void;
-	siteId?: number | null;
-	planActionOverrides?: PlanActionOverrides;
-	selectedPlan?: string;
-	selectedFeature?: string;
-	showLegacyStorageFeature?: boolean;
-	showUpgradeableStorage: boolean;
-	stickyRowOffset: number;
-	onStorageAddOnClick?: ( addOnSlug: WPComStorageAddOnSlug ) => void;
-	showRefundPeriod?: boolean;
-	planTypeSelectorProps?: PlanTypeSelectorProps;
-};
+}
 
 type ComparisonGridHeaderProps = {
 	displayedGridPlans: GridPlan[];

--- a/client/my-sites/plans-grid/components/comparison-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/comparison-grid/index.tsx
@@ -45,12 +45,11 @@ import { Plans2023Tooltip } from '../plans-2023-tooltip';
 import PopularBadge from '../popular-badge';
 import { StickyContainer } from '../sticky-container';
 import StorageAddOnDropdown from '../storage-add-on-dropdown';
-import type { PlansGridProps } from '../..';
 import type {
 	GridPlan,
 	TransformedFeatureObject,
 } from '../../hooks/npm-ready/data-store/use-grid-plans';
-import type { PlanActionOverrides } from '../../types';
+import type { ComparisonGridProps, PlanActionOverrides } from '../../types';
 import type {
 	FeatureObject,
 	Feature,
@@ -324,14 +323,6 @@ const FeatureFootnote = styled.span`
 		left: 0;
 	}
 `;
-
-interface ComparisonGridProps
-	extends Omit<
-		PlansGridProps,
-		'onUpgradeClick' | 'generatedWPComSubdomain' | 'gridPlanForSpotlight' | 'intent'
-	> {
-	onUpgradeClick: ( planSlug: PlanSlug ) => void;
-}
 
 type ComparisonGridHeaderProps = {
 	displayedGridPlans: GridPlan[];

--- a/client/my-sites/plans-grid/components/comparison-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/comparison-grid/index.tsx
@@ -325,7 +325,11 @@ const FeatureFootnote = styled.span`
 	}
 `;
 
-interface ComparisonGridProps extends Omit< PlansGridProps, 'onUpgradeClick' > {
+interface ComparisonGridProps
+	extends Omit<
+		PlansGridProps,
+		'onUpgradeClick' | 'generatedWPComSubdomain' | 'gridPlanForSpotlight' | 'intent'
+	> {
 	onUpgradeClick: ( planSlug: PlanSlug ) => void;
 }
 

--- a/client/my-sites/plans-grid/components/features-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/features-grid/index.tsx
@@ -1,14 +1,13 @@
 import {
+	FEATURE_CUSTOM_DOMAIN,
 	getPlanClass,
+	isBusinessTrial,
 	isFreePlan,
+	isWooExpressMediumPlan,
+	isWooExpressPlan,
+	isWooExpressSmallPlan,
 	isWpComFreePlan,
 	isWpcomEnterpriseGridPlan,
-	isWooExpressMediumPlan,
-	isWooExpressSmallPlan,
-	PlanSlug,
-	isBusinessTrial,
-	isWooExpressPlan,
-	FEATURE_CUSTOM_DOMAIN,
 } from '@automattic/calypso-products';
 import {
 	BloombergLogo,
@@ -16,15 +15,15 @@ import {
 	CondenastLogo,
 	DisneyLogo,
 	FacebookLogo,
+	FoldableCard,
 	SalesforceLogo,
 	SlackLogo,
 	TimeLogo,
-	FoldableCard,
 } from '@automattic/components';
 import classNames from 'classnames';
-import { LocalizeProps } from 'i18n-calypso';
 import { Component } from 'react';
 import { isStorageUpgradeableForPlan } from '../../lib/is-storage-upgradeable-for-plan';
+import { FeaturesGridProps } from '../../types';
 import { getStorageStringFromFeature } from '../../util';
 import PlanFeatures2023GridActions from '../actions';
 import PlanFeatures2023GridBillingTimeframe from '../billing-timeframe';
@@ -35,7 +34,6 @@ import PlanFeaturesContainer from '../plan-features-container';
 import PlanLogo from '../plan-logo';
 import { StickyContainer } from '../sticky-container';
 import StorageAddOnDropdown from '../storage-add-on-dropdown';
-import type { PlansGridProps } from '../..';
 import type { GridPlan } from '../../hooks/npm-ready/data-store/use-grid-plans';
 
 type PlanRowOptions = {
@@ -43,15 +41,7 @@ type PlanRowOptions = {
 	isStuck?: boolean;
 };
 
-interface FeaturesGridType extends Omit< PlansGridProps, 'onUpgradeClick' | 'intent' > {
-	isLargeCurrency: boolean;
-	translate: LocalizeProps[ 'translate' ];
-	currentPlanManageHref?: string;
-	isPlanUpgradeCreditEligible: boolean;
-	onUpgradeClick: ( planSlug: PlanSlug ) => void;
-}
-
-class FeaturesGrid extends Component< FeaturesGridType > {
+class FeaturesGrid extends Component< FeaturesGridProps > {
 	renderTable( renderedGridPlans: GridPlan[] ) {
 		const { translate, gridPlanForSpotlight, stickyRowOffset } = this.props;
 		// Do not render the spotlight plan if it exists

--- a/client/my-sites/plans-grid/components/features-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/features-grid/index.tsx
@@ -43,12 +43,12 @@ type PlanRowOptions = {
 	isStuck?: boolean;
 };
 
-interface FeaturesGridType extends PlansGridProps {
+interface FeaturesGridType extends Omit< PlansGridProps, 'onUpgradeClick' > {
 	isLargeCurrency: boolean;
 	translate: LocalizeProps[ 'translate' ];
 	currentPlanManageHref?: string;
 	isPlanUpgradeCreditEligible: boolean;
-	handleUpgradeClick: ( planSlug: PlanSlug ) => void;
+	onUpgradeClick: ( planSlug: PlanSlug ) => void;
 }
 
 class FeaturesGrid extends Component< FeaturesGridType > {
@@ -354,7 +354,7 @@ class FeaturesGrid extends Component< FeaturesGridType > {
 			planActionOverrides,
 			siteId,
 			isLargeCurrency,
-			handleUpgradeClick,
+			onUpgradeClick,
 		} = this.props;
 
 		return renderedGridPlans.map(
@@ -393,7 +393,7 @@ class FeaturesGrid extends Component< FeaturesGridType > {
 							isLaunchPage={ isLaunchPage }
 							isMonthlyPlan={ isMonthlyPlan }
 							onUpgradeClick={ ( overridePlanSlug ) =>
-								handleUpgradeClick( overridePlanSlug ?? planSlug )
+								onUpgradeClick( overridePlanSlug ?? planSlug )
 							}
 							planSlug={ planSlug }
 							currentSitePlanSlug={ currentSitePlanSlug }

--- a/client/my-sites/plans-grid/components/features-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/features-grid/index.tsx
@@ -43,7 +43,7 @@ type PlanRowOptions = {
 	isStuck?: boolean;
 };
 
-interface FeaturesGridType extends Omit< PlansGridProps, 'onUpgradeClick' > {
+interface FeaturesGridType extends Omit< PlansGridProps, 'onUpgradeClick' | 'intent' > {
 	isLargeCurrency: boolean;
 	translate: LocalizeProps[ 'translate' ];
 	currentPlanManageHref?: string;

--- a/client/my-sites/plans-grid/components/header-price.tsx
+++ b/client/my-sites/plans-grid/components/header-price.tsx
@@ -10,6 +10,9 @@ interface PlanFeatures2023GridHeaderPriceProps {
 	isLargeCurrency: boolean;
 	isPlanUpgradeCreditEligible: boolean;
 	currentSitePlanSlug?: string | null;
+	/**
+	 * @deprecated Site id is not used here to be cleaned up
+	 */
 	siteId?: number | null;
 	visibleGridPlans: GridPlan[];
 }

--- a/client/my-sites/plans-grid/grid-context.tsx
+++ b/client/my-sites/plans-grid/grid-context.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext } from '@wordpress/element';
+import { GridContextProps } from './types';
 import type {
 	GridPlan,
 	PlansIntent,
@@ -16,21 +17,13 @@ interface PlansGridContext {
 
 const PlansGridContext = createContext< PlansGridContext >( {} as PlansGridContext );
 
-interface PlansGridContextProviderProps {
-	intent?: PlansIntent;
-	gridPlans: GridPlan[];
-	usePricingMetaForGridPlans: UsePricingMetaForGridPlans;
-	allFeaturesList: FeatureList;
-	children: React.ReactNode;
-}
-
 const PlansGridContextProvider = ( {
 	intent,
 	gridPlans,
 	usePricingMetaForGridPlans,
 	allFeaturesList,
 	children,
-}: PlansGridContextProviderProps ) => {
+}: GridContextProps ) => {
 	const gridPlansIndex = gridPlans.reduce(
 		( acc, gridPlan ) => ( {
 			...acc,

--- a/client/my-sites/plans-grid/index.tsx
+++ b/client/my-sites/plans-grid/index.tsx
@@ -1,67 +1,14 @@
 import { useTranslate } from 'i18n-calypso';
 import ComparisonGrid from './components/comparison-grid';
 import FeaturesGrid from './components/features-grid';
-import PlanTypeSelector, { type PlanTypeSelectorProps } from './components/plan-type-selector';
+import PlanTypeSelector from './components/plan-type-selector';
 import PlansGridContextProvider from './grid-context';
 import useIsLargeCurrency from './hooks/npm-ready/use-is-large-currency';
 import useUpgradeClickHandler from './hooks/npm-ready/use-upgrade-click-handler';
 import { useIsPlanUpgradeCreditVisible } from './hooks/use-is-plan-upgrade-credit-visible';
 import { usePlanPricingInfoFromGridPlans } from './hooks/use-plan-pricing-info-from-grid-plans';
-import type {
-	GridPlan,
-	PlansIntent,
-	UsePricingMetaForGridPlans,
-} from './hooks/npm-ready/data-store/use-grid-plans';
-import type { DataResponse, PlanActionOverrides } from './types';
-import type { FeatureList, WPComStorageAddOnSlug, PlanSlug } from '@automattic/calypso-products';
-import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import './style.scss';
-
-/*
- *	TODO clk: On PlansGridProps:
- *	1.	These props need to be split into what's needed separately for the internal grids and what's needed for the exported wrappers.
- *		This is currently also used as the internal type for the FeaturesGrid (wrongly).
- *			- onUpgradeClick is only needed for the wrappers exported from here. Internally the grids take a transformed
- *			handleUpgradeClick/onUpgradeClick function (force renamed to handleUpgradeClick in FeaturesGrid)
- *			- allFeaturesList is only relevant for the ComparisonGrid
- *			- gridPlanForSpotlight is only relevant for the FeaturesGrid
- *			- etc.
- *	2.	Explicitly set optional props and default values. Only absolutely vital props should be required.
- */
-export interface PlansGridProps {
-	gridPlans: GridPlan[];
-	gridPlanForSpotlight?: GridPlan;
-	// allFeaturesList temporary until feature definitions are ported to calypso-products package
-	allFeaturesList: FeatureList;
-	isInSignup: boolean;
-	siteId?: number | null;
-	isLaunchPage?: boolean | null;
-	isReskinned?: boolean;
-	onUpgradeClick?: (
-		cartItems?: MinimalRequestCartProduct[] | null,
-		clickedPlanSlug?: PlanSlug
-	) => void;
-	onStorageAddOnClick?: ( addOnSlug: WPComStorageAddOnSlug ) => void;
-	paidDomainName?: string;
-	generatedWPComSubdomain: DataResponse< { domain_name: string } >; // used to show a wpcom free domain in the Free plan column when a paid domain is picked.
-	intervalType: string;
-	currentSitePlanSlug?: string | null;
-	hideUnavailableFeatures?: boolean; // used to hide features that are not available, instead of strike-through as explained in #76206
-	planActionOverrides?: PlanActionOverrides;
-	// Value of the `?plan=` query param, so we can highlight a given plan.
-	selectedPlan?: string;
-	// Value of the `?feature=` query param, so we can highlight a given feature and hide plans without it.
-	selectedFeature?: string;
-	intent?: PlansIntent;
-	isCustomDomainAllowedOnFreePlan: DataResponse< boolean >; // indicate when a custom domain is allowed to be used with the Free plan.
-	showLegacyStorageFeature?: boolean;
-	showUpgradeableStorage: boolean; // feature flag used to show the storage add-on dropdown
-	stickyRowOffset: number;
-	usePricingMetaForGridPlans: UsePricingMetaForGridPlans;
-	showRefundPeriod?: boolean;
-	// only used for comparison grid
-	planTypeSelectorProps?: PlanTypeSelectorProps;
-}
+import type { ComparisonGridExternalProps, FeaturesGridExternalProps } from './types';
 
 const WrappedComparisonGrid = ( {
 	siteId,
@@ -76,12 +23,11 @@ const WrappedComparisonGrid = ( {
 	currentSitePlanSlug,
 	selectedPlan,
 	selectedFeature,
-	showLegacyStorageFeature,
 	showUpgradeableStorage,
 	onStorageAddOnClick,
 	stickyRowOffset,
 	...otherProps
-}: PlansGridProps ) => {
+}: ComparisonGridExternalProps ) => {
 	const handleUpgradeClick = useUpgradeClickHandler( {
 		gridPlans,
 		onUpgradeClick,
@@ -103,7 +49,6 @@ const WrappedComparisonGrid = ( {
 				siteId={ siteId }
 				selectedPlan={ selectedPlan }
 				selectedFeature={ selectedFeature }
-				showLegacyStorageFeature={ showLegacyStorageFeature }
 				showUpgradeableStorage={ showUpgradeableStorage }
 				stickyRowOffset={ stickyRowOffset }
 				onStorageAddOnClick={ onStorageAddOnClick }
@@ -113,7 +58,7 @@ const WrappedComparisonGrid = ( {
 	);
 };
 
-const WrappedFeaturesGrid = ( props: PlansGridProps ) => {
+const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 	const { siteId, intent, gridPlans, usePricingMetaForGridPlans, allFeaturesList, onUpgradeClick } =
 		props;
 	const translate = useTranslate();
@@ -146,14 +91,14 @@ const WrappedFeaturesGrid = ( props: PlansGridProps ) => {
 				isPlanUpgradeCreditEligible={ isPlanUpgradeCreditEligible }
 				isLargeCurrency={ isLargeCurrency }
 				translate={ translate }
-				handleUpgradeClick={ handleUpgradeClick }
+				onUpgradeClick={ handleUpgradeClick }
 			/>
 		</PlansGridContextProvider>
 	);
 };
 
 export {
-	WrappedFeaturesGrid as FeaturesGrid,
 	WrappedComparisonGrid as ComparisonGrid,
+	WrappedFeaturesGrid as FeaturesGrid,
 	PlanTypeSelector,
 };

--- a/client/my-sites/plans-grid/types.ts
+++ b/client/my-sites/plans-grid/types.ts
@@ -1,5 +1,13 @@
 import { FeatureObject } from 'calypso/lib/plans/features-list';
-import type { TranslateResult } from 'i18n-calypso';
+import { type PlanTypeSelectorProps } from './components/plan-type-selector';
+import type {
+	GridPlan,
+	PlansIntent,
+	UsePricingMetaForGridPlans,
+} from './hooks/npm-ready/data-store/use-grid-plans';
+import type { FeatureList, PlanSlug, WPComStorageAddOnSlug } from '@automattic/calypso-products';
+import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
+import type { LocalizeProps, TranslateResult } from 'i18n-calypso';
 
 export type TransformedFeatureObject = FeatureObject & {
 	availableForCurrentPlan: boolean;
@@ -26,3 +34,64 @@ export type DataResponse< T > = {
 	isLoading: boolean;
 	result?: T;
 };
+
+export interface CommonGridProps {
+	/**
+	 * Site id may not be used in ComparisonGrid, but need to be investigated further
+	 */
+	siteId?: number | null;
+	isInSignup: boolean;
+	isLaunchPage?: boolean | null;
+	isReskinned?: boolean;
+	onStorageAddOnClick?: ( addOnSlug: WPComStorageAddOnSlug ) => void;
+	intervalType: string;
+	currentSitePlanSlug?: string | null;
+	hideUnavailableFeatures?: boolean; // used to hide features that are not available, instead of strike-through as explained in #76206
+	planActionOverrides?: PlanActionOverrides;
+
+	// Value of the `?feature=` query param, so we can highlight a given feature and hide plans without it.
+	selectedFeature?: string;
+	showUpgradeableStorage: boolean; // feature flag used to show the storage add-on dropdown
+	stickyRowOffset: number;
+	showRefundPeriod?: boolean;
+	// only used for comparison grid
+	planTypeSelectorProps?: PlanTypeSelectorProps;
+	onUpgradeClick: ( planSlug: PlanSlug ) => void;
+}
+
+export interface FeaturesGridProps extends CommonGridProps {
+	gridPlans: GridPlan[];
+	isLargeCurrency: boolean;
+	translate: LocalizeProps[ 'translate' ];
+	currentPlanManageHref?: string;
+	isPlanUpgradeCreditEligible: boolean;
+	generatedWPComSubdomain: DataResponse< { domain_name: string } >;
+	gridPlanForSpotlight?: GridPlan;
+	isCustomDomainAllowedOnFreePlan: DataResponse< boolean >; // indicate when a custom domain is allowed to be used with the Free plan.
+	paidDomainName?: string;
+	showLegacyStorageFeature: boolean;
+}
+
+export interface ComparisonGridProps extends CommonGridProps {
+	// Value of the `?plan=` query param, so we can highlight a given plan.
+	selectedPlan?: string;
+}
+
+export type GridContextProps = {
+	gridPlans: GridPlan[];
+	allFeaturesList: FeatureList;
+	intent?: PlansIntent;
+	usePricingMetaForGridPlans: UsePricingMetaForGridPlans;
+	onUpgradeClick?: (
+		cartItems?: MinimalRequestCartProduct[] | null,
+		clickedPlanSlug?: PlanSlug
+	) => void;
+};
+
+export type ComparisonGridExternalProps = GridContextProps &
+	Omit< ComparisonGridProps, 'onUpgradeClick' >;
+export type FeaturesGridExternalProps = GridContextProps &
+	Omit<
+		FeaturesGridProps,
+		'onUpgradeClick' | 'isLargeCurrency' | 'translate' | 'isPlanUpgradeCreditEligible'
+	>;

--- a/client/my-sites/plans-grid/types.ts
+++ b/client/my-sites/plans-grid/types.ts
@@ -82,16 +82,24 @@ export type GridContextProps = {
 	allFeaturesList: FeatureList;
 	intent?: PlansIntent;
 	usePricingMetaForGridPlans: UsePricingMetaForGridPlans;
-	onUpgradeClick?: (
-		cartItems?: MinimalRequestCartProduct[] | null,
-		clickedPlanSlug?: PlanSlug
-	) => void;
+	children: React.ReactNode;
 };
 
-export type ComparisonGridExternalProps = GridContextProps &
-	Omit< ComparisonGridProps, 'onUpgradeClick' >;
-export type FeaturesGridExternalProps = GridContextProps &
+export type ComparisonGridExternalProps = Omit< GridContextProps, 'children' > &
+	Omit< ComparisonGridProps, 'onUpgradeClick' > & {
+		onUpgradeClick?: (
+			cartItems?: MinimalRequestCartProduct[] | null,
+			clickedPlanSlug?: PlanSlug
+		) => void;
+	};
+
+export type FeaturesGridExternalProps = Omit< GridContextProps, 'children' > &
 	Omit<
 		FeaturesGridProps,
 		'onUpgradeClick' | 'isLargeCurrency' | 'translate' | 'isPlanUpgradeCreditEligible'
-	>;
+	> & {
+		onUpgradeClick?: (
+			cartItems?: MinimalRequestCartProduct[] | null,
+			clickedPlanSlug?: PlanSlug
+		) => void;
+	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Fixes https://github.com/Automattic/wp-calypso/issues/82335
## Proposed Changes

* Proposes a restructured prop setup where the `FeaturesGridProps`, `ComparisonGridProps` have a private set of props and also share a set of `CommonGridProps`.
* The props that are required by the grid context will be `GridContextProps`
* External props contracts for the FeaturesGrid and ComparisonGrid are defined by selectively combining `CommonGridProps` and the respective props Contracts (`FeaturesGridProps`, `ComparisonGridProps`).
* The upgrade click callback is handled uniquely since the callback we provide externally and the callback used by the internal Features, Comparison grids have different prop signatures. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* This is a refactor and the behaviour of the grid in production should not be changed.
* Make sure the general behaviour of the grids on onboarding and on a purchased site content works well.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?