### PR TITLE
Add tracks event when viewing the reader on the Customer Home

### DIFF
--- a/client/my-sites/customer-home/cards/features/reader/index.tsx
+++ b/client/my-sites/customer-home/cards/features/reader/index.tsx
@@ -47,7 +47,7 @@ const ReaderCard = ( props: ReaderCardProps ) => {
 
 	useEffect( () => {
 		dispatch( recordReaderTracksEvent( 'calypso_reader_discover_viewed' ) );
-	}, [] );
+	}, [ dispatch ] );
 
 	return (
 		<>

--- a/client/my-sites/customer-home/cards/features/reader/index.tsx
+++ b/client/my-sites/customer-home/cards/features/reader/index.tsx
@@ -46,7 +46,7 @@ const ReaderCard = ( props: ReaderCardProps ) => {
 	const dispatch = useDispatch();
 
 	useEffect( () => {
-		dispatch( recordReaderTracksEvent( 'calypso_reader_discover_view' ) );
+		dispatch( recordReaderTracksEvent( 'calypso_reader_discover_viewed' ) );
 	}, [] );
 
 	return (

--- a/client/my-sites/customer-home/cards/features/reader/index.tsx
+++ b/client/my-sites/customer-home/cards/features/reader/index.tsx
@@ -1,6 +1,7 @@
 import { useLocale } from '@automattic/i18n-utils';
 import { useQuery } from '@tanstack/react-query';
 import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
 import iconReaderLightbulb from 'calypso/assets/images/customer-home/reader-lightbulb.svg';
 import withDimensions from 'calypso/lib/with-dimensions';
 import wpcom from 'calypso/lib/wp';
@@ -8,6 +9,8 @@ import { trackScrollPage } from 'calypso/reader/controller-helper';
 import DiscoverNavigation from 'calypso/reader/discover/discover-navigation';
 import { DEFAULT_TAB, buildDiscoverStreamKey } from 'calypso/reader/discover/helper';
 import Stream from 'calypso/reader/stream';
+import { useDispatch } from 'calypso/state';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
 import './style.scss';
 
@@ -40,6 +43,11 @@ const ReaderCard = ( props: ReaderCardProps ) => {
 	const selectedTab = queryParams.get( 'selectedTab' ) || DEFAULT_TAB;
 
 	const streamKey = buildDiscoverStreamKey( selectedTab, [ 'dailyprompt' ] );
+	const dispatch = useDispatch();
+
+	useEffect( () => {
+		dispatch( recordReaderTracksEvent( 'calypso_reader_discover_view' ) );
+	}, [] );
 
 	return (
 		<>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p4lB9U-YY-p2#comment-1453

## Proposed Changes

* Adds the `calypso_reader_discover_viewed` tracks event when viewing the reader on the Customer Home.

![Screen Shot 2023-11-27 at 23 07 18](https://github.com/Automattic/wp-calypso/assets/1234758/3788b5bb-8ab6-4355-be02-84f12855017b)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso Live link or apply this PR to your local environment
* Make sure you are sandboxed
* Edit this(fbhepr%2Skers%2Sjcpbz%2Sjc%2Qpbagrag%2Syvo%2Subzr%2Sivrjf.cuc%3Se%3Q0o594289%23408-og) condition to always return true so you can fall into the experiment.
* Create a site through `/setup/start-writing`
* Go through the flow until you reach the Customer Home, dismiss or complete actions on the main banners
* You should then see the Reader on the Customer Home
* Make sure that the `calypso_reader_discover_viewed` tracks events being fired from the customer home.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?