### PR TITLE
Purchase Management: Hide tooltip if the text isn't translated

### DIFF
--- a/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
@@ -6,6 +6,7 @@ import {
 	isJetpackProduct,
 	JETPACK_LEGACY_PLANS,
 } from '@automattic/calypso-products';
+import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import InfoPopover from 'calypso/components/info-popover';
@@ -51,6 +52,7 @@ function PurchaseMetaExpiration( {
 	renderRenewsOrExpiresOnLabel,
 }: ExpirationProps ) {
 	const translate = useTranslate();
+	const { hasTranslation } = useI18n();
 	const moment = useLocalizedMoment();
 
 	const isProductOwner = purchase?.userId === useSelector( getCurrentUserId );
@@ -152,6 +154,11 @@ function PurchaseMetaExpiration( {
 			return false;
 		};
 
+		// TODO - remove this once the translation is available in all languages - see https://translate.wordpress.com/deliverables/overview/9768580/
+		const hasToolTipTextBeenTranslated = hasTranslation(
+			'Your subscription is paid through {{dateSpan}}%(expireDate)s{{/dateSpan}}, but will be renewed prior to that date. {{inlineSupportLink}}Learn more{{/inlineSupportLink}}'
+		);
+
 		return (
 			<li className="manage-purchase__meta-expiration">
 				<em className="manage-purchase__detail-label">{ translate( 'Subscription Renewal' ) }</em>
@@ -168,7 +175,7 @@ function PurchaseMetaExpiration( {
 					} ) }
 				>
 					{ subsBillingText }
-					{ shouldShowTooltip() && (
+					{ shouldShowTooltip() && hasToolTipTextBeenTranslated && (
 						<InfoPopover position="bottom right">
 							{ translate(
 								'Your subscription is paid through {{dateSpan}}%(expireDate)s{{/dateSpan}}, but will be renewed prior to that date. {{inlineSupportLink}}Learn more{{/inlineSupportLink}}',

--- a/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-expiration.tsx
@@ -8,7 +8,7 @@ import {
 } from '@automattic/calypso-products';
 import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
-import { useTranslate } from 'i18n-calypso';
+import { useTranslate, getLocaleSlug } from 'i18n-calypso';
 import InfoPopover from 'calypso/components/info-popover';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
@@ -54,7 +54,7 @@ function PurchaseMetaExpiration( {
 	const translate = useTranslate();
 	const { hasTranslation } = useI18n();
 	const moment = useLocalizedMoment();
-
+	const locale = getLocaleSlug();
 	const isProductOwner = purchase?.userId === useSelector( getCurrentUserId );
 	const isJetpackPurchase = isJetpackPlan( purchase ) || isJetpackProduct( purchase );
 	const isCancellableSitelessPurchase = isAkismetTemporarySitePurchase( purchase );
@@ -175,7 +175,7 @@ function PurchaseMetaExpiration( {
 					} ) }
 				>
 					{ subsBillingText }
-					{ shouldShowTooltip() && hasToolTipTextBeenTranslated && (
+					{ shouldShowTooltip() && ( locale === 'en' || hasToolTipTextBeenTranslated ) && (
 						<InfoPopover position="bottom right">
 							{ translate(
 								'Your subscription is paid through {{dateSpan}}%(expireDate)s{{/dateSpan}}, but will be renewed prior to that date. {{inlineSupportLink}}Learn more{{/inlineSupportLink}}',


### PR DESCRIPTION
This is a follow up PR to hide the purchase management tooltip added in https://github.com/Automattic/wp-calypso/pull/83383#issuecomment-1828633469 if the tooltip text is not translated.

Related to https://github.com/Automattic/wp-calypso/pull/83383#issuecomment-1828633469

## Proposed Changes
* This PR adds two conditions when showing/hiding a tooltip, if the user's locale is set to `en` OR the user's locale `hasTranslations`, then show the tooltip.
* This will effectively hide the tooltip until the tooltip's language has a translated string for the user's locale.

## Testing Instructions
* Go to `/me/purchases/` and select a purchase that is set to renew
* In the Subscription Renewal column you should see a tooltip icon with English text

![image](https://github.com/Automattic/wp-calypso/assets/16580129/4444f39a-8a9e-4bbd-af7b-64fb28560c90)


* Now, set your account language to Spanish (or another locale not yet translated)
* Go to `/me/purchases/` and select a purchase that is set to renew
* In the Purchase Renewal column you should see _no tooltip_ icon

![image](https://github.com/Automattic/wp-calypso/assets/16580129/7b067d27-5835-4815-aa52-48c66b0c1326)