### PR TITLE
Fix hosting signup tracks bug introduced by #84191

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -347,7 +347,7 @@ class Signup extends Component {
 			intent: get( signupDependencies, 'intent' ),
 			starting_point: get( signupDependencies, 'startingPoint' ),
 			is_in_hosting_flow: hostingFlow,
-			...( flow ? { flow } : {} ),
+			...( flow && flow !== 'new-hosted-site' ? { flow } : {} ),
 		};
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This change fixes a bug that was introduced in #84191. The meaning of the `?flow` query param was extended to also override the `flow` prop of `calypso_signup_*` events. That breaks events we use to analyse performance of the hosting signup flow which uses `?flow` but never intended it to override existing tracks events props.

I discuss here what would be a better fix that'd work for the hosting and sensei flows: p1701139288935069/1701130484.284429-slack-C04H4NY6STW

But in the meantime if we really wanted to quickly fix our hosting events we could add this hack:
* If `?flow=new-hosted-site` then we ignore the new behaviour of overriding tracks events props

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**The hosting flow**
* Go through hosting flow starting at `wordpress.com/hosting`, but switching to `calypso.localhost:3000` once you land in Calypso
* Check the `calypso_signup_start` and `calypso_signup_step_start` events use `flow=hosting` prop.

**The sensei flow**
* Start at `/setup/sensei` but logged out
* Go through flow until you get to the account creation step
* Check the `calypso_signup_start` and `calypso_signup_step_start` events use `flow=sensei` prop.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?