### PR TITLE
Jetpack Manage: Show the total cost for the selected bundle licenses

### DIFF
--- a/client/jetpack-cloud/components/layout/header.tsx
+++ b/client/jetpack-cloud/components/layout/header.tsx
@@ -16,7 +16,7 @@ export function LayoutHeaderSubtitle( { children }: Props ) {
 }
 
 export function LayoutHeaderActions( { children }: Props ) {
-	return <h2 className="jetpack-cloud-layout__header-actions">{ children }</h2>;
+	return <div className="jetpack-cloud-layout__header-actions">{ children }</div>;
 }
 
 export default function LayoutHeader( { showStickyContent, children }: Props ) {

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/index.tsx
@@ -19,6 +19,7 @@ import { useProductBundleSize } from './hooks/use-product-bundle-size';
 import useSubmitForm from './hooks/use-submit-form';
 import LicensesForm from './licenses-form';
 import ReviewLicenses from './review-licenses';
+import TotalCost from './total-cost';
 import type { SelectedLicenseProp } from './types';
 import type { AssignLicenceProps } from '../types';
 
@@ -88,24 +89,27 @@ export default function IssueLicenseV2( { selectedSite, suggestedProduct }: Assi
 						</Subtitle>
 						<Actions>
 							{ selectedLicenses.length > 0 && (
-								<Button
-									primary
-									className="issue-license-v2__select-license"
-									busy={ ! isReady }
-									onClick={ onClickIssueLicenses }
-								>
-									{ translate(
-										'Review %(numLicenses)d license',
-										'Review %(numLicenses)d licenses',
-										{
-											context: 'button label',
-											count: selectedLicenseCount,
-											args: {
-												numLicenses: selectedLicenseCount,
-											},
-										}
-									) }
-								</Button>
+								<div className="issue-license-v2__actions">
+									<TotalCost selectedLicenses={ selectedLicenses } />
+									<Button
+										primary
+										className="issue-license-v2__select-license"
+										busy={ ! isReady }
+										onClick={ onClickIssueLicenses }
+									>
+										{ translate(
+											'Review %(numLicenses)d license',
+											'Review %(numLicenses)d licenses',
+											{
+												context: 'button label',
+												count: selectedLicenseCount,
+												args: {
+													numLicenses: selectedLicenseCount,
+												},
+											}
+										) }
+									</Button>
+								</div>
 							) }
 						</Actions>
 					</LayoutHeader>

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/pricing-breakdown.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/pricing-breakdown.tsx
@@ -48,7 +48,11 @@ export default function PricingBreakdown( {
 		<>
 			<div className="review-licenses__pricing-breakdown">
 				{ selectedLicenses.map( ( license ) => (
-					<LicenseItem license={ license } userProducts={ userProducts } />
+					<LicenseItem
+						key={ `license-item-${ license.product_id }` }
+						license={ license }
+						userProducts={ userProducts }
+					/>
 				) ) }
 			</div>
 			<div className="review-licenses__pricing-breakdown-total">

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/style.scss
@@ -22,3 +22,14 @@
 		color: var(--studio-white);
 	}
 }
+
+.issue-license-v2__actions {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	gap: 8px;
+
+	@include breakpoint-deprecated( "<960px" ) {
+		justify-content: normal;
+	}
+}

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/total-cost/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/total-cost/index.tsx
@@ -1,0 +1,32 @@
+import formatCurrency from '@automattic/format-currency';
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'calypso/state';
+import { getProductsList } from 'calypso/state/products-list/selectors';
+import { getTotalInvoiceValue } from '../lib/pricing';
+import type { SelectedLicenseProp } from '../types';
+
+import './style.scss';
+
+interface Props {
+	selectedLicenses: SelectedLicenseProp[];
+}
+
+export default function TotalCost( { selectedLicenses }: Props ) {
+	const translate = useTranslate();
+
+	const userProducts = useSelector( getProductsList );
+	const { discountedCost } = getTotalInvoiceValue( userProducts, selectedLicenses );
+	const currencyCode = selectedLicenses?.[ 0 ]?.currency ?? 'USD';
+	const formattedTotalCost = <strong>{ formatCurrency( discountedCost, currencyCode ) }</strong>;
+
+	const getTotalCostDisplayString = () => {
+		return translate( 'Total: {{formattedTotalCost/}}', {
+			comment: `%(formattedTotalCost)s is a price formatted for display in the user's locale. In en-us it would be like "$4.00"`,
+			components: {
+				formattedTotalCost,
+			},
+		} );
+	};
+
+	return <div className="issue-license-v2__total-cost">{ getTotalCostDisplayString() }</div>;
+}

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/total-cost/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/total-cost/style.scss
@@ -1,0 +1,10 @@
+
+.issue-license-v2__total-cost {
+	border: 1px solid var(--studio-gray-5);
+	border-radius: 4px;
+	padding: 8px 14px;
+}
+
+.jetpack-cloud-layout__sticky-header .issue-license-v2__total-cost {
+	border: none;
+}


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/121

## Proposed Changes

This PR displays the total cost for the selected bundle licenses.

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Visit the Jetpack Cloud link > Replace `dashboard` in the URL with `/partner-portal/issue-license?flags=jetpack/bundle-licensing`.
2. Select a few licenses and verify that the total cost of the selected licenses is displayed as shown below. Also, scroll through the page and verify the total cost is displayed on the sticky header.

Note: The sticky header is not responsive on all the devices. This will be fixed in another PR.

**Normal header**

![mobile (45)](https://github.com/Automattic/wp-calypso/assets/10586875/7453c54a-6ad9-4a32-9d2e-fd259b10674f)

**Sticky header**

![mobile (46)](https://github.com/Automattic/wp-calypso/assets/10586875/74bc2add-1be1-4535-9c57-744832c022ba)

**Tablet view**

![mobile (47)](https://github.com/Automattic/wp-calypso/assets/10586875/25f5d8b6-c533-4a20-a793-c4fbe60abc4f)

**Mobile view**

![mobile (48)](https://github.com/Automattic/wp-calypso/assets/10586875/459a1363-38ab-42ea-9912-0c38c942ed5e)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?