### PR TITLE
Change the name of the sensei query prop to main_flow

### DIFF
--- a/client/landing/stepper/declarative-flow/sensei.ts
+++ b/client/landing/stepper/declarative-flow/sensei.ts
@@ -20,7 +20,7 @@ import './internals/sensei.scss';
 function getStartUrl( step: string, locale: string ) {
 	const localeUrlPart = locale && locale !== 'en' ? `/${ locale }` : '';
 
-	return `/start/account/user${ localeUrlPart }?redirect_to=/setup/${ SENSEI_FLOW }/${ step }&flow=${ SENSEI_FLOW }`;
+	return `/start/account/user${ localeUrlPart }?redirect_to=/setup/${ SENSEI_FLOW }/${ step }&main_flow=${ SENSEI_FLOW }`;
 }
 
 const sensei: Flow = {

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -331,7 +331,7 @@ class Signup extends Component {
 
 	getRecordProps() {
 		const { signupDependencies, hostingFlow, queryObject } = this.props;
-		const flow = queryObject?.flow;
+		const mainFlow = queryObject?.main_flow;
 
 		let theme = get( signupDependencies, 'selectedDesign.theme' );
 
@@ -347,7 +347,7 @@ class Signup extends Component {
 			intent: get( signupDependencies, 'intent' ),
 			starting_point: get( signupDependencies, 'startingPoint' ),
 			is_in_hosting_flow: hostingFlow,
-			...( flow ? { flow } : {} ),
+			...( mainFlow ? { flow: mainFlow } : {} ),
 		};
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/84153

## Proposed Changes

* We introduced a query param to keep the flow name 'sensei' instead af 'account' when the user was redirected to the login flow from senesi flow here https://github.com/Automattic/wp-calypso/pull/84191, but query param named flow was already being used for newly hosted sites, so in tracks, it showed a different flow name than before. So we've changed the query param from sensei to `main_flow` to avoid this.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Add a debugging step at https://github.com/Automattic/wp-calypso/blob/a7c2207d0929c98991013206153a6277e747a6a1/client/lib/analytics/tracks.js#L11
2. Start at http://calypso.localhost:3000/setup/sensei/senseiSetup.
3. Enter a _Site name_ and click _Continue_.
4. Output the `eventName` and `eventProperties` to the console when the debugger is triggered.
5. Make sure that the value `flow` is still set to `senesi`, not `account` as it says in the issue.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?