### PR TITLE
Lighten placeholder colour for Launchpad checklist

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -12,11 +12,11 @@ import QueryMembershipsSettings from 'calypso/components/data/query-memberships-
 import ClipboardButton from 'calypso/components/forms/clipboard-button';
 import Tooltip from 'calypso/components/tooltip';
 import { useDomainEmailVerification } from 'calypso/data/domains/use-domain-email-verfication';
-import { NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
+import { type NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { ResponseDomain } from 'calypso/lib/domains/types';
+import { type ResponseDomain } from 'calypso/lib/domains/types';
 import RecurringPaymentsPlanAddEditModal from 'calypso/my-sites/earn/components/add-edit-plan-modal';
 import { TYPE_TIER } from 'calypso/my-sites/earn/memberships/constants';
 import { useSelector } from 'calypso/state';
@@ -25,7 +25,7 @@ import { getConnectUrlForSiteId } from 'calypso/state/memberships/settings/selec
 import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
 import { getEnhancedTasks } from './task-helper';
 import { getLaunchpadTranslations } from './translations';
-import { Task } from './types';
+import { type Task } from './types';
 
 type SidebarProps = {
 	sidebarDomain: ResponseDomain;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -129,6 +129,11 @@
 		margin: 0 20px 24px 24px;
 		gap: 80px;
 	}
+
+	.launchpad__checklist-wrapper .checklist__tasks .checklist-item__task-content.is-placeholder .checklist-item__content {
+		/* Override default placeholder colours to align with other elements on the page. */
+		background-color: var(--color-neutral-5);
+	}
 }
 
 .launchpad__sidebar-content-container {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #84567

## Proposed Changes

* This PR builds on @andres-blanco's work in #84567 and lightens the colour of the placeholder items we show in the fullscreen launchpad, as per [this suggestion](https://github.com/Automattic/wp-calypso/pull/84567#issuecomment-1829071004) from @nuriapenya
* The PR also switches some imports to use type imports

### Screen capture

https://github.com/Automattic/wp-calypso/assets/3376401/4c8aa13f-335e-4edb-8544-cb5ea67c72ea

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch locally or via Calypso.live
* Navigate to the fullscreen launchpad you have for an existing site, or create a new site that will show you a fullscreen launchpad (e.g. `/setup/free` or `/setup/newsletter`)
* Verify that you see the lighter colour for the placeholders
  - If your page is loading too quickly, try reloading the page, or even throttling your network and then reloading the page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [N/A] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
