### PR TITLE
Assembler: Update the inserted pattern auto-scroll logic in the large preview

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -224,7 +224,15 @@ const PatternLargePreview = ( {
 			}
 		};
 
-		scrollIntoView();
+		// Only scroll when the pattern is added via the pattern list panel.
+		// This prevents auto-scrolling when the pattern is added via shuffle, which causes the pattern action bar to jump around.
+		const focusedElement = document.activeElement;
+		if (
+			! focusedElement ||
+			focusedElement.classList.contains( 'pattern-list-renderer__pattern-list-item' )
+		) {
+			scrollIntoView();
+		}
 
 		return () => {
 			if ( timerId ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #83528

## Proposed Changes

This PR updates the logic of inserted patterns in the large preview, so that shuffled patterns are not automatically scrolling into view. This prevents the pattern action bar jumping around when users shuffle patterns. 

Before:

https://github.com/Automattic/wp-calypso/assets/797888/03284e9d-8989-4731-9ff9-6f4b55729d62

After:


https://github.com/Automattic/wp-calypso/assets/797888/8b73505f-c3e1-4e1c-a6c2-27d61d85565a



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Assembler.
* Select any patterns.
* Hover on a pattern in the large preview and click on the Shuffle button.
* Ensure that the large preview doesn't automatically scroll to position the shuffled pattern into the view.
* Now insert any pattern from the sidebar's pattern list.
* Ensure that the large preview automatically scroll to position the inserted pattern into the view.
 
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?