### PR TITLE
Purchases: don't render meta attribute for storage addon

### DIFF
--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -850,6 +850,10 @@ export function purchaseType( purchase: Purchase ) {
 		return null;
 	}
 
+	if ( isTieredVolumeSpaceAddon( purchase ) ) {
+		return null;
+	}
+
 	if ( isGSuiteOrGoogleWorkspace( purchase ) ) {
 		return i18n.translate( 'Mailboxes and Productivity Tools at %(domain)s', {
 			args: {


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/4633

## Proposed Changes

On `trunk`, we don't render a description for space add-ons in the purchases page:

<img width="460" alt="image" src="https://github.com/Automattic/wp-calypso/assets/26530524/f788546a-654c-47f8-b4e1-9ee18cf4f2f7">

But if the storage add-on has a meta attribute, it's rendering whatever is in meta. Let's not render it:

| Before | After |
| -------| ------|
| <img width="512" alt="image" src="https://github.com/Automattic/wp-calypso/assets/26530524/1698f5a9-c447-4e06-8273-c3a139b50955"> | <img width="449" alt="image" src="https://github.com/Automattic/wp-calypso/assets/26530524/16baa490-2700-4807-9e43-47e8cd868abc"> |

## Testing Instructions

Buy a space add-on normally (outside the agency migration flow), open purchases and verify that no description is displayed for the storage add-on.

Buy a space add-on from the agency migration offer and verify that on `trunk` you see the `agency-offer` meta being displayed; checkout this branch and verify that the description is gone.