### PR TITLE
Theme install: fix wp-admin URLs

### DIFF
--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -325,7 +325,7 @@ function Options( { isFSEActive, recordTracksEvent, searchTerm, translate, upsel
 					destination: 'upload-theme',
 				} ),
 			url: isAtomic
-				? `https://${ selectedSite.slug }/wp-admin/theme-install.php`
+				? `${ selectedSite.options.admin_url }theme-install.php`
 				: `/themes/upload/${ selectedSite.slug }`,
 			buttonText: translate( 'Upload theme' ),
 		} );

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -18,6 +18,7 @@ import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import getSiteEditorUrl from 'calypso/state/selectors/get-site-editor-url';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
+import { getSiteThemeInstallUrl } from 'calypso/state/sites/selectors';
 import { upsellCardDisplayed as upsellCardDisplayedAction } from 'calypso/state/themes/actions';
 import { DEFAULT_THEME_QUERY } from 'calypso/state/themes/constants';
 import { getThemesBookmark } from 'calypso/state/themes/themes-ui/selectors';
@@ -236,6 +237,9 @@ function Options( { isFSEActive, recordTracksEvent, searchTerm, translate, upsel
 			assembler: '1',
 		} )
 	);
+	const siteThemeInstallUrl = useSelector( ( state ) =>
+		getSiteThemeInstallUrl( state, selectedSite?.ID )
+	);
 	const assemblerCtaData = usePatternAssemblerCtaData();
 
 	const options = [];
@@ -324,9 +328,7 @@ function Options( { isFSEActive, recordTracksEvent, searchTerm, translate, upsel
 					search_term: searchTerm,
 					destination: 'upload-theme',
 				} ),
-			url: isAtomic
-				? `${ selectedSite.options.admin_url }theme-install.php`
-				: `/themes/upload/${ selectedSite.slug }`,
+			url: isAtomic ? siteThemeInstallUrl : `/themes/upload/${ selectedSite.slug }`,
 			buttonText: translate( 'Upload theme' ),
 		} );
 	} else {

--- a/client/my-sites/themes/install-theme-button.jsx
+++ b/client/my-sites/themes/install-theme-button.jsx
@@ -32,12 +32,12 @@ function getInstallThemeUrl( state, siteId ) {
 	return `/themes/upload/${ siteSlug }`;
 }
 
-function getSiteType( atomicSite, jetpackSite, selectedSiteId ) {
-	if ( atomicSite ) {
+function getSiteType( state, siteId ) {
+	if ( isAtomicSite( state, siteId ) ) {
 		return 'atomic';
-	} else if ( jetpackSite ) {
+	} else if ( isJetpackSite( state, siteId ) ) {
 		return 'jetpack';
-	} else if ( selectedSiteId ) {
+	} else if ( siteId ) {
 		return 'simple';
 	}
 
@@ -46,10 +46,8 @@ function getSiteType( atomicSite, jetpackSite, selectedSiteId ) {
 
 const InstallThemeButton = ( {
 	isLoggedIn,
-	selectedSiteId,
 	isMultisite,
-	atomicSite,
-	jetpackSite,
+	siteType,
 	installThemeUrl,
 	dispatchTracksEvent,
 } ) => {
@@ -59,11 +57,7 @@ const InstallThemeButton = ( {
 
 	const clickHandler = () => {
 		trackClick( 'upload theme' );
-		dispatchTracksEvent( {
-			tracksEventProps: {
-				site_type: getSiteType( atomicSite, jetpackSite, selectedSiteId ),
-			},
-		} );
+		dispatchTracksEvent( { tracksEventProps: { site_type: siteType } } );
 	};
 
 	return (
@@ -77,10 +71,8 @@ const mapStateToProps = ( state ) => {
 	const selectedSiteId = getSelectedSiteId( state );
 	return {
 		isLoggedIn: isUserLoggedIn( state ),
-		selectedSiteId,
 		isMultisite: isJetpackSiteMultiSite( state, selectedSiteId ),
-		atomicSite: isAtomicSite( state, selectedSiteId ),
-		jetpackSite: isJetpackSite( state, selectedSiteId ),
+		siteType: getSiteType( state, selectedSiteId ),
 		installThemeUrl: getInstallThemeUrl( state, selectedSiteId ),
 	};
 };

--- a/client/my-sites/themes/install-theme-button.jsx
+++ b/client/my-sites/themes/install-theme-button.jsx
@@ -9,7 +9,7 @@ import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import {
 	isJetpackSiteMultiSite,
 	isJetpackSite,
-	getSiteAdminUrl,
+	getSiteThemeInstallUrl,
 	getSiteSlug,
 } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -25,7 +25,7 @@ function getInstallThemeUrl( state, siteId ) {
 	const atomicSite = isAtomicSite( state, siteId );
 	const siteCanInstallThemes = siteHasFeature( state, siteId, FEATURE_INSTALL_THEMES );
 	if ( atomicSite && siteCanInstallThemes ) {
-		return getSiteAdminUrl( state, siteId, 'theme-install.php' );
+		return getSiteThemeInstallUrl( state, siteId );
 	}
 
 	const siteSlug = getSiteSlug( state, siteId );

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -4,7 +4,6 @@ import {
 	FEATURE_UPLOAD_PLUGINS,
 	PLAN_ECOMMERCE,
 } from '@automattic/calypso-products';
-import page from '@automattic/calypso-router';
 import { Card, ProgressBar, Button } from '@automattic/components';
 import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
@@ -130,7 +129,7 @@ class Upload extends Component {
 	}
 
 	redirectToWpAdmin() {
-		page( `https://${ this.props.siteSlug }/wp-admin/theme-install.php` );
+		window.location = `${ this.props.siteAdminUrl }theme-install.php`;
 	}
 
 	successMessage() {

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -45,6 +45,7 @@ import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { isSiteOnECommerceTrial } from 'calypso/state/sites/plans/selectors';
 import {
 	getSiteAdminUrl,
+	getSiteThemeInstallUrl,
 	isJetpackSite,
 	isJetpackSiteMultiSite,
 } from 'calypso/state/sites/selectors';
@@ -129,7 +130,7 @@ class Upload extends Component {
 	}
 
 	redirectToWpAdmin() {
-		window.location = `${ this.props.siteAdminUrl }theme-install.php`;
+		window.location = this.props.siteThemeInstallUrl;
 	}
 
 	successMessage() {
@@ -417,6 +418,7 @@ const mapStateToProps = ( state ) => {
 		backPath: getBackPath( state ),
 		showEligibility,
 		siteAdminUrl: getSiteAdminUrl( state, siteId ),
+		siteThemeInstallUrl: getSiteThemeInstallUrl( state, siteId ),
 		canUploadThemesOrPlugins,
 		isFetchingPurchases:
 			isFetchingSitePurchases( state ) || ! hasLoadedSitePurchasesFromServer( state ),

--- a/client/state/sites/selectors/get-site-theme-install-url.js
+++ b/client/state/sites/selectors/get-site-theme-install-url.js
@@ -1,0 +1,12 @@
+import getSiteAdminUrl from './get-site-admin-url';
+
+/**
+ * Returns a site's wp-admin Theme Install URL, or null if the admin URL
+ * for the site cannot be determined.
+ * @param  {Object}  state  Global state tree
+ * @param  {number}  siteId Site ID
+ * @returns {?string}       Full URL to Theme Install in wp-admin
+ */
+export default function getSiteThemeInstallUrl( state, siteId ) {
+	return getSiteAdminUrl( state, siteId, 'theme-install.php' );
+}

--- a/client/state/sites/selectors/index.js
+++ b/client/state/sites/selectors/index.js
@@ -65,6 +65,7 @@ export { default as isSitePreviewable } from './is-site-previewable';
 export { default as isSSOEnabled } from './is-sso-enabled';
 export { default as verifyJetpackModulesActive } from './verify-jetpack-modules-active';
 export { default as getSelectedSiteWithFallback } from './get-site-with-fallback';
+export { default as getSiteThemeInstallUrl } from './get-site-theme-install-url';
 export { default as getSiteWooCommerceUrl } from './get-site-woocommerce-url';
 export { default as getSiteWooCommerceWizardUrl } from './get-site-woocommerce-wizard-url';
 export { default as getJetpackSearchCustomizeUrl } from './get-jetpack-search-customize-url';


### PR DESCRIPTION
Fixes an error reported in Sentry where we call `page( url )` with a theme upload URL (`wp-admin/theme-install.php`) that is not Calypso, but wp-admin. Because it has different origin, a `history.pushState` call throws a security error.

I'm fixing this by assigning directly to `window.location`. I'm also fixing how the `wp-admin/theme-install.php` URLs are constructed in the first place. Using the site slug directly won't work with Jetpack slugs like `example.com::blog`. That's why I'm using `site.options.admin_url` or the `getSiteAdminUrl` instead. That's the right way. Unfortunately there are still many instances of the wrong pattern across Calypso.

The `InstallThemeButton` component needed a mid-size refactoring of its `connect` call, so the diff is a little bit bigger.

**How to test:**
1. Go to `/themes/upload/atomic-site.blog`. The page should redirect to wp-admin
2. Go to `/themes/atomic-site.blog`. In the top right corner there should be an "Install new theme" button that navigates you to wp-admin.