### PR TITLE
RQ: fix more `unknown` > `Error` type

### DIFF
--- a/client/data/jetpack-licensing/use-user-license-by-receipt-query.ts
+++ b/client/data/jetpack-licensing/use-user-license-by-receipt-query.ts
@@ -5,7 +5,7 @@ import type { UserLicenseApi, UserLicense } from './types';
 
 const useUserLicenseByReceiptQuery = ( receiptId: number ): UseQueryResult< UserLicense[] > => {
 	const queryKey = [ 'user-license', receiptId ];
-	return useQuery< UserLicenseApi[], unknown, UserLicense[] >( {
+	return useQuery< UserLicenseApi[], Error, UserLicense[] >( {
 		queryKey,
 		queryFn: async () =>
 			wpcom.req.get( {

--- a/client/data/jetpack-licensing/use-user-license-by-subscription-query.ts
+++ b/client/data/jetpack-licensing/use-user-license-by-subscription-query.ts
@@ -7,7 +7,7 @@ const useUserLicenseBySubscriptionQuery = (
 	subscriptionId: number
 ): UseQueryResult< UserLicense > => {
 	const queryKey = [ 'user-license', subscriptionId ];
-	return useQuery< UserLicenseApi, unknown, UserLicense >( {
+	return useQuery< UserLicenseApi, Error, UserLicense >( {
 		queryKey,
 		queryFn: async () =>
 			wpcom.req.get( {

--- a/client/landing/stepper/hooks/use-countries.ts
+++ b/client/landing/stepper/hooks/use-countries.ts
@@ -4,9 +4,9 @@ import wpcom from 'calypso/lib/wp';
 type WooCountries = Record< string, string >;
 
 export function useCountries(
-	queryOptions: Omit< UseQueryOptions< any, unknown, WooCountries >, 'queryKey' > = {}
+	queryOptions: Omit< UseQueryOptions< any, Error, WooCountries >, 'queryKey' > = {}
 ): UseQueryResult< WooCountries > {
-	return useQuery< any, unknown, WooCountries >( {
+	return useQuery< any, Error, WooCountries >( {
 		queryKey: [ 'countries' ],
 		queryFn: () => wpcom.req.get( '/woocommerce/countries/regions/', { apiNamespace: 'wpcom/v2' } ),
 		staleTime: Infinity,


### PR DESCRIPTION
Follow up to #84474 and related to #84338

## Proposed Changes

There's a few more `Error` types we have to fix in order to comply with the v5 update. With v5 the `TError` generic will default to `Error` instead of `unknown`. A mismatch between used generics will cause a type error.

## Testing Instructions

There souldn't be any runtime changes. Verify tests are passing and there aren't any type errors.
