### PR TITLE
types: omit `queryKey` if we expose `UseQueryOptions` /2

### DIFF
--- a/packages/data-stores/src/queries/use-site-domains-query.ts
+++ b/packages/data-stores/src/queries/use-site-domains-query.ts
@@ -117,14 +117,14 @@ export interface SiteDomainsQueryFnData {
 
 export function useSiteDomainsQuery< TError = unknown, TData = SiteDomainsQueryFnData >(
 	siteIdOrSlug: number | string | null | undefined,
-	options: UseQueryOptions< SiteDomainsQueryFnData, TError, TData > = {}
+	options: Omit< UseQueryOptions< SiteDomainsQueryFnData, TError, TData >, 'queryKey' > = {}
 ) {
 	return useQuery( getSiteDomainsQueryObject( siteIdOrSlug, options ) );
 }
 
 export function getSiteDomainsQueryObject< TError = unknown, TData = SiteDomainsQueryFnData >(
 	siteIdOrSlug: number | string | null | undefined,
-	options: UseQueryOptions< SiteDomainsQueryFnData, TError, TData > = {}
+	options: Omit< UseQueryOptions< SiteDomainsQueryFnData, TError, TData >, 'queryKey' > = {}
 ): UseQueryOptions< SiteDomainsQueryFnData, TError, TData > {
 	return {
 		queryKey: [ 'site-domains', siteIdOrSlug ],


### PR DESCRIPTION
Follow up to #84472 and related to #84338

## Proposed Changes

With RQv5 we have to omit the `queryKey` from `UseQueryOptions` if we expose them from our custom query hooks. Otherwise this will result in a type error (in RQv5).

## Testing Instructions

There souldn't be any runtime changes. Verify tests are passing and there aren't any type errors.
