### PR TITLE
Multi-domain: Remove multiple domains correctly

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -838,6 +838,10 @@ export class RenderDomainsStep extends Component {
 			if ( ! shouldUseMultipleDomainsInCart( this.props.flowName ) || cartIsLoading ) {
 				return null;
 			}
+			const domainCount =
+				domainsInCart.length +
+				( this.state.wpcomSubdomainSelected ? 1 : 0 ) -
+				this.state.domainRemovalQueue.length;
 
 			if ( isMobile() ) {
 				const MobileHeader = (
@@ -845,8 +849,8 @@ export class RenderDomainsStep extends Component {
 						<div className="domains__domain-cart-total">
 							<div key="rowtotal" className="domains__domain-cart-total-items">
 								{ this.props.translate( '%d domain', '%d domains', {
-									count: domainsInCart.length,
-									args: [ domainsInCart.length ],
+									count: domainCount,
+									args: [ domainCount ],
 								} ) }
 							</div>
 							<div key="rowtotalprice" className="domains__domain-cart-total-price">
@@ -937,8 +941,8 @@ export class RenderDomainsStep extends Component {
 					<div className="domains__domain-cart-total">
 						<div key="rowtotal" className="domains__domain-cart-count">
 							{ this.props.translate( '%d domain', '%d domains', {
-								count: domainsInCart.length + ( this.state.wpcomSubdomainSelected ? 1 : 0 ),
-								args: [ domainsInCart.length + ( this.state.wpcomSubdomainSelected ? 1 : 0 ) ],
+								count: domainCount,
+								args: [ domainCount ],
 							} ) }
 						</div>
 						<div key="rowtotalprice" className="domains__domain-cart-total-price">

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -697,22 +697,6 @@ export class RenderDomainsStep extends Component {
 		}
 	}
 
-	removeAllDomains() {
-		const cartProducts = this.props.cart.products;
-		const domainsToRemove = cartProducts.filter( ( product ) =>
-			product.product_slug.includes( 'domain' )
-		);
-
-		if ( domainsToRemove.length ) {
-			domainsToRemove.forEach( ( domain ) => {
-				this.removeDomain( {
-					domain_name: domain.meta,
-					product_slug: domain.product_slug,
-				} );
-			} );
-		}
-	}
-
 	goToNext = () => {
 		this.setState( { isGoingToNextStep: true } );
 		const shouldUseThemeAnnotation = this.shouldUseThemeAnnotation();
@@ -980,7 +964,6 @@ export class RenderDomainsStep extends Component {
 							borderless
 							className="domains__domain-cart-choose-later"
 							onClick={ () => {
-								this.removeAllDomains();
 								this.handleSkip( undefined, false );
 							} }
 						>

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -690,7 +690,7 @@ export class RenderDomainsStep extends Component {
 				.finally( () => {
 					this.setState( ( prevState ) => ( {
 						domainRemovalQueue: prevState.domainRemovalQueue.filter(
-							( domainName ) => domainName !== domain_name
+							( item ) => item.meta !== domain_name
 						),
 					} ) );
 				} );
@@ -840,7 +840,7 @@ export class RenderDomainsStep extends Component {
 							className="domains__domain-cart-remove"
 							onClick={ this.removeDomainClickHandler( domain ) }
 						>
-							{ this.state.domainRemovalQueue.includes( domain.meta )
+							{ this.state.domainRemovalQueue.some( ( item ) => item.meta === domain.meta )
 								? this.props.translate( 'Removing' )
 								: this.props.translate( 'Remove' ) }
 						</Button>

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -797,8 +797,11 @@ export class RenderDomainsStep extends Component {
 			} );
 			const costDifference = domain.item_original_cost - domain.cost;
 			const hasPromotion = costDifference > 0;
+			const isRemoving = this.state.domainRemovalQueue.some(
+				( item ) => item.meta === domain.meta
+			);
 
-			return (
+			return isRemoving ? null : (
 				<>
 					<div>
 						<div
@@ -824,9 +827,7 @@ export class RenderDomainsStep extends Component {
 							className="domains__domain-cart-remove"
 							onClick={ this.removeDomainClickHandler( domain ) }
 						>
-							{ this.state.domainRemovalQueue.some( ( item ) => item.meta === domain.meta )
-								? this.props.translate( 'Removing' )
-								: this.props.translate( 'Remove' ) }
+							{ translate( 'Remove' ) }
 						</Button>
 					</div>
 				</>

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -148,17 +148,16 @@
 		}
 
 		.domains__domain-cart-rows {
-			.domains__domain-cart-row {
-				padding-bottom: 6px;
-				padding-top: 6px;
-			}
 
 			.domains__domain-cart-row > div {
 				display: flex;
 				justify-content: space-between;
+				padding-top: 6px;
 			}
 			.domains__domain-cart-row > div:nth-child(2) {
 				display: block;
+				padding-bottom: 6px;
+				padding-top: 0;
 			}
 
 			.savings-message {


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/4515, Fixes https://github.com/Automattic/dotcom-forge/issues/4533

## Proposed Changes

* Deletion from the mini cart is instant (API is run in the background)
* Remove multiple domains correctly, meaning when one deletion API is still running, we can click on the next domain to delete

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /start/domain
* Select a couple of domains
* Remove the domains while another one is in "Removing state"
* Try to break things

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?