### PR TITLE
Import flow: Remove onError handler from the code

### DIFF
--- a/client/data/site-migration/use-source-migration-status-query.ts
+++ b/client/data/site-migration/use-source-migration-status-query.ts
@@ -3,14 +3,8 @@ import { useQuery } from '@tanstack/react-query';
 import wp from 'calypso/lib/wp';
 import type { SiteId, SiteSlug } from 'calypso/types';
 
-export interface MigrationStatusError {
-	status: number;
-	message: string;
-}
-
 export const useSourceMigrationStatusQuery = (
-	sourceIdOrSlug: SiteId | SiteSlug | null | undefined,
-	onErrorCallback?: ( error: MigrationStatusError ) => void
+	sourceIdOrSlug: SiteId | SiteSlug | null | undefined
 ) => {
 	return useQuery( {
 		queryKey: [ 'source-migration-status', sourceIdOrSlug ],
@@ -25,8 +19,5 @@ export const useSourceMigrationStatusQuery = (
 		enabled: !! sourceIdOrSlug,
 		retry: false,
 		refetchOnWindowFocus: false,
-		onError: ( error: MigrationStatusError ) => {
-			onErrorCallback && onErrorCallback( error );
-		},
 	} );
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-handler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-handler/index.tsx
@@ -32,16 +32,19 @@ const MigrationHandler: Step = function MigrationHandler( { navigation } ) {
 	const [ isUnAuthorized, setIsUnAuthorized ] = useState( false );
 	const urlQueryParams = useQuery();
 	const sourceSiteSlug = urlQueryParams.get( 'from' ) || '';
-	const onSourceMigrationStatusError = () => {
-		setIsUnAuthorized( true );
-	};
 	const { data: sites } = useSiteExcerptsQuery( SITE_PICKER_FILTER_CONFIG );
 	const { data: sourceSiteMigrationStatus, isError: isErrorSourceSiteMigrationStatus } =
-		useSourceMigrationStatusQuery( sourceSiteSlug, onSourceMigrationStatusError );
+		useSourceMigrationStatusQuery( sourceSiteSlug );
 
 	useEffect( () => {
 		setIsMigrateFromWp( true );
 	}, [] );
+
+	useEffect( () => {
+		if ( isErrorSourceSiteMigrationStatus ) {
+			setIsUnAuthorized( true );
+		}
+	}, [ isErrorSourceSiteMigrationStatus ] );
 
 	useEffect( () => {
 		if ( ! submit || ! sourceSiteMigrationStatus || isErrorSourceSiteMigrationStatus || ! sites ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-handler/test/index.test.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-handler/test/index.test.tsx
@@ -89,8 +89,6 @@ describe( 'MigrationHandlerStep', () => {
 			isError: true,
 		} ) );
 		renderMigrationHandlerStep();
-
-		expect( screen.getByText( 'Scanning your site' ) ).toBeInTheDocument();
 		expect( jest.spyOn( navigation, 'submit' ) ).not.toHaveBeenCalled();
 	} );
 
@@ -117,8 +115,7 @@ describe( 'MigrationHandlerStep', () => {
 	test( 'should show non authorized screen', async () => {
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-ignore
-		useSourceMigrationStatusQuery.mockImplementationOnce( ( sourceIdOrSlug, onErrorCallback ) => {
-			onErrorCallback?.();
+		useSourceMigrationStatusQuery.mockImplementationOnce( () => {
 			return { data: {}, isError: true };
 		} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #84603

## Proposed Changes

* Remove `onError` handler from the `useSourceMigrationStatusQuery` to meet the refactor requirement from https://github.com/Automattic/wp-calypso/pull/84338#issuecomment-1824525840

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a JN and do not connect to your account. You can also use a WordPress site you don't own.
* Navigate to http://calypso.localhost:3000/setup/import-focused/migrationHandler?from=${source site}
* Make sure the `You are not authorized to import content` screen shows up like it was before.
* Run `npx jest -c=test/client/jest.config.js migration-handler` for unit test and make sure there's no error.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?