### PR TITLE
Plans 2023: Plans data store - useCurrentPlan selector and use

### DIFF
--- a/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
+++ b/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
@@ -11,7 +11,6 @@ import { getPlanPrices } from 'calypso/state/plans/selectors';
 import { PlanPrices } from 'calypso/state/plans/types';
 import { getByPurchaseId } from 'calypso/state/purchases/selectors';
 import {
-	getCurrentPlan,
 	getSitePlanRawPrice,
 	isPlanAvailableForPurchase,
 } from 'calypso/state/sites/plans/selectors';
@@ -56,14 +55,11 @@ const usePricingMetaForGridPlans: UsePricingMetaForGridPlans = ( {
 	storageAddOns,
 }: Props ) => {
 	const selectedSiteId = useSelector( getSelectedSiteId ) ?? undefined;
-	const currentPlan = useSelector( ( state: IAppState ) =>
-		getCurrentPlan( state, selectedSiteId )
-	);
-	const currentSitePlanSlug = currentPlan?.productSlug;
 	// pricedAPIPlans - should have a definition for all plans, being the main source of API data
 	const pricedAPIPlans = Plans.usePlans();
 	// pricedAPISitePlans - unclear if all plans are included
 	const pricedAPISitePlans = Plans.useSitePlans( { siteId: selectedSiteId } );
+	const currentPlan = Plans.useCurrentPlan( { siteId: selectedSiteId } );
 	const introOffers = Plans.useIntroOffers( { siteId: selectedSiteId } );
 	const selectedStorageOptions = useSelect( ( select ) => {
 		return select( WpcomPlansUI.store ).getSelectedStorageOptions();
@@ -76,7 +72,7 @@ const usePricingMetaForGridPlans: UsePricingMetaForGridPlans = ( {
 		return planSlugs.reduce(
 			( acc, planSlug ) => {
 				const availableForPurchase =
-					! currentSitePlanSlug ||
+					! currentPlan?.planSlug ||
 					( selectedSiteId
 						? isPlanAvailableForPurchase( state, selectedSiteId, planSlug )
 						: false );
@@ -107,7 +103,7 @@ const usePricingMetaForGridPlans: UsePricingMetaForGridPlans = ( {
 				const totalPricesFull = getTotalPrices( planPricesFull, storageAddOnPriceYearly );
 
 				// raw prices for current site's plan
-				if ( selectedSiteId && currentSitePlanSlug === planSlug ) {
+				if ( selectedSiteId && currentPlan?.planSlug === planSlug ) {
 					let monthlyPrice = getSitePlanRawPrice( state, selectedSiteId, planSlug, {
 						returnMonthly: true,
 						returnSmallestUnit: true,

--- a/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
+++ b/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
@@ -66,7 +66,7 @@ const usePricingMetaForGridPlans: UsePricingMetaForGridPlans = ( {
 	}, [] );
 
 	const purchasedPlan = useSelector(
-		( state: IAppState ) => currentPlan && getByPurchaseId( state, currentPlan.id || 0 )
+		( state: IAppState ) => currentPlan && getByPurchaseId( state, currentPlan.purchaseId || 0 )
 	);
 	const planPrices = useSelector( ( state: IAppState ) => {
 		return planSlugs.reduce(

--- a/client/my-sites/plans-features-main/hooks/test/use-pricing-meta-for-grid-plans.ts
+++ b/client/my-sites/plans-features-main/hooks/test/use-pricing-meta-for-grid-plans.ts
@@ -14,7 +14,6 @@ jest.mock( 'calypso/state/plans/selectors', () => ( {
 	getPlanPrices: jest.fn(),
 } ) );
 jest.mock( 'calypso/state/sites/plans/selectors', () => ( {
-	getCurrentPlan: jest.fn(),
 	getSitePlanRawPrice: jest.fn(),
 	isPlanAvailableForPurchase: jest.fn(),
 } ) );
@@ -28,6 +27,7 @@ jest.mock( '@automattic/data-stores', () => ( {
 		usePlans: jest.fn(),
 		useSitePlans: jest.fn(),
 		useIntroOffers: jest.fn(),
+		useCurrentPlan: jest.fn(),
 	},
 } ) );
 
@@ -36,7 +36,6 @@ import { Plans } from '@automattic/data-stores';
 import { getPlanPrices } from 'calypso/state/plans/selectors';
 import { getByPurchaseId } from 'calypso/state/purchases/selectors';
 import {
-	getCurrentPlan,
 	getSitePlanRawPrice,
 	isPlanAvailableForPurchase,
 } from 'calypso/state/sites/plans/selectors';
@@ -64,10 +63,14 @@ describe( 'usePricingMetaForGridPlans', () => {
 				},
 			},
 		} ) );
+		Plans.useCurrentPlan.mockImplementation( () => undefined );
 	} );
 
 	it( 'should return the original price as the site plan price and discounted price as Null for the current plan', () => {
-		getCurrentPlan.mockImplementation( () => ( { productSlug: PLAN_PREMIUM } ) );
+		Plans.useCurrentPlan.mockImplementation( () => ( {
+			productSlug: PLAN_PREMIUM,
+			planSlug: PLAN_PREMIUM,
+		} ) );
 		getSelectedSiteId.mockImplementation( () => 100 );
 		getPlanPrices.mockImplementation( () => null );
 		getSitePlanRawPrice.mockImplementation( () => 300 );
@@ -76,6 +79,7 @@ describe( 'usePricingMetaForGridPlans', () => {
 		const pricingMeta = usePricingMetaForGridPlans( {
 			planSlugs: [ PLAN_PREMIUM ],
 			withoutProRatedCredits: false,
+			storageAddOns: null,
 		} );
 
 		const expectedPricingMeta = {
@@ -97,7 +101,10 @@ describe( 'usePricingMetaForGridPlans', () => {
 	} );
 
 	it( 'should return the original price as the site plan price and discounted price as Null for plans not available for purchase', () => {
-		getCurrentPlan.mockImplementation( () => ( { productSlug: PLAN_PREMIUM } ) );
+		Plans.useCurrentPlan.mockImplementation( () => ( {
+			productSlug: PLAN_PREMIUM,
+			planSlug: PLAN_PREMIUM,
+		} ) );
 		getSelectedSiteId.mockImplementation( () => 100 );
 		getPlanPrices.mockImplementation( () => ( {
 			rawPrice: 300,
@@ -131,7 +138,10 @@ describe( 'usePricingMetaForGridPlans', () => {
 	} );
 
 	it( 'should return the original price and discounted price without pro-rated credits when withoutProRatedCredits is true', () => {
-		getCurrentPlan.mockImplementation( () => ( { productSlug: PLAN_PREMIUM } ) );
+		Plans.useCurrentPlan.mockImplementation( () => ( {
+			productSlug: PLAN_PREMIUM,
+			planSlug: PLAN_PREMIUM,
+		} ) );
 		getSelectedSiteId.mockImplementation( () => 100 );
 		getPlanPrices.mockImplementation( () => ( {
 			rawPrice: 300,
@@ -144,6 +154,7 @@ describe( 'usePricingMetaForGridPlans', () => {
 		const pricingMeta = usePricingMetaForGridPlans( {
 			planSlugs: [ PLAN_PERSONAL ],
 			withoutProRatedCredits: true,
+			storageAddOns: null,
 		} );
 
 		const expectedPricingMeta = {
@@ -165,7 +176,10 @@ describe( 'usePricingMetaForGridPlans', () => {
 	} );
 
 	it( 'should return the original price and discounted price with pro-rated credits when withoutProRatedCredits is false', () => {
-		getCurrentPlan.mockImplementation( () => ( { productSlug: PLAN_PREMIUM } ) );
+		Plans.useCurrentPlan.mockImplementation( () => ( {
+			productSlug: PLAN_PREMIUM,
+			planSlug: PLAN_PREMIUM,
+		} ) );
 		getSelectedSiteId.mockImplementation( () => 100 );
 		getPlanPrices.mockImplementation( () => ( {
 			rawPrice: 300,
@@ -178,6 +192,7 @@ describe( 'usePricingMetaForGridPlans', () => {
 		const pricingMeta = usePricingMetaForGridPlans( {
 			planSlugs: [ PLAN_PERSONAL ],
 			withoutProRatedCredits: false,
+			storageAddOns: null,
 		} );
 
 		const expectedPricingMeta = {

--- a/packages/data-stores/src/plans/hooks/test/use-current-plan.ts
+++ b/packages/data-stores/src/plans/hooks/test/use-current-plan.ts
@@ -1,0 +1,43 @@
+// Mocks
+jest.mock( '@wordpress/element', () => ( {
+	useMemo: jest.fn( ( callback ) => callback() ),
+} ) );
+
+jest.mock( '../../queries/use-site-plans', () => jest.fn() );
+
+import * as MockData from '../../mock';
+import useSitePlans from '../../queries/use-site-plans';
+import useCurrentPlan from '../use-current-plan';
+
+describe( 'useCurrentPlan selector', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'should bring back current plan when one exists in Site Plans', () => {
+		useSitePlans.mockImplementation( () => ( {
+			data: {
+				[ MockData.NEXT_STORE_SITE_PLAN_FREE.planSlug ]: MockData.NEXT_STORE_SITE_PLAN_FREE,
+				[ MockData.NEXT_STORE_SITE_PLAN_BUSINESS_CURRENT.planSlug ]:
+					MockData.NEXT_STORE_SITE_PLAN_BUSINESS_CURRENT,
+			},
+		} ) );
+
+		const currentPlan = useCurrentPlan( { siteId: 1 } );
+
+		expect( currentPlan ).toEqual( MockData.NEXT_STORE_SITE_PLAN_BUSINESS_CURRENT );
+	} );
+
+	it( 'should bring back undefined if no current plan exists in Site Plans', () => {
+		useSitePlans.mockImplementation( () => ( {
+			data: {
+				[ MockData.NEXT_STORE_SITE_PLAN_FREE.planSlug ]: MockData.NEXT_STORE_SITE_PLAN_FREE,
+				[ MockData.NEXT_STORE_SITE_PLAN_BUSINESS.planSlug ]: MockData.NEXT_STORE_SITE_PLAN_BUSINESS,
+			},
+		} ) );
+
+		const currentPlan = useCurrentPlan( { siteId: 1 } );
+
+		expect( currentPlan ).toEqual( undefined );
+	} );
+} );

--- a/packages/data-stores/src/plans/hooks/use-current-plan.ts
+++ b/packages/data-stores/src/plans/hooks/use-current-plan.ts
@@ -1,0 +1,21 @@
+import { useMemo } from '@wordpress/element';
+import useSitePlans from '../queries/use-site-plans';
+import { SitePlan } from '../types';
+
+interface Props {
+	siteId?: string | number | null;
+}
+
+const useCurrentPlan = ( { siteId }: Props ): SitePlan | undefined => {
+	const sitePlans = useSitePlans( { siteId } );
+
+	return useMemo(
+		() =>
+			sitePlans?.data
+				? Object.values( sitePlans?.data ).find( ( plan ) => plan.currentPlan )
+				: undefined,
+		[ sitePlans.data ]
+	);
+};
+
+export default useCurrentPlan;

--- a/packages/data-stores/src/plans/index.ts
+++ b/packages/data-stores/src/plans/index.ts
@@ -19,8 +19,11 @@ export type {
 	PlanSimplifiedFeature,
 } from './types';
 
+/** Queries */
 export { default as usePlans } from './queries/use-plans';
 export { default as useSitePlans } from './queries/use-site-plans';
+/** Hooks/Selectors */
+export { default as useCurrentPlan } from './hooks/use-current-plan';
 export { default as useIntroOffers } from './hooks/use-intro-offers';
 export { default as useIntroOffersForWooExpress } from './hooks/use-intro-offers-for-woo-express';
 

--- a/packages/data-stores/src/plans/mock/index.ts
+++ b/packages/data-stores/src/plans/mock/index.ts
@@ -3,3 +3,7 @@ export * from './apis/plans';
 export * from './store/features';
 export * from './store/plans';
 export * from './store/products';
+/**
+ * New mocks to gradually inform/replace the above.
+ */
+export * from './next';

--- a/packages/data-stores/src/plans/mock/next/README.md
+++ b/packages/data-stores/src/plans/mock/next/README.md
@@ -1,0 +1,3 @@
+# Mocked data for testing
+
+Mocks under `/mock/next` will gradually evolve to inform & override the previous ones in `/mock` folder.

--- a/packages/data-stores/src/plans/mock/next/index.ts
+++ b/packages/data-stores/src/plans/mock/next/index.ts
@@ -1,0 +1,1 @@
+export * from './store/site-plans';

--- a/packages/data-stores/src/plans/mock/next/store/site-plans.ts
+++ b/packages/data-stores/src/plans/mock/next/store/site-plans.ts
@@ -1,0 +1,18 @@
+import type { SitePlan } from '../../../types';
+
+export const NEXT_STORE_SITE_PLAN_FREE: SitePlan = {
+	planSlug: 'free_plan',
+	productSlug: 'free_plan',
+	productId: 1,
+};
+
+export const NEXT_STORE_SITE_PLAN_BUSINESS: SitePlan = {
+	planSlug: 'business-bundle',
+	productSlug: 'business-bundle',
+	productId: 2,
+};
+
+export const NEXT_STORE_SITE_PLAN_BUSINESS_CURRENT: SitePlan = {
+	...NEXT_STORE_SITE_PLAN_BUSINESS,
+	currentPlan: true,
+};

--- a/packages/data-stores/src/plans/queries/use-plans.ts
+++ b/packages/data-stores/src/plans/queries/use-plans.ts
@@ -24,6 +24,7 @@ function usePlans() {
 					...acc,
 					[ plan.product_slug ]: {
 						planSlug: plan.product_slug,
+						productSlug: plan.product_slug,
 						productId: plan.product_id,
 						productNameShort: plan.product_name_short,
 						billPeriod: plan.bill_period,

--- a/packages/data-stores/src/plans/queries/use-site-plans.ts
+++ b/packages/data-stores/src/plans/queries/use-site-plans.ts
@@ -57,9 +57,11 @@ function useSitePlans( { siteId }: Props ) {
 					...acc,
 					[ plan.product_slug ]: {
 						planSlug: plan.product_slug,
+						productSlug: plan.product_slug,
 						productId: Number( productId ),
 						introOffer: unpackIntroOffer( plan ),
 						expiry: plan.expiry,
+						currentPlan: plan.current_plan,
 					},
 				};
 			}, {} );

--- a/packages/data-stores/src/plans/queries/use-site-plans.ts
+++ b/packages/data-stores/src/plans/queries/use-site-plans.ts
@@ -62,6 +62,7 @@ function useSitePlans( { siteId }: Props ) {
 						introOffer: unpackIntroOffer( plan ),
 						expiry: plan.expiry,
 						currentPlan: plan.current_plan,
+						purchaseId: plan.id ? Number( plan.id ) : undefined,
 					},
 				};
 			}, {} );

--- a/packages/data-stores/src/plans/types.ts
+++ b/packages/data-stores/src/plans/types.ts
@@ -65,13 +65,23 @@ export interface SitePlan {
 	productSlug: PlanSlugFromProducts;
 	productId: number;
 	/* END: Same SitePlan/PlanNext props */
-	introOffer?: PlanIntroductoryOffer | null;
-	/* This value is only returned for the current plan on the site. */
-	expiry?: string;
+
 	currentPlan?: boolean;
+
+	/**
+	 * This value is only returned for the current plan on the site.
+	 */
+	expiry?: string;
+
+	/**
+	 * This is only set when `currentPlan` is true (so for the current plan on the site).
+	 * It is sent through as `id` from the endpoint and remapped here to avoid confusion e.g. with `productId`.
+	 */
+	purchaseId?: number;
+	introOffer?: PlanIntroductoryOffer | null;
 }
 
-/*
+/**
  * This is the new interface for API Plans that will replace the existing Plan interface above.
  * The existing Plan interface will be removed once this interface is fully implemented.
  */
@@ -81,6 +91,7 @@ export interface PlanNext {
 	productSlug: PlanSlugFromProducts;
 	productId: number;
 	/* END: Same SitePlan/PlanNext props */
+
 	productNameShort: string;
 	billPeriod: -1 | ( typeof PERIOD_LIST )[ number ];
 	currencyCode: string;
@@ -140,9 +151,20 @@ export interface PricedAPIPlan {
  */
 export interface PricedAPISitePlan extends PricedAPIPlanIntroductoryOffer {
 	/* product_id: number; // not included in the plan's payload */
-	current_plan?: boolean;
-	expiry?: string;
 	product_slug: StorePlanSlug;
+	current_plan?: boolean;
+
+	/**
+	 * This is the purchase ID present when `current_plan` is true.
+	 * For this, we map it (on `SitePlan` interface) as `purchaseId` instead
+	 * of `id` to avoid confusion e.g. with `productId`.
+	 */
+	id?: string;
+
+	/**
+	 * This value is only returned for the current plan on the site
+	 */
+	expiry?: string;
 }
 
 export interface PricedAPIPlanFree extends PricedAPIPlan {

--- a/packages/data-stores/src/plans/types.ts
+++ b/packages/data-stores/src/plans/types.ts
@@ -60,11 +60,15 @@ export interface PlanIntroductoryOffer {
 }
 
 export interface SitePlan {
+	/* START: Same SitePlan/PlanNext props */
 	planSlug: PlanSlugFromProducts;
+	productSlug: PlanSlugFromProducts;
 	productId: number;
+	/* END: Same SitePlan/PlanNext props */
 	introOffer?: PlanIntroductoryOffer | null;
 	/* This value is only returned for the current plan on the site. */
 	expiry?: string;
+	currentPlan?: boolean;
 }
 
 /*
@@ -72,8 +76,11 @@ export interface SitePlan {
  * The existing Plan interface will be removed once this interface is fully implemented.
  */
 export interface PlanNext {
+	/* START: Same SitePlan/PlanNext props */
 	planSlug: PlanSlugFromProducts;
+	productSlug: PlanSlugFromProducts;
 	productId: number;
+	/* END: Same SitePlan/PlanNext props */
 	productNameShort: string;
 	billPeriod: -1 | ( typeof PERIOD_LIST )[ number ];
 	currencyCode: string;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/79005

## Proposed Changes

- Adds a new `useCurrentPlan` selector hook to the store for getting the current plan off `SitePlans` in the store.
- This is the equivalent to `getCurrentPlan` selector in the Calypso Redux state
- Some tests and initial mocks (to be extended and refined as we introduce more full-fledged plan definitions into the store)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Ensure `/plans/[site]` and `/start/plans` render correctly without issues
- The current plan is only used for grid to display the price that the current plan was purchased with. So a little tricky to test. See instructions from previous work in https://github.com/Automattic/wp-calypso/pull/82761:

```
- Go to the SA panel
- Assign yourself a plan that is not purchasable ex. (WordPress.com Personal Yearly 2021-10-01 -> only available for USD)
- Ensure the plan's price is correctly shown on /plans
```

<img width="400" alt="Screenshot 2023-11-28 at 2 54 45 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/b8ad05dc-1bd2-4057-8069-a7b904a4b86f">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?