### PR TITLE
State: Fix a few more incorrect `useSelector` usages

### DIFF
--- a/client/my-sites/earn/hooks/use-earn-launchpad-tasks.ts
+++ b/client/my-sites/earn/hooks/use-earn-launchpad-tasks.ts
@@ -8,11 +8,10 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
 export const useEarnLaunchpadTasks = () => {
 	const checklistSlug = 'earn';
 	const site = useSelector( ( state ) => getSelectedSite( state ) );
-
-	const { products, connectedAccountId } = useSelector( ( state ) => ( {
-		products: getProductsForSiteId( state, site?.ID ),
-		connectedAccountId: getConnectedAccountIdForSiteId( state, site?.ID ),
-	} ) );
+	const products = useSelector( ( state ) => getProductsForSiteId( state, site?.ID ) );
+	const connectedAccountId = useSelector( ( state ) =>
+		getConnectedAccountIdForSiteId( state, site?.ID )
+	);
 
 	const {
 		data: { checklist },

--- a/client/my-sites/plans/ecommerce-trial/wooexpress-plans/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/wooexpress-plans/index.tsx
@@ -51,14 +51,13 @@ export function WooExpressPlans( props: WooExpressPlansProps ) {
 
 	const mediumPlanAnnual = getPlans()[ PLAN_WOOEXPRESS_MEDIUM ];
 	const mediumPlanMonthly = getPlans()[ PLAN_WOOEXPRESS_MEDIUM_MONTHLY ];
-	const mediumPlanPrices = useSelector( ( state ) => ( {
-		annualPlanMonthlyPrice: getPlanRawPrice( state, mediumPlanAnnual.getProductId(), true ) || 0,
-		monthlyPlanPrice: getPlanRawPrice( state, mediumPlanMonthly.getProductId() ) || 0,
-	} ) );
-
-	const percentageSavings = Math.floor(
-		( 1 - mediumPlanPrices.annualPlanMonthlyPrice / mediumPlanPrices.monthlyPlanPrice ) * 100
+	const annualPlanMonthlyPrice = useSelector(
+		( state ) => getPlanRawPrice( state, mediumPlanAnnual.getProductId(), true ) || 0
 	);
+	const monthlyPlanPrice = useSelector(
+		( state ) => getPlanRawPrice( state, mediumPlanMonthly.getProductId() ) || 0
+	);
+	const percentageSavings = Math.floor( ( 1 - annualPlanMonthlyPrice / monthlyPlanPrice ) * 100 );
 
 	const planIntervals = useMemo( () => {
 		return [

--- a/client/my-sites/plans/woo-express-plans-page/index.tsx
+++ b/client/my-sites/plans/woo-express-plans-page/index.tsx
@@ -49,12 +49,18 @@ const WooExpressPlansPage = ( {
 	const annualPlan = getPlans()[ annualPlanSlug ];
 	const monthlyPlan = getPlans()[ monthlyPlanSlug ];
 
-	const planPrices = useSelector( ( state ) => ( {
-		annualPlanPrice: getPlanRawPrice( state, annualPlan.getProductId(), false ) || 0,
-		annualPlanMonthlyPrice: getPlanRawPrice( state, annualPlan.getProductId(), true ) || 0,
-		monthlyPlanPrice: getPlanRawPrice( state, monthlyPlan.getProductId() ) || 0,
-		currencyCode: getPlan( state, annualPlan.getProductId() )?.currency_code || '',
-	} ) );
+	const annualPlanPrice = useSelector(
+		( state ) => getPlanRawPrice( state, annualPlan.getProductId(), false ) || 0
+	);
+	const annualPlanMonthlyPrice = useSelector(
+		( state ) => getPlanRawPrice( state, annualPlan.getProductId(), true ) || 0
+	);
+	const monthlyPlanPrice = useSelector(
+		( state ) => getPlanRawPrice( state, monthlyPlan.getProductId() ) || 0
+	);
+	const currencyCode = useSelector(
+		( state ) => getPlan( state, annualPlan.getProductId() )?.currency_code || ''
+	);
 
 	const isAnnualSubscription = ! isMonthly( currentPlan.productSlug );
 	const activePlan = isAnnualSubscription ? annualPlan : monthlyPlan;
@@ -74,12 +80,10 @@ const WooExpressPlansPage = ( {
 				'{{monthlyPriceWrapper}}%(monthlyPrice)s{{/monthlyPriceWrapper}} {{priceDescription}}per month, %(annualPrice)s billed annually{{/priceDescription}}',
 				{
 					args: {
-						monthlyPrice: formatCurrency(
-							planPrices.annualPlanMonthlyPrice,
-							planPrices.currencyCode,
-							{ stripZeros: true }
-						),
-						annualPrice: formatCurrency( planPrices.annualPlanPrice, planPrices.currencyCode, {
+						monthlyPrice: formatCurrency( annualPlanMonthlyPrice, currencyCode, {
+							stripZeros: true,
+						} ),
+						annualPrice: formatCurrency( annualPlanPrice, currencyCode, {
 							stripZeros: true,
 						} ),
 					},
@@ -93,7 +97,7 @@ const WooExpressPlansPage = ( {
 				'{{monthlyPriceWrapper}}%(monthlyPrice)s{{/monthlyPriceWrapper}} {{priceDescription}}per month{{/priceDescription}}',
 				{
 					args: {
-						monthlyPrice: formatCurrency( planPrices.monthlyPlanPrice, planPrices.currencyCode, {
+						monthlyPrice: formatCurrency( monthlyPlanPrice, currencyCode, {
 							stripZeros: true,
 						} ),
 					},


### PR DESCRIPTION
## Proposed Changes

This PR fixes a few more `Selector returned a different result when called with the same parameters.` warnings similar to #84556 where we were needlessly returning a new object every time inside `useSelector()`. 

The fix is straightforward - we just use a separate `useSelector()` for every selector. 

## Testing Instructions

Shouldn't be needed, changes are very straightforward. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?