### PR TITLE
Show subscribe block support doc on help center on editor when url param `help-center=subscribe-block` exists.

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.js
@@ -46,19 +46,7 @@ function HelpCenterContent() {
 		return () => clearTimeout( timeout );
 	}, [] );
 
-	const actionHooks = useActionHooks();
-	useEffect( () => {
-		const timeout = setTimeout( () => {
-			actionHooks.forEach( ( actionHook ) => {
-				if ( actionHook.condition() ) {
-					actionHook.action();
-				}
-			} );
-		}, 0 );
-		return () => clearTimeout( timeout );
-		// Only want to run this once
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [] );
+	useActionHooks();
 
 	const closeCallback = useCallback( () => setShowHelpCenter( false ), [ setShowHelpCenter ] );
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.js
@@ -12,6 +12,7 @@ import { useSelector } from 'react-redux';
 import { getSectionName } from 'calypso/state/ui/selectors';
 import { whatsNewQueryClient } from '../../common/what-new-query-client';
 import CalypsoStateProvider from './CalypsoStateProvider';
+import useActionHooks from './use-action-hooks';
 
 // Implement PinnedItems to avoid importing @wordpress/interface.
 // Because @wordpress/interface depends on @wordpress/preferences which is not always available outside the editor,
@@ -43,6 +44,20 @@ function HelpCenterContent() {
 	useEffect( () => {
 		const timeout = setTimeout( () => setShowHelpIcon( true ), 0 );
 		return () => clearTimeout( timeout );
+	}, [] );
+
+	const actionHooks = useActionHooks();
+	useEffect( () => {
+		const timeout = setTimeout( () => {
+			actionHooks.forEach( ( actionHook ) => {
+				if ( actionHook.condition() ) {
+					actionHook.action();
+				}
+			} );
+		}, 0 );
+		return () => clearTimeout( timeout );
+		// Only want to run this once
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 
 	const closeCallback = useCallback( () => setShowHelpCenter( false ), [ setShowHelpCenter ] );

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/use-action-hooks.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/use-action-hooks.js
@@ -1,5 +1,6 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useDispatch } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
 
 const useActionHooks = () => {
 	const { setShowHelpCenter, setShowSupportDoc } = useDispatch( 'automattic/help-center' );
@@ -21,7 +22,18 @@ const useActionHooks = () => {
 		},
 	];
 
-	return actionHooks;
+	useEffect( () => {
+		const timeout = setTimeout( () => {
+			actionHooks.forEach( ( actionHook ) => {
+				if ( actionHook.condition() ) {
+					actionHook.action();
+				}
+			} );
+		}, 0 );
+		return () => clearTimeout( timeout );
+		// Only want to run this once
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
 };
 
 export default useActionHooks;

--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/use-action-hooks.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/use-action-hooks.js
@@ -1,0 +1,27 @@
+import { localizeUrl } from '@automattic/i18n-utils';
+import { useDispatch } from '@wordpress/data';
+
+const useActionHooks = () => {
+	const { setShowHelpCenter, setShowSupportDoc } = useDispatch( 'automattic/help-center' );
+
+	const actionHooks = [
+		{
+			condition() {
+				return (
+					new URLSearchParams( window.location.search ).get( 'help-center' ) === 'subscribe-block'
+				);
+			},
+			action() {
+				setShowHelpCenter( true );
+				setShowSupportDoc(
+					localizeUrl( 'https://wordpress.com/support/wordpress-editor/blocks/subscribe-block/' ),
+					170164 // post id of subscribe block support doc page
+				);
+			},
+		},
+	];
+
+	return actionHooks;
+};
+
+export default useActionHooks;


### PR DESCRIPTION
Related to #84594.

P2s:
- pdDOJh-2JD-p2
- pdDOJh-2Ee-p2#comment-2017

## Proposed Changes

* Show subscribe block support doc on help center on editor when url param `help-center=subscribe-block` exists.
* Related PR: https://github.com/Automattic/jetpack/pull/34329

## Testing Instructions

* Go to `apps/editing-toolkit`.
* Run `yarn dev --sync`.
* Sandbox your site.
* Go to `your-site.wordpress.com/wp-admin/site-editor.php?canvas=edit&help-center=subscribe-block`.
* You should see the help center show up automatically with the subscribe block support doc page loaded.

## Screenshot

<img width="1524" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1287077/9c79b121-557d-4de5-8928-c80910fe7c1b">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?