### PR TITLE
State: Fix even more incorrect useSelector usages

### DIFF
--- a/client/blocks/authentication/social/index.tsx
+++ b/client/blocks/authentication/social/index.tsx
@@ -47,15 +47,12 @@ const SocialAuthenticationForm = ( {
 }: SocialAuthenticationFormProps ) => {
 	const translate = useTranslate();
 
-	const { currentRoute, oauth2Client, isWoo } = useSelector( ( state: IAppState ) => {
-		return {
-			currentRoute: getCurrentRoute( state ),
-			oauth2Client: getCurrentOAuth2Client( state ),
-			isWoo:
-				isWooOAuth2Client( getCurrentOAuth2Client( state ) ) ||
-				isWooCommerceCoreProfilerFlow( state ),
-		};
-	} );
+	const currentRoute = useSelector( getCurrentRoute );
+	const oauth2Client = useSelector( getCurrentOAuth2Client );
+	const isWoo = useSelector(
+		( state: IAppState ) =>
+			isWooOAuth2Client( oauth2Client ) || isWooCommerceCoreProfilerFlow( state )
+	);
 
 	const shouldUseRedirectFlow = () => {
 		// If calypso is loaded in a popup, we don't want to open a second popup for social signup or login

--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -47,16 +47,10 @@ const SignupFormSocialFirst = ( {
 }: SignupFormSocialFirst ) => {
 	const [ currentStep, setCurrentStep ] = useState( 'initial' );
 	const { __ } = useI18n();
-
-	const { isWoo, isGravatar } = useSelector( ( state ) => {
-		const oauth2Client = getCurrentOAuth2Client( state );
-		const isWooCoreProfilerFlow = isWooCommerceCoreProfilerFlow( state );
-
-		return {
-			isWoo: isWooOAuth2Client( oauth2Client ) || isWooCoreProfilerFlow,
-			isGravatar: isGravatarOAuth2Client( oauth2Client ),
-		};
-	} );
+	const oauth2Client = useSelector( getCurrentOAuth2Client );
+	const isWooCoreProfilerFlow = useSelector( isWooCommerceCoreProfilerFlow );
+	const isWoo = isWooOAuth2Client( oauth2Client ) || isWooCoreProfilerFlow;
+	const isGravatar = isGravatarOAuth2Client( oauth2Client );
 
 	const renderContent = () => {
 		if ( currentStep === 'initial' ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
@@ -53,12 +53,8 @@ export function DomainFormControl( {
 	isCartPendingUpdate,
 	isCartPendingUpdateDomain,
 }: DomainFormControlProps ) {
-	const { selectedSite, productsList } = useSelector( ( state ) => {
-		return {
-			selectedSite: getSelectedSite( state ),
-			productsList: getAvailableProductsList( state ),
-		};
-	} );
+	const selectedSite = useSelector( getSelectedSite );
+	const productsList = useSelector( getAvailableProductsList );
 
 	const { domainForm, siteTitle } = useSelect(
 		( select ) => ( {

--- a/client/layout/masterbar/woo-core-profiler.tsx
+++ b/client/layout/masterbar/woo-core-profiler.tsx
@@ -16,36 +16,27 @@ import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 
 // Masterbar for WooCommerce Core Profiler Jetpack step
 const WooCoreProfilerMasterbar = ( { translate }: { translate: ( text: string ) => string } ) => {
-	const { redirectTo, shouldShowProgressBar, shouldShowNoThanks, currentRoute } = useSelector(
-		( state ) => {
-			const currentRoute = getCurrentRoute( state );
-			let redirectTo = null;
-			let shouldShowProgressBar = true;
-			let shouldShowNoThanks = true;
-			switch ( currentRoute ) {
-				case '/jetpack/connect/authorize':
-					redirectTo = getCurrentQueryArguments( state )?.redirect_after_auth;
-				case '/log-in/jetpack':
-					redirectTo = getQueryArg( getRedirectToOriginal( state ) || '', 'redirect_after_auth' );
-				default:
-			}
+	const currentQueryArguments = useSelector( getCurrentQueryArguments );
+	const currentRoute = useSelector( getCurrentRoute );
+	const redirectToOriginal = useSelector( getRedirectToOriginal );
 
-			if (
-				currentRoute === '/log-in/jetpack/lostpassword' ||
-				getCurrentQueryArguments( state )?.lostpassword_flow
-			) {
-				shouldShowProgressBar = false;
-				shouldShowNoThanks = false;
-			}
+	let redirectTo = null;
+	let shouldShowProgressBar = true;
+	let shouldShowNoThanks = true;
+	switch ( currentRoute ) {
+		case '/jetpack/connect/authorize':
+			redirectTo = currentQueryArguments?.redirect_after_auth;
+		case '/log-in/jetpack':
+			redirectTo = getQueryArg( redirectToOriginal || '', 'redirect_after_auth' );
+	}
 
-			return {
-				redirectTo,
-				shouldShowProgressBar,
-				shouldShowNoThanks,
-				currentRoute,
-			};
-		}
-	);
+	if (
+		currentRoute === '/log-in/jetpack/lostpassword' ||
+		currentQueryArguments?.lostpassword_flow
+	) {
+		shouldShowProgressBar = false;
+		shouldShowNoThanks = false;
+	}
 
 	return (
 		<Fragment>

--- a/client/layout/masterbar/woo-core-profiler.tsx
+++ b/client/layout/masterbar/woo-core-profiler.tsx
@@ -26,8 +26,10 @@ const WooCoreProfilerMasterbar = ( { translate }: { translate: ( text: string ) 
 	switch ( currentRoute ) {
 		case '/jetpack/connect/authorize':
 			redirectTo = currentQueryArguments?.redirect_after_auth;
+			break;
 		case '/log-in/jetpack':
 			redirectTo = getQueryArg( redirectToOriginal || '', 'redirect_after_auth' );
+			break;
 	}
 
 	if (

--- a/client/my-sites/add-ons/hooks/use-add-on-purchase-status.ts
+++ b/client/my-sites/add-ons/hooks/use-add-on-purchase-status.ts
@@ -10,17 +10,14 @@ import type { AddOnMeta } from '@automattic/data-stores';
  */
 const useAddOnPurchaseStatus = ( { productSlug, featureSlugs }: AddOnMeta ) => {
 	const translate = useTranslate();
-
-	const { purchased, isSiteFeature } = useSelector( ( state ) => {
-		const selectedSite = getSelectedSite( state );
-		const sitePurchases = getSitePurchases( state, selectedSite?.ID );
-		return {
-			purchased: sitePurchases.find( ( product ) => product.productSlug === productSlug ),
-			isSiteFeature:
-				selectedSite &&
-				featureSlugs?.find( ( slug ) => siteHasFeature( state, selectedSite?.ID, slug ) ),
-		};
-	} );
+	const selectedSite = useSelector( getSelectedSite );
+	const sitePurchases = useSelector( ( state ) => getSitePurchases( state, selectedSite?.ID ) );
+	const purchased = sitePurchases.find( ( product ) => product.productSlug === productSlug );
+	const isSiteFeature = useSelector(
+		( state ) =>
+			selectedSite &&
+			featureSlugs?.find( ( slug ) => siteHasFeature( state, selectedSite?.ID, slug ) )
+	);
 
 	/*
 	 * Order matters below:

--- a/client/my-sites/checkout/modal/async.tsx
+++ b/client/my-sites/checkout/modal/async.tsx
@@ -4,19 +4,9 @@ import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-
 import { KEY_PRODUCTS } from './constants';
 import type { Props } from '.';
 
-const useProducts = () => {
-	const { products } = useSelector( ( state ) => {
-		const query = getCurrentQueryArguments( state ) || {};
-		return {
-			products: query[ KEY_PRODUCTS ],
-		};
-	} );
-
-	return products;
-};
-
 const AsyncCheckoutModal = ( props: Props ) => {
-	const products = useProducts();
+	const queryArguments = useSelector( getCurrentQueryArguments );
+	const products = queryArguments?.[ KEY_PRODUCTS ];
 
 	if ( ! products ) {
 		return null;

--- a/client/my-sites/checkout/modal/index.tsx
+++ b/client/my-sites/checkout/modal/index.tsx
@@ -40,31 +40,20 @@ const CheckoutModal: FunctionComponent< Props > = ( {
 } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
-	const {
-		siteSlug,
-		selectedSiteId,
-		hasSelectedSiteId,
-		previousRoute,
-		redirectTo,
-		cancelTo,
-		isJetpackNotAtomic,
-	} = useSelector( ( state ) => {
-		const site = getSelectedSite( state );
-		const selectedSiteId = getSelectedSiteId( state );
-		const hasSelectedSiteId = selectedSiteId && siteId === selectedSiteId;
-		const previousRoute = getPreviousRoute( state );
-
-		return {
-			siteSlug: site?.slug,
-			selectedSiteId,
-			hasSelectedSiteId,
-			previousRoute: removeQueryArgs( previousRoute, KEY_PRODUCTS ),
-			redirectTo: ( getQueryArg( window.location.href, 'redirect_to' ) as string ) || previousRoute,
-			cancelTo: ( getQueryArg( window.location.href, 'cancel_to' ) as string ) || previousRoute,
-			isJetpackNotAtomic:
-				!! isJetpackSite( state, selectedSiteId ) && ! isAtomicSite( state, selectedSiteId ),
-		};
-	} );
+	const site = useSelector( getSelectedSite );
+	const selectedSiteId = useSelector( getSelectedSiteId );
+	const hasSelectedSiteId = selectedSiteId && siteId === selectedSiteId;
+	const previousRouteWithArgs = useSelector( getPreviousRoute );
+	const siteSlug = site?.slug;
+	const previousRoute = removeQueryArgs( previousRouteWithArgs, KEY_PRODUCTS );
+	const redirectTo =
+		( getQueryArg( window.location.href, 'redirect_to' ) as string ) || previousRouteWithArgs;
+	const cancelTo =
+		( getQueryArg( window.location.href, 'cancel_to' ) as string ) || previousRouteWithArgs;
+	const isJetpackNotAtomic = useSelector(
+		( state ) =>
+			!! isJetpackSite( state, selectedSiteId ) && ! isAtomicSite( state, selectedSiteId )
+	);
 
 	const handleRequestClose = () => {
 		onClose?.();

--- a/client/reader/feed-stream/index.jsx
+++ b/client/reader/feed-stream/index.jsx
@@ -27,7 +27,7 @@ const emptyContent = () => <EmptyContent />;
 const FeedStream = ( props ) => {
 	const { className = 'is-site-stream', feedId, showBack = true } = props;
 	const translate = useTranslate();
-	const feed = useSelector( ( state ) => getFeed( state, feedId ) );
+	let feed = useSelector( ( state ) => getFeed( state, feedId ) );
 	const siteId = getReaderSiteId( feed );
 	const followForFeed = useSelector( ( state ) =>
 		getReaderFollowForFeed( state, parseInt( feedId ) )
@@ -40,7 +40,7 @@ const FeedStream = ( props ) => {
 
 	if ( feed ) {
 		// Add site icon to feed object so have icon for external feeds
-		feed.site_icon = followForFeed?.site_icon;
+		feed = { ...feed, site_icon: followForFeed?.site_icon };
 	}
 
 	const siteTags = useSiteTags( siteId );

--- a/client/reader/feed-stream/index.jsx
+++ b/client/reader/feed-stream/index.jsx
@@ -27,24 +27,21 @@ const emptyContent = () => <EmptyContent />;
 const FeedStream = ( props ) => {
 	const { className = 'is-site-stream', feedId, showBack = true } = props;
 	const translate = useTranslate();
+	const feed = useSelector( ( state ) => getFeed( state, feedId ) );
+	const siteId = getReaderSiteId( feed );
+	const followForFeed = useSelector( ( state ) =>
+		getReaderFollowForFeed( state, parseInt( feedId ) )
+	);
+	const isBlocked = useSelector( ( state ) => siteId && isSiteBlocked( state, siteId ) );
+	const postCount = useSelector(
+		( state ) => siteId && getAllPostCount( state, siteId, 'post', 'publish' )
+	);
+	const site = useSelector( ( state ) => siteId && getSite( state, siteId ) );
 
-	const { feed, isBlocked, postCount, site, siteId } = useSelector( ( state ) => {
-		const _feed = getFeed( state, feedId );
-		const _siteId = getReaderSiteId( _feed );
-
-		if ( _feed ) {
-			// Add site icon to feed object so have icon for external feeds
-			_feed.site_icon = getReaderFollowForFeed( state, parseInt( feedId ) )?.site_icon;
-		}
-
-		return {
-			feed: _feed,
-			isBlocked: _siteId && isSiteBlocked( state, _siteId ),
-			postCount: _siteId && getAllPostCount( state, _siteId, 'post', 'publish' ),
-			site: _siteId && getSite( state, _siteId ),
-			siteId: _siteId,
-		};
-	} );
+	if ( feed ) {
+		// Add site icon to feed object so have icon for external feeds
+		feed.site_icon = followForFeed?.site_icon;
+	}
 
 	const siteTags = useSiteTags( siteId );
 	const title = getSiteName( { feed, site } ) || translate( 'Loading Feed' );

--- a/client/reader/site-stream/index.jsx
+++ b/client/reader/site-stream/index.jsx
@@ -25,16 +25,12 @@ const emptyContent = () => <EmptyContent />;
 const SiteStream = ( props ) => {
 	const { className = 'is-site-stream', showBack = true, siteId } = props;
 	const translate = useTranslate();
-
-	const { feed, isBlocked, postCount, site } = useSelector( ( state ) => {
-		const _site = getSite( state, siteId );
-		return {
-			feed: _site && _site.feed_ID && getFeed( state, _site.feed_ID ),
-			isBlocked: isSiteBlocked( state, siteId ),
-			postCount: siteId && getAllPostCount( state, siteId, 'post', 'publish' ),
-			site: _site,
-		};
-	} );
+	const site = useSelector( ( state ) => getSite( state, siteId ) );
+	const feed = useSelector( ( state ) => site && site.feed_ID && getFeed( state, site.feed_ID ) );
+	const isBlocked = useSelector( ( state ) => isSiteBlocked( state, siteId ) );
+	const postCount = useSelector(
+		( state ) => siteId && getAllPostCount( state, siteId, 'post', 'publish' )
+	);
 
 	// check for redirect
 	useEffect( () => {

--- a/packages/help-center/src/components/help-center-more-resources.tsx
+++ b/packages/help-center/src/components/help-center-more-resources.tsx
@@ -29,17 +29,12 @@ type CoreDataPlaceholder = {
 export const HelpCenterMoreResources = () => {
 	const { __ } = useI18n();
 	const sectionName = useSelector( getSectionName );
-
-	const { isBusinessOrEcomPlanUser } = useSelector( ( state ) => {
-		const purchases = getUserPurchases( state );
-		const purchaseSlugs = purchases && purchases.map( ( purchase ) => purchase.productSlug );
-		return {
-			isBusinessOrEcomPlanUser: !! (
-				purchaseSlugs &&
-				( purchaseSlugs.some( isWpComBusinessPlan ) || purchaseSlugs.some( isWpComEcommercePlan ) )
-			),
-		};
-	} );
+	const purchases = useSelector( getUserPurchases );
+	const purchaseSlugs = purchases && purchases.map( ( purchase ) => purchase.productSlug );
+	const isBusinessOrEcomPlanUser = !! (
+		purchaseSlugs &&
+		( purchaseSlugs.some( isWpComBusinessPlan ) || purchaseSlugs.some( isWpComEcommercePlan ) )
+	);
 
 	const { hasSeenWhatsNewModal, doneLoading } = useSelect(
 		( select ) => ( {

--- a/packages/help-center/src/components/help-center-search-results.tsx
+++ b/packages/help-center/src/components/help-center-search-results.tsx
@@ -103,14 +103,9 @@ function HelpSearchResults( {
 	location = 'inline-help-popover',
 }: HelpSearchResultsProps ) {
 	const dispatch = useDispatch();
-
-	const { hasPurchases, sectionName, adminResults } = useSelector( ( state ) => {
-		return {
-			hasPurchases: hasCancelableUserPurchases( state ),
-			sectionName: getSectionName( state ),
-			adminResults: getAdminHelpResults( state, searchQuery, 3 ),
-		};
-	} );
+	const hasPurchases = useSelector( hasCancelableUserPurchases );
+	const sectionName = useSelector( getSectionName );
+	const adminResults = useSelector( ( state ) => getAdminHelpResults( state, searchQuery, 3 ) );
 
 	const isPurchasesSection = [ 'purchases', 'site-purchases' ].includes( sectionName );
 	const siteIntent = useSiteOption( 'site_intent' );


### PR DESCRIPTION
## Proposed Changes

This PR fixes a few more `Selector returned a different result when called with the same parameters.` warnings similar to #84556 and #84608 where we were needlessly returning a new object every time inside `useSelector()`. 

The fix is straightforward - we just use a separate `useSelector()` for every selector. 

## Testing Instructions

Shouldn't be needed, changes are very straightforward. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?