### PR TITLE
Update domain suggester logic (Update Levenshtein distance and add avoid list)

### DIFF
--- a/packages/onboarding/src/utils/domain-suggester.ts
+++ b/packages/onboarding/src/utils/domain-suggester.ts
@@ -13,6 +13,9 @@ const validDomains = [
 	'sbcglobal.net',
 ];
 
+// Skip suggestions for these domains
+const avoidList = [ 'mail.com', 'ymail.com', 'email.com' ];
+
 // This function extracts the domain from an email address.
 const extractDomainWithExtension = ( email: string ) => {
 	if ( email ) {
@@ -91,7 +94,11 @@ export const suggestEmailCorrection = ( inputDomain: string, maxDistance: number
 	let bestMatch = null;
 	let bestMatchDistance = Infinity;
 
-	if ( extractedInputEmailDomain && ! validDomains.includes( extractedInputEmailDomain ) ) {
+	if (
+		extractedInputEmailDomain &&
+		! validDomains.includes( extractedInputEmailDomain ) &&
+		! avoidList.includes( extractedInputEmailDomain )
+	) {
 		// Iterate through each valid domain and calculate the Levenshtein distance
 		for ( let i = 0; i < validDomains.length; i++ ) {
 			const validDomain = validDomains[ i ];

--- a/packages/onboarding/src/utils/domain-suggester.ts
+++ b/packages/onboarding/src/utils/domain-suggester.ts
@@ -85,7 +85,7 @@ const calculateLevenshteinDistance = ( str1: string, str2: string ) => {
  * @param {string} inputDomain - The email address to be corrected.
  * @param {number} maxDistance - The maximum Levenshtein distance between the input and the suggestion.
  */
-export const suggestEmailCorrection = ( inputDomain: string, maxDistance: number = 2 ) => {
+export const suggestEmailCorrection = ( inputDomain: string, maxDistance: number = 1 ) => {
 	const extractedInputEmailDomain = extractDomainWithExtension( inputDomain );
 
 	let bestMatch = null;

--- a/packages/onboarding/src/utils/domain-suggester.ts
+++ b/packages/onboarding/src/utils/domain-suggester.ts
@@ -104,8 +104,11 @@ export const suggestEmailCorrection = ( inputDomain: string, maxDistance: number
 			const validDomain = validDomains[ i ];
 			const distance = calculateLevenshteinDistance( extractedInputEmailDomain, validDomain );
 
+			// Check if the input is in the middle of typing the domain
+			const inTheMiddleOfTyping = validDomain.startsWith( extractedInputEmailDomain );
+
 			// If the distance is within the limit and better than the previous best match, update the suggestion
-			if ( distance <= maxDistance && distance < bestMatchDistance ) {
+			if ( distance <= maxDistance && distance < bestMatchDistance && ! inTheMiddleOfTyping ) {
 				bestMatch = validDomain;
 				bestMatchDistance = distance;
 			}

--- a/packages/onboarding/src/utils/test/domain-suggester.ts
+++ b/packages/onboarding/src/utils/test/domain-suggester.ts
@@ -60,4 +60,16 @@ describe( 'suggestEmailCorrection', () => {
 			wasCorrected: false,
 		} );
 	} );
+
+	test( 'should not suggest a correction for a domain included in the domain avoid list', () => {
+		const result = suggestEmailCorrection( 'example@mail.com' );
+		expect( result ).toEqual( {
+			oldEmail: 'example@mail.com',
+			oldDomain: 'mail.com',
+			newDomain: null,
+			newEmail: null,
+			distance: Infinity,
+			wasCorrected: false,
+		} );
+	} );
 } );

--- a/packages/onboarding/src/utils/test/domain-suggester.ts
+++ b/packages/onboarding/src/utils/test/domain-suggester.ts
@@ -74,10 +74,10 @@ describe( 'suggestEmailCorrection', () => {
 	} );
 
 	test( 'should not suggest a correction for a domain if user is still typing', () => {
-		const result = suggestEmailCorrection( 'example@mail' );
+		const result = suggestEmailCorrection( 'example@gmail.co' );
 		expect( result ).toEqual( {
-			oldEmail: 'example@mail',
-			oldDomain: 'mail',
+			oldEmail: 'example@gmail.co',
+			oldDomain: 'gmail.co',
 			newDomain: null,
 			newEmail: null,
 			distance: Infinity,

--- a/packages/onboarding/src/utils/test/domain-suggester.ts
+++ b/packages/onboarding/src/utils/test/domain-suggester.ts
@@ -72,4 +72,16 @@ describe( 'suggestEmailCorrection', () => {
 			wasCorrected: false,
 		} );
 	} );
+
+	test( 'should not suggest a correction for a domain if user is still typing', () => {
+		const result = suggestEmailCorrection( 'example@mail' );
+		expect( result ).toEqual( {
+			oldEmail: 'example@mail',
+			oldDomain: 'mail',
+			newDomain: null,
+			newEmail: null,
+			distance: Infinity,
+			wasCorrected: false,
+		} );
+	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Context: pdDR7T-19z-p2#comment-1368

## Proposed Changes

* Reduce potential bad suggestions by updating Levenshtein distance from 2 to 1 
* Add a list of domains to skip domain suggestions for ( `[ 'mail.com', 'ymail.com', 'email.com' ]` )
* Skip domain suggestion while user is still typing

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch or use live link
* Navigate to `/start/` and click on the "Continue with email" button
* Test different email typos against the valid domain list. You should only see a suggestion if the domain typo is one character away from the correct domain.

```
const validDomains = [
	'gmail.com',
	'yahoo.com',
	'hotmail.com',
	'aol.com',
	'outlook.com',
	'comcast.net',
	'icloud.com',
	'msn.com',
	'hotmail.co.uk',
	'sbcglobal.net',
];
```
* Verify you do not recieve a suggestion for input emails that include a domain from the avoid list
(If you enter `random@mail.com`, you should not see a domain suggestion)

```
const avoidList = [ 
	'mail.com', 
	'ymail.com', 
	'email.com'
];
```

* Verify test cases are passing. Run `yarn test-packages domain-suggester`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?