### PR TITLE
Stepper: Add a back button to domains step for Start Writing flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
@@ -1,12 +1,10 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
-import { Gridicon } from '@automattic/components';
 import { ProductsList } from '@automattic/data-stores';
 import {
 	DESIGN_FIRST_FLOW,
 	START_WRITING_FLOW,
 	isBlogOnboardingFlow,
 } from '@automattic/onboarding';
-import { Button } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs, getQueryArg } from '@wordpress/url';
@@ -61,10 +59,6 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 		} else {
 			onAddDomain( null );
 		}
-	};
-
-	const handleGoBack = async ( goBack: ( () => void ) | undefined ) => {
-		return goBack?.();
 	};
 
 	const onClickUseYourDomain = function () {
@@ -128,12 +122,6 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 					isCartPendingUpdate={ isCartPendingUpdate }
 					isCartPendingUpdateDomain={ isCartPendingUpdateDomain }
 				/>
-				<div>
-					<Button variant="tertiary" onClick={ () => handleGoBack( goBack ) }>
-						<Gridicon icon="chevron-left" />
-						{ __( 'Back' ) }
-					</Button>
-				</div>
 			</CalypsoShoppingCartProvider>
 		);
 	};
@@ -249,7 +237,8 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 			<QueryProductsList />
 			<StepContainer
 				stepName="chooseADomain"
-				shouldHideNavButtons={ isVideoPressFlow || isBlogOnboardingFlow( flow ) }
+				shouldHideNavButtons={ isVideoPressFlow }
+				hideSkip={ isBlogOnboardingFlow( flow ) }
 				goBack={ goBack }
 				goNext={ goNext }
 				isHorizontalLayout={ false }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
@@ -1,10 +1,12 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
-import { ProductsList } from '@automattic/data-stores';
+import { Gridicon } from '@automattic/components';
+import { ProductsList, useLaunchpad } from '@automattic/data-stores';
 import {
 	DESIGN_FIRST_FLOW,
 	START_WRITING_FLOW,
 	isBlogOnboardingFlow,
 } from '@automattic/onboarding';
+import { Button } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs, getQueryArg } from '@wordpress/url';
@@ -14,7 +16,9 @@ import QueryProductsList from 'calypso/components/data/query-products-list';
 import RegisterDomainStep from 'calypso/components/domains/register-domain-step';
 import { recordUseYourDomainButtonClick } from 'calypso/components/domains/register-domain-step/analytics';
 import FormattedHeader from 'calypso/components/formatted-header';
+import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
+import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
@@ -59,6 +63,19 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 		} else {
 			onAddDomain( null );
 		}
+	};
+
+	const flowName = useQuery().get( 'flowToReturnTo' );
+	const siteSlug = useSiteSlug();
+	const { data: { launchpad_screen: launchpadScreenOption } = {} } = useLaunchpad( siteSlug );
+
+	const returnUrl =
+		launchpadScreenOption === 'skipped'
+			? `/home/${ siteSlug }`
+			: `/setup/${ flowName ?? 'free' }/launchpad?siteSlug=${ siteSlug }`;
+
+	const onBack = () => {
+		return window.location.assign( returnUrl );
 	};
 
 	const onClickUseYourDomain = function () {
@@ -122,6 +139,12 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 					isCartPendingUpdate={ isCartPendingUpdate }
 					isCartPendingUpdateDomain={ isCartPendingUpdateDomain }
 				/>
+				<div>
+					<Button variant="tertiary" onClick={ onBack }>
+						<Gridicon icon="chevron-left" />
+						{ __( 'Back' ) }
+					</Button>
+				</div>
 			</CalypsoShoppingCartProvider>
 		);
 	};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 import { Gridicon } from '@automattic/components';
-import { ProductsList, useLaunchpad } from '@automattic/data-stores';
+import { ProductsList } from '@automattic/data-stores';
 import {
 	DESIGN_FIRST_FLOW,
 	START_WRITING_FLOW,
@@ -16,9 +16,7 @@ import QueryProductsList from 'calypso/components/data/query-products-list';
 import RegisterDomainStep from 'calypso/components/domains/register-domain-step';
 import { recordUseYourDomainButtonClick } from 'calypso/components/domains/register-domain-step/analytics';
 import FormattedHeader from 'calypso/components/formatted-header';
-import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
-import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
@@ -65,17 +63,8 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 		}
 	};
 
-	const flowName = useQuery().get( 'flowToReturnTo' );
-	const siteSlug = useSiteSlug();
-	const { data: { launchpad_screen: launchpadScreenOption } = {} } = useLaunchpad( siteSlug );
-
-	const returnUrl =
-		launchpadScreenOption === 'skipped'
-			? `/home/${ siteSlug }`
-			: `/setup/${ flowName ?? 'free' }/launchpad?siteSlug=${ siteSlug }`;
-
-	const onBack = () => {
-		return window.location.assign( returnUrl );
+	const handleGoBack = async ( goBack: ( () => void ) | undefined ) => {
+		return goBack?.();
 	};
 
 	const onClickUseYourDomain = function () {
@@ -140,7 +129,7 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 					isCartPendingUpdateDomain={ isCartPendingUpdateDomain }
 				/>
 				<div>
-					<Button variant="tertiary" onClick={ onBack }>
+					<Button variant="tertiary" onClick={ () => handleGoBack( goBack ) }>
 						<Gridicon icon="chevron-left" />
 						{ __( 'Back' ) }
 					</Button>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/style.scss
@@ -381,6 +381,7 @@ $videopress-background: #010101;
 	}
 
 	.step-container__navigation .navigation-link:first-of-type {
-		margin-left: 30px;
+		margin-left: 40px;
+		margin-top: 4px;
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/style.scss
@@ -1,4 +1,6 @@
 @import "../../videopress-constants.scss";
+@import "@wordpress/base-styles/breakpoints.scss";
+@import "@wordpress/base-styles/mixins.scss";
 
 $videopress-mobile-layout-width: 1200px;
 $videopress-link-color: #c377ff;
@@ -380,8 +382,10 @@ $videopress-background: #010101;
 		text-decoration: underline;
 	}
 
-	.step-container__navigation .navigation-link:first-of-type {
-		margin-left: 40px;
-		margin-top: 4px;
+	@include break-small {
+		.step-container__navigation .navigation-link:first-of-type {
+			margin-left: 40px;
+			margin-top: 4px;
+		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/style.scss
@@ -379,4 +379,8 @@ $videopress-background: #010101;
 	.has-underline {
 		text-decoration: underline;
 	}
+
+	.step-container__navigation .navigation-link:first-of-type {
+		margin-left: 30px;
+	}
 }

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -234,6 +234,13 @@ const startWriting: Flow = {
 			}
 		}
 
+		const goBack = async () => {
+			switch ( currentStep ) {
+				case 'domains':
+					return navigate( 'launchpad' );
+			}
+		};
+
 		const goNext = async () => {
 			switch ( currentStep ) {
 				case 'launchpad':
@@ -247,7 +254,7 @@ const startWriting: Flow = {
 			}
 		};
 
-		return { goNext, submit };
+		return { goNext, goBack, submit };
 	},
 
 	useAssertConditions(): AssertConditionResult {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #84510

## Proposed Changes

* Un-hide the step navigation for the writing/design-first flows
* Nudge the Back button in the step navigation over to avoid overlap with the flow logo
* This domains step is accessed from the Launchpad after you've created a site from `/setup/start-writing` and is not the same domains step as you see when creating a site from `/start`
* This doesn't account for the case where the user has skipped the Launchpad during onboarding because the "Choose a domain" task goes to a different variation of the domains step in that case.

**Before**

<img width="1359" alt="Screenshot 2023-11-29 at 10 32 45 AM" src="https://github.com/Automattic/wp-calypso/assets/2124984/24b6743b-506b-4d51-ac80-f35c2ab95b45">

**After**
<img width="1358" alt="Screenshot 2023-11-29 at 10 34 35 AM" src="https://github.com/Automattic/wp-calypso/assets/2124984/f59ca1e9-8332-49f9-9e91-c04f681736d2">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR and navigate to `/setup/start-writing`
* Choose a new site (it will work with an existing site as well, but the domains step will already be marked completed).
* Complete the onboarding process until you get to the full-screen Launchpad.
* Click "Choose a domain" in the list of tasks.
* Click the "Back" button in the top left.
* Click on it; you should return to the Launchpad screen without having completing the "Choose a domain" task.
* Click on "Choose a domain" again.
* Click "Decide later" in the heading area.
* You should return to the Launchpad with the domain step completed.
* Create a second new site from the same flow. Proceed through the flow until you get to the Launchpad step.
* Skip the Launchpad using the link in the upper right corner; you'll be redirected to My Home.
* Click Choose a domain in the task list.
* You'll be brought to a different domain picking step; these changes should have no impact on this step.
* Also check that the navigation looks/works on mobile/small screens.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?