### PR TITLE
Router: remove support for NW.js and Windows paths

### DIFF
--- a/packages/calypso-router/src/index.js
+++ b/packages/calypso-router/src/index.js
@@ -397,7 +397,6 @@ pathToRegexp.tokensToRegExp = tokensToRegExp;
 const hasDocument = 'undefined' !== typeof document;
 const hasWindow = 'undefined' !== typeof window;
 const hasHistory = 'undefined' !== typeof history;
-const hasProcess = typeof process !== 'undefined';
 
 /**
  * Detect click event
@@ -809,11 +808,6 @@ Page.prototype.clickHandler = function ( e ) {
 	let path = svg ? el.href.baseVal : el.pathname + el.search + ( el.hash || '' );
 
 	path = path[ 0 ] !== '/' ? '/' + path : path;
-
-	// strip leading "/[drive letter]:" on NW.js on Windows
-	if ( hasProcess && path.match( /^\/[a-zA-Z]:\// ) ) {
-		path = path.replace( /^\/[a-zA-Z]:\//, '/' );
-	}
 
 	// same page
 	const orig = path;


### PR DESCRIPTION
Here's a little PR that removes a very niche feature from the router: support for paths that are Windows FS path. According to the comment they can be used by [NW.js](https://nwjs.io/), which is something like Electron, but older. Haven't heard about it before today.