### PR TITLE
Checkout: Switch cart cost overrides to integer subtotals

### DIFF
--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -115,7 +115,8 @@ function filterAndGroupCostOverridesForDisplay(
 				return;
 			}
 			const discountAmount = grouped[ costOverride.override_code ]?.discountAmount ?? 0;
-			const newDiscountAmount = costOverride.old_price - costOverride.new_price;
+			const newDiscountAmount =
+				costOverride.old_subtotal_integer - costOverride.new_subtotal_integer;
 			grouped[ costOverride.override_code ] = {
 				humanReadableReason: costOverride.human_readable_reason,
 				overrideCode: costOverride.override_code,
@@ -165,7 +166,7 @@ function CostOverridesList( {
 							{ costOverride.humanReadableReason }
 						</span>
 						<span className="cost-overrides-list-item__discount">
-							{ formatCurrency( -costOverride.discountAmount, currency ) }
+							{ formatCurrency( -costOverride.discountAmount, currency, { isSmallestUnit: true } ) }
 						</span>
 					</div>
 				);
@@ -190,7 +191,7 @@ function CostOverridesList( {
 								: costOverride.humanReadableReason }
 						</span>
 						<span className="cost-overrides-list-item__discount">
-							{ formatCurrency( -costOverride.discountAmount, currency ) }
+							{ formatCurrency( -costOverride.discountAmount, currency, { isSmallestUnit: true } ) }
 						</span>
 						<span className="cost-overrides-list-item__actions">
 							<DeleteButton

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -552,11 +552,10 @@ export interface ResponseCartProductVariant {
 
 export interface ResponseCartCostOverride {
 	human_readable_reason: string;
-	new_price: number;
-	old_price: number;
+	new_subtotal_integer: number;
+	old_subtotal_integer: number;
 	override_code: string;
 	does_override_original_cost: boolean;
-	reason: string;
 }
 
 export interface IntroductoryOfferTerms {

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -229,7 +229,6 @@ export interface ResponseCart< P = ResponseCartProduct > {
 
 	/**
 	 * The amount of tax collected.
-	 *
 	 * @deprecated This is a float and is unreliable. Use total_tax_integer.
 	 */
 	total_tax: string;
@@ -246,7 +245,6 @@ export interface ResponseCart< P = ResponseCartProduct > {
 
 	/**
 	 * The cart's total cost.
-	 *
 	 * @deprecated This is a float and is unreliable. Use total_cost_integer.
 	 */
 	total_cost: number;
@@ -363,7 +361,6 @@ export interface ResponseCartProduct {
 
 	/**
 	 * The cart item's original price in the currency's smallest unit.
-	 *
 	 * @deprecated Use item_original_cost_integer or item_original_subtotal_integer.
 	 */
 	product_cost_integer: number;
@@ -404,7 +401,6 @@ export interface ResponseCartProduct {
 
 	/**
 	 * The cart item's subtotal without volume.
-	 *
 	 * @deprecated This is a float and is unreliable. Use item_subtotal_integer
 	 */
 	cost: number;
@@ -416,7 +412,6 @@ export interface ResponseCartProduct {
 	 * before a coupon was applied, it already includes sale coupons (which are
 	 * actually discounts), and other discounts and does not include certain
 	 * other price changes (eg: domain discounts). It's best not to rely on it.
-	 *
 	 * @deprecated This is a float and is unreliable. Use
 	 * item_original_subtotal_integer if you
 	 * can, although those have slightly different meanings.

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -1046,8 +1046,7 @@ const DesktopGiftWrapper = styled.div`
 `;
 
 /**
- * Note that this function returns the cost in the currency's standard unit as
- * a float (eg: dollars in USD).
+ * Note that this function returns the cost in the currency's smallest unit.
  */
 function getCostBeforeDiscounts( product: ResponseCartProduct ): number {
 	const originalCostOverrides =
@@ -1055,16 +1054,16 @@ function getCostBeforeDiscounts( product: ResponseCartProduct ): number {
 	if ( originalCostOverrides.length > 0 ) {
 		const lastOriginalCostOverride = originalCostOverrides.pop();
 		if ( lastOriginalCostOverride ) {
-			return lastOriginalCostOverride.new_price;
+			return lastOriginalCostOverride.new_subtotal_integer;
 		}
 	}
 	if ( product.cost_overrides && product.cost_overrides.length > 0 ) {
 		const firstOverride = product.cost_overrides[ 0 ];
 		if ( firstOverride ) {
-			return firstOverride.old_price;
+			return firstOverride.old_subtotal_integer;
 		}
 	}
-	return product.cost;
+	return product.item_subtotal_integer;
 }
 
 function CheckoutLineItem( {
@@ -1131,7 +1130,9 @@ function CheckoutLineItem( {
 	);
 	const originalAmountInteger = product.item_original_subtotal_integer;
 
-	// Introductory offers have their renewal price returned as the original cost property, and we don't want to show that as the item's cost before discounts, so we calculate that separately here.
+	// Introductory offers have their renewal price returned as the original
+	// cost property, and we don't want to show that as the item's cost before
+	// discounts, so we calculate that separately here.
 	const costBeforeDiscounts = getCostBeforeDiscounts( product );
 
 	const actualAmountDisplay = formatCurrency( product.item_subtotal_integer, product.currency, {
@@ -1175,6 +1176,7 @@ function CheckoutLineItem( {
 				{ hasCheckoutVersion( '2' ) ? (
 					<LineItemPrice
 						actualAmount={ formatCurrency( costBeforeDiscounts, product.currency, {
+							isSmallestUnit: true,
 							stripZeros: true,
 						} ) }
 						isSummary={ isSummary }


### PR DESCRIPTION
## Proposed Changes

This PR applies the changes to cost overrides in the shopping cart endpoint made in D129863-code so that each override now includes volume, which is relevant primarily for multi-year domains but also Google Workspace.

**NOTE:** These changes are only used by the new checkout design, which is not yet live: https://github.com/Automattic/payments-shilling/issues/1969

Before             |  After
:-------------------------:|:-------------------------:
<img width="274" alt="Screenshot 2023-11-29 at 10 26 31 AM" src="https://github.com/Automattic/wp-calypso/assets/2036909/544d881d-67a9-43b9-9e08-4456a2798a8c"> | <img width="269" alt="Screenshot 2023-11-29 at 10 26 36 AM" src="https://github.com/Automattic/wp-calypso/assets/2036909/a9cd6656-efc2-484c-a5e6-df812b7ae74c">

## Testing Instructions

- Add a domain with a discount to your cart and visit checkout. The discount can be because of a bundled domain or a coupon or a sale.
- Select a multi-year domain (eg: 3 years).
- Add `?checkoutVersion=2` to the URL and reload the page.
- Verify that the discounts listed make sense given the number of years purchased.