### PR TITLE
Domains: Use site name as default domain search term when launching site

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -661,7 +661,7 @@ export class SiteSettingsFormGeneral extends Component {
 		} else {
 			btnComponent = (
 				<Button
-					href={ `/start/launch-site?siteSlug=${ siteSlug }&source=general-settings&hide_initial_query=yes` }
+					href={ `/start/launch-site?siteSlug=${ siteSlug }&source=general-settings&new=${ siteSlug }&search=yes` }
 				>
 					{ btnText }
 				</Button>


### PR DESCRIPTION
Currently, we don't have a default term for the domain search when launching the site from the "General settings" page. This PR adds the site name as the default term.

## Testing Instructions
- For an unlaunched site, go to `/settings/general/:siteSlug`;
- Try clicking the "Launch site" button and ensure you get the site name on the search bar;
- Make sure finishing the flow launches the site correctly.

### Before
https://github.com/Automattic/wp-calypso/assets/18705930/6b81713f-f1e9-492c-8e54-d5cdeae92711

### After
https://github.com/Automattic/wp-calypso/assets/18705930/e53c84bb-6298-441d-a81f-45c2761d3fbb


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?