### PR TITLE
Domains: Use site title instead of slug on search for `launch-site` flow

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -133,6 +133,7 @@ class RegisterDomainStep extends Component {
 		domainAndPlanUpsellFlow: PropTypes.bool,
 		useProvidedProductsList: PropTypes.bool,
 		otherManagedSubdomains: PropTypes.array,
+		forceExactSuggestion: PropTypes.bool,
 
 		/**
 		 * If an override is not provided we generate 1 suggestion per 1 other subdomain
@@ -168,6 +169,7 @@ class RegisterDomainStep extends Component {
 		useProvidedProductsList: false,
 		otherManagedSubdomains: null,
 		hasPendingRequests: false,
+		forceExactSuggestion: false,
 	};
 
 	constructor( props ) {
@@ -206,6 +208,11 @@ class RegisterDomainStep extends Component {
 			// If there's a domain name as a query parameter suggestion, we always search for it first when the page loads
 			if ( props.suggestion ) {
 				this.state.lastQuery = getDomainSuggestionSearch( props.suggestion, MIN_QUERY_LENGTH );
+
+				// If we're coming from the general settings page, we want to use the exact site title as the initial query
+				if ( props.forceExactSuggestion ) {
+					this.state.lastQuery = props.suggestion;
+				}
 			}
 		}
 	}

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -661,7 +661,7 @@ export class SiteSettingsFormGeneral extends Component {
 		} else {
 			btnComponent = (
 				<Button
-					href={ `/start/launch-site?siteSlug=${ siteSlug }&source=general-settings&new=${ siteSlug }&search=yes` }
+					href={ `/start/launch-site?siteSlug=${ siteSlug }&source=general-settings&new=${ site.title }&search=yes` }
 				>
 					{ btnText }
 				</Button>

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1112,6 +1112,7 @@ export class RenderDomainsStep extends Component {
 						wpcomSubdomainSelected={ this.state.wpcomSubdomainSelected }
 						hasPendingRequests={ isLoadingExperiment }
 						temporaryCart={ this.state.temporaryCart }
+						forceExactSuggestion={ this.props?.queryObject?.source === 'general-settings' }
 					/>
 				) }
 			</ProvideExperimentData>


### PR DESCRIPTION
Follow-up PR to #84625 - we need to use the site title instead of the site slug.

## Testing Instructions
Follow the same test instructions as #84625, and ensure you get the site title on the search input, not the site slug.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?