### PR TITLE
Assembler: Add copy in the Pages screen

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-screen.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-screen.tsx
@@ -1,6 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
-import { useTranslate } from 'i18n-calypso';
+import { useTranslate, TranslateResult } from 'i18n-calypso';
 import { NAVIGATOR_PATHS } from '../constants';
 import type { ScreenName } from '../types';
 
@@ -12,7 +12,7 @@ export type UseScreenOptions = {
 export type Screen = {
 	name: string;
 	title: string;
-	description: string;
+	description: TranslateResult;
 	continueLabel: string;
 	/** The label for going back from the next screen */
 	backLabel?: string;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-screen.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-screen.tsx
@@ -66,7 +66,12 @@ const useScreen = ( screenName: ScreenName, options: UseScreenOptions = {} ): Sc
 			name: 'pages',
 			title: translate( 'Add more pages' ),
 			description: translate(
-				"We've pre-selected common pages for your site. You can add more pages or unselect the current ones."
+				"We've pre-selected common pages for your site. You can add more pages or unselect the current ones.{{br/}}{{br/}}Page content can be edited later, in the Site Editor.",
+				{
+					components: {
+						br: <br />,
+					},
+				}
 			),
 			continueLabel: translate( 'Save and continue' ),
 			backLabel: translate( 'pages' ),

--- a/packages/onboarding/src/navigator/navigator-header/index.tsx
+++ b/packages/onboarding/src/navigator/navigator-header/index.tsx
@@ -3,12 +3,12 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalNavigatorBackButton as NavigatorBackButton,
 } from '@wordpress/components';
-import { useTranslate } from 'i18n-calypso';
+import { useTranslate, TranslateResult } from 'i18n-calypso';
 import './style.scss';
 
 interface Props {
 	title: JSX.Element;
-	description?: string;
+	description?: TranslateResult;
 	hideBack?: boolean;
 	onBack?: () => void;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #84454

## Proposed Changes

This PR adds the sentence "Page content can be edited later, in the Site Editor" to let users know that the page contents are not editable in this screen, but rather later in the Site Editor.

![Screenshot 2023-11-29 at 10 46 37 AM](https://github.com/Automattic/wp-calypso/assets/797888/e0c4f57f-c7d2-41f6-88c3-e138b7a3e3f0)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Assembler.
* Add any patterns and click on the "Select styles" button.
* Click on the "Select pages" button.
* Ensure that the description is updated as shown in the screenshot above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?