### PR TITLE
Jetpack Manage: Fix the issue license sticky header responsiveness

### DIFF
--- a/client/jetpack-cloud/components/layout/style.scss
+++ b/client/jetpack-cloud/components/layout/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 .is-jetpack-new-navigation {
 	.jetpack-cloud-layout__header h1 {
 		font-weight: 600;
@@ -122,6 +125,11 @@
 	.jetpack-cloud-layout__header-title {
 		font-size: rem(24px);
 		margin-block-end: 0;
+		display: none;
+
+		@include break-large {
+			display: block;
+		}
 	}
 
 	@include breakpoint-deprecated( ">660px" ) {

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/index.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@automattic/components';
+import { useBreakpoint } from '@automattic/viewport-react';
 import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
@@ -53,7 +54,7 @@ export default function IssueLicenseV2( { selectedSite, suggestedProduct }: Assi
 		handleShowLicenseOverview();
 	}, [ handleShowLicenseOverview ] );
 
-	const showStickyContent = selectedLicenses.length > 0;
+	const showStickyContent = useBreakpoint( '>660px' ) && selectedLicenses.length > 0;
 
 	// Group licenses by slug and sort them by quantity
 	const getGroupedLicenses = useCallback( () => {
@@ -89,26 +90,28 @@ export default function IssueLicenseV2( { selectedSite, suggestedProduct }: Assi
 						</Subtitle>
 						<Actions>
 							{ selectedLicenses.length > 0 && (
-								<div className="issue-license-v2__actions">
-									<TotalCost selectedLicenses={ selectedLicenses } />
-									<Button
-										primary
-										className="issue-license-v2__select-license"
-										busy={ ! isReady }
-										onClick={ onClickIssueLicenses }
-									>
-										{ translate(
-											'Review %(numLicenses)d license',
-											'Review %(numLicenses)d licenses',
-											{
-												context: 'button label',
-												count: selectedLicenseCount,
-												args: {
-													numLicenses: selectedLicenseCount,
-												},
-											}
-										) }
-									</Button>
+								<div className="issue-license-v2__controls">
+									<div className="issue-license-v2__actions">
+										<TotalCost selectedLicenses={ selectedLicenses } />
+										<Button
+											primary
+											className="issue-license-v2__select-license"
+											busy={ ! isReady }
+											onClick={ onClickIssueLicenses }
+										>
+											{ translate(
+												'Review %(numLicenses)d license',
+												'Review %(numLicenses)d licenses',
+												{
+													context: 'button label',
+													count: selectedLicenseCount,
+													args: {
+														numLicenses: selectedLicenseCount,
+													},
+												}
+											) }
+										</Button>
+									</div>
 								</div>
 							) }
 						</Actions>

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/style.scss
@@ -33,5 +33,5 @@
 
 .issue-license-v2__controls {
 	@include licensing-portal-bottom-action-bar;
-	padding: 0.875rem;
+	padding: 14px;
 }

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/style.scss
@@ -1,10 +1,12 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "../mixins.scss";
 
 .issue-license-v2__select-license {
 	// :active introduces a 1px border but :focus introduces a 1.5px border which causes the button to move around.
 	border-width: 1.5px !important;
 	border-color: transparent;
+	text-wrap: nowrap;
 
 	@include breakpoint-deprecated("<660px") {
 		width: auto;
@@ -25,11 +27,11 @@
 
 .issue-license-v2__actions {
 	display: flex;
-	justify-content: space-between;
 	align-items: center;
 	gap: 8px;
+}
 
-	@include breakpoint-deprecated( "<960px" ) {
-		justify-content: normal;
-	}
+.issue-license-v2__controls {
+	@include licensing-portal-bottom-action-bar;
+	padding: 0.875rem;
 }

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/total-cost/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/total-cost/style.scss
@@ -3,6 +3,7 @@
 	border: 1px solid var(--studio-gray-5);
 	border-radius: 4px;
 	padding: 8px 14px;
+	text-wrap: nowrap;
 }
 
 .jetpack-cloud-layout__sticky-header .issue-license-v2__total-cost {


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/125

## Proposed Changes

This PR fixes the Issue License page sticky header responsiveness.

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Visit the Jetpack Cloud link > Replace `dashboard` in the URL with `/partner-portal/issue-license?flags=jetpack/bundle-licensing`.
2. Select a few licenses and verify that the total cost and `Review X licenses` button is displayed. Also, scroll through the page and verify the sticky header is displayed. Verify the same on various devices.

Large screen:

![mobile (51)](https://github.com/Automattic/wp-calypso/assets/10586875/abc04320-d897-4d0b-8143-1456b41e9038)

Tablet view (Notice the header title is not displayed):

![mobile (50)](https://github.com/Automattic/wp-calypso/assets/10586875/fd7d171c-57cc-40c2-ac7c-f72b44d06b2a)

Mobile view (Notice there are only bottom controls, and the actions in the header region are hidden)

![mobile (52)](https://github.com/Automattic/wp-calypso/assets/10586875/5564c7ae-35c2-4ea0-a40f-840d34bda9da)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?