### PR TITLE
Jetpack Manage: Migrate the onError handler to useEffect from useFetchDashboardSites

### DIFF
--- a/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
+++ b/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
@@ -1,9 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { useTranslate } from 'i18n-calypso';
-import { useEffect } from 'react';
 import { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
-import { useDispatch } from 'calypso/state';
-import { errorNotice } from 'calypso/state/notices/actions';
 import type {
 	AgencyDashboardFilter,
 	DashboardSortInterface,
@@ -36,10 +32,7 @@ const useFetchDashboardSites = (
 	filter: AgencyDashboardFilter,
 	sort: DashboardSortInterface
 ) => {
-	const translate = useTranslate();
-	const dispatch = useDispatch();
-
-	const data = useQuery( {
+	return useQuery( {
 		queryKey: [ 'jetpack-agency-dashboard-sites', searchQuery, currentPage, filter, sort ],
 		queryFn: () =>
 			wpcomJpl.req.get(
@@ -64,16 +57,6 @@ const useFetchDashboardSites = (
 		},
 		enabled: isPartnerOAuthTokenLoaded,
 	} );
-
-	useEffect( () => {
-		if ( data.isError ) {
-			dispatch(
-				errorNotice( translate( 'Failed to retrieve your sites. Please try again later.' ) )
-			);
-		}
-	}, [ data.isError, dispatch, translate ] );
-
-	return data;
 };
 
 export default useFetchDashboardSites;

--- a/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
+++ b/client/data/agency-dashboard/use-fetch-dashboard-sites.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
 import { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
 import { useDispatch } from 'calypso/state';
 import { errorNotice } from 'calypso/state/notices/actions';
@@ -38,7 +39,7 @@ const useFetchDashboardSites = (
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	return useQuery( {
+	const data = useQuery( {
 		queryKey: [ 'jetpack-agency-dashboard-sites', searchQuery, currentPage, filter, sort ],
 		queryFn: () =>
 			wpcomJpl.req.get(
@@ -61,12 +62,18 @@ const useFetchDashboardSites = (
 				totalFavorites: data.total_favorites,
 			};
 		},
-		onError: () =>
-			dispatch(
-				errorNotice( translate( 'Failed to retrieve your sites. Please try again later.' ) )
-			),
 		enabled: isPartnerOAuthTokenLoaded,
 	} );
+
+	useEffect( () => {
+		if ( data.isError ) {
+			dispatch(
+				errorNotice( translate( 'Failed to retrieve your sites. Please try again later.' ) )
+			);
+		}
+	}, [ data.isError, dispatch, translate ] );
+
+	return data;
 };
 
 export default useFetchDashboardSites;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -23,6 +23,7 @@ import {
 	getSelectedLicenses,
 	getSelectedLicensesSiteId,
 } from 'calypso/state/jetpack-agency-dashboard/selectors';
+import { errorNotice } from 'calypso/state/notices/actions';
 import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
 import { getIsPartnerOAuthTokenLoaded } from 'calypso/state/partner-portal/partner/selectors';
 import OnboardingWidget from '../../partner-portal/primary/onboarding-widget';
@@ -126,6 +127,17 @@ export default function SitesOverview() {
 			refetch();
 		}
 	}, [ refetch, jetpackSiteDisconnected ] );
+
+	useEffect( () => {
+		if ( isError ) {
+			dispatch(
+				errorNotice( translate( 'Failed to retrieve your sites. Please try again later.' ), {
+					id: 'dashboard-sites-fetch-failure',
+					duration: 5000,
+				} )
+			);
+		}
+	}, [ isError, translate, dispatch ] );
 
 	const pageTitle = translate( 'Sites' );
 


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/84338

## Proposed Changes

This PR migrates the onError handler to `useEffect` from `useFetchDashboardSites`

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

**Instructions**

1. Visit the Jetpack Cloud link > Open the dev console > Go to the Network tab > Find the `
https://public-api.wordpress.com/wpcom/v2/jetpack-agency/sites?page=1` API call > Right click & click on `Block Request URL`

<img width="369" alt="Screenshot 2023-11-29 at 12 49 24 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/59af80e6-d1f9-4881-be24-8361df4c00fd">

2. Now go to the Console tab > Run `localStorage.clear();` and right-click on the refresh icon and click `Empty cache & hard reload` > Allow & login again 

<img width="471" alt="Screenshot 2023-11-29 at 12 51 28 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/0b8d749b-6bbd-4385-a369-d4c46cfb4868">

3. Verify that the API call fails 3 times, and you see an error message as shown below. Now follow step 1 & unblock the request URL > Click on any place on the dashboard(fetch on window focus), and verify that the sites load as expected.

<img width="514" alt="Screenshot 2023-11-29 at 12 34 29 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/d83beed1-7d7e-4eb4-b1ae-6242080acc9a">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?