### PR TITLE
Purchase Modal: add feature list

### DIFF
--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -173,7 +173,7 @@ function CheckoutSummaryPriceList() {
 	);
 }
 
-function LoadingCheckoutSummaryFeaturesList() {
+export function LoadingCheckoutSummaryFeaturesList() {
 	return (
 		<>
 			<LoadingCopy />
@@ -361,7 +361,7 @@ export function CheckoutSummaryRefundWindows( {
 	);
 }
 
-function CheckoutSummaryFeaturesList( props: {
+export function CheckoutSummaryFeaturesList( props: {
 	siteId: number | undefined;
 	nextDomainIsFree: boolean;
 } ) {

--- a/client/my-sites/checkout/upsell-nudge/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/index.tsx
@@ -1,4 +1,10 @@
-import { isMonthly, getPlanByPathSlug, TERM_MONTHLY, Product } from '@automattic/calypso-products';
+import {
+	isMonthly,
+	getPlanByPathSlug,
+	TERM_MONTHLY,
+	Product,
+	isPlan,
+} from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { StripeHookProvider } from '@automattic/calypso-stripe';
 import { CompactCard, Gridicon } from '@automattic/components';
@@ -415,6 +421,9 @@ export class UpsellNudge extends Component< UpsellNudgeProps, UpsellNudgeState >
 					productToAdd={ this.props.product }
 					onClose={ onCloseModal }
 					siteSlug={ this.props.siteSlug }
+					showFeatureList={
+						!! ( this.props.product && isPlan( { productSlug: this.props.product?.product_slug } ) )
+					}
 				/>
 			</StripeHookProvider>
 		);

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/content.tsx
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/content.tsx
@@ -237,7 +237,6 @@ export default function PurchaseModalContent( {
 				{ firstProduct && <OrderStep siteSlug={ siteSlug } product={ firstProduct } /> }
 				{ firstCard && <PaymentMethodStep siteSlug={ siteSlug } card={ firstCard } /> }
 				<CheckoutTerms cart={ cart } />
-				<hr />
 				<OrderReview
 					creditsLineItem={ cart.sub_total_integer > 0 ? creditsLineItem : null }
 					shouldDisplayTax={ cart.tax.display_taxes }

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/content.tsx
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/content.tsx
@@ -14,6 +14,7 @@ import { useTranslate } from 'i18n-calypso';
 import React, { useCallback } from 'react';
 import CheckoutTerms from 'calypso/my-sites/checkout/src/components/checkout-terms';
 import { CheckIcon } from '../../src/components/check-icon';
+import { CheckoutSummaryFeaturesList } from '../../src/components/wp-checkout-order-summary';
 import { BEFORE_SUBMIT } from './constants';
 import type { ResponseCart, ResponseCartProduct } from '@automattic/shopping-cart';
 import type { StoredPaymentMethodCard } from 'calypso/lib/checkout/payment-methods';
@@ -223,40 +224,51 @@ export default function PurchaseModalContent( {
 	const firstCard = cards.length > 0 ? cards[ 0 ] : undefined;
 
 	return (
-		<>
-			<Button
-				borderless
-				className="purchase-modal__close"
-				aria-label={ translate( 'Close dialog' ) }
-				onClick={ onClose }
-			>
-				<Gridicon icon="cross-small" />
-			</Button>
-			{ firstProduct && <OrderStep siteSlug={ siteSlug } product={ firstProduct } /> }
-			{ firstCard && <PaymentMethodStep siteSlug={ siteSlug } card={ firstCard } /> }
-			<CheckoutTerms cart={ cart } />
-			<hr />
-			<OrderReview
-				creditsLineItem={ cart.sub_total_integer > 0 ? creditsLineItem : null }
-				shouldDisplayTax={ cart.tax.display_taxes }
-				total={ formatCurrency( cart.total_cost_integer, cart.currency, {
-					isSmallestUnit: true,
-					stripZeros: true,
-				} ) }
-				tax={ formatCurrency( cart.total_tax_integer, cart.currency, {
-					isSmallestUnit: true,
-					stripZeros: true,
-				} ) }
-			/>
-			<PayButton
-				busy={ BEFORE_SUBMIT !== step }
-				onClick={ submitTransaction }
-				totalCost={ cart.total_cost_integer }
-				totalCostDisplay={ formatCurrency( cart.total_cost_integer, cart.currency, {
-					isSmallestUnit: true,
-					stripZeros: true,
-				} ) }
-			/>
-		</>
+		<div className="purchase-modal__wrapper">
+			<div className="purchase-modal__steps">
+				<Button
+					borderless
+					className="purchase-modal__close"
+					aria-label={ translate( 'Close dialog' ) }
+					onClick={ onClose }
+				>
+					<Gridicon icon="cross-small" />
+				</Button>
+				{ firstProduct && <OrderStep siteSlug={ siteSlug } product={ firstProduct } /> }
+				{ firstCard && <PaymentMethodStep siteSlug={ siteSlug } card={ firstCard } /> }
+				<CheckoutTerms cart={ cart } />
+				<hr />
+				<OrderReview
+					creditsLineItem={ cart.sub_total_integer > 0 ? creditsLineItem : null }
+					shouldDisplayTax={ cart.tax.display_taxes }
+					total={ formatCurrency( cart.total_cost_integer, cart.currency, {
+						isSmallestUnit: true,
+						stripZeros: true,
+					} ) }
+					tax={ formatCurrency( cart.total_tax_integer, cart.currency, {
+						isSmallestUnit: true,
+						stripZeros: true,
+					} ) }
+				/>
+				<PayButton
+					busy={ BEFORE_SUBMIT !== step }
+					onClick={ submitTransaction }
+					totalCost={ cart.total_cost_integer }
+					totalCostDisplay={ formatCurrency( cart.total_cost_integer, cart.currency, {
+						isSmallestUnit: true,
+						stripZeros: true,
+					} ) }
+				/>
+			</div>
+			<div className="purchase-modal__features">
+				<h3 className="purchase-modal__features-title">
+					{ translate( 'Included with your purchase' ) }
+				</h3>
+				<CheckoutSummaryFeaturesList
+					siteId={ cart.blog_id }
+					nextDomainIsFree={ cart.next_domain_is_free }
+				/>
+			</div>
+		</div>
 	);
 }

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/content.tsx
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/content.tsx
@@ -210,6 +210,7 @@ export default function PurchaseModalContent( {
 	siteSlug,
 	step,
 	submitTransaction,
+	showFeatureList,
 }: {
 	cards: StoredPaymentMethodCard[];
 	cart: ResponseCart;
@@ -217,6 +218,7 @@ export default function PurchaseModalContent( {
 	siteSlug: string;
 	step: string;
 	submitTransaction(): void;
+	showFeatureList: boolean;
 } ) {
 	const translate = useTranslate();
 	const creditsLineItem = getCreditsLineItemFromCart( cart );
@@ -259,15 +261,17 @@ export default function PurchaseModalContent( {
 					} ) }
 				/>
 			</div>
-			<div className="purchase-modal__features">
-				<h3 className="purchase-modal__features-title">
-					{ translate( 'Included with your purchase' ) }
-				</h3>
-				<CheckoutSummaryFeaturesList
-					siteId={ cart.blog_id }
-					nextDomainIsFree={ cart.next_domain_is_free }
-				/>
-			</div>
+			{ showFeatureList && (
+				<div className="purchase-modal__features">
+					<h3 className="purchase-modal__features-title">
+						{ translate( 'Included with your purchase' ) }
+					</h3>
+					<CheckoutSummaryFeaturesList
+						siteId={ cart.blog_id }
+						nextDomainIsFree={ cart.next_domain_is_free }
+					/>
+				</div>
+			) }
 		</div>
 	);
 }

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/index.tsx
@@ -2,6 +2,7 @@ import { useStripe } from '@automattic/calypso-stripe';
 import { Dialog } from '@automattic/components';
 import { CheckoutProvider } from '@automattic/composite-checkout';
 import { useShoppingCart } from '@automattic/shopping-cart';
+import classNames from 'classnames';
 import { useState, useMemo, useEffect } from 'react';
 import QueryPaymentCountries from 'calypso/components/data/query-countries/payments';
 import { isCreditCard, type StoredPaymentMethodCard } from 'calypso/lib/checkout/payment-methods';
@@ -28,6 +29,7 @@ type PurchaseModalProps = {
 	onClose: () => void;
 	siteSlug: string;
 	productToAdd: MinimalRequestCartProduct;
+	showFeatureList: boolean;
 };
 
 export function PurchaseModal( {
@@ -36,12 +38,14 @@ export function PurchaseModal( {
 	isCartUpdating,
 	onClose,
 	siteSlug,
+	showFeatureList,
 }: {
 	cards: StoredPaymentMethodCard[];
 	isCartUpdating: boolean;
 	cart: ResponseCart;
 	onClose: () => void;
 	siteSlug: string;
+	showFeatureList: boolean;
 } ) {
 	const [ step, setStep ] = useState( BEFORE_SUBMIT );
 	const submitTransaction = useSubmitTransaction( {
@@ -56,11 +60,23 @@ export function PurchaseModal( {
 		siteSlug,
 		step,
 		submitTransaction,
+		showFeatureList,
 	};
 
 	return (
-		<Dialog isVisible={ true } baseClassName="purchase-modal dialog" onClose={ onClose }>
-			{ isCartUpdating ? <Placeholder /> : <Content { ...contentProps } /> }
+		<Dialog
+			isVisible={ true }
+			baseClassName="purchase-modal dialog"
+			className={ classNames( {
+				'has-feature-list': showFeatureList,
+			} ) }
+			onClose={ onClose }
+		>
+			{ isCartUpdating ? (
+				<Placeholder showFeatureList={ showFeatureList } />
+			) : (
+				<Content { ...contentProps } />
+			) }
 		</Dialog>
 	);
 }
@@ -74,7 +90,7 @@ export function wrapValueInManagedValue( value: string | undefined ): ManagedVal
 }
 
 export default function PurchaseModalWrapper( props: PurchaseModalProps ) {
-	const { onClose, productToAdd, siteSlug } = props;
+	const { onClose, productToAdd, siteSlug, showFeatureList } = props;
 
 	const onComplete = useCreatePaymentCompleteCallback( {
 		isComingFromUpsell: true,
@@ -181,6 +197,7 @@ export default function PurchaseModalWrapper( props: PurchaseModalProps ) {
 				cart={ responseCart }
 				onClose={ handleOnClose }
 				siteSlug={ siteSlug }
+				showFeatureList={ showFeatureList }
 			/>
 		</CheckoutProvider>
 	);

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/placeholder.jsx
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/placeholder.jsx
@@ -23,7 +23,7 @@ function PayButton() {
 	return <div className="purchase-modal__pay-button is-placeholder">Pay button</div>;
 }
 
-export default function PurchaseModalPlaceHolder() {
+export default function PurchaseModalPlaceHolder( { showFeatureList } ) {
 	return (
 		<div className="purchase-modal__wrapper">
 			<div className="purchase-modal__steps">
@@ -35,9 +35,11 @@ export default function PurchaseModalPlaceHolder() {
 				<OrderReview />
 				<PayButton />
 			</div>
-			<div className="purchase-modal__features is-placeholder">
-				<LoadingCheckoutSummaryFeaturesList />
-			</div>
+			{ showFeatureList && (
+				<div className="purchase-modal__features is-placeholder">
+					<LoadingCheckoutSummaryFeaturesList />
+				</div>
+			) }
 		</div>
 	);
 }

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/placeholder.jsx
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/placeholder.jsx
@@ -1,3 +1,5 @@
+import { LoadingCheckoutSummaryFeaturesList } from '../../src/components/wp-checkout-order-summary';
+
 function OrderStep() {
 	return (
 		<div className="purchase-modal__step is-placeholder">
@@ -23,12 +25,19 @@ function PayButton() {
 
 export default function PurchaseModalPlaceHolder() {
 	return (
-		<>
-			<OrderStep />
-			<OrderStep />
-			<hr />
-			<OrderReview />
-			<PayButton />
-		</>
+		<div className="purchase-modal__wrapper">
+			<div className="purchase-modal__steps">
+				<OrderStep />
+				<OrderStep />
+				<OrderStep />
+				<OrderStep />
+				<hr />
+				<OrderReview />
+				<PayButton />
+			</div>
+			<div className="purchase-modal__features is-placeholder">
+				<LoadingCheckoutSummaryFeaturesList />
+			</div>
+		</div>
 	);
 }

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/style.scss
@@ -42,7 +42,7 @@ $left-margin: 36px;
 	width: 100%;
 	flex-direction: column;
 	gap: 12px;
-	@include break-small {
+	@include break-medium {
 		gap: 36px;
 		flex-direction: row;
 	}
@@ -54,7 +54,7 @@ $left-margin: 36px;
 	flex-direction: column;
 	max-width: 100%;
 	padding: 16px;
-	@include break-small {
+	@include break-medium {
 		padding: 45px 36px;
 		.has-feature-list & {
 			padding: 45px 0 45px 36px;
@@ -64,7 +64,10 @@ $left-margin: 36px;
 
 .purchase-modal__features {
 	background: var(--gray-gray-0, #f6f7f7);
-	padding: 45px 64px 45px 36px;
+	padding: 45px 36px;
+	@include break-medium {
+		padding: 45px 64px 45px 36px;
+	}
 	&.is-placeholder {
 		flex: 1;
 	}
@@ -174,14 +177,14 @@ $left-margin: 36px;
 	flex-wrap: wrap;
 
 	padding-inline-end: 18px;
-	@include break-small {
+	@include break-medium {
 		padding-inline-end: 0;
 	}
 
 	> dt {
 		width: 60%;
 		margin-inline-start: 18px;
-		@include break-small {
+		@include break-medium {
 			margin-inline-start: $left-margin;
 		}
 	}
@@ -217,7 +220,7 @@ $left-margin: 36px;
 	font-size: 1rem;
 
 	margin: 24px 18px 0 18px;
-	@include break-small {
+	@include break-medium {
 		margin: 24px 0 0 36px;
 	}
 

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 $left-margin: 36px;
 
 @keyframes purchaseModalBackdropfadeIn {
@@ -17,18 +20,15 @@ $left-margin: 36px;
 }
 
 .purchase-modal.dialog__content {
-	--padding: -24px;
-
 	display: flex;
 	flex-direction: column;
 	align-items: flex-start;
-	width: 460px;
+	width: 750px;
 	max-width: 100%;
 	box-sizing: border-box;
 
-	@media ( max-width: 480px ) {
-		--padding: -16px;
-		width: unset;
+	@media ( min-width: 480px ) {
+		padding: 0;
 	}
 
 	> hr {
@@ -40,6 +40,34 @@ $left-margin: 36px;
 		@media screen, ( -webkit-min-device-pixel-ratio: 1.25 ), ( min-resolution: 120dpi ) {
 			height: 0.5px;
 		}
+	}
+}
+
+.purchase-modal__wrapper {
+	display: flex;
+	gap: 30px;
+	width: 100%;
+}
+
+.purchase-modal__steps {
+	flex: 1;
+	display: flex;
+	flex-direction: column;
+	max-width: 100%;
+	@include break-mobile {
+		padding: 36px 0 36px 30px;
+	}
+}
+
+.purchase-modal__features {
+	background: var(--gray-gray-0, #f6f7f7);
+	padding: 36px 30px;
+	&.is-placeholder {
+		flex: 1;
+	}
+	display: none;
+	@include break-mobile {
+		display: block;
 	}
 }
 
@@ -178,13 +206,21 @@ $left-margin: 36px;
  * Pay button
  */
 .purchase-modal__pay-button {
-	align-self: flex-end;
-	margin-top: 24px;
-	min-width: 35%;
+	align-self: stretch;
+	margin: 24px 0 0 36px;
 	font-size: 1rem;
 
 	&.is-placeholder {
 		@include placeholder();
 		height: 2rem;
 	}
+}
+
+.purchase-modal__features-title {
+	color: var(--gray-gray-70, #3c434a);
+	font-size: 1rem;
+	font-style: normal;
+	font-weight: 500;
+	line-height: 20px;
+	margin-bottom: 8px;
 }

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/style.scss
@@ -42,7 +42,7 @@ $left-margin: 36px;
 	width: 100%;
 	flex-direction: column;
 	gap: 12px;
-	@include break-mobile {
+	@include break-small {
 		gap: 36px;
 		flex-direction: row;
 	}
@@ -54,7 +54,7 @@ $left-margin: 36px;
 	flex-direction: column;
 	max-width: 100%;
 	padding: 16px;
-	@include break-mobile {
+	@include break-small {
 		padding: 45px 36px;
 		.has-feature-list & {
 			padding: 45px 0 45px 36px;
@@ -174,14 +174,14 @@ $left-margin: 36px;
 	flex-wrap: wrap;
 
 	padding-inline-end: 18px;
-	@include break-mobile {
+	@include break-small {
 		padding-inline-end: 0;
 	}
 
 	> dt {
 		width: 60%;
 		margin-inline-start: 18px;
-		@include break-mobile {
+		@include break-small {
 			margin-inline-start: $left-margin;
 		}
 	}
@@ -217,7 +217,7 @@ $left-margin: 36px;
 	font-size: 1rem;
 
 	margin: 24px 18px 0 18px;
-	@include break-mobile {
+	@include break-small {
 		margin: 24px 0 0 36px;
 	}
 

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/style.scss
@@ -23,10 +23,14 @@ $left-margin: 36px;
 	display: flex;
 	flex-direction: column;
 	align-items: flex-start;
-	width: 800px;
 	max-width: 100%;
 	box-sizing: border-box;
 	padding: 0;
+
+	width: 460px;
+	&.has-feature-list {
+		width: 800px;
+	}
 
 	@media ( min-width: 480px ) {
 		padding: 0;
@@ -51,7 +55,10 @@ $left-margin: 36px;
 	max-width: 100%;
 	padding: 16px;
 	@include break-mobile {
-		padding: 45px 0 45px 36px;
+		padding: 45px 36px;
+		.has-feature-list & {
+			padding: 45px 0 45px 36px;
+		}
 	}
 }
 

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/style.scss
@@ -23,30 +23,25 @@ $left-margin: 36px;
 	display: flex;
 	flex-direction: column;
 	align-items: flex-start;
-	width: 750px;
+	width: 800px;
 	max-width: 100%;
 	box-sizing: border-box;
+	padding: 0;
 
 	@media ( min-width: 480px ) {
 		padding: 0;
-	}
-
-	> hr {
-		width: calc(100% + var(--padding) * -2);
-		margin: 16px var(--padding);
-		background: var(--color-neutral-5);
-
-		// stylelint-disable-next-line unit-allowed-list
-		@media screen, ( -webkit-min-device-pixel-ratio: 1.25 ), ( min-resolution: 120dpi ) {
-			height: 0.5px;
-		}
 	}
 }
 
 .purchase-modal__wrapper {
 	display: flex;
-	gap: 30px;
 	width: 100%;
+	flex-direction: column;
+	gap: 12px;
+	@include break-mobile {
+		gap: 36px;
+		flex-direction: row;
+	}
 }
 
 .purchase-modal__steps {
@@ -54,20 +49,17 @@ $left-margin: 36px;
 	display: flex;
 	flex-direction: column;
 	max-width: 100%;
+	padding: 16px;
 	@include break-mobile {
-		padding: 36px 0 36px 30px;
+		padding: 45px 0 45px 36px;
 	}
 }
 
 .purchase-modal__features {
 	background: var(--gray-gray-0, #f6f7f7);
-	padding: 36px 30px;
+	padding: 45px 64px 45px 36px;
 	&.is-placeholder {
 		flex: 1;
-	}
-	display: none;
-	@include break-mobile {
-		display: block;
 	}
 }
 
@@ -174,9 +166,17 @@ $left-margin: 36px;
 	justify-content: space-between;
 	flex-wrap: wrap;
 
+	padding-inline-end: 18px;
+	@include break-mobile {
+		padding-inline-end: 0;
+	}
+
 	> dt {
 		width: 60%;
-		margin-left: $left-margin;
+		margin-inline-start: 18px;
+		@include break-mobile {
+			margin-inline-start: $left-margin;
+		}
 	}
 
 	> dd {
@@ -207,8 +207,12 @@ $left-margin: 36px;
  */
 .purchase-modal__pay-button {
 	align-self: stretch;
-	margin: 24px 0 0 36px;
 	font-size: 1rem;
+
+	margin: 24px 18px 0 18px;
+	@include break-mobile {
+		margin: 24px 0 0 36px;
+	}
 
 	&.is-placeholder {
 		@include placeholder();
@@ -222,5 +226,5 @@ $left-margin: 36px;
 	font-style: normal;
 	font-weight: 500;
 	line-height: 20px;
-	margin-bottom: 8px;
+	margin-bottom: 10px;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/2399

## Proposed Changes

This PR adds the feature list to the 1-click checkout modal (PurchaseModal). This will be used in an upcoming test: pau2Xa-5hw-p2

Design Reference: AcoItGd4I74ynixtbanwj4-fi-2%3A504

**Before**
<img width="1920" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/73fed7e1-e844-46b4-a750-1e90768e6131">

**After**
<img width="1920" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/bf7f891d-4e7b-4e6a-9524-a20a1b26df4e">

Mobile:

https://github.com/Automattic/wp-calypso/assets/5436027/f50e15ed-bfa6-4740-b4c7-096e911e863e




## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Make sure that you have a saved credit card.
* Go to `/checkout/<site slug>/offer-plan-upgrade/business/12345` where `<site slug>` can be the slug for any site.
* Click on the "Upgrade Now" button.
* Confirm that you can see the 1-click checkout purchase modal and that the feature list is visible.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?