### PR TITLE
Purchase Modal: extract checkout functions from upsell nudge

### DIFF
--- a/client/my-sites/checkout/src/hooks/use-stored-payment-methods.tsx
+++ b/client/my-sites/checkout/src/hooks/use-stored-payment-methods.tsx
@@ -81,6 +81,7 @@ export function useStoredPaymentMethods( {
 		queryKey,
 		queryFn: () => fetchPaymentMethods( type, expired ),
 		enabled: ! isLoggedOut,
+		staleTime: 5 * 60 * 1000, // 5 minutes
 	} );
 
 	const translate = useTranslate();

--- a/client/my-sites/checkout/src/hooks/use-stored-payment-methods.tsx
+++ b/client/my-sites/checkout/src/hooks/use-stored-payment-methods.tsx
@@ -81,7 +81,6 @@ export function useStoredPaymentMethods( {
 		queryKey,
 		queryFn: () => fetchPaymentMethods( type, expired ),
 		enabled: ! isLoggedOut,
-		staleTime: 5 * 60 * 1000, // 5 minutes
 	} );
 
 	const translate = useTranslate();

--- a/client/my-sites/checkout/upsell-nudge/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/index.tsx
@@ -412,7 +412,6 @@ export class UpsellNudge extends Component< UpsellNudgeProps, UpsellNudgeState >
 		return (
 			<StripeHookProvider fetchStripeConfiguration={ getStripeConfiguration }>
 				<PurchaseModal
-					cart={ this.props.cart }
 					productToAdd={ this.props.product }
 					onClose={ onCloseModal }
 					siteSlug={ this.props.siteSlug }

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/content.tsx
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/content.tsx
@@ -15,10 +15,19 @@ import React, { useCallback } from 'react';
 import CheckoutTerms from 'calypso/my-sites/checkout/src/components/checkout-terms';
 import { CheckIcon } from '../../src/components/check-icon';
 import { BEFORE_SUBMIT } from './constants';
-import { formatDate } from './util';
 import type { ResponseCart, ResponseCartProduct } from '@automattic/shopping-cart';
 import type { StoredPaymentMethodCard } from 'calypso/lib/checkout/payment-methods';
 import type { MouseEventHandler, ReactNode } from 'react';
+
+function formatDate( cardExpiry: string ): string {
+	const expiryDate = new Date( cardExpiry );
+	const formattedDate = expiryDate.toLocaleDateString( 'en-US', {
+		month: '2-digit',
+		year: '2-digit',
+	} );
+
+	return formattedDate;
+}
 
 function PurchaseModalStep( { children, id }: { children: ReactNode; id: string } ) {
 	return (

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/index.tsx
@@ -17,7 +17,7 @@ import { updateCartContactDetailsForCheckout } from '../../src/lib/update-cart-c
 import { BEFORE_SUBMIT } from './constants';
 import Content from './content';
 import Placeholder from './placeholder';
-import { useSubmitTransaction } from './util';
+import { useSubmitTransaction } from './use-submit-transaction';
 import type { MinimalRequestCartProduct, ResponseCart } from '@automattic/shopping-cart';
 import type { ManagedContactDetails, ManagedValue, VatDetails } from '@automattic/wpcom-checkout';
 import type { PaymentProcessorOptions } from 'calypso/my-sites/checkout/src/types/payment-processors';

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/index.tsx
@@ -158,12 +158,8 @@ export default function PurchaseModalWrapper( props: PurchaseModalProps ) {
 	}, [ replaceProductsInCart, updateLocation, storedCard, productToAdd, countries ] );
 
 	const handleOnClose = () => {
-		try {
-			updateLocation( { countryCode: '' } );
-			replaceProductsInCart( [] );
-		} catch {
-			// No need to do anything if this fails.
-		}
+		Promise.all( [ updateLocation( { countryCode: '' } ), replaceProductsInCart( [] ) ] ).catch();
+		// We don't need to wait for the result of the above.
 		onClose();
 	};
 

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/index.tsx
@@ -154,6 +154,8 @@ export default function PurchaseModalWrapper( props: PurchaseModalProps ) {
 		return () => {
 			isUpdatingCart = true;
 		};
+		// This hook updates cart values which also changes the `responseCart` variable.
+		// We do not want this effect to run when `responseCart` is updated to avoid an infinite loop.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ replaceProductsInCart, updateLocation, storedCard, productToAdd, countries ] );
 

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/use-is-eligible-for-one-click-checkout.ts
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/use-is-eligible-for-one-click-checkout.ts
@@ -1,0 +1,68 @@
+import { UseQueryResult, useQuery } from '@tanstack/react-query';
+import { isCreditCard, type StoredPaymentMethod } from 'calypso/lib/checkout/payment-methods';
+import { useStoredPaymentMethods } from '../../src/hooks/use-stored-payment-methods';
+import {
+	getTaxValidationResult,
+	isContactValidationResponseValid,
+} from '../../src/lib/contact-validation';
+import { wrapValueInManagedValue } from '.';
+
+export interface IsEligibleForOneClickCheckoutReturnValue {
+	result: boolean | null;
+	isLoading: boolean;
+}
+
+const useIsContactInfoValid = (
+	paymentMethods: StoredPaymentMethod[]
+): UseQueryResult< boolean | null > => {
+	const storedCard = paymentMethods.length > 0 ? paymentMethods[ 0 ] : undefined;
+
+	const validateContactDetails = async () => {
+		const validationResult = await getTaxValidationResult( {
+			state: wrapValueInManagedValue( storedCard?.tax_location?.subdivision_code ),
+			city: wrapValueInManagedValue( storedCard?.tax_location?.city ),
+			postalCode: wrapValueInManagedValue( storedCard?.tax_location?.postal_code ),
+			countryCode: wrapValueInManagedValue( storedCard?.tax_location?.country_code ),
+			organization: wrapValueInManagedValue( storedCard?.tax_location?.organization ),
+			address1: wrapValueInManagedValue( storedCard?.tax_location?.address ),
+			vatId: wrapValueInManagedValue( storedCard?.tax_location?.vat_id ),
+		} );
+		return isContactValidationResponseValid( validationResult );
+	};
+
+	return useQuery( {
+		queryKey: [ 'contact-info-validation-result' ],
+		queryFn: validateContactDetails,
+		enabled: paymentMethods.length !== 0,
+		refetchOnWindowFocus: true,
+	} );
+};
+
+export const useIsEligibleForOneClickCheckout = (): IsEligibleForOneClickCheckoutReturnValue => {
+	const { isLoading: isStoredPaymentsLoading, paymentMethods } = useStoredPaymentMethods( {
+		type: 'card',
+	} );
+	const { isLoading: isContactInfoValidationLoading, data: contactValidationResult } =
+		useIsContactInfoValid( paymentMethods );
+
+	if ( isStoredPaymentsLoading || isContactInfoValidationLoading ) {
+		return {
+			isLoading: true,
+			result: null,
+		};
+	}
+
+	const storedCards = paymentMethods.filter( isCreditCard );
+
+	if ( ! storedCards.length ) {
+		return {
+			isLoading: false,
+			result: false,
+		};
+	}
+
+	return {
+		isLoading: false,
+		result: contactValidationResult || null,
+	};
+};

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/use-is-eligible-for-one-click-checkout.ts
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/use-is-eligible-for-one-click-checkout.ts
@@ -42,7 +42,7 @@ export const useIsEligibleForOneClickCheckout = (): IsEligibleForOneClickCheckou
 	const { isLoading: isStoredPaymentsLoading, paymentMethods } = useStoredPaymentMethods( {
 		type: 'card',
 	} );
-	const { isLoading: isContactInfoValidationLoading, data: contactValidationResult } =
+	const { isInitialLoading: isContactInfoValidationLoading, data: contactValidationResult } =
 		useIsContactInfoValid( paymentMethods );
 
 	if ( isStoredPaymentsLoading || isContactInfoValidationLoading ) {

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/use-submit-transaction.ts
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/use-submit-transaction.ts
@@ -56,13 +56,3 @@ export function useSubmitTransaction( {
 			} );
 	}, [ callPaymentProcessor, storedCard, setStep, onClose, reduxDispatch ] );
 }
-
-export function formatDate( cardExpiry: string ): string {
-	const expiryDate = new Date( cardExpiry );
-	const formattedDate = expiryDate.toLocaleDateString( 'en-US', {
-		month: '2-digit',
-		year: '2-digit',
-	} );
-
-	return formattedDate;
-}

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/with-is-eligible-for-one-click-checkout.tsx
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/with-is-eligible-for-one-click-checkout.tsx
@@ -1,0 +1,23 @@
+import {
+	type IsEligibleForOneClickCheckoutReturnValue,
+	useIsEligibleForOneClickCheckout,
+} from './use-is-eligible-for-one-click-checkout';
+import type { ComponentType } from 'react';
+
+export interface WithIsEligibleForOneClickCheckoutProps {
+	isEligibleForOneClickCheckout: IsEligibleForOneClickCheckoutReturnValue;
+}
+
+export function withIsEligibleForOneClickCheckout< P >( Component: ComponentType< P > ) {
+	return function IsEligibleForOneClickCheckoutWrapper(
+		props: Omit< P, keyof WithIsEligibleForOneClickCheckoutProps >
+	) {
+		const isEligibleForOneClickCheckout = useIsEligibleForOneClickCheckout();
+		return (
+			<Component
+				{ ...( props as P ) }
+				isEligibleForOneClickCheckout={ isEligibleForOneClickCheckout }
+			/>
+		);
+	};
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/2399

## Proposed Changes

This refactor is required for an upcoming experiment to test the 1-click checkout modal: pau2Xa-5hw-p2

This PR contains the following 2 refactors:
1. Move logic for determining 1-click checkout eligibility by fetching/validating payment and contact details from `UpsellNudge` to a new `useIsEligibleForOneClickCheckout` hook.
1. Move logic for updating contact details and adding product to the cart from `UpsellNudge` to `PurchaseModal`.

Going forward, any page/component that needs to render the 1-click purchase modal can do so via the following (pseudo-code)
```js
const isEligibleForOneClickCheckout = useIsEligibleForOneClickCheckout();

if ( isEligibleForOneClickCheckout.isLoading ) {
	return <Loader />
}

if ( isEligibleForOneClickCheckout.result ) {
	<StripeHookProvider fetchStripeConfiguration={ getStripeConfiguration }>
		<PurchaseModal
			siteSlug={ /* site slug */ }
			productToAdd={ /* MinimalRequestCartProduct */ }
			onClose={ onCloseModal }
		/>
	</StripeHookProvider>
}
```

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure that you have a saved credit card.
* Go to `/checkout/<site slug>/offer-plan-upgrade/business/12345` where `<site slug>` can be the slug for any site.
* Click on the "Upgrade Now" button.
* Confirm that you can see the 1-click checkout purchase modal.
* Close the modal.
* In a new tab, go to `/checkout/<site slug>`. Confirm that the cart is empty. (Closing the modal should clear the cart)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?