### PR TITLE
Hosting Command Palette: Implement site selection step

### DIFF
--- a/client/components/command-pallette/wpcom-command-pallette.tsx
+++ b/client/components/command-pallette/wpcom-command-pallette.tsx
@@ -214,13 +214,11 @@ export const WpcomCommandPalette = () => {
 			<StyledCommandsMenuContainer className="commands-command-menu__container">
 				<Command label={ __( 'Command palette' ) } onKeyDown={ onKeyDown }>
 					<div className="commands-command-menu__header">
-						<div>
-							{ selectedCommandName ? (
-								<Icon icon={ backIcon } onClick={ reset } />
-							) : (
-								<Icon icon={ inputIcon } />
-							) }
-						</div>
+						{ selectedCommandName ? (
+							<Icon icon={ backIcon } onClick={ reset } />
+						) : (
+							<Icon icon={ inputIcon } />
+						) }
 						<CommandInput
 							search={ search }
 							setSearch={ setSearch }

--- a/client/components/command-pallette/wpcom-command-pallette.tsx
+++ b/client/components/command-pallette/wpcom-command-pallette.tsx
@@ -112,7 +112,7 @@ export function CommandMenuGroup( {
 									</SubLabel>
 								) }
 							</LabelWrapper>
-							{ selectedCommandName ? null : <Icon icon={ forwardIcon } /> }
+							{ command.siteFunctions ? <Icon icon={ forwardIcon } /> : null }
 						</HStack>
 					</Command.Item>
 				);

--- a/client/components/command-pallette/wpcom-command-pallette.tsx
+++ b/client/components/command-pallette/wpcom-command-pallette.tsx
@@ -1,7 +1,12 @@
 import styled from '@emotion/styled';
 import { Modal, TextHighlight, __experimentalHStack as HStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Icon, search as inputIcon, chevronLeft as backIcon } from '@wordpress/icons';
+import {
+	Icon,
+	search as inputIcon,
+	chevronLeft as backIcon,
+	chevronRight as forwardIcon,
+} from '@wordpress/icons';
 import { cleanForSlug } from '@wordpress/url';
 import classnames from 'classnames';
 import { Command, useCommandState } from 'cmdk';
@@ -107,6 +112,7 @@ export function CommandMenuGroup( {
 									</SubLabel>
 								) }
 							</LabelWrapper>
+							{ selectedCommandName ? null : <Icon icon={ forwardIcon } /> }
 						</HStack>
 					</Command.Item>
 				);

--- a/client/components/command-pallette/wpcom-command-pallette.tsx
+++ b/client/components/command-pallette/wpcom-command-pallette.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { Modal, TextHighlight, __experimentalHStack as HStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Icon, search as inputIcon } from '@wordpress/icons';
+import { Icon, search as inputIcon, chevronLeft as backIcon } from '@wordpress/icons';
 import { cleanForSlug } from '@wordpress/url';
 import classnames from 'classnames';
 import { Command, useCommandState } from 'cmdk';
@@ -214,7 +214,13 @@ export const WpcomCommandPalette = () => {
 			<StyledCommandsMenuContainer className="commands-command-menu__container">
 				<Command label={ __( 'Command palette' ) } onKeyDown={ onKeyDown }>
 					<div className="commands-command-menu__header">
-						<Icon icon={ inputIcon } />
+						<div>
+							{ selectedCommandName ? (
+								<Icon icon={ backIcon } onClick={ reset } />
+							) : (
+								<Icon icon={ inputIcon } />
+							) }
+						</div>
 						<CommandInput
 							search={ search }
 							setSearch={ setSearch }

--- a/client/sites-dashboard/components/wpcom-smp-commands.tsx
+++ b/client/sites-dashboard/components/wpcom-smp-commands.tsx
@@ -38,7 +38,7 @@ export const useCommandsArrayWpcom = ( {
 		( { setSearch, setPlaceholderOverride }: CommandCallBackParams ) => {
 			setSearch( '' );
 			setSelectedCommandName( actionName );
-			setPlaceholderOverride( translate( 'Search for a site' ) );
+			setPlaceholderOverride( translate( 'Select a site' ) );
 		};
 
 	const { __ } = useI18n();


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/4668

## Proposed Changes

This PR adds the back button (chevron) to the nested commands modal and the forward button for each top-level command as suggested by designs:

**Back button with nested commands**:

<img width="804" alt="Screenshot 2023-11-29 at 10 01 29 AM" src="https://github.com/Automattic/wp-calypso/assets/25575134/075bccb5-53cc-4e24-ac0b-08891b927852">

**Forward button with each individual top-level command:**

<img width="889" alt="Screenshot 2023-11-29 at 10 01 21 AM" src="https://github.com/Automattic/wp-calypso/assets/25575134/2168aae7-1884-4d56-a115-5b84e372bd8d">

**Suggested designs**:

<img width="642" alt="Screenshot 2023-11-29 at 10 03 14 AM" src="https://github.com/Automattic/wp-calypso/assets/25575134/1deb1498-7ad4-49ee-abb4-ecf3262bbdd6">

<img width="451" alt="Screenshot 2023-11-29 at 10 03 22 AM" src="https://github.com/Automattic/wp-calypso/assets/25575134/19d48503-8619-47a3-8f90-2da60d33e68d">

## Testing Instructions

* Navigate to Calypso Live link or pull changes from this branch locally
* Navigate to `/sites`
* Press `cmd + k` on macOS and `ctrl + k` on Windows to trigger command palette
* Observe the forward button present by each top-level command
* Select one of the commands that has a nested command e.g. `Manage DNS`
* Confirm that the back button (chevron) is present on the top instead of a search icon
* Confirm that clicking the back button brings you to the top-level commands
* Confirm that there is no forward button by each listed site
* Check mobile view and confirm that the chevron placement looks good

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?