### PR TITLE
Jetpack App: remove the redirect to / when not mobile app

### DIFF
--- a/client/jetpack-app/controller.tsx
+++ b/client/jetpack-app/controller.tsx
@@ -1,7 +1,6 @@
-import page, { type Callback } from '@automattic/calypso-router';
-import { isWpMobileApp } from 'calypso/lib/mobile-app';
 import JetpackAppEmptyContent from './empty';
 import JetpackAppPlans from './plans/main';
+import type { Callback } from '@automattic/calypso-router';
 
 export const jetpackAppPlans: Callback = ( context, next ) => {
 	context.primary = (
@@ -12,14 +11,6 @@ export const jetpackAppPlans: Callback = ( context, next ) => {
 	);
 
 	next();
-};
-
-export const redirectIfNotJetpackApp: Callback = ( _context, next ) => {
-	if ( ! isWpMobileApp() ) {
-		page.redirect( '/' );
-	} else {
-		next();
-	}
 };
 
 export const pageNotFound: Callback = ( context, next ) => {

--- a/client/jetpack-app/index.ts
+++ b/client/jetpack-app/index.ts
@@ -1,16 +1,10 @@
 import page from '@automattic/calypso-router';
 import { render as clientRender } from 'calypso/controller';
-import { jetpackAppPlans, pageNotFound, redirectIfNotJetpackApp } from './controller';
+import { jetpackAppPlans, pageNotFound } from './controller';
 import { makeJetpackAppLayout } from './page-middleware/layout';
 
 export default function () {
-	page(
-		'/jetpack-app/plans',
-		redirectIfNotJetpackApp,
-		jetpackAppPlans,
-		makeJetpackAppLayout,
-		clientRender
-	);
+	page( '/jetpack-app/plans', jetpackAppPlans, makeJetpackAppLayout, clientRender );
 
 	// Default to /plans page until we have more pages
 	page( '/jetpack-app', '/jetpack-app/plans' );


### PR DESCRIPTION
The `/jetpack-app/plans` route redirects to `/` when the request doesn't have a mobile app user agent (`wp-android` etc.). This PR removes that redirect because it's one possible failure point when the `/jetpack-app/plans` page is displayed. And the redirect doesn't serve any useful purpose. For a non-mobile client, it doesn't redirect you to a "better" page, it's a blunt redirect to `/`, a completely unrelated page.