### PR TITLE
Jetpack Manage: Redirect to https://jetpack.com/manage/ if a non-agency user visits dashboard with `wp-admin` as origin

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/controller.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/controller.tsx
@@ -7,7 +7,14 @@ import DashboardOverview from './dashboard-overview';
 import Header from './header';
 
 export const agencyDashboardContext: Callback = ( context, next ) => {
-	const { s: search, page: contextPage, issue_types, sort_field, sort_direction } = context.query;
+	const {
+		s: search,
+		page: contextPage,
+		issue_types,
+		sort_field,
+		sort_direction,
+		origin,
+	} = context.query;
 	const filter = {
 		issueTypes: issue_types?.split( ',' ),
 		showOnlyFavorites: context.params.filter === 'favorites',
@@ -20,6 +27,10 @@ export const agencyDashboardContext: Callback = ( context, next ) => {
 	const isAgency = isAgencyUser( state );
 	const isAgencyEnabled = config.isEnabled( 'jetpack/agency-dashboard' );
 	if ( ! isAgency || ! isAgencyEnabled ) {
+		if ( origin === 'wp-admin' ) {
+			window.location.href = 'https://jetpack.com/manage/';
+			return;
+		}
 		return page.redirect( '/' );
 	}
 

--- a/client/jetpack-cloud/sections/agency-dashboard/controller.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/controller.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import page, { type Callback } from '@automattic/calypso-router';
 import JetpackManageSidebar from 'calypso/jetpack-cloud/sections/sidebar-navigation/jetpack-manage';
@@ -27,7 +28,9 @@ export const agencyDashboardContext: Callback = ( context, next ) => {
 	const isAgency = isAgencyUser( state );
 	const isAgencyEnabled = config.isEnabled( 'jetpack/agency-dashboard' );
 	if ( ! isAgency || ! isAgencyEnabled ) {
+		// Redirect to Jetpack.com if the user is not an agency user & the origin is wp-admin
 		if ( origin === 'wp-admin' ) {
+			recordTracksEvent( 'calypso_jetpack_manage_redirect_to_manage_in_jetpack_dot_com' );
 			window.location.href = 'https://jetpack.com/manage/';
 			return;
 		}


### PR DESCRIPTION
Related to https://github.com/Automattic/jetpack-manage/issues/138

## Proposed Changes

This PR handles the redirect to https://jetpack.com/manage/ if a non-agency user visits the dashboard with wp-admin as the origin.

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. 

**Instructions**

1. Set yourself as a non-agency user if you are already using an agent user.
2. Visit the Jetpack Cloud link > Visit `/dashboard?origin=wp-admin` > You should be redirect to `https://jetpack.com/manage/`. 
3. Now visit the `/dashboard` without the query, and verify that you are redirected to `/landing`.
4. Set yourself as an agency and visit `/dashboard?origin=wp-admin` > You should not be redirected now. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?