### PR TITLE
Jetpack Manage: Fix a typo in review licenses modal

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/pricing-summary.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/pricing-summary.tsx
@@ -40,7 +40,7 @@ export default function PricingSummary( {
 				<span className="review-licenses__pricing-original">
 					{ formatCurrency( actualCost, currency ) }
 				</span>
-				<div className="review-licenses__pricing-interval">{ translate( '/per month' ) }</div>
+				<div className="review-licenses__pricing-interval">{ translate( '/month' ) }</div>
 			</div>
 			<Button primary className="review-licenses__cta-button" onClick={ handleCTAClick }>
 				{ translate( 'Issue %(numLicenses)d license', 'Issue %(numLicenses)d licenses', {


### PR DESCRIPTION
## Proposed Changes

This PR fixes a minor typo reported by the i18n team.

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

**Instructions**

1. Visit the Jetpack Cloud link > Replace `dashboard` in the URL with `/partner-portal/issue-license?flags=jetpack/bundle-licensing`.
2. Select a few licenses > Click the `Review X licenses` button. Verify that the text now shows `/month` instead of `/per month` since `/ ` & `per` means the same.

<img width="421" alt="Screenshot 2023-11-29 at 3 23 52 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/10fbf05a-a376-4432-a987-05761ac5e426">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?