### PR TITLE
Jetpack Manage: Merged products and plans variants in the same product card.

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/hooks/use-product-and-plans.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/hooks/use-product-and-plans.tsx
@@ -75,7 +75,9 @@ const getDisplayablePlans = ( filteredProductsAndBundles: APIProductFamilyProduc
 
 	const filteredPlans = MERGABLE_PLANS.map( ( filter ) => {
 		return plans.filter( ( { slug } ) => slug.startsWith( filter ) );
-	} ).filter( ( subArray ) => subArray.length > 0 ); // Remove empty arrays
+	} )
+		.filter( ( subArray ) => subArray.length > 0 ) // Remove empty arrays
+		.map( ( mergedPlans ) => ( mergedPlans.length === 1 ? mergedPlans[ 0 ] : mergedPlans ) ); // flat out if only one plan.
 
 	const restOfPlans = plans.filter( ( { slug } ) => {
 		return ! MERGABLE_PLANS.some( ( filter ) => slug.startsWith( filter ) );
@@ -92,7 +94,11 @@ const getDisplayableProducts = ( filteredProductsAndBundles: APIProductFamilyPro
 	);
 	const filteredProducts = MERGABLE_PRODUCTS.map( ( filter ) => {
 		return products.filter( ( { slug } ) => slug.startsWith( filter ) );
-	} ).filter( ( subArray ) => subArray.length > 0 ); // Remove empty arrays
+	} )
+		.filter( ( subArray ) => subArray.length > 0 ) // Remove empty arrays
+		.map( ( mergedProducts ) =>
+			mergedProducts.length === 1 ? mergedProducts[ 0 ] : mergedProducts
+		); // flat out if only one product.
 
 	const restOfProducts = products.filter( ( { slug } ) => {
 		return ! MERGABLE_PRODUCTS.some( ( filter ) => slug.startsWith( filter ) );

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/hooks/use-product-and-plans.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/hooks/use-product-and-plans.tsx
@@ -65,6 +65,33 @@ const getProductsAndPlansByFilter = (
 	return allProductsAndPlans || [];
 };
 
+// This function gets the displayable Plans based on how it should be arranged in the listing.
+const getDisplayablePlans = ( filteredProductsAndBundles: APIProductFamilyProduct[] ) => {
+	const plans = getProductsAndPlansByFilter( PRODUCT_FILTER_PLANS, filteredProductsAndBundles );
+
+	const securityPlans = plans.filter( ( { slug } ) => slug.startsWith( 'jetpack-security' ) );
+	const restOfPlans = plans.filter( ( { slug } ) => ! slug.startsWith( 'jetpack-security' ) );
+
+	return [ securityPlans, ...restOfPlans ];
+};
+
+// This function gets the displayable Products based on how it should be arranged in the listing.
+const getDisplayableProducts = ( filteredProductsAndBundles: APIProductFamilyProduct[] ) => {
+	const products = getProductsAndPlansByFilter(
+		PRODUCT_FILTER_PRODUCTS,
+		filteredProductsAndBundles
+	);
+
+	const backupProducts = products.filter( ( { slug } ) => slug.startsWith( 'jetpack-backup' ) );
+	const restOfProducts = products.filter( ( { slug } ) => ! slug.startsWith( 'jetpack-backup' ) );
+
+	return [ ...restOfProducts, backupProducts ].sort( ( a, b ) => {
+		const product_a = Array.isArray( a ) ? a[ 0 ].name : a.name;
+		const product_b = Array.isArray( b ) ? b[ 0 ].name : b.name;
+		return product_a.localeCompare( product_b );
+	} );
+};
+
 export default function useProductAndPlans( {
 	selectedBundleSize = 1,
 	selectedSite,
@@ -130,8 +157,8 @@ export default function useProductAndPlans( {
 		return {
 			isLoadingProducts,
 			filteredProductsAndBundles,
-			plans: getProductsAndPlansByFilter( PRODUCT_FILTER_PLANS, filteredProductsAndBundles ),
-			products: getProductsAndPlansByFilter( PRODUCT_FILTER_PRODUCTS, filteredProductsAndBundles ),
+			plans: getDisplayablePlans( filteredProductsAndBundles ),
+			products: getDisplayableProducts( filteredProductsAndBundles ),
 			backupAddons: getProductsAndPlansByFilter(
 				PRODUCT_FILTER_VAULTPRESS_BACKUP_ADDONS,
 				filteredProductsAndBundles

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
@@ -126,6 +126,7 @@ export default function LicensesForm( {
 					isDisabled={ ! isReady }
 					tabIndex={ 100 + i }
 					hideDiscount={ isSingleLicenseView }
+					suggestedProduct={ suggestedProduct }
 				/>
 			) : (
 				<LicenseProductCard
@@ -134,9 +135,10 @@ export default function LicensesForm( {
 					product={ productOption }
 					onSelectProduct={ onSelectProduct }
 					isSelected={ isSelected( productOption.slug ) }
-					isDisabled={ ! isReady }
+					isDisabled={ ! isReady || disabledProductSlugs.includes( productOption.slug ) }
 					tabIndex={ 100 + i }
 					hideDiscount={ isSingleLicenseView }
+					suggestedProduct={ suggestedProduct }
 				/>
 			)
 		);
@@ -192,19 +194,7 @@ export default function LicensesForm( {
 						'You must have WooCommerce installed to utilize these paid extensions.'
 					) }
 				>
-					{ wooExtensions.map( ( productOption, i ) => (
-						<LicenseProductCard
-							isMultiSelect
-							key={ productOption.slug }
-							product={ productOption }
-							onSelectProduct={ onSelectProduct }
-							isSelected={ isSelected( productOption.slug ) }
-							isDisabled={ disabledProductSlugs.includes( productOption.slug ) }
-							tabIndex={ 100 + i }
-							suggestedProduct={ suggestedProduct }
-							hideDiscount={ isSingleLicenseView }
-						/>
-					) ) }
+					{ getProductCards( wooExtensions ) }
 				</LicensesFormSection>
 			) }
 
@@ -215,19 +205,7 @@ export default function LicensesForm( {
 						'Add additional storage to your current VaultPress Backup plans.'
 					) }
 				>
-					{ backupAddons.map( ( productOption, i ) => (
-						<LicenseProductCard
-							isMultiSelect
-							key={ productOption.slug }
-							product={ productOption }
-							onSelectProduct={ onSelectProduct }
-							isSelected={ isSelected( productOption.slug ) }
-							isDisabled={ disabledProductSlugs.includes( productOption.slug ) }
-							tabIndex={ 100 + i }
-							suggestedProduct={ suggestedProduct }
-							hideDiscount={ isSingleLicenseView }
-						/>
-					) ) }
+					{ getProductCards( backupAddons ) }
 				</LicensesFormSection>
 			) }
 		</div>

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
@@ -113,6 +113,35 @@ export default function LicensesForm( {
 
 	const isSingleLicenseView = quantity === 1;
 
+	const getProductCards = (
+		products: ( APIProductFamilyProduct | APIProductFamilyProduct[] )[]
+	) => {
+		return products.map( ( productOption, i ) =>
+			Array.isArray( productOption ) ? (
+				<LicenseMultiProductCard
+					key={ productOption.map( ( { slug } ) => slug ).join( ',' ) }
+					products={ productOption }
+					onSelectProduct={ onSelectOrReplaceProduct }
+					isSelected={ isSelected( productOption.map( ( { slug } ) => slug ) ) }
+					isDisabled={ ! isReady }
+					tabIndex={ 100 + i }
+					hideDiscount={ isSingleLicenseView }
+				/>
+			) : (
+				<LicenseProductCard
+					isMultiSelect
+					key={ productOption.slug }
+					product={ productOption }
+					onSelectProduct={ onSelectProduct }
+					isSelected={ isSelected( productOption.slug ) }
+					isDisabled={ ! isReady }
+					tabIndex={ 100 + i }
+					hideDiscount={ isSingleLicenseView }
+				/>
+			)
+		);
+	};
+
 	if ( isLoadingProducts ) {
 		return (
 			<div className="licenses-form">
@@ -141,30 +170,7 @@ export default function LicensesForm( {
 					) }
 					isTwoColumns
 				>
-					{ plans.map( ( productOption, i ) =>
-						Array.isArray( productOption ) ? (
-							<LicenseMultiProductCard
-								key={ productOption.map( ( { slug } ) => slug ).join( ',' ) }
-								products={ productOption }
-								onSelectProduct={ onSelectOrReplaceProduct }
-								isSelected={ isSelected( productOption.map( ( { slug } ) => slug ) ) }
-								isDisabled={ ! isReady }
-								tabIndex={ 100 + i }
-								hideDiscount={ isSingleLicenseView }
-							/>
-						) : (
-							<LicenseProductCard
-								isMultiSelect
-								key={ productOption.slug }
-								product={ productOption }
-								onSelectProduct={ onSelectProduct }
-								isSelected={ isSelected( productOption.slug ) }
-								isDisabled={ ! isReady }
-								tabIndex={ 100 + i }
-								hideDiscount={ isSingleLicenseView }
-							/>
-						)
-					) }
+					{ getProductCards( plans ) }
 				</LicensesFormSection>
 			) }
 
@@ -175,31 +181,7 @@ export default function LicensesForm( {
 						'Mix and match powerful security, performance, and growth tools for your sites.'
 					) }
 				>
-					{ products.map( ( productOption, i ) =>
-						Array.isArray( productOption ) ? (
-							<LicenseMultiProductCard
-								key={ productOption.map( ( { slug } ) => slug ).join( ',' ) }
-								products={ productOption }
-								onSelectProduct={ onSelectOrReplaceProduct }
-								isSelected={ isSelected( productOption.map( ( { slug } ) => slug ) ) }
-								isDisabled={ ! isReady }
-								tabIndex={ 100 + i }
-								hideDiscount={ isSingleLicenseView }
-							/>
-						) : (
-							<LicenseProductCard
-								isMultiSelect
-								key={ productOption.slug }
-								product={ productOption }
-								onSelectProduct={ onSelectProduct }
-								isSelected={ isSelected( productOption.slug ) }
-								isDisabled={ disabledProductSlugs.includes( productOption.slug ) }
-								tabIndex={ 100 + i }
-								suggestedProduct={ suggestedProduct }
-								hideDiscount={ isSingleLicenseView }
-							/>
-						)
-					) }
+					{ getProductCards( products ) }
 				</LicensesFormSection>
 			) }
 

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/sections.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/sections.tsx
@@ -1,14 +1,21 @@
+import classNames from 'classnames';
 import { ReactNode } from 'react';
 
 type Props = {
 	title: string;
 	description: string;
 	children: ReactNode;
+	isTwoColumns?: boolean;
 };
 
-export default function LicensesFormSection( { title, description, children }: Props ) {
+export default function LicensesFormSection( {
+	title,
+	description,
+	children,
+	isTwoColumns,
+}: Props ) {
 	return (
-		<div className="licenses-form__section">
+		<div className={ classNames( 'licenses-form__section', { 'is-two-columns': isTwoColumns } ) }>
 			<h2 className="licenses-form__section-title">
 				<span>{ title }</span>
 				<hr />

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/style.scss
@@ -50,6 +50,12 @@ p.licenses-form__section-description {
 	}
 }
 
+.licenses-form__section.is-two-columns .licenses-form__section-content {
+	@include break-wide {
+		grid-template-columns: repeat(2, 1fr);
+	}
+}
+
 p.licenses-form__description {
 	flex: 1 1 auto;
 	align-self: flex-end;

--- a/client/jetpack-cloud/sections/partner-portal/lib/get-product-title.ts
+++ b/client/jetpack-cloud/sections/partner-portal/lib/get-product-title.ts
@@ -1,15 +1,20 @@
 /**
  * Format the string by removing Jetpack, (, ) from the product name
  * @param product Product name
+ * @param removeVariant if we need to remove variant information
  * @returns Product title
  */
-export default function getProductTitle( product: string ): string {
+export default function getProductTitle( product: string, removeVariant: boolean = false ): string {
 	if ( 'Jetpack AI' === product ) {
 		return 'AI Assistant';
 	}
 
 	if ( 'Jetpack Stats (Commercial license)' === product ) {
 		return 'Stats';
+	}
+
+	if ( removeVariant && product.startsWith( 'Jetpack Security' ) ) {
+		return 'Security';
 	}
 
 	return product.replace( /(?:Jetpack\s|[)(])/gi, '' );

--- a/client/jetpack-cloud/sections/partner-portal/lib/get-product-variant-short-title.ts
+++ b/client/jetpack-cloud/sections/partner-portal/lib/get-product-variant-short-title.ts
@@ -4,25 +4,6 @@
  * @returns Product title
  */
 export default function getProductVariantShortTitle( product: string ): string {
-	if ( product.includes( '10GB' ) ) {
-		return '10GB';
-	}
-
-	if ( product.includes( '100GB' ) ) {
-		return '100GB';
-	}
-
-	if ( product.includes( '1TB' ) ) {
-		return '1TB';
-	}
-
-	if ( product.includes( '3TB' ) ) {
-		return '3TB';
-	}
-
-	if ( product.includes( '5TB' ) ) {
-		return '5TB';
-	}
-
-	return product;
+	const match = product.match( /(\d+(?:GB|TB))/ );
+	return match ? match[ 1 ] : product;
 }

--- a/client/jetpack-cloud/sections/partner-portal/lib/get-product-variant-short-title.ts
+++ b/client/jetpack-cloud/sections/partner-portal/lib/get-product-variant-short-title.ts
@@ -1,0 +1,28 @@
+/**
+ * Format the string to return variant name
+ * @param product Product name
+ * @returns Product title
+ */
+export default function getProductVariantShortTitle( product: string ): string {
+	if ( product.includes( '10GB' ) ) {
+		return '10GB';
+	}
+
+	if ( product.includes( '100GB' ) ) {
+		return '100GB';
+	}
+
+	if ( product.includes( '1TB' ) ) {
+		return '1TB';
+	}
+
+	if ( product.includes( '3TB' ) ) {
+		return '3TB';
+	}
+
+	if ( product.includes( '5TB' ) ) {
+		return '5TB';
+	}
+
+	return product;
+}

--- a/client/jetpack-cloud/sections/partner-portal/license-multi-product-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-multi-product-card/index.tsx
@@ -1,0 +1,198 @@
+import { Gridicon } from '@automattic/components';
+import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useEffect, useState } from 'react';
+import { useDispatch } from 'react-redux';
+import MultipleChoiceQuestion from 'calypso/components/multiple-choice-question';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { APIProductFamilyProduct } from '../../../../state/partner-portal/types';
+import { useProductDescription, useURLQueryParams } from '../hooks';
+import { getProductTitle, LICENSE_INFO_MODAL_ID } from '../lib';
+import getProductVariantShortTitle from '../lib/get-product-variant-short-title';
+import LicenseLightbox from '../license-lightbox';
+import LicenseLightboxLink from '../license-lightbox-link';
+import ProductPriceWithDiscount from '../primary/product-price-with-discount-info';
+
+import '../license-product-card/style.scss';
+
+interface Props {
+	tabIndex: number;
+	products: APIProductFamilyProduct[];
+	isSelected: boolean;
+	isDisabled?: boolean;
+	onSelectProduct: (
+		value: APIProductFamilyProduct,
+		replace?: APIProductFamilyProduct
+	) => void | null;
+	suggestedProduct?: string | null;
+	hideDiscount?: boolean;
+	withBackground?: boolean;
+}
+
+export default function LicenseMultiProductCard( props: Props ) {
+	const {
+		tabIndex,
+		products,
+		isSelected,
+		isDisabled,
+		onSelectProduct,
+		suggestedProduct,
+		hideDiscount,
+		withBackground,
+	} = props;
+	const [ product, setProduct ] = useState( products[ 0 ] );
+	const { setParams, resetParams, getParamValue } = useURLQueryParams();
+	const modalParamValue = getParamValue( LICENSE_INFO_MODAL_ID );
+	const productTitle = getProductTitle( product.name, true );
+	const [ showLightbox, setShowLightbox ] = useState( modalParamValue === product.slug );
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const onSelect = useCallback( () => {
+		if ( isDisabled ) {
+			return;
+		}
+
+		onSelectProduct?.( product );
+	}, [ isDisabled, onSelectProduct, product ] );
+
+	const onKeyDown = useCallback(
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		( e: any ) => {
+			// Spacebar
+			if ( 32 === e.keyCode ) {
+				onSelect();
+			}
+		},
+		[ onSelect ]
+	);
+
+	useEffect( () => {
+		if ( suggestedProduct ) {
+			// Transform the comma-separated list of products to array.
+			const suggestedProducts = suggestedProduct.split( ',' );
+
+			if ( suggestedProducts.includes( product.slug ) ) {
+				onSelect();
+			}
+		}
+	}, [ onSelect, product.slug, suggestedProduct ] );
+
+	const { description: productDescription } = useProductDescription( product.slug );
+
+	const onShowLightbox = useCallback(
+		( e: React.MouseEvent< HTMLElement > ) => {
+			e.stopPropagation();
+
+			dispatch(
+				recordTracksEvent( 'calypso_partner_portal_issue_license_product_view', {
+					product: product.slug,
+				} )
+			);
+
+			setParams( [
+				{
+					key: LICENSE_INFO_MODAL_ID,
+					value: product.slug,
+				},
+			] );
+			setShowLightbox( true );
+		},
+		[ dispatch, product.slug, setParams ]
+	);
+
+	const onHideLightbox = useCallback( () => {
+		resetParams( [ LICENSE_INFO_MODAL_ID ] );
+		setShowLightbox( false );
+	}, [ resetParams ] );
+
+	const variantOptions = products.map( ( option ) => ( {
+		id: option.slug,
+		answerText: getProductVariantShortTitle( option.name ),
+	} ) );
+
+	const onChangeOption = useCallback(
+		( selectedProductSlug: string ) => {
+			if ( isDisabled ) {
+				return;
+			}
+
+			const selectedProduct =
+				products.find( ( { slug } ) => slug === selectedProductSlug ) ?? products[ 0 ];
+
+			if ( isSelected ) {
+				// If the current card is selected, we need to update selected licenses.
+				onSelectProduct?.( selectedProduct, product );
+			}
+
+			setProduct( selectedProduct );
+		},
+		[ isDisabled, isSelected, onSelectProduct, product, products ]
+	);
+
+	return (
+		<>
+			<div
+				className={ classNames( 'license-product-card', 'license-product-card--with-variant', {
+					selected: isSelected,
+					disabled: isDisabled,
+					'license-product-card--with-background': withBackground,
+				} ) }
+			>
+				<div className="license-product-card__inner">
+					<div className="license-product-card__details">
+						<div className="license-product-card__main">
+							<div className="license-product-card__heading">
+								<h3 className="license-product-card__title">{ productTitle }</h3>
+
+								<MultipleChoiceQuestion
+									question={ translate( 'Select variant:' ) }
+									answers={ variantOptions }
+									selectedAnswerId={ product?.slug }
+									onAnswerChange={ onChangeOption }
+									shouldShuffleAnswers={ false }
+								/>
+
+								<div className="license-product-card__description">{ productDescription }</div>
+
+								{ ! /^jetpack-backup-addon-storage-/.test( product.slug ) && (
+									<LicenseLightboxLink productName={ productTitle } onClick={ onShowLightbox } />
+								) }
+							</div>
+
+							<div
+								className="license-product-card__select-button license-product-card_multi-select"
+								onKeyDown={ onKeyDown }
+								onClick={ () => onSelect() }
+								role="checkbox"
+								aria-checked={ isSelected }
+								aria-disabled={ isDisabled }
+								tabIndex={ tabIndex }
+							>
+								{ isSelected && <Gridicon icon="checkmark" /> }
+							</div>
+						</div>
+
+						<div className="license-product-card__pricing">
+							<ProductPriceWithDiscount product={ product } hideDiscount={ hideDiscount } />
+						</div>
+					</div>
+				</div>
+			</div>
+			{ showLightbox && (
+				<LicenseLightbox
+					product={ product }
+					ctaLabel={ isSelected ? translate( 'Unselect License' ) : translate( 'Select License' ) }
+					isCTAPrimary={ ! isSelected }
+					isDisabled={ isDisabled }
+					onActivate={ onSelectProduct }
+					onClose={ onHideLightbox }
+				/>
+			) }
+		</>
+	);
+}
+
+LicenseMultiProductCard.defaultProps = {
+	onSelectProduct: null,
+};

--- a/client/jetpack-cloud/sections/partner-portal/license-multi-product-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-multi-product-card/index.tsx
@@ -26,7 +26,6 @@ interface Props {
 	) => void | null;
 	suggestedProduct?: string | null;
 	hideDiscount?: boolean;
-	withBackground?: boolean;
 }
 
 export default function LicenseMultiProductCard( props: Props ) {
@@ -38,7 +37,6 @@ export default function LicenseMultiProductCard( props: Props ) {
 		onSelectProduct,
 		suggestedProduct,
 		hideDiscount,
-		withBackground,
 	} = props;
 	const [ product, setProduct ] = useState( products[ 0 ] );
 	const { setParams, resetParams, getParamValue } = useURLQueryParams();
@@ -136,7 +134,6 @@ export default function LicenseMultiProductCard( props: Props ) {
 				className={ classNames( 'license-product-card', 'license-product-card--with-variant', {
 					selected: isSelected,
 					disabled: isDisabled,
-					'license-product-card--with-background': withBackground,
 				} ) }
 			>
 				<div className="license-product-card__inner">

--- a/client/jetpack-cloud/sections/partner-portal/license-multi-product-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-multi-product-card/index.tsx
@@ -38,13 +38,21 @@ export default function LicenseMultiProductCard( props: Props ) {
 		suggestedProduct,
 		hideDiscount,
 	} = props;
-	const [ product, setProduct ] = useState( products[ 0 ] );
-	const { setParams, resetParams, getParamValue } = useURLQueryParams();
-	const modalParamValue = getParamValue( LICENSE_INFO_MODAL_ID );
-	const productTitle = getProductTitle( product.name, true );
-	const [ showLightbox, setShowLightbox ] = useState( modalParamValue === product.slug );
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+
+	const [ product, setProduct ] = useState( products[ 0 ] );
+	const { description: productDescription } = useProductDescription( product.slug );
+
+	const { setParams, resetParams, getParamValue } = useURLQueryParams();
+	const [ showLightbox, setShowLightbox ] = useState(
+		getParamValue( LICENSE_INFO_MODAL_ID ) === product.slug
+	);
+
+	const variantOptions = products.map( ( option ) => ( {
+		id: option.slug,
+		answerText: getProductVariantShortTitle( option.name ),
+	} ) );
 
 	const onSelect = useCallback( () => {
 		if ( isDisabled ) {
@@ -76,8 +84,6 @@ export default function LicenseMultiProductCard( props: Props ) {
 		}
 	}, [ onSelect, product.slug, suggestedProduct ] );
 
-	const { description: productDescription } = useProductDescription( product.slug );
-
 	const onShowLightbox = useCallback(
 		( e: React.MouseEvent< HTMLElement > ) => {
 			e.stopPropagation();
@@ -103,11 +109,6 @@ export default function LicenseMultiProductCard( props: Props ) {
 		resetParams( [ LICENSE_INFO_MODAL_ID ] );
 		setShowLightbox( false );
 	}, [ resetParams ] );
-
-	const variantOptions = products.map( ( option ) => ( {
-		id: option.slug,
-		answerText: getProductVariantShortTitle( option.name ),
-	} ) );
 
 	const onChangeOption = useCallback(
 		( selectedProductSlug: string ) => {
@@ -140,7 +141,9 @@ export default function LicenseMultiProductCard( props: Props ) {
 					<div className="license-product-card__details">
 						<div className="license-product-card__main">
 							<div className="license-product-card__heading">
-								<h3 className="license-product-card__title">{ productTitle }</h3>
+								<h3 className="license-product-card__title">
+									{ getProductTitle( product.name, true ) }
+								</h3>
 
 								<MultipleChoiceQuestion
 									question={ translate( 'Select variant:' ) }
@@ -153,7 +156,10 @@ export default function LicenseMultiProductCard( props: Props ) {
 								<div className="license-product-card__description">{ productDescription }</div>
 
 								{ ! /^jetpack-backup-addon-storage-/.test( product.slug ) && (
-									<LicenseLightboxLink productName={ productTitle } onClick={ onShowLightbox } />
+									<LicenseLightboxLink
+										productName={ getProductTitle( product.name ) }
+										onClick={ onShowLightbox }
+									/>
 								) }
 							</div>
 

--- a/client/jetpack-cloud/sections/partner-portal/license-product-card/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-product-card/style.scss
@@ -238,3 +238,35 @@
 		background-size: 100% 100%;
 	}
 }
+
+.license-product-card .multiple-choice-question {
+	margin-block-start: 16px;
+	margin-block-end: 8px;
+
+	.form-legend {
+		display: none;
+	}
+
+	.multiple-choice-question__answers {
+		display: flex;
+		gap: 36px;
+	}
+
+	.form-label {
+		font-size: 1rem;
+		line-height: 1.2;
+		margin: 0;
+	}
+
+	.form-radio:checked::before {
+		background: var(--studio-green-50);
+	}
+}
+
+.license-product-card--with-variant .license-product-card__inner {
+	cursor: default;
+
+	.license-product-card__select-button {
+		cursor: pointer;
+	}
+}


### PR DESCRIPTION
This pull request adds a multi-variant product card that combines the Security and Backup 10GB/1TB options into a single card.


<img width="565" alt="Screen Shot 2023-11-29 at 6 04 38 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/88c049f6-1acf-4b7c-8462-6f4a9b24da34">

<img width="488" alt="Screen Shot 2023-11-28 at 7 23 10 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/0b86863d-f50c-4738-bf50-5a856ab8ec40">


Closes https://github.com/Automattic/jetpack-genesis/issues/123

## Proposed Changes

* Introduce a new component, `LicenseMultiProductCard`, based on `LicenseProductCard` with slight changes to handle multi-variant options.
* Remove the background for the Plans card to match the new design changes.
* Update the Issue License page to follow the listing arrangement.

## Testing Instructions
Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. Make sure to switch it back to the previous type.

* Use the Jetpack cloud live link below and go to the Licenses page (/partner-portal/issue-license?flags=jetpack/bundle-licensing)
* Confirm that the new **Security** and **Backup** product cards work as expected.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?