### PR TITLE
Replace hardcoded Plan names in the Upgrade Pricing Plan block in Happy apps 

### DIFF
--- a/apps/happy-blocks/block-library/pricing-plans/components/pricing-plans-header.tsx
+++ b/apps/happy-blocks/block-library/pricing-plans/components/pricing-plans-header.tsx
@@ -16,7 +16,7 @@ const PricingPlansHeader: FunctionComponent< Props > = ( { currentPlan, attribut
 
 	return (
 		<section className="hb-pricing-plans-embed__header">
-			<div className="hb-pricing-plans-embed__header-label">{ currentPlan.getTitle() }</div>
+			<div className="hb-pricing-plans-embed__header-label">{ currentPlan.productNameShort }</div>
 			{ attributes.domain && (
 				<div className="hb-pricing-plans-embed__header-domain">
 					{

--- a/apps/happy-blocks/block-library/pricing-plans/hooks/plan-options.ts
+++ b/apps/happy-blocks/block-library/pricing-plans/hooks/plan-options.ts
@@ -2,7 +2,7 @@ import { BlockPlan } from './pricing-plans';
 
 const usePlanOptions = ( plans: BlockPlan[] ) => {
 	const options = plans.map( ( plan ) => ( {
-		label: plan.getTitle().toString(),
+		label: plan.productNameShort,
 		value: plan.type,
 	} ) );
 

--- a/apps/happy-blocks/block-library/pricing-plans/hooks/pricing-plans.ts
+++ b/apps/happy-blocks/block-library/pricing-plans/hooks/pricing-plans.ts
@@ -12,6 +12,8 @@ export interface BlockPlan extends Plan {
 	rawPrice: number;
 	price: string;
 	upgradeLabel: string;
+	productNameShort: string;
+	productName: string;
 }
 
 const parsePlans = ( data: ApiPricingPlan[] ): BlockPlan[] => {
@@ -33,8 +35,10 @@ const parsePlans = ( data: ApiPricingPlan[] ): BlockPlan[] => {
 				upgradeLabel: sprintf(
 					// translators: %s is the plan name
 					__( 'Upgrade to %s', 'happy-blocks' ),
-					plan.getTitle()
+					apiPlan.product_name_short
 				),
+				productName: apiPlan.product_name,
+				productNameShort: apiPlan.product_name_short,
 			};
 		} );
 };

--- a/apps/happy-blocks/block-library/pricing-plans/index.jsx
+++ b/apps/happy-blocks/block-library/pricing-plans/index.jsx
@@ -4,8 +4,9 @@ import {
 	PLAN_PERSONAL,
 	PLAN_PREMIUM,
 } from '@automattic/calypso-products';
+import { PLANS_LIST } from '@automattic/calypso-products/src/plans-list';
 import { registerBlockType } from '@wordpress/blocks';
-import { __ } from '@wordpress/i18n';
+import { sprintf, __ } from '@wordpress/i18n';
 import config from './config';
 import { Edit } from './edit';
 
@@ -42,32 +43,80 @@ function registerBlocks() {
 			{
 				isDefault: true,
 				name: 'personal',
-				title: __( 'Upgrade Personal', 'happy-blocks' ),
-				description: __( 'Upgrade to Personal pricing plan', 'happy-blocks' ),
+				title: sprintf(
+					/* translators: planName can be any short name of WPCOM Plan bundle (ex. Personal, Permium, Business) */
+					__( 'Upgrade %(planName)s', 'happy-blocks' ),
+					{
+						planName: PLANS_LIST[ PLAN_PERSONAL ].getTitle(),
+					}
+				),
+				description: sprintf(
+					/* translators: planName can be any short name of WPCOM Plan bundle (ex. Personal, Permium, Business) */
+					__( 'Upgrade to %(planName)s pricing plan', 'happy-blocks' ),
+					{
+						planName: PLANS_LIST[ PLAN_PERSONAL ].getTitle(),
+					}
+				),
 				attributes: {
 					defaultProductSlug: PLAN_PERSONAL,
 				},
 			},
 			{
 				name: 'premium',
-				title: __( 'Upgrade Premium', 'happy-blocks' ),
-				description: __( 'Upgrade to Premium pricing plan', 'happy-blocks' ),
+				title: sprintf(
+					/* translators: planName can be any short name of WPCOM Plan bundle (ex. Personal, Permium, Business) */
+					__( 'Upgrade %(planName)s', 'happy-blocks' ),
+					{
+						planName: PLANS_LIST[ PLAN_PREMIUM ].getTitle(),
+					}
+				),
+				description: sprintf(
+					/* translators: planName can be any short name of WPCOM Plan bundle (ex. Personal, Permium, Business) */
+					__( 'Upgrade to %(planName)s pricing plan', 'happy-blocks' ),
+					{
+						planName: PLANS_LIST[ PLAN_PREMIUM ].getTitle(),
+					}
+				),
 				attributes: {
 					defaultProductSlug: PLAN_PREMIUM,
 				},
 			},
 			{
 				name: 'business',
-				title: __( 'Upgrade Business', 'happy-blocks' ),
-				description: __( 'Upgrade to Business pricing plan', 'happy-blocks' ),
+				title: sprintf(
+					/* translators: planName can be any short name of WPCOM Plan bundle (ex. Personal, Permium, Business) */
+					__( 'Upgrade %(planName)s', 'happy-blocks' ),
+					{
+						planName: PLANS_LIST[ PLAN_BUSINESS ].getTitle(),
+					}
+				),
+				description: sprintf(
+					/* translators: planName can be any short name of WPCOM Plan bundle (ex. Personal, Permium, Business) */
+					__( 'Upgrade to %(planName)s pricing plan', 'happy-blocks' ),
+					{
+						planName: PLANS_LIST[ PLAN_BUSINESS ].getTitle(),
+					}
+				),
 				attributes: {
 					defaultProductSlug: PLAN_BUSINESS,
 				},
 			},
 			{
 				name: 'ecommerce',
-				title: __( 'Upgrade Commerce', 'happy-blocks' ),
-				description: __( 'Upgrade to Commerce pricing plan', 'happy-blocks' ),
+				title: sprintf(
+					/* translators: planName can be any short name of WPCOM Plan bundle (ex. Personal, Permium, Business) */
+					__( 'Upgrade %(planName)s', 'happy-blocks' ),
+					{
+						planName: PLANS_LIST[ PLAN_ECOMMERCE ].getTitle(),
+					}
+				),
+				description: sprintf(
+					/* translators: planName can be any short name of WPCOM Plan bundle (ex. Personal, Permium, Business) */
+					__( 'Upgrade to %(planName)s pricing plan', 'happy-blocks' ),
+					{
+						planName: PLANS_LIST[ PLAN_ECOMMERCE ].getTitle(),
+					}
+				),
 				attributes: {
 					defaultProductSlug: PLAN_ECOMMERCE,
 				},

--- a/apps/happy-blocks/block-library/pricing-plans/types.d.ts
+++ b/apps/happy-blocks/block-library/pricing-plans/types.d.ts
@@ -14,6 +14,8 @@ export interface ApiPricingPlan {
 	bill_period: number;
 	product_slug: string;
 	currency_code: 'EUR' | 'USD' | 'GBP';
+	product_name_short: string;
+	product_name: string;
 }
 
 declare global {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

This replaces the hardcoded Plan names in the block attributes.
However, the actual Plans names on the frontend are fetched from the [plans-list.tsx](https://github.com/Automattic/wp-calypso/blob/trunk/packages/calypso-products/src/plans-list.tsx). Although this is good, it will become tricky to ensure the assignment is done at load time in case of a [Plan name experiment](https://github.com/Automattic/wp-calypso/pull/84610). To sidestep this issue, we'll use the plan names from the `/plans` API, which will contain the correct plan names (D129814-code)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run yarn dev --sync in `apps/happy-blocks` to sync code to your sandbox (might need to follow the[ instructions](https://github.com/Automattic/wp-calypso/blob/trunk/apps/happy-blocks/README.md#development-environment) and/or the Calypso Apps field guide to get it to work)
* Log with a user with a non-USD currency

* Sandbox `wordpress.com` and `en.support.wordpress.com`
* Handle any certificate errors that appear for the assets

* Go to https://wordpress.com/support/domains/register-domain/
* The block should render correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
