### PR TITLE
Show subscriber launchpad on subscriber stats page when there are no subscribers.

### DIFF
--- a/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
@@ -1,10 +1,14 @@
 import config from '@automattic/calypso-config';
 import { CountComparisonCard } from '@automattic/components';
+import { useLocale } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import QueryMembershipProducts from 'calypso/components/data/query-memberships';
+import { SubscriberLaunchpad } from 'calypso/my-sites/subscribers/components/subscriber-launchpad';
 import { useSelector } from 'calypso/state';
-import useSubscribersTotalsQueries from '../hooks/use-subscribers-totals-query';
 import './style.scss';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
+import { isSimpleSite } from 'calypso/state/sites/selectors';
+import useSubscribersTotalsQueries from '../hooks/use-subscribers-totals-query';
 
 function useSubscriberHighlights(
 	siteId: number | null,
@@ -102,11 +106,28 @@ function SubscriberHighlightsListing( { siteId }: { siteId: number | null } ) {
 	);
 }
 
+function SubscriberLaunchpadSection( { siteId }: { siteId: number | null } ) {
+	const { data: subscribersTotals, isLoading } = useSubscribersTotalsQueries( siteId );
+
+	const isSimple = useSelector( isSimpleSite );
+	const isAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
+	const locale = useLocale();
+
+	const showLaunchpad =
+		! isLoading &&
+		( isSimple || isAtomic ) &&
+		SubscriberLaunchpad.hasTranslationsAvailable( locale ) &&
+		! subscribersTotals?.total;
+
+	return showLaunchpad ? <SubscriberLaunchpad /> : <></>;
+}
+
 export default function SubscribersHighlightSection( { siteId }: { siteId: number | null } ) {
 	return (
 		<div className="highlight-cards subscribers-page has-odyssey-stats-bg-color">
 			<SubscriberHighlightsHeader />
 			<SubscriberHighlightsListing siteId={ siteId } />
+			<SubscriberLaunchpadSection siteId={ siteId } />
 		</div>
 	);
 }

--- a/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
@@ -1,6 +1,5 @@
 import config from '@automattic/calypso-config';
 import { CountComparisonCard } from '@automattic/components';
-import { useLocale } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import QueryMembershipProducts from 'calypso/components/data/query-memberships';
 import { SubscriberLaunchpad } from 'calypso/my-sites/subscribers/components/subscriber-launchpad';
@@ -111,13 +110,8 @@ function SubscriberLaunchpadSection( { siteId }: { siteId: number | null } ) {
 
 	const isSimple = useSelector( isSimpleSite );
 	const isAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
-	const locale = useLocale();
 
-	const showLaunchpad =
-		! isLoading &&
-		( isSimple || isAtomic ) &&
-		SubscriberLaunchpad.hasTranslationsAvailable( locale ) &&
-		! subscribersTotals?.total;
+	const showLaunchpad = ! isLoading && ( isSimple || isAtomic ) && ! subscribersTotals?.total;
 
 	return showLaunchpad ? <SubscriberLaunchpad /> : <></>;
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/84595

## Proposed Changes

* Show subscriber launchpad on subscriber stats page when there are no subscribers.

## Testing Instructions

* On a site without subscribers, go to `http://calypso.localhost:3000/stats/subscribers/your_site.wordpress.com`.
* You should see the launchpad.
* You should not see the launchpad on site with subscribers.

<img width="1428" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1287077/9e86c998-2475-42ef-b958-36ff383c3577">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?