### PR TITLE
Hosting Command Palette: Improve back button semantics

### DIFF
--- a/client/components/command-pallette/wpcom-command-pallette.tsx
+++ b/client/components/command-pallette/wpcom-command-pallette.tsx
@@ -225,7 +225,11 @@ export const WpcomCommandPalette = () => {
 				<Command label={ __( 'Command palette' ) } onKeyDown={ onKeyDown }>
 					<div className="commands-command-menu__header">
 						{ selectedCommandName ? (
-							<BackButton type="button" onClick={ reset }>
+							<BackButton
+								type="button"
+								onClick={ reset }
+								aria-label={ __( 'Go back to the previous screen' ) }
+							>
 								<Icon icon={ backIcon } />
 							</BackButton>
 						) : (

--- a/client/components/command-pallette/wpcom-command-pallette.tsx
+++ b/client/components/command-pallette/wpcom-command-pallette.tsx
@@ -31,6 +31,10 @@ const StyledCommandsMenuContainer = styled.div( {
 	},
 } );
 
+const BackButton = styled.button( {
+	cursor: 'pointer',
+} );
+
 const LabelWrapper = styled.div( {
 	display: 'flex',
 	flexDirection: 'column',
@@ -221,7 +225,9 @@ export const WpcomCommandPalette = () => {
 				<Command label={ __( 'Command palette' ) } onKeyDown={ onKeyDown }>
 					<div className="commands-command-menu__header">
 						{ selectedCommandName ? (
-							<Icon icon={ backIcon } onClick={ reset } />
+							<BackButton type="button" onClick={ reset }>
+								<Icon icon={ backIcon } />
+							</BackButton>
 						) : (
 							<Icon icon={ inputIcon } />
 						) }


### PR DESCRIPTION
## Proposed Changes

Improves the semantics of the back button by using `<button type="button">` and using `cursor: pointer;`:

![CleanShot 2023-11-29 at 11 28 28@2x](https://github.com/Automattic/wp-calypso/assets/36432/4223bc73-8da6-46dc-b5a6-861a8ccb9b59)


https://github.com/Automattic/wp-calypso/assets/36432/57c6d053-b6ea-4706-8b03-1ece7798107c


## Testing Instructions

N/A