### PR TITLE
Live Preview: Suppress the template part hint in the editor sidebar

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/index.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/index.tsx
@@ -21,6 +21,7 @@ const LivePreviewNotice: FC< {
 	previewingThemeName: string;
 } > = ( { previewingThemeName } ) => {
 	const { createWarningNotice, removeNotice } = useDispatch( 'core/notices' );
+	const { set: setPreferences } = useDispatch( 'core/preferences' );
 
 	const siteEditorStore = useSelect( ( select ) => select( 'core/edit-site' ), [] );
 	const dashboardLink =
@@ -37,6 +38,11 @@ const LivePreviewNotice: FC< {
 			removeNotice( NOTICE_ID );
 			return;
 		}
+
+		// Suppress the "Looking for template parts?" notice in the Site Editor sidebar.
+		// The preference name is defined in https://github.com/WordPress/gutenberg/blob/d47419499cd58e20db25c370cdbf02ddf7cffce0/packages/edit-site/src/components/sidebar-navigation-screen-main/template-part-hint.js#L9.
+		setPreferences( 'core', 'isTemplatePartMoveHintVisible', false );
+
 		createWarningNotice(
 			sprintf(
 				// translators: %s: theme name


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/wp-calypso/issues/84399

## Proposed Changes

Always hide the "Looking for template parts?" notice in the Site Editor's left sidebar, during live-preview of a theme, as follows:

|Before|After|
|-|-|
|<img width="811" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/f477c030-6314-4dec-bc38-a39052103485">|<img width="861" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/593bb5d1-98af-4cd6-bc2c-39b21fa24755">|

This is so that the user can focus on the more important things, such as trying out Styles.

### Implementation Details

This is done by setting the `isTemplatePartMoveHintVisible` preference to `false`.

We don't need to "restore" the preferences because [it is not persisted to the browser](https://github.com/WordPress/gutenberg/blob/00ccb8b18ea45295bf5edc74f94b7197c768cb96/packages/preferences/README.md?plain=1#L87).

## Testing Instructions

1. Sandbox `wp.widgets.com`.
2. Patch this PR to your sandbox: `install-plugin.sh wpcom-block-editor feat/suppress-template-part-notice`.
3. Go to theme showcase, choose a block theme, and click `Preview & Customize`.
4. Verify that you don't see the template-part notice as shown in the above images.
   - (You might need to "Disable cache" in your browser so that it doesn't return the content of wp.widgets.com from cache)
5. Go to Site Editor (without previewing a theme), and verify that the above notice is still there.
6. Verify that the other Editors (Post & Page) are unaffected at all (do not crash)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)