### PR TITLE
Import flow: Redesign importers list step

### DIFF
--- a/client/blocks/import/list/index.tsx
+++ b/client/blocks/import/list/index.tsx
@@ -1,17 +1,14 @@
-import { Button } from '@automattic/components';
-import { Title } from '@automattic/onboarding';
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { Button, FormLabel, SelectDropdown } from '@automattic/components';
+import { Title, SubTitle } from '@automattic/onboarding';
+import { chevronRight, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import React, { useEffect } from 'react';
-import { connect } from 'react-redux';
-import illustrationImg from 'calypso/assets/images/onboarding/import-1.svg';
-import ActionCard from 'calypso/components/action-card';
 import ImporterLogo from 'calypso/my-sites/importer/importer-logo';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { useDispatch } from 'calypso/state';
 import { urlDataUpdate } from 'calypso/state/imports/url-analyzer/actions';
-import { GoToStep, ImporterPlatform, UrlData, RecordTracksEvent } from '../types';
+import type { GoToStep, ImporterPlatform } from '../types';
 import './style.scss';
-
-/* eslint-disable wpcalypso/jsx-classname-namespace */
 
 const trackEventName = 'calypso_signup_step_start';
 const trackEventParams = {
@@ -19,25 +16,48 @@ const trackEventParams = {
 	step: 'list',
 };
 
-interface Props {
-	goToStep: GoToStep;
-	urlDataUpdate: ( urlData: UrlData ) => void;
-	recordTracksEvent: RecordTracksEvent;
+interface ImporterOption {
+	value: ImporterPlatform;
+	label: string;
+	icon?: string;
 }
 
-const ListStep: React.FunctionComponent< Props > = ( props ) => {
-	const { __ } = useI18n();
-	const { goToStep, urlDataUpdate, recordTracksEvent } = props;
+interface Props {
+	goToStep: GoToStep;
+}
 
-	const onButtonClick = ( platform: ImporterPlatform ): void => {
-		urlDataUpdate( {
-			url: '',
-			platform,
-			meta: {
-				favicon: null,
-				title: null,
-			},
-		} );
+export default function ListStep( props: Props ) {
+	const dispatch = useDispatch();
+	const { __ } = useI18n();
+	const { goToStep } = props;
+
+	const primaryListOptions: ImporterOption[] = [
+		{ value: 'wordpress', label: 'WordPress', icon: 'wordpress' },
+		{ value: 'blogger', label: 'Blogger', icon: 'blogger-alt' },
+		{ value: 'medium', label: 'Medium', icon: 'medium' },
+		{ value: 'squarespace', label: 'Squarespace', icon: 'squarespace' },
+	];
+
+	const secondaryListOptions: ImporterOption[] = [
+		{ value: 'blogroll', label: 'Blogroll' },
+		{ value: 'ghost', label: 'Ghost' },
+		{ value: 'tumblr', label: 'Tumblr' },
+		{ value: 'livejournal', label: 'LiveJournal' },
+		{ value: 'movabletype', label: 'Movable Type & TypePad' },
+		{ value: 'xanga', label: 'Xanga' },
+	];
+
+	const onImporterSelect = ( platform: ImporterPlatform ): void => {
+		dispatch(
+			urlDataUpdate( {
+				url: '',
+				platform,
+				meta: {
+					favicon: null,
+					title: null,
+				},
+			} )
+		);
 		goToStep( `ready` );
 	};
 
@@ -53,93 +73,32 @@ const ListStep: React.FunctionComponent< Props > = ( props ) => {
 	return (
 		<>
 			<div className="import-layout list__wrapper">
-				<div className="import-layout__column">
-					<div className="import__heading">
-						<Title>{ __( 'Import your content from another platform' ) }</Title>
-
-						<img alt="Import" src={ illustrationImg } aria-hidden="true" />
-					</div>
+				<div className="import__heading import__heading-center">
+					<Title>{ __( 'Import content from another platform' ) }</Title>
+					<SubTitle>{ __( 'Select the platform where your content lives' ) }</SubTitle>
 				</div>
-				<div className="import-layout__column">
-					<div className="list__importers list__importers-primary">
-						<ImporterLogo icon="wordpress" />
-						<ActionCard
-							classNames="list__importer-action"
-							headerText="WordPress"
-							mainText="www.wordpress.org"
-							buttonIcon="chevron-right"
-							buttonOnClick={ () => onButtonClick( 'wordpress' ) }
-						/>
-						<ImporterLogo icon="blogger-alt" />
-						<ActionCard
-							classNames="list__importer-action"
-							headerText="Blogger"
-							mainText="www.blogger.com"
-							buttonIcon="chevron-right"
-							buttonOnClick={ () => onButtonClick( 'blogger' ) }
-						/>
-						<ImporterLogo icon="medium" />
-						<ActionCard
-							classNames="list__importer-action"
-							headerText="Medium"
-							mainText="www.medium.com"
-							buttonIcon="chevron-right"
-							buttonOnClick={ () => onButtonClick( 'medium' ) }
-						/>
-						<ImporterLogo icon="squarespace" />
-						<ActionCard
-							classNames="list__importer-action"
-							headerText="Squarespace"
-							mainText="www.squarespace.com"
-							buttonIcon="chevron-right"
-							buttonOnClick={ () => onButtonClick( 'squarespace' ) }
-						/>
-					</div>
+				<div className="list__importers list__importers-primary">
+					{ primaryListOptions.map( ( x ) => (
+						<Button
+							className="list__importers-item-card"
+							onClick={ () => onImporterSelect( x.value ) }
+						>
+							<ImporterLogo icon={ x.icon } />
+							<h2>{ x.label }</h2>
+							<Icon icon={ chevronRight } />
+						</Button>
+					) ) }
+				</div>
 
-					<div className="list__importers list__importers-secondary">
-						<h3>{ __( 'Other platforms' ) }</h3>
-						<ul>
-							<li>
-								<Button borderless={ true } onClick={ () => onButtonClick( 'blogroll' ) }>
-									Blogroll
-								</Button>
-							</li>
-							<li>
-								<Button borderless={ true } onClick={ () => onButtonClick( 'ghost' ) }>
-									Ghost
-								</Button>
-							</li>
-							<li>
-								<Button borderless={ true } onClick={ () => onButtonClick( 'tumblr' ) }>
-									Tumblr
-								</Button>
-							</li>
-							<li>
-								<Button borderless={ true } onClick={ () => onButtonClick( 'livejournal' ) }>
-									LiveJournal
-								</Button>
-							</li>
-							<li>
-								<Button borderless={ true } onClick={ () => onButtonClick( 'movabletype' ) }>
-									Movable Type & TypePad
-								</Button>
-							</li>
-							<li>
-								<Button borderless={ true } onClick={ () => onButtonClick( 'xanga' ) }>
-									Xanga
-								</Button>
-							</li>
-						</ul>
-					</div>
+				<div className="list__importers list__importers-secondary">
+					<FormLabel>{ __( 'Other platforms' ) }</FormLabel>
+					<SelectDropdown
+						selectedText={ __( 'Select other platform' ) }
+						options={ secondaryListOptions }
+						onSelect={ ( x: ImporterOption ) => onImporterSelect( x.value ) }
+					></SelectDropdown>
 				</div>
 			</div>
 		</>
 	);
-};
-
-const connector = connect( () => ( {} ), {
-	urlDataUpdate,
-	recordTracksEvent,
-} );
-
-export default connector( ListStep );
+}

--- a/client/blocks/import/list/style.scss
+++ b/client/blocks/import/list/style.scss
@@ -23,17 +23,29 @@ html[dir="rtl"] {
 	}
 }
 
+.is-section-stepper > .wpcom-site > .import-list {
+	padding: 2rem 0;
+
+	@include break-small {
+		padding: 3.75rem 0 0 0;
+	}
+}
+
 .import__onboarding-page {
+	.import-layout {
+		flex-direction: column;
+	}
+
 	.list__wrapper {
 		margin-left: auto !important;
 		margin-right: auto !important;
 
 		.import__heading {
-			max-width: 420px;
+			margin-bottom: 2.5rem;
 
 			.onboarding-title {
-				margin-bottom: 40px;
 				width: 100%;
+				max-width: 100%;
 			}
 		}
 
@@ -55,64 +67,59 @@ html[dir="rtl"] {
 			}
 		}
 
-		ul {
-			margin: 0;
-
-			li {
-				margin-bottom: 10px;
-				list-style: none;
-				/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-				line-height: 1.25em;
-			}
-
-			a,
-			button {
-				padding: 0;
-				font-size: 0.875em; /* stylelint-disable-line declaration-property-unit-allowed-list */
-				font-weight: 500;
-				line-height: 20px;
-				text-decoration: underline;
-				color: var(--studio-gray-100);
-			}
-		}
-
-		.importer__service-icon {
-			width: 48px;
-			min-width: 48px !important;
-			height: 48px;
-			margin-top: 10px;
-			margin-right: 0;
-			margin-inline-end: 1.5em !important;
-			border-radius: 4px;
-		}
-
-		.list__importers-primary {
-			margin-bottom: 1.5em;
-		}
-
+		.list__importers-primary,
 		.list__importers-secondary {
-			padding: 0;
+			margin: 0 auto 1.5rem auto;
+			min-width: 100%;
 
 			@include break-small {
-				padding-inline-start: 72px;
+				min-width: 433px;
 			}
 		}
+	}
+}
 
-		.list__importer-action {
-			position: relative;
-			display: inline-block !important;
-			width: calc(100% - 72px);
+.list__importers {
+	.select-dropdown > div {
+		width: 100%;
+	}
 
-			button {
-				background: none;
-				width: 100%;
-				position: absolute;
-				margin: 0;
-				top: 0;
-				right: 0;
-				bottom: 0;
-				left: 0;
-			}
-		}
+	.select-dropdown__header-text {
+		font-weight: 400;
+	}
+
+	.select-dropdown__header {
+		border-radius: 4px;
+	}
+
+	.form-label {
+		font-weight: 500;
+	}
+}
+
+.list__importers-item-card {
+	display: flex;
+	width: 100%;
+	padding: 1.5em;
+	border: solid 1px var(--studio-gray-5);
+	border-radius: 4px;
+	margin-bottom: 0.5rem;
+	align-items: center;
+
+	h2 {
+		flex-grow: 1;
+		color: var(--studio-gray-100);
+		/* stylelint-disable-next-line scales/font-sizes */
+		font-size: 1.125rem;
+		font-weight: 500;
+		text-align: left;
+	}
+
+	.importer__service-icon {
+		width: 32px;
+		min-width: 32px !important;
+		height: 32px;
+		margin-inline-end: 0.5em !important;
+		border-radius: 4px;
 	}
 }

--- a/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
@@ -32,7 +32,7 @@ const selectors = {
 	startImportGoalButton: 'span:has-text("Import my existing website content")',
 	// And entry of the list of selectable importers
 	importerListButton: ( index: number ) =>
-		`div.list__importers-primary:nth-child(${ index + 1 }) .action-card__button-container button`,
+		`div.list__importers-primary button:nth-child(${ index + 1 })`,
 };
 
 /**
@@ -173,7 +173,7 @@ export class StartImportFlow {
 	 */
 	async validateImporterListPage(): Promise< void > {
 		await this.page
-			.locator( selectors.startBuildingHeader( 'Import your content from another platform' ) )
+			.locator( selectors.startBuildingHeader( 'Import content from another platform' ) )
 			.waitFor();
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/84572

## Proposed Changes

* Redesign importers list step following the Figma design proposal: Qk6oQI6SxPhh7FyngXVnAV-fi-1911_1631

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/import-focused?siteSlug={SITE_SLUG}`
* Click on the "choose a content platform" link
* Select any of proposed importers
* Check if everything works as before the redesign

<img width="976" alt="Screenshot 2023-11-29 at 14 29 11" src="https://github.com/Automattic/wp-calypso/assets/1241413/224d811f-28da-4761-b60d-e11513a64a88">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?