### PR TITLE
Jetpack Manage: Add product search field in bundling licenses UI

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/hooks/use-product-and-plans.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/hooks/use-product-and-plans.tsx
@@ -26,6 +26,7 @@ type Props = {
 	selectedBundleSize?: number;
 	selectedSite?: SiteDetails | null;
 	selectedProductFilter?: string | null;
+	productSearchQuery?: string;
 };
 
 const getProductsAndPlansByFilter = (
@@ -69,6 +70,7 @@ export default function useProductAndPlans( {
 	selectedBundleSize = 1,
 	selectedSite,
 	selectedProductFilter = PRODUCT_FILTER_ALL,
+	productSearchQuery,
 }: Props ) {
 	const { data, isLoading: isLoadingProducts } = useProductsQuery();
 	const dispatch = useDispatch();
@@ -114,6 +116,13 @@ export default function useProductAndPlans( {
 			supportedProducts
 		);
 
+		// Filter products based on the search term
+		if ( productSearchQuery ) {
+			filteredProductsAndBundles = filteredProductsAndBundles.filter(
+				( product ) => product.name?.toLowerCase().includes( productSearchQuery.toLowerCase() )
+			);
+		}
+
 		// Filter products & plan that are already assigned to a site
 		if ( selectedSite && addedPlanAndProducts && filteredProductsAndBundles ) {
 			filteredProductsAndBundles = filteredProductsAndBundles.filter(
@@ -147,6 +156,7 @@ export default function useProductAndPlans( {
 		data,
 		isLoadingProducts,
 		selectedBundleSize,
+		productSearchQuery,
 		selectedProductFilter,
 		selectedSite,
 	] );

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
@@ -8,6 +8,7 @@ import { PRODUCT_FILTER_ALL } from '../constants';
 import IssueLicenseContext from '../context';
 import useSubmitForm from '../hooks/use-submit-form';
 import useProductAndPlans from './hooks/use-product-and-plans';
+import ProductFilterSearch from './product-filter-search';
 import ProductFilterSelect from './product-filter-select';
 import LicensesFormSection from './sections';
 import type { AssignLicenceProps } from '../../types';
@@ -27,6 +28,8 @@ export default function LicensesForm( {
 
 	const { selectedLicenses, setSelectedLicenses } = useContext( IssueLicenseContext );
 
+	const [ productSearchQuery, setProductSearchQuery ] = useState< string >( '' );
+
 	const [ selectedProductFilter, setSelectedProductFilter ] = useState< string | null >(
 		PRODUCT_FILTER_ALL
 	);
@@ -39,7 +42,12 @@ export default function LicensesForm( {
 		products,
 		wooExtensions,
 		suggestedProductSlugs,
-	} = useProductAndPlans( { selectedSite, selectedProductFilter, selectedBundleSize: quantity } );
+	} = useProductAndPlans( {
+		selectedSite,
+		selectedProductFilter,
+		selectedBundleSize: quantity,
+		productSearchQuery,
+	} );
 
 	const disabledProductSlugs = useSelector< PartnerPortalStore, string[] >( ( state ) =>
 		getDisabledProductSlugs( state, filteredProductsAndBundles ?? [] )
@@ -89,6 +97,13 @@ export default function LicensesForm( {
 		[ setSelectedProductFilter ]
 	);
 
+	const onProductSearch = useCallback(
+		( value: string ) => {
+			setProductSearchQuery( value );
+		},
+		[ setProductSearchQuery ]
+	);
+
 	const isSingleLicenseView = quantity === 1;
 
 	if ( isLoadingProducts ) {
@@ -104,6 +119,7 @@ export default function LicensesForm( {
 			<QueryProductsList type="jetpack" currency="USD" />
 
 			<div className="licenses-form__actions">
+				<ProductFilterSearch onProductSearch={ onProductSearch } />
 				<ProductFilterSelect
 					selectedProductFilter={ selectedProductFilter }
 					onProductFilterSelect={ onProductFilterSelect }

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/product-filter-search.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/product-filter-search.tsx
@@ -1,0 +1,21 @@
+import { useTranslate } from 'i18n-calypso';
+import Search from 'calypso/components/search';
+
+type Props = {
+	onProductSearch: ( value: string ) => void;
+};
+
+export default function ProductFilterSearch( { onProductSearch }: Props ) {
+	const translate = useTranslate();
+
+	return (
+		<div className="licenses-form__product-filter-search">
+			<Search
+				onSearch={ onProductSearch }
+				placeholder={ translate( 'Search plans, products, add-ons, and extensions' ) }
+				compact
+				hideFocus
+			/>
+		</div>
+	);
+}

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/style.scss
@@ -69,10 +69,19 @@ p.licenses-form__description {
 }
 
 .licenses-form__actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
 	margin: 16px 0 32px;
 }
 
 .licenses-form__product-filter-select {
+	flex-basis: 100%;
+
+	@include break-xlarge {
+		flex-basis: auto;
+	}
+
 	.select-dropdown__header-text {
 		font-size: rem(13px);
 		font-weight: 400;
@@ -82,5 +91,35 @@ p.licenses-form__description {
 
 	.select-dropdown__header-text b {
 		color: var(--studio-black);
+	}
+
+	.select-dropdown__container {
+		width: 100%;
+
+		@include break-xlarge {
+			width: auto;
+		}
+	}
+}
+
+.licenses-form__product-filter-search {
+	flex-basis: 100%;
+
+	@include break-xlarge {
+		flex-basis: 360px;
+	}
+
+	.search {
+		&.is-open {
+			height: 33px;
+		}
+		margin-bottom: 0;
+		border: 1px solid var(--color-neutral-10);
+	}
+
+	.search__input.form-text-input[type="search"] {
+		font-size: rem(13px);
+		font-weight: 400;
+		color: var(--studio-grey-5);
 	}
 }


### PR DESCRIPTION
Related to https://github.com/Automattic/jetpack-genesis/issues/94

## Proposed Changes

This PR allows search through the available products, plans, and add-ons in the new UI for issuing licenses.

![Screen_Recording_at_November_29th_2023_-_4 48 58_pm](https://github.com/Automattic/wp-calypso/assets/1749918/c2f86a9a-c8e8-4cd5-8ea6-38ed1a00a6b4)

## Testing Instructions

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. 

- Use the Jetpack cloud live link below and go to the Licenses page with enabled feature flag: `/partner-portal/issue-license?flags=jetpack/bundle-licensing`
- Verify that the search and filtering work as expected. Please test the filter by switching to a different bundle size tab, and different screen sizes.
- Verify that the issue licensing UI without the feature flag works as expected (_i.e., no regressions were introduced with this PR_)

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?