### PR TITLE
[Odie] Better message/error handling

### DIFF
--- a/client/odie/context/index.tsx
+++ b/client/odie/context/index.tsx
@@ -115,10 +115,17 @@ const OdieAssistantProvider = ( {
 	}, [ existingChat, existingChat.chat_id ] );
 
 	const trackEvent = useCallback(
-		( event: string, properties?: Record< string, unknown > ) => {
-			dispatch( recordTracksEvent( event, properties ) );
+		( event: string, properties: Record< string, unknown > = {} ) => {
+			dispatch(
+				recordTracksEvent( event, {
+					...properties,
+					chat_id: chat?.chat_id,
+					bot_name_slug: botNameSlug,
+					bot_setting: botSetting,
+				} )
+			);
 		},
-		[ dispatch ]
+		[ botNameSlug, botSetting, chat?.chat_id, dispatch ]
 	);
 
 	const clearChat = useCallback( () => {

--- a/client/odie/context/index.tsx
+++ b/client/odie/context/index.tsx
@@ -19,7 +19,6 @@ interface OdieAssistantContextInterface {
 	addMessage: ( message: Message | Message[] ) => void;
 	botName?: string;
 	botNameSlug: OdieAllowedBots;
-	botSetting?: string;
 	chat: Chat;
 	clearChat: () => void;
 	initialUserMessage: string | null | undefined;
@@ -79,7 +78,6 @@ const useOdieAssistantContext = () => useContext( OdieAssistantContext );
 const OdieAssistantProvider = ( {
 	botName = 'Wapuu assistant',
 	botNameSlug = 'wpcom-support-chat',
-	botSetting = 'wapuu',
 	initialUserMessage,
 	isMinimized = false,
 	extraContactOptions,
@@ -88,7 +86,6 @@ const OdieAssistantProvider = ( {
 }: {
 	botName?: string;
 	botNameSlug: OdieAllowedBots;
-	botSetting?: string;
 	enabled?: boolean;
 	initialUserMessage?: string | null | undefined;
 	isMinimized?: boolean;
@@ -121,11 +118,10 @@ const OdieAssistantProvider = ( {
 					...properties,
 					chat_id: chat?.chat_id,
 					bot_name_slug: botNameSlug,
-					bot_setting: botSetting,
 				} )
 			);
 		},
-		[ botNameSlug, botSetting, chat?.chat_id, dispatch ]
+		[ botNameSlug, chat?.chat_id, dispatch ]
 	);
 
 	const clearChat = useCallback( () => {
@@ -214,7 +210,6 @@ const OdieAssistantProvider = ( {
 				addMessage,
 				botName,
 				botNameSlug,
-				botSetting,
 				chat,
 				clearChat,
 				extraContactOptions,

--- a/client/odie/context/index.tsx
+++ b/client/odie/context/index.tsx
@@ -39,7 +39,7 @@ interface OdieAssistantContextInterface {
 	setIsVisible: ( isVisible: boolean ) => void;
 	setIsLoading: ( isLoading: boolean ) => void;
 	trackEvent: ( event: string, properties?: Record< string, unknown > ) => void;
-	updateMessage: ( client_message_id: string, message: Message ) => void;
+	updateMessage: ( message: Message ) => void;
 }
 
 const defaultContextInterfaceValues = {
@@ -184,21 +184,16 @@ const OdieAssistantProvider = ( {
 		} );
 	};
 
-	// Update the message, passing the client_message_id and properties to update
-	const updateMessage = ( client_message_id: string, message: Partial< Message > ) => {
+	const updateMessage = ( message: Partial< Message > ) => {
 		setChat( ( prevChat ) => {
-			const messageIndex = prevChat.messages.findIndex(
-				( m ) => m.client_message_id === client_message_id
+			const updatedMessages = prevChat.messages.map( ( m ) =>
+				( message.internal_message_id && m.internal_message_id === message.internal_message_id ) ||
+				( message.message_id && m.message_id === message.message_id )
+					? { ...m, ...message }
+					: m
 			);
-			const updatedMessage = { ...prevChat.messages[ messageIndex ], ...message };
-			return {
-				...prevChat,
-				messages: [
-					...prevChat.messages.slice( 0, messageIndex ),
-					updatedMessage,
-					...prevChat.messages.slice( messageIndex + 1 ),
-				],
-			};
+
+			return { ...prevChat, messages: updatedMessages };
 		} );
 	};
 

--- a/client/odie/message/custom-a-link.tsx
+++ b/client/odie/message/custom-a-link.tsx
@@ -18,7 +18,7 @@ const CustomALink = ( {
 	children: React.ReactNode;
 	inline?: boolean;
 } ) => {
-	const { botNameSlug, trackEvent } = useOdieAssistantContext();
+	const { trackEvent } = useOdieAssistantContext();
 
 	const classNames = classnames( 'odie-sources', {
 		'odie-sources-inline': inline,
@@ -33,7 +33,6 @@ const CustomALink = ( {
 				rel="noopener noreferrer"
 				onClick={ () => {
 					trackEvent( 'calypso_odie_chat_message_action_click', {
-						bot_name_slug: botNameSlug,
 						action: 'link',
 						href: href,
 					} );

--- a/client/odie/message/index.tsx
+++ b/client/odie/message/index.tsx
@@ -302,14 +302,12 @@ const ChatMessage = (
 					} ) }
 					onClose={ () =>
 						trackEvent( 'calypso_odie_chat_message_action_sources', {
-							bot_name_slug: botName,
 							action: 'close',
 							message_id: message.message_id,
 						} )
 					}
 					onOpen={ () =>
 						trackEvent( 'calypso_odie_chat_message_action_sources', {
-							bot_name_slug: botName,
 							action: 'open',
 							message_id: message.message_id,
 						} )

--- a/client/odie/message/jump-to-recent.tsx
+++ b/client/odie/message/jump-to-recent.tsx
@@ -19,14 +19,11 @@ export const JumpToRecent = ( {
 	enableJumpToRecent: boolean;
 	bottomOffset: number;
 } ) => {
-	const { botSetting, botNameSlug, trackEvent, isMinimized } = useOdieAssistantContext();
+	const { trackEvent, isMinimized } = useOdieAssistantContext();
 	const translate = useTranslate();
 	const jumpToRecent = () => {
 		scrollToBottom();
-		trackEvent( 'calypso_odie_chat_jump_to_recent_click', {
-			bot_name_slug: botNameSlug,
-			bot_setting: botSetting,
-		} );
+		trackEvent( 'calypso_odie_chat_jump_to_recent_click' );
 	};
 
 	if ( isMinimized ) {

--- a/client/odie/message/was-this-helpful-buttons.tsx
+++ b/client/odie/message/was-this-helpful-buttons.tsx
@@ -18,7 +18,7 @@ const WasThisHelpfulButtons = ( {
 	const THUMBS_UP_RATING_VALUE = 4;
 
 	const translate = useTranslate();
-	const { setMessageLikedStatus, botNameSlug, trackEvent } = useOdieAssistantContext();
+	const { setMessageLikedStatus, trackEvent } = useOdieAssistantContext();
 	const { mutateAsync: sendOdieMessageFeedback } = useOdieSendMessageFeedback();
 
 	const liked = message.liked === true;
@@ -37,7 +37,6 @@ const WasThisHelpfulButtons = ( {
 		}
 
 		trackEvent( 'calypso_odie_chat_message_action_feedback', {
-			bot_name_slug: botNameSlug,
 			action: 'feedback',
 			is_helpful: isHelpful,
 			message_id: message.message_id,

--- a/client/odie/query/index.ts
+++ b/client/odie/query/index.ts
@@ -1,6 +1,5 @@
 import { useMutation, UseMutationResult, useQuery } from '@tanstack/react-query';
 import apiFetch from '@wordpress/api-fetch';
-import { v4 as uuid } from 'uuid';
 import { canAccessWpcomApis } from 'wpcom-proxy-request';
 import wpcom from 'calypso/lib/wp';
 import { WAPUU_ERROR_MESSAGE } from '..';
@@ -41,6 +40,15 @@ function odieWpcomSendSupportMessage( message: Message, path: string ) {
 		path,
 		apiNamespace: 'wpcom/v2',
 		body: { message: message.content },
+	} );
+}
+
+// Internal helper function to generate a uuid
+function uuid() {
+	return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace( /[xy]/g, function ( c ) {
+		const r = ( Math.random() * 16 ) | 0;
+		const v = c === 'x' ? r : ( r & 0x3 ) | 0x8;
+		return v.toString( 16 );
 	} );
 }
 

--- a/client/odie/send-message-input/index.tsx
+++ b/client/odie/send-message-input/index.tsx
@@ -22,8 +22,7 @@ export const OdieSendMessageButton = ( {
 } ) => {
 	const [ messageString, setMessageString ] = useState< string >( '' );
 	const divContainerRef = useRef< HTMLDivElement >( null );
-	const { botNameSlug, initialUserMessage, chat, isLoading, trackEvent } =
-		useOdieAssistantContext();
+	const { initialUserMessage, chat, isLoading, trackEvent } = useOdieAssistantContext();
 	const { mutateAsync: sendOdieMessage } = useOdieSendMessage();
 	const translate = useTranslate();
 
@@ -35,9 +34,7 @@ export const OdieSendMessageButton = ( {
 
 	const sendMessage = async () => {
 		try {
-			trackEvent( 'calypso_odie_chat_message_action_send', {
-				bot_name_slug: botNameSlug,
-			} );
+			trackEvent( 'calypso_odie_chat_message_action_send' );
 
 			const message = {
 				content: messageString,
@@ -47,14 +44,11 @@ export const OdieSendMessageButton = ( {
 
 			await sendOdieMessage( { message } );
 
-			trackEvent( 'calypso_odie_chat_message_action_receive', {
-				bot_name_slug: botNameSlug,
-			} );
+			trackEvent( 'calypso_odie_chat_message_action_receive' );
 		} catch ( e ) {
 			const error = e as Error;
 			trackEvent( 'calypso_odie_chat_message_error', {
 				error: error?.message,
-				bot_name_slug: botNameSlug,
 			} );
 		}
 	};

--- a/client/odie/types/index.ts
+++ b/client/odie/types/index.ts
@@ -67,6 +67,7 @@ export type MessageType =
 	| 'introduction';
 
 export type Message = {
+	client_message_id?: string;
 	message_id?: number;
 	content: string;
 	meta?: Record< string, string >;

--- a/client/odie/types/index.ts
+++ b/client/odie/types/index.ts
@@ -67,16 +67,16 @@ export type MessageType =
 	| 'introduction';
 
 export type Message = {
-	client_message_id?: string;
-	message_id?: number;
 	content: string;
-	meta?: Record< string, string >;
-	role: MessageRole;
-	type: MessageType;
-	liked?: boolean | null;
-	simulateTyping?: boolean;
 	context?: Context;
+	internal_message_id?: string;
+	message_id?: number;
+	meta?: Record< string, string >;
+	liked?: boolean | null;
 	rating_value?: number;
+	role: MessageRole;
+	simulateTyping?: boolean;
+	type: MessageType;
 };
 
 export type Chat = {

--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -83,7 +83,6 @@ const HelpCenterContent: React.FC< { isRelative?: boolean } > = () => {
 					element={
 						<OdieAssistantProvider
 							botNameSlug="wpcom-support-chat"
-							botSetting="supportDocs"
 							botName="Wapuu"
 							enabled={ isWapuuEnabled }
 							isMinimized={ isMinimized }


### PR DESCRIPTION
## Proposed Changes

Simplified logic on controls, as creating the unit testing components was a pain. I realised that we could move some logic and not only that, develop things differently, in a calmer and not rushed way, as the initial implementation was a bit mess (due to myself!) :)

This patch also includes better tracking information as well as a bit of code clean up and more comments towards creating a package in the near-mid future.

## Testing Instructions

Please thoughtfully test the Help Center, sending and receiving messages, feedback, etc.  

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?