### PR TITLE
Add dailyprompt block to editor when answering a daily prompt.

### DIFF
--- a/apps/wpcom-block-editor/src/default/editor.js
+++ b/apps/wpcom-block-editor/src/default/editor.js
@@ -1,2 +1,3 @@
 import './features/rich-text';
 import './features/press-this';
+import './features/blogging-prompt';

--- a/apps/wpcom-block-editor/src/default/features/blogging-prompt.js
+++ b/apps/wpcom-block-editor/src/default/features/blogging-prompt.js
@@ -1,0 +1,16 @@
+import { createBlock } from '@wordpress/blocks';
+import { dispatch } from '@wordpress/data';
+import { getQueryArgs } from '@wordpress/url';
+import { isEditorReady } from '../../utils';
+
+const { answer_prompt } = getQueryArgs( window.location.href );
+
+if ( answer_prompt ) {
+	( async () => {
+		await isEditorReady();
+
+		dispatch( 'core/editor' ).resetEditorBlocks( [
+			createBlock( 'jetpack/blogging-prompt', { promptId: answer_prompt } ),
+		] );
+	} )();
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to hackathon project # https://github.com/Automattic/wp-calypso/pull/84254

## Proposed Changes

* This PR adds the daily prompt block to the editor when the user is answering a daily prompt (`answer_prompt` query arg is present).
* I brought this fix out of the hackathon PR noted above so we can separate concerns of this fix vs. the other new functionality contained there.

<img width="991" alt="Screenshot 2023-11-29 at 10 24 53 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/e47c6f9c-02d2-4432-b277-17ae08dea6f5">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Patch this build of wpcom-block-editor to your sandbox (use script from the bot below, or cd to apps/wpcom-block-editor and `yarn dev --sync`)
* sandbox widgets.wp.com and a test site that gets daily prompt cards
* select a daily prompt from the cards on my home to enter the editor
* verify the editor loads with the daily prompt block in place

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
