### PR TITLE
Remove `user-management-revamp` feature flag and un-used components

### DIFF
--- a/client/my-sites/site-settings/subscriptions.jsx
+++ b/client/my-sites/site-settings/subscriptions.jsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { CompactCard } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
 import { localize } from 'i18n-calypso';
@@ -23,68 +22,60 @@ const Subscriptions = ( {
 	selectedSiteSlug,
 	subscriptionsModuleActive,
 	translate,
-} ) => {
-	const viewFollowersSubscribersLink = ! isEnabled( 'user-management-revamp' )
-		? `/people/email-followers/${ selectedSiteSlug }`
-		: `/people/subscribers/${ selectedSiteSlug }`;
+} ) => (
+	<div>
+		<QueryJetpackConnection siteId={ selectedSiteId } />
 
-	return (
-		<div>
-			<QueryJetpackConnection siteId={ selectedSiteId } />
+		<CompactCard className="subscriptions__card site-settings__discussion-settings">
+			<FormFieldset>
+				<SupportInfo
+					text={ translate(
+						'Allows readers to subscribe to your posts or comments, ' +
+							'and receive notifications of new content by email.'
+					) }
+					link="https://jetpack.com/support/subscriptions/"
+				/>
 
-			<CompactCard className="subscriptions__card site-settings__discussion-settings">
-				<FormFieldset>
-					<SupportInfo
-						text={ translate(
-							'Allows readers to subscribe to your posts or comments, ' +
-								'and receive notifications of new content by email.'
-						) }
-						link="https://jetpack.com/support/subscriptions/"
+				<JetpackModuleToggle
+					siteId={ selectedSiteId }
+					moduleSlug="subscriptions"
+					label={ translate( 'Let visitors subscribe to new posts and comments via email' ) }
+					disabled={ isRequestingSettings || isSavingSettings || moduleUnavailable }
+				/>
+
+				<div className="subscriptions__module-settings site-settings__child-settings">
+					<ToggleControl
+						checked={ !! fields.stb_enabled }
+						disabled={
+							isRequestingSettings ||
+							isSavingSettings ||
+							! subscriptionsModuleActive ||
+							moduleUnavailable
+						}
+						onChange={ handleAutosavingToggle( 'stb_enabled' ) }
+						label={ translate( 'Enable the "subscribe to site" option on your comment form' ) }
 					/>
 
-					<JetpackModuleToggle
-						siteId={ selectedSiteId }
-						moduleSlug="subscriptions"
-						label={ translate( 'Let visitors subscribe to new posts and comments via email' ) }
-						disabled={ isRequestingSettings || isSavingSettings || moduleUnavailable }
+					<ToggleControl
+						checked={ !! fields.stc_enabled }
+						disabled={
+							isRequestingSettings ||
+							isSavingSettings ||
+							! subscriptionsModuleActive ||
+							moduleUnavailable
+						}
+						onChange={ handleAutosavingToggle( 'stc_enabled' ) }
+						label={ translate( 'Enable the "subscribe to comments" option on your comment form' ) }
 					/>
+				</div>
+			</FormFieldset>
+		</CompactCard>
 
-					<div className="subscriptions__module-settings site-settings__child-settings">
-						<ToggleControl
-							checked={ !! fields.stb_enabled }
-							disabled={
-								isRequestingSettings ||
-								isSavingSettings ||
-								! subscriptionsModuleActive ||
-								moduleUnavailable
-							}
-							onChange={ handleAutosavingToggle( 'stb_enabled' ) }
-							label={ translate( 'Enable the "subscribe to site" option on your comment form' ) }
-						/>
-
-						<ToggleControl
-							checked={ !! fields.stc_enabled }
-							disabled={
-								isRequestingSettings ||
-								isSavingSettings ||
-								! subscriptionsModuleActive ||
-								moduleUnavailable
-							}
-							onChange={ handleAutosavingToggle( 'stc_enabled' ) }
-							label={ translate(
-								'Enable the "subscribe to comments" option on your comment form'
-							) }
-						/>
-					</div>
-				</FormFieldset>
-			</CompactCard>
-
-			<CompactCard href={ viewFollowersSubscribersLink }>
-				{ translate( 'View or add subscribers' ) }
-			</CompactCard>
-		</div>
-	);
-};
+		<CompactCard href={ `/subscribers/${ selectedSiteSlug }` }>
+			{ translate( 'View or add subscribers' ) }
+		</CompactCard>
+	</div>
+);
 
 Subscriptions.defaultProps = {
 	isSavingSettings: false,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
