### PR TITLE
Calypso typography: apply pretty and balanced text-wrapping selectively

### DIFF
--- a/client/assets/stylesheets/_main.scss
+++ b/client/assets/stylesheets/_main.scss
@@ -145,6 +145,7 @@ h4,
 h5,
 h6 {
 	clear: both;
+	text-wrap: balance;
 }
 hr {
 	background: var(--color-neutral-10);
@@ -154,6 +155,12 @@ hr {
 }
 
 /* Text elements */
+p,
+ul,
+ol,
+blockquote {
+	text-wrap: pretty;
+}
 p {
 	margin-bottom: 1.5em;
 }

--- a/client/assets/stylesheets/_main.scss
+++ b/client/assets/stylesheets/_main.scss
@@ -147,6 +147,10 @@ h6 {
 	clear: both;
 	text-wrap: balance;
 }
+caption,
+figcaption {
+	text-wrap: balance;
+}
 hr {
 	background: var(--color-neutral-10);
 	border: 0;


### PR DESCRIPTION
Adds `text-wrap: pretty` to help with [orphans/widows](https://en.wikipedia.org/wiki/Widows_and_orphans) in paragraphs and few other similar elements.

Adds `text-wrap: balance` to heading elements and captions to produce visually balanced long headings.

Not adding the rule to `body` to avoid any performance issues, as adviced [by Chrome dev article](https://developer.chrome.com/blog/css-text-wrap-pretty/ ).

## Before / after

<img width="639" alt="Screenshot 2023-11-29 at 18 29 49" src="https://github.com/Automattic/wp-calypso/assets/87168/cb263ff1-8325-49f8-9491-14d677c94c92">
<img width="644" alt="Screenshot 2023-11-29 at 18 30 03" src="https://github.com/Automattic/wp-calypso/assets/87168/3d2cbec1-0e11-476b-a78c-1f1b9b23e39d">


### Read more
Design convo in Slack p1692190691450239-slack-C9EJ7KSGH

- https://clagnut.com/blog/2424/
- https://developer.chrome.com/blog/css-text-wrap-pretty/ 
- https://developer.chrome.com/blog/css-text-wrap-balance/


### Related convos in Gutenberg
- https://github.com/WordPress/gutenberg/issues/55190
- https://github.com/WordPress/gutenberg/issues/52387

### Browser support
Fallback in case of lacking browser support will be just what we have today.

- https://caniuse.com/mdn-css_properties_text-wrap_pretty
- https://caniuse.com/mdn-css_properties_text-wrap_balance

