### PR TITLE
Signup-Login: Fix social buttons overflowing

### DIFF
--- a/client/blocks/authentication/social/index.tsx
+++ b/client/blocks/authentication/social/index.tsx
@@ -96,39 +96,41 @@ const SocialAuthenticationForm = ( {
 				) }
 
 				<div className="auth-form__social-buttons">
-					<GoogleSocialButton
-						clientId={ config( 'google_oauth_client_id' ) }
-						responseHandler={ handleGoogleResponse }
-						uxMode={ uxMode }
-						redirectUri={ getRedirectUri( 'google' ) }
-						onClick={ () => {
-							trackLoginAndRememberRedirect( 'google' );
-						} }
-						socialServiceResponse={ socialService === 'google' ? socialServiceResponse : null }
-						startingPoint={ isLogin ? 'login' : 'signup' }
-					/>
+					<div className="auth-form__social-buttons-container">
+						<GoogleSocialButton
+							clientId={ config( 'google_oauth_client_id' ) }
+							responseHandler={ handleGoogleResponse }
+							uxMode={ uxMode }
+							redirectUri={ getRedirectUri( 'google' ) }
+							onClick={ () => {
+								trackLoginAndRememberRedirect( 'google' );
+							} }
+							socialServiceResponse={ socialService === 'google' ? socialServiceResponse : null }
+							startingPoint={ isLogin ? 'login' : 'signup' }
+						/>
 
-					<AppleLoginButton
-						clientId={ config( 'apple_oauth_client_id' ) }
-						responseHandler={ handleAppleResponse }
-						uxMode={ uxModeApple }
-						redirectUri={ getRedirectUri( 'apple' ) }
-						onClick={ () => {
-							trackLoginAndRememberRedirect( 'apple' );
-						} }
-						socialServiceResponse={ socialService === 'apple' ? socialServiceResponse : null }
-						originalUrlPath={
-							// Since the signup form is only ever called from the user step, currently, we can rely on window.location.pathname
-							// to return back to the user step, which then allows us to continue on with the flow once the submitSignupStep action is called within the user step.
-							isLogin ? null : window?.location?.pathname
-						}
-						// If we are on signup, attach the query string to the state so we can pass it back to the server to show the correct UI.
-						// We need this because Apple doesn't allow to have dynamic parameters in redirect_uri.
-						queryString={
-							isWpccFlow( flowName ) && ! isLogin ? window?.location?.search?.slice( 1 ) : null
-						}
-					/>
-					{ children }
+						<AppleLoginButton
+							clientId={ config( 'apple_oauth_client_id' ) }
+							responseHandler={ handleAppleResponse }
+							uxMode={ uxModeApple }
+							redirectUri={ getRedirectUri( 'apple' ) }
+							onClick={ () => {
+								trackLoginAndRememberRedirect( 'apple' );
+							} }
+							socialServiceResponse={ socialService === 'apple' ? socialServiceResponse : null }
+							originalUrlPath={
+								// Since the signup form is only ever called from the user step, currently, we can rely on window.location.pathname
+								// to return back to the user step, which then allows us to continue on with the flow once the submitSignupStep action is called within the user step.
+								isLogin ? null : window?.location?.pathname
+							}
+							// If we are on signup, attach the query string to the state so we can pass it back to the server to show the correct UI.
+							// We need this because Apple doesn't allow to have dynamic parameters in redirect_uri.
+							queryString={
+								isWpccFlow( flowName ) && ! isLogin ? window?.location?.search?.slice( 1 ) : null
+							}
+						/>
+						{ children }
+					</div>
 					{ ! isWoo && ! disableTosText && <SocialToS /> }
 				</div>
 				{ isWoo && ! disableTosText && <SocialToS /> }

--- a/client/blocks/authentication/social/style.scss
+++ b/client/blocks/authentication/social/style.scss
@@ -8,8 +8,11 @@
 	.auth-form__social-buttons {
 		display: flex;
 		flex-direction: column;
-		height: 100%;
-		justify-content: center;
+	}
+
+	.auth-form__social-buttons-container {
+		display: flex;
+		flex-direction: column;
 	}
 
 	.social-buttons__button {
@@ -40,11 +43,13 @@
 	}
 
 	.auth-form__social-buttons {
-		gap: 10px;
-
 		@include break-small {
 			align-items: center;
 		}
+	}
+
+	.auth-form__social-buttons-container {
+		gap: 10px;
 	}
 
 	.social-buttons__button.button {
@@ -54,7 +59,7 @@
 }
 
 .auth-form__social.is-social-first {
-	.auth-form__social-buttons {
+	.auth-form__social-buttons-container {
 		gap: 16px;
 	}
 

--- a/client/jetpack-connect/test/__snapshots__/signup.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/signup.js.snap
@@ -232,8 +232,12 @@ exports[`JetpackSignup should render 1`] = `
           <div
             class="auth-form__social-buttons"
           >
-            GoogleSocialButton
-            AppleLoginButton
+            <div
+              class="auth-form__social-buttons-container"
+            >
+              GoogleSocialButton
+              AppleLoginButton
+            </div>
             <p
               class="auth-form__social-buttons-tos"
             >
@@ -525,8 +529,12 @@ exports[`JetpackSignup should render with locale suggestions 1`] = `
           <div
             class="auth-form__social-buttons"
           >
-            GoogleSocialButton
-            AppleLoginButton
+            <div
+              class="auth-form__social-buttons-container"
+            >
+              GoogleSocialButton
+              AppleLoginButton
+            </div>
             <p
               class="auth-form__social-buttons-tos"
             >

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -386,8 +386,13 @@ $image-height: 47px;
 				background-color: #fdfdfd;
 				border: 0;
 				height: unset;
-				width: 194px;
 				text-align: start;
+			}
+		}
+
+		.login__form-userdata {
+			button {
+				width: 194px;
 			}
 		}
 	}

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -392,7 +392,7 @@ $image-height: 47px;
 
 		.login__form-userdata {
 			button {
-				width: 194px;
+				min-width: 194px;
 			}
 		}
 	}


### PR DESCRIPTION
With https://github.com/Automattic/wp-calypso/pull/84473 we changed the structure of the social component of Login, and introduced this problem: 

## Issue

<img width="373" alt="image" src="https://github.com/Automattic/wp-calypso/assets/52076348/2eb3b928-cf1b-4a20-9c41-ad9af13b7376">

In certain locales, the button overflows.

## Solution

Do not set a fixed width to the button, but make it responsive using flex

## Testing

1. Live Link
2. Visit `wordpress.com/log-in` and live link version. Test desktop and mobile.
3. Visit `wordpress.com/log-in/es` and live link version. Test desktop and mobile.
4. Visit `wordpress.com/start/hosting` and live link version. Test desktop and mobile.
5. Visit `wordpress.com/start/hosting/de` and live link version. Test desktop and mobile.
6. Visit `wordpress.com/start` and live link version. Test desktop and mobile.
7. Visit `wordpress.com/start/de` and live link version. Test desktop and mobile.
No need to go through all the flows for this change.