### PR TITLE
Self Service Site Reset: Add settings/start-over/site-reset feature flag

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -175,7 +175,7 @@
 		"server-side-rendering": true,
 		"settings/newsletter-settings-page": true,
 		"settings/security/monitor": true,
-		"settings/start-over/site-reset": true,
+		"settings/self-serve-site-reset": true,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
 		"signup/design-picker-preview-colors": true,

--- a/config/development.json
+++ b/config/development.json
@@ -175,6 +175,7 @@
 		"server-side-rendering": true,
 		"settings/newsletter-settings-page": true,
 		"settings/security/monitor": true,
+		"settings/start-over/site-reset": true,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
 		"signup/design-picker-preview-colors": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -115,6 +115,7 @@
 		"server-side-rendering": true,
 		"settings/newsletter-settings-page": true,
 		"settings/security/monitor": true,
+		"settings/start-over/site-reset": false,
 		"sign-in-with-apple": false,
 		"signup/design-picker-preview-colors": true,
 		"signup/design-picker-preview-fonts": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -115,7 +115,7 @@
 		"server-side-rendering": true,
 		"settings/newsletter-settings-page": true,
 		"settings/security/monitor": true,
-		"settings/start-over/site-reset": false,
+		"settings/self-serve-site-reset": false,
 		"sign-in-with-apple": false,
 		"signup/design-picker-preview-colors": true,
 		"signup/design-picker-preview-fonts": true,

--- a/config/production.json
+++ b/config/production.json
@@ -139,6 +139,7 @@
 		"server-side-rendering": true,
 		"settings/newsletter-settings-page": true,
 		"settings/security/monitor": true,
+		"settings/start-over/site-reset": false,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
 		"signup/design-picker-preview-colors": true,

--- a/config/production.json
+++ b/config/production.json
@@ -139,7 +139,7 @@
 		"server-side-rendering": true,
 		"settings/newsletter-settings-page": true,
 		"settings/security/monitor": true,
-		"settings/start-over/site-reset": false,
+		"settings/self-serve-site-reset": false,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
 		"signup/design-picker-preview-colors": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -136,6 +136,7 @@
 		"server-side-rendering": true,
 		"settings/newsletter-settings-page": true,
 		"settings/security/monitor": true,
+		"settings/start-over/site-reset": false,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
 		"signup/design-picker-preview-colors": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -136,7 +136,7 @@
 		"server-side-rendering": true,
 		"settings/newsletter-settings-page": true,
 		"settings/security/monitor": true,
-		"settings/start-over/site-reset": false,
+		"settings/self-serve-site-reset": false,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
 		"signup/design-picker-preview-colors": true,

--- a/config/test.json
+++ b/config/test.json
@@ -97,6 +97,7 @@
 		"seller-experience": true,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
+		"settings/start-over/site-reset": false,
 		"signup/social": true,
 		"signup/social-first": true,
 		"site-indicator": true,

--- a/config/test.json
+++ b/config/test.json
@@ -97,7 +97,7 @@
 		"seller-experience": true,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
-		"settings/start-over/site-reset": false,
+		"settings/self-serve-site-reset": false,
 		"signup/social": true,
 		"signup/social-first": true,
 		"site-indicator": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -145,6 +145,7 @@
 		"server-side-rendering": true,
 		"settings/newsletter-settings-page": true,
 		"settings/security/monitor": true,
+		"settings/start-over/site-reset": false,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
 		"signup/design-picker-preview-colors": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -145,7 +145,7 @@
 		"server-side-rendering": true,
 		"settings/newsletter-settings-page": true,
 		"settings/security/monitor": true,
-		"settings/start-over/site-reset": false,
+		"settings/self-serve-site-reset": false,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
 		"signup/design-picker-preview-colors": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Add feature flags for site reset project.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* N/A

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?