### PR TITLE
Marketplace Reviews: Use slug property instead of product_slug

### DIFF
--- a/client/data/marketplace/use-marketplace-reviews.ts
+++ b/client/data/marketplace/use-marketplace-reviews.ts
@@ -133,15 +133,15 @@ const deleteReview = ( {
 };
 
 export const useMarketplaceReviewsQuery = (
-	{ productType, slug: productSlug }: ProductProps,
+	{ productType, slug }: ProductProps,
 	{
 		enabled = true,
 		staleTime = BASE_STALE_TIME,
 		refetchOnMount = true,
 	}: MarketplaceReviewsQueryOptions = {}
 ) => {
-	const queryKey: QueryKey = [ queryKeyBase, productSlug ];
-	const queryFn = () => fetchMarketplaceReviews( productType, productSlug );
+	const queryKey: QueryKey = [ queryKeyBase, slug ];
+	const queryFn = () => fetchMarketplaceReviews( productType, slug );
 	return useQuery( {
 		queryKey,
 		queryFn,

--- a/client/my-sites/plugins/plugin-details-header/index.jsx
+++ b/client/my-sites/plugins/plugin-details-header/index.jsx
@@ -25,7 +25,7 @@ const PluginDetailsHeader = ( { plugin, isPlaceholder, isJetpackCloud } ) => {
 
 	const { data: marketplaceReviews } = useMarketplaceReviewsQuery( {
 		productType: 'plugin',
-		pluginSlug: plugin.slug,
+		slug: plugin.slug,
 	} );
 	const numberOfReviews = marketplaceReviews?.length || 0;
 


### PR DESCRIPTION
Related to #84506
Related to #84480

## Proposed Changes

Use slug property instead of product_slug.

After the update in the property name on #84480, the feature added on #84506 stopped working.
 
## Testing Instructions

Check if the instructions on #84506 are working fine on this PR.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
