### PR TITLE
Hosting Command Palette: Fix Jetpack product names

### DIFF
--- a/client/sites-dashboard/components/wpcom-smp-commands.tsx
+++ b/client/sites-dashboard/components/wpcom-smp-commands.tsx
@@ -246,7 +246,7 @@ export const useCommandsArrayWpcom = ( {
 		},
 		{
 			name: 'openJetpackStats',
-			label: __( 'Open Jetpack stats' ),
+			label: __( 'Open Jetpack Stats' ),
 			callback: setStateCallback( 'openJetpackStats' ),
 			siteFunctions: {
 				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
@@ -280,9 +280,9 @@ export const useCommandsArrayWpcom = ( {
 			icon: acitvityLogIcon,
 		},
 		{
-			name: 'openJetpackBackups',
-			label: __( 'Open Jetpack backups' ),
-			callback: setStateCallback( 'openJetpackBackups' ),
+			name: 'openJetpackBackup',
+			label: __( 'Open Jetpack Backup' ),
+			callback: setStateCallback( 'openJetpackBackup' ),
 			siteFunctions: {
 				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {
 					close();


### PR DESCRIPTION
From https://github.com/Automattic/wp-calypso/pull/84617

Props @dlind1 

## Proposed Changes

Should be 'Jetpack Backup' and 'Jetpack Stats'

## Testing Instructions

None.