### PR TITLE
Jetpack Manage: Use the WordPress.com sites dashboard instead of the JPM dashboard

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/controller.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/controller.tsx
@@ -1,6 +1,7 @@
 import config from '@automattic/calypso-config';
 import page, { type Callback } from '@automattic/calypso-router';
 import JetpackManageSidebar from 'calypso/jetpack-cloud/sections/sidebar-navigation/jetpack-manage';
+import { SitesDashboard } from 'calypso/sites-dashboard/components/sites-dashboard';
 import { isAgencyUser } from 'calypso/state/partner-portal/partner/selectors';
 import { setAllSitesSelected } from 'calypso/state/ui/actions';
 import DashboardOverview from './dashboard-overview';
@@ -27,11 +28,14 @@ export const agencyDashboardContext: Callback = ( context, next ) => {
 	context.header = <Header />;
 	context.secondary = <JetpackManageSidebar path={ context.path } />;
 	context.primary = (
-		<DashboardOverview
-			search={ search }
-			currentPage={ currentPage }
-			filter={ filter }
-			sort={ sort }
+		<SitesDashboard
+			queryParams={ {
+				page: context.query.page ? parseInt( context.query.page ) : undefined,
+				perPage: context.query[ 'per-page' ] ? parseInt( context.query[ 'per-page' ] ) : undefined,
+				search: context.query.search,
+				status: context.query.status,
+				newSiteID: parseInt( context.query[ 'new-site' ] ) || undefined,
+			} }
 		/>
 	);
 


### PR DESCRIPTION
## Proposed Changes

* Just trying something silly. **DO NOT MERGE**.

## Testing Instructions

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?