### PR TITLE
Assembler: Improve Pages screen resize behavior

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pages/page-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pages/page-preview.scss
@@ -27,6 +27,13 @@ $font-family: "SF Pro Text", $sans;
 			top: 0;
 		}
 
+		&.pattern-assembler__preview--fullscreen-enter,
+		&.pattern-assembler__preview--fullscreen-leave {
+			.pattern-assembler__preview-frame {
+				transition: all 0.2s;
+			}
+		}
+
 		.pattern-assembler__preview-frame {
 			--fullscreen-x-px: calc(50vw - calc(var(--fullscreen-x, 0) * 1px));
 			--fullscreen-y-px: calc(50vh - calc(var(--fullscreen-y, 0) * 1px));
@@ -37,6 +44,7 @@ $font-family: "SF Pro Text", $sans;
 				0 21.57518px 16.59629px 0 rgba(0, 0, 0, 0.03);
 			cursor: default;
 			transform: translate(var(--fullscreen-x-px), var(--fullscreen-y-px)) scale(var(--scale));
+			transition: none;
 
 			@include break-medium {
 				--scale: var(--fullscreen-scale, 1.8);
@@ -55,6 +63,12 @@ $font-family: "SF Pro Text", $sans;
 		.pattern-assembler__preview-title {
 			opacity: 0;
 		}
+	}
+
+	.pattern-assembler__preview-container {
+		display: flex;
+		flex: 1;
+		flex-direction: column;
 	}
 
 	.pattern-assembler__preview-frame {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pages/page-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pages/page-preview.tsx
@@ -69,9 +69,10 @@ const PatternPagePreview = ( {
 }: PagePreviewProps ) => {
 	const { slug, title, patterns } = pageProps;
 	const [ isFullscreen, setIsFullscreen ] = useState( false );
+	const [ isFullscreenEnter, setIsFullscreenEnter ] = useState( false );
 	const [ isFullscreenLeave, setIsFullscreenLeave ] = useState( false );
 	const [ frameStyles, setFrameStyles ] = useState( {} );
-	const ref = useRef< HTMLButtonElement >( null );
+	const ref = useRef< HTMLDivElement >( null );
 
 	const calculateFrameStyles = useCallback( () => {
 		if ( ! ref.current ) {
@@ -90,6 +91,10 @@ const PatternPagePreview = ( {
 		if ( ! isFullscreen ) {
 			setIsFullscreen( true );
 			onFullscreenEnter();
+
+			// The timeout delay should match the CSS transition timing of the element.
+			setIsFullscreenEnter( true );
+			setTimeout( () => setIsFullscreenEnter( false ), 200 );
 		}
 	};
 
@@ -120,11 +125,11 @@ const PatternPagePreview = ( {
 	}, [ isFullscreen, calculateFrameStyles ] );
 
 	useEffect( () => {
-		window.addEventListener( 'resize', handleFullscreenLeave );
+		window.addEventListener( 'resize', calculateFrameStyles );
 		return () => {
-			window.removeEventListener( 'resize', handleFullscreenLeave );
+			window.removeEventListener( 'resize', calculateFrameStyles );
 		};
-	}, [ handleFullscreenLeave ] );
+	}, [ calculateFrameStyles ] );
 
 	useOutsideClickCallback( ref, handleFullscreenLeave );
 
@@ -132,22 +137,24 @@ const PatternPagePreview = ( {
 		<div
 			className={ classnames( 'pattern-assembler__preview', {
 				'pattern-assembler__preview--fullscreen': isFullscreen,
+				'pattern-assembler__preview--fullscreen-enter': isFullscreenEnter,
 				'pattern-assembler__preview--fullscreen-leave': isFullscreenLeave,
 			} ) }
 		>
-			<CompositeItem
-				{ ...composite }
-				ref={ ref }
-				role="option"
-				as="button"
-				className="pattern-assembler__preview-frame"
-				style={ frameStyles }
-				aria-label={ title }
-				onClick={ handleClick }
-			>
-				<Page className="pattern-assembler__preview-frame-content" { ...pageProps } />
-			</CompositeItem>
-			<div className="pattern-assembler__preview-title">{ title }</div>
+			<div className="pattern-assembler__preview-container" ref={ ref }>
+				<CompositeItem
+					{ ...composite }
+					role="option"
+					as="button"
+					className="pattern-assembler__preview-frame"
+					style={ frameStyles }
+					aria-label={ title }
+					onClick={ handleClick }
+				>
+					<Page className="pattern-assembler__preview-frame-content" { ...pageProps } />
+				</CompositeItem>
+				<div className="pattern-assembler__preview-title">{ title }</div>
+			</div>
 		</div>
 	);
 };


### PR DESCRIPTION
## Proposed Changes

This PR is a continuation of @arthur791004's [proposal](https://github.com/Automattic/wp-calypso/commit/101ee476999a601da538c1f82320da8c37df0b35) in https://github.com/Automattic/wp-calypso/pull/84453#issuecomment-1829935507. This implementation supports the resizing of the page preview while full-screen. See recording below for reference:


https://github.com/Automattic/wp-calypso/assets/797888/306a43de-8be7-41b9-81db-9ea3cabec39e



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Assembler.
* Select any patterns and click on the Select styles button.
* Click on the Select pages button.
* Click on any page preview to make it full-screen.
* Ensure that the full-screen preview resizes well with the viewport change.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?