### PR TITLE
Jetpack Manage: Remove "Overview" navigation item

### DIFF
--- a/client/jetpack-cloud/sections/sidebar-navigation/jetpack-manage.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/jetpack-manage.tsx
@@ -1,4 +1,4 @@
-import { plugins, currencyDollar, category, home } from '@wordpress/icons';
+import { plugins, currencyDollar, category } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import JetpackIcons from 'calypso/components/jetpack/sidebar/menu-items/jetpack-icons';
 import GuidedTour from 'calypso/jetpack-cloud/components/guided-tour';
@@ -9,7 +9,6 @@ import {
 	JETPACK_MANAGE_PLUGINS_LINK,
 	JETPACK_MANAGE_LICENCES_LINK,
 	JETPACK_MANAGE_BILLING_LINK,
-	JETPACK_MANAGE_OVERVIEW_LINK,
 } from './lib/constants';
 import type { MenuItemProps } from './types';
 
@@ -25,15 +24,6 @@ const JetpackManageSidebar = ( { path }: { path: string } ) => {
 	} );
 
 	const menuItems = [
-		createItem( {
-			icon: home,
-			path: '/',
-			link: JETPACK_MANAGE_OVERVIEW_LINK,
-			title: translate( 'Overview' ),
-			trackEventProps: {
-				menu_item: 'Jetpack Cloud / Overview',
-			},
-		} ),
 		createItem( {
 			icon: category,
 			path: '/',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

**TL;DR:** The `Overview` page is visible to all users but the page only exist behind proxy.

#84434 introduced a new `Jetpack Manage Overview` page in Calypso Green that can only be seen behind proxy, but the corresponding nav item doesn't have a feature flag condition.

<img width="212" alt="284972523-9441a1b7-17e6-4dce-85f9-411956b91bd0" src="https://github.com/Automattic/wp-calypso/assets/3846700/fb1a103c-92b8-413a-8e33-8e8fa2912c9f">


## Proposed Changes

* Remove nav item

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up Calypso Green based on this branch
* Go to `/dashboard` 
* Verify that the Overview menu item no longer appears

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?