### PR TITLE
Self service site reset: Add initial UI card 

### DIFF
--- a/client/my-sites/site-settings/start-over.jsx
+++ b/client/my-sites/site-settings/start-over.jsx
@@ -1,5 +1,8 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Button, Gridicon } from '@automattic/components';
 import { useLocalizeUrl } from '@automattic/i18n-utils';
+import { createInterpolateElement } from '@wordpress/element';
+import { sprintf } from '@wordpress/i18n';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import ActionPanel from 'calypso/components/action-panel';
@@ -7,13 +10,25 @@ import ActionPanelBody from 'calypso/components/action-panel/body';
 import ActionPanelFigure from 'calypso/components/action-panel/figure';
 import ActionPanelFooter from 'calypso/components/action-panel/footer';
 import ActionPanelTitle from 'calypso/components/action-panel/title';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormTextInput from 'calypso/components/forms/form-text-input';
 import HeaderCake from 'calypso/components/header-cake';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { EMPTY_SITE } from 'calypso/lib/url/support';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getSiteDomain } from 'calypso/state/sites/selectors';
+import { getSelectedSiteSlug, getSelectedSiteId } from 'calypso/state/ui/selectors';
 
-const StartOver = ( { translate, selectedSiteSlug } ) => {
+const StartOver = ( { translate, selectedSiteSlug, siteDomain } ) => {
 	const localizeUrl = useLocalizeUrl();
+	if ( isEnabled( 'settings/self-serve-site-reset' ) ) {
+		return (
+			<SiteResetCard
+				translate={ translate }
+				selectedSiteSlug={ selectedSiteSlug }
+				siteDomain={ siteDomain }
+			/>
+		);
+	}
 	return (
 		<div
 			className="main main-column" // eslint-disable-line wpcalypso/jsx-classname-namespace
@@ -67,6 +82,84 @@ const StartOver = ( { translate, selectedSiteSlug } ) => {
 	);
 };
 
-export default connect( ( state ) => ( {
-	selectedSiteSlug: getSelectedSiteSlug( state ),
-} ) )( localize( StartOver ) );
+function SiteResetCard( { translate, selectedSiteSlug, siteDomain } ) {
+	const contentInfo = [
+		translate( 'posts' ),
+		translate( 'pages' ),
+		translate( 'user installed plugins' ),
+		translate( 'user themes' ),
+	];
+	return (
+		<div
+			className="main main-column" // eslint-disable-line wpcalypso/jsx-classname-namespace
+			role="main"
+		>
+			<PageViewTracker path="/settings/start-over/:site" title="Settings > Start Over" />
+			<HeaderCake backHref={ '/settings/general/' + selectedSiteSlug }>
+				<h1>{ translate( 'Start Over' ) }</h1>
+			</HeaderCake>
+			<ActionPanel>
+				<ActionPanelBody>
+					<ActionPanelFigure inlineBodyText={ true }>
+						<img src="/calypso/images/wordpress/logo-stars.svg" alt="" width="170" height="143" />
+					</ActionPanelFigure>
+					<ActionPanelTitle>{ translate( 'Start Over' ) }</ActionPanelTitle>
+					<p>
+						{ createInterpolateElement(
+							sprintf(
+								// translators: %s is the site domain
+								translate( 'Resetting <strong>%s</strong> will remove all of my content includes' ),
+								siteDomain
+							),
+							{
+								strong: <strong />,
+							}
+						) }
+					</p>
+					<ul>
+						{ contentInfo.map( ( content ) => (
+							<li key={ content }>{ content }</li>
+						) ) }
+					</ul>
+				</ActionPanelBody>
+				<ActionPanelFooter>
+					<FormLabel htmlFor="confirmResetInput" className="reset-site__confirm-label">
+						{ createInterpolateElement(
+							sprintf(
+								// translators: %s is the site domain
+								translate( 'Enter <strong>%s</strong> to continue' ),
+								siteDomain
+							),
+							{
+								strong: <strong />,
+							}
+						) }
+					</FormLabel>
+					<span className="site-settings__reset-site-controls">
+						<FormTextInput
+							autoCapitalize="off"
+							aria-required="true"
+							id="confirmResetInput"
+							style={ { flex: 2 } }
+						/>
+						<Button
+							style={ { flex: '1' } }
+							primary // eslint-disable-line wpcalypso/jsx-classname-namespace
+						>
+							{ translate( 'Reset Site' ) }
+						</Button>
+					</span>
+				</ActionPanelFooter>
+			</ActionPanel>
+		</div>
+	);
+}
+
+export default connect( ( state ) => {
+	const siteId = getSelectedSiteId( state );
+	const siteDomain = getSiteDomain( state, siteId );
+	return {
+		siteDomain,
+		selectedSiteSlug: getSelectedSiteSlug( state ),
+	};
+} )( localize( StartOver ) );

--- a/client/my-sites/site-settings/start-over.jsx
+++ b/client/my-sites/site-settings/start-over.jsx
@@ -1,8 +1,8 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { Button, Gridicon } from '@automattic/components';
-import { useSiteResetMutation } from '@automattic/data-stores/';
+import { useSiteResetMutation } from '@automattic/data-stores';
 import { useLocalizeUrl } from '@automattic/i18n-utils';
-import { createInterpolateElement, useState } from '@wordpress/element';
+import { createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
@@ -88,7 +88,6 @@ const StartOver = ( { translate, selectedSiteSlug, siteDomain } ) => {
 function SiteResetCard( { translate, selectedSiteSlug, siteDomain } ) {
 	const siteId = useSelector( getSelectedSiteId );
 	const dispatch = useDispatch();
-	const [ disabled, setDisabled ] = useState( false );
 
 	const handleError = () => {
 		dispatch(
@@ -112,7 +111,10 @@ function SiteResetCard( { translate, selectedSiteSlug, siteDomain } ) {
 		}
 	};
 
-	const { resetSite } = useSiteResetMutation( { onSuccess: handleResult, onError: handleError } );
+	const { resetSite, isLoading } = useSiteResetMutation( {
+		onSuccess: handleResult,
+		onError: handleError,
+	} );
 
 	const contentInfo = [
 		translate( 'posts' ),
@@ -121,13 +123,8 @@ function SiteResetCard( { translate, selectedSiteSlug, siteDomain } ) {
 		translate( 'user themes' ),
 	];
 
-	const handleReset = async () => {
-		try {
-			setDisabled( true );
-			await resetSite( siteId );
-		} finally {
-			setDisabled( false );
-		}
+	const handleReset = () => {
+		resetSite( siteId );
 	};
 
 	return (
@@ -181,15 +178,15 @@ function SiteResetCard( { translate, selectedSiteSlug, siteDomain } ) {
 							autoCapitalize="off"
 							aria-required="true"
 							id="confirmResetInput"
-							disabled={ disabled }
+							disabled={ isLoading }
 							style={ { flex: 2 } }
 						/>
 						<Button
 							style={ { flex: '1' } }
 							primary // eslint-disable-line wpcalypso/jsx-classname-namespace
 							onClick={ handleReset }
-							disabled={ disabled }
-							busy={ disabled }
+							disabled={ isLoading }
+							busy={ isLoading }
 						>
 							{ translate( 'Reset Site' ) }
 						</Button>

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -718,3 +718,16 @@ button.site-settings__general-settings-set-guessed-timezone.button.is-borderless
 		margin-inline-end: 0;
 	}
 }
+
+.site-settings__reset-site-controls {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 16px;
+}
+
+.form-label.reset-site__confirm-label {
+	margin-bottom: 8px;
+	line-height: 24px;
+	color: var(--color-text-subtle);
+	font-weight: normal;
+}

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -736,8 +736,4 @@ button.site-settings__general-settings-set-guessed-timezone.button.is-borderless
 	.card {
 		margin-bottom: 0;
 	}
-
-	.action-panel__body {
-		color: var(--color-primary);
-	}
 }

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -731,3 +731,13 @@ button.site-settings__general-settings-set-guessed-timezone.button.is-borderless
 	color: var(--color-text-subtle);
 	font-weight: normal;
 }
+
+.site-settings__reset-site {
+	.card {
+		margin-bottom: 0;
+	}
+
+	.action-panel__body {
+		color: var(--color-primary);
+	}
+}

--- a/packages/data-stores/src/index.ts
+++ b/packages/data-stores/src/index.ts
@@ -33,6 +33,7 @@ export * from './queries/use-site-domains-query';
 export * from './queries/use-site-query';
 export * from './mutations/use-domains-bulk-actions-mutation';
 export * from './queries/use-bulk-domain-update-status-query';
+export * from './mutations/use-site-reset-mutation';
 
 const { SubscriptionManager } = Reader;
 

--- a/packages/data-stores/src/mutations/use-site-reset-mutation.ts
+++ b/packages/data-stores/src/mutations/use-site-reset-mutation.ts
@@ -2,7 +2,7 @@ import { UseMutationOptions, useMutation } from '@tanstack/react-query';
 import { useCallback } from 'react';
 import wpcomRequest from 'wpcom-proxy-request';
 
-interface APIResponse {
+export interface SiteResetAPIResponse {
 	success: boolean;
 }
 
@@ -13,7 +13,11 @@ export interface APIError {
 	data?: any;
 }
 
-export const useSiteResetMutation = < TData = APIResponse, TError = APIError, TContext = unknown >(
+export const useSiteResetMutation = <
+	TData = SiteResetAPIResponse | APIError,
+	TError = APIError,
+	TContext = unknown,
+>(
 	options: UseMutationOptions< TData, TError, { siteId: number }, TContext > = {}
 ) => {
 	const { mutate, ...rest } = useMutation( {
@@ -23,7 +27,6 @@ export const useSiteResetMutation = < TData = APIResponse, TError = APIError, TC
 				apiNamespace: 'wpcom/v2',
 				method: 'POST',
 			} ),
-
 		...options,
 	} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label t
the linked issue.
-->

Relates to https://github.com/Automattic/dotcom-forge/issues/4690

## Proposed Changes
This PR creates the initial UI card based on the mock up, no functionality is added and design will change with further PRs

* Show reset site initial UI

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to `/settings/start-over/siteSlug`


![Screenshot 2023-12-05 at 6 45 49 PM](https://github.com/Automattic/wp-calypso/assets/47489215/5bca062e-2909-4862-8b3f-1f9ee3386a3b)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?