### PR TITLE
Live Preview: Add the upgrade notice on the sidebar for Premium and Woo themes

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-notice.scss
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-notice.scss
@@ -2,3 +2,21 @@
 	display: flex;
 	align-items: center;
 }
+
+.wpcom-live-preview-upgrade-notice-view-container {
+	padding: 24px 24px 0;
+	border-top: 1px solid #2f2f2f;
+	.wpcom-live-preview-upgrade-notice-view {
+		margin: 0 0 24px;
+		color: var(--color-text);
+
+		.components-notice__content {
+			margin-right: 0;
+		}
+
+		.components-notice__action {
+			margin: 8px 0 0;
+		}
+	}
+}
+

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-notice.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-notice.tsx
@@ -24,7 +24,7 @@ const LivePreviewUpgradeNoticeView: FC< {
 		<Notice
 			status="warning"
 			isDismissible={ false }
-			className="wpcom-global-styles-notice"
+			className="wpcom-live-preview-upgrade-notice-view"
 			actions={ [
 				{
 					// TODO: Add the tracking event.
@@ -115,6 +115,10 @@ export const LivePreviewUpgradeNotice: FC< {
 	] );
 
 	useEffect( () => {
+		// Do nothing in the Post Editor context.
+		if ( ! siteEditorStore ) {
+			return;
+		}
 		if ( canvasMode !== 'view' ) {
 			return;
 		}
@@ -146,7 +150,7 @@ export const LivePreviewUpgradeNotice: FC< {
 		);
 
 		setIsRendered( true );
-	}, [ canvasMode, isRendered, previewingTheme, upgradePlan ] );
+	}, [ canvasMode, isRendered, previewingTheme, siteEditorStore, upgradePlan ] );
 
 	return null;
 };

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-notice.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-notice.tsx
@@ -1,6 +1,8 @@
+import { Notice } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { render } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { FC, useEffect } from 'react';
+import { FC, useEffect, useState } from 'react';
 import { usePreviewingTheme } from './hooks/use-previewing-theme';
 import { getUnlock, isPreviewingTheme } from './utils';
 
@@ -14,13 +16,45 @@ const UPGRADE_NOTICE_ID = 'wpcom-live-preview/notice/upgrade';
 
 const unlock = getUnlock();
 
+const LivePreviewUpgradeNoticeView: FC< {
+	previewingTheme: ReturnType< typeof usePreviewingTheme >;
+	upgradePlan: any;
+} > = ( { previewingTheme, upgradePlan } ) => {
+	return (
+		<Notice
+			status="warning"
+			isDismissible={ false }
+			className="wpcom-global-styles-notice"
+			actions={ [
+				{
+					// TODO: Add the tracking event.
+					label: __( 'Upgrade now', 'wpcom-live-preview' ),
+					onClick: upgradePlan,
+					variant: 'primary',
+				},
+			] }
+		>
+			{ sprintf(
+				// translators: %1$s: The previewing theme name, %2$s: The theme type ('WooCommerce' or 'Premium')
+				__(
+					'You are previewing %1$s, a %2$s theme. You can try out your own style customizations, which will only be saved if you upgrade and activate this theme.',
+					'wpcom-live-preview'
+				),
+				previewingTheme.name,
+				previewingTheme.typeDisplay
+			) }
+		</Notice>
+	);
+};
+
 export const LivePreviewUpgradeNotice: FC< {
 	previewingTheme: ReturnType< typeof usePreviewingTheme >;
 	upgradePlan: () => void;
 } > = ( { previewingTheme, upgradePlan } ) => {
-	const siteEditorStore = useSelect( ( select ) => select( 'core/edit-site' ), [] );
+	const [ isRendered, setIsRendered ] = useState( false );
 	const { createWarningNotice, removeNotice } = useDispatch( 'core/notices' );
-
+	const siteEditorStore = useSelect( ( select ) => select( 'core/edit-site' ), [] );
+	const canvasMode = unlock && siteEditorStore && unlock( siteEditorStore ).getCanvasMode();
 	const dashboardLink =
 		unlock &&
 		siteEditorStore &&
@@ -79,5 +113,40 @@ export const LivePreviewUpgradeNotice: FC< {
 		dashboardLink,
 		previewingTheme.typeDisplay,
 	] );
+
+	useEffect( () => {
+		if ( canvasMode !== 'view' ) {
+			return;
+		}
+		if ( isRendered ) {
+			return;
+		}
+
+		const SAVE_HUB_SELECTOR = '.edit-site-save-hub';
+		const saveHub = document.querySelector( SAVE_HUB_SELECTOR );
+		if ( ! saveHub ) {
+			return;
+		}
+
+		// Insert the notice as a sibling of the save hub instead of as a child,
+		// to prevent our notice from breaking the flex styles of the hub.
+		const container = saveHub.parentNode;
+		const noticeContainer = document.createElement( 'div' );
+		noticeContainer.classList.add( 'wpcom-live-preview-upgrade-notice-view-container' );
+		if ( container ) {
+			container.insertBefore( noticeContainer, saveHub );
+		}
+
+		render(
+			<LivePreviewUpgradeNoticeView
+				previewingTheme={ previewingTheme }
+				upgradePlan={ upgradePlan }
+			/>,
+			noticeContainer
+		);
+
+		setIsRendered( true );
+	}, [ canvasMode, isRendered, previewingTheme, upgradePlan ] );
+
 	return null;
 };

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/utils.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/utils.ts
@@ -4,6 +4,10 @@ import { getQueryArg } from '@wordpress/url';
 export const WOOCOMMERCE_THEME = 'woocommerce';
 export const PREMIUM_THEME = 'premium';
 
+/**
+ * Get unlock API from Gutenberg.
+ * Sometimes Gutenberg doesn't allow you to re-register the module and throws an error.
+ */
 export const getUnlock = () => {
 	/**
 	 * Sometimes Gutenberg doesn't allow you to re-register the module and throws an error.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/79223, https://github.com/Automattic/wp-calypso/pull/83630

## Proposed Changes

This PR adds the upgrade-needed notice on the Site Editor sidebar when live-previewing Premium and WooCommerce themes.

UI:
<img width="1431" alt="Screenshot 2023-12-01 at 15 46 44" src="https://github.com/Automattic/wp-calypso/assets/5287479/3de2135e-e17a-42e3-ae7b-b0adda2ebb71">

Flow:

https://github.com/Automattic/wp-calypso/assets/5287479/7c4812fd-48f9-4fb7-a3aa-8965e85e5808

- [x] Currently, there's unnecessary DOM by Global Style notice even when the user is not using Global Style. I'll address it later. -> https://github.com/Automattic/wp-calypso/pull/84799 
<img width="393" alt="Screenshot 2023-12-01 at 15 51 11" src="https://github.com/Automattic/wp-calypso/assets/5287479/7478d079-0c94-4c58-9413-b926e6fc11f1">

Other tasks are listed in https://github.com/Automattic/wp-calypso/issues/79223.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `install-plugin.sh wpcom-block-editor add/live-preview-upgrade-notice-sidebar` on your sandbox.
- Sandbox widgets.wp.com and your site.
- **Upgrade Notice for Premium themes**
	- Prepare a site with the Personal plan or lower plan. 
	- Access `https://<your-site>/wp-admin/site-editor.php?wp_theme_preview=<premium-theme>` to preview a premium theme (e.g., `premium/outland`).
	- Try to edit the homepage and see the upgrade notice.
	- Click `Upgrade now`.
	- Verify the **Premium** plan is in the cart and complete checkout.
	- Verify it redirects to the Site Editor.
	- Verify you don't see the upgrade notice and the plan is upgraded.
- **Upgrade Notice for WooCommerce themes**
	- Prepare a site with the Premium plan or lower plan. 
	- Access `https://<your-site>/wp-admin/site-editor.php?wp_theme_preview=<woo-theme>` to preview a woo commerce theme (e.g. `premium/tsubaki`).
	- Try to edit the homepage and see the upgrade notice.
	- Click `Upgrade now`.
	- Verify the **Business** plan is in the cart and complete checkout.
	- Verify it redirects to the Site Editor.
	- Verify you don't see the upgrade notice and the plan is upgraded.
- **No Upgrade Notices**
	- Prepare a site with the Business plan or higher plan.
	- Access `https://<your-site>/wp-admin/site-editor.php?wp_theme_preview=<premium-theme>` to preview a premium theme (e.g., `premium/outland`). 
		- If your site is on Atomic, you need to install the theme before previewing it. 
	- Verify you don't see the upgrade notice. 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?