### PR TITLE
Implement the flow level props

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -167,13 +167,24 @@ export function generateFlows( {
 		},
 		{
 			name: 'onboarding-pm',
-			steps: [ 'user', 'domains', 'plans-pm' ],
+			steps: [ 'user', 'domains', 'plans' ],
 			destination: getSignupDestination,
 			description:
 				'Paid media version of the onboarding flow. Read more in https://wp.me/pau2Xa-4Kk.',
 			lastModified: '2023-07-18',
 			showRecaptcha: true,
 			hideProgressIndicator: true,
+			props: {
+				[ 'plans' ]: {
+					showBiennialToggle: true,
+					/**
+					 * This intent is geared towards customizations related to the paid media flow
+					 * Current customizations are as follows
+					 * - Show only Personal, Premium, Business, and eCommerce plans (Hide free, enterprise)
+					 */
+					intent: 'plans-paid-media',
+				},
+			},
 		},
 		{
 			name: 'import',

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -26,7 +26,6 @@ const stepNameToModuleName = {
 	'plans-business': 'plans',
 	'plans-business-with-plugin': 'plans',
 	'plans-hosting': 'plans',
-	'plans-pm': 'plans',
 	'plans-pro': 'plans',
 	'plans-starter': 'plans',
 	'plans-import': 'plans',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -304,24 +304,6 @@ export function generateSteps( {
 			},
 		},
 
-		'plans-pm': {
-			stepName: 'plans-pm',
-			apiRequestFunction: addPlanToCart,
-			dependencies: [ 'siteSlug' ],
-			optionalDependencies: [ 'emailItem', 'themeSlugWithRepo' ],
-			providesDependencies: [ 'cartItems', 'themeSlugWithRepo' ],
-			fulfilledStepCallback: isPlanFulfilled,
-			props: {
-				showBiennialToggle: true,
-				/**
-				 * This intent is geared towards customizations related to the paid media flow
-				 * Current customizations are as follows
-				 * - Show only Personal, Premium, Business, and eCommerce plans (Hide free, enterprise)
-				 */
-				intent: 'plans-paid-media',
-			},
-		},
-
 		'plans-new': {
 			stepName: 'plans',
 			providesDependencies: [ 'cartItems', 'themeSlugWithRepo' ],

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -789,15 +789,19 @@ class Signup extends Component {
 	}
 
 	renderCurrentStep( isReskinned ) {
-		const currentStepProgress = find( this.props.progress, { stepName: this.props.stepName } );
+		const { stepName, flowName } = this.props;
+
+		const flow = flows.getFlow( flowName, this.props.isLoggedIn );
+		const flowStepProps = flow?.props?.[ stepName ] || {};
+
+		const currentStepProgress = find( this.props.progress, { stepName } );
 		const CurrentComponent = this.props.stepComponent;
 		const propsFromConfig = {
 			...omit( this.props, 'locale' ),
-			...steps[ this.props.stepName ].props,
+			...steps[ stepName ].props,
+			...flowStepProps,
 		};
-		const stepKey = this.state.shouldShowLoadingScreen ? 'processing' : this.props.stepName;
-		const flow = flows.getFlow( this.props.flowName, this.props.isLoggedIn );
-
+		const stepKey = this.state.shouldShowLoadingScreen ? 'processing' : stepName;
 		const shouldRenderLocaleSuggestions = 0 === this.getPositionInFlow() && ! this.props.isLoggedIn;
 
 		let propsForCurrentStep = propsFromConfig;
@@ -810,7 +814,7 @@ class Signup extends Component {
 			};
 		}
 
-		const stepClassName = this.props.stepName === 'user-hosting' ? 'user' : this.props.stepName;
+		const stepClassName = stepName === 'user-hosting' ? 'user' : stepName;
 
 		return (
 			<div className="signup__step" key={ stepKey }>
@@ -826,12 +830,12 @@ class Signup extends Component {
 							step={ currentStepProgress }
 							initialContext={ this.props.initialContext }
 							steps={ flow.steps }
-							stepName={ this.props.stepName }
+							stepName={ stepName }
 							meta={ flow.meta || {} }
 							goToNextStep={ this.goToNextStep }
 							goToStep={ this.goToStep }
 							previousFlowName={ this.state.previousFlowName }
-							flowName={ this.props.flowName }
+							flowName={ flowName }
 							signupDependencies={ this.props.signupDependencies }
 							stepSectionName={ this.props.stepSectionName }
 							positionInFlow={ this.getPositionInFlow() }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

When implementing or fine-tuning a flow on the classic signup framework, I often find myself have to duplicate a step configuration just to add one or two props. This PR implements a "flow-level props" mechanism where we can move some props to the flow configuration to avoid having to duplicate the step configuration everytime. `onboarding-pm` flow is a good example, so the PR also removes `plans-pm` and uses the flow-level props instead.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* The target example, `/start/onboarding-pm`, should work as expected.
* For the rest, the maually triggered pre-release tests should be enough to cover.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
