### PR TITLE
Fix typo in Enterprise ecommerce card

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/wooexpress-plans/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/wooexpress-plans/index.tsx
@@ -140,7 +140,7 @@ export function WooExpressPlans( props: WooExpressPlansProps ) {
 					<h3 className="enterprise-ecommerce__title">{ translate( 'Enterprise ecommerce' ) }</h3>
 					<div className="enterprise-ecommerce__subtitle">
 						{ translate(
-							'Learn how Woo can support the unique needs of high-volume stores throught dedicated support, discounts, and more.'
+							'Learn how Woo can support the unique needs of high-volume stores through dedicated support, discounts, and more.'
 						) }
 					</div>
 					<div className="enterprise-ecommerce__cta">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* This PR fixes a typo in the _Enterprice ecommerce_ card we show on the Woo Express plans page - we were using "throught" instead of "through"

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Inspection should be sufficient for this change, but you can also test as follows:

* Run this branch locally or via Calypso.live
* Navigate to the plans page or the expired trial page for a Woo Express site
* Verify that we're using "through" instead of "throught" in the card text

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [N/A] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
