### PR TITLE
Jetpack Manage: Display only supported product bundles based on product families API.

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/hooks/use-product-bundle-size.ts
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/hooks/use-product-bundle-size.ts
@@ -12,20 +12,16 @@ const parseLocationHash = ( supportedBundleSizes: number[], value: string ) => {
 };
 
 const getSupportedBundleSizes = ( products?: APIProductFamilyProduct[] ) => {
-	if ( products?.length ) {
-		return [
-			1,
-			...products.reduce( ( set, product ) => {
-				product.supported_bundles.forEach( ( { quantity } ) => {
-					set.add( quantity );
-				} );
-
-				return set;
-			}, new Set< number >() ),
-		];
+	if ( ! products ) {
+		return [ 1 ];
 	}
 
-	return [ 1 ];
+	const supported = new Set( [
+		1,
+		...products.flatMap( ( p ) => p.supported_bundles?.map( ( { quantity } ) => quantity ) ),
+	] );
+
+	return [ ...supported ];
 };
 
 export function useProductBundleSize() {

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/hooks/use-product-and-plans.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/hooks/use-product-and-plans.tsx
@@ -104,7 +104,7 @@ export default function useProductAndPlans( {
 			selectedBundleSize > 1
 				? data?.filter(
 						( { supported_bundles } ) =>
-							!! supported_bundles?.find( ( { quantity } ) => selectedBundleSize === quantity )
+							supported_bundles?.some?.( ( { quantity } ) => selectedBundleSize === quantity )
 				  )
 				: data;
 

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/hooks/use-product-and-plans.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/hooks/use-product-and-plans.tsx
@@ -23,6 +23,7 @@ import {
 import type { SiteDetails } from '@automattic/data-stores';
 
 type Props = {
+	selectedBundleSize?: number;
 	selectedSite?: SiteDetails | null;
 	selectedProductFilter?: string | null;
 };
@@ -65,6 +66,7 @@ const getProductsAndPlansByFilter = (
 };
 
 export default function useProductAndPlans( {
+	selectedBundleSize = 1,
 	selectedSite,
 	selectedProductFilter = PRODUCT_FILTER_ALL,
 }: Props ) {
@@ -97,8 +99,20 @@ export default function useProductAndPlans( {
 	);
 
 	return useMemo( () => {
+		// List only products that is compatible with current bundle size.
+		const supportedProducts =
+			selectedBundleSize > 1
+				? data?.filter(
+						( { supported_bundles } ) =>
+							!! supported_bundles?.find( ( { quantity } ) => selectedBundleSize === quantity )
+				  )
+				: data;
+
 		// We pre-filter the list by current selected filter
-		let filteredProductsAndBundles = getProductsAndPlansByFilter( selectedProductFilter, data );
+		let filteredProductsAndBundles = getProductsAndPlansByFilter(
+			selectedProductFilter,
+			supportedProducts
+		);
 
 		// Filter products & plan that are already assigned to a site
 		if ( selectedSite && addedPlanAndProducts && filteredProductsAndBundles ) {
@@ -128,5 +142,12 @@ export default function useProductAndPlans( {
 			),
 			suggestedProductSlugs,
 		};
-	}, [ addedPlanAndProducts, data, isLoadingProducts, selectedProductFilter, selectedSite ] );
+	}, [
+		addedPlanAndProducts,
+		data,
+		isLoadingProducts,
+		selectedBundleSize,
+		selectedProductFilter,
+		selectedSite,
+	] );
 }

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
@@ -157,7 +157,7 @@ export default function LicensesForm( {
 				</LicensesFormSection>
 			) }
 
-			{ isSingleLicenseView && wooExtensions.length > 0 && (
+			{ wooExtensions.length > 0 && (
 				<LicensesFormSection
 					title={ translate( 'WooCommerce Extensions' ) }
 					description={ translate(
@@ -174,12 +174,13 @@ export default function LicensesForm( {
 							isDisabled={ disabledProductSlugs.includes( productOption.slug ) }
 							tabIndex={ 100 + i }
 							suggestedProduct={ suggestedProduct }
+							hideDiscount={ isSingleLicenseView }
 						/>
 					) ) }
 				</LicensesFormSection>
 			) }
 
-			{ isSingleLicenseView && backupAddons.length > 0 && (
+			{ backupAddons.length > 0 && (
 				<LicensesFormSection
 					title={ translate( 'VaultPress Backup Add-ons' ) }
 					description={ translate(
@@ -196,6 +197,7 @@ export default function LicensesForm( {
 							isDisabled={ disabledProductSlugs.includes( productOption.slug ) }
 							tabIndex={ 100 + i }
 							suggestedProduct={ suggestedProduct }
+							hideDiscount={ isSingleLicenseView }
 						/>
 					) ) }
 				</LicensesFormSection>

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
@@ -39,7 +39,7 @@ export default function LicensesForm( {
 		products,
 		wooExtensions,
 		suggestedProductSlugs,
-	} = useProductAndPlans( { selectedSite, selectedProductFilter } );
+	} = useProductAndPlans( { selectedSite, selectedProductFilter, selectedBundleSize: quantity } );
 
 	const disabledProductSlugs = useSelector< PartnerPortalStore, string[] >( ( state ) =>
 		getDisabledProductSlugs( state, filteredProductsAndBundles ?? [] )

--- a/client/state/partner-portal/types.ts
+++ b/client/state/partner-portal/types.ts
@@ -95,6 +95,11 @@ export interface APILicense {
 	revoked_at: string | null;
 }
 
+export interface APIProductFamilyProductBundlePrice {
+	quantity: number;
+	amount: number;
+}
+
 export interface APIProductFamilyProduct {
 	name: string;
 	slug: string;
@@ -103,6 +108,7 @@ export interface APIProductFamilyProduct {
 	amount: number;
 	price_interval: string;
 	family_slug: string;
+	supported_bundles: APIProductFamilyProductBundlePrice[];
 }
 
 export interface APIProductFamily {


### PR DESCRIPTION
Our current implementation hardcodes the bundle size options and supported products. This pull request dynamically renders supported products based on the data provided by the Product Families API.

<img width="1430" alt="Screen Shot 2023-11-30 at 4 53 42 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/e190cb5f-eb9a-40a1-a6df-0242f39ad8e8">

Closes https://github.com/Automattic/jetpack-genesis/issues/126

## Proposed Changes

* Update `useProductBundleSize` hook to load bundle sizes based on the data provided by the product families API.
* Update `useProductsAndPlans` hook to filter products based on `supported_bundles` field.

## Testing Instructions
Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

* Before testing, you need to override your billing scheme to **874** to get the full list of supported bundles.
* Use the Jetpack cloud live link below and go to the Licenses page (`/partner-portal/issue-license?flags=jetpack/bundle-licensing`)
* Confirm that the products and bundle sizes loaded are based from the product families API.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?