### PR TITLE
Magic Login page: fix margin

### DIFF
--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -138,10 +138,6 @@
 	}
 }
 
-.magic-login__email-fields {
-	margin: 0;
-}
-
 .magic-login__form-action {
 	margin-top: 20px;
 	overflow: auto;


### PR DESCRIPTION
## Issue
[Link](https://wordpress.com/log-in/link) to the page, the error is in the margin.

![image](https://github.com/Automattic/wp-calypso/assets/52076348/e6162d88-14cb-4d31-9669-eab5ae544151)

## After Fix

![image](https://github.com/Automattic/wp-calypso/assets/52076348/2104ed1c-a638-48d8-bd5d-51b0bf8e5247)


## Testing

1. Live link.
2. Visit `/log-in/link` desktop and mobile.
