### PR TITLE
LoTS: Introduce the assembler-first flow

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -11,7 +11,7 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { __, isRTL } from '@wordpress/i18n';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
 import { ESCAPE } from '@wordpress/keycodes';
-import { addQueryArgs } from '@wordpress/url';
+import { addQueryArgs, getQueryArg } from '@wordpress/url';
 import classNames from 'classnames';
 import { get, isEmpty, partition } from 'lodash';
 import * as React from 'react';
@@ -116,9 +116,11 @@ function WpcomBlockEditorNavSidebar() {
 
 	const launchpadScreenOption = window?.wpcomBlockEditorNavSidebar?.currentSite?.launchpad_screen;
 	const siteIntent = window?.wpcomBlockEditorNavSidebar?.currentSite?.site_intent;
+	const siteOrigin =
+		getQueryArg( window.location.search, 'calypso_origin' ) || 'https://wordpress.com';
 
 	if ( launchpadScreenOption === 'full' && siteIntent !== false ) {
-		defaultCloseUrl = `http://wordpress.com/setup/${ siteIntent }/launchpad?siteSlug=${ siteSlug }`;
+		defaultCloseUrl = `${ siteOrigin }/setup/${ siteIntent }/launchpad?siteSlug=${ siteSlug }`;
 		defaultCloseLabel = __( 'Next steps', 'full-site-editing' );
 	} else {
 		defaultCloseUrl = addQueryArgs( 'edit.php', { post_type: postType.slug } );
@@ -153,17 +155,6 @@ function WpcomBlockEditorNavSidebar() {
 		defaultListHeading,
 		postType.slug
 	) as string;
-
-	const dialogDescription =
-		postType.slug === 'page'
-			? __(
-					'Contains links to your dashboard or to edit other pages on your site. Press the Escape key to close.',
-					'full-site-editing'
-			  )
-			: __(
-					'Contains links to your dashboard or to edit other posts on your site. Press the Escape key to close.',
-					'full-site-editing'
-			  );
 
 	const dismissSidebar = () => {
 		if ( isOpen && ! isClosing ) {
@@ -204,8 +195,17 @@ function WpcomBlockEditorNavSidebar() {
 			<div
 				aria-label={ __( 'Block editor sidebar', 'full-site-editing' ) }
 				// Waiting for jsx-a11y version bump to support aria-description attribute
-				// eslint-disable-next-line jsx-a11y/aria-props
-				aria-description={ dialogDescription }
+				// aria-description={
+				// 	postType.slug === 'page'
+				// 		? __(
+				// 		'Contains links to your dashboard or to edit other pages on your site. Press the Escape key to close.',
+				// 		'full-site-editing'
+				//   	)
+				// 	: __(
+				// 		'Contains links to your dashboard or to edit other posts on your site. Press the Escape key to close.',
+				// 		'full-site-editing'
+				//  	)
+				// }
 				className={ classNames( 'wpcom-block-editor-nav-sidebar-nav-sidebar__container', {
 					'is-sliding-left': isClosing,
 				} ) }

--- a/client/components/themes-list/get-site-assembler-url.js
+++ b/client/components/themes-list/get-site-assembler-url.js
@@ -1,4 +1,5 @@
-import { WITH_THEME_ASSEMBLER_FLOW } from '@automattic/onboarding';
+import { isEnabled } from '@automattic/calypso-config';
+import { WITH_THEME_ASSEMBLER_FLOW, ASSEMBLER_FIRST_FLOW } from '@automattic/onboarding';
 
 export default function getSiteAssemblerUrl( {
 	isLoggedIn,
@@ -10,9 +11,13 @@ export default function getSiteAssemblerUrl( {
 		return siteEditorUrl;
 	}
 
+	const params = new URLSearchParams( { ref: 'calypshowcase' } );
+	if ( isEnabled( 'themes/assembler-first' ) ) {
+		return `/setup/${ ASSEMBLER_FIRST_FLOW }?${ params }`;
+	}
+
 	// Redirect people to create a site first if they don't log in or they have no sites.
 	const basePathname = isLoggedIn && selectedSite ? '/setup' : '/start';
-	const params = new URLSearchParams( { ref: 'calypshowcase' } );
 
 	if ( selectedSite?.slug ) {
 		params.set( 'siteSlug', selectedSite.slug );

--- a/client/landing/stepper/declarative-flow/assembler-first-flow.ts
+++ b/client/landing/stepper/declarative-flow/assembler-first-flow.ts
@@ -58,7 +58,7 @@ const assemblerFirstFlow: Flow = {
 				design_type: 'assembler',
 			} );
 
-			setIntent( SiteIntent.WithThemeAssembler );
+			setIntent( SiteIntent.AssemblerFirst );
 		}, [ theme ] );
 	},
 
@@ -100,7 +100,7 @@ const assemblerFirstFlow: Flow = {
 			const selectedSiteId = providedDependencies?.siteId as string;
 			const isNewSite = providedDependencies?.isNewSite === 'true';
 			setSelectedSite( selectedSiteId );
-			setIntentOnSite( selectedSiteSlug, ASSEMBLER_FIRST_FLOW );
+			setIntentOnSite( selectedSiteSlug, SiteIntent.AssemblerFirst );
 			saveSiteSettings( selectedSiteId, { launchpad_screen: 'full' } );
 
 			// Check whether to go to the assembler. If not, go to the site editor directly

--- a/client/landing/stepper/declarative-flow/assembler-first-flow.ts
+++ b/client/landing/stepper/declarative-flow/assembler-first-flow.ts
@@ -1,0 +1,250 @@
+import { Onboard } from '@automattic/data-stores';
+import { DEFAULT_ASSEMBLER_DESIGN, isAssemblerSupported } from '@automattic/design-picker';
+import { useLocale } from '@automattic/i18n-utils';
+import { useFlowProgress, ASSEMBLER_FIRST_FLOW } from '@automattic/onboarding';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import { getLocaleFromQueryParam, getLocaleFromPathname } from 'calypso/boot/locale';
+import { useQueryTheme } from 'calypso/components/data/query-theme';
+import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { getTheme } from 'calypso/state/themes/selectors';
+import { useSiteSlug } from '../hooks/use-site-slug';
+import { ONBOARD_STORE, SITE_STORE } from '../stores';
+import { useLoginUrl } from '../utils/path';
+import { recordSubmitStep } from './internals/analytics/record-submit-step';
+import { STEPS } from './internals/steps';
+import { ProcessingResult } from './internals/steps-repository/processing-step/constants';
+import {
+	AssertConditionResult,
+	AssertConditionState,
+	Flow,
+	ProvidedDependencies,
+} from './internals/types';
+import type { OnboardSelect } from '@automattic/data-stores';
+
+const SiteIntent = Onboard.SiteIntent;
+
+const assemblerFirstFlow: Flow = {
+	name: ASSEMBLER_FIRST_FLOW,
+	useSideEffect() {
+		const selectedDesign = useSelect(
+			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedDesign(),
+			[]
+		);
+		const { setSelectedDesign, setIntent } = useDispatch( ONBOARD_STORE );
+		const selectedTheme = DEFAULT_ASSEMBLER_DESIGN.slug;
+		const theme = useSelector( ( state ) => getTheme( state, 'wpcom', selectedTheme ) );
+
+		// We have to query theme for the Jetpack site.
+		useQueryTheme( 'wpcom', selectedTheme );
+
+		useEffect( () => {
+			if ( ! theme ) {
+				// eslint-disable-next-line no-console
+				console.log( `The ${ selectedTheme } theme is loading...` );
+				return;
+			}
+
+			setSelectedDesign( {
+				...selectedDesign,
+				slug: theme.id,
+				title: theme.name,
+				recipe: {
+					...selectedDesign?.recipe,
+					stylesheet: theme.stylesheet,
+				},
+				design_type: 'assembler',
+			} );
+
+			setIntent( SiteIntent.WithThemeAssembler );
+		}, [ theme ] );
+	},
+
+	useSteps() {
+		return [
+			STEPS.CHECK_SITES,
+			STEPS.NEW_OR_EXISTING_SITE,
+			STEPS.SITE_PICKER,
+			STEPS.SITE_CREATION_STEP,
+			STEPS.PATTERN_ASSEMBLER,
+			STEPS.PROCESSING,
+			STEPS.ERROR,
+			STEPS.LAUNCHPAD,
+		];
+	},
+
+	useStepNavigation( _currentStep, navigate ) {
+		const flowName = this.name;
+		const intent = useSelect(
+			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getIntent(),
+			[]
+		);
+		const { setStepProgress, setPendingAction, setSelectedSite } = useDispatch( ONBOARD_STORE );
+		const { saveSiteSettings, setIntentOnSite } = useDispatch( SITE_STORE );
+
+		const flowProgress = useFlowProgress( { stepName: _currentStep, flowName } );
+		setStepProgress( flowProgress );
+		const siteSlug = useSiteSlug();
+
+		const exitFlow = ( to: string ) => {
+			setPendingAction( () => {
+				return new Promise( () => {
+					window.location.assign( to );
+				} );
+			} );
+
+			return navigate( 'processing' );
+		};
+
+		const handleSelectSite = ( providedDependencies: ProvidedDependencies = {} ) => {
+			const selectedSiteSlug = providedDependencies?.siteSlug as string;
+			const selectedSiteId = providedDependencies?.siteId as string;
+			const isNewSite = providedDependencies?.isNewSite as string;
+			setSelectedSite( selectedSiteId );
+			setIntentOnSite( selectedSiteSlug, ASSEMBLER_FIRST_FLOW );
+			saveSiteSettings( selectedSiteId, { launchpad_screen: 'full' } );
+
+			// Check whether to go to the assembler. If not, go to the site editor directly
+			let params;
+			if ( ! isAssemblerSupported() ) {
+				params = new URLSearchParams( {
+					canvas: 'edit',
+					assembler: '1',
+				} );
+
+				return `/site-editor/${ selectedSiteSlug }?${ params }`;
+			}
+
+			params = new URLSearchParams( {
+				siteSlug: selectedSiteSlug,
+				siteId: selectedSiteId,
+				isNewSite,
+			} );
+			return navigate( `patternAssembler?${ params }` );
+		};
+
+		const submit = ( providedDependencies: ProvidedDependencies = {}, ...results: string[] ) => {
+			recordSubmitStep( providedDependencies, intent, flowName, _currentStep );
+
+			switch ( _currentStep ) {
+				case 'check-sites': {
+					// Check for unlaunched sites
+					if ( providedDependencies?.filteredSitesCount === 0 ) {
+						// No unlaunched sites, redirect to new site creation step
+						return navigate( 'site-creation-step' );
+					}
+					// With unlaunched sites, continue to new-or-existing-site step
+					return navigate( 'new-or-existing-site' );
+				}
+
+				case 'new-or-existing-site': {
+					if ( 'new-site' === providedDependencies?.newExistingSiteChoice ) {
+						return navigate( 'site-creation-step' );
+					}
+					return navigate( 'site-picker' );
+				}
+
+				case 'site-creation-step': {
+					return navigate( 'processing' );
+				}
+
+				case 'site-picker': {
+					return handleSelectSite( providedDependencies );
+				}
+
+				case 'processing': {
+					if ( results.some( ( result ) => result === ProcessingResult.FAILURE ) ) {
+						return navigate( 'error' );
+					}
+
+					// If we just created a new site, navigate to the assembler step.
+					if ( providedDependencies?.siteSlug && ! providedDependencies?.blogLaunched ) {
+						return handleSelectSite( {
+							...providedDependencies,
+							isNewSite: 'true',
+						} );
+					}
+
+					const params = new URLSearchParams( {
+						canvas: 'edit',
+						assembler: '1',
+					} );
+
+					return exitFlow( `/site-editor/${ siteSlug }?${ params }` );
+				}
+
+				case 'patternAssembler': {
+					return navigate( 'processing' );
+				}
+			}
+		};
+
+		const goBack = () => {
+			switch ( _currentStep ) {
+				case 'site-picker': {
+					return navigate( 'new-or-existing-site' );
+				}
+
+				case 'patternAssembler': {
+					return window.location.assign( `/themes/${ siteSlug }` );
+				}
+			}
+		};
+
+		return { submit, goBack };
+	},
+
+	useAssertConditions(): AssertConditionResult {
+		const flowName = this.name;
+		const isLoggedIn = useSelector( isUserLoggedIn );
+		const currentUserSiteCount = useSelector( getCurrentUserSiteCount );
+		const currentPath = window.location.pathname;
+		const isSiteCreationStep =
+			currentPath.endsWith( `setup/${ flowName }` ) ||
+			currentPath.endsWith( `setup/${ flowName }/` ) ||
+			currentPath.includes( `setup/${ flowName }/check-sites` );
+		const userAlreadyHasSites = currentUserSiteCount && currentUserSiteCount > 0;
+
+		// There is a race condition where useLocale is reporting english,
+		// despite there being a locale in the URL so we need to look it up manually.
+		// We also need to support both query param and path suffix localized urls
+		// depending on where the user is coming from.
+		const useLocaleSlug = useLocale();
+		// Query param support can be removed after dotcom-forge/issues/2960 and 2961 are closed.
+		const queryLocaleSlug = getLocaleFromQueryParam();
+		const pathLocaleSlug = getLocaleFromPathname();
+		const locale = queryLocaleSlug || pathLocaleSlug || useLocaleSlug;
+		const logInUrl = useLoginUrl( {
+			variationName: flowName,
+			redirectTo: window.location.href.replace( window.location.origin, '' ),
+			locale,
+		} );
+
+		useEffect( () => {
+			if ( ! isLoggedIn ) {
+				window.location.assign( logInUrl );
+			} else if ( isSiteCreationStep && ! userAlreadyHasSites ) {
+				window.location.assign( `/setup/${ flowName }/site-creation-step` );
+			}
+		}, [] );
+
+		let result: AssertConditionResult = { state: AssertConditionState.SUCCESS };
+
+		if ( ! isLoggedIn ) {
+			result = {
+				state: AssertConditionState.CHECKING,
+				message: `${ flowName } requires a logged in user`,
+			};
+		} else if ( isSiteCreationStep && ! userAlreadyHasSites ) {
+			result = {
+				state: AssertConditionState.CHECKING,
+				message: `${ flowName } with no preexisting sites`,
+			};
+		}
+
+		return result;
+	},
+};
+
+export default assemblerFirstFlow;

--- a/client/landing/stepper/declarative-flow/assembler-first-flow.ts
+++ b/client/landing/stepper/declarative-flow/assembler-first-flow.ts
@@ -98,7 +98,7 @@ const assemblerFirstFlow: Flow = {
 		const handleSelectSite = ( providedDependencies: ProvidedDependencies = {} ) => {
 			const selectedSiteSlug = providedDependencies?.siteSlug as string;
 			const selectedSiteId = providedDependencies?.siteId as string;
-			const isNewSite = providedDependencies?.isNewSite as string;
+			const isNewSite = providedDependencies?.isNewSite === 'true';
 			setSelectedSite( selectedSiteId );
 			setIntentOnSite( selectedSiteSlug, ASSEMBLER_FIRST_FLOW );
 			saveSiteSettings( selectedSiteId, { launchpad_screen: 'full' } );
@@ -117,8 +117,12 @@ const assemblerFirstFlow: Flow = {
 			params = new URLSearchParams( {
 				siteSlug: selectedSiteSlug,
 				siteId: selectedSiteId,
-				isNewSite,
 			} );
+
+			if ( isNewSite ) {
+				params.set( 'isNewSite', 'true' );
+			}
+
 			return navigate( `patternAssembler?${ params }` );
 		};
 

--- a/client/landing/stepper/declarative-flow/build.ts
+++ b/client/landing/stepper/declarative-flow/build.ts
@@ -1,4 +1,3 @@
-import { LaunchpadNavigator } from '@automattic/data-stores';
 import { useFlowProgress, BUILD_FLOW } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
@@ -30,7 +29,6 @@ const build: Flow = {
 		const { setStepProgress } = useDispatch( ONBOARD_STORE );
 		const siteId = useSiteIdParam();
 		const siteSlug = useSiteSlug();
-		const { setActiveChecklist } = useDispatch( LaunchpadNavigator.store );
 		const flowProgress = useFlowProgress( { stepName: _currentStep, flowName } );
 
 		setStepProgress( flowProgress );
@@ -74,7 +72,6 @@ const build: Flow = {
 				case 'launchpad':
 					skipLaunchpad( {
 						checklistSlug: 'build',
-						setActiveChecklist,
 						siteId,
 						siteSlug,
 					} );

--- a/client/landing/stepper/declarative-flow/design-first.ts
+++ b/client/landing/stepper/declarative-flow/design-first.ts
@@ -1,8 +1,4 @@
-import {
-	OnboardSelect,
-	LaunchpadNavigator,
-	updateLaunchpadSettings,
-} from '@automattic/data-stores';
+import { OnboardSelect, updateLaunchpadSettings } from '@automattic/data-stores';
 import { useLocale } from '@automattic/i18n-utils';
 import { DESIGN_FIRST_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch, dispatch } from '@wordpress/data';
@@ -93,7 +89,6 @@ const designFirst: Flow = {
 			[]
 		).getState();
 		const site = useSite();
-		const { setActiveChecklist } = useDispatch( LaunchpadNavigator.store );
 
 		// This flow clear the site_intent when flow is completed.
 		// We need to check if the site is launched and if so, clear the site_intent to avoid errors.
@@ -262,7 +257,6 @@ const designFirst: Flow = {
 				case 'launchpad':
 					skipLaunchpad( {
 						checklistSlug: site?.options?.site_intent,
-						setActiveChecklist,
 						siteId,
 						siteSlug,
 					} );

--- a/client/landing/stepper/declarative-flow/free.ts
+++ b/client/landing/stepper/declarative-flow/free.ts
@@ -91,9 +91,9 @@ const free: Flow = {
 
 			switch ( _currentStep ) {
 				case 'freeSetup':
-					return navigate( 'siteCreationStep' );
+					return navigate( 'site-creation-step' );
 
-				case 'siteCreationStep':
+				case 'site-creation-step':
 					return navigate( 'processing' );
 
 				case 'processing':

--- a/client/landing/stepper/declarative-flow/free.ts
+++ b/client/landing/stepper/declarative-flow/free.ts
@@ -1,4 +1,4 @@
-import { LaunchpadNavigator, type OnboardSelect, type UserSelect } from '@automattic/data-stores';
+import { type OnboardSelect, type UserSelect } from '@automattic/data-stores';
 import { isAssemblerDesign } from '@automattic/design-picker';
 import { useLocale } from '@automattic/i18n-utils';
 import { useFlowProgress, FREE_FLOW } from '@automattic/onboarding';
@@ -62,7 +62,6 @@ const free: Flow = {
 			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedDesign(),
 			[]
 		);
-		const { setActiveChecklist } = useDispatch( LaunchpadNavigator.store );
 
 		// trigger guides on step movement, we don't care about failures or response
 		wpcom.req.post(
@@ -171,7 +170,6 @@ const free: Flow = {
 				case 'launchpad':
 					skipLaunchpad( {
 						checklistSlug: 'free',
-						setActiveChecklist,
 						siteId,
 						siteSlug,
 					} );

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -88,6 +88,7 @@ button {
 .free-post-setup,
 .free,
 .with-theme-assembler,
+.assembler-first,
 .setup-blog,
 .celebration-step,
 .use-my-domain,
@@ -121,6 +122,12 @@ button {
 	.import-step,
 	.importer-step {
 		@include onboarding-block-margin;
+	}
+
+	&.site-picker,
+	&.new-or-existing-site,
+	&.launchpad {
+		padding: 0;
 	}
 
 	/**

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
@@ -9,6 +9,7 @@ import {
 	DESIGN_FIRST_FLOW,
 	VIDEOPRESS_FLOW,
 	VIDEOPRESS_ACCOUNT,
+	ASSEMBLER_FIRST_FLOW,
 	isVideoPressFlow,
 } from '@automattic/onboarding';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
@@ -31,6 +32,7 @@ const LaunchpadSitePreview = ( { siteSlug, flow }: Props ) => {
 			case WRITE_FLOW:
 			case START_WRITING_FLOW:
 			case DESIGN_FIRST_FLOW:
+			case ASSEMBLER_FIRST_FLOW:
 				return DEVICE_TYPES.COMPUTER;
 			case VIDEOPRESS_FLOW:
 			case VIDEOPRESS_ACCOUNT:

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -155,7 +155,8 @@
 .link-in-bio-tld:not(.domains),
 .free,
 .build,
-.write {
+.write,
+.assembler-first {
 	.step-container {
 		.step-container__content h1,
 		.step-container__content h1.launchpad__sidebar-h1 {
@@ -378,9 +379,10 @@
 	}
 }
 
-// Write and Build flow
+// Write, Build, and Assembler First flow
 .write.launchpad,
-.build.launchpad {
+.build.launchpad,
+.assembler-first.launchpad {
 	.launchpad__sidebar-header-flow-name {
 		display: none;
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/index.tsx
@@ -6,8 +6,10 @@ import {
 	HUNDRED_YEAR_PLAN_FLOW,
 	StepContainer,
 	isBlogOnboardingFlow,
+	isSiteAssemblerFlow,
 	START_WRITING_FLOW,
 	DESIGN_FIRST_FLOW,
+	ASSEMBLER_FIRST_FLOW,
 } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -60,6 +62,7 @@ const useIntentsForFlow = ( flowName: string ): NewOrExistingSiteIntent[] => {
 			];
 		case DESIGN_FIRST_FLOW:
 		case START_WRITING_FLOW:
+		case ASSEMBLER_FIRST_FLOW:
 			return [
 				{
 					key: 'existing-site',
@@ -94,7 +97,7 @@ const NewOrExistingSiteStep: Step = function NewOrExistingSiteStep( { navigation
 	};
 
 	const getHeaderText = () => {
-		if ( isBlogOnboardingFlow( flow ) ) {
+		if ( isBlogOnboardingFlow( flow ) || isSiteAssemblerFlow( flow ) ) {
 			return translate( 'New or existing site' );
 		}
 		switch ( flow ) {
@@ -124,7 +127,7 @@ const NewOrExistingSiteStep: Step = function NewOrExistingSiteStep( { navigation
 			stepName="new-or-existing-site"
 			flowName={ flow }
 			recordTracksEvent={ recordTracksEvent }
-			hideBack={ isBlogOnboardingFlow( flow ) }
+			hideBack={ isBlogOnboardingFlow( flow ) || isSiteAssemblerFlow( flow ) }
 		/>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/styles.scss
@@ -40,7 +40,8 @@
 }
 
 .start-writing,
-.design-first {
+.design-first,
+.assembler-first {
 	&.new-or-existing-site {
 		.signup-header {
 			.wordpress-logo {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -674,7 +674,11 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 			goNext={ goNext }
 			isHorizontalLayout={ false }
 			isFullLayout={ true }
-			hideBack={ isSiteAssemblerFlow( flow ) && isNewSite }
+			hideBack={
+				isSiteAssemblerFlow( flow ) &&
+				navigator.location.path?.startsWith( NAVIGATOR_PATHS.MAIN ) &&
+				isNewSite
+			}
 			hideSkip={ true }
 			stepContent={
 				<PatternAssemblerContainer

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -18,6 +18,7 @@ import {
 	isNewHostedSiteCreationFlow,
 	isNewsletterFlow,
 	isBlogOnboardingFlow,
+	isSiteAssemblerFlow,
 	setThemeOnSite,
 } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -138,6 +139,7 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, da
 		isMigrationFlow( flow ) ||
 		isBlogOnboardingFlow( flow ) ||
 		isNewHostedSiteCreationFlow( flow ) ||
+		isSiteAssemblerFlow( flow ) ||
 		wooFlows.includes( flow || '' )
 	) {
 		siteVisibility = Site.Visibility.PublicNotIndexed;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker-list/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker-list/index.tsx
@@ -1,4 +1,4 @@
-import { StepContainer } from '@automattic/onboarding';
+import { StepContainer, isSiteAssemblerFlow } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
@@ -16,6 +16,7 @@ import './styles.scss';
 
 const SitePicker: Step = function SitePicker( { navigation, flow } ) {
 	const translate = useTranslate();
+	const { submit, goBack } = navigation;
 
 	const [ selectedSiteId, setSelectedSiteId ] = useState< SiteId | null >( null );
 
@@ -33,7 +34,7 @@ const SitePicker: Step = function SitePicker( { navigation, flow } ) {
 		const siteSlug = new URL( site?.URL || '' ).host;
 		const siteId = site?.ID;
 
-		navigation.submit?.( { siteSlug, siteId } );
+		submit?.( { siteSlug, siteId } );
 	}, [ site ] );
 
 	const selectSite = ( siteId: SiteId ) => {
@@ -70,7 +71,8 @@ const SitePicker: Step = function SitePicker( { navigation, flow } ) {
 				}
 				recordTracksEvent={ recordTracksEvent }
 				flowName={ flow }
-				hideBack={ true }
+				hideBack={ ! isSiteAssemblerFlow( flow ) }
+				goBack={ goBack }
 			/>
 		</>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker-list/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker-list/styles.scss
@@ -27,6 +27,7 @@
 			@include break-small {
 				max-width: 780px;
 				margin: 0 auto;
+				padding-bottom: 60px;
 			}
 			.site-selector.sites-list {
 				border-radius: 4px;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sites-checker/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sites-checker/index.tsx
@@ -1,5 +1,5 @@
 import { SiteDetails } from '@automattic/data-stores';
-import { StepContainer, isBlogOnboardingFlow } from '@automattic/onboarding';
+import { StepContainer, isBlogOnboardingFlow, isSiteAssemblerFlow } from '@automattic/onboarding';
 import { useI18n } from '@wordpress/react-i18n';
 import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -21,11 +21,12 @@ const SitesChecker: Step = function SitePicker( { navigation, flow } ) {
 
 	useEffect( () => {
 		if ( hasAllSitesFetched ) {
-			const filteredSites = isBlogOnboardingFlow( flow )
-				? allSites?.filter(
-						( site: SiteDetails | null | undefined ) => site?.launch_status === 'unlaunched'
-				  )
-				: allSites;
+			const filteredSites =
+				isBlogOnboardingFlow( flow ) || isSiteAssemblerFlow( flow )
+					? allSites?.filter(
+							( site: SiteDetails | null | undefined ) => site?.launch_status === 'unlaunched'
+					  )
+					: allSites;
 			submit?.( { filteredSitesCount: filteredSites.length } );
 			return;
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps.tsx
@@ -14,6 +14,11 @@ export const STEPS = {
 		asyncComponent: () => import( './steps-repository/celebration-step' ),
 	},
 
+	CHECK_SITES: {
+		slug: 'check-sites',
+		asyncComponent: () => import( './steps-repository/sites-checker' ),
+	},
+
 	COURSES: { slug: 'courses', asyncComponent: () => import( './steps-repository/courses' ) },
 
 	DESIGN_SETUP: {
@@ -102,6 +107,11 @@ export const STEPS = {
 		asyncComponent: () => import( './steps-repository/intent-step' ),
 	},
 
+	NEW_OR_EXISTING_SITE: {
+		slug: 'new-or-existing-site',
+		asyncComponent: () => import( './steps-repository/new-or-existing-site' ),
+	},
+
 	LAUNCHPAD: { slug: 'launchpad', asyncComponent: () => import( './steps-repository/launchpad' ) },
 
 	OPTIONS: {
@@ -120,8 +130,13 @@ export const STEPS = {
 	},
 
 	SITE_CREATION_STEP: {
-		slug: 'siteCreationStep',
+		slug: 'site-creation-step',
 		asyncComponent: () => import( './steps-repository/site-creation-step' ),
+	},
+
+	SITE_PICKER: {
+		slug: 'site-picker',
+		asyncComponent: () => import( './steps-repository/site-picker-list' ),
 	},
 
 	SITE_PROMPT: {

--- a/client/landing/stepper/declarative-flow/link-in-bio-tld.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio-tld.ts
@@ -1,4 +1,4 @@
-import { LaunchpadNavigator, type UserSelect } from '@automattic/data-stores';
+import { type UserSelect } from '@automattic/data-stores';
 import { useFlowProgress, LINK_IN_BIO_TLD_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
@@ -52,7 +52,6 @@ const linkInBio: Flow = {
 			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
 			[]
 		);
-		const { setActiveChecklist } = useDispatch( LaunchpadNavigator.store );
 
 		setStepProgress( flowProgress );
 
@@ -142,7 +141,6 @@ const linkInBio: Flow = {
 				case 'launchpad':
 					skipLaunchpad( {
 						checklistSlug: 'link-in-bio-tld',
-						setActiveChecklist,
 						siteId,
 						siteSlug,
 					} );

--- a/client/landing/stepper/declarative-flow/link-in-bio.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio.ts
@@ -1,4 +1,4 @@
-import { LaunchpadNavigator, type UserSelect } from '@automattic/data-stores';
+import { type UserSelect } from '@automattic/data-stores';
 import { useFlowProgress, LINK_IN_BIO_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
@@ -69,7 +69,6 @@ const linkInBio: Flow = {
 			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
 			[]
 		);
-		const { setActiveChecklist } = useDispatch( LaunchpadNavigator.store );
 
 		setStepProgress( flowProgress );
 
@@ -162,7 +161,6 @@ const linkInBio: Flow = {
 				case 'launchpad':
 					skipLaunchpad( {
 						checklistSlug: 'link-in-bio',
-						setActiveChecklist,
 						siteId,
 						siteSlug,
 					} );

--- a/client/landing/stepper/declarative-flow/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/newsletter.ts
@@ -1,8 +1,4 @@
-import {
-	LaunchpadNavigator,
-	updateLaunchpadSettings,
-	type UserSelect,
-} from '@automattic/data-stores';
+import { updateLaunchpadSettings, type UserSelect } from '@automattic/data-stores';
 import { useFlowProgress, NEWSLETTER_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
@@ -101,8 +97,6 @@ const newsletter: Flow = {
 			pageTitle: 'Newsletter',
 		} );
 
-		const { setActiveChecklist } = useDispatch( LaunchpadNavigator.store );
-
 		const completeSubscribersTask = async () => {
 			if ( siteSlug ) {
 				await updateLaunchpadSettings( siteSlug, {
@@ -195,7 +189,6 @@ const newsletter: Flow = {
 				case 'launchpad':
 					skipLaunchpad( {
 						checklistSlug: 'newsletter',
-						setActiveChecklist,
 						siteId,
 						siteSlug,
 					} );

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -69,6 +69,9 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 	'with-theme-assembler': () =>
 		import( /* webpackChunkName: "with-theme-assembler-flow" */ './with-theme-assembler-flow' ),
 
+	'assembler-first': () =>
+		import( /* webpackChunkName: "assembler-first-flow" */ './assembler-first-flow' ),
+
 	'free-post-setup': () =>
 		import( /* webpackChunkName: "free-post-setup-flow" */ '../declarative-flow/free-post-setup' ),
 

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -1,8 +1,4 @@
-import {
-	LaunchpadNavigator,
-	OnboardSelect,
-	updateLaunchpadSettings,
-} from '@automattic/data-stores';
+import { OnboardSelect, updateLaunchpadSettings } from '@automattic/data-stores';
 import { useLocale } from '@automattic/i18n-utils';
 import { START_WRITING_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch, dispatch } from '@wordpress/data';
@@ -91,7 +87,6 @@ const startWriting: Flow = {
 			[]
 		).getState();
 		const site = useSite();
-		const { setActiveChecklist } = useDispatch( LaunchpadNavigator.store );
 
 		// This flow clear the site_intent when flow is completed.
 		// We need to check if the site is launched and if so, clear the site_intent to avoid errors.
@@ -246,7 +241,6 @@ const startWriting: Flow = {
 				case 'launchpad':
 					skipLaunchpad( {
 						checklistSlug: 'start-writing',
-						setActiveChecklist,
 						siteId,
 						siteSlug,
 					} );

--- a/client/landing/stepper/declarative-flow/videopress.ts
+++ b/client/landing/stepper/declarative-flow/videopress.ts
@@ -1,5 +1,5 @@
 import config from '@automattic/calypso-config';
-import { LaunchpadNavigator, PlansSelect, SiteSelect } from '@automattic/data-stores';
+import { PlansSelect, SiteSelect } from '@automattic/data-stores';
 import { StyleVariation } from '@automattic/design-picker';
 import { useLocale } from '@automattic/i18n-utils';
 import { useFlowProgress, VIDEOPRESS_FLOW } from '@automattic/onboarding';
@@ -106,7 +106,6 @@ const videopress: Flow = {
 			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedDomain(),
 			[]
 		);
-		const { setActiveChecklist } = useDispatch( LaunchpadNavigator.store );
 
 		const [ isSiteCreationPending, setIsSiteCreationPending ] = useState( false );
 
@@ -361,7 +360,6 @@ const videopress: Flow = {
 				case 'launchpad':
 					await skipLaunchpad( {
 						checklistSlug: 'videopress',
-						setActiveChecklist,
 						siteId,
 						siteSlug,
 					} );

--- a/client/landing/stepper/declarative-flow/write.ts
+++ b/client/landing/stepper/declarative-flow/write.ts
@@ -1,4 +1,3 @@
-import { LaunchpadNavigator } from '@automattic/data-stores';
 import { useLocale } from '@automattic/i18n-utils';
 import { useFlowProgress, WRITE_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -42,7 +41,6 @@ const write: Flow = {
 		setStepProgress( flowProgress );
 		const siteId = useSiteIdParam();
 		const siteSlug = useSiteSlug();
-		const { setActiveChecklist } = useDispatch( LaunchpadNavigator.store );
 
 		// trigger guides on step movement, we don't care about failures or response
 		wpcom.req.post(
@@ -82,7 +80,6 @@ const write: Flow = {
 				case 'launchpad':
 					skipLaunchpad( {
 						checklistSlug: 'write',
-						setActiveChecklist,
 						siteId,
 						siteSlug,
 					} );

--- a/client/landing/stepper/utils/skip-launchpad.ts
+++ b/client/landing/stepper/utils/skip-launchpad.ts
@@ -1,26 +1,21 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { updateLaunchpadSettings } from '@automattic/data-stores';
+import { LaunchpadNavigator, updateLaunchpadSettings } from '@automattic/data-stores';
+import { dispatch } from '@wordpress/data';
 
 type SkipLaunchpadProps = {
 	checklistSlug?: string | null;
-	setActiveChecklist: ( siteSlug: string, checklistSlug: string ) => Promise< unknown >;
-	siteId: string | null;
+	siteId: string | number | null;
 	siteSlug: string | null;
 };
 
-export const skipLaunchpad = async ( {
-	checklistSlug,
-	setActiveChecklist,
-	siteId,
-	siteSlug,
-}: SkipLaunchpadProps ) => {
+export const skipLaunchpad = async ( { checklistSlug, siteId, siteSlug }: SkipLaunchpadProps ) => {
 	if ( siteSlug ) {
 		// Only set the active checklist if we have the checklist slug AND the feature is enabled.
 		if ( checklistSlug && isEnabled( 'launchpad/navigator' ) ) {
 			// If we're making both API calls, allow them to happen concurrently.
 			await Promise.allSettled( [
 				updateLaunchpadSettings( siteSlug, { launchpad_screen: 'skipped' } ),
-				setActiveChecklist( siteSlug, checklistSlug ),
+				dispatch( LaunchpadNavigator.store ).setActiveChecklist( siteSlug, checklistSlug ),
 			] );
 		} else {
 			await updateLaunchpadSettings( siteSlug, { launchpad_screen: 'skipped' } );

--- a/client/landing/stepper/utils/skip-launchpad.ts
+++ b/client/landing/stepper/utils/skip-launchpad.ts
@@ -22,5 +22,5 @@ export const skipLaunchpad = async ( { checklistSlug, siteId, siteSlug }: SkipLa
 		}
 	}
 
-	return window.location.assign( `/home/${ siteId ?? siteSlug }` );
+	return window.location.assign( `/home/${ siteId ? siteId : siteSlug }` );
 };

--- a/config/development.json
+++ b/config/development.json
@@ -212,6 +212,7 @@
 		"themes/subscription-purchases": true,
 		"themes/text-search-lots": true,
 		"themes/theme-switch-persist-template": false,
+		"themes/assembler-first": true,
 		"titan/iframe-control-panel": false,
 		"unified-pages/virtual-home-page": true,
 		"upgrades/redirect-payments": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -151,6 +151,7 @@
 		"themes/subscription-purchases": false,
 		"themes/text-search-lots": true,
 		"themes/theme-switch-persist-template": false,
+		"themes/assembler-first": false,
 		"unified-pages/virtual-home-page": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,

--- a/config/production.json
+++ b/config/production.json
@@ -178,6 +178,7 @@
 		"themes/subscription-purchases": false,
 		"themes/text-search-lots": true,
 		"themes/theme-switch-persist-template": false,
+		"themes/assembler-first": false,
 		"unified-pages/virtual-home-page": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -173,6 +173,7 @@
 		"themes/subscription-purchases": false,
 		"themes/text-search-lots": true,
 		"themes/theme-switch-persist-template": false,
+		"themes/assembler-first": false,
 		"unified-pages/virtual-home-page": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -181,6 +181,7 @@
 		"themes/subscription-purchases": false,
 		"themes/text-search-lots": true,
 		"themes/theme-switch-persist-template": false,
+		"themes/assembler-first": false,
 		"unified-pages/virtual-home-page": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,

--- a/packages/data-stores/src/onboard/constants.ts
+++ b/packages/data-stores/src/onboard/constants.ts
@@ -20,4 +20,5 @@ export enum SiteIntent {
 	WpAdmin = 'wpadmin',
 	Import = 'import', // deprecated
 	WithThemeAssembler = 'with-theme-assembler',
+	AssemblerFirst = 'assembler-first',
 }

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -29,6 +29,7 @@ export const DESIGN_FIRST_FLOW = 'design-first';
 export const SITE_SETUP_FLOW = 'site-setup';
 export const WITH_THEME_FLOW = 'with-theme';
 export const WITH_THEME_ASSEMBLER_FLOW = 'with-theme-assembler';
+export const ASSEMBLER_FIRST_FLOW = 'assembler-first';
 export const UPDATE_DESIGN_FLOW = 'update-design';
 export const DOMAIN_UPSELL_FLOW = 'domain-upsell';
 export const DOMAIN_TRANSFER = 'domain-transfer';
@@ -144,7 +145,11 @@ export const isDomainUpsellFlow = ( flowName: string | null ) => {
 };
 
 export const isSiteAssemblerFlow = ( flowName: string | null ) => {
-	const SITE_ASSEMBLER_FLOWS = [ WITH_THEME_ASSEMBLER_FLOW, AI_ASSEMBLER_FLOW ];
+	const SITE_ASSEMBLER_FLOWS = [
+		WITH_THEME_ASSEMBLER_FLOW,
+		AI_ASSEMBLER_FLOW,
+		ASSEMBLER_FIRST_FLOW,
+	];
 
 	return !! flowName && SITE_ASSEMBLER_FLOWS.includes( flowName );
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/83390

## Proposed Changes

* Introduce the assembler-first flow to move the Assembler before domains & plans.
* The feature is controlled by the `themes/assembler-first` flag
* I'll create a follow-up PR to display the launchpad for this flow after updating your homepage in the Site Editor

### User without any un-launched sites

https://github.com/Automattic/wp-calypso/assets/13596067/775d5170-edb9-4a65-8002-66fc018f3bb2

### Use with un-launched sites

https://github.com/Automattic/wp-calypso/assets/13596067/037bb09d-f748-41d4-8ebe-aafba236543a

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to logged-out TS
* Select the Assembler CTA
* Sign up or Sign in
* If your account has an un-launched site, you will see “New or existing site”. Pick an existing site or create a new site.
* After the site selection or the site creation, you will see the Assembler immediately
* Finish the Assembler and ensure you land on the Site Editor

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?