### PR TITLE
Jetpack Manage: Restore the Overview item for development and staging enviroments

### DIFF
--- a/client/jetpack-cloud/sections/sidebar-navigation/jetpack-manage.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/jetpack-manage.tsx
@@ -1,10 +1,10 @@
-import config from '@automattic/calypso-config';
 import { plugins, currencyDollar, category, home } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import JetpackIcons from 'calypso/components/jetpack/sidebar/menu-items/jetpack-icons';
 import GuidedTour from 'calypso/jetpack-cloud/components/guided-tour';
 import NewSidebar from 'calypso/jetpack-cloud/components/sidebar';
 import { itemLinkMatches } from 'calypso/my-sites/sidebar/utils';
+import { isSectionNameEnabled } from 'calypso/sections-filter';
 import {
 	JETPACK_MANAGE_DASHBOARD_LINK,
 	JETPACK_MANAGE_PLUGINS_LINK,
@@ -26,7 +26,6 @@ const JetpackManageSidebar = ( { path }: { path: string } ) => {
 	} );
 
 	// Overview menu items. Will be only visible if the jetpack-cloud-overview section is enabled.
-	const sections = config( 'sections' );
 	const overviewMenuItem = createItem( {
 		icon: home,
 		path: '/',
@@ -38,7 +37,7 @@ const JetpackManageSidebar = ( { path }: { path: string } ) => {
 	} );
 
 	const menuItems = [
-		...( sections[ 'jetpack-cloud-overview' ] ? [ overviewMenuItem ] : [] ),
+		...( isSectionNameEnabled( 'jetpack-cloud-overview' ) ? [ overviewMenuItem ] : [] ),
 		createItem( {
 			icon: category,
 			path: '/',

--- a/client/jetpack-cloud/sections/sidebar-navigation/jetpack-manage.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/jetpack-manage.tsx
@@ -1,4 +1,5 @@
-import { plugins, currencyDollar, category } from '@wordpress/icons';
+import config from '@automattic/calypso-config';
+import { plugins, currencyDollar, category, home } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import JetpackIcons from 'calypso/components/jetpack/sidebar/menu-items/jetpack-icons';
 import GuidedTour from 'calypso/jetpack-cloud/components/guided-tour';
@@ -9,6 +10,7 @@ import {
 	JETPACK_MANAGE_PLUGINS_LINK,
 	JETPACK_MANAGE_LICENCES_LINK,
 	JETPACK_MANAGE_BILLING_LINK,
+	JETPACK_MANAGE_OVERVIEW_LINK,
 } from './lib/constants';
 import type { MenuItemProps } from './types';
 
@@ -23,7 +25,27 @@ const JetpackManageSidebar = ( { path }: { path: string } ) => {
 		isSelected: itemLinkMatches( props.link, path ),
 	} );
 
+	// Overview menu items. Will be only visible in development/staging environments.
+	// @todo: Once the Overview page is ready for production, remove the isDevEnv check.
+	const calypsoEnv = config( 'env_id' );
+	const isDevEnv = [ 'jetpack-cloud-stage', 'jetpack-cloud-development' ].includes(
+		calypsoEnv as string
+	);
+	const overviewMenuItem = [
+		createItem( {
+			icon: home,
+			path: '/',
+			link: JETPACK_MANAGE_OVERVIEW_LINK,
+			title: translate( 'Overview' ),
+			trackEventProps: {
+				menu_item: 'Jetpack Cloud / Overview',
+			},
+		} ),
+	];
+
 	const menuItems = [
+		...( isDevEnv ? overviewMenuItem : [] ),
+		// Production menu items:
 		createItem( {
 			icon: category,
 			path: '/',

--- a/client/jetpack-cloud/sections/sidebar-navigation/jetpack-manage.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/jetpack-manage.tsx
@@ -28,9 +28,11 @@ const JetpackManageSidebar = ( { path }: { path: string } ) => {
 	// Overview menu items. Will be only visible in development/staging environments.
 	// @todo: Once the Overview page is ready for production, remove the isDevEnv check.
 	const calypsoEnv = config( 'env_id' );
-	const isDevEnv = [ 'jetpack-cloud-stage', 'jetpack-cloud-development' ].includes(
-		calypsoEnv as string
-	);
+	const isDevEnv = [
+		'jetpack-cloud-stage',
+		'jetpack-cloud-horizon',
+		'jetpack-cloud-development',
+	].includes( calypsoEnv as string );
 	const overviewMenuItem = [
 		createItem( {
 			icon: home,

--- a/client/jetpack-cloud/sections/sidebar-navigation/jetpack-manage.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/jetpack-manage.tsx
@@ -25,8 +25,7 @@ const JetpackManageSidebar = ( { path }: { path: string } ) => {
 		isSelected: itemLinkMatches( props.link, path ),
 	} );
 
-	// Overview menu items. Will be only visible in development/staging environments.
-	// @todo: Once the Overview page is ready for production, remove the isDevEnv check.
+	// Overview menu items. Will be only visible if the jetpack-cloud-overview section is enabled.
 	const sections = config( 'sections' );
 	const overviewMenuItem = createItem( {
 		icon: home,

--- a/client/jetpack-cloud/sections/sidebar-navigation/jetpack-manage.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/jetpack-manage.tsx
@@ -27,27 +27,19 @@ const JetpackManageSidebar = ( { path }: { path: string } ) => {
 
 	// Overview menu items. Will be only visible in development/staging environments.
 	// @todo: Once the Overview page is ready for production, remove the isDevEnv check.
-	const calypsoEnv = config( 'env_id' );
-	const isDevEnv = [
-		'jetpack-cloud-stage',
-		'jetpack-cloud-horizon',
-		'jetpack-cloud-development',
-	].includes( calypsoEnv as string );
-	const overviewMenuItem = [
-		createItem( {
-			icon: home,
-			path: '/',
-			link: JETPACK_MANAGE_OVERVIEW_LINK,
-			title: translate( 'Overview' ),
-			trackEventProps: {
-				menu_item: 'Jetpack Cloud / Overview',
-			},
-		} ),
-	];
+	const sections = config( 'sections' );
+	const overviewMenuItem = createItem( {
+		icon: home,
+		path: '/',
+		link: JETPACK_MANAGE_OVERVIEW_LINK,
+		title: translate( 'Overview' ),
+		trackEventProps: {
+			menu_item: 'Jetpack Cloud / Overview',
+		},
+	} );
 
 	const menuItems = [
-		...( isDevEnv ? overviewMenuItem : [] ),
-		// Production menu items:
+		...( sections[ 'jetpack-cloud-overview' ] ? [ overviewMenuItem ] : [] ),
 		createItem( {
 			icon: category,
 			path: '/',


### PR DESCRIPTION
Resolve: https://github.com/Automattic/jetpack-manage/issues/145

## Proposed Changes

![image](https://github.com/Automattic/wp-calypso/assets/9832440/a678b777-a1bf-427e-820e-1bbf749f1f64)

This PR restores the Overview menu item only for developments and staging environments. Once the new Overview page is ready for production, we have set the Overview menu item for production. It will be addressed with this issue: https://github.com/Automattic/jetpack-manage/issues/144


## Testing Instructions

- Check the code
- Go to any JP Cloud page on your development local site: you will see the Overview menu item.
- Now, stop the Jetpack Cloud service, and modify the `jetpack-cloud-development.json` setting in the sections `"jetpack-cloud-overview": false,` instead of true.
- Start again the server, you shouldn't see the Overview menu item.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
