### PR TITLE
Set admin interface to classic during sensei onboarding flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-launch/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-launch/index.tsx
@@ -11,11 +11,11 @@ import {
 	getSelectedPlugins,
 	saveSelectedPurposesAsSenseiSiteSettings,
 } from '../sensei-purpose/purposes';
+import { setAdminInterfaceStyle } from './launch-completion-tasks';
 import { useAtomicSiteChecklist } from './use-atomic-site-checklist';
 import { useAtomicSitePlugins } from './use-atomic-site-plugins';
 import { useSubSteps, wait } from './use-sub-steps';
 import type { Step } from '../../types';
-
 import './style.scss';
 
 const SENSEI_PRO_PLUGIN_SLUG = 'sensei-pro';
@@ -59,6 +59,10 @@ const SenseiLaunch: Step = ( { navigation: { submit } } ) => {
 				requestChecklist();
 				await wait( 5000 );
 				return isSenseiIncluded();
+			},
+			async function switchToDefaultAdminPanelView() {
+				await setAdminInterfaceStyle( siteId, 'wp-admin' );
+				return true;
 			},
 			async function done() {
 				setTimeout( () => submit?.(), 1000 );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-launch/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-launch/index.tsx
@@ -11,10 +11,10 @@ import {
 	getSelectedPlugins,
 	saveSelectedPurposesAsSenseiSiteSettings,
 } from '../sensei-purpose/purposes';
-import { setAdminInterfaceStyle } from './launch-completion-tasks';
+import { setAdminInterfaceStyle, wait } from './launch-completion-tasks';
 import { useAtomicSiteChecklist } from './use-atomic-site-checklist';
 import { useAtomicSitePlugins } from './use-atomic-site-plugins';
-import { useSubSteps, wait } from './use-sub-steps';
+import { useSubSteps } from './use-sub-steps';
 import type { Step } from '../../types';
 import './style.scss';
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-launch/launch-completion-tasks.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-launch/launch-completion-tasks.ts
@@ -1,0 +1,34 @@
+import wp from 'calypso/lib/wp';
+
+const PERSISTENT_DATA_DELAY = 1200;
+
+function waitMs( ms: number ) {
+	return new Promise( ( resolve ) => {
+		setTimeout( () => {
+			resolve( null );
+		}, ms );
+	} );
+}
+
+export const setAdminInterfaceStyle = async ( siteId: number | string, interfaceName: string ) => {
+	let response = false;
+
+	try {
+		response = await wp.req.post(
+			{
+				path: `/sites/${ siteId }/hosting/admin-interface`,
+				apiNamespace: 'wpcom/v2',
+			},
+			{
+				interface: interfaceName,
+			}
+		);
+
+		// Wait for persistent data to be updated on the atomic server
+		await waitMs( PERSISTENT_DATA_DELAY );
+	} catch ( e ) {
+		response = false;
+	}
+
+	return response;
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-launch/launch-completion-tasks.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-launch/launch-completion-tasks.ts
@@ -2,13 +2,7 @@ import wp from 'calypso/lib/wp';
 
 const PERSISTENT_DATA_DELAY = 1200;
 
-function waitMs( ms: number ) {
-	return new Promise( ( resolve ) => {
-		setTimeout( () => {
-			resolve( null );
-		}, ms );
-	} );
-}
+export const wait = ( ms: number ) => new Promise( ( resolve ) => setTimeout( resolve, ms ) );
 
 export const setAdminInterfaceStyle = async ( siteId: number | string, interfaceName: string ) => {
 	let response = false;
@@ -24,8 +18,8 @@ export const setAdminInterfaceStyle = async ( siteId: number | string, interface
 			}
 		);
 
-		// Wait for persistent data to be updated on the atomic server
-		await waitMs( PERSISTENT_DATA_DELAY );
+		// Wait for persistent data to be updated on the atomic server.
+		await wait( PERSISTENT_DATA_DELAY );
 	} catch ( e ) {
 		response = false;
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-launch/use-sub-steps.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-launch/use-sub-steps.ts
@@ -1,7 +1,5 @@
 import { useEffect, useState } from 'react';
 
-export const wait = ( ms: number ) => new Promise( ( res ) => setTimeout( res, ms ) );
-
 /**
  * A step in a linear installation process.
  * @param {number} retries Number of times this step was executed.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/84467

## Proposed Changes

* When the Default style is enabled in Calypso, some behaviors in admin panel are different, there are no Edit Course or Edit Lesson links and no Preview as Student link. So as part of the onboarding flow, we are setting the admin interface style to classic.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to `calypso.localhost:3000/setup/sensei/senseiSetup`
2. Follow the steps to create a sensei site
3. Once the site is created, go to Settings -> Hosting Configuration
4. In the bottom of that page, make sure the _Classic Style_ radio button is selected for "Admin Interface Style" section

<img width="785" alt="Screenshot 2023-11-30 at 5 27 55 PM" src="https://github.com/Automattic/wp-calypso/assets/6820724/7e601a19-e128-49af-9cac-b25299a23ab4">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?