### PR TITLE
Hosting Command Palette: Add "View my sites" command

### DIFF
--- a/client/sites-dashboard/components/wpcom-smp-commands.tsx
+++ b/client/sites-dashboard/components/wpcom-smp-commands.tsx
@@ -16,6 +16,7 @@ import {
 	settings as accountSettingsIcon,
 	tool as toolIcon,
 	upload as uploadIcon,
+	wordpress as wordpressIcon,
 } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { CommandCallBackParams } from 'calypso/components/command-palette/use-command-palette';
@@ -110,6 +111,15 @@ export const useCommandsArrayWpcom = ( {
 	const { openPhpMyAdmin } = useOpenPhpMyAdmin();
 
 	const commands = [
+		{
+			name: 'viewMySites',
+			label: __( 'View my sites' ),
+			callback: ( { close }: { close: () => void } ) => {
+				close();
+				navigate( `/sites` );
+			},
+			icon: wordpressIcon,
+		},
 		{
 			name: 'openSiteDashboard',
 			label: __( 'Open site dashboard' ),


### PR DESCRIPTION
See https://github.com/Automattic/dotcom-forge/issues/4705

## Proposed Changes

Adds a 'View my sites' command to the command palette:

![CleanShot 2023-11-30 at 04 34 32@2x](https://github.com/Automattic/wp-calypso/assets/36432/bcecf272-2adb-4650-be2e-ce866449cec5)

## Testing Instructions

1. Test it out and verify you end up on the Sites Management page.