### PR TITLE
Live Preview: Improve loading state when starting Preview & Customize

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -43,8 +43,8 @@ export class Theme extends Component {
 		} ),
 		// If true, highlight this theme as active
 		active: PropTypes.bool,
-		// If true, the theme is being installed
-		installing: PropTypes.bool,
+		// If true, highlight this theme in a loading state
+		loading: PropTypes.bool,
 		// If true, render a placeholder
 		isPlaceholder: PropTypes.bool,
 		// URL the screenshot link points to
@@ -107,7 +107,7 @@ export class Theme extends Component {
 		return (
 			nextProps.theme.id !== this.props.theme.id ||
 			nextProps.active !== this.props.active ||
-			nextProps.installing !== this.props.installing ||
+			nextProps.loading !== this.props.loading ||
 			! isEqual(
 				Object.keys( nextProps.buttonContents ),
 				Object.keys( this.props.buttonContents )
@@ -320,7 +320,7 @@ export class Theme extends Component {
 				selectedStyleVariation={ selectedStyleVariation }
 				optionsMenu={ this.renderMoreButton() }
 				isActive={ this.props.active }
-				isInstalling={ this.props.installing }
+				isLoading={ this.props.loading }
 				isSoftLaunched={ this.props.softLaunched }
 				isShowDescriptionOnImageHover
 				onClick={ this.setBookmark }

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -155,6 +155,7 @@ ThemesList.propTypes = {
 	isActive: PropTypes.func,
 	getPrice: PropTypes.func,
 	isInstalling: PropTypes.func,
+	isLivePreviewStarted: PropTypes.func,
 	// i18n function provided by localize()
 	translate: PropTypes.func,
 	placeholderCount: PropTypes.number,
@@ -180,6 +181,7 @@ ThemesList.defaultProps = {
 	isActive: () => false,
 	getPrice: () => '',
 	isInstalling: () => false,
+	isLivePreviewStarted: () => false,
 };
 
 export function ThemeBlock( props ) {
@@ -213,8 +215,8 @@ export function ThemeBlock( props ) {
 			index={ index }
 			theme={ theme }
 			active={ props.isActive( theme.id ) }
+			loading={ props.isInstalling( theme.id ) || props.isLivePreviewStarted( theme.id ) }
 			price={ props.getPrice( theme.id ) }
-			installing={ props.isInstalling( theme.id ) }
 			upsellUrl={ props.upsellUrl }
 			bookmarkRef={ bookmarkRef }
 			siteId={ siteId }

--- a/client/my-sites/theme/live-preview-button/index.tsx
+++ b/client/my-sites/theme/live-preview-button/index.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { FC } from 'react';
+import { FC, useState } from 'react';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { useDispatch, useSelector } from 'calypso/state';
 import { livePreview } from 'calypso/state/themes/actions';
@@ -19,6 +19,8 @@ export const LivePreviewButton: FC< Props > = ( { themeId, siteId } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
+	const [ isLoading, setIsLoading ] = useState( false );
+
 	const isLivePreviewSupported = useSelector( ( state ) =>
 		getIsLivePreviewSupported( state, themeId, siteId )
 	);
@@ -26,10 +28,15 @@ export const LivePreviewButton: FC< Props > = ( { themeId, siteId } ) => {
 		return null;
 	}
 
+	const handleClick = () => {
+		setIsLoading( true );
+		dispatch( livePreview( themeId, siteId, 'detail' ) );
+	};
+
 	return (
 		<>
 			<TrackComponentView eventName="calypso_block_theme_live_preview_impression" />
-			<Button onClick={ () => dispatch( livePreview( themeId, siteId, 'detail' ) ) }>
+			<Button busy={ isLoading } onClick={ handleClick }>
 				{ translate( 'Preview & Customize' ) }
 			</Button>
 		</>

--- a/client/my-sites/themes/collections/showcase-theme-collection.tsx
+++ b/client/my-sites/themes/collections/showcase-theme-collection.tsx
@@ -42,6 +42,7 @@ export default function ShowcaseThemeCollection( {
 		themes,
 		isActive,
 		isInstalling,
+		isLivePreviewStarted,
 		siteId,
 		getThemeType,
 		filterString,
@@ -101,6 +102,7 @@ export default function ShowcaseThemeCollection( {
 								index={ index }
 								isActive={ isActive }
 								isInstalling={ isInstalling }
+								isLivePreviewStarted={ isLivePreviewStarted }
 								siteId={ siteId }
 								theme={ theme }
 								onMoreButtonClick={ recordThemeClick }

--- a/client/my-sites/themes/collections/use-theme-collection.ts
+++ b/client/my-sites/themes/collections/use-theme-collection.ts
@@ -1,5 +1,6 @@
 import { useSelector } from 'calypso/state';
 import {
+	getIsLivePreviewStarted,
 	getPremiumThemePrice,
 	getThemeDetailsUrl as getThemeDetailsUrlSelector,
 	getThemesForQueryIgnoringPage,
@@ -29,6 +30,10 @@ export function useThemeCollection( query: ThemesQuery ) {
 		( state ) => ( themeId: string ) => isInstallingTheme( state, themeId, siteId as number )
 	);
 
+	const isLivePreviewStarted = useSelector(
+		( state ) => ( themeId: string ) => getIsLivePreviewStarted( state, themeId )
+	);
+
 	const getPrice = useSelector(
 		( state ) => ( themeId: string ) => getPremiumThemePrice( state, themeId, siteId as number )
 	);
@@ -53,6 +58,7 @@ export function useThemeCollection( query: ThemesQuery ) {
 		themes,
 		isActive,
 		isInstalling,
+		isLivePreviewStarted,
 		siteId,
 		getThemeType,
 		filterString,

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -17,6 +17,7 @@ import {
 	doesThemeBundleUsableSoftwareSet,
 	getActiveTheme,
 	getCanonicalTheme,
+	getIsLivePreviewStarted,
 	getThemeDetailsUrl,
 	getThemeForumUrl,
 	hasActivatedTheme,
@@ -65,6 +66,12 @@ class ThanksModal extends Component {
 	}
 
 	static getDerivedStateFromProps( nextProps, prevState ) {
+		if ( nextProps.isLivePreviewStarted ) {
+			return {
+				isVisible: false,
+				wasInstalling: false,
+			};
+		}
 		if ( nextProps.shouldRedirectToThankYouPage ) {
 			return {
 				isVisible: false,
@@ -363,6 +370,8 @@ const ConnectedThanksModal = connect(
 
 		const activatingThemeId = state.themes.activationRequests?.themeId;
 
+		const isLivePreviewStarted = getIsLivePreviewStarted( state );
+
 		return {
 			siteId,
 			siteUrl,
@@ -382,6 +391,7 @@ const ConnectedThanksModal = connect(
 			isActivating: !! isActivatingTheme( state, siteId ),
 			isFSEActive,
 			isInstalling: isInstallingTheme( state, currentThemeId, siteId ),
+			isLivePreviewStarted,
 			isThemeWpcom: isWpcomTheme( state, currentThemeId ),
 		};
 	},

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -17,7 +17,6 @@ import {
 	doesThemeBundleUsableSoftwareSet,
 	getActiveTheme,
 	getCanonicalTheme,
-	getIsLivePreviewStarted,
 	getThemeDetailsUrl,
 	getThemeForumUrl,
 	hasActivatedTheme,
@@ -66,12 +65,6 @@ class ThanksModal extends Component {
 	}
 
 	static getDerivedStateFromProps( nextProps, prevState ) {
-		if ( nextProps.isLivePreviewStarted ) {
-			return {
-				isVisible: true,
-				wasInstalling: false,
-			};
-		}
 		if ( nextProps.shouldRedirectToThankYouPage ) {
 			return {
 				isVisible: false,
@@ -242,12 +235,6 @@ class ThanksModal extends Component {
 	};
 
 	getLoadingLabel = () => {
-		const { isLivePreviewStarted } = this.props;
-
-		if ( isLivePreviewStarted ) {
-			return this.props.translate( 'Preparing theme preview…' );
-		}
-
 		return this.props.translate( 'Activating theme…' );
 	};
 
@@ -333,11 +320,9 @@ class ThanksModal extends Component {
 	};
 
 	render() {
-		const { currentTheme, hasActivated, doesThemeBundleUsableSoftware, isLivePreviewStarted } =
-			this.props;
+		const { currentTheme, hasActivated, doesThemeBundleUsableSoftware } = this.props;
 
-		const shouldDisplayContent =
-			hasActivated && currentTheme && ! doesThemeBundleUsableSoftware && ! isLivePreviewStarted;
+		const shouldDisplayContent = hasActivated && currentTheme && ! doesThemeBundleUsableSoftware;
 
 		return (
 			<Dialog
@@ -378,8 +363,6 @@ const ConnectedThanksModal = connect(
 
 		const activatingThemeId = state.themes.activationRequests?.themeId;
 
-		const isLivePreviewStarted = getIsLivePreviewStarted( state );
-
 		return {
 			siteId,
 			siteUrl,
@@ -399,7 +382,6 @@ const ConnectedThanksModal = connect(
 			isActivating: !! isActivatingTheme( state, siteId ),
 			isFSEActive,
 			isInstalling: isInstallingTheme( state, currentThemeId, siteId ),
-			isLivePreviewStarted,
 			isThemeWpcom: isWpcomTheme( state, currentThemeId ),
 		};
 	},

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -27,6 +27,7 @@ import {
 	isThemeActive,
 	isInstallingTheme,
 	prependThemeFilterKeys,
+	getIsLivePreviewStarted,
 	getThemeType,
 } from 'calypso/state/themes/selectors';
 import { getThemeHiddenFilters } from 'calypso/state/themes/selectors/get-theme-hidden-filters';
@@ -52,6 +53,7 @@ class ThemesSelection extends Component {
 		getThemeDetailsUrl: PropTypes.func,
 		getThemeType: PropTypes.func,
 		isInstallingTheme: PropTypes.func,
+		isThemeLivePreviewStarted: PropTypes.func,
 		isLastPage: PropTypes.bool,
 		isRequesting: PropTypes.bool,
 		isThemeActive: PropTypes.func,
@@ -234,6 +236,7 @@ class ThemesSelection extends Component {
 					isActive={ this.props.isThemeActive }
 					getPrice={ this.props.getPremiumThemePrice }
 					isInstalling={ this.props.isInstallingTheme }
+					isLivePreviewStarted={ this.props.isThemeLivePreviewStarted }
 					loading={ isRequesting }
 					placeholderCount={ this.props.placeholderCount }
 					bookmarkRef={ this.props.bookmarkRef }
@@ -261,6 +264,10 @@ function bindIsThemeActive( state, siteId ) {
 
 function bindIsInstallingTheme( state, siteId ) {
 	return ( themeId ) => isInstallingTheme( state, themeId, siteId );
+}
+
+function bindIsThemeLivePreviewStarted( state ) {
+	return ( themeId ) => getIsLivePreviewStarted( state, themeId );
 }
 
 function bindGetPremiumThemePrice( state, siteId ) {
@@ -370,6 +377,7 @@ export const ConnectedThemesSelection = connect(
 			isLoggedIn: isUserLoggedIn( state ),
 			isThemeActive: boundIsThemeActive,
 			isInstallingTheme: bindIsInstallingTheme( state, siteId ),
+			isThemeLivePreviewStarted: bindIsThemeLivePreviewStarted( state ),
 			// Note: This component assumes that purchase and plans data is already present in the state tree
 			// (used by the `isPremiumThemeAvailable` selector). That data is provided by the `<QuerySitePurchases />`
 			// and `<QuerySitePlans />` components, respectively. At the time of implementation, neither of them

--- a/client/state/themes/actions/live-preview.ts
+++ b/client/state/themes/actions/live-preview.ts
@@ -17,7 +17,7 @@ export function livePreview( themeId: string, siteId: number, source?: 'list' | 
 			theme_type: getThemeType( getState(), themeId ),
 			theme: themeId,
 		} );
-		dispatch( withAnalytics( analysis, { type: LIVE_PREVIEW_START } ) );
+		dispatch( withAnalytics( analysis, { type: LIVE_PREVIEW_START, themeId } ) );
 		if ( isJetpackSite( getState(), siteId ) && ! getTheme( getState(), siteId, themeId ) ) {
 			const installId = suffixThemeIdForInstall( getState(), siteId, themeId );
 			// If theme is already installed, installation will silently fail, and we just switch to the Live Preview.

--- a/client/state/themes/reducer.js
+++ b/client/state/themes/reducer.js
@@ -653,17 +653,19 @@ export function startActivationSync( state = {}, { type, siteId, themeId } ) {
 	return state;
 }
 
-export function livePreview( state = {}, { type } ) {
+export function livePreview( state = {}, { type, themeId } ) {
 	switch ( type ) {
 		case LIVE_PREVIEW_START:
 			return {
 				...state,
 				started: true,
+				themeId,
 			};
 		case LIVE_PREVIEW_END:
 			return {
 				...state,
 				started: false,
+				themeId: undefined,
 			};
 	}
 

--- a/client/state/themes/selectors/get-is-live-preview-preparing.ts
+++ b/client/state/themes/selectors/get-is-live-preview-preparing.ts
@@ -1,5 +1,0 @@
-import { AppState } from 'calypso/types';
-
-export function getIsLivePreviewStarted( state: AppState ): boolean {
-	return state.themes.livePreview.started;
-}

--- a/client/state/themes/selectors/get-is-live-preview-started.ts
+++ b/client/state/themes/selectors/get-is-live-preview-started.ts
@@ -1,5 +1,6 @@
 import { AppState } from 'calypso/types';
 
-export function getIsLivePreviewStarted( state: AppState, themeId: string ): boolean {
-	return state.themes.livePreview.started && state.themes.livePreview.themeId === themeId;
+export function getIsLivePreviewStarted( state: AppState, themeId?: string ): boolean {
+	const { livePreview } = state.themes;
+	return livePreview.started && ( ! themeId || livePreview.themeId === themeId );
 }

--- a/client/state/themes/selectors/get-is-live-preview-started.ts
+++ b/client/state/themes/selectors/get-is-live-preview-started.ts
@@ -1,0 +1,5 @@
+import { AppState } from 'calypso/types';
+
+export function getIsLivePreviewStarted( state: AppState, themeId: string ): boolean {
+	return state.themes.livePreview.started && state.themes.livePreview.themeId === themeId;
+}

--- a/client/state/themes/selectors/index.js
+++ b/client/state/themes/selectors/index.js
@@ -8,7 +8,7 @@ export { findThemeFilterTerm } from 'calypso/state/themes/selectors/find-theme-f
 export { getActiveTheme } from 'calypso/state/themes/selectors/get-active-theme';
 export { getCanonicalTheme } from 'calypso/state/themes/selectors/get-canonical-theme';
 export { getIsLivePreviewSupported } from 'calypso/state/themes/selectors/get-is-live-preview-supported';
-export { getIsLivePreviewStarted } from 'calypso/state/themes/selectors/get-is-live-preview-preparing';
+export { getIsLivePreviewStarted } from 'calypso/state/themes/selectors/get-is-live-preview-started';
 export { getJetpackUpgradeUrlIfPremiumTheme } from 'calypso/state/themes/selectors/get-jetpack-upgrade-url-if-premium-theme';
 export { getLastThemeQuery } from 'calypso/state/themes/selectors/get-last-theme-query';
 export { getLivePreviewUrl } from 'calypso/state/themes/selectors/get-live-preview-url';

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -1420,6 +1420,7 @@ describe( 'actions', () => {
 		);
 		const livePreviewStartAction = {
 			type: 'LIVE_PREVIEW_START',
+			themeId: 'pendant',
 			meta: {
 				analytics: [
 					{

--- a/packages/design-picker/src/components/theme-card/index.tsx
+++ b/packages/design-picker/src/components/theme-card/index.tsx
@@ -20,7 +20,7 @@ interface ThemeCardProps {
 	selectedStyleVariation?: StyleVariation;
 	optionsMenu?: React.ReactNode;
 	isActive?: boolean;
-	isInstalling?: boolean;
+	isLoading?: boolean;
 	isShowDescriptionOnImageHover?: boolean;
 	isSoftLaunched?: boolean;
 	onClick?: () => void;
@@ -44,7 +44,7 @@ const ThemeCard = forwardRef(
 			selectedStyleVariation,
 			optionsMenu,
 			isActive,
-			isInstalling,
+			isLoading,
 			isShowDescriptionOnImageHover,
 			isSoftLaunched,
 			onClick,
@@ -97,9 +97,9 @@ const ThemeCard = forwardRef(
 							{ image }
 						</a>
 					</div>
-					{ isInstalling && (
-						<div className="theme-card__installing">
-							<div className="theme-card__installing-dot" />
+					{ isLoading && (
+						<div className="theme-card__loading">
+							<div className="theme-card__loading-dot" />
 						</div>
 					) }
 					{ isShowDescriptionOnImageHover && description && (

--- a/packages/design-picker/src/components/theme-card/style.scss
+++ b/packages/design-picker/src/components/theme-card/style.scss
@@ -123,7 +123,7 @@ $theme-card-info-margin-top: 16px;
 	}
 }
 
-.theme-card__installing {
+.theme-card__loading {
 	bottom: $theme-card-info-height + $theme-card-info-margin-top;
 	background: rgba(var(--color-neutral-dark-rgb), 0.5);
 	left: 0;


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/wp-calypso/issues/84401

## Proposed Changes

This PR improves the loading state of Preview & Customize feature, in the theme details page and theme showcase cards. It's split into 2 commits if you want to review them separately.

### Theme Details Page

We're updating the button to loading state when clicked:

|Before|After|
|-|-|
|<img width="875" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/cb00b52e-d8ef-495b-9567-1640293d6092">|<img width="866" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/578b5ae4-982e-4f67-9799-7b9a737a9e6d">|

Note: I didn't change the button text when in loading state (such as to `Preparing Preview & Customize...`). I think it's weird (and too wordy) because we are redirecting to another page anyway, and user won't see this button finishes loading.

---

### Theme Showcase Card

We're reusing the loading state when a theme is being installed:

|Before|After|
|-|-|
|<img width="647" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/b2f5e5ed-4ae8-4316-95cb-70dbfae4930a">|<img width="662" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/ed9bc4b0-ac4c-414b-a3d0-506070ed1790">|

## Testing Instructions

### Theme Details Page

1. Go to `/theme/twentytwentyfour/<siteSlug>`
2. Click "Preview & Customize" button
3. Verify that the button changes to loading state
4. Also try for Community themes (in a Business plan)

### Theme Showcase Card

1. Go to `/themes/<siteSlug>`
2. Click the "three-dot" menu of any free theme
3. Click "Preview & Customize" menu
5. Verify that the theme card changes to loading state
6. Bonus (regression test): use an Atomic site, try installing a theme, make sure that the card still changes to a loading state

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?