### PR TITLE
Stats: Use API query for the plan usage section

### DIFF
--- a/client/my-sites/stats/hooks/use-plan-usage-query.ts
+++ b/client/my-sites/stats/hooks/use-plan-usage-query.ts
@@ -1,0 +1,38 @@
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+
+interface PeriodUsage {
+	current_start: string | null;
+	next_start: string | null;
+	views_count: number;
+	days_to_reset: number;
+}
+
+export interface PlanUsage {
+	current_usage: PeriodUsage;
+	recent_usages: Array< PeriodUsage >;
+	views_limit: number;
+	over_limit_months: number;
+}
+
+function selectPlanUsage( payload: PlanUsage ): PlanUsage {
+	return payload;
+}
+
+function queryPlanUsage( siteId: number | null ): Promise< PlanUsage > {
+	return wpcom.req.get( {
+		apiNamespace: 'wpcom/v2',
+		path: `/sites/${ siteId }/jetpack-stats/usage`,
+	} );
+}
+
+export default function usePlanUsageQuery(
+	siteId: number | null
+): UseQueryResult< PlanUsage, unknown > {
+	return useQuery( {
+		queryKey: [ 'stats', 'usage', siteId ],
+		queryFn: () => queryPlanUsage( siteId ),
+		select: selectPlanUsage,
+		staleTime: 1000 * 60 * 5, // 5 minutes
+	} );
+}

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -462,7 +462,7 @@ class StatsSite extends Component {
 						}
 					</div>
 				</div>
-				{ config.isEnabled( 'stats/plan-usage' ) && <StatsPlanUsage /> }
+				{ config.isEnabled( 'stats/plan-usage' ) && <StatsPlanUsage siteId={ siteId } /> }
 				{ /* Only load Jetpack Upsell Section for Odyssey Stats */ }
 				{ ! isOdysseyStats ? null : (
 					<AsyncLoad require="calypso/my-sites/stats/jetpack-upsell-section" />

--- a/client/my-sites/stats/stats-plan-usage/index.tsx
+++ b/client/my-sites/stats/stats-plan-usage/index.tsx
@@ -2,6 +2,8 @@ import { formattedNumber } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
+import usePlanUsageQuery from 'calypso/my-sites/stats/hooks/use-plan-usage-query';
+
 import './style.scss';
 
 interface PlanUsageProps {
@@ -94,10 +96,17 @@ const PlanUsage: React.FC< PlanUsageProps > = ( {
 	);
 };
 
-const StatsPlanUsage: React.FC< StatsPlanUsageProps > = () => {
+const StatsPlanUsage: React.FC< StatsPlanUsageProps > = ( { siteId } ) => {
+	const { data } = usePlanUsageQuery( siteId );
+
 	return (
 		<div className="stats__plan-usage">
-			<PlanUsage />
+			<PlanUsage
+				limit={ data?.views_limit }
+				usage={ data?.current_usage?.views_count }
+				daysToReset={ data?.current_usage?.days_to_reset }
+				overLimitMonths={ data?.over_limit_months }
+			/>
 		</div>
 	);
 };

--- a/config/development.json
+++ b/config/development.json
@@ -190,7 +190,7 @@
 		"stats/date-control": true,
 		"stats/new-video-summary": true,
 		"stats/paid-wpcom-stats": true,
-		"stats/plan-usage": false,
+		"stats/plan-usage": true,
 		"stats/tier-upgrade-slider": false,
 		"stats/type-detection": true,
 		"stepper-woocommerce-poc": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #84485 

## Proposed Changes

* Apply the Stats usage API endpoint query for props `usage`, `limit`, `daysToReset`, and `overLimitMonths` to the plan usage section.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox `public-api.wordpress.com` with the Diff `D130435-code`.
* Spin this change on the `local` Calypso.
* Navigate to Stats > `Traffic` page.
* Ensure the plan usage section numbers show the data from the API endpoint: `/wpcom/v2/sites/{site-id}/jetpack-stats/usage`.
* Ensure the text `Restart in xx days` shows the day difference between today and the start date of the next tier.

<img width="1285" alt="截圖 2023-11-30 下午3 59 00" src="https://github.com/Automattic/wp-calypso/assets/6869813/e6cf3273-86f8-4047-bb51-463869820d7f">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?