### PR TITLE
Preparations to relaunch 50% experiment with better tracks and data usage

### DIFF
--- a/client/odie/send-message-input/index.tsx
+++ b/client/odie/send-message-input/index.tsx
@@ -108,6 +108,11 @@ export const OdieSendMessageButton = ( {
 
 	const divContainerHeight = divContainerRef?.current?.clientHeight;
 
+	const userHasAskedToContactHE = chat.messages.some(
+		( message ) => message.context?.flags?.forward_to_human_support === true
+	);
+	const userHasNegativeFeedback = chat.messages.some( ( message ) => message.liked === false );
+
 	return (
 		<>
 			<JumpToRecent
@@ -118,10 +123,17 @@ export const OdieSendMessageButton = ( {
 			<div className="odie-chat-message-input-container" ref={ divContainerRef }>
 				<form onSubmit={ handleSubmit } className="odie-send-message-input-container">
 					<TextareaAutosize
-						placeholder={ translate( 'Ask your question', {
-							context: 'Placeholder text for the message input field (chat)',
-							textOnly: true,
-						} ) }
+						placeholder={
+							userHasAskedToContactHE || userHasNegativeFeedback
+								? translate( 'Continue chatting with Wapuu', {
+										context: 'Placeholder text for the message input field (chat)',
+										textOnly: true,
+								  } )
+								: translate( 'Ask your question', {
+										context: 'Placeholder text for the message input field (chat)',
+										textOnly: true,
+								  } )
+						}
 						className="odie-send-message-input"
 						rows={ 1 }
 						value={ messageString }

--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -10,6 +10,7 @@ import { useState } from 'react';
 import { useSelector } from 'react-redux';
 import { Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 import { OdieAssistantProvider } from 'calypso/odie/context';
+import { clearOdieStorage } from 'calypso/odie/data';
 import { getSectionName } from 'calypso/state/ui/selectors';
 /**
  * Internal Dependencies
@@ -87,7 +88,13 @@ const HelpCenterContent: React.FC< { isRelative?: boolean } > = () => {
 							enabled={ isWapuuEnabled }
 							isMinimized={ isMinimized }
 							initialUserMessage={ searchTerm }
-							extraContactOptions={ <HelpCenterContactPage hideHeaders /> }
+							extraContactOptions={
+								<HelpCenterContactPage
+									hideHeaders
+									trackEventName="calypso_odie_extra_contact_option"
+									onClick={ () => clearOdieStorage( 'chat_id' ) }
+								/>
+							}
 						>
 							<HelpCenterOdie />
 						</OdieAssistantProvider>


### PR DESCRIPTION
## Proposed Changes

- Change the wording in the input text when the user is presented with a different communication flow.
- Add new events when navigating to a different contact options
- When navigating to another flow, clear automatically the chat

## Testing Instructions

- Ask Wapuu to connect with a HE or dislike a message.
- The input text field placeholder should change to "Continue chatting with Wapuu"
- Click on a contact option (either email, chat, or forum)
- Assert that the corresponding event is fired
- ![image](https://github.com/Automattic/wp-calypso/assets/5689927/51969579-ae9d-453a-a964-64778292ba70)
- Go back to Wapuu and assert that the chat has been cleared

Clear the flag add a minus symbol (flags=-wapuu)
- Assert that regular flows are still working as before; eg, not firing new events, behaving like normal, etc.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
