### PR TITLE
Import flow: Update content only step

### DIFF
--- a/client/blocks/importer/components/error-message/style.scss
+++ b/client/blocks/importer/components/error-message/style.scss
@@ -4,12 +4,20 @@
 	.onboarding-title,
 	.onboarding-subtitle {
 		max-width: 100%;
-		margin-bottom: rem(40px);
+		margin-bottom: 0.75rem;
 	}
 
 	.onboarding-subtitle a {
 		font-weight: 500;
 		text-decoration: underline;
 		color: var(--studio-gray-100);
+	}
+
+	.import__buttons-group {
+		margin: 1.5rem 0;
+
+		button {
+			margin-bottom: 0.5rem;
+		}
 	}
 }

--- a/client/blocks/importer/components/importer-drag/index.tsx
+++ b/client/blocks/importer/components/importer-drag/index.tsx
@@ -1,3 +1,4 @@
+import { SubTitle, Title } from '@automattic/onboarding';
 import classnames from 'classnames';
 import { includes } from 'lodash';
 import React from 'react';
@@ -5,15 +6,14 @@ import { connect } from 'react-redux';
 import { UrlData } from 'calypso/blocks/import/types';
 import { ImporterConfig } from 'calypso/lib/importer/importer-config';
 import ErrorPane from 'calypso/my-sites/importer/error-pane';
-import ImporterHeader from 'calypso/my-sites/importer/importer-header';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { startImport } from 'calypso/state/imports/actions';
 import { appStates } from 'calypso/state/imports/constants';
-import { ImportJob } from '../../types';
-import './style.scss';
 import ImportingPane from '../importing-pane/importing-pane';
 import UploadingPane from '../uploading-pane/uploading-pane';
+import type { ImportJob } from '../../types';
 import type { SiteDetails } from '@automattic/data-stores';
+import './style.scss';
 
 /**
  * Module variables
@@ -47,12 +47,10 @@ const ImporterDrag: React.FunctionComponent< Props > = ( props ) => {
 
 	return (
 		<div className={ classnames( 'importer-drag', `importer-drag-${ importerData?.engine }` ) }>
-			<ImporterHeader
-				importerStatus={ importerStatus }
-				icon={ importerData?.icon }
-				title={ importerData?.title }
-				description={ importerData?.description }
-			/>
+			<div className="import__heading import__heading-center">
+				<Title>{ importerData?.title }</Title>
+				<SubTitle>{ importerData?.description }</SubTitle>
+			</div>
 			{ errorData && (
 				<ErrorPane
 					type={ errorData.type }

--- a/client/blocks/importer/components/importer-drag/style.scss
+++ b/client/blocks/importer/components/importer-drag/style.scss
@@ -3,9 +3,32 @@
 		border-radius: 4px;
 	}
 
+	.import__heading {
+		margin-bottom: 3.25rem;
+
+		.onboarding-title,
+		.onboarding-subtitle {
+			max-width: none;
+			width: 100%;
+		}
+	}
+
 	.importer-header {
 		margin-bottom: 40px;
 		padding-bottom: 20px;
+	}
+
+	.uploading-pane__upload-content.importer-ready-for-upload {
+		flex-direction: column;
+
+		svg {
+			width: 32px;
+			height: 32px;
+		}
+
+		p {
+			margin: 0.5rem 0 0;
+		}
 	}
 
 	.importer-header__service-info {

--- a/client/blocks/importer/components/progress-screen/index.tsx
+++ b/client/blocks/importer/components/progress-screen/index.tsx
@@ -1,10 +1,9 @@
 import { Progress, SubTitle, Title } from '@automattic/onboarding';
-import { createElement, createInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import React from 'react';
 import { ProgressBar } from 'calypso/devdocs/design/playground-scope';
 import { calculateProgress } from 'calypso/my-sites/importer/importing-pane';
-import { ImportJob } from '../../types';
+import type { ImportJob } from '../../types';
 
 interface Props {
 	job?: ImportJob;
@@ -19,12 +18,7 @@ const ProgressScreen: React.FunctionComponent< Props > = ( props ) => {
 			<Title>{ __( 'Importing' ) }...</Title>
 			<ProgressBar compact={ true } value={ Number.isNaN( progress ) ? 0 : progress } />
 			<SubTitle>
-				{ createInterpolateElement(
-					__(
-						"This may take long depending on your content.<br />No need to wait, we'll notify you by email when it's done."
-					),
-					{ br: createElement( 'br' ) }
-				) }
+				{ __( 'Feel free to close this window. We’ll email you when your new site is ready.' ) }
 			</SubTitle>
 		</Progress>
 	);

--- a/client/blocks/importer/components/uploading-pane/uploading-pane.scss
+++ b/client/blocks/importer/components/uploading-pane/uploading-pane.scss
@@ -5,7 +5,7 @@
 	margin-bottom: 40px;
 
 	background-color: transparent;
-	border: 2px dashed var(--studio-gray-10);
+	border: 1px dashed var(--studio-gray-10);
 	border-radius: 4px;
 	transition: all 200ms ease-out, color 100ms ease-out;
 	fill: var(--color-neutral-20);
@@ -41,7 +41,6 @@
 	}
 
 	.drop-zone {
-		// background: none;
 		margin: 0;
 		border: none;
 		transition: none;

--- a/client/blocks/importer/wordpress/import-content-only/index.tsx
+++ b/client/blocks/importer/wordpress/import-content-only/index.tsx
@@ -10,7 +10,6 @@ import { appStates } from 'calypso/state/imports/constants';
 import { importSite } from 'calypso/state/imports/site-importer/actions';
 import CompleteScreen from '../../components/complete-screen';
 import ErrorMessage from '../../components/error-message';
-import GettingStartedVideo from '../../components/getting-started-video';
 import ImporterDrag from '../../components/importer-drag';
 import { getImportDragConfig } from '../../components/importer-drag/config';
 import ProgressScreen from '../../components/progress-screen';
@@ -80,10 +79,6 @@ const ImportContentOnly: React.FunctionComponent< Props > = ( props ) => {
 		return job?.importerState === appStates.IMPORT_FAILURE;
 	}
 
-	function showVideoComponent() {
-		return checkProgress() || checkIsSuccess();
-	}
-
 	/**
 	 ↓ HTML Renders
 	 */
@@ -144,7 +139,6 @@ const ImportContentOnly: React.FunctionComponent< Props > = ( props ) => {
 					return renderImportDrag();
 				} )() }
 			</div>
-			{ showVideoComponent() && <GettingStartedVideo /> }
 		</>
 	);
 };

--- a/client/blocks/importer/wordpress/import-content-only/index.tsx
+++ b/client/blocks/importer/wordpress/import-content-only/index.tsx
@@ -121,25 +121,27 @@ const ImportContentOnly: React.FunctionComponent< Props > = ( props ) => {
 	}
 
 	return (
-		<>
-			<div className={ classnames( 'import__import-content-only' ) }>
-				{ ( () => {
-					if ( checkIsSuccess() ) {
-						return renderHooray();
-					} else if ( checkIsFailed() ) {
-						return (
-							<ErrorMessage
-								onStartBuilding={ stepNavigator?.goToIntentPage }
-								onBackToStart={ stepNavigator?.goToImportCapturePage }
-							/>
-						);
-					} else if ( checkProgress() ) {
-						return renderProgress();
-					}
-					return renderImportDrag();
-				} )() }
-			</div>
-		</>
+		<div
+			className={ classnames( 'import__import-content-only', {
+				'import__error-message': checkIsFailed(),
+			} ) }
+		>
+			{ ( () => {
+				if ( checkIsSuccess() ) {
+					return renderHooray();
+				} else if ( checkIsFailed() ) {
+					return (
+						<ErrorMessage
+							onStartBuilding={ stepNavigator?.goToIntentPage }
+							onBackToStart={ stepNavigator?.goToImportCapturePage }
+						/>
+					);
+				} else if ( checkProgress() ) {
+					return renderProgress();
+				}
+				return renderImportDrag();
+			} )() }
+		</div>
 	);
 };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer/style.scss
@@ -11,7 +11,7 @@
 
 	.import__onboarding-page {
 		.onboarding-progress {
-			max-width: 465px;
+			max-width: 500px;
 			margin: auto;
 
 			@include break-small {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/84661

## Proposed Changes

* Updated "Content only" step with new heading and slightly changed styles

## Testing Instructions

* Go to `/setup/import-focused?siteSlug={SITE_SLUG}`
* Click on the "choose a content platform" link
* Select "WordPress"
* Press on the "Import your content" button
* Check if the Drag&Drop screen has been updated (see screenshots)
* Select a zip backup file
* Check if everything works as before

**Before:**
<img width="856" alt="Screenshot 2023-11-30 at 15 53 02" src="https://github.com/Automattic/wp-calypso/assets/1241413/10797539-94db-45e0-9689-9507fbf1957e">

**After:**
<img width="872" alt="Screenshot 2023-11-30 at 15 52 48" src="https://github.com/Automattic/wp-calypso/assets/1241413/c49c27ce-648e-48a2-8c6a-0ca88c2d3e74">


**Before:**
<img width="671" alt="Screenshot 2023-12-01 at 13 27 56" src="https://github.com/Automattic/wp-calypso/assets/1241413/4e0ae7dc-1db0-4d44-8b0e-b7ea3a759672">

**After:**
<img width="678" alt="Screenshot 2023-12-01 at 13 56 01" src="https://github.com/Automattic/wp-calypso/assets/1241413/a33d4254-2dc7-4079-96bc-6ccfc934f0e3">

**Wider importing progress bar:**
<img width="712" alt="Screenshot 2023-12-01 at 16 17 29" src="https://github.com/Automattic/wp-calypso/assets/1241413/3101e4ec-a3b7-4c67-ac9f-93ea11ed4743">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?