### PR TITLE
Sidebar: link "all sites" to sites dash

### DIFF
--- a/client/blocks/all-sites/index.jsx
+++ b/client/blocks/all-sites/index.jsx
@@ -108,7 +108,7 @@ class AllSites extends Component {
 					{ showIcon && this.renderIcon() }
 					<div className="all-sites__info site__info">
 						<span className="all-sites__title site__title">
-							{ title || translate( 'All My Sites' ) }
+							{ title || translate( 'All sites' ) }
 							{ showChevronDownIcon && (
 								<Icon icon={ chevronDown } className="all-sites__title-chevron-icon" size={ 24 } />
 							) }

--- a/client/blocks/all-sites/style.scss
+++ b/client/blocks/all-sites/style.scss
@@ -31,7 +31,7 @@
 		line-height: 22px;
 	}
 
-	&:hover {
+	a:hover {
 		background-color: var(--color-sidebar-menu-hover-background);
 	}
 }

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -90,7 +90,7 @@ class CurrentSite extends Component {
 							<Site site={ selectedSite } homeLink={ true } />
 						</div>
 					) : (
-						<AllSites />
+						<AllSites href="/sites" />
 					) }
 					{ selectedSite && isEnabled( 'current-site/domain-warning' ) && (
 						<AsyncLoad

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -38,6 +38,10 @@ class CurrentSite extends Component {
 		this.props.recordGoogleEvent( 'Sidebar', 'Clicked Switch Site' );
 	};
 
+	onAllSitesClick = () => {
+		this.props.recordTracksEvent( 'calypso_sidebar_all_sites_click' );
+	};
+
 	render() {
 		const { selectedSite, translate, anySiteSelected } = this.props;
 
@@ -90,7 +94,7 @@ class CurrentSite extends Component {
 							<Site site={ selectedSite } homeLink={ true } />
 						</div>
 					) : (
-						<AllSites href="/sites" />
+						<AllSites href="/sites" onSelect={ this.onAllSitesClick } />
 					) }
 					{ selectedSite && isEnabled( 'current-site/domain-warning' ) && (
 						<AsyncLoad


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

* Add href to `/sites`
* Add click tracking
* Updates copy from Camel Case to Sentence case: "All My Sites" -> "All sites", seem to match how we talk about "Sites" dash more closely.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to page like `/domains/manage`

Before
<img width="352" alt="Screenshot 2023-11-30 at 16 54 09" src="https://github.com/Automattic/wp-calypso/assets/87168/3066fcbb-9cca-4a05-8671-01cb5f2e69fb">

After
<img width="361" alt="Screenshot 2023-11-30 at 16 53 56" src="https://github.com/Automattic/wp-calypso/assets/87168/73d4ceca-a232-43a9-a824-43da614b0180">

Click, and end up at `/sites`.

Observe tracks events (e.g. write `localStorage.debug="calypso:analytics:*` in console) and see the event after clicking:

<img width="832" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/2dd3dbf9-0dee-4707-92a8-379d93e21a56">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
