### PR TITLE
Separate context for subscriber stats launchpad.

### DIFF
--- a/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
@@ -113,7 +113,7 @@ function SubscriberLaunchpadSection( { siteId }: { siteId: number | null } ) {
 
 	const showLaunchpad = ! isLoading && ( isSimple || isAtomic ) && ! subscribersTotals?.total;
 
-	return showLaunchpad ? <SubscriberLaunchpad /> : <></>;
+	return showLaunchpad ? <SubscriberLaunchpad launchpadContext="subscriber-stats" /> : <></>;
 }
 
 export default function SubscribersHighlightSection( { siteId }: { siteId: number | null } ) {
@@ -121,7 +121,7 @@ export default function SubscribersHighlightSection( { siteId }: { siteId: numbe
 		<div className="highlight-cards subscribers-page has-odyssey-stats-bg-color">
 			<SubscriberHighlightsHeader />
 			<SubscriberHighlightsListing siteId={ siteId } />
-			<SubscriberLaunchpadSection siteId={ siteId } launchpadContext="subscriber-stats" />
+			<SubscriberLaunchpadSection siteId={ siteId } />
 		</div>
 	);
 }

--- a/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
@@ -121,7 +121,7 @@ export default function SubscribersHighlightSection( { siteId }: { siteId: numbe
 		<div className="highlight-cards subscribers-page has-odyssey-stats-bg-color">
 			<SubscriberHighlightsHeader />
 			<SubscriberHighlightsListing siteId={ siteId } />
-			<SubscriberLaunchpadSection siteId={ siteId } />
+			<SubscriberLaunchpadSection siteId={ siteId } launchpadContext="subscriber-stats" />
 		</div>
 	);
 }

--- a/client/my-sites/subscribers/components/subscriber-launchpad/subscriber-launchpad.tsx
+++ b/client/my-sites/subscribers/components/subscriber-launchpad/subscriber-launchpad.tsx
@@ -6,7 +6,11 @@ import { useSelector } from 'calypso/state';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import './styles.scss';
 
-const SubscriberLaunchpad = ( launchpadContext: string = 'subscriber-list' ) => {
+const SubscriberLaunchpad = ( {
+	launchpadContext = 'subscriber-list',
+}: {
+	launchpadContext: string;
+} ) => {
 	const { checklistSlug, taskFilter, numberOfSteps, completedSteps } =
 		useSubscriberLaunchpadTasks();
 	const translate = useTranslate();

--- a/client/my-sites/subscribers/components/subscriber-launchpad/subscriber-launchpad.tsx
+++ b/client/my-sites/subscribers/components/subscriber-launchpad/subscriber-launchpad.tsx
@@ -6,7 +6,7 @@ import { useSelector } from 'calypso/state';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import './styles.scss';
 
-const SubscriberLaunchpad = () => {
+const SubscriberLaunchpad = ( launchpadContext: string = 'subscriber-list' ) => {
 	const { checklistSlug, taskFilter, numberOfSteps, completedSteps } =
 		useSubscriberLaunchpadTasks();
 	const translate = useTranslate();
@@ -35,7 +35,7 @@ const SubscriberLaunchpad = () => {
 				siteSlug={ site?.slug ?? null }
 				checklistSlug={ checklistSlug }
 				onPostFilterTasks={ taskFilter }
-				launchpadContext="subscriber-list"
+				launchpadContext={ launchpadContext }
 			/>
 		</div>
 	);

--- a/client/my-sites/subscribers/components/subscriber-launchpad/subscriber-launchpad.tsx
+++ b/client/my-sites/subscribers/components/subscriber-launchpad/subscriber-launchpad.tsx
@@ -9,7 +9,7 @@ import './styles.scss';
 const SubscriberLaunchpad = ( {
 	launchpadContext = 'subscriber-list',
 }: {
-	launchpadContext: string;
+	launchpadContext?: string;
 } ) => {
 	const { checklistSlug, taskFilter, numberOfSteps, completedSteps } =
 		useSubscriberLaunchpadTasks();


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/84596

## Proposed Changes

* Set a separate context for subscriber stats launchpad.

## Testing Instructions

**Test context**
* On a site without subscribers, go to `http://calypso.localhost:3000/stats/subscribers/your_site.wordpress.com`.
* Open up network panel and filter down to ".gif".
* Click on the launchpad, and look for launchpad related tracks events in the network panel.
* The context prop should be `subscriber-stats`.

**Test regression**
* On a site without subscribers, go to `http://calypso.localhost:3000/subscribers/your_site.wordpress.com`.
* Open up network panel and filter down to ".gif".
* Click on the launchpad, and look for launchpad related tracks events in the network panel.
* The context prop should be `subscriber-list`.

<img width="1139" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1287077/a23d1ef7-5195-4ef2-88ef-cc51e657f6b6">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?