### PR TITLE
Remove translation check for subscriber launchpad.

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-launchpad/subscriber-launchpad.tsx
+++ b/client/my-sites/subscribers/components/subscriber-launchpad/subscriber-launchpad.tsx
@@ -1,5 +1,6 @@
 import { CircularProgressBar } from '@automattic/components';
 import { Launchpad } from '@automattic/launchpad';
+import { useTranslate } from 'i18n-calypso';
 import { useSubscriberLaunchpadTasks } from 'calypso/my-sites/subscribers/hooks';
 import { useSelector } from 'calypso/state';
 import { getSelectedSite } from 'calypso/state/ui/selectors';

--- a/client/my-sites/subscribers/components/subscriber-launchpad/subscriber-launchpad.tsx
+++ b/client/my-sites/subscribers/components/subscriber-launchpad/subscriber-launchpad.tsx
@@ -1,6 +1,5 @@
 import { CircularProgressBar } from '@automattic/components';
 import { Launchpad } from '@automattic/launchpad';
-import i18n, { useTranslate } from 'i18n-calypso';
 import { useSubscriberLaunchpadTasks } from 'calypso/my-sites/subscribers/hooks';
 import { useSelector } from 'calypso/state';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
@@ -38,14 +37,6 @@ const SubscriberLaunchpad = () => {
 				launchpadContext="subscriber-list"
 			/>
 		</div>
-	);
-};
-
-SubscriberLaunchpad.hasTranslationsAvailable = ( locale: string ) => {
-	return (
-		locale.startsWith( 'en' ) ||
-		( i18n.hasTranslation( 'No subscribers yet?' ) &&
-			i18n.hasTranslation( 'Follow these steps to get started.' ) )
 	);
 };
 

--- a/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
@@ -1,4 +1,3 @@
-import { useLocale } from '@automattic/i18n-utils';
 import { numberFormat, translate } from 'i18n-calypso';
 import Pagination from 'calypso/components/pagination';
 import { EmptyListView } from 'calypso/my-sites/subscribers/components/empty-list-view';
@@ -33,11 +32,7 @@ const SubscriberListContainer = ( {
 
 	const isSimple = useSelector( isSimpleSite );
 	const isAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
-	const locale = useLocale();
-	const EmptyComponent =
-		( isSimple || isAtomic ) && SubscriberLaunchpad.hasTranslationsAvailable( locale )
-			? SubscriberLaunchpad
-			: EmptyListView;
+	const EmptyComponent = isSimple || isAtomic ? SubscriberLaunchpad : EmptyListView;
 
 	return (
 		<section className="subscriber-list-container">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/84642

## Proposed Changes

* Just removing translation checks as translations are ready. https://translate.wordpress.com/developer/?path=client/my-sites/subscribers/components/subscriber-launchpad/subscriber-launchpad.tsx

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On a site without subscribers, go to http://calypso.localhost:3000/subscribers/your_site.wordpress.com.
* The launchpad should display just fine.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?