### PR TITLE
Revert "Checkout: prevent calling a payment processor function if checkout disabled"

### DIFF
--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/content.tsx
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/content.tsx
@@ -179,14 +179,13 @@ function PayButton( {
 			? translate( 'Complete Checkout' )
 			: sprintf( translate( 'Pay %s' ), totalCostDisplay );
 	const processingText = translate( 'Processing…' );
-	const noop = () => {};
 
 	return (
 		<Button
 			primary={ ! busy }
 			busy={ busy }
 			disabled={ busy }
-			onClick={ busy ? noop : onClick }
+			onClick={ onClick }
 			className="purchase-modal__pay-button"
 		>
 			{ busy ? processingText : payText }

--- a/packages/composite-checkout/src/components/checkout-submit-button.tsx
+++ b/packages/composite-checkout/src/components/checkout-submit-button.tsx
@@ -4,13 +4,7 @@ import { cloneElement } from 'react';
 import joinClasses from '../lib/join-classes';
 import { useAllPaymentMethods, usePaymentMethodId } from '../lib/payment-methods';
 import { makeErrorResponse } from '../lib/payment-processors';
-import {
-	useFormStatus,
-	FormStatus,
-	useProcessPayment,
-	useTransactionStatus,
-	TransactionStatus,
-} from '../public-api';
+import { useFormStatus, FormStatus, useProcessPayment } from '../public-api';
 import CheckoutErrorBoundary from './checkout-error-boundary';
 import type { PaymentMethod, PaymentProcessorSubmitData, ProcessPayment } from '../types';
 
@@ -67,24 +61,13 @@ function CheckoutSubmitButtonForPaymentMethod( {
 	const [ activePaymentMethodId ] = usePaymentMethodId();
 	const isActive = paymentMethod.id === activePaymentMethodId;
 	const { formStatus } = useFormStatus();
-	const { transactionStatus } = useTransactionStatus();
 	const { __ } = useI18n();
-	const isDisabled =
-		disabled ||
-		formStatus !== FormStatus.READY ||
-		transactionStatus !== TransactionStatus.NOT_STARTED ||
-		! isActive;
+	const isDisabled = disabled || formStatus !== FormStatus.READY || ! isActive;
 	const onClick = useProcessPayment( paymentMethod?.paymentProcessorId ?? '' );
 	const onClickWithValidation: ProcessPayment = async (
 		processorData: PaymentProcessorSubmitData
 	) => {
-		if ( formStatus === FormStatus.SUBMITTING || transactionStatus === TransactionStatus.PENDING ) {
-			return Promise.resolve(
-				makeErrorResponse( __( 'A transaction is currently pending. Please wait.' ) )
-			);
-		}
-
-		if ( isDisabled ) {
+		if ( ! isActive ) {
 			return Promise.resolve(
 				makeErrorResponse( __( 'This payment method is not currently available.' ) )
 			);


### PR DESCRIPTION
Reverts Automattic/wp-calypso#84516

We're seeing some instances of users getting stuck on the processing page for Apple Pay, but are unable to reproduce the issue ourselves. Reverting until we figure out the issue.