### PR TITLE
Onboarding: With theme: Make intervalType an optional dependency

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -108,7 +108,7 @@ export function generateFlows( {
 			description: 'Preselect a theme to activate/buy from an external source',
 			lastModified: '2023-10-11',
 			showRecaptcha: true,
-			providesDependenciesInQuery: [ 'theme' ],
+			providesDependenciesInQuery: [ 'theme', 'intervalType' ],
 			optionalDependenciesInQuery: [ 'theme_type', 'style_variation', 'intervalType' ],
 			hideProgressIndicator: true,
 		},

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -108,8 +108,8 @@ export function generateFlows( {
 			description: 'Preselect a theme to activate/buy from an external source',
 			lastModified: '2023-10-11',
 			showRecaptcha: true,
-			providesDependenciesInQuery: [ 'theme', 'intervalType' ],
-			optionalDependenciesInQuery: [ 'theme_type', 'style_variation' ],
+			providesDependenciesInQuery: [ 'theme' ],
+			optionalDependenciesInQuery: [ 'theme_type', 'style_variation', 'intervalType' ],
 			hideProgressIndicator: true,
 		},
 		{


### PR DESCRIPTION
Related to #

## Proposed Changes

* Make intervalType query arg optional to minimize error.

See p1701358905969129-slack-C029GN3KD

## Testing Instructions

- Logged out, select theme in Hero on wordpress.com and ensure flow works (when on calypso.localhost:3000 or a live URL)
- Test flow as mentioned in #83444. Note, the flow works. But, doesn't seem to persist the interval. This seems acceptable.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?