### PR TITLE
Posts: Properly handle new post status in PostRelativeTime

### DIFF
--- a/client/my-sites/post-relative-time-status/index.jsx
+++ b/client/my-sites/post-relative-time-status/index.jsx
@@ -40,24 +40,10 @@ class PostRelativeTime extends PureComponent {
 		}
 	}
 
-	/**
-	 * The `sameElse` setting of moment.js expects a string.
-	 * Since `translate()` could return an object, we need to ensure we pass a string.
-	 */
-	formatSameElseSetting( sameElse ) {
-		const defaultSameElse = 'll [at] LT';
-
-		if ( typeof sameElse === 'object' && sameElse ) {
-			return defaultSameElse;
-		}
-
-		return sameElse ?? defaultSameElse;
-	}
-
 	getDisplayedTimeForLabel() {
 		const moment = this.props.moment;
 		const now = moment();
-		const timestamp = moment( this.getTimestamp() );
+		const timestamp = moment( this.getTimestamp() ?? now );
 
 		const isScheduledPost = this.props.post.status === 'future';
 
@@ -67,24 +53,22 @@ class PostRelativeTime extends PureComponent {
 				nextDay: this.props.translate( '[tomorrow at] LT', {
 					comment: 'LT refers to time (eg. 18:00)',
 				} ),
-				sameElse: this.formatSameElseSetting(
+				sameElse:
 					this.props.translate( 'll [at] LT', {
 						comment:
 							'll refers to date (eg. 21 Apr) for when the post will be published & LT refers to time (eg. 18:00) - "at" is translated',
-					} )
-				),
+					} ) ?? 'll [at] LT',
 			} );
 		} else {
 			if ( Math.abs( now.diff( this.getTimestamp(), 'days' ) ) < 7 ) {
 				return timestamp.fromNow();
 			}
 
-			const sameElse = this.formatSameElseSetting(
+			const sameElse =
 				this.props.translate( 'll [at] LT', {
 					comment:
 						'll refers to date (eg. 21 Apr) & LT refers to time (eg. 18:00) - "at" is translated',
-				} )
-			);
+				} ) ?? 'll [at] LT';
 
 			displayedTime = timestamp.calendar( null, {
 				sameElse,

--- a/client/my-sites/post-relative-time-status/index.jsx
+++ b/client/my-sites/post-relative-time-status/index.jsx
@@ -98,6 +98,10 @@ class PostRelativeTime extends PureComponent {
 	}
 
 	getTimeText() {
+		if ( this.props.post.status === 'new' ) {
+			return null;
+		}
+
 		const time = this.getTimestamp();
 		return (
 			<span className="post-relative-time-status__time">
@@ -117,6 +121,11 @@ class PostRelativeTime extends PureComponent {
 
 	getStatusText() {
 		const status = this.props.post.status;
+
+		if ( status === 'new' ) {
+			return '';
+		}
+
 		const args = {
 			displayedTime: this.getDisplayedTimeForLabel(),
 		};

--- a/client/my-sites/post-relative-time-status/index.jsx
+++ b/client/my-sites/post-relative-time-status/index.jsx
@@ -43,7 +43,7 @@ class PostRelativeTime extends PureComponent {
 	getDisplayedTimeForLabel() {
 		const moment = this.props.moment;
 		const now = moment();
-		const timestamp = moment( this.getTimestamp() );
+		const timestamp = moment( this.getTimestamp() ?? now );
 
 		const isScheduledPost = this.props.post.status === 'future';
 

--- a/client/my-sites/post-relative-time-status/index.jsx
+++ b/client/my-sites/post-relative-time-status/index.jsx
@@ -98,10 +98,6 @@ class PostRelativeTime extends PureComponent {
 	}
 
 	getTimeText() {
-		if ( this.props.post.status === 'new' ) {
-			return null;
-		}
-
 		const time = this.getTimestamp();
 		return (
 			<span className="post-relative-time-status__time">
@@ -121,11 +117,6 @@ class PostRelativeTime extends PureComponent {
 
 	getStatusText() {
 		const status = this.props.post.status;
-
-		if ( status === 'new' ) {
-			return '';
-		}
-
 		const args = {
 			displayedTime: this.getDisplayedTimeForLabel(),
 		};

--- a/client/my-sites/post-relative-time-status/index.jsx
+++ b/client/my-sites/post-relative-time-status/index.jsx
@@ -52,11 +52,13 @@ class PostRelativeTime extends PureComponent {
 			displayedTime = timestamp.calendar( null, {
 				nextDay: this.props.translate( '[tomorrow at] LT', {
 					comment: 'LT refers to time (eg. 18:00)',
+					textOnly: true,
 				} ),
 				sameElse:
 					this.props.translate( 'll [at] LT', {
 						comment:
 							'll refers to date (eg. 21 Apr) for when the post will be published & LT refers to time (eg. 18:00) - "at" is translated',
+						textOnly: true,
 					} ) ?? 'll [at] LT',
 			} );
 		} else {
@@ -68,6 +70,7 @@ class PostRelativeTime extends PureComponent {
 				this.props.translate( 'll [at] LT', {
 					comment:
 						'll refers to date (eg. 21 Apr) & LT refers to time (eg. 18:00) - "at" is translated',
+					textOnly: true,
 				} ) ?? 'll [at] LT';
 
 			displayedTime = timestamp.calendar( null, {

--- a/client/my-sites/post-relative-time-status/index.jsx
+++ b/client/my-sites/post-relative-time-status/index.jsx
@@ -40,10 +40,24 @@ class PostRelativeTime extends PureComponent {
 		}
 	}
 
+	/**
+	 * The `sameElse` setting of moment.js expects a string.
+	 * Since `translate()` could return an object, we need to ensure we pass a string.
+	 */
+	formatSameElseSetting( sameElse ) {
+		const defaultSameElse = 'll [at] LT';
+
+		if ( typeof sameElse === 'object' && sameElse ) {
+			return defaultSameElse;
+		}
+
+		return sameElse ?? defaultSameElse;
+	}
+
 	getDisplayedTimeForLabel() {
 		const moment = this.props.moment;
 		const now = moment();
-		const timestamp = moment( this.getTimestamp() ?? now );
+		const timestamp = moment( this.getTimestamp() );
 
 		const isScheduledPost = this.props.post.status === 'future';
 
@@ -53,22 +67,24 @@ class PostRelativeTime extends PureComponent {
 				nextDay: this.props.translate( '[tomorrow at] LT', {
 					comment: 'LT refers to time (eg. 18:00)',
 				} ),
-				sameElse:
+				sameElse: this.formatSameElseSetting(
 					this.props.translate( 'll [at] LT', {
 						comment:
 							'll refers to date (eg. 21 Apr) for when the post will be published & LT refers to time (eg. 18:00) - "at" is translated',
-					} ) ?? 'll [at] LT',
+					} )
+				),
 			} );
 		} else {
 			if ( Math.abs( now.diff( this.getTimestamp(), 'days' ) ) < 7 ) {
 				return timestamp.fromNow();
 			}
 
-			const sameElse =
+			const sameElse = this.formatSameElseSetting(
 				this.props.translate( 'll [at] LT', {
 					comment:
 						'll refers to date (eg. 21 Apr) & LT refers to time (eg. 18:00) - "at" is translated',
-				} ) ?? 'll [at] LT';
+				} )
+			);
 
 			displayedTime = timestamp.calendar( null, {
 				sameElse,

--- a/client/my-sites/post-relative-time-status/index.jsx
+++ b/client/my-sites/post-relative-time-status/index.jsx
@@ -43,7 +43,7 @@ class PostRelativeTime extends PureComponent {
 	getDisplayedTimeForLabel() {
 		const moment = this.props.moment;
 		const now = moment();
-		const timestamp = moment( this.getTimestamp() ?? now );
+		const timestamp = moment( this.getTimestamp() );
 
 		const isScheduledPost = this.props.post.status === 'future';
 


### PR DESCRIPTION
## Proposed Changes

This fixes a [bug reported by Sentry](https://a8c.sentry.io/issues/4671462345/?referrer=slack), where the moment timestamp won't exist, and will cause an issue when trying to use as a formatted string. It will happen only in the case of a post with a "new" status, which I'm not sure how to reproduce, but through the code path it's easy to track that by falling back to the current moment timestamp is a reasonable solution.