### PR TITLE
Components: Add back compat to StatsCard component

### DIFF
--- a/packages/components/src/horizontal-bar-list/stats-card.tsx
+++ b/packages/components/src/horizontal-bar-list/stats-card.tsx
@@ -94,7 +94,7 @@ const StatsCard = ( {
 					href={ footerAction?.url }
 					aria-label={
 						translate( 'View all %(title)s', {
-							args: { title: title.toLocaleLowerCase() },
+							args: { title: title.toLocaleLowerCase?.() ?? title.toLowerCase() },
 							comment: '"View all posts & pages", "View all referrers", etc.',
 						} ) as string
 					}


### PR DESCRIPTION
## Proposed Changes

This adds a backward compatibility fix for a [bug reported by Sentry](https://a8c.sentry.io/issues/4660486835/?referrer=slack) that occurs in the Desktop app which apparently uses an old browser. `String.prototype.toLocaleLowerCase()` has quite a broad browser support, but just in case it's not defined, we're falling back to the broader supported `String.prototype.toLowerCase()`.