### PR TITLE
Theme Showcase: Hide the Screen Switcher

### DIFF
--- a/client/my-sites/themes/theme-showcase-header.jsx
+++ b/client/my-sites/themes/theme-showcase-header.jsx
@@ -5,7 +5,6 @@ import InlineSupportLink from 'calypso/components/inline-support-link';
 import NavigationHeader from 'calypso/components/navigation-header';
 import { preventWidows } from 'calypso/lib/formatting';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import { isSimpleSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import InstallThemeButton from './install-theme-button';
 import useThemeShowcaseDescription from './use-theme-showcase-description';
@@ -24,7 +23,6 @@ export default function ThemeShowcaseHeader( {
 	const translate = useTranslate();
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const selectedSiteId = useSelector( getSelectedSiteId );
-	const isSimple = useSelector( isSimpleSite );
 	const description = useThemeShowcaseDescription( { filter, tier, vertical } );
 	const title = useThemeShowcaseTitle( { filter, tier, vertical } );
 	const loggedOutSeoContent = useThemeShowcaseLoggedOutSeoContent( filter, tier );
@@ -77,7 +75,6 @@ export default function ThemeShowcaseHeader( {
 			<DocumentHead title={ documentHeadTitle } meta={ metas } />
 			{ isLoggedIn ? (
 				<NavigationHeader
-					screenOptionsTab={ isSimple ? null : 'themes.php' }
 					compactBreadcrumb={ false }
 					navigationItems={ [] }
 					mobileItem={ null }

--- a/client/my-sites/themes/theme-showcase-header.jsx
+++ b/client/my-sites/themes/theme-showcase-header.jsx
@@ -5,6 +5,7 @@ import InlineSupportLink from 'calypso/components/inline-support-link';
 import NavigationHeader from 'calypso/components/navigation-header';
 import { preventWidows } from 'calypso/lib/formatting';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { isSimpleSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import InstallThemeButton from './install-theme-button';
 import useThemeShowcaseDescription from './use-theme-showcase-description';
@@ -23,6 +24,7 @@ export default function ThemeShowcaseHeader( {
 	const translate = useTranslate();
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const selectedSiteId = useSelector( getSelectedSiteId );
+	const isSimple = useSelector( isSimpleSite );
 	const description = useThemeShowcaseDescription( { filter, tier, vertical } );
 	const title = useThemeShowcaseTitle( { filter, tier, vertical } );
 	const loggedOutSeoContent = useThemeShowcaseLoggedOutSeoContent( filter, tier );
@@ -75,7 +77,7 @@ export default function ThemeShowcaseHeader( {
 			<DocumentHead title={ documentHeadTitle } meta={ metas } />
 			{ isLoggedIn ? (
 				<NavigationHeader
-					screenOptionsTab="themes.php"
+					screenOptionsTab={ isSimple ? null : 'themes.php' }
 					compactBreadcrumb={ false }
 					navigationItems={ [] }
 					mobileItem={ null }


### PR DESCRIPTION
## Proposed Changes

* Hide the screen switcher for the Theme Showcase.

The wp-admin Theme Showcase has several issues that we won't fix in the short term. Its filtering hasn't been working in a while; it displays just a fraction of our themes; there is no editorial curation; it still shows individual Premium theme prices even though we haven't supported individual Premium theme purchases in a long time.

On the other hand, the Calypso Theme Showcase is actively developed and refined.

We are aware that Atomic sites rely on the wp-admin theme uploader, for example, to update custom themes by overwriting them. This change does not remove the `themes.php` page and related, such as `theme-install.php`. It simply removes the screen switcher from Calypso.

Users will still be able to reach wp-admin via direct link, or when [directed there by Calypso itself](https://github.com/Automattic/wp-calypso/blob/0206aa0e167edbd71dc7c168d34481506eb887e0/client/state/sites/selectors/get-site-theme-install-url.js). They will also be able to switch back to Calypso, since the wp-admin screen switcher is not affected by this change.

| Before | After |
|--------|--------|
| <img width="732" alt="Screenshot 2023-11-30 at 18 31 42" src="https://github.com/Automattic/wp-calypso/assets/2070010/f8c119fa-c817-468c-84f3-b03d1480458d"> | <img width="732" alt="Screenshot 2023-11-30 at 18 37 05" src="https://github.com/Automattic/wp-calypso/assets/2070010/82eaec11-0eb0-4d77-91d6-93ce5fdd51b9"> | 

To summarize, this change:

- Removes the screen switcher in Calypso's Theme Showcase.
- Does not affect the screen switcher in wp-admin's `themes.php`. 
- Does not affect wp-admin's `themes.php` and `theme-install.php`.
- Does not affect the `theme-install.php` links used by Calypso.

### ⚠️ IMPORTANT ⚠️ 

This PR is flagged "do not merge" because we must give a HE heads-up first.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* A Simple site, an Atomic site, and a Jetpack site enter `/themes`.
* None of them see the little "View" screen switcher in the top-right corner of the page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?