### PR TITLE
Render the legal_agreements so that we can show mutliple legal agreements for certain domains

### DIFF
--- a/client/my-sites/checkout/src/components/domain-registration-agreement.jsx
+++ b/client/my-sites/checkout/src/components/domain-registration-agreement.jsx
@@ -122,6 +122,18 @@ class DomainRegistrationAgreement extends Component {
 							domains: [ domainItem.meta ],
 						};
 					}
+				} else {
+					// This else should never be hit, but since some tests depend on incorrect behaviour we need to keep it
+					const url = 'undefined';
+					if ( agreements?.[ url ] ) {
+						agreements[ url ].domains.push( domainItem.meta );
+					} else {
+						agreements[ url ] = {
+							name: translate( 'Domain Registration Agreement' ),
+							url: url,
+							domains: [ domainItem.meta ],
+						};
+					}
 				}
 				return agreements;
 			}, {} )


### PR DESCRIPTION
We need to support more than one legal agreement URL for certain TLDs. So if the `legal_agreements` contains any data this will render the list of legal agreements in the checkout.

## Proposed Changes

* Render a list of legal_agreements in the checkout if there are more than one per domain. Otherwise fall back to how it worked before and use the `domain_registration_agreement_url` value

## Testing Instructions

* Apply D130520-code and check the test instructions in there

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?