### PR TITLE
Jetpack Manage: enable purchasing of licenses with a specified quantity

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/hooks/use-issue-and-assign-licenses.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/hooks/use-issue-and-assign-licenses.tsx
@@ -169,7 +169,9 @@ function useIssueAndAssignLicenses(
 
 			dispatch(
 				recordTracksEvent( 'calypso_partner_portal_multiple_licenses_issued', {
-					products: issuedLicenses.map( ( { slug } ) => slug ).join( ',' ),
+					products: issuedLicenses
+						.map( ( license ) => `${ license.slug }:${ license.quantity ?? 1 }` )
+						.join( ',' ),
 				} )
 			);
 

--- a/client/jetpack-cloud/sections/partner-portal/hooks/use-issue-and-assign-licenses.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/hooks/use-issue-and-assign-licenses.tsx
@@ -13,7 +13,10 @@ import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-pr
 import { type APIError } from 'calypso/state/partner-portal/types';
 import getSites from 'calypso/state/selectors/get-sites';
 import useAssignLicensesToSite from './use-assign-licenses-to-site';
-import useIssueLicenses, { type FulfilledIssueLicenseResult } from './use-issue-licenses';
+import useIssueLicenses, {
+	type IssueLicenseRequest,
+	type FulfilledIssueLicenseResult,
+} from './use-issue-licenses';
 
 const NO_OP = () => {
 	/* Do nothing */
@@ -150,12 +153,12 @@ function useIssueAndAssignLicenses(
 	return useMemo( () => {
 		const isReady = isIssueReady && isAssignReady;
 
-		const issueAndAssignLicenses = async ( productSlugs: string[] ) => {
-			if ( ! isReady || productSlugs.length === 0 ) {
+		const issueAndAssignLicenses = async ( selectedLicenses: IssueLicenseRequest[] ) => {
+			if ( ! isReady || selectedLicenses.length === 0 ) {
 				return;
 			}
 
-			const issuedLicenses = ( await issueLicenses( productSlugs ) ).filter(
+			const issuedLicenses = ( await issueLicenses( selectedLicenses ) ).filter(
 				( r ): r is FulfilledIssueLicenseResult => r.status === 'fulfilled'
 			);
 

--- a/client/jetpack-cloud/sections/partner-portal/hooks/use-issue-and-assign-licenses.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/hooks/use-issue-and-assign-licenses.tsx
@@ -186,6 +186,13 @@ function useIssueAndAssignLicenses(
 				const issuedMessage = getLicenseIssuedMessage( issuedLicenses );
 				dispatch( successNotice( issuedMessage, { displayOnNextPage: true } ) );
 
+				// When bundle licensing is available, all license purchases
+				// will result in a redirect to the main Licenses page
+				if ( isEnabled( 'jetpack/bundle-licensing' ) ) {
+					page.redirect( partnerPortalBasePath( '/licenses' ) );
+					return;
+				}
+
 				// If this user has no sites, send them to the licenses listing page
 				if ( sitesCount === 0 ) {
 					page.redirect( partnerPortalBasePath( '/licenses' ) );

--- a/client/jetpack-cloud/sections/partner-portal/hooks/use-issue-licenses.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/hooks/use-issue-licenses.tsx
@@ -7,6 +7,11 @@ const NO_OP = () => {
 	/* Do nothing */
 };
 
+export type IssueLicenseRequest = {
+	slug: string;
+	quantity: number;
+};
+
 export type FulfilledIssueLicenseResult = APILicense & {
 	status: 'fulfilled';
 	slug: string;
@@ -41,13 +46,16 @@ const useIssueLicenses = ( options: UseIssueLicensesOptions = {} ) => {
 		},
 	} );
 
-	const issueLicenses = ( productSlugs: string[] ): Promise< IssueLicenseResult[] > => {
-		const requests: Promise< IssueLicenseResult >[] = productSlugs.map( ( slug ) =>
-			mutateAsync( { product: slug } )
-				.then(
-					( value ): FulfilledIssueLicenseResult => ( { slug, status: 'fulfilled', ...value } )
-				)
-				.catch( (): RejectedIssueLicenseResult => ( { slug, status: 'rejected' } ) )
+	const issueLicenses = (
+		selectedLicenses: IssueLicenseRequest[]
+	): Promise< IssueLicenseResult[] > => {
+		const requests: Promise< IssueLicenseResult >[] = selectedLicenses.map(
+			( { slug, quantity } ) =>
+				mutateAsync( { product: slug, quantity } )
+					.then(
+						( value ): FulfilledIssueLicenseResult => ( { slug, status: 'fulfilled', ...value } )
+					)
+					.catch( (): RejectedIssueLicenseResult => ( { slug, status: 'rejected' } ) )
 		);
 
 		return Promise.all( requests );

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
@@ -41,6 +41,21 @@ export default function LicensesForm( {
 		suggestedProductSlugs,
 	} = useProductAndPlans( { selectedSite, selectedProductFilter } );
 
+	// useEffect( () => {
+	// 	const productsQueryArg = getQueryArg( window.location.href, 'products' )?.toString?.();
+	// 	if ( ! productsQueryArg ) {
+	// 		return;
+	// 	}
+
+	// 	if ( isLoadingProducts ) {
+	// 		return;
+	// 	}
+
+	// 	const parsedItems = parseQueryStringProducts( productsQueryArg );
+	// 	// TODO: Validate parsed items from the query string exist and are selectable;
+	// 	// then, set them as selected items on the page
+	// }, [ isLoadingProducts ] );
+
 	const disabledProductSlugs = useSelector< PartnerPortalStore, string[] >( ( state ) =>
 		getDisabledProductSlugs( state, filteredProductsAndBundles ?? [] )
 	);

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/pricing-summary.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/pricing-summary.tsx
@@ -4,6 +4,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { useSelector } from 'calypso/state';
 import { getProductsList } from 'calypso/state/products-list/selectors';
+import useSubmitForm from '../hooks/use-submit-form';
 import { getTotalInvoiceValue } from '../lib/pricing';
 import PricingBreakdown from './pricing-breakdown';
 import type { SelectedLicenseProp } from '../types';
@@ -22,10 +23,17 @@ export default function PricingSummary( {
 		.map( ( license ) => license.quantity )
 		.reduce( ( a, b ) => a + b, 0 );
 
+	// NOTE: Because we're now able to issue multiple licenses, we may need to
+	// re-spec the behavior for when a specific site is selected
+	const { isReady: isFormReady, submitForm } = useSubmitForm( null );
 	const handleCTAClick = useCallback( () => {
+		if ( ! isFormReady ) {
+			return;
+		}
+
 		// TODO: Add tracking
-		// TODO: Handle onclick
-	}, [] );
+		submitForm( selectedLicenses );
+	}, [ isFormReady, selectedLicenses, submitForm ] );
 
 	const link = '#link'; // TODO: Add link
 

--- a/client/jetpack-cloud/sections/partner-portal/lib/querystring-products.ts
+++ b/client/jetpack-cloud/sections/partner-portal/lib/querystring-products.ts
@@ -1,0 +1,22 @@
+import { type IssueLicenseRequest } from '../hooks/use-issue-licenses';
+
+export const serializeQueryStringProducts = ( products: IssueLicenseRequest[] ): string => {
+	return products.map( ( { slug, quantity } ) => `${ slug }:${ quantity }` ).join( ',' );
+};
+
+export const parseQueryStringProducts = (
+	products: string | null | undefined
+): IssueLicenseRequest[] => {
+	if ( ! products ) {
+		return [];
+	}
+
+	const commaSeparated = products.split( ',' );
+	return commaSeparated.map( ( i ) => {
+		const colonSeparatedItem = i.split( ':' );
+		const quantity = parseInt( colonSeparatedItem[ 1 ] ?? 1, 10 );
+		const slug = colonSeparatedItem[ 0 ];
+
+		return { slug, quantity };
+	} );
+};

--- a/client/jetpack-cloud/sections/partner-portal/lib/querystring-products.ts
+++ b/client/jetpack-cloud/sections/partner-portal/lib/querystring-products.ts
@@ -13,9 +13,12 @@ export const parseQueryStringProducts = (
 
 	const commaSeparated = products.split( ',' );
 	return commaSeparated.map( ( i ) => {
-		const colonSeparatedItem = i.split( ':' );
-		const quantity = parseInt( colonSeparatedItem[ 1 ] ?? 1, 10 );
-		const slug = colonSeparatedItem[ 0 ];
+		const [ slug, quantityStr ] = i.split( ':', 2 );
+
+		const quantity = parseInt( quantityStr, 10 );
+		if ( Number.isNaN( quantity ) ) {
+			return { slug, quantity: 1 };
+		}
 
 		return { slug, quantity };
 	} );

--- a/client/jetpack-cloud/sections/partner-portal/lib/test/querystring-products.ts
+++ b/client/jetpack-cloud/sections/partner-portal/lib/test/querystring-products.ts
@@ -1,0 +1,55 @@
+import { parseQueryStringProducts, serializeQueryStringProducts } from '../querystring-products';
+
+describe( 'parseQueryStringProducts', () => {
+	it( 'returns the correct product slug', () => {
+		const [ item ] = parseQueryStringProducts( 'myslug:1' );
+		expect( item.slug ).toBe( 'myslug' );
+	} );
+
+	it( 'correctly recognizes quantities when present', () => {
+		const [ item ] = parseQueryStringProducts( 'my-other-slug:5' );
+		expect( item.quantity ).toBe( 5 );
+	} );
+
+	it( 'assumes a quantity of 1 when no quantity is specified', () => {
+		const [ item ] = parseQueryStringProducts( 'this_is_a_test' );
+		expect( item.quantity ).toBe( 1 );
+	} );
+
+	it( 'can parse multiple products', () => {
+		const result = parseQueryStringProducts( 'item:1,otheritem:2,thirditem:4' );
+		expect( result.length ).toBe( 3 );
+
+		const [ first, second, third ] = result;
+		expect( first.slug ).toBe( 'item' );
+		expect( first.quantity ).toBe( 1 );
+
+		expect( second.slug ).toBe( 'otheritem' );
+		expect( second.quantity ).toBe( 2 );
+
+		expect( third.slug ).toBe( 'thirditem' );
+		expect( third.quantity ).toBe( 4 );
+	} );
+
+	it( 'returns an empty list when the input is not a string', () => {
+		const result = parseQueryStringProducts( null );
+		expect( result ).toEqual( [] );
+	} );
+} );
+
+describe( 'serializeQueryStringProducts', () => {
+	it( 'separates individual products with a comma', () => {
+		const products = [
+			{ slug: 'first', quantity: 1 },
+			{ slug: 'second', quantity: 1 },
+		];
+
+		const result = serializeQueryStringProducts( products );
+		expect( result.split( ',' ).length ).toBe( 2 );
+	} );
+
+	it( 'formats individual products as slug:quantity', () => {
+		const result = serializeQueryStringProducts( [ { slug: 'my_item', quantity: 4 } ] );
+		expect( result ).toBe( 'my_item:4' );
+	} );
+} );

--- a/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add/index.tsx
@@ -38,6 +38,7 @@ import { APIError } from 'calypso/state/partner-portal/types';
 import getSites from 'calypso/state/selectors/get-sites';
 import Layout from '../../layout';
 import LayoutHeader from '../../layout/header';
+import { parseQueryStringProducts } from '../../lib/querystring-products';
 import type { SiteDetails } from '@automattic/data-stores';
 
 import './style.scss';
@@ -176,7 +177,7 @@ function PaymentMethodAdd( { selectedSite }: { selectedSite?: SiteDetails | null
 			} )
 		);
 
-		const itemsToIssue = products.split( ',' );
+		const itemsToIssue = parseQueryStringProducts( products );
 		issueAndAssignLicenses( itemsToIssue );
 		// Do not update the dependency array with products since
 		// it gets changed on every product change, which triggers this `useEffect` to run infinitely.

--- a/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/card-content.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/card-content.tsx
@@ -138,7 +138,7 @@ export default function CardContent( {
 		dispatch( infoNotice( translate( 'A new WordPress.com site is on the way!' ) ) );
 		dispatch( recordTracksEvent( getCTAEventName( planSlug ) ) );
 
-		issueLicenses( [ productSlug ] );
+		issueLicenses( [ { slug: productSlug, quantity: 1 } ] );
 
 		setIsRequesting( false );
 		page.redirect( `/dashboard?provisioning=true` );

--- a/client/state/partner-portal/licenses/hooks/use-issue-license-mutation.ts
+++ b/client/state/partner-portal/licenses/hooks/use-issue-license-mutation.ts
@@ -4,13 +4,17 @@ import { APIError, APILicense } from 'calypso/state/partner-portal/types';
 
 export interface MutationIssueLicenseVariables {
 	product: string;
+	quantity: number;
 }
 
-function mutationIssueLicense( { product }: MutationIssueLicenseVariables ): Promise< APILicense > {
+function mutationIssueLicense( {
+	product,
+	quantity,
+}: MutationIssueLicenseVariables ): Promise< APILicense > {
 	return wpcomJpl.req.post( {
 		apiNamespace: 'wpcom/v2',
 		path: '/jetpack-licensing/license',
-		body: { product },
+		body: { product, quantity },
 	} );
 }
 


### PR DESCRIPTION
This PR adds and updates code to allow for purchasing of bundle licenses when the `jetpack/bundle-licensing` flag is enabled.

Resolves https://github.com/Automattic/jetpack-genesis/issues/120.

## Proposed Changes

* Add a new pair of methods for serializing and de-serializing couples of product slugs and quantities to/from the browser's query string. (With unit test coverage)
* Refactor existing license issue methods to incorporate quantity alongside product slug.
* Update analytics events to supply both product slugs and their quantities.
* Add event handling for the "Issue Licenses" button in the review modal, so that clicking it actually issues the selected licenses.

## Testing Instructions

### Analytics

Throughout all the below test cases, pay attention to analytics events emitted by Calypso. Verify that products are now identified not just by their slug, but by a supplemental quantity; e.g., `jetpack-scan:10` would signify a 10-license bundle of Jetpack Scan; `jetpack-complete:1` would signify an individual Jetpack Complete license.

### New functionality

* Complete the following steps without having a payment method associated with your account, and then do the same with a payment method associated:

* First, visit your Jetpack Manage test environment and go to the Issue Licenses page. Enable the bundle licensing flag by adding `?flags=jetpack/bundle-licensing` to your browser's URL.
* Select any number of individual licenses and bundles to purchase. (NOTE: Currently, Jetpack Complete bundles of size 10 are the safest option.)
* Click the "Issue N Licenses" button and review your choices in the modal that pops up. If everything looks accurate, click the modal button to issue your licenses.
* Verify that the licenses you picked are now available for assignment. (NOTE: If you picked a product that does not support bundling, that product may not be displayed and its license may not have been issued. This issue is being addressed simultaneously in another PR.)

### Regression testing

* Complete the following steps without having a payment method associated with your account, and then do the same with a payment method associated:

* Without the `jetpack/bundle-licensing` flag enabled, visit the same Issue Licenses page.
* Attempt to buy any individual product license, or a bundle like Complete.
* Verify your purchase is successful and all user-facing functionality behaves exactly the same as in production.

* Visit the Sites page and attempt to issue a license via the `...` menu to the right of any site in the dashboard.
* Verify this license purchase is also successful and behaves the same as production.