### PR TITLE
Components: Remove background and shadow from SectionNav

### DIFF
--- a/client/components/section-nav/style.scss
+++ b/client/components/section-nav/style.scss
@@ -30,6 +30,7 @@
 }
 
 .section-nav__mobile-header {
+	background: var(--color-surface);
 	display: flex;
 	width: 100%;
 	padding: 15px;

--- a/client/components/section-nav/style.scss
+++ b/client/components/section-nav/style.scss
@@ -3,11 +3,8 @@
 	width: 100%;
 	padding: 0;
 	margin: 0 0 17px;
-	background: var(--color-surface);
 	box-sizing: border-box;
-	box-shadow:
-		0 0 0 1px rgba(var(--color-neutral-10-rgb), 0.5),
-		0 1px 2px var(--color-neutral-0);
+	box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.05);
 
 	&.is-empty .section-nav__panel {
 		visibility: hidden;


### PR DESCRIPTION
**DRAFT: FOR DISCUSSION**

## Proposed Changes

This PR removes the background color and box shadow around the SectionNav component, and then adds the background color back for mobile dropdown. This is a simple change that works in many but not all cases.
- Change is immediately spurred by redesign of Earn / Monetize (DqXCQr1dEWpF3P2dIEwiwd-fi-791_88014)
- Also in line with changes to the SectionNav envisioned in the Calypso page header project (see p9Jlb4-8ec-p2)
- QUESTION: **This change DOES NOT WORK in cases where the section nav contains other secondary components** with their own white background colors (see below). Looking for thoughts on how we might proceed (ie, change styling of child nav components too, exclude some nav bars from this change, or other options). 
   - There has also been a push to make all screen backgrounds white. If we did so, most secondary issues below would be resolved. We'd still need to adjust a few borders/shadows on nav child components. 

This component is widely used in Calypso, but here are example of before/after on different pages. 

**Works: Monetize (before and after)**
<img width="1098" alt="monetize-before" src="https://github.com/Automattic/wp-calypso/assets/21228350/4d43bd1b-310a-43d9-a0c6-5d16238c9824">
<img width="1094" alt="monetize-after" src="https://github.com/Automattic/wp-calypso/assets/21228350/7f583390-2091-474e-a258-f207bb964d42">

**Works: Comments (before and after)**
<img width="1090" alt="comments-before" src="https://github.com/Automattic/wp-calypso/assets/21228350/ed1f951e-80c5-49c2-95bb-2e8a03bcfd48">
<img width="1112" alt="comments-after" src="https://github.com/Automattic/wp-calypso/assets/21228350/0ecbce13-1922-4b41-beae-de77e542eef2">

**Works: Stats (before and after)**
<img width="1240" alt="stats-before" src="https://github.com/Automattic/wp-calypso/assets/21228350/4a6a3f47-809e-43a9-b311-7a5ce141de87">
<img width="1240" alt="stats-after" src="https://github.com/Automattic/wp-calypso/assets/21228350/0e1cb724-9d88-483d-a2f4-f117705bab5e">

**Does not work: Posts (before and after)**
<img width="1080" alt="posts-before" src="https://github.com/Automattic/wp-calypso/assets/21228350/70994865-1d16-49b6-b6b8-9005830a2d42">
<img width="1081" alt="posts-after" src="https://github.com/Automattic/wp-calypso/assets/21228350/a841d126-5f3a-454d-ae2b-45fc8f3ad917">

**Does not work: Media (before and after)**
<img width="1198" alt="media-before" src="https://github.com/Automattic/wp-calypso/assets/21228350/86892e5c-d8e6-49d8-a32c-a551aaef54a4">
<img width="1208" alt="media-after" src="https://github.com/Automattic/wp-calypso/assets/21228350/ecca0236-2326-469f-8a02-85f6a641f3a3">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Load this branch and visit any page using the SectionNav component, including Tools (Marketing, Earn, Advertising), Comments, Stats, Posts, Pages, Media, etc. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?