### PR TITLE
Fix discount percentage issues on wpcom products and don't show discount on selected item

### DIFF
--- a/client/my-sites/checkout/src/components/item-variation-picker/util.ts
+++ b/client/my-sites/checkout/src/components/item-variation-picker/util.ts
@@ -4,10 +4,6 @@ export function getItemVariantCompareToPrice(
 	variant: WPCOMProductVariant,
 	compareTo?: WPCOMProductVariant
 ): number | undefined {
-	// If the same product is being compared to itself, there is no discount
-	if ( variant.productSlug === compareTo?.productSlug ) {
-		return undefined;
-	}
 	// This is the price that the compareTo variant would be if it was using the
 	// billing term of the variant. For example, if the price of the compareTo
 	// variant was 120 per year, and the variant we are displaying here is 5 per
@@ -15,6 +11,16 @@ export function getItemVariantCompareToPrice(
 	// or 10 (per month). In this case, selecting the variant would save the user
 	// 50% (5 / 10).
 	if ( ! compareTo ) {
+		return undefined;
+	}
+
+	// If the same product is being compared to itself, there is no discount
+	if ( variant.productSlug === compareTo.productSlug ) {
+		return undefined;
+	}
+
+	// A variant with a shorter term should never be cheaper than a variant with a longer term
+	if ( compareTo.termIntervalInMonths > variant.termIntervalInMonths ) {
 		return undefined;
 	}
 

--- a/client/my-sites/checkout/src/components/item-variation-picker/util.ts
+++ b/client/my-sites/checkout/src/components/item-variation-picker/util.ts
@@ -4,6 +4,10 @@ export function getItemVariantCompareToPrice(
 	variant: WPCOMProductVariant,
 	compareTo?: WPCOMProductVariant
 ): number | undefined {
+	// If the same product is being compared to itself, there is no discount
+	if ( variant.productSlug === compareTo?.productSlug ) {
+		return undefined;
+	}
 	// This is the price that the compareTo variant would be if it was using the
 	// billing term of the variant. For example, if the price of the compareTo
 	// variant was 120 per year, and the variant we are displaying here is 5 per

--- a/client/my-sites/checkout/src/components/item-variation-picker/util.ts
+++ b/client/my-sites/checkout/src/components/item-variation-picker/util.ts
@@ -39,9 +39,15 @@ export function getItemVariantCompareToPrice(
 
 	// CompareTo price for Biennial, Triennial, Quadrennial, and so on, products
 	if ( compareTo.termIntervalInMonths >= 12 && variant.termIntervalInMonths >= 24 ) {
+		const compareToTermIntervalInYears = compareTo.termIntervalInMonths / 12;
+
+		const compareToPricePerYear = compareTo.priceInteger / compareToTermIntervalInYears;
+		const compareToPricePerYearBeforeDiscounts =
+			compareTo.priceBeforeDiscounts / compareToTermIntervalInYears;
+
 		return (
-			compareTo.priceInteger +
-			compareTo.priceBeforeDiscounts * ( variant.termIntervalInMonths / 12 - 1 )
+			compareToPricePerYear +
+			compareToPricePerYearBeforeDiscounts * ( variant.termIntervalInMonths / 12 - 1 )
 		);
 	}
 

--- a/client/my-sites/checkout/src/components/item-variation-picker/variant-dropdown-price.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/variant-dropdown-price.tsx
@@ -239,7 +239,7 @@ export const ItemVariantDropDownPrice: FunctionComponent< {
 	const hasDiscount = discountPercentage > 0;
 	// Display the discount percentage if it's not an introductory offer
 	// or if it's a Jetpack 2 or 3-year plan
-	const canDisplayDiscountPercentage = ! isIntroductoryOffer || ( isJetpack && introCount > 1 );
+	const canDisplayDiscountPercentage = ! isIntroductoryOffer || ( isJetpack && introCount >= 1 );
 
 	return (
 		<Variant>


### PR DESCRIPTION
## Proposed Changes

* Return undefined on discount if product slugs are the same
* Fix Biennial and Triennial etc comparisons, previously the price comparison was not being calculated correctly because the years per plan were not being taken into account

## Testing Instructions

1. Checkout this branch or use the calypso live link
2. Go to `/checkout/jetpack/jetpack_security_t1_bi_yearly`
3. Make sure the dropdown picker doesn't show a 76% discount when the 2 year plan is selected (this should only show if Monthly is selected)
![image](https://github.com/Automattic/wp-calypso/assets/65001528/65015e70-11fd-4ace-94fa-b4fdc9f02b12)
4. Check with an Akismet checkout as well to make sure the discounts work correctly there
![image](https://github.com/Automattic/wp-calypso/assets/65001528/a173ed9e-4936-4263-8db4-a25fad44dc33)
5. Add a Wordpress Business plan to your cart by going to https://wordpress.com/plans/{site_url}
6. Make sure the 1, 2, and 3 year plans all have discounts correctly calculated no matter which one is selected
![image](https://github.com/Automattic/wp-calypso/assets/65001528/1a1a95a4-1a15-44ef-b9da-1bb8bcc7355b)
![image](https://github.com/Automattic/wp-calypso/assets/65001528/66f34f7e-3727-4185-b726-367fdb067325)
![image](https://github.com/Automattic/wp-calypso/assets/65001528/92169c40-af0a-437f-b1d4-cba46549eb28)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?