### PR TITLE
Domains: Fix "Registro.br" name in the pending registration notice for `.com.br` domains

### DIFF
--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -615,7 +615,7 @@ const Settings = ( {
 		return (
 			<Notice
 				text={ translate(
-					'We forwarded the domain registration request to Registro (.com.br registry). It may take up to 3 days for the request to be evaluated and accepted.'
+					'We forwarded the domain registration request to Registro.br (.com.br registry). It may take up to 3 days for the request to be evaluated and accepted.'
 				) }
 				icon="info"
 				showDismiss={ false }


### PR DESCRIPTION
## Proposed Changes

This PR updates the name of the `.br` registry from `Registro` to `Registro.br` (its actual name) in the pending registration notice for `.com.br` domains.

### Screenshots

- Before

> ![Markup on 2023-11-30 at 18:53:51](https://github.com/Automattic/wp-calypso/assets/5324818/72d1a552-eae3-4782-80db-0ef17b08a1a9)

- After

> ![Markup on 2023-11-30 at 18:53:36](https://github.com/Automattic/wp-calypso/assets/5324818/77b5abd8-89ba-4b66-b245-1e32e6795d1c)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Code inspection should be enough

You can also test by

- Opening the live Calypso link or building this branch locally
- Check the domain management page for a `.com.br` domain that is still pending registration at the registry

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?