### PR TITLE
Importers flow: Extend importers list with the Substack importer

### DIFF
--- a/client/blocks/import/list/index.tsx
+++ b/client/blocks/import/list/index.tsx
@@ -41,11 +41,11 @@ export default function ListStep( props: Props ) {
 	const secondaryListOptions: ImporterOption[] = [
 		{ value: 'blogroll', label: 'Blogroll' },
 		{ value: 'ghost', label: 'Ghost' },
-		{ value: 'tumblr', label: 'Tumblr' },
 		{ value: 'livejournal', label: 'LiveJournal' },
 		{ value: 'movabletype', label: 'Movable Type & TypePad' },
-		{ value: 'xanga', label: 'Xanga' },
 		{ value: 'substack', label: 'Substack' },
+		{ value: 'tumblr', label: 'Tumblr' },
+		{ value: 'xanga', label: 'Xanga' },
 	];
 
 	const onImporterSelect = ( platform: ImporterPlatform ): void => {

--- a/client/blocks/import/list/index.tsx
+++ b/client/blocks/import/list/index.tsx
@@ -45,6 +45,7 @@ export default function ListStep( props: Props ) {
 		{ value: 'livejournal', label: 'LiveJournal' },
 		{ value: 'movabletype', label: 'Movable Type & TypePad' },
 		{ value: 'xanga', label: 'Xanga' },
+		{ value: 'substack', label: 'Substack' },
 	];
 
 	const onImporterSelect = ( platform: ImporterPlatform ): void => {
@@ -80,6 +81,7 @@ export default function ListStep( props: Props ) {
 				<div className="list__importers list__importers-primary">
 					{ primaryListOptions.map( ( x ) => (
 						<Button
+							key={ x.value }
 							className="list__importers-item-card"
 							onClick={ () => onImporterSelect( x.value ) }
 						>

--- a/client/blocks/import/types.ts
+++ b/client/blocks/import/types.ts
@@ -57,7 +57,8 @@ export type ImporterPlatformOther =
 	| 'livejournal'
 	| 'movabletype'
 	| 'tumblr'
-	| 'xanga';
+	| 'xanga'
+	| 'substack';
 export type ImporterPlatformExtra = 'godaddy-central';
 export type ImporterPlatform =
 	| ImporterMainPlatform

--- a/client/blocks/import/util.ts
+++ b/client/blocks/import/util.ts
@@ -28,6 +28,7 @@ const platformMap: { [ key in ImporterPlatform ]: string } = {
 	livejournal: 'LiveJournal',
 	movabletype: 'Movable Type & TypePad',
 	xanga: 'Xanga',
+	substack: 'Substack',
 	unknown: 'Unknown',
 };
 

--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -122,9 +122,15 @@ const importFlow: Flow = {
 
 					if (
 						depUrl.startsWith( 'http' ) ||
-						[ 'blogroll', 'ghost', 'tumblr', 'livejournal', 'movabletype', 'xanga' ].indexOf(
-							providedDependencies?.platform as ImporterMainPlatform
-						) !== -1
+						[
+							'blogroll',
+							'ghost',
+							'tumblr',
+							'livejournal',
+							'movabletype',
+							'xanga',
+							'substack',
+						].indexOf( providedDependencies?.platform as ImporterMainPlatform ) !== -1
 					) {
 						return exitFlow( providedDependencies?.url as string );
 					}

--- a/client/landing/stepper/declarative-flow/import-hosted-site.ts
+++ b/client/landing/stepper/declarative-flow/import-hosted-site.ts
@@ -85,9 +85,15 @@ const importHostedSiteFlow: Flow = {
 
 					if (
 						depUrl.startsWith( 'http' ) ||
-						[ 'blogroll', 'ghost', 'tumblr', 'livejournal', 'movabletype', 'xanga' ].indexOf(
-							providedDependencies?.platform as ImporterMainPlatform
-						) !== -1
+						[
+							'blogroll',
+							'ghost',
+							'tumblr',
+							'livejournal',
+							'movabletype',
+							'xanga',
+							'substack',
+						].indexOf( providedDependencies?.platform as ImporterMainPlatform ) !== -1
 					) {
 						return exitFlow( providedDependencies?.url as string );
 					}

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -424,9 +424,15 @@ const siteSetupFlow: Flow = {
 
 					if (
 						depUrl.startsWith( 'http' ) ||
-						[ 'blogroll', 'ghost', 'tumblr', 'livejournal', 'movabletype', 'xanga' ].indexOf(
-							providedDependencies?.platform as ImporterMainPlatform
-						) !== -1
+						[
+							'blogroll',
+							'ghost',
+							'tumblr',
+							'livejournal',
+							'movabletype',
+							'xanga',
+							'substack',
+						].indexOf( providedDependencies?.platform as ImporterMainPlatform ) !== -1
 					) {
 						return exitFlow( providedDependencies?.url as string );
 					}


### PR DESCRIPTION
## Proposed Changes

* Import flow: Extend the importers list with the Substack importer
* The CTA will redirect to the "Tools / Import / Substack" page

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/import-focused?siteSlug={SITE_SLUG}`
* Click on "choose a content platform"
* From the "Other platforms" dropdown, choose the "Substack"
* Check if there is a "Substack content ready" screen
* Press the "Import your content" button
* Check if it redirects to the "Tools / Import / Substack" page

<img width="868" alt="Screenshot 2023-12-01 at 01 40 36" src="https://github.com/Automattic/wp-calypso/assets/1241413/7e61fda7-489a-4a49-9358-359bcabc89c8">

<img width="604" alt="Screenshot 2023-12-01 at 01 40 51" src="https://github.com/Automattic/wp-calypso/assets/1241413/f0834e68-4bb7-4184-9b13-c7f4c72df131">

<img width="788" alt="Screenshot 2023-12-01 at 01 41 00" src="https://github.com/Automattic/wp-calypso/assets/1241413/912346ef-60cf-4098-8904-f1a4a12ff8f4">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?