### PR TITLE
Stats: Use yearly product tier pricing as default and a refactoring

### DIFF
--- a/client/my-sites/stats/stats-purchase/index.tsx
+++ b/client/my-sites/stats/stats-purchase/index.tsx
@@ -209,7 +209,6 @@ const StatsPurchasePage = ( {
 											redirectUri={ query.redirect_uri ?? '' }
 											from={ query.from ?? '' }
 											isCommercial={ isCommercial }
-											priceTiers={ commercialMonthlyProduct?.price_tier_list } // personal plan can also purchase commercial plans
 										/>
 									</div>
 								)

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -22,7 +22,6 @@ import {
 	UI_EMOJI_HEART_TIER_THRESHOLD,
 	UI_IMAGE_CELEBRATION_TIER_THRESHOLD,
 } from './stats-purchase-wizard';
-import { PriceTierListItemProps } from './types';
 import './styles.scss';
 
 interface StatsCommercialPurchaseProps {
@@ -34,7 +33,6 @@ interface StatsCommercialPurchaseProps {
 	redirectUri: string;
 	from: string;
 	showClassificationDispute?: boolean;
-	priceTiers: [ PriceTierListItemProps ];
 }
 
 interface StatsSingleItemPagePurchaseProps {
@@ -45,7 +43,6 @@ interface StatsSingleItemPagePurchaseProps {
 	from: string;
 	siteId: number | null;
 	isCommercial: boolean | null;
-	priceTiers: [ PriceTierListItemProps ];
 }
 
 interface StatsSingleItemPersonalPurchasePageProps {
@@ -86,7 +83,6 @@ const StatsCommercialPurchase = ( {
 	adminUrl,
 	redirectUri,
 	showClassificationDispute = true,
-	priceTiers,
 }: StatsCommercialPurchaseProps ) => {
 	const translate = useTranslate();
 	const isWPCOMSite = useSelector( ( state ) => siteId && getIsSiteWPCOM( state, siteId ) );
@@ -143,9 +139,7 @@ Thanks\n\n`;
 			>
 				{ translate( 'Get Stats' ) }
 			</ButtonComponent>
-			{ isTierUpgradeSliderEnabled && (
-				<TierUpgradeSlider priceTiers={ priceTiers } currencyCode={ currencyCode } />
-			) }
+			{ isTierUpgradeSliderEnabled && <TierUpgradeSlider currencyCode={ currencyCode } /> }
 
 			{ showClassificationDispute && (
 				<div className={ `${ COMPONENT_CLASS_NAME }__additional-card-panel` }>
@@ -314,7 +308,6 @@ const StatsSingleItemPagePurchase = ( {
 	from,
 	siteId,
 	isCommercial,
-	priceTiers,
 }: StatsSingleItemPagePurchaseProps ) => {
 	const adminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
 
@@ -329,7 +322,6 @@ const StatsSingleItemPagePurchase = ( {
 				redirectUri={ redirectUri }
 				from={ from }
 				showClassificationDispute={ !! isCommercial }
-				priceTiers={ priceTiers }
 			/>
 		</StatsSingleItemPagePurchaseFrame>
 	);

--- a/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.tsx
@@ -65,8 +65,8 @@ function TierUpgradeSlider( { className, currencyCode }: TierUpgradeSliderProps 
 				<div className="stats-tier-upgrade-slider__plan-callout">
 					<h2>{ translatedStrings.limits }</h2>
 					<p className="left-aligned">
-						{ hasExtension && <span>+</span> }
 						<ShortenedNumber value={ lhValue } />
+						{ hasExtension && <span>+</span> }
 					</p>
 				</div>
 				<div className="stats-tier-upgrade-slider__plan-callout right-aligned">

--- a/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.tsx
@@ -65,14 +65,8 @@ function TierUpgradeSlider( { className, currencyCode }: TierUpgradeSliderProps 
 				<div className="stats-tier-upgrade-slider__plan-callout">
 					<h2>{ translatedStrings.limits }</h2>
 					<p className="left-aligned">
-						{ hasExtension ? (
-							<>
-								<span>+</span>
-								<ShortenedNumber value={ lhValue } />
-							</>
-						) : (
-							<ShortenedNumber value={ lhValue } />
-						) }
+						{ hasExtension && <span>+</span> }
+						<ShortenedNumber value={ lhValue } />
 					</p>
 				</div>
 				<div className="stats-tier-upgrade-slider__plan-callout right-aligned">

--- a/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.tsx
@@ -54,7 +54,7 @@ function TierUpgradeSlider( { className, currencyCode }: TierUpgradeSliderProps 
 	// TODO: Review tier values from API.
 	// Should consider validating the inputs before displaying them.
 	// The following will draw a "-" for the views value if it's undefined.
-	const hasExtension = tiers[ currentPlanIndex ]?.extension || false;
+	const hasExtension = !! tiers[ currentPlanIndex ]?.extension;
 	const lhValue = hasExtension
 		? EXTENSION_THRESHOLD * 1000000
 		: Number( tiers[ currentPlanIndex ]?.views );
@@ -65,7 +65,7 @@ function TierUpgradeSlider( { className, currencyCode }: TierUpgradeSliderProps 
 				<div className="stats-tier-upgrade-slider__plan-callout">
 					<h2>{ translatedStrings.limits }</h2>
 					<p className="left-aligned">
-						{ tiers[ currentPlanIndex ]?.extension ? (
+						{ hasExtension ? (
 							<>
 								<span>+</span>
 								<ShortenedNumber value={ lhValue } />
@@ -94,7 +94,7 @@ function TierUpgradeSlider( { className, currencyCode }: TierUpgradeSliderProps 
 			<Popover
 				position="right"
 				context={ infoReferenceElement?.current }
-				isVisible={ tiers[ currentPlanIndex ]?.extension }
+				isVisible={ hasExtension }
 				className="stats-tier-upgrade-slider__extension-popover-wrapper"
 			>
 				<div className="stats-tier-upgrade-slider__extension-popover-content">

--- a/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.tsx
@@ -3,21 +3,14 @@ import formatCurrency from '@automattic/format-currency';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import React, { useState, useRef } from 'react';
-import { PriceTierListItemProps } from './types';
-
+import { useSelector } from 'calypso/state';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import useAvailableUpgradeTiers from './use-available-upgrade-tiers';
 import './stats-purchase-tier-upgrade-slider.scss';
 
 type TierUpgradeSliderProps = {
 	className?: string;
-	priceTiers: [ PriceTierListItemProps ];
 	currencyCode: string;
-};
-
-type StatsPlanTierUI = {
-	price: string;
-	views: number;
-	extension?: boolean;
-	per_unit_fee?: number;
 };
 
 function useTranslatedStrings() {
@@ -39,72 +32,18 @@ function useTranslatedStrings() {
 	};
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const MOCK_PLAN_DATA = [
-	{
-		price: '$9',
-		views: 10000,
-		description: '$9/month for 10k views',
-	},
-	{
-		price: '$19',
-		views: 100000,
-		description: '$19/month for 100k views',
-	},
-	{
-		price: '$29',
-		views: 250000,
-		description: '$29/month for 250k views',
-	},
-	{
-		price: '$49',
-		views: 500000,
-		description: '$49/month for 500k views',
-	},
-	{
-		price: '$69',
-		views: 1000000,
-		description: '$69/month for 1M views',
-	},
-	{
-		price: '$89.99',
-		views: '1M++',
-		extension: true,
-		per_unit_fee: 1799,
-		description: '$25/month per million views if views exceed 1M',
-	},
-];
-
-function TierUpgradeSlider( { className, priceTiers, currencyCode }: TierUpgradeSliderProps ) {
+function TierUpgradeSlider( { className, currencyCode }: TierUpgradeSliderProps ) {
 	const translate = useTranslate();
 	const infoReferenceElement = useRef( null );
 	const componentClassNames = classNames( 'stats-tier-upgrade-slider', className );
+	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const tiers = useAvailableUpgradeTiers( siteId );
 	const EXTENSION_THRESHOLD = 2; // in millions
-
-	// Transform plan details to dusplay.
-	const plans = priceTiers?.map( ( plan ): StatsPlanTierUI => {
-		if ( plan?.maximum_units === null ) {
-			// highest tier extension
-			return {
-				price: plan?.minimum_price_monthly_display,
-				views: plan?.minimum_units,
-				extension: true,
-				per_unit_fee: plan?.per_unit_fee,
-			};
-		}
-
-		return {
-			price: plan?.maximum_price_monthly_display,
-			views: plan?.maximum_units,
-		};
-	} );
-
-	// const plans = MOCK_PLAN_DATA; // TODO: REMOVE MOCK DATA!
 
 	// Slider state.
 	const [ currentPlanIndex, setCurrentPlanIndex ] = useState( 0 );
 	const sliderMin = 0;
-	const sliderMax = plans?.length - 1;
+	const sliderMax = tiers?.length - 1;
 
 	const handleSliderChange = ( value: number ) => {
 		setCurrentPlanIndex( value );
@@ -118,20 +57,20 @@ function TierUpgradeSlider( { className, priceTiers, currencyCode }: TierUpgrade
 				<div className="stats-tier-upgrade-slider__plan-callout">
 					<h2>{ translatedStrings.limits }</h2>
 					<p className="left-aligned">
-						{ plans[ currentPlanIndex ]?.extension ? (
+						{ tiers[ currentPlanIndex ]?.extension ? (
 							<>
 								<span>+</span>
 								<ShortenedNumber value={ EXTENSION_THRESHOLD * 1000000 } />
 							</>
 						) : (
-							<ShortenedNumber value={ plans[ currentPlanIndex ]?.views } />
+							<ShortenedNumber value={ tiers[ currentPlanIndex ]?.views } />
 						) }
 					</p>
 				</div>
 				<div className="stats-tier-upgrade-slider__plan-callout right-aligned">
 					<h2>{ translatedStrings.price }</h2>
 					<p className="right-aligned" ref={ infoReferenceElement }>
-						{ plans[ currentPlanIndex ]?.price }
+						{ tiers[ currentPlanIndex ]?.price }
 					</p>
 				</div>
 			</div>
@@ -147,18 +86,18 @@ function TierUpgradeSlider( { className, priceTiers, currencyCode }: TierUpgrade
 			<Popover
 				position="right"
 				context={ infoReferenceElement?.current }
-				isVisible={ plans[ currentPlanIndex ]?.extension }
+				isVisible={ tiers[ currentPlanIndex ]?.extension }
 				className="stats-tier-upgrade-slider__extension-popover-wrapper"
 			>
 				<div className="stats-tier-upgrade-slider__extension-popover-content">
-					{ plans[ currentPlanIndex ]?.per_unit_fee &&
+					{ tiers[ currentPlanIndex ]?.per_unit_fee &&
 						translate(
 							'This is the base price for %(views_extension_limit)s million monthly views; beyond that, you will be charged additional +%(extension_value)s per million views.',
 							{
 								args: {
 									views_extension_limit: EXTENSION_THRESHOLD,
 									extension_value: formatCurrency(
-										plans[ currentPlanIndex ].per_unit_fee as number,
+										tiers[ currentPlanIndex ].per_unit_fee as number,
 										currencyCode,
 										{
 											isSmallestUnit: true,

--- a/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.tsx
@@ -51,6 +51,14 @@ function TierUpgradeSlider( { className, currencyCode }: TierUpgradeSliderProps 
 
 	const translatedStrings = useTranslatedStrings();
 
+	// TODO: Review tier values from API.
+	// Should consider validating the inputs before displaying them.
+	// The following will draw a "-" for the views value if it's undefined.
+	const hasExtension = tiers[ currentPlanIndex ]?.extension || false;
+	const lhValue = hasExtension
+		? EXTENSION_THRESHOLD * 1000000
+		: Number( tiers[ currentPlanIndex ]?.views );
+
 	return (
 		<div className={ componentClassNames }>
 			<div className="stats-tier-upgrade-slider__plan-callouts">
@@ -60,10 +68,10 @@ function TierUpgradeSlider( { className, currencyCode }: TierUpgradeSliderProps 
 						{ tiers[ currentPlanIndex ]?.extension ? (
 							<>
 								<span>+</span>
-								<ShortenedNumber value={ EXTENSION_THRESHOLD * 1000000 } />
+								<ShortenedNumber value={ lhValue } />
 							</>
 						) : (
-							<ShortenedNumber value={ tiers[ currentPlanIndex ]?.views } />
+							<ShortenedNumber value={ lhValue } />
 						) }
 					</p>
 				</div>

--- a/client/my-sites/stats/stats-purchase/types.ts
+++ b/client/my-sites/stats/stats-purchase/types.ts
@@ -9,3 +9,11 @@ export type PriceTierListItemProps = {
 	minimum_units: number;
 	per_unit_fee?: number;
 };
+
+export type StatsPlanTierUI = {
+	price: string | undefined;
+	description?: string;
+	views: string | number | undefined;
+	extension?: boolean;
+	per_unit_fee?: number;
+};

--- a/client/my-sites/stats/stats-purchase/use-available-upgrade-tiers.tsx
+++ b/client/my-sites/stats/stats-purchase/use-available-upgrade-tiers.tsx
@@ -50,7 +50,8 @@ function transformTier( tier: PriceTierListItemProps ): StatsPlanTierUI {
 			price: tier?.minimum_price_monthly_display,
 			views: tier?.maximum_units,
 			extension: true,
-			per_unit_fee: tier?.per_unit_fee,
+			// The price is yearly for yearly plans, so we need to divide by 12.
+			per_unit_fee: ( tier?.per_unit_fee ?? 0 ) / 12,
 		};
 	}
 

--- a/client/my-sites/stats/stats-purchase/use-available-upgrade-tiers.tsx
+++ b/client/my-sites/stats/stats-purchase/use-available-upgrade-tiers.tsx
@@ -4,7 +4,8 @@ import { useSelector } from 'calypso/state';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import { PriceTierListItemProps, StatsPlanTierUI } from './types';
 
-// TODO: remove the mock data after release.
+// TODO: Remove the mock data after release.
+// No need to translate mock data.
 const MOCK_PLAN_DATA = [
 	{
 		price: '$9',
@@ -41,6 +42,8 @@ const MOCK_PLAN_DATA = [
 ];
 
 function transformTier( tier: PriceTierListItemProps ): StatsPlanTierUI {
+	// TODO: Some description of transform logic here.
+	// So as to clarify what we should expect from the API.
 	if ( tier?.maximum_units === null ) {
 		// highest tier extension
 		return {
@@ -66,7 +69,7 @@ function getPlanTiersForSite( siteId: number | null, tiers: StatsPlanTierUI[] ):
 }
 
 function useAvailableUpgradeTiers( siteId: number | null ): StatsPlanTierUI[] {
-	// 1. Get the tiers.
+	// 1. Get the tiers. Default to yearly pricing.
 	const commercialProduct = useSelector( ( state ) =>
 		getProductBySlug( state, PRODUCT_JETPACK_STATS_YEARLY )
 	) as ProductsList.ProductsListItem | null;

--- a/client/my-sites/stats/stats-purchase/use-available-upgrade-tiers.tsx
+++ b/client/my-sites/stats/stats-purchase/use-available-upgrade-tiers.tsx
@@ -1,0 +1,85 @@
+import { PRODUCT_JETPACK_STATS_YEARLY } from '@automattic/calypso-products';
+import { ProductsList } from '@automattic/data-stores';
+import { useSelector } from 'calypso/state';
+import { getProductBySlug } from 'calypso/state/products-list/selectors';
+import { PriceTierListItemProps, StatsPlanTierUI } from './types';
+
+// TODO: remove the mock data after release.
+const MOCK_PLAN_DATA = [
+	{
+		price: '$9',
+		views: 10000,
+		description: '$9/month for 10k views',
+	},
+	{
+		price: '$19',
+		views: 100000,
+		description: '$19/month for 100k views',
+	},
+	{
+		price: '$29',
+		views: 250000,
+		description: '$29/month for 250k views',
+	},
+	{
+		price: '$49',
+		views: 500000,
+		description: '$49/month for 500k views',
+	},
+	{
+		price: '$69',
+		views: 1000000,
+		description: '$69/month for 1M views',
+	},
+	{
+		price: '$89.99',
+		views: '1M++',
+		extension: true,
+		per_unit_fee: 1799,
+		description: '$25/month per million views if views exceed 1M',
+	},
+];
+
+function transformTier( tier: PriceTierListItemProps ): StatsPlanTierUI {
+	if ( tier?.maximum_units === null ) {
+		// highest tier extension
+		return {
+			price: tier?.minimum_price_monthly_display,
+			views: tier?.maximum_units,
+			extension: true,
+			per_unit_fee: tier?.per_unit_fee,
+		};
+	}
+
+	return {
+		price: tier?.maximum_price_monthly_display,
+		views: tier?.maximum_units,
+	};
+}
+
+function getPlanTiersForSite( siteId: number | null, tiers: StatsPlanTierUI[] ): StatsPlanTierUI[] {
+	// TODO: Determine if we need to filter tiers locally.
+	// Accept the fill list of tiers and filter out options
+	// that don't apply to the current site (ie: only upgrades, not downgrades)
+	// Could happen on the server, in which case, we could remove this step.
+	return tiers;
+}
+
+function useAvailableUpgradeTiers( siteId: number | null ): StatsPlanTierUI[] {
+	// 1. Get the tiers.
+	const commercialProduct = useSelector( ( state ) =>
+		getProductBySlug( state, PRODUCT_JETPACK_STATS_YEARLY )
+	) as ProductsList.ProductsListItem | null;
+
+	let tiersForUi = commercialProduct?.price_tier_list?.map( transformTier );
+
+	tiersForUi = tiersForUi?.length > 0 ? tiersForUi : MOCK_PLAN_DATA;
+
+	// 2. Filter based on current plan. (this could also happen on the server)
+	tiersForUi = getPlanTiersForSite( siteId, tiersForUi );
+
+	// 3. Return the relevant upgrade options as a list.
+	return tiersForUi;
+}
+
+export default useAvailableUpgradeTiers;


### PR DESCRIPTION
## Proposed Changes

* Use yearly product tier pricing as default
* Use `maximum_units` for display
* Refactored the tiers logic to a hook like it was, which I think looks a bit clearer and we don't have to pass down the tiers for so many levels

## Testing Instructions

Please follow instructions for https://github.com/Automattic/wp-calypso/pull/84535, but note the pricing is based on yearly and the units are maximum.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?