### PR TITLE
Live Preview: dismiss sticky notice after activating the theme (season 2)

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-previewing-theme.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-previewing-theme.ts
@@ -1,3 +1,4 @@
+import { useSelect } from '@wordpress/data';
 import { useEffect, useState } from 'react';
 import wpcom from 'calypso/lib/wp';
 import { currentlyPreviewingTheme, PREMIUM_THEME, WOOCOMMERCE_THEME } from '../utils';
@@ -22,7 +23,12 @@ const getThemeType = ( theme?: Theme ) => {
 };
 
 export const usePreviewingTheme = () => {
-	const previewingThemeSlug = currentlyPreviewingTheme();
+	const previewingThemeSlug = useSelect( ( select ) => {
+		// Subscribe to the core store, so that previewingThemeSlug can be updated when the theme is activated.
+		// We need this hack because the currentlyPreviewingTheme() function is not a hook.
+		select( 'core' );
+		return currentlyPreviewingTheme();
+	}, [] );
 	const previewingThemeId =
 		( previewingThemeSlug as string )?.split( '/' )?.[ 1 ] || previewingThemeSlug;
 	const [ previewingThemeName, setPreviewingThemeName ] = useState< string >(

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-previewing-theme.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-previewing-theme.ts
@@ -29,37 +29,31 @@ export const usePreviewingTheme = () => {
 		select( 'core' );
 		return currentlyPreviewingTheme();
 	}, [] );
-	const previewingThemeId =
-		( previewingThemeSlug as string )?.split( '/' )?.[ 1 ] || previewingThemeSlug;
-	const [ previewingThemeName, setPreviewingThemeName ] = useState< string >(
-		previewingThemeSlug as string
-	);
-	const [ previewingThemeType, setPreviewingThemeType ] = useState< string >();
+	const [ previewingTheme, setPreviewingTheme ] = useState< Theme | undefined >( undefined );
+
+	const previewingThemeName = previewingTheme?.name || previewingThemeSlug;
+	const previewingThemeType = previewingTheme ? getThemeType( previewingTheme ) : undefined;
 	const previewingThemeTypeDisplay =
 		previewingThemeType === WOOCOMMERCE_THEME ? 'WooCommerce' : 'Premium';
 
 	useEffect( () => {
-		wpcom.req
-			.get( `/themes/${ previewingThemeId }`, { apiVersion: '1.2' } )
-			.then( ( theme: Theme ) => {
-				const name = theme?.name;
-				if ( name ) {
-					setPreviewingThemeName( name );
-				}
-				return theme;
-			} )
-			.then( ( theme: Theme ) => {
-				const type = getThemeType( theme );
-				if ( ! type ) {
-					return;
-				}
-				setPreviewingThemeType( type );
-			} )
-			.catch( () => {
-				// do nothing
-			} );
+		const previewingThemeId =
+			( previewingThemeSlug as string )?.split( '/' )?.[ 1 ] || previewingThemeSlug;
+
+		if ( previewingThemeId ) {
+			wpcom.req
+				.get( `/themes/${ previewingThemeId }`, { apiVersion: '1.2' } )
+				.then( ( theme: Theme ) => {
+					setPreviewingTheme( theme );
+				} )
+				.catch( () => {
+					// do nothing
+				} );
+		} else {
+			setPreviewingTheme( undefined );
+		}
 		return;
-	}, [ previewingThemeId ] );
+	}, [ previewingThemeSlug ] );
 
 	return {
 		name: previewingThemeName,

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-previewing-theme.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-previewing-theme.ts
@@ -24,8 +24,8 @@ const getThemeType = ( theme?: Theme ) => {
 
 export const usePreviewingTheme = () => {
 	const previewingThemeSlug = useSelect( ( select ) => {
-		// Subscribe to the core store, so that previewingThemeSlug can be updated when the theme is activated.
-		// We need this hack because the currentlyPreviewingTheme() function is not a hook.
+		// Subscribe to the core store, so that we can recompute `previewingThemeSlug` when the active theme changes.
+		// This is a workaround because we're not listening to the changes to the `wp_theme_preview` param in the URL.
 		select( 'core' );
 		return currentlyPreviewingTheme();
 	}, [] );

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/index.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/index.tsx
@@ -6,7 +6,7 @@ import { FC, useEffect } from 'react';
 import { useCanPreviewButNeedUpgrade } from './hooks/use-can-preview-but-need-upgrade';
 import { usePreviewingTheme } from './hooks/use-previewing-theme';
 import { LivePreviewUpgradeNotice } from './upgrade-notice';
-import { getUnlock, isPreviewingTheme } from './utils';
+import { getUnlock } from './utils';
 
 const unlock = getUnlock();
 
@@ -18,7 +18,7 @@ const NOTICE_ID = 'wpcom-live-preview/notice';
  * @see https://github.com/Automattic/wp-calypso/issues/82218
  */
 const LivePreviewNotice: FC< {
-	previewingThemeName: string;
+	previewingThemeName?: string;
 } > = ( { previewingThemeName } ) => {
 	const { createWarningNotice, removeNotice } = useDispatch( 'core/notices' );
 	const { set: setPreferences } = useDispatch( 'core/preferences' );
@@ -34,7 +34,7 @@ const LivePreviewNotice: FC< {
 		if ( ! siteEditorStore ) {
 			return;
 		}
-		if ( ! isPreviewingTheme() ) {
+		if ( ! previewingThemeName ) {
 			removeNotice( NOTICE_ID );
 			return;
 		}

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/index.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/index.tsx
@@ -65,7 +65,14 @@ const LivePreviewNotice: FC< {
 			}
 		);
 		return () => removeNotice( NOTICE_ID );
-	}, [ siteEditorStore, dashboardLink, createWarningNotice, removeNotice, previewingThemeName ] );
+	}, [
+		siteEditorStore,
+		dashboardLink,
+		setPreferences,
+		createWarningNotice,
+		removeNotice,
+		previewingThemeName,
+	] );
 	return null;
 };
 

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/utils.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/utils.ts
@@ -42,7 +42,7 @@ export function isPreviewingTheme() {
 
 export function currentlyPreviewingTheme() {
 	if ( isPreviewingTheme() ) {
-		return getQueryArg( window.location.href, 'wp_theme_preview' );
+		return getQueryArg( window.location.href, 'wp_theme_preview' ) as string;
 	}
-	return null;
+	return undefined;
 }


### PR DESCRIPTION
## Proposed Changes

This recent PR:

- https://github.com/Automattic/wp-calypso/pull/83630

resurfaced a bug which have been previously fixed by:

- https://github.com/Automattic/wp-calypso/pull/82857

The fix was subtle, so it can be easily missed. This PR reintroduces the fix, with code comments.

This PR also fixes a bug where we ALWAYS call the theme API (with null ID) event though we're not previewing anything.

Reviewers are encouraged to review commit-by-commit :)

## Testing Instructions

1. Sandbox `widgets.wp.com`
1. Patch this PR to your sandbox (`install-plugin.sh wpcom-block-editor live-preview-broken-activate`)
1. Live-preview a theme, then activate it.
1. Verify that the sticky notice is dismissed.
1. Reminder: you might have to Disable Cache so that the right code is pulled from `widgets.wp.com`.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?