### PR TITLE
Onboarding: Prevent domain overflow in multi domain selection

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -804,11 +804,7 @@ export class RenderDomainsStep extends Component {
 			return isRemoving ? null : (
 				<>
 					<div>
-						<div
-							className={ classNames( 'domains__domain-cart-domain', {
-								'limit-width': hasPromotion,
-							} ) }
-						>
+						<div className="domains__domain-cart-domain">
 							<BoldTLD domain={ domain.meta } />
 						</div>
 						<div className="domain-product-price__price">

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -83,7 +83,13 @@ import { getExternalBackUrl, shouldUseMultipleDomainsInCart } from './utils';
 import './style.scss';
 
 const BoldTLD = ( { domain } ) => {
-	const tld = domain.split( '.' ).pop();
+	const split = domain.split( '.' );
+	let tld = split.pop();
+	const wp = split.pop();
+	if ( wp === 'wordpress' && tld === 'com' ) {
+		tld = `wordpress.com`;
+	}
+
 	return (
 		<>
 			<span>{ domain.replace( `.${ tld }`, '' ) }</span>

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -180,9 +180,8 @@
 					text-overflow: ellipsis;
 				}
 
-				&.limit-width {
-					width: 35%;
-				}
+				width: 0;
+				flex-grow: 1;
 			}
 
 			.domains__domain-cart-remove {

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -152,7 +152,7 @@
 				display: flex;
 				justify-content: space-between;
 				padding-top: 6px;
-				column-gap: 7px;
+				column-gap: 10px;
 			}
 			.domains__domain-cart-row > div:nth-child(2) {
 				display: block;
@@ -199,7 +199,7 @@
 
 				del {
 					font-size: 0.75rem;
-					margin-right: 7px;
+					margin-right: 10px;
 				}
 			}
 

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -148,11 +148,11 @@
 		}
 
 		.domains__domain-cart-rows {
-
 			.domains__domain-cart-row > div {
 				display: flex;
 				justify-content: space-between;
 				padding-top: 6px;
+				column-gap: 7px;
 			}
 			.domains__domain-cart-row > div:nth-child(2) {
 				display: block;
@@ -200,7 +200,6 @@
 				del {
 					font-size: 0.75rem;
 					margin-right: 7px;
-					margin-left: 7px;
 				}
 			}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/4685

## Proposed Changes

* Limits the width of domains so they don't overflow the mini cart
* Grows shorter domains to take up available space when promos are shown
* Bolds the wordpress part of wordpress.com "tld"

## Testing Instructions

* http://calypso.localhost:3000/start/
* Enter a long domain name search term
* Check the sidebar is no longer overflowing
* Check mobile works correctly

Before

![Screenshot 2023-12-01 at 16-17-31 Create a site — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/714286f5-0201-419c-b179-9534e6e3afa6)


After

![Screenshot 2023-12-01 at 16-25-17 Create a site — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/8755d25c-19d9-4159-b602-6dfcf6fc0f77)

