### PR TITLE
BBE Landing: update header text

### DIFF
--- a/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
@@ -11,10 +11,11 @@ import {
 } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { NextButton } from '@automattic/onboarding';
 import styled from '@emotion/styled';
 import { Button } from '@wordpress/components';
-import { useTranslate } from 'i18n-calypso';
+import i18n, { useTranslate } from 'i18n-calypso';
 import React, { useEffect, useRef, useState, useCallback } from 'react';
 import AsyncLoad from 'calypso/components/async-load';
 import QueryProductsList from 'calypso/components/data/query-products-list';
@@ -331,18 +332,39 @@ export default function DIFMLanding( {
 		}
 	}, [ isFAQSectionOpen ] );
 
-	const headerText = translate(
-		'Let us build your site for {{PriceWrapper}}%(displayCost)s{{/PriceWrapper}}{{sup}}*{{/sup}}',
-		{
-			components: {
-				PriceWrapper: ! hasPriceDataLoaded ? <Placeholder /> : <span />,
-				sup: <sup />,
-			},
-			args: {
-				displayCost,
-			},
-		}
-	);
+	const isEnglishLocale = useIsEnglishLocale();
+
+	const headerText =
+		isEnglishLocale ||
+		i18n.hasTranslation(
+			'Let us build your site{{br}}{{/br}}in %(days)d days for {{PriceWrapper}}%(displayCost)s{{/PriceWrapper}}{{sup}}*{{/sup}}'
+		)
+			? translate(
+					'Let us build your site{{br}}{{/br}}in %(days)d days for {{PriceWrapper}}%(displayCost)s{{/PriceWrapper}}{{sup}}*{{/sup}}',
+					{
+						components: {
+							PriceWrapper: ! hasPriceDataLoaded ? <Placeholder /> : <span />,
+							sup: <sup />,
+							br: <br />,
+						},
+						args: {
+							displayCost,
+							days: 4,
+						},
+					}
+			  )
+			: translate(
+					'Let us build your site for {{PriceWrapper}}%(displayCost)s{{/PriceWrapper}}{{sup}}*{{/sup}}',
+					{
+						components: {
+							PriceWrapper: ! hasPriceDataLoaded ? <Placeholder /> : <span />,
+							sup: <sup />,
+						},
+						args: {
+							displayCost,
+						},
+					}
+			  );
 
 	const currentPlan = useSelector( ( state ) => ( siteId ? getSitePlan( state, siteId ) : null ) );
 	const hasCurrentPlanOrHigherPlan = currentPlan?.product_slug


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/martech/issues/2465

## Proposed Changes

* Updates the header text on the BBE landing page.

<img width="760" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/a3aa1e6c-e9ff-4c12-9be2-82857eeacbc0">



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/do-it-for-me`.
* Confirm that the header matches the screenshot.
* Go to the same page in a non-EN locale. Confirm that the old header is shown.

<img width="739" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/9a37926d-1dfc-4709-adbb-4380a8f36d4f">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?