### PR TITLE
Jetpack Manage: Update the discount info for licenses based on the bundle size

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/upgrade-link/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/upgrade-link/index.tsx
@@ -19,7 +19,9 @@ export default function UpgradeLink( { isInline = false } ) {
 		( product ) => product.slug === 'jetpack-monitor' && product.price_interval === 'month'
 	);
 
-	const price = monthlyProduct && formatCurrency( monthlyProduct.amount, monthlyProduct.currency );
+	const price =
+		monthlyProduct &&
+		formatCurrency( parseFloat( monthlyProduct.amount ), monthlyProduct.currency );
 
 	const handleOnClick = () => {
 		recordEvent( 'downtime_monitoring_upgrade_link_click' );

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/lib/pricing.ts
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/lib/pricing.ts
@@ -9,7 +9,9 @@ export const getProductPricingInfo = (
 	quantity: number
 ) => {
 	const bundle = product?.supported_bundles?.find( ( bundle ) => bundle.quantity === quantity );
-	const productBundleCost = bundle ? parseFloat( bundle.amount ) : product?.amount || 0;
+	const productBundleCost = bundle
+		? parseFloat( bundle.amount )
+		: parseFloat( product?.amount ) || 0;
 
 	const isDailyPricing = product.price_interval === 'day';
 

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
@@ -157,6 +157,7 @@ export default function LicensesForm( {
 					tabIndex={ 100 + i }
 					hideDiscount={ isSingleLicenseView }
 					suggestedProduct={ suggestedProduct }
+					quantity={ quantity }
 				/>
 			) : (
 				<LicenseProductCard
@@ -169,6 +170,7 @@ export default function LicensesForm( {
 					tabIndex={ 100 + i }
 					hideDiscount={ isSingleLicenseView }
 					suggestedProduct={ suggestedProduct }
+					quantity={ quantity }
 				/>
 			)
 		);

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/pricing-breakdown.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/pricing-breakdown.tsx
@@ -13,7 +13,11 @@ const LicenseItem = ( {
 	license: SelectedLicenseProp;
 	userProducts: Record< string, ProductListItem >;
 } ) => {
-	const { actualCost, discountedCost } = getProductPricingInfo( userProducts, license );
+	const { actualCost, discountedCost } = getProductPricingInfo(
+		userProducts,
+		license,
+		license.quantity
+	);
 
 	const { title } = useLicenseLightboxData( license );
 

--- a/client/jetpack-cloud/sections/partner-portal/license-multi-product-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-multi-product-card/index.tsx
@@ -26,6 +26,7 @@ interface Props {
 	) => void | null;
 	suggestedProduct?: string | null;
 	hideDiscount?: boolean;
+	quantity?: number;
 }
 
 export default function LicenseMultiProductCard( props: Props ) {
@@ -37,6 +38,7 @@ export default function LicenseMultiProductCard( props: Props ) {
 		onSelectProduct,
 		suggestedProduct,
 		hideDiscount,
+		quantity,
 	} = props;
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -175,7 +177,11 @@ export default function LicenseMultiProductCard( props: Props ) {
 						</div>
 
 						<div className="license-product-card__pricing">
-							<ProductPriceWithDiscount product={ product } hideDiscount={ hideDiscount } />
+							<ProductPriceWithDiscount
+								product={ product }
+								hideDiscount={ hideDiscount }
+								quantity={ quantity }
+							/>
 						</div>
 					</div>
 				</div>

--- a/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
@@ -23,6 +23,7 @@ interface Props {
 	isMultiSelect?: boolean;
 	hideDiscount?: boolean;
 	withBackground?: boolean;
+	quantity?: number;
 }
 
 export default function LicenseProductCard( props: Props ) {
@@ -36,6 +37,7 @@ export default function LicenseProductCard( props: Props ) {
 		isMultiSelect,
 		hideDiscount,
 		withBackground,
+		quantity,
 	} = props;
 	const { setParams, resetParams, getParamValue } = useURLQueryParams();
 	const modalParamValue = getParamValue( LICENSE_INFO_MODAL_ID );
@@ -140,7 +142,11 @@ export default function LicenseProductCard( props: Props ) {
 						</div>
 
 						<div className="license-product-card__pricing">
-							<ProductPriceWithDiscount product={ product } hideDiscount={ hideDiscount } />
+							<ProductPriceWithDiscount
+								product={ product }
+								hideDiscount={ hideDiscount }
+								quantity={ quantity }
+							/>
 						</div>
 					</div>
 				</div>

--- a/client/jetpack-cloud/sections/partner-portal/primary/prices/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/prices/index.tsx
@@ -30,7 +30,7 @@ export default function Prices() {
 			return null;
 		}
 
-		const dailyAgencyPrice = ( product.amount * 12 ) / 365;
+		const dailyAgencyPrice = ( parseFloat( product.amount ) * 12 ) / 365;
 		const dailyUserYearlyPrice = userYearlyProduct.cost / 365;
 
 		const userMonthlyProduct =

--- a/client/jetpack-cloud/sections/partner-portal/primary/product-price-with-discount-info/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/product-price-with-discount-info/index.tsx
@@ -3,70 +3,46 @@ import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'calypso/state';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import { getProductsList } from 'calypso/state/products-list/selectors';
+import { getProductPricingInfo } from '../../issue-license-v2/lib/pricing';
 
 import './style.scss';
 
 interface Props {
 	product: APIProductFamilyProduct;
 	hideDiscount?: boolean;
+	quantity?: number;
 }
 
-export default function ProductPriceWithDiscount( { product, hideDiscount }: Props ) {
+export default function ProductPriceWithDiscount( { product, hideDiscount, quantity = 1 }: Props ) {
 	const translate = useTranslate();
 
 	const userProducts = useSelector( ( state ) => getProductsList( state ) );
-	const productCost = product?.amount || 0;
-
 	const isDailyPricing = product.price_interval === 'day';
 
-	const discountInfo: {
-		actualCost: string;
-		discountedCost: string;
-		discountPercentage: number;
-	} = {
-		actualCost: '',
-		discountedCost: formatCurrency( productCost, product.currency ),
-		discountPercentage: 0,
-	};
-	if ( Object.keys( userProducts ).length && product ) {
-		const yearlyProduct = Object.values( userProducts ).find(
-			( prod ) => prod.product_id === product.product_id
-		);
-		const monthlyProduct =
-			yearlyProduct &&
-			Object.values( userProducts ).find(
-				( p ) =>
-					p.billing_product_slug === yearlyProduct.billing_product_slug &&
-					p.product_term === 'month'
-			);
-		if ( monthlyProduct ) {
-			const actualCost = isDailyPricing ? monthlyProduct.cost / 365 : monthlyProduct.cost;
-			const discountedCost = actualCost - productCost;
-			discountInfo.discountPercentage = ! productCost
-				? 100
-				: Math.round( ( discountedCost / actualCost ) * 100 );
-			discountInfo.actualCost = formatCurrency( actualCost, product.currency );
-		}
-	}
+	const { actualCost, discountedCost, discountPercentage } = getProductPricingInfo(
+		userProducts,
+		product,
+		quantity
+	);
 
 	return (
 		<div>
 			<div className="product-price-with-discount__price">
-				{ discountInfo.discountedCost }
+				{ formatCurrency( discountedCost, product.currency ) }
 				{
 					// Display discount info only if there is a discount
-					discountInfo.discountPercentage > 0 && ! hideDiscount && (
+					discountPercentage > 0 && ! hideDiscount && (
 						<>
 							<span className="product-price-with-discount__price-discount">
 								{ translate( 'Save %(discountPercentage)s%', {
 									args: {
-										discountPercentage: discountInfo.discountPercentage,
+										discountPercentage,
 									},
 								} ) }
 							</span>
 							<div>
 								<span className="product-price-with-discount__price-old">
-									{ discountInfo.actualCost }
+									{ formatCurrency( actualCost, product.currency ) }
 								</span>
 							</div>
 						</>

--- a/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/card-content.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/card-content.tsx
@@ -109,9 +109,13 @@ export default function CardContent( {
 		return {
 			title: plan?.getTitle?.().toString() || '',
 			description: getProductTagline( planSlug ) || '',
-			price: formatCurrency( parseFloat( agencyProduct?.amount as string ) || 0, 'USD', {
-				stripZeros: true,
-			} ),
+			price: formatCurrency(
+				parseFloat( agencyProduct?.amount as string ) || 0,
+				agencyProduct?.currency || 'USD',
+				{
+					stripZeros: true,
+				}
+			),
 			interval: 'month',
 			wpcomFeatures: planFeaturesObject.map( ( feature ) => ( {
 				text: ( feature?.getTitle?.() as string ) || '',

--- a/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/card-content.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/card-content.tsx
@@ -109,7 +109,9 @@ export default function CardContent( {
 		return {
 			title: plan?.getTitle?.().toString() || '',
 			description: getProductTagline( planSlug ) || '',
-			price: formatCurrency( agencyProduct?.amount || 0, 'USD', { stripZeros: true } ),
+			price: formatCurrency( parseFloat( agencyProduct?.amount as string ) || 0, 'USD', {
+				stripZeros: true,
+			} ),
 			interval: 'month',
 			wpcomFeatures: planFeaturesObject.map( ( feature ) => ( {
 				text: ( feature?.getTitle?.() as string ) || '',

--- a/client/state/partner-portal/products/selectors.ts
+++ b/client/state/partner-portal/products/selectors.ts
@@ -41,7 +41,7 @@ export function getTotalSelectedCost(
 
 	const totalSelectedProductCost = allProducts
 		.filter( ( product ) => selectedProductSlugs.includes( product.slug ) )
-		.map( ( product ) => product.amount )
+		.map( ( product ) => parseFloat( product.amount ) )
 		.reduce( ( totalCost, productCost ) => totalCost + productCost, 0 );
 
 	return totalSelectedProductCost;

--- a/client/state/partner-portal/types.ts
+++ b/client/state/partner-portal/types.ts
@@ -105,7 +105,7 @@ export interface APIProductFamilyProduct {
 	slug: string;
 	product_id: number;
 	currency: string;
-	amount: number;
+	amount: string;
 	price_interval: string;
 	family_slug: string;
 	supported_bundles: APIProductFamilyProductBundlePrice[];

--- a/client/state/partner-portal/types.ts
+++ b/client/state/partner-portal/types.ts
@@ -97,7 +97,7 @@ export interface APILicense {
 
 export interface APIProductFamilyProductBundlePrice {
 	quantity: number;
-	amount: number;
+	amount: string;
 }
 
 export interface APIProductFamilyProduct {


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/124
Resolves https://github.com/Automattic/jetpack-genesis/issues/107

## Proposed Changes

This PR updates the discount info for licenses based on the bundle size.

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. 

**Instructions**

1. Switch to billing scheme: 32b1d-pb
2. Visit the Jetpack Cloud link > Replace `dashboard` in the URL with `/partner-portal/issue-license?flags=jetpack/bundle-licensing`.
3. Verify that the correct price is displayed for all the products. Switch the different tabs and verify that the discount info & price is properly displayed. Check the API response. 

<img width="1422" alt="Screenshot 2023-12-01 at 1 59 59 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/3343b1e1-fc1c-49f8-af8a-3696abe98857">

4. Now select a few licenses > Verify that the Total cost is displayed correctly based on the discount and quantity > Click the `Review X licenses` and verify the pricing breakdown and the total cost is displayed as expected. 

<img width="1422" alt="Screenshot 2023-12-01 at 2 00 15 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/f14d63f8-9047-43fc-a77a-402bbf2dd445">

<img width="1117" alt="Screenshot 2023-12-01 at 2 00 41 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/0788d21c-6d72-4373-8d9b-396a1e0bb5ed">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?