### PR TITLE
Design Setup: fix crash in allDesigns.designs.find

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-carousel/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-carousel/index.tsx
@@ -1,10 +1,10 @@
+import { type StarterDesigns, useStarterDesignsQuery } from '@automattic/data-stores';
 import { Design } from '@automattic/design-picker';
 import { useLocale } from '@automattic/i18n-utils';
 import { ECOMMERCE_FLOW, StepContainer, isLinkInBioFlow } from '@automattic/onboarding';
 import { useMediaQuery } from '@wordpress/compose';
 import { useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
-import { StarterDesigns, useStarterDesignsQuery } from 'calypso/../packages/data-stores/src';
 import AsyncLoad from 'calypso/components/async-load';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/hooks/use-recipe.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/hooks/use-recipe.ts
@@ -67,14 +67,8 @@ const useRecipe = (
 		[]
 	);
 
-	const preselectedDesign = useMemo(
-		() =>
-			allDesigns?.designs.find( ( design ) =>
-				design.is_virtual
-					? design.recipe?.slug === preselectedThemeSlug
-					: design.slug === preselectedThemeSlug
-			),
-		[ allDesigns ]
+	const preselectedDesign = allDesigns?.designs?.find(
+		( design ) => ( design.is_virtual ? design.recipe?.slug : design.slug ) === preselectedThemeSlug
 	);
 
 	const { stylesheet = '' } = selectedDesign?.recipe || {};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -19,7 +19,7 @@ import { StepContainer, DESIGN_FIRST_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import { useRef, useState, useEffect, useMemo } from 'react';
+import { useRef, useState, useEffect } from 'react';
 import AsyncLoad from 'calypso/components/async-load';
 import QueryEligibility from 'calypso/components/data/query-atat-eligibility';
 import { useQueryProductsList } from 'calypso/components/data/query-products-list';
@@ -81,6 +81,8 @@ import type { GlobalStylesObject } from '@automattic/global-styles';
 import type { AnyAction } from 'redux';
 import type { ThunkAction } from 'redux-thunk';
 const SiteIntent = Onboard.SiteIntent;
+
+const EMPTY_ARRAY: Design[] = [];
 
 const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	const queryParams = useQuery();
@@ -177,7 +179,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		}
 	);
 
-	const designs = useMemo( () => allDesigns?.designs ?? [], [ allDesigns?.designs ] );
+	const designs = allDesigns?.designs ?? EMPTY_ARRAY;
 	const hasTrackedView = useRef( false );
 	useEffect( () => {
 		if ( ! hasTrackedView.current && designs.length > 0 ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -83,6 +83,7 @@ import type { ThunkAction } from 'redux-thunk';
 const SiteIntent = Onboard.SiteIntent;
 
 const EMPTY_ARRAY: Design[] = [];
+const EMPTY_OBJECT = {};
 
 const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	const queryParams = useQuery();
@@ -190,7 +191,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 
 	const categorizationOptions = getCategorizationOptions( intent );
 	const categorization = useCategorizationFromApi(
-		allDesigns?.filters?.subject || {},
+		allDesigns?.filters?.subject || EMPTY_OBJECT,
 		categorizationOptions
 	);
 

--- a/packages/design-picker/src/hooks/use-categorization.ts
+++ b/packages/design-picker/src/hooks/use-categorization.ts
@@ -98,7 +98,11 @@ function shouldSetToDefaultSelection(
 	categories: Category[],
 	currentSelection: string | null
 ): boolean {
-	return ! categories.find( ( { slug } ) => slug === currentSelection );
+	// For an empty list, `null` selection is the only correct one.
+	if ( categories.length === 0 && currentSelection === null ) {
+		return false;
+	}
+	return ! categories.some( ( { slug } ) => slug === currentSelection );
 }
 
 /**


### PR DESCRIPTION
Fixes a crash reported in Sentry where `allDesigns?.designs.find()` would crash because `allDesigns` is a valid object, but it doesn't have a `.designs` field.

I'm adding a `?.` before `find`. But what worries me is that I'm not really addressing the root cause. How can `useStarterDesignsQuery` return a valid `allDesigns` results which doesn't have a `.designs` field? The REST response (`/wpcom/v2/starter-designs`) always has the `.static.designs` field. Maybe we're interpreting an error response as a success there?

As a drive-by, I'm removing a redundant usage of `useMemo` (replaced by a constant empty array), and fixing an import of `data-stores` which was added in #77120, and looks like a VS code autocomplete.