### PR TITLE
Pricing Upgrade Happy app block: Avoid referencing PLANS_LIST directly

### DIFF
--- a/apps/happy-blocks/block-library/pricing-plans/index.jsx
+++ b/apps/happy-blocks/block-library/pricing-plans/index.jsx
@@ -4,7 +4,7 @@ import {
 	PLAN_PERSONAL,
 	PLAN_PREMIUM,
 } from '@automattic/calypso-products';
-import { PLANS_LIST } from '@automattic/calypso-products/src/plans-list';
+import { getPlans } from '@automattic/calypso-products/src';
 import { registerBlockType } from '@wordpress/blocks';
 import { sprintf, __ } from '@wordpress/i18n';
 import config from './config';
@@ -47,14 +47,14 @@ function registerBlocks() {
 					/* translators: planName can be any short name of WPCOM Plan bundle (ex. Personal, Permium, Business) */
 					__( 'Upgrade %(planName)s', 'happy-blocks' ),
 					{
-						planName: PLANS_LIST[ PLAN_PERSONAL ].getTitle(),
+						planName: getPlans()[ PLAN_PERSONAL ].getTitle(),
 					}
 				),
 				description: sprintf(
 					/* translators: planName can be any short name of WPCOM Plan bundle (ex. Personal, Permium, Business) */
 					__( 'Upgrade to %(planName)s pricing plan', 'happy-blocks' ),
 					{
-						planName: PLANS_LIST[ PLAN_PERSONAL ].getTitle(),
+						planName: getPlans()[ PLAN_PERSONAL ].getTitle(),
 					}
 				),
 				attributes: {
@@ -67,14 +67,14 @@ function registerBlocks() {
 					/* translators: planName can be any short name of WPCOM Plan bundle (ex. Personal, Permium, Business) */
 					__( 'Upgrade %(planName)s', 'happy-blocks' ),
 					{
-						planName: PLANS_LIST[ PLAN_PREMIUM ].getTitle(),
+						planName: getPlans()[ PLAN_PREMIUM ].getTitle(),
 					}
 				),
 				description: sprintf(
 					/* translators: planName can be any short name of WPCOM Plan bundle (ex. Personal, Permium, Business) */
 					__( 'Upgrade to %(planName)s pricing plan', 'happy-blocks' ),
 					{
-						planName: PLANS_LIST[ PLAN_PREMIUM ].getTitle(),
+						planName: getPlans()[ PLAN_PREMIUM ].getTitle(),
 					}
 				),
 				attributes: {
@@ -87,14 +87,14 @@ function registerBlocks() {
 					/* translators: planName can be any short name of WPCOM Plan bundle (ex. Personal, Permium, Business) */
 					__( 'Upgrade %(planName)s', 'happy-blocks' ),
 					{
-						planName: PLANS_LIST[ PLAN_BUSINESS ].getTitle(),
+						planName: getPlans()[ PLAN_BUSINESS ].getTitle(),
 					}
 				),
 				description: sprintf(
 					/* translators: planName can be any short name of WPCOM Plan bundle (ex. Personal, Permium, Business) */
 					__( 'Upgrade to %(planName)s pricing plan', 'happy-blocks' ),
 					{
-						planName: PLANS_LIST[ PLAN_BUSINESS ].getTitle(),
+						planName: getPlans()[ PLAN_BUSINESS ].getTitle(),
 					}
 				),
 				attributes: {
@@ -107,14 +107,14 @@ function registerBlocks() {
 					/* translators: planName can be any short name of WPCOM Plan bundle (ex. Personal, Permium, Business) */
 					__( 'Upgrade %(planName)s', 'happy-blocks' ),
 					{
-						planName: PLANS_LIST[ PLAN_ECOMMERCE ].getTitle(),
+						planName: getPlans()[ PLAN_ECOMMERCE ].getTitle(),
 					}
 				),
 				description: sprintf(
 					/* translators: planName can be any short name of WPCOM Plan bundle (ex. Personal, Permium, Business) */
 					__( 'Upgrade to %(planName)s pricing plan', 'happy-blocks' ),
 					{
-						planName: PLANS_LIST[ PLAN_ECOMMERCE ].getTitle(),
+						planName: getPlans()[ PLAN_ECOMMERCE ].getTitle(),
 					}
 				),
 				attributes: {

--- a/apps/happy-blocks/block-library/pricing-plans/index.jsx
+++ b/apps/happy-blocks/block-library/pricing-plans/index.jsx
@@ -4,7 +4,7 @@ import {
 	PLAN_PERSONAL,
 	PLAN_PREMIUM,
 } from '@automattic/calypso-products';
-import { getPlans } from '@automattic/calypso-products/src';
+import { getPlan } from '@automattic/calypso-products/src';
 import { registerBlockType } from '@wordpress/blocks';
 import { sprintf, __ } from '@wordpress/i18n';
 import config from './config';
@@ -47,14 +47,14 @@ function registerBlocks() {
 					/* translators: planName can be any short name of WPCOM Plan bundle (ex. Personal, Permium, Business) */
 					__( 'Upgrade %(planName)s', 'happy-blocks' ),
 					{
-						planName: getPlans()[ PLAN_PERSONAL ].getTitle(),
+						planName: getPlan( PLAN_PERSONAL )?.getTitle(),
 					}
 				),
 				description: sprintf(
 					/* translators: planName can be any short name of WPCOM Plan bundle (ex. Personal, Permium, Business) */
 					__( 'Upgrade to %(planName)s pricing plan', 'happy-blocks' ),
 					{
-						planName: getPlans()[ PLAN_PERSONAL ].getTitle(),
+						planName: getPlan( PLAN_PERSONAL )?.getTitle(),
 					}
 				),
 				attributes: {
@@ -67,14 +67,14 @@ function registerBlocks() {
 					/* translators: planName can be any short name of WPCOM Plan bundle (ex. Personal, Permium, Business) */
 					__( 'Upgrade %(planName)s', 'happy-blocks' ),
 					{
-						planName: getPlans()[ PLAN_PREMIUM ].getTitle(),
+						planName: getPlan( PLAN_PREMIUM )?.getTitle(),
 					}
 				),
 				description: sprintf(
 					/* translators: planName can be any short name of WPCOM Plan bundle (ex. Personal, Permium, Business) */
 					__( 'Upgrade to %(planName)s pricing plan', 'happy-blocks' ),
 					{
-						planName: getPlans()[ PLAN_PREMIUM ].getTitle(),
+						planName: getPlan( PLAN_PREMIUM )?.getTitle(),
 					}
 				),
 				attributes: {
@@ -87,14 +87,14 @@ function registerBlocks() {
 					/* translators: planName can be any short name of WPCOM Plan bundle (ex. Personal, Permium, Business) */
 					__( 'Upgrade %(planName)s', 'happy-blocks' ),
 					{
-						planName: getPlans()[ PLAN_BUSINESS ].getTitle(),
+						planName: getPlan( PLAN_BUSINESS )?.getTitle(),
 					}
 				),
 				description: sprintf(
 					/* translators: planName can be any short name of WPCOM Plan bundle (ex. Personal, Permium, Business) */
 					__( 'Upgrade to %(planName)s pricing plan', 'happy-blocks' ),
 					{
-						planName: getPlans()[ PLAN_BUSINESS ].getTitle(),
+						planName: getPlan( PLAN_BUSINESS )?.getTitle(),
 					}
 				),
 				attributes: {
@@ -107,14 +107,14 @@ function registerBlocks() {
 					/* translators: planName can be any short name of WPCOM Plan bundle (ex. Personal, Permium, Business) */
 					__( 'Upgrade %(planName)s', 'happy-blocks' ),
 					{
-						planName: getPlans()[ PLAN_ECOMMERCE ].getTitle(),
+						planName: getPlan( PLAN_ECOMMERCE )?.getTitle(),
 					}
 				),
 				description: sprintf(
 					/* translators: planName can be any short name of WPCOM Plan bundle (ex. Personal, Permium, Business) */
 					__( 'Upgrade to %(planName)s pricing plan', 'happy-blocks' ),
 					{
-						planName: getPlans()[ PLAN_ECOMMERCE ].getTitle(),
+						planName: getPlan( PLAN_ECOMMERCE )?.getTitle(),
 					}
 				),
 				attributes: {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

This refactors the Pricing upgrade block to use [getPlan](https://github.com/Automattic/wp-calypso/blob/trunk/packages/calypso-products/src/main.ts#L87)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run yarn dev --sync in `apps/happy-blocks` to sync code to your sandbox (might need to follow the[ instructions](https://github.com/Automattic/wp-calypso/blob/trunk/apps/happy-blocks/README.md#development-environment) and/or the Calypso Apps field guide to get it to work)

* Sandbox `wordpress.com` and `en.support.wordpress.com`
* Handle any certificate errors that appear for the assets

* Go to https://wordpress.com/support/domains/register-domain/
* The block should render correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
