### PR TITLE
Unhardcode Personal from the Cancel form so that it can be renamed

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
@@ -1,5 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { getPlan } from '@automattic/calypso-products';
+import { PLAN_PERSONAL, getPlan } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import formatCurrency from '@automattic/format-currency';
 import { useChatWidget } from '@automattic/help-center/src/hooks';
@@ -240,15 +240,24 @@ export default function UpsellStep( { upsell, site, purchase, ...props }: StepPr
 			return (
 				<Upsell
 					title={ translate( 'Switch to a more affordable plan' ) }
-					acceptButtonText={ translate( 'Switch to the Personal plan' ) }
+					/* translators: %(plan)s is WordPress.com Personal or another plan */
+					acceptButtonText={ translate( 'Switch to the %(plan)s plan', {
+						args: { plan: getPlan( PLAN_PERSONAL )?.getTitle() ?? '' },
+					} ) }
 					onAccept={ () => props.onClickDowngrade?.( upsell ) }
 					onDecline={ props.onDeclineUpsell }
 					image={ imgSwitchPlan }
 				>
 					<>
-						{ translate(
-							'WordPress.com Personal still gives you access to customer support via email, removal of ads, and more — and for 50% of the cost of your current plan.'
-						) }{ ' ' }
+						{
+							/* translators: %(plan)s is WordPress.com Personal or another plan */
+							translate(
+								'%(plan)s still gives you access to customer support via email, removal of ads, and more — and for 50% of the cost of your current plan.',
+								{
+									args: { plan: getPlan( PLAN_PERSONAL )?.getTitle() ?? '' },
+								}
+							)
+						}{ ' ' }
 						{ refundAmount &&
 							translate(
 								'You can downgrade and get a partial refund of %(amount)s or ' +


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Unhardcode Personal from the upsell nudge in the cancellation form. This also changes the plan name from WordPress.com X to X. I believe it is appropriate for the cancellation form.


## Testing Instructions

* Buy Premium
* Try to cancel it and select it's too expensive

Before:
<img width="981" alt="Screenshot 2023-12-01 at 11 35 15" src="https://github.com/Automattic/wp-calypso/assets/82778/d1b19a62-dcc0-4980-b806-25a950f05dfd">

After:
<img width="1006" alt="Screenshot 2023-12-01 at 11 32 02" src="https://github.com/Automattic/wp-calypso/assets/82778/b00efb33-103c-4bd4-8bba-1978b9f3012e">

After in another language to show it's changed:
<img width="996" alt="Screenshot 2023-12-01 at 11 19 43" src="https://github.com/Automattic/wp-calypso/assets/82778/3a3662fe-1d1f-4cb2-ab7f-e4ce84338601">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
