### PR TITLE
Unhardcode the Checkout Personal upsell

### DIFF
--- a/client/my-sites/checkout/cart/cart-free-user-plan-upsell.tsx
+++ b/client/my-sites/checkout/cart/cart-free-user-plan-upsell.tsx
@@ -35,8 +35,8 @@ import type { AppState } from 'calypso/types';
 export interface CartFreeUserPlanUpsellProps {
 	cart: Pick< ResponseCart, 'products' >;
 	isCartPendingUpdate?: boolean;
-	planName?: string | null | undefined;
 	addItemToCart: ( item: MinimalRequestCartProduct ) => void;
+	upsellPlan?: ReturnType< typeof getPlan >;
 }
 
 interface CartFreeUserPlanUpsellHocProps {
@@ -67,8 +67,9 @@ class CartFreeUserPlanUpsell extends Component<
 	};
 
 	getUpgradeText() {
-		const { cart, planPrice, planName, translate } = this.props;
+		const { cart, planPrice, translate, upsellPlan } = this.props;
 		const firstDomain = cart.products.find( this.isRegistrationOrTransfer );
+		const planName = upsellPlan?.getTitle() ?? '';
 
 		if ( planPrice && firstDomain && planPrice > firstDomain.cost ) {
 			const extraToPay = planPrice - firstDomain.cost;
@@ -185,9 +186,9 @@ const mapStateToProps = ( state: AppState, { cart }: CartFreeUserPlanUpsellProps
 			selectedSiteId &&
 			upsellPlan &&
 			getPlanPrice( state, selectedSiteId, upsellPlan, false ),
-		planName: upsellPlan?.getTitle() ?? '',
 		selectedSite,
 		showPlanUpsell: !! selectedSiteId,
+		upsellPlan,
 	};
 };
 

--- a/client/my-sites/checkout/cart/cart-free-user-plan-upsell.tsx
+++ b/client/my-sites/checkout/cart/cart-free-user-plan-upsell.tsx
@@ -35,6 +35,7 @@ import type { AppState } from 'calypso/types';
 export interface CartFreeUserPlanUpsellProps {
 	cart: Pick< ResponseCart, 'products' >;
 	isCartPendingUpdate?: boolean;
+	planName: string;
 	addItemToCart: ( item: MinimalRequestCartProduct ) => void;
 }
 
@@ -66,17 +67,18 @@ class CartFreeUserPlanUpsell extends Component<
 	};
 
 	getUpgradeText() {
-		const { cart, planPrice, translate } = this.props;
+		const { cart, planPrice, planName, translate } = this.props;
 		const firstDomain = cart.products.find( this.isRegistrationOrTransfer );
 
 		if ( planPrice && firstDomain && planPrice > firstDomain.cost ) {
 			const extraToPay = planPrice - firstDomain.cost;
 			return translate(
-				'Pay an {{strong}}extra %(extraToPay)s{{/strong}} for our Personal plan, and get access to all its ' +
+				'Pay an {{strong}}extra %(extraToPay)s{{/strong}} for our %(planName)s plan, and get access to all its ' +
 					'features, plus the first year of your domain for free.',
 				{
 					args: {
 						extraToPay: formatCurrency( extraToPay, firstDomain.currency ),
+						planName,
 					},
 					components: {
 						strong: <strong />,
@@ -86,10 +88,11 @@ class CartFreeUserPlanUpsell extends Component<
 		} else if ( planPrice && firstDomain && planPrice < firstDomain.cost ) {
 			const savings = firstDomain.cost - planPrice;
 			return translate(
-				'{{strong}}Save %(savings)s{{/strong}} when you purchase a WordPress.com Personal plan ' +
+				'{{strong}}Save %(savings)s{{/strong}} when you purchase a WordPress.com %(planName)s plan ' +
 					'instead — your domain comes free for a year.',
 				{
 					args: {
+						planName,
 						savings: formatCurrency( savings, firstDomain.currency ),
 					},
 					components: {
@@ -100,9 +103,10 @@ class CartFreeUserPlanUpsell extends Component<
 		}
 
 		return translate(
-			'Purchase our Personal plan at {{strong}}no extra cost{{/strong}}, and get access to all its ' +
+			'Purchase our %(planName)s plan at {{strong}}no extra cost{{/strong}}, and get access to all its ' +
 				'features, plus the first year of your domain for free.',
 			{
+				args: { planName },
 				components: {
 					strong: <strong />,
 				},
@@ -181,6 +185,7 @@ const mapStateToProps = ( state: AppState, { cart }: CartFreeUserPlanUpsellProps
 			selectedSiteId &&
 			upsellPlan &&
 			getPlanPrice( state, selectedSiteId, upsellPlan, false ),
+		planName: upsellPlan?.getTitle() ?? '',
 		selectedSite,
 		showPlanUpsell: !! selectedSiteId,
 	};

--- a/client/my-sites/checkout/cart/cart-free-user-plan-upsell.tsx
+++ b/client/my-sites/checkout/cart/cart-free-user-plan-upsell.tsx
@@ -35,7 +35,7 @@ import type { AppState } from 'calypso/types';
 export interface CartFreeUserPlanUpsellProps {
 	cart: Pick< ResponseCart, 'products' >;
 	isCartPendingUpdate?: boolean;
-	planName: string;
+	planName?: string | null | undefined;
 	addItemToCart: ( item: MinimalRequestCartProduct ) => void;
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Remove the hardcoded Personal from the checkout personal upsell so that the plan can be renamed

## Testing Instructions

* Add any domain to checkout on a Free site and proceed to checkout
* You should see the upsell to the right
* In order to see all 3 version of this upsell, you need to either hack the API, or hack the front-end code (for example `is_tld_eligible_for_wpcom_registration` should always return `true`. The reason for this hack is that we currently do not have any domains that are >= the Personal cost and can be bundled.

<img width="338" alt="Screenshot 2023-12-01 at 12 20 59" src="https://github.com/Automattic/wp-calypso/assets/82778/c39acd7e-7154-42ff-91c8-5a671dab657b">

<img width="332" alt="Screenshot 2023-12-01 at 12 10 45" src="https://github.com/Automattic/wp-calypso/assets/82778/e8315346-cd45-43f1-a400-f5f0de2f3a5a">

<img width="349" alt="Screenshot 2023-12-01 at 12 22 15" src="https://github.com/Automattic/wp-calypso/assets/82778/90473a26-010b-41ac-8d67-4dc2b9273551">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
