### PR TITLE
Jetpack Manage: Make the Multi-variant card entire area clickable.

### DIFF
--- a/client/components/multiple-choice-question/index.jsx
+++ b/client/components/multiple-choice-question/index.jsx
@@ -30,7 +30,7 @@ const MultipleChoiceQuestion = ( {
 	const [ selectedAnswer, setSelectedAnswer ] = useState( selectedAnswerId );
 	const shuffledAnswers = shouldShuffleAnswers ? shuffleAnswers( answers ) : answers;
 	return (
-		<FormFieldset className="multiple-choice-question">
+		<FormFieldset className="multiple-choice-question" onClick={ ( e ) => e.stopPropagation() }>
 			<FormLegend>{ question }</FormLegend>
 			<div className="multiple-choice-question__answers">
 				{ shuffledAnswers.map( ( answer ) => (

--- a/client/components/multiple-choice-question/test/__snapshots__/index.js.snap
+++ b/client/components/multiple-choice-question/test/__snapshots__/index.js.snap
@@ -3,6 +3,7 @@
 exports[`MultipleChoiceQuestion should render with the minimum required properties ( plus extra prop to guarantee order ) 1`] = `
 <fieldset
   className="multiple-choice-question form-fieldset"
+  onClick={[Function]}
   role="group"
 >
   <legend

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/constants.ts
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/constants.ts
@@ -1,4 +1,4 @@
-export const PRODUCT_FILTER_ALL = null;
+export const PRODUCT_FILTER_ALL = '';
 export const PRODUCT_FILTER_PLANS = 'plans';
 export const PRODUCT_FILTER_PRODUCTS = 'products';
 export const PRODUCT_FILTER_WOOCOMMERCE_EXTENSIONS = 'woocommerce-extensions';

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/product-filter-select.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/product-filter-select.tsx
@@ -20,7 +20,7 @@ type Option = {
 	label: string;
 };
 
-const getOptionByFuction = ( options: Option[], value: string | null ): Option => {
+const getOptionByValue = ( options: Option[], value: string | null ): Option => {
 	return options.find( ( option ) => option.value === value ) ?? options[ 0 ];
 };
 
@@ -63,7 +63,7 @@ export default function ProductFilterSelect( {
 		return options;
 	}, [ isSingleLicense, translate ] );
 
-	const currentSelectedOption = getOptionByFuction( productFilterOptions, selectedProductFilter );
+	const currentSelectedOption = getOptionByValue( productFilterOptions, selectedProductFilter );
 
 	const selectedText = translate( '{{b}}Products{{/b}}: %(productFilter)s', {
 		args: {

--- a/client/jetpack-cloud/sections/partner-portal/license-multi-product-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-multi-product-card/index.tsx
@@ -136,6 +136,12 @@ export default function LicenseMultiProductCard( props: Props ) {
 					selected: isSelected,
 					disabled: isDisabled,
 				} ) }
+				onKeyDown={ onKeyDown }
+				onClick={ onSelect }
+				role="checkbox"
+				aria-checked={ isSelected }
+				aria-disabled={ isDisabled }
+				tabIndex={ tabIndex }
 			>
 				<div className="license-product-card__inner">
 					<div className="license-product-card__details">
@@ -163,15 +169,7 @@ export default function LicenseMultiProductCard( props: Props ) {
 								) }
 							</div>
 
-							<div
-								className="license-product-card__select-button license-product-card_multi-select"
-								onKeyDown={ onKeyDown }
-								onClick={ () => onSelect() }
-								role="checkbox"
-								aria-checked={ isSelected }
-								aria-disabled={ isDisabled }
-								tabIndex={ tabIndex }
-							>
+							<div className="license-product-card__select-button license-product-card_multi-select">
 								{ isSelected && <Gridicon icon="checkmark" /> }
 							</div>
 						</div>

--- a/client/jetpack-cloud/sections/partner-portal/license-product-card/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-product-card/style.scss
@@ -262,11 +262,3 @@
 		background: var(--studio-green-50);
 	}
 }
-
-.license-product-card--with-variant .license-product-card__inner {
-	cursor: default;
-
-	.license-product-card__select-button {
-		cursor: pointer;
-	}
-}


### PR DESCRIPTION
Clicking the checkbox is no longer the only way to select multi-variant product cards. The entire card can now be clicked with these changes.

https://github.com/Automattic/wp-calypso/assets/56598660/1c648f62-6610-41cd-af66-67e37ef970c6


Closes https://github.com/Automattic/jetpack-genesis/issues/128

## Proposed Changes
* Update `LicensesMultiProductCard` component to capture click events from the main container.
* Stop click event propagation in the `MultipleChoiceQuestion` component.
* Minor fixes not related to the main goal.

## Testing Instructions

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

* Use the Jetpack cloud live link below and go to the Licenses page (`/partner-portal/issue-license?flags=jetpack/bundle-licensing`)
* Confirm that clicking any part of the Multi-variant cards (e.g. Security and Backups) will trigger Select. Except when selecting an option.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?