### PR TITLE
Added hover state to subscription management in reader

### DIFF
--- a/client/landing/subscriptions/components/settings/comment-settings/comment-settings.tsx
+++ b/client/landing/subscriptions/components/settings/comment-settings/comment-settings.tsx
@@ -12,7 +12,7 @@ type CommentSettingsProps = {
 const CommentSettings = ( { onUnsubscribe, unsubscribing }: CommentSettingsProps ) => {
 	const translate = useTranslate();
 	return (
-		<SubscriptionsEllipsisMenu>
+		<SubscriptionsEllipsisMenu popoverClassName="comment-settings-popover">
 			<Button
 				className={ classNames( 'unsubscribe-button', { 'is-loading': unsubscribing } ) }
 				disabled={ unsubscribing }

--- a/client/landing/subscriptions/components/settings/site-settings/styles.scss
+++ b/client/landing/subscriptions/components/settings/site-settings/styles.scss
@@ -13,6 +13,18 @@
 		margin-bottom: 24px;
 	}
 
+	button {
+		&:hover,
+		&:focus {
+			color: var(--color-primary);
+			background: rgba(var(--color-primary-light-rgb), 1);
+
+			.reader-export-button__label {
+				color: var(--color-text-inverted);
+			}
+		}
+	}
+
 	&__unsubscribe-button.components-button.has-icon,
 	&__view-feed-button.components-button.has-icon,
 	&__manage-subscription-button.components-button.has-icon {

--- a/client/reader/site-subscriptions-manager/style.scss
+++ b/client/reader/site-subscriptions-manager/style.scss
@@ -4,6 +4,23 @@
 @import "client/landing/subscriptions/styles/search-component";
 @import "client/landing/subscriptions/components/site-subscriptions-list/styles/variables";
 
+@mixin hover-color {
+	&:hover,
+	&:focus {
+		color: var(--color-text-inverted);
+		background: rgba(var(--color-primary-light-rgb), 1);
+
+		.reader-import-button__label,
+		.reader-export-button__label {
+			color: var(--color-text-inverted);
+		}
+
+		path {
+			stroke: var(--color-text-inverted);
+		}
+	}
+}
+
 .site-subscriptions-manager {
 	&.main {
 		max-width: 1168px;
@@ -63,9 +80,13 @@
 		width: 305px;
 
 		button.components-button {
+			@include hover-color;
+
 			svg {
 				fill: none;
 			}
+
+			padding: 0 15px;
 
 			justify-content: flex-start;
 
@@ -98,4 +119,44 @@ hr.subscriptions__separator {
 	padding: 0;
 	border: none;
 	border-top: 1px solid $studio-gray-5;
+}
+
+.subscriptions-ellipsis-menu__popover.popover.site-subscriptions-manager__import-export-popover .popover__inner,
+.subscriptions-ellipsis-menu__popover.popover.comment-settings-popover .popover__inner {
+	padding: 5px 0 !important;
+}
+
+.subscriptions-ellipsis-menu__popover.popover .popover__inner {
+	padding: 5px 0 14px !important;
+
+	.settings.site-settings {
+		padding: 15px 0 0;
+
+		.setting-item {
+			padding: 0 21px;
+
+			&.email-me-new-comments-toggle {
+				margin-bottom: 16px;
+			}
+		}
+	}
+
+	.site-settings-popover__unsubscribe-button.components-button.has-icon:not(:last-child) {
+		margin-bottom: 16px;
+	}
+
+	.subscriptions__separator {
+		margin: 0 24px 15px;
+		width: auto;
+	}
+
+	& > .components-button,
+	.site-settings-popover__view-feed-button {
+		padding: 0 21px;
+		line-height: 36px;
+		width: 100%;
+
+		@include hover-color;
+
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/78793

## Proposed Changes

This PR adds hover state to the popup menus in the subscription management in the reader.

## Testing Instructions

- Apply this PR and start the application
- Go to `http://calypso.localhost:3000/read/subscriptions`.
- Click on the top right meatballs and hover over the menu items. You should see them changing the colours on hover:
<img width="499" alt="Screenshot 2023-12-01 at 13 06 24" src="https://github.com/Automattic/wp-calypso/assets/3832570/e7b9461a-a5c4-498b-94be-0fbc56c1d103">
- Click on the meatballs on one of the rows. If you hover over the last 2 options of the menus (the clickable buttons) they should behave the same:
<img width="368" alt="Screenshot 2023-12-01 at 13 06 34" src="https://github.com/Automattic/wp-calypso/assets/3832570/be2b1cc7-7473-4a3e-941e-93fc061f04cc">
- Go to the Comments tab and click on the meatballs of one of the rows. There is only one option now, but it should be behaving the same on hovering:
<img width="477" alt="Screenshot 2023-12-01 at 13 06 46" src="https://github.com/Automattic/wp-calypso/assets/3832570/a4e4e66d-9000-45d2-9786-86f28dff8bb3">


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?