### PR TITLE
Hosting Command Palette: Update secondary step indicator

### DIFF
--- a/client/components/command-palette/index.tsx
+++ b/client/components/command-palette/index.tsx
@@ -104,7 +104,7 @@ export function CommandMenuGroup( {
 							<LabelWrapper>
 								<Label>
 									<TextHighlight
-										text={ `${ command.label }${ command.siteFunctions ? '\u2026' : '' }` }
+										text={ `${ command.label }${ command.siteFunctions ? '…' : '' }` }
 										highlight={ search }
 									/>
 								</Label>

--- a/client/components/command-palette/index.tsx
+++ b/client/components/command-palette/index.tsx
@@ -103,8 +103,10 @@ export function CommandMenuGroup( {
 							{ command.image }
 							<LabelWrapper>
 								<Label>
-									<TextHighlight text={ command.label } highlight={ search } />
-									{ command.siteFunctions && '...' }
+									<TextHighlight
+										text={ `${ command.label }${ command.siteFunctions ? '...' : '' }` }
+										highlight={ search }
+									/>
 								</Label>
 								{ command.subLabel && (
 									<SubLabel>

--- a/client/components/command-palette/index.tsx
+++ b/client/components/command-palette/index.tsx
@@ -104,10 +104,11 @@ export function CommandMenuGroup( {
 							<LabelWrapper>
 								<Label>
 									<TextHighlight
-										text={ `${ command.label }${ command.siteFunctions ? '...' : '' }` }
+										text={ `${ command.label }${ command.siteFunctions ? '\u2026' : '' }` }
 										highlight={ search }
 									/>
 								</Label>
+
 								{ command.subLabel && (
 									<SubLabel>
 										<TextHighlight text={ command.subLabel } highlight={ search } />

--- a/client/components/command-palette/index.tsx
+++ b/client/components/command-palette/index.tsx
@@ -1,12 +1,7 @@
 import styled from '@emotion/styled';
 import { Modal, TextHighlight, __experimentalHStack as HStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import {
-	Icon,
-	search as inputIcon,
-	chevronLeft as backIcon,
-	chevronRight as forwardIcon,
-} from '@wordpress/icons';
+import { Icon, search as inputIcon, chevronLeft as backIcon } from '@wordpress/icons';
 import { cleanForSlug } from '@wordpress/url';
 import classnames from 'classnames';
 import { Command, useCommandState } from 'cmdk';
@@ -109,6 +104,7 @@ export function CommandMenuGroup( {
 							<LabelWrapper>
 								<Label>
 									<TextHighlight text={ command.label } highlight={ search } />
+									{ command.siteFunctions && '...' }
 								</Label>
 								{ command.subLabel && (
 									<SubLabel>
@@ -116,7 +112,6 @@ export function CommandMenuGroup( {
 									</SubLabel>
 								) }
 							</LabelWrapper>
-							{ command.siteFunctions ? <Icon icon={ forwardIcon } /> : null }
 						</HStack>
 					</Command.Item>
 				);


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/pull/84697

## Proposed Changes

This PR replaces the `chevronRight` with the ellipsis `...` for the nested commands. 

## Testing Instructions

* Navigate to Calypso Live link
* Navigate to `/sites` page
* Press `cmd + k` on macOS or `ctrl + k` on Windows to trigger command palette
* Observe that nested commands appear with `...` right by them and there is no `chevronRight`:

<img width="1232" alt="Screenshot 2023-12-01 at 2 35 43 PM" src="https://github.com/Automattic/wp-calypso/assets/25575134/b5b8fbdf-2ede-4143-897d-ebe56fec290c">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?