### PR TITLE
Hosting Command Palette: Add 'Open reader' command

### DIFF
--- a/client/sites-dashboard/components/wpcom-smp-commands.tsx
+++ b/client/sites-dashboard/components/wpcom-smp-commands.tsx
@@ -18,6 +18,7 @@ import {
 	plugins as pluginsIcon,
 	plus as plusIcon,
 	postComments as postCommentsIcon,
+	postFeaturedImage as postFeaturedImageIcon,
 	settings as accountSettingsIcon,
 	tool as toolIcon,
 	upload as uploadIcon,
@@ -145,6 +146,15 @@ export const useCommandsArrayWpcom = ( {
 				navigate( `/sites` );
 			},
 			icon: wordpressIcon,
+		},
+		{
+			name: 'openReader',
+			label: __( 'Open reader' ),
+			callback: ( { close }: { close: () => void } ) => {
+				close();
+				navigate( `/read` );
+			},
+			icon: postFeaturedImageIcon,
 		},
 		{
 			name: 'openSiteDashboard',

--- a/client/sites-dashboard/components/wpcom-smp-commands.tsx
+++ b/client/sites-dashboard/components/wpcom-smp-commands.tsx
@@ -1,3 +1,4 @@
+import { Gridicon } from '@automattic/components';
 import {
 	alignJustify as acitvityLogIcon,
 	backup as backupIcon,
@@ -18,7 +19,6 @@ import {
 	plugins as pluginsIcon,
 	plus as plusIcon,
 	postComments as postCommentsIcon,
-	postFeaturedImage as postFeaturedImageIcon,
 	settings as accountSettingsIcon,
 	tool as toolIcon,
 	upload as uploadIcon,
@@ -154,7 +154,7 @@ export const useCommandsArrayWpcom = ( {
 				close();
 				navigate( `/read` );
 			},
-			icon: postFeaturedImageIcon,
+			icon: <Gridicon icon="reader" />,
 		},
 		{
 			name: 'openSiteDashboard',


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/4730

## Proposed Changes

Adds an 'Open reader' command:

![CleanShot 2023-12-01 at 05 49 50@2x](https://github.com/Automattic/wp-calypso/assets/36432/dc6791cd-3461-4699-be58-3b80d67d8878)

## Testing Instructions

1. Use the command and verify you end up on the Reader.