### PR TITLE
Fix 1gb space showed when renewing 50gb space

### DIFF
--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -659,7 +659,10 @@ export function LineItemSublabelAndPrice( { product }: { product: ResponseCartPr
 	}
 
 	if ( isTieredVolumeSpaceAddon( product ) ) {
-		const spaceQuantity = product?.quantity ?? 1;
+		const productQuantity = product?.quantity ?? 1;
+		const currentQuantity = product?.current_quantity ?? 1;
+		const spaceQuantity = productQuantity > 1 ? productQuantity : currentQuantity;
+
 		return (
 			<>
 				{ translate( '%(quantity)s GB extra space, %(price)s per year', {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Renewing 50GB space from the new type shows 1GB on checkout. Make it show 50.

Note that this can also be fixed from the backend but it appears that the quantity has a dual meaning there and fixing it would require resolving the dual meaning problem. By dual meaning, I mean that the cart item can add 50GB space or renew the existing 50GB space, and the backend doesn't allow renew items to have quantity. I tried removing this check and it felt like a potential problem for other add-ons.

## Testing Instructions

1. Buy 50GB Space from the add-ons page with the store sandbox and a card that expires soon (just fill a same year date with one of the sandbox credit cards)
2. Go to /me/purchases and try to renew it

<img width="1107" alt="Screenshot 2023-12-01 at 16 18 28" src="https://github.com/Automattic/wp-calypso/assets/82778/9647ec30-da46-4348-a9af-0d05e2153bd8">

Before the fix, it would be 1GB instead of 50.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
