### PR TITLE
Update Billing History for Space add-ons

### DIFF
--- a/client/me/purchases/billing-history/utils.tsx
+++ b/client/me/purchases/billing-history/utils.tsx
@@ -216,16 +216,14 @@ function renderSpaceAddOnquantitySummary(
 	translate: LocalizeProps[ 'translate' ]
 ) {
 	if ( isRenewal ) {
-		return translate( 'Renewal for %(quantity)d GB', 'Renewal for %(quantity)d GBs', {
+		return translate( 'Renewal for %(quantity)d GB', {
 			args: { quantity: licensed_quantity },
-			count: licensed_quantity,
 			comment: '%(quantity)d is number of GBs renewed',
 		} );
 	}
 
-	return translate( 'Purchase of %(quantity)d GB', 'Purchase of %(quantity)d GBs', {
+	return translate( 'Purchase of %(quantity)d GB', {
 		args: { quantity: licensed_quantity },
-		count: licensed_quantity,
 		comment: '%(quantity)d is number of GBs purchased',
 	} );
 }

--- a/client/me/purchases/billing-history/utils.tsx
+++ b/client/me/purchases/billing-history/utils.tsx
@@ -3,6 +3,7 @@ import {
 	isDIFMProduct,
 	isGoogleWorkspace,
 	isTitanMail,
+	isTieredVolumeSpaceAddon,
 } from '@automattic/calypso-products';
 import formatCurrency from '@automattic/format-currency';
 import { LocalizeProps, useTranslate } from 'i18n-calypso';
@@ -209,6 +210,26 @@ function renderDIFMTransactionQuantitySummary(
 	);
 }
 
+function renderSpaceAddOnquantitySummary(
+	licensed_quantity: number,
+	isRenewal: boolean,
+	translate: LocalizeProps[ 'translate' ]
+) {
+	if ( isRenewal ) {
+		return translate( 'Renewal for %(quantity)d GB', 'Renewal for %(quantity)d GBs', {
+			args: { quantity: licensed_quantity },
+			count: licensed_quantity,
+			comment: '%(quantity)d is number of GBs renewed',
+		} );
+	}
+
+	return translate( 'Purchase of %(quantity)d GB', 'Purchase of %(quantity)d GBs', {
+		args: { quantity: licensed_quantity },
+		count: licensed_quantity,
+		comment: '%(quantity)d is number of GBs purchased',
+	} );
+}
+
 export function renderTransactionQuantitySummary(
 	{ licensed_quantity, new_quantity, type, wpcom_product_slug }: BillingTransactionItem,
 	translate: LocalizeProps[ 'translate' ]
@@ -235,6 +256,10 @@ export function renderTransactionQuantitySummary(
 
 	if ( isDIFMProduct( product ) ) {
 		return renderDIFMTransactionQuantitySummary( licensed_quantity, translate );
+	}
+
+	if ( isTieredVolumeSpaceAddon( product ) ) {
+		return renderSpaceAddOnquantitySummary( licensed_quantity, isRenewal, translate );
 	}
 
 	if ( isRenewal ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

The billing history for Space would show items instead of GB. Fix it to show GB.

## Testing Instructions

* Fron add-ons, buy 50GB (or 100) space with an expiring card
* Go to /me/purchases and renew the space 
* Go to /me/purchases/billing and make sure that the space shows GB instead of items:

<img width="1063" alt="Screenshot 2023-12-01 at 17 01 55" src="https://github.com/Automattic/wp-calypso/assets/82778/3f3546e2-c6de-4cf9-b30f-203fefb7bf86">

Before:
<img width="1060" alt="Screenshot 2023-12-01 at 17 04 39" src="https://github.com/Automattic/wp-calypso/assets/82778/c67817e1-47f3-47ef-81dd-20e723846a6e">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
