### PR TITLE
Checkout: add non-production hosts to pending page redirect allowed list

### DIFF
--- a/client/my-sites/checkout/src/lib/pending-page.ts
+++ b/client/my-sites/checkout/src/lib/pending-page.ts
@@ -243,7 +243,6 @@ function isRedirectAllowed( url: string, siteSlug: string | undefined ): boolean
 		'wordpress.com',
 		'wpcalypso.wordpress.com',
 		'horizon.wordpress.com',
-		'calypso.live',
 		'calypso.localhost',
 		'jetpack.cloud.localhost',
 		'cloud.jetpack.com',
@@ -270,6 +269,11 @@ function isRedirectAllowed( url: string, siteSlug: string | undefined ): boolean
 			) {
 				return false;
 			}
+			return true;
+		}
+
+		// Return true for *.calypso.live urls.
+		if ( /^([a-zA-Z0-9-]+\.)?calypso\.live$/.test( hostname ) ) {
 			return true;
 		}
 

--- a/client/my-sites/checkout/src/lib/pending-page.ts
+++ b/client/my-sites/checkout/src/lib/pending-page.ts
@@ -241,6 +241,9 @@ function isRedirectAllowed( url: string, siteSlug: string | undefined ): boolean
 
 	const allowedHostsForRedirect = [
 		'wordpress.com',
+		'wpcalypso.wordpress.com',
+		'horizon.wordpress.com',
+		'calypso.live',
 		'calypso.localhost',
 		'jetpack.cloud.localhost',
 		'cloud.jetpack.com',


### PR DESCRIPTION
In order to add better test coverage and tracking to post-Checkout redirects and thank-you pages, we now route all Checkouts run through the pending page. That page accepts and validates a `redirectTo` url parameter, but the allowed list was missing non-production WPcom hosts (horizon, wpcalypso, and calypso.live), causing the `redirectTo` query parameter to be ignored and instead showing the default Thank You page.

This PR adds those hosts to the allowed list.

Fixes: https://github.com/Automattic/wp-calypso/issues/84767

**To test:**
- use the calypso.live link in this PR
- on a free site, visit Appearance > Themes
- select "store" from the theme filters and click on a Woo theme (e.g. Tsubaki)
- select "upgrade to activate" from the theme page
- complete checkout
- verify that you're redirected to the setup flow for Woo themes