### PR TITLE
Jetpack Manage: Add an empty state when searching for products or plans

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
@@ -2,6 +2,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useCallback, useContext, useState, useMemo } from 'react';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import LicenseProductCard from 'calypso/jetpack-cloud/sections/partner-portal/license-product-card';
+import { JETPACK_CONTACT_SUPPORT } from 'calypso/lib/url/support';
 import { useSelector } from 'calypso/state';
 import { getDisabledProductSlugs } from 'calypso/state/partner-portal/products/selectors';
 import LicenseMultiProductCard from '../../license-multi-product-card';
@@ -206,7 +207,16 @@ export default function LicensesForm( {
 			</div>
 
 			{ isSearchResultEmpty && (
-				<h3>{ translate( 'No results found. Please try refining your search.' ) } </h3>
+				<p>
+					{ translate(
+						"Sorry, we couldn't find a product with that name. Please refine your search, or {{link}}contact our support team{{/link}} if you continue to experience an issue.",
+						{
+							components: {
+								link: <a target="_blank" href={ JETPACK_CONTACT_SUPPORT } rel="noreferrer" />,
+							},
+						}
+					) }
+				</p>
 			) }
 
 			{ plans.length > 0 && (

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
@@ -1,5 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useContext, useState } from 'react';
+import { useCallback, useContext, useState, useMemo } from 'react';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import LicenseProductCard from 'calypso/jetpack-cloud/sections/partner-portal/license-product-card';
 import { useSelector } from 'calypso/state';
@@ -174,6 +174,16 @@ export default function LicensesForm( {
 		);
 	};
 
+	const isSearchResultEmpty = useMemo( () => {
+		return (
+			productSearchQuery !== '' &&
+			plans.length === 0 &&
+			products.length === 0 &&
+			wooExtensions.length === 0 &&
+			backupAddons.length === 0
+		);
+	}, [ productSearchQuery, plans, products, wooExtensions, backupAddons ] );
+
 	if ( isLoadingProducts ) {
 		return (
 			<div className="licenses-form">
@@ -194,6 +204,10 @@ export default function LicensesForm( {
 					isSingleLicense={ isSingleLicenseView }
 				/>
 			</div>
+
+			{ isSearchResultEmpty && (
+				<h3>{ translate( 'No results found. Please try refining your search.' ) } </h3>
+			) }
 
 			{ plans.length > 0 && (
 				<LicensesFormSection

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
@@ -2,7 +2,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useCallback, useContext, useState, useMemo } from 'react';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import LicenseProductCard from 'calypso/jetpack-cloud/sections/partner-portal/license-product-card';
-import { JETPACK_CONTACT_SUPPORT } from 'calypso/lib/url/support';
+import { JETPACK_CONTACT_SUPPORT_NO_ASSISTANT } from 'calypso/lib/url/support';
 import { useSelector } from 'calypso/state';
 import { getDisabledProductSlugs } from 'calypso/state/partner-portal/products/selectors';
 import LicenseMultiProductCard from '../../license-multi-product-card';
@@ -212,7 +212,13 @@ export default function LicensesForm( {
 						"Sorry, we couldn't find a product with that name. Please refine your search, or {{link}}contact our support team{{/link}} if you continue to experience an issue.",
 						{
 							components: {
-								link: <a target="_blank" href={ JETPACK_CONTACT_SUPPORT } rel="noreferrer" />,
+								link: (
+									<a
+										target="_blank"
+										href={ JETPACK_CONTACT_SUPPORT_NO_ASSISTANT }
+										rel="noreferrer"
+									/>
+								),
 							},
 						}
 					) }

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
@@ -1,5 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useContext, useState, useMemo } from 'react';
+import { useCallback, useContext, useState } from 'react';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import LicenseProductCard from 'calypso/jetpack-cloud/sections/partner-portal/license-product-card';
 import { JETPACK_CONTACT_SUPPORT_NO_ASSISTANT } from 'calypso/lib/url/support';
@@ -175,16 +175,6 @@ export default function LicensesForm( {
 		);
 	};
 
-	const isSearchResultEmpty = useMemo( () => {
-		return (
-			productSearchQuery !== '' &&
-			plans.length === 0 &&
-			products.length === 0 &&
-			wooExtensions.length === 0 &&
-			backupAddons.length === 0
-		);
-	}, [ productSearchQuery, plans, products, wooExtensions, backupAddons ] );
-
 	if ( isLoadingProducts ) {
 		return (
 			<div className="licenses-form">
@@ -206,7 +196,7 @@ export default function LicensesForm( {
 				/>
 			</div>
 
-			{ isSearchResultEmpty && (
+			{ productSearchQuery !== '' && filteredProductsAndBundles.length === 0 && (
 				<p>
 					{ translate(
 						"Sorry, we couldn't find a product with that name. Please refine your search, or {{link}}contact our support team{{/link}} if you continue to experience an issue.",

--- a/client/lib/url/support.js
+++ b/client/lib/url/support.js
@@ -42,6 +42,8 @@ export const JETPACK_SUPPORT = 'https://jetpack.com/support/';
 export const JETPACK_SUPPORT_CONNECTION_ISSUES =
 	'https://jetpack.com/support/getting-started-with-jetpack/fixing-jetpack-connection-issues/';
 export const JETPACK_CONTACT_SUPPORT = 'https://jetpack.com/contact-support/?rel=support';
+export const JETPACK_CONTACT_SUPPORT_NO_ASSISTANT =
+	'https://jetpack.com/contact-support/?rel=support&assistant=false';
 export const JETPACK_PRICING_PAGE = 'https://jetpack.com/pricing/';
 export const JETPACK_SERVICE_VAULTPRESS = 'https://help.vaultpress.com/install-vaultpress/';
 export const JETPACK_SERVICE_AKISMET = 'https://akismet.com/support/';


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/127

## Proposed Changes

This PR implements an empty state for the cases when no products were found. It's a super basic one, and the copy is the same as on the dashboard. I'm happy to make some design adjustments if needed!

**Screenshot**

![Screenshot 2023-12-05 at 12 49 50](https://github.com/Automattic/wp-calypso/assets/1749918/63eef870-fec2-47b8-909d-be3da52c02e0)

## Testing Instructions

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

- Use the Jetpack cloud live link below and go to the Licenses page with enabled feature flag: `/partner-portal/issue-license?flags=jetpack/bundle-licensing`
- Search for product or plan that don't exist and verify that the empty state message is displayed correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?