### PR TITLE
Remove Button dependency

### DIFF
--- a/client/odie/button/index.tsx
+++ b/client/odie/button/index.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import { PropsWithChildren, MouseEvent, Ref } from 'react';
+import { PropsWithChildren, MouseEvent, forwardRef } from 'react';
 
 import './style.scss';
 
@@ -7,30 +7,24 @@ type ButtonProps = {
 	compact?: boolean;
 	borderless?: boolean;
 	onClick?: ( event: MouseEvent ) => void;
-	ref?: Ref< HTMLButtonElement >;
 	title?: string;
 	disabled?: boolean;
 	className?: string;
 } & PropsWithChildren;
 
-const Button = ( {
-	compact,
-	borderless,
-	onClick,
-	className: externalClassName,
-	children,
-	disabled,
-}: ButtonProps ) => {
-	const className = classNames( 'odie-button-default', externalClassName, {
-		'odie-button-compact': compact,
-		'odie-button-borderless': borderless,
-	} );
+const Button = forwardRef< HTMLButtonElement, ButtonProps >(
+	( { compact, borderless, onClick, className: externalClassName, children, disabled }, ref ) => {
+		const className = classNames( 'odie-button-default', externalClassName, {
+			'odie-button-compact': compact,
+			'odie-button-borderless': borderless,
+		} );
 
-	return (
-		<button className={ className } onClick={ onClick } disabled={ disabled }>
-			{ children }
-		</button>
-	);
-};
+		return (
+			<button ref={ ref } className={ className } onClick={ onClick } disabled={ disabled }>
+				{ children }
+			</button>
+		);
+	}
+);
 
 export default Button;

--- a/client/odie/button/index.tsx
+++ b/client/odie/button/index.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import { PropsWithChildren, MouseEvent, PropsWithRef } from 'react';
+import { PropsWithChildren, MouseEvent, Ref } from 'react';
 
 import './style.scss';
 
@@ -7,17 +7,27 @@ type ButtonProps = {
 	compact?: boolean;
 	borderless?: boolean;
 	onClick?: ( event: MouseEvent ) => void;
-} & PropsWithRef< HTMLButtonElement > &
-	PropsWithChildren;
+	ref?: Ref< HTMLButtonElement >;
+	title?: string;
+	disabled?: boolean;
+	className?: string;
+} & PropsWithChildren;
 
-const Button = ( { compact, borderless, onClick, children }: ButtonProps ) => {
-	const className = classNames( 'odie-button-default', {
+const Button = ( {
+	compact,
+	borderless,
+	onClick,
+	className: externalClassName,
+	children,
+	disabled,
+}: ButtonProps ) => {
+	const className = classNames( 'odie-button-default', externalClassName, {
 		'odie-button-compact': compact,
 		'odie-button-borderless': borderless,
 	} );
 
 	return (
-		<button className={ className } onClick={ onClick }>
+		<button className={ className } onClick={ onClick } disabled={ disabled }>
 			{ children }
 		</button>
 	);

--- a/client/odie/button/index.tsx
+++ b/client/odie/button/index.tsx
@@ -1,12 +1,14 @@
 import classNames from 'classnames';
-import { PropsWithChildren } from 'react';
-import './style.scss'; // Assuming you have a Button.scss file for styles
+import { PropsWithChildren, MouseEvent, PropsWithRef } from 'react';
+
+import './style.scss';
 
 type ButtonProps = {
 	compact?: boolean;
 	borderless?: boolean;
-	onClick?: () => void;
-} & PropsWithChildren;
+	onClick?: ( event: MouseEvent ) => void;
+} & PropsWithRef< HTMLButtonElement > &
+	PropsWithChildren;
 
 const Button = ( { compact, borderless, onClick, children }: ButtonProps ) => {
 	const className = classNames( 'odie-button-default', {

--- a/client/odie/button/index.tsx
+++ b/client/odie/button/index.tsx
@@ -1,0 +1,24 @@
+import classNames from 'classnames';
+import { PropsWithChildren } from 'react';
+import './style.scss'; // Assuming you have a Button.scss file for styles
+
+type ButtonProps = {
+	compact?: boolean;
+	borderless?: boolean;
+	onClick?: () => void;
+} & PropsWithChildren;
+
+const Button = ( { compact, borderless, onClick, children }: ButtonProps ) => {
+	const className = classNames( 'odie-button-default', {
+		'odie-button-compact': compact,
+		'odie-button-borderless': borderless,
+	} );
+
+	return (
+		<button className={ className } onClick={ onClick }>
+			{ children }
+		</button>
+	);
+};
+
+export default Button;

--- a/client/odie/button/style.scss
+++ b/client/odie/button/style.scss
@@ -1,0 +1,22 @@
+@import "@automattic/typography/styles/variables";
+
+.odie-button-default {
+	padding: 10px 20px;
+	border: 1px solid #000;
+	background-color: #fff;
+	color: #000;
+
+	&:hover {
+		cursor: pointer;
+	}
+}
+
+.odie-button-compact {
+	padding: 5px 10px;
+	font-size: $font-body-small;
+}
+
+.odie-button-borderless {
+	border: none;
+	padding: 10px;
+}

--- a/client/odie/ellipsis-menu/ellisis-menu.tsx
+++ b/client/odie/ellipsis-menu/ellisis-menu.tsx
@@ -1,0 +1,85 @@
+import { Gridicon } from '@automattic/components';
+import classnames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import { useRef, useState, MouseEvent, FunctionComponent, PropsWithChildren } from 'react';
+import PopoverMenu from 'calypso/components/popover-menu';
+import Button from '../button';
+import { noop } from '../context';
+
+import './style.scss';
+
+type EllipsisMenuProps = {
+	toggleTitle?: string;
+	position?: string;
+	disabled?: boolean;
+	onClick?: ( event: MouseEvent ) => void;
+	onToggle?: ( isMenuVisible: boolean ) => void;
+	popoverClassName?: string;
+	icon?: React.ReactElement;
+	className?: string;
+} & PropsWithChildren;
+
+const EllipsisMenu: FunctionComponent< EllipsisMenuProps > = ( {
+	toggleTitle,
+	position,
+	children,
+	disabled = false,
+	onClick = noop,
+	onToggle = noop,
+	popoverClassName,
+	icon,
+	className,
+} ) => {
+	const [ isMenuVisible, setMenuVisible ] = useState( false );
+	const popoverContext = useRef< HTMLButtonElement >( null );
+	const translate = useTranslate();
+
+	const handleClick = ( event: MouseEvent ) => {
+		onClick( event );
+		setMenuVisible( ! isMenuVisible );
+		if ( ! isMenuVisible ) {
+			onToggle( true );
+		} else {
+			onToggle( false );
+		}
+	};
+
+	const hideMenu = () => {
+		setMenuVisible( false );
+		onToggle( false );
+	};
+
+	const classes = classnames( 'ellipsis-menu', className, {
+		'is-menu-visible': isMenuVisible,
+		'is-disabled': disabled,
+	} );
+	const popoverClasses = classnames( 'ellipsis-menu__menu', 'popover', popoverClassName );
+
+	return (
+		<span className={ classes }>
+			<Button
+				ref={ popoverContext }
+				onClick={ handleClick }
+				title={ toggleTitle || translate( 'Toggle menu' ) }
+				borderless
+				disabled={ disabled }
+				className="ellipsis-menu__toggle"
+			>
+				{ icon || <Gridicon icon="ellipsis" className="ellipsis-menu__toggle-icon" /> }
+			</Button>
+			{ isMenuVisible && (
+				<PopoverMenu
+					isVisible
+					onClose={ hideMenu }
+					position={ position }
+					context={ popoverContext.current }
+					className={ popoverClasses }
+				>
+					{ children }
+				</PopoverMenu>
+			) }
+		</span>
+	);
+};
+
+export default EllipsisMenu;

--- a/client/odie/ellipsis-menu/index.tsx
+++ b/client/odie/ellipsis-menu/index.tsx
@@ -1,3 +1,4 @@
+import { Gridicon } from '@automattic/components';
 import classnames from 'classnames';
 import { useRef, useState, FunctionComponent, PropsWithChildren } from 'react';
 import PopoverMenu from 'calypso/components/popover-menu';
@@ -26,10 +27,10 @@ const EllipsisMenu: FunctionComponent< EllipsisMenuProps > = ( {
 		setMenuVisible( false );
 	};
 
-	const classes = classnames( 'ellipsis-menu', popoverClassName, {
+	const classes = classnames( 'ellipsis-menu', {
 		'is-menu-visible': isMenuVisible,
 	} );
-	const popoverClasses = classnames( 'ellipsis-menu__menu', 'popover' );
+	const popoverClasses = classnames( 'ellipsis-menu__menu', 'popover', popoverClassName );
 
 	return (
 		<span className={ classes }>
@@ -38,7 +39,9 @@ const EllipsisMenu: FunctionComponent< EllipsisMenuProps > = ( {
 				onClick={ handleClick }
 				borderless
 				className="ellipsis-menu__toggle"
-			/>
+			>
+				<Gridicon icon="ellipsis" className="ellipsis-menu__toggle-icon" />
+			</Button>
 			{ isMenuVisible && (
 				<PopoverMenu
 					isVisible

--- a/client/odie/ellipsis-menu/index.tsx
+++ b/client/odie/ellipsis-menu/index.tsx
@@ -1,72 +1,44 @@
-import { Gridicon } from '@automattic/components';
 import classnames from 'classnames';
-import { useTranslate } from 'i18n-calypso';
-import { useRef, useState, MouseEvent, FunctionComponent, PropsWithChildren } from 'react';
+import { useRef, useState, FunctionComponent, PropsWithChildren } from 'react';
 import PopoverMenu from 'calypso/components/popover-menu';
 import Button from '../button';
-import { noop } from '../context';
 
 import './style.scss';
 
 type EllipsisMenuProps = {
-	toggleTitle?: string;
 	position?: string;
-	disabled?: boolean;
-	onClick?: ( event: MouseEvent ) => void;
-	onToggle?: ( isMenuVisible: boolean ) => void;
 	popoverClassName?: string;
-	icon?: React.ReactElement;
-	className?: string;
 } & PropsWithChildren;
 
 const EllipsisMenu: FunctionComponent< EllipsisMenuProps > = ( {
-	toggleTitle,
 	position,
 	children,
-	disabled = false,
-	onClick = noop,
-	onToggle = noop,
 	popoverClassName,
-	icon,
-	className,
 } ) => {
 	const [ isMenuVisible, setMenuVisible ] = useState( false );
 	const popoverContext = useRef< HTMLButtonElement >( null );
-	const translate = useTranslate();
 
-	const handleClick = ( event: MouseEvent ) => {
-		onClick( event );
+	const handleClick = () => {
 		setMenuVisible( ! isMenuVisible );
-		if ( ! isMenuVisible ) {
-			onToggle( true );
-		} else {
-			onToggle( false );
-		}
 	};
 
 	const hideMenu = () => {
 		setMenuVisible( false );
-		onToggle( false );
 	};
 
-	const classes = classnames( 'ellipsis-menu', className, {
+	const classes = classnames( 'ellipsis-menu', popoverClassName, {
 		'is-menu-visible': isMenuVisible,
-		'is-disabled': disabled,
 	} );
-	const popoverClasses = classnames( 'ellipsis-menu__menu', 'popover', popoverClassName );
+	const popoverClasses = classnames( 'ellipsis-menu__menu', 'popover' );
 
 	return (
 		<span className={ classes }>
 			<Button
 				ref={ popoverContext }
 				onClick={ handleClick }
-				title={ toggleTitle || translate( 'Toggle menu' ) }
 				borderless
-				disabled={ disabled }
 				className="ellipsis-menu__toggle"
-			>
-				{ icon || <Gridicon icon="ellipsis" className="ellipsis-menu__toggle-icon" /> }
-			</Button>
+			/>
 			{ isMenuVisible && (
 				<PopoverMenu
 					isVisible

--- a/client/odie/ellipsis-menu/style.scss
+++ b/client/odie/ellipsis-menu/style.scss
@@ -1,0 +1,7 @@
+.gridicon.ellipsis-menu__toggle-icon {
+	transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+}
+
+.ellipsis-menu.is-menu-visible .gridicon.ellipsis-menu__toggle-icon {
+	transform: rotate(90deg);
+}

--- a/client/odie/message/index.tsx
+++ b/client/odie/message/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
-import { Button, FoldableCard } from '@automattic/components';
+import { FoldableCard } from '@automattic/components';
 import { useTyper } from '@automattic/help-center/src/hooks';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -14,6 +14,7 @@ import WapuuThinking from 'calypso/assets/images/odie/wapuu-thinking.svg';
 import AsyncLoad from 'calypso/components/async-load';
 import Gravatar from 'calypso/components/gravatar';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import Button from '../button';
 import { useOdieAssistantContext } from '../context';
 import CustomALink from './custom-a-link';
 import { uriTransformer } from './uri-transformer';

--- a/packages/help-center/src/components/help-center-odie.tsx
+++ b/packages/help-center/src/components/help-center-odie.tsx
@@ -4,10 +4,10 @@
  */
 import { Gridicon } from '@automattic/components';
 import { useI18n } from '@wordpress/react-i18n';
-import EllipsisMenu from 'calypso/components/ellipsis-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import OdieAssistant from 'calypso/odie';
 import { useOdieAssistantContext } from 'calypso/odie/context';
+import EllipsisMenu from 'calypso/odie/ellipsis-menu';
 /**
  * Internal Dependencies
  */

--- a/packages/help-center/src/components/index.d.ts
+++ b/packages/help-center/src/components/index.d.ts
@@ -129,6 +129,16 @@ declare module 'calypso/components/popover-menu/item' {
 	export default PopoverMenuItem;
 }
 
+declare module 'calypso/components/popover-menu' {
+	const PopoverMenuItem: FC< {
+		popoverClassName?: string;
+		position?: string;
+		children: React.ReactNode;
+	} >;
+
+	export default PopoverMenuItem;
+}
+
 declare module 'calypso/components/gravatar' {
 	const Gravatar: FC< {
 		user?: { display_name: string };

--- a/packages/help-center/src/components/index.d.ts
+++ b/packages/help-center/src/components/index.d.ts
@@ -130,13 +130,13 @@ declare module 'calypso/components/popover-menu/item' {
 }
 
 declare module 'calypso/components/popover-menu' {
-	const PopoverMenuItem: FC< {
+	const EllipsisMenu: FC< {
 		popoverClassName?: string;
 		position?: string;
 		children: React.ReactNode;
 	} >;
 
-	export default PopoverMenuItem;
+	export default EllipsisMenu;
 }
 
 declare module 'calypso/components/gravatar' {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Remove Button dependency from Automattic that bleeds CSS over other components due to the pretty basic class naming for that component (Button) 

## Testing Instructions

Access Help Center within Calypso (previously you need to append ?flags=wapuu into the URL.
Click Still need help, and ask for help for a domain and assert that you can see the button (that button was previously Automattic/Button)

![image](https://github.com/Automattic/wp-calypso/assets/5689927/2e846274-d7ab-4832-bbaa-5e50998758e5)

Optionally you can assert that in the classic view, the counter for messages is displayed correctly (eg: not looking like this):
![image](https://github.com/Automattic/wp-calypso/assets/5689927/e7039e4b-ddc0-4129-bc4f-87ff32385b11)

But requires a bit more further set up


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
