### PR TITLE
Launchpad: redirect when clicking on 'Set up your site'

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -94,6 +94,7 @@ button {
 .use-my-domain,
 .domain-transfer,
 .update-design,
+.update-options,
 .hundred-year-plan,
 .link-in-bio-tld {
 	padding: 60px 0 0;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -315,6 +315,20 @@ export function getEnhancedTasks(
 						},
 					};
 					break;
+				case 'setup_general':
+					taskData = {
+						disabled: false,
+						actionDispatch: () => {
+							recordTaskClickTracksEvent( flow, task.completed, task.id );
+							window.location.assign(
+								addQueryArgs( `/setup/update-options/options`, {
+									siteSlug,
+									flowToReturnTo: flow,
+								} )
+							);
+						},
+					};
+					break;
 				case 'setup_link_in_bio':
 					taskData = {
 						actionDispatch: () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/site-options.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/site-options.tsx
@@ -2,7 +2,6 @@ import { Button } from '@automattic/components';
 import { StepContainer } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { Icon } from '@wordpress/icons';
-import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import React, { useEffect } from 'react';
 import siteOptionsUrl from 'calypso/assets/images/onboarding/site-options.svg';
@@ -56,9 +55,6 @@ export const SiteOptions = ( { navigation }: Pick< StepProps, 'navigation' > ) =
 		setSiteTitle( site.name || '' );
 		setTagline( site.description );
 	}, [ site, formTouched ] );
-
-	const shouldHideActionButtons =
-		getQueryArg( window.location.search, 'flowToReturnTo' ) !== undefined;
 
 	const handleSubmit = async ( event: React.FormEvent ) => {
 		event.preventDefault();
@@ -159,7 +155,6 @@ export const SiteOptions = ( { navigation }: Pick< StepProps, 'navigation' > ) =
 				className={ `is-step-${ intent }` }
 				headerImageUrl={ headerImage }
 				hideSkip={ true }
-				hideBack={ shouldHideActionButtons }
 				goBack={ goBack }
 				goNext={ goNext }
 				isHorizontalLayout

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/site-options.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/site-options.tsx
@@ -2,6 +2,7 @@ import { Button } from '@automattic/components';
 import { StepContainer } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { Icon } from '@wordpress/icons';
+import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import React, { useEffect } from 'react';
 import siteOptionsUrl from 'calypso/assets/images/onboarding/site-options.svg';
@@ -55,6 +56,9 @@ export const SiteOptions = ( { navigation }: Pick< StepProps, 'navigation' > ) =
 		setSiteTitle( site.name || '' );
 		setTagline( site.description );
 	}, [ site, formTouched ] );
+
+	const shouldHideActionButtons =
+		getQueryArg( window.location.search, 'flowToReturnTo' ) !== undefined;
 
 	const handleSubmit = async ( event: React.FormEvent ) => {
 		event.preventDefault();
@@ -155,6 +159,7 @@ export const SiteOptions = ( { navigation }: Pick< StepProps, 'navigation' > ) =
 				className={ `is-step-${ intent }` }
 				headerImageUrl={ headerImage }
 				hideSkip={ true }
+				hideBack={ shouldHideActionButtons }
 				goBack={ goBack }
 				goNext={ goNext }
 				isHorizontalLayout

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -78,6 +78,9 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 	'update-design': () =>
 		import( /* webpackChunkName: "update-design-flow" */ '../declarative-flow/update-design' ),
 
+	'update-options': () =>
+		import( /* webpackChunkName: "update-options-flow" */ '../declarative-flow/update-options' ),
+
 	'domain-upsell': () =>
 		import( /* webpackChunkName: "update-design-flow" */ '../declarative-flow/domain-upsell' ),
 

--- a/client/landing/stepper/declarative-flow/update-options.ts
+++ b/client/landing/stepper/declarative-flow/update-options.ts
@@ -34,7 +34,16 @@ const updateOptions: Flow = {
 			}
 		}
 
-		return { submit };
+		const goBack = async () => {
+			switch ( currentStep ) {
+				case 'options':
+					return window.location.assign(
+						`/setup/${ flowToReturnTo }/launchpad?siteSlug=${ siteSlug }`
+					);
+			}
+		};
+
+		return { goBack, submit };
 	},
 };
 

--- a/client/landing/stepper/declarative-flow/update-options.ts
+++ b/client/landing/stepper/declarative-flow/update-options.ts
@@ -16,18 +16,6 @@ const updateOptions: Flow = {
 		const flowName = this.name;
 		const siteSlug = useSiteSlug();
 		const flowToReturnTo = useQuery().get( 'flowToReturnTo' ) || 'free';
-		// const { setPendingAction } = useDispatch( ONBOARD_STORE );
-		// const { data: { launchpad_screen: launchpadScreenOption } = {} } = useLaunchpad( siteSlug );
-
-		// const exitFlow = ( to: string ) => {
-		// 	setPendingAction( () => {
-		// 		return new Promise( () => {
-		// 			window.location.assign( to );
-		// 		} );
-		// 	} );
-
-		// 	return navigate( 'processing' );
-		// };
 
 		function submit( providedDependencies: ProvidedDependencies = {}, ...results: string[] ) {
 			recordSubmitStep( providedDependencies, 'update-options', flowName, currentStep );
@@ -45,13 +33,6 @@ const updateOptions: Flow = {
 				}
 			}
 		}
-
-		// const goBack = () => {
-		// 	switch ( currentStep ) {
-		// 		case 'patternAssembler':
-		// 			return navigate( 'designSetup' );
-		// 	}
-		// };
 
 		return { submit };
 	},

--- a/client/landing/stepper/declarative-flow/update-options.ts
+++ b/client/landing/stepper/declarative-flow/update-options.ts
@@ -1,0 +1,64 @@
+import { translate } from 'i18n-calypso';
+import { useQuery } from '../hooks/use-query';
+import { useSiteSlug } from '../hooks/use-site-slug';
+import { recordSubmitStep } from './internals/analytics/record-submit-step';
+import { STEPS } from './internals/steps';
+import { ProcessingResult } from './internals/steps-repository/processing-step/constants';
+import { ProvidedDependencies } from './internals/types';
+import type { Flow } from './internals/types';
+
+const updateOptions: Flow = {
+	name: 'update-options',
+	get title() {
+		return translate( 'Choose Design' );
+	},
+	useSteps() {
+		return [ STEPS.OPTIONS, STEPS.PROCESSING, STEPS.ERROR ];
+	},
+
+	useStepNavigation( currentStep, navigate ) {
+		const flowName = this.name;
+		const siteSlug = useSiteSlug();
+		const flowToReturnTo = useQuery().get( 'flowToReturnTo' ) || 'free';
+		// const { setPendingAction } = useDispatch( ONBOARD_STORE );
+		// const { data: { launchpad_screen: launchpadScreenOption } = {} } = useLaunchpad( siteSlug );
+
+		// const exitFlow = ( to: string ) => {
+		// 	setPendingAction( () => {
+		// 		return new Promise( () => {
+		// 			window.location.assign( to );
+		// 		} );
+		// 	} );
+
+		// 	return navigate( 'processing' );
+		// };
+
+		function submit( providedDependencies: ProvidedDependencies = {}, ...results: string[] ) {
+			recordSubmitStep( providedDependencies, 'update-options', flowName, currentStep );
+			switch ( currentStep ) {
+				case 'processing':
+					if ( results.some( ( result ) => result === ProcessingResult.FAILURE ) ) {
+						return navigate( 'error' );
+					}
+
+					return window.location.assign(
+						`/setup/${ flowToReturnTo }/launchpad?siteSlug=${ siteSlug }`
+					);
+				case 'options': {
+					return navigate( `processing?siteSlug=${ siteSlug }&flowToReturnTo=${ flowToReturnTo }` );
+				}
+			}
+		}
+
+		// const goBack = () => {
+		// 	switch ( currentStep ) {
+		// 		case 'patternAssembler':
+		// 			return navigate( 'designSetup' );
+		// 	}
+		// };
+
+		return { submit };
+	},
+};
+
+export default updateOptions;

--- a/client/landing/stepper/declarative-flow/update-options.ts
+++ b/client/landing/stepper/declarative-flow/update-options.ts
@@ -1,4 +1,3 @@
-import { translate } from 'i18n-calypso';
 import { useQuery } from '../hooks/use-query';
 import { useSiteSlug } from '../hooks/use-site-slug';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
@@ -9,9 +8,6 @@ import type { Flow } from './internals/types';
 
 const updateOptions: Flow = {
 	name: 'update-options',
-	get title() {
-		return translate( 'Choose Design' );
-	},
 	useSteps() {
 		return [ STEPS.OPTIONS, STEPS.PROCESSING, STEPS.ERROR ];
 	},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/84058

## Proposed Changes

I've added a new flow with only the options step. This way we can redirect to it from the Launchpad, that's the way it's being done currently for the design step.

Some backend changes need to be done so the task is not marked as complete, but this should be mergeable as-is.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this diff
* Go to calypso.localhost:3000/start and create a new free site
* Select `other` as intent
* On the launchpad click on the `Set up your site` task and verify you get redirected to the options step
* Update the title & subtitle
* Click `Continue` and verify you get redirected to the launchpad

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?