### PR TITLE
Jetpack Mange: Add a layout for overview page with a right sidebar

### DIFF
--- a/client/jetpack-cloud/components/content-sidebar/index.tsx
+++ b/client/jetpack-cloud/components/content-sidebar/index.tsx
@@ -1,0 +1,18 @@
+import './style.scss';
+import React from 'react';
+
+type Props = {
+	mainContent: React.ReactNode;
+	rightSidebar: React.ReactNode;
+};
+
+const ContentSidebar = ( { mainContent, rightSidebar }: Props ) => {
+	return (
+		<div className="jetpack-cloud-content-sidebar">
+			<div className="main-content">{ mainContent }</div>
+			<aside className="right-sidebar">{ rightSidebar }</aside>
+		</div>
+	);
+};
+
+export default ContentSidebar;

--- a/client/jetpack-cloud/components/content-sidebar/style.scss
+++ b/client/jetpack-cloud/components/content-sidebar/style.scss
@@ -1,0 +1,31 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.jetpack-cloud-content-sidebar {
+
+	margin: 40px auto auto;
+
+	display: flex;
+	flex-direction: column;
+
+	// todo: remove this testing/design purposes
+	border: 1px dashed var(--color-accent-40);
+
+	@include break-xlarge {
+		display: grid;
+		grid-template-columns: 3fr 1fr;
+		column-gap: 32px;
+		min-height: calc(100vh - 123px);
+		max-width: 1500px;
+	}
+
+	.right-sidebar {
+
+		// todo: remove this testing/design purposes
+		border: 1px dashed var(--color-accent-40);
+
+		> *:not(:first-child) {
+			margin-top: 40px;
+		}
+	}
+}

--- a/client/jetpack-cloud/sections/overview/controller.tsx
+++ b/client/jetpack-cloud/sections/overview/controller.tsx
@@ -1,5 +1,7 @@
 import { type Callback, type Context } from '@automattic/calypso-router';
+import ContentSidebar from 'calypso/jetpack-cloud/components/content-sidebar';
 import Overview from 'calypso/jetpack-cloud/sections/overview/primary/overview';
+import OverviewSidebar from 'calypso/jetpack-cloud/sections/overview/sidebar';
 import JetpackManageSidebar from 'calypso/jetpack-cloud/sections/sidebar-navigation/jetpack-manage';
 
 const setSidebar = ( context: Context ): void => {
@@ -8,6 +10,8 @@ const setSidebar = ( context: Context ): void => {
 
 export const overviewContext: Callback = ( context, next ) => {
 	setSidebar( context );
-	context.primary = <Overview />;
+	context.primary = (
+		<ContentSidebar mainContent={ <Overview /> } rightSidebar={ <OverviewSidebar /> } />
+	);
 	next();
 };

--- a/client/jetpack-cloud/sections/overview/primary/overview/index.tsx
+++ b/client/jetpack-cloud/sections/overview/primary/overview/index.tsx
@@ -1,6 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
+import './style.scss';
 
 export default function Overview() {
 	const translate = useTranslate();
@@ -8,6 +9,35 @@ export default function Overview() {
 	return (
 		<Main className="manage-overview">
 			<DocumentHead title={ translate( 'Overview' ) } />
+			<div className="welcome-section">
+				<h1>Welcome to Jetpack Manage 👋</h1>
+				<p>
+					Jetpack Manage helps you to monitor security and performance across all of your sites in a
+					single place.
+				</p>
+				<ul className="benefits-list">
+					<li>Insights: traffic and real-time uptime stats.</li>
+					<li>Plugin Updates: bulk update plugins in one click.</li>
+					<li>Backups & Scans: safeguard your sites and data.</li>
+					<li>Boost: manage performance across all of your sites.</li>
+				</ul>
+				<button className="next-button">Next</button>
+			</div>
+
+			<section className="next-steps">
+				<h2>Next steps</h2>
+				<ol className="steps-list">
+					<li>Get familiar with the sites management dashboard</li>
+					<li>Learn how to add new sites</li>
+					<li>Learn bulk editing and enabling downtime monitoring</li>
+					<li>Explore plugin management</li>
+				</ol>
+			</section>
+
+			<section className="jetpack-products">
+				<h2>Jetpack products</h2>
+				<p>Purchase single products or save big when you buy in bulk.</p>
+			</section>
 		</Main>
 	);
 }

--- a/client/jetpack-cloud/sections/overview/primary/overview/style.scss
+++ b/client/jetpack-cloud/sections/overview/primary/overview/style.scss
@@ -1,0 +1,65 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.jetpack-cloud-content-sidebar {
+	.manage-overview {
+		max-width: 100%;
+		h1 {
+			font-family: "SF Pro Display", serif;
+			font-size: rem(36px);
+			font-weight: 700;
+			line-height: 48px;
+		}
+		h2 {
+			font-family: "SF Pro Text", serif;
+			font-size: rem(16px);
+			font-weight: 500;
+			line-height: 24px;
+			color: var(--studio-gray-100);
+		}
+		.welcome-section {
+			padding: 32px;
+			background-color: var(--studio-white);
+
+			p {
+				color: #333;
+				margin-bottom: 16px;
+			}
+			.benefits-list {
+				list-style: none;
+				padding: 0;
+				margin-bottom: 24px;
+				li {
+					margin-bottom: 8px;
+				}
+			}
+			.next-button {
+				padding: 8px 16px;
+				background-color: var(--studio-jetpack-green-50);
+				color: var(--studio-white);
+				border: none;
+				cursor: pointer;
+			}
+		}
+
+		.next-steps {
+			margin-top: 16px;
+			padding: 16px 32px 16px 32px;
+			background-color: var(--studio-white);
+
+			.steps-list {
+				list-style: none;
+				padding: 0;
+				li {
+					margin-bottom: 16px;
+				}
+			}
+		}
+
+		.jetpack-products {
+			background-color: var(--studio-white);
+			margin-top: 32px;
+			padding: 24px;
+		}
+	}
+}

--- a/client/jetpack-cloud/sections/overview/sidebar/index.tsx
+++ b/client/jetpack-cloud/sections/overview/sidebar/index.tsx
@@ -1,0 +1,58 @@
+import './style.scss';
+
+export default function OverviewSidebar() {
+	return (
+		<>
+			<section className="intro-video">
+				<div className="video-placeholder"></div>
+				<p>Intro video</p>
+				Watch a short intro video
+			</section>
+			<section className="quick-links">
+				<h3>Quick links</h3>
+				<ul>
+					<li>
+						<div className="icon-placeholder"></div>
+						Manage all sites{ ' ' }
+					</li>
+					<li>
+						<div className="icon-placeholder"></div>
+						Add sites to Jetpack Manage{ ' ' }
+					</li>
+					<li>
+						<div className="icon-placeholder"></div>
+						Manage plugins{ ' ' }
+					</li>
+					<li>
+						<div className="icon-placeholder"></div>
+						View all licenses{ ' ' }
+					</li>
+					<li>
+						<div className="icon-placeholder"></div>
+						View billing{ ' ' }
+					</li>
+					<li>
+						<div className="icon-placeholder"></div>
+						View invoices{ ' ' }
+					</li>
+					<li>
+						<div className="icon-placeholder"></div>
+						View prices{ ' ' }
+					</li>
+				</ul>
+			</section>
+			<section className="get-help">
+				<h3>Get help</h3>
+				<ul>
+					<li> Get started guide </li>
+					<li> All sites management </li>
+					<li> Issuing, assigning, and revoking licenses </li>
+					<li> Billing/payment FAQs </li>
+					<li> Managing plugins </li>
+				</ul>
+				<div className="button-placeholder">Contact support</div>
+				Provide product feedback
+			</section>
+		</>
+	);
+}

--- a/client/jetpack-cloud/sections/overview/sidebar/style.scss
+++ b/client/jetpack-cloud/sections/overview/sidebar/style.scss
@@ -1,0 +1,62 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.jetpack-cloud-content-sidebar {
+	.right-sidebar {
+		background: #f9f9f9;
+		padding: 16px;
+
+		.intro-video,
+		.quick-links,
+		.get-help {
+			margin-bottom: 48px;
+		}
+
+		h2,
+		h3 {
+			margin: 0 0 16px;
+		}
+
+		.video-placeholder {
+			background: var(--color-accent-20);
+			height: 150px;
+			margin-bottom: 16px;
+		}
+
+		.icon-placeholder {
+			display: inline-block;
+			background: var(--color-accent-10);
+			width: 20px;
+			height: 20px;
+			margin-right: 8px;
+		}
+
+		.button-placeholder {
+			display: block;
+			background: var(--studio-jetpack-green-10);
+			padding: 8px 16px;
+			text-align: center;
+			margin: 24px 0;
+		}
+
+		ul {
+			list-style: none;
+			padding: 0;
+			margin: 0;
+			li {
+				margin-bottom: 40px;
+
+				&:last-child {
+					margin-bottom: 0;
+				}
+			}
+		}
+
+		.watch-video,
+		.feedback {
+			text-decoration: none;
+			display: block;
+			margin-top: 24px;
+		}
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack-manage/issues/133

## Proposed Changes

This PR adds a layout with a right sidebar for being used by the new Overview section.

This PR includes some mock content that should be replaced by the following PRs. The layout will need some style tweaks, but the next tasks need this place for their work, so we could merge this and later tweak styles if it is necessary. 

The dash border was added for testing/design purposes, in the next PRs we have to remove it.

The Overview section is only available for development and staging sites.

Desktop:
![image](https://github.com/Automattic/wp-calypso/assets/9832440/ea37da4b-9afa-4a2e-9188-b96df2242ace)

Mobile:
![image](https://github.com/Automattic/wp-calypso/assets/9832440/4491e409-90e0-445a-8e9b-c7482fa65a52)

## Testing Instructions

- Check the code
- Go to the Overview section and you should see the main content and the sidebar at the right.
- For small screens, the sidebar will wrap at the bottom of the main content.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
