### PR TITLE
Launchpad: remove remnants of old recordSignupComplete logic

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -85,12 +85,6 @@ const Launchpad: Step = ( { navigation, flow }: LaunchpadProps ) => {
 		}
 	}, [ verifiedParam, translate, dispatch ] );
 
-	useEffect( () => {
-		if ( siteSlug && site && localStorage.getItem( 'launchpad_siteSlug' ) !== siteSlug ) {
-			localStorage.setItem( 'launchpad_siteSlug', siteSlug );
-		}
-	}, [ siteSlug, site ] );
-
 	if ( launchpadScreenOption === 'skipped' ) {
 		window.location.assign( `/home/${ siteSlug }` );
 		return;

--- a/packages/launchpad/src/checklist-item/index.tsx
+++ b/packages/launchpad/src/checklist-item/index.tsx
@@ -13,11 +13,6 @@ const ChecklistItem = ( { task, isPrimaryAction }: { task: Task; isPrimaryAction
 	// Display chevron if task is incomplete. Don't display chevron and badge at the same time.
 	const shouldDisplayChevron = ! completed && ! disabled && ! task.badge_text;
 
-	const handlePrimaryAction = () => {
-		localStorage.removeItem( 'launchpad_siteSlug' );
-		actionDispatch && actionDispatch();
-	};
-
 	// Display task counter if task is incomplete and has the count properties;
 	const shouldDisplayTaskCounter =
 		task.target_repetitions &&
@@ -49,7 +44,7 @@ const ChecklistItem = ( { task, isPrimaryAction }: { task: Task; isPrimaryAction
 				<Button
 					className="checklist-item__checklist-primary-button"
 					data-task={ id }
-					onClick={ handlePrimaryAction }
+					onClick={ actionDispatch }
 					{ ...buttonProps }
 				>
 					{ title }


### PR DESCRIPTION
Fixes an error reported in Sentry where a call to `localStorage.getItem` was throwing and exception, because `window.localStorage` is `null`. Probably some very incognito mode in Chrome, or a privacy extension is causing that.

The fix is to remove the entire `launchpad_siteSlug` logic because it was added in #72309 to wrap the `recordSignupComplete` logic. But the `recordSignupComplete` was then moved in #78333 to a completely different place. Leaving behind code that no longer has any purpose.
