### PR TITLE
Hosting Command Palette: Fix hook name

### DIFF
--- a/client/components/command-palette/README.md
+++ b/client/components/command-palette/README.md
@@ -14,7 +14,7 @@ This differences were highlighted in <https://github.com/WordPress/gutenberg/iss
 
 ## Add a command
 
-In order to add a new command to the palette, you can include the command object in `useCommandsArrayWpcom` or create a new hook and include it to `useCommandPallette` hooks.
+In order to add a new command to the palette, you can include the command object in `useCommandsArrayWpcom` or create a new hook and include it to `useCommandPalette` hooks.
 
 ### Command properties
 
@@ -48,7 +48,7 @@ Please consider carefully before adding a new command to the palette. We aim to 
 Embed the command example. This is already done for all WPcom calypso pages using `client/layout/index.jsx`.
 
 ```tsx
-import { WpcomCommandPalette } from 'calypso/components/command-pallette/wpcom-command-pallette';
+import { WpcomCommandPalette } from 'calypso/components/command-palette/wpcom-command-palette';
 
 export default function MyComponent() {
 	return <WpcomCommandPalette />;

--- a/client/components/command-palette/index.tsx
+++ b/client/components/command-palette/index.tsx
@@ -8,7 +8,7 @@ import { Command, useCommandState } from 'cmdk';
 import { useEffect, useState, useRef, useMemo } from 'react';
 import { useSelector } from 'calypso/state';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
-import { CommandCallBackParams, useCommandPallette } from './use-command-palette';
+import { CommandCallBackParams, useCommandPalette } from './use-command-palette';
 
 import '@wordpress/commands/build-style/style.css';
 
@@ -72,7 +72,7 @@ export function CommandMenuGroup( {
 	setSelectedCommandName,
 }: CommandMenuGroupProps ) {
 	const currentPath = useSelector( ( state ) => getCurrentRoute( state ) );
-	const { commands } = useCommandPallette( {
+	const { commands } = useCommandPalette( {
 		selectedCommandName,
 		setSelectedCommandName,
 		filter: isContextual ? ( command ) => command.context?.includes( currentPath ) : undefined,

--- a/client/components/command-palette/use-command-palette.tsx
+++ b/client/components/command-palette/use-command-palette.tsx
@@ -43,7 +43,7 @@ interface Command {
 	image?: JSX.Element;
 	siteFunctions?: SiteFunctions;
 }
-interface useCommandPalletteOptions {
+interface useCommandPaletteOptions {
 	selectedCommandName: string;
 	setSelectedCommandName: ( name: string ) => void;
 	filter?: ( command: Command ) => boolean | undefined;
@@ -70,11 +70,11 @@ const siteToAction =
 		};
 	};
 
-export const useCommandPallette = ( {
+export const useCommandPalette = ( {
 	selectedCommandName,
 	setSelectedCommandName,
 	filter,
-}: useCommandPalletteOptions ): { commands: Command[] } => {
+}: useCommandPaletteOptions ): { commands: Command[] } => {
 	const { data: allSites = [] } = useSiteExcerptsQuery(
 		[],
 		( site ) => ! site.options?.is_domain_only


### PR DESCRIPTION
## Proposed Changes

Renames `useCommandPallette` to `useCommandPalette`.

## Testing Instructions

Command palette should continue to work as expected