### PR TITLE
Bold free blog subdomains as if they were tlds

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -82,12 +82,45 @@ import { getExternalBackUrl, shouldUseMultipleDomainsInCart } from './utils';
 
 import './style.scss';
 
+const wpcomSubdomains = [
+	'wordpress.com',
+	'art.blog',
+	'business.blog',
+	'car.blog',
+	'code.blog',
+	'data.blog',
+	'design.blog',
+	'family.blog',
+	'fashion.blog',
+	'finance.blog',
+	'fitness.blog',
+	'food.blog',
+	'game.blog',
+	'health.blog',
+	'home.blog',
+	'law.blog',
+	'movie.blog',
+	'music.blog',
+	'news.blog',
+	'photo.blog',
+	'poetry.blog',
+	'politics.blog',
+	'school.blog',
+	'science.blog',
+	'sport.blog',
+	'tech.blog',
+	'travel.blog',
+	'video.blog',
+	'water.blog',
+];
+
 const BoldTLD = ( { domain } ) => {
 	const split = domain.split( '.' );
 	let tld = split.pop();
 	const wp = split.pop();
-	if ( wp === 'wordpress' && tld === 'com' ) {
-		tld = `wordpress.com`;
+
+	if ( wpcomSubdomains.includes( `${ wp }.${ tld }` ) ) {
+		tld = `${ wp }.${ tld }`;
 	}
 
 	return (

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -82,6 +82,7 @@ import { getExternalBackUrl, shouldUseMultipleDomainsInCart } from './utils';
 
 import './style.scss';
 
+// Referenced from WordAds_Ads_Txt
 const wpcomSubdomains = [
 	'wordpress.com',
 	'art.blog',


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/84732/files?w=1#r1412136707

## Proposed Changes

* Includes a list of blog subdomains to bold in the multi domain cart along side tld's and wpcom subdomains

## Testing Instructions

- http://calypso.localhost:3000/start/
- Search for one of the free subdomains, e.g. testdomain.news.blog
- Once you add the domain, the news.blog portion of the domain name should be bolded in the mini cart on the right
- other tlds and wordpress.com subdomains should also remain bolded

Before

![Screenshot 2023-12-04 at 09-19-06 Create a site — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/9a7ab2eb-5f4b-4fd0-8c37-e383bd6d136b)

After

![Screenshot 2023-12-04 at 09-21-16 Create a site — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/a1cc57b7-0228-4ab5-8217-610b63286daf)
