### PR TITLE
Theme Showcase: Add the is_logged_in prop to the calypso_themeshowcase_pattern_assembler_cta_click event

### DIFF
--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -83,6 +83,7 @@ export const ThemesList = ( { tabFilter, ...props } ) => {
 		const shouldGoToAssemblerStep = isAssemblerSupported();
 		props.recordTracksEvent( 'calypso_themeshowcase_pattern_assembler_cta_click', {
 			goes_to_assembler_step: shouldGoToAssemblerStep,
+			is_logged_in: isLoggedIn,
 		} );
 
 		const destinationUrl = getSiteAssemblerUrl( {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1701401147738549/1701240624.830939-slack-CRWCHQGUB

## Proposed Changes

* Add the `is_logged_in` prop to the `calypso_themeshowcase_pattern_assembler_cta_click` event

| Logged-out | Logged-in |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/33f6cbf6-a0e9-4b56-b65f-2c8032313920) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/7b387328-f05f-4de5-84c0-a628a8a33030) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the Theme Showcase
* Click the Assembler CTA
* Verify the `is_logged_in` prop is shown in the `calypso_themeshowcase_pattern_assembler_cta_click` event
* Check the value depends on whether you log in or not

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?