### PR TITLE
Render Global Style notice only when necessary 

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.scss
@@ -1,11 +1,11 @@
-.edit-site-save-hub {
-	border-top: none;
-	padding-top: 0;
-}
-
 .wpcom-global-styles-notice-container {
 	padding: 24px 24px 0;
 	border-top: 1px solid #2f2f2f;
+	// Hide the original border only when the notice is present.
+	+ .edit-site-save-hub {
+		border-top: none;
+		padding-top: 0;
+	}
 }
 
 .wpcom-global-styles-notice {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/84676, https://github.com/Automattic/wp-calypso/issues/79223

## Proposed Changes

Currently, there's unnecessary DOM by Global Style notice even when the user is not using Global Style. This PR changes to render Global Style notice only when it is in use. 

While this change appears trivial, I expect it to reduce the complexity when we add the new notice in the same place (See https://github.com/Automattic/wp-calypso/pull/84676). I'll create the follow-up PR to ensure showing only one notice simultaneously.

| before | after |
|--------|--------|
| <img width="347" alt="Screenshot 2023-12-04 at 15 35 56" src="https://github.com/Automattic/wp-calypso/assets/5287479/855374f9-f3cc-4cf8-94b8-ba09a6310971"> <img width="353" alt="Screenshot 2023-12-04 at 15 33 11" src="https://github.com/Automattic/wp-calypso/assets/5287479/9342d778-b9d9-4f31-8bf1-86d0a39b8420"> | <img width="349" alt="Screenshot 2023-12-04 at 16 08 20" src="https://github.com/Automattic/wp-calypso/assets/5287479/86e39121-16d4-415c-8083-744d923476f5"> <img width="353" alt="Screenshot 2023-12-04 at 16 08 27" src="https://github.com/Automattic/wp-calypso/assets/5287479/947f2762-9398-49d7-bf82-d2d9aa734acc"> |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `install-plugin.sh editing-toolkit fix/gs-notice` on your sandbox
* Prepare a free site
* Sandbox your site
* Go to `Appearance > Editor` (https://<your site>/wp-admin/site-editor.php)
* Confirm it does not render Global Style notice when Global Style is NOT in use  (e.g., See `document.querySelector('.wpcom-global-styles-notice-container')` returns null) 
* Add custom styles from the `Style` navigation
* Confirm it shows Global Style notice
* Confirm it sends the tracking event (`calypso_global_styles_gating_notice_view_canvas_show`)
* Undo your change in Global Style
* Confirm it does not render Global Style notice

On Atomic sites, we don't show the Global Style notice. You can test that breaks nothing, too, by downloading/uploading the plugin .zip file from TeamCity PCYsg-ly5-p2#atomic-testing.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?