### PR TITLE
Assembler: Add component PatternTooltipDeadClick

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pages/page-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pages/page-preview.scss
@@ -62,6 +62,7 @@ $font-family: "SF Pro Text", $sans;
 
 		.pattern-assembler__preview-title {
 			opacity: 0;
+			pointer-events: none;
 		}
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pages/page-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pages/page-preview.tsx
@@ -6,6 +6,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import useOutsideClickCallback from 'calypso/lib/use-outside-click-callback';
 import { PATTERN_ASSEMBLER_EVENTS } from '../events';
 import prependTitleBlockToPagePattern from '../html-transformers/prepend-title-block-to-page-pattern';
+import PatternTooltipDeadClick from '../pattern-tooltip-dead-click';
 import { encodePatternId, isPagePattern } from '../utils';
 import type { Pattern } from '../types';
 import './page-preview.scss';
@@ -71,8 +72,11 @@ const PatternPagePreview = ( {
 	const [ isFullscreen, setIsFullscreen ] = useState( false );
 	const [ isFullscreenEnter, setIsFullscreenEnter ] = useState( false );
 	const [ isFullscreenLeave, setIsFullscreenLeave ] = useState( false );
+	const [ shouldShowTooltip, setShouldShowTooltip ] = useState( false );
+
 	const [ frameStyles, setFrameStyles ] = useState( {} );
 	const ref = useRef< HTMLDivElement >( null );
+	const frameRef = useRef( null );
 
 	const calculateFrameStyles = useCallback( () => {
 		if ( ! ref.current ) {
@@ -95,6 +99,11 @@ const PatternPagePreview = ( {
 			// The timeout delay should match the CSS transition timing of the element.
 			setIsFullscreenEnter( true );
 			setTimeout( () => setIsFullscreenEnter( false ), 200 );
+
+			recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_PAGES_PAGE_PREVIEW_CLICK, {
+				pattern_names: patterns.map( ( pattern ) => pattern.name ).join( ',' ),
+				page_slug: slug,
+			} );
 		}
 	};
 
@@ -110,12 +119,16 @@ const PatternPagePreview = ( {
 		}
 	}, [ isFullscreen, onFullscreenLeave ] );
 
-	const handleClick = () => {
-		handleFullscreenEnter();
-		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_PAGES_PAGE_PREVIEW_CLICK, {
-			pattern_names: patterns.map( ( pattern ) => pattern.name ).join( ',' ),
-			page_slug: slug,
-		} );
+	const handleMouseDown = () => {
+		if ( isFullscreen ) {
+			setShouldShowTooltip( true );
+		}
+	};
+
+	const handleMouseLeave = () => {
+		if ( isFullscreen ) {
+			setShouldShowTooltip( false );
+		}
 	};
 
 	useEffect( () => {
@@ -146,15 +159,21 @@ const PatternPagePreview = ( {
 					{ ...composite }
 					role="option"
 					as="button"
+					ref={ frameRef }
 					className="pattern-assembler__preview-frame"
 					style={ frameStyles }
 					aria-label={ title }
-					onClick={ handleClick }
+					onClick={ handleFullscreenEnter }
+					onMouseDown={ handleMouseDown }
+					onMouseLeave={ handleMouseLeave }
 				>
 					<Page className="pattern-assembler__preview-frame-content" { ...pageProps } />
 				</CompositeItem>
 				<div className="pattern-assembler__preview-title">{ title }</div>
 			</div>
+			{ isFullscreen && (
+				<PatternTooltipDeadClick targetRef={ frameRef } isVisible={ shouldShowTooltip } />
+			) }
 		</div>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pages/page-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pages/page-preview.tsx
@@ -68,7 +68,7 @@ const PatternPagePreview = ( {
 	onFullscreenLeave,
 	...pageProps
 }: PagePreviewProps ) => {
-	const { slug, title, patterns } = pageProps;
+	const { slug, title } = pageProps;
 	const [ isFullscreen, setIsFullscreen ] = useState( false );
 	const [ isFullscreenEnter, setIsFullscreenEnter ] = useState( false );
 	const [ isFullscreenLeave, setIsFullscreenLeave ] = useState( false );
@@ -101,7 +101,6 @@ const PatternPagePreview = ( {
 			setTimeout( () => setIsFullscreenEnter( false ), 200 );
 
 			recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_PAGES_PAGE_PREVIEW_CLICK, {
-				pattern_names: patterns.map( ( pattern ) => pattern.name ).join( ',' ),
 				page_slug: slug,
 			} );
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-tooltip-dead-click.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-tooltip-dead-click.scss
@@ -1,0 +1,25 @@
+@import "@automattic/typography/styles/variables";
+
+.pattern-assembler__tooltip-dead-click {
+	pointer-events: none;
+	position: fixed !important;
+
+	&-content {
+		background: var(--studio-gray-100);
+		border-radius: 4px;
+		box-sizing: border-box;
+		box-shadow: 0 4px 4px 0 rgba(0, 0, 0, 0.1);
+		color: #fff;
+		font-size: $font-body-extra-small;
+		left: 16px;
+		opacity: 0;
+		padding: 8px 10px;
+		position: relative;
+		top: 16px;
+		white-space: nowrap;
+
+		&--visible {
+			opacity: 1;
+		}
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-tooltip-dead-click.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-tooltip-dead-click.tsx
@@ -1,0 +1,83 @@
+import { Popover } from '@wordpress/components';
+import classnames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect, useMemo, useRef } from 'react';
+import './pattern-tooltip-dead-click.scss';
+
+interface Props {
+	targetRef: React.MutableRefObject< HTMLDivElement | null >;
+	isVisible: boolean;
+}
+
+const PatternTooltipDeadClick = ( { targetRef, isVisible }: Props ) => {
+	const translate = useTranslate();
+	const ref = useRef< HTMLDivElement | null >( null );
+
+	const anchor = useMemo( () => {
+		return {
+			getBoundingClientRect() {
+				if ( ! ref.current || ! isVisible ) {
+					return new window.DOMRect();
+				}
+
+				const { width, height } = ref.current.getBoundingClientRect();
+				return new window.DOMRect( 0, 0, width, height );
+			},
+		};
+	}, [] );
+
+	useEffect( () => {
+		const setXY = ( event: MouseEvent ) => {
+			if ( ! ref.current ) {
+				return;
+			}
+
+			const { clientX, clientY } = event;
+			const { height, width } = ref.current.getBoundingClientRect();
+			const x = Math.min( clientX, window.innerWidth - ( width + 32 ) );
+			const y = Math.min( clientY, window.innerHeight - ( height + 32 ) );
+
+			ref.current.style.transform = `translate( ${ x }px, ${ y }px )`;
+		};
+
+		const handleMouseDown = ( event: MouseEvent ) => {
+			setXY( event );
+		};
+
+		const handleMouseMove = ( event: MouseEvent ) => {
+			if ( isVisible ) {
+				setXY( event );
+			}
+		};
+
+		targetRef.current?.addEventListener( 'mousedown', handleMouseDown );
+		targetRef.current?.addEventListener( 'mousemove', handleMouseMove );
+		return () => {
+			targetRef.current?.removeEventListener( 'mousedown', handleMouseDown );
+			targetRef.current?.removeEventListener( 'mousemove', handleMouseMove );
+		};
+	}, [ targetRef, ref, isVisible ] );
+
+	return (
+		<Popover
+			className="pattern-assembler__tooltip-dead-click"
+			animate={ false }
+			focusOnMount={ false }
+			resize={ false }
+			anchor={ anchor }
+			placement="bottom-end"
+			variant="unstyled"
+		>
+			<div
+				className={ classnames( 'pattern-assembler__tooltip-dead-click-content', {
+					'pattern-assembler__tooltip-dead-click-content--visible': isVisible,
+				} ) }
+				ref={ ref }
+			>
+				{ translate( 'You can edit your content later in the Site Editor' ) }
+			</div>
+		</Popover>
+	);
+};
+
+export default PatternTooltipDeadClick;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/style.scss
@@ -261,27 +261,3 @@ $font-family: "SF Pro Text", $sans;
 		box-shadow: 0 0 0 2px var(--color-primary-light);
 	}
 }
-
-.pattern-assembler__tooltip {
-	pointer-events: none;
-	position: fixed !important;
-
-	&-content {
-		background: var(--studio-gray-100);
-		border-radius: 4px;
-		box-sizing: border-box;
-		box-shadow: 0 4px 4px 0 rgba(0, 0, 0, 0.1);
-		color: #fff;
-		font-size: $font-body-extra-small;
-		left: 16px;
-		opacity: 0;
-		padding: 8px 10px;
-		position: relative;
-		top: 16px;
-		white-space: nowrap;
-
-		&--visible {
-			opacity: 1;
-		}
-	}
-}


### PR DESCRIPTION
## Proposed Changes

This PR implements the component `PatternTooltipDeadClick` which is shown whenever users click on (1) any pattern in the large preview, or (2) any page preview while in full-screen mode. The purpose of the tooltip is to let users know that the preview content can later be edited in the Site Editor. 

https://github.com/Automattic/wp-calypso/assets/797888/6ca06bfc-813f-4b43-a571-1f25a74e1824

The component is called dead click as described in:
- https://www.fullstory.com/blog/dead-clicks, or 
- https://docs.sessionstack.com/docs/dead-click

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Assembler.
* Select any pattern.
* In the large preview, click on the pattern and ensure that the tooltip shows up.
* Ensure that the tooltip goes away if users leave the pattern or hovers over the pattern action bar.
* Click on Select pages.
* In the Pages screen, click on any page preview.
* Once the page preview is in full screen, click on the preview and ensure that the tooltip shows up.
* Ensure that the tooltip goes away if users leave the pattern.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?