### PR TITLE
Jetpack Cloud: Fix the responsiveness of the nav tabs when the content overflows. 

### DIFF
--- a/client/jetpack-cloud/components/layout/nav.tsx
+++ b/client/jetpack-cloud/components/layout/nav.tsx
@@ -21,32 +21,40 @@ type LayoutNavigationItemProps = {
 	selected?: boolean;
 };
 
-export function LayoutNavigationItem( {
-	label,
-	onClick,
-	path,
-	count,
-	selected,
-	compactCount = true,
-}: LayoutNavigationItemProps ) {
+type LayoutNavigationTabsProps = {
+	selectedText: string;
+	selectedCount?: number;
+	items: LayoutNavigationItemProps[];
+};
+
+export function LayoutNavigationTabs( {
+	selectedText,
+	selectedCount,
+	items,
+}: LayoutNavigationTabsProps ) {
 	return (
-		<NavItem
-			compactCount={ compactCount }
-			count={ count }
-			path={ path }
-			onClick={ onClick }
-			selected={ selected }
-		>
-			{ label }
-		</NavItem>
+		<NavTabs selectedText={ selectedText } selectedCount={ selectedCount }>
+			{ items.map( ( { label, onClick, selected, count, path, compactCount = true } ) => (
+				<NavItem
+					key={ label.replace( /[^a-zA-Z0-9]/g, '' ).toLowerCase() }
+					compactCount={ compactCount }
+					count={ count }
+					path={ path }
+					onClick={ onClick }
+					selected={ selected }
+				>
+					{ label }
+				</NavItem>
+			) ) }
+		</NavTabs>
 	);
 }
 
 export default function LayoutNavigation( {
 	className,
-	children,
 	selectedText,
 	selectedCount,
+	children,
 }: LayoutNavigationProps ) {
 	return (
 		<SectionNav
@@ -59,9 +67,7 @@ export default function LayoutNavigation( {
 				</span>
 			}
 		>
-			<NavTabs selectedText={ selectedText } selectedCount={ selectedCount }>
-				{ children }
-			</NavTabs>
+			{ children }
 		</SectionNav>
 	);
 }

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/index.tsx
@@ -11,7 +11,7 @@ import LayoutHeader, {
 	LayoutHeaderTitle as Title,
 } from 'calypso/jetpack-cloud/components/layout/header';
 import LayoutNavigation, {
-	LayoutNavigationItem as NavigationItem,
+	LayoutNavigationTabs as NavigationTabs,
 } from 'calypso/jetpack-cloud/components/layout/nav';
 import LayoutTop from 'calypso/jetpack-cloud/components/layout/top';
 import AssignLicenseStepProgress from '../assign-license-step-progress';
@@ -72,6 +72,11 @@ export default function IssueLicenseV2( { selectedSite, suggestedProduct }: Assi
 
 	const currentStep = showReviewLicenses ? 'reviewLicense' : 'issueLicense';
 
+	const selectedText =
+		selectedSize === 1
+			? translate( 'Single license' )
+			: ( translate( '%(size)d licenses', { args: { size: selectedSize } } ) as string );
+
 	return (
 		<>
 			<Layout
@@ -117,25 +122,20 @@ export default function IssueLicenseV2( { selectedSite, suggestedProduct }: Assi
 						</Actions>
 					</LayoutHeader>
 
-					<LayoutNavigation
-						selectedText={
-							selectedSize === 1
-								? translate( 'Single license' )
-								: ( translate( '%(size)d licenses', { args: { size: selectedSize } } ) as string )
-						}
-					>
-						{ availableSizes.map( ( size ) => (
-							<NavigationItem
-								key={ `bundle-size-${ size }` }
-								label={
+					<LayoutNavigation selectedText={ selectedText }>
+						<NavigationTabs
+							selectedText={ selectedText }
+							items={ availableSizes.map( ( size ) => ( {
+								label:
 									size === 1
 										? translate( 'Single license' )
-										: ( translate( '%(size)d licenses', { args: { size } } ) as string )
-								}
-								selected={ selectedSize === size }
-								onClick={ () => setSelectedSize( size ) }
-							/>
-						) ) }
+										: ( translate( '%(size)d licenses', {
+												args: { size },
+										  } ) as string ),
+								selected: selectedSize === size,
+								onClick: () => setSelectedSize( size ),
+							} ) ) }
+						/>
 					</LayoutNavigation>
 				</LayoutTop>
 


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/129

## Proposed Changes

This PR fixes the responsiveness of the nav tabs when the content overflows. 

The ref of the child component isn't set properly, causing the component not to switch to the dropdown view. This PR does some refactoring by moving the `NavTabs` & `NavItems` together into one component: `LayoutNavigationTabs`

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. 

**Instructions**

1. Visit the Jetpack Cloud link > Replace `dashboard` in the URL with `/partner-portal/issue-license?flags=jetpack/bundle-licensing`.
2. Verify that the tabs for the bundle sizes switch to dropdown view when the content overflows. Note: We need to do some style updates(spacing) on the mobile views, which will be done in another PR.

When the content is not overflowing:

<img width="837" alt="Screenshot 2023-12-04 at 12 00 39 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/16a3434f-d964-4666-bdd4-d1944f14c40a">

When the content is overflowing:

<img width="704" alt="Screenshot 2023-12-04 at 12 01 01 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/103d1d8c-ee16-4a02-b492-98932f19a17d">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?