### PR TITLE
Stats: Update slider SCSS to use “math.div” calls

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.scss
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.scss
@@ -1,9 +1,11 @@
+@use "sass:math";
+
 $slider-height: 40px;
 $slider-bg-color: var(--studio-white);
 $thumb-width: 40px;
 $mark-diameter: 8px;
 $mark-border-width: 2px;
-$track-extra-width: ($thumb-width - $mark-diameter - $mark-border-width * 2) / 2;
+$track-extra-width: math.div($thumb-width - $mark-diameter - $mark-border-width * 2, 2);
 $track-height: 4px;
 
 // The trick is to cover the extra slider track with blocks with the same background color as the slider.
@@ -38,7 +40,7 @@ $track-height: 4px;
 	.jp-components-pricing-slider__track {
 		// Based on slider height of 40px & track height of 4px.
 		height: $track-height;
-		top: $slider-height / 2 - $track-height / 2;
+		top: math.div($slider-height, 2) - math.div($track-height, 2);
 	}
 
 	.jp-components-pricing-slider__control {

--- a/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.scss
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.scss
@@ -69,7 +69,7 @@ $track-height: 4px;
 			border-radius: 50%;
 			cursor: pointer;
 			margin: 0 $track-extra-width;
-			bottom: calc(50% - ($mark-diameter / 2 + $mark-border-width));
+			bottom: calc(50% - (math.div($mark-diameter, 2) + $mark-border-width));
 		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #83898

## Proposed Changes

Addresses issue raised with the `/` in SCSS here:

https://github.com/Automattic/wp-calypso/pull/84547#issuecomment-1833443970

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Launch the Calypso Live link.
2. Navigate to **Stats → Traffic**.
3. Update URL to: `http://calypso.localhost:3000/stats/purchase/SITE_SLUG?productType=commercial&flags=stats/type-detection,stats/tier-upgrade-slider`
4. Confirm slider tracks/marks appear correctly.

<img width="500" alt="SCR-20231204-ngot" src="https://github.com/Automattic/wp-calypso/assets/40267301/4e9a6028-871f-48dc-aa65-c7064334a4a9">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?