### PR TITLE
Marketplace: Add pagination to the reviews query

### DIFF
--- a/client/data/marketplace/use-marketplace-reviews.ts
+++ b/client/data/marketplace/use-marketplace-reviews.ts
@@ -19,6 +19,13 @@ export type ProductProps = {
 	slug: string;
 };
 
+export type PaginationProps = {
+	page: number;
+	perPage: number;
+};
+
+export type MarketplaceReviewsQueryProps = ProductProps & PaginationProps;
+
 export type MarketplaceReviewBody = {
 	content: string;
 	rating: number;
@@ -67,7 +74,9 @@ type MarketplaceReviewsQueryOptions = Pick<
 
 const fetchMarketplaceReviews = (
 	productType: ProductType,
-	productSlug: string
+	productSlug: string,
+	page: number = 1,
+	perPage: number = 10
 ): Promise< MarketplaceReviewResponse[] | ErrorResponse > => {
 	return wpcom.req.get(
 		{
@@ -77,6 +86,8 @@ const fetchMarketplaceReviews = (
 		{
 			product_type: productType,
 			product_slug: productSlug,
+			page,
+			per_pave: perPage,
 		}
 	);
 };
@@ -133,7 +144,7 @@ const deleteReview = ( {
 };
 
 export const useMarketplaceReviewsQuery = (
-	{ productType, slug }: ProductProps,
+	{ productType, slug, page, perPage }: MarketplaceReviewsQueryProps,
 	{
 		enabled = true,
 		staleTime = BASE_STALE_TIME,
@@ -141,7 +152,7 @@ export const useMarketplaceReviewsQuery = (
 	}: MarketplaceReviewsQueryOptions = {}
 ) => {
 	const queryKey: QueryKey = [ queryKeyBase, slug ];
-	const queryFn = () => fetchMarketplaceReviews( productType, slug );
+	const queryFn = () => fetchMarketplaceReviews( productType, slug, page, perPage );
 	return useQuery( {
 		queryKey,
 		queryFn,

--- a/client/data/marketplace/use-marketplace-reviews.ts
+++ b/client/data/marketplace/use-marketplace-reviews.ts
@@ -151,7 +151,7 @@ export const useMarketplaceReviewsQuery = (
 		refetchOnMount = true,
 	}: MarketplaceReviewsQueryOptions = {}
 ) => {
-	const queryKey: QueryKey = [ queryKeyBase, slug ];
+	const queryKey: QueryKey = [ queryKeyBase, productType, slug, page, perPage ];
 	const queryFn = () => fetchMarketplaceReviews( productType, slug, page, perPage );
 	return useQuery( {
 		queryKey,

--- a/client/data/marketplace/use-marketplace-reviews.ts
+++ b/client/data/marketplace/use-marketplace-reviews.ts
@@ -20,8 +20,8 @@ export type ProductProps = {
 };
 
 export type PaginationProps = {
-	page: number;
-	perPage: number;
+	page?: number;
+	perPage?: number;
 };
 
 export type MarketplaceReviewsQueryProps = ProductProps & PaginationProps;

--- a/client/data/marketplace/use-marketplace-reviews.ts
+++ b/client/data/marketplace/use-marketplace-reviews.ts
@@ -87,7 +87,7 @@ const fetchMarketplaceReviews = (
 			product_type: productType,
 			product_slug: productSlug,
 			page,
-			per_pave: perPage,
+			per_page: perPage,
 		}
 	);
 };

--- a/client/my-sites/marketplace/components/reviews-list/index.tsx
+++ b/client/my-sites/marketplace/components/reviews-list/index.tsx
@@ -4,16 +4,16 @@ import moment from 'moment';
 import { LegacyRef, forwardRef } from 'react';
 import Rating from 'calypso/components/rating';
 import {
-	ProductProps,
 	useMarketplaceReviewsQuery,
 	MarketplaceReviewResponse,
+	MarketplaceReviewsQueryProps,
 } from 'calypso/data/marketplace/use-marketplace-reviews';
 import './style.scss';
 import { sanitizeSectionContent } from 'calypso/lib/plugins/sanitize-section-content';
 
 export const MarketplaceReviewsList = forwardRef<
 	HTMLDivElement,
-	ProductProps & { innerRef: LegacyRef< HTMLDivElement > }
+	MarketplaceReviewsQueryProps & { innerRef: LegacyRef< HTMLDivElement > }
 >( ( props, ref ) => {
 	const translate = useTranslate();
 	const { data: reviews } = useMarketplaceReviewsQuery( props );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4562

## Proposed Changes

* Adds `page` and `per_page` params to the review queries
* Adds all params to the query key

## Testing Instructions

All tests should pass

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?