### PR TITLE
Migrate subscribers: update support link

### DIFF
--- a/client/my-sites/subscribers/components/migrate-subscribers-modal/migrate-subscribers-modal.tsx
+++ b/client/my-sites/subscribers/components/migrate-subscribers-modal/migrate-subscribers-modal.tsx
@@ -95,7 +95,9 @@ const MigrateSubscribersModal = () => {
 								<Button
 									variant="link"
 									target="_blank"
-									href={ localizeUrl( 'https://jetpack.com/support/subscription-migration-tool/' ) }
+									href={ localizeUrl(
+										'https://wordpress.com/support/migrate-subscribers-from-another-site/'
+									) }
 								/>
 							),
 						}


### PR DESCRIPTION

## Proposed Changes

* Swap Jetpack support link to new .com support link.

Was considering keeping the Jetpack link for Jetpack sites .... but in this case we have source sites and target site, when should we show Jetpack docs? Honestly .com docs answer the questions well enough for everyone about .com interface anyway.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Users -> Subscribers
* From three dots menu, migrate subscribers
* See support link

<img width="854" alt="Screenshot 2023-12-04 at 11 52 13" src="https://github.com/Automattic/wp-calypso/assets/87168/f8713a2f-36a0-4f0f-ba3c-b8cb1f8f4cbc">
<img width="451" alt="Screenshot 2023-12-04 at 11 52 31" src="https://github.com/Automattic/wp-calypso/assets/87168/c022c485-8fed-4d4b-9c4a-0b5a19e0b540">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
