### PR TITLE
Subscriber management: remove email/wpcom filter

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-list-actions-bar/subscriber-list-actions-bar.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-actions-bar/subscriber-list-actions-bar.tsx
@@ -1,13 +1,10 @@
 import SearchInput from '@automattic/search';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
-import SelectDropdown from 'calypso/components/select-dropdown';
 import { SearchIcon } from 'calypso/landing/subscriptions/components/icons';
-import { Option, SortControls } from 'calypso/landing/subscriptions/components/sort-controls';
-import { getOptionLabel } from 'calypso/landing/subscriptions/helpers';
-import { useSubscribersFilterOptions } from 'calypso/landing/subscriptions/hooks';
+import { SortControls } from 'calypso/landing/subscriptions/components/sort-controls';
 import { useSubscribersPage } from 'calypso/my-sites/subscribers/components/subscribers-page/subscribers-page-context';
-import { SubscribersFilterBy, SubscribersSortBy } from '../../constants';
+import { SubscribersSortBy } from '../../constants';
 import useManySubsSite from '../../hooks/use-many-subs-site';
 import './style.scss';
 import { useRecordSort } from '../../tracks';
@@ -19,23 +16,10 @@ const getSortOptions = ( translate: ReturnType< typeof useTranslate > ) => [
 
 const ListActionsBar = () => {
 	const translate = useTranslate();
-	const {
-		handleSearch,
-		searchTerm,
-		pageChangeCallback,
-		sortTerm,
-		setSortTerm,
-		filterOption,
-		setFilterOption,
-		siteId,
-	} = useSubscribersPage();
+	const { handleSearch, searchTerm, sortTerm, setSortTerm, siteId } = useSubscribersPage();
 	const sortOptions = useMemo( () => getSortOptions( translate ), [ translate ] );
 	const recordSort = useRecordSort();
 	const { hasManySubscribers } = useManySubsSite( siteId );
-	const filterOptions = useSubscribersFilterOptions( hasManySubscribers, siteId );
-	const selectedText = translate( 'Subscribers: %s', {
-		args: getOptionLabel( filterOptions, filterOption ) || '',
-	} );
 
 	return (
 		<div className="list-actions-bar">
@@ -45,17 +29,6 @@ const ListActionsBar = () => {
 				onSearch={ handleSearch }
 				onSearchClose={ () => handleSearch( '' ) }
 				defaultValue={ searchTerm }
-			/>
-
-			<SelectDropdown
-				className="subscribers__filter-control"
-				options={ filterOptions }
-				onSelect={ ( selectedOption: Option< SubscribersFilterBy > ) => {
-					setFilterOption( selectedOption.value );
-					pageChangeCallback( 1 );
-				} }
-				selectedText={ selectedText }
-				initialSelected={ filterOption }
 			/>
 
 			{ ! hasManySubscribers && (

--- a/client/my-sites/subscribers/components/subscriber-list-actions-bar/subscriber-list-actions-bar.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-actions-bar/subscriber-list-actions-bar.tsx
@@ -1,10 +1,13 @@
 import SearchInput from '@automattic/search';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
+import SelectDropdown from 'calypso/components/select-dropdown';
 import { SearchIcon } from 'calypso/landing/subscriptions/components/icons';
-import { SortControls } from 'calypso/landing/subscriptions/components/sort-controls';
+import { Option, SortControls } from 'calypso/landing/subscriptions/components/sort-controls';
+import { getOptionLabel } from 'calypso/landing/subscriptions/helpers';
+import { useSubscribersFilterOptions } from 'calypso/landing/subscriptions/hooks';
 import { useSubscribersPage } from 'calypso/my-sites/subscribers/components/subscribers-page/subscribers-page-context';
-import { SubscribersSortBy } from '../../constants';
+import { SubscribersFilterBy, SubscribersSortBy } from '../../constants';
 import useManySubsSite from '../../hooks/use-many-subs-site';
 import './style.scss';
 import { useRecordSort } from '../../tracks';
@@ -16,10 +19,23 @@ const getSortOptions = ( translate: ReturnType< typeof useTranslate > ) => [
 
 const ListActionsBar = () => {
 	const translate = useTranslate();
-	const { handleSearch, searchTerm, sortTerm, setSortTerm, siteId } = useSubscribersPage();
+	const {
+		handleSearch,
+		searchTerm,
+		pageChangeCallback,
+		sortTerm,
+		setSortTerm,
+		filterOption,
+		setFilterOption,
+		siteId,
+	} = useSubscribersPage();
 	const sortOptions = useMemo( () => getSortOptions( translate ), [ translate ] );
 	const recordSort = useRecordSort();
 	const { hasManySubscribers } = useManySubsSite( siteId );
+	const filterOptions = useSubscribersFilterOptions( hasManySubscribers, siteId );
+	const selectedText = translate( 'Subscribers: %s', {
+		args: getOptionLabel( filterOptions, filterOption ) || '',
+	} );
 
 	return (
 		<div className="list-actions-bar">
@@ -29,6 +45,17 @@ const ListActionsBar = () => {
 				onSearch={ handleSearch }
 				onSearchClose={ () => handleSearch( '' ) }
 				defaultValue={ searchTerm }
+			/>
+
+			<SelectDropdown
+				className="subscribers__filter-control"
+				options={ filterOptions }
+				onSelect={ ( selectedOption: Option< SubscribersFilterBy > ) => {
+					setFilterOption( selectedOption.value );
+					pageChangeCallback( 1 );
+				} }
+				selectedText={ selectedText }
+				initialSelected={ filterOption }
 			/>
 
 			{ ! hasManySubscribers && (

--- a/client/my-sites/subscribers/components/subscriber-list-actions-bar/subscriber-list-actions-bar.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-actions-bar/subscriber-list-actions-bar.tsx
@@ -47,17 +47,21 @@ const ListActionsBar = () => {
 				defaultValue={ searchTerm }
 			/>
 
-			<SelectDropdown
-				className="subscribers__filter-control"
-				options={ filterOptions }
-				onSelect={ ( selectedOption: Option< SubscribersFilterBy > ) => {
-					setFilterOption( selectedOption.value );
-					pageChangeCallback( 1 );
-				} }
-				selectedText={ selectedText }
-				initialSelected={ filterOption }
-			/>
+			{ /* TODO: with too many subscribers, we're showing filter to split list between the types of users for performance reasons. */ }
+			{ hasManySubscribers && (
+				<SelectDropdown
+					className="subscribers__filter-control"
+					options={ filterOptions }
+					onSelect={ ( selectedOption: Option< SubscribersFilterBy > ) => {
+						setFilterOption( selectedOption.value );
+						pageChangeCallback( 1 );
+					} }
+					selectedText={ selectedText }
+					initialSelected={ filterOption }
+				/>
+			) }
 
+			{ /* TODO: with too many subscribers, we're hiding sorting for performance reasons. */ }
 			{ ! hasManySubscribers && (
 				<SortControls
 					options={ sortOptions }

--- a/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
@@ -58,7 +58,7 @@ const SubscriberListContainer = ( {
 						</span>
 					</div>
 
-					<SubscriberListActionsBar />
+					{ total > 3 && <SubscriberListActionsBar /> }
 				</>
 			) }
 			{ isLoading &&


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

The wpcom/email subscribers filter isn't meaningful to publishers; they're all subscribers, related if they have account or not. It can even confuse them to think .com users don't receive emails. We've also been combining these terms in stats, and removed other mentions of the difference.

<img width="1628" alt="Screenshot 2023-12-04 at 13 51 15" src="https://github.com/Automattic/wp-calypso/assets/87168/63c6b962-ec3b-4c59-8ecb-9362858a9171">

Other better alternatives:

- Free/paid subscribers
- Receives emails

## Proposed Changes

* Remove wpcom/email subscribers filter

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Users -> Subscribers

<img width="1627" alt="Screenshot 2023-12-04 at 13 50 39" src="https://github.com/Automattic/wp-calypso/assets/87168/52ac0ff6-0c64-40d5-ad1d-9b1b01f86b1e">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?