### PR TITLE
Unhardcode Plan names in upsell nudges

### DIFF
--- a/client/blocks/domain-to-plan-nudge/index.jsx
+++ b/client/blocks/domain-to-plan-nudge/index.jsx
@@ -67,7 +67,12 @@ class DomainToPlanNudge extends Component {
 				plan={ PLAN_PERSONAL }
 				price={ prices }
 				showIcon
-				title={ translate( 'Upgrade to a Personal Plan and Save!' ) }
+				title={
+					/* translators: %(planName)s is the short-hand version of the Personal plan name */
+					translate( 'Upgrade to a %(planName)s Plan and Save!', {
+						args: { planName: getPlan( PLAN_PERSONAL )?.getTitle() ?? '' },
+					} )
+				}
 			/>
 		);
 	}

--- a/client/blocks/post-share/nudges.jsx
+++ b/client/blocks/post-share/nudges.jsx
@@ -1,4 +1,9 @@
-import { findFirstSimilarPlanKey, TYPE_PREMIUM } from '@automattic/calypso-products';
+import {
+	findFirstSimilarPlanKey,
+	TYPE_PREMIUM,
+	PLAN_PREMIUM,
+	getPlan,
+} from '@automattic/calypso-products';
 import formatCurrency from '@automattic/format-currency';
 import { connect } from 'react-redux';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
@@ -36,7 +41,12 @@ export const UpgradeToPremiumNudgePure = ( props ) => {
 			list={ featureList }
 			plan={ planSlug }
 			showIcon
-			title={ translate( 'Upgrade to a Premium Plan!' ) }
+			title={
+				/* translators: %(planName)s is the short-hand version of the Personal plan name */
+				translate( 'Upgrade to a %(planName)s Plan!', {
+					args: { planName: getPlan( PLAN_PREMIUM )?.getTitle() ?? '' },
+				} )
+			}
 		/>
 	);
 };

--- a/client/my-sites/checkout/upsell-nudge/business-plan-upgrade-upsell/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/business-plan-upgrade-upsell/index.jsx
@@ -1,3 +1,4 @@
+import { PLAN_BUSINESS, PLAN_PREMIUM, getPlan } from '@automattic/calypso-products';
 import { Button, Gridicon } from '@automattic/components';
 import { PureComponent } from 'react';
 import formatCurrency from 'calypso/../packages/format-currency/src';
@@ -78,7 +79,14 @@ export class BusinessPlanUpgradeUpsell extends PureComponent {
 			<>
 				<div className="business-plan-upgrade-upsell-new-design__column-pane">
 					<p>
-						<b>{ translate( 'Unlock the power of the Business Plan and gain access to:' ) }</b>
+						<b>
+							{
+								/* translators: %(planName)s is the short-hand version of the Business plan name */
+								translate( 'Unlock the power of the %(planName)s Plan and gain access to:', {
+									args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
+								} )
+							}
+						</b>
 					</p>
 					<ul className="business-plan-upgrade-upsell-new-design__checklist">
 						<li className="business-plan-upgrade-upsell-new-design__checklist-item">
@@ -121,22 +129,26 @@ export class BusinessPlanUpgradeUpsell extends PureComponent {
 						</li>
 					</ul>
 					<p>
-						{ translate(
-							'The great news is that you can upgrade today and try the Business Plan risk-free thanks to our {{b}}%(days)d-day money-back guarantee{{/b}}.',
-							{
-								components: {
-									b: <b />,
-								},
-								args: {
-									days: hasSevenDayRefundPeriod ? 7 : 14,
-									comment: 'A number, e.g. 7-day money-back guarantee',
-								},
-							}
-						) }
+						{
+							/* translators: %(planName)s is the short-hand version of the Business plan name */
+							translate(
+								'The great news is that you can upgrade today and try the %(planName)s Plan risk-free thanks to our {{b}}%(days)d-day money-back guarantee{{/b}}.',
+								{
+									components: {
+										b: <b />,
+									},
+									args: {
+										days: hasSevenDayRefundPeriod ? 7 : 14,
+										planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+										comment: 'A number, e.g. 7-day money-back guarantee',
+									},
+								}
+							)
+						}
 					</p>
 					<p>
 						{ translate(
-							'Simply click below to upgrade. You’ll only have to pay the difference to the Premium Plan ({{del}}%(fullPrice)s{{/del}} %(discountPrice)s).',
+							'Simply click below to upgrade. You’ll only have to pay the difference to the %(planName)s Plan ({{del}}%(fullPrice)s{{/del}} %(discountPrice)s).',
 							{
 								components: {
 									del: <del />,
@@ -146,6 +158,7 @@ export class BusinessPlanUpgradeUpsell extends PureComponent {
 									discountPrice: formatCurrency( planDiscountedRawPrice, currencyCode, {
 										stripZeros: true,
 									} ),
+									planName: getPlan( PLAN_PREMIUM )?.getTitle() ?? '',
 									comment: 'A monetary value at the end, e.g. $25',
 								},
 							}

--- a/client/my-sites/domains/domain-management/components/domain/new-domains-redirection-notice-upsell.jsx
+++ b/client/my-sites/domains/domain-management/components/domain/new-domains-redirection-notice-upsell.jsx
@@ -1,3 +1,4 @@
+import { PLAN_PERSONAL, getPlan } from '@automattic/calypso-products';
 import { localize } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -42,16 +43,20 @@ class NewDomainsRedirectionNoticeUpsell extends Component {
 				icon="info"
 				href={ `/checkout/${ selectedSiteId }/${ checkoutPlan }` }
 				title=""
-				description={ translate(
-					'Domains purchased on a free site will get redirected to %(primaryDomain)s. If you upgrade to ' +
-						'the Personal plan, you can use your own domain name instead of having WordPress.com ' +
-						'in your URL.',
-					{
-						args: {
-							primaryDomain: selectedSite.slug,
-						},
-					}
-				) }
+				description={
+					/* translators: %(planName)s is the short-hand version of the Personal plan name */
+					translate(
+						'Domains purchased on a free site will get redirected to %(primaryDomain)s. If you upgrade to ' +
+							'the %(planName)s plan, you can use your own domain name instead of having WordPress.com ' +
+							'in your URL.',
+						{
+							args: {
+								primaryDomain: selectedSite.slug,
+								planName: getPlan( PLAN_PERSONAL )?.getTitle() ?? '',
+							},
+						}
+					)
+				}
 				callToAction={ translate( 'Upgrade' ) }
 				primaryButton={ false }
 				tracksImpressionName="calypso_new_domain_will_redirect_notice_upsell_impression"

--- a/client/my-sites/media-library/list-plan-upgrade-nudge.jsx
+++ b/client/my-sites/media-library/list-plan-upgrade-nudge.jsx
@@ -1,6 +1,9 @@
 import {
 	WPCOM_FEATURES_UPLOAD_AUDIO_FILES,
 	WPCOM_FEATURES_UPLOAD_VIDEO_FILES,
+	PLAN_PERSONAL,
+	PLAN_PREMIUM,
+	getPlan,
 } from '@automattic/calypso-products';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -9,21 +12,33 @@ import ListPlanPromo from './list-plan-promo';
 
 function getTitle( filter, translate ) {
 	if ( filter === 'audio' ) {
-		return translate( 'Upgrade to the Personal Plan to Enable Audio Uploads' );
+		/* translators: %(planName)s is the short-hand version of the Personal plan name */
+		return translate( 'Upgrade to the %(planName)s Plan to Enable Audio Uploads', {
+			args: { planName: getPlan( PLAN_PERSONAL )?.getTitle() ?? '' },
+		} );
 	}
-
-	return translate( 'Upgrade to the Premium Plan to Enable VideoPress' );
+	/* translators: %(planName)s is the short-hand version of the Premium plan name */
+	return translate( 'Upgrade to the %(planName)s Plan to Enable VideoPress', {
+		args: { planName: getPlan( PLAN_PREMIUM )?.getTitle() ?? '' },
+	} );
 }
 
 function getSubtitle( filter, translate ) {
 	if ( filter === 'audio' ) {
 		return translate(
-			"By upgrading to the Personal plan, you'll enable audio upload support on your site."
+			/* translators: %(planName)s is the short-hand version of the Personal plan name */
+			"By upgrading to the %(planName)s plan, you'll enable audio upload support on your site.",
+			{
+				args: { planName: getPlan( PLAN_PERSONAL )?.getTitle() ?? '' },
+			}
 		);
 	}
-
+	/* translators: %(planName)s is the short-hand version of the Premium plan name */
 	return translate(
-		"By upgrading to the Premium plan, you'll enable VideoPress support on your site."
+		"By upgrading to the %(planName)s plan, you'll enable VideoPress support on your site.",
+		{
+			args: { planName: getPlan( PLAN_PREMIUM )?.getTitle() ?? '' },
+		}
 	);
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

This replaces a few hardcoded Plan names, found in multiple upsell nudges, with references to the Plan configurations.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure the plan mentions are updated correctly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
