### PR TITLE
Theme Showcase Survey: Add survey to code

### DIFF
--- a/client/my-sites/themes/survey/index.tsx
+++ b/client/my-sites/themes/survey/index.tsx
@@ -56,7 +56,6 @@ const Survey = ( { survey, condition, title = null }: SurveyProps ) => {
 		<Banner
 			className="theme-showcase__survey"
 			title={ title || defaultTitle }
-			event={ surveyData.eventName }
 			onDismiss={ ( e: Event ) => {
 				e.stopPropagation();
 				setIsDismissed( true );
@@ -67,9 +66,6 @@ const Survey = ( { survey, condition, title = null }: SurveyProps ) => {
 			disableHref
 			showIcon={ false }
 			showLinkIcon={ false }
-			tracksImpressionName="calypso_theme_showcase_survey_impression"
-			tracksClickName="calypso_theme_showcase_survey_click"
-			tracksDismissName="calypso_theme_showcase_survey_dismiss"
 		/>
 	);
 };

--- a/client/my-sites/themes/survey/index.tsx
+++ b/client/my-sites/themes/survey/index.tsx
@@ -1,5 +1,5 @@
 import { translate } from 'i18n-calypso';
-import React from 'react';
+import { useState } from 'react';
 import Banner from 'calypso/components/banner';
 import './survey.scss';
 
@@ -33,7 +33,7 @@ let isGloballyDismissed = false;
 
 const Survey = ( { survey, condition, title = null }: SurveyProps ) => {
 	const surveyData = surveys.get( survey );
-	const [ isDismissed, setIsDismissed ] = React.useState( isGloballyDismissed );
+	const [ isDismissed, setIsDismissed ] = useState( isGloballyDismissed );
 
 	if ( ! isVisible && condition() ) {
 		isVisible = true;

--- a/client/my-sites/themes/survey/index.tsx
+++ b/client/my-sites/themes/survey/index.tsx
@@ -1,0 +1,64 @@
+import React, { useState } from 'react';
+import Banner from 'calypso/components/banner';
+import './survey.scss';
+
+export enum SurveyType {
+	DECEMBER_2023 = 'DECEMBER_2023',
+}
+
+const surveys = new Map< SurveyType, { eventName: string; eventUrl: string } >( [
+	[
+		SurveyType.DECEMBER_2023,
+		{
+			eventName: 'theme-showcase-december-2023',
+			eventUrl: 'https://automattic.survey.fm/lits-survey-v1',
+		},
+	],
+] );
+
+type SurveyProps = {
+	survey: SurveyType;
+	condition: () => boolean;
+};
+
+const Survey = ( { survey, condition }: SurveyProps ) => {
+	const surveyData = surveys.get( survey );
+	const [ surveyDismissed, setSurveyDismissed ] = useState( false );
+
+	if ( ! surveyData || ! condition() || surveyDismissed ) {
+		return null;
+	}
+
+	const title = // Translation to other locales is not required
+		(
+			<>
+				We’d love to hear your thoughts. Fill out this{ ' ' }
+				<a href={ surveyData.eventUrl } target="blank">
+					quick survey
+				</a>{ ' ' }
+				on your theme selection experience.
+			</>
+		);
+
+	return (
+		<Banner
+			className="theme-showcase__survey"
+			title={ title }
+			event={ surveyData.eventName }
+			onDismiss={ ( e: Event ) => {
+				e.stopPropagation();
+				setSurveyDismissed( true );
+			} }
+			dismissWithoutSavingPreference={ true }
+			dismissTemporary={ true }
+			disableHref
+			showIcon={ false }
+			showLinkIcon={ false }
+			tracksImpressionName="calypso_theme_showcase_survey_impression"
+			tracksClickName="calypso_theme_showcase_survey_click"
+			tracksDismissName="calypso_theme_showcase_survey_dismiss"
+		/>
+	);
+};
+
+export default Survey;

--- a/client/my-sites/themes/survey/survey.scss
+++ b/client/my-sites/themes/survey/survey.scss
@@ -1,0 +1,5 @@
+.theme-showcase__survey {
+	.banner__close-icon {
+		top: inherit;
+	}
+}

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -25,6 +25,7 @@ import ThemeCollectionViewHeader from 'calypso/my-sites/themes/collections/theme
 import ThemeShowcaseSurvey, { SurveyType } from 'calypso/my-sites/themes/survey';
 import ThanksModal from 'calypso/my-sites/themes/thanks-modal';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import getLastNonEditorRoute from 'calypso/state/selectors/get-last-non-editor-route';
 import getSiteFeaturesById from 'calypso/state/selectors/get-site-features';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
@@ -528,6 +529,7 @@ class ThemeShowcase extends Component {
 			isSiteWooExpressOrEcomFreeTrial,
 			isCollectionView,
 			isJetpackSite,
+			lastNonEditorRoute,
 		} = this.props;
 		const tier = this.props.tier || 'all';
 		const canonicalUrl = 'https://wordpress.com' + pathName;
@@ -582,7 +584,10 @@ class ThemeShowcase extends Component {
 					isCollectionView={ isCollectionView }
 					noIndex={ isCollectionView }
 				/>
-				<ThemeShowcaseSurvey survey={ SurveyType.DECEMBER_2023 } condition={ () => true } />
+				<ThemeShowcaseSurvey
+					survey={ SurveyType.DECEMBER_2023 }
+					condition={ () => lastNonEditorRoute.includes( 'theme/' ) }
+				/>
 				<div className="themes__content" ref={ this.scrollRef }>
 					<QueryThemeFilters />
 					{ isSiteWooExpressOrEcomFreeTrial && (
@@ -681,6 +686,7 @@ const mapStateToProps = ( state, { siteId, filter } ) => {
 		isSiteWooExpressOrEcomFreeTrial:
 			isSiteOnECommerceTrial( state, siteId ) || isSiteOnWooExpress( state, siteId ),
 		isSearchV2: ! isUserLoggedIn( state ) && config.isEnabled( 'themes/text-search-lots' ),
+		lastNonEditorRoute: getLastNonEditorRoute( state ),
 	};
 };
 

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -22,6 +22,7 @@ import ActivationModal from 'calypso/my-sites/themes/activation-modal';
 import { THEME_COLLECTIONS } from 'calypso/my-sites/themes/collections/collection-definitions';
 import ShowcaseThemeCollection from 'calypso/my-sites/themes/collections/showcase-theme-collection';
 import ThemeCollectionViewHeader from 'calypso/my-sites/themes/collections/theme-collection-view-header';
+import ThemeShowcaseSurvey, { SurveyType } from 'calypso/my-sites/themes/survey';
 import ThanksModal from 'calypso/my-sites/themes/thanks-modal';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import getSiteFeaturesById from 'calypso/state/selectors/get-site-features';
@@ -581,6 +582,7 @@ class ThemeShowcase extends Component {
 					isCollectionView={ isCollectionView }
 					noIndex={ isCollectionView }
 				/>
+				<ThemeShowcaseSurvey survey={ SurveyType.DECEMBER_2023 } condition={ () => true } />
 				<div className="themes__content" ref={ this.scrollRef }>
 					<QueryThemeFilters />
 					{ isSiteWooExpressOrEcomFreeTrial && (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
## Proposed Changes
* Added a survey component.
* Added the December 2023 survey to the Survey list.
* The Survey will be shown when the user navigates back from the theme details page to the theme showcase.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso live link.
* Goto to the LiTS.
* Open the details of any theme.
* Navigate back to the theme showcase.
* You should see the Survey banner.
* If you click on the link you should see the survey in a new tab.

Before:
![Captura de pantalla 2023-12-05 a las 10 50 16](https://github.com/Automattic/wp-calypso/assets/1989914/0b1884cd-bde4-4576-a819-abeab987be63)

After:
![Captura de pantalla 2023-12-05 a las 10 49 46](https://github.com/Automattic/wp-calypso/assets/1989914/a74202b9-2a07-4927-806d-8ca71b19dbfe)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?