### PR TITLE
Marketplace review: update success message wording

### DIFF
--- a/client/my-sites/marketplace/components/reviews-modal/index.tsx
+++ b/client/my-sites/marketplace/components/reviews-modal/index.tsx
@@ -47,7 +47,9 @@ export const ReviewsModal = ( {
 						{ translate( 'Review submitted for %(productName)s', { args: { productName } } ) }
 					</CardHeading>
 					<CardHeading tagName="h2">
-						{ translate( 'Thank you for your contribution.' ) }
+						{ translate(
+							'Thank you for your contribution. It will be published following a review from our team.'
+						) }
 					</CardHeading>
 				</Card>
 			</Dialog>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4557

This PR updates the wording of the success message to make it more clear that reviews are going through an approval process. Related thread: p1701706266397849-slack-C02JPCHEKDY

This message is displayed when the user has added a new review for a marketplace product (plugin, theme or SaaS offering):
![CleanShot 2023-12-05 at 14 13 08@2x](https://github.com/Automattic/wp-calypso/assets/11555574/4501a912-c1ed-4f09-89e2-2f79163277b0)

## Proposed Changes

* Update the success message

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* After submitting a review for a theme, check that the updated message is shown in the modal.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?