### PR TITLE
Hosting Command Palette: Check if site fragment exists in the URL to move currentSite to the top

### DIFF
--- a/client/components/command-palette/use-current-site-rank-top.ts
+++ b/client/components/command-palette/use-current-site-rank-top.ts
@@ -1,3 +1,4 @@
+import { getSiteFragment } from 'calypso/lib/route';
 import { useSelector } from 'calypso/state';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -5,11 +6,8 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 export function useCurrentSiteRankTop() {
 	let currentSiteId = useSelector( getSelectedSiteId );
 	const currentPath = useSelector( ( state ) => getCurrentRoute( state ) );
-	if (
-		currentPath.startsWith( '/sites' ) ||
-		currentPath.startsWith( '/read' ) ||
-		currentPath.startsWith( '/me' )
-	) {
+	const siteFragment = getSiteFragment( currentPath );
+	if ( ! siteFragment ) {
 		currentSiteId = null;
 	}
 	return {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Related to https://github.com/Automattic/dotcom-forge/issues/4710
- Follow up of https://github.com/Automattic/wp-calypso/pull/84726

## Proposed Changes

* Refactor how we check if we are in a global context or site context to display the selected site as the first one.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/sites`
* Open the command palette , by pressing `cmd+k`
* Select `Open site dashboard`
* Observe the sites order match the sites order inside the command palette
* Navigate to `Hosting config`
* Open the command palette
* Select `Open site dashboard`
* Observe the first site is your current site, and then the rest of the sites.


# Screencast


https://github.com/Automattic/wp-calypso/assets/779993/01451639-e526-457b-8cc6-0644f6961108



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?