### PR TITLE
Fix: Verify email hook throws null user exception 

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/test/use-verify-email.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/test/use-verify-email.tsx
@@ -1,0 +1,66 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook } from '@testing-library/react';
+import React from 'react';
+import { Provider } from 'react-redux';
+import { createReduxStore } from 'calypso/state';
+import { useVerifyEmail } from '../use-verify-email';
+
+describe( 'use-verify-email hook', () => {
+	test( 'returns isVerified false when user is null', async () => {
+		const store = createReduxStore( {} );
+		const queryClient = new QueryClient();
+		const wrapper = ( { children } ) => (
+			<Provider store={ store }>
+				<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+			</Provider>
+		);
+
+		const expected = {
+			isVerified: false,
+			isSending: false,
+			email: '',
+			hasUser: false,
+			resendEmail: expect.any( Function ),
+		};
+
+		const { result } = renderHook( () => useVerifyEmail(), {
+			wrapper,
+		} );
+
+		expect( result.current ).toEqual( expected );
+	} );
+
+	test( 'returns user verified when user is verified', async () => {
+		const store = createReduxStore( {
+			currentUser: {
+				user: {
+					email_verified: true,
+					email: 'test@mail.com',
+				},
+			},
+		} );
+		const queryClient = new QueryClient();
+		const wrapper = ( { children } ) => (
+			<Provider store={ store }>
+				<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+			</Provider>
+		);
+
+		const expected = {
+			isVerified: true,
+			isSending: false,
+			email: 'test@mail.com',
+			hasUser: true,
+			resendEmail: expect.any( Function ),
+		};
+
+		const { result } = renderHook( () => useVerifyEmail(), {
+			wrapper,
+		} );
+
+		expect( result.current ).toEqual( expected );
+	} );
+} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/use-verify-email.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/use-verify-email.tsx
@@ -2,7 +2,6 @@ import { useI18n } from '@wordpress/react-i18n';
 import { useEffect, useState } from 'react';
 import { useSendEmailVerification } from 'calypso/landing/stepper/hooks/use-send-email-verification';
 import { EVERY_FIVE_SECONDS } from 'calypso/lib/interval';
-import { UserData } from 'calypso/lib/user/user';
 import { useDispatch, useSelector } from 'calypso/state';
 import { fetchCurrentUser } from 'calypso/state/current-user/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
@@ -10,7 +9,7 @@ import { successNotice, warningNotice } from 'calypso/state/notices/actions';
 
 export const useVerifyEmail = () => {
 	const dispatch = useDispatch();
-	const user = useSelector( getCurrentUser ) as UserData;
+	const user = useSelector( getCurrentUser );
 	const safeUser = user ?? { email_verified: false, email: '' };
 	const sendEmail = useSendEmailVerification();
 	const { __ } = useI18n();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/use-verify-email.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/use-verify-email.tsx
@@ -11,13 +11,14 @@ import { successNotice, warningNotice } from 'calypso/state/notices/actions';
 export const useVerifyEmail = () => {
 	const dispatch = useDispatch();
 	const user = useSelector( getCurrentUser ) as UserData;
+	const safeUser = user ?? { email_verified: false, email: '' };
 	const sendEmail = useSendEmailVerification();
 	const { __ } = useI18n();
 
 	const [ data, setData ] = useState( {
-		isVerified: user.email_verified,
+		isVerified: safeUser.email_verified,
 		isSending: false,
-		email: user.email,
+		email: safeUser.email,
 		resent: false,
 	} );
 
@@ -47,7 +48,7 @@ export const useVerifyEmail = () => {
 
 	useEffect( () => {
 		const interval = setInterval( () => {
-			if ( ! user.email_verified ) {
+			if ( ! safeUser.email_verified ) {
 				dispatch( fetchCurrentUser() );
 			} else {
 				setData( ( prevState ) => ( {
@@ -57,7 +58,7 @@ export const useVerifyEmail = () => {
 			}
 		}, EVERY_FIVE_SECONDS );
 		return () => clearInterval( interval );
-	}, [ user.email_verified, dispatch ] );
+	}, [ safeUser.email_verified, dispatch ] );
 
 	return {
 		isVerified: data.isVerified,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes
This PR fixes a sentry issue where an exception is thrown in the `useVerifyEmail` hook due to the user property being null

* Handle null case in a safe manner
* Add tests cases to verify exception is handled

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `yarn test-client client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/test/use-verify-email.tsx`
* Verify also free trial email verify step is shown and works (`setup/new-hosted-site/trialAcknowledge`)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?