### PR TITLE
Multi-Domains: Honoring a free domain name after a free + custom domain selection

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -257,13 +257,8 @@ export class RenderDomainsStep extends Component {
 			shouldUseMultipleDomainsInCart( this.props.flowName ) &&
 			suggestion?.isSubDomainSuggestion
 		) {
-			suggestion.domain_name = suggestion.domain_name.replace( '.wordpress.com', '' );
-			await this.setState( { wpcomSubdomainSelected: suggestion } );
-
-			this.props.saveSignupStep( {
-				stepName: this.props.stepName,
-				suggestion,
-			} );
+			this.setState( { wpcomSubdomainSelected: suggestion } );
+			this.props.saveSignupStep( stepData );
 
 			return;
 		}
@@ -287,9 +282,6 @@ export class RenderDomainsStep extends Component {
 
 		// If we already have a free selection in place, let's enforce that as a free site suggestion
 		if ( this.state.wpcomSubdomainSelected ) {
-			this.state.wpcomSubdomainSelected.domain_name =
-				this.state.wpcomSubdomainSelected.domain_name.replace( '.wordpress.com', '' );
-
 			await this.props.saveSignupStep( {
 				stepName: this.props.stepName,
 				suggestion: this.state.wpcomSubdomainSelected,
@@ -770,7 +762,8 @@ export class RenderDomainsStep extends Component {
 			( suggestion && Boolean( suggestion.product_slug ) ) || domainCart?.length > 0;
 		const siteUrl =
 			suggestion &&
-			( isPurchasingItem
+			// If we have a free domain in the cart, we want to use it as the siteUrl
+			( isPurchasingItem && ! this.state.wpcomSubdomainSelected
 				? suggestion.domain_name
 				: suggestion.domain_name.replace( '.wordpress.com', '' ) );
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -259,7 +259,6 @@ export class RenderDomainsStep extends Component {
 		) {
 			this.setState( { wpcomSubdomainSelected: suggestion } );
 			this.props.saveSignupStep( stepData );
-
 			return;
 		}
 
@@ -278,14 +277,19 @@ export class RenderDomainsStep extends Component {
 			suggestion?.is_premium
 		);
 		await this.props.saveSignupStep( stepData );
-		await this.submitWithDomain( { signupDomainOrigin, position } );
 
-		// If we already have a free selection in place, let's enforce that as a free site suggestion
-		if ( this.state.wpcomSubdomainSelected ) {
-			await this.props.saveSignupStep( {
-				stepName: this.props.stepName,
-				suggestion: this.state.wpcomSubdomainSelected,
-			} );
+		if ( shouldUseMultipleDomainsInCart( this.props.flowName ) && suggestion ) {
+			this.handleDomainToDomainCart();
+
+			// If we already have a free selection in place, let's enforce that as a free site suggestion
+			if ( this.state.wpcomSubdomainSelected ) {
+				await this.props.saveSignupStep( {
+					stepName: this.props.stepName,
+					suggestion: this.state.wpcomSubdomainSelected,
+				} );
+			}
+		} else {
+			await this.submitWithDomain( { signupDomainOrigin, position } );
 		}
 	};
 
@@ -399,12 +403,9 @@ export class RenderDomainsStep extends Component {
 	};
 
 	submitWithDomain = ( { googleAppsCartItem, shouldHideFreePlan = false, signupDomainOrigin } ) => {
-		const { step, flowName } = this.props;
+		const { step } = this.props;
 		const { suggestion } = step;
 
-		if ( shouldUseMultipleDomainsInCart( flowName ) && suggestion ) {
-			return this.handleDomainToDomainCart();
-		}
 		const shouldUseThemeAnnotation = this.shouldUseThemeAnnotation();
 		const useThemeHeadstartItem = shouldUseThemeAnnotation
 			? { useThemeHeadstart: shouldUseThemeAnnotation }

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -278,6 +278,14 @@ export class RenderDomainsStep extends Component {
 		);
 		await this.props.saveSignupStep( stepData );
 		await this.submitWithDomain( { signupDomainOrigin, position } );
+
+		// If we already have a free selection in place, let's enforce that as a free site suggestion
+		if ( this.state.wpcomSubdomainSelected ) {
+			await this.props.saveSignupStep( {
+				stepName: this.props.stepName,
+				suggestion: this.state.wpcomSubdomainSelected,
+			} );
+		}
 	};
 
 	handleDomainMappingError = ( domain_name ) => {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -257,8 +257,14 @@ export class RenderDomainsStep extends Component {
 			shouldUseMultipleDomainsInCart( this.props.flowName ) &&
 			suggestion?.isSubDomainSuggestion
 		) {
-			this.setState( { wpcomSubdomainSelected: suggestion } );
-			this.props.saveSignupStep( stepData );
+			suggestion.domain_name = suggestion.domain_name.replace( '.wordpress.com', '' );
+			await this.setState( { wpcomSubdomainSelected: suggestion } );
+
+			this.props.saveSignupStep( {
+				stepName: this.props.stepName,
+				suggestion,
+			} );
+
 			return;
 		}
 
@@ -281,6 +287,9 @@ export class RenderDomainsStep extends Component {
 
 		// If we already have a free selection in place, let's enforce that as a free site suggestion
 		if ( this.state.wpcomSubdomainSelected ) {
+			this.state.wpcomSubdomainSelected.domain_name =
+				this.state.wpcomSubdomainSelected.domain_name.replace( '.wordpress.com', '' );
+
 			await this.props.saveSignupStep( {
 				stepName: this.props.stepName,
 				suggestion: this.state.wpcomSubdomainSelected,

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -279,7 +279,7 @@ export class RenderDomainsStep extends Component {
 		await this.props.saveSignupStep( stepData );
 
 		if ( shouldUseMultipleDomainsInCart( this.props.flowName ) && suggestion ) {
-			this.handleDomainToDomainCart();
+			await this.handleDomainToDomainCart();
 
 			// If we already have a free selection in place, let's enforce that as a free site suggestion
 			if ( this.state.wpcomSubdomainSelected ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 4170-gh-Automattic/dotcom-forge

## Proposed Changes

* Honors free domain selection

https://github.com/Automattic/wp-calypso/assets/1044309/430ae2f4-300a-46b0-9193-e2a5c12f31f4




## Testing Instructions

### Bug 1: We didn't honor the free domain after adding a paid domain

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Search for a domain and ad its free domain version in the mini-cart
* Search for a new domain and add some paid version.
* Advance to the next screen and see that now we're honoring the free domain version.
* Try to break it

### Bug 2: Please enter a site name error

Follow these steps (4170-gh-Automattic/dotcom-forge#issuecomment-1839385693) to ensure it doesn't happens anymore

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?