### PR TITLE
Reader: Add support for the Post Carousel and Jetpack Slideshow blocks

### DIFF
--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -6,10 +6,8 @@
 // some unnecessary styles removed.
 @import "story.scss";
 
-// Import styles for Newspack Post Carousel block.
-// This is a copy of Newspack's blocks/carousel/view.scss, with
-// some unnecessary styles removed.
-@import "post-carousel.scss";
+// Import styles for carousel blocks (Newspack Post Carousel, Jetpack Slideshow).
+@import "carousel.scss";
 
 .reader-full-post__story-content {
 	@extend %rendered-block-content;

--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -6,6 +6,11 @@
 // some unnecessary styles removed.
 @import "story.scss";
 
+// Import styles for Newspack Post Carousel block.
+// This is a copy of Newspack's blocks/carousel/view.scss, with
+// some unnecessary styles removed.
+@import "post-carousel.scss";
+
 .reader-full-post__story-content {
 	@extend %rendered-block-content;
 	padding-top: 16px;

--- a/client/blocks/reader-full-post/carousel.scss
+++ b/client/blocks/reader-full-post/carousel.scss
@@ -3,14 +3,18 @@
 .wp-block-newspack-blocks-carousel {
 	position: relative;
 	margin-top: 0;
+	margin-bottom: 1.5em;
 
-	div {
-		max-width: 100%;
+	.carousel-slide {
 		padding: 0;
 		position: relative;
 		margin-bottom: 0;
 		word-break: break-word;
 		overflow-wrap: break-word;
+		height: auto;
+		max-width: 100%;
+		max-height: 75vh;
+
 		a {
 			color: var(--studio-white);
 
@@ -20,8 +24,10 @@
 				color: var(--studio-white);
 			}
 		}
+
 		.entry-title {
 			font-size: $font-title-small;
+			margin: 0 0 0.25em;
 
 			a {
 				-webkit-box-orient: vertical;
@@ -30,9 +36,15 @@
 				max-height: 3.5625em;
 				overflow: hidden;
 				text-overflow: ellipsis;
+				color: var(--studio-white);
+				text-decoration: none;
 			}
 		}
+
 		.avatar {
+			border-radius: 100%;
+			display: block;
+			margin-right: 0.5em;
 			height: 1.8em;
 			width: 1.8em;
 		}
@@ -46,10 +58,23 @@
 			position: absolute;
 			right: 0;
 		}
+
+		figcaption {
+			font-size: $font-body-small;
+		}
+
 		.entry-meta {
 			color: var(--studio-white);
+			margin-top: 0.5em;
 			margin-bottom: 0;
 			font-size: $font-body-small;
+			display: flex;
+			flex-wrap: wrap;
+			align-items: center;
+
+			.byline:not(:last-child) {
+				margin-right: 1.5em;
+			}
 
 			a {
 				color: var(--studio-white);
@@ -61,6 +86,25 @@
 				&:hover {
 					color: rgba(var(--studio-white), 0.75);
 				}
+			}
+		}
+
+		.cat-links {
+			color: var(--studio-white);
+			font-size: $font-body-small;
+			font-weight: bold;
+			margin: 0 0 0.5em;
+
+			&.sponsor-label {
+				align-items: center;
+
+				.flag + a {
+					margin-left: 0.5em;
+				}
+			}
+
+			a {
+				text-decoration: none;
 			}
 		}
 	}
@@ -82,73 +126,9 @@
 			}
 		}
 	}
-	&__placeholder {
+
+	.wp-block-newspack-blocks-carousel__placeholder {
 		height: 420px;
 		background: var(--color-neutral-10);
-	}
-
-	.carousel-slide {
-		height: auto;
-		max-height: 75vh;
-	}
-
-	/* Image styles */
-	figcaption {
-		font-size: $font-body-small;
-	}
-
-	/* Headings */
-	.entry-title {
-		margin: 0 0 0.25em;
-		a {
-			color: var(--studio-white);
-			text-decoration: none;
-		}
-	}
-
-	/* Article meta */
-	.entry-meta {
-		display: flex;
-		flex-wrap: wrap;
-		align-items: center;
-		margin-top: 0.5em;
-		.byline:not(:last-child) {
-			margin-right: 1.5em;
-		}
-	}
-	.cat-links {
-		color: var(--studio-white);
-		font-size: $font-body-small;
-		font-weight: bold;
-		margin: 0 0 0.5em;
-
-		&.sponsor-label {
-			align-items: center;
-
-			.flag + a {
-				margin-left: 0.5em;
-			}
-		}
-
-		a {
-			text-decoration: none;
-		}
-	}
-	.avatar {
-		border-radius: 100%;
-		display: block;
-		margin-right: 0.5em;
-	}
-
-	// Make sure Jetpack Content Options don't affect the block.
-	.posted-on,
-	.cat-links,
-	.tags-links,
-	.byline,
-	.author-avatar {
-		clip: auto;
-		height: auto;
-		position: relative;
-		width: auto;
 	}
 }

--- a/client/blocks/reader-full-post/carousel.scss
+++ b/client/blocks/reader-full-post/carousel.scss
@@ -4,7 +4,7 @@
 	position: relative;
 	margin-top: 0;
 
-	article {
+	div {
 		max-width: 100%;
 		padding: 0;
 		position: relative;

--- a/client/blocks/reader-full-post/post-carousel.scss
+++ b/client/blocks/reader-full-post/post-carousel.scss
@@ -1,0 +1,157 @@
+/* Post carousel block styles */
+
+.wp-block-newspack-blocks-carousel {
+	position: relative;
+	margin-top: 0;
+
+	article {
+		max-width: 100%;
+		padding: 0;
+		position: relative;
+		margin-bottom: 0;
+		word-break: break-word;
+		overflow-wrap: break-word;
+		a {
+			color: var(--studio-white);
+
+			&:active,
+			&:focus,
+			&:hover {
+				color: var(--studio-white);
+			}
+		}
+		.entry-title {
+			font-size: $font-title-small;
+
+			a {
+				/* autoprefixer: off */
+				-webkit-box-orient: vertical;
+				/* autoprefixer: on */
+				display: -webkit-box;
+				-webkit-line-clamp: 3;
+				max-height: 3.5625em;
+				overflow: hidden;
+				text-overflow: ellipsis;
+			}
+		}
+		.avatar {
+			height: 1.8em;
+			width: 1.8em;
+		}
+
+		.entry-wrapper {
+			bottom: 0;
+			background-color: rgba(var(--color-text-rgb), 0.5);
+			color: var(--studio-white);
+			left: 0;
+			padding: 1.5em;
+			position: absolute;
+			right: 0;
+		}
+		.entry-meta {
+			color: var(--studio-white);
+			margin-bottom: 0;
+			font-size: $font-body-small;
+
+			a {
+				color: var(--studio-white);
+				font-weight: bold;
+				text-decoration: none;
+
+				&:active,
+				&:focus,
+				&:hover {
+					color: rgba(var(--studio-white), 0.75);
+				}
+			}
+		}
+	}
+	.post-thumbnail {
+		margin: 0;
+		height: 100%;
+		width: 100%;
+		padding: 0;
+		position: relative;
+		a,
+		img {
+			display: block;
+			height: 100%;
+			object-fit: cover;
+			width: 100%;
+
+			&.image-fit-contain {
+				object-fit: contain;
+			}
+		}
+	}
+	&__placeholder {
+		height: 420px;
+		background: var(--color-neutral-0);
+	}
+
+	/* Swiper Slide */
+	.swiper-slide {
+		height: auto;
+		max-height: 75vh;
+	}
+
+	/* Image styles */
+	figcaption {
+		font-size: $font-body-small;
+	}
+
+	/* Headings */
+	.entry-title {
+		margin: 0 0 0.25em;
+		a {
+			color: var(--studio-white);
+			text-decoration: none;
+		}
+	}
+
+	/* Article meta */
+	.entry-meta {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		margin-top: 0.5em;
+		.byline:not(:last-child) {
+			margin-right: 1.5em;
+		}
+	}
+	.cat-links {
+		color: var(--studio-white);
+		font-size: $font-body-small;
+		font-weight: bold;
+		margin: 0 0 0.5em;
+
+		&.sponsor-label {
+			align-items: center;
+
+			.flag + a {
+				margin-left: 0.5em;
+			}
+		}
+
+		a {
+			text-decoration: none;
+		}
+	}
+	.avatar {
+		border-radius: 100%;
+		display: block;
+		margin-right: 0.5em;
+	}
+
+	// Make sure Jetpack Content Options don't affect the block.
+	.posted-on,
+	.cat-links,
+	.tags-links,
+	.byline,
+	.author-avatar {
+		clip: auto;
+		height: auto;
+		position: relative;
+		width: auto;
+	}
+}

--- a/client/blocks/reader-full-post/post-carousel.scss
+++ b/client/blocks/reader-full-post/post-carousel.scss
@@ -24,9 +24,7 @@
 			font-size: $font-title-small;
 
 			a {
-				/* autoprefixer: off */
 				-webkit-box-orient: vertical;
-				/* autoprefixer: on */
 				display: -webkit-box;
 				-webkit-line-clamp: 3;
 				max-height: 3.5625em;
@@ -86,7 +84,7 @@
 	}
 	&__placeholder {
 		height: 420px;
-		background: var(--color-neutral-0);
+		background: var(--color-neutral-10);
 	}
 
 	/* Swiper Slide */

--- a/client/blocks/reader-full-post/post-carousel.scss
+++ b/client/blocks/reader-full-post/post-carousel.scss
@@ -87,8 +87,7 @@
 		background: var(--color-neutral-10);
 	}
 
-	/* Swiper Slide */
-	.swiper-slide {
+	.carousel-slide {
 		height: auto;
 		max-height: 75vh;
 	}

--- a/client/components/embed-container/index.jsx
+++ b/client/components/embed-container/index.jsx
@@ -1,7 +1,7 @@
 import { loadScript } from '@automattic/load-script';
 import debugFactory from 'debug';
 import { filter, forEach } from 'lodash';
-import { React, Children, PureComponent } from 'react';
+import { Children, PureComponent } from 'react';
 import ReactDom from 'react-dom';
 import { createRoot } from 'react-dom/client';
 import DotPager from 'calypso/components/dot-pager';

--- a/client/components/embed-container/index.jsx
+++ b/client/components/embed-container/index.jsx
@@ -1,4 +1,5 @@
 import { loadScript } from '@automattic/load-script';
+import classNames from 'classnames';
 import debugFactory from 'debug';
 import { filter, forEach } from 'lodash';
 import { Children, PureComponent } from 'react';
@@ -18,7 +19,7 @@ const embedsToLookFor = {
 	'.jetpack-slideshow': embedSlideshow,
 	'.wp-block-jetpack-story': embedStory,
 	'.embed-reddit': embedReddit,
-	'.wp-block-newspack-blocks-carousel': embedPostCarousel,
+	'.wp-block-jetpack-slideshow, .wp-block-newspack-blocks-carousel': embedCarousel,
 };
 
 const cacheBustQuery = `?v=${ Math.floor( new Date().getTime() / ( 1000 * 60 * 60 * 24 * 10 ) ) }`; // A new query every 10 days
@@ -195,20 +196,9 @@ function embedSlideshow( domNode ) {
 	}
 }
 
-function embedStory( domNode ) {
-	debug( 'processing story for ', domNode );
+function embedCarousel( domNode ) {
+	debug( 'processing carousel for ', domNode );
 
-	// wp-story-overlay is here for backwards compatiblity with Stories on Jetpack 9.7 and below.
-	const storyLink = domNode.querySelector( 'a.wp-story-container, a.wp-story-overlay' );
-
-	// Open story in a new tab
-	if ( storyLink ) {
-		storyLink.setAttribute( 'target', '_blank' );
-	}
-}
-
-function embedPostCarousel( domNode ) {
-	debug( 'processing post carousel for ', domNode );
 	const carouselItemsWrapper = domNode.querySelector( '.swiper-wrapper' );
 
 	// Inject the DotPager component.
@@ -219,21 +209,30 @@ function embedPostCarousel( domNode ) {
 			createRoot( domNode ).render(
 				<DotPager>
 					{ carouselItems.map( ( item, index ) => {
-						return (
-							<article
-								className="carousel-slide"
-								id={ index }
-								// eslint-disable-next-line react/no-danger
-								dangerouslySetInnerHTML={ { __html: item?.innerHTML } }
-							/>
-						);
+						const itemProps = {
+							key: index,
+							className: classNames( 'carousel-slide', item?.className ),
+							id: index,
+							// eslint-disable-next-line react/no-danger
+							dangerouslySetInnerHTML: { __html: item?.innerHTML },
+						};
+						return <div { ...itemProps } />;
 					} ) }
 				</DotPager>
 			);
 		}
+	}
+}
 
-		// Remove unused slider markup.
-		domNode.querySelector( '.swiper-pagination-bullets' )?.remove();
+function embedStory( domNode ) {
+	debug( 'processing story for ', domNode );
+
+	// wp-story-overlay is here for backwards compatiblity with Stories on Jetpack 9.7 and below.
+	const storyLink = domNode.querySelector( 'a.wp-story-container, a.wp-story-overlay' );
+
+	// Open story in a new tab
+	if ( storyLink ) {
+		storyLink.setAttribute( 'target', '_blank' );
 	}
 }
 

--- a/client/components/embed-container/index.jsx
+++ b/client/components/embed-container/index.jsx
@@ -209,15 +209,14 @@ function embedStory( domNode ) {
 
 function embedPostCarousel( domNode ) {
 	debug( 'processing post carousel for ', domNode );
-	const carouselWrapper = domNode.querySelector( '.swiper' );
-	const carouselItemsWrapper = carouselWrapper?.querySelector( '.swiper-wrapper' );
+	const carouselItemsWrapper = domNode.querySelector( '.swiper-wrapper' );
 
 	// Inject the DotPager component.
-	if ( carouselWrapper && carouselItemsWrapper ) {
+	if ( carouselItemsWrapper ) {
 		const carouselItems = Array.from( carouselItemsWrapper?.children );
 
 		if ( carouselItems ) {
-			createRoot( carouselWrapper ).render(
+			createRoot( domNode ).render(
 				<DotPager>
 					{ carouselItems.map( ( item, index ) => {
 						return (

--- a/client/components/embed-container/index.jsx
+++ b/client/components/embed-container/index.jsx
@@ -205,18 +205,18 @@ function embedCarousel( domNode ) {
 	if ( carouselItemsWrapper ) {
 		const carouselItems = Array.from( carouselItemsWrapper?.children );
 
-		if ( carouselItems ) {
+		if ( carouselItems && carouselItems.length ) {
 			createRoot( domNode ).render(
 				<DotPager>
 					{ carouselItems.map( ( item, index ) => {
-						const itemProps = {
-							key: index,
-							className: classNames( 'carousel-slide', item?.className ),
-							id: index,
-							// eslint-disable-next-line react/no-danger
-							dangerouslySetInnerHTML: { __html: item?.innerHTML },
-						};
-						return <div { ...itemProps } />;
+						return (
+							<div
+								key={ index }
+								className={ classNames( 'carousel-slide', item?.className ) }
+								// eslint-disable-next-line react/no-danger
+								dangerouslySetInnerHTML={ { __html: item?.innerHTML } }
+							/>
+						);
 					} ) }
 				</DotPager>
 			);

--- a/client/components/embed-container/index.jsx
+++ b/client/components/embed-container/index.jsx
@@ -210,28 +210,31 @@ function embedStory( domNode ) {
 function embedPostCarousel( domNode ) {
 	debug( 'processing post carousel for ', domNode );
 	const carouselWrapper = domNode.querySelector( '.swiper' );
-	const carouselItemsWrapper = carouselWrapper.querySelector( '.swiper-wrapper' );
+	const carouselItemsWrapper = carouselWrapper?.querySelector( '.swiper-wrapper' );
 
 	// Inject the DotPager component.
-	if ( carouselItemsWrapper ) {
-		const carouselItems = Array.from( carouselItemsWrapper.children );
-		createRoot( carouselWrapper ).render(
-			<DotPager>
-				{ carouselItems.map( ( item, index ) => {
-					return (
-						<article
-							className="swiper-slide"
-							id={ index }
-							// eslint-disable-next-line react/no-danger
-							dangerouslySetInnerHTML={ { __html: item.innerHTML } }
-						/>
-					);
-				} ) }
-			</DotPager>
-		);
+	if ( carouselWrapper && carouselItemsWrapper ) {
+		const carouselItems = Array.from( carouselItemsWrapper?.children );
+
+		if ( carouselItems ) {
+			createRoot( carouselWrapper ).render(
+				<DotPager>
+					{ carouselItems.map( ( item, index ) => {
+						return (
+							<article
+								className="carousel-slide"
+								id={ index }
+								// eslint-disable-next-line react/no-danger
+								dangerouslySetInnerHTML={ { __html: item?.innerHTML } }
+							/>
+						);
+					} ) }
+				</DotPager>
+			);
+		}
 
 		// Remove unused slider markup.
-		domNode.querySelector( '.swiper-pagination-bullets' ).remove();
+		domNode.querySelector( '.swiper-pagination-bullets' )?.remove();
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #81255 and #45085

## Proposed Changes

* Treat the Post Carousel and Jetpack Slideshows like embeds in the Reader (and other embed contexts, like inline help)
* When we find an instance of a post carousel block or a Jetpack Slideshow block in a post, wrap the markup in a `DotPager` component.
* I experimented with using Swiper (which is the library originally powering these blocks) but opted for DotPager for simplicity and consistency with other carousels (like gallery posts) in the Reader.
* Adds some carousel-specific styles.

**Before**

<img width="1026" alt="Screenshot 2023-12-04 at 2 31 47 PM" src="https://github.com/Automattic/wp-calypso/assets/2124984/3b78867a-cf1f-4322-8138-5ee4ada60163">

**After**

<img width="1054" alt="Screenshot 2023-12-04 at 2 30 55 PM" src="https://github.com/Automattic/wp-calypso/assets/2124984/a350abfe-6237-4615-ba15-45a2144e12b3">

## Testing Instructions

* Switch to this PR
* Navigate to `/read`
* Find a post (I had to publish one) with a Post Carousel block containing several posts.
* View the full post; you should see a working carousel rather than an unformatted list of post details.
* Find or publish a post with a Jetpack Slideshow and view it in the Reader (full post view)
* You should see a slideshow instead of a list of images in the full post view.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?