### PR TITLE
Improving likes: Update sharing buttons preview

### DIFF
--- a/client/my-sites/marketing/buttons/preview.jsx
+++ b/client/my-sites/marketing/buttons/preview.jsx
@@ -1,5 +1,6 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 import { Gridicon } from '@automattic/components';
+import { Icon, starEmpty } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
 import { filter, some } from 'lodash';
 import PropTypes from 'prop-types';
@@ -147,11 +148,10 @@ class SharingButtonsPreview extends Component {
 	getLikeButtonElement = () => {
 		if ( this.props.showLike ) {
 			return (
-				<span>
+				<span className="sharing-buttons-preview__like-container">
 					<div className="sharing-buttons-preview-button is-enabled style-icon-text sharing-buttons-preview__like">
-						{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
 						{ /* 16 is used in the preview to match the buttons on the frontend of the website. */ }
-						<Gridicon icon="star" size={ 16 } />
+						<Icon icon={ starEmpty } className="sharing-buttons-preview__like-icon" />
 						{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
 						{ this.props.translate( 'Like' ) }
 					</div>
@@ -162,7 +162,7 @@ class SharingButtonsPreview extends Component {
 						/>
 					</div>
 					<div className="sharing-buttons-preview__fake-like">
-						{ this.props.translate( 'One blogger likes this.' ) }
+						{ this.props.translate( '1 like' ) }
 					</div>
 				</span>
 			);

--- a/client/my-sites/marketing/style.scss
+++ b/client/my-sites/marketing/style.scss
@@ -642,11 +642,20 @@
 }
 
 .sharing-buttons-preview__reblog-like {
+	display: flex;
 	margin: 14px 0;
 }
 
+.sharing-buttons-preview__like-container {
+	display: flex;
+	align-items: center;
+}
+
+.sharing-buttons-preview__like-icon {
+	fill: var(--color-neutral-80);
+}
+
 .sharing-buttons-preview__reblog-like .sharing-buttons-preview-button {
-	margin-bottom: 3px;
 	margin-top: 0;
 }
 
@@ -658,32 +667,41 @@
 	&::before {
 		display: none;
 	}
+}
+
+.sharing-buttons-preview__like-container .sharing-buttons-preview__like {
+	display: flex !important;
+	padding-left: 5px;
+	padding-top: 3px;
 
 	&:hover {
-		color: #777;
+		.sharing-buttons-preview__like-icon {
+			fill: var(--studio-blue-50);
+		}
 	}
 }
 
-.sharing-buttons-preview__reblog .gridicon,
-.sharing-buttons-preview__like .gridicon {
+.sharing-buttons-preview__reblog .gridicon {
 	vertical-align: top;
 	margin: 3px 4px 0 0;
-	fill: var(--color-accent);
 }
 
 .sharing-buttons-preview__fake-user {
-	display: inline-block;
-	height: 32px;
-	width: 32px;
-	line-height: 1;
-	vertical-align: top;
-	position: relative;
-	top: -1px;
+	height: 29px;
+	width: 29px;
+}
+
+.sharing-buttons-preview__fake-user img {
+	height: 26px;
+	width: 26px;
+	border-radius: 50%;
+	border: solid 1.5px #fff;
 }
 
 .sharing-buttons-preview__fake-like {
-	color: var(--color-neutral-40);
+	color: var(--color-neutral-80);
 	font-size: $font-body-extra-small;
+	margin-left: 8px;
 }
 
 .sharing-buttons-preview .sortable-list__navigation {


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/84808

## Proposed Changes

* Update sharing buttons preview to match the design on Figma

<img width="593" alt="Screenshot 2023-12-04 at 19 32 27" src="https://github.com/Automattic/wp-calypso/assets/3113712/99f53402-88f8-4c5e-9978-d1a7e602f744">

## Testing Instructions

* Apply this PR to your local
* Run `yarn start`
* Go to http://calypso.localhost:3000/marketing/sharing-buttons and choose a site
* You should see the updated preview (new like button icon and rounded avatars)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?