### PR TITLE
Self service site reset: Add hook to reset site 

### DIFF
--- a/packages/data-stores/src/mutations/test/use-site-reset-mutation.tsx
+++ b/packages/data-stores/src/mutations/test/use-site-reset-mutation.tsx
@@ -54,7 +54,7 @@ describe( 'use-site-reset-mutation hook', () => {
 		);
 
 		const error = {
-			success: false,
+			code: 'Unauthorized',
 			message: 'Something went wrong',
 		};
 

--- a/packages/data-stores/src/mutations/test/use-site-reset-mutation.tsx
+++ b/packages/data-stores/src/mutations/test/use-site-reset-mutation.tsx
@@ -1,0 +1,76 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { waitFor } from '@testing-library/dom';
+import { renderHook } from '@testing-library/react';
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import wpcomRequest from 'wpcom-proxy-request';
+import { useSiteResetMutation } from '../use-site-reset-mutation';
+
+jest.mock( 'wpcom-proxy-request', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+describe( 'use-site-reset-mutation hook', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	test( 'returns success from the api', async () => {
+		const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+		const wrapper = ( { children } ) => (
+			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+		);
+
+		const expected = {
+			success: true,
+		};
+
+		( wpcomRequest as jest.Mock ).mockImplementation( () => Promise.resolve( expected ) );
+
+		const { result } = renderHook( () => useSiteResetMutation(), {
+			wrapper,
+		} );
+
+		expect( result.current.isSuccess ).toBe( false );
+
+		act( () => {
+			result.current.resetSite( 123 );
+		} );
+
+		await waitFor( () => {
+			expect( result.current.isSuccess ).toBe( true );
+			expect( result.current.data ).toEqual( expected );
+		} );
+	} );
+
+	test( 'returns failure from the api', async () => {
+		const queryClient = new QueryClient();
+		const wrapper = ( { children } ) => (
+			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+		);
+
+		const error = {
+			success: false,
+			message: 'Something went wrong',
+		};
+
+		( wpcomRequest as jest.Mock ).mockImplementation( () => Promise.reject( error ) );
+
+		const { result } = renderHook( () => useSiteResetMutation(), {
+			wrapper,
+		} );
+
+		act( () => {
+			result.current.resetSite( 123 );
+		} );
+
+		await waitFor( () => {
+			expect( result.current.isError ).toBe( true );
+			expect( result.current.error ).toEqual( error );
+		} );
+	} );
+} );

--- a/packages/data-stores/src/mutations/use-site-reset-mutation.ts
+++ b/packages/data-stores/src/mutations/use-site-reset-mutation.ts
@@ -2,7 +2,18 @@ import { UseMutationOptions, useMutation } from '@tanstack/react-query';
 import { useCallback } from 'react';
 import wpcomRequest from 'wpcom-proxy-request';
 
-export const useSiteResetMutation = < TData = unknown, TError = unknown, TContext = unknown >(
+interface APIResponse {
+	success: boolean;
+}
+
+export interface APIError {
+	status: number;
+	code: string | null;
+	message: string;
+	data?: any;
+}
+
+export const useSiteResetMutation = < TData = APIResponse, TError = APIError, TContext = unknown >(
 	options: UseMutationOptions< TData, TError, { siteId: number }, TContext > = {}
 ) => {
 	const { mutate, ...rest } = useMutation( {

--- a/packages/data-stores/src/mutations/use-site-reset-mutation.ts
+++ b/packages/data-stores/src/mutations/use-site-reset-mutation.ts
@@ -1,0 +1,25 @@
+import { UseMutationOptions, useMutation } from '@tanstack/react-query';
+import { useCallback } from 'react';
+import wpcomRequest from 'wpcom-proxy-request';
+
+export const useSiteResetMutation = < TData = unknown, TError = unknown, TContext = unknown >(
+	options: UseMutationOptions< TData, TError, { siteId: number }, TContext > = {}
+) => {
+	const { mutate, ...rest } = useMutation( {
+		mutationFn: ( { siteId } ) =>
+			wpcomRequest( {
+				path: `/sites/${ siteId }/reset-site`,
+				apiNamespace: 'wpcom/v2',
+				method: 'POST',
+			} ),
+
+		...options,
+	} );
+
+	const resetSite = useCallback( ( siteId: number ) => mutate( { siteId } ), [ mutate ] );
+
+	return {
+		resetSite,
+		...rest,
+	};
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Relates to https://github.com/Automattic/dotcom-forge/issues/4690
## Proposed Changes

* Add a `useSiteResetMutation` to reset site
* Add tests to validate the hook

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
This is not connected to any UI so the tests is to run the unit test
* Run  `yarn test-packages packages/data-stores/src/mutations/test/use-site-reset-mutation.tsx`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?