### PR TITLE
Refine the Pressable promo banner

### DIFF
--- a/client/my-sites/plans-features-main/components/pressable-promo-banner.tsx
+++ b/client/my-sites/plans-features-main/components/pressable-promo-banner.tsx
@@ -26,13 +26,16 @@ const Banner = styled.div`
 
 const LogoContainer = styled.div`
 	display: none;
-	height: 18px;
 
 	${ plansBreakSmall( css`
 		display: inherit;
-		flex-basis: 120px;
+		background-color: #f9f9f9;
+		border-radius: 4px;
+		height: 100px;
+		flex-basis: 100px;
 		flex-shrink: 0;
-		background-color: var( --studio-white );
+		align-items: center;
+		justify-content: center;
 	` ) }
 `;
 
@@ -81,6 +84,7 @@ const CtaButton = styled( Button )`
 	width: 100%;
 	height: 40px;
 	padding: 10px, 24px, 10px, 24px;
+	border: 0;
 	border-radius: 4px;
 	background-color: var( --studio-black );
 	color: var( --studio-white );
@@ -113,7 +117,7 @@ const PressablePromoBanner = ( {
 	return (
 		<Banner>
 			<LogoContainer>
-				<PressableLogo />
+				<PressableLogo height={ 10 } width={ 69 } />
 			</LogoContainer>
 			<TextContainer>
 				<Subtitle>{ translate( 'Hosting partner' ) }</Subtitle>

--- a/client/my-sites/plans-features-main/components/pressable-promo-banner.tsx
+++ b/client/my-sites/plans-features-main/components/pressable-promo-banner.tsx
@@ -56,25 +56,31 @@ const CtaContainer = styled.div`
 `;
 
 const Subtitle = styled.h4`
+	font-name: SF Pro Text;
 	font-size: 12px;
 	font-weight: 400;
 	text-align: left;
 	line-height: 20px;
+	color: var( --studio-gray-50 );
 `;
 
 const Title = styled.h2`
+	font-name: SF Pro Display;
 	font-size: 20px;
 	font-weight: 500;
 	text-align: left;
 	line-height: 26px;
+	color: var( --studio-black );
 `;
 
 const Description = styled.p`
+	font-name: SF Pro Text;
 	font-size: 14px;
 	font-weight: 400;
 	text-align: left;
 	margin: 0;
 	line-height: 20px;
+	color: var( --studio-black );
 `;
 
 const CtaButton = styled( Button )`

--- a/client/my-sites/plans-features-main/components/pressable-promo-banner.tsx
+++ b/client/my-sites/plans-features-main/components/pressable-promo-banner.tsx
@@ -135,6 +135,7 @@ const PressablePromoBanner = ( {
 					target="_blank"
 				>
 					{ translate( 'See Pressable Plans' ) }
+					&nbsp;
 					<Gridicon icon="external" />
 				</CtaButton>
 			</CtaContainer>

--- a/client/my-sites/plans-features-main/components/pressable-promo-banner.tsx
+++ b/client/my-sites/plans-features-main/components/pressable-promo-banner.tsx
@@ -9,18 +9,16 @@ const Banner = styled.div`
 	display: flex;
 	flex-direction: column;
 	justify-content: start;
-	min-height: 128px;
-	padding: 0px, 24px, 0px, 0px;
+	min-height: 80px;
 	border-radius: 4px;
 	border: 1px solid #dcdcde;
 	margin: 24px 20px 24px 20px;
-	padding: 24px 20px 24px 20px;
+	padding: 24px;
 	align-items: center;
-	gap: 16px;
+	gap: 32px;
 
 	${ plansBreakSmall( css`
 		flex-direction: row;
-		padding: 0 20px 0 20px;
 	` ) }
 `;
 
@@ -61,12 +59,14 @@ const Subtitle = styled.h4`
 	font-size: 12px;
 	font-weight: 400;
 	text-align: left;
+	line-height: 20px;
 `;
 
 const Title = styled.h2`
 	font-size: 20px;
 	font-weight: 500;
 	text-align: left;
+	line-height: 26px;
 `;
 
 const Description = styled.p`
@@ -74,6 +74,7 @@ const Description = styled.p`
 	font-weight: 400;
 	text-align: left;
 	margin: 0;
+	line-height: 20px;
 `;
 
 const CtaButton = styled( Button )`

--- a/packages/components/src/logos/pressable-logo/index.tsx
+++ b/packages/components/src/logos/pressable-logo/index.tsx
@@ -1,5 +1,13 @@
-const PressableLogo = () => (
-	<svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" viewBox="0 0 495 75.1">
+const PressableLogo = ( props: React.SVGProps< SVGSVGElement > ) => (
+	<svg
+		version="1.1"
+		xmlns="http://www.w3.org/2000/svg"
+		x="0px"
+		y="0px"
+		viewBox="0 0 495 75.1"
+		width={ props.width }
+		height={ props.height }
+	>
 		<style type="text/css">{ '.st0{fill: #040047; }' }</style>
 		<g id="pressable-logo">
 			<g id="pressable">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This PR addresses @vinimotaa 's design feedback on the missing details of the Pressable promotion banner. For more details, please refer to p9Jlb4-9Dn-p2#comment-10090

In summary,

* Adjust the gaps between logo, text, and CTA to 32px
* Adjust the padding around the banner to 24px
* Update background of the logo container should be `F9F9F9`
* Tweak size of the logo container and the logo itself
* The rounded corners for the banner and the logo container.
* Spacing between the grid icon and the CTA text.

Before:
<img width="1378" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1842898/57da93c8-edf2-406a-adb6-cb48ba02b930">

After:
<img width="1392" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1842898/79beea9a-edac-493e-9a8d-b78fd12fecbd">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* The banner should work as expected.
* Confirm the styling updates match the request.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
