### PR TITLE
Stats: Filter already purchased tiers

### DIFF
--- a/client/my-sites/stats/stats-purchase/index.tsx
+++ b/client/my-sites/stats/stats-purchase/index.tsx
@@ -42,6 +42,7 @@ const StatsPurchasePage = ( {
 } ) => {
 	const translate = useTranslate();
 	const isTypeDetectionEnabled = config.isEnabled( 'stats/type-detection' );
+	const isTierUpgradeSliderEnabled = config.isEnabled( 'stats/tier-upgrade-slider' );
 
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
@@ -54,8 +55,13 @@ const StatsPurchasePage = ( {
 		getSiteOption( state, siteId, 'is_commercial' )
 	) as boolean;
 
-	const { isRequestingSitePurchases, isFreeOwned, isPWYWOwned, supportCommercialUse } =
-		useStatsPurchases( siteId );
+	const {
+		isRequestingSitePurchases,
+		isFreeOwned,
+		isPWYWOwned,
+		isCommercialOwned,
+		supportCommercialUse,
+	} = useStatsPurchases( siteId );
 
 	useEffect( () => {
 		if ( ! siteSlug ) {
@@ -107,15 +113,18 @@ const StatsPurchasePage = ( {
 	const maxSliderPrice = commercialMonthlyProduct?.cost;
 
 	// Redirect to commercial is there is the query param is set and the site doesn't have commercial license yet
-	const redirectToCommercial = query?.productType === 'commercial' && ! supportCommercialUse;
+	const redirectToCommercial = ! isTierUpgradeSliderEnabled
+		? query?.productType === 'commercial' && ! supportCommercialUse
+		: query?.productType === 'commercial'; // allow multiple visit to upgrade commercial tier.
 	// Redirect to personal is there is the query param is set, the site doesn't have personal license yet, and it's not redirecting to commercial
 	const redirectToPersonal =
 		query?.productType === 'personal' && ! isPWYWOwned && ! redirectToCommercial;
 	// Whether it's forced to redirect to a product
 	const isForceProductRedirect = redirectToPersonal || redirectToCommercial;
 	const noPlanOwned = ! supportCommercialUse && ! isFreeOwned && ! isPWYWOwned;
+	const allowCommercialTierUpgrade = isTierUpgradeSliderEnabled && isCommercialOwned;
 	// We show purchase page if there is no plan owned or if we are forcing a product redirect
-	const showPurchasePage = noPlanOwned || isForceProductRedirect;
+	const showPurchasePage = noPlanOwned || isForceProductRedirect || allowCommercialTierUpgrade;
 
 	return (
 		<Main fullWidthLayout>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.tsx
@@ -3,8 +3,10 @@ import formatCurrency from '@automattic/format-currency';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import React, { useState, useRef } from 'react';
+import usePlanUsageQuery from 'calypso/my-sites/stats/hooks/use-plan-usage-query';
 import { useSelector } from 'calypso/state';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { StatsPlanTierUI } from './types';
 import useAvailableUpgradeTiers from './use-available-upgrade-tiers';
 import './stats-purchase-tier-upgrade-slider.scss';
 
@@ -42,8 +44,28 @@ function TierUpgradeSlider( {
 	const infoReferenceElement = useRef( null );
 	const componentClassNames = classNames( 'stats-tier-upgrade-slider', className );
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
-	const tiers = useAvailableUpgradeTiers( siteId );
+	const availableTiers = useAvailableUpgradeTiers( siteId );
 	const EXTENSION_THRESHOLD = 2; // in millions
+
+	// Filter out already purchased tiers.
+	const { data: purchasedTierData } = usePlanUsageQuery( siteId );
+	let tiers: StatsPlanTierUI[];
+
+	if ( purchasedTierData?.views_limit === null || purchasedTierData?.views_limit === 0 ) {
+		// No tier has been purchased.
+		tiers = availableTiers;
+	} else {
+		tiers = availableTiers.filter( ( availableTier ) => {
+			if ( ! availableTier?.views || ! purchasedTierData?.views_limit ) {
+				return true;
+			}
+
+			return (
+				availableTier.views === null ||
+				( availableTier?.views as number ) > purchasedTierData?.views_limit
+			);
+		} );
+	}
 
 	// Slider state.
 	const [ currentPlanIndex, setCurrentPlanIndex ] = useState( 0 );

--- a/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.tsx
@@ -3,7 +3,6 @@ import formatCurrency from '@automattic/format-currency';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import React, { useState, useRef } from 'react';
-import usePlanUsageQuery from 'calypso/my-sites/stats/hooks/use-plan-usage-query';
 import { useSelector } from 'calypso/state';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import useAvailableUpgradeTiers from './use-available-upgrade-tiers';
@@ -43,8 +42,7 @@ function TierUpgradeSlider( {
 	const infoReferenceElement = useRef( null );
 	const componentClassNames = classNames( 'stats-tier-upgrade-slider', className );
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
-	const { data: purchasedTierData } = usePlanUsageQuery( siteId ); // pass to the filtering function
-	const tiers = useAvailableUpgradeTiers( siteId, purchasedTierData );
+	const tiers = useAvailableUpgradeTiers( siteId );
 	const EXTENSION_THRESHOLD = 2; // in millions
 
 	// Slider state.

--- a/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.tsx
@@ -6,7 +6,6 @@ import React, { useState, useRef } from 'react';
 import usePlanUsageQuery from 'calypso/my-sites/stats/hooks/use-plan-usage-query';
 import { useSelector } from 'calypso/state';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { StatsPlanTierUI } from './types';
 import useAvailableUpgradeTiers from './use-available-upgrade-tiers';
 import './stats-purchase-tier-upgrade-slider.scss';
 
@@ -44,28 +43,9 @@ function TierUpgradeSlider( {
 	const infoReferenceElement = useRef( null );
 	const componentClassNames = classNames( 'stats-tier-upgrade-slider', className );
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
-	const availableTiers = useAvailableUpgradeTiers( siteId );
+	const { data: purchasedTierData } = usePlanUsageQuery( siteId ); // pass to the filtering function
+	const tiers = useAvailableUpgradeTiers( siteId, purchasedTierData );
 	const EXTENSION_THRESHOLD = 2; // in millions
-
-	// Filter out already purchased tiers.
-	const { data: purchasedTierData } = usePlanUsageQuery( siteId );
-	let tiers: StatsPlanTierUI[];
-
-	if ( purchasedTierData?.views_limit === null || purchasedTierData?.views_limit === 0 ) {
-		// No tier has been purchased.
-		tiers = availableTiers;
-	} else {
-		tiers = availableTiers.filter( ( availableTier ) => {
-			if ( ! availableTier?.views || ! purchasedTierData?.views_limit ) {
-				return true;
-			}
-
-			return (
-				availableTier.views === null ||
-				( availableTier?.views as number ) > purchasedTierData?.views_limit
-			);
-		} );
-	}
 
 	// Slider state.
 	const [ currentPlanIndex, setCurrentPlanIndex ] = useState( 0 );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #84803

## Proposed Changes

* avoid showing purchased tiers in the upgrade slider

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to the live branch and visit the Stats purchase page
* navigate to a commercial licence and verify that the old flow is not affected by checking that you are redirected to a checkout page (don't purchase it)
* make sure that your store is running in a sandbox mode and that you applied the tiered billing patch
* go back to the Stats purchase page and apply the stats/tier-upgrade-slider feature flag
* select a desired tier and purchase it (note the tier you purchased)
* visit the purchase page again
* verify that the tiers equal or below the limit you purchased are not available to select (note that handling of the highest tier will be addressed in a following PR)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?