### PR TITLE
Jetpack Manage: Update the Licenses page to group bundles and their child licenses together

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/index.tsx
@@ -35,7 +35,7 @@ export default function ReviewLicenses( { onClose, selectedLicenses }: Props ) {
 					</div>
 					<div className="review-licenses__selected-licenses">
 						{ selectedLicenses.map( ( license ) => (
-							<LicenseInfo product={ license } />
+							<LicenseInfo key={ `license-info-${ license.product_id }` } product={ license } />
 						) ) }
 					</div>
 				</div>

--- a/client/jetpack-cloud/sections/partner-portal/license-details/bundle-details.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/bundle-details.tsx
@@ -1,0 +1,34 @@
+import { LicenseType } from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import useBundleLicensesQuery from 'calypso/state/partner-portal/licenses/hooks/use-bundle-licenses-query';
+import LicensePreview, { LicensePreviewPlaceholder } from '../license-preview';
+
+interface Props {
+	parentLicenseId: number;
+}
+
+export default function BundleDetails( { parentLicenseId }: Props ) {
+	const { data } = useBundleLicensesQuery( parentLicenseId );
+
+	if ( ! data ) {
+		return <LicensePreviewPlaceholder />;
+	}
+
+	return data.map( ( item ) => (
+		<LicensePreview
+			isChildLicense
+			key={ item.licenseId }
+			licenseKey={ item.licenseKey }
+			product={ item.product }
+			username={ item.username }
+			blogId={ item.blogId }
+			siteUrl={ item.siteUrl }
+			hasDownloads={ item.hasDownloads }
+			issuedAt={ item.issuedAt }
+			attachedAt={ item.attachedAt }
+			revokedAt={ item.revokedAt }
+			licenseType={
+				item.ownerType === LicenseType.Standard ? LicenseType.Standard : LicenseType.Partner
+			}
+		/>
+	) );
+}

--- a/client/jetpack-cloud/sections/partner-portal/license-list-item/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-list-item/style.scss
@@ -170,3 +170,36 @@ $grid-wide: 0.5fr 0.5fr 128px 128px 128px 36px;
 		font-size: 1rem;
 	}
 }
+
+.license-preview__bundle {
+	.license-preview__no-value {
+		display: none;
+
+		@include break-xlarge() {
+			display: block;
+		}
+	}
+
+	.license-preview__license-count {
+		display: block;
+		max-width: fit-content;
+		margin-block-start: 4px;
+
+		@include break-xlarge() {
+			display: none;
+		}
+	}
+}
+
+.license-preview__badge-container {
+	display: flex;
+
+	.license-preview__license-count {
+		text-wrap: nowrap;
+		display: none;
+
+		@include break-xlarge() {
+			display: block;
+		}
+	}
+}

--- a/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
@@ -83,6 +83,7 @@ export default function LicenseList() {
 					licenses.items.map( ( license ) => (
 						<LicenseTransition key={ license.licenseKey }>
 							<LicensePreview
+								parentLicenseId={ license.licenseId }
 								licenseKey={ license.licenseKey }
 								product={ license.product }
 								username={ license.username }
@@ -92,12 +93,12 @@ export default function LicenseList() {
 								issuedAt={ license.issuedAt }
 								attachedAt={ license.attachedAt }
 								revokedAt={ license.revokedAt }
-								filter={ filter }
 								licenseType={
 									license.ownerType === LicenseType.Standard
 										? LicenseType.Standard
 										: LicenseType.Partner
 								}
+								quantity={ license.quantity }
 							/>
 						</LicenseTransition>
 					) ) }

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/style.scss
@@ -202,3 +202,7 @@ button {
 		}
 	}
 }
+
+.card.license-preview__card.license-preview__card--child-license {
+	padding: 16px 32px;
+}

--- a/client/state/partner-portal/licenses/handlers.ts
+++ b/client/state/partner-portal/licenses/handlers.ts
@@ -37,6 +37,7 @@ interface APILicense {
 	attached_at: string | null;
 	revoked_at: string | null;
 	owner_type: string | null;
+	quantity: number | null;
 }
 
 interface APIPaginatedItems< T > {
@@ -96,7 +97,7 @@ export function receiveLicensesErrorHandler(): NoticeAction {
 	return errorNotice( translate( 'Failed to retrieve your licenses. Please try again later.' ) );
 }
 
-function formatLicenses( items: APILicense[] ): License[] {
+export function formatLicenses( items: APILicense[] ): License[] {
 	return items.map( ( item ) => ( {
 		licenseId: item.license_id,
 		licenseKey: item.license_key,
@@ -111,6 +112,7 @@ function formatLicenses( items: APILicense[] ): License[] {
 		attachedAt: item.attached_at,
 		revokedAt: item.revoked_at,
 		ownerType: item.owner_type,
+		quantity: item.quantity,
 	} ) );
 }
 

--- a/client/state/partner-portal/licenses/hooks/use-bundle-licenses-query.ts
+++ b/client/state/partner-portal/licenses/hooks/use-bundle-licenses-query.ts
@@ -22,7 +22,7 @@ export default function useBundleLicensesQuery(
 					path: '/jetpack-licensing/licenses',
 				},
 				{
-					...( parentLicenseId && { parent_id: parentLicenseId } ),
+					parent_id: parentLicenseId,
 				}
 			),
 		select: ( data ) => formatLicenses( data.items ),

--- a/client/state/partner-portal/licenses/hooks/use-bundle-licenses-query.ts
+++ b/client/state/partner-portal/licenses/hooks/use-bundle-licenses-query.ts
@@ -1,0 +1,47 @@
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
+import { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
+import { useDispatch } from 'calypso/state';
+import { License } from 'calypso/state/partner-portal/types';
+import { errorNotice } from '../../../notices/actions';
+import { formatLicenses } from '../handlers';
+
+export default function useBundleLicensesQuery(
+	parentLicenseId: number
+): UseQueryResult< License[] > {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const query = useQuery( {
+		queryKey: [ 'partner-portal', 'bundle-licenses', parentLicenseId ],
+		queryFn: () =>
+			wpcomJpl.req.get(
+				{
+					apiNamespace: 'wpcom/v2',
+					path: '/jetpack-licensing/licenses',
+				},
+				{
+					...( parentLicenseId && { parent_id: parentLicenseId } ),
+				}
+			),
+		select: ( data ) => formatLicenses( data.items ),
+	} );
+
+	const { isError } = query;
+
+	useEffect( () => {
+		if ( isError ) {
+			dispatch(
+				errorNotice(
+					translate( 'We were unable to retrieve the license details. Please try again later.' ),
+					{
+						id: 'partner-portal-bundle-licenses-failure',
+					}
+				)
+			);
+		}
+	}, [ dispatch, translate, isError ] );
+
+	return query;
+}

--- a/client/state/partner-portal/types.ts
+++ b/client/state/partner-portal/types.ts
@@ -242,6 +242,7 @@ export interface License {
 	attachedAt: string | null;
 	revokedAt: string | null;
 	ownerType: string | null;
+	quantity: number | null;
 }
 
 export interface LicenseCounts {


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/130

## Proposed Changes

This PR updates the Licenses page to group bundles and their child licenses together.

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. 

**Instructions**

PLEASE NOTE: 

- Please verify everything works as before(production) without the feature flag.
- Append the URL with `?flags=jetpack/bundle-licensing` if something doesn't work as expected.

1. Switch to billing scheme: 32b1d-pb.
2. Apply the patch: D130819-code. Please note: The bundle with 100 licenses might display only 50 licenses, we need some API changes to be done.
3. Visit the Jetpack Cloud link > Replace `dashboard` in the URL with `/partner-portal/issue-license?flags=jetpack/bundle-licensing`.
4. Select any bundle to purchase. (NOTE: Currently, Jetpack Complete bundles of size 10 are the safest option.)
5. Click the "Review N license" button and review your choices in the modal that pops up. If everything looks accurate, click the modal button to issue your licenses.
6. Once the licenses are assigned > You will be redirected to the Licenses page.
7. Verify that you can now see the issued bundle as displayed below. 

<img width="1091" alt="Screenshot 2023-12-05 at 12 28 48 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/adf1ef02-b217-4944-aa2d-bae5f1a526bb">

8. Expand the card and verify that all the child licenses are loaded.

<img width="1057" alt="Screenshot 2023-12-05 at 12 31 43 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/17889183-0c64-4918-a91a-ed6ad3b59836">

9. Click on the Assign button > assign this license to any site and verify that the site name is displayed when it is assigned to a site.

<img width="1057" alt="Screenshot 2023-12-05 at 12 30 14 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/3912a7e9-724b-413d-988b-5568ce687691">

Mobile view:

<img width="292" alt="Screenshot 2023-12-05 at 12 36 36 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/5a26ca38-7062-4202-856a-66a62c09a233">

Tablet view:

<img width="504" alt="Screenshot 2023-12-05 at 12 36 50 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/543dd91b-3866-4fcd-b2d4-84f2fd775c7b">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?