### PR TITLE
Assembler First Flow: Add the personalize your site step

### DIFF
--- a/client/landing/stepper/declarative-flow/assembler-first-flow.ts
+++ b/client/landing/stepper/declarative-flow/assembler-first-flow.ts
@@ -69,6 +69,7 @@ const assemblerFirstFlow: Flow = {
 			STEPS.SITE_PICKER,
 			STEPS.SITE_CREATION_STEP,
 			STEPS.PATTERN_ASSEMBLER,
+			STEPS.FREE_POST_SETUP,
 			STEPS.PROCESSING,
 			STEPS.ERROR,
 			STEPS.LAUNCHPAD,
@@ -155,6 +156,10 @@ const assemblerFirstFlow: Flow = {
 					return handleSelectSite( providedDependencies );
 				}
 
+				case 'freePostSetup': {
+					return navigate( 'launchpad' );
+				}
+
 				case 'processing': {
 					if ( results.some( ( result ) => result === ProcessingResult.FAILURE ) ) {
 						return navigate( 'error' );
@@ -186,6 +191,10 @@ const assemblerFirstFlow: Flow = {
 			switch ( _currentStep ) {
 				case 'site-picker': {
 					return navigate( 'new-or-existing-site' );
+				}
+
+				case 'freePostSetup': {
+					return navigate( 'launchpad' );
 				}
 
 				case 'patternAssembler': {

--- a/client/landing/stepper/declarative-flow/free-post-setup.ts
+++ b/client/landing/stepper/declarative-flow/free-post-setup.ts
@@ -2,7 +2,7 @@ import { FREE_POST_SETUP_FLOW } from '@automattic/onboarding';
 import { translate } from 'i18n-calypso';
 import { useSiteSlug } from '../hooks/use-site-slug';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
-import FreePostSetup from './internals/steps-repository/free-post-setup';
+import { STEPS } from './internals/steps';
 import { ProvidedDependencies } from './internals/types';
 import type { Flow } from './internals/types';
 
@@ -12,7 +12,7 @@ const freePostSetup: Flow = {
 		return translate( 'Free' );
 	},
 	useSteps() {
-		return [ { slug: 'freePostSetup', component: FreePostSetup } ];
+		return [ STEPS.FREE_POST_SETUP ];
 	},
 
 	useStepNavigation( currentStep, navigate ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -133,7 +133,7 @@ export function getEnhancedTasks(
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							window.location.assign(
-								addQueryArgs( `/setup/free-post-setup/freePostSetup`, {
+								addQueryArgs( `/setup/${ flow }/freePostSetup`, {
 									siteSlug,
 								} )
 							);

--- a/client/landing/stepper/declarative-flow/internals/steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps.tsx
@@ -38,6 +38,11 @@ export const STEPS = {
 
 	ERROR: { slug: 'error', asyncComponent: () => import( './steps-repository/error-step' ) },
 
+	FREE_POST_SETUP: {
+		slug: 'freePostSetup',
+		asyncComponent: () => import( './steps-repository/free-post-setup' ),
+	},
+
 	FREE_SETUP: {
 		slug: 'freeSetup',
 		asyncComponent: () => import( './steps-repository/free-setup' ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/83390

## Proposed Changes

* Add the “Personalize your site” step to the assembler-first flow so the user can go to set up the site logo, site title, site tagline from the launchpad checklist

![image](https://github.com/Automattic/wp-calypso/assets/13596067/2138faf4-fdac-48a5-8359-268b14ed87d9)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply latest jetpack-mu-wpcom to your sandbox
  ```
  bin/jetpack-downloader test jetpack-mu-wpcom-plugin trunk
  ```
* Go to `/setup/assembler-first?flags=themes/assembler-first`
* Create a new site
* Finish the Assembler step
* Go to the launchpad, `/setup/assembler-first/launchpad?siteSlug=<your_site>`
* Pick the “Personalize your site” task
* Ensure you can see the “Personalize your site” step
* Reset jetpack-mu-wpcom on your sandbox
  ```
  jetpack-downloader reset jetpack-mu-wpcom-plugin
  ```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?