### PR TITLE
Unhardcode Plan names in themes pages

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -198,6 +198,7 @@ const BannerUpsellTitle = ( {
 		} );
 	} else if ( isExternallyManagedTheme && ! isMarketplaceThemeSubscribed ) {
 		if ( ! isSiteEligibleForManagedExternalThemes ) {
+			/* translators: %(planName)s is the short-hand version of the Business plan name */
 			return translate( 'Upgrade to a %(planName)s plan and subscribe to this theme!', {
 				args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
 			} );
@@ -205,7 +206,7 @@ const BannerUpsellTitle = ( {
 		return translate( 'Subscribe to this theme!' );
 	}
 
-	/* translators: %(planName1)s and %(planName1)s the short-hand version of the Premium and Business plan names */
+	/* translators: %(planName1)s and %(planName2)s the short-hand version of the Premium and Business plan names */
 	return translate( 'Access this theme for FREE with a %(planName1)s or %(planName2)s plan!', {
 		args: {
 			planName1: getPlan( PLAN_PREMIUM )?.getTitle() ?? '',

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -7,6 +7,7 @@ import {
 	PLAN_BUSINESS,
 	PLAN_PREMIUM,
 	WPCOM_FEATURES_PREMIUM_THEMES,
+	getPlan,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button, Card, Gridicon } from '@automattic/components';
@@ -131,16 +132,24 @@ const BannerUpsellDescription = ( {
 
 	if ( isBundledSoftwareSet && ! isExternallyManagedTheme ) {
 		if ( ! bundleSettings ) {
+			/* translators: %(planName)s is the short-hand version of the Business plan name */
 			return translate(
-				'This theme comes bundled with a plugin. Upgrade to a Business plan to select this theme and unlock all its features.'
+				'This theme comes bundled with a plugin. Upgrade to a %(planName)s plan to select this theme and unlock all its features.',
+				{
+					args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
+				}
 			);
 		}
 
 		return bundleSettings.bannerUpsellDescription;
 	} else if ( isExternallyManagedTheme && ! isMarketplaceThemeSubscribed ) {
 		if ( ! isSiteEligibleForManagedExternalThemes ) {
+			/* translators: %(planName)s is the short-hand version of the Business plan name */
 			return translate(
-				'Unlock this theme by upgrading to a Business plan and subscribing to this theme.'
+				'Unlock this theme by upgrading to a %(planName)s plan and subscribing to this theme.',
+				{
+					args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
+				}
 			);
 		}
 		return translate( 'Subscribe to this theme and unlock all its features.' );
@@ -175,23 +184,34 @@ const BannerUpsellTitle = ( {
 
 	if ( isBundledSoftwareSet && ! isExternallyManagedTheme ) {
 		if ( ! bundleSettings ) {
-			return translate( 'Access this theme with a Business plan!' );
+			/* translators: %(planName)s is the short-hand version of the Business plan name */
+			return translate( 'Access this theme with a %(planName)s plan!', {
+				args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
+			} );
 		}
 
 		const bundleName = bundleSettings.name;
 
-		// Translators: %(bundleName)s is the name of the bundle, sometimes represented as a product name. Examples: "WooCommerce" or "Special".
-		return translate( 'Access this %(bundleName)s theme with a Business plan!', {
-			args: { bundleName },
+		// Translators: %(bundleName)s is the name of the bundle, sometimes represented as a product name. Examples: "WooCommerce" or "Special".  %(planName)s is the short-hand version of the Business plan name */
+		return translate( 'Access this %(bundleName)s theme with a %(planName)s plan!', {
+			args: { bundleName, planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
 		} );
 	} else if ( isExternallyManagedTheme && ! isMarketplaceThemeSubscribed ) {
 		if ( ! isSiteEligibleForManagedExternalThemes ) {
-			return translate( 'Upgrade to a Business plan and subscribe to this theme!' );
+			return translate( 'Upgrade to a %(planName)s plan and subscribe to this theme!', {
+				args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
+			} );
 		}
 		return translate( 'Subscribe to this theme!' );
 	}
 
-	return translate( 'Access this theme for FREE with a Premium or Business plan!' );
+	/* translators: %(planName1)s and %(planName1)s the short-hand version of the Premium and Business plan names */
+	return translate( 'Access this theme for FREE with a %(planName1)s or %(planName2)s plan!', {
+		args: {
+			planName1: getPlan( PLAN_PREMIUM )?.getTitle() ?? '',
+			planName2: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+		},
+	} );
 };
 
 class ThemeSheet extends Component {
@@ -1195,7 +1215,10 @@ class ThemeSheet extends Component {
 			return;
 		}
 
-		return translate( 'Additional styles require the Business plan or higher.' );
+		/* translators: %(planName)s is the short-hand version of the Business plan name */
+		return translate( 'Additional styles require the %(planName)s plan or higher.', {
+			args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
+		} );
 	};
 
 	handleAddReview = () => {
@@ -1346,10 +1369,19 @@ class ThemeSheet extends Component {
 					plan={ PLAN_BUSINESS }
 					className="theme__page-upsell-banner"
 					onClick={ () => this.props.setProductToBeInstalled( themeId, siteSlug ) }
-					title={ translate( 'Access this third-party theme with the Business plan!' ) }
+					title={
+						/* translators: %(planName)s is the short-hand version of the Business plan name */
+						translate( 'Access this third-party theme with the %(planName)s plan!', {
+							args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
+						} )
+					}
 					description={ preventWidows(
+						/* translators: %(planName)s is the short-hand version of the Business plan name */
 						translate(
-							'Instantly unlock thousands of different themes and install your own when you upgrade to the Business plan.'
+							'Instantly unlock thousands of different themes and install your own when you upgrade to the %(planName)s plan.',
+							{
+								args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
+							}
 						)
 					) }
 					forceHref

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -7,7 +7,6 @@ import {
 	PLAN_BUSINESS,
 	PLAN_PREMIUM,
 	WPCOM_FEATURES_PREMIUM_THEMES,
-	getPlan,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button, Card, Gridicon } from '@automattic/components';
@@ -132,24 +131,16 @@ const BannerUpsellDescription = ( {
 
 	if ( isBundledSoftwareSet && ! isExternallyManagedTheme ) {
 		if ( ! bundleSettings ) {
-			/* translators: %(planName)s is the short-hand version of the Business plan name */
 			return translate(
-				'This theme comes bundled with a plugin. Upgrade to a %(planName)s plan to select this theme and unlock all its features.',
-				{
-					args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
-				}
+				'This theme comes bundled with a plugin. Upgrade to a Business plan to select this theme and unlock all its features.'
 			);
 		}
 
 		return bundleSettings.bannerUpsellDescription;
 	} else if ( isExternallyManagedTheme && ! isMarketplaceThemeSubscribed ) {
 		if ( ! isSiteEligibleForManagedExternalThemes ) {
-			/* translators: %(planName)s is the short-hand version of the Business plan name */
 			return translate(
-				'Unlock this theme by upgrading to a %(planName)s plan and subscribing to this theme.',
-				{
-					args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
-				}
+				'Unlock this theme by upgrading to a Business plan and subscribing to this theme.'
 			);
 		}
 		return translate( 'Subscribe to this theme and unlock all its features.' );
@@ -184,35 +175,23 @@ const BannerUpsellTitle = ( {
 
 	if ( isBundledSoftwareSet && ! isExternallyManagedTheme ) {
 		if ( ! bundleSettings ) {
-			/* translators: %(planName)s is the short-hand version of the Business plan name */
-			return translate( 'Access this theme with a %(planName)s plan!', {
-				args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
-			} );
+			return translate( 'Access this theme with a Business plan!' );
 		}
 
 		const bundleName = bundleSettings.name;
 
-		// Translators: %(bundleName)s is the name of the bundle, sometimes represented as a product name. Examples: "WooCommerce" or "Special".  %(planName)s is the short-hand version of the Business plan name */
-		return translate( 'Access this %(bundleName)s theme with a %(planName)s plan!', {
-			args: { bundleName, planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
+		// Translators: %(bundleName)s is the name of the bundle, sometimes represented as a product name. Examples: "WooCommerce" or "Special".
+		return translate( 'Access this %(bundleName)s theme with a Business plan!', {
+			args: { bundleName },
 		} );
 	} else if ( isExternallyManagedTheme && ! isMarketplaceThemeSubscribed ) {
 		if ( ! isSiteEligibleForManagedExternalThemes ) {
-			/* translators: %(planName)s is the short-hand version of the Business plan name */
-			return translate( 'Upgrade to a %(planName)s plan and subscribe to this theme!', {
-				args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
-			} );
+			return translate( 'Upgrade to a Business plan and subscribe to this theme!' );
 		}
 		return translate( 'Subscribe to this theme!' );
 	}
 
-	/* translators: %(planName1)s and %(planName2)s the short-hand version of the Premium and Business plan names */
-	return translate( 'Access this theme for FREE with a %(planName1)s or %(planName2)s plan!', {
-		args: {
-			planName1: getPlan( PLAN_PREMIUM )?.getTitle() ?? '',
-			planName2: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
-		},
-	} );
+	return translate( 'Access this theme for FREE with a Premium or Business plan!' );
 };
 
 class ThemeSheet extends Component {
@@ -1216,10 +1195,7 @@ class ThemeSheet extends Component {
 			return;
 		}
 
-		/* translators: %(planName)s is the short-hand version of the Business plan name */
-		return translate( 'Additional styles require the %(planName)s plan or higher.', {
-			args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
-		} );
+		return translate( 'Additional styles require the Business plan or higher.' );
 	};
 
 	handleAddReview = () => {
@@ -1370,19 +1346,10 @@ class ThemeSheet extends Component {
 					plan={ PLAN_BUSINESS }
 					className="theme__page-upsell-banner"
 					onClick={ () => this.props.setProductToBeInstalled( themeId, siteSlug ) }
-					title={
-						/* translators: %(planName)s is the short-hand version of the Business plan name */
-						translate( 'Access this third-party theme with the %(planName)s plan!', {
-							args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
-						} )
-					}
+					title={ translate( 'Access this third-party theme with the Business plan!' ) }
 					description={ preventWidows(
-						/* translators: %(planName)s is the short-hand version of the Business plan name */
 						translate(
-							'Instantly unlock thousands of different themes and install your own when you upgrade to the %(planName)s plan.',
-							{
-								args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
-							}
+							'Instantly unlock thousands of different themes and install your own when you upgrade to the Business plan.'
 						)
 					) }
 					forceHref

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -5,7 +5,6 @@ import {
 	PLAN_ECOMMERCE_TRIAL_MONTHLY,
 	getPlan,
 } from '@automattic/calypso-products';
-import { PLAN_PREMIUM } from '@automattic/data-stores/src/plans/constants';
 import { connect } from 'react-redux';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import QueryActiveTheme from 'calypso/components/data/query-active-theme';
@@ -56,15 +55,18 @@ const ConnectedSingleSiteJetpack = connectOptions( ( props ) => {
 				event="calypso_themes_list_install_themes"
 				feature={ FEATURE_UPLOAD_THEMES }
 				plan={ PLAN_BUSINESS }
-				title={ translate(
-					'Unlock ALL premium themes and upload your own themes with our %(planName1)s and %(planName2)s plans!',
-					{
-						args: {
-							planName1: getPlan( PLAN_PREMIUM )?.getTitle() ?? '',
-							planName2: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
-						},
-					}
-				) }
+				title={
+					/* translators: %(planName1)s and %(planName2)s are the short-hand version of the Business and Commerce plan names */
+					translate(
+						'Unlock ALL premium themes and upload your own themes with our %(planName1)s and %(planName2)s plans!',
+						{
+							args: {
+								planName1: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+								planName2: getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '',
+							},
+						}
+					)
+				}
 				callToAction={ translate( 'Upgrade now' ) }
 				showIcon={ true }
 			/>

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -3,7 +3,9 @@ import {
 	PLAN_BUSINESS,
 	PLAN_ECOMMERCE,
 	PLAN_ECOMMERCE_TRIAL_MONTHLY,
+	getPlan,
 } from '@automattic/calypso-products';
+import { PLAN_PREMIUM } from '@automattic/data-stores/src/plans/constants';
 import { connect } from 'react-redux';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import QueryActiveTheme from 'calypso/components/data/query-active-theme';
@@ -55,7 +57,13 @@ const ConnectedSingleSiteJetpack = connectOptions( ( props ) => {
 				feature={ FEATURE_UPLOAD_THEMES }
 				plan={ PLAN_BUSINESS }
 				title={ translate(
-					'Unlock ALL premium themes and upload your own themes with our Business and eCommerce plans!'
+					'Unlock ALL premium themes and upload your own themes with our %(planName1)s and %(planName2)s plans!',
+					{
+						args: {
+							planName1: getPlan( PLAN_PREMIUM )?.getTitle() ?? '',
+							planName2: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+						},
+					}
 				) }
 				callToAction={ translate( 'Upgrade now' ) }
 				showIcon={ true }

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -1,5 +1,11 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { FEATURE_UPLOAD_THEMES, PLAN_PREMIUM, PLAN_BUSINESS } from '@automattic/calypso-products';
+import {
+	FEATURE_UPLOAD_THEMES,
+	PLAN_PREMIUM,
+	PLAN_BUSINESS,
+	getPlan,
+} from '@automattic/calypso-products';
+import { PLAN_ECOMMERCE } from '@automattic/data-stores/src/plans/constants';
 import { connect } from 'react-redux';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import QueryActiveTheme from 'calypso/components/data/query-active-theme';
@@ -27,7 +33,14 @@ const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
 			event: 'calypso_themes_list_install_themes',
 			feature: FEATURE_UPLOAD_THEMES,
 			plan: PLAN_BUSINESS,
-			title: translate( 'Upload your own themes with our Business and eCommerce plans!' ),
+			title:
+				/* translators: %(planName1)s and %(planName2)s the short-hand version of the Business and Commerce plan names */
+				translate( 'Upload your own themes with our %(planName1)s and %(planName2)s plans!', {
+					args: {
+						planName1: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+						planName2: getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '',
+					},
+				} ),
 			callToAction: translate( 'Upgrade now' ),
 			showIcon: true,
 		};

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -2,10 +2,10 @@ import { isEnabled } from '@automattic/calypso-config';
 import {
 	FEATURE_UPLOAD_THEMES,
 	PLAN_PREMIUM,
+	PLAN_ECOMMERCE,
 	PLAN_BUSINESS,
 	getPlan,
 } from '@automattic/calypso-products';
-import { PLAN_ECOMMERCE } from '@automattic/data-stores/src/plans/constants';
 import { connect } from 'react-redux';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import QueryActiveTheme from 'calypso/components/data/query-active-theme';

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -3,6 +3,7 @@ import {
 	FEATURE_UPLOAD_THEMES,
 	FEATURE_UPLOAD_PLUGINS,
 	PLAN_ECOMMERCE,
+	getPlan,
 } from '@automattic/calypso-products';
 import { Card, ProgressBar, Button } from '@automattic/components';
 import debugFactory from 'debug';
@@ -209,7 +210,11 @@ class Upload extends Component {
 		const redirectTo = encodeURIComponent( `/themes/upload/${ siteSlug }` );
 
 		let upsellPlan = PLAN_BUSINESS;
-		let title = translate( 'Upgrade to the Business plan to access the theme install features' );
+		let title =
+			/* translators: %(planName)s the short-hand version of the Business plan name */
+			translate( 'Upgrade to the %(planName)s plan to access the theme install features', {
+				args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
+			} );
 		let upgradeUrl = `/checkout/${ siteSlug }/business?redirect_to=${ redirectTo }`;
 
 		if ( isCommerceTrial ) {

--- a/client/my-sites/themes/use-theme-showcase-logged-out-seo-content.js
+++ b/client/my-sites/themes/use-theme-showcase-logged-out-seo-content.js
@@ -1,3 +1,9 @@
+import {
+	PLAN_BUSINESS,
+	PLAN_ECOMMERCE,
+	PLAN_PERSONAL,
+	getPlan,
+} from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 
@@ -37,9 +43,18 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 				premium: {
 					title: translate( 'Premium WordPress Themes' ),
 					header: translate( 'Find the perfect premium WordPress theme for your blog or website.' ),
-					description: translate(
-						"Browse all premium themes for WordPress.com. Available on all Premium, Business, and Commerce plans. Activate the one that's right for you."
-					),
+					description:
+						/* translators: %(planName1)s, %(planName2)s, and %(planName3)s the short-hand version of the Premium, Business, and Commerce plan names */
+						translate(
+							"Browse all premium themes for WordPress.com. Available on all %(planName1), %(planName2), and %(planName3) plans. Activate the one that's right for you.",
+							{
+								args: {
+									planName1: getPlan( PLAN_PERSONAL )?.getTitle() ?? '',
+									planName2: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+									planName3: getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '',
+								},
+							}
+						),
 				},
 				marketplace: {
 					title: translate( 'Partner WordPress Themes' ),
@@ -67,9 +82,18 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 				premium: {
 					title: translate( 'Premium Blog WordPress Themes' ),
 					header: translate( 'Choose premium themes for your blog.' ),
-					description: translate(
-						"Enhance your blog with the perfect premium theme. Available on all Premium, Business, and Commerce plans. Activate the one that's right for you."
-					),
+					description:
+						/* translators: %(planName1)s, %(planName2)s, and %(planName3)s the short-hand version of the Premium, Business, and Commerce plan names */
+						translate(
+							"Enhance your blog with the perfect premium theme. Available on all %(planName1), %(planName2), and %(planName3) plans. Activate the one that's right for you.",
+							{
+								args: {
+									planName1: getPlan( PLAN_PERSONAL )?.getTitle() ?? '',
+									planName2: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+									planName3: getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '',
+								},
+							}
+						),
 				},
 				marketplace: {
 					title: translate( 'Partner Blog WordPress Themes' ),
@@ -97,9 +121,18 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 				premium: {
 					title: translate( 'Premium Business WordPress Themes' ),
 					header: translate( 'Choose premium themes for your business website.' ),
-					description: translate(
-						"Enhance your business website with the perfect premium theme. Available on all Premium, Business, and Commerce plans. Activate the one that's right for you."
-					),
+					description:
+						/* translators: %(planName1)s, %(planName2)s, and %(planName3)s the short-hand version of the Premium, Business, and Commerce plan names */
+						translate(
+							"Enhance your business website with the perfect premium theme. Available on all %(planName1), %(planName2)s, and %(planName3)s plans. Activate the one that's right for you.",
+							{
+								args: {
+									planName1: getPlan( PLAN_PERSONAL )?.getTitle() ?? '',
+									planName2: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+									planName3: getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '',
+								},
+							}
+						),
 				},
 				marketplace: {
 					title: translate( 'Partner Business WordPress Themes' ),
@@ -127,9 +160,18 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 				premium: {
 					title: translate( 'Premium Portfolio WordPress Themes' ),
 					header: translate( 'Choose premium themes for your portfolio.' ),
-					description: translate(
-						"Enhance your portfolio website with the perfect premium theme. Available on all Premium, Business, and Commerce plans. Activate the one that's right for you."
-					),
+					description:
+						/* translators: %(planName1)s, %(planName2)s, and %(planName3)s the short-hand version of the Premium, Business, and Commerce plan names */
+						translate(
+							"Enhance your portfolio website with the perfect premium theme. Available on all %(planName1), %(planName2), and %(planName3) plans. Activate the one that's right for you.",
+							{
+								args: {
+									planName1: getPlan( PLAN_PERSONAL )?.getTitle() ?? '',
+									planName2: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+									planName3: getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '',
+								},
+							}
+						),
 				},
 				marketplace: {
 					title: translate( 'Partner Portfolio WordPress Themes' ),
@@ -157,9 +199,18 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 				premium: {
 					title: translate( 'Premium Store WordPress Themes' ),
 					header: translate( 'Choose premium themes for your online store.' ),
-					description: translate(
-						"Enhance your online store with the perfect premium theme. Available on all Premium, Business, and Commerce plans. Activate the one that's right for you."
-					),
+					description:
+						/* translators: %(planName1)s, %(planName2)s, and %(planName3)s the short-hand version of the Premium, Business, and Commerce plan names */
+						translate(
+							"Enhance your online store with the perfect premium theme. Available on all %(planName1), %(planName2), and %(planName3) plans. Activate the one that's right for you.",
+							{
+								args: {
+									planName1: getPlan( PLAN_PERSONAL )?.getTitle() ?? '',
+									planName2: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+									planName3: getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '',
+								},
+							}
+						),
 				},
 				marketplace: {
 					title: translate( 'Partner Store WordPress Themes' ),
@@ -187,9 +238,18 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 				premium: {
 					title: translate( 'Premium About Me WordPress Themes' ),
 					header: translate( 'Choose premium themes for your About Me website.' ),
-					description: translate(
-						"Enhance your About Me website with the perfect premium theme. Available on all Premium, Business, and Commerce plans. Activate the one that's right for you."
-					),
+					description:
+						/* translators: %(planName1)s, %(planName2)s, and %(planName3)s the short-hand version of the Premium, Business, and Commerce plan names */
+						translate(
+							"Enhance your About Me website with the perfect premium theme. Available on all %(planName1), %(planName2), and %(planName3) plans. Activate the one that's right for you.",
+							{
+								args: {
+									planName1: getPlan( PLAN_PERSONAL )?.getTitle() ?? '',
+									planName2: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+									planName3: getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '',
+								},
+							}
+						),
 				},
 				marketplace: {
 					title: translate( 'Partner About Me WordPress Themes' ),
@@ -217,9 +277,18 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 				premium: {
 					title: translate( 'Premium Link in Bio WordPress Themes' ),
 					header: translate( 'Choose premium themes for your link in bio website.' ),
-					description: translate(
-						"Enhance your link in bio website with the perfect premium theme. Available on all Premium, Business, and Commerce plans. Activate the one that's right for you."
-					),
+					description:
+						/* translators: %(planName1)s, %(planName2)s, and %(planName3)s the short-hand version of the Premium, Business, and Commerce plan names */
+						translate(
+							"Enhance your link in bio website with the perfect premium theme. Available on all %(planName1), %(planName2), and %(planName3) plans. Activate the one that's right for you.",
+							{
+								args: {
+									planName1: getPlan( PLAN_PERSONAL )?.getTitle() ?? '',
+									planName2: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+									planName3: getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '',
+								},
+							}
+						),
 				},
 				marketplace: {
 					title: translate( 'Partner Link in Bio WordPress Themes' ),
@@ -247,9 +316,18 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 				premium: {
 					title: translate( 'Premium Newsletter WordPress Themes' ),
 					header: translate( 'Choose premium themes for your site-hosted newsletter.' ),
-					description: translate(
-						"Enhance your newsletter with the perfect premium theme. Available on all Premium, Business, and Commerce plans. Activate the one that's right for you."
-					),
+					description:
+						/* translators: %(planName1)s, %(planName2)s, and %(planName3)s the short-hand version of the Premium, Business, and Commerce plan names */
+						translate(
+							"Enhance your newsletter with the perfect premium theme. Available on all %(planName1), %(planName2), and %(planName3) plans. Activate the one that's right for you.",
+							{
+								args: {
+									planName1: getPlan( PLAN_PERSONAL )?.getTitle() ?? '',
+									planName2: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+									planName3: getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '',
+								},
+							}
+						),
 				},
 				marketplace: {
 					title: translate( 'Partner Newsletter WordPress Themes' ),
@@ -277,9 +355,18 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 				premium: {
 					title: translate( 'Premium Entertainment WordPress Themes' ),
 					header: translate( 'Choose premium themes for your entertainment website.' ),
-					description: translate(
-						"Enhance your entertainment website with the perfect premium theme. Available on all Premium, Business, and Commerce plans. Activate the one that's right for you."
-					),
+					description:
+						/* translators: %(planName1)s, %(planName2)s, and %(planName3)s the short-hand version of the Premium, Business, and Commerce plan names */
+						translate(
+							"Enhance your entertainment website with the perfect premium theme. Available on all %(planName1), %(planName2), and %(planName3) plans. Activate the one that's right for you.",
+							{
+								args: {
+									planName1: getPlan( PLAN_PERSONAL )?.getTitle() ?? '',
+									planName2: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+									planName3: getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '',
+								},
+							}
+						),
 				},
 				marketplace: {
 					title: translate( 'Partner Entertainment WordPress Themes' ),
@@ -307,9 +394,18 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 				premium: {
 					title: translate( 'Premium Coming Soon WordPress Themes' ),
 					header: translate( 'Choose premium coming soon themes for your website.' ),
-					description: translate(
-						"Enhance your website with the perfect premium coming soon theme. Available on all Premium, Business, and Commerce plans. Activate the one that's right for you."
-					),
+					description:
+						/* translators: %(planName1)s, %(planName2)s, and %(planName3)s the short-hand version of the Premium, Business, and Commerce plan names */
+						translate(
+							"Enhance your website with the perfect premium coming soon theme. Available on all %(planName1), %(planName2), and %(planName3) plans. Activate the one that's right for you.",
+							{
+								args: {
+									planName1: getPlan( PLAN_PERSONAL )?.getTitle() ?? '',
+									planName2: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+									planName3: getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '',
+								},
+							}
+						),
 				},
 				marketplace: {
 					title: translate( 'Partner Coming Soon WordPress Themes' ),
@@ -337,9 +433,18 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 				premium: {
 					title: translate( 'Premium Podcast WordPress Themes' ),
 					header: translate( 'Choose premium themes for your podcast website.' ),
-					description: translate(
-						"Enhance your podcast website with the perfect premium theme. Available on all Premium, Business, and Commerce plans. Activate the one that's right for you."
-					),
+					description:
+						/* translators: %(planName1)s, %(planName2)s, and %(planName3)s the short-hand version of the Premium, Business, and Commerce plan names */
+						translate(
+							"Enhance your podcast website with the perfect premium theme. Available on all %(planName1), %(planName2), and %(planName3) plans. Activate the one that's right for you.",
+							{
+								args: {
+									planName1: getPlan( PLAN_PERSONAL )?.getTitle() ?? '',
+									planName2: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+									planName3: getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '',
+								},
+							}
+						),
 				},
 				marketplace: {
 					title: translate( 'Partner Podcast WordPress Themes' ),
@@ -373,9 +478,18 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 					header: translate(
 						"Choose premium themes for your non-profit or community organization's website."
 					),
-					description: translate(
-						"Enhance your non-profit or community organization's website with the perfect premium theme. Available on all Premium, Business, and Commerce plans. Activate the one that's right for you."
-					),
+					description:
+						/* translators: %(planName1)s, %(planName2)s, and %(planName3)s the short-hand version of the Premium, Business, and Commerce plan names */
+						translate(
+							"Enhance your non-profit or community organization's website with the perfect premium theme. Available on all %(planName1), %(planName2), and %(planName3) plans. Activate the one that's right for you.",
+							{
+								args: {
+									planName1: getPlan( PLAN_PERSONAL )?.getTitle() ?? '',
+									planName2: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+									planName3: getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '',
+								},
+							}
+						),
 				},
 				marketplace: {
 					title: translate( 'Partner Community & Non-profit WordPress Themes' ),
@@ -407,9 +521,18 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 				premium: {
 					title: translate( 'Premium Fashion & Beauty WordPress Themes' ),
 					header: translate( 'Choose premium themes for your fashion and beauty website.' ),
-					description: translate(
-						"Enhance your fashion and beauty website with the perfect premium theme. Available on all Premium, Business, and Commerce plans. Activate the one that's right for you."
-					),
+					description:
+						/* translators: %(planName1)s, %(planName2)s, and %(planName3)s the short-hand version of the Premium, Business, and Commerce plan names */
+						translate(
+							"Enhance your fashion and beauty website with the perfect premium theme. Available on all %(planName1), %(planName2), and %(planName3) plans. Activate the one that's right for you.",
+							{
+								args: {
+									planName1: getPlan( PLAN_PERSONAL )?.getTitle() ?? '',
+									planName2: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+									planName3: getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '',
+								},
+							}
+						),
 				},
 				marketplace: {
 					title: translate( 'Partner Fashion & Beauty WordPress Themes' ),
@@ -439,9 +562,18 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 				premium: {
 					title: translate( 'Premium Travel & Lifestyle WordPress Themes' ),
 					header: translate( 'Choose premium themes for your travel and lifestyle website.' ),
-					description: translate(
-						"Enhance your travel and lifestyle website with the perfect premium theme. Available on all Premium, Business, and Commerce plans. Activate the one that's right for you."
-					),
+					description:
+						/* translators: %(planName1)s, %(planName2)s, and %(planName3)s the short-hand version of the Premium, Business, and Commerce plan names */
+						translate(
+							"Enhance your travel and lifestyle website with the perfect premium theme. Available on all %(planName1), %(planName2), and %(planName3) plans. Activate the one that's right for you.",
+							{
+								args: {
+									planName1: getPlan( PLAN_PERSONAL )?.getTitle() ?? '',
+									planName2: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+									planName3: getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '',
+								},
+							}
+						),
 				},
 				marketplace: {
 					title: translate( 'Partner Travel & Lifestyle WordPress Themes' ),
@@ -469,9 +601,18 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 				premium: {
 					title: translate( 'Premium Restaurant WordPress Themes' ),
 					header: translate( 'Choose premium themes for your restaurant website.' ),
-					description: translate(
-						"Enhance your restaurant website with the perfect premium theme. Available on all Premium, Business, and Commerce plans. Activate the one that's right for you."
-					),
+					description:
+						/* translators: %(planName1)s, %(planName2)s, and %(planName3)s the short-hand version of the Premium, Business, and Commerce plan names */
+						translate(
+							"Enhance your restaurant website with the perfect premium theme. Available on all %(planName1), %(planName2), and %(planName3) plans. Activate the one that's right for you.",
+							{
+								args: {
+									planName1: getPlan( PLAN_PERSONAL )?.getTitle() ?? '',
+									planName2: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+									planName3: getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '',
+								},
+							}
+						),
 				},
 				marketplace: {
 					title: translate( 'Partner Restaurant WordPress Themes' ),
@@ -499,9 +640,18 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 				premium: {
 					title: translate( 'Premium Music WordPress Themes' ),
 					header: translate( 'Choose premium themes for your music website.' ),
-					description: translate(
-						"Enhance your music website with the perfect premium theme. Available on all Premium, Business, and Commerce plans. Activate the one that's right for you."
-					),
+					description:
+						/* translators: %(planName1)s, %(planName2)s, and %(planName3)s the short-hand version of the Premium, Business, and Commerce plan names */
+						translate(
+							"Enhance your music website with the perfect premium theme. Available on all %(planName1), %(planName2), and %(planName3) plans. Activate the one that's right for you.",
+							{
+								args: {
+									planName1: getPlan( PLAN_PERSONAL )?.getTitle() ?? '',
+									planName2: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+									planName3: getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '',
+								},
+							}
+						),
 				},
 				marketplace: {
 					title: translate( 'Partner Music WordPress Themes' ),
@@ -529,9 +679,18 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 				premium: {
 					title: translate( 'Premium Magazine WordPress Themes' ),
 					header: translate( 'Choose premium themes for your magazine website.' ),
-					description: translate(
-						"Enhance your magazine website with the perfect premium theme. Available on all Premium, Business, and Commerce plans. Activate the one that's right for you."
-					),
+					description:
+						/* translators: %(planName1)s, %(planName2)s, and %(planName3)s the short-hand version of the Premium, Business, and Commerce plan names */
+						translate(
+							"Enhance your magazine website with the perfect premium theme. Available on all %(planName1), %(planName2), and %(planName3) plans. Activate the one that's right for you.",
+							{
+								args: {
+									planName1: getPlan( PLAN_PERSONAL )?.getTitle() ?? '',
+									planName2: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+									planName3: getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '',
+								},
+							}
+						),
 				},
 				marketplace: {
 					title: translate( 'Partner Magazine WordPress Themes' ),
@@ -559,9 +718,18 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 				premium: {
 					title: translate( 'Premium Education WordPress Themes' ),
 					header: translate( 'Choose premium themes for your education website.' ),
-					description: translate(
-						"Enhance your education website with the perfect premium theme. Available on all Premium, Business, and Commerce plans. Activate the one that's right for you."
-					),
+					description:
+						/* translators: %(planName1)s, %(planName2)s, and %(planName3)s the short-hand version of the Premium, Business, and Commerce plan names */
+						translate(
+							"Enhance your education website with the perfect premium theme. Available on all %(planName1), %(planName2), and %(planName3) plans. Activate the one that's right for you.",
+							{
+								args: {
+									planName1: getPlan( PLAN_PERSONAL )?.getTitle() ?? '',
+									planName2: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+									planName3: getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '',
+								},
+							}
+						),
 				},
 				marketplace: {
 					title: translate( 'Partner Education WordPress Themes' ),
@@ -589,9 +757,18 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 				premium: {
 					title: translate( 'Premium Author & Writer WordPress Themes' ),
 					header: translate( 'Choose premium themes for your author or writer website.' ),
-					description: translate(
-						"Enhance your author or writer website with the perfect premium theme. Available on all Premium, Business, and Commerce plans. Activate the one that's right for you."
-					),
+					description:
+						/* translators: %(planName1)s, %(planName2)s, and %(planName3)s the short-hand version of the Premium, Business, and Commerce plan names */
+						translate(
+							"Enhance your author or writer website with the perfect premium theme. Available on all %(planName1), %(planName2), and %(planName3) plans. Activate the one that's right for you.",
+							{
+								args: {
+									planName1: getPlan( PLAN_PERSONAL )?.getTitle() ?? '',
+									planName2: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+									planName3: getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '',
+								},
+							}
+						),
 				},
 				marketplace: {
 					title: translate( 'Partner Author & Writer WordPress Themes' ),
@@ -621,9 +798,18 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 				premium: {
 					title: translate( 'Premium Health & Wellness WordPress Themes' ),
 					header: translate( 'Choose premium themes for your health and wellness website.' ),
-					description: translate(
-						"Enhance your health and wellness website with the perfect premium theme. Available on all Premium, Business, and Commerce plans. Activate the one that's right for you."
-					),
+					description:
+						/* translators: %(planName1)s, %(planName2)s, and %(planName3)s the short-hand version of the Premium, Business, and Commerce plan names */
+						translate(
+							"Enhance your health and wellness website with the perfect premium theme. Available on all %(planName1), %(planName2), and %(planName3) plans. Activate the one that's right for you.",
+							{
+								args: {
+									planName1: getPlan( PLAN_PERSONAL )?.getTitle() ?? '',
+									planName2: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+									planName3: getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '',
+								},
+							}
+						),
 				},
 				marketplace: {
 					title: translate( 'Partner Health & Wellness WordPress Themes' ),
@@ -651,9 +837,18 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 				premium: {
 					title: translate( 'Premium Real Estate WordPress Themes' ),
 					header: translate( 'Choose premium themes for your real estate website.' ),
-					description: translate(
-						"Enhance your real estate website with the perfect premium theme. Available on all Premium, Business, and Commerce plans. Activate the one that's right for you."
-					),
+					description:
+						/* translators: %(planName1)s, %(planName2)s, and %(planName3)s the short-hand version of the Premium, Business, and Commerce plan names */
+						translate(
+							"Enhance your real estate website with the perfect premium theme. Available on all %(planName1), %(planName2), and %(planName3) plans. Activate the one that's right for you.",
+							{
+								args: {
+									planName1: getPlan( PLAN_PERSONAL )?.getTitle() ?? '',
+									planName2: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+									planName3: getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '',
+								},
+							}
+						),
 				},
 				marketplace: {
 					title: translate( 'Partner Real Estate WordPress Themes' ),
@@ -681,9 +876,18 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 				premium: {
 					title: translate( 'Premium Video WordPress Themes' ),
 					header: translate( 'Choose premium themes for your video website.' ),
-					description: translate(
-						"Enhance your video website with the perfect premium theme. Available on all Premium, Business, and Commerce plans. Activate the one that's right for you."
-					),
+					description:
+						/* translators: %(planName1)s, %(planName2)s, and %(planName3)s the short-hand version of the Premium, Business, and Commerce plan names */
+						translate(
+							"Enhance your video website with the perfect premium theme. Available on all %(planName1), %(planName2), and %(planName3) plans. Activate the one that's right for you.",
+							{
+								args: {
+									planName1: getPlan( PLAN_PERSONAL )?.getTitle() ?? '',
+									planName2: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+									planName3: getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '',
+								},
+							}
+						),
 				},
 				marketplace: {
 					title: translate( 'Partner Video WordPress Themes' ),
@@ -711,9 +915,18 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 				premium: {
 					title: translate( 'Premium Art and Design WordPress Themes' ),
 					header: translate( 'Choose premium themes for your art and design website.' ),
-					description: translate(
-						"Enhance your art and design website with the perfect premium theme. Available on all Premium, Business, and Commerce plans. Activate the one that's right for you."
-					),
+					description:
+						/* translators: %(planName1)s, %(planName2)s, and %(planName3)s the short-hand version of the Premium, Business, and Commerce plan names */
+						translate(
+							"Enhance your art and design website with the perfect premium theme. Available on all %(planName1), %(planName2), and %(planName3) plans. Activate the one that's right for you.",
+							{
+								args: {
+									planName1: getPlan( PLAN_PERSONAL )?.getTitle() ?? '',
+									planName2: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+									planName3: getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '',
+								},
+							}
+						),
 				},
 				marketplace: {
 					title: translate( 'Partner Art and Design WordPress Themes' ),

--- a/client/my-sites/themes/use-theme-showcase-logged-out-seo-content.js
+++ b/client/my-sites/themes/use-theme-showcase-logged-out-seo-content.js
@@ -46,7 +46,7 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 					description:
 						/* translators: %(planName1)s, %(planName2)s, and %(planName3)s the short-hand version of the Premium, Business, and Commerce plan names */
 						translate(
-							"Browse all premium themes for WordPress.com. Available on all %(planName1), %(planName2), and %(planName3) plans. Activate the one that's right for you.",
+							"Browse all premium themes for WordPress.com. Available on all %(planName1)s, %(planName2)s, and %(planName3)s plans. Activate the one that's right for you.",
 							{
 								args: {
 									planName1: getPlan( PLAN_PERSONAL )?.getTitle() ?? '',
@@ -85,7 +85,7 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 					description:
 						/* translators: %(planName1)s, %(planName2)s, and %(planName3)s the short-hand version of the Premium, Business, and Commerce plan names */
 						translate(
-							"Enhance your blog with the perfect premium theme. Available on all %(planName1), %(planName2), and %(planName3) plans. Activate the one that's right for you.",
+							"Enhance your blog with the perfect premium theme. Available on all %(planName1)s, %(planName2)s, and %(planName3)s plans. Activate the one that's right for you.",
 							{
 								args: {
 									planName1: getPlan( PLAN_PERSONAL )?.getTitle() ?? '',
@@ -124,7 +124,7 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 					description:
 						/* translators: %(planName1)s, %(planName2)s, and %(planName3)s the short-hand version of the Premium, Business, and Commerce plan names */
 						translate(
-							"Enhance your business website with the perfect premium theme. Available on all %(planName1), %(planName2)s, and %(planName3)s plans. Activate the one that's right for you.",
+							"Enhance your business website with the perfect premium theme. Available on all %(planName1)s, %(planName2)s, and %(planName3)s plans. Activate the one that's right for you.",
 							{
 								args: {
 									planName1: getPlan( PLAN_PERSONAL )?.getTitle() ?? '',
@@ -163,7 +163,7 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 					description:
 						/* translators: %(planName1)s, %(planName2)s, and %(planName3)s the short-hand version of the Premium, Business, and Commerce plan names */
 						translate(
-							"Enhance your portfolio website with the perfect premium theme. Available on all %(planName1), %(planName2), and %(planName3) plans. Activate the one that's right for you.",
+							"Enhance your portfolio website with the perfect premium theme. Available on all %(planName1)s, %(planName2)s, and %(planName3)s plans. Activate the one that's right for you.",
 							{
 								args: {
 									planName1: getPlan( PLAN_PERSONAL )?.getTitle() ?? '',
@@ -202,7 +202,7 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 					description:
 						/* translators: %(planName1)s, %(planName2)s, and %(planName3)s the short-hand version of the Premium, Business, and Commerce plan names */
 						translate(
-							"Enhance your online store with the perfect premium theme. Available on all %(planName1), %(planName2), and %(planName3) plans. Activate the one that's right for you.",
+							"Enhance your online store with the perfect premium theme. Available on all %(planName1)s, %(planName2)s, and %(planName3)s plans. Activate the one that's right for you.",
 							{
 								args: {
 									planName1: getPlan( PLAN_PERSONAL )?.getTitle() ?? '',
@@ -241,7 +241,7 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 					description:
 						/* translators: %(planName1)s, %(planName2)s, and %(planName3)s the short-hand version of the Premium, Business, and Commerce plan names */
 						translate(
-							"Enhance your About Me website with the perfect premium theme. Available on all %(planName1), %(planName2), and %(planName3) plans. Activate the one that's right for you.",
+							"Enhance your About Me website with the perfect premium theme. Available on all %(planName1)s, %(planName2)s, and %(planName3)s plans. Activate the one that's right for you.",
 							{
 								args: {
 									planName1: getPlan( PLAN_PERSONAL )?.getTitle() ?? '',
@@ -280,7 +280,7 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 					description:
 						/* translators: %(planName1)s, %(planName2)s, and %(planName3)s the short-hand version of the Premium, Business, and Commerce plan names */
 						translate(
-							"Enhance your link in bio website with the perfect premium theme. Available on all %(planName1), %(planName2), and %(planName3) plans. Activate the one that's right for you.",
+							"Enhance your link in bio website with the perfect premium theme. Available on all %(planName1)s, %(planName2)s, and %(planName3)s plans. Activate the one that's right for you.",
 							{
 								args: {
 									planName1: getPlan( PLAN_PERSONAL )?.getTitle() ?? '',
@@ -319,7 +319,7 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 					description:
 						/* translators: %(planName1)s, %(planName2)s, and %(planName3)s the short-hand version of the Premium, Business, and Commerce plan names */
 						translate(
-							"Enhance your newsletter with the perfect premium theme. Available on all %(planName1), %(planName2), and %(planName3) plans. Activate the one that's right for you.",
+							"Enhance your newsletter with the perfect premium theme. Available on all %(planName1)s, %(planName2)s, and %(planName3)s plans. Activate the one that's right for you.",
 							{
 								args: {
 									planName1: getPlan( PLAN_PERSONAL )?.getTitle() ?? '',
@@ -358,7 +358,7 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 					description:
 						/* translators: %(planName1)s, %(planName2)s, and %(planName3)s the short-hand version of the Premium, Business, and Commerce plan names */
 						translate(
-							"Enhance your entertainment website with the perfect premium theme. Available on all %(planName1), %(planName2), and %(planName3) plans. Activate the one that's right for you.",
+							"Enhance your entertainment website with the perfect premium theme. Available on all %(planName1)s, %(planName2)s, and %(planName3)s plans. Activate the one that's right for you.",
 							{
 								args: {
 									planName1: getPlan( PLAN_PERSONAL )?.getTitle() ?? '',
@@ -397,7 +397,7 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 					description:
 						/* translators: %(planName1)s, %(planName2)s, and %(planName3)s the short-hand version of the Premium, Business, and Commerce plan names */
 						translate(
-							"Enhance your website with the perfect premium coming soon theme. Available on all %(planName1), %(planName2), and %(planName3) plans. Activate the one that's right for you.",
+							"Enhance your website with the perfect premium coming soon theme. Available on all %(planName1)s, %(planName2)s, and %(planName3)s plans. Activate the one that's right for you.",
 							{
 								args: {
 									planName1: getPlan( PLAN_PERSONAL )?.getTitle() ?? '',
@@ -436,7 +436,7 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 					description:
 						/* translators: %(planName1)s, %(planName2)s, and %(planName3)s the short-hand version of the Premium, Business, and Commerce plan names */
 						translate(
-							"Enhance your podcast website with the perfect premium theme. Available on all %(planName1), %(planName2), and %(planName3) plans. Activate the one that's right for you.",
+							"Enhance your podcast website with the perfect premium theme. Available on all %(planName1)s, %(planName2)s, and %(planName3)s plans. Activate the one that's right for you.",
 							{
 								args: {
 									planName1: getPlan( PLAN_PERSONAL )?.getTitle() ?? '',
@@ -481,7 +481,7 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 					description:
 						/* translators: %(planName1)s, %(planName2)s, and %(planName3)s the short-hand version of the Premium, Business, and Commerce plan names */
 						translate(
-							"Enhance your non-profit or community organization's website with the perfect premium theme. Available on all %(planName1), %(planName2), and %(planName3) plans. Activate the one that's right for you.",
+							"Enhance your non-profit or community organization's website with the perfect premium theme. Available on all %(planName1)s, %(planName2)s, and %(planName3)s plans. Activate the one that's right for you.",
 							{
 								args: {
 									planName1: getPlan( PLAN_PERSONAL )?.getTitle() ?? '',
@@ -524,7 +524,7 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 					description:
 						/* translators: %(planName1)s, %(planName2)s, and %(planName3)s the short-hand version of the Premium, Business, and Commerce plan names */
 						translate(
-							"Enhance your fashion and beauty website with the perfect premium theme. Available on all %(planName1), %(planName2), and %(planName3) plans. Activate the one that's right for you.",
+							"Enhance your fashion and beauty website with the perfect premium theme. Available on all %(planName1)s, %(planName2)s, and %(planName3)s plans. Activate the one that's right for you.",
 							{
 								args: {
 									planName1: getPlan( PLAN_PERSONAL )?.getTitle() ?? '',
@@ -565,7 +565,7 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 					description:
 						/* translators: %(planName1)s, %(planName2)s, and %(planName3)s the short-hand version of the Premium, Business, and Commerce plan names */
 						translate(
-							"Enhance your travel and lifestyle website with the perfect premium theme. Available on all %(planName1), %(planName2), and %(planName3) plans. Activate the one that's right for you.",
+							"Enhance your travel and lifestyle website with the perfect premium theme. Available on all %(planName1)s, %(planName2)s, and %(planName3)s plans. Activate the one that's right for you.",
 							{
 								args: {
 									planName1: getPlan( PLAN_PERSONAL )?.getTitle() ?? '',
@@ -604,7 +604,7 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 					description:
 						/* translators: %(planName1)s, %(planName2)s, and %(planName3)s the short-hand version of the Premium, Business, and Commerce plan names */
 						translate(
-							"Enhance your restaurant website with the perfect premium theme. Available on all %(planName1), %(planName2), and %(planName3) plans. Activate the one that's right for you.",
+							"Enhance your restaurant website with the perfect premium theme. Available on all %(planName1)s, %(planName2)s, and %(planName3)s plans. Activate the one that's right for you.",
 							{
 								args: {
 									planName1: getPlan( PLAN_PERSONAL )?.getTitle() ?? '',
@@ -643,7 +643,7 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 					description:
 						/* translators: %(planName1)s, %(planName2)s, and %(planName3)s the short-hand version of the Premium, Business, and Commerce plan names */
 						translate(
-							"Enhance your music website with the perfect premium theme. Available on all %(planName1), %(planName2), and %(planName3) plans. Activate the one that's right for you.",
+							"Enhance your music website with the perfect premium theme. Available on all %(planName1)s, %(planName2)s, and %(planName3)s plans. Activate the one that's right for you.",
 							{
 								args: {
 									planName1: getPlan( PLAN_PERSONAL )?.getTitle() ?? '',
@@ -682,7 +682,7 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 					description:
 						/* translators: %(planName1)s, %(planName2)s, and %(planName3)s the short-hand version of the Premium, Business, and Commerce plan names */
 						translate(
-							"Enhance your magazine website with the perfect premium theme. Available on all %(planName1), %(planName2), and %(planName3) plans. Activate the one that's right for you.",
+							"Enhance your magazine website with the perfect premium theme. Available on all %(planName1)s, %(planName2)s, and %(planName3)s plans. Activate the one that's right for you.",
 							{
 								args: {
 									planName1: getPlan( PLAN_PERSONAL )?.getTitle() ?? '',
@@ -721,7 +721,7 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 					description:
 						/* translators: %(planName1)s, %(planName2)s, and %(planName3)s the short-hand version of the Premium, Business, and Commerce plan names */
 						translate(
-							"Enhance your education website with the perfect premium theme. Available on all %(planName1), %(planName2), and %(planName3) plans. Activate the one that's right for you.",
+							"Enhance your education website with the perfect premium theme. Available on all %(planName1)s, %(planName2)s, and %(planName3)s plans. Activate the one that's right for you.",
 							{
 								args: {
 									planName1: getPlan( PLAN_PERSONAL )?.getTitle() ?? '',
@@ -760,7 +760,7 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 					description:
 						/* translators: %(planName1)s, %(planName2)s, and %(planName3)s the short-hand version of the Premium, Business, and Commerce plan names */
 						translate(
-							"Enhance your author or writer website with the perfect premium theme. Available on all %(planName1), %(planName2), and %(planName3) plans. Activate the one that's right for you.",
+							"Enhance your author or writer website with the perfect premium theme. Available on all %(planName1)s, %(planName2)s, and %(planName3)s plans. Activate the one that's right for you.",
 							{
 								args: {
 									planName1: getPlan( PLAN_PERSONAL )?.getTitle() ?? '',
@@ -801,7 +801,7 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 					description:
 						/* translators: %(planName1)s, %(planName2)s, and %(planName3)s the short-hand version of the Premium, Business, and Commerce plan names */
 						translate(
-							"Enhance your health and wellness website with the perfect premium theme. Available on all %(planName1), %(planName2), and %(planName3) plans. Activate the one that's right for you.",
+							"Enhance your health and wellness website with the perfect premium theme. Available on all %(planName1)s, %(planName2)s, and %(planName3)s plans. Activate the one that's right for you.",
 							{
 								args: {
 									planName1: getPlan( PLAN_PERSONAL )?.getTitle() ?? '',
@@ -840,7 +840,7 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 					description:
 						/* translators: %(planName1)s, %(planName2)s, and %(planName3)s the short-hand version of the Premium, Business, and Commerce plan names */
 						translate(
-							"Enhance your real estate website with the perfect premium theme. Available on all %(planName1), %(planName2), and %(planName3) plans. Activate the one that's right for you.",
+							"Enhance your real estate website with the perfect premium theme. Available on all %(planName1)s, %(planName2)s, and %(planName3)s plans. Activate the one that's right for you.",
 							{
 								args: {
 									planName1: getPlan( PLAN_PERSONAL )?.getTitle() ?? '',
@@ -879,7 +879,7 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 					description:
 						/* translators: %(planName1)s, %(planName2)s, and %(planName3)s the short-hand version of the Premium, Business, and Commerce plan names */
 						translate(
-							"Enhance your video website with the perfect premium theme. Available on all %(planName1), %(planName2), and %(planName3) plans. Activate the one that's right for you.",
+							"Enhance your video website with the perfect premium theme. Available on all %(planName1)s, %(planName2)s, and %(planName3)s plans. Activate the one that's right for you.",
 							{
 								args: {
 									planName1: getPlan( PLAN_PERSONAL )?.getTitle() ?? '',
@@ -918,7 +918,7 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 					description:
 						/* translators: %(planName1)s, %(planName2)s, and %(planName3)s the short-hand version of the Premium, Business, and Commerce plan names */
 						translate(
-							"Enhance your art and design website with the perfect premium theme. Available on all %(planName1), %(planName2), and %(planName3) plans. Activate the one that's right for you.",
+							"Enhance your art and design website with the perfect premium theme. Available on all %(planName1)s, %(planName2)s, and %(planName3)s plans. Activate the one that's right for you.",
 							{
 								args: {
 									planName1: getPlan( PLAN_PERSONAL )?.getTitle() ?? '',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

This replaces a few hardcoded Plan names, found in the /themes pages, with references to the Plan configurations.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure the plan mentions are updated correctly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
