### PR TITLE
Jetpack Manage: Add a warning message explaining what will happen when revoking a Child license

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/license-details/actions.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/actions.tsx
@@ -8,6 +8,7 @@ import { addQueryArgs } from 'calypso/lib/url';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice } from 'calypso/state/notices/actions';
+import RevokeChildLicenseDialog from '../revoke-child-license-dialog';
 
 interface Props {
 	licenseKey: string;
@@ -99,14 +100,23 @@ export default function LicenseDetailsActions( {
 				</Button>
 			) }
 
-			{ revokeDialog && (
-				<RevokeLicenseDialog
-					licenseKey={ licenseKey }
-					product={ product }
-					siteUrl={ siteUrl }
-					onClose={ closeRevokeDialog }
-				/>
-			) }
+			{ revokeDialog &&
+				( bundleGroupSize ? (
+					<RevokeChildLicenseDialog
+						licenseKey={ licenseKey }
+						product={ product }
+						siteUrl={ siteUrl }
+						onClose={ closeRevokeDialog }
+						bundleGroupSize={ bundleGroupSize }
+					/>
+				) : (
+					<RevokeLicenseDialog
+						licenseKey={ licenseKey }
+						product={ product }
+						siteUrl={ siteUrl }
+						onClose={ closeRevokeDialog }
+					/>
+				) ) }
 		</div>
 	);
 }

--- a/client/jetpack-cloud/sections/partner-portal/license-details/actions.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/actions.tsx
@@ -16,6 +16,7 @@ interface Props {
 	licenseState: LicenseState;
 	licenseType: LicenseType;
 	hasDownloads: boolean;
+	bundleGroupSize?: number;
 }
 
 export default function LicenseDetailsActions( {
@@ -25,6 +26,7 @@ export default function LicenseDetailsActions( {
 	licenseState,
 	licenseType,
 	hasDownloads,
+	bundleGroupSize,
 }: Props ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
@@ -82,7 +84,7 @@ export default function LicenseDetailsActions( {
 
 			{ licenseState !== LicenseState.Revoked && licenseType === LicenseType.Partner && (
 				<Button compact onClick={ openRevokeDialog } scary>
-					{ translate( 'Revoke' ) }
+					{ bundleGroupSize ? translate( 'Detach' ) : translate( 'Revoke' ) }
 				</Button>
 			) }
 

--- a/client/jetpack-cloud/sections/partner-portal/license-details/bundle-details.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/bundle-details.tsx
@@ -4,9 +4,10 @@ import LicensePreview, { LicensePreviewPlaceholder } from '../license-preview';
 
 interface Props {
 	parentLicenseId: number;
+	size: number;
 }
 
-export default function BundleDetails( { parentLicenseId }: Props ) {
+export default function BundleDetails( { parentLicenseId, size }: Props ) {
 	const { data } = useBundleLicensesQuery( parentLicenseId );
 
 	if ( ! data ) {
@@ -16,6 +17,7 @@ export default function BundleDetails( { parentLicenseId }: Props ) {
 	return data.map( ( item ) => (
 		<LicensePreview
 			isChildLicense
+			bundleGroupSize={ size }
 			key={ item.licenseId }
 			licenseKey={ item.licenseKey }
 			product={ item.product }

--- a/client/jetpack-cloud/sections/partner-portal/license-details/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/index.tsx
@@ -19,6 +19,7 @@ interface Props {
 	revokedAt: string | null;
 	onCopyLicense?: () => void;
 	licenseType: LicenseType;
+	bundleGroupSize?: number;
 }
 
 const DETAILS_DATE_FORMAT = 'YYYY-MM-DD h:mm:ss A';
@@ -36,6 +37,7 @@ export default function LicenseDetails( {
 	revokedAt,
 	onCopyLicense = noop,
 	licenseType,
+	bundleGroupSize,
 }: Props ) {
 	const translate = useTranslate();
 	const licenseState = getLicenseState( attachedAt, revokedAt );
@@ -100,6 +102,7 @@ export default function LicenseDetails( {
 				licenseState={ licenseState }
 				licenseType={ licenseType }
 				hasDownloads={ hasDownloads }
+				bundleGroupSize={ bundleGroupSize }
 			/>
 		</Card>
 	);

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
@@ -41,6 +41,7 @@ interface Props {
 	parentLicenseId?: number | null;
 	quantity?: number | null;
 	isChildLicense?: boolean;
+	bundleGroupSize?: number;
 }
 
 export default function LicensePreview( {
@@ -57,6 +58,7 @@ export default function LicensePreview( {
 	parentLicenseId,
 	quantity,
 	isChildLicense,
+	bundleGroupSize,
 }: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -241,6 +243,7 @@ export default function LicensePreview( {
 							attachedAt={ attachedAt }
 							revokedAt={ revokedAt }
 							licenseType={ licenseType }
+							bundleGroupSize={ bundleGroupSize }
 						/>
 					) : (
 						<Button onClick={ open } className="license-preview__toggle" borderless>
@@ -252,7 +255,7 @@ export default function LicensePreview( {
 
 			{ isOpen &&
 				( showBundleDetails ? (
-					<BundleDetails parentLicenseId={ parentLicenseId } />
+					<BundleDetails parentLicenseId={ parentLicenseId } size={ quantity } />
 				) : (
 					<LicenseDetails
 						licenseKey={ licenseKey }
@@ -266,6 +269,7 @@ export default function LicensePreview( {
 						revokedAt={ revokedAt }
 						onCopyLicense={ onCopyLicense }
 						licenseType={ licenseType }
+						bundleGroupSize={ bundleGroupSize }
 					/>
 				) ) }
 		</div>

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
@@ -243,7 +243,6 @@ export default function LicensePreview( {
 							attachedAt={ attachedAt }
 							revokedAt={ revokedAt }
 							licenseType={ licenseType }
-							bundleGroupSize={ bundleGroupSize }
 						/>
 					) : (
 						<Button onClick={ open } className="license-preview__toggle" borderless>

--- a/client/jetpack-cloud/sections/partner-portal/revoke-child-license-dialog/hooks/use-product-bundle-detached-size.ts
+++ b/client/jetpack-cloud/sections/partner-portal/revoke-child-license-dialog/hooks/use-product-bundle-detached-size.ts
@@ -1,0 +1,32 @@
+import { useMemo } from 'react';
+import { useProductBundleSize } from '../../issue-license-v2/hooks/use-product-bundle-size';
+
+export type DetachSize = {
+	size: number;
+	count: number;
+};
+
+export function useProductBundleDetachedSize( originalSize: number ): DetachSize[] {
+	const { availableSizes } = useProductBundleSize();
+
+	return useMemo( () => {
+		const detachedSizes = [];
+		let remainingLicenses = originalSize - 1;
+
+		for ( let i = availableSizes.indexOf( originalSize ) - 1; i > 0; i-- ) {
+			const size = availableSizes[ i ];
+			detachedSizes.push( {
+				size,
+				count: 1,
+			} );
+			remainingLicenses -= size;
+		}
+
+		detachedSizes.push( {
+			size: 1,
+			count: remainingLicenses,
+		} );
+
+		return detachedSizes;
+	}, [ availableSizes, originalSize ] );
+}

--- a/client/jetpack-cloud/sections/partner-portal/revoke-child-license-dialog/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/revoke-child-license-dialog/index.tsx
@@ -1,0 +1,118 @@
+import { Button, Dialog } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
+import { noop } from 'calypso/jetpack-cloud/sections/partner-portal/lib/constants';
+import LicenseListContext from 'calypso/jetpack-cloud/sections/partner-portal/license-list-context';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { errorNotice } from 'calypso/state/notices/actions';
+import useRefreshLicenseList from 'calypso/state/partner-portal/licenses/hooks/use-refresh-license-list';
+import useRevokeLicenseMutation from 'calypso/state/partner-portal/licenses/hooks/use-revoke-license-mutation';
+import './style.scss';
+import { useProductBundleDetachedSize } from './hooks/use-product-bundle-detached-size';
+
+interface Props {
+	licenseKey: string;
+	product: string;
+	siteUrl: string | null;
+	onClose: ( action?: string ) => void;
+	bundleGroupSize: number;
+}
+
+export default function RevokeLicenseDialog( {
+	licenseKey,
+	product,
+	siteUrl,
+	onClose,
+	bundleGroupSize,
+	...rest
+}: Props ) {
+	let close = noop;
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const refreshLicenceList = useRefreshLicenseList( LicenseListContext );
+	const detachedSizes = useProductBundleDetachedSize( bundleGroupSize );
+
+	const mutation = useRevokeLicenseMutation( {
+		onSuccess: () => {
+			close();
+			dispatch( refreshLicenceList() );
+		},
+		onError: ( error: Error ) => {
+			dispatch( errorNotice( error.message ) );
+		},
+	} );
+
+	close = useCallback( () => {
+		if ( ! mutation.isLoading ) {
+			onClose();
+		}
+	}, [ onClose, mutation.isLoading ] );
+
+	const revoke = useCallback( () => {
+		dispatch(
+			recordTracksEvent( 'calypso_partner_portal_license_list_revoke_child_license_dialog_revoke' )
+		);
+		mutation.mutate( { licenseKey } );
+	}, [ dispatch, licenseKey, mutation ] );
+
+	return (
+		<Dialog
+			isVisible={ true }
+			additionalClassNames="revoke-child-license-dialog"
+			onClose={ close }
+			{ ...rest }
+		>
+			<h2 className="revoke-child-license-dialog__heading">
+				{ translate( 'Revoke %(productName)s License?', {
+					args: {
+						productName: product,
+					},
+				} ) }
+			</h2>
+
+			<p>
+				{ detachedSizes.length === 1
+					? translate(
+							'This license is part of a bundle of %(size)d licenses. If you revoke this license, the bundle will be removed and the remaining licenses will be converted to individual licenses, billed at full price.',
+							{
+								args: {
+									size: bundleGroupSize,
+								},
+							}
+					  )
+					: translate(
+							'This license is part of a bundle of %(size)d licenses. If you revoke this license, the bundle will be removed and the remaining %(remainingSize)d licenses will be converted into:',
+							{
+								args: {
+									size: bundleGroupSize,
+									remainingSize: bundleGroupSize - 1,
+								},
+							}
+					  ) }
+			</p>
+
+			{ detachedSizes.length > 1 && (
+				<ul className="revoke-child-license-dialog__list">
+					{ detachedSizes.map( ( { size, count } ) => (
+						<li key={ size }>
+							{ size === 1
+								? translate( '%(count)d single licenses', { args: { count } } )
+								: translate( 'Bundle of %(size)d licenses', { args: { size } } ) }
+						</li>
+					) ) }
+				</ul>
+			) }
+
+			<div className="revoke-child-license-dialog__actions">
+				<Button primary scary busy={ mutation.isLoading } onClick={ revoke }>
+					{ translate( 'Revoke License' ) }
+				</Button>
+
+				<Button disabled={ false } onClick={ close } borderless>
+					{ translate( 'Cancel' ) }
+				</Button>
+			</div>
+		</Dialog>
+	);
+}

--- a/client/jetpack-cloud/sections/partner-portal/revoke-child-license-dialog/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/revoke-child-license-dialog/style.scss
@@ -1,0 +1,82 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.revoke-child-license-dialog {
+	&.dialog.card {
+		max-height: 100vh;
+		max-width: 100vh;
+		margin: 0;
+		align-self: stretch;
+
+		@include break-small {
+			max-height: 90%;
+			max-width: 90%;
+			margin: auto 0;
+			align-self: center;
+			/* stylelint-disable-next-line scales/radii */
+			border-radius: 8px;
+			padding: 64px;
+		}
+	}
+
+	.dialog__content {
+		max-width: 628px;
+		align-self: stretch;
+		height: 100%;
+		display: flex;
+		flex-direction: column;
+		gap: 16px;
+
+		@include break-small {
+			align-self: center;
+			padding: 0;
+		}
+
+		p {
+			font-size: 1rem;
+			margin: 0;
+		}
+	}
+}
+
+.revoke-child-license-dialog__heading {
+	font-size: 1.5rem;
+	font-weight: 700;
+	line-height: 1.2;
+	color: var(--studio-gray-100);
+}
+
+.revoke-child-license-dialog__list {
+	list-style: none;
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	margin: 0;
+
+	li {
+		background: url(../../../../assets/images/jetpack/jetpack-green-checkmark.svg) no-repeat 0 2px;
+		padding-inline-start: 40px;
+	}
+}
+
+.revoke-child-license-dialog__actions {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	margin-block-start: auto;
+
+	.button.is-primary {
+		font-weight: 600;
+	}
+
+	.button.is-borderless {
+		padding: 8px 24px;
+		text-decoration: underline;
+		font-weight: 400;
+	}
+
+	@include break-small {
+		margin-block-start: 24px;
+		flex-direction: row;
+	}
+}


### PR DESCRIPTION
This pull request introduces a new warning message for revoking licenses that are part of a bundle. The message will now provide a clear explanation of what will happen when a license is revoked. It's important to note that this change will only affect bundled licenses, and non-bundled licenses will continue to function as usual.

<img width="782" alt="Screen Shot 2023-12-05 at 6 07 43 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/201fd9ae-8e70-423d-8349-12f9de2730a3">
<img width="807" alt="Screen Shot 2023-12-05 at 6 07 59 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/6de3f9ed-0fbb-4f99-aa4d-d10e44ddbcff">


Closes https://github.com/Automattic/jetpack-genesis/issues/100
Closes https://github.com/Automattic/jetpack-genesis/issues/101

Depends on https://github.com/Automattic/wp-calypso/pull/84848

## Proposed Changes

* Update the Current License table component to keep track of bundled licenses. If the license is part of the bundled, show 'Detach' instead of 'Revoke' in the button label.

<img width="509" alt="Screen Shot 2023-12-05 at 6 13 17 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/cbe61c6a-f0b6-4c09-a748-430608d49323">

* Show a warning message and explain how the bundle where the license is part will be split. 

## Testing Instructions

Refer to https://github.com/Automattic/wp-calypso/pull/84848 for instructions on how to issue bundled licenses.

* Visit the Jetpack Cloud link > Replace dashboard in the URL with `/partner-portal/issue-license?flags=jetpack/bundle-licensing`
* Detach a license that is part of a bundle and confirm that the new warning message is displayed. Depending on the size of the bundle, a message will have different copies.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?