### PR TITLE
Jetpack Manage: Fix the Issue Licenses page responsiveness

### DIFF
--- a/client/jetpack-cloud/components/layout/style.scss
+++ b/client/jetpack-cloud/components/layout/style.scss
@@ -52,10 +52,6 @@
 }
 
 .main.jetpack-cloud-layout.is-with-border {
-	.jetpack-cloud-layout__body {
-		padding-block: 16px;
-	}
-
 	@include breakpoint-deprecated( ">660px" ) {
 		.jetpack-cloud-layout__top {
 			border-block-end: 1px solid var(--color-primary-5);
@@ -63,6 +59,7 @@
 
 		.jetpack-cloud-layout__body {
 			background: rgba(255, 255, 255, 0.5);
+			padding-block: 16px;
 		}
 	}
 }
@@ -159,7 +156,6 @@
 }
 
 .section-nav.jetpack-cloud-layout__navigation {
-	margin-block-start: 32px;
 	.section-nav__mobile-header-text .count {
 		margin-inline-start: 8px;
 	}
@@ -202,6 +198,10 @@
 		// Since the search below the dropdown has z-index: 22,
 		// we need to make sure the dropdown is above it
 		z-index: 23;
+	}
+
+	@include breakpoint-deprecated( ">960px" ) {
+		margin-block-start: 32px;
 	}
 }
 

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/style.scss
@@ -77,15 +77,28 @@ p.licenses-form__description {
 .licenses-form__actions {
 	display: flex;
 	flex-wrap: wrap;
-	gap: 8px;
+	gap: 16px;
 	margin: 16px 0 32px;
 }
 
-.licenses-form__product-filter-select {
+.select-dropdown.is-compact.licenses-form__product-filter-select {
 	flex-basis: 100%;
+	height: 46px;
 
 	@include break-xlarge {
 		flex-basis: auto;
+	}
+
+	.select-dropdown__header {
+		height: 46px;
+	}
+
+	@include breakpoint-deprecated( ">660px" ) {
+		height: 35px;
+
+		.select-dropdown__header {
+			height: 35px;
+		}
 	}
 
 	.select-dropdown__header-text {
@@ -117,7 +130,11 @@ p.licenses-form__description {
 
 	.search {
 		&.is-open {
-			height: 33px;
+			height: 46px;
+
+			@include breakpoint-deprecated( ">660px" ) {
+				height: 33px;
+			}
 		}
 		margin-bottom: 0;
 		border: 1px solid var(--color-neutral-10);


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/131

## Proposed Changes

This PR fixes the Issue Licenses page responsiveness.

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb. 

**Instructions**

1. Visit the Jetpack Cloud link > Replace `dashboard` in the URL with `/partner-portal/issue-license?flags=jetpack/bundle-licensing`.
2. Verify that the page looks good on all screen sizes.

Mobile:

![mobile (53)](https://github.com/Automattic/wp-calypso/assets/10586875/4269b5ba-3072-4bf1-8470-d6833b03c014)

Tablet:

![mobile (54)](https://github.com/Automattic/wp-calypso/assets/10586875/561d026c-0547-42a4-ab50-bae9dba392e3)

Laptop:

![mobile (55)](https://github.com/Automattic/wp-calypso/assets/10586875/7f3b2667-0563-497b-a0ff-620f264735a1)



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?