### PR TITLE
Stats: Update PWYW flow with new slider

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
@@ -12,13 +12,13 @@ function useTranslatedStrings() {
 	const translate = useTranslate();
 	const limits = translate( 'Monthly site views limit', {
 		comment: 'Heading for Stats Upgrade slider. The monthly views limit.',
-	} );
+	} ) as string;
 	const price = translate( 'You will pay', {
 		comment: 'Heading for Stats Upgrade slider. The monthly price.',
-	} );
+	} ) as string;
 	const strategy = translate( 'Price per month, billed yearly', {
 		comment: 'Stats Upgrade slider message. The billing strategy.',
-	} );
+	} ) as string;
 
 	return {
 		limits,
@@ -89,7 +89,7 @@ function StatsCommercialUpgradeSlider( {
 					} ),
 				},
 			}
-		);
+		) as string;
 		lastTier.views = `${ formatNumber( EXTENSION_THRESHOLD * 1000000 ) }+`;
 	}
 

--- a/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
@@ -1,0 +1,111 @@
+import formatNumber from '@automattic/components/src/number-formatters/lib/format-number';
+import formatCurrency from '@automattic/format-currency';
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'calypso/state';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import TierUpgradeSlider from '../stats-purchase-tier-upgrade-slider';
+import { StatsPlanTierUI } from '../types';
+import useAvailableUpgradeTiers from '../use-available-upgrade-tiers';
+import './styles.scss';
+
+function useTranslatedStrings() {
+	const translate = useTranslate();
+	const limits = translate( 'Monthly site views limit', {
+		comment: 'Heading for Stats Upgrade slider. The monthly views limit.',
+	} );
+	const price = translate( 'You will pay', {
+		comment: 'Heading for Stats Upgrade slider. The monthly price.',
+	} );
+	const strategy = translate( 'Price per month, billed yearly', {
+		comment: 'Stats Upgrade slider message. The billing strategy.',
+	} );
+
+	return {
+		limits,
+		price,
+		strategy,
+	};
+}
+
+function getStepsForTiers( tiers: StatsPlanTierUI[] ) {
+	// TODO: Review tier values from API.
+	// Should consider validating the inputs before displaying them.
+	return tiers.map( ( tier ) => {
+		// No transformation needed (yet).
+		const price = tier.price;
+		// Views can be a number or a string so address that.
+		let views = '';
+		if ( typeof tier.views === 'string' ) {
+			views = tier.views;
+		} else if ( typeof tier.views === 'number' ) {
+			views = formatNumber( tier.views );
+		}
+		// Return the new step with string values.
+		return {
+			lhValue: views,
+			rhValue: price,
+		};
+	} );
+}
+
+type StatsCommercialUpgradeSliderProps = {
+	currencyCode: string;
+	onSliderChange: ( quantity: number ) => void;
+};
+
+function StatsCommercialUpgradeSlider( {
+	currencyCode,
+	onSliderChange,
+}: StatsCommercialUpgradeSliderProps ) {
+	// 1. Prepare and translate UI strings.
+	// 2. Fetch tier data.
+	// 3. Transform data for slider.
+	// 4. Render component parts.
+
+	const translate = useTranslate();
+	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const tiers = useAvailableUpgradeTiers( siteId );
+	const uiStrings = useTranslatedStrings();
+
+	// Special case for per-unit fees.
+	// Determine this based on last tier in the list.
+	// The translate() call returns a node so we need to set the type correctly.
+	let perUnitFeeMessaging;
+	const lastTier = tiers.at( -1 );
+	const hasPerUnitFee = !! lastTier?.per_unit_fee;
+	if ( hasPerUnitFee ) {
+		const EXTENSION_THRESHOLD = 2; // in millions
+		const perUnitFee = Number( lastTier?.per_unit_fee );
+		perUnitFeeMessaging = translate(
+			'This is the base price for %(views_extension_limit)s million monthly views; beyond that, you will be charged additional +%(extension_value)s per million views.',
+			{
+				args: {
+					views_extension_limit: EXTENSION_THRESHOLD,
+					extension_value: formatCurrency( perUnitFee, currencyCode, {
+						isSmallestUnit: true,
+						stripZeros: true,
+					} ),
+				},
+			}
+		);
+		lastTier.views = `${ formatNumber( EXTENSION_THRESHOLD * 1000000 ) }+`;
+	}
+
+	const steps = getStepsForTiers( tiers );
+
+	const handleSliderChanged = ( index: number ) => {
+		onSliderChange( tiers[ index ]?.views as number );
+	};
+
+	return (
+		<TierUpgradeSlider
+			className="stats-commercial-upgrade-slider"
+			uiStrings={ uiStrings }
+			popupInfoString={ perUnitFeeMessaging }
+			steps={ steps }
+			onSliderChange={ handleSliderChanged }
+		/>
+	);
+}
+
+export default StatsCommercialUpgradeSlider;

--- a/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
@@ -1,9 +1,9 @@
 import formatNumber from '@automattic/components/src/number-formatters/lib/format-number';
 import formatCurrency from '@automattic/format-currency';
 import { useTranslate } from 'i18n-calypso';
+import TierUpgradeSlider from 'calypso/my-sites/stats/stats-purchase/tier-upgrade-slider';
 import { useSelector } from 'calypso/state';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import TierUpgradeSlider from '../stats-purchase-tier-upgrade-slider';
 import { StatsPlanTierUI } from '../types';
 import useAvailableUpgradeTiers from '../use-available-upgrade-tiers';
 import './styles.scss';

--- a/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
@@ -32,7 +32,10 @@ function getStepsForTiers( tiers: StatsPlanTierUI[] ) {
 	// Should consider validating the inputs before displaying them.
 	return tiers.map( ( tier ) => {
 		// No transformation needed (yet).
-		const price = tier.price;
+		let price = '';
+		if ( typeof tier.price === 'string' ) {
+			price = tier.price;
+		}
 		// Views can be a number or a string so address that.
 		let views = '';
 		if ( typeof tier.views === 'string' ) {

--- a/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
@@ -104,6 +104,7 @@ function StatsCommercialUpgradeSlider( {
 			popupInfoString={ perUnitFeeMessaging }
 			steps={ steps }
 			onSliderChange={ handleSliderChanged }
+			marks={ true }
 		/>
 	);
 }

--- a/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
@@ -57,10 +57,12 @@ function StatsCommercialUpgradeSlider( {
 	currencyCode,
 	onSliderChange,
 }: StatsCommercialUpgradeSliderProps ) {
-	// 1. Prepare and translate UI strings.
-	// 2. Fetch tier data.
-	// 3. Transform data for slider.
-	// 4. Render component parts.
+	// Responsible for:
+	// 1. Fetching the tiers from the API.
+	// 2. Transforming the tiers into a format that the slider can use.
+	// 3. Preparing the UI strings for the slider.
+	// 4. Rendering the slider.
+	// 5. Nofiying the parent component when the slider changes.
 
 	const translate = useTranslate();
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );

--- a/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/styles.scss
+++ b/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/styles.scss
@@ -1,0 +1,5 @@
+// Styles specific to layout on the Commercial Upgrade page.
+
+.stats-commercial-upgrade-slider {
+	margin: 42px 0;
+}

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -13,6 +13,7 @@ import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
 import gotoCheckoutPage from './stats-purchase-checkout-redirect';
 import { COMPONENT_CLASS_NAME, MIN_STEP_SPLITS } from './stats-purchase-wizard';
 import StatsPWYWUpgradeSlider from './stats-pwyw-uprade-slider';
+import { StatsPWYWSliderSettings } from './types';
 
 interface PersonalPurchaseProps {
 	subscriptionValue: number;
@@ -22,13 +23,7 @@ interface PersonalPurchaseProps {
 	currencyCode: string;
 	siteId: number | null;
 	siteSlug: string;
-	sliderSettings: {
-		sliderStepPrice: number;
-		minSliderPrice: number;
-		maxSliderPrice: number;
-		uiEmojiHeartTier: number;
-		uiImageCelebrationTier: number;
-	};
+	sliderSettings: StatsPWYWSliderSettings;
 	adminUrl: string;
 	redirectUri: string;
 	from: string;

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -125,13 +125,6 @@ const PersonalPurchase = ( {
 				maxValue={ Math.floor( maxSliderPrice / sliderStepPrice ) }
 				minValue={ Math.round( minSliderPrice / sliderStepPrice ) }
 			/>
-			{ isTierUpgradeSliderEnabled && (
-				<StatsPWYWUpgradeSlider
-					settings={ sliderSettings }
-					currencyCode={ currencyCode }
-					onSliderChange={ handleSliderChanged }
-				/>
-			) }
 
 			<p className={ `${ COMPONENT_CLASS_NAME }__average-price` }>
 				{ translate( 'Our users pay %(value)s per month on average', {
@@ -140,6 +133,14 @@ const PersonalPurchase = ( {
 					},
 				} ) }
 			</p>
+
+			{ isTierUpgradeSliderEnabled && (
+				<StatsPWYWUpgradeSlider
+					settings={ sliderSettings }
+					currencyCode={ currencyCode }
+					onSliderChange={ handleSliderChanged }
+				/>
+			) }
 
 			<div className={ `${ COMPONENT_CLASS_NAME }__benefits` }>
 				<ul>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -103,6 +103,9 @@ const PersonalPurchase = ( {
 		// Value is used below to determine tier price.
 		setSubscriptionValue( index );
 	};
+	// TODO: Remove old slider code paths.
+	const showOldSlider = ! isTierUpgradeSliderEnabled;
+	// const showOldSlider = true;
 
 	return (
 		<div>
@@ -117,22 +120,26 @@ const PersonalPurchase = ( {
 				) }
 			</div>
 
-			<PricingSlider
-				className={ `${ COMPONENT_CLASS_NAME }__slider` }
-				value={ subscriptionValue }
-				renderThumb={ sliderLabel }
-				onChange={ setSubscriptionValue }
-				maxValue={ Math.floor( maxSliderPrice / sliderStepPrice ) }
-				minValue={ Math.round( minSliderPrice / sliderStepPrice ) }
-			/>
+			{ showOldSlider && (
+				<>
+					<PricingSlider
+						className={ `${ COMPONENT_CLASS_NAME }__slider` }
+						value={ subscriptionValue }
+						renderThumb={ sliderLabel }
+						onChange={ setSubscriptionValue }
+						maxValue={ Math.floor( maxSliderPrice / sliderStepPrice ) }
+						minValue={ Math.round( minSliderPrice / sliderStepPrice ) }
+					/>
 
-			<p className={ `${ COMPONENT_CLASS_NAME }__average-price` }>
-				{ translate( 'Our users pay %(value)s per month on average', {
-					args: {
-						value: formatCurrency( defaultStartingValue * sliderStepPrice, currencyCode ),
-					},
-				} ) }
-			</p>
+					<p className={ `${ COMPONENT_CLASS_NAME }__average-price` }>
+						{ translate( 'Our users pay %(value)s per month on average', {
+							args: {
+								value: formatCurrency( defaultStartingValue * sliderStepPrice, currencyCode ),
+							},
+						} ) }
+					</p>
+				</>
+			) }
 
 			{ isTierUpgradeSliderEnabled && (
 				<StatsPWYWUpgradeSlider

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import {
 	PricingSlider,
 	RenderThumbFunction,
@@ -11,6 +12,7 @@ import { useSelector } from 'calypso/state';
 import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
 import gotoCheckoutPage from './stats-purchase-checkout-redirect';
 import { COMPONENT_CLASS_NAME, MIN_STEP_SPLITS } from './stats-purchase-wizard';
+import StatsPWYWUpgradeSlider from './stats-pwyw-uprade-slider';
 
 interface PersonalPurchaseProps {
 	subscriptionValue: number;
@@ -94,6 +96,14 @@ const PersonalPurchase = ( {
 	// The button of @automattic/components has built-in color scheme support for Calypso.
 	const ButtonComponent = isWPCOMSite ? CalypsoButton : Button;
 
+	const isTierUpgradeSliderEnabled = config.isEnabled( 'stats/tier-upgrade-slider' );
+	const handleSliderChanged = ( index: number ) => {
+		// TODO: Remove state from caller.
+		// Caller expects an index but doesn't do anything with it.
+		// Value is used below to determine tier price.
+		setSubscriptionValue( index );
+	};
+
 	return (
 		<div>
 			<div className={ `${ COMPONENT_CLASS_NAME }__notice` }>
@@ -115,6 +125,13 @@ const PersonalPurchase = ( {
 				maxValue={ Math.floor( maxSliderPrice / sliderStepPrice ) }
 				minValue={ Math.round( minSliderPrice / sliderStepPrice ) }
 			/>
+			{ isTierUpgradeSliderEnabled && (
+				<StatsPWYWUpgradeSlider
+					settings={ sliderSettings }
+					currencyCode={ currencyCode }
+					onSliderChange={ handleSliderChanged }
+				/>
+			) }
 
 			<p className={ `${ COMPONENT_CLASS_NAME }__average-price` }>
 				{ translate( 'Our users pay %(value)s per month on average', {

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -8,6 +8,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector } from 'calypso/state';
 import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
 import getSiteAdminUrl from 'calypso/state/sites/selectors/get-site-admin-url';
+import StatsCommercialUpgradeSlider from './stats-commercial-upgrade-slider';
 import gotoCheckoutPage from './stats-purchase-checkout-redirect';
 import PersonalPurchase from './stats-purchase-personal';
 import {
@@ -15,7 +16,6 @@ import {
 	StatsBenefitsCommercial,
 	StatsSingleItemPagePurchaseFrame,
 } from './stats-purchase-shared';
-import { StatsCommercialUpgradeSlider } from './stats-purchase-tier-upgrade-slider';
 import {
 	MIN_STEP_SPLITS,
 	DEFAULT_STARTING_FRACTION,

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -152,7 +152,7 @@ Thanks\n\n`;
 				<>
 					<StatsCommercialUpgradeSlider
 						currencyCode={ currencyCode }
-						onSliderChanged={ handleSliderChanged }
+						onSliderChange={ handleSliderChanged }
 					/>
 					<ButtonComponent
 						variant="primary"

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -15,9 +15,7 @@ import {
 	StatsBenefitsCommercial,
 	StatsSingleItemPagePurchaseFrame,
 } from './stats-purchase-shared';
-import TierUpgradeSlider, {
-	StatsCommercialUpgradeSlider,
-} from './stats-purchase-tier-upgrade-slider';
+import { StatsCommercialUpgradeSlider } from './stats-purchase-tier-upgrade-slider';
 import {
 	MIN_STEP_SPLITS,
 	DEFAULT_STARTING_FRACTION,
@@ -152,10 +150,6 @@ Thanks\n\n`;
 			) }
 			{ isTierUpgradeSliderEnabled && (
 				<>
-					<TierUpgradeSlider
-						currencyCode={ currencyCode }
-						setPurchaseTierQuantity={ setPurchaseTierQuantity }
-					/>
 					<StatsCommercialUpgradeSlider
 						currencyCode={ currencyCode }
 						onSliderChanged={ handleSliderChanged }

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -15,7 +15,9 @@ import {
 	StatsBenefitsCommercial,
 	StatsSingleItemPagePurchaseFrame,
 } from './stats-purchase-shared';
-import TierUpgradeSlider from './stats-purchase-tier-upgrade-slider';
+import TierUpgradeSlider, {
+	StatsCommercialUpgradeSlider,
+} from './stats-purchase-tier-upgrade-slider';
 import {
 	MIN_STEP_SPLITS,
 	DEFAULT_STARTING_FRACTION,
@@ -125,6 +127,10 @@ Thanks\n\n`;
 	// Currently displaying below the flow to maintain existing behaviour.
 	const isTierUpgradeSliderEnabled = config.isEnabled( 'stats/tier-upgrade-slider' );
 
+	const handleSliderChanged = ( value: number ) => {
+		setPurchaseTierQuantity( value );
+	};
+
 	return (
 		<>
 			<h1>{ translate( 'Jetpack Stats' ) }</h1>
@@ -149,6 +155,10 @@ Thanks\n\n`;
 					<TierUpgradeSlider
 						currencyCode={ currencyCode }
 						setPurchaseTierQuantity={ setPurchaseTierQuantity }
+					/>
+					<StatsCommercialUpgradeSlider
+						currencyCode={ currencyCode }
+						onSliderChanged={ handleSliderChanged }
 					/>
 					<ButtonComponent
 						variant="primary"

--- a/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.tsx
@@ -126,4 +126,27 @@ function TierUpgradeSlider( {
 	);
 }
 
+type StatsCommercialUpgradeSliderProps = {
+	currencyCode: string;
+	onSliderChanged: ( quantity: number ) => void;
+};
+
+export function StatsCommercialUpgradeSlider( {
+	currencyCode,
+	onSliderChanged,
+}: StatsCommercialUpgradeSliderProps ) {
+	// const translate = useTranslate();
+	// 1. Prepare and translate UI strings.
+	// 2. Fetch tier data.
+	// 3. Transform data for slider.
+	// 4. Render component parts.
+	return (
+		<TierUpgradeSlider
+			className="stats-commercial-upgrade-slider"
+			currencyCode={ currencyCode }
+			setPurchaseTierQuantity={ onSliderChanged }
+		/>
+	);
+}
+
 export default TierUpgradeSlider;

--- a/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.tsx
@@ -51,7 +51,7 @@ function TierUpgradeSlider( {
 					</p>
 				</div>
 			</div>
-			{ tiers.length > 1 && (
+			{ steps.length > 1 && (
 				<PricingSlider
 					className="stats-tier-upgrade-slider__slider"
 					thumbClassName="stats-tier-upgrade-slider__thumb"

--- a/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.tsx
@@ -5,11 +5,13 @@ import { useTranslate } from 'i18n-calypso';
 import React, { useState, useRef } from 'react';
 import { useSelector } from 'calypso/state';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { StatsPlanTierUI } from './types';
 import useAvailableUpgradeTiers from './use-available-upgrade-tiers';
 import './stats-purchase-tier-upgrade-slider.scss';
 
 type TierUpgradeSliderProps = {
 	className?: string;
+	tiers: StatsPlanTierUI[];
 	currencyCode: string;
 	setPurchaseTierQuantity: ( quantity: number ) => void;
 };
@@ -35,14 +37,13 @@ function useTranslatedStrings() {
 
 function TierUpgradeSlider( {
 	className,
+	tiers,
 	currencyCode,
 	setPurchaseTierQuantity,
 }: TierUpgradeSliderProps ) {
 	const translate = useTranslate();
 	const infoReferenceElement = useRef( null );
 	const componentClassNames = classNames( 'stats-tier-upgrade-slider', className );
-	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
-	const tiers = useAvailableUpgradeTiers( siteId );
 	const EXTENSION_THRESHOLD = 2; // in millions
 
 	// Slider state.
@@ -136,6 +137,8 @@ export function StatsCommercialUpgradeSlider( {
 	onSliderChanged,
 }: StatsCommercialUpgradeSliderProps ) {
 	// const translate = useTranslate();
+	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const tiers = useAvailableUpgradeTiers( siteId );
 	// 1. Prepare and translate UI strings.
 	// 2. Fetch tier data.
 	// 3. Transform data for slider.
@@ -143,6 +146,7 @@ export function StatsCommercialUpgradeSlider( {
 	return (
 		<TierUpgradeSlider
 			className="stats-commercial-upgrade-slider"
+			tiers={ tiers }
 			currencyCode={ currencyCode }
 			setPurchaseTierQuantity={ onSliderChanged }
 		/>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.tsx
@@ -13,7 +13,7 @@ type TierUpgradeSliderProps = {
 	className?: string;
 	tiers: StatsPlanTierUI[];
 	currencyCode: string;
-	setPurchaseTierQuantity: ( quantity: number ) => void;
+	onSliderChange: ( index: number ) => void;
 };
 
 function useTranslatedStrings() {
@@ -39,7 +39,7 @@ function TierUpgradeSlider( {
 	className,
 	tiers,
 	currencyCode,
-	setPurchaseTierQuantity,
+	onSliderChange,
 }: TierUpgradeSliderProps ) {
 	const translate = useTranslate();
 	const infoReferenceElement = useRef( null );
@@ -53,8 +53,7 @@ function TierUpgradeSlider( {
 
 	const handleSliderChange = ( value: number ) => {
 		setCurrentPlanIndex( value );
-
-		setPurchaseTierQuantity( tiers[ value ]?.views as number );
+		onSliderChange( value );
 	};
 
 	const translatedStrings = useTranslatedStrings();
@@ -129,26 +128,32 @@ function TierUpgradeSlider( {
 
 type StatsCommercialUpgradeSliderProps = {
 	currencyCode: string;
-	onSliderChanged: ( quantity: number ) => void;
+	onSliderChange: ( quantity: number ) => void;
 };
 
 export function StatsCommercialUpgradeSlider( {
 	currencyCode,
-	onSliderChanged,
+	onSliderChange,
 }: StatsCommercialUpgradeSliderProps ) {
-	// const translate = useTranslate();
-	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
-	const tiers = useAvailableUpgradeTiers( siteId );
 	// 1. Prepare and translate UI strings.
 	// 2. Fetch tier data.
 	// 3. Transform data for slider.
 	// 4. Render component parts.
+
+	// const translate = useTranslate();
+	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const tiers = useAvailableUpgradeTiers( siteId );
+
+	const handleSliderChanged = ( index: number ) => {
+		onSliderChange( tiers[ index ]?.views as number );
+	};
+
 	return (
 		<TierUpgradeSlider
 			className="stats-commercial-upgrade-slider"
 			tiers={ tiers }
 			currencyCode={ currencyCode }
-			setPurchaseTierQuantity={ onSliderChanged }
+			onSliderChange={ handleSliderChanged }
 		/>
 	);
 }

--- a/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.tsx
@@ -11,6 +11,7 @@ import './stats-purchase-tier-upgrade-slider.scss';
 
 type TierUpgradeSliderProps = {
 	className?: string;
+	uiStrings: any;
 	tiers: StatsPlanTierUI[];
 	currencyCode: string;
 	onSliderChange: ( index: number ) => void;
@@ -37,6 +38,7 @@ function useTranslatedStrings() {
 
 function TierUpgradeSlider( {
 	className,
+	uiStrings,
 	tiers,
 	currencyCode,
 	onSliderChange,
@@ -56,8 +58,6 @@ function TierUpgradeSlider( {
 		onSliderChange( value );
 	};
 
-	const translatedStrings = useTranslatedStrings();
-
 	// TODO: Review tier values from API.
 	// Should consider validating the inputs before displaying them.
 	// The following will draw a "-" for the views value if it's undefined.
@@ -70,14 +70,14 @@ function TierUpgradeSlider( {
 		<div className={ componentClassNames }>
 			<div className="stats-tier-upgrade-slider__plan-callouts">
 				<div className="stats-tier-upgrade-slider__plan-callout">
-					<h2>{ translatedStrings.limits }</h2>
+					<h2>{ uiStrings.limits }</h2>
 					<p className="left-aligned">
 						<ShortenedNumber value={ lhValue } />
 						{ hasExtension && <span>+</span> }
 					</p>
 				</div>
 				<div className="stats-tier-upgrade-slider__plan-callout right-aligned">
-					<h2>{ translatedStrings.price }</h2>
+					<h2>{ uiStrings.price }</h2>
 					<p className="right-aligned" ref={ infoReferenceElement }>
 						{ tiers[ currentPlanIndex ]?.price }
 					</p>
@@ -121,7 +121,7 @@ function TierUpgradeSlider( {
 						) }
 				</div>
 			</Popover>
-			<p className="stats-tier-upgrade-slider__info-message">{ translatedStrings.strategy }</p>
+			<p className="stats-tier-upgrade-slider__info-message">{ uiStrings.strategy }</p>
 		</div>
 	);
 }
@@ -143,6 +143,7 @@ export function StatsCommercialUpgradeSlider( {
 	// const translate = useTranslate();
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const tiers = useAvailableUpgradeTiers( siteId );
+	const uiStrings = useTranslatedStrings();
 
 	const handleSliderChanged = ( index: number ) => {
 		onSliderChange( tiers[ index ]?.views as number );
@@ -151,6 +152,7 @@ export function StatsCommercialUpgradeSlider( {
 	return (
 		<TierUpgradeSlider
 			className="stats-commercial-upgrade-slider"
+			uiStrings={ uiStrings }
 			tiers={ tiers }
 			currencyCode={ currencyCode }
 			onSliderChange={ handleSliderChanged }

--- a/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.tsx
@@ -13,8 +13,8 @@ import './stats-purchase-tier-upgrade-slider.scss';
 type TierUpgradeSliderProps = {
 	className?: string;
 	uiStrings: any;
+	popupInfoString: any;
 	tiers: StatsPlanTierUI[];
-	currencyCode: string;
 	onSliderChange: ( index: number ) => void;
 };
 
@@ -40,11 +40,10 @@ function useTranslatedStrings() {
 function TierUpgradeSlider( {
 	className,
 	uiStrings,
+	popupInfoString,
 	tiers,
-	currencyCode,
 	onSliderChange,
 }: TierUpgradeSliderProps ) {
-	const translate = useTranslate();
 	const infoReferenceElement = useRef( null );
 	const componentClassNames = classNames( 'stats-tier-upgrade-slider', className );
 	const EXTENSION_THRESHOLD = 2; // in millions
@@ -69,20 +68,7 @@ function TierUpgradeSlider( {
 	const rhValue = tiers[ currentPlanIndex ]?.price;
 
 	// Special case for per-unit fees.
-	const hasPerUnitFee = !! tiers[ currentPlanIndex ]?.per_unit_fee;
-	const perUnitFee = hasPerUnitFee ? Number( tiers[ currentPlanIndex ]?.per_unit_fee ) : 0;
-	const perUnitFeeMessaging = translate(
-		'This is the base price for %(views_extension_limit)s million monthly views; beyond that, you will be charged additional +%(extension_value)s per million views.',
-		{
-			args: {
-				views_extension_limit: EXTENSION_THRESHOLD,
-				extension_value: formatCurrency( perUnitFee, currencyCode, {
-					isSmallestUnit: true,
-					stripZeros: true,
-				} ),
-			},
-		}
-	);
+	const hasPerUnitFee = popupInfoString !== undefined;
 
 	return (
 		<div className={ componentClassNames }>
@@ -120,7 +106,7 @@ function TierUpgradeSlider( {
 				className="stats-tier-upgrade-slider__extension-popover-wrapper"
 			>
 				<div className="stats-tier-upgrade-slider__extension-popover-content">
-					{ hasPerUnitFee && perUnitFeeMessaging }
+					{ hasPerUnitFee && popupInfoString }
 				</div>
 			</Popover>
 			<p className="stats-tier-upgrade-slider__info-message">{ uiStrings.strategy }</p>
@@ -161,11 +147,36 @@ export function StatsCommercialUpgradeSlider( {
 	// 3. Transform data for slider.
 	// 4. Render component parts.
 
-	// const translate = useTranslate();
+	const translate = useTranslate();
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const tiers = useAvailableUpgradeTiers( siteId );
 	const uiStrings = useTranslatedStrings();
 
+	// Special case for per-unit fees.
+	// Determine this based on last tier in the list.
+	// The translate() call returns a node so we need to set the type correctly.
+	let perUnitFeeMessaging;
+	const lastTier = tiers.at( -1 );
+	const hasPerUnitFee = !! lastTier?.per_unit_fee;
+	if ( hasPerUnitFee ) {
+		const EXTENSION_THRESHOLD = 2; // in millions
+		const perUnitFee = Number( lastTier?.per_unit_fee );
+		perUnitFeeMessaging = translate(
+			'This is the base price for %(views_extension_limit)s million monthly views; beyond that, you will be charged additional +%(extension_value)s per million views.',
+			{
+				args: {
+					views_extension_limit: EXTENSION_THRESHOLD,
+					extension_value: formatCurrency( perUnitFee, currencyCode, {
+						isSmallestUnit: true,
+						stripZeros: true,
+					} ),
+				},
+			}
+		);
+		lastTier.views = `${ formatNumber( EXTENSION_THRESHOLD * 1000000 ) }+`;
+	}
+
+	// TODO: Pass steps to slider.
 	const steps = getStepsForTiers( tiers );
 	console.log( 'steps', steps );
 	console.log( 'tiers', tiers );
@@ -178,8 +189,8 @@ export function StatsCommercialUpgradeSlider( {
 		<TierUpgradeSlider
 			className="stats-commercial-upgrade-slider"
 			uiStrings={ uiStrings }
+			popupInfoString={ perUnitFeeMessaging }
 			tiers={ tiers }
-			currencyCode={ currencyCode }
 			onSliderChange={ handleSliderChanged }
 		/>
 	);

--- a/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.tsx
@@ -1,13 +1,6 @@
 import { PricingSlider, Popover } from '@automattic/components';
-import formatNumber from '@automattic/components/src/number-formatters/lib/format-number';
-import formatCurrency from '@automattic/format-currency';
 import classNames from 'classnames';
-import { useTranslate } from 'i18n-calypso';
-import React, { useState, useRef } from 'react';
-import { useSelector } from 'calypso/state';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { StatsPlanTierUI } from './types';
-import useAvailableUpgradeTiers from './use-available-upgrade-tiers';
+import { useState, useRef } from 'react';
 import './stats-purchase-tier-upgrade-slider.scss';
 
 type TierUpgradeSliderProps = {
@@ -17,25 +10,6 @@ type TierUpgradeSliderProps = {
 	steps: any[];
 	onSliderChange: ( index: number ) => void;
 };
-
-function useTranslatedStrings() {
-	const translate = useTranslate();
-	const limits = translate( 'Monthly site views limit', {
-		comment: 'Heading for Stats Upgrade slider. The monthly views limit.',
-	} );
-	const price = translate( 'You will pay', {
-		comment: 'Heading for Stats Upgrade slider. The monthly price.',
-	} );
-	const strategy = translate( 'Price per month, billed yearly', {
-		comment: 'Stats Upgrade slider message. The billing strategy.',
-	} );
-
-	return {
-		limits,
-		price,
-		strategy,
-	};
-}
 
 function TierUpgradeSlider( {
 	className,
@@ -101,87 +75,6 @@ function TierUpgradeSlider( {
 			</Popover>
 			<p className="stats-tier-upgrade-slider__info-message">{ uiStrings.strategy }</p>
 		</div>
-	);
-}
-
-type StatsCommercialUpgradeSliderProps = {
-	currencyCode: string;
-	onSliderChange: ( quantity: number ) => void;
-};
-
-function getStepsForTiers( tiers: StatsPlanTierUI[] ) {
-	// TODO: Review tier values from API.
-	// Should consider validating the inputs before displaying them.
-	return tiers.map( ( tier ) => {
-		// No transformation needed (yet).
-		const price = tier.price;
-		// Views can be a number or a string so address that.
-		let views = '';
-		if ( typeof tier.views === 'string' ) {
-			views = tier.views;
-		} else if ( typeof tier.views === 'number' ) {
-			views = formatNumber( tier.views );
-		}
-		// Return the new step with string values.
-		return {
-			lhValue: views,
-			rhValue: price,
-		};
-	} );
-}
-
-export function StatsCommercialUpgradeSlider( {
-	currencyCode,
-	onSliderChange,
-}: StatsCommercialUpgradeSliderProps ) {
-	// 1. Prepare and translate UI strings.
-	// 2. Fetch tier data.
-	// 3. Transform data for slider.
-	// 4. Render component parts.
-
-	const translate = useTranslate();
-	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
-	const tiers = useAvailableUpgradeTiers( siteId );
-	const uiStrings = useTranslatedStrings();
-
-	// Special case for per-unit fees.
-	// Determine this based on last tier in the list.
-	// The translate() call returns a node so we need to set the type correctly.
-	let perUnitFeeMessaging;
-	const lastTier = tiers.at( -1 );
-	const hasPerUnitFee = !! lastTier?.per_unit_fee;
-	if ( hasPerUnitFee ) {
-		const EXTENSION_THRESHOLD = 2; // in millions
-		const perUnitFee = Number( lastTier?.per_unit_fee );
-		perUnitFeeMessaging = translate(
-			'This is the base price for %(views_extension_limit)s million monthly views; beyond that, you will be charged additional +%(extension_value)s per million views.',
-			{
-				args: {
-					views_extension_limit: EXTENSION_THRESHOLD,
-					extension_value: formatCurrency( perUnitFee, currencyCode, {
-						isSmallestUnit: true,
-						stripZeros: true,
-					} ),
-				},
-			}
-		);
-		lastTier.views = `${ formatNumber( EXTENSION_THRESHOLD * 1000000 ) }+`;
-	}
-
-	const steps = getStepsForTiers( tiers );
-
-	const handleSliderChanged = ( index: number ) => {
-		onSliderChange( tiers[ index ]?.views as number );
-	};
-
-	return (
-		<TierUpgradeSlider
-			className="stats-commercial-upgrade-slider"
-			uiStrings={ uiStrings }
-			popupInfoString={ perUnitFeeMessaging }
-			steps={ steps }
-			onSliderChange={ handleSliderChanged }
-		/>
 	);
 }
 

--- a/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.tsx
@@ -65,6 +65,23 @@ function TierUpgradeSlider( {
 	const lhValue = hasExtension
 		? EXTENSION_THRESHOLD * 1000000
 		: Number( tiers[ currentPlanIndex ]?.views );
+	const rhValue = tiers[ currentPlanIndex ]?.price;
+
+	// Special case for per-unit fees.
+	const hasPerUnitFee = !! tiers[ currentPlanIndex ]?.per_unit_fee;
+	const perUnitFee = hasPerUnitFee ? Number( tiers[ currentPlanIndex ]?.per_unit_fee ) : 0;
+	const perUnitFeeMessaging = translate(
+		'This is the base price for %(views_extension_limit)s million monthly views; beyond that, you will be charged additional +%(extension_value)s per million views.',
+		{
+			args: {
+				views_extension_limit: EXTENSION_THRESHOLD,
+				extension_value: formatCurrency( perUnitFee, currencyCode, {
+					isSmallestUnit: true,
+					stripZeros: true,
+				} ),
+			},
+		}
+	);
 
 	return (
 		<div className={ componentClassNames }>
@@ -79,7 +96,7 @@ function TierUpgradeSlider( {
 				<div className="stats-tier-upgrade-slider__plan-callout right-aligned">
 					<h2>{ uiStrings.price }</h2>
 					<p className="right-aligned" ref={ infoReferenceElement }>
-						{ tiers[ currentPlanIndex ]?.price }
+						{ rhValue }
 					</p>
 				</div>
 			</div>
@@ -102,23 +119,7 @@ function TierUpgradeSlider( {
 				className="stats-tier-upgrade-slider__extension-popover-wrapper"
 			>
 				<div className="stats-tier-upgrade-slider__extension-popover-content">
-					{ tiers[ currentPlanIndex ]?.per_unit_fee &&
-						translate(
-							'This is the base price for %(views_extension_limit)s million monthly views; beyond that, you will be charged additional +%(extension_value)s per million views.',
-							{
-								args: {
-									views_extension_limit: EXTENSION_THRESHOLD,
-									extension_value: formatCurrency(
-										tiers[ currentPlanIndex ].per_unit_fee as number,
-										currencyCode,
-										{
-											isSmallestUnit: true,
-											stripZeros: true,
-										}
-									),
-								},
-							}
-						) }
+					{ hasPerUnitFee && perUnitFeeMessaging }
 				</div>
 			</Popover>
 			<p className="stats-tier-upgrade-slider__info-message">{ uiStrings.strategy }</p>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.tsx
@@ -1,4 +1,5 @@
 import { PricingSlider, ShortenedNumber, Popover } from '@automattic/components';
+import formatNumber from '@automattic/components/src/number-formatters/lib/format-number';
 import formatCurrency from '@automattic/format-currency';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -132,6 +133,25 @@ type StatsCommercialUpgradeSliderProps = {
 	onSliderChange: ( quantity: number ) => void;
 };
 
+function getStepsForTiers( tiers: StatsPlanTierUI[] ) {
+	return tiers.map( ( tier ) => {
+		// No transformation needed (yet).
+		const price = tier.price;
+		// Views can be a number or a string so address that.
+		let views = '';
+		if ( typeof tier.views === 'string' ) {
+			views = tier.views;
+		} else if ( typeof tier.views === 'number' ) {
+			views = formatNumber( tier.views );
+		}
+		// Return the new step with string values.
+		return {
+			lhValue: views,
+			rhValue: price,
+		};
+	} );
+}
+
 export function StatsCommercialUpgradeSlider( {
 	currencyCode,
 	onSliderChange,
@@ -145,6 +165,10 @@ export function StatsCommercialUpgradeSlider( {
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const tiers = useAvailableUpgradeTiers( siteId );
 	const uiStrings = useTranslatedStrings();
+
+	const steps = getStepsForTiers( tiers );
+	console.log( 'steps', steps );
+	console.log( 'tiers', tiers );
 
 	const handleSliderChanged = ( index: number ) => {
 		onSliderChange( tiers[ index ]?.views as number );

--- a/client/my-sites/stats/stats-purchase/stats-pwyw-uprade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-pwyw-uprade-slider/index.tsx
@@ -1,0 +1,76 @@
+import formatCurrency from '@automattic/format-currency';
+import TierUpgradeSlider from 'calypso/my-sites/stats/stats-purchase/tier-upgrade-slider';
+import './styles.scss';
+
+function getPWYWPlanTiers( minPrice: number, stepPrice: number ) {
+	// From $0 to $20, in $1 increments.
+	let tiers = [];
+	for ( let i = 0; i <= 28; i++ ) {
+		tiers.push( {
+			price: formatCurrency( ( minPrice + i * stepPrice ) / 100, 'USD' ),
+			raw: minPrice + i * stepPrice,
+		} );
+	}
+	tiers = tiers.map( ( tier ) => {
+		const emoji = tier.raw < 500 ? ':|' : ':)';
+		return {
+			...tier,
+			lhValue: tier.price,
+			rhValue: emoji,
+		};
+	} );
+	return tiers;
+}
+
+function getPWYWSteps() {
+	return [
+		{
+			lhValue: '$0',
+			rhValue: ':|',
+		},
+		{
+			lhValue: '50 cents',
+			rhValue: ':|',
+		},
+		{
+			lhValue: '$1',
+			rhValue: ':|',
+		},
+		{
+			lhValue: '$1.50',
+			rhValue: ':|',
+		},
+		{
+			lhValue: '$2',
+			rhValue: ':)',
+		},
+		{
+			lhValue: '$5',
+			rhValue: ':>',
+		},
+	];
+}
+
+function StatsPWYWUpgradeSlider() {
+	const strings = {
+		limits: 'Your monthly contribution',
+		price: 'Thank you!',
+		strategy: 'The average person pays $5 per month, billed yearly',
+	};
+	// TODO: Set up tiers/steps for slider.
+	const smallSteps = true;
+	const steps = smallSteps ? getPWYWPlanTiers( 0, 50 ) : getPWYWSteps();
+	const handleSliderChanged = () => {
+		console.log( 'handleSliderChanged' );
+	};
+	return (
+		<TierUpgradeSlider
+			className="stats-pwyw-upgrade-slider"
+			uiStrings={ strings }
+			steps={ steps }
+			onSliderChange={ handleSliderChanged }
+		/>
+	);
+}
+
+export default StatsPWYWUpgradeSlider;

--- a/client/my-sites/stats/stats-purchase/stats-pwyw-uprade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-pwyw-uprade-slider/index.tsx
@@ -31,17 +31,17 @@ function useTranslatedStrings() {
 	const translate = useTranslate();
 	const limits = translate( 'Your monthly contribution', {
 		comment: 'Heading for Stats PWYW Upgrade slider. The monthly payment amount.',
-	} );
+	} ) as string;
 	const price = translate( 'Thank you!', {
 		comment: 'Heading for Stats PWYW Upgrade slider. The thank you message.',
-	} );
+	} ) as string;
 	const defaultAverageAmount = 7; // Matches the default set in the slider.
 	const strategy = translate( 'The average person pays %(value)s per month, billed yearly', {
 		comment: 'Stats PWYW Upgrade slider message. The billing strategy.',
 		args: {
 			value: formatCurrency( defaultAverageAmount, '', { stripZeros: true } ),
 		},
-	} );
+	} ) as string;
 
 	return {
 		limits,

--- a/client/my-sites/stats/stats-purchase/stats-pwyw-uprade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-pwyw-uprade-slider/index.tsx
@@ -35,8 +35,12 @@ function useTranslatedStrings() {
 	const price = translate( 'Thank you!', {
 		comment: 'Heading for Stats PWYW Upgrade slider. The thank you message.',
 	} );
-	const strategy = translate( 'The average person pays $7 per month, billed yearly', {
+	const defaultAverageAmount = 7; // Matches the default set in the slider.
+	const strategy = translate( 'The average person pays %(value)s per month, billed yearly', {
 		comment: 'Stats PWYW Upgrade slider message. The billing strategy.',
+		args: {
+			value: formatCurrency( defaultAverageAmount, '', { stripZeros: true } ),
+		},
 	} );
 
 	return {

--- a/client/my-sites/stats/stats-purchase/stats-pwyw-uprade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-pwyw-uprade-slider/index.tsx
@@ -44,12 +44,18 @@ function emojiForStep( index: number ) {
 	return String.fromCodePoint( 0x1f525 );
 }
 
-function stepsFromSettings( settings: any, currencyCode: string ) {
+// Takes a StatsPWYWSliderSettings object and returns an array of slider steps.
+// The slider wants string values for the left and right labels.
+// We ignore the emoji thresholds and use our own.
+function stepsFromSettings(
+	{ sliderStepPrice, minSliderPrice, maxSliderPrice }: StatsPWYWSliderSettings,
+	currencyCode: string
+) {
 	const sliderSteps = [];
-	const maxSliderValue = Math.floor( settings.maxSliderPrice / settings.sliderStepPrice );
-	const minSliderValue = Math.round( settings.minSliderPrice / settings.sliderStepPrice );
+	const maxSliderValue = Math.floor( maxSliderPrice / sliderStepPrice );
+	const minSliderValue = Math.round( minSliderPrice / sliderStepPrice );
 	for ( let i = minSliderValue; i <= maxSliderValue; i++ ) {
-		const rawValue = settings.minSliderPrice + i * settings.sliderStepPrice;
+		const rawValue = minSliderPrice + i * sliderStepPrice;
 		sliderSteps.push( {
 			raw: rawValue,
 			lhValue: formatCurrency( rawValue, currencyCode ),
@@ -83,7 +89,6 @@ function StatsPWYWUpgradeSlider( {
 	}
 	const marks = [ 0, steps.length - 1 ];
 
-	// TODO: Wire up parent to handle changes.
 	const handleSliderChanged = ( index: number ) => {
 		onSliderChange( index );
 	};

--- a/client/my-sites/stats/stats-purchase/stats-pwyw-uprade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-pwyw-uprade-slider/index.tsx
@@ -3,6 +3,8 @@ import TierUpgradeSlider from 'calypso/my-sites/stats/stats-purchase/tier-upgrad
 import './styles.scss';
 
 // TODO: Remove test data.
+// Currently used as a fallback if no plan info is provided.
+// Better approach is to require plan info and do some form of validation on it.
 function getPWYWPlanTiers( minPrice: number, stepPrice: number ) {
 	// From $0 to $20, in $1 increments.
 	let tiers: any[] = [];
@@ -21,36 +23,6 @@ function getPWYWPlanTiers( minPrice: number, stepPrice: number ) {
 		};
 	} );
 	return tiers;
-}
-
-// TODO: Remove this test data too.
-function getPWYWSteps() {
-	return [
-		{
-			lhValue: '$0',
-			rhValue: ':|',
-		},
-		{
-			lhValue: '50 cents',
-			rhValue: ':|',
-		},
-		{
-			lhValue: '$1',
-			rhValue: ':|',
-		},
-		{
-			lhValue: '$1.50',
-			rhValue: ':|',
-		},
-		{
-			lhValue: '$2',
-			rhValue: ':)',
-		},
-		{
-			lhValue: '$5',
-			rhValue: ':>',
-		},
-	];
 }
 
 function emojiForStep( index: number ) {

--- a/client/my-sites/stats/stats-purchase/stats-pwyw-uprade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-pwyw-uprade-slider/index.tsx
@@ -1,5 +1,6 @@
 import formatCurrency from '@automattic/format-currency';
 import TierUpgradeSlider from 'calypso/my-sites/stats/stats-purchase/tier-upgrade-slider';
+import { StatsPWYWSliderSettings } from 'calypso/my-sites/stats/stats-purchase/types';
 import './styles.scss';
 
 // TODO: Remove test data.
@@ -59,7 +60,7 @@ function stepsFromSettings( settings: any, currencyCode: string ) {
 }
 
 type StatsPWYWUpgradeSliderProps = {
-	settings?: any;
+	settings?: StatsPWYWSliderSettings;
 	currencyCode?: string;
 	onSliderChange: ( index: number ) => void;
 };

--- a/client/my-sites/stats/stats-purchase/stats-pwyw-uprade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-pwyw-uprade-slider/index.tsx
@@ -46,11 +46,11 @@ function emojiForStep( index: number ) {
 
 // Takes a StatsPWYWSliderSettings object and returns an array of slider steps.
 // The slider wants string values for the left and right labels.
-// We ignore the emoji thresholds and use our own.
-function stepsFromSettings(
-	{ sliderStepPrice, minSliderPrice, maxSliderPrice }: StatsPWYWSliderSettings,
-	currencyCode: string
-) {
+function stepsFromSettings( settings: StatsPWYWSliderSettings, currencyCode: string ) {
+	// Pull tier strategy from settings.
+	// We ignore the emoji thresholds and use our own.
+	const { sliderStepPrice, minSliderPrice, maxSliderPrice } = settings;
+	// Set up our slider steps based on above strategy.
 	const sliderSteps = [];
 	const maxSliderValue = Math.floor( maxSliderPrice / sliderStepPrice );
 	const minSliderValue = Math.round( minSliderPrice / sliderStepPrice );

--- a/client/my-sites/stats/stats-purchase/stats-pwyw-uprade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-pwyw-uprade-slider/index.tsx
@@ -1,4 +1,5 @@
 import formatCurrency from '@automattic/format-currency';
+import { useTranslate } from 'i18n-calypso';
 import TierUpgradeSlider from 'calypso/my-sites/stats/stats-purchase/tier-upgrade-slider';
 import { StatsPWYWSliderSettings } from 'calypso/my-sites/stats/stats-purchase/types';
 import './styles.scss';
@@ -24,6 +25,25 @@ function getPWYWPlanTiers( minPrice: number, stepPrice: number ) {
 		};
 	} );
 	return tiers;
+}
+
+function useTranslatedStrings() {
+	const translate = useTranslate();
+	const limits = translate( 'Your monthly contribution', {
+		comment: 'Heading for Stats PWYW Upgrade slider. The monthly payment amount.',
+	} );
+	const price = translate( 'Thank you!', {
+		comment: 'Heading for Stats PWYW Upgrade slider. The thank you message.',
+	} );
+	const strategy = translate( 'The average person pays $7 per month, billed yearly', {
+		comment: 'Stats PWYW Upgrade slider message. The billing strategy.',
+	} );
+
+	return {
+		limits,
+		price,
+		strategy,
+	};
 }
 
 function emojiForStep( index: number ) {
@@ -76,13 +96,8 @@ function StatsPWYWUpgradeSlider( {
 	currencyCode,
 	onSliderChange,
 }: StatsPWYWUpgradeSliderProps ) {
-	// TODO: Translate UI strings.
-	const strings = {
-		limits: 'Your monthly contribution',
-		price: 'Thank you!',
-		strategy: 'The average person pays $5 per month, billed yearly',
-	};
-	// TODO: Set up tiers/steps for slider.
+	const uiStrings = useTranslatedStrings();
+
 	let steps = getPWYWPlanTiers( 0, 50 );
 	if ( settings !== undefined ) {
 		steps = stepsFromSettings( settings, currencyCode || '' );
@@ -96,7 +111,7 @@ function StatsPWYWUpgradeSlider( {
 	return (
 		<TierUpgradeSlider
 			className="stats-pwyw-upgrade-slider"
-			uiStrings={ strings }
+			uiStrings={ uiStrings }
 			steps={ steps }
 			initialValue={ ( steps.length - 1 ) / 2 }
 			onSliderChange={ handleSliderChanged }

--- a/client/my-sites/stats/stats-purchase/stats-pwyw-uprade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-pwyw-uprade-slider/index.tsx
@@ -100,6 +100,12 @@ function StatsPWYWUpgradeSlider( {
 	currencyCode,
 	onSliderChange,
 }: StatsPWYWUpgradeSliderProps ) {
+	// Responsible for:
+	// 1. Transforming the slider settings into tiers that the slider can use.
+	// 2. Preparing the UI strings for the slider.
+	// 3. Rendering the slider.
+	// 4. Nofiying the parent component when the slider changes.
+
 	const uiStrings = useTranslatedStrings();
 
 	let steps = getPWYWPlanTiers( 0, 50 );

--- a/client/my-sites/stats/stats-purchase/stats-pwyw-uprade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-pwyw-uprade-slider/index.tsx
@@ -2,9 +2,10 @@ import formatCurrency from '@automattic/format-currency';
 import TierUpgradeSlider from 'calypso/my-sites/stats/stats-purchase/tier-upgrade-slider';
 import './styles.scss';
 
+// TODO: Remove test data.
 function getPWYWPlanTiers( minPrice: number, stepPrice: number ) {
 	// From $0 to $20, in $1 increments.
-	let tiers = [];
+	let tiers: any[] = [];
 	for ( let i = 0; i <= 28; i++ ) {
 		tiers.push( {
 			price: formatCurrency( ( minPrice + i * stepPrice ) / 100, 'USD' ),
@@ -22,6 +23,7 @@ function getPWYWPlanTiers( minPrice: number, stepPrice: number ) {
 	return tiers;
 }
 
+// TODO: Remove this test data too.
 function getPWYWSteps() {
 	return [
 		{
@@ -51,19 +53,68 @@ function getPWYWSteps() {
 	];
 }
 
-function StatsPWYWUpgradeSlider() {
+function emojiForStep( index: number ) {
+	const uiEmojiHeartTier = 14;
+	const uiImageCelebrationTier = 23;
+	if ( index === 0 ) {
+		return '';
+	}
+	// Smiling face emoji.
+	if ( index < uiEmojiHeartTier ) {
+		return String.fromCodePoint( 0x1f60a );
+	}
+	// Heart emoji.
+	if ( index < uiImageCelebrationTier ) {
+		return String.fromCodePoint( 0x2764, 0xfe0f );
+	}
+	// Big spender! Fire emoji.
+	return String.fromCodePoint( 0x1f525 );
+}
+
+function stepsFromSettings( settings: any, currencyCode: string ) {
+	const sliderSteps = [];
+	const maxSliderValue = Math.floor( settings.maxSliderPrice / settings.sliderStepPrice );
+	const minSliderValue = Math.round( settings.minSliderPrice / settings.sliderStepPrice );
+	for ( let i = minSliderValue; i <= maxSliderValue; i++ ) {
+		const rawValue = settings.minSliderPrice + i * settings.sliderStepPrice;
+		sliderSteps.push( {
+			raw: rawValue,
+			lhValue: formatCurrency( rawValue, currencyCode ),
+			rhValue: emojiForStep( i ),
+		} );
+	}
+	return sliderSteps;
+}
+
+type StatsPWYWUpgradeSliderProps = {
+	settings?: any;
+	currencyCode?: string;
+	onSliderChange: ( index: number ) => void;
+};
+
+function StatsPWYWUpgradeSlider( {
+	settings,
+	currencyCode,
+	onSliderChange,
+}: StatsPWYWUpgradeSliderProps ) {
+	// TODO: Translate UI strings.
 	const strings = {
 		limits: 'Your monthly contribution',
 		price: 'Thank you!',
 		strategy: 'The average person pays $5 per month, billed yearly',
 	};
 	// TODO: Set up tiers/steps for slider.
-	const smallSteps = true;
-	const steps = smallSteps ? getPWYWPlanTiers( 0, 50 ) : getPWYWSteps();
-	const handleSliderChanged = () => {
-		console.log( 'handleSliderChanged' );
-	};
+	let steps = getPWYWPlanTiers( 0, 50 );
+	if ( settings !== undefined ) {
+		steps = stepsFromSettings( settings, currencyCode || '' );
+	}
 	const marks = [ 0, steps.length - 1 ];
+
+	// TODO: Wire up parent to handle changes.
+	const handleSliderChanged = ( index: number ) => {
+		onSliderChange( index );
+	};
+
 	return (
 		<TierUpgradeSlider
 			className="stats-pwyw-upgrade-slider"

--- a/client/my-sites/stats/stats-purchase/stats-pwyw-uprade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-pwyw-uprade-slider/index.tsx
@@ -63,12 +63,14 @@ function StatsPWYWUpgradeSlider() {
 	const handleSliderChanged = () => {
 		console.log( 'handleSliderChanged' );
 	};
+	const marks = [ 0, steps.length - 1 ];
 	return (
 		<TierUpgradeSlider
 			className="stats-pwyw-upgrade-slider"
 			uiStrings={ strings }
 			steps={ steps }
 			onSliderChange={ handleSliderChanged }
+			marks={ marks }
 		/>
 	);
 }

--- a/client/my-sites/stats/stats-purchase/stats-pwyw-uprade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-pwyw-uprade-slider/index.tsx
@@ -69,6 +69,7 @@ function StatsPWYWUpgradeSlider() {
 			className="stats-pwyw-upgrade-slider"
 			uiStrings={ strings }
 			steps={ steps }
+			initialValue={ ( steps.length - 1 ) / 2 }
 			onSliderChange={ handleSliderChanged }
 			marks={ marks }
 		/>

--- a/client/my-sites/stats/stats-purchase/stats-pwyw-uprade-slider/styles.scss
+++ b/client/my-sites/stats/stats-purchase/stats-pwyw-uprade-slider/styles.scss
@@ -1,0 +1,5 @@
+// Styles specific to layout on the PWYW Upgrade page.
+
+.stats-pwyw-upgrade-slider {
+	margin: 42px 0;
+}

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -121,7 +121,6 @@ $button-padding: 8px 32px;
 		}
 
 		.jp-components-pricing-slider__thumb {
-			border-radius: 2px;
 			border-color: var(--color-primary);
 		}
 

--- a/client/my-sites/stats/stats-purchase/tier-upgrade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/tier-upgrade-slider/index.tsx
@@ -8,6 +8,7 @@ type TierUpgradeSlider2Props = {
 	uiStrings: any;
 	popupInfoString?: any;
 	steps: any[];
+	initialValue?: number;
 	onSliderChange: ( index: number ) => void;
 	marks?: boolean | number[];
 };
@@ -17,13 +18,14 @@ function TierUpgradeSlider2( {
 	uiStrings,
 	popupInfoString,
 	steps,
+	initialValue = 0,
 	onSliderChange,
 	marks,
 }: TierUpgradeSlider2Props ) {
 	const componentClassNames = classNames( 'tier-upgrade-slider', className );
 
 	// Slider state.
-	const [ currentPlanIndex, setCurrentPlanIndex ] = useState( 0 );
+	const [ currentPlanIndex, setCurrentPlanIndex ] = useState( initialValue );
 	const sliderMin = 0;
 	const sliderMax = steps?.length - 1;
 

--- a/client/my-sites/stats/stats-purchase/tier-upgrade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/tier-upgrade-slider/index.tsx
@@ -9,11 +9,16 @@ type TierUIStrings = {
 	strategy: string;
 };
 
+interface TierStep {
+	lhValue: string;
+	rhValue: string;
+}
+
 type TierUpgradeSliderProps = {
 	className?: string;
 	uiStrings: TierUIStrings;
 	popupInfoString?: string;
-	steps: any[];
+	steps: TierStep[];
 	initialValue?: number;
 	onSliderChange: ( index: number ) => void;
 	marks?: boolean | number[];

--- a/client/my-sites/stats/stats-purchase/tier-upgrade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/tier-upgrade-slider/index.tsx
@@ -9,6 +9,7 @@ type TierUpgradeSlider2Props = {
 	popupInfoString?: any;
 	steps: any[];
 	onSliderChange: ( index: number ) => void;
+	marks?: boolean | number[];
 };
 
 function TierUpgradeSlider2( {
@@ -17,6 +18,7 @@ function TierUpgradeSlider2( {
 	popupInfoString,
 	steps,
 	onSliderChange,
+	marks,
 }: TierUpgradeSlider2Props ) {
 	const componentClassNames = classNames( 'tier-upgrade-slider', className );
 
@@ -56,7 +58,7 @@ function TierUpgradeSlider2( {
 				minValue={ sliderMin }
 				maxValue={ sliderMax }
 				onChange={ handleSliderChange }
-				marks
+				marks={ marks }
 			/>
 			<Popover
 				position="right"

--- a/client/my-sites/stats/stats-purchase/tier-upgrade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/tier-upgrade-slider/index.tsx
@@ -6,7 +6,7 @@ import './styles.scss';
 type TierUpgradeSlider2Props = {
 	className?: string;
 	uiStrings: any;
-	popupInfoString: any;
+	popupInfoString?: any;
 	steps: any[];
 	onSliderChange: ( index: number ) => void;
 };

--- a/client/my-sites/stats/stats-purchase/tier-upgrade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/tier-upgrade-slider/index.tsx
@@ -77,6 +77,7 @@ function TierUpgradeSlider( {
 				position="right"
 				context={ infoReferenceElement?.current }
 				isVisible={ showPopup }
+				focusOnShow={ false }
 				className="tier-upgrade-slider__extension-popover-wrapper"
 			>
 				<div className="tier-upgrade-slider__extension-popover-content">

--- a/client/my-sites/stats/stats-purchase/tier-upgrade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/tier-upgrade-slider/index.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import { useState, useRef } from 'react';
 import './styles.scss';
 
-type TierUpgradeSlider2Props = {
+type TierUpgradeSliderProps = {
 	className?: string;
 	uiStrings: any;
 	popupInfoString?: any;
@@ -13,7 +13,7 @@ type TierUpgradeSlider2Props = {
 	marks?: boolean | number[];
 };
 
-function TierUpgradeSlider2( {
+function TierUpgradeSlider( {
 	className,
 	uiStrings,
 	popupInfoString,
@@ -21,7 +21,7 @@ function TierUpgradeSlider2( {
 	initialValue = 0,
 	onSliderChange,
 	marks,
-}: TierUpgradeSlider2Props ) {
+}: TierUpgradeSliderProps ) {
 	const componentClassNames = classNames( 'tier-upgrade-slider', className );
 
 	// Slider state.
@@ -77,4 +77,4 @@ function TierUpgradeSlider2( {
 	);
 }
 
-export default TierUpgradeSlider2;
+export default TierUpgradeSlider;

--- a/client/my-sites/stats/stats-purchase/tier-upgrade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/tier-upgrade-slider/index.tsx
@@ -1,0 +1,76 @@
+import { PricingSlider, Popover } from '@automattic/components';
+import classNames from 'classnames';
+import { useState, useRef } from 'react';
+import './styles.scss';
+
+type TierUpgradeSlider2Props = {
+	className?: string;
+	uiStrings: any;
+	popupInfoString: any;
+	steps: any[];
+	onSliderChange: ( index: number ) => void;
+};
+
+function TierUpgradeSlider2( {
+	className,
+	uiStrings,
+	popupInfoString,
+	steps,
+	onSliderChange,
+}: TierUpgradeSlider2Props ) {
+	const componentClassNames = classNames( 'tier-upgrade-slider', className );
+
+	// Slider state.
+	const [ currentPlanIndex, setCurrentPlanIndex ] = useState( 0 );
+	const sliderMin = 0;
+	const sliderMax = steps?.length - 1;
+
+	const handleSliderChange = ( value: number ) => {
+		setCurrentPlanIndex( value );
+		onSliderChange( value );
+	};
+
+	// Info popup state.
+	// Only visible if the slider is at the max value and we have a string/node to display.
+	const infoReferenceElement = useRef( null );
+	const showPopup = currentPlanIndex === sliderMax && popupInfoString !== undefined;
+	const lhValue = steps[ currentPlanIndex ]?.lhValue;
+	const rhValue = steps[ currentPlanIndex ]?.rhValue;
+
+	return (
+		<div className={ componentClassNames }>
+			<div className="tier-upgrade-slider__step-callouts">
+				<div className="tier-upgrade-slider__step-callout">
+					<h2>{ uiStrings.limits }</h2>
+					<p>{ lhValue }</p>
+				</div>
+				<div className="tier-upgrade-slider__step-callout right-aligned">
+					<h2>{ uiStrings.price }</h2>
+					<p ref={ infoReferenceElement }>{ rhValue }</p>
+				</div>
+			</div>
+			<PricingSlider
+				className="tier-upgrade-slider__slider"
+				thumbClassName="tier-upgrade-slider__thumb"
+				value={ currentPlanIndex }
+				minValue={ sliderMin }
+				maxValue={ sliderMax }
+				onChange={ handleSliderChange }
+				marks
+			/>
+			<Popover
+				position="right"
+				context={ infoReferenceElement?.current }
+				isVisible={ showPopup }
+				className="tier-upgrade-slider__extension-popover-wrapper"
+			>
+				<div className="tier-upgrade-slider__extension-popover-content">
+					{ showPopup && popupInfoString }
+				</div>
+			</Popover>
+			<p className="tier-upgrade-slider__info-message">{ uiStrings.strategy }</p>
+		</div>
+	);
+}
+
+export default TierUpgradeSlider2;

--- a/client/my-sites/stats/stats-purchase/tier-upgrade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/tier-upgrade-slider/index.tsx
@@ -3,10 +3,16 @@ import classNames from 'classnames';
 import { useState, useRef } from 'react';
 import './styles.scss';
 
+type TierUIStrings = {
+	limits: string;
+	price: string;
+	strategy: string;
+};
+
 type TierUpgradeSliderProps = {
 	className?: string;
-	uiStrings: any;
-	popupInfoString?: any;
+	uiStrings: TierUIStrings;
+	popupInfoString?: string;
 	steps: any[];
 	initialValue?: number;
 	onSliderChange: ( index: number ) => void;

--- a/client/my-sites/stats/stats-purchase/tier-upgrade-slider/styles.scss
+++ b/client/my-sites/stats/stats-purchase/tier-upgrade-slider/styles.scss
@@ -1,0 +1,115 @@
+@use "sass:math";
+
+$slider-height: 40px;
+$slider-bg-color: var(--studio-white);
+$thumb-width: 40px;
+$mark-diameter: 8px;
+$mark-border-width: 2px;
+$track-extra-width: math.div($thumb-width - $mark-diameter - $mark-border-width * 2, 2);
+$track-height: 4px;
+
+// The trick is to cover the extra slider track with blocks with the same background color as the slider.
+@mixin slider-track-extra-cover() {
+	content: "";
+	position: absolute;
+	width: $track-extra-width;
+	height: $slider-height;
+	background-color: $slider-bg-color;
+}
+
+.tier-upgrade-slider {
+	--jp-white: #fff;
+	--jp-green-50: #008710;
+	--gray-gray-5: #dcdcde;
+
+	margin-top: 42px;
+	background-color: $slider-bg-color;
+
+	border: 1px solid var(--gray-gray-5);
+	border-radius: 5px; // stylelint-disable-line scales/radii
+	padding: 12px;
+
+	.jp-components-pricing-slider__thumb.tier-upgrade-slider__thumb {
+		width: $thumb-width;
+		height: $slider-height;
+		border-radius: 50%;
+		background-color: var(--jp-green-50);
+		color: var(--jp-white);
+	}
+
+	.jp-components-pricing-slider__track {
+		// Based on slider height of 40px & track height of 4px.
+		height: $track-height;
+		top: math.div($slider-height, 2) - math.div($track-height, 2);
+	}
+
+	.jp-components-pricing-slider__control {
+		// TODO: Determine control alignment.
+		// Do we want the slider full-width or do we align based on thumb?
+		// Alternatively, we could use some CSS to reposition the thumbs if either end-cap is selected.
+		// width: calc(100% + $track-extra-width * 2);
+		// margin-left: -($track-extra-width);
+
+		&::before {
+			@include slider-track-extra-cover();
+			left: 0;
+			z-index: 1;
+		}
+
+		&::after {
+			@include slider-track-extra-cover();
+			right: 0;
+		}
+
+		.mark {
+			height: $mark-diameter;
+			width: $mark-diameter;
+			border: $mark-border-width solid var(--gray-gray-5);
+			background-color: var(--gray-gray-5);
+			border-radius: 50%;
+			cursor: pointer;
+			margin: 0 $track-extra-width;
+			bottom: calc(50% - (math.div($mark-diameter, 2) + $mark-border-width));
+		}
+	}
+}
+
+// Override colors for WPCOM context.
+.stats-purchase-page--is-wpcom {
+	.jp-components-pricing-slider__thumb.tier-upgrade-slider__thumb {
+		background-color: var(--color-primary);
+	}
+}
+
+.tier-upgrade-slider__info-message {
+	color: var(--studio-gray-40);
+	margin: 12px 0;
+	text-align: center;
+}
+
+.tier-upgrade-slider__step-callouts {
+	display: flex;
+	justify-content: space-between;
+
+	h2 {
+		font-weight: 500;
+	}
+	p {
+		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+		font-size: 2em;
+		font-weight: 500;
+		margin: 0;
+	}
+	.right-aligned {
+		text-align: right;
+	}
+}
+
+.tier-upgrade-slider__extension-popover-wrapper {
+	max-width: 245px;
+}
+
+.tier-upgrade-slider__extension-popover-content {
+	padding: 24px;
+	text-align: left;
+}

--- a/client/my-sites/stats/stats-purchase/tier-upgrade-slider/styles.scss
+++ b/client/my-sites/stats/stats-purchase/tier-upgrade-slider/styles.scss
@@ -23,6 +23,7 @@ $track-height: 4px;
 	--gray-gray-5: #dcdcde;
 
 	margin-top: 42px;
+	margin-bottom: 24px;
 	background-color: $slider-bg-color;
 
 	border: 1px solid var(--gray-gray-5);
@@ -71,6 +72,11 @@ $track-height: 4px;
 			margin: 0 $track-extra-width;
 			bottom: calc(50% - (math.div($mark-diameter, 2) + $mark-border-width));
 		}
+
+		.jp-components-pricing-slider__mark--selected {
+			background-color: var(--jp-green-40);
+			border-color: var(--jp-green-40);
+		}
 	}
 }
 
@@ -78,6 +84,13 @@ $track-height: 4px;
 .stats-purchase-page--is-wpcom {
 	.jp-components-pricing-slider__thumb.tier-upgrade-slider__thumb {
 		background-color: var(--color-primary);
+	}
+
+	.jp-components-pricing-slider__control {
+		.jp-components-pricing-slider__mark--selected {
+			background-color: var(--color-primary);
+			border-color: var(--color-primary);
+		}
 	}
 }
 
@@ -107,6 +120,7 @@ $track-height: 4px;
 
 .tier-upgrade-slider__extension-popover-wrapper {
 	max-width: 245px;
+	margin-left: 15px;
 }
 
 .tier-upgrade-slider__extension-popover-content {

--- a/client/my-sites/stats/stats-purchase/tier-upgrade-slider/styles.scss
+++ b/client/my-sites/stats/stats-purchase/tier-upgrade-slider/styles.scss
@@ -24,7 +24,6 @@ $track-height: 4px;
 
 	margin-top: 42px;
 	background-color: $slider-bg-color;
-	min-width: 500px;
 
 	border: 1px solid var(--gray-gray-5);
 	border-radius: 5px; // stylelint-disable-line scales/radii

--- a/client/my-sites/stats/stats-purchase/tier-upgrade-slider/styles.scss
+++ b/client/my-sites/stats/stats-purchase/tier-upgrade-slider/styles.scss
@@ -24,6 +24,7 @@ $track-height: 4px;
 
 	margin-top: 42px;
 	background-color: $slider-bg-color;
+	min-width: 500px;
 
 	border: 1px solid var(--gray-gray-5);
 	border-radius: 5px; // stylelint-disable-line scales/radii

--- a/client/my-sites/stats/stats-purchase/types.ts
+++ b/client/my-sites/stats/stats-purchase/types.ts
@@ -17,3 +17,14 @@ export type StatsPlanTierUI = {
 	extension?: boolean;
 	per_unit_fee?: number;
 };
+
+// TODO: Break this down.
+// Ideally we'd have a type describing the plan strategy (steps, increments, etc)
+// and leave the UI stuff (emoji threasholds, etc) to the UI layer.
+export type StatsPWYWSliderSettings = {
+	sliderStepPrice: number;
+	minSliderPrice: number;
+	maxSliderPrice: number;
+	uiEmojiHeartTier: number;
+	uiImageCelebrationTier: number;
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #84859

## Proposed Changes

- Adds updated tier slider to PWYW flow.
- Refactors `TierUpgradeSlider` to be reusable across flows.
- Adds `StatsCommercialUpgradeSlider` and `StatsPWYWUpgradeSlider` for flow-specific logic.
- Updates Commercial flow to use new component.

<img width="598" alt="SCR-20231207-nwyj" src="https://github.com/Automattic/wp-calypso/assets/40267301/f6323c91-9067-4558-bea7-86fb4c79e588">

## Follow-on Changes

To come in follow-up PR(s):

- Remove the old `TierUpgradeSlider` component/file.
- Remove the old slider code from the PWYW flow. (it's hidden for now)
- Move the new `TierUpgradeSlider` to the component library.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Currently behind the `stats/tier-upgrade-slider` flag. More to come…

1. Launch the Calypso Live link.
2. Navigate to **Stats → Traffic**.
3. Click on CTA to purchase Stats plan.
4. Add `stats/tier-upgrade-slider` to URL flags.
5. Confirm new tier slider is visible and updates the page correctly.

1. Click the "choose a commercial plan" link in the highlighted box.
2. Confirm the new tier slider shows correctly here too.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?