### PR TITLE
BBE Page Picker: switch to 2 column grid on mobile

### DIFF
--- a/client/signup/difm/components/BrowserView.tsx
+++ b/client/signup/difm/components/BrowserView.tsx
@@ -71,11 +71,16 @@ const Container = styled.div< { isSelected?: boolean; isClickDisabled?: boolean 
 			return '0px 0px 0px 3px #E3EAF0';
 		} };
 	}
-	width: 222px;
-	height: 170px;
+	height: 100%;
+	width: 100%;
+
 	position: relative;
 	cursor: ${ ( { isClickDisabled } ) => ( isClickDisabled ? 'default' : 'pointer' ) };
 	pointer-events: ${ ( { isClickDisabled } ) => ( isClickDisabled ? 'none' : 'default' ) };
+
+	display: flex;
+	flex-direction: column;
+	align-items: stretch;
 `;
 
 const HeaderContainer = styled.div< { isSelected?: boolean; isClickDisabled?: boolean } >`
@@ -92,12 +97,9 @@ const Line = styled.div< { isSelected?: boolean; isClickDisabled?: boolean } >`
 	height: 0.75px;
 	background-color: var( --studio-gray-10 );
 	position: absolute;
-	width: ${ ( { isSelected } ) => ( isSelected ? '224px' : '222px' ) };
 	left: ${ ( { isSelected } ) => ( isSelected ? '-1px' : '0' ) };
 	top: 12px;
-	&:hover {
-		width: ${ ( { isSelected } ) => ( isSelected ? '224px' : '221px' ) };
-	}
+	width: 100%;
 `;
 
 function Header( props: { isSelected?: boolean; isClickDisabled?: boolean } ) {
@@ -110,10 +112,13 @@ function Header( props: { isSelected?: boolean; isClickDisabled?: boolean } ) {
 }
 
 const Content = styled.div`
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	height: 157px;
+	padding: 15px;
+	text-align: center;
+	> img {
+		aspect-ratio: 1.5;
+		width: 100%;
+		max-width: 186px;
+	}
 `;
 
 const SelectedCount = styled.div`

--- a/client/signup/steps/page-picker/index.tsx
+++ b/client/signup/steps/page-picker/index.tsx
@@ -51,13 +51,13 @@ import './style.scss';
 
 const PageGrid = styled.div`
 	display: grid;
-	grid-template-columns: 1fr;
+	grid-template-columns: repeat( 2, minmax( 0, 1fr ) );
 	row-gap: 20px;
-	column-gap: 35px;
+	column-gap: 15px;
 	margin: 0 0 30px;
 
-	@media ( min-width: 960px ) and ( max-width: 1200px ) {
-		grid-template-columns: 1fr 1fr;
+	@media ( min-width: 600px ) and ( max-width: 750px ) {
+		grid-template-columns: 1fr;
 		column-gap: 15px;
 		row-gap: 25px;
 	}
@@ -69,7 +69,7 @@ const PageGrid = styled.div`
 	}
 
 	@media ( max-width: 600px ) {
-		margin: 0 0 145px;
+		margin: 0 0 200px;
 	}
 `;
 
@@ -93,11 +93,11 @@ const CellLabelContainer = styled.div`
 	display: flex;
 	justify-content: center;
 	align-items: center;
-	font-size: 14px;
+	font-size: 12px;
 	gap: 8px;
-
-	width: 222px;
+	width: 100%;
 	@media ( min-width: 960px ) {
+		font-size: 14px;
 		justify-content: left;
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/martech/issues/2467

## Proposed Changes

* This PR switches the page picker step to a 2 column layout on mobile. On desktop, the 3 column layout is the same as before.

<img width="297" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/0c02411a-67d6-471c-b9e8-2a46df069adf">

<img width="1351" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/f67f8440-dff4-40c3-8480-456aab01376b">



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/do-it-for-me` and go through the flow steps till you reach the page picker step.
* Switch to a mobile resolution and confirm that it matches the screenshot.
* Also confirm that the grid flows responsively in all other screen resolutions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?