### PR TITLE
Import flow: Recognize playground file and adapt a flow for that use-case

### DIFF
--- a/client/blocks/importer/components/uploading-pane/uploading-pane.tsx
+++ b/client/blocks/importer/components/uploading-pane/uploading-pane.tsx
@@ -6,7 +6,12 @@ import { connect } from 'react-redux';
 import DropZone from 'calypso/components/drop-zone';
 import { UploadingPane as UploadingPaneBase } from 'calypso/my-sites/importer/uploading-pane';
 import { upload } from 'calypso/signup/icons';
-import { startMappingAuthors, startUpload, failPreUpload } from 'calypso/state/imports/actions';
+import {
+	startMappingAuthors,
+	startUpload,
+	startImporting,
+	failPreUpload,
+} from 'calypso/state/imports/actions';
 import { appStates } from 'calypso/state/imports/constants';
 import {
 	getUploadFilename,
@@ -96,5 +101,5 @@ export default connect(
 		filename: getUploadFilename( state ),
 		percentComplete: getUploadPercentComplete( state ),
 	} ),
-	{ startMappingAuthors, startUpload, failPreUpload }
+	{ startMappingAuthors, startUpload, failPreUpload, startImporting }
 )( localize( UploadingPane ) );

--- a/client/blocks/importer/types.ts
+++ b/client/blocks/importer/types.ts
@@ -32,6 +32,7 @@ export interface ImportError {
 export interface ImportJob {
 	importerId: string;
 	importerState: string;
+	importerFileType: 'content' | 'playground' | 'jetpack_backup';
 	statusMessage?: string;
 	type: string;
 	site: { ID: number };

--- a/client/my-sites/importer/uploading-pane.jsx
+++ b/client/my-sites/importer/uploading-pane.jsx
@@ -65,7 +65,15 @@ export class UploadingPane extends PureComponent {
 				prevImporterStatus.importerState === appStates.UPLOAD_SUCCESS ) &&
 			importerStatus.importerState === appStates.UPLOAD_SUCCESS
 		) {
-			this.props.startMappingAuthors( importerStatus.importerId );
+			switch ( importerStatus.importerFileType ) {
+				case 'content':
+					this.props.startMappingAuthors( importerStatus.importerId );
+					break;
+				case 'playground':
+				case 'jetpack_backup':
+					// Placeholder for starting the import
+					break;
+			}
 		}
 	}
 

--- a/client/my-sites/importer/uploading-pane.jsx
+++ b/client/my-sites/importer/uploading-pane.jsx
@@ -13,7 +13,12 @@ import TextInput from 'calypso/components/forms/form-text-input';
 import ImporterActionButton from 'calypso/my-sites/importer/importer-action-buttons/action-button';
 import ImporterCloseButton from 'calypso/my-sites/importer/importer-action-buttons/close-button';
 import ImporterActionButtonContainer from 'calypso/my-sites/importer/importer-action-buttons/container';
-import { startMappingAuthors, startUpload, failPreUpload } from 'calypso/state/imports/actions';
+import {
+	startMappingAuthors,
+	startUpload,
+	failPreUpload,
+	startImporting,
+} from 'calypso/state/imports/actions';
 import { appStates, MAX_FILE_SIZE } from 'calypso/state/imports/constants';
 import {
 	getUploadFilename,
@@ -71,7 +76,7 @@ export class UploadingPane extends PureComponent {
 					break;
 				case 'playground':
 				case 'jetpack_backup':
-					// Placeholder for starting the import
+					this.props.startImporting( importerStatus );
 					break;
 			}
 		}
@@ -293,5 +298,5 @@ export default connect(
 		filename: getUploadFilename( state ),
 		percentComplete: getUploadPercentComplete( state ),
 	} ),
-	{ startMappingAuthors, startUpload, failPreUpload }
+	{ startMappingAuthors, startUpload, startImporting, failPreUpload }
 )( localize( UploadingPane ) );

--- a/client/state/imports/api.js
+++ b/client/state/imports/api.js
@@ -57,6 +57,7 @@ export function fromApi( state ) {
 	const {
 		importId: importerId,
 		importStatus,
+		importerFileType,
 		type,
 		progress,
 		customData,
@@ -67,6 +68,7 @@ export function fromApi( state ) {
 	return {
 		importerId,
 		importerState: apiToAppState( importStatus ),
+		importerFileType,
 		type: `importer-type-${ type }`,
 		progress,
 		...( customData && { customData: generateSourceAuthorIds( customData ) } ),


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/84863

## Proposed Changes

* Introduced logic:
  * recognize playground/jetpack_backup file type
  * skip author mapping screen
  * for simple sites, show the UpgradePlan screen
  * run the importing process if all conditions are met

## Testing Instructions

* Go to `/setup/import-focused?siteSlug={SIMPLE_SITE}`
* Click on the link `choose a content platform`
* Select the "WordPress" importer
* Press the "Import your content" button
* Select a playground zip file
* After uploading, check if the `UpgradePlan` screen is render
* Upgrade your plan to business
* Check if the `Importing` process is started (you should see the progress bar)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?