### PR TITLE
Activity Log: Add ThreatDialog to ThreatAlert fix and ignore actions

### DIFF
--- a/client/my-sites/activity/activity-log/threat-alert.jsx
+++ b/client/my-sites/activity/activity-log/threat-alert.jsx
@@ -6,6 +6,7 @@ import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import DiffViewer from 'calypso/components/diff-viewer';
 import InfoPopover from 'calypso/components/info-popover';
+import ThreatDialog from 'calypso/components/jetpack/threat-dialog';
 import MarkedLines from 'calypso/components/marked-lines';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import SplitButton from 'calypso/components/split-button';
@@ -21,7 +22,28 @@ import ActivityIcon from '../activity-log-item/activity-icon';
 import './threat-alert.scss';
 
 export class ThreatAlert extends Component {
-	state = { requesting: false };
+	state = { requesting: false, showThreatDialog: false, actionToPerform: 'fix' };
+
+	openDialog = ( action ) => {
+		this.setState( { showThreatDialog: true, actionToPerform: action } );
+	};
+
+	closeDialog = () => {
+		this.setState( { showThreatDialog: false } );
+	};
+
+	confirmAction = () => {
+		this.closeDialog();
+
+		switch ( this.state.actionToPerform ) {
+			case 'fix':
+				this.handleFix();
+				break;
+			case 'ignore':
+				this.handleIgnore();
+				break;
+		}
+	};
 
 	handleFix = () => {
 		this.setState( { requesting: true } );
@@ -318,62 +340,73 @@ export class ThreatAlert extends Component {
 		} );
 
 		return (
-			<Fragment>
-				<FoldableCard
-					className={ className }
-					compact
-					clickableHeader={ true }
-					actionButton={ <span /> }
-					header={
-						<Fragment>
-							<ActivityIcon activityIcon="notice-outline" activityStatus="error" />
-							<div className="activity-log__threat-alert-header">
-								<div className="activity-log__threat-header-top">
-									<span className="activity-log__threat-alert-title">
-										{ this.renderTitle() }
-										<TimeSince
-											className="activity-log__threat-alert-time-since"
-											date={ threat.first_detected }
-											dateFormat="ll"
-										/>
-									</span>
-									{ inProgress && <Spinner /> }
-									{ inProgress && (
-										<Interval onTick={ this.refreshRewindState } period={ EVERY_TEN_SECONDS } />
-									) }
-									<SplitButton
-										compact
-										primary
-										label={ threat.fixable ? translate( 'Fix threat' ) : translate( 'Get help' ) }
-										onClick={ threat.fixable ? this.handleFix : this.handleGetHelp }
-										disabled={ inProgress }
-									>
-										{ threat.fixable && (
-											<PopoverMenuItem
-												onClick={ this.handleGetHelp }
-												className="activity-log__threat-menu-item"
-												icon="chat"
-											>
-												<span>{ translate( 'Get help' ) }</span>
-											</PopoverMenuItem>
+			<>
+				<Fragment>
+					<FoldableCard
+						className={ className }
+						compact
+						clickableHeader={ true }
+						actionButton={ <span /> }
+						header={
+							<Fragment>
+								<ActivityIcon activityIcon="notice-outline" activityStatus="error" />
+								<div className="activity-log__threat-alert-header">
+									<div className="activity-log__threat-header-top">
+										<span className="activity-log__threat-alert-title">
+											{ this.renderTitle() }
+											<TimeSince
+												className="activity-log__threat-alert-time-since"
+												date={ threat.first_detected }
+												dateFormat="ll"
+											/>
+										</span>
+										{ inProgress && <Spinner /> }
+										{ inProgress && (
+											<Interval onTick={ this.refreshRewindState } period={ EVERY_TEN_SECONDS } />
 										) }
-										<PopoverMenuItem
-											onClick={ this.handleIgnore }
-											className="activity-log__threat-menu-item"
-											icon="trash"
+										<SplitButton
+											compact
+											primary
+											label={ threat.fixable ? translate( 'Fix threat' ) : translate( 'Get help' ) }
+											onClick={
+												threat.fixable ? () => this.openDialog( 'fix' ) : this.handleGetHelp
+											}
+											disabled={ inProgress }
 										>
-											<span>{ translate( 'Ignore threat' ) }</span>
-										</PopoverMenuItem>
-									</SplitButton>
+											{ threat.fixable && (
+												<PopoverMenuItem
+													onClick={ this.handleGetHelp }
+													className="activity-log__threat-menu-item"
+													icon="chat"
+												>
+													<span>{ translate( 'Get help' ) }</span>
+												</PopoverMenuItem>
+											) }
+											<PopoverMenuItem
+												onClick={ () => this.openDialog( 'ignore' ) }
+												className="activity-log__threat-menu-item"
+												icon="trash"
+											>
+												<span>{ translate( 'Ignore threat' ) }</span>
+											</PopoverMenuItem>
+										</SplitButton>
+									</div>
+									<span className="activity-log__threat-alert-type">{ this.renderSubtitle() }</span>
 								</div>
-								<span className="activity-log__threat-alert-type">{ this.renderSubtitle() }</span>
-							</div>
-						</Fragment>
-					}
-				>
-					{ this.renderCardContent() }
-				</FoldableCard>
-			</Fragment>
+							</Fragment>
+						}
+					>
+						{ this.renderCardContent() }
+					</FoldableCard>
+				</Fragment>
+				<ThreatDialog
+					showDialog={ this.state.showThreatDialog }
+					onCloseDialog={ this.closeDialog }
+					onConfirmation={ this.confirmAction }
+					threat={ this.props.threat }
+					action={ this.state.actionToPerform }
+				/>
+			</>
 		);
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Description
Currently, the Activity Log displays a `RewindAlerts` card where a user can view their current threats, and if applicable fix, ignore, or get help. The fix threat button immediately triggers the associated fixer without checking if valid credentials are available resulting in a failed attempt without a clear notice as to what has occurred. To bring the Activity Log in line with the dedicated Scan dashboard in Calypso, the fix threat button should trigger the `ThreatDialog` component that internally checks for a valid connection first, prompts a user to connect if they have not, and only then allows the user to confirm before initiating the fixer. The ignore threats button should also trigger the `ThreatDialog` component, but in this case, the credentials wizard will be skipped and you will only be prompted to confirm your decision.

Further discussion - Automattic/jetpack-scan-team#771

## Proposed Changes
* Add the `ThreatDialog` component to the `ThreatAlert` component and have it displayed in advance of initiating the `fix` and `ignore` actions.

## Testing Instructions
- Create a test site, install/connect Jetpack, and upgrade to a plan that includes Scan
- Add several fixable threats
- Do not yet provide your server credentials
- Trigger a scan and verify that the threats are identified
- Proceed to the dedicated Scan dashboard in Calypso - `https://wordpress.com/scan/your-site.com`
- Click on `Fix threat` and view the threat dialog, confirm that it prompts you to enter your server credentials
- Proceed to the Activity Log in Calypso - `https://wordpress.com/activity-log/your-site.com`
- Click on Fix threat and verify that the associated fixer is initiated despite not having provided credentials and that it eventually silently fails
- Check out this branch and run `yarn` then `yarn start`
- Proceed to the Activity Log in Calypso localhost - `http://calypso.localhost:3000/activity-log/your-site.com`
- Confirm that `Fix threat` now presents the threat dialog
- Proceed through authenticating your credentials, and confirm that the fixer now has completed successfully
- Confirm that `Ignore threat` also presents the threat dialog, skips the credentials wizard when they aren't found, and immediately provides the option to confirm the action
- Ensure that there are no regressions introduced

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?