### PR TITLE
Checkout: Create A/B test for 'Included with your purchase'

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -38,6 +38,7 @@ import useCreatePaymentCompleteCallback from '../hooks/use-create-payment-comple
 import useCreatePaymentMethods from '../hooks/use-create-payment-methods';
 import useDetectedCountryCode from '../hooks/use-detected-country-code';
 import useGetThankYouUrl from '../hooks/use-get-thank-you-url';
+import { useHideCheckoutIncludedPurchases } from '../hooks/use-hide-checkout-included-purchases';
 import { useHideCheckoutUpsellNudge } from '../hooks/use-hide-checkout-upsell-nudge';
 import usePrepareProductsForCart from '../hooks/use-prepare-products-for-cart';
 import useRecordCartLoaded from '../hooks/use-record-cart-loaded';
@@ -525,6 +526,9 @@ export default function CheckoutMain( {
 
 	const isHideUpsellNudgeExperimentLoading = useHideCheckoutUpsellNudge() === 'loading';
 
+	const isCheckoutIncludedPurchasesExperimentLoading =
+		useHideCheckoutIncludedPurchases() === 'loading';
+
 	// This variable determines if we see the loading page or if checkout can
 	// render its steps.
 	//
@@ -549,6 +553,7 @@ export default function CheckoutMain( {
 		},
 		{ name: translate( 'Loading countries list' ), isLoading: countriesList.length < 1 },
 		{ name: translate( 'Loading Site' ), isLoading: isHideUpsellNudgeExperimentLoading },
+		{ name: translate( 'Loading Site' ), isLoading: isCheckoutIncludedPurchasesExperimentLoading },
 	];
 	const isCheckoutPageLoading: boolean = checkoutLoadingConditions.some(
 		( condition ) => condition.isLoading

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -44,7 +44,7 @@ import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
 import { useSelector } from 'calypso/state';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
-import { useShowCheckoutIncludedPurchases } from '../hooks/use-show-checkout-included-purchases';
+import { useHideCheckoutIncludedPurchases } from '../hooks/use-hide-checkout-included-purchases';
 import getAkismetProductFeatures from '../lib/get-akismet-product-features';
 import getFlowPlanFeatures from '../lib/get-flow-plan-features';
 import getJetpackProductFeatures from '../lib/get-jetpack-product-features';
@@ -86,14 +86,14 @@ export default function WPCheckoutOrderSummary( {
 	const plan = responseCart.products.find( ( product ) => isPlan( product ) );
 	const hasMonthlyPlanInCart = Boolean( plan && isMonthly( plan?.product_slug ) );
 
-	const shouldShowCheckoutIncludedPurchases = useShowCheckoutIncludedPurchases() === 'treatment';
+	const shouldHideCheckoutIncludedPurchases = useHideCheckoutIncludedPurchases() === 'treatment';
 
 	return (
 		<CheckoutSummaryCard
 			className={ isCartUpdating ? 'is-loading' : '' }
 			data-e2e-cart-is-loading={ isCartUpdating }
 		>
-			{ ! hasCheckoutVersion( '2' ) && shouldShowCheckoutIncludedPurchases && (
+			{ ! hasCheckoutVersion( '2' ) && ! shouldHideCheckoutIncludedPurchases && (
 				<CheckoutSummaryFeatures>
 					<CheckoutSummaryFeaturesTitle>
 						{ responseCart.is_gift_purchase
@@ -114,7 +114,7 @@ export default function WPCheckoutOrderSummary( {
 			{ ! isCartUpdating && ! hasRenewalInCart && ! isWcMobile && plan && hasMonthlyPlanInCart && (
 				<CheckoutSummaryAnnualUpsell plan={ plan } onChangeSelection={ onChangeSelection } />
 			) }
-			{ ! shouldShowCheckoutIncludedPurchases && (
+			{ shouldHideCheckoutIncludedPurchases && (
 				<CheckoutSummaryPriceListTitle>{ translate( 'Your order' ) }</CheckoutSummaryPriceListTitle>
 			) }
 			<CheckoutSummaryPriceList />

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -114,6 +114,9 @@ export default function WPCheckoutOrderSummary( {
 			{ ! isCartUpdating && ! hasRenewalInCart && ! isWcMobile && plan && hasMonthlyPlanInCart && (
 				<CheckoutSummaryAnnualUpsell plan={ plan } onChangeSelection={ onChangeSelection } />
 			) }
+			{ shouldHideCheckoutIncludedPurchases && (
+				<CheckoutSummaryPriceListTitle>Your order</CheckoutSummaryPriceListTitle>
+			) }
 			<CheckoutSummaryPriceList />
 		</CheckoutSummaryCard>
 	);
@@ -856,6 +859,14 @@ const CheckoutSummaryFeaturesListItem = styled( 'li' )< { isSupported?: boolean 
 CheckoutSummaryFeaturesListItem.defaultProps = {
 	isSupported: true,
 };
+
+const CheckoutSummaryPriceListTitle = styled.div`
+	color: ${ ( props ) => props.theme.colors.textColorDark };
+	font-size: 16px;
+	font-weight: ${ ( props ) => props.theme.weights.bold };
+	line-height: 26px;
+	margin: 1em 0 0.5em;
+`;
 
 const CheckoutSummaryAmountWrapper = styled.div`
 	border-top: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -44,6 +44,7 @@ import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
 import { useSelector } from 'calypso/state';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
+import { useHideCheckoutIncludedPurchases } from '../hooks/use-hide-checkout-included-purchases';
 import getAkismetProductFeatures from '../lib/get-akismet-product-features';
 import getFlowPlanFeatures from '../lib/get-flow-plan-features';
 import getJetpackProductFeatures from '../lib/get-jetpack-product-features';
@@ -85,12 +86,14 @@ export default function WPCheckoutOrderSummary( {
 	const plan = responseCart.products.find( ( product ) => isPlan( product ) );
 	const hasMonthlyPlanInCart = Boolean( plan && isMonthly( plan?.product_slug ) );
 
+	const shouldHideCheckoutIncludedPurchases = useHideCheckoutIncludedPurchases();
+
 	return (
 		<CheckoutSummaryCard
 			className={ isCartUpdating ? 'is-loading' : '' }
 			data-e2e-cart-is-loading={ isCartUpdating }
 		>
-			{ ! hasCheckoutVersion( '2' ) && (
+			{ ! hasCheckoutVersion( '2' ) && ! shouldHideCheckoutIncludedPurchases && (
 				<CheckoutSummaryFeatures>
 					<CheckoutSummaryFeaturesTitle>
 						{ responseCart.is_gift_purchase

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -115,7 +115,7 @@ export default function WPCheckoutOrderSummary( {
 				<CheckoutSummaryAnnualUpsell plan={ plan } onChangeSelection={ onChangeSelection } />
 			) }
 			{ shouldHideCheckoutIncludedPurchases && (
-				<CheckoutSummaryPriceListTitle>Your order</CheckoutSummaryPriceListTitle>
+				<CheckoutSummaryPriceListTitle>{ translate( 'Your order' ) }</CheckoutSummaryPriceListTitle>
 			) }
 			<CheckoutSummaryPriceList />
 		</CheckoutSummaryCard>

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -44,7 +44,7 @@ import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
 import { useSelector } from 'calypso/state';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
-import { useHideCheckoutIncludedPurchases } from '../hooks/use-hide-checkout-included-purchases';
+import { useShowCheckoutIncludedPurchases } from '../hooks/use-show-checkout-included-purchases';
 import getAkismetProductFeatures from '../lib/get-akismet-product-features';
 import getFlowPlanFeatures from '../lib/get-flow-plan-features';
 import getJetpackProductFeatures from '../lib/get-jetpack-product-features';
@@ -86,14 +86,14 @@ export default function WPCheckoutOrderSummary( {
 	const plan = responseCart.products.find( ( product ) => isPlan( product ) );
 	const hasMonthlyPlanInCart = Boolean( plan && isMonthly( plan?.product_slug ) );
 
-	const shouldHideCheckoutIncludedPurchases = useHideCheckoutIncludedPurchases();
+	const shouldShowCheckoutIncludedPurchases = useShowCheckoutIncludedPurchases() === 'treatment';
 
 	return (
 		<CheckoutSummaryCard
 			className={ isCartUpdating ? 'is-loading' : '' }
 			data-e2e-cart-is-loading={ isCartUpdating }
 		>
-			{ ! hasCheckoutVersion( '2' ) && ! shouldHideCheckoutIncludedPurchases && (
+			{ ! hasCheckoutVersion( '2' ) && shouldShowCheckoutIncludedPurchases && (
 				<CheckoutSummaryFeatures>
 					<CheckoutSummaryFeaturesTitle>
 						{ responseCart.is_gift_purchase
@@ -114,7 +114,7 @@ export default function WPCheckoutOrderSummary( {
 			{ ! isCartUpdating && ! hasRenewalInCart && ! isWcMobile && plan && hasMonthlyPlanInCart && (
 				<CheckoutSummaryAnnualUpsell plan={ plan } onChangeSelection={ onChangeSelection } />
 			) }
-			{ shouldHideCheckoutIncludedPurchases && (
+			{ ! shouldShowCheckoutIncludedPurchases && (
 				<CheckoutSummaryPriceListTitle>{ translate( 'Your order' ) }</CheckoutSummaryPriceListTitle>
 			) }
 			<CheckoutSummaryPriceList />

--- a/client/my-sites/checkout/src/hooks/use-hide-checkout-included-purchases.tsx
+++ b/client/my-sites/checkout/src/hooks/use-hide-checkout-included-purchases.tsx
@@ -1,8 +1,36 @@
-import { hasCheckoutVersion } from '@automattic/wpcom-checkout';
+import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
+import { useExperiment } from 'calypso/lib/explat';
+import isJetpackCheckout from 'calypso/lib/jetpack/is-jetpack-checkout';
+import { useSelector } from 'calypso/state';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId, getSectionName } from 'calypso/state/ui/selectors';
 
-export function useHideCheckoutIncludedPurchases(): boolean {
-	if ( hasCheckoutVersion( 'hide-checkout-included-purchases' ) ) {
-		return true;
+export function useHideCheckoutIncludedPurchases(): 'loading' | 'treatment' | 'control' {
+	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+
+	const isJetpackNotAtomic = useSelector(
+		( state ) => isJetpackSite( state, siteId ) && ! isSiteAutomatedTransfer( state, siteId )
+	);
+	const isWPcomCheckout =
+		useSelector( getSectionName ) === 'checkout' &&
+		! isJetpackCheckout() &&
+		! isAkismetCheckout() &&
+		! isJetpackNotAtomic;
+
+	const [ isLoadingExperimentAssignment, experimentAssignment ] = useExperiment(
+		'wp_calypso_checkout_included_purchases_visibility',
+		{ isEligible: isWPcomCheckout }
+	);
+
+	// Is loading experiment assignment
+	if ( isLoadingExperimentAssignment ) {
+		return 'loading';
 	}
-	return false;
+	// Done loading experiment assignment, and treatment assignment found
+	if ( experimentAssignment?.variationName === 'treatment' ) {
+		return 'treatment';
+	}
+	// Done loading experiment assignment, and control or null assignment found
+	return 'control';
 }

--- a/client/my-sites/checkout/src/hooks/use-hide-checkout-included-purchases.tsx
+++ b/client/my-sites/checkout/src/hooks/use-hide-checkout-included-purchases.tsx
@@ -6,7 +6,7 @@ import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-t
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSectionName } from 'calypso/state/ui/selectors';
 
-export function useShowCheckoutIncludedPurchases(): 'loading' | 'treatment' | 'control' {
+export function useHideCheckoutIncludedPurchases(): 'loading' | 'treatment' | 'control' {
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 
 	const isJetpackNotAtomic = useSelector(
@@ -27,10 +27,10 @@ export function useShowCheckoutIncludedPurchases(): 'loading' | 'treatment' | 'c
 	if ( isLoadingExperimentAssignment ) {
 		return 'loading';
 	}
-	// Done loading experiment assignment, and treatment assignment found - show included purchases
+	// Done loading experiment assignment, and treatment assignment found - hide included purchases
 	if ( experimentAssignment?.variationName === 'treatment' ) {
 		return 'treatment';
 	}
-	// Done loading experiment assignment, and control or null assignment found - hide included purchases
+	// Done loading experiment assignment, and control or null assignment found - show included purchases
 	return 'control';
 }

--- a/client/my-sites/checkout/src/hooks/use-hide-checkout-included-purchases.tsx
+++ b/client/my-sites/checkout/src/hooks/use-hide-checkout-included-purchases.tsx
@@ -1,0 +1,8 @@
+import { hasCheckoutVersion } from '@automattic/wpcom-checkout';
+
+export function useHideCheckoutIncludedPurchases(): boolean {
+	if ( hasCheckoutVersion( 'hide-checkout-included-purchases' ) ) {
+		return true;
+	}
+	return false;
+}

--- a/client/my-sites/checkout/src/hooks/use-show-checkout-included-purchases.tsx
+++ b/client/my-sites/checkout/src/hooks/use-show-checkout-included-purchases.tsx
@@ -6,7 +6,7 @@ import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-t
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSectionName } from 'calypso/state/ui/selectors';
 
-export function useHideCheckoutIncludedPurchases(): 'loading' | 'treatment' | 'control' {
+export function useShowCheckoutIncludedPurchases(): 'loading' | 'treatment' | 'control' {
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 
 	const isJetpackNotAtomic = useSelector(
@@ -27,10 +27,10 @@ export function useHideCheckoutIncludedPurchases(): 'loading' | 'treatment' | 'c
 	if ( isLoadingExperimentAssignment ) {
 		return 'loading';
 	}
-	// Done loading experiment assignment, and treatment assignment found
+	// Done loading experiment assignment, and treatment assignment found - show included purchases
 	if ( experimentAssignment?.variationName === 'treatment' ) {
 		return 'treatment';
 	}
-	// Done loading experiment assignment, and control or null assignment found
+	// Done loading experiment assignment, and control or null assignment found - hide included purchases
 	return 'control';
 }


### PR DESCRIPTION
This PR will implement an A/B test for the checkout 'Included with your purchase' feature list
- Feature list shown (control - how it is in production currently)
- No feature list (treatment)

The goal of this test is to create a baseline for the 'Included with your purchase' feature list component to gauge whether it positively impacts our conversion rate in Checkout.

The impetus for this test comes from the Checkout Redesign project (pbOQVh-45k-p2) which removes the feature list entirely. If we know how the feature list impacts our conversion rate, then we can better judge its inclusion in the new design.

**Hypothesis** - Showing the feature list helps persuade our customers to complete checkout.

Related to https://github.com/Automattic/payments-shilling/issues/1969
Experiment - 21552-explat-experiment

## Proposed Changes
- This PR implements a `useHideCheckoutIncludedPurchases` hook to toggle the visibility of the 'Included with your purchase' feature list.

| Control | Treatment |
| ----- | ----- |
| <img src='https://github.com/Automattic/wp-calypso/assets/16580129/a30a30e6-dd77-4bb2-9727-19a2f6788c57' width="400px" /> | <img src='https://github.com/Automattic/wp-calypso/assets/16580129/812a3b43-299d-403a-a8d4-21656460e0a0' width="400px" /> |





## Testing Instructions

**Testing the Control**
- Add a plan to your cart and go to checkout
- You should see the 'Included with your purchase' feature list in the sidebar

**Testing the Treatment**
- Testing the treatment outside of Staging is tricky, you'll need to edit the `useHideCheckoutIncludedPurchases` hook to return the treatment like so:
![image](https://github.com/Automattic/wp-calypso/assets/16580129/95b897fa-499a-45be-9c7b-51a0e06f51fe)
- Add a plan to your cart and go to checkout
- Make sure that the 'Included with your purchase' feature list is **not shown** in the checkout sidebar 
- Instead, you should see the subtotal/total price list with a 'Your order' title above it
- Also check the mobile checkout sidebar, when you click on the 'Purchase Details' dropdown the pricing list should be spaced correctly

