### PR TITLE
Live Preview: Lift up common states in the notices

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-hide-template-part-hint.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-hide-template-part-hint.ts
@@ -1,0 +1,13 @@
+import { useDispatch } from '@wordpress/data';
+import { useEffect } from 'react';
+
+/**
+ * Suppress the "Looking for template parts?" notice in the Site Editor sidebar.
+ */
+export const useHideTemplatePartHint = () => {
+	const { set: setPreferences } = useDispatch( 'core/preferences' );
+	useEffect( () => {
+		// The preference name is defined in https://github.com/WordPress/gutenberg/blob/d47419499cd58e20db25c370cdbf02ddf7cffce0/packages/edit-site/src/components/sidebar-navigation-screen-main/template-part-hint.js#L9.
+		setPreferences( 'core', 'isTemplatePartMoveHintVisible', false );
+	}, [ setPreferences ] );
+};

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/index.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/index.tsx
@@ -4,6 +4,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
 import { FC, useEffect } from 'react';
 import { useCanPreviewButNeedUpgrade } from './hooks/use-can-preview-but-need-upgrade';
+import { useHideTemplatePartHint } from './hooks/use-hide-template-part-hint';
 import { usePreviewingTheme } from './hooks/use-previewing-theme';
 import { LivePreviewUpgradeNotice } from './upgrade-notice';
 import { getUnlock } from './utils';
@@ -18,26 +19,14 @@ const NOTICE_ID = 'wpcom-live-preview/notice';
  * @see https://github.com/Automattic/wp-calypso/issues/82218
  */
 const LivePreviewNotice: FC< {
+	dashboardLink?: string;
 	previewingThemeName?: string;
-} > = ( { previewingThemeName } ) => {
+} > = ( { dashboardLink, previewingThemeName } ) => {
 	const { createWarningNotice, removeNotice } = useDispatch( 'core/notices' );
 
-	const siteEditorStore = useSelect( ( select ) => select( 'core/edit-site' ), [] );
-	const dashboardLink =
-		unlock &&
-		siteEditorStore &&
-		unlock( siteEditorStore ).getSettings().__experimentalDashboardLink;
+	useHideTemplatePartHint();
 
 	useEffect( () => {
-		// Do nothing in the Post Editor context.
-		if ( ! siteEditorStore ) {
-			return;
-		}
-		if ( ! previewingThemeName ) {
-			removeNotice( NOTICE_ID );
-			return;
-		}
-
 		createWarningNotice(
 			sprintf(
 				// translators: %s: theme name
@@ -60,7 +49,7 @@ const LivePreviewNotice: FC< {
 			}
 		);
 		return () => removeNotice( NOTICE_ID );
-	}, [ siteEditorStore, dashboardLink, createWarningNotice, removeNotice, previewingThemeName ] );
+	}, [ dashboardLink, createWarningNotice, removeNotice, previewingThemeName ] );
 	return null;
 };
 
@@ -70,24 +59,27 @@ const LivePreviewNoticePlugin = () => {
 	const { canPreviewButNeedUpgrade, upgradePlan } = useCanPreviewButNeedUpgrade( {
 		previewingTheme,
 	} );
+	const dashboardLink = useSelect(
+		( select ) =>
+			unlock &&
+			select( 'core/edit-site' ) &&
+			unlock( siteEditorStore ).getSettings().__experimentalDashboardLink,
+		[ siteEditorStore ]
+	);
 
-	const { set: setPreferences } = useDispatch( 'core/preferences' );
-	useEffect( () => {
-		if ( ! siteEditorStore ) {
-			return;
-		}
-		if ( ! previewingTheme.name ) {
-			return;
-		}
-		// Suppress the "Looking for template parts?" notice in the Site Editor sidebar.
-		// The preference name is defined in https://github.com/WordPress/gutenberg/blob/d47419499cd58e20db25c370cdbf02ddf7cffce0/packages/edit-site/src/components/sidebar-navigation-screen-main/template-part-hint.js#L9.
-		setPreferences( 'core', 'isTemplatePartMoveHintVisible', false );
-	}, [ previewingTheme.name, setPreferences, siteEditorStore ] );
+	// Do nothing in the Post Editor context.
+	if ( ! siteEditorStore ) {
+		return null;
+	}
+	// Do nothing if the user is NOT previewing a theme.
+	if ( ! previewingTheme.name ) {
+		return null;
+	}
 
 	if ( canPreviewButNeedUpgrade ) {
-		return <LivePreviewUpgradeNotice { ...{ previewingTheme, upgradePlan } } />;
+		return <LivePreviewUpgradeNotice { ...{ previewingTheme, upgradePlan, dashboardLink } } />;
 	}
-	return <LivePreviewNotice { ...{ previewingThemeName: previewingTheme.name } } />;
+	return <LivePreviewNotice { ...{ dashboardLink, previewingThemeName: previewingTheme.name } } />;
 };
 
 const registerLivePreviewPlugin = () => {

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-notice.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-notice.tsx
@@ -48,7 +48,7 @@ export const LivePreviewUpgradeNotice: FC< {
 	upgradePlan: () => void;
 } > = ( { dashboardLink, previewingTheme, upgradePlan } ) => {
 	const [ isRendered, setIsRendered ] = useState( false );
-	const { createWarningNotice, removeNotice } = useDispatch( 'core/notices' );
+	const { createWarningNotice } = useDispatch( 'core/notices' );
 	const canvasMode = useSelect(
 		( select ) =>
 			unlock && select( 'core/edit-site' ) && unlock( select( 'core/edit-site' ) ).getCanvasMode(),
@@ -91,18 +91,7 @@ export const LivePreviewUpgradeNotice: FC< {
 					: [] ),
 			],
 		} );
-		return () => removeNotice( UPGRADE_NOTICE_ID );
-	}, [
-		canvasMode,
-		createWarningNotice,
-		dashboardLink,
-		noticeText,
-		previewingTheme.name,
-		previewingTheme.type,
-		previewingTheme.typeDisplay,
-		removeNotice,
-		upgradePlan,
-	] );
+	}, [ createWarningNotice, dashboardLink, noticeText, upgradePlan ] );
 
 	/**
 	 * Show the notice when the canvas mode is 'view'.
@@ -136,11 +125,7 @@ export const LivePreviewUpgradeNotice: FC< {
 		);
 
 		setIsRendered( true );
-
-		return () => {
-			document.querySelector( `.${ LIVE_PREVIEW_UPGRADE_NOTICE_VIEW_SELECTOR }` )?.remove();
-		};
-	}, [ canvasMode, isRendered, noticeText, previewingTheme, upgradePlan ] );
+	}, [ canvasMode, isRendered, noticeText, upgradePlan ] );
 
 	return null;
 };

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-notice.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-notice.tsx
@@ -70,11 +70,6 @@ export const LivePreviewUpgradeNotice: FC< {
 	 * Show the notice when the canvas mode is 'edit'.
 	 */
 	useEffect( () => {
-		if ( canvasMode !== 'edit' ) {
-			removeNotice( UPGRADE_NOTICE_ID );
-			return;
-		}
-
 		createWarningNotice( noticeText, {
 			id: UPGRADE_NOTICE_ID,
 			isDismissible: false,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

This PR refactors Live Preview notices implementation by lifting up the states. See https://github.com/Automattic/wp-calypso/pull/84676#issuecomment-1840108224 for the original proposal. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `install-plugin.sh wpcom-block-editor add/live-preview-upgrade-notice-sidebar-refactor` on your sandbox.
- Sandbox widgets.wp.com and your site.
- Follow the Testing Instructions in https://github.com/Automattic/wp-calypso/issues/79223

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?