### PR TITLE
Refactor: The getEnhancedTasks function and ChecklistStatuses type of Launchpad

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -8,6 +8,7 @@ import { useSelect } from '@wordpress/data';
 import { useRef, useState } from '@wordpress/element';
 import { copy, Icon } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
 import QueryMembershipsSettings from 'calypso/components/data/query-memberships-settings';
 import ClipboardButton from 'calypso/components/forms/clipboard-button';
 import { type NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
@@ -89,15 +90,20 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goToStep, flow }: SidebarPr
 		[]
 	);
 
-	const enhancedTasks: Task[] | null =
-		site &&
-		getEnhancedTasks(
-			launchpadChecklist,
+	const displayGlobalStylesWarning = globalStylesInUse && shouldLimitGlobalStyles;
+
+	const enhancedTasks: Task[] | null = useMemo( () => {
+		if ( ! site ) {
+			return null;
+		}
+
+		return getEnhancedTasks( {
+			tasks: launchpadChecklist,
 			siteSlug,
 			site,
 			submit,
-			globalStylesInUse && shouldLimitGlobalStyles,
-			PLAN_PREMIUM,
+			displayGlobalStylesWarning,
+			globalStylesMinimumPlan: PLAN_PREMIUM,
 			setShowPlansModal,
 			queryClient,
 			goToStep,
@@ -107,8 +113,25 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goToStep, flow }: SidebarPr
 			planCartItem,
 			domainCartItem,
 			productCartItems,
-			stripeConnectUrl
-		);
+			stripeConnectUrl,
+		} );
+	}, [
+		site,
+		launchpadChecklist,
+		siteSlug,
+		submit,
+		displayGlobalStylesWarning,
+		setShowPlansModal,
+		queryClient,
+		goToStep,
+		flow,
+		isEmailVerified,
+		checklistStatuses,
+		planCartItem,
+		domainCartItem,
+		productCartItems,
+		stripeConnectUrl,
+	] );
 
 	const currentTask = enhancedTasks?.filter( ( task ) => task.completed ).length;
 	const launchTask = enhancedTasks?.find( ( task ) => task.isLaunchTask === true );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -4,6 +4,7 @@ import {
 	FEATURE_STYLE_CUSTOMIZATION,
 	getPlans,
 	isFreePlanProduct,
+	PLAN_PREMIUM,
 } from '@automattic/calypso-products';
 import {
 	updateLaunchpadSettings,
@@ -43,14 +44,14 @@ interface GetEnhancedTasksProps {
 	siteSlug: string | null;
 	site: SiteDetails | null;
 	submit: NavigationControls[ 'submit' ];
-	displayGlobalStylesWarning: boolean;
-	globalStylesMinimumPlan: string;
+	displayGlobalStylesWarning?: boolean;
+	globalStylesMinimumPlan?: string;
 	setShowPlansModal: Dispatch< SetStateAction< boolean > >;
 	queryClient: QueryClient;
 	goToStep?: NavigationControls[ 'goToStep' ];
 	flow: string | null;
-	isEmailVerified: boolean;
-	checklistStatuses: ChecklistStatuses | undefined;
+	isEmailVerified?: boolean;
+	checklistStatuses?: ChecklistStatuses;
 	planCartItem?: MinimalRequestCartProduct | null;
 	domainCartItem?: MinimalRequestCartProduct | null;
 	productCartItems?: MinimalRequestCartProduct[] | null;
@@ -70,11 +71,11 @@ const PLANS_LIST = getPlans();
  */
 export function getEnhancedTasks( {
 	tasks,
-	siteSlug,
-	site,
+	siteSlug = '',
+	site = null,
 	submit,
-	displayGlobalStylesWarning,
-	globalStylesMinimumPlan,
+	displayGlobalStylesWarning = false,
+	globalStylesMinimumPlan = PLAN_PREMIUM,
 	setShowPlansModal,
 	queryClient,
 	goToStep,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/task-helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/task-helper.ts
@@ -1,10 +1,12 @@
 /**
  * @jest-environment jsdom
  */
-import { PLAN_PREMIUM } from '@automattic/calypso-products';
 import { QueryClient } from '@tanstack/react-query';
 import { getEnhancedTasks } from '../task-helper';
 import { buildTask } from './lib/fixtures';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
 
 const queryClient = new QueryClient( {
 	defaultOptions: {},
@@ -12,6 +14,15 @@ const queryClient = new QueryClient( {
 
 describe( 'Task Helpers', () => {
 	describe( 'getEnhancedTasks', () => {
+		const defaultProps = {
+			site: null,
+			siteSlug: 'fake.wordpress.com',
+			flow: '',
+			queryClient,
+			submit: noop,
+			setShowPlansModal: noop,
+		};
+
 		describe( 'when a task should not be enhanced', () => {
 			it( 'then it is not enhanced', () => {
 				const fakeTasks = [
@@ -20,18 +31,10 @@ describe( 'Task Helpers', () => {
 					buildTask( { id: 'fake-task-3' } ),
 				];
 				expect(
-					getEnhancedTasks(
-						fakeTasks,
-						'fake.wordpress.com',
-						null,
-						// eslint-disable-next-line @typescript-eslint/no-empty-function
-						() => {},
-						false,
-						PLAN_PREMIUM,
-						// eslint-disable-next-line @typescript-eslint/no-empty-function
-						() => {},
-						queryClient
-					)
+					getEnhancedTasks( {
+						...defaultProps,
+						tasks: fakeTasks,
+					} )
 				).toEqual( fakeTasks );
 			} );
 		} );
@@ -40,22 +43,12 @@ describe( 'Task Helpers', () => {
 				it( 'marks the task as complete', () => {
 					const fakeTasks = [ buildTask( { id: 'verify_email', completed: false } ) ];
 					const isEmailVerified = true;
-					const enhancedTasks = getEnhancedTasks(
-						fakeTasks,
-						'fake.wordpress.com',
-						null,
-						// eslint-disable-next-line @typescript-eslint/no-empty-function
-						() => {},
-						false,
-						PLAN_PREMIUM,
-						// eslint-disable-next-line @typescript-eslint/no-empty-function
-						() => {},
-						queryClient,
-						// eslint-disable-next-line @typescript-eslint/no-empty-function
-						() => {},
-						'newsletter',
-						isEmailVerified
-					);
+					const enhancedTasks = getEnhancedTasks( {
+						...defaultProps,
+						tasks: fakeTasks,
+						flow: 'newsletter',
+						isEmailVerified,
+					} );
 					expect( enhancedTasks[ 0 ].completed ).toEqual( true );
 				} );
 			} );
@@ -64,21 +57,11 @@ describe( 'Task Helpers', () => {
 			describe( 'and the flow is start-writing', () => {
 				it( 'disable the click link so the user will not get distracted going back to the post', () => {
 					const fakeTasks = [ buildTask( { id: 'first_post_published', completed: true } ) ];
-					const enhancedTasks = getEnhancedTasks(
-						fakeTasks,
-						'fake.wordpress.com',
-						null,
-						// eslint-disable-next-line @typescript-eslint/no-empty-function
-						() => {},
-						false,
-						PLAN_PREMIUM,
-						// eslint-disable-next-line @typescript-eslint/no-empty-function
-						() => {},
-						queryClient,
-						// eslint-disable-next-line @typescript-eslint/no-empty-function
-						() => {},
-						'start-writing'
-					);
+					const enhancedTasks = getEnhancedTasks( {
+						...defaultProps,
+						tasks: fakeTasks,
+						flow: 'start-writing',
+					} );
 					expect( enhancedTasks[ 0 ].disabled ).toEqual( true );
 				} );
 			} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
@@ -22,21 +22,3 @@ export interface TranslatedLaunchpadStrings {
 	launchTitle?: string;
 	subtitle: string;
 }
-
-export interface LaunchpadStatuses {
-	links_edited?: boolean;
-	site_edited?: boolean;
-	site_launched?: boolean;
-	first_post_published?: boolean;
-	video_uploaded?: boolean;
-	publish_first_course?: boolean;
-	plan_selected?: boolean;
-	plan_completed?: boolean;
-	domain_upsell_deferred?: boolean;
-}
-
-export interface LaunchpadResponse {
-	site_intent: string;
-	launchpad_screen: boolean | string;
-	checklist_statuses: LaunchpadStatuses[];
-}

--- a/packages/data-stores/src/queries/use-launchpad.ts
+++ b/packages/data-stores/src/queries/use-launchpad.ts
@@ -20,20 +20,21 @@ interface Task {
 	order?: number;
 }
 
-interface ChecklistStatuses {
+export interface ChecklistStatuses {
 	links_edited?: boolean;
 	site_edited?: boolean;
 	site_launched?: boolean;
 	first_post_published?: boolean;
 	video_uploaded?: boolean;
 	publish_first_course?: boolean;
+	plan_selected?: boolean;
 	plan_completed?: boolean;
 	domain_upsell_deferred?: boolean;
 }
 
 type LaunchpadScreen = 'full' | 'off' | 'skipped' | 'minimized';
 
-interface LaunchpadResponse {
+export interface LaunchpadResponse {
 	site_intent?: string | null;
 	launchpad_screen?: LaunchpadScreen | boolean | null | undefined;
 	checklist?: Task[] | null;

--- a/packages/launchpad/src/types.ts
+++ b/packages/launchpad/src/types.ts
@@ -50,12 +50,6 @@ export interface LaunchpadStatuses {
 	domain_upsell_deferred?: boolean;
 }
 
-export interface LaunchpadResponse {
-	site_intent: string;
-	launchpad_screen: boolean | string;
-	checklist_statuses: LaunchpadStatuses[];
-}
-
 export interface PermittedActions {
 	setShareSiteModalIsOpen?: ( isOpen: boolean ) => void;
 	setActiveChecklist: ( siteSlug: string, activeChecklistSlug: string ) => void;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Memo the computation of the `enhancedTasks` function
* Change the input of the `getEnhancedTasks` function to an object as there are so many parameters
* Export the `ChecklistStatuses` from the `@automattic/data-stores` instead of defining it multiple times

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site
* Finish the onboarding flow
* When you land on the launchpad, ensure the tasks still work as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?