### PR TITLE
Assembler First Flow: Navigate the Assembler step back to the Site Pick step

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -215,7 +215,8 @@ export class SiteSelector extends Component {
 			} );
 		}
 
-		const handledByHost = this.props.onSiteSelect( siteId );
+		const selectedSite = this.props.sites.find( ( site ) => site.ID === siteId );
+		const handledByHost = this.props.onSiteSelect( siteId, selectedSite );
 		this.props.onClose( event, siteId );
 
 		if ( ! this.siteSelectorRef ) {

--- a/client/landing/stepper/declarative-flow/assembler-first-flow.ts
+++ b/client/landing/stepper/declarative-flow/assembler-first-flow.ts
@@ -189,7 +189,7 @@ const assemblerFirstFlow: Flow = {
 				}
 
 				case 'patternAssembler': {
-					return window.location.assign( `/themes/${ siteSlug }` );
+					return navigate( 'site-picker' );
 				}
 			}
 		};

--- a/client/landing/stepper/declarative-flow/assembler-first-flow.ts
+++ b/client/landing/stepper/declarative-flow/assembler-first-flow.ts
@@ -114,11 +114,10 @@ const assemblerFirstFlow: Flow = {
 				return `/site-editor/${ selectedSiteSlug }?${ params }`;
 			}
 
-			params = new URLSearchParams( {
-				siteSlug: selectedSiteSlug,
-				siteId: selectedSiteId,
-			} );
-
+			// Carry over the current search parameters
+			params = new URLSearchParams( window.location.search );
+			params.set( 'siteSlug', selectedSiteSlug );
+			params.set( 'siteId', selectedSiteId );
 			if ( isNewSite ) {
 				params.set( 'isNewSite', 'true' );
 			}
@@ -189,7 +188,11 @@ const assemblerFirstFlow: Flow = {
 				}
 
 				case 'patternAssembler': {
-					return navigate( 'site-picker' );
+					const params = new URLSearchParams( window.location.search );
+					params.delete( 'siteSlug' );
+					params.delete( 'siteId' );
+					setSelectedSite( null );
+					return navigate( `site-picker?${ params }` );
 				}
 			}
 		};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -6,7 +6,12 @@ import {
 	getVariationType,
 } from '@automattic/global-styles';
 import { useLocale } from '@automattic/i18n-utils';
-import { StepContainer, isSiteAssemblerFlow, NavigatorScreen } from '@automattic/onboarding';
+import {
+	StepContainer,
+	isSiteAssemblerFlow,
+	isWithThemeAssemblerFlow,
+	NavigatorScreen,
+} from '@automattic/onboarding';
 import {
 	__experimentalNavigatorProvider as NavigatorProvider,
 	__experimentalUseNavigator as useNavigator,
@@ -414,8 +419,17 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 		recordTracksEvent,
 	} );
 
+	// Don't show the “Back” button if the site is being created by the site assembler flow
+	// as the previous step is the site creation step that cannot be undone.
+	const hideBack = ! currentScreen.previousScreen && isSiteAssemblerFlow( flow ) && isNewSite;
+
 	const getBackLabel = () => {
 		if ( ! currentScreen.previousScreen ) {
+			// Go back to the Theme Showcase if people are from the with-theme-assembler flow.
+			if ( isWithThemeAssemblerFlow( flow ) ) {
+				return translate( 'Back to themes' );
+			}
+
 			return undefined;
 		}
 
@@ -665,20 +679,12 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 		<StepContainer
 			stepName="pattern-assembler"
 			stepSectionName={ currentScreen.name }
-			backLabelText={
-				isSiteAssemblerFlow( flow ) && navigator.location.path?.startsWith( NAVIGATOR_PATHS.MAIN )
-					? translate( 'Back to themes' )
-					: getBackLabel()
-			}
+			backLabelText={ getBackLabel() }
 			goBack={ onBack }
 			goNext={ goNext }
 			isHorizontalLayout={ false }
 			isFullLayout={ true }
-			hideBack={
-				isSiteAssemblerFlow( flow ) &&
-				navigator.location.path?.startsWith( NAVIGATOR_PATHS.MAIN ) &&
-				isNewSite
-			}
+			hideBack={ hideBack }
 			hideSkip={ true }
 			stepContent={
 				<PatternAssemblerContainer

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker-list/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker-list/index.tsx
@@ -1,10 +1,8 @@
 import { StepContainer, isSiteAssemblerFlow } from '@automattic/onboarding';
-import { useSelect } from '@wordpress/data';
+import { select } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useState } from 'react';
 import QuerySites from 'calypso/components/data/query-sites';
 import FormattedHeader from 'calypso/components/formatted-header';
-import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import SiteSelector from 'calypso/components/site-selector';
 import { SITE_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -18,27 +16,11 @@ const SitePicker: Step = function SitePicker( { navigation, flow } ) {
 	const translate = useTranslate();
 	const { submit, goBack } = navigation;
 
-	const [ selectedSiteId, setSelectedSiteId ] = useState< SiteId | null >( null );
-
-	const site = useSelect(
-		( select ) =>
-			( selectedSiteId && ( select( SITE_STORE ) as SiteSelect ).getSite( selectedSiteId ) ) ||
-			null,
-		[ selectedSiteId ]
-	);
-
-	useEffect( () => {
-		if ( ! site ) {
-			return;
-		}
+	const selectSite = ( siteId: SiteId ) => {
+		const site = ( select( SITE_STORE ) as SiteSelect ).getSite( siteId );
 		const siteSlug = new URL( site?.URL || '' ).host;
-		const siteId = site?.ID;
 
 		submit?.( { siteSlug, siteId } );
-	}, [ site ] );
-
-	const selectSite = ( siteId: SiteId ) => {
-		setSelectedSiteId( siteId );
 	};
 
 	const filter = ( site: SiteDetails ) => {
@@ -58,8 +40,7 @@ const SitePicker: Step = function SitePicker( { navigation, flow } ) {
 				stepContent={
 					<div className="site-picker__container">
 						<QuerySites allSites />
-						{ ! selectedSiteId && <SiteSelector filter={ filter } onSiteSelect={ selectSite } /> }
-						{ selectedSiteId && <LoadingEllipsis /> }
+						<SiteSelector filter={ filter } onSiteSelect={ selectSite } />
 					</div>
 				}
 				formattedHeader={

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker-list/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker-list/index.tsx
@@ -1,13 +1,11 @@
 import { StepContainer, isSiteAssemblerFlow } from '@automattic/onboarding';
-import { select } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import QuerySites from 'calypso/components/data/query-sites';
 import FormattedHeader from 'calypso/components/formatted-header';
 import SiteSelector from 'calypso/components/site-selector';
-import { SITE_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { Step } from '../../types';
-import type { SiteDetails, SiteSelect } from '@automattic/data-stores';
+import type { SiteDetails } from '@automattic/data-stores';
 import type { SiteId } from 'calypso/types';
 
 import './styles.scss';
@@ -16,10 +14,8 @@ const SitePicker: Step = function SitePicker( { navigation, flow } ) {
 	const translate = useTranslate();
 	const { submit, goBack } = navigation;
 
-	const selectSite = ( siteId: SiteId ) => {
-		const site = ( select( SITE_STORE ) as SiteSelect ).getSite( siteId );
-		const siteSlug = new URL( site?.URL || '' ).host;
-
+	const selectSite = ( siteId: SiteId, site: SiteDetails ) => {
+		const siteSlug = site.URL ? new URL( site.URL ).host : '';
 		submit?.( { siteSlug, siteId } );
 	};
 

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -154,6 +154,10 @@ export const isSiteAssemblerFlow = ( flowName: string | null ) => {
 	return !! flowName && SITE_ASSEMBLER_FLOWS.includes( flowName );
 };
 
+export const isWithThemeAssemblerFlow = ( flowName: string | null ) => {
+	return !! flowName && WITH_THEME_ASSEMBLER_FLOW === flowName;
+};
+
 export const isWithThemeFlow = ( flowName: string | null ) => {
 	const WITH_THEME_FLOWS = [ WITH_THEME_FLOW, WITH_THEME_ASSEMBLER_FLOW ];
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/83390

## Proposed Changes

* Change the label of the “Back“ button on the Assembler step to “Back” if people are from the Site Pick step
* Proceed to the next step after selecting the site on the Site Pick step to avoid displaying the loading state

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/assembler-first`
* Pick “Select a site”, and select a site
* On the Assembler step, ensure you can see the “Back” button
* Click the “Back” button, and ensure you can go back to the “Select a site” step

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?