### PR TITLE
Assembler First Flow: Adjust styles for the new-or-existing, site-picker, and launchpad step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/components/step-route/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/index.tsx
@@ -47,6 +47,7 @@ const StepRoute = ( {
 	return (
 		<div
 			className={ classnames(
+				'step-route',
 				flow.name,
 				flow.variantSlug,
 				flow.classnames,

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -96,12 +96,7 @@ button {
 .update-design,
 .hundred-year-plan,
 .link-in-bio-tld {
-	padding: 60px 0 0;
 	box-sizing: border-box;
-
-	&.courses {
-		padding: 0;
-	}
 
 	.flow-progress {
 		position: absolute;
@@ -124,10 +119,21 @@ button {
 		@include onboarding-block-margin;
 	}
 
-	&.site-picker,
-	&.new-or-existing-site,
-	&.launchpad {
-		padding: 0;
+	&.step-route {
+		padding: 60px 0 0;
+
+		// Launchpad has its own header
+		&.launchpad {
+			margin-top: -60px;
+		}
+
+		@include break-small {
+			&.courses,
+			&.site-picker,
+			&.new-or-existing-site {
+				margin-top: -60px;
+			}
+		}
 	}
 
 	/**

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -6,16 +6,21 @@
 // This is styling common parts of stepper page
 .launchpad {
 	.flow-progress,
+	.signup-header,
 	.step-container .step-container__header {
 		display: none;
 	}
 
 	.step-container {
 		background: #fdfdfd;
-		padding: 0;
+		padding: 0 0 60px;
 		margin: 0;
 		max-width: none;
 		min-height: 100vh;
+
+		@include break-large {
+			padding: 0;
+		}
 	}
 
 	.step-container__buttons {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/styles.scss
@@ -43,6 +43,10 @@
 .design-first,
 .assembler-first {
 	&.new-or-existing-site {
+		.step-container__header {
+			margin-top: 0;
+		}
+
 		.signup-header {
 			.wordpress-logo {
 				position: absolute;
@@ -56,10 +60,10 @@
 			.formatted-header__title {
 				font-size: rem(32px);
 				@include break-small {
-					font-size: rem(36px);
+					font-size: rem(44px);
 				}
 			}
-			margin-top: 72px;
+
 			@include break-small {
 				margin-top: 0;
 			}
@@ -69,26 +73,24 @@
 			display: flex;
 			flex-direction: column;
 			-webkit-box-align: center;
-			align-items: center;
+			align-items: flex-start;
 			-webkit-box-pack: center;
 			justify-content: center;
-			@include break-small {
-				margin-top: 0;
-				min-height: 100vh;
-			}
+			margin: 44px 20px 0;
+			box-sizing: content-box;
 
+			@include break-small {
+				min-height: 100vh;
+				align-items: center;
+				margin: 0 auto;
+			}
 
 			.step-container__content {
 				min-height: auto;
 				@media (max-width: $break-mobile ) {
 					width: 100%;
 				}
-				.select-items {
-					@media (max-width: $break-mobile ) {
-						margin-left: 20px;
-						margin-right: 20px;
-					}
-				}
+
 				.select-items__item {
 					.select-items__item-icon {
 						@media (min-width: $break-mobile ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker-list/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker-list/styles.scss
@@ -4,24 +4,28 @@
 
 .site-picker {
 	.step-container__header {
-		margin-top: 74px;
-	}
-	.step-container__content {
+		margin: 24px;
+
+		@include break-small {
+			margin-top: 74px;
+		}
+
 		.formatted-header {
 			.formatted-header__title {
 				font-size: rem(32px);
+				text-align: left;
 				@include break-small {
 					font-size: rem(44px);
+					text-align: center;
 				}
 			}
-			margin: 32px 24px 0 24px;
-			@include break-small {
-				margin-top: 72px;
-			}
 		}
+	}
 
+	.step-container__content {
 		.site-picker__container {
 			width: 100%;
+			height: calc(100vh - 240px);
 			display: flex;
 			justify-content: center;
 			@include break-small {
@@ -89,14 +93,6 @@
 }
 
 .start-writing.site-picker {
-	.formatted-header {
-		.formatted-header__title {
-			font-size: rem(32px);
-			@include break-small {
-				font-size: rem(36px);
-			}
-		}
-	}
 	.signup-header {
 		.wordpress-logo {
 			position: absolute;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker-list/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker-list/styles.scss
@@ -4,7 +4,7 @@
 
 .site-picker {
 	.step-container__header {
-		margin: 24px;
+		margin: 44px 24px 24px;
 
 		@include break-small {
 			margin-top: 74px;
@@ -25,7 +25,7 @@
 	.step-container__content {
 		.site-picker__container {
 			width: 100%;
-			height: calc(100vh - 240px);
+			max-height: calc(100vh - 240px);
 			display: flex;
 			justify-content: center;
 			@include break-small {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/83390

## Proposed Changes

* New or Existing: Update the mobile styles
* Site Picker: Make the scroll behavior inside the site list and update the mobile styles
* Launchpad: Fix the preview and navigation bar are overlapping on mobile

### Desktop

| Before | After |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/70e9818c-9532-4628-adbb-7c760301e1f2) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/73ef7089-c6aa-47ab-a665-3494358416d4) |

### Mobile

| Before | After |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/5fc998ed-671d-4555-8b51-573c7dfb4c0e) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/4329e463-decf-434f-8608-40eb9efffc9f) |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/6496a758-9ef6-4110-a7ff-7afd7092e116) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/1be797bd-b8af-411d-ac7c-695652e88f51) |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/010cdf31-cdce-41f9-b9fc-ab90b137e601) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/1aba2425-cf58-47fc-9788-9e53129a6c38) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/assembler-first`
* Ensure the styles on the “New or Existing site” step look good
* Pick the “Select a site” button
* Ensure the styles on the “Select a site” step look good
* Finish the Assembler First Flow
* When you land on the launchpad, ensure the styles look good

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?