### PR TITLE
Improve UI responsiveness for reader recommendations

### DIFF
--- a/client/blocks/reader-unsubscribed-feeds-search-list/reader-unsubscribed-feed-item.tsx
+++ b/client/blocks/reader-unsubscribed-feeds-search-list/reader-unsubscribed-feed-item.tsx
@@ -91,9 +91,14 @@ const ReaderUnsubscribedFeedItem = ( {
 					>
 						{ filteredDisplayUrl }
 					</ExternalLink>
+
+					<div className="reader-unsubscribed-feed-item__mobile-description" aria-hidden="true">
+						{ description }
+					</div>
 				</VStack>
 			</HStack>
 			<div className="reader-unsubscribed-feed-item__description">{ description }</div>
+
 			<div>
 				<Button
 					primary

--- a/client/blocks/reader-unsubscribed-feeds-search-list/style.scss
+++ b/client/blocks/reader-unsubscribed-feeds-search-list/style.scss
@@ -6,13 +6,24 @@
 	.reader-unsubscribed-feed-item {
 		@extend %site-subscriptions-list-site-row;
 
+
 		&__site-preview-h-stack {
 			flex: 1;
 			max-width: 250px;
+
+			@include breakpoint-deprecated( "<660px" ) {
+				align-items: flex-start;
+			}
 		}
 
 		&__title-with-url-v-stack {
 			flex: 1;
+		}
+
+		&__icon {
+			@include breakpoint-deprecated( "<660px" ) {
+				padding-top: 6px;
+			}
 		}
 
 		&__title {
@@ -23,6 +34,17 @@
 			@extend %site-subscriptions-list-site-url;
 		}
 
+		&__mobile-description {
+			@extend %site-subscriptions-list-default-text;
+			display: none;
+			margin-top: 4px;
+			margin-bottom: 4px;
+
+			@include breakpoint-deprecated( "<660px" ) {
+				display: block;
+			}
+		}
+
 		&__description {
 			@extend %site-subscriptions-list-default-text;
 			flex: 1;
@@ -30,6 +52,11 @@
 			overflow: hidden;
 			white-space: nowrap;
 			text-overflow: ellipsis;
+
+
+			@include breakpoint-deprecated( "<660px" ) {
+				display: none;
+			}
 		}
 	}
 }


### PR DESCRIPTION
> [!NOTE]
> This is a temporary fix. @crisbusquets will take a look at this soon and come up with something better. 

Related to https://github.com/Automattic/wp-calypso/issues/84900

## Proposed Changes

Changes the layout on mobile of the recommended sites when searching in Reader > Manage Subscriptions.

| Before | After |
|-|-|
| ![CleanShot 2023-12-06 at 09 38 37@2x](https://github.com/Automattic/wp-calypso/assets/528287/1009d1b4-ca0c-4d69-983e-4430f2b3b2a5) |  ![CleanShot 2023-12-06 at 09 38 11@2x](https://github.com/Automattic/wp-calypso/assets/528287/ac118fc5-788f-4ac7-8613-e9d7d07cfb10) |



## Testing Instructions

1. Apply this PR
2. Visit http://calypso.localhost:3000/read/subscriptions?s=lala
3. Change your viewport size to mobile
4. Behold better rendering

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?