### PR TITLE
Jetpack Manage: Rearrange product card content based on the new format.

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/license-multi-product-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-multi-product-card/index.tsx
@@ -161,6 +161,15 @@ export default function LicenseMultiProductCard( props: Props ) {
 									shouldShuffleAnswers={ false }
 								/>
 
+								<div className="license-product-card__pricing is-compact">
+									<ProductPriceWithDiscount
+										product={ product }
+										hideDiscount={ hideDiscount }
+										quantity={ quantity }
+										compact
+									/>
+								</div>
+
 								<div className="license-product-card__description">{ productDescription }</div>
 
 								{ ! /^jetpack-backup-addon-storage-/.test( product.slug ) && (
@@ -174,14 +183,6 @@ export default function LicenseMultiProductCard( props: Props ) {
 							<div className="license-product-card__select-button license-product-card_multi-select">
 								{ isSelected && <Gridicon icon="checkmark" /> }
 							</div>
-						</div>
-
-						<div className="license-product-card__pricing">
-							<ProductPriceWithDiscount
-								product={ product }
-								hideDiscount={ hideDiscount }
-								quantity={ quantity }
-							/>
 						</div>
 					</div>
 				</div>

--- a/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -103,6 +104,8 @@ export default function LicenseProductCard( props: Props ) {
 		setShowLightbox( false );
 	}, [ resetParams ] );
 
+	const isNewCardFormat = isEnabled( 'jetpack/bundle-licensing' );
+
 	return (
 		<>
 			<div
@@ -125,6 +128,17 @@ export default function LicenseProductCard( props: Props ) {
 							<div className="license-product-card__heading">
 								<h3 className="license-product-card__title">{ productTitle }</h3>
 
+								{ isNewCardFormat && (
+									<div className="license-product-card__pricing is-compact">
+										<ProductPriceWithDiscount
+											product={ product }
+											hideDiscount={ hideDiscount }
+											quantity={ quantity }
+											compact
+										/>
+									</div>
+								) }
+
 								<div className="license-product-card__description">{ productDescription }</div>
 
 								{ ! /^jetpack-backup-addon-storage-/.test( product.slug ) && (
@@ -141,13 +155,15 @@ export default function LicenseProductCard( props: Props ) {
 							</div>
 						</div>
 
-						<div className="license-product-card__pricing">
-							<ProductPriceWithDiscount
-								product={ product }
-								hideDiscount={ hideDiscount }
-								quantity={ quantity }
-							/>
-						</div>
+						{ ! isNewCardFormat && (
+							<div className="license-product-card__pricing">
+								<ProductPriceWithDiscount
+									product={ product }
+									hideDiscount={ hideDiscount }
+									quantity={ quantity }
+								/>
+							</div>
+						) }
 					</div>
 				</div>
 			</div>

--- a/client/jetpack-cloud/sections/partner-portal/license-product-card/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-product-card/style.scss
@@ -211,7 +211,7 @@
 	text-align: right;
 }
 
-.license-product-card__pricing {
+.license-product-card__pricing:not(.is-compact) {
 	white-space: nowrap;
 	@include license-product-card-block__pricing;
 
@@ -232,6 +232,10 @@
 	}
 }
 
+.license-product-card__pricing.is-compact {
+	margin: 1rem 0 0;
+}
+
 .license-product-card--with-background {
 	.license-product-card__inner {
 		background-image: url(./gradient.svg);
@@ -241,7 +245,7 @@
 
 .license-product-card .multiple-choice-question {
 	margin-block-start: 16px;
-	margin-block-end: 8px;
+	margin-block-end: 0;
 
 	.form-legend {
 		display: none;
@@ -250,6 +254,10 @@
 	.multiple-choice-question__answers {
 		display: flex;
 		gap: 36px;
+	}
+
+	.multiple-choice-question__answer-item-content {
+		margin: 0;
 	}
 
 	.form-label {

--- a/client/jetpack-cloud/sections/partner-portal/primary/product-price-with-discount-info/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/product-price-with-discount-info/index.tsx
@@ -1,4 +1,5 @@
 import formatCurrency from '@automattic/format-currency';
+import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'calypso/state';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
@@ -11,9 +12,15 @@ interface Props {
 	product: APIProductFamilyProduct;
 	hideDiscount?: boolean;
 	quantity?: number;
+	compact?: boolean;
 }
 
-export default function ProductPriceWithDiscount( { product, hideDiscount, quantity = 1 }: Props ) {
+export default function ProductPriceWithDiscount( {
+	product,
+	hideDiscount,
+	quantity = 1,
+	compact,
+}: Props ) {
 	const translate = useTranslate();
 
 	const userProducts = useSelector( ( state ) => getProductsList( state ) );
@@ -27,12 +34,20 @@ export default function ProductPriceWithDiscount( { product, hideDiscount, quant
 
 	return (
 		<div>
-			<div className="product-price-with-discount__price">
+			<div
+				className={ classNames( 'product-price-with-discount__price', { 'is-compact': compact } ) }
+			>
 				{ formatCurrency( discountedCost, product.currency ) }
 				{
 					// Display discount info only if there is a discount
 					discountPercentage > 0 && ! hideDiscount && (
 						<>
+							{ compact && (
+								<span className="product-price-with-discount__price-old">
+									{ formatCurrency( actualCost, product.currency ) }
+								</span>
+							) }
+
 							<span className="product-price-with-discount__price-discount">
 								{ translate( 'Save %(discountPercentage)s%', {
 									args: {
@@ -40,11 +55,14 @@ export default function ProductPriceWithDiscount( { product, hideDiscount, quant
 									},
 								} ) }
 							</span>
-							<div>
-								<span className="product-price-with-discount__price-old">
-									{ formatCurrency( actualCost, product.currency ) }
-								</span>
-							</div>
+
+							{ ! compact && (
+								<div>
+									<span className="product-price-with-discount__price-old">
+										{ formatCurrency( actualCost, product.currency ) }
+									</span>
+								</div>
+							) }
 						</>
 					)
 				}

--- a/client/jetpack-cloud/sections/partner-portal/primary/product-price-with-discount-info/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/primary/product-price-with-discount-info/style.scss
@@ -11,6 +11,7 @@
 		text-decoration: line-through;
 		font-weight: 400;
 		font-size: 1rem;
+		text-wrap: nowrap;
 	}
 
 	.product-price-with-discount__price-discount {
@@ -18,6 +19,7 @@
 		font-size: 1rem;
 		font-weight: 500;
 		color: var(--studio-jetpack-green-50);
+		text-wrap: nowrap;
 	}
 
 	@include break-xlarge {
@@ -32,4 +34,8 @@
 	font-weight: 400;
 	color: var(--studio-gray-60);
 	line-height: 2;
+}
+
+.product-price-with-discount__price.is-compact .product-price-with-discount__price-old {
+	margin-inline-start: 8px;
 }


### PR DESCRIPTION
This pull request aims to update the format of the product card in accordance with the new design.

<img width="1104" alt="Screen Shot 2023-12-06 at 5 04 18 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/843438fe-1bfa-4c55-b965-0a3370996c0b">

<img width="1125" alt="Screen Shot 2023-12-06 at 5 01 20 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/b741b7bc-e280-407f-8a6e-0a373585c877">


Closes https://github.com/Automattic/jetpack-genesis/issues/133
Closes https://github.com/Automattic/jetpack-manage/issues/153

## Proposed Changes

* Update the Product card component to follow the new design. Add feature flag checking before rendering the new format.

## Testing Instructions
Before testing, you must switch the billing scheme in your sandbox using the following command 32b1d-pb to load the complete bundle list.

* Visit the Jetpack Cloud link with `/partner-portal/issue-license?flags=jetpack/bundle-licensing`
* Confirm that the product cards are rendered in the correct format.
* Additionally, test if the product cards without the feature flag still work exactly the same. `/partner-portal/issue-license`

**_Please note that if you wish to test the Multi-variant product card (Security and Backup), you will need to switch to the default billing scheme first. This is necessary in order to load the 1TB variant options. If you do not switch to the default billing scheme, you will only be able to see a single product card for Security and Backup as the 784 billing scheme does not have the complete product list. To reset your billing scheme in your sandbox, please use the following command: 32c12-pb._**

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?