### PR TITLE
Stepper flows: add missing translations to titles

### DIFF
--- a/client/landing/stepper/declarative-flow/blog.ts
+++ b/client/landing/stepper/declarative-flow/blog.ts
@@ -48,6 +48,7 @@ const Blog: Flow = {
 			variationName: 'blogger-intent',
 			redirectTo: `/setup/blog`,
 			locale,
+			pageTitle: translate( 'Blog' ),
 		} );
 
 		// Despite sending a CHECKING state, this function gets called again with the

--- a/client/landing/stepper/declarative-flow/build.ts
+++ b/client/landing/stepper/declarative-flow/build.ts
@@ -1,6 +1,5 @@
 import { BUILD_FLOW } from '@automattic/onboarding';
 import { addQueryArgs } from '@wordpress/url';
-import { translate } from 'i18n-calypso';
 import { skipLaunchpad } from 'calypso/landing/stepper/utils/skip-launchpad';
 import wpcom from 'calypso/lib/wp';
 import { useSiteIdParam } from '../hooks/use-site-id-param';
@@ -13,7 +12,7 @@ import { Flow, ProvidedDependencies } from './internals/types';
 const build: Flow = {
 	name: BUILD_FLOW,
 	get title() {
-		return translate( 'WordPress' );
+		return 'WordPress';
 	},
 	useSteps() {
 		return [

--- a/client/landing/stepper/declarative-flow/design-first.ts
+++ b/client/landing/stepper/declarative-flow/design-first.ts
@@ -261,7 +261,7 @@ const designFirst: Flow = {
 		const logInUrl = useLoginUrl( {
 			variationName: flowName,
 			redirectTo: window.location.href.replace( window.location.origin, '' ),
-			pageTitle: 'Pick a design',
+			pageTitle: translate( 'Pick a design' ),
 			locale,
 		} );
 

--- a/client/landing/stepper/declarative-flow/domain-user-transfer.ts
+++ b/client/landing/stepper/declarative-flow/domain-user-transfer.ts
@@ -1,5 +1,6 @@
 import { useLocale } from '@automattic/i18n-utils';
 import { useEffect } from '@wordpress/element';
+import { translate } from 'i18n-calypso';
 import { getLocaleFromPathname } from 'calypso/boot/locale';
 import { recordSubmitStep } from 'calypso/landing/stepper/declarative-flow/internals/analytics/record-submit-step';
 import { redirect } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/import/util';
@@ -65,7 +66,7 @@ const domainUserTransfer: Flow = {
 		const logInUrl = useLoginUrl( {
 			variationName: flowName,
 			redirectTo: `/setup/${ flowName }?domain=${ domain }`,
-			pageTitle: 'Receive domain',
+			pageTitle: translate( 'Receive domain' ),
 			locale,
 		} );
 

--- a/client/landing/stepper/declarative-flow/link-in-bio-domain.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio-domain.ts
@@ -91,7 +91,7 @@ const linkInBioDomain: Flow = {
 		const logInUrl = useLoginUrl( {
 			variationName: variantSlug,
 			redirectTo: redirectTo,
-			pageTitle: 'Link in Bio',
+			pageTitle: translate( 'Link in Bio' ),
 		} );
 
 		const submit = ( providedDependencies: ProvidedDependencies = {} ) => {

--- a/client/landing/stepper/declarative-flow/link-in-bio-tld.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio-tld.ts
@@ -66,7 +66,7 @@ const linkInBio: Flow = {
 		const logInUrl = useLoginUrl( {
 			variationName: flowName,
 			redirectTo: `/setup/${ flowName }/patterns`,
-			pageTitle: 'Link in Bio',
+			pageTitle: translate( 'Link in Bio' ),
 		} );
 
 		const submit = ( providedDependencies: ProvidedDependencies = {} ) => {

--- a/client/landing/stepper/declarative-flow/link-in-bio.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio.ts
@@ -83,7 +83,7 @@ const linkInBio: Flow = {
 		const logInUrl = useLoginUrl( {
 			variationName: flowName,
 			redirectTo: `/setup/${ flowName }/patterns`,
-			pageTitle: 'Link in Bio',
+			pageTitle: translate( 'Link in Bio' ),
 		} );
 
 		const submit = ( providedDependencies: ProvidedDependencies = {} ) => {

--- a/client/landing/stepper/declarative-flow/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/newsletter.ts
@@ -88,7 +88,7 @@ const newsletter: Flow = {
 		const logInUrl = useLoginUrl( {
 			variationName: flowName,
 			redirectTo: `/setup/${ flowName }/newsletterSetup`,
-			pageTitle: 'Newsletter',
+			pageTitle: translate( 'Newsletter' ),
 		} );
 
 		const completeSubscribersTask = async () => {

--- a/client/landing/stepper/declarative-flow/podcasts.ts
+++ b/client/landing/stepper/declarative-flow/podcasts.ts
@@ -1,3 +1,4 @@
+import { translate } from 'i18n-calypso';
 import { useSiteIdParam } from '../hooks/use-site-id-param';
 import { useSiteSlug } from '../hooks/use-site-slug';
 import ChooseADomain from './internals/steps-repository/choose-a-domain';
@@ -6,6 +7,9 @@ import type { Flow, ProvidedDependencies } from './internals/types';
 
 const podcasts: Flow = {
 	name: 'podcasts',
+	get title() {
+		return translate( 'Podcasting' );
+	},
 	useSteps() {
 		return [
 			{ slug: 'letsGetStarted', component: LetsGetStarted },

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -3,6 +3,7 @@ import { useLocale } from '@automattic/i18n-utils';
 import { START_WRITING_FLOW } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
+import { translate } from 'i18n-calypso';
 import { getLocaleFromQueryParam, getLocaleFromPathname } from 'calypso/boot/locale';
 import { recordSubmitStep } from 'calypso/landing/stepper/declarative-flow/internals/analytics/record-submit-step';
 import { redirect } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/import/util';
@@ -21,7 +22,9 @@ import { useLoginUrl } from '../utils/path';
 
 const startWriting: Flow = {
 	name: START_WRITING_FLOW,
-	title: 'Blog',
+	get title() {
+		return translate( 'Blog' );
+	},
 	useSteps() {
 		return [
 			{
@@ -243,7 +246,7 @@ const startWriting: Flow = {
 		const logInUrl = useLoginUrl( {
 			variationName: flowName,
 			redirectTo: `/setup/${ flowName }`,
-			pageTitle: 'Start writing',
+			pageTitle: translate( 'Start writing' ),
 			locale,
 		} );
 		// Despite sending a CHECKING state, this function gets called again with the


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

* Adds missing translations to titles in various flows:

![image](https://github.com/Automattic/wp-calypso/assets/87168/423c4b61-79db-4de0-a406-33b1fe34faa7)

The signup step doesn't show anymore the heading even when passed via URL, but that's a separate issue. Brought up with Vertex at p1701855368939879-slack-C02T4NVL4JJ

![image](https://github.com/Automattic/wp-calypso/assets/87168/e88766d7-33d9-4c03-b11e-c9141e30bd38)


## Testing Instructions

* Go through variuous flows under `/setup/*`  (TODO, list exact test flow URLs)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?