### PR TITLE
Gained more space in subscription page in mobile

### DIFF
--- a/client/blocks/reader-unsubscribed-feeds-search-list/reader-unsubscribed-feed-item.tsx
+++ b/client/blocks/reader-unsubscribed-feeds-search-list/reader-unsubscribed-feed-item.tsx
@@ -1,4 +1,5 @@
-import { Button } from '@automattic/components';
+import { Button, Gridicon } from '@automattic/components';
+import { isMobile } from '@automattic/viewport';
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
@@ -106,15 +107,19 @@ const ReaderUnsubscribedFeedItem = ( {
 					busy={ isSubscribing }
 					onClick={ onSubscribeClick }
 				>
-					{ hasSubscribed
-						? translate( 'Subscribed', {
-								comment:
-									'The user just subscribed to the site that the button relates to, and so the button is in disabled state.',
-						  } )
-						: translate( 'Subscribe', {
-								comment:
-									'Describes an action to be done on the click of the button, i.e. subscribe to the site that this button relates to.',
-						  } ) }
+					{ isMobile() && (
+						<Gridicon className="subscriptions-add-sites__button-icon" icon="plus" size={ 24 } />
+					) }
+					{ ! isMobile() &&
+						( hasSubscribed
+							? translate( 'Subscribed', {
+									comment:
+										'The user just subscribed to the site that the button relates to, and so the button is in disabled state.',
+							  } )
+							: translate( 'Subscribe', {
+									comment:
+										'Describes an action to be done on the click of the button, i.e. subscribe to the site that this button relates to.',
+							  } ) ) }
 				</Button>
 			</div>
 		</HStack>


### PR DESCRIPTION
> [!NOTE]  
> This is a temporal fix while we have a better design from @crisbusquets 

Relates to https://github.com/Automattic/wp-calypso/issues/84900

## Proposed Changes

This PR changes the `Subscribe` button for a `+` button in the subscriptions page on mobile. This way we have more space for the title and description of the sites in the list.
<img width="388" alt="Screenshot 2023-12-06 at 11 16 50" src="https://github.com/Automattic/wp-calypso/assets/3832570/173b0333-d928-41ac-b044-997ed5a70fdf">

The desktop view keeps the same style:
<img width="1462" alt="Screenshot 2023-12-06 at 11 17 50" src="https://github.com/Automattic/wp-calypso/assets/3832570/bb00cf25-ce92-4cb7-8ecc-a06b02d50fec">

## Testing Instructions

- Apply this PR and start the application
- Visit http://calypso.localhost:3000/read/subscriptions?s=rpg
- Change your viewport size to mobile
- Refresh again (the mobile check is done not on resize but on load of the page, which for mobile is ok).
- You should see `+` buttons instead of the `Subscribe` buttons.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?