### PR TITLE
Fix empty Nav in Reader > Manage Subscriptions

### DIFF
--- a/client/reader/site-subscriptions-manager/subscriptions-manager-wrapper.tsx
+++ b/client/reader/site-subscriptions-manager/subscriptions-manager-wrapper.tsx
@@ -1,7 +1,7 @@
 import page from '@automattic/calypso-router';
 import { SubscriptionManager } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
@@ -62,6 +62,17 @@ const SubscriptionsManagerWrapper = ( {
 	// sync its subscriptions state with the reader redux store.
 	useMarkFollowsAsStaleOnUnmount();
 
+	const selectedTabText = useMemo( () => {
+		switch ( selectedTab ) {
+			case 'comments':
+				return translate( 'Comments' );
+			case 'pending':
+				return translate( 'Pending' );
+			default:
+				return translate( 'Sites' );
+		}
+	}, [ selectedTab ] );
+
 	return (
 		<SubscriptionManagerContextProvider portal={ SubscriptionsPortal.Reader }>
 			<Main className="site-subscriptions-manager">
@@ -90,19 +101,19 @@ const SubscriptionsManagerWrapper = ( {
 					) }
 				</NavigationHeader>
 
-				<Nav className="site-subscriptions-manager__nav">
+				<Nav className="site-subscriptions-manager__nav" selectedText={ selectedTabText }>
 					<NavTabs>
 						<NavItem
 							count={ counts?.blogs }
 							selected={ selectedTab === 'sites' }
-							onClick={ () => page( '/read/subscriptions' ) }
+							path="/read/subscriptions"
 						>
 							{ translate( 'Sites' ) }
 						</NavItem>
 						<NavItem
 							count={ counts?.comments }
 							selected={ selectedTab === 'comments' }
-							onClick={ () => page( '/read/subscriptions/comments' ) }
+							path="/read/subscriptions/comments"
 						>
 							{ translate( 'Comments' ) }
 						</NavItem>
@@ -110,7 +121,7 @@ const SubscriptionsManagerWrapper = ( {
 							<NavItem
 								count={ counts?.pending }
 								selected={ selectedTab === 'pending' }
-								onClick={ () => page( '/read/subscriptions/pending' ) }
+								path="/read/subscriptions/pending"
 							>
 								{ translate( 'Pending' ) }
 							</NavItem>


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the Dlinked issue.
-->

Related to #

## Proposed Changes

- Sets the selectedText prop, showing the selected tab on mobile
- Instead of using an 'onClick' event, a 'path' prop is introduced. This simplifies the navigation solution.

| Before | After |
|-|-|
| ![CleanShot 2023-12-06 at 11 37 58@2x](https://github.com/Automattic/wp-calypso/assets/528287/08a264e4-6e0c-4896-a1f3-a503fd96ecd7) |  ![CleanShot 2023-12-06 at 11 35 45@2x](https://github.com/Automattic/wp-calypso/assets/528287/7dbed862-03ae-4759-9396-05e47e3d52fb) |



## Testing Instructions

- Apply this PR
- Visit http://calypso.localhost:3000/read/subscriptions
- Resize your viewport to mobile size
- Ensure that the label is now rendered correctly in the SectionNav
- Click on each tab, it should take you to the correct screen


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?