### PR TITLE
Plans 2023: Fixes to header-price alignments. Intro offers accounted

### DIFF
--- a/client/my-sites/plans-grid/components/header-price.tsx
+++ b/client/my-sites/plans-grid/components/header-price.tsx
@@ -143,18 +143,23 @@ const PlanFeatures2023GridHeaderPrice = ( {
 		current,
 		pricing: { currencyCode, originalPrice, discountedPrice, introOffer },
 	} = gridPlansIndex[ planSlug ];
+	const isPricedPlan = null !== originalPrice.monthly;
+
 	const isGridPlanDiscounted = Boolean( discountedPrice.monthly );
 	const isAnyVisibleGridPlanDiscounted = visibleGridPlans.some(
 		( { pricing } ) => pricing.discountedPrice.monthly
 	);
-	const isPricedPlan = null !== originalPrice.monthly;
-	const shouldShowIntroPricing = introOffer && ! introOffer.isOfferComplete;
+
+	const isGridPlanOnIntroOffer = introOffer && ! introOffer.isOfferComplete;
+	const isAnyVisibleGridPlanOnIntroOffer = visibleGridPlans.some(
+		( { pricing } ) => pricing.introOffer && ! pricing.introOffer.isOfferComplete
+	);
 
 	if ( isWpcomEnterpriseGridPlan( planSlug ) || ! isPricedPlan ) {
 		return null;
 	}
 
-	if ( shouldShowIntroPricing ) {
+	if ( isGridPlanOnIntroOffer ) {
 		return (
 			<HeaderPriceContainer>
 				{ ! current && (
@@ -162,40 +167,95 @@ const PlanFeatures2023GridHeaderPrice = ( {
 						{ translate( 'Limited Time Offer' ) }
 					</Badge>
 				) }
-				<PlanPrice
-					currencyCode={ currencyCode }
-					rawPrice={ introOffer.rawPrice }
-					displayPerMonthNotation={ false }
-					isLargeCurrency={ isLargeCurrency }
-					isSmallestUnit={ false }
-					priceDisplayWrapperClassName="plans-grid-2023__html-price-display-wrapper"
-				/>
-			</HeaderPriceContainer>
-		);
-	}
-
-	return (
-		<HeaderPriceContainer>
-			{ isGridPlanDiscounted ? (
-				<>
-					<Badge className="plan-features-2023-grid__badge">
-						{ isPlanUpgradeCreditEligible
-							? translate( 'Credit applied' )
-							: translate( 'One time discount' ) }
-					</Badge>
+				{ isLargeCurrency ? (
 					<PricesGroup isLargeCurrency={ isLargeCurrency }>
 						<PlanPrice
 							currencyCode={ currencyCode }
-							rawPrice={ originalPrice.monthly }
+							rawPrice={ 0 }
 							displayPerMonthNotation={ false }
 							isLargeCurrency={ isLargeCurrency }
 							isSmallestUnit={ true }
 							priceDisplayWrapperClassName="plans-grid-2023__html-price-display-wrapper"
+							className="is-placeholder-price" // This is a placeholder price to keep the layout consistent
 							original
 						/>
 						<PlanPrice
 							currencyCode={ currencyCode }
-							rawPrice={ discountedPrice.monthly }
+							rawPrice={ introOffer.rawPrice }
+							displayPerMonthNotation={ false }
+							isLargeCurrency={ isLargeCurrency }
+							isSmallestUnit={ false }
+							priceDisplayWrapperClassName="plans-grid-2023__html-price-display-wrapper"
+							discounted
+						/>
+					</PricesGroup>
+				) : (
+					<PlanPrice
+						currencyCode={ currencyCode }
+						rawPrice={ introOffer.rawPrice }
+						displayPerMonthNotation={ false }
+						isLargeCurrency={ isLargeCurrency }
+						isSmallestUnit={ false }
+						priceDisplayWrapperClassName="plans-grid-2023__html-price-display-wrapper"
+					/>
+				) }
+			</HeaderPriceContainer>
+		);
+	}
+
+	if ( isGridPlanDiscounted ) {
+		return (
+			<HeaderPriceContainer>
+				<Badge className="plan-features-2023-grid__badge">
+					{ isPlanUpgradeCreditEligible
+						? translate( 'Credit applied' )
+						: translate( 'One time discount' ) }
+				</Badge>
+				<PricesGroup isLargeCurrency={ isLargeCurrency }>
+					<PlanPrice
+						currencyCode={ currencyCode }
+						rawPrice={ originalPrice.monthly }
+						displayPerMonthNotation={ false }
+						isLargeCurrency={ isLargeCurrency }
+						isSmallestUnit={ true }
+						priceDisplayWrapperClassName="plans-grid-2023__html-price-display-wrapper"
+						original
+					/>
+					<PlanPrice
+						currencyCode={ currencyCode }
+						rawPrice={ discountedPrice.monthly }
+						displayPerMonthNotation={ false }
+						isLargeCurrency={ isLargeCurrency }
+						isSmallestUnit={ true }
+						priceDisplayWrapperClassName="plans-grid-2023__html-price-display-wrapper"
+						discounted
+					/>
+				</PricesGroup>
+			</HeaderPriceContainer>
+		);
+	}
+
+	if ( isAnyVisibleGridPlanDiscounted || isAnyVisibleGridPlanOnIntroOffer ) {
+		return (
+			<HeaderPriceContainer>
+				<Badge className="plan-features-2023-grid__badge" isHidden={ true }>
+					' '
+				</Badge>
+				{ isLargeCurrency ? (
+					<PricesGroup isLargeCurrency={ isLargeCurrency }>
+						<PlanPrice
+							currencyCode={ currencyCode }
+							rawPrice={ 0 }
+							displayPerMonthNotation={ false }
+							isLargeCurrency={ isLargeCurrency }
+							isSmallestUnit={ true }
+							priceDisplayWrapperClassName="plans-grid-2023__html-price-display-wrapper"
+							className="is-placeholder-price" // This is a placeholder price to keep the layout consistent
+							original
+						/>
+						<PlanPrice
+							currencyCode={ currencyCode }
+							rawPrice={ originalPrice.monthly }
 							displayPerMonthNotation={ false }
 							isLargeCurrency={ isLargeCurrency }
 							isSmallestUnit={ true }
@@ -203,46 +263,30 @@ const PlanFeatures2023GridHeaderPrice = ( {
 							discounted
 						/>
 					</PricesGroup>
-				</>
-			) : (
-				<>
-					{ isAnyVisibleGridPlanDiscounted && (
-						<Badge className="plan-features-2023-grid__badge" isHidden={ true }></Badge>
-					) }
-					{ isLargeCurrency && isAnyVisibleGridPlanDiscounted ? (
-						<PricesGroup isLargeCurrency={ isLargeCurrency }>
-							<PlanPrice
-								currencyCode={ currencyCode }
-								rawPrice={ 0 }
-								displayPerMonthNotation={ false }
-								isLargeCurrency={ isLargeCurrency }
-								isSmallestUnit={ true }
-								priceDisplayWrapperClassName="plans-grid-2023__html-price-display-wrapper"
-								className="is-placeholder-price"
-								original
-							/>
-							<PlanPrice
-								currencyCode={ currencyCode }
-								rawPrice={ originalPrice.monthly }
-								displayPerMonthNotation={ false }
-								isLargeCurrency={ isLargeCurrency }
-								isSmallestUnit={ true }
-								priceDisplayWrapperClassName="plans-grid-2023__html-price-display-wrapper"
-								discounted
-							/>
-						</PricesGroup>
-					) : (
-						<PlanPrice
-							currencyCode={ currencyCode }
-							rawPrice={ originalPrice.monthly }
-							displayPerMonthNotation={ false }
-							isLargeCurrency={ isLargeCurrency }
-							isSmallestUnit={ true }
-							priceDisplayWrapperClassName="plans-grid-2023__html-price-display-wrapper"
-						/>
-					) }
-				</>
-			) }
+				) : (
+					<PlanPrice
+						currencyCode={ currencyCode }
+						rawPrice={ originalPrice.monthly }
+						displayPerMonthNotation={ false }
+						isLargeCurrency={ isLargeCurrency }
+						isSmallestUnit={ true }
+						priceDisplayWrapperClassName="plans-grid-2023__html-price-display-wrapper"
+					/>
+				) }
+			</HeaderPriceContainer>
+		);
+	}
+
+	return (
+		<HeaderPriceContainer>
+			<PlanPrice
+				currencyCode={ currencyCode }
+				rawPrice={ originalPrice.monthly }
+				displayPerMonthNotation={ false }
+				isLargeCurrency={ isLargeCurrency }
+				isSmallestUnit={ true }
+				priceDisplayWrapperClassName="plans-grid-2023__html-price-display-wrapper"
+			/>
 		</HeaderPriceContainer>
 	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4570

## Proposed Changes

- Fixes a couple of existing and intro-offer-related misalignments in header price. 
- Intro offers have to interplay with the existing setup of prices and badges, where things are aligned via placeholder prices and badges when not present.

## Media

### Intro offer badge and plain/non-discounted prices for the rest

**Before**

<img width="700" alt="Screenshot 2023-12-05 at 6 03 21 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/57f2de88-a4ec-405f-bbc6-dfe77cef1ea6">

**After** 

<img width="700" alt="Screenshot 2023-12-05 at 6 03 21 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/7849dbdf-caa3-4bf6-b1a9-cb23241d8082">


### Intro offer badge and discounted prices in others

**Before**

<img width="700" alt="Screenshot 2023-12-05 at 6 24 59 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/b1ed382c-c3fb-4009-82d0-4675c592332c">

**After** 

<img width="700" alt="Screenshot 2023-12-05 at 6 31 42 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/6170dc82-09c5-4b65-890d-7ef1b133a799">


### In prod - prices aligned better

**Before**

<img width="700" alt="Screenshot 2023-12-06 at 12 27 00 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/0ce63a7e-f049-4a5c-a371-f146c8123232">


**After** 

<img width="700" alt="Screenshot 2023-12-06 at 12 26 11 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/3a0418c7-3845-44b4-b8d1-827924814902">

 
## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check `/plans/[site]` and `/start/plans`:
    * paid plan to force a prorated prices display
    * INR to force large currency display
* To test intro offers:
    * Apply D130783-code on sandbox and follow instructions to get intro offers served on `/plans/[site]` page
    * Set USD as currency in SA
    * Confirm intro offer price & badge are aligned correctly, as per media above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?