### PR TITLE
Launchpad: Disable the Plan task only when the task is completed and the site has a paid plan

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -2,6 +2,8 @@ import {
 	FEATURE_VIDEO_UPLOADS,
 	planHasFeature,
 	FEATURE_STYLE_CUSTOMIZATION,
+	getPlans,
+	isFreePlanProduct,
 } from '@automattic/calypso-products';
 import {
 	updateLaunchpadSettings,
@@ -26,7 +28,6 @@ import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
 import { Dispatch, SetStateAction } from 'react';
-import { PLANS_LIST } from 'calypso/../packages/calypso-products/src/plans-list';
 import { NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { ADD_TIER_PLAN_HASH } from 'calypso/my-sites/earn/memberships/constants';
@@ -35,6 +36,8 @@ import { ONBOARD_STORE, SITE_STORE } from '../../../../stores';
 import { goToCheckout } from '../../../../utils/checkout';
 import { launchpadFlowTasks } from './tasks';
 import { LaunchpadChecklist, LaunchpadStatuses, Task } from './types';
+
+const PLANS_LIST = getPlans();
 
 /**
  * Some attributes of these enhanced tasks will soon be fetched through a WordPress REST
@@ -69,10 +72,9 @@ export function getEnhancedTasks(
 
 	const enhancedTaskList: Task[] = [];
 
-	const productSlug =
-		( isBlogOnboardingFlow( flow ) || isSiteAssemblerFlow( flow )
-			? planCartItem?.product_slug
-			: null ) ?? site?.plan?.product_slug;
+	const isCurrentPlanFree = site?.plan ? isFreePlanProduct( site?.plan ) : true;
+
+	const productSlug = planCartItem?.product_slug ?? site?.plan?.product_slug;
 
 	const translatedPlanName = ( productSlug && PLANS_LIST[ productSlug ]?.getTitle() ) || '';
 
@@ -134,6 +136,36 @@ export function getEnhancedTasks(
 		[ planCartItem, domainCartItem, ...( productCartItems ?? [] ) ].filter(
 			Boolean
 		) as MinimalRequestCartProduct[];
+
+	const getPlanTaskSubtitle = ( task: Task ) => {
+		if ( ! displayGlobalStylesWarning ) {
+			return task.subtitle;
+		}
+
+		const removeCustomStyles = translate( 'Or, {{a}}remove your premium styles{{/a}}.', {
+			components: {
+				a: (
+					<ExternalLink
+						children={ null }
+						href={ localizeUrl( 'https://wordpress.com/support/using-styles/#reset-all-styles' ) }
+						onClick={ ( event ) => {
+							event.stopPropagation();
+							recordTracksEvent(
+								'calypso_launchpad_global_styles_gating_plan_selected_reset_styles',
+								{ flow }
+							);
+						} }
+					/>
+				),
+			},
+		} );
+
+		return (
+			<>
+				{ task.subtitle }&nbsp;{ removeCustomStyles }
+			</>
+		);
+	};
 
 	const getLaunchSiteTaskTitle = ( task: Task ) => {
 		const onboardingCartItems = getOnboardingCartItems();
@@ -286,39 +318,11 @@ export function getEnhancedTasks(
 					};
 
 					const completed = task.completed && ! isVideoPressFlowWithUnsupportedPlan;
-					let subtitle = task.subtitle;
-
-					if ( displayGlobalStylesWarning ) {
-						const removeCustomStyles = translate( 'Or, {{a}}remove your premium styles{{/a}}.', {
-							components: {
-								a: (
-									<ExternalLink
-										children={ null }
-										href={ localizeUrl(
-											'https://wordpress.com/support/using-styles/#reset-all-styles'
-										) }
-										onClick={ ( event ) => {
-											event.stopPropagation();
-											recordTracksEvent(
-												'calypso_launchpad_global_styles_gating_plan_selected_reset_styles',
-												{ flow }
-											);
-										} }
-									/>
-								),
-							},
-						} );
-						subtitle = (
-							<>
-								{ subtitle }&nbsp;{ removeCustomStyles }
-							</>
-						);
-					}
 
 					taskData = {
 						actionDispatch: openPlansPage,
 						completed,
-						subtitle,
+						subtitle: getPlanTaskSubtitle( task ),
 					};
 					/* eslint-enable no-case-declarations */
 					break;
@@ -332,11 +336,9 @@ export function getEnhancedTasks(
 
 							window.location.assign( plansUrl );
 						},
-						badge_text: ! task.completed ? null : translatedPlanName,
-						disabled:
-							( task.completed || ! domainUpsellCompleted ) &&
-							! isBlogOnboardingFlow( flow ) &&
-							! isSiteAssemblerFlow( flow ),
+						badge_text: task.completed ? translatedPlanName : task.badge_text,
+						subtitle: getPlanTaskSubtitle( task ),
+						disabled: task.completed && ! isCurrentPlanFree,
 					};
 					break;
 				case 'subscribers_added':


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/83390

## Proposed Changes

* Disable the Plan task only when the task is completed and fix/assembler-first-plan-task-not-clickable

| The Plan task is clickable if the current plan is free | The Plan task is not clickable if the current plan is a paid plan |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/32391ae4-811f-44cf-9074-197ef2e3886f) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/0b63ccbd-3881-467f-bfcc-a27b2207efd8) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply https://github.com/Automattic/jetpack/pull/34480 to your sandbox
* Go to /setup/assembler-first to create a new site
* On the Assembler step
  * Select any patterns
  * Select any styles
  * Upgrade to the Premium plan immediately or decide later
  * Finish the Assembler step
* Go to the launchpad, /setup/assembler-first/launchpad?siteSlug=<your_site>
* If you upgraded to the Premium plan on the Assembler step, the Plan task should be disabled
* If you didn't upgrade to the Premium plan, the Plan task should be clickable no matter whether the task is completed or not

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?