### PR TITLE
Import flow: Update DropFile component styles and content

### DIFF
--- a/client/blocks/importer/components/importer-drag/config.tsx
+++ b/client/blocks/importer/components/importer-drag/config.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { translate, TranslateOptions, TranslateOptionsText } from 'i18n-calypso';
 import React from 'react';
 import { convertPlatformName } from 'calypso/blocks/import/util';
@@ -12,6 +13,13 @@ export function getImportDragConfig( importer: Importer, supportLinkModal?: bool
 		},
 		components: {
 			supportLink: <SupportLink importer={ importer } supportLinkModal={ supportLinkModal } />,
+			supportLinkAlt: (
+				<SupportLink
+					text={ translate( 'Learn how to export your content' ) }
+					importer={ importer }
+					supportLinkModal={ supportLinkModal }
+				/>
+			),
 		},
 	};
 	const translateConfig: { [ key: string ]: Partial< ImporterConfig > } = {
@@ -57,13 +65,19 @@ export function getImportDragConfig( importer: Importer, supportLinkModal?: bool
 				'Import posts, pages, and media from a supported %(importerName)s export file',
 				options
 			),
-			uploadDescription: translate(
-				'A %(importerName)s export is ' +
-					'an XML file with your page and post content, or a zip archive ' +
-					'containing several XML files. ' +
-					'{{supportLink/}}',
-				options
-			),
+			uploadDescription: isEnabled( 'importer/site-backups' )
+				? translate(
+						'We support: XML, ZIP, and TAR.GZ files from Playground exports ' +
+							'{{supportLinkAlt/}}',
+						options
+				  )
+				: translate(
+						'A %(importerName)s export is ' +
+							'an XML file with your page and post content, or a zip archive ' +
+							'containing several XML files. ' +
+							'{{supportLink/}}',
+						options
+				  ),
 		},
 	};
 	const importerData = importerConfig( {} )[ importer ];

--- a/client/blocks/importer/components/importer-drag/config.tsx
+++ b/client/blocks/importer/components/importer-drag/config.tsx
@@ -54,7 +54,7 @@ export function getImportDragConfig( importer: Importer, supportLinkModal?: bool
 		},
 		wordpress: {
 			description: translate(
-				'Import posts, pages, and media from your %(importerName)s export file.',
+				'Import posts, pages, and media from a supported %(importerName)s export file',
 				options
 			),
 			uploadDescription: translate(

--- a/client/blocks/importer/components/importer-drag/style.scss
+++ b/client/blocks/importer/components/importer-drag/style.scss
@@ -1,8 +1,4 @@
 .importer-drag {
-	.social-logo {
-		border-radius: 4px;
-	}
-
 	.import__heading {
 		margin-bottom: 3.25rem;
 
@@ -32,6 +28,18 @@
 
 			span {
 				text-decoration: underline;
+			}
+		}
+	}
+
+	.drop-zone {
+		&.is-active {
+			background: linear-gradient(0deg, var(--studio-gray-0), var(--studio-gray-0)), linear-gradient(0deg, var(--studio-gray-40), var(--studio-gray-40));
+			box-shadow: 0 3px 1px 0 rgba(0, 0, 0, 0.04), 0 3px 8px 0 rgba(0, 0, 0, 0.12);
+
+			.drop-zone__content-text {
+				font-weight: 400;
+				color: var(--studio-gray-70);
 			}
 		}
 	}

--- a/client/blocks/importer/components/importer-drag/style.scss
+++ b/client/blocks/importer/components/importer-drag/style.scss
@@ -27,7 +27,12 @@
 		}
 
 		p {
+			font-size: 0.875rem;
 			margin: 0.5rem 0 0;
+
+			span {
+				text-decoration: underline;
+			}
 		}
 	}
 

--- a/client/blocks/importer/components/support-link/index.tsx
+++ b/client/blocks/importer/components/support-link/index.tsx
@@ -4,11 +4,12 @@ import InlineSupportLink from 'calypso/components/inline-support-link';
 import type { Importer } from 'calypso/blocks/importer/types';
 
 interface Props {
+	text?: string;
 	importer: Importer;
 	supportLinkModal?: boolean;
 }
 const SupportLink: React.FunctionComponent< Props > = ( props ) => {
-	const { importer, supportLinkModal } = props;
+	const { text, importer, supportLinkModal } = props;
 
 	return (
 		<InlineSupportLink
@@ -16,7 +17,7 @@ const SupportLink: React.FunctionComponent< Props > = ( props ) => {
 			supportContext={ `importers-${ importer }` }
 			showSupportModal={ supportLinkModal }
 		>
-			{ translate( 'Need help exporting your content?' ) }
+			{ text || translate( 'Need help exporting your content?' ) }
 		</InlineSupportLink>
 	);
 };

--- a/client/blocks/importer/components/uploading-pane/uploading-pane.scss
+++ b/client/blocks/importer/components/uploading-pane/uploading-pane.scss
@@ -1,8 +1,8 @@
 .uploading-pane {
 	cursor: pointer;
 	position: relative;
-	height: 180px;
-	margin-bottom: 40px;
+	height: 200px;
+	margin-bottom: 1rem;
 
 	background-color: transparent;
 	border: 1px dashed var(--studio-gray-10);
@@ -70,9 +70,13 @@
 			content: "\A";
 		}
 
+		&:hover {
+			color: var(--studio-gray-100);
+		}
+
 		white-space: pre;
 		text-decoration: underline;
-		color: var(--studio-gray-100);
+		color: inherit;
 	}
 }
 

--- a/client/my-sites/importer/uploading-pane.jsx
+++ b/client/my-sites/importer/uploading-pane.jsx
@@ -79,7 +79,16 @@ export class UploadingPane extends PureComponent {
 				if ( this.state.fileToBeUploaded ) {
 					return <p>{ this.state?.fileToBeUploaded?.name?.substring?.( 0, 100 ) }</p>;
 				}
-				return <p>{ this.props.translate( 'Drag a file here, or click to upload a file' ) }</p>;
+				return (
+					<p>
+						{ this.props.translate(
+							'Drag a file here, or {{span}}click to upload a file{{/span}}',
+							{
+								components: { span: <span /> },
+							}
+						) }
+					</p>
+				);
 			case appStates.UPLOAD_PROCESSING:
 			case appStates.UPLOADING: {
 				const uploadPercent = percentComplete;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/84915
Closes https://github.com/Automattic/wp-calypso/issues/84916

## Proposed Changes

* Updated Drop component matching the Figma design (more details in related ticket)


## Testing Instructions

- Go to `/setup/import-focused?siteSlug={SIMPLE_SITE}`
- Click on the link `choose a content platform`
- Select the "WordPress" importer
- Press the "Import your content" button
- Check if the Subtitle and Description under the drop area have been updated
- Drag a file and place it over the drop zone; check if drop styles are updated (it used to be blue bg color)
- For more details, check the related ticket above

<img width="826" alt="Screenshot 2023-12-06 at 14 41 05" src="https://github.com/Automattic/wp-calypso/assets/1241413/43209af0-4e54-44ab-9204-e4265ade0b44">
<img width="795" alt="Screenshot 2023-12-06 at 14 41 27" src="https://github.com/Automattic/wp-calypso/assets/1241413/f16e547e-d93c-45f3-a748-0d4fc55424b8">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?