### PR TITLE
Jetpack Manage: Fix monitor toggle border color

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/style.scss
@@ -3,6 +3,7 @@
 
 .components-form-toggle.is-checked .components-form-toggle__track {
 	background-color: var(--studio-jetpack-green-50);
+	border-color: var(--studio-jetpack-green-50);
 }
 
 .inline-flex-align-centre {


### PR DESCRIPTION
## Proposed Changes

This PR fixes the border color to match one of the Jetpack Clouds. I've set the border color explicitly to ensure any other PRs will not introduce such regression in the future.

**Screenshot**

The border color on the first screenshot is blue.

Before | After
--|--
![image](https://github.com/Automattic/wp-calypso/assets/1749918/861b167b-f454-4fea-95fe-1733d97a7956)|![image](https://github.com/Automattic/wp-calypso/assets/1749918/a4205a10-1d8f-4bd4-bb06-684daac03568)

## Testing Instructions

- Visit the Jetpack Cloud Live link below
- Verify that the toggle for enabling/disabling monitor matches the toggle color itself

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?