### PR TITLE
Live Preview: Disable the Global Styles limit when live previewing Woo and Premium themes

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -654,5 +654,5 @@ function wpcom_global_styles_is_previewing_premium_theme_with_premium_plan( $blo
 	// Check for a Premium plan or higher by checking if can use global styles.
 	$has_premium_plan_or_higher = wpcom_site_has_feature( WPCOM_Features::GLOBAL_STYLES, $blog_id );
 
-	return $has_premium_plan_or_higher;
+	return ! $has_premium_plan_or_higher;
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -62,8 +62,9 @@ function wpcom_should_limit_global_styles( $blog_id = 0 ) {
 		return false;
 	}
 
-	// Do not limit Global Styles when live previewing a Premium theme with a Premium plan or higher.
-	if ( wpcom_global_styles_is_previewing_premium_theme_with_premium_plan( $blog_id ) ) {
+	// Do not limit Global Styles when live previewing a Premium theme without a Premium plan or higher
+	// because the live preview already shows an upgrade notice, and we avoid duplication.
+	if ( wpcom_global_styles_is_previewing_premium_theme_without_premium_plan( $blog_id ) ) {
 		return false;
 	}
 
@@ -633,12 +634,12 @@ function wpcom_site_has_global_styles_feature( $blog_id = 0 ) {
 }
 
 /**
- * Checks whether the site has access to the Global Styles feature when the editor is live previewing a Premium theme with a Premium plan or higher.
+ * Checks whether the site has access to the Global Styles feature when the editor is live previewing a Premium theme without a Premium plan or higher.
  *
  * @param int $blog_id The WPCOM blog ID.
  * @return bool Whether the site has access to Global Styles when live previewing.
  */
-function wpcom_global_styles_is_previewing_premium_theme_with_premium_plan( $blog_id ) {
+function wpcom_global_styles_is_previewing_premium_theme_without_premium_plan( $blog_id ) {
 	if ( ! isset( $_GET['wp_theme_preview'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		// Not live previewing.
 		return false;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -62,13 +62,8 @@ function wpcom_should_limit_global_styles( $blog_id = 0 ) {
 		return false;
 	}
 
-	// Do not limit Global Styles when live previewing a Woo theme without a Business plan or higher.
-	if ( wpcom_global_styles_is_previewing_woo_theme_without_business_plan( $blog_id ) ) {
-		return false;
-	}
-
-	// Do not limit Global Styles when live previewing a Premium theme without a Premium plan or higher.
-	if ( wpcom_global_styles_is_previewing_premium_theme_without_premium_plan( $blog_id ) ) {
+	// Do not limit Global Styles when live previewing a Premium theme with a Premium plan or higher.
+	if ( wpcom_global_styles_is_previewing_premium_theme_with_premium_plan( $blog_id ) ) {
 		return false;
 	}
 
@@ -638,55 +633,12 @@ function wpcom_site_has_global_styles_feature( $blog_id = 0 ) {
 }
 
 /**
- * Checks whether the site has access to the Global Styles feature when the editor is live previewing a Woo theme without a Business plan or higher.
+ * Checks whether the site has access to the Global Styles feature when the editor is live previewing a Premium theme with a Premium plan or higher.
  *
  * @param int $blog_id The WPCOM blog ID.
  * @return bool Whether the site has access to Global Styles when live previewing.
  */
-function wpcom_global_styles_is_previewing_woo_theme_without_business_plan( $blog_id ) {
-	if ( ! isset( $_GET['wp_theme_preview'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		// Not live previewing.
-		return false;
-	}
-	$wp_theme_preview = sanitize_text_field( wp_unslash( $_GET['wp_theme_preview'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-
-	$is_previewing_premium_theme = str_starts_with( $wp_theme_preview, 'premium/' );
-	if ( ! $is_previewing_premium_theme ) {
-		// Not a premium theme.
-		return false;
-	}
-
-	// Check for a Woo theme.
-	require_once WP_CONTENT_DIR . '/lib/wpcom-themes.php';
-	$software_sets = \WPCom_Themes::get_theme_software_set( $wp_theme_preview );
-
-	$is_previewing_woo_theme = ! empty(
-		array_filter(
-			$software_sets,
-			function ( $software_set ) {
-				return $software_set->product_slug === 'woo-on-plans';
-			}
-		)
-	);
-
-	if ( ! $is_previewing_woo_theme ) {
-		// Not a Woo theme
-		return false;
-	}
-
-	// Check for a Business plan or higher by checking if can install plugins.
-	$has_business_plan_or_higher = wpcom_site_has_feature( WPCOM_Features::INSTALL_PLUGINS, $blog_id );
-
-	return ! $has_business_plan_or_higher;
-}
-
-/**
- * Checks whether the site has access to the Global Styles feature when the editor is live previewing a Premium theme without a Premium plan or higher.
- *
- * @param int $blog_id The WPCOM blog ID.
- * @return bool Whether the site has access to Global Styles when live previewing.
- */
-function wpcom_global_styles_is_previewing_premium_theme_without_premium_plan( $blog_id ) {
+function wpcom_global_styles_is_previewing_premium_theme_with_premium_plan( $blog_id ) {
 	if ( ! isset( $_GET['wp_theme_preview'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		// Not live previewing.
 		return false;
@@ -702,5 +654,5 @@ function wpcom_global_styles_is_previewing_premium_theme_without_premium_plan( $
 	// Check for a Premium plan or higher by checking if can use global styles.
 	$has_premium_plan_or_higher = wpcom_site_has_feature( WPCOM_Features::GLOBAL_STYLES, $blog_id );
 
-	return ! $has_premium_plan_or_higher;
+	return $has_premium_plan_or_higher;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #79223 #83630 #84676
Closes #84899

## Proposed Changes

* Do not enqueue the assets that limit Global Styles when live previewing a Premium theme if the site doesn't have a premium plan or higher.
* The effect of the change above ^ is showing only one notice asking users to upgrade because the Global Styles notice won't appear when users change styles.
* Plus, because the Global Styles gateway doesn't replace the Styles Welcome Guide, that guide appears when users click on the styles icon ☯️ and helps them to learn more about the Global Styles feature. 
  * We could also show that guide to users when live previewing any theme because it adds value. WDYT?

BTW. I reported a minor [issue](https://github.com/WordPress/gutenberg/issues/56816) on the copy of the Styles Welcome Guide that has been fixed.

|BEFORE|AFTER|
|--|--|
|<img width="1544" alt="Screenshot 2566-12-06 at 20 27 59" src="https://github.com/Automattic/wp-calypso/assets/1881481/6c8c8378-9851-4cc3-9428-9fc827cd596b">|<img width="1546" alt="Screenshot 2566-12-06 at 20 29 52" src="https://github.com/Automattic/wp-calypso/assets/1881481/ff812b7c-6712-4655-a279-ccb55fa57160">|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

In your sandbox run `install-plugin.sh etk fix/live-preview-unique-notice`

**Upgrade Notice for Premium themes**
* Prepare a simple site with the Personal plan or lower plan.
* Sandbox that site
* Access `https://<your-site>/wp-admin/site-editor.php?wp_theme_preview=<premium-theme>` to preview a premium theme (e.g., premium/outland).
* Change global styles and expect to see only the upgrade notice "You are previewing..."
* Repeat the test on atomic uploading the ETK plugin for this branch

https://github.com/Automattic/wp-calypso/assets/1881481/e6d2b443-01dd-4ae7-8112-86c965fe3d73

**Upgrade Notice for Woo themes**
* Prepare a simple site with the Premium plan or higher plan.
* Sandbox that site
* Access https://<your-site>/wp-admin/site-editor.php?wp_theme_preview=<woo-theme> to preview a premium theme (e.g., premium/tsubaki).
* Change global styles and expect to see only the upgrade notice "You are previewing..."
* Repeat the test on atomic uploading the ETK plugin for this branch

https://github.com/Automattic/wp-calypso/assets/1881481/b5652973-5fe8-4e21-9687-58e10bbabe45



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?