### PR TITLE
BBE Page Picker: update header

### DIFF
--- a/client/signup/steps/page-picker/index.tsx
+++ b/client/signup/steps/page-picker/index.tsx
@@ -418,7 +418,7 @@ function DIFMPagePicker( props: StepProps ) {
 
 	const subHeaderText = isStoreFlow
 		? translate(
-				'Select pages by clicking on the thumbnails to select or unselect them. Your site build includes up to %(freePageCount)s pages; you can add additional pages for {{PriceWrapper}}%(extraPagePrice)s{{/PriceWrapper}} each.' +
+				'Click on the thumbnails to select or deselect pages. Your site build includes up to %(freePageCount)s pages, and you can add more for {{PriceWrapper}}%(extraPagePrice)s{{/PriceWrapper}} each. After checkout, you will have the opportunity to submit your content.' +
 					'{{br}}{{/br}}{{br}}{{/br}}A cart and checkout are also included with your site.{{br}}{{/br}}You can add products later with the WordPress editor.',
 				{
 					components: {
@@ -444,7 +444,7 @@ function DIFMPagePicker( props: StepProps ) {
 				}
 		  )
 		: translate(
-				'Select pages by clicking on the thumbnails to select or unselect them. Your site build includes up to %(freePageCount)s pages; you can add additional pages for {{PriceWrapper}}%(extraPagePrice)s{{/PriceWrapper}} each.',
+				'Click on the thumbnails to select or deselect pages. Your site build includes up to %(freePageCount)s pages, and you can add more for {{PriceWrapper}}%(extraPagePrice)s{{/PriceWrapper}} each. After checkout, you will have the opportunity to submit your content.',
 				{
 					components: {
 						br: <br />,

--- a/client/signup/steps/page-picker/index.tsx
+++ b/client/signup/steps/page-picker/index.tsx
@@ -418,7 +418,7 @@ function DIFMPagePicker( props: StepProps ) {
 
 	const subHeaderText = isStoreFlow
 		? translate(
-				'Select your desired pages by clicking the thumbnails. {{br}}{{/br}}Your site build includes up to %(freePageCount)s pages, add additional pages for {{PriceWrapper}}%(extraPagePrice)s{{/PriceWrapper}} each.' +
+				'Select pages by clicking on the thumbnails to select or unselect them. Your site build includes up to %(freePageCount)s pages; you can add additional pages for {{PriceWrapper}}%(extraPagePrice)s{{/PriceWrapper}} each.' +
 					'{{br}}{{/br}}{{br}}{{/br}}A cart and checkout are also included with your site.{{br}}{{/br}}You can add products later with the WordPress editor.',
 				{
 					components: {
@@ -444,7 +444,7 @@ function DIFMPagePicker( props: StepProps ) {
 				}
 		  )
 		: translate(
-				'Select your desired pages by clicking the thumbnails. {{br}}{{/br}}Your site build includes up to %(freePageCount)s pages, add additional pages for {{PriceWrapper}}%(extraPagePrice)s{{/PriceWrapper}} each.',
+				'Select pages by clicking on the thumbnails to select or unselect them. Your site build includes up to %(freePageCount)s pages; you can add additional pages for {{PriceWrapper}}%(extraPagePrice)s{{/PriceWrapper}} each.',
 				{
 					components: {
 						br: <br />,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pdh1Xd-2qX-p2


## Proposed Changes

* Updates the header copy on the page picker step of the BBE flow.

<img width="479" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/d515e98f-3b8c-4b96-bb10-b344ebe6be31">



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/do-it-for-me`.
* Go through the flow steps till you reach the page picker step.
* Confirm that the header matches the screenshot.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?