### PR TITLE
Congrats page box-shadow fix

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/style.scss
@@ -15,6 +15,7 @@
 
 		> .card {
 			border: none;
+			box-shadow: none;
 		}
 	}
 


### PR DESCRIPTION
Slack report: p1701858849742799-slack-C9EJ7KSGH

## Proposed Changes

Fix box shadow on congrats page.

| Before | After |
| --- | --- |
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/eec95fd5-7a64-4af5-82b2-d31df1e8ff87) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/1a801643-635b-440d-8f47-0ff6e3108199) |

## Testing Instructions

* Upgrade free site using /plans
* Check congrats page border