### PR TITLE
Launchpad: Pass context with api request

### DIFF
--- a/client/my-sites/customer-home/cards/launchpad/index.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/index.tsx
@@ -28,7 +28,7 @@ const CustomerHomeLaunchpad = ( {
 	const [ isDismissed, setIsDismissed ] = useState( false );
 	const {
 		data: { checklist, is_dismissed: initialIsChecklistDismissed, title },
-	} = useSortedLaunchpadTasks( siteSlug, checklistSlug );
+	} = useSortedLaunchpadTasks( siteSlug, checklistSlug, launchpadContext );
 
 	useEffect( () => {
 		setIsDismissed( initialIsChecklistDismissed );

--- a/packages/launchpad/src/launchpad-internal.tsx
+++ b/packages/launchpad/src/launchpad-internal.tsx
@@ -10,6 +10,7 @@ export interface LaunchpadInternalProps {
 	makeLastTaskPrimaryAction?: boolean;
 	taskFilter?: ( tasks: Task[] ) => Task[];
 	useLaunchpadOptions?: UseLaunchpadOptions;
+	launchpadContext?: string | undefined;
 }
 
 /**
@@ -22,8 +23,14 @@ const LaunchpadInternal = ( {
 	taskFilter,
 	makeLastTaskPrimaryAction,
 	useLaunchpadOptions = {},
+	launchpadContext,
 }: LaunchpadInternalProps ) => {
-	const launchpadData = useLaunchpad( siteSlug || '', checklistSlug, useLaunchpadOptions );
+	const launchpadData = useLaunchpad(
+		siteSlug || '',
+		checklistSlug,
+		useLaunchpadOptions,
+		launchpadContext
+	);
 	const { isFetchedAfterMount, data } = launchpadData;
 	const tasks = useRef< Task[] >( [] );
 

--- a/packages/launchpad/src/launchpad.tsx
+++ b/packages/launchpad/src/launchpad.tsx
@@ -34,8 +34,7 @@ const Launchpad = ( {
 }: LaunchpadProps ) => {
 	const {
 		data: { checklist },
-	} = useSortedLaunchpadTasks( siteSlug, checklistSlug );
-
+	} = useSortedLaunchpadTasks( siteSlug, checklistSlug, launchpadContext );
 	const { setActiveChecklist } = useDispatch( LaunchpadNavigator.store );
 
 	const tasklistCompleted = checklist?.every( ( task: Task ) => task.completed ) || false;
@@ -119,6 +118,7 @@ const Launchpad = ( {
 				checklistSlug={ checklistSlug }
 				taskFilter={ taskFilter }
 				useLaunchpadOptions={ launchpadOptions }
+				launchpadContext={ launchpadContext }
 			/>
 		</>
 	);


### PR DESCRIPTION
**Companion to:**
D131162-code
https://github.com/Automattic/jetpack/pull/34498

## Proposed Changes

* This PR updates the Launchpad package to pass the launchpad_context as part of the API request.
* The immediate reason is that we want to be able to update the task to set up payments/stripe so that the stripe return url will return a user directly back to which ever launchpad they were on when they initiated the request. There are two companion PRs that implement the needed backend logic: 
   - Jetpack PR: https://github.com/Automattic/jetpack/pull/34498
   - Diff: D131162-code
* I also think knowing the launchpad context could be useful for a conditionally adjusting a range of launchpad tasks.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1) **Test that new param works.** This is difficult to test in isolation. You'll need to test it together with the two backend changes. 
   - Setup the backend
      - Load D131162-code in your sandbox with arc patch. 
      - Load the Jetpack PR in your sandbox at the same time by running `bin/jetpack-downloader test jetpack-mu-wpcom-plugin add/launchpad-context-for-api-requests`.
      - Add `define( 'JETPACK_MU_WPCOM_LOAD_VIA_BETA_PLUGIN', true );` to your 0-sandbox.php file. 
      - Add `define( 'USE_STORE_SANDBOX', true );` to your 0-sandbox.php file to make testing stripe easier.
      - Finally sandbox publi-api
   - Test
      - Checkout this calypso branch locally
      - Create a newsletter site at http://calypso.localhost:3000/setup/newsletter/intro, select the paid option, and proceed to Launchpad.
      - Without completing any Launchpad tasks, click Skip to Dashaboard and navigate to My Home. You should see the My Home Launchpad, including the task to 'Set up payments'
      - Click 'Set up payments'. If you added the USE_SANDBOX_STORE constant above, you'll see a 'Skip this form' button and you can click that. Otherwise, connect a live stripe account. 
     - Confirm that when you are done, you are returned directly to My Home. You should not see the Earn/Monetize screen.
      
2) **Test for no regressions.** Test one or more other instances of Launchpad. These can be for newsletter or non-newsletter sites, and can be for full screen launchpad, my home launchpad, or otherwise. The goal is to make sure that the changes in this PR (and associated backend changes) do not break any existing Launchpad functionality.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?