### PR TITLE
WooExpress: Fix padding on post-checkout screen

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/style.scss
+++ b/client/my-sites/plans/ecommerce-trial/upgrade-confirmation/style.scss
@@ -6,6 +6,10 @@ body.business-trial-upgraded {
 	background-color: var(--color-surface);
 	font-family: $font-sf-pro-text;
 
+	&.is-section-plans .layout__content {
+		padding-left: 0 !important;
+	}
+
 	.trial-upgrade-confirmation__header {
 		text-align: center;
 		padding: 20px 0;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Found this while testing, no related issue AFAIK.

## Proposed Changes

* Override the layout left padding on the post-checkout screen after purchasing an upgraded WooExpress plan.
* The dreaded `!important` makes an appearance here to override the existing `!importants` in the Plans CSS. I hesitate to get too into the weeds with the main plans screen since it's kind of a big deal. :-/ 

**Before**
<img width="1291" alt="Screenshot 2023-12-06 at 12 13 39 PM" src="https://github.com/Automattic/wp-calypso/assets/2124984/1f6a615a-2f27-4846-ad79-aa7996b35e14">

**After**
<img width="1288" alt="Screenshot 2023-12-06 at 12 22 13 PM" src="https://github.com/Automattic/wp-calypso/assets/2124984/f82f2815-3bf0-4c43-9632-b5b68fbe7b44">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR
* Navigate to `/setup/wooexpress` and create a new site.
* Go to Upgrades -> Purchase an upgrade (either plan is fine)
* Check out
* The post-checkout screen should look less lopsided.



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?