### PR TITLE
Staging Sites: Redirect from site tools subpages if accessing them directly

### DIFF
--- a/client/my-sites/site-settings/controller.js
+++ b/client/my-sites/site-settings/controller.js
@@ -5,6 +5,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import canCurrentUserStartSiteOwnerTransfer from 'calypso/state/selectors/can-current-user-start-site-owner-transfer';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 import wasBusinessTrialSite from 'calypso/state/selectors/was-business-trial-site';
 import wasEcommerceTrialSite from 'calypso/state/selectors/was-ecommerce-trial-site';
@@ -22,6 +23,10 @@ function canDeleteSite( state, siteId ) {
 
 	if ( ! siteId || ! canManageOptions ) {
 		// Current user doesn't have manage options to delete the site
+		return false;
+	}
+
+	if ( isSiteWpcomStaging( state, siteId ) ) {
 		return false;
 	}
 

--- a/client/state/selectors/can-current-user-start-site-owner-transfer.ts
+++ b/client/state/selectors/can-current-user-start-site-owner-transfer.ts
@@ -5,6 +5,7 @@ import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+import isSiteWpcomStaging from './is-site-wpcom-staging';
 import type { AppState } from 'calypso/types';
 
 /**
@@ -31,7 +32,8 @@ export default function canCurrentUserStartSiteOwnerTransfer(
 		isNonAtomicJetpackSite ||
 		isSiteP2Hub( state, siteId ) ||
 		isSiteWPForTeams( state, siteId ) ||
-		isVipSite( state, siteId )
+		isVipSite( state, siteId ) ||
+		isSiteWpcomStaging( state, siteId )
 	) {
 		return false;
 	}


### PR DESCRIPTION
## Proposed Changes

We're hiding the site tools submenu in `/settings/general/%s`, but the user can still access them directly by copying the URL from a production site and replacing with the staging URL.

This PR redirects the user to `/settings/general/%s` in case they type the URL directly.

Question: Are we preventing the actions in the back-end?

## Testing Instructions

On `trunk`, verify you can access `/settings/start-site-transfer/%s` for the production site and for the staging site.

Switch to this branch and verify you're redirected to `/settings/%s` when trying to access the transfer site subpage for a staging site.