### PR TITLE
Checkout: Update experiment name for collapse payment method step test

### DIFF
--- a/client/my-sites/checkout/src/hooks/use-should-collapse-last-step.tsx
+++ b/client/my-sites/checkout/src/hooks/use-should-collapse-last-step.tsx
@@ -15,7 +15,7 @@ export function useShouldCollapseLastStep(): 'loading' | 'collapse' | 'no-collap
 
 	const isWPcomCheckout = ! isJetpackCheckout() && ! isAkismetCheckout() && ! isJetpackNotAtomic;
 	const [ isLoadingExperimentAssignment, experimentAssignment ] = useExperiment(
-		'wp_web_checkout_collapse_payment_method',
+		'wp_web_checkout_collapse_payment_method_2',
 		{ isEligible: isWPcomCheckout }
 	);
 


### PR DESCRIPTION
## Proposed Changes

This updates the experiment name for the test described in pbxNRc-3le-p2. The experiment was originally prepared in https://github.com/Automattic/wp-calypso/pull/84517 but then the experiment data got corrupted somehow (see p1701887980856859-slack-C7HH3V5AS), so a new test needed to be created.

## Testing Instructions

None