### PR TITLE
Assembler: Improve page preview CSS when full-screen

### DIFF
--- a/client/assets/stylesheets/shared/functions/_z-index.scss
+++ b/client/assets/stylesheets/shared/functions/_z-index.scss
@@ -110,6 +110,7 @@ $z-layers: (
 		".billing-history-page .filter-popover-content": 23,
 		".reader-mobile-sidebar": 23,
 		".checkout-modal": 30,
+		".pattern-assembler__preview-list--fullscreen-preview": 30,
 		".community-translator": 99,
 		".author-selector__popover.popover": 100,
 		".feature-example__gradient": 170,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pages/page-preview-list.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pages/page-preview-list.scss
@@ -12,7 +12,7 @@
 	height: 100vh;
 	overflow-y: scroll;
 	padding: 100px 12px;
-	z-index: 2;
+	z-index: z-index("root", ".pattern-assembler__preview-list--fullscreen-preview");
 
 	&--fullscreen-preview {
 		margin-left: -$pattern-assembler-sidebar-width;
@@ -25,7 +25,7 @@
 		}
 
 		.pattern-assembler__preview--fullscreen-leave {
-			z-index: 2;
+			z-index: z-index("root", ".pattern-assembler__preview-list--fullscreen-preview");
 		}
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pages/page-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pages/page-preview.scss
@@ -59,7 +59,7 @@ $font-family: "SF Pro Text", $sans;
 				overflow-y: scroll;
 
 				.scaled-block-renderer {
-					transform: scale(var(--scaled-block-renderer-scale), 1) perspective(1px);
+					transform: scale(var(--scaled-block-renderer-scale, 1)) perspective(1px);
 				}
 			}
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pages/page-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pages/page-preview.scss
@@ -57,6 +57,10 @@ $font-family: "SF Pro Text", $sans;
 
 			&-content {
 				overflow-y: scroll;
+
+				.scaled-block-renderer {
+					transform: scale(var(--scaled-block-renderer-scale), 1) perspective(1px);
+				}
 			}
 		}
 

--- a/packages/block-renderer/src/components/block-renderer-container.scss
+++ b/packages/block-renderer/src/components/block-renderer-container.scss
@@ -11,6 +11,7 @@
 		margin: 0;
 		overflow: visible;
 		min-height: auto;
+		transform: scale(var(--scaled-block-renderer-scale, 1));
 
 		iframe {
 			max-width: initial;

--- a/packages/block-renderer/src/components/block-renderer-container.tsx
+++ b/packages/block-renderer/src/components/block-renderer-container.tsx
@@ -6,7 +6,7 @@ import {
 } from '@wordpress/block-editor';
 import { useResizeObserver, useRefEffect, useMergeRefs } from '@wordpress/compose';
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
-import React, { useMemo, useState, useContext, ReactNode } from 'react';
+import React, { useMemo, useState, useContext, CSSProperties, ReactNode } from 'react';
 import { BLOCK_MAX_HEIGHT } from '../constants';
 import useParsedAssets from '../hooks/use-parsed-assets';
 import loadScripts from '../utils/load-scripts';
@@ -105,14 +105,16 @@ const ScaledBlockRendererContainer = ( {
 	return (
 		<div
 			className="scaled-block-renderer"
-			style={ {
-				'--scaled-block-renderer-scale': scale,
-				height: scaledHeight,
-				maxHeight:
-					maxHeight && maxHeight !== 'none' && contentHeight > maxHeight
-						? maxHeight * scale
-						: undefined,
-			} }
+			style={
+				{
+					'--scaled-block-renderer-scale': scale,
+					height: scaledHeight,
+					maxHeight:
+						maxHeight && maxHeight !== 'none' && contentHeight > maxHeight
+							? maxHeight * scale
+							: undefined,
+				} as CSSProperties
+			}
 		>
 			<Iframe
 				contentRef={ useMergeRefs( [ contentRef, contentAssetsRef ] ) }

--- a/packages/block-renderer/src/components/block-renderer-container.tsx
+++ b/packages/block-renderer/src/components/block-renderer-container.tsx
@@ -106,7 +106,7 @@ const ScaledBlockRendererContainer = ( {
 		<div
 			className="scaled-block-renderer"
 			style={ {
-				transform: `scale(${ scale })`,
+				'--scaled-block-renderer-scale': scale,
 				height: scaledHeight,
 				maxHeight:
 					maxHeight && maxHeight !== 'none' && contentHeight > maxHeight


### PR DESCRIPTION
## Proposed Changes

This PR updates the `ScaledBlockRendererContainer` component so that its scaling is defined as a CSS variable instead of directly setting it via `transform: scale()`. With this change, we can easily create override the `transform` rule when needed. 

In this case, the Assembler's `PagePreview` component overrides the `transform` rule by adding a `perspective(1px)` to the transform, so that it's `transform: scale(...) perspective(1px)`. This is to solve a Safari rendering issue where scaling the preview would cause the rendering to be blurry. We add `perspective` to the transform to force a repaint via creating a new stacking context.

| Before | After |
| --- | --- |
| <img width="1036" alt="Screenshot 2023-12-07 at 10 03 53 AM" src="https://github.com/Automattic/wp-calypso/assets/797888/cec4b3d5-786f-43b7-a3e1-408984310829"> | <img width="1056" alt="Screenshot 2023-12-07 at 10 03 59 AM" src="https://github.com/Automattic/wp-calypso/assets/797888/8567af01-1267-49ff-97aa-f1fba81de4ba"> |

> [!NOTE]
> This PR mainly improves the rendering in Safari. Firefox didn't have the blurry rendering issue.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Safari.
* Head to the Assembler.
* Select any patterns.
* Select any styles.
* Click on any page preview and ensure that the full-screen preview looks good.
* Ensure that Chrome and Firefox looks as before. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?