### PR TITLE
Checkout: Add condition to load treatment only on checkout page

### DIFF
--- a/client/my-sites/checkout/src/hooks/use-tos-foldable-card.tsx
+++ b/client/my-sites/checkout/src/hooks/use-tos-foldable-card.tsx
@@ -4,7 +4,7 @@ import isJetpackCheckout from 'calypso/lib/jetpack/is-jetpack-checkout';
 import { useSelector } from 'calypso/state';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getSelectedSiteId, getSectionName } from 'calypso/state/ui/selectors';
 
 export function useToSFoldableCard(): 'loading' | 'treatment' | 'control' {
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
@@ -12,8 +12,11 @@ export function useToSFoldableCard(): 'loading' | 'treatment' | 'control' {
 	const isJetpackNotAtomic = useSelector(
 		( state ) => isJetpackSite( state, siteId ) && ! isSiteAutomatedTransfer( state, siteId )
 	);
-
-	const isWPcomCheckout = ! isJetpackCheckout() && ! isAkismetCheckout() && ! isJetpackNotAtomic;
+	const isWPcomCheckout =
+		useSelector( getSectionName ) === 'checkout' &&
+		! isJetpackCheckout() &&
+		! isAkismetCheckout() &&
+		! isJetpackNotAtomic;
 
 	const [ isLoadingExperimentAssignment, experimentAssignment ] = useExperiment(
 		'wp_web_checkout_tos_foldable_card_v1',


### PR DESCRIPTION
In a recent PR I launched an a/b test to modify the visibility of the Terms of Service section of checkout, unfortunately I did not realize that this component was also used in the "purchase modal" found on upgrade nudge pages like the one found at `http://calypso.localhost:3000/checkout/<your-site>/offer-plan-upgrade/business/12345`, this has resulted in a subpar experience:

| Incorrect | Correct |
| ----- | ----- |
| <img src='https://github.com/Automattic/wp-calypso/assets/16580129/4842f662-7c36-4ed9-b317-fe643f4485a7' width='500px' /> | <img src='https://github.com/Automattic/wp-calypso/assets/16580129/c30ee5fb-65cc-40de-abba-f9ea2a27fbba' width='500px' /> |

Related to #84395 

## Proposed Changes

* Add a condition to the `useToSFoldableCard` hook to ensure the section name is `checkout`, which will only trigger on the checkout page.

## Testing Instructions

* You'll need to assign yourself to the treatment group following these instructions (PCYsg-SwK-p2), and using the bookmarklet found in the Audience section of 21525-explat-experiment
* Make sure you have a test card on your wpcom account
* Load up Calypso locally or .live and go to `http://calypso.localhost:3000/checkout/<your-site>/offer-plan-upgrade/business/12345`
* Click on 'Upgrade Now' to trigger the purchase modal
* Ensure that the modal displays correctly (reference production's control) and doesn't show the ToS treatment
