### PR TITLE
Stats: Update purchase page layout

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -130,17 +130,19 @@ Thanks\n\n`;
 			<h1>{ translate( 'Jetpack Stats' ) }</h1>
 			<p>{ translate( 'The most advanced stats Jetpack has to offer.' ) }</p>
 			<StatsBenefitsCommercial />
-			<StatsCommercialPriceDisplay planValue={ planValue } currencyCode={ currencyCode } />
 			{ ! isTierUpgradeSliderEnabled && (
-				<ButtonComponent
-					variant="primary"
-					primary={ isWPCOMSite ? true : undefined }
-					onClick={ () =>
-						gotoCheckoutPage( { from, type: 'commercial', siteSlug, adminUrl, redirectUri } )
-					}
-				>
-					{ translate( 'Get Stats' ) }
-				</ButtonComponent>
+				<>
+					<StatsCommercialPriceDisplay planValue={ planValue } currencyCode={ currencyCode } />
+					<ButtonComponent
+						variant="primary"
+						primary={ isWPCOMSite ? true : undefined }
+						onClick={ () =>
+							gotoCheckoutPage( { from, type: 'commercial', siteSlug, adminUrl, redirectUri } )
+						}
+					>
+						{ translate( 'Get Stats' ) }
+					</ButtonComponent>
+				</>
 			) }
 			{ isTierUpgradeSliderEnabled && (
 				<>
@@ -163,7 +165,7 @@ Thanks\n\n`;
 							} )
 						}
 					>
-						{ translate( 'Get Stats' ) }
+						{ translate( 'Purchase' ) }
 					</ButtonComponent>
 				</>
 			) }

--- a/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.scss
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.scss
@@ -23,6 +23,7 @@ $track-height: 4px;
 	--gray-gray-5: #dcdcde;
 
 	margin-top: 42px;
+	margin-bottom: 24px;
 	background-color: $slider-bg-color;
 
 	border: 1px solid var(--gray-gray-5);

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -155,6 +155,8 @@ $button-padding: 8px 32px;
 
 	.stats-purchase-wizard__card-parent {
 		border-radius: 4px;
+		width: 1124px;
+		max-width: 100%;
 	}
 
 	.stats-purchase-wizard__card {
@@ -173,6 +175,7 @@ $button-padding: 8px 32px;
 		padding: 64px;
 		min-width: var(--stats-purchase-left-min-width);
 		max-width: var(--stats-purchase-left-max-width);
+		width: 60%;
 		box-sizing: border-box;
 	}
 


### PR DESCRIPTION
Related to #84885 

## Proposed Changes

* Wider card left according to design
* Switch price fully on feature flag
* Adjust button text and margin

## Testing Instructions

* Open Calypso Live Branch
* Open  `/stats/purchase/{site-slug}?flags=stats/tier-upgrade-slider&from=calypso-stats-upgrade-notice&productType=commercial`
* Ensure it looks like the following

<img width="1221" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/4887fc14-4de0-4a88-9284-2d15edabf1a8">

* Open  `/stats/purchase/{site-slug}?flags=stats/tier-upgrade-slider&from=calypso-stats-upgrade-notice&productType=personal`
* Ensure it looks like the following

<img width="1206" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/6c42fb7c-c437-4687-8ca3-0984f764efb1">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?