### PR TITLE
Stats: Visual updates for the new purchase slider

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.scss
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.scss
@@ -70,11 +70,11 @@ $track-height: 4px;
 			cursor: pointer;
 			margin: 0 $track-extra-width;
 			bottom: calc(50% - (math.div($mark-diameter, 2) + $mark-border-width));
+		}
 
-			&.jp-components-pricing-slider__mark--selected {
-				background-color: var(--jp-green-40);
-				border-color: var(--jp-green-40);
-			}
+		.jp-components-pricing-slider__mark--selected {
+			background-color: var(--jp-green-40);
+			border-color: var(--jp-green-40);
 		}
 	}
 }
@@ -83,6 +83,13 @@ $track-height: 4px;
 .stats-purchase-page--is-wpcom {
 	.jp-components-pricing-slider__thumb.stats-tier-upgrade-slider__thumb {
 		background-color: var(--color-primary);
+	}
+
+	.jp-components-pricing-slider__control {
+		.jp-components-pricing-slider__mark--selected {
+			background-color: var(--color-primary);
+			border-color: var(--color-primary);
+		}
 	}
 }
 

--- a/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.scss
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.scss
@@ -70,6 +70,11 @@ $track-height: 4px;
 			cursor: pointer;
 			margin: 0 $track-extra-width;
 			bottom: calc(50% - (math.div($mark-diameter, 2) + $mark-border-width));
+
+			&.jp-components-pricing-slider__mark--selected {
+				background-color: var(--jp-green-40);
+				border-color: var(--jp-green-40);
+			}
 		}
 	}
 }
@@ -107,6 +112,7 @@ $track-height: 4px;
 
 .stats-tier-upgrade-slider__extension-popover-wrapper {
 	max-width: 245px;
+	margin-left: 15px;
 }
 
 .stats-tier-upgrade-slider__extension-popover-content {

--- a/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-tier-upgrade-slider.tsx
@@ -83,19 +83,22 @@ function TierUpgradeSlider( {
 					</p>
 				</div>
 			</div>
-			<PricingSlider
-				className="stats-tier-upgrade-slider__slider"
-				thumbClassName="stats-tier-upgrade-slider__thumb"
-				value={ currentPlanIndex }
-				minValue={ sliderMin }
-				maxValue={ sliderMax }
-				onChange={ handleSliderChange }
-				marks
-			/>
+			{ tiers.length > 1 && (
+				<PricingSlider
+					className="stats-tier-upgrade-slider__slider"
+					thumbClassName="stats-tier-upgrade-slider__thumb"
+					value={ currentPlanIndex }
+					minValue={ sliderMin }
+					maxValue={ sliderMax }
+					onChange={ handleSliderChange }
+					marks
+				/>
+			) }
 			<Popover
 				position="right"
 				context={ infoReferenceElement?.current }
 				isVisible={ hasExtension }
+				focusOnShow={ false }
 				className="stats-tier-upgrade-slider__extension-popover-wrapper"
 			>
 				<div className="stats-tier-upgrade-slider__extension-popover-content">

--- a/client/my-sites/stats/stats-purchase/use-available-upgrade-tiers.tsx
+++ b/client/my-sites/stats/stats-purchase/use-available-upgrade-tiers.tsx
@@ -67,27 +67,18 @@ function transformTier( tier: PriceTierListItemProps ): StatsPlanTierUI {
 
 function filterPurchasedTiers(
 	availableTiers: StatsPlanTierUI[],
-	purchasedTiers: PlanUsage | undefined
+	usageData: PlanUsage | undefined
 ): StatsPlanTierUI[] {
 	// Filter out already purchased tiers.
 	let tiers: StatsPlanTierUI[];
 
-	if (
-		! purchasedTiers ||
-		purchasedTiers?.views_limit === null ||
-		purchasedTiers?.views_limit === 0
-	) {
+	if ( ! usageData || usageData?.views_limit === null || usageData?.views_limit === 0 ) {
 		// No tier has been purchased.
 		tiers = availableTiers;
 	} else {
 		tiers = availableTiers.filter( ( availableTier ) => {
-			if ( ! availableTier?.views || ! purchasedTiers?.views_limit ) {
-				return true;
-			}
-
 			return (
-				availableTier.views === null ||
-				( availableTier?.views as number ) > purchasedTiers?.views_limit
+				availableTier.views === null || ( availableTier?.views as number ) > usageData?.views_limit
 			);
 		} );
 	}
@@ -103,7 +94,7 @@ function useAvailableUpgradeTiers(
 	const commercialProduct = useSelector( ( state ) =>
 		getProductBySlug( state, PRODUCT_JETPACK_STATS_YEARLY )
 	) as ProductsList.ProductsListItem | null;
-	const { data: purchasedTiers } = usePlanUsageQuery( siteId );
+	const { data: usageData } = usePlanUsageQuery( siteId );
 
 	let tiersForUi = commercialProduct?.price_tier_list?.map( transformTier );
 
@@ -111,7 +102,7 @@ function useAvailableUpgradeTiers(
 
 	// 2. Filter based on current plan.
 	if ( shouldFilterPurchasedTiers ) {
-		tiersForUi = filterPurchasedTiers( tiersForUi, purchasedTiers );
+		tiersForUi = filterPurchasedTiers( tiersForUi, usageData );
 	}
 
 	// 3. Return the relevant upgrade options as a list.

--- a/packages/components/src/pricing-slider/index.tsx
+++ b/packages/components/src/pricing-slider/index.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import React from 'react';
+import React, { HTMLProps } from 'react';
 import ReactSlider from 'react-slider';
 import { RenderThumbFunction, PricingSliderProps } from './types';
 import './style.scss';
@@ -52,6 +52,16 @@ const PricingSlider: React.FC< PricingSliderProps > = ( {
 				return <div { ...props }>{ state.valueNow }</div>;
 		  } ) as RenderThumbFunction );
 
+	const renderMarks = ( props: HTMLProps< HTMLSpanElement > ) => (
+		<span
+			{ ...props }
+			className={ classNames( props?.className, {
+				[ 'jp-components-pricing-slider__mark--selected' ]:
+					( ( props?.key as number ) ?? 0 ) <= ( value ?? 0 ),
+			} ) }
+		/>
+	);
+
 	return (
 		<div className={ componentClassName } data-testid="pricing-slider">
 			<ReactSlider
@@ -60,6 +70,7 @@ const PricingSlider: React.FC< PricingSliderProps > = ( {
 				thumbActiveClassName="jp-components-pricing-slider__thumb--is-active"
 				trackClassName="jp-components-pricing-slider__track"
 				marks={ marks }
+				renderMark={ renderMarks }
 				value={ value }
 				max={ maxValue }
 				min={ minValue }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #84803

## Proposed Changes

* hide the purchase slider when there is only one item available (e.g. for upgrading to the highest tier from the second to the last tier)
* fix popover taking over focus from the slider
* add proper colour to slider marks on the left side of the currently selected tier (tiers below the selected)
* adjust popover position for the last tier

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* navigate to the live branch and verify that the slider looks fine after applying `stats/tier-upgrade-slider` feature flag
* purchase the second to last tier (apply proper patch to your environment)
* verify that the slider is not visible but the price still is

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?