### PR TITLE
Self service site reset: Add built by upsell banner

### DIFF
--- a/client/my-sites/site-settings/built-by-upsell-banner.tsx
+++ b/client/my-sites/site-settings/built-by-upsell-banner.tsx
@@ -1,0 +1,47 @@
+import { SiteDetails } from '@automattic/data-stores';
+import { useI18n } from '@wordpress/react-i18n';
+import builtByLogo from 'calypso/assets/images/illustrations/built-by-wp-vert-blue.png';
+import { Banner } from 'calypso/components/banner';
+
+type Props = {
+	site: SiteDetails;
+	isUnlaunchedSite: boolean;
+};
+
+export function BuiltByUpsell( { site, isUnlaunchedSite }: Props ) {
+	const { __ } = useI18n();
+	// Do not show for launched sites
+	if ( ! isUnlaunchedSite ) {
+		return null;
+	}
+
+	// Do not show if we don't know when the site was created
+	if ( ! site?.options?.created_at ) {
+		return null;
+	}
+
+	// Do not show if the site is less than 4 days old
+	const siteCreatedAt = Date.parse( site?.options?.created_at );
+	const FOUR_DAYS_IN_MILLISECONDS = 4 * 24 * 60 * 60 * 1000;
+	if ( Date.now() - siteCreatedAt < FOUR_DAYS_IN_MILLISECONDS ) {
+		return null;
+	}
+
+	return (
+		<Banner
+			className="site-settings__built-by-upsell"
+			title={ __( 'We’ll build your site for you' ) }
+			description={ __(
+				'Leave the heavy lifting to us and let our professional builders craft your compelling website.'
+			) }
+			callToAction={ __( 'Get started' ) }
+			href="https://wordpress.com/website-design-service/?ref=unlaunched-settings"
+			target="_blank"
+			iconPath={ builtByLogo }
+			disableCircle={ true }
+			event="settings_bb_upsell"
+			tracksImpressionName="calypso_settings_bb_upsell_impression"
+			tracksClickName="calypso_settings_bb_upsell_cta_click"
+		/>
+	);
+}

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -20,9 +20,7 @@ import { flowRight, get } from 'lodash';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import fiverrLogo from 'calypso/assets/images/customer-home/fiverr-logo.svg';
-import builtByLogo from 'calypso/assets/images/illustrations/built-by-wp-vert-blue.png';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
-import Banner from 'calypso/components/banner';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import QuerySiteSettings from 'calypso/components/data/query-site-settings';
 import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
@@ -66,6 +64,7 @@ import {
 	getSelectedSiteId,
 	getSelectedSiteSlug,
 } from 'calypso/state/ui/selectors';
+import { BuiltByUpsell } from './built-by-upsell-banner';
 import Masterbar from './masterbar';
 import SiteIconSetting from './site-icon-setting';
 import TrialUpsellNotice from './trial-upsell-notice';
@@ -879,45 +878,6 @@ export class SiteSettingsFormGeneral extends Component {
 		}
 	}
 
-	builtByUpsell() {
-		const { translate, site, isUnlaunchedSite: propsisUnlaunchedSite } = this.props;
-
-		// Do not show for launched sites
-		if ( ! propsisUnlaunchedSite ) {
-			return;
-		}
-
-		// Do not show if we don't know when the site was created
-		if ( ! site?.options?.created_at ) {
-			return;
-		}
-
-		// Do not show if the site is less than 4 days old
-		const siteCreatedAt = Date.parse( site?.options?.created_at );
-		const FOUR_DAYS_IN_MILLISECONDS = 4 * 24 * 60 * 60 * 1000;
-		if ( Date.now() - siteCreatedAt < FOUR_DAYS_IN_MILLISECONDS ) {
-			return;
-		}
-
-		return (
-			<Banner
-				className="site-settings__built-by-upsell"
-				title={ translate( 'We’ll build your site for you' ) }
-				description={ translate(
-					'Leave the heavy lifting to us and let our professional builders craft your compelling website.'
-				) }
-				callToAction={ translate( 'Get started' ) }
-				href="https://wordpress.com/website-design-service/?ref=unlaunched-settings"
-				target="_blank"
-				iconPath={ builtByLogo }
-				disableCircle={ true }
-				event="settings_bb_upsell"
-				tracksImpressionName="calypso_settings_bb_upsell_impression"
-				tracksClickName="calypso_settings_bb_upsell_cta_click"
-			/>
-		);
-	}
-
 	render() {
 		const {
 			customizerUrl,
@@ -932,6 +892,7 @@ export class SiteSettingsFormGeneral extends Component {
 			translate,
 			isAtomicAndEditingToolkitDeactivated,
 			isWpcomStagingSite,
+			isUnlaunchedSite: propsisUnlaunchedSite,
 		} = this.props;
 
 		const classes = classNames( 'site-settings__general-settings', {
@@ -966,7 +927,7 @@ export class SiteSettingsFormGeneral extends Component {
 					? this.renderLaunchSite()
 					: this.privacySettings() }
 				{ this.enhancedOwnershipSettings() }
-				{ this.builtByUpsell() }
+				<BuiltByUpsell site={ site } isUnlaunchedSite={ propsisUnlaunchedSite } />
 				{ ! isWpcomStagingSite && this.giftOptions() }
 				{ ! isWPForTeamsSite && ! ( siteIsJetpack && ! siteIsAtomic ) && (
 					<div className="site-settings__footer-credit-container">

--- a/client/my-sites/site-settings/start-over.jsx
+++ b/client/my-sites/site-settings/start-over.jsx
@@ -22,10 +22,19 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { EMPTY_SITE } from 'calypso/lib/url/support';
 import { useDispatch, useSelector } from 'calypso/state';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
-import { getSiteDomain } from 'calypso/state/sites/selectors';
+import isUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
+import { getSite, getSiteDomain } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { BuiltByUpsell } from './built-by-upsell-banner';
 
-const StartOver = ( { translate, selectedSiteSlug, siteDomain, isAtomic } ) => {
+const StartOver = ( {
+	translate,
+	selectedSiteSlug,
+	siteDomain,
+	isAtomic,
+	site,
+	isUnlaunchedSite: isUnlaunchedSiteProp,
+} ) => {
 	const localizeUrl = useLocalizeUrl();
 	if ( isEnabled( 'settings/self-serve-site-reset' ) ) {
 		return (
@@ -34,6 +43,8 @@ const StartOver = ( { translate, selectedSiteSlug, siteDomain, isAtomic } ) => {
 				selectedSiteSlug={ selectedSiteSlug }
 				siteDomain={ siteDomain }
 				isAtomic={ isAtomic }
+				site={ site }
+				isUnlaunchedSite={ isUnlaunchedSiteProp }
 			/>
 		);
 	}
@@ -90,7 +101,14 @@ const StartOver = ( { translate, selectedSiteSlug, siteDomain, isAtomic } ) => {
 	);
 };
 
-function SiteResetCard( { translate, selectedSiteSlug, siteDomain, isAtomic } ) {
+function SiteResetCard( {
+	translate,
+	selectedSiteSlug,
+	siteDomain,
+	isAtomic,
+	isUnlaunchedSite: isUnlaunchedSiteProp,
+	site,
+} ) {
 	const siteId = useSelector( getSelectedSiteId );
 	const dispatch = useDispatch();
 
@@ -220,6 +238,7 @@ function SiteResetCard( { translate, selectedSiteSlug, siteDomain, isAtomic } ) 
 					</div>
 				</ActionPanelFooter>
 			</ActionPanel>
+			<BuiltByUpsell site={ site } isUnlaunchedSite={ isUnlaunchedSiteProp } />
 		</Main>
 	);
 }
@@ -227,9 +246,12 @@ function SiteResetCard( { translate, selectedSiteSlug, siteDomain, isAtomic } ) 
 export default connect( ( state ) => {
 	const siteId = getSelectedSiteId( state );
 	const siteDomain = getSiteDomain( state, siteId );
+	const site = getSite( state, siteId );
 	return {
 		siteDomain,
+		site,
 		selectedSiteSlug: getSelectedSiteSlug( state ),
 		isAtomic: isSiteAtomic( state, siteId ),
+		isUnlaunchedSite: isUnlaunchedSite( state, siteId ),
 	};
 } )( localize( StartOver ) );

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -736,4 +736,8 @@ button.site-settings__general-settings-set-guessed-timezone.button.is-borderless
 	.card {
 		margin-bottom: 0;
 	}
+
+	.banner {
+		margin-top: 16px;
+	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/4780

## Proposed Changes
This PR adds the builtby upsell banner to site reset page. 
**Question:** The built by banner CTA sets ref=unlaunched-setting, do we want to keep that ref on the site reset page?
* Move builty by upsell into a reusable component
* Add the component to the general setting and site reset page

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to `/settings` and verify the buily by banner is present
* go to `/settings/start-over/siteSlug` and verify banner is there
* verify banner is shown only for unlaunched site

![image](https://github.com/Automattic/wp-calypso/assets/47489215/d17709c3-ba2e-46f6-bca1-62358db37d29)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?