### PR TITLE
Jetpack Manage: Change child license revoke messaging.

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/license-details/actions.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/actions.tsx
@@ -16,6 +16,7 @@ interface Props {
 	licenseState: LicenseState;
 	licenseType: LicenseType;
 	hasDownloads: boolean;
+	isChildLicense?: boolean;
 }
 
 export default function LicenseDetailsActions( {
@@ -25,6 +26,7 @@ export default function LicenseDetailsActions( {
 	licenseState,
 	licenseType,
 	hasDownloads,
+	isChildLicense,
 }: Props ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
@@ -80,11 +82,14 @@ export default function LicenseDetailsActions( {
 				</Button>
 			) }
 
-			{ licenseState !== LicenseState.Revoked && licenseType === LicenseType.Partner && (
-				<Button compact onClick={ openRevokeDialog } scary>
-					{ translate( 'Revoke' ) }
-				</Button>
-			) }
+			{ ( isChildLicense
+				? licenseState === LicenseState.Attached
+				: licenseState !== LicenseState.Revoked ) &&
+				licenseType === LicenseType.Partner && (
+					<Button compact onClick={ openRevokeDialog } scary>
+						{ translate( 'Revoke' ) }
+					</Button>
+				) }
 
 			{ licenseState === LicenseState.Detached && licenseType === LicenseType.Partner && (
 				<Button
@@ -103,6 +108,7 @@ export default function LicenseDetailsActions( {
 					product={ product }
 					siteUrl={ siteUrl }
 					onClose={ closeRevokeDialog }
+					isChildLicense={ isChildLicense }
 				/>
 			) }
 		</div>

--- a/client/jetpack-cloud/sections/partner-portal/license-details/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/index.tsx
@@ -1,10 +1,12 @@
 import { Card, Gridicon } from '@automattic/components';
+import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import FormattedDate from 'calypso/components/formatted-date';
 import ClipboardButton from 'calypso/components/forms/clipboard-button';
 import LicenseDetailsActions from 'calypso/jetpack-cloud/sections/partner-portal/license-details/actions';
 import { LicenseState, LicenseType } from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import { getLicenseState, noop } from '../lib';
+
 import './style.scss';
 
 interface Props {
@@ -43,7 +45,11 @@ export default function LicenseDetails( {
 	const licenseState = getLicenseState( attachedAt, revokedAt );
 
 	return (
-		<Card className="license-details">
+		<Card
+			className={ classNames( 'license-details', {
+				'license-details--child-license': isChildLicense,
+			} ) }
+		>
 			<ul className="license-details__list">
 				<li className="license-details__list-item">
 					<h4 className="license-details__label">{ translate( 'License code' ) }</h4>

--- a/client/jetpack-cloud/sections/partner-portal/license-details/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/index.tsx
@@ -19,6 +19,7 @@ interface Props {
 	revokedAt: string | null;
 	onCopyLicense?: () => void;
 	licenseType: LicenseType;
+	isChildLicense?: boolean;
 }
 
 const DETAILS_DATE_FORMAT = 'YYYY-MM-DD h:mm:ss A';
@@ -36,6 +37,7 @@ export default function LicenseDetails( {
 	revokedAt,
 	onCopyLicense = noop,
 	licenseType,
+	isChildLicense,
 }: Props ) {
 	const translate = useTranslate();
 	const licenseState = getLicenseState( attachedAt, revokedAt );
@@ -100,6 +102,7 @@ export default function LicenseDetails( {
 				licenseState={ licenseState }
 				licenseType={ licenseType }
 				hasDownloads={ hasDownloads }
+				isChildLicense={ isChildLicense }
 			/>
 		</Card>
 	);

--- a/client/jetpack-cloud/sections/partner-portal/license-details/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/style.scss
@@ -105,3 +105,11 @@
 		}
 	}
 }
+
+.license-details--child-license {
+	&,
+	.license-details__actions a,
+	.license-details__actions button {
+		background-color: #fafafa;
+	}
+}

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
@@ -241,6 +241,7 @@ export default function LicensePreview( {
 							attachedAt={ attachedAt }
 							revokedAt={ revokedAt }
 							licenseType={ licenseType }
+							isChildLicense={ isChildLicense }
 						/>
 					) : (
 						<Button onClick={ open } className="license-preview__toggle" borderless>
@@ -266,6 +267,7 @@ export default function LicensePreview( {
 						revokedAt={ revokedAt }
 						onCopyLicense={ onCopyLicense }
 						licenseType={ licenseType }
+						isChildLicense={ isChildLicense }
 					/>
 				) ) }
 		</div>

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/license-actions.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/license-actions.tsx
@@ -14,6 +14,7 @@ interface Props {
 	attachedAt: string | null;
 	revokedAt: string | null;
 	licenseType: LicenseType;
+	isChildLicense?: boolean;
 }
 
 export default function LicenseActions( {
@@ -23,13 +24,20 @@ export default function LicenseActions( {
 	attachedAt,
 	revokedAt,
 	licenseType,
+	isChildLicense,
 }: Props ) {
 	const buttonActionRef = useRef< HTMLButtonElement | null >( null );
 
 	const [ isOpen, setIsOpen ] = useState( false );
 	const [ showRevokeDialog, setShowRevokeDialog ] = useState( false );
 
-	const licenseActions = useLicenseActions( siteUrl, attachedAt, revokedAt, licenseType );
+	const licenseActions = useLicenseActions(
+		siteUrl,
+		attachedAt,
+		revokedAt,
+		licenseType,
+		isChildLicense
+	);
 
 	const handleActionClick = ( action: LicenseAction ) => {
 		action.onClick();
@@ -70,6 +78,7 @@ export default function LicenseActions( {
 					product={ product }
 					siteUrl={ siteUrl }
 					onClose={ () => setShowRevokeDialog( false ) }
+					isChildLicense={ isChildLicense }
 				/>
 			) }
 		</>

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/style.scss
@@ -205,4 +205,5 @@ button {
 
 .card.license-preview__card.license-preview__card--child-license {
 	padding: 16px 32px;
+	background-color: #fafafa;
 }

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/use-license-actions.ts
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/use-license-actions.ts
@@ -14,7 +14,8 @@ export default function useLicenseActions(
 	siteUrl: string | null,
 	attachedAt: string | null,
 	revokedAt: string | null,
-	licenseType: LicenseType
+	licenseType: LicenseType,
+	isChildLicense?: boolean
 ): LicenseAction[] {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -73,9 +74,12 @@ export default function useLicenseActions(
 				onClick: () =>
 					handleClickMenuItem( 'calypso_jetpack_licenses_hosting_configuration_click' ),
 				type: 'revoke',
-				isEnabled: licenseState !== LicenseState.Revoked && licenseType === LicenseType.Partner,
+				isEnabled:
+					( isChildLicense
+						? licenseState === LicenseState.Attached
+						: licenseState !== LicenseState.Revoked ) && licenseType === LicenseType.Partner,
 				className: 'is-destructive',
 			},
 		];
-	}, [ attachedAt, dispatch, licenseType, revokedAt, siteUrl, translate ] );
+	}, [ attachedAt, dispatch, isChildLicense, licenseType, revokedAt, siteUrl, translate ] );
 }

--- a/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/index.tsx
@@ -65,13 +65,12 @@ export default function RevokeLicenseDialog( {
 
 	const renderHeading = () => {
 		if ( isAssignedChildLicense ) {
-			return translate( 'Revoke %(product)s license from %(siteUrl)s?', {
+			return translate( 'Revoke %(product)s license?', {
 				args: {
 					product,
 					siteUrl,
 				},
-				comment:
-					'The %(product)s and %(siteUrl)s placeholders are replaced with the product name and site URL, respectively.',
+				comment: 'The %(product)s is replaced with the product name.',
 			} );
 		}
 

--- a/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/index.tsx
@@ -68,7 +68,6 @@ export default function RevokeLicenseDialog( {
 			return translate( 'Revoke %(product)s license?', {
 				args: {
 					product,
-					siteUrl,
 				},
 				comment: 'The %(product)s is replaced with the product name.',
 			} );

--- a/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/index.tsx
@@ -65,7 +65,7 @@ export default function RevokeLicenseDialog( {
 
 	const renderHeading = () => {
 		if ( isAssignedChildLicense ) {
-			return translate( 'Revoke %(product)s license from (siteUrl)s?', {
+			return translate( 'Revoke %(product)s license from %(siteUrl)s?', {
 				args: {
 					product,
 					siteUrl,


### PR DESCRIPTION
This pull request aims to improve the Revoke flow for the Child license. It includes an update that displays a different message when a Child license is revoked. Additionally, Child licenses can only be revoked if they are in the attached state.  
Non-child licenses will work exactly the same and will not be affected by this change.

![image](https://github.com/Automattic/wp-calypso/assets/1749918/e3243936-513d-4e3b-b56a-3170546bf63a)

**The design of the license modals will be updated later, but for now, the modal follows the current style of the revoke modal to ensure consistency.** 



**_Extra: The preview component Child license now has a background with different gray in accordance with the new design._**
<img width="1524" alt="Screen Shot 2023-12-07 at 1 12 32 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/772598e0-88e9-4c71-a30f-a9841d5fa596">


Closes https://github.com/Automattic/jetpack-genesis/issues/100

## Proposed Changes

* Update the background color of the License Preview component for Child licenses. Additional class names are included to differentiate the preview of a Child license.
* Update the revoke flow for Child licenses and update the message to reflect the new behavior. When a Child license is revoked, it will now be reissued as a new Child license, which will keep the bundle's available licenses intact. Note that a bundle may have a longer list than its bundle size due to additional Child licenses issued after a revoke.
* The Revoke button for a Child license will only be available when a license is assigned.

## Testing Instructions

Before testing, please issue a license bundle. Go to `/issue-license?flags=jetpack/bundle-licensing`. If you can't see any bundles in your list, please update your billing scheme using the command 32b1d-pb in your WPCOM sandbox.

* Use the live link below, Go to `/partner-portal/licenses?flags=jetpack/bundle-licensing`
* Expand any licenses part of a bundle that is not yet assigned.
* Confirm that the revoke button is not visible. 
  <img width="1520" alt="Screen Shot 2023-12-07 at 1 26 31 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/4ce12d9e-dcdf-4dbc-9f65-0a3ba0a0b409">

* Assign the license to a site and confirm that the revoke button is displayed. 
  <img width="1521" alt="Screen Shot 2023-12-07 at 1 27 16 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/a313fef0-8b5b-4794-bf01-af7ea833666e">

* Clicking the Revoke button will show a different modal messaging
![image](https://github.com/Automattic/wp-calypso/assets/1749918/e3243936-513d-4e3b-b56a-3170546bf63a)

* Click the 'Revoke License' button and confirm that the child license is revoked and a new one is added to the bundle. 
* Additionally, test that the rest of the licenses that are not part of a bundle work exactly the same.





## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?