### PR TITLE
Jetpack Manage: Enable Bundle licensing UI in Dev, Horizon, and Staging.

### DIFF
--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -40,7 +40,7 @@
 		"dev/auth-helper": true,
 		"dev/preferences-helper": true,
 		"jetpack-cloud": true,
-		"jetpack/bundle-licensing": false,
+		"jetpack/bundle-licensing": true,
 		"jetpack/activity-log-sharing": true,
 		"jetpack/agency-dashboard": true,
 		"jetpack/backup-messaging-i3": true,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -35,7 +35,7 @@
 		"current-site/notice": false,
 		"current-site/stale-cart-notice": false,
 		"jetpack-cloud": true,
-		"jetpack/bundle-licensing": false,
+		"jetpack/bundle-licensing": true,
 		"jetpack/agency-dashboard": true,
 		"jetpack/backup-messaging-i3": true,
 		"jetpack/backup-retention-settings": true,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -38,7 +38,7 @@
 		"current-site/stale-cart-notice": false,
 		"jetpack-cloud": true,
 		"jetpack/activity-log-sharing": true,
-		"jetpack/bundle-licensing": false,
+		"jetpack/bundle-licensing": true,
 		"jetpack/agency-dashboard": true,
 		"jetpack/backup-messaging-i3": true,
 		"jetpack/backup-retention-settings": true,


### PR DESCRIPTION
In preparation for the upcoming CFT, this PR will enable the Bundle Licensing UI in Dev, Horizon, and Staging environments.

**NOTE: DO NOT MERGE UNTIL THE PROJECT IS READY FOR TESTING.**

## Proposed Changes

* Enable `jetpack/bundle-licensing` feature flag in Dev, Horizon, and Staging environment.

## Testing Instructions

* Review the changes and ensure it only the correct feature flag.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?