### PR TITLE
Update/header subscribers

### DIFF
--- a/client/components/navigation-header/index.tsx
+++ b/client/components/navigation-header/index.tsx
@@ -70,7 +70,6 @@ const NavigationHeader = React.forwardRef< HTMLElement, Props >( ( props, ref ) 
 							align="left"
 							headerText={ title }
 							subHeaderText={ subtitle }
-							tooltipText={ subtitle }
 							screenReader={ screenReader }
 						/>
 					) }

--- a/client/components/navigation-header/style.scss
+++ b/client/components/navigation-header/style.scss
@@ -44,6 +44,7 @@
 	justify-content: space-between;
 	align-items: center;
 	box-sizing: border-box;
+	column-gap: 10px;
 
 	@media ( max-width: 660px ) {
 		min-height: 60px;

--- a/client/my-sites/subscribers/style.scss
+++ b/client/my-sites/subscribers/style.scss
@@ -17,6 +17,10 @@
 			display: none;
 		}
 
+		@media ( max-width: $break-medium ) {
+			display: inline-block;
+		}
+
 		@media ( min-width: $break-small ) {
 			.add-subscribers-button-text {
 				display: inline;


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/4788
Fixes https://github.com/Automattic/dotcom-forge/issues/4789

## Proposed Changes

* Adds column gap between header and button actions on mobile
* Forces /subscribers button to use block instead of flex as there is existing rules expecting this when text is not present
* No longer displays subheader in the info popover as it interfered with word wrapping inconsistently and we already have a help icon in the main nav bar. See p9Jlb4-8ec-p2#comment-8807 for context.

## Testing Instructions

* /subscribers
* /read/subscriptions
* Check other pages with buttons, e.g. advertising and domains. Mobile + desktop.

<img src="https://github.com/Automattic/wp-calypso/assets/811776/81b24688-0671-4af2-aa25-3a0b9d79c1d2" width="300" />

<img src="https://github.com/Automattic/wp-calypso/assets/811776/5620a69c-3291-43f2-acec-fe4f148d0025" width="300" />