### PR TITLE
Multi-Domains: Show the selected free domain on mobile

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -908,6 +908,30 @@ export class RenderDomainsStep extends Component {
 			);
 		};
 
+		const FreeDomain = () => (
+			<div key="row-free" className="domains__domain-cart-row">
+				<div>
+					<div className="domains__domain-cart-domain">
+						<BoldTLD domain={ this.state.wpcomSubdomainSelected.domain_name } />
+					</div>
+					<div className="domain-product-price__price">
+						<span className="domains__price-free">{ this.props.translate( 'Free' ) }</span>
+					</div>
+				</div>
+				<div>
+					<Button
+						borderless
+						className="button domains__domain-cart-remove"
+						onClick={ () => {
+							this.setState( { wpcomSubdomainSelected: false } );
+						} }
+					>
+						{ this.props.translate( 'Remove' ) }
+					</Button>
+				</div>
+			</div>
+		);
+
 		const DomainsInCart = () => {
 			if (
 				! shouldUseMultipleDomainsInCart( this.props.flowName ) ||
@@ -969,6 +993,7 @@ export class RenderDomainsStep extends Component {
 					>
 						<div className="domains__domain-side-content domains__domain-cart">
 							<div className="domains__domain-cart-rows">
+								{ this.state.wpcomSubdomainSelected && <FreeDomain /> }
 								{ domainsInCart.map( ( domain, i ) => (
 									<div key={ `row${ i }` } className="domains__domain-cart-row">
 										<DomainNameAndCost domain={ domain } />
@@ -986,29 +1011,7 @@ export class RenderDomainsStep extends Component {
 						{ this.props.translate( 'Your domains' ) }
 					</div>
 					<div className="domains__domain-cart-rows">
-						{ this.state.wpcomSubdomainSelected && (
-							<div key="row-free" className="domains__domain-cart-row">
-								<div>
-									<div className="domains__domain-cart-domain">
-										<BoldTLD domain={ this.state.wpcomSubdomainSelected.domain_name } />
-									</div>
-									<div className="domain-product-price__price">
-										<span className="domains__price-free">{ this.props.translate( 'Free' ) }</span>
-									</div>
-								</div>
-								<div>
-									<Button
-										borderless
-										className="button domains__domain-cart-remove"
-										onClick={ () => {
-											this.setState( { wpcomSubdomainSelected: false } );
-										} }
-									>
-										{ this.props.translate( 'Remove' ) }
-									</Button>
-								</div>
-							</div>
-						) }
+						{ this.state.wpcomSubdomainSelected && <FreeDomain /> }
 						{ domainsInCart.map( ( domain, i ) => (
 							<div key={ `row${ i }` } className="domains__domain-cart-row">
 								<DomainNameAndCost domain={ domain } />


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/4744

## Proposed Changes

| Before  | After |
| :-------------: | :-------------: |
| <img src="https://github.com/Automattic/wp-calypso/assets/6586048/52373b18-11d4-4870-b8af-94e40d6c2979">  | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/832ac490-79e6-418b-a4dc-790d9ebf6248">|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /start Domain step
* Select the free domain
* Make sure it shows on Desktop and Mobile

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?