### PR TITLE
Staging Sites: Allow starting sync with status allow_retry

### DIFF
--- a/client/my-sites/hosting/staging-site-card/use-site-sync-status.tsx
+++ b/client/my-sites/hosting/staging-site-card/use-site-sync-status.tsx
@@ -56,6 +56,12 @@ export const useCheckSyncStatus = ( siteId: number ) => {
 			return;
 		}
 
+		if ( ! siteId || syncStatus === SiteSyncStatus.ALLOW_RETRY ) {
+			dispatch( setSyncInProgress( siteId, false ) );
+			clearIntervalId();
+			return;
+		}
+
 		if ( ! siteId || syncStatus === SiteSyncStatus.FAILED ) {
 			dispatch( setSyncInProgress( siteId, false ) );
 			clearIntervalId();

--- a/client/state/data-layer/wpcom/sites/sync/status/index.js
+++ b/client/state/data-layer/wpcom/sites/sync/status/index.js
@@ -42,6 +42,10 @@ export const receiveStatus =
 			// Update the site object to reflect the new status
 			dispatch( requestSite( siteId ) );
 		}
+		if ( status === SiteSyncStatus.ALLOW_RETRY ) {
+			// Update the site object to reflect the new status
+			dispatch( requestSite( siteId ) );
+		}
 		if ( status === SiteSyncStatus.FAILED ) {
 			dispatch(
 				siteSyncFailure( {

--- a/client/state/sync/constants.ts
+++ b/client/state/sync/constants.ts
@@ -4,6 +4,7 @@ export enum SiteSyncStatus {
 	RESTORE = 'restoring',
 	COMPLETED = 'completed',
 	FAILED = 'failed',
+	ALLOW_RETRY = 'allow_retry',
 }
 
 export enum SiteSyncStatusProgress {
@@ -12,5 +13,6 @@ export enum SiteSyncStatusProgress {
 	RESTORE = 0.6,
 	COMPLETED = 1,
 	FAILED = 0,
+	ALLOW_RETRY = 0.1,
 	DELTA = 0.004,
 }

--- a/client/state/sync/reducer.js
+++ b/client/state/sync/reducer.js
@@ -108,7 +108,12 @@ export const isSyncingInProgress = ( state = false, action ) => {
 		case IS_SYNCING_IN_PROGRESS:
 			return action.isSyncingInProgress || false;
 		case SET_STATUS:
-			return ( action.status && action.status !== SiteSyncStatus.COMPLETED ) || false;
+			return (
+				( action.status &&
+					action.status !== SiteSyncStatus.COMPLETED &&
+					action.status !== SiteSyncStatus.ALLOW_RETRY ) ||
+				false
+			);
 		case REQUEST_STATUS_FAILURE:
 			return false;
 		default:
@@ -140,6 +145,9 @@ export const progress = withPersistence( ( state = 0, action ) => {
 					break;
 				case SiteSyncStatus.COMPLETED:
 					newStatus = Math.max( newStatus, SiteSyncStatusProgress.COMPLETED );
+					break;
+				case SiteSyncStatus.ALLOW_RETRY:
+					newStatus = Math.max( newStatus, SiteSyncStatusProgress.ALLOW_RETRY );
 					break;
 				case SiteSyncStatus.FAILED:
 					newStatus = SiteSyncStatusProgress.FAILED;

--- a/client/state/sync/test/reducer.js
+++ b/client/state/sync/test/reducer.js
@@ -97,6 +97,29 @@ describe( 'state', () => {
 				expect( newState ).toHaveProperty( 'progress', 1 );
 				expect( newState ).toHaveProperty( 'fetchingStatus', false );
 			} );
+
+			test( 'should set isSyncingInProgress to false if status become allow_retry', () => {
+				const SITE_ID = 12345;
+				const AT_STATE = {
+					status: SiteSyncStatus.PENDING,
+					progress: 1,
+					isSyncingInProgress: true,
+					syncingTargetSite: 'production',
+					syncingSourceSite: 'staging',
+					lastRestoreId: '12345',
+					fetchingStatus: false,
+					error: null,
+				};
+				reducer( AT_STATE, {} );
+				const newState = reducer(
+					AT_STATE,
+					setSiteSyncStatus( SITE_ID, SiteSyncStatus.ALLOW_RETRY )
+				);
+				expect( newState ).toHaveProperty( 'isSyncingInProgress', false );
+				expect( newState ).toHaveProperty( 'status', SiteSyncStatus.ALLOW_RETRY );
+				expect( newState ).toHaveProperty( 'progress', 1 );
+				expect( newState ).toHaveProperty( 'fetchingStatus', false );
+			} );
 		} );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4736

## Proposed Changes

In this PR, I propose to allow starting production<->staging synchronization if the last sync status is `allow_retry`. This will let us unblock synchronization that was `failed` when the underlying problem is fixed.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Apply D131105-code and D131106-code

1. Create a site with a Business plan
2. Activate hosting features, create a staging site, run synchronization
3. Using snippet from linked diff, change sync status to `failed` and confirm that synchronization can't be started
4. Change sync status to `allow_retry` and confirm that synchronization can be started

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?