### PR TITLE
Assembler AI: Add account steps to the ai-assembler flow

### DIFF
--- a/client/landing/stepper/declarative-flow/ai-assembler.ts
+++ b/client/landing/stepper/declarative-flow/ai-assembler.ts
@@ -1,17 +1,26 @@
-import { Onboard } from '@automattic/data-stores';
-import { DEFAULT_ASSEMBLER_DESIGN } from '@automattic/design-picker';
-import { useFlowProgress, AI_ASSEMBLER_FLOW } from '@automattic/onboarding';
+import { Onboard, updateLaunchpadSettings } from '@automattic/data-stores';
+import { DEFAULT_ASSEMBLER_DESIGN, isAssemblerSupported } from '@automattic/design-picker';
+import { useLocale } from '@automattic/i18n-utils';
+import { AI_ASSEMBLER_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
+import { getLocaleFromQueryParam, getLocaleFromPathname } from 'calypso/boot/locale';
 import { useQueryTheme } from 'calypso/components/data/query-theme';
+import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getTheme } from 'calypso/state/themes/selectors';
-import { useSiteSlug } from '../hooks/use-site-slug';
-import { ONBOARD_STORE } from '../stores';
+import { useSiteData } from '../hooks/use-site-data';
+import { ONBOARD_STORE, SITE_STORE } from '../stores';
+import { useLoginUrl } from '../utils/path';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import { STEPS } from './internals/steps';
 import { ProcessingResult } from './internals/steps-repository/processing-step/constants';
-import { Flow, ProvidedDependencies } from './internals/types';
+import {
+	AssertConditionResult,
+	AssertConditionState,
+	Flow,
+	ProvidedDependencies,
+} from './internals/types';
 import type { OnboardSelect } from '@automattic/data-stores';
 
 const SiteIntent = Onboard.SiteIntent;
@@ -48,16 +57,23 @@ const withAIAssemblerFlow: Flow = {
 				design_type: 'assembler',
 			} );
 
-			setIntent( SiteIntent.WithThemeAssembler );
+			setIntent( SiteIntent.AIAssembler );
 		}, [ theme ] );
 	},
 
 	useSteps() {
 		return [
+			STEPS.CHECK_SITES,
+			STEPS.NEW_OR_EXISTING_SITE,
+			STEPS.SITE_PICKER,
+			STEPS.SITE_CREATION_STEP,
 			STEPS.SITE_PROMPT,
 			STEPS.PATTERN_ASSEMBLER,
 			STEPS.PROCESSING,
 			STEPS.ERROR,
+			STEPS.LAUNCHPAD,
+			STEPS.PLANS,
+			STEPS.SITE_LAUNCH,
 			STEPS.CELEBRATION,
 		];
 	},
@@ -68,11 +84,10 @@ const withAIAssemblerFlow: Flow = {
 			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getIntent(),
 			[]
 		);
-		const { setStepProgress, setPendingAction } = useDispatch( ONBOARD_STORE );
 
-		const flowProgress = useFlowProgress( { stepName: _currentStep, flowName } );
-		setStepProgress( flowProgress );
-		const siteSlug = useSiteSlug();
+		const { setPendingAction, setSelectedSite } = useDispatch( ONBOARD_STORE );
+		const { saveSiteSettings, setIntentOnSite } = useDispatch( SITE_STORE );
+		const { siteSlug } = useSiteData();
 
 		const exitFlow = ( to: string ) => {
 			setPendingAction( () => {
@@ -84,13 +99,97 @@ const withAIAssemblerFlow: Flow = {
 			return navigate( 'processing' );
 		};
 
-		const submit = ( providedDependencies: ProvidedDependencies = {}, ...results: string[] ) => {
+		const handleSelectSite = ( providedDependencies: ProvidedDependencies = {} ) => {
+			const selectedSiteSlug = providedDependencies?.siteSlug as string;
+			const selectedSiteId = providedDependencies?.siteId as string;
+			const isNewSite = providedDependencies?.isNewSite === 'true';
+			setSelectedSite( selectedSiteId );
+			setIntentOnSite( selectedSiteSlug, SiteIntent.AIAssembler );
+			saveSiteSettings( selectedSiteId, { launchpad_screen: 'full' } );
+
+			// Check whether to go to the assembler. If not, go to the site editor directly
+			let params;
+			if ( ! isAssemblerSupported() ) {
+				params = new URLSearchParams( {
+					canvas: 'edit',
+					assembler: '1',
+				} );
+
+				return `/site-editor/${ selectedSiteSlug }?${ params }`;
+			}
+
+			params = new URLSearchParams( {
+				siteSlug: selectedSiteSlug,
+				siteId: selectedSiteId,
+			} );
+
+			if ( isNewSite ) {
+				params.set( 'isNewSite', 'true' );
+			}
+
+			return navigate( `site-prompt?${ params }` );
+		};
+
+		const submit = async (
+			providedDependencies: ProvidedDependencies = {},
+			...results: string[]
+		) => {
 			recordSubmitStep( providedDependencies, intent, flowName, _currentStep );
 
 			switch ( _currentStep ) {
+				case 'check-sites': {
+					// Check for unlaunched sites
+					if ( providedDependencies?.filteredSitesCount === 0 ) {
+						// No unlaunched sites, redirect to new site creation step
+						return navigate( 'site-creation-step' );
+					}
+					// With unlaunched sites, continue to new-or-existing-site step
+					return navigate( 'new-or-existing-site' );
+				}
+
+				case 'new-or-existing-site': {
+					if ( 'new-site' === providedDependencies?.newExistingSiteChoice ) {
+						return navigate( 'site-creation-step' );
+					}
+					return navigate( 'site-picker' );
+				}
+
+				case 'site-creation-step': {
+					return navigate( 'processing' );
+				}
+
+				case 'site-picker': {
+					return handleSelectSite( providedDependencies );
+				}
+
+				case 'site-prompt': {
+					return navigate( 'patternAssembler' );
+				}
+
 				case 'processing': {
 					if ( results.some( ( result ) => result === ProcessingResult.FAILURE ) ) {
 						return navigate( 'error' );
+					}
+
+					// If we just created a new site, navigate to the assembler step.
+					if ( providedDependencies?.siteSlug && ! providedDependencies?.isLaunched ) {
+						return handleSelectSite( {
+							...providedDependencies,
+							isNewSite: 'true',
+						} );
+					}
+
+					// If the user's site has just been launched.
+					if ( providedDependencies?.siteSlug && providedDependencies?.isLaunched ) {
+						await saveSiteSettings( providedDependencies?.siteSlug, {
+							launchpad_screen: 'off',
+						} );
+						return navigate( 'celebration-step' );
+					}
+
+					if ( providedDependencies?.goToCheckout ) {
+						// Do nothing and wait for checkout redirect
+						return;
 					}
 
 					const params = new URLSearchParams( {
@@ -98,7 +197,6 @@ const withAIAssemblerFlow: Flow = {
 						assembler: '1',
 					} );
 
-					// We will navigate to the celebration step in the follow-up PR
 					return exitFlow( `/site-editor/${ siteSlug }?${ params }` );
 				}
 
@@ -106,9 +204,20 @@ const withAIAssemblerFlow: Flow = {
 					return navigate( 'processing' );
 				}
 
-				case 'site-prompt': {
-					return navigate( 'patternAssembler' );
+				case 'launchpad': {
+					return navigate( 'processing' );
 				}
+
+				case 'plans': {
+					await updateLaunchpadSettings( siteSlug, {
+						checklist_statuses: { plan_completed: true },
+					} );
+
+					return navigate( 'launchpad' );
+				}
+
+				case 'site-launch':
+					return navigate( 'processing' );
 
 				case 'celebration-step': {
 					return window.location.assign( providedDependencies.destinationUrl as string );
@@ -118,8 +227,12 @@ const withAIAssemblerFlow: Flow = {
 
 		const goBack = () => {
 			switch ( _currentStep ) {
+				case 'site-picker': {
+					return navigate( 'new-or-existing-site' );
+				}
+
 				case 'patternAssembler': {
-					return window.location.assign( `/themes/${ siteSlug }` );
+					return navigate( 'site-prompt' );
 				}
 			}
 		};
@@ -133,6 +246,56 @@ const withAIAssemblerFlow: Flow = {
 		};
 
 		return { submit, goBack, goNext };
+	},
+
+	useAssertConditions(): AssertConditionResult {
+		const flowName = this.name;
+		const isLoggedIn = useSelector( isUserLoggedIn );
+		const currentUserSiteCount = useSelector( getCurrentUserSiteCount );
+		const currentPath = window.location.pathname;
+		const isSiteCreationStep =
+			currentPath.endsWith( `setup/${ flowName }` ) ||
+			currentPath.endsWith( `setup/${ flowName }/` ) ||
+			currentPath.includes( `setup/${ flowName }/check-sites` );
+		const userAlreadyHasSites = currentUserSiteCount && currentUserSiteCount > 0;
+
+		// There is a race condition where useLocale is reporting english,
+		// despite there being a locale in the URL so we need to look it up manually.
+		// We also need to support both query param and path suffix localized urls
+		// depending on where the user is coming from.
+		const useLocaleSlug = useLocale();
+		const queryLocaleSlug = getLocaleFromQueryParam();
+		const pathLocaleSlug = getLocaleFromPathname();
+		const locale = queryLocaleSlug || pathLocaleSlug || useLocaleSlug;
+		const logInUrl = useLoginUrl( {
+			variationName: flowName,
+			redirectTo: window.location.href.replace( window.location.origin, '' ),
+			locale,
+		} );
+
+		useEffect( () => {
+			if ( ! isLoggedIn ) {
+				window.location.assign( logInUrl );
+			} else if ( isSiteCreationStep && ! userAlreadyHasSites ) {
+				window.location.assign( `/setup/${ flowName }/site-creation-step` );
+			}
+		}, [] );
+
+		let result: AssertConditionResult = { state: AssertConditionState.SUCCESS };
+
+		if ( ! isLoggedIn ) {
+			result = {
+				state: AssertConditionState.CHECKING,
+				message: `${ flowName } requires a logged in user`,
+			};
+		} else if ( isSiteCreationStep && ! userAlreadyHasSites ) {
+			result = {
+				state: AssertConditionState.CHECKING,
+				message: `${ flowName } with no preexisting sites`,
+			};
+		}
+
+		return result;
 	},
 };
 

--- a/client/landing/stepper/declarative-flow/assembler-first-flow.ts
+++ b/client/landing/stepper/declarative-flow/assembler-first-flow.ts
@@ -274,7 +274,6 @@ const assemblerFirstFlow: Flow = {
 		// We also need to support both query param and path suffix localized urls
 		// depending on where the user is coming from.
 		const useLocaleSlug = useLocale();
-		// Query param support can be removed after dotcom-forge/issues/2960 and 2961 are closed.
 		const queryLocaleSlug = getLocaleFromQueryParam();
 		const pathLocaleSlug = getLocaleFromPathname();
 		const locale = queryLocaleSlug || pathLocaleSlug || useLocaleSlug;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/ai-site-prompt/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/ai-site-prompt/index.tsx
@@ -118,7 +118,7 @@ const AISitePrompt: Step = function ( props ) {
 					stepName="site-prompt"
 					className={ `is-step-${ intent }` }
 					skipButtonAlign="top"
-					goBack={ goBack }
+					hideBack
 					goNext={ goNext }
 					isHorizontalLayout={ true }
 					formattedHeader={

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/index.tsx
@@ -10,6 +10,7 @@ import {
 	START_WRITING_FLOW,
 	DESIGN_FIRST_FLOW,
 	ASSEMBLER_FIRST_FLOW,
+	AI_ASSEMBLER_FLOW,
 } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -63,6 +64,7 @@ const useIntentsForFlow = ( flowName: string ): NewOrExistingSiteIntent[] => {
 		case DESIGN_FIRST_FLOW:
 		case START_WRITING_FLOW:
 		case ASSEMBLER_FIRST_FLOW:
+		case AI_ASSEMBLER_FLOW:
 			return [
 				{
 					key: 'existing-site',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/new-or-existing-site/styles.scss
@@ -41,7 +41,8 @@
 
 .start-writing,
 .design-first,
-.assembler-first {
+.assembler-first,
+.ai-assembler {
 	&.new-or-existing-site {
 		.step-container__header {
 			margin-top: 0;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -7,6 +7,7 @@ import {
 } from '@automattic/global-styles';
 import { useLocale } from '@automattic/i18n-utils';
 import {
+	AI_ASSEMBLER_FLOW,
 	StepContainer,
 	isSiteAssemblerFlow,
 	isWithThemeAssemblerFlow,
@@ -419,11 +420,16 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 		recordTracksEvent,
 	} );
 
-	// Don't show the “Back” button if the site is being created by the site assembler flow
-	// as the previous step is the site creation step that cannot be undone.
-	const hideBack = ! currentScreen.previousScreen && isSiteAssemblerFlow( flow ) && isNewSite;
-
 	const getBackLabel = () => {
+		// Exits the Assembler.
+		if ( isSiteAssemblerFlow( flow ) && ! currentScreen.previousScreen ) {
+			if ( flow === AI_ASSEMBLER_FLOW ) {
+				return translate( 'Back' );
+			}
+
+			return translate( 'Back to themes' );
+		}
+
 		if ( ! currentScreen.previousScreen ) {
 			// Go back to the Theme Showcase if people are from the with-theme-assembler flow.
 			if ( isWithThemeAssemblerFlow( flow ) ) {
@@ -438,6 +444,27 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 				pageTitle: currentScreen.previousScreen.backLabel || currentScreen.previousScreen.title,
 			},
 		} );
+	};
+
+	const shouldHideBack = () => {
+		// Back button goes to the previous Assembler navigation screen.
+		if ( currentScreen.previousScreen ) {
+			return false;
+		}
+
+		// Back button goes to the Theme Showcase.
+		if ( ! isNewSite ) {
+			return false;
+		}
+
+		// Back button goes to the AI prompt step.
+		if ( flow === AI_ASSEMBLER_FLOW ) {
+			return false;
+		}
+
+		// Don't show the “Back” button if the site is being created by the site assembler flow.
+		// as the previous step is the site creation step that cannot be undone.
+		return isSiteAssemblerFlow( flow );
 	};
 
 	const onBack = () => {
@@ -684,7 +711,7 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 			goNext={ goNext }
 			isHorizontalLayout={ false }
 			isFullLayout={ true }
-			hideBack={ hideBack }
+			hideBack={ shouldHideBack() }
 			hideSkip={ true }
 			stepContent={
 				<PatternAssemblerContainer

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -72,6 +72,9 @@ const availableFlows: Record< string, () => Promise< { default: Flow } > > = {
 	'assembler-first': () =>
 		import( /* webpackChunkName: "assembler-first-flow" */ './assembler-first-flow' ),
 
+	[ AI_ASSEMBLER_FLOW ]: () =>
+		import( /* webpackChunkName: "ai-assembler-flow" */ './ai-assembler' ),
+
 	'free-post-setup': () =>
 		import( /* webpackChunkName: "free-post-setup-flow" */ '../declarative-flow/free-post-setup' ),
 
@@ -141,13 +144,4 @@ const videoPressTvFlows: Record< string, () => Promise< { default: Flow } > > = 
 	  }
 	: {};
 
-const aiAssemblerFlows: Record< string, () => Promise< { default: Flow } > > = config.isEnabled(
-	'calypso/ai-assembler'
-)
-	? {
-			[ AI_ASSEMBLER_FLOW ]: () =>
-				import( /* webpackChunkName: "ai-assembler-flow" */ './ai-assembler' ),
-	  }
-	: {};
-
-export default { ...availableFlows, ...videoPressTvFlows, ...aiAssemblerFlows };
+export default { ...availableFlows, ...videoPressTvFlows };

--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -141,7 +141,7 @@ const videoPressTvFlows: Record< string, () => Promise< { default: Flow } > > = 
 	  }
 	: {};
 
-const aiAsseblerFlows: Record< string, () => Promise< { default: Flow } > > = config.isEnabled(
+const aiAssemblerFlows: Record< string, () => Promise< { default: Flow } > > = config.isEnabled(
 	'calypso/ai-assembler'
 )
 	? {
@@ -150,4 +150,4 @@ const aiAsseblerFlows: Record< string, () => Promise< { default: Flow } > > = co
 	  }
 	: {};
 
-export default { ...availableFlows, ...videoPressTvFlows, ...aiAsseblerFlows };
+export default { ...availableFlows, ...videoPressTvFlows, ...aiAssemblerFlows };

--- a/packages/data-stores/src/onboard/constants.ts
+++ b/packages/data-stores/src/onboard/constants.ts
@@ -21,4 +21,5 @@ export enum SiteIntent {
 	Import = 'import', // deprecated
 	WithThemeAssembler = 'with-theme-assembler',
 	AssemblerFirst = 'assembler-first',
+	AIAssembler = 'ai-assembler',
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #84839

## Proposed Changes

This PR adds account steps to the existing `ai-assembler` flow. Most of the logic in the flow is copied from the [assembler-first](https://github.com/Automattic/wp-calypso/blob/trunk/client/landing/stepper/declarative-flow/assembler-first-flow.ts) flow.

https://github.com/Automattic/wp-calypso/assets/797888/87e7e8ab-d9a7-430a-8d27-2388e4fd87e3

> [!NOTE]
> This flow currently has no entry point, so it can only be access by directly visiting the URL.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/setup/ai-assembler`.
* Ensure to see the Account screen if you are logged-out.
* Ensure to see the New or Existing screen (after checking your sites) if you are logged-in. 
* Ensure that choosing Select a site leads to Site picker and then the AI prompt screen. 
* Ensure that choosing New site leads to the site creation and then the AI prompt screen.
* Ensure that the AI prompt screen works as before (and the Skip for now takes you to the Assembler).
* Ensure that the Assembler has a Back button that takes you back to the AI prompt screen.
* Ensure that the Assembler works as before.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?