### PR TITLE
Global Styles Modal: Fix orphan word

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/modal.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/modal.scss
@@ -73,6 +73,7 @@
 		line-height: 24px;
 		margin-top: 0;
 		margin-bottom: 32px;
+		text-wrap: pretty;
 	}
 
 	.wpcom-global-styles-modal__actions {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

*  Fix orphan word on Global Styles Modal with `text-wrap: pretty` 

|BEFORE|AFTER|
|--|--|
|<img width="1544" alt="Screenshot 2566-12-07 at 15 48 10" src="https://github.com/Automattic/wp-calypso/assets/1881481/e2a2f27b-77d4-4cd5-9903-7eda98c5764d">|<img width="1547" alt="Screenshot 2566-12-07 at 15 56 15" src="https://github.com/Automattic/wp-calypso/assets/1881481/85bb693a-ec94-4013-839d-4e033ee45d57">|


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox a free site 
* Run in your sandbox `install-plugin.sh etk fix/global-styles-modal-orphan-word`
* Click on the global styles icon and expect to see the modal without the orphan 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?