### PR TITLE
Assembler: Use new theme under feature flag

### DIFF
--- a/client/landing/stepper/declarative-flow/assembler-first-flow.ts
+++ b/client/landing/stepper/declarative-flow/assembler-first-flow.ts
@@ -1,5 +1,5 @@
 import { Onboard, updateLaunchpadSettings } from '@automattic/data-stores';
-import { DEFAULT_ASSEMBLER_DESIGN, isAssemblerSupported } from '@automattic/design-picker';
+import { getAssemblerDesign, isAssemblerSupported } from '@automattic/design-picker';
 import { useLocale } from '@automattic/i18n-utils';
 import { ASSEMBLER_FIRST_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -34,7 +34,7 @@ const assemblerFirstFlow: Flow = {
 			[]
 		);
 		const { setSelectedDesign, setIntent } = useDispatch( ONBOARD_STORE );
-		const selectedTheme = DEFAULT_ASSEMBLER_DESIGN.slug;
+		const selectedTheme = getAssemblerDesign().slug;
 		const theme = useSelector( ( state ) => getTheme( state, 'wpcom', selectedTheme ) );
 
 		// We have to query theme for the Jetpack site.

--- a/client/landing/stepper/declarative-flow/with-theme-assembler-flow.ts
+++ b/client/landing/stepper/declarative-flow/with-theme-assembler-flow.ts
@@ -1,5 +1,5 @@
 import { Onboard } from '@automattic/data-stores';
-import { DEFAULT_ASSEMBLER_DESIGN } from '@automattic/design-picker';
+import { getAssemblerDesign } from '@automattic/design-picker';
 import { useFlowProgress, WITH_THEME_ASSEMBLER_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from 'react';
@@ -24,7 +24,7 @@ const withThemeAssemblerFlow: Flow = {
 			[]
 		);
 		const { setSelectedDesign, setIntent } = useDispatch( ONBOARD_STORE );
-		const selectedTheme = DEFAULT_ASSEMBLER_DESIGN.slug;
+		const selectedTheme = getAssemblerDesign().slug;
 		const theme = useSelector( ( state ) => getTheme( state, 'wpcom', selectedTheme ) );
 
 		// We have to query theme for the Jetpack site.

--- a/config/development.json
+++ b/config/development.json
@@ -141,6 +141,7 @@
 		"onboarding/import-redirect-to-themes": true,
 		"p2/p2-plus": true,
 		"page/export": true,
+		"pattern-assembler/v2": false,
 		"pattern-assembler/add-pages": true,
 		"plans/hosting-trial": false,
 		"plans/migration-trial": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -86,6 +86,7 @@
 		"my-sites/add-ons": true,
 		"network-connection": true,
 		"p2/p2-plus": true,
+		"pattern-assembler/v2": true,
 		"pattern-assembler/add-pages": true,
 		"plans/hosting-trial": false,
 		"plans/migration-trial": true,

--- a/config/production.json
+++ b/config/production.json
@@ -107,6 +107,7 @@
 		"onboarding/import-from-wordpress": true,
 		"onboarding/import-redirect-to-themes": true,
 		"p2/p2-plus": true,
+		"pattern-assembler/v2": false,
 		"pattern-assembler/add-pages": true,
 		"plans/hosting-trial": false,
 		"plans/migration-trial": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -104,6 +104,7 @@
 		"onboarding/import-redirect-to-themes": true,
 		"p2/p2-plus": true,
 		"page/export": true,
+		"pattern-assembler/v2": false,
 		"pattern-assembler/add-pages": true,
 		"plans/hosting-trial": false,
 		"plans/migration-trial": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -113,6 +113,7 @@
 		"onboarding/import-light": false,
 		"onboarding/import-redirect-to-themes": true,
 		"p2/p2-plus": true,
+		"pattern-assembler/v2": false,
 		"pattern-assembler/add-pages": true,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -6,8 +6,9 @@ import classnames from 'classnames';
 import photon from 'photon';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { useInView } from 'react-intersection-observer';
-import { SHOW_ALL_SLUG, DEFAULT_ASSEMBLER_DESIGN } from '../constants';
+import { SHOW_ALL_SLUG } from '../constants';
 import {
+	getAssemblerDesign,
 	getDesignPreviewUrl,
 	getMShotOptions,
 	isBlankCanvasDesign,
@@ -254,7 +255,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 						className={ classnames( 'design-picker__design-your-own-button', {
 							'design-picker__design-your-own-button-without-categories': ! hasCategories,
 						} ) }
-						onClick={ () => onClickDesignYourOwnTopButton( DEFAULT_ASSEMBLER_DESIGN ) }
+						onClick={ () => onClickDesignYourOwnTopButton( getAssemblerDesign() ) }
 					>
 						{ assemblerCtaData.title }
 					</Button>
@@ -281,7 +282,7 @@ const DesignPicker: React.FC< DesignPickerProps > = ( {
 						/>
 					);
 				} ) }
-				<PatternAssemblerCta onButtonClick={ () => onDesignYourOwn( DEFAULT_ASSEMBLER_DESIGN ) } />
+				<PatternAssemblerCta onButtonClick={ () => onDesignYourOwn( getAssemblerDesign() ) } />
 			</div>
 		</div>
 	);

--- a/packages/design-picker/src/constants.ts
+++ b/packages/design-picker/src/constants.ts
@@ -77,6 +77,15 @@ export const DEFAULT_ASSEMBLER_DESIGN = {
 	design_type: 'assembler',
 } as Design;
 
+export const ASSEMBLER_V2_DESIGN = {
+	slug: 'assembler',
+	title: 'Assembler',
+	recipe: {
+		stylesheet: 'pub/assembler',
+	},
+	design_type: 'assembler',
+} as Design;
+
 export const FREE_THEME = 'free';
 export const PREMIUM_THEME = 'premium';
 export const DOT_ORG_THEME = 'dot-org';

--- a/packages/design-picker/src/index.ts
+++ b/packages/design-picker/src/index.ts
@@ -14,6 +14,7 @@ export {
 } from './components/pattern-assembler-cta';
 export {
 	availableDesignsConfig,
+	getAssemblerDesign,
 	getAvailableDesigns,
 	getFontTitle,
 	getDesignUrl,

--- a/packages/design-picker/src/utils/designs.ts
+++ b/packages/design-picker/src/utils/designs.ts
@@ -1,6 +1,11 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { isWithinBreakpoint } from '@automattic/viewport';
 import { addQueryArgs } from '@wordpress/url';
-import { DEFAULT_VIEWPORT_HEIGHT } from '../constants';
+import {
+	ASSEMBLER_V2_DESIGN,
+	DEFAULT_ASSEMBLER_DESIGN,
+	DEFAULT_VIEWPORT_HEIGHT,
+} from '../constants';
 import type { Design, DesignPreviewOptions } from '../types';
 
 function encodeParenthesesInText( text: string ) {
@@ -62,6 +67,13 @@ export const getDesignPreviewUrl = (
 	}
 
 	return url;
+};
+
+export const getAssemblerDesign = () => {
+	if ( isEnabled( 'pattern-assembler/v2' ) ) {
+		return ASSEMBLER_V2_DESIGN;
+	}
+	return DEFAULT_ASSEMBLER_DESIGN;
 };
 
 export const isAssemblerDesign = ( design?: Design ) => design?.design_type === 'assembler';


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/wp-calypso/issues/84948

## Proposed Changes

Use the new theme (`pub/assembler`) under feature flag (`pattern-assembler/v2`).

## Testing Instructions

1. Always append the `flags=pattern-assembler/v2` query param when testing.
1. Test the Onboarding Assembler flow (`/start` => Design your own):
   - Verify that the patterns are rendered in the new theme.
   - Verify that after completing the flow, the site's new theme is Assembler.
1. Similarly, test the Theme Showcase Assembler flow (TS => Design your own) and verify the same things as above.
1. Similarly, test the Assembler-First flow and verify the same things as above.
1. Test the AI-Assembler flow (`site-setup/ai-assembler`) and verify that it's still using Creatio 2.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?