### PR TITLE
Multi-Domains: Persisting free subdomain selection for domains page

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -158,6 +158,7 @@ export class RenderDomainsStep extends Component {
 		const domain = get( props, 'queryObject.new', false );
 		const search = get( props, 'queryObject.search', false ) === 'yes';
 		const suggestedDomain = get( props, 'signupDependencies.suggestedDomain' );
+		const siteUrl = get( props, 'signupDependencies.siteUrl' );
 
 		// If we landed anew from `/domains` and it's the `new-flow` variation
 		// or there's a suggestedDomain from previous steps, always rerun the search.
@@ -202,7 +203,8 @@ export class RenderDomainsStep extends Component {
 		this.state = {
 			currentStep: null,
 			isCartPendingUpdateDomain: null,
-			wpcomSubdomainSelected: false,
+			wpcomSubdomainSelected:
+				siteUrl && siteUrl.indexOf( '.wordpress.com' ) !== -1 ? { domain_name: siteUrl } : null,
 			domainRemovalQueue: [],
 			isGoingToNextStep: false,
 			temporaryCart: [],
@@ -1002,6 +1004,12 @@ export class RenderDomainsStep extends Component {
 										className="button domains__domain-cart-remove"
 										onClick={ () => {
 											this.setState( { wpcomSubdomainSelected: false } );
+											this.props.saveSignupStep( {
+												stepName: this.props.stepName,
+												suggestion: {
+													domain_name: 'no-suggestion',
+												},
+											} );
 										} }
 									>
 										{ this.props.translate( 'Remove' ) }

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -822,7 +822,7 @@ export class RenderDomainsStep extends Component {
 			Object.assign(
 				{ domainItem, domainCart },
 				useThemeHeadstartItem,
-				suggestion?.domain_name ? { siteUrl: suggestion?.domain_name } : {},
+				{ siteUrl: suggestion?.domain_name },
 				lastDomainSearched ? { lastDomainSearched } : {},
 				{ domainCart }
 			)
@@ -1007,9 +1007,15 @@ export class RenderDomainsStep extends Component {
 											this.props.saveSignupStep( {
 												stepName: this.props.stepName,
 												suggestion: {
-													domain_name: 'no-suggestion',
+													domain_name: false,
 												},
 											} );
+											this.props.submitSignupStep(
+												Object.assign( {
+													stepName: this.props.stepName,
+												} ),
+												Object.assign( { siteUrl: false } )
+											);
 										} }
 									>
 										{ this.props.translate( 'Remove' ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 4776-gh-Automattic/dotcom-forge

## Proposed Changes

* We're now persisting the free subdomain selection in the mini-cart

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open [/start/domains](http://calypso.localhost:3000/start/domains)
* Add a free subdomain on your cart
* Advance to the next page
* Go back to /start/domains using your back browser button or just the `Back` button
* Ensure you still see the free subdomain rendered on the mini-cart

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?