### PR TITLE
fix: css overrides for auth separator under woo signup login page

### DIFF
--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -509,14 +509,7 @@
 	}
 
 	.signup-form .auth-form__separator {
-		@media ( min-width: 782px ) {
-			width: 100%;
-		}
-
-		&::before,
-		&::after {
-			content: none;
-		}
+		width: 100%;
 	}
 
 	.auth-form__separator + .auth-form__social.card {
@@ -525,6 +518,12 @@
 		max-width: 100%;
 	}
 
+	.auth-form__separator {
+		&::before,
+		&::after {
+			content: none;
+		}
+	}
 	.auth-form__social,
 	.two-factor-authentication__actions {
 		background: initial;

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -285,7 +285,7 @@
 			align-items: flex-start;
 		}
 
-		.social-buttons__button {
+		button.social-buttons__button.button {
 			border: 0;
 			text-align: left;
 			padding-bottom: 0;
@@ -508,6 +508,23 @@
 		display: none;
 	}
 
+	.signup-form .auth-form__separator {
+		@media ( min-width: 782px ) {
+			width: 100%;
+		}
+
+		&::before,
+		&::after {
+			content: none;
+		}
+	}
+
+	.auth-form__separator + .auth-form__social.card {
+		clip-path: unset; // unset the rule applied in ./client/blocks/authentication/form-divider/style.scss
+		border-top: 1px solid #e6e6e6;
+		max-width: 100%;
+	}
+
 	.auth-form__social,
 	.two-factor-authentication__actions {
 		background: initial;
@@ -562,6 +579,7 @@
 
 	.auth-form__separator .auth-form__separator-text {
 		padding: 0 27px;
+		background: #fff;
 	}
 
 	.wp-login__footer--oauth {


### PR DESCRIPTION
## Proposed Changes

Close https://github.com/woocommerce/team-ghidorah/issues/275

* Fixed the CSS for login auth separator that was broken by some refactors

Before:

![image](https://github.com/Automattic/wp-calypso/assets/27843274/8dc805ed-6e1b-49a4-8580-b1fb2de10c0c)

![image](https://github.com/Automattic/wp-calypso/assets/27843274/684a6719-368b-48b1-a697-1d4d5a70691e)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


* Either start the flow from woo.com/start or use the login url below
* Go to https://calypso.localhost:3000/start/wpcc/oauth2-user?ref=oauth2&oauth2_redirect=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3Dec48f481d15c69be7606f5b9ab4215c77b54baa146f2a7728ca2461b2c29940c%26redirect_uri%3Dhttps%253A%252F%252Fwoo.com%252Fwc-api%252Fwpcom-signin%253Fnext%253D%25252Fstart%25252F%252523%25252Finstallation%2526source%253Dsignup_menu%26blog_id%3D0%26wpcom_connect%3D1%26wccom-from%26calypso_env%3Dproduction%26jetpack-code%26jetpack-user-id%3D0%26action%3Doauth2-login%26from-calypso%3D1&oauth2_client_id=50916


Create account page should look like:

![image](https://github.com/Automattic/wp-calypso/assets/27843274/360d0407-7c2b-4161-8c1a-6c57a5a2ec7a)

Login page should look like:
![image](https://github.com/Automattic/wp-calypso/assets/27843274/0787d671-17a6-433b-a2ad-1f194477accb)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?