### PR TITLE
Reader: Add TikTok block support

### DIFF
--- a/client/components/embed-container/index.jsx
+++ b/client/components/embed-container/index.jsx
@@ -19,6 +19,7 @@ const embedsToLookFor = {
 	'.jetpack-slideshow': embedSlideshow,
 	'.wp-block-jetpack-story': embedStory,
 	'.embed-reddit': embedReddit,
+	'.embed-tiktok': embedTikTok,
 	'.wp-block-jetpack-slideshow, .wp-block-newspack-blocks-carousel': embedCarousel,
 };
 
@@ -118,6 +119,11 @@ function embedFacebook( domNode ) {
 function embedReddit( domNode ) {
 	debug( 'processing reddit for ', domNode );
 	loadAndRun( 'https://embed.redditmedia.com/widgets/platform.js', noop );
+}
+
+function embedTikTok( domNode ) {
+	debug( 'processing tiktok for ', domNode );
+	loadAndRun( 'https://www.tiktok.com/embed.js', noop );
 }
 
 let tumblrLoader;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #55479

## Proposed Changes

* Load the required TikTok JS when a TikTok embed is found in the full-post view.
* Unfortunately that ugly white background is part of the TikTok iframe and not something we can change 🙃 but at least it keeps the user in the Reader rather than sending them to TikTok to watch!

**Before**

<img width="1029" alt="Screenshot 2023-12-07 at 8 34 17 AM" src="https://github.com/Automattic/wp-calypso/assets/2124984/529628eb-3485-4b33-bb0d-0948f1ea4890">

**After**

<img width="1015" alt="Screenshot 2023-12-07 at 8 31 14 AM" src="https://github.com/Automattic/wp-calypso/assets/2124984/c6b2e79b-1992-4170-bf54-b65192a625a2">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR
* Find a post with a TikTok embed or create one
* Visit `/read` and click on the post to view it in full
* You should see the video embed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?