### PR TITLE
PlanPrice to packages (Step 1): Add PlanPrice to components package

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -30,6 +30,7 @@
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/calypso-url": "workspace:^",
 		"@automattic/data-stores": "workspace:^",
+		"@automattic/format-currency": "workspace:^",
 		"@automattic/search": "workspace:^",
 		"@automattic/typography": "workspace:^",
 		"@automattic/viewport-react": "workspace:^",

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -62,6 +62,7 @@ export { default as PricingSlider } from './pricing-slider';
 export { default as Tooltip } from './tooltip';
 export { default as SegmentedControl } from './segmented-control';
 export { default as SimplifiedSegmentedControl } from './segmented-control/simplified';
+export { default as PlanPrice } from './plan-price';
 export * from './theme-type-badge';
 
 // Types

--- a/packages/components/src/plan-price/README.md
+++ b/packages/components/src/plan-price/README.md
@@ -1,0 +1,62 @@
+# PlanPrice Component
+
+The PlanPrice component is a React component used to display a plan's price with a currency and a discount, if any. It can be used anywhere where a plan's price is required.
+
+If you want to emphasize that a plan's price is discounted, use two `<PlanPrice>` components as below and wrap them in a
+flexbox container.
+
+## Usage
+
+PlanPrice can take a `productDisplayPrice` or a `rawPrice` prop.
+
+A `productDisplayPrice` can be retrieved from the `/purchases` or `/plans` REST endpoints and are stored in Redux; for example:
+
+```jsx
+function MyComponent( { purchaseId } ) {
+	const { productDisplayPrice } = useSelector( ( state ) => getByPurchaseId( state, purchaseId ) );
+	return <PlanPrice productDisplayPrice={ productDisplayPrice } />;
+}
+```
+
+```jsx
+<PlanPrice
+	productDisplayPrice={ purchase.productDisplayPrice }
+	taxText={ purchase.taxText }
+	isOnSale={ !! purchase.saleAmount }
+/>;
+```
+
+```jsx
+<PlanPrice
+	productDisplayPrice={ purchase.productDisplayPrice }
+	rawPrice={ getRenewalPrice( purchase ) }
+	currencyCode={ purchase.currencyCode }
+	taxText={ purchase.taxText }
+	isOnSale={ !! purchase.saleAmount }
+/>;
+```
+
+If you pass an array of two numbers in the `rawPrice` prop, a range of prices will be displayed.
+
+```jsx
+import { PlanPrice } from '@automattic/components';
+
+export default class extends React.Component {
+	static displayName = 'MyPlanPrice';
+
+	render() {
+		return (
+			<div>
+				<span className="my-plan-price-with-flexbox">
+					<PlanPrice rawPrice={ 99 } original />
+					<PlanPrice rawPrice={ 30 } discounted />
+				</span>
+				<span className="my-plan-price-with-flexbox">
+					<PlanPrice rawPrice={ [ 132.2, 110.4 ] } original />
+					<PlanPrice rawPrice={ [ 99.99, 87 ] } discounted />
+				</span>
+			</div>
+		);
+	}
+}
+```

--- a/packages/components/src/plan-price/docs/example.jsx
+++ b/packages/components/src/plan-price/docs/example.jsx
@@ -1,0 +1,56 @@
+import PlanPrice from '../';
+
+function PlanPriceExample() {
+	return (
+		<div>
+			<h3>Plan with standard price</h3>
+			<PlanPrice rawPrice={ 99.8 } />
+			<br />
+			<h3>Plan with a price range</h3>
+			<PlanPrice rawPrice={ [ 99.99, 139.99 ] } />
+			<br />
+			<h3>Plan with a price of '0'</h3>
+			<PlanPrice rawPrice={ 0 } />
+			<br />
+			<h3>Plan with discounted price</h3>
+			<div style={ { display: 'flex' } }>
+				<PlanPrice rawPrice={ 8.25 } original />
+				<PlanPrice rawPrice={ 2 } discounted />
+			</div>
+			<br />
+			<h3>Plan with discounted price range</h3>
+			<div style={ { display: 'flex' } }>
+				<PlanPrice rawPrice={ [ 8.25, 20.23 ] } original />
+				<PlanPrice rawPrice={ [ 2.25, 3 ] } discounted />
+			</div>
+			<br />
+			<h3>Plan with discounted price and tax</h3>
+			<div style={ { display: 'flex' } }>
+				<PlanPrice rawPrice={ 8.25 } original taxText="10%" />
+				<PlanPrice rawPrice={ 2 } discounted taxText="10%" />
+			</div>
+			<br />
+			<h3>Plan with discounted price range and tax</h3>
+			<div style={ { display: 'flex' } }>
+				<PlanPrice rawPrice={ [ 8.25, 20.23 ] } original taxText="10%" />
+				<PlanPrice rawPrice={ [ 2.25, 3 ] } discounted taxText="10%" />
+			</div>
+			<br />
+			<h3>Simple View (isInSignup) - Plan with discounted price and tax </h3>
+			<div style={ { display: 'flex' } }>
+				<PlanPrice rawPrice={ 8.25 } original taxText="10%" isInSignup={ true } />
+				<PlanPrice rawPrice={ 2 } discounted taxText="10%" isInSignup={ true } />
+			</div>
+			<br />
+			<h3>Simple View (isInSignup) - Plan with discounted price range and tax </h3>
+			<div style={ { display: 'flex' } }>
+				<PlanPrice rawPrice={ [ 8.25, 20.23 ] } original taxText="10%" isInSignup={ true } />
+				<PlanPrice rawPrice={ [ 2.25, 3 ] } discounted taxText="10%" isInSignup={ true } />
+			</div>
+		</div>
+	);
+}
+
+PlanPriceExample.displayName = 'PlanPrice';
+
+export default PlanPriceExample;

--- a/packages/components/src/plan-price/index.stories.js
+++ b/packages/components/src/plan-price/index.stories.js
@@ -1,0 +1,57 @@
+import PlanPrice from './';
+
+export const Default = () => {
+	return (
+		<div>
+			<h3>Plan with standard price</h3>
+			<PlanPrice rawPrice={ 99.8 } />
+			<br />
+			<h3>Plan with a price range</h3>
+			<PlanPrice rawPrice={ [ 99.99, 139.99 ] } />
+			<br />
+			<h3>Plan with a price of '0'</h3>
+			<PlanPrice rawPrice={ 0 } />
+			<br />
+			<h3>Plan with discounted price</h3>
+			<div style={ { display: 'flex' } }>
+				<PlanPrice rawPrice={ 8.25 } original />
+				<PlanPrice rawPrice={ 2 } discounted />
+			</div>
+			<br />
+			<h3>Plan with discounted price range</h3>
+			<div style={ { display: 'flex' } }>
+				<PlanPrice rawPrice={ [ 8.25, 20.23 ] } original />
+				<PlanPrice rawPrice={ [ 2.25, 3 ] } discounted />
+			</div>
+			<br />
+			<h3>Plan with discounted price and tax</h3>
+			<div style={ { display: 'flex' } }>
+				<PlanPrice rawPrice={ 8.25 } original taxText="10%" />
+				<PlanPrice rawPrice={ 2 } discounted taxText="10%" />
+			</div>
+			<br />
+			<h3>Plan with discounted price range and tax</h3>
+			<div style={ { display: 'flex' } }>
+				<PlanPrice rawPrice={ [ 8.25, 20.23 ] } original taxText="10%" />
+				<PlanPrice rawPrice={ [ 2.25, 3 ] } discounted taxText="10%" />
+			</div>
+			<br />
+			<h3>Simple View (isInSignup) - Plan with discounted price and tax </h3>
+			<div style={ { display: 'flex' } }>
+				<PlanPrice rawPrice={ 8.25 } original taxText="10%" isInSignup={ true } />
+				<PlanPrice rawPrice={ 2 } discounted taxText="10%" isInSignup={ true } />
+			</div>
+			<br />
+			<h3>Simple View (isInSignup) - Plan with discounted price range and tax </h3>
+			<div style={ { display: 'flex' } }>
+				<PlanPrice rawPrice={ [ 8.25, 20.23 ] } original taxText="10%" isInSignup={ true } />
+				<PlanPrice rawPrice={ [ 2.25, 3 ] } discounted taxText="10%" isInSignup={ true } />
+			</div>
+		</div>
+	);
+};
+
+export default {
+	title: 'packages/components/PlanPrice',
+	component: PlanPrice,
+};

--- a/packages/components/src/plan-price/index.tsx
+++ b/packages/components/src/plan-price/index.tsx
@@ -1,0 +1,410 @@
+import { Badge } from '@automattic/components';
+import { getCurrencyObject } from '@automattic/format-currency';
+import classNames from 'classnames';
+import { useTranslate, TranslateResult } from 'i18n-calypso';
+import { Component, createElement } from 'react';
+
+import './style.scss';
+
+export class PlanPrice extends Component< PlanPriceProps > {
+	render() {
+		const {
+			currencyCode = 'USD',
+			rawPrice,
+			isSmallestUnit,
+			original,
+			discounted,
+			className,
+			displayFlatPrice,
+			displayPerMonthNotation,
+			productDisplayPrice,
+			isOnSale,
+			taxText,
+			omitHeading,
+			priceDisplayWrapperClassName,
+			isLargeCurrency,
+		} = this.props;
+
+		const classes = classNames( 'plan-price', className, {
+			'is-original': original,
+			'is-discounted': discounted,
+			'is-large-currency': isLargeCurrency,
+		} );
+
+		const tagName = omitHeading ? 'span' : 'h4';
+
+		const areThereMultipleRawPrices = rawPrice && Array.isArray( rawPrice ) && rawPrice.length > 1;
+
+		if ( productDisplayPrice && ! areThereMultipleRawPrices ) {
+			return createElement(
+				tagName,
+				{ className: classes },
+				<span
+					className="plan-price__integer"
+					// eslint-disable-next-line react/no-danger
+					dangerouslySetInnerHTML={ { __html: productDisplayPrice } }
+				/>
+			);
+		}
+
+		if ( ! currencyCode || rawPrice === undefined || rawPrice === null ) {
+			return null;
+		}
+
+		// "Normalize" the input price or price range.
+		const rawPriceRange = Array.isArray( rawPrice ) ? rawPrice.slice( 0, 2 ) : [ rawPrice ];
+
+		// If zero is in an array of length 2, render nothing
+		if ( Array.isArray( rawPrice ) && rawPriceRange.includes( 0 ) ) {
+			return null;
+		}
+
+		if ( displayFlatPrice ) {
+			return (
+				<FlatPriceDisplay
+					smallerPrice={ rawPriceRange[ 0 ] }
+					higherPrice={ rawPriceRange[ 1 ] }
+					currencyCode={ currencyCode }
+					className={ classes }
+					isSmallestUnit={ isSmallestUnit }
+				/>
+			);
+		}
+
+		return (
+			<MultiPriceDisplay
+				className={ classes }
+				tagName={ tagName }
+				smallerPrice={ rawPriceRange[ 0 ] }
+				higherPrice={ rawPriceRange[ 1 ] }
+				currencyCode={ currencyCode }
+				taxText={ taxText }
+				displayPerMonthNotation={ displayPerMonthNotation }
+				isOnSale={ isOnSale }
+				priceDisplayWrapperClassName={ priceDisplayWrapperClassName }
+				isSmallestUnit={ isSmallestUnit }
+			/>
+		);
+	}
+}
+
+export default PlanPrice;
+
+export interface PlanPriceProps {
+	/**
+	 * Can be either a floating point price to display, or a pair of floating
+	 * point prices.
+	 *
+	 * If there are a pair of prices, they will be displayed as a range (eg:
+	 * '$5-$10').
+	 *
+	 * If either of the numbers is a 0, nothing will be rendered at all.
+	 *
+	 * If specified along with `productDisplayPrice`, this will be ignored unless
+	 * it is an array, in which case `productDisplayPrice` will be ignored.
+	 */
+	rawPrice?: number | [ number, number ] | null;
+
+	/**
+	 * If true, the number(s) in `rawPrice` will be interpreted as integers in
+	 * the currency's smallest unit rather than floating point numbers.
+	 *
+	 * Has no effect if `productDisplayPrice` is being used.
+	 */
+	isSmallestUnit?: boolean;
+
+	/**
+	 * Adds the `is-original` CSS class.
+	 */
+	original?: boolean;
+
+	/**
+	 * Adds the `is-discounted` CSS class.
+	 */
+	discounted?: boolean;
+
+	/**
+	 * The currency code for the price.
+	 *
+	 * Ignored if `productDisplayPrice` is set and `rawPrice` is not an array.
+	 *
+	 * Defaults to `USD` if not set or if undefined, but if it is `null`, the
+	 * component will render nothing at all (if using `rawPrice`).
+	 */
+	currencyCode?: string | null;
+
+	/**
+	 * A string to add to the className of the component's output.
+	 */
+	className?: string;
+
+	/**
+	 * Displays a "Sale" banner over the price if set.
+	 *
+	 * Ignored if `productDisplayPrice` is set and `rawPrice` is not an array.
+	 * Also ignored if `displayFlatPrice` is set.
+	 */
+	isOnSale?: boolean;
+
+	/**
+	 * Text to display adjacent to the price referring to taxes.
+	 *
+	 * It is rendered inside the string '(+X tax)' where `X` is this prop.
+	 *
+	 * Ignored if `productDisplayPrice` is set and `rawPrice` is not an array.
+	 * Also ignored if `displayFlatPrice` is set.
+	 */
+	taxText?: string;
+
+	/**
+	 * Whether to display a "per month" label adjacent to the price.
+	 *
+	 * Ignored if `productDisplayPrice` is set and `rawPrice` is not an array.
+	 * Also ignored if `displayFlatPrice` is set.
+	 */
+	displayPerMonthNotation?: boolean;
+
+	/**
+	 * A pre-formatted price to display.
+	 *
+	 * Ignored if `rawPrice` is set and is an array.
+	 */
+	productDisplayPrice?: string | TranslateResult;
+
+	/**
+	 * If set, the component will render a `span` instead of an `h4`.
+	 */
+	omitHeading?: boolean;
+
+	/**
+	 * If set, the component will render without separating the integer part of
+	 * the price from the decimal part of the price.
+	 *
+	 * If set, many of the other formatting options will be ignored.
+	 *
+	 * Ignored if `productDisplayPrice` is set and `rawPrice` is not an array.
+	 */
+	displayFlatPrice?: boolean;
+
+	/**
+	 * If set, this renders each price inside a `div` with the class passed,
+	 * but is otherwise identical to the output normally used by `rawPrice`.
+	 *
+	 * Ignored if `displayFlatPrice` is set.
+	 *
+	 * Ignored if `productDisplayPrice` is set and `rawPrice` is not an array.
+	 */
+	priceDisplayWrapperClassName?: string;
+
+	/**
+	 * If true, this renders the price with a smaller font size by adding the `is-large-currency` class.
+	 */
+	isLargeCurrency?: boolean;
+}
+
+function PriceWithoutHtml( {
+	price,
+	currencyCode,
+	isSmallestUnit,
+}: {
+	price: number;
+	currencyCode: string;
+	isSmallestUnit?: boolean;
+} ) {
+	const priceObj = getCurrencyObject( price, currencyCode, { isSmallestUnit } );
+	if ( priceObj.hasNonZeroFraction ) {
+		return <>{ `${ priceObj.integer }${ priceObj.fraction }` }</>;
+	}
+	return <>{ priceObj.integer }</>;
+}
+
+function FlatPriceDisplay( {
+	smallerPrice,
+	higherPrice,
+	currencyCode,
+	className,
+	isSmallestUnit,
+}: {
+	smallerPrice: number;
+	higherPrice?: number;
+	currencyCode: string;
+	className?: string;
+	isSmallestUnit?: boolean;
+} ) {
+	const { symbol: currencySymbol, symbolPosition } = getCurrencyObject(
+		smallerPrice,
+		currencyCode
+	);
+	const translate = useTranslate();
+
+	if ( ! higherPrice ) {
+		return (
+			<span className={ className }>
+				{ symbolPosition === 'before' ? currencySymbol : null }
+				<PriceWithoutHtml
+					price={ smallerPrice }
+					currencyCode={ currencyCode }
+					isSmallestUnit={ isSmallestUnit }
+				/>
+				{ symbolPosition === 'after' ? currencySymbol : null }
+			</span>
+		);
+	}
+
+	return (
+		<span className={ className }>
+			{ symbolPosition === 'before' ? currencySymbol : null }
+			{ translate( '%(smallerPrice)s-%(higherPrice)s', {
+				args: {
+					smallerPrice: (
+						<PriceWithoutHtml
+							price={ smallerPrice }
+							currencyCode={ currencyCode }
+							isSmallestUnit={ isSmallestUnit }
+						/>
+					),
+					higherPrice: (
+						<PriceWithoutHtml
+							price={ higherPrice }
+							currencyCode={ currencyCode }
+							isSmallestUnit={ isSmallestUnit }
+						/>
+					),
+				},
+				comment: 'The price range for a particular product',
+			} ) }
+			{ symbolPosition === 'after' ? currencySymbol : null }
+		</span>
+	);
+}
+
+function MultiPriceDisplay( {
+	tagName,
+	className,
+	smallerPrice,
+	higherPrice,
+	currencyCode,
+	taxText,
+	displayPerMonthNotation,
+	isOnSale,
+	priceDisplayWrapperClassName,
+	isSmallestUnit,
+}: {
+	tagName: 'h4' | 'span';
+	className?: string;
+	smallerPrice: number;
+	higherPrice?: number;
+	currencyCode: string;
+	taxText?: string;
+	displayPerMonthNotation?: boolean;
+	isOnSale?: boolean;
+	priceDisplayWrapperClassName?: string;
+	isSmallestUnit?: boolean;
+} ) {
+	const { symbol: currencySymbol, symbolPosition } = getCurrencyObject(
+		smallerPrice,
+		currencyCode
+	);
+	const translate = useTranslate();
+
+	return createElement(
+		tagName,
+		{ className },
+		<>
+			{ symbolPosition === 'before' ? (
+				<sup className="plan-price__currency-symbol">{ currencySymbol }</sup>
+			) : null }
+
+			{ ! higherPrice && (
+				<HtmlPriceDisplay
+					price={ smallerPrice }
+					currencyCode={ currencyCode }
+					priceDisplayWrapperClassName={ priceDisplayWrapperClassName }
+					isSmallestUnit={ isSmallestUnit }
+				/>
+			) }
+			{ higherPrice &&
+				translate( '{{smallerPrice/}}-{{higherPrice/}}', {
+					components: {
+						smallerPrice: (
+							<HtmlPriceDisplay
+								price={ smallerPrice }
+								currencyCode={ currencyCode }
+								priceDisplayWrapperClassName={ priceDisplayWrapperClassName }
+								isSmallestUnit={ isSmallestUnit }
+							/>
+						),
+						higherPrice: (
+							<HtmlPriceDisplay
+								price={ higherPrice }
+								currencyCode={ currencyCode }
+								priceDisplayWrapperClassName={ priceDisplayWrapperClassName }
+								isSmallestUnit={ isSmallestUnit }
+							/>
+						),
+					},
+					comment: 'The price range for a particular product',
+				} ) }
+
+			{ symbolPosition === 'after' ? (
+				<sup className="plan-price__currency-symbol">{ currencySymbol }</sup>
+			) : null }
+
+			{ taxText && (
+				<sup className="plan-price__tax-amount">
+					{ translate( '(+%(taxText)s tax)', { args: { taxText } } ) }
+				</sup>
+			) }
+			{ displayPerMonthNotation && (
+				<span className="plan-price__term">
+					{ translate( 'per{{newline/}}month', {
+						components: { newline: <br /> },
+						comment:
+							'Displays next to the price. You can remove the "{{newline/}}" if it is not proper for your language.',
+					} ) }
+				</span>
+			) }
+			{ isOnSale && (
+				<Badge>
+					{ translate( 'Sale', {
+						comment: 'Shown next to a domain that has a special discounted sale price',
+					} ) }
+				</Badge>
+			) }
+		</>
+	);
+}
+
+function HtmlPriceDisplay( {
+	price,
+	currencyCode,
+	priceDisplayWrapperClassName,
+	isSmallestUnit,
+}: {
+	price: number;
+	currencyCode: string;
+	priceDisplayWrapperClassName?: string;
+	isSmallestUnit?: boolean;
+} ) {
+	const priceObj = getCurrencyObject( price, currencyCode, { isSmallestUnit } );
+
+	if ( priceDisplayWrapperClassName ) {
+		return (
+			<div className={ priceDisplayWrapperClassName }>
+				<span className="plan-price__integer">
+					{ priceObj.integer }
+					{ priceObj.hasNonZeroFraction && priceObj.fraction }
+				</span>
+			</div>
+		);
+	}
+
+	return (
+		<>
+			<span className="plan-price__integer">{ priceObj.integer }</span>
+			<sup className="plan-price__fraction">
+				{ priceObj.hasNonZeroFraction && priceObj.fraction }
+			</sup>
+		</>
+	);
+}

--- a/packages/components/src/plan-price/index.tsx
+++ b/packages/components/src/plan-price/index.tsx
@@ -1,8 +1,8 @@
-import { Badge } from '@automattic/components';
 import { getCurrencyObject } from '@automattic/format-currency';
 import classNames from 'classnames';
 import { useTranslate, TranslateResult } from 'i18n-calypso';
 import { Component, createElement } from 'react';
+import { Badge } from '../';
 
 import './style.scss';
 

--- a/packages/components/src/plan-price/style.scss
+++ b/packages/components/src/plan-price/style.scss
@@ -1,0 +1,77 @@
+@import "@automattic/typography/styles/variables";
+
+.plan-price {
+	margin: 0;
+	font-size: $font-title-large;
+	line-height: 1.5;
+	color: var(--color-neutral-70);
+
+	.badge {
+		margin-left: 8px;
+		vertical-align: super;
+	}
+}
+
+.plan-price.is-original {
+	color: var(--color-neutral-light);
+}
+
+.plan-price.is-discounted {
+	color: var(--color-success);
+}
+
+.plan-price.is-discounted,
+.plan-price.is-original {
+	position: relative;
+	align-items: stretch;
+	margin-right: 8px;
+}
+
+.plan-price.is-original::before {
+	position: absolute;
+	content: "";
+	left: 0;
+	top: 50%;
+	right: 0;
+	border-top: 2px solid var(--color-accent);
+	transform: rotate(-16deg);
+	opacity: 0.9;
+}
+
+.plan-price__currency-symbol,
+.plan-price__fraction,
+.plan-price__tax-amount {
+	vertical-align: super;
+	font-size: $font-body-extra-small;
+}
+
+.plan-price.is-discounted .plan-price__currency-symbol {
+	color: var(--color-success);
+}
+
+.plan-price__tax-amount {
+	margin-left: 4px;
+}
+
+.plan-price__currency-symbol,
+.plan-price__tax-amount {
+	color: var(--color-text-subtle);
+}
+
+.plan-price__integer {
+	margin: 0 1px;
+	font-weight: 400;
+}
+
+.plan-price__fraction {
+	font-weight: 600;
+}
+
+.plan-price__term {
+	display: inline-block;
+	font-size: 0.875rem;
+	text-align: left;
+	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+	line-height: 1rem;
+	margin-left: 5px;
+}

--- a/packages/components/src/plan-price/test/index.tsx
+++ b/packages/components/src/plan-price/test/index.tsx
@@ -1,0 +1,381 @@
+/**
+ * @jest-environment jsdom
+ */
+import { geolocateCurrencySymbol, setDefaultLocale } from '@automattic/format-currency';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import PlanPrice from '../index';
+
+describe( 'PlanPrice', () => {
+	const originalFetch = globalThis.fetch;
+
+	beforeEach( () => {
+		setDefaultLocale( 'en-US' );
+		globalThis.fetch = originalFetch;
+	} );
+
+	it( 'renders a zero when rawPrice is passed a "0"', () => {
+		render( <PlanPrice rawPrice={ 0 } /> );
+		expect( document.body ).toHaveTextContent( '$0' );
+	} );
+
+	it( 'renders a rawPrice of $50', () => {
+		render( <PlanPrice rawPrice={ 50 } /> );
+		expect( document.body ).toHaveTextContent( '$50' );
+	} );
+
+	it( 'renders a rawPrice with a decimal', () => {
+		render( <PlanPrice rawPrice={ 50.01 } /> );
+		expect( document.body ).toHaveTextContent( '$50.01' );
+		expect( screen.queryByText( '50.01' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( '50' ) ).toBeInTheDocument();
+		expect( screen.getByText( '.01' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders a rawPrice if isSmallestUnit is set', () => {
+		render( <PlanPrice rawPrice={ 5001 } isSmallestUnit /> );
+		expect( document.body ).toHaveTextContent( '$50.01' );
+		expect( screen.queryByText( '50.01' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( '50' ) ).toBeInTheDocument();
+		expect( screen.getByText( '.01' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders a range of prices', () => {
+		render( <PlanPrice rawPrice={ [ 10, 50 ] } /> );
+		expect( document.body ).toHaveTextContent( '$10-50' );
+		expect( screen.queryByText( '$10-50' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( '10' ) ).toBeInTheDocument();
+		expect( screen.getByText( '50' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders a range of prices with decimals', () => {
+		render( <PlanPrice rawPrice={ [ 10, 50.01 ] } /> );
+		expect( document.body ).toHaveTextContent( '$10-50.01' );
+		expect( screen.queryByText( '$10-50.01' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( '10' ) ).toBeInTheDocument();
+		expect( screen.getByText( '50' ) ).toBeInTheDocument();
+		expect( screen.getByText( '.01' ) ).toBeInTheDocument();
+	} );
+
+	it( 'will not render a range of prices with a 0', () => {
+		render( <PlanPrice rawPrice={ [ 10, 0 ] } /> );
+		expect( document.body ).not.toHaveTextContent( '$10-0' );
+		expect( screen.queryByText( '$10-0' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'will use productDisplayPrice when rawPrice is a number', () => {
+		render(
+			<PlanPrice
+				rawPrice={ 10 }
+				productDisplayPrice={ '<abbr title="United States Dollars">$</abbr>96.00' }
+			/>
+		);
+		expect( document.body ).toHaveTextContent( '$96.00' );
+		expect( document.body ).not.toHaveTextContent( '$10' );
+		expect( screen.queryByText( '$96.00' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( '96.00' ) ).toBeInTheDocument();
+		expect( screen.getByTitle( 'United States Dollars' ) ).toBeInTheDocument();
+	} );
+
+	it( 'will use productDisplayPrice when rawPrice is an array with length of 1', () => {
+		render(
+			<PlanPrice
+				rawPrice={ [ 10 ] }
+				productDisplayPrice={ '<abbr title="United States Dollars">$</abbr>96.00' }
+			/>
+		);
+		expect( document.body ).toHaveTextContent( '$96.00' );
+		expect( document.body ).not.toHaveTextContent( '$10' );
+		expect( screen.queryByText( '$96.00' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( '96.00' ) ).toBeInTheDocument();
+		expect( screen.getByTitle( 'United States Dollars' ) ).toBeInTheDocument();
+	} );
+
+	it( 'will use rawPrice over productDisplayPrice when rawPrice is passed an array with length > 1', () => {
+		render(
+			<PlanPrice
+				rawPrice={ [ 5, 10 ] }
+				productDisplayPrice={ '<abbr title="United States Dollars">$</abbr>96.00' }
+			/>
+		);
+		expect( document.body ).toHaveTextContent( '$5-10' );
+		expect( document.body ).not.toHaveTextContent( '$96.00' );
+		expect( screen.getByText( '5' ) ).toBeInTheDocument();
+		expect( screen.getByText( '10' ) ).toBeInTheDocument();
+		expect( screen.queryByTitle( 'United States Dollars' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'ignores currencyCode when productDisplayPrice is set', () => {
+		render(
+			<PlanPrice
+				productDisplayPrice={ '<abbr title="United States Dollars">$</abbr>96.00' }
+				currencyCode="IDR"
+			/>
+		);
+		expect( document.body ).toHaveTextContent( '$96.00' );
+		expect( screen.getByTitle( 'United States Dollars' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders a currency when set', () => {
+		render( <PlanPrice rawPrice={ 5.05 } currencyCode="EUR" /> );
+		expect( document.body ).toHaveTextContent( '€5.05' );
+		expect( screen.queryByText( '€5.05' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( '5' ) ).toBeInTheDocument();
+		expect( screen.getByText( '.05' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders USD currency when currency is undefined', () => {
+		render( <PlanPrice rawPrice={ 5.05 } currencyCode={ undefined } /> );
+		expect( document.body ).toHaveTextContent( '$5.05' );
+		expect( screen.queryByText( '$5.05' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( '5' ) ).toBeInTheDocument();
+		expect( screen.getByText( '.05' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders nothing when currency is null', () => {
+		render( <PlanPrice rawPrice={ 5.05 } currencyCode={ null } /> );
+		expect( document.body ).not.toHaveTextContent( '$5.05' );
+	} );
+
+	it( 'renders no decimal section when price is integer', () => {
+		render( <PlanPrice rawPrice={ 44700 } currencyCode="IDR" /> );
+		expect( document.body ).toHaveTextContent( 'Rp44,700' );
+		expect( document.body ).not.toHaveTextContent( 'Rp44,700.00' );
+		expect( screen.queryByText( 'Rp44,700' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( '44,700' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders a decimal section when price is not integer', () => {
+		render( <PlanPrice rawPrice={ 44700.5 } currencyCode="IDR" /> );
+		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
+		expect( screen.queryByText( 'Rp 44,700' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( '44,700' ) ).toBeInTheDocument();
+		expect( screen.getByText( '.50' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders a price without html when displayFlatPrice is set', () => {
+		render( <PlanPrice rawPrice={ 44700.5 } currencyCode="IDR" displayFlatPrice /> );
+		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
+		expect( screen.getByText( 'Rp44,700.50' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders a price without html when displayFlatPrice and isSmallestUnit are set', () => {
+		render( <PlanPrice rawPrice={ 4470050 } currencyCode="IDR" isSmallestUnit displayFlatPrice /> );
+		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
+		expect( screen.getByText( 'Rp44,700.50' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders a price without sale text when displayFlatPrice is set', () => {
+		render( <PlanPrice rawPrice={ 44700.5 } currencyCode="IDR" displayFlatPrice isOnSale /> );
+		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
+		expect( screen.getByText( 'Rp44,700.50' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Sale' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders a price without sale text when productDisplayPrice is set', () => {
+		render(
+			<PlanPrice
+				productDisplayPrice={ '<abbr title="United States Dollars">$</abbr>96.00' }
+				isOnSale
+			/>
+		);
+		expect( document.body ).toHaveTextContent( '$96.00' );
+		expect( screen.queryByText( 'Sale' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders a price with sale text when using rawPrice and isOnSale', () => {
+		render( <PlanPrice rawPrice={ 44700.5 } currencyCode="IDR" isOnSale /> );
+		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
+		expect( screen.getByText( 'Sale' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders a price with monthly text when using rawPrice and displayPerMonthNotation', () => {
+		render( <PlanPrice rawPrice={ 44700.5 } currencyCode="IDR" displayPerMonthNotation /> );
+		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
+		// Note: there is a newline between "per" and "month" but testing-library cannot detect those.
+		expect( screen.getByText( 'permonth' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders a price without monthly text when using productDisplayPrice and displayPerMonthNotation', () => {
+		render( <PlanPrice productDisplayPrice="$96.00" currencyCode="IDR" displayPerMonthNotation /> );
+		expect( document.body ).toHaveTextContent( '$96.00' );
+		expect( screen.queryByText( /per/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders a price with $ when using displayFlatPrice and US locale', async () => {
+		globalThis.fetch = jest.fn(
+			( url: string ) =>
+				Promise.resolve( {
+					json: () =>
+						url.includes( '/geo' )
+							? Promise.resolve( { country_short: 'US' } )
+							: Promise.resolve( 'invalid' ),
+				} ) as any
+		);
+		await geolocateCurrencySymbol();
+		render( <PlanPrice rawPrice={ 96.05 } currencyCode="USD" displayFlatPrice /> );
+		expect( document.body ).toHaveTextContent( '$96.05' );
+		expect( document.body ).not.toHaveTextContent( 'US$96.05' );
+	} );
+
+	it( 'renders a price with US$ when using displayFlatPrice and non-US locale', async () => {
+		globalThis.fetch = jest.fn(
+			( url: string ) =>
+				Promise.resolve( {
+					json: () =>
+						url.includes( '/geo' )
+							? Promise.resolve( { country_short: 'CA' } )
+							: Promise.resolve( 'invalid' ),
+				} ) as any
+		);
+		await geolocateCurrencySymbol();
+		render( <PlanPrice rawPrice={ 96.05 } currencyCode="USD" displayFlatPrice /> );
+		expect( document.body ).toHaveTextContent( 'US$96.05' );
+	} );
+
+	it( 'renders a price without monthly text when using displayFlatPrice and displayPerMonthNotation', () => {
+		render(
+			<PlanPrice rawPrice={ 96.05 } currencyCode="USD" displayFlatPrice displayPerMonthNotation />
+		);
+		expect( document.body ).toHaveTextContent( '$96.05' );
+		expect( screen.queryByText( /per/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders a price with tax text when using rawPrice and taxText', () => {
+		render( <PlanPrice rawPrice={ 44700.5 } currencyCode="IDR" taxText="25" /> );
+		expect( document.body ).toHaveTextContent( 'Rp44,700.50(+25 tax)' );
+		expect( screen.getByText( '(+25 tax)' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders a price without tax text when using productDisplayPrice and taxText', () => {
+		render( <PlanPrice productDisplayPrice="$96.00" currencyCode="IDR" taxText="25" /> );
+		expect( document.body ).toHaveTextContent( '$96.00' );
+		expect( screen.queryByText( '(+25 tax)' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders a price without tax text when using displayFlatPrice and taxText', () => {
+		render( <PlanPrice rawPrice={ 44700.5 } currencyCode="IDR" displayFlatPrice taxText="25" /> );
+		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
+		expect( screen.queryByText( '(+25 tax)' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders a price with a heading tag if omitHeading is false', () => {
+		render( <PlanPrice rawPrice={ 44700.5 } currencyCode="IDR" /> );
+		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
+		expect( document.querySelector( 'h4' ) ).toBeTruthy();
+	} );
+
+	it( 'renders a price with a non-heading tag if omitHeading is true', () => {
+		render( <PlanPrice rawPrice={ 44700.5 } currencyCode="IDR" omitHeading /> );
+		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
+		expect( document.querySelector( 'h4' ) ).toBeFalsy();
+	} );
+
+	it( 'renders a price with a heading tag if productDisplayPrice is set and omitHeading is false', () => {
+		render( <PlanPrice productDisplayPrice="Rp44,700.50" currencyCode="IDR" /> );
+		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
+		expect( document.querySelector( 'h4' ) ).toBeTruthy();
+	} );
+
+	it( 'renders a price with a non-heading tag if productDisplayPrice is set and omitHeading is true', () => {
+		render( <PlanPrice productDisplayPrice="Rp44,700.50" currencyCode="IDR" omitHeading /> );
+		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
+		expect( document.querySelector( 'h4' ) ).toBeFalsy();
+	} );
+
+	it( 'renders a price without an outer div if priceDisplayWrapperClassName is not set', () => {
+		render( <PlanPrice rawPrice={ 44700.5 } currencyCode="IDR" /> );
+		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
+		expect( document.querySelector( 'div.foo-price-display-wrapper-class' ) ).toBeFalsy();
+	} );
+
+	it( 'renders a price with an outer div if priceDisplayWrapperClassName is set', () => {
+		render(
+			<PlanPrice
+				rawPrice={ 44700.5 }
+				currencyCode="IDR"
+				priceDisplayWrapperClassName="foo-price-display-wrapper-class"
+			/>
+		);
+		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
+		expect( document.querySelector( 'div.foo-price-display-wrapper-class' ) ).toBeTruthy();
+	} );
+
+	it( 'renders a price without an outer div if productDisplayPrice is set and priceDisplayWrapperClassName is set', () => {
+		render(
+			<PlanPrice
+				productDisplayPrice="$45"
+				priceDisplayWrapperClassName="foo-price-display-wrapper-class"
+			/>
+		);
+		expect( document.body ).toHaveTextContent( '$45' );
+		expect( document.querySelector( 'div.foo-price-display-wrapper-class' ) ).toBeFalsy();
+	} );
+
+	it( 'renders a price without an outer div if displayFlatPrice is set and priceDisplayWrapperClassName is set', () => {
+		render(
+			<PlanPrice
+				rawPrice={ 44700.5 }
+				currencyCode="IDR"
+				displayFlatPrice
+				priceDisplayWrapperClassName="foo-price-display-wrapper-class"
+			/>
+		);
+		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
+		expect( document.querySelector( 'div.foo-price-display-wrapper-class' ) ).toBeFalsy();
+	} );
+
+	it( 'renders a price without the "is-discounted" class if discounted is not set', () => {
+		render( <PlanPrice rawPrice={ 44700.5 } currencyCode="IDR" /> );
+		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
+		expect( document.querySelector( '.is-discounted' ) ).toBeFalsy();
+	} );
+
+	it( 'renders a price with the "is-discounted" class if discounted is set', () => {
+		render( <PlanPrice rawPrice={ 44700.5 } currencyCode="IDR" discounted /> );
+		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
+		expect( document.querySelector( '.is-discounted' ) ).toBeTruthy();
+	} );
+
+	it( 'renders a price with the "is-discounted" class if using productDisplayPrice and discounted is set', () => {
+		render( <PlanPrice productDisplayPrice="$45" discounted /> );
+		expect( document.body ).toHaveTextContent( '$45' );
+		expect( document.querySelector( '.is-discounted' ) ).toBeTruthy();
+	} );
+
+	it( 'renders a price without the "is-original" class if original is not set', () => {
+		render( <PlanPrice rawPrice={ 44700.5 } currencyCode="IDR" /> );
+		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
+		expect( document.querySelector( '.is-discounted' ) ).toBeFalsy();
+	} );
+
+	it( 'renders a price with the "is-original" class if original is set', () => {
+		render( <PlanPrice rawPrice={ 44700.5 } currencyCode="IDR" original /> );
+		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
+		expect( document.querySelector( '.is-original' ) ).toBeTruthy();
+	} );
+
+	it( 'renders a price with the "is-original" class if using productDisplayPrice and original is set', () => {
+		render( <PlanPrice productDisplayPrice="$45" original /> );
+		expect( document.body ).toHaveTextContent( '$45' );
+		expect( document.querySelector( '.is-original' ) ).toBeTruthy();
+	} );
+
+	it( 'renders a price with the "is-large-currency" class if isLargeCurrency is set', () => {
+		render( <PlanPrice rawPrice={ 44700.5 } currencyCode="IDR" isLargeCurrency={ true } /> );
+		expect( document.body ).toHaveTextContent( 'Rp44,700.50' );
+		expect( document.querySelector( '.is-large-currency' ) ).toBeTruthy();
+	} );
+
+	it( 'renders the symbol to the left of the integer when symbolPosition is "before"', () => {
+		setDefaultLocale( 'en-US' );
+		render( <PlanPrice rawPrice={ 48 } currencyCode="CAD" /> );
+		expect( document.body ).toHaveTextContent( 'C$48' );
+	} );
+
+	it( 'renders the symbol to the right of the integer when symbolPosition is "after"', () => {
+		setDefaultLocale( 'fr-CA' );
+		render( <PlanPrice rawPrice={ 48 } currencyCode="CAD" /> );
+		expect( document.body ).toHaveTextContent( '48C$' );
+	} );
+} );

--- a/yarn.lock
+++ b/yarn.lock
@@ -538,6 +538,7 @@ __metadata:
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/calypso-url": "workspace:^"
     "@automattic/data-stores": "workspace:^"
+    "@automattic/format-currency": "workspace:^"
     "@automattic/search": "workspace:^"
     "@automattic/typography": "workspace:^"
     "@automattic/viewport-react": "workspace:^"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/84912

~**NOTES:** StoryBook is broken in Calypso right now, so not possible to test per the instructions below. It is being investigated in Slack.~

## Proposed Changes

We are migrating `PlanPrice` to `@automattic/components` because it is a dependency for plans-grid, which we are in the process of migrating to NPM.

The same principle applies to previous related migrations (see https://github.com/Automattic/wp-calypso/pull/79257):

> The entirety of the migration is a 4 step process that creates easily digestible ( and revertible ) PRs to work with. Unfortunately, this process also eliminates the git history from migrated files unless the 4 steps are condensed into a single one. I don't have a great answer to this, but the tradeoff, to me, is worth the added safety of more understandable, compact, iterative pull requests.

This is Step 1: 
- adding a new component to `@automattic/components` package
- adding Storybook

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Code review
- Ensure Storybook stories render correctly with no errors: `run yarn storybook:start`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?