### PR TITLE
Experimental: Subscribe Auto Block

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -224,6 +224,20 @@ function load_blog_posts_block() {
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_blog_posts_block' );
 
 /**
+ * Load Subscribe Auto Block.
+ */
+function load_subscribe_auto_block() {
+	if ( class_exists( 'Subscribe_Auto_Block' ) ) {
+		return;
+	}
+
+	require_once __DIR__ . '/subscribe-auto-block/class-subscribe-auto-block.php';
+
+	Subscribe_Auto_Block::get_instance();
+}
+add_action( 'plugins_loaded', __NAMESPACE__ . '\load_subscribe_auto_block' );
+
+/**
  * Load WPCOM Block Editor NUX.
  */
 function load_wpcom_block_editor_nux() {

--- a/apps/editing-toolkit/editing-toolkit-plugin/subscribe-auto-block/blocks/subscribe-auto/block.json
+++ b/apps/editing-toolkit/editing-toolkit-plugin/subscribe-auto-block/blocks/subscribe-auto/block.json
@@ -1,0 +1,5 @@
+{
+	"name": "a8c/subscribe-auto",
+	"category": "layout",
+	"attributes": {}
+}

--- a/apps/editing-toolkit/editing-toolkit-plugin/subscribe-auto-block/blocks/subscribe-auto/editor.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/subscribe-auto-block/blocks/subscribe-auto/editor.scss
@@ -1,0 +1,3 @@
+.a8c-subscribe-auto {
+	background: yellow;
+}

--- a/apps/editing-toolkit/editing-toolkit-plugin/subscribe-auto-block/blocks/subscribe-auto/editor.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/subscribe-auto-block/blocks/subscribe-auto/editor.scss
@@ -1,3 +1,3 @@
 .a8c-subscribe-auto {
-	background: yellow;
+	// editor specific CSS goes here
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/subscribe-auto-block/blocks/subscribe-auto/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/subscribe-auto-block/blocks/subscribe-auto/index.js
@@ -15,8 +15,6 @@ const icon = (
 	</svg>
 );
 
-console.log( 'HELLO THERE!!' );
-
 registerBlockType( metadata.name, {
 	title: __( 'Subscribe Auto Block', 'full-site-editing' ),
 	description: __( 'Automatically inserts subsribe block on your site.', 'full-site-editing' ),

--- a/apps/editing-toolkit/editing-toolkit-plugin/subscribe-auto-block/blocks/subscribe-auto/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/subscribe-auto-block/blocks/subscribe-auto/index.js
@@ -1,0 +1,48 @@
+import { InspectorControls } from '@wordpress/block-editor';
+import { registerBlockType } from '@wordpress/blocks';
+import { Placeholder, PanelBody } from '@wordpress/components';
+import { Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import metadata from './block.json';
+
+import './editor.scss';
+import './style.scss';
+
+const icon = (
+	<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+		<path opacity=".87" fill="none" d="M0 0h24v24H0V0z" />
+		<path d="M3 5v14h17V5H3zm4 2v2H5V7h2zm-2 6v-2h2v2H5zm0 2h2v2H5v-2zm13 2H9v-2h9v2zm0-4H9v-2h9v2zm0-4H9V7h9v2z" />
+	</svg>
+);
+
+console.log( 'HELLO THERE!!' );
+
+registerBlockType( metadata.name, {
+	title: __( 'Subscribe Auto Block', 'full-site-editing' ),
+	description: __( 'Automatically inserts subsribe block on your site.', 'full-site-editing' ),
+	icon: icon,
+	category: 'layout',
+	supports: {
+		html: false,
+		multiple: true,
+		reusable: true,
+		inserter: true,
+	},
+	attributes: metadata.attributes,
+	edit: () => {
+		return (
+			<Fragment>
+				<Placeholder
+					icon={ icon }
+					label={ __( 'Your subscribe block will be displayed here.', 'full-site-editing' ) }
+				>
+					This is a placeholder for subscribe block.
+				</Placeholder>
+				<InspectorControls>
+					<PanelBody>This is the panel body</PanelBody>
+				</InspectorControls>
+			</Fragment>
+		);
+	},
+	save: () => null,
+} );

--- a/apps/editing-toolkit/editing-toolkit-plugin/subscribe-auto-block/blocks/subscribe-auto/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/subscribe-auto-block/blocks/subscribe-auto/style.scss
@@ -1,3 +1,5 @@
 .a8c-subscribe-auto {
-	background: yellow;
+	max-width: 720px;
+	padding: 64px;
+	margin: 0 auto;
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/subscribe-auto-block/blocks/subscribe-auto/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/subscribe-auto-block/blocks/subscribe-auto/style.scss
@@ -1,0 +1,3 @@
+.a8c-subscribe-auto {
+	background: yellow;
+}

--- a/apps/editing-toolkit/editing-toolkit-plugin/subscribe-auto-block/class-subscribe-auto-block.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/subscribe-auto-block/class-subscribe-auto-block.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * Subscribe auto block file.
+ *
+ * @package A8C\FSE
+ */
+
+namespace A8C\FSE;
+
+/**
+ * Class Subscribe_Auto_Block
+ */
+class Subscribe_Auto_Block {
+
+	/**
+	 * Class instance.
+	 *
+	 * @var \A8C\FSE\Subscribe_Auto_Block
+	 */
+	private static $instance = null;	
+
+	/**
+	 * Subscribe_Auto_Block constructor.
+	 */
+	private function __construct() {
+		add_action( 'init', [ $this, 'register_blocks' ], 100 );
+		add_action( 'enqueue_block_editor_assets', [ $this, 'enqueue_scripts' ], 100 );
+		add_action( 'enqueue_block_assets', [ $this, 'enqueue_styles' ], 100 );
+	}
+	
+	/**
+	 * Creates instance.
+	 *
+	 * @return \A8C\FSE\Subscribe_Auto_Block
+	 */
+	public static function get_instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Enqueue block editor scripts.
+	 */
+	public function enqueue_scripts() {
+		// if ( ! has_block( 'a8c/subscribe-auto' ) ) {
+		// 	return;
+		// }
+
+		$asset_file          = include plugin_dir_path( __FILE__ ) . 'dist/subscribe-auto-block.asset.php';
+		$script_dependencies = $asset_file['dependencies'];
+		wp_enqueue_script(
+			'a8c-subscribe-auto-block',
+			plugins_url( 'dist/subscribe-auto-block.min.js', __FILE__ ),
+			is_array( $script_dependencies ) ? $script_dependencies : [],
+			filemtime( plugin_dir_path( __FILE__ ) . 'dist/subscribe-auto-block.min.js' ),
+			true
+		);
+
+		wp_set_script_translations( 'a8c-subscribe-auto-script', 'full-site-editing' );
+	}
+
+	/**
+	 * Enqueue block styles.
+	 */
+	public function enqueue_styles() {
+		// if ( ! has_block( 'a8c/subscribe-auto' ) ) {
+		// 	return;
+		// }
+
+		$style_file = is_rtl()
+			? 'subscribe-auto-block.rtl.css'
+			: 'subscribe-auto-block.css';
+		wp_enqueue_style(
+			'subscribe-auto-block-style',
+			plugins_url( 'dist/' . $style_file, __FILE__ ),
+			array(),
+			filemtime( plugin_dir_path( __FILE__ ) . 'dist/' . $style_file )
+		);
+	}
+
+	/**
+	 * Register block.
+	 */
+	public function register_blocks() {
+		register_block_type(
+			'a8c/subscribe-auto',
+			[
+				'api_version'     => 3,
+				'attributes'      => [],
+				'render_callback' => [ $this, 'render_a8c_subscribe_auto_block' ]
+			]
+		);
+	}
+
+	/**
+	 * Renders subscribe auto block.
+	 *
+	 * @param array  $attributes Block attributes.
+	 * @param string $content    Block content.
+	 * @return string
+	 */
+	public function render_a8c_subscribe_auto_block( $attributes, $content ) {
+		$subscribe_block_html = do_blocks( '<!-- wp:jetpack/subscriptions /-->' );
+		$subscribe_block_html = 'temp placeholder';
+		return "<div style=\"background: yellow; padding 10px; color: black;\">" . $subscribe_block_html . "</div>";
+	}
+
+	public static function insert_subscribe_auto_block( $hooked_blocks, $relative_position, $anchor_block, $context ) {
+		if ( $context instanceof \WP_Block_Template ) {
+			if ( $context->area == 'footer' &&
+				$relative_position == 'before' &&
+				$anchor_block == 'core/pattern' ) {
+				$hooked_blocks[] = 'jetpack/subscribe';
+			}
+		}
+	
+		return $hooked_blocks;
+	} 
+}
+
+add_filter( 'hooked_block_types', [ 'A8C\FSE\Subscribe_Auto_Block', 'insert_subscribe_auto_block' ], 10, 4 );
+
+
+
+
+
+		// $hooked_blocks[] = 'a8c/subscribe-auto';
+
+
+				// echo '<pre style="font-size: 10px;">';
+				// var_dump( [ 'context' => $context, 'anchor_block' => $anchor_block, 'relative_position' => $relative_position, 'hooked_blocks' => 'a8c/subscribe-auto' ] );
+				// echo '</pre>';
+				// echo '<hr />';

--- a/apps/editing-toolkit/editing-toolkit-plugin/subscribe-auto-block/class-subscribe-auto-block.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/subscribe-auto-block/class-subscribe-auto-block.php
@@ -45,10 +45,6 @@ class Subscribe_Auto_Block {
 	 * Enqueue block editor scripts.
 	 */
 	public function enqueue_scripts() {
-		// if ( ! has_block( 'a8c/subscribe-auto' ) ) {
-		// 	return;
-		// }
-
 		$asset_file          = include plugin_dir_path( __FILE__ ) . 'dist/subscribe-auto-block.asset.php';
 		$script_dependencies = $asset_file['dependencies'];
 		wp_enqueue_script(
@@ -66,10 +62,6 @@ class Subscribe_Auto_Block {
 	 * Enqueue block styles.
 	 */
 	public function enqueue_styles() {
-		// if ( ! has_block( 'a8c/subscribe-auto' ) ) {
-		// 	return;
-		// }
-
 		$style_file = is_rtl()
 			? 'subscribe-auto-block.rtl.css'
 			: 'subscribe-auto-block.css';
@@ -104,8 +96,7 @@ class Subscribe_Auto_Block {
 	 */
 	public function render_a8c_subscribe_auto_block( $attributes, $content ) {
 		$subscribe_block_html = do_blocks( '<!-- wp:jetpack/subscriptions /-->' );
-		$subscribe_block_html = 'temp placeholder';
-		return "<div style=\"background: yellow; padding 10px; color: black;\">" . $subscribe_block_html . "</div>";
+		return '<div class="a8c-subscribe-auto">' . $subscribe_block_html . '</div>';
 	}
 
 	public static function insert_subscribe_auto_block( $hooked_blocks, $relative_position, $anchor_block, $context ) {
@@ -113,7 +104,7 @@ class Subscribe_Auto_Block {
 			if ( $context->area == 'footer' &&
 				$relative_position == 'before' &&
 				$anchor_block == 'core/pattern' ) {
-				$hooked_blocks[] = 'jetpack/subscribe';
+				$hooked_blocks[] = 'a8c/subscribe-auto';
 			}
 		}
 	
@@ -122,15 +113,3 @@ class Subscribe_Auto_Block {
 }
 
 add_filter( 'hooked_block_types', [ 'A8C\FSE\Subscribe_Auto_Block', 'insert_subscribe_auto_block' ], 10, 4 );
-
-
-
-
-
-		// $hooked_blocks[] = 'a8c/subscribe-auto';
-
-
-				// echo '<pre style="font-size: 10px;">';
-				// var_dump( [ 'context' => $context, 'anchor_block' => $anchor_block, 'relative_position' => $relative_position, 'hooked_blocks' => 'a8c/subscribe-auto' ] );
-				// echo '</pre>';
-				// echo '<hr />';

--- a/apps/editing-toolkit/editing-toolkit-plugin/subscribe-auto-block/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/subscribe-auto-block/index.js
@@ -1,0 +1,1 @@
+import './blocks/subscribe-auto';

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -27,6 +27,7 @@
 		"build:newspack-blocks": "npm run sync:newspack-blocks -- --nodemodules && calypso-build --env source='newspack-blocks/blog-posts-block-editor','newspack-blocks/blog-posts-block-view','newspack-blocks/carousel-block-editor','newspack-blocks/carousel-block-view'",
 		"build:paragraph-block": "calypso-build --env source='paragraph-block'",
 		"build:posts-list-block": "calypso-build --env source='posts-list-block'",
+		"build:subscribe-auto-block": "calypso-build --env source='subscribe-auto-block'",
 		"build:starter-page-templates": "calypso-build --env source='starter-page-templates'",
 		"build:tags-education": "calypso-build --env source='tags-education'",
 		"build:whats-new": "calypso-build --env source='whats-new'",


### PR DESCRIPTION
THIS PR IS EXPERIMENTAL AND SHOULD NOT BE MERGED.

Related to #84594

## Proposed Changes

This is an experimental PR for a "Subscribe Auto" block which automatically inserts the subscribe block before (first element of) the footer using [Block Hooks](https://make.wordpress.org/core/2023/10/15/introducing-block-hooks-for-dynamic-blocks/).

* This block is needed to have finer control over the rendering of the subscribe block, such as inserting subscribe block inside a group block, styling control, etc.
  * It could also allow us the ability to have theme-specific adjustments either within the HTML structure or via CSS.
  * Eventually, I'd like to see if we can avoid having an additional block by just relying on the Subscribe block itself, but if Block Hooks API allow block attributes to be passed in, that would be nice.
* I am using ETK to create the block as it is faster for dev & testing purposes.

**Known issues:**
 - The block doesn't show on the editor end depending on how the footer is constructed for the theme. Context: p1701956104012569-slack-C065QF2R1B6

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox `your-site.wordpress.com` and `public-api.wordpress.com`.
* Run `cd apps/editing-toolkit && yarn dev --watch`.
* Go to your site's homepage, you should see the subscribe block on your footer.
* Go to site editor, you should see the subscribe block on the footer (this is not working because of p1701956104012569-slack-C065QF2R1B6, but works on Livro theme though).

## Screenshots

**TwentyTwentyThree**
<img width="1759" alt="2023-12-07_22-04-05" src="https://github.com/Automattic/wp-calypso/assets/1287077/8501c434-6977-4135-a7d2-e92ad4d20c12">

**TwentyTwentyFour**
<img width="1759" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1287077/a648ea0e-16b0-4cc0-a07d-0f70668145c5">

**Livro**
<img width="1507" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1287077/0d839cfa-d3a8-4414-affb-d702b6287540">

**Livro (Editor View)**
The placeholder is temporary.

<img width="1507" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1287077/ff71363a-d3bc-4748-bf03-c9f8c7a5245e">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?