### PR TITLE
Components: Fix NoticeBanner style variables

### DIFF
--- a/packages/components/src/notice-banner/style.scss
+++ b/packages/components/src/notice-banner/style.scss
@@ -5,7 +5,6 @@ $banner-title-height: 22px;
 
 :root {
 	--font-title-small: 20px;
-	--font-body: 16px;
 	--jp-black: #000;
 	--jp-gray-5: #dcdcde;
 	--jp-red-50: #d63638;
@@ -17,7 +16,7 @@ $banner-title-height: 22px;
 	display: flex;
 	align-items: flex-start;
 
-	font-size: var(--font-body);
+	font-size: $font-body;
 
 	background-color: var(--studio-white);
 
@@ -40,7 +39,7 @@ $banner-title-height: 22px;
 	.notice-banner__action-button,
 	.notice-banner__action-link {
 		font-family: inherit;
-		font-size: var(--font-body);
+		font-size: $font-body;
 		font-weight: 600;
 		line-height: 24px;
 		cursor: pointer;

--- a/packages/components/src/notice-banner/style.scss
+++ b/packages/components/src/notice-banner/style.scss
@@ -1,3 +1,4 @@
+@import "@automattic/typography/styles/variables";
 @import "@automattic/components/src/styles/typography";
 
 $banner-title-height: 22px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1701954219498559/1701952494.615109-slack-C7YPUHBB2

## Proposed Changes

* Introduce the base style variables `@automattic/typography/styles/variables` to the component `NoticeBanner`.
* Use the defined base variable `$font-body` rather than declaring the root variable `--font-body` again.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `yarn storybook:build` and ensure there is no error of `Undefined variable` for the `notice-banner` component.

<img width="742" alt="截圖 2023-12-07 下午10 11 08" src="https://github.com/Automattic/wp-calypso/assets/6869813/f10e0ad6-1916-42b9-a25f-942fbf682ca1">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?