### PR TITLE
Add/reddit ads tracking

### DIFF
--- a/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
@@ -12,6 +12,10 @@ import QuerySites from 'calypso/components/data/query-sites';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import useAddHostingTrialMutation from 'calypso/data/hosting/use-add-hosting-trial-mutation';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
+import {
+	recordFreeHostingTrialStarted,
+	FlowNames,
+} from 'calypso/lib/analytics/ad-tracking/record-hosting-trial-started';
 import { Interval, EVERY_FIVE_SECONDS } from 'calypso/lib/interval';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCredentials } from 'calypso/state/jetpack/credentials/actions';
@@ -100,6 +104,9 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 	const { isLoading: isAddingTrial } = useAddHostingTrialMutation( {
 		onSuccess: () => {
 			setQueryTargetSitePlanStatus( 'fetching' );
+			recordFreeHostingTrialStarted(
+				migrationTrackingProps.is_migrate_from_wp ? FlowNames.SiteMigration : FlowNames.NewSite
+			);
 		},
 	} );
 

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
@@ -12,10 +12,6 @@ import QuerySites from 'calypso/components/data/query-sites';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import useAddHostingTrialMutation from 'calypso/data/hosting/use-add-hosting-trial-mutation';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
-import {
-	recordFreeHostingTrialStarted,
-	FlowNames,
-} from 'calypso/lib/analytics/ad-tracking/record-hosting-trial-started';
 import { Interval, EVERY_FIVE_SECONDS } from 'calypso/lib/interval';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCredentials } from 'calypso/state/jetpack/credentials/actions';
@@ -104,9 +100,6 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 	const { isLoading: isAddingTrial } = useAddHostingTrialMutation( {
 		onSuccess: () => {
 			setQueryTargetSitePlanStatus( 'fetching' );
-			recordFreeHostingTrialStarted(
-				migrationTrackingProps.is_migrate_from_wp ? FlowNames.SiteMigration : FlowNames.NewSite
-			);
 		},
 	} );
 

--- a/client/landing/stepper/declarative-flow/import-hosted-site.ts
+++ b/client/landing/stepper/declarative-flow/import-hosted-site.ts
@@ -9,10 +9,7 @@ import SiteCreationStep from 'calypso/landing/stepper/declarative-flow/internals
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
 import { ONBOARD_STORE, USER_STORE } from 'calypso/landing/stepper/stores';
-import {
-	recordFreeHostingTrialStarted,
-	FlowNames,
-} from 'calypso/lib/analytics/ad-tracking/record-hosting-trial-started';
+import { recordFreeHostingTrialStarted } from 'calypso/lib/analytics/ad-tracking/record-hosting-trial-started';
 import Import from './internals/steps-repository/import';
 import ImportReady from './internals/steps-repository/import-ready';
 import ImportReadyNot from './internals/steps-repository/import-ready-not';
@@ -163,7 +160,7 @@ const importHostedSiteFlow: Flow = {
 						case 'verify-email':
 							return navigate( `verifyEmail?${ urlQueryParams.toString() }` );
 						case 'importer':
-							recordFreeHostingTrialStarted( FlowNames.SiteMigration );
+							recordFreeHostingTrialStarted( 'site_migration' );
 							return navigate( `importerWordpress?${ urlQueryParams.toString() }` );
 						case 'checkout':
 							return exitFlow( providedDependencies?.checkoutUrl as string );

--- a/client/landing/stepper/declarative-flow/import-hosted-site.ts
+++ b/client/landing/stepper/declarative-flow/import-hosted-site.ts
@@ -9,6 +9,10 @@ import SiteCreationStep from 'calypso/landing/stepper/declarative-flow/internals
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
 import { ONBOARD_STORE, USER_STORE } from 'calypso/landing/stepper/stores';
+import {
+	recordFreeHostingTrialStarted,
+	FlowNames,
+} from 'calypso/lib/analytics/ad-tracking/record-hosting-trial-started';
 import Import from './internals/steps-repository/import';
 import ImportReady from './internals/steps-repository/import-ready';
 import ImportReadyNot from './internals/steps-repository/import-ready-not';
@@ -159,6 +163,7 @@ const importHostedSiteFlow: Flow = {
 						case 'verify-email':
 							return navigate( `verifyEmail?${ urlQueryParams.toString() }` );
 						case 'importer':
+							recordFreeHostingTrialStarted( FlowNames.SiteMigration );
 							return navigate( `importerWordpress?${ urlQueryParams.toString() }` );
 						case 'checkout':
 							return exitFlow( providedDependencies?.checkoutUrl as string );

--- a/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
@@ -3,10 +3,7 @@ import { NEW_HOSTED_SITE_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { useEffect, useLayoutEffect } from 'react';
-import {
-	recordFreeHostingTrialStarted,
-	FlowNames,
-} from 'calypso/lib/analytics/ad-tracking/record-hosting-trial-started';
+import { recordFreeHostingTrialStarted } from 'calypso/lib/analytics/ad-tracking/record-hosting-trial-started';
 import {
 	setSignupCompleteSlug,
 	persistSignupDestination,
@@ -74,7 +71,7 @@ const hosting: Flow = {
 				}
 
 				case 'trialAcknowledge': {
-					recordFreeHostingTrialStarted( FlowNames.NewSite );
+					recordFreeHostingTrialStarted( 'new_site' );
 					return navigate( 'siteCreationStep' );
 				}
 

--- a/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
@@ -4,6 +4,10 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { useEffect, useLayoutEffect } from 'react';
 import {
+	recordFreeHostingTrialStarted,
+	FlowNames,
+} from 'calypso/lib/analytics/ad-tracking/record-hosting-trial-started';
+import {
 	setSignupCompleteSlug,
 	persistSignupDestination,
 	setSignupCompleteFlowName,
@@ -70,6 +74,7 @@ const hosting: Flow = {
 				}
 
 				case 'trialAcknowledge': {
+					recordFreeHostingTrialStarted( FlowNames.NewSite );
 					return navigate( 'siteCreationStep' );
 				}
 

--- a/client/lib/analytics/ad-tracking/constants.js
+++ b/client/lib/analytics/ad-tracking/constants.js
@@ -40,7 +40,7 @@ export const OUTBRAIN_SCRIPT_URL = 'https://amplify.outbrain.com/cp/obtp.js';
 export const PINTEREST_SCRIPT_URL = 'https://s.pinimg.com/ct/core.js';
 export const PARSLEY_SCRIPT_URL = 'https://cdn.parsely.com/keys/wordpress.com/p.js?ver=3.3.2';
 export const REDDIT_TRACKING_SCRIPT = 'https://www.redditstatic.com/ads/pixel.js';
-export const WPCOM_REDDIT_PIXEL_ID = 'a2_e41564o4pd5f'; //TODO - Replace with real pixel id.
+export const WPCOM_REDDIT_PIXEL_ID = 'a2_e2nbora1pqet';
 
 export const TRACKING_IDS = {
 	bingInit: '4074038',

--- a/client/lib/analytics/ad-tracking/constants.js
+++ b/client/lib/analytics/ad-tracking/constants.js
@@ -39,6 +39,9 @@ export const QUORA_SCRIPT_URL = 'https://a.quora.com/qevents.js';
 export const OUTBRAIN_SCRIPT_URL = 'https://amplify.outbrain.com/cp/obtp.js';
 export const PINTEREST_SCRIPT_URL = 'https://s.pinimg.com/ct/core.js';
 export const PARSLEY_SCRIPT_URL = 'https://cdn.parsely.com/keys/wordpress.com/p.js?ver=3.3.2';
+export const REDDIT_TRACKING_SCRIPT = 'https://www.redditstatic.com/ads/pixel.js';
+export const WPCOM_REDDIT_PIXEL_ID = 'a2_e41564o4pd5f'; //TODO - Replace with real pixel id.
+
 export const TRACKING_IDS = {
 	bingInit: '4074038',
 	criteo: '31321',

--- a/client/lib/analytics/ad-tracking/record-hosting-trial-started.ts
+++ b/client/lib/analytics/ad-tracking/record-hosting-trial-started.ts
@@ -1,9 +1,18 @@
 import { redditTrackerFreeTrialStarted } from './reddit';
 
 /**
+ * Flow names for free hosting trials. Can be used in third-party trackers to distinguish between different flows,
+ * e.g. whether it's an import of an existing site, or a new site.
+ */
+export enum FlowNames {
+	NewSite = 'new_site',
+	SiteMigration = 'site_migration',
+}
+
+/**
  * Tracks a lead (free trial) in third-party trackers.
  */
-export const recordFreeHostingTrialStarted = ( flow_name: string ) => {
+export const recordFreeHostingTrialStarted = ( flow_name: FlowNames ) => {
 	// Reddit.
 	redditTrackerFreeTrialStarted( flow_name );
 };

--- a/client/lib/analytics/ad-tracking/record-hosting-trial-started.ts
+++ b/client/lib/analytics/ad-tracking/record-hosting-trial-started.ts
@@ -1,0 +1,9 @@
+import { redditTrackerFreeTrialStarted } from './reddit';
+
+/**
+ * Tracks a lead (free trial) in third-party trackers.
+ */
+export const recordFreeHostingTrialStarted = ( flow_name: string ) => {
+	// Reddit.
+	redditTrackerFreeTrialStarted( flow_name );
+};

--- a/client/lib/analytics/ad-tracking/record-hosting-trial-started.ts
+++ b/client/lib/analytics/ad-tracking/record-hosting-trial-started.ts
@@ -4,10 +4,7 @@ import { redditTrackerFreeTrialStarted } from './reddit';
  * Flow names for free hosting trials. Can be used in third-party trackers to distinguish between different flows,
  * e.g. whether it's an import of an existing site, or a new site.
  */
-export enum FlowNames {
-	NewSite = 'new_site',
-	SiteMigration = 'site_migration',
-}
+export type FlowNames = 'new_site' | 'site_migration';
 
 /**
  * Tracks a lead (free trial) in third-party trackers.

--- a/client/lib/analytics/ad-tracking/reddit.ts
+++ b/client/lib/analytics/ad-tracking/reddit.ts
@@ -52,7 +52,7 @@ export const redditTrackerPageView = (): void => {
 	if ( ! mayWeTrackByTracker( 'reddit' ) ) {
 		return;
 	}
-	loadRedditTracker().then( () => window.rdt( 'track', 'PageVisit' ) );
+	loadRedditTracker().then( () => window.rdt && window.rdt( 'track', 'PageVisit' ) );
 };
 
 /**
@@ -80,7 +80,7 @@ export const redditTrackerPurchase = (
 			name: product_name.toString(),
 		} ) ),
 	};
-	loadRedditTracker().then( () => window.rdt( 'track', 'Purchase', params ) );
+	loadRedditTracker().then( () => window.rdt && window.rdt( 'track', 'Purchase', params ) );
 };
 
 /**
@@ -100,5 +100,5 @@ export const redditTrackerFreeTrialStarted = ( trial_flow_name: string ): void =
 			},
 		],
 	};
-	loadRedditTracker().then( () => window.rdt( 'track', 'Lead', params ) );
+	loadRedditTracker().then( () => window.rdt && window.rdt( 'track', 'Lead', params ) );
 };

--- a/client/lib/analytics/ad-tracking/reddit.ts
+++ b/client/lib/analytics/ad-tracking/reddit.ts
@@ -95,9 +95,9 @@ export const redditTrackerFreeTrialStarted = ( trial_flow_name: FlowNames ): voi
 	const params = {
 		products: [
 			{
-				id: 'wpcom_hosting_trial',
+				id: 'wpcom_creator_trial',
 				name: trial_flow_name,
-				category: 'Free Trial',
+				category: 'free_trial',
 			},
 		],
 	};

--- a/client/lib/analytics/ad-tracking/reddit.ts
+++ b/client/lib/analytics/ad-tracking/reddit.ts
@@ -20,7 +20,7 @@ declare global {
  */
 export const loadRedditTracker = async (): Promise< void > => {
 	// Are we allowed to track (user consent, e2e, etc.)?
-	if ( ! mayWeInitTracker( 'reddit' ) ) {
+	if ( ! mayWeTrackByTracker( 'reddit' ) ) {
 		throw new Error( 'Tracking is not allowed' );
 	}
 
@@ -39,7 +39,7 @@ export const loadRedditTracker = async (): Promise< void > => {
  * @returns Promise<void>
  */
 export const redditTrackerPageView = async (): Promise< void > => {
-	if ( ! mayWeTrackByTracker( 'reddit' ) ) {
+	if ( ! mayWeInitTracker( 'reddit' ) ) {
 		return;
 	}
 	await loadRedditTracker();

--- a/client/lib/analytics/ad-tracking/reddit.ts
+++ b/client/lib/analytics/ad-tracking/reddit.ts
@@ -86,7 +86,7 @@ export const redditTrackerPurchase = (
 /**
  * Tracks a lead (free trial) in Reddit.
  */
-export const redditTrackerFreeTrialStarted = (): void => {
+export const redditTrackerFreeTrialStarted = ( trial_flow_name: string ): void => {
 	if ( ! mayWeTrackByTracker( 'reddit' ) ) {
 		return;
 	}
@@ -95,7 +95,7 @@ export const redditTrackerFreeTrialStarted = (): void => {
 		products: [
 			{
 				id: 'wpcom_hosting_trial',
-				name: 'WordPress.com Hosting Trial',
+				name: trial_flow_name,
 				category: 'Free Trial',
 			},
 		],

--- a/client/lib/analytics/ad-tracking/reddit.ts
+++ b/client/lib/analytics/ad-tracking/reddit.ts
@@ -3,6 +3,7 @@ import { ResponseCart } from '@automattic/shopping-cart';
 import { mayWeTrackByTracker } from '../tracker-buckets';
 import { WpcomJetpackCartInfo } from '../utils/split-wpcom-jetpack-cart-info';
 import { REDDIT_TRACKING_SCRIPT, WPCOM_REDDIT_PIXEL_ID } from './constants';
+import { FlowNames } from './record-hosting-trial-started';
 
 /**
  * We'll be accessing rdt from the window object.
@@ -86,7 +87,7 @@ export const redditTrackerPurchase = (
 /**
  * Tracks a lead (free trial) in Reddit.
  */
-export const redditTrackerFreeTrialStarted = ( trial_flow_name: string ): void => {
+export const redditTrackerFreeTrialStarted = ( trial_flow_name: FlowNames ): void => {
 	if ( ! mayWeTrackByTracker( 'reddit' ) ) {
 		return;
 	}

--- a/client/lib/analytics/ad-tracking/reddit.ts
+++ b/client/lib/analytics/ad-tracking/reddit.ts
@@ -1,0 +1,95 @@
+import { loadScript } from '@automattic/load-script';
+import { ResponseCart } from '@automattic/shopping-cart';
+import { mayWeInitTracker, mayWeTrackByTracker } from '../tracker-buckets';
+import { WpcomJetpackCartInfo } from '../utils/split-wpcom-jetpack-cart-info';
+import { REDDIT_TRACKING_SCRIPT, WPCOM_REDDIT_PIXEL_ID } from './constants';
+
+/**
+ * We'll be accessing rdt from the window object.
+ */
+declare global {
+	interface Window {
+		rdt: ( T: string, V?: string, W?: object ) => void; //TODO - Temp types for now to pass TS warnings.
+	}
+}
+
+/**
+ * Loads the Reddit script, if the user has consented to tracking,
+ * and tracking is allowed by the current environment.
+ * @returns Promise<void>
+ */
+export const loadRedditTracker = async (): Promise< void > => {
+	// Are we allowed to track (user consent, e2e, etc.)?
+	if ( ! mayWeInitTracker( 'reddit' ) ) {
+		throw new Error( 'Tracking is not allowed' );
+	}
+
+	// Load the Reddit Tracker script
+	await loadScript( REDDIT_TRACKING_SCRIPT );
+
+	const params = {
+		optOut: false,
+		useDecimalCurrencyValues: true,
+	};
+	window.rdt( 'init', WPCOM_REDDIT_PIXEL_ID, params );
+};
+
+/**
+ * Tracks a page view in Reddit.
+ * @returns Promise<void>
+ */
+export const redditTrackerPageView = async (): Promise< void > => {
+	if ( ! window.rdt ) {
+		return;
+	}
+	await loadRedditTracker();
+	window.rdt( 'track', 'PageView' );
+};
+
+/**
+ * Tracks a purchase in Reddit.
+ */
+export const redditTrackerPurchase = (
+	cart: ResponseCart,
+	orderId: string,
+	wpcomJetpackCartInfo: WpcomJetpackCartInfo
+): void => {
+	if ( ! mayWeTrackByTracker( 'reddit' ) ) {
+		return;
+	}
+
+	if ( ! wpcomJetpackCartInfo.containsWpcomProducts ) {
+		return;
+	}
+	const params = {
+		currency: 'USD',
+		itemCount: wpcomJetpackCartInfo.wpcomProducts.length,
+		transactionId: orderId,
+		value: wpcomJetpackCartInfo.wpcomCostUSD,
+		products: wpcomJetpackCartInfo.wpcomProducts.map( ( { product_id, product_name } ) => ( {
+			id: product_id.toString(),
+			name: product_name.toString(),
+		} ) ),
+	};
+	loadRedditTracker().then( () => window.rdt( 'track', 'Purchase', params ) );
+};
+
+/**
+ * Tracks a lead (free trial) in Reddit.
+ */
+export const redditTrackerFreeTrialStarted = (): void => {
+	if ( ! mayWeTrackByTracker( 'reddit' ) ) {
+		return;
+	}
+
+	const params = {
+		products: [
+			{
+				id: 'wpcom_hosting_trial',
+				name: 'WordPress.com Hosting Trial',
+				category: 'Free Trial',
+			},
+		],
+	};
+	loadRedditTracker().then( () => window.rdt( 'track', 'Lead', params ) );
+};

--- a/client/lib/analytics/ad-tracking/reddit.ts
+++ b/client/lib/analytics/ad-tracking/reddit.ts
@@ -39,7 +39,7 @@ export const loadRedditTracker = async (): Promise< void > => {
  * @returns Promise<void>
  */
 export const redditTrackerPageView = async (): Promise< void > => {
-	if ( ! window.rdt ) {
+	if ( ! mayWeTrackByTracker( 'reddit' ) ) {
 		return;
 	}
 	await loadRedditTracker();

--- a/client/lib/analytics/ad-tracking/reddit.ts
+++ b/client/lib/analytics/ad-tracking/reddit.ts
@@ -12,7 +12,7 @@ declare global {
 		rdt: {
 			callQueue: object[];
 			sendEvent: ( ...args: [ string, string?, object? ] ) => void;
-		};
+		} & ( ( ...args: [ string, string?, object? ] ) => void );
 	}
 }
 

--- a/client/lib/analytics/tracker-buckets.ts
+++ b/client/lib/analytics/tracker-buckets.ts
@@ -32,6 +32,7 @@ const allAdTrackers = [
 	'adroll',
 	'parsely',
 	'clarity',
+	'reddit',
 ] as const;
 
 type AdTracker = ( typeof allAdTrackers )[ number ];
@@ -58,6 +59,7 @@ export const AdTrackersBuckets: { [ key in AdTracker ]: Bucket | null } = {
 	pinterest: Bucket.ADVERTISING,
 	twitter: Bucket.ADVERTISING,
 	facebook: Bucket.ADVERTISING,
+	reddit: Bucket.ADVERTISING,
 
 	// Advertising trackers (only Jetpack Cloud or on Jetpack Checkout):
 	linkedin: isJetpackCloud() || isJetpackCheckout() ? Bucket.ADVERTISING : null,
@@ -96,6 +98,7 @@ export const AdTrackersInitGuards: Partial< { [ key in AdTracker ]: () => boolea
 	quora: () => 'qp' in window,
 	adroll: () => 'adRoll' in window,
 	clarity: () => 'clarity' in window,
+	reddit: () => 'rdt' in window,
 };
 
 const isTrackerIntialized = ( tracker: AdTracker ): boolean => {

--- a/client/lib/analytics/tracker-buckets.ts
+++ b/client/lib/analytics/tracker-buckets.ts
@@ -98,7 +98,6 @@ export const AdTrackersInitGuards: Partial< { [ key in AdTracker ]: () => boolea
 	quora: () => 'qp' in window,
 	adroll: () => 'adRoll' in window,
 	clarity: () => 'clarity' in window,
-	reddit: () => 'rdt' in window,
 };
 
 const isTrackerIntialized = ( tracker: AdTracker ): boolean => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/martech#2350

## Proposed Changes

* Adds the base pixel script (adapted and Calypso-y-fied from https://gist.github.com/gmovr/741861b668a52d741e664a85d16fe5aa). This is using the async `loadScript` function (similar to other trackers), and is aware of the GDPR/CCPA logic for compliance.
* Global types for `window.rdt`. This is an external script that we have no control over, but this pleases TS and lint rules.
* POST requests for conversions, page views, and a lead event for free trial starts.
* Set up tracking for free trial starts when a free hosting trial for WPcom is started.

## Testing Instructions
* To see that the logic works (requests go to Reddit), you can do the following:

```
diff --git a/client/lib/analytics/ad-tracking/setup.js b/client/lib/analytics/ad-tracking/setup.js
index 2f476f2b01..1f7bec7171 100644
--- a/client/lib/analytics/ad-tracking/setup.js
+++ b/client/lib/analytics/ad-tracking/setup.js
@@ -9,6 +9,7 @@ import {
        ADROLL_PURCHASE_PIXEL_URL_2,
        TRACKING_IDS,
 } from './constants';
+import { redditTrackerPageView } from './reddit';

 if ( typeof window !== 'undefined' ) {
        if ( mayWeInitTracker( 'ga' ) ) {
@@ -20,6 +21,10 @@ if ( typeof window !== 'undefined' ) {
                setupFacebookGlobal();
        }

+       if ( mayWeTrackByTracker( 'reddit' ) ) {
+               redditTrackerPageView();
+       }
+
        // Bing
        if ( mayWeInitTracker( 'bing' ) && ! window.uetq ) {
                window.uetq = [];
```

Then in `development.json` activate `ad-tracking` and `cookie-banner`. Reload Calypso, and refresh a random Calypso page, e.g. stats. You will see both the pixel loading and the tracking call going through in the network tab.

The logic will be the same for any event, here we're just testing it via a page view because it's easier. If you have access to the Reddit ads account, you can also verify in the debug utility that the event comes through.

----

For the free hosting trials, you can test as following: pduY5I-Hn-p2#comment-477


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
