### PR TITLE
Reader: Clean up Jetpack Tiled Gallery blocks

### DIFF
--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -1,6 +1,9 @@
 /* stylelint-disable-next-line scss/at-import-no-partial-leading-underscore */
 @import "calypso/assets/stylesheets/shared/_rendered-blocks.scss";
 
+// Style tiled galleries.
+@import "tiled-gallery.scss";
+
 // Import styles for Jetpack Story block.
 // This is a copy of Jetpack's extensions/blocks/story/player/style.scss, with
 // some unnecessary styles removed.

--- a/client/blocks/reader-full-post/tiled-gallery.scss
+++ b/client/blocks/reader-full-post/tiled-gallery.scss
@@ -1,0 +1,66 @@
+$tiled-gallery-max-rounded-corners: 20;
+
+.wp-block-jetpack-tiled-gallery {
+	margin: 0 auto 1.5em;
+
+	&.is-style-circle .tiled-gallery__item img {
+		border-radius: 50%;
+	}
+
+	@for $i from 1 through $tiled-gallery-max-rounded-corners {
+		&.has-rounded-corners-#{$i} .tiled-gallery__item img {
+			border-radius: #{$i}px;
+		}
+	}
+
+	.tiled-gallery__gallery {
+		width: 100%;
+		padding: 0;
+	}
+
+	.gallery-container {
+		display: flex;
+		flex-wrap: wrap;
+	}
+
+	.gallery-item-wrapper {
+		margin: 0;
+		display: flex;
+		flex-direction: column;
+		flex-grow: 1;
+		align-self: inherit;
+
+		> img {
+			background-color: rgba(var(--color-text-rgb), 0.1);
+		}
+
+		> a,
+		> a > img,
+		> img {
+			display: block;
+			margin: 0;
+			flex: 1 0 0%;
+			object-fit: cover;
+			object-position: center;
+			padding: 0;
+			width: 100%;
+			height: 100%;
+			max-width: 100%;
+		}
+	}
+
+	.gallery-item {
+		margin: 0 12px 12px 0;
+		overflow: hidden;
+		padding: 0;
+		position: relative;
+		display: flex;
+		flex-grow: 1;
+		justify-content: center;
+		width: calc(50% - 6px);
+
+		&:nth-child(2n) {
+			margin-right: 0;
+		}
+	}
+}

--- a/client/blocks/reader-full-post/tiled-gallery.scss
+++ b/client/blocks/reader-full-post/tiled-gallery.scss
@@ -3,14 +3,8 @@ $tiled-gallery-max-rounded-corners: 20;
 .wp-block-jetpack-tiled-gallery {
 	margin: 0 auto 1.5em;
 
-	&.is-style-circle .tiled-gallery__item img {
+	&.is-style-circle .gallery-item img {
 		border-radius: 50%;
-	}
-
-	@for $i from 1 through $tiled-gallery-max-rounded-corners {
-		&.has-rounded-corners-#{$i} .tiled-gallery__item img {
-			border-radius: #{$i}px;
-		}
 	}
 
 	.tiled-gallery__gallery {

--- a/client/components/embed-container/index.jsx
+++ b/client/components/embed-container/index.jsx
@@ -21,6 +21,7 @@ const embedsToLookFor = {
 	'.embed-reddit': embedReddit,
 	'.embed-tiktok': embedTikTok,
 	'.wp-block-jetpack-slideshow, .wp-block-newspack-blocks-carousel': embedCarousel,
+	'.wp-block-jetpack-tiled-gallery': embedTiledGallery,
 };
 
 const cacheBustQuery = `?v=${ Math.floor( new Date().getTime() / ( 1000 * 60 * 60 * 24 * 10 ) ) }`; // A new query every 10 days
@@ -239,6 +240,36 @@ function embedStory( domNode ) {
 	// Open story in a new tab
 	if ( storyLink ) {
 		storyLink.setAttribute( 'target', '_blank' );
+	}
+}
+
+function embedTiledGallery( domNode ) {
+	debug( 'processing tiled gallery for', domNode );
+
+	const galleryToReplace = domNode.querySelector( '.tiled-gallery__gallery' );
+	const galleryItems = domNode.getElementsByTagName( 'img' );
+
+	if ( galleryItems ) {
+		const imageItems = Array.from( galleryItems );
+		// Replace the gallery with a list of images
+		createRoot( galleryToReplace ).render(
+			<div className="gallery-container">
+				{ imageItems.map( ( item ) => {
+					return (
+						<figure className="gallery-item">
+							<div className="gallery-item-wrapper">
+								<img
+									id={ item?.id }
+									className={ item?.className }
+									src={ item?.src }
+									alt={ item?.alt }
+								/>
+							</div>
+						</figure>
+					);
+				} ) }
+			</div>
+		);
 	}
 }
 

--- a/client/components/embed-container/index.jsx
+++ b/client/components/embed-container/index.jsx
@@ -245,14 +245,13 @@ function embedStory( domNode ) {
 
 function embedTiledGallery( domNode ) {
 	debug( 'processing tiled gallery for', domNode );
-	const galleryToReplace = domNode.querySelector( '.tiled-gallery__gallery' );
 	const galleryItems = domNode.getElementsByClassName( 'tiled-gallery__item' );
 
 	if ( galleryItems && galleryItems.length ) {
 		const imageItems = Array.from( galleryItems );
 
 		// Replace the gallery with updated markup
-		createRoot( galleryToReplace ).render(
+		createRoot( domNode ).render(
 			<div className="gallery-container">
 				{ imageItems.map( ( item ) => {
 					const itemImage = item.querySelector( 'img' );

--- a/client/components/embed-container/index.jsx
+++ b/client/components/embed-container/index.jsx
@@ -245,25 +245,35 @@ function embedStory( domNode ) {
 
 function embedTiledGallery( domNode ) {
 	debug( 'processing tiled gallery for', domNode );
-
 	const galleryToReplace = domNode.querySelector( '.tiled-gallery__gallery' );
-	const galleryItems = domNode.getElementsByTagName( 'img' );
+	const galleryItems = domNode.getElementsByClassName( 'tiled-gallery__item' );
 
 	if ( galleryItems ) {
 		const imageItems = Array.from( galleryItems );
+
 		// Replace the gallery with a list of images
 		createRoot( galleryToReplace ).render(
 			<div className="gallery-container">
 				{ imageItems.map( ( item ) => {
+					const itemImage = item.querySelector( 'img' );
+					const itemLink = item.querySelector( 'a' );
+
+					const imgProps = {
+						id: itemImage?.id || undefined,
+						className: itemImage?.className || undefined,
+						src: itemImage?.src || undefined,
+					};
+
 					return (
 						<figure className="gallery-item">
 							<div className="gallery-item-wrapper">
-								<img
-									id={ item?.id }
-									className={ item?.className }
-									src={ item?.src }
-									alt={ item?.alt }
-								/>
+								{ itemLink?.href ? (
+									<a href={ itemLink.href }>
+										<img alt={ itemImage?.alt || '' } { ...imgProps } />
+									</a>
+								) : (
+									<img alt={ itemImage?.alt || '' } { ...imgProps } />
+								) }
 							</div>
 						</figure>
 					);

--- a/client/components/embed-container/index.jsx
+++ b/client/components/embed-container/index.jsx
@@ -257,22 +257,20 @@ function embedTiledGallery( domNode ) {
 					const itemImage = item.querySelector( 'img' );
 					const itemLink = item.querySelector( 'a' );
 
-					const imgProps = {
-						id: itemImage?.id || undefined,
-						className: itemImage?.className || undefined,
-						src: itemImage?.src || undefined,
-					};
+					const imageElement = (
+						<img
+							id={ itemImage?.id || undefined }
+							className={ itemImage?.className || undefined }
+							alt={ itemImage?.alt || '' }
+							src={ itemImage?.src || undefined }
+							srcSet={ itemImage?.srcSet || undefined }
+						/>
+					);
 
 					return (
 						<figure className="gallery-item">
 							<div className="gallery-item-wrapper">
-								{ itemLink?.href ? (
-									<a href={ itemLink.href }>
-										<img alt={ itemImage?.alt || '' } { ...imgProps } />
-									</a>
-								) : (
-									<img alt={ itemImage?.alt || '' } { ...imgProps } />
-								) }
+								{ itemLink?.href ? <a href={ itemLink.href }>{ imageElement }</a> : imageElement }
 							</div>
 						</figure>
 					);

--- a/client/components/embed-container/index.jsx
+++ b/client/components/embed-container/index.jsx
@@ -248,10 +248,10 @@ function embedTiledGallery( domNode ) {
 	const galleryToReplace = domNode.querySelector( '.tiled-gallery__gallery' );
 	const galleryItems = domNode.getElementsByClassName( 'tiled-gallery__item' );
 
-	if ( galleryItems ) {
+	if ( galleryItems && galleryItems.length ) {
 		const imageItems = Array.from( galleryItems );
 
-		// Replace the gallery with a list of images
+		// Replace the gallery with updated markup
 		createRoot( galleryToReplace ).render(
 			<div className="gallery-container">
 				{ imageItems.map( ( item ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #45122

## Proposed Changes

* Re-format the Tiled Gallery markup so we can style it for the Reader/other embed contexts (like inline help) without the use of JS.

**Before**

![wordpress com_read_feeds_151198233_posts_5019502943](https://github.com/Automattic/wp-calypso/assets/2124984/720d30de-880a-4f22-94c2-de8d64bd0884)

**After**

![calypso localhost_3000_read_feeds_151198233_posts_5019502943](https://github.com/Automattic/wp-calypso/assets/2124984/59862f6f-0c2d-4152-a530-94c8413ace77)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR
* Navigate to `/read` and find a post with a Tiled Gallery (or make one on a test site)
* Click on the post in the Reader to open the full page view
* You should see a basic gallery rather than a single column of images.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?