### PR TITLE
Jetpack Manage: add contact support button and video to overview page sidebar

### DIFF
--- a/client/jetpack-cloud/components/content-sidebar/style.scss
+++ b/client/jetpack-cloud/components/content-sidebar/style.scss
@@ -8,9 +8,6 @@
 	display: flex;
 	flex-direction: column;
 
-	// todo: remove this testing/design purposes
-	border: 1px dashed var(--color-accent-40);
-
 	@include break-xlarge {
 		display: grid;
 		grid-template-columns: 3fr 1fr;
@@ -20,9 +17,6 @@
 	}
 
 	.right-sidebar {
-
-		// todo: remove this testing/design purposes
-		border: 1px dashed var(--color-accent-40);
 
 		> *:not(:first-child) {
 			margin-top: 40px;

--- a/client/jetpack-cloud/sections/overview/foldable-nav/style.scss
+++ b/client/jetpack-cloud/sections/overview/foldable-nav/style.scss
@@ -17,8 +17,8 @@
 
 		.foldable-card__main {
 			color: var(--studio-gray-100);
-			font-weight: 600;
-			font-size: 16;
+			font-weight: 500;
+			font-size: rem(16px);
 		}
 	}
 
@@ -27,9 +27,9 @@
 		padding: 0;
 
 		p.no-content,
-		li {
+		.components-flex-item {
 			color: var(--studio-gray-80);
-			font-size: 20;
+			font-size: rem(14px);
 			margin-bottom: 0;
 		}
 

--- a/client/jetpack-cloud/sections/overview/primary/overview/style.scss
+++ b/client/jetpack-cloud/sections/overview/primary/overview/style.scss
@@ -2,64 +2,66 @@
 @import "@wordpress/base-styles/mixins";
 
 .jetpack-cloud-content-sidebar {
-	.manage-overview {
-		max-width: 100%;
-		h1 {
-			font-family: "SF Pro Display", serif;
-			font-size: rem(36px);
-			font-weight: 700;
-			line-height: 48px;
-		}
-		h2 {
-			font-family: "SF Pro Text", serif;
-			font-size: rem(16px);
-			font-weight: 500;
-			line-height: 24px;
-			color: var(--studio-gray-100);
-		}
-		.welcome-section {
-			padding: 32px;
-			background-color: var(--studio-white);
-
-			p {
-				color: #333;
-				margin-bottom: 16px;
+	.main-content {
+		.manage-overview {
+			padding-left: 0;
+			padding-right: 0;
+			max-width: 100%;
+			h1 {
+				font-size: rem(36px);
+				font-weight: 700;
+				line-height: 48px;
 			}
-			.benefits-list {
-				list-style: none;
-				padding: 0;
-				margin-bottom: 24px;
-				li {
-					margin-bottom: 8px;
-				}
+			h2 {
+				font-size: rem(16px);
+				font-weight: 500;
+				line-height: 24px;
+				color: var(--studio-gray-100);
 			}
-			.next-button {
-				padding: 8px 16px;
-				background-color: var(--studio-jetpack-green-50);
-				color: var(--studio-white);
-				border: none;
-				cursor: pointer;
-			}
-		}
+			.welcome-section {
+				padding: 32px;
+				background-color: var(--studio-white);
 
-		.next-steps {
-			margin-top: 16px;
-			padding: 16px 32px 16px 32px;
-			background-color: var(--studio-white);
-
-			.steps-list {
-				list-style: none;
-				padding: 0;
-				li {
+				p {
+					color: #333;
 					margin-bottom: 16px;
 				}
+				.benefits-list {
+					list-style: none;
+					padding: 0;
+					margin-bottom: 24px;
+					li {
+						margin-bottom: 8px;
+					}
+				}
+				.next-button {
+					padding: 8px 16px;
+					background-color: var(--studio-jetpack-green-50);
+					color: var(--studio-white);
+					border: none;
+					cursor: pointer;
+				}
 			}
-		}
 
-		.jetpack-products {
-			background-color: var(--studio-white);
-			margin-top: 32px;
-			padding: 24px;
+			.next-steps {
+				margin-top: 16px;
+				padding: 16px 32px 16px 32px;
+				background-color: var(--studio-white);
+
+				.steps-list {
+					list-style: none;
+					padding: 0;
+					li {
+						margin-bottom: 16px;
+					}
+				}
+			}
+
+			.jetpack-products {
+				background-color: var(--studio-white);
+				margin-top: 32px;
+				padding: 24px;
+			}
 		}
 	}
 }

--- a/client/jetpack-cloud/sections/overview/primary/sidebar/index.tsx
+++ b/client/jetpack-cloud/sections/overview/primary/sidebar/index.tsx
@@ -1,11 +1,14 @@
 import { Button } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import GetHelpNav from '../get-help-nav';
 import QuickLinksNav from '../quick-links-nav';
 import './style.scss';
 
 export default function OverviewSidebar() {
+	const dispatch = useDispatch();
 	const translate = useTranslate();
 	return (
 		<>
@@ -27,11 +30,14 @@ export default function OverviewSidebar() {
 
 			<section>
 				<GetHelpNav />
-
 				<Button
 					href={ localizeUrl( 'https://jetpack.com/contact-support/' ) }
 					className="contact-support-button"
-					onClick={ () => {} }
+					onClick={ () =>
+						dispatch(
+							recordTracksEvent( 'calypso_jetpack_manage_overview_contact_support_button_click' )
+						)
+					}
 				>
 					{ translate( 'Contact support' ) }
 				</Button>

--- a/client/jetpack-cloud/sections/overview/primary/sidebar/index.tsx
+++ b/client/jetpack-cloud/sections/overview/primary/sidebar/index.tsx
@@ -9,25 +9,35 @@ export default function OverviewSidebar() {
 	const translate = useTranslate();
 	return (
 		<>
-			<iframe
-				className="intro-video"
-				title={ translate( 'Jetpack Manage Overview' ) }
-				aria-label={ translate( 'Jetpack Manage Overview' ) }
-				src={
-					'https://video.wordpress.com/embed/Z9piKY9s?hd=1&amp;autoPlay=0&amp;permalink=1&amp;loop=0&amp;preloadContent=metadata&amp;muted=0&amp;playsinline=0&amp;controls=1&amp;cover=1%27'
-				}
-				allowFullScreen
-			></iframe>
-			<QuickLinksNav />
-			<GetHelpNav />
+			<section>
+				<iframe
+					className="intro-video"
+					title={ translate( 'Jetpack Manage Overview' ) }
+					aria-label={ translate( 'Jetpack Manage Overview' ) }
+					src={
+						'https://video.wordpress.com/embed/Z9piKY9s?hd=1&amp;autoPlay=0&amp;permalink=1&amp;loop=0&amp;preloadContent=metadata&amp;muted=0&amp;playsinline=0&amp;controls=1&amp;cover=1%27'
+					}
+					allowFullScreen
+				></iframe>
+			</section>
 
-			<Button
-				href={ localizeUrl( 'https://jetpack.com/contact-support/' ) }
-				className="contact-support-button"
-				onClick={ () => {} }
-			>
-				{ translate( 'Contact support' ) }
-			</Button>
+			<section>
+				<QuickLinksNav />
+			</section>
+
+			<section>
+				<GetHelpNav />
+			</section>
+
+			<section>
+				<Button
+					href={ localizeUrl( 'https://jetpack.com/contact-support/' ) }
+					className="contact-support-button"
+					onClick={ () => {} }
+				>
+					{ translate( 'Contact support' ) }
+				</Button>
+			</section>
 		</>
 	);
 }

--- a/client/jetpack-cloud/sections/overview/primary/sidebar/index.tsx
+++ b/client/jetpack-cloud/sections/overview/primary/sidebar/index.tsx
@@ -1,15 +1,21 @@
+import { useTranslate } from 'i18n-calypso';
 import GetHelpNav from '../get-help-nav';
 import QuickLinksNav from '../quick-links-nav';
 import './style.scss';
 
 export default function OverviewSidebar() {
+	const translate = useTranslate();
 	return (
 		<>
-			<section className="intro-video">
-				<div className="video-placeholder"></div>
-				<p>Intro video</p>
-				Watch a short intro video
-			</section>
+			<iframe
+				className="intro-video"
+				title={ translate( 'Jetpack Manage Overview' ) }
+				aria-label={ translate( 'Jetpack Manage Overview' ) }
+				src={
+					'https://video.wordpress.com/embed/Z9piKY9s?hd=1&amp;autoPlay=0&amp;permalink=1&amp;loop=0&amp;preloadContent=metadata&amp;muted=0&amp;playsinline=0&amp;controls=1&amp;cover=1%27'
+				}
+				allowFullScreen
+			></iframe>
 			<QuickLinksNav />
 			<GetHelpNav />
 		</>

--- a/client/jetpack-cloud/sections/overview/primary/sidebar/index.tsx
+++ b/client/jetpack-cloud/sections/overview/primary/sidebar/index.tsx
@@ -31,13 +31,14 @@ export default function OverviewSidebar() {
 			<section>
 				<GetHelpNav />
 				<Button
-					href={ localizeUrl( 'https://jetpack.com/contact-support/' ) }
 					className="contact-support-button"
+					href={ localizeUrl( 'https://jetpack.com/contact-support/' ) }
 					onClick={ () =>
 						dispatch(
 							recordTracksEvent( 'calypso_jetpack_manage_overview_contact_support_button_click' )
 						)
 					}
+					target="_blank"
 				>
 					{ translate( 'Contact support' ) }
 				</Button>

--- a/client/jetpack-cloud/sections/overview/primary/sidebar/index.tsx
+++ b/client/jetpack-cloud/sections/overview/primary/sidebar/index.tsx
@@ -1,3 +1,5 @@
+import { Button } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import GetHelpNav from '../get-help-nav';
 import QuickLinksNav from '../quick-links-nav';
@@ -18,6 +20,14 @@ export default function OverviewSidebar() {
 			></iframe>
 			<QuickLinksNav />
 			<GetHelpNav />
+
+			<Button
+				href={ localizeUrl( 'https://jetpack.com/contact-support/' ) }
+				className="contact-support-button"
+				onClick={ () => {} }
+			>
+				{ translate( 'Contact support' ) }
+			</Button>
 		</>
 	);
 }

--- a/client/jetpack-cloud/sections/overview/primary/sidebar/index.tsx
+++ b/client/jetpack-cloud/sections/overview/primary/sidebar/index.tsx
@@ -27,9 +27,7 @@ export default function OverviewSidebar() {
 
 			<section>
 				<GetHelpNav />
-			</section>
 
-			<section>
 				<Button
 					href={ localizeUrl( 'https://jetpack.com/contact-support/' ) }
 					className="contact-support-button"

--- a/client/jetpack-cloud/sections/overview/primary/sidebar/style.scss
+++ b/client/jetpack-cloud/sections/overview/primary/sidebar/style.scss
@@ -3,7 +3,6 @@
 
 .jetpack-cloud-content-sidebar {
 	.right-sidebar {
-		background: #f9f9f9;
 
 		.intro-video {
 			width: 100%;
@@ -15,6 +14,7 @@
 
 		.contact-support-button {
 			width: 100%;
+			font-weight: 500;
 			color: var(--studio-gray-100);
 			border-color: var(--studio-gray-10);
 		}

--- a/client/jetpack-cloud/sections/overview/primary/sidebar/style.scss
+++ b/client/jetpack-cloud/sections/overview/primary/sidebar/style.scss
@@ -9,57 +9,8 @@
 			width: 100%;
 		}
 
-		.intro-video,
-		.quick-links,
-		.get-help {
-			margin-bottom: 48px;
-		}
-
-		h2,
-		h3 {
-			margin: 0 0 16px;
-		}
-
-		.video-placeholder {
-			background: var(--color-accent-20);
-			height: 150px;
-			margin-bottom: 16px;
-		}
-
-		.icon-placeholder {
-			display: inline-block;
-			background: var(--color-accent-10);
-			width: 20px;
-			height: 20px;
-			margin-right: 8px;
-		}
-
-		.button-placeholder {
-			display: block;
-			background: var(--studio-jetpack-green-10);
-			padding: 8px 16px;
-			text-align: center;
-			margin: 24px 0;
-		}
-
-		ul {
-			list-style: none;
-			padding: 0;
-			margin: 0;
-			li {
-				margin-bottom: 40px;
-
-				&:last-child {
-					margin-bottom: 0;
-				}
-			}
-		}
-
-		.watch-video,
-		.feedback {
-			text-decoration: none;
-			display: block;
-			margin-top: 24px;
+		.foldable-card__expand {
+			width: 24px;
 		}
 
 		.contact-support-button {

--- a/client/jetpack-cloud/sections/overview/primary/sidebar/style.scss
+++ b/client/jetpack-cloud/sections/overview/primary/sidebar/style.scss
@@ -61,5 +61,11 @@
 			display: block;
 			margin-top: 24px;
 		}
+
+		.contact-support-button {
+			width: 100%;
+			color: var(--studio-gray-100);
+			border-color: var(--studio-gray-10);
+		}
 	}
 }

--- a/client/jetpack-cloud/sections/overview/primary/sidebar/style.scss
+++ b/client/jetpack-cloud/sections/overview/primary/sidebar/style.scss
@@ -5,6 +5,10 @@
 	.right-sidebar {
 		background: #f9f9f9;
 
+		.intro-video {
+			width: 100%;
+		}
+
 		.intro-video,
 		.quick-links,
 		.get-help {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves Automattic/jetpack-manage#146

## Proposed Changes

This adds the "Contact Support" and intro video to the overview page's sidebar. I also did a pass at moving general styles closer to the Figma.

Specs:
* Video: pf36In-mf-p2#intro-video
* Button: pf36In-mf-p2#contact-support-button

In scope for review is the sidebar content, layout, and styling. Note that the text content accompanying the video is no longer part of spec, and nor is the feedback link at the bottom.

Out of scope is the main content area (not yet developed) and nitpick layout adjustments applying to the full page (this will be done at a later point as needed).

Before:
![image](https://github.com/Automattic/wp-calypso/assets/32492176/012aeeed-3368-4ef3-a038-50370ba2eb1c)

After:
![image](https://github.com/Automattic/wp-calypso/assets/32492176/1f4a828e-175b-4280-b5a5-0226b043b6e0)

Figma:
![image](https://github.com/Automattic/wp-calypso/assets/32492176/4d0fac9b-68b9-47f5-b5ff-a69d4dd1d112)


## Testing Instructions

* Make sure the sidebar looks adequate.
* Make sure the video works.
* Make sure the button works and fires a tracks event.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?