### PR TITLE
Fix inconsistencies in Reader > Recent 

### DIFF
--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -563,7 +563,7 @@ class ReaderStream extends Component {
 										selected={ this.state.selectedTab === 'sites' }
 										onClick={ this.handleSitesSelected }
 									>
-										{ this.props.sidebarTabTitle || translate( 'Sites' ) }
+										{ this.props.sidebarTabTitle || translate( 'Subscriptions' ) }
 									</NavItem>
 								</NavTabs>
 							</SectionNav>

--- a/client/reader/stream/reader-list-followed-sites/index.jsx
+++ b/client/reader/stream/reader-list-followed-sites/index.jsx
@@ -1,4 +1,5 @@
 import { Button } from '@automattic/components';
+import { isMobile } from '@automattic/viewport';
 import { localize } from 'i18n-calypso';
 import { map } from 'lodash';
 import PropTypes from 'prop-types';
@@ -94,13 +95,22 @@ export class ReaderListFollowedSites extends Component {
 
 		return (
 			<>
-				<h2>
-					{ translate( 'Subscriptions' ) }{ ' ' }
-					<a href="/read/subscriptions">{ translate( 'Manage' ) }</a>
-				</h2>
+				{ ! isMobile() ? (
+					<h2>
+						{ translate( 'Subscriptions' ) }{ ' ' }
+						<a href="/read/subscriptions">{ translate( 'Manage' ) }</a>
+					</h2>
+				) : null }
 				{ sites.length >= searchThreshold && (
 					<FollowingManageSearchFollowed onSearch={ this.searchEvent } initialValue={ query } />
 				) }
+
+				{ isMobile() ? (
+					<h2>
+						<a href="/read/subscriptions">{ translate( 'Manage your subscriptions' ) }</a>
+					</h2>
+				) : null }
+
 				<ul>
 					{ this.renderSites( sitesToShow ) }
 					{ ! allSitesLoaded && (


### PR DESCRIPTION
Closes #84962

## Proposed Changes

On mobile:

- Replaced Sites tab with "Subscriptions"
- Removed header
- Manage -> Manage your subscriptions


| Before | After |
|-|-|
| ![CleanShot 2023-12-07 at 16 27 38@2x](https://github.com/Automattic/wp-calypso/assets/528287/73f734eb-ed6a-443a-a0f4-fa125b82adc3) | ![CleanShot 2023-12-07 at 16 27 02@2x](https://github.com/Automattic/wp-calypso/assets/528287/c27ca0c7-fb82-441d-ab08-0a0a38cf6730) |



## Testing Instructions

1. Apply this PR
2. Using a mobile viewport navigate to http://calypso.localhost:3000/read
3. Click the second tab (name should be Subscriptions)

Verify that the tasks from #84962 are done correctly:

- [ ] Change Sites to Subscriptions
- [ ]  Reorder the search input and the manage link
- [ ]  Remove the Subscriptions title and change it to Manage your subscriptions

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?