### PR TITLE
Stats: Apply upgrade link to the plan usage section

### DIFF
--- a/client/my-sites/stats/hooks/use-plan-usage-query.ts
+++ b/client/my-sites/stats/hooks/use-plan-usage-query.ts
@@ -33,6 +33,6 @@ export default function usePlanUsageQuery(
 		queryKey: [ 'stats', 'usage', siteId ],
 		queryFn: () => queryPlanUsage( siteId ),
 		select: selectPlanUsage,
-		staleTime: 1000 * 60 * 5, // 5 minutes
+		// staleTime: 1000 * 60 * 5, // 5 minutes
 	} );
 }

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -462,7 +462,9 @@ class StatsSite extends Component {
 						}
 					</div>
 				</div>
-				{ config.isEnabled( 'stats/plan-usage' ) && <StatsPlanUsage siteId={ siteId } /> }
+				{ config.isEnabled( 'stats/plan-usage' ) && (
+					<StatsPlanUsage siteId={ siteId } isOdysseyStats={ isOdysseyStats } />
+				) }
 				{ /* Only load Jetpack Upsell Section for Odyssey Stats */ }
 				{ ! isOdysseyStats ? null : (
 					<AsyncLoad require="calypso/my-sites/stats/jetpack-upsell-section" />

--- a/client/my-sites/stats/stats-plan-usage/index.tsx
+++ b/client/my-sites/stats/stats-plan-usage/index.tsx
@@ -108,6 +108,12 @@ const StatsPlanUsage: React.FC< StatsPlanUsageProps > = ( { siteId, isOdysseySta
 
 	const { data } = usePlanUsageQuery( siteId );
 
+	// If there's no limit, don't show the component.
+	// Site with legacy plans or no plans at all will have a null limit.
+	if ( data?.views_limit === null ) {
+		return null;
+	}
+
 	return (
 		<div className="stats__plan-usage">
 			<PlanUsage

--- a/client/my-sites/stats/stats-plan-usage/index.tsx
+++ b/client/my-sites/stats/stats-plan-usage/index.tsx
@@ -7,27 +7,34 @@ import usePlanUsageQuery from 'calypso/my-sites/stats/hooks/use-plan-usage-query
 import './style.scss';
 
 interface PlanUsageProps {
-	limit?: number;
+	limit?: number | null;
 	usage?: number;
 	daysToReset?: number;
-	overLimitMonths?: number;
+	overLimitMonths?: number | null;
+	upgradeLink?: string;
 }
 interface StatsPlanUsageProps {
 	siteId: number;
+	isOdysseyStats: boolean;
 }
+
+const getStatsPurchaseURL = ( siteId: number | null, isOdysseyStats: boolean ) => {
+	const from = isOdysseyStats ? 'jetpack' : 'calypso';
+	const purchasePath = `/stats/purchase/${ siteId }?flags=stats/tier-upgrade-slider&from=${ from }-stats-tier-upgrade-usage-section&productType=commercial`;
+
+	return purchasePath;
+};
 
 const PlanUsage: React.FC< PlanUsageProps > = ( {
 	limit = 10000,
 	usage = 0,
 	daysToReset = 30,
 	overLimitMonths = 0,
+	upgradeLink,
 } ) => {
 	const translate = useTranslate();
 
-	// TODO: Replace with real upgrade link.
-	const upgradeLink = '#';
-
-	const isOverLimit = usage >= limit;
+	const isOverLimit = limit && usage >= limit;
 	const progressClassNames = classNames( 'plan-usage-progress', {
 		'is-over-limit': isOverLimit,
 	} );
@@ -35,7 +42,7 @@ const PlanUsage: React.FC< PlanUsageProps > = ( {
 	// 0, 1, 2, or greater than 2
 	let overLimitMonthsText = '';
 
-	if ( overLimitMonths === 1 ) {
+	if ( overLimitMonths && overLimitMonths === 1 ) {
 		overLimitMonthsText = translate(
 			"{{bold}}You've surpassed your limit the past month.{{/bold}} ",
 			{
@@ -46,7 +53,7 @@ const PlanUsage: React.FC< PlanUsageProps > = ( {
 		) as string;
 	}
 
-	if ( overLimitMonths >= 2 ) {
+	if ( overLimitMonths && overLimitMonths >= 2 ) {
 		overLimitMonthsText = translate(
 			"{{bold}}You've surpassed your limit for two consecutive months already.{{/bold}} ",
 			{
@@ -96,7 +103,9 @@ const PlanUsage: React.FC< PlanUsageProps > = ( {
 	);
 };
 
-const StatsPlanUsage: React.FC< StatsPlanUsageProps > = ( { siteId } ) => {
+const StatsPlanUsage: React.FC< StatsPlanUsageProps > = ( { siteId, isOdysseyStats } ) => {
+	const upgradeLink = getStatsPurchaseURL( siteId, isOdysseyStats );
+
 	const { data } = usePlanUsageQuery( siteId );
 
 	return (
@@ -106,6 +115,7 @@ const StatsPlanUsage: React.FC< StatsPlanUsageProps > = ( { siteId } ) => {
 				usage={ data?.current_usage?.views_count }
 				daysToReset={ data?.current_usage?.days_to_reset }
 				overLimitMonths={ data?.over_limit_months }
+				upgradeLink={ upgradeLink }
 			/>
 		</div>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #84485 

## Proposed Changes

* Add the upgrade link directed to the Stats purchase page for the tier upgrade flow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Calypso Stats
* Spin this change with the Calypso Live link.
* Navigate to **Stats** > **Traffic** page with the feature flag `?flags=stats/plan-usage`.
* Ensure the plan usage section shows usage from the API.
* Ensure the `Upgrade now` button directs to the Stas purchase page for tier upgrade flow.

<img width="1255" alt="截圖 2023-12-08 上午12 14 51" src="https://github.com/Automattic/wp-calypso/assets/6869813/a90f44d7-7736-4621-86f4-959371e11fd9">

#### Odyssey Stats
* Spin this change on Odyssey Stats: `cd apps/odyssey-stats && STATS_PACKAGE_PATH=/path-to-jetpack/projects/packages/stats-admin yarn dev`.
* Apply the change for the plan usage endpoint on Jetpack: https://github.com/Automattic/jetpack/pull/34516.
* Navigate to **Stats** > **Traffic** page with the feature flag `?flags=stats/plan-usage`.
* Ensure the plan usage section shows usage from the API.
* Ensure the `Upgrade now` button directs to the Stas purchase page for tier upgrade flow.

<img width="1274" alt="截圖 2023-12-08 上午12 24 33" src="https://github.com/Automattic/wp-calypso/assets/6869813/191ea116-43ab-49a3-96a3-13e5dcc9eeb6">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?