### PR TITLE
Fixed margins in mobile view for search subscriptions

### DIFF
--- a/client/blocks/reader-unsubscribed-feeds-search-list/style.scss
+++ b/client/blocks/reader-unsubscribed-feeds-search-list/style.scss
@@ -12,6 +12,7 @@
 			max-width: 250px;
 
 			@include breakpoint-deprecated( "<660px" ) {
+				max-width: none;
 				align-items: flex-start;
 			}
 		}


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/84963

## Proposed Changes

This changes fixes the margins of the suggestions in the search results of the subscription screen. They goes from this:
<img width="367" alt="Screenshot 2023-12-07 at 18 02 53" src="https://github.com/Automattic/wp-calypso/assets/3832570/fd3db3c7-32b8-4690-b895-cca44bb12680">

To this:
<img width="897" alt="Screenshot 2023-12-07 at 18 04 33" src="https://github.com/Automattic/wp-calypso/assets/3832570/8a03c0ba-d989-44ca-a007-50d2523773f3">


## Testing Instructions

- Apply this PR and start the application.
- Open a browser tab. Then open the development tools and set the viewport size to mobile (under 660px width).
- Go to https://wordpress.com/read/subscriptions?s=rpg (note: you can change the `s` parameter in that URL for whatever you want to search for).
- You should see the results of the search aligned with the rest of the elements, like in the images above.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?