### PR TITLE
Theme Showcase: Create the `theme/tiers` Feature Flag

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -216,6 +216,7 @@
 		"themes/text-search-lots": true,
 		"themes/theme-switch-persist-template": false,
 		"themes/assembler-first": true,
+		"themes/tiers": true,
 		"titan/iframe-control-panel": false,
 		"unified-pages/virtual-home-page": true,
 		"upgrades/redirect-payments": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -154,6 +154,7 @@
 		"themes/text-search-lots": true,
 		"themes/theme-switch-persist-template": false,
 		"themes/assembler-first": true,
+		"themes/tiers": false,
 		"unified-pages/virtual-home-page": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,

--- a/config/production.json
+++ b/config/production.json
@@ -182,6 +182,7 @@
 		"themes/text-search-lots": true,
 		"themes/theme-switch-persist-template": false,
 		"themes/assembler-first": false,
+		"themes/tiers": false,
 		"unified-pages/virtual-home-page": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -177,6 +177,7 @@
 		"themes/text-search-lots": true,
 		"themes/theme-switch-persist-template": false,
 		"themes/assembler-first": false,
+		"themes/tiers": false,
 		"unified-pages/virtual-home-page": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -185,7 +185,7 @@
 		"themes/text-search-lots": true,
 		"themes/theme-switch-persist-template": false,
 		"themes/assembler-first": true,
-		"themes/tiers": true,
+		"themes/tiers": false,
 		"unified-pages/virtual-home-page": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -185,6 +185,7 @@
 		"themes/text-search-lots": true,
 		"themes/theme-switch-persist-template": false,
 		"themes/assembler-first": true,
+		"themes/tiers": true,
 		"unified-pages/virtual-home-page": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,


### PR DESCRIPTION
Create the `theme/tiers` feature flag, and turn it on in development and wpcalypso.

The flag is not used yet, so there's nothing to test.