### PR TITLE
GF Signup: Dropdown Interval: Restructure interval type props

### DIFF
--- a/client/my-sites/plans-features-main/hooks/use-plan-billing-period.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plan-billing-period.ts
@@ -4,17 +4,22 @@ import {
 	TERM_BIENNIALLY,
 	TERM_MONTHLY,
 	TERM_TRIENNIALLY,
+	UrlFriendlyTermType,
 } from '@automattic/calypso-products';
-import type { IntervalType } from '../types';
+
+type SupportedIntervalTypes = Extract<
+	UrlFriendlyTermType,
+	'monthly' | 'yearly' | '2yearly' | '3yearly'
+>;
 
 const usePlanBillingPeriod = ( {
 	intervalType,
 	defaultValue,
 }: {
-	intervalType: IntervalType;
+	intervalType: SupportedIntervalTypes;
 	defaultValue?: ( typeof TERMS_LIST )[ number ];
 } ) => {
-	const plans = {
+	const plans: Record< SupportedIntervalTypes, ( typeof TERMS_LIST )[ number ] > = {
 		monthly: TERM_MONTHLY,
 		yearly: TERM_ANNUALLY,
 		'2yearly': TERM_BIENNIALLY,

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -14,6 +14,7 @@ import {
 	PLAN_FREE,
 	isWpcomEnterpriseGridPlan,
 	type PlanSlug,
+	UrlFriendlyTermType,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button, Spinner, LoadingPlaceholder } from '@automattic/components';
@@ -80,7 +81,6 @@ import usePlanFromUpsells from './hooks/use-plan-from-upsells';
 import usePlanIntentFromSiteMeta from './hooks/use-plan-intent-from-site-meta';
 import usePlanUpgradeabilityCheck from './hooks/use-plan-upgradeability-check';
 import useGetFreeSubdomainSuggestion from './hooks/use-suggested-free-domain-from-paid-domain';
-import type { IntervalType } from './types';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import type {
 	GridPlan,
@@ -138,7 +138,7 @@ export interface PlansFeaturesMainProps {
 	flowName?: string | null;
 	removePaidDomain?: () => void;
 	setSiteUrlAsFreeDomainSuggestion?: ( freeDomainSuggestion: { domain_name: string } ) => void;
-	intervalType?: IntervalType;
+	intervalType?: UrlFriendlyTermType;
 	planTypeSelector?: 'interval';
 	withDiscount?: string;
 	discountEndDate?: Date;

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -138,7 +138,7 @@ export interface PlansFeaturesMainProps {
 	flowName?: string | null;
 	removePaidDomain?: () => void;
 	setSiteUrlAsFreeDomainSuggestion?: ( freeDomainSuggestion: { domain_name: string } ) => void;
-	intervalType?: UrlFriendlyTermType;
+	intervalType?: Extract< UrlFriendlyTermType, 'monthly' | 'yearly' | '2yearly' | '3yearly' >;
 	planTypeSelector?: 'interval';
 	withDiscount?: string;
 	discountEndDate?: Date;

--- a/client/my-sites/plans-features-main/types.ts
+++ b/client/my-sites/plans-features-main/types.ts
@@ -1,1 +1,0 @@
-export type IntervalType = 'monthly' | 'yearly' | '2yearly' | '3yearly';

--- a/client/my-sites/plans-grid/components/plan-type-selector/hooks/use-max-discount.ts
+++ b/client/my-sites/plans-grid/components/plan-type-selector/hooks/use-max-discount.ts
@@ -31,13 +31,12 @@ export default function useMaxDiscount(
 
 	const discounts = wpcomMonthlyPlans.map( ( planSlug ) => {
 		const yearlyVariantPlanSlug = getPlanSlugForTermVariant( planSlug, TERM_ANNUALLY );
-
+		const monthlyPlanSlug = monthlyPlansPricing?.[ planSlug ];
 		if ( ! yearlyVariantPlanSlug ) {
 			return 0;
 		}
 
-		const monthlyPlanAnnualCost =
-			( monthlyPlansPricing?.[ planSlug ]?.originalPrice.full ?? 0 ) * 12;
+		const monthlyPlanAnnualCost = ( monthlyPlanSlug?.originalPrice.full ?? 0 ) * 12;
 
 		if ( ! monthlyPlanAnnualCost ) {
 			return 0;

--- a/client/my-sites/plans-grid/components/plan-type-selector/hooks/use-max-discount.ts
+++ b/client/my-sites/plans-grid/components/plan-type-selector/hooks/use-max-discount.ts
@@ -31,12 +31,13 @@ export default function useMaxDiscount(
 
 	const discounts = wpcomMonthlyPlans.map( ( planSlug ) => {
 		const yearlyVariantPlanSlug = getPlanSlugForTermVariant( planSlug, TERM_ANNUALLY );
-		const monthlyPlanSlug = monthlyPlansPricing?.[ planSlug ];
+
 		if ( ! yearlyVariantPlanSlug ) {
 			return 0;
 		}
 
-		const monthlyPlanAnnualCost = ( monthlyPlanSlug?.originalPrice.full ?? 0 ) * 12;
+		const monthlyPlanAnnualCost =
+			( monthlyPlansPricing?.[ planSlug ]?.originalPrice.full ?? 0 ) * 12;
 
 		if ( ! monthlyPlanAnnualCost ) {
 			return 0;

--- a/client/signup/steps/plans/util.ts
+++ b/client/signup/steps/plans/util.ts
@@ -1,10 +1,24 @@
+import { UrlFriendlyTermType } from '@automattic/calypso-products';
 import { getUrlParts } from '@automattic/calypso-url';
-import type { IntervalType } from 'calypso/my-sites/plans-features-main/types';
 
-export const getIntervalType = ( path?: string ): IntervalType => {
+type SupportedIntervalTypes = Extract<
+	UrlFriendlyTermType,
+	'monthly' | 'yearly' | '2yearly' | '3yearly'
+>;
+const supportedIntervalTypes: SupportedIntervalTypes[] = [
+	'monthly',
+	'yearly',
+	'2yearly',
+	'3yearly',
+];
+
+export const getIntervalType = ( path?: string ): SupportedIntervalTypes => {
 	const url = path ?? window?.location?.href ?? '';
 	const intervalType = getUrlParts( url ).searchParams.get( 'intervalType' ) || 'yearly';
+
 	return (
-		[ 'yearly', '2yearly', 'monthly' ].includes( intervalType ) ? intervalType : 'yearly'
-	) as IntervalType;
+		supportedIntervalTypes.includes( intervalType as SupportedIntervalTypes )
+			? intervalType
+			: 'yearly'
+	) as SupportedIntervalTypes;
 };

--- a/packages/calypso-products/src/constants/terms.ts
+++ b/packages/calypso-products/src/constants/terms.ts
@@ -26,6 +26,38 @@ export const TERMS_LIST = < const >[
 	TERM_CENTENNIALLY,
 ];
 
+export type UrlFriendlyTermType =
+	| 'monthly'
+	| 'yearly'
+	| '2yearly'
+	| '3yearly'
+	| '4yearly'
+	| '5yearly'
+	| '6yearly'
+	| '7yearly'
+	| '8yearly'
+	| '9yearly'
+	| '10yearly'
+	| '100yearly';
+
+export const URL_FRIENDLY_TERMS_MAPPING: Record<
+	UrlFriendlyTermType,
+	( typeof TERMS_LIST )[ number ]
+> = {
+	monthly: TERM_MONTHLY,
+	yearly: TERM_ANNUALLY,
+	'2yearly': TERM_BIENNIALLY,
+	'3yearly': TERM_TRIENNIALLY,
+	'4yearly': TERM_QUADRENNIALLY,
+	'5yearly': TERM_QUINQUENNIALLY,
+	'6yearly': TERM_SEXENNIALLY,
+	'7yearly': TERM_SEPTENNIALLY,
+	'8yearly': TERM_OCTENNIALLY,
+	'9yearly': TERM_NOVENNIALLY,
+	'10yearly': TERM_DECENNIALLY,
+	'100yearly': TERM_CENTENNIALLY,
+};
+
 export const PLAN_MONTHLY_PERIOD = 31;
 export const PLAN_ANNUAL_PERIOD = 365;
 export const PLAN_BIENNIAL_PERIOD = 730;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* We currently have two string based methods to identify intervals. The constant based TERM_*** and the url friendly 2yearly, 3 yearly, monthly texts which are scattered throughout the code.
* This change centralises these two constructs and introduces a mapping object which will be used subsequently https://github.com/Automattic/wp-calypso/pull/84895 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* There should not be any changes in behaviour just a rework of the props.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?