### PR TITLE
E2E: Fix test for Jetpack change

### DIFF
--- a/test/e2e/specs/published-content/forms__submissions.ts
+++ b/test/e2e/specs/published-content/forms__submissions.ts
@@ -87,11 +87,9 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 
 			await publishedFormLocator.getByRole( 'textbox', { name: 'Phone' } ).fill( formData.phone );
 
-			// Not a true "select" element, so we can't use the native Playwright select() method.
-			await publishedFormLocator.getByRole( 'combobox' ).click();
 			await publishedFormLocator
-				.getByRole( 'option', { name: formData.hearAboutUsOption } )
-				.click();
+				.getByRole( 'combobox', { name: 'How did you hear about us?' } )
+				.selectOption( { label: formData.hearAboutUsOption } );
 
 			await publishedFormLocator
 				.getByRole( 'textbox', { name: 'Other details' } )


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Automattic/jetpack#34441 switched from jQuery UI select to native select. Switch the test to expect it as such.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run the E2E test, e.g. with `TEST_ON_ATOMIC=true JETPACK_TARGET=wpcom-deployment yarn workspace wp-e2e-tests test -- test/e2e/specs/published-content/forms__submissions.ts`. It should now pass.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
