### PR TITLE
Plugins Discovery Page: Add 1 click checkout experiment to business plan upsell

### DIFF
--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -80,6 +80,7 @@ export const UpsellNudge = ( {
 	tracksImpressionProperties,
 	displayAsLink,
 	isSiteWooExpressOrEcomFreeTrial,
+	isBusy,
 } ) => {
 	const shouldNotDisplay =
 		isVip ||
@@ -163,6 +164,7 @@ export const UpsellNudge = ( {
 			tracksImpressionName={ tracksImpressionName }
 			tracksImpressionProperties={ tracksImpressionProperties }
 			displayAsLink={ displayAsLink }
+			isBusy={ isBusy }
 		/>
 	);
 };

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -77,6 +77,7 @@ export class Banner extends Component {
 		displayAsLink: PropTypes.bool,
 		showLinkIcon: PropTypes.bool,
 		extraContent: PropTypes.node,
+		isBusy: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -97,6 +98,7 @@ export class Banner extends Component {
 		tracksClickName: 'calypso_banner_cta_click',
 		tracksDismissName: 'calypso_banner_dismiss',
 		isSiteWPForTeams: false,
+		isBusy: false,
 	};
 
 	getHref() {
@@ -224,6 +226,7 @@ export class Banner extends Component {
 			tracksImpressionName,
 			tracksImpressionProperties,
 			extraContent,
+			isBusy,
 		} = this.props;
 
 		const prices = Array.isArray( price ) ? price : [ price ];
@@ -271,7 +274,12 @@ export class Banner extends Component {
 						) }
 						{ callToAction &&
 							( forceHref ? (
-								<Button compact={ compactButton } primary={ primaryButton } target={ target }>
+								<Button
+									compact={ compactButton }
+									primary={ primaryButton }
+									target={ target }
+									busy={ isBusy }
+								>
 									{ preventWidows( callToAction ) }
 								</Button>
 							) : (
@@ -281,6 +289,7 @@ export class Banner extends Component {
 									onClick={ this.handleClick }
 									primary={ primaryButton }
 									target={ target }
+									busy={ isBusy }
 								>
 									{ preventWidows( callToAction ) }
 								</Button>

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/index.tsx
@@ -30,7 +30,7 @@ type PurchaseModalProps = {
 	siteSlug: string;
 	productToAdd: MinimalRequestCartProduct;
 	showFeatureList: boolean;
-	isLoadingProduct: boolean;
+	isLoadingProduct?: boolean;
 };
 
 export function PurchaseModal( {

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/index.tsx
@@ -30,7 +30,6 @@ type PurchaseModalProps = {
 	siteSlug: string;
 	productToAdd: MinimalRequestCartProduct;
 	showFeatureList: boolean;
-	isLoadingProduct?: boolean;
 };
 
 export function PurchaseModal( {
@@ -91,7 +90,7 @@ export function wrapValueInManagedValue( value: string | undefined ): ManagedVal
 }
 
 export default function PurchaseModalWrapper( props: PurchaseModalProps ) {
-	const { onClose, productToAdd, siteSlug, showFeatureList, isLoadingProduct = false } = props;
+	const { onClose, productToAdd, siteSlug, showFeatureList } = props;
 
 	const onComplete = useCreatePaymentCompleteCallback( {
 		isComingFromUpsell: true,
@@ -194,7 +193,7 @@ export default function PurchaseModalWrapper( props: PurchaseModalProps ) {
 			{ countries?.length === 0 && <QueryPaymentCountries /> }
 			<PurchaseModal
 				cards={ cards }
-				isLoading={ isPendingUpdate || ! countries?.length || isLoadingProduct }
+				isLoading={ isPendingUpdate || ! countries?.length }
 				cart={ responseCart }
 				onClose={ handleOnClose }
 				siteSlug={ siteSlug }

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/index.tsx
@@ -91,7 +91,7 @@ export function wrapValueInManagedValue( value: string | undefined ): ManagedVal
 }
 
 export default function PurchaseModalWrapper( props: PurchaseModalProps ) {
-	const { onClose, productToAdd, siteSlug, showFeatureList, isLoadingProduct } = props;
+	const { onClose, productToAdd, siteSlug, showFeatureList, isLoadingProduct = false } = props;
 
 	const onComplete = useCreatePaymentCompleteCallback( {
 		isComingFromUpsell: true,

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/index.tsx
@@ -30,18 +30,19 @@ type PurchaseModalProps = {
 	siteSlug: string;
 	productToAdd: MinimalRequestCartProduct;
 	showFeatureList: boolean;
+	isLoadingProduct: boolean;
 };
 
 export function PurchaseModal( {
 	cart,
 	cards,
-	isCartUpdating,
+	isLoading,
 	onClose,
 	siteSlug,
 	showFeatureList,
 }: {
 	cards: StoredPaymentMethodCard[];
-	isCartUpdating: boolean;
+	isLoading: boolean;
 	cart: ResponseCart;
 	onClose: () => void;
 	siteSlug: string;
@@ -72,7 +73,7 @@ export function PurchaseModal( {
 			} ) }
 			onClose={ onClose }
 		>
-			{ isCartUpdating ? (
+			{ isLoading ? (
 				<Placeholder showFeatureList={ showFeatureList } />
 			) : (
 				<Content { ...contentProps } />
@@ -90,7 +91,7 @@ export function wrapValueInManagedValue( value: string | undefined ): ManagedVal
 }
 
 export default function PurchaseModalWrapper( props: PurchaseModalProps ) {
-	const { onClose, productToAdd, siteSlug, showFeatureList } = props;
+	const { onClose, productToAdd, siteSlug, showFeatureList, isLoadingProduct } = props;
 
 	const onComplete = useCreatePaymentCompleteCallback( {
 		isComingFromUpsell: true,
@@ -193,7 +194,7 @@ export default function PurchaseModalWrapper( props: PurchaseModalProps ) {
 			{ countries?.length === 0 && <QueryPaymentCountries /> }
 			<PurchaseModal
 				cards={ cards }
-				isCartUpdating={ isPendingUpdate || ! countries?.length }
+				isLoading={ isPendingUpdate || ! countries?.length || isLoadingProduct }
 				cart={ responseCart }
 				onClose={ handleOnClose }
 				siteSlug={ siteSlug }

--- a/client/my-sites/plugins/plugins-discovery-page/index.jsx
+++ b/client/my-sites/plugins/plugins-discovery-page/index.jsx
@@ -1,4 +1,4 @@
-import { PLAN_BUSINESS, isPlan } from '@automattic/calypso-products';
+import { PLAN_BUSINESS } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { StripeHookProvider } from '@automattic/calypso-stripe';
 import { ProductsList } from '@automattic/data-stores';
@@ -108,13 +108,14 @@ const ExperimentLoading = ( { setIsLoadingExperiment } ) => {
 };
 
 const OneClickPurchaseModal = ( { localeSlug, setShowPurchaseModal, siteSlug } ) => {
+	const { result: isEligibleForOneClickCheckout, isLoading } = useIsEligibleForOneClickCheckout();
 	const businessPlanProduct = useSelect(
 		( select ) => select( ProductsList.store ).getProductBySlug( PLAN_BUSINESS ),
 		[]
 	);
-	const { result: isEligibleForOneClickCheckout, isLoading } = useIsEligibleForOneClickCheckout();
 
-	// TODO: Fix businessPlanProduct undefined value
+	const isLoadingBusinessPlan = ! businessPlanProduct;
+
 	if ( isEligibleForOneClickCheckout && ! isLoading ) {
 		return (
 			<CalypsoShoppingCartProvider>
@@ -123,12 +124,12 @@ const OneClickPurchaseModal = ( { localeSlug, setShowPurchaseModal, siteSlug } )
 					locale={ localeSlug }
 				>
 					<PurchaseModal
-						// isLoading={ true }
+						isLoadingProduct={ isLoadingBusinessPlan }
 						productToAdd={ businessPlanProduct }
 						onClose={ () => {
 							setShowPurchaseModal( false );
 						} }
-						showFeatureList={ !! ( businessPlanProduct && isPlan( businessPlanProduct ) ) }
+						showFeatureList={ ! isLoadingBusinessPlan }
 						siteSlug={ siteSlug }
 					/>
 				</StripeHookProvider>
@@ -176,6 +177,12 @@ const PluginsDiscoveryPage = ( props ) => {
 				paidPlugins={ true }
 				handleUpsellNudgeClick={ ( e ) => {
 					e.preventDefault();
+
+					// Prevent multiple clicks
+					if ( isLoadingExperiment ) {
+						return;
+					}
+
 					setShowPurchaseModal( true );
 				} }
 			/>

--- a/client/my-sites/plugins/plugins-discovery-page/index.jsx
+++ b/client/my-sites/plugins/plugins-discovery-page/index.jsx
@@ -161,7 +161,7 @@ const PluginsDiscoveryPage = ( props ) => {
 			) }
 			<UpgradeNudge
 				{ ...props }
-				isLoadingExperiment={ isLoadingExperiment }
+				isBusy={ isLoadingExperiment || isLoading }
 				paidPlugins={ true }
 				handleUpsellNudgeClick={ ( e ) => {
 					e.preventDefault();

--- a/client/my-sites/plugins/plugins-discovery-page/index.jsx
+++ b/client/my-sites/plugins/plugins-discovery-page/index.jsx
@@ -4,6 +4,7 @@ import { useSelect } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
+import { useExperiment } from 'calypso/lib/explat';
 import { getStripeConfiguration } from 'calypso/lib/store-transactions';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import PurchaseModal from 'calypso/my-sites/checkout/upsell-nudge/purchase-modal';
@@ -110,14 +111,26 @@ const PluginsDiscoveryPage = ( props ) => {
 
 	const isEligibleForOneClickCheckout = useIsEligibleForOneClickCheckout();
 
-	// TODO: Add loading state
-	// if ( isEligibleForOneClickCheckout.isLoading ) {
+	// TODO: Uncomment when experiment is ready for testing
+	// const [ isLoadingExperiment, experimentAssignment ] = useExperiment(
+	// 	'calypso_plugins_page_business_plan_one_click_upsell',
+	// 	{
+	// 		isEligible: translate.localeSlug === 'en',
+	// 	}
+	// );
+
+	// TODO: Account for loading state
+	// if ( isEligibleForOneClickCheckout.isLoading || isLoadingExperiment ) {
 	// 	return <Loader />
 	// }
 
+	const canDisplayPurchaseModal = isEligibleForOneClickCheckout.result;
+	// TODO: Uncomment when experiment is ready for testing
+	// && experimentAssignment?.variationName === 'treatment';
+
 	return (
 		<>
-			{ isEligibleForOneClickCheckout.result && (
+			{ canDisplayPurchaseModal && (
 				<CalypsoShoppingCartProvider>
 					<StripeHookProvider
 						fetchStripeConfiguration={ getStripeConfiguration }

--- a/client/my-sites/plugins/plugins-discovery-page/index.jsx
+++ b/client/my-sites/plugins/plugins-discovery-page/index.jsx
@@ -129,7 +129,7 @@ const OneClickPurchaseModal = ( { localeSlug, setShowPurchaseModal, siteSlug } )
 						onClose={ () => {
 							setShowPurchaseModal( false );
 						} }
-						showFeatureList={ ! isLoadingBusinessPlan }
+						showFeatureList={ true }
 						siteSlug={ siteSlug }
 					/>
 				</StripeHookProvider>

--- a/client/my-sites/plugins/plugins-discovery-page/index.jsx
+++ b/client/my-sites/plugins/plugins-discovery-page/index.jsx
@@ -97,6 +97,16 @@ const RedirectToCheckout = ( { siteSlug } ) => {
 	return null;
 };
 
+const ExperimentLoading = ( { setIsLoadingExperiment } ) => {
+	useEffect( () => {
+		setIsLoadingExperiment( true );
+
+		return () => setIsLoadingExperiment( false );
+	}, [] );
+
+	return null;
+};
+
 const OneClickPurchaseModal = ( { localeSlug, setShowPurchaseModal, siteSlug } ) => {
 	const businessPlanProduct = useSelect(
 		( select ) => select( ProductsList.store ).getProductBySlug( PLAN_BUSINESS ),
@@ -140,6 +150,7 @@ const PluginsDiscoveryPage = ( props ) => {
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const translate = useTranslate();
 	const [ showPurchaseModal, setShowPurchaseModal ] = useState( false );
+	const [ isLoadingExperiment, setIsLoadingExperiment ] = useState( false );
 
 	return (
 		<>
@@ -154,12 +165,14 @@ const PluginsDiscoveryPage = ( props ) => {
 							siteSlug={ props.siteSlug }
 						/>
 					}
-					// Fix loading experience
-					loadingExperience={ <div>Hello world</div> }
+					loadingExperience={
+						<ExperimentLoading setIsLoadingExperiment={ setIsLoadingExperiment } />
+					}
 				/>
 			) }
 			<UpgradeNudge
 				{ ...props }
+				isLoadingExperiment={ isLoadingExperiment }
 				paidPlugins={ true }
 				handleUpsellNudgeClick={ ( e ) => {
 					e.preventDefault();

--- a/client/my-sites/plugins/plugins-discovery-page/index.jsx
+++ b/client/my-sites/plugins/plugins-discovery-page/index.jsx
@@ -101,14 +101,12 @@ const PluginsDiscoveryPage = ( props ) => {
 	const translate = useTranslate();
 	const [ showPurchaseModal, setShowPurchaseModal ] = useState( false );
 	const isEligibleForOneClickCheckout = useIsEligibleForOneClickCheckout();
-
 	const [ isLoadingExperiment, experimentAssignment ] = useExperiment(
 		'calypso_plugins_page_business_plan_one_click_upsell',
 		{
 			isEligible: translate.localeSlug === 'en',
 		}
 	);
-
 	const businessPlanProduct = useSelect(
 		( select ) => select( ProductsList.store ).getProductBySlug( PLAN_BUSINESS ),
 		[]
@@ -123,11 +121,11 @@ const PluginsDiscoveryPage = ( props ) => {
 	const handleUpsellNudgeClick = ( e ) => {
 		e.preventDefault();
 
-		if ( isEligibleForOneClickCheckout ) {
+		if ( isEligibleForOneClickCheckout.result ) {
 			setShowPurchaseModal( true );
+		} else {
+			page( `/checkout/${ PLAN_BUSINESS }/${ props.siteSlug }` );
 		}
-
-		page( `/checkout/${ PLAN_BUSINESS }/${ props.siteSlug }` );
 	};
 
 	return (

--- a/client/my-sites/plugins/plugins-discovery-page/index.jsx
+++ b/client/my-sites/plugins/plugins-discovery-page/index.jsx
@@ -111,22 +111,20 @@ const PluginsDiscoveryPage = ( props ) => {
 
 	const isEligibleForOneClickCheckout = useIsEligibleForOneClickCheckout();
 
-	// TODO: Uncomment when experiment is ready for testing
-	// const [ isLoadingExperiment, experimentAssignment ] = useExperiment(
-	// 	'calypso_plugins_page_business_plan_one_click_upsell',
-	// 	{
-	// 		isEligible: translate.localeSlug === 'en',
-	// 	}
-	// );
+	const [ isLoadingExperiment, experimentAssignment ] = useExperiment(
+		'calypso_plugins_page_business_plan_one_click_upsell',
+		{
+			isEligible: translate.localeSlug === 'en',
+		}
+	);
 
 	// TODO: Account for loading state
-	// if ( isEligibleForOneClickCheckout.isLoading || isLoadingExperiment ) {
-	// 	return <Loader />
-	// }
+	if ( isEligibleForOneClickCheckout.isLoading || isLoadingExperiment ) {
+		// render loader
+	}
 
-	const canDisplayPurchaseModal = isEligibleForOneClickCheckout.result;
-	// TODO: Uncomment when experiment is ready for testing
-	// && experimentAssignment?.variationName === 'treatment';
+	const canDisplayPurchaseModal =
+		isEligibleForOneClickCheckout.result && experimentAssignment?.variationName === 'treatment';
 
 	return (
 		<>

--- a/client/my-sites/plugins/plugins-discovery-page/upgrade-nudge.jsx
+++ b/client/my-sites/plugins/plugins-discovery-page/upgrade-nudge.jsx
@@ -21,7 +21,7 @@ import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSitePlan, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
-const UpgradeNudge = ( { siteSlug, paidPlugins } ) => {
+const UpgradeNudge = ( { siteSlug, paidPlugins, setShowPurchaseModal } ) => {
 	const selectedSite = useSelector( getSelectedSite );
 	const sitePlan = useSelector( ( state ) => getSitePlan( state, selectedSite?.ID ) );
 
@@ -149,6 +149,11 @@ const UpgradeNudge = ( { siteSlug, paidPlugins } ) => {
 			icon="notice-outline"
 			showIcon={ true }
 			href={ pluginsPlansPageFlag ? pluginsPlansPage : `/checkout/${ siteSlug }/business` }
+			// We can use preventDefault or render a new button, but we'd need to reimplement tracking
+			onClick={ ( e ) => {
+				e.preventDefault();
+				setShowPurchaseModal( true );
+			} }
 			feature={ FEATURE_INSTALL_PLUGINS }
 			plan={ plan }
 			title={ title }

--- a/client/my-sites/plugins/plugins-discovery-page/upgrade-nudge.jsx
+++ b/client/my-sites/plugins/plugins-discovery-page/upgrade-nudge.jsx
@@ -21,7 +21,12 @@ import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSitePlan, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
-const UpgradeNudge = ( { siteSlug, paidPlugins, setShowPurchaseModal } ) => {
+const UpgradeNudge = ( {
+	siteSlug,
+	paidPlugins,
+	handleUpsellNudgeClick,
+	showOneClickUpsellExperiment,
+} ) => {
 	const selectedSite = useSelector( getSelectedSite );
 	const sitePlan = useSelector( ( state ) => getSitePlan( state, selectedSite?.ID ) );
 
@@ -141,7 +146,19 @@ const UpgradeNudge = ( { siteSlug, paidPlugins, setShowPurchaseModal } ) => {
 	}
 
 	// This banner upsells the ability to install free and paid plugins on a Business plan.
-	return (
+	return showOneClickUpsellExperiment ? (
+		<UpsellNudge
+			event="calypso_plugins_browser_upgrade_nudge"
+			className="plugins-discovery-page__upsell"
+			callToAction={ translate( 'Upgrade to Business' ) }
+			icon="notice-outline"
+			showIcon={ true }
+			onClick={ handleUpsellNudgeClick }
+			feature={ FEATURE_INSTALL_PLUGINS }
+			plan={ plan }
+			title={ title }
+		/>
+	) : (
 		<UpsellNudge
 			event="calypso_plugins_browser_upgrade_nudge"
 			className="plugins-discovery-page__upsell"
@@ -149,11 +166,6 @@ const UpgradeNudge = ( { siteSlug, paidPlugins, setShowPurchaseModal } ) => {
 			icon="notice-outline"
 			showIcon={ true }
 			href={ pluginsPlansPageFlag ? pluginsPlansPage : `/checkout/${ siteSlug }/business` }
-			// We can use preventDefault or render a new button, but we'd need to reimplement tracking
-			onClick={ ( e ) => {
-				e.preventDefault();
-				setShowPurchaseModal( true );
-			} }
 			feature={ FEATURE_INSTALL_PLUGINS }
 			plan={ plan }
 			title={ title }

--- a/client/my-sites/plugins/plugins-discovery-page/upgrade-nudge.jsx
+++ b/client/my-sites/plugins/plugins-discovery-page/upgrade-nudge.jsx
@@ -21,7 +21,7 @@ import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSitePlan, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
-const UpgradeNudge = ( { siteSlug, paidPlugins, handleUpsellNudgeClick } ) => {
+const UpgradeNudge = ( { siteSlug, paidPlugins, handleUpsellNudgeClick, isLoadingExperiment } ) => {
 	const selectedSite = useSelector( getSelectedSite );
 	const sitePlan = useSelector( ( state ) => getSitePlan( state, selectedSite?.ID ) );
 
@@ -145,7 +145,9 @@ const UpgradeNudge = ( { siteSlug, paidPlugins, handleUpsellNudgeClick } ) => {
 		<UpsellNudge
 			event="calypso_plugins_browser_upgrade_nudge"
 			className="plugins-discovery-page__upsell"
-			callToAction={ translate( 'Upgrade to Business' ) }
+			callToAction={
+				isLoadingExperiment ? translate( 'Loading' ) : translate( 'Upgrade to Business' )
+			}
 			icon="notice-outline"
 			showIcon={ true }
 			onClick={ handleUpsellNudgeClick }

--- a/client/my-sites/plugins/plugins-discovery-page/upgrade-nudge.jsx
+++ b/client/my-sites/plugins/plugins-discovery-page/upgrade-nudge.jsx
@@ -21,7 +21,7 @@ import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSitePlan, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
-const UpgradeNudge = ( { siteSlug, paidPlugins, handleUpsellNudgeClick, isLoadingExperiment } ) => {
+const UpgradeNudge = ( { siteSlug, paidPlugins, handleUpsellNudgeClick, isBusy } ) => {
 	const selectedSite = useSelector( getSelectedSite );
 	const sitePlan = useSelector( ( state ) => getSitePlan( state, selectedSite?.ID ) );
 
@@ -145,15 +145,14 @@ const UpgradeNudge = ( { siteSlug, paidPlugins, handleUpsellNudgeClick, isLoadin
 		<UpsellNudge
 			event="calypso_plugins_browser_upgrade_nudge"
 			className="plugins-discovery-page__upsell"
-			callToAction={
-				isLoadingExperiment ? translate( 'Loading' ) : translate( 'Upgrade to Business' )
-			}
+			callToAction={ translate( 'Upgrade to Business' ) }
 			icon="notice-outline"
 			showIcon={ true }
 			onClick={ handleUpsellNudgeClick }
 			feature={ FEATURE_INSTALL_PLUGINS }
 			plan={ plan }
 			title={ title }
+			isBusy={ isBusy }
 		/>
 	);
 };

--- a/client/my-sites/plugins/plugins-discovery-page/upgrade-nudge.jsx
+++ b/client/my-sites/plugins/plugins-discovery-page/upgrade-nudge.jsx
@@ -21,12 +21,7 @@ import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSitePlan, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
-const UpgradeNudge = ( {
-	siteSlug,
-	paidPlugins,
-	handleUpsellNudgeClick,
-	showOneClickUpsellExperiment,
-} ) => {
+const UpgradeNudge = ( { siteSlug, paidPlugins, handleUpsellNudgeClick } ) => {
 	const selectedSite = useSelector( getSelectedSite );
 	const sitePlan = useSelector( ( state ) => getSitePlan( state, selectedSite?.ID ) );
 
@@ -146,7 +141,7 @@ const UpgradeNudge = ( {
 	}
 
 	// This banner upsells the ability to install free and paid plugins on a Business plan.
-	return showOneClickUpsellExperiment ? (
+	return (
 		<UpsellNudge
 			event="calypso_plugins_browser_upgrade_nudge"
 			className="plugins-discovery-page__upsell"
@@ -154,18 +149,6 @@ const UpgradeNudge = ( {
 			icon="notice-outline"
 			showIcon={ true }
 			onClick={ handleUpsellNudgeClick }
-			feature={ FEATURE_INSTALL_PLUGINS }
-			plan={ plan }
-			title={ title }
-		/>
-	) : (
-		<UpsellNudge
-			event="calypso_plugins_browser_upgrade_nudge"
-			className="plugins-discovery-page__upsell"
-			callToAction={ translate( 'Upgrade to Business' ) }
-			icon="notice-outline"
-			showIcon={ true }
-			href={ pluginsPlansPageFlag ? pluginsPlansPage : `/checkout/${ siteSlug }/business` }
 			feature={ FEATURE_INSTALL_PLUGINS }
 			plan={ plan }
 			title={ title }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/2399

## Proposed Changes

* Adds an experiment on the Plugins Discovery Page
* For control groups, after clicking on the business plan upsell CTA, keep the original UX and redirect users to a checkout page with a business plan added to the cart
* For treatment groups, for those with a saved credit card, display a 1-click business plan purchase modal. For those without a saved credit card, redirect users to a checkout page 

## Screenshots
### Control
![2023-12-10 16 37 17](https://github.com/Automattic/wp-calypso/assets/5414230/5678bb5a-f0a8-4b34-a051-e654ed627193)

### Treatment
![2023-12-14 11 08 20](https://github.com/Automattic/wp-calypso/assets/5414230/7d698a1b-3553-4b88-9d27-7c095d851f5b)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Abacus link: 21553-explat-experiment

#### Control
* Assign yourself to the control variant.
* Ensure that test site is _not_ on a business plan or higher
* Go to `/plugins/{SITE_SLUG}`
* Click on the plugins discovery page business plan upsell CTA
* Verify that you are redirected to the checkout page with the ability to purchase a business plan

#### Treatment
* Assign yourself to the treatment variant.
  * Visit 21553-explat-experiment
  * Scroll down to "Audience" Card
  * Find the "Variations" subsection and follow the instructions on the "treatment" Bookmarklet tooltip
* Ensure that test site is _not_ on a business plan or higher
* Ensure that *no* credit card is saved to the account `/me/purchases/payment-methods`
* Go to `/plugins/{SITE_SLUG}`
* Click on the plugins discovery page business plan upsell CTA
* Verify that the user is redirected to a checkout screen with the business plan added to the cart
* Add a saved credit card to user account `/me/purchases/payment-methods`
* Return to `/plugins/{SITE_SLUG}`
* Click on the plugins discovery page business plan upsell CTA
* Verify that there is no page redirect and that, instead, the 1-click checkout modal is shown for users
* Verify that the business plan can be purchased from the modal

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?