### PR TITLE
Domains: Add Tracks events to glue records card

### DIFF
--- a/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button, FormInputValidation, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
@@ -130,6 +131,12 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 	const handleDelete = ( record: GlueRecordObject ) => {
 		setIsRemoving( true );
 		deleteGlueRecord( record );
+
+		recordTracksEvent( 'calypso_domain_glue_records_delete_record', {
+			domain: domain.domain,
+			record: record.record,
+			address: record.address,
+		} );
 	};
 
 	const validateRecord = () => {
@@ -168,6 +175,12 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 
 		setIsSaving( true );
 		updateGlueRecord( {
+			record: `${ record }.${ domain.domain }`,
+			address: ipAddress,
+		} );
+
+		recordTracksEvent( 'calypso_domain_glue_records_add_record', {
+			domain: domain.domain,
 			record: `${ record }.${ domain.domain }`,
 			address: ipAddress,
 		} );
@@ -283,6 +296,10 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 		// We want to always fetch the latest glue record when the card is expanded
 		// otherwise the user might see stale data if they made an update and refreshed the page
 		refetchGlueRecordsData();
+
+		recordTracksEvent( 'calypso_domain_glue_records_expand_card_click', {
+			domain: domain.domain,
+		} );
 	};
 
 	const renderGlueRecords = () => {


### PR DESCRIPTION
## Proposed Changes

This PR adds Tracks events to the glue records management card in the domain management page (introduced in #84261). Three events are being tracked:
- `calypso_domain_glue_records_expand_card_click` - when the glue record card is expanded
- `calypso_domain_glue_records_add_record` - when a record is created
- `calypso_domain_glue_records_delete_record` - when a record is deleted

## Testing Instructions

- Open the live Calypso link or build this branch locally
- Enable Tracks debugging (PCYsg-nSS-p2)
- Go to the domain management page of a domain that was registered through Key-Systems
- Open your browser's console and ensure the three aforementioned events are tracked when the corresponding actions are taken
 
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?