### PR TITLE
Fix/mobile subscription manager padding

### DIFF
--- a/client/blocks/reader-unsubscribed-feeds-search-list/reader-unsubscribed-feed-item.tsx
+++ b/client/blocks/reader-unsubscribed-feeds-search-list/reader-unsubscribed-feed-item.tsx
@@ -1,5 +1,4 @@
-import { Button, Gridicon } from '@automattic/components';
-import { isMobile } from '@automattic/viewport';
+import { Button } from '@automattic/components';
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
@@ -44,85 +43,97 @@ const ReaderUnsubscribedFeedItem = ( {
 }: ReaderUnsubscribedFeedItemProps ) => {
 	const translate = useTranslate();
 	const filteredDisplayUrl = filterURLForDisplay( displayUrl );
-	return (
-		<HStack as="li" className="reader-unsubscribed-feed-item" alignment="center" spacing={ 8 }>
-			<HStack className="reader-unsubscribed-feed-item__site-preview-h-stack" spacing={ 3 }>
-				{ isExternalLink ? (
-					<ExternalLink
-						className="reader-unsubscribed-feed-item__icon"
-						href={ feedUrl }
-						onClick={ onIconClick }
-						target="_blank"
-					>
-						<SiteIcon iconUrl={ iconUrl } defaultIcon={ defaultIcon } size={ 40 } />
-					</ExternalLink>
-				) : (
-					<a
-						className="reader-unsubscribed-feed-item__icon"
-						href={ feedUrl }
-						onClick={ onIconClick }
-					>
-						<SiteIcon iconUrl={ iconUrl } defaultIcon={ defaultIcon } size={ 40 } />
-					</a>
-				) }
-				<VStack className="reader-unsubscribed-feed-item__title-with-url-v-stack" spacing={ 0 }>
-					{ isExternalLink ? (
-						<ExternalLink
-							className="reader-unsubscribed-feed-item__title"
-							href={ feedUrl }
-							target="_blank"
-							onClick={ onTitleClick }
-						>
-							{ title ? title : filteredDisplayUrl }
-						</ExternalLink>
-					) : (
-						<a
-							className="reader-unsubscribed-feed-item__title"
-							href={ feedUrl }
-							onClick={ onTitleClick }
-						>
-							{ title ? title : filteredDisplayUrl }
-						</a>
-					) }
-					<ExternalLink
-						className="reader-unsubscribed-feed-item__url"
-						href={ displayUrl }
-						target="_blank"
-						onClick={ onDisplayUrlClick }
-					>
-						{ filteredDisplayUrl }
-					</ExternalLink>
 
+	const SubscribeButton = () => (
+		<Button
+			primary
+			disabled={ subscribeDisabled }
+			busy={ isSubscribing }
+			onClick={ onSubscribeClick }
+		>
+			{ hasSubscribed
+				? translate( 'Subscribed', {
+						comment:
+							'The user just subscribed to the site that the button relates to, and so the button is in disabled state.',
+				  } )
+				: translate( 'Subscribe', {
+						comment:
+							'Describes an action to be done on the click of the button, i.e. subscribe to the site that this button relates to.',
+				  } ) }
+		</Button>
+	);
+
+	return (
+		<>
+			<HStack as="li" className="reader-unsubscribed-feed-item" alignment="center" spacing={ 8 }>
+				<VStack className="reader-unsubscribed-feed-item__site-preview-v-stack">
+					<HStack>
+						<HStack className="reader-unsubscribed-feed-item__site-preview-h-stack" spacing={ 3 }>
+							{ isExternalLink ? (
+								<ExternalLink
+									className="reader-unsubscribed-feed-item__icon"
+									href={ feedUrl }
+									onClick={ onIconClick }
+									target="_blank"
+								>
+									<SiteIcon iconUrl={ iconUrl } defaultIcon={ defaultIcon } size={ 40 } />
+								</ExternalLink>
+							) : (
+								<a
+									className="reader-unsubscribed-feed-item__icon"
+									href={ feedUrl }
+									onClick={ onIconClick }
+								>
+									<SiteIcon iconUrl={ iconUrl } defaultIcon={ defaultIcon } size={ 40 } />
+								</a>
+							) }
+							<VStack
+								className="reader-unsubscribed-feed-item__title-with-url-v-stack"
+								spacing={ 0 }
+							>
+								{ isExternalLink ? (
+									<ExternalLink
+										className="reader-unsubscribed-feed-item__title"
+										href={ feedUrl }
+										target="_blank"
+										onClick={ onTitleClick }
+									>
+										{ title ? title : filteredDisplayUrl }
+									</ExternalLink>
+								) : (
+									<a
+										className="reader-unsubscribed-feed-item__title"
+										href={ feedUrl }
+										onClick={ onTitleClick }
+									>
+										{ title ? title : filteredDisplayUrl }
+									</a>
+								) }
+								<ExternalLink
+									className="reader-unsubscribed-feed-item__url"
+									href={ displayUrl }
+									target="_blank"
+									onClick={ onDisplayUrlClick }
+								>
+									{ filteredDisplayUrl }
+								</ExternalLink>
+							</VStack>
+						</HStack>
+						<div className="reader-unsubscribed-feed-item__description">{ description }</div>
+
+						<div className="reader-unsubscribed-feed-item__subscribe-button">
+							<SubscribeButton />
+						</div>
+					</HStack>
 					<div className="reader-unsubscribed-feed-item__mobile-description" aria-hidden="true">
 						{ description }
 					</div>
+					<div className="reader-unsubscribed-feed-item__mobile-subscribe-button">
+						<SubscribeButton />
+					</div>
 				</VStack>
 			</HStack>
-			<div className="reader-unsubscribed-feed-item__description">{ description }</div>
-
-			<div>
-				<Button
-					primary
-					disabled={ subscribeDisabled }
-					busy={ isSubscribing }
-					onClick={ onSubscribeClick }
-				>
-					{ isMobile() && (
-						<Gridicon className="subscriptions-add-sites__button-icon" icon="plus" size={ 24 } />
-					) }
-					{ ! isMobile() &&
-						( hasSubscribed
-							? translate( 'Subscribed', {
-									comment:
-										'The user just subscribed to the site that the button relates to, and so the button is in disabled state.',
-							  } )
-							: translate( 'Subscribe', {
-									comment:
-										'Describes an action to be done on the click of the button, i.e. subscribe to the site that this button relates to.',
-							  } ) ) }
-				</Button>
-			</div>
-		</HStack>
+		</>
 	);
 };
 

--- a/client/blocks/reader-unsubscribed-feeds-search-list/style.scss
+++ b/client/blocks/reader-unsubscribed-feeds-search-list/style.scss
@@ -3,9 +3,30 @@
 .reader-unsubscribed-feeds-search-list {
 	margin: 0;
 
+	@include breakpoint-deprecated( "<660px" ) {
+		gap: unset !important;
+
+		* {
+			gap: unset !important;
+		}
+	}
+
 	.reader-unsubscribed-feed-item {
 		@extend %site-subscriptions-list-site-row;
 
+		@include breakpoint-deprecated( "<660px" ) {
+			padding: 10px 0 16px;
+		}
+
+		&__site-preview-v-stack {
+			flex: 1;
+			max-width: none;
+
+			@include breakpoint-deprecated( "<660px" ) {
+				max-width: none;
+				align-items: flex-start;
+			}
+		}
 
 		&__site-preview-h-stack {
 			flex: 1;
@@ -19,6 +40,11 @@
 
 		&__title-with-url-v-stack {
 			flex: 1;
+
+			@include breakpoint-deprecated( "<660px" ) {
+				padding-left: 16px;
+				padding-top: 5px;
+			}
 		}
 
 		&__icon {
@@ -38,8 +64,8 @@
 		&__mobile-description {
 			@extend %site-subscriptions-list-default-text;
 			display: none;
-			margin-top: 4px;
-			margin-bottom: 4px;
+			margin-top: 14px;
+			margin-bottom: 11px;
 
 			@include breakpoint-deprecated( "<660px" ) {
 				display: block;
@@ -57,6 +83,22 @@
 
 			@include breakpoint-deprecated( "<660px" ) {
 				display: none;
+			}
+		}
+
+		&__subscribe-button {
+			display: block;
+
+			@include breakpoint-deprecated( "<660px" ) {
+				display: none;
+			}
+		}
+
+		&__mobile-subscribe-button {
+			display: none;
+
+			@include breakpoint-deprecated( "<660px" ) {
+				display: block;
 			}
 		}
 	}

--- a/client/blocks/reader-unsubscribed-feeds-search-list/style.scss
+++ b/client/blocks/reader-unsubscribed-feeds-search-list/style.scss
@@ -12,6 +12,7 @@
 			max-width: 250px;
 
 			@include breakpoint-deprecated( "<660px" ) {
+				max-width: none;
 				align-items: flex-start;
 			}
 		}


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/84964

## Proposed Changes

This PR changes the layout of the mobile version of the search subscriptions screen. You can find more details of these changes here: https://github.com/Automattic/wp-calypso/issues/84964

## Testing Instructions

- Apply this PR and start the application.
- Go to http://calypso.localhost:3000/read/subscriptions?s=rpg (Note: you can change the `s` parameter to whatever you want to search for)
- Check the layout of this screen didn't change for desktop (you can compare with production in https://wordpress.com/read/subscriptions?s=rpg)
- Using the developer tools, change to mobile layout.
- Check that the mobile view shows the list as the new design (https://github.com/Automattic/wp-calypso/issues/84964)

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?