### PR TITLE
Checkout: Implement ToS experiment attempt 2

### DIFF
--- a/client/my-sites/checkout/src/hooks/use-tos-foldable-card.tsx
+++ b/client/my-sites/checkout/src/hooks/use-tos-foldable-card.tsx
@@ -19,7 +19,7 @@ export function useToSFoldableCard(): 'loading' | 'treatment' | 'control' {
 		! isJetpackNotAtomic;
 
 	const [ isLoadingExperimentAssignment, experimentAssignment ] = useExperiment(
-		'wp_web_checkout_tos_foldable_card_v1',
+		'wp_web_checkout_tos_foldable_card_v1_attempt_2',
 		{ isEligible: isWPcomCheckout }
 	);
 


### PR DESCRIPTION
The original ToS Foldable Card experiment (pbxNRc-3hx-p2) was disabled due to unexpected experiences polluting the results.

This PR will implement the new experiment and prepare it for launch.

Main PR – [https://github.com/Automattic/wp-calypso/pull/84031](https://github.com/Automattic/wp-calypso/pull/84031)
Original experiment implementation – [https://github.com/Automattic/wp-calypso/pull/84395](https://github.com/Automattic/wp-calypso/pull/84395)

## Proposed Changes

* This PR updates the experiment string in our useToSFoldableCard hook which will allow us to bifurcate traffic into a control or treatment flow

## Testing Instructions

See testing instructions here PCYsg-SwK-p2

This is hard to test since the bookmarklet approach outlined in the link above doesn't work in Calypso.live environments. If you pull this branch locally, you can edit the conditions to toggle the treatment or control:

<img width="711" alt="image" src="https://github.com/Automattic/wp-calypso/assets/16580129/1609602f-2eec-4b6a-b4f4-4b9849b145fe">
