### PR TITLE
Subscription Management: Improve resubscribe flow on subscriptions list

### DIFF
--- a/client/landing/subscriptions/components/site-subscriptions-list/site-subscription-row.tsx
+++ b/client/landing/subscriptions/components/site-subscriptions-list/site-subscription-row.tsx
@@ -75,6 +75,8 @@ const scrollToFirstRow = () => {
 	}
 };
 
+const siteUnsubscribedNoticeId = 'site-unsubscribed';
+
 const SiteSubscriptionRow = ( {
 	ID: subscriptionId,
 	blog_ID: blog_id,
@@ -138,7 +140,7 @@ const SiteSubscriptionRow = ( {
 			successNotice(
 				translate( 'You have successfully unsubscribed from %(name)s.', { args: { name } } ),
 				{
-					id: 'site-unsubscribed',
+					id: siteUnsubscribedNoticeId,
 					button: translate( 'Resubscribe' ),
 					onClick: () => {
 						if ( unsubscribeInProgress.current ) {
@@ -150,7 +152,7 @@ const SiteSubscriptionRow = ( {
 								doNotInvalidateSiteSubscriptions: true,
 								resubscribed: true,
 							} );
-							dispatch( removeNotice( 'site-unsubscribed' ) );
+							dispatch( removeNotice( siteUnsubscribedNoticeId ) );
 							scrollToFirstRow();
 
 							recordSiteResubscribed( {

--- a/client/landing/subscriptions/components/site-subscriptions-list/site-subscription-row.tsx
+++ b/client/landing/subscriptions/components/site-subscriptions-list/site-subscription-row.tsx
@@ -21,7 +21,7 @@ import {
 	SOURCE_SUBSCRIPTIONS_SITE_LIST,
 	SOURCE_SUBSCRIPTIONS_UNSUBSCRIBED_NOTICE,
 } from 'calypso/landing/subscriptions/tracks';
-import { successNotice } from 'calypso/state/notices/actions';
+import { removeNotice, successNotice } from 'calypso/state/notices/actions';
 import { Link } from '../link';
 import { SiteSettingsPopover } from '../settings';
 import { useSubscriptionManagerContext } from '../subscription-manager-context';
@@ -67,6 +67,14 @@ const SelectedNewPostDeliveryMethods = ( {
 
 type SiteRowProps = Reader.SiteSubscriptionsResponseItem;
 
+const scrollToFirstRow = () => {
+	const firstRow = document.querySelector( '.site-subscriptions-list li.site-subscription-row' );
+
+	if ( firstRow ) {
+		firstRow.scrollIntoView( { block: 'center' } );
+	}
+};
+
 const SiteSubscriptionRow = ( {
 	ID: subscriptionId,
 	blog_ID: blog_id,
@@ -80,6 +88,7 @@ const SiteSubscriptionRow = ( {
 	is_paid_subscription,
 	isDeleted,
 	is_rss,
+	resubscribed,
 }: SiteRowProps ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -129,13 +138,21 @@ const SiteSubscriptionRow = ( {
 			successNotice(
 				translate( 'You have successfully unsubscribed from %(name)s.', { args: { name } } ),
 				{
-					duration: 5000,
+					id: 'site-unsubscribed',
 					button: translate( 'Resubscribe' ),
 					onClick: () => {
 						if ( unsubscribeInProgress.current ) {
 							resubscribePending.current = true;
 						} else {
-							resubscribe( { blog_id, url, doNotInvalidateSiteSubscriptions: true } );
+							resubscribe( {
+								blog_id,
+								url,
+								doNotInvalidateSiteSubscriptions: true,
+								resubscribed: true,
+							} );
+							dispatch( removeNotice( 'site-unsubscribed' ) );
+							scrollToFirstRow();
+
 							recordSiteResubscribed( {
 								blog_id,
 								url,
@@ -159,6 +176,11 @@ const SiteSubscriptionRow = ( {
 				return feedUrl;
 			}
 
+			if ( resubscribed ) {
+				// If the site was resubscribed, the id of the optmistic update is not the same as the id of the new subscription
+				return `/read/site/subscription/${ blog_id }`;
+			}
+
 			return `/read/subscriptions/${ subscriptionId }`;
 		}
 
@@ -169,7 +191,7 @@ const SiteSubscriptionRow = ( {
 			}
 			return `/subscriptions/site/${ blog_id }`;
 		}
-	}, [ blog_id, feed_id, isReaderPortal, isSubscriptionsPortal, subscriptionId ] );
+	}, [ blog_id, feed_id, isReaderPortal, isSubscriptionsPortal, resubscribed, subscriptionId ] );
 
 	const handleNotifyMeOfNewPostsChange = ( send_posts: boolean ) => {
 		// Update post notification settings
@@ -212,7 +234,7 @@ const SiteSubscriptionRow = ( {
 	};
 
 	return ! isDeleted ? (
-		<HStack as="li" alignment="center" className="row" role="row">
+		<HStack as="li" alignment="center" className="row site-subscription-row" role="row">
 			<span className="title-cell" role="cell">
 				<Link
 					className="title-icon"
@@ -332,7 +354,12 @@ const SiteSubscriptionRow = ( {
 
 									if ( resubscribePending.current ) {
 										resubscribePending.current = false;
-										resubscribe( { blog_id, url, doNotInvalidateSiteSubscriptions: true } );
+										resubscribe( {
+											blog_id,
+											url,
+											doNotInvalidateSiteSubscriptions: true,
+											resubscribed: true,
+										} );
 										recordSiteResubscribed( {
 											blog_id,
 											url,

--- a/packages/data-stores/src/reader/mutations/use-site-subscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-subscribe-mutation.ts
@@ -12,6 +12,7 @@ type SubscribeParams = {
 	onSuccess?: () => void;
 	onError?: () => void;
 	subscriptionId?: number;
+	resubscribed?: boolean;
 };
 
 type SubscribeResponse = {
@@ -98,6 +99,7 @@ const useSiteSubscribeMutation = () => {
 
 			const previousSiteSubscriptions =
 				queryClient.getQueryData< SiteSubscriptionsPages >( siteSubscriptionsCacheKey );
+
 			if ( previousSiteSubscriptions ) {
 				queryClient.setQueryData( siteSubscriptionsCacheKey, {
 					...previousSiteSubscriptions,
@@ -105,15 +107,16 @@ const useSiteSubscribeMutation = () => {
 						return {
 							...page,
 							total_subscriptions: page.total_subscriptions - 1,
-							subscriptions: page.subscriptions.map( ( siteSubscription ) => ( {
-								...siteSubscription,
-								isDeleted:
-									siteSubscription.blog_ID === params.blog_id ? false : siteSubscription.isDeleted,
-								date_subscribed:
-									siteSubscription.blog_ID === params.blog_id
-										? new Date()
-										: siteSubscription.date_subscribed,
-							} ) ),
+							subscriptions: page.subscriptions.map( ( siteSubscription ) =>
+								siteSubscription.blog_ID === params.blog_id
+									? {
+											...siteSubscription,
+											date_subscribed: new Date(),
+											isDeleted: false,
+											resubscribed: params.resubscribed ?? false,
+									  }
+									: siteSubscription
+							),
 						};
 					} ),
 				} );

--- a/packages/data-stores/src/reader/mutations/use-site-unsubscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-unsubscribe-mutation.ts
@@ -91,6 +91,7 @@ const useSiteUnsubscribeMutation = () => {
 
 			const previousSiteSubscriptions =
 				queryClient.getQueryData< SiteSubscriptionsPages >( siteSubscriptionsQueryKey );
+
 			// remove blog from site subscriptions
 			if ( previousSiteSubscriptions ) {
 				queryClient.setQueryData( siteSubscriptionsQueryKey, {
@@ -99,14 +100,16 @@ const useSiteUnsubscribeMutation = () => {
 						return {
 							...page,
 							total_subscriptions: page.total_subscriptions - 1,
-							subscriptions: page.subscriptions.map( ( siteSubscription ) => ( {
-								...siteSubscription,
-								isDeleted:
-									Number( siteSubscription.ID ) === params.subscriptionId ||
-									( isValidId( params.blog_id ) && siteSubscription.blog_ID === params.blog_id ) //siteSubscription.blog_ID is not valid ID for non-wpcom subscriptions, so when unsubscribing from such site, the param.blog_id will also be not valid, this would create false positive
-										? true
-										: siteSubscription.isDeleted,
-							} ) ),
+							subscriptions: page.subscriptions.map( ( siteSubscription ) =>
+								Number( siteSubscription.ID ) === params.subscriptionId ||
+								( isValidId( params.blog_id ) && siteSubscription.blog_ID === params.blog_id ) //siteSubscription.blog_ID is not valid ID for non-wpcom subscriptions, so when unsubscribing from such site, the param.blog_id will also be not valid, this would create false positive
+									? {
+											...siteSubscription,
+											isDeleted: true,
+											resubscribed: false,
+									  }
+									: siteSubscription
+							),
 						};
 					} ),
 				} );

--- a/packages/data-stores/src/reader/types/index.ts
+++ b/packages/data-stores/src/reader/types/index.ts
@@ -70,8 +70,9 @@ export type SiteSubscriptionsResponseItem = {
 	meta: SiteSubscriptionMeta;
 	is_wpforteams_site: boolean;
 	is_paid_subscription: boolean;
-	isDeleted: boolean;
 	is_rss: boolean;
+	isDeleted: boolean;
+	resubscribed: boolean;
 };
 
 export type SiteSubscriptionPage = {


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/78271
Closes https://github.com/Automattic/wp-calypso/issues/78273

## Proposed Changes

* Remove timeout from resubscribe notice
* Close notice after resubscribe
* Scroll into view (centralized) the first row after resubscribe
* Fix resubscribed item URL

## Testing Instructions

* Apply this PR to your local
* Go to http://calypso.localhost:3000/read/subscriptions
* Unsubscribe to a subscription
* Check if the notice remains on the window until it is dismissed
* Click to resubscribe
* It should scroll to the first row (with the resubscribed site)
* Click on the resubscribed site to see the details page
* The details page should open as expected (using the blog_id URL `/read/site/subscription/:blog_id`)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?