### PR TITLE
Set the signup_domain_origin prop on multi-domain selection

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -808,6 +808,10 @@ export class RenderDomainsStep extends Component {
 			} );
 		}
 
+		const signupDomainOrigin = isPurchasingItem
+			? SIGNUP_DOMAIN_ORIGIN.CUSTOM
+			: SIGNUP_DOMAIN_ORIGIN.FREE;
+
 		this.props.submitSignupStep(
 			Object.assign(
 				{
@@ -823,6 +827,7 @@ export class RenderDomainsStep extends Component {
 			Object.assign(
 				{ domainItem, domainCart },
 				useThemeHeadstartItem,
+				signupDomainOrigin ? { signupDomainOrigin } : {},
 				{ siteUrl: suggestion?.domain_name },
 				lastDomainSearched ? { lastDomainSearched } : {},
 				{ domainCart }
@@ -1064,7 +1069,7 @@ export class RenderDomainsStep extends Component {
 							borderless
 							className="domains__domain-cart-choose-later"
 							onClick={ () => {
-								this.handleSkip( undefined, false );
+								this.handleSkip( undefined, false, SIGNUP_DOMAIN_ORIGIN.CHOOSE_LATER );
 							} }
 						>
 							{ this.props.translate( 'Choose my domain later' ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4807

## Proposed Changes

* This PR populates the `signup_domain_origin` prop in multi-domain selection for the `calypso_signup_actions_submit_step` and `calypso_signup_complete` Tracks events

For domain selection if:
* User selected both paid and free domains `signup_domain_origin` = `custom`
* User only selected paid domains `signup_domain_origin` = `custom`
* User only selected the free domain `signup_domain_origin` = `free`

Other possible values can be seen [here](https://github.com/Automattic/wp-calypso/blob/d096763cb0d9e93a42f7b11254387ea42a48c17e/client/lib/analytics/signup.js#L32-L38).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /start/domains
* When you select a domain and click "Continue", "Choose my domain later", or "Use a domain I own" you should see the event `calypso_signup_actions_submit_step` and the `signup_domain_origin` prop should be properly assigned a correct value based on what you selected. (Note that for "Use a domain I own" the `calypso_signup_actions_submit_step` doesn't fire until you complete the domain entry form.)
* As you continue through the flow, create your site, and land on the "What are you Goals?" page, the `calypso_signup_complete` Tracks event will fire, and again the `signup_domain_origin` prop should be properly assigned a correct value based on what you selected on the Domains step.

> [!NOTE]  
> There is a followup https://github.com/Automattic/dotcom-forge/issues/4808 to update the `signup_domain_origin` prop if the user drops their custom domain by selecting the free plan on the Plans page. That issue is outside the scope of this PR.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?