### PR TITLE
Monetize: Add single customer screen

### DIFF
--- a/client/my-sites/earn/customers/customer/customer-details.tsx
+++ b/client/my-sites/earn/customers/customer/customer-details.tsx
@@ -1,0 +1,77 @@
+import formatCurrency from '@automattic/format-currency';
+import { useTranslate } from 'i18n-calypso';
+import TimeSince from 'calypso/components/time-since';
+import {
+	PLAN_YEARLY_FREQUENCY,
+	PLAN_MONTHLY_FREQUENCY,
+	PLAN_ONE_TIME_FREQUENCY,
+} from '../../memberships/constants';
+import { Subscriber } from '../../types';
+
+import './style.scss';
+
+type CustomerDetailsProps = {
+	customer: Subscriber;
+};
+
+const CustomerDetails = ( { customer }: CustomerDetailsProps ) => {
+	const translate = useTranslate();
+
+	function getPaymentIntervalWording( interval: string ) {
+		switch ( interval ) {
+			case PLAN_ONE_TIME_FREQUENCY:
+				return translate( ' once' );
+				break;
+			case PLAN_MONTHLY_FREQUENCY:
+				return translate( ' monthly' );
+				break;
+			case PLAN_YEARLY_FREQUENCY:
+				return translate( ' yearly' );
+				break;
+			default:
+				break;
+		}
+	}
+
+	return (
+		<>
+			<div className="customer-details__content">
+				<h3 className="customer-details__content-title">{ translate( 'Details' ) }</h3>
+				<div className="customer-details__content-body">
+					<div className="customer-details__content-column">
+						<div className="customer-details__content-label">{ translate( 'Offer Type' ) }</div>
+						<div className="customer-details__content-value">{ customer.plan.title }</div>
+					</div>
+					<div className="customer-details__content-column">
+						<div className="customer-details__content-label">{ translate( 'Amount' ) }</div>
+						<div className="customer-details__content-value">
+							{ formatCurrency( customer.plan.renewal_price, customer.plan.currency ) }
+							{ getPaymentIntervalWording( customer.plan.renew_interval ) }
+						</div>
+					</div>
+					<div className="customer-details__content-column">
+						<div className="customer-details__content-label">{ translate( 'Since' ) }</div>
+						<TimeSince
+							className="customer-details__content-value"
+							date={ customer.start_date }
+							dateFormat="LL"
+						/>
+					</div>
+				</div>
+			</div>
+			<div className="customer-details__content">
+				<h3 className="customer-details__content-title">
+					{ translate( 'Subscriber information' ) }
+				</h3>
+				<div className="customer-details__content-body">
+					<div className="customer-details__content-column">
+						<div className="customer-details__content-label">{ translate( 'Email' ) }</div>
+						<div className="customer-details__content-value">{ customer.user.user_email }</div>
+					</div>
+				</div>
+			</div>
+		</>
+	);
+};
+
+export default CustomerDetails;

--- a/client/my-sites/earn/customers/customer/customer-header.tsx
+++ b/client/my-sites/earn/customers/customer/customer-header.tsx
@@ -1,0 +1,49 @@
+import { useTranslate } from 'i18n-calypso';
+import { Item } from 'calypso/components/breadcrumb';
+import Gravatar from 'calypso/components/gravatar';
+import NavigationHeader from 'calypso/components/navigation-header';
+import { decodeEntities } from 'calypso/lib/formatting';
+import { useSelector } from 'calypso/state';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { Subscriber } from '../../types';
+
+import './style.scss';
+
+type CustomerHeaderProps = {
+	customer: Subscriber;
+};
+
+const CustomerHeader = ( { customer }: CustomerHeaderProps ) => {
+	const translate = useTranslate();
+	const siteSlug = useSelector( getSelectedSiteSlug );
+
+	const breadcrumbs: Item[] = [
+		{
+			label: translate( 'Monetize' ),
+			href: `/earn/${ siteSlug }`,
+		},
+		{
+			label: translate( 'Supporters' ),
+			href: `/earn/supporters/${ siteSlug }`,
+		},
+		{
+			label: translate( 'Details' ),
+			href: '#',
+		},
+	];
+
+	return (
+		<>
+			<NavigationHeader navigationItems={ breadcrumbs } />
+			<div className="customer__header">
+				<Gravatar user={ customer.user } size={ 40 } className="customer__header-image" />
+				<div className="customer__header-details">
+					<span className="customer__header-name">{ decodeEntities( customer.user.name ) }</span>
+					<span className="customer__header-email">{ customer.user.user_email }</span>
+				</div>
+			</div>
+		</>
+	);
+};
+
+export default CustomerHeader;

--- a/client/my-sites/earn/customers/customer/customer-stats.tsx
+++ b/client/my-sites/earn/customers/customer/customer-stats.tsx
@@ -1,0 +1,45 @@
+import { Card } from '@automattic/components';
+import formatCurrency from '@automattic/format-currency';
+import { payment, chartBar } from '@wordpress/icons';
+import { Subscriber } from '../../types';
+
+import '@automattic/components/src/highlight-cards/style.scss';
+
+type CustomerStatsProps = {
+	customer: Subscriber;
+};
+
+const CustomerStats = ( { customer }: CustomerStatsProps ) => {
+	return (
+		<div className="customer__stats">
+			<div className="customer__stats-list highlight-cards-list">
+				<Card className="highlight-card customer__stats-card">
+					<div className="highlight-card-icon customer__stats-card-icon">{ payment }</div>
+					<div className="highlight-card-heading customer__stats-card-heading">Last 30 Days</div>
+					<div className="highlight-card-count customer__stats-card-count">
+						<span
+							className="highlight-card-count-value customer__stats-card-value"
+							title={ String( customer.plan.renewal_price ) }
+						>
+							{ formatCurrency( customer.plan.renewal_price, customer.plan.currency ) }
+						</span>
+					</div>
+				</Card>
+				<Card className="highlight-card customer__stats-card">
+					<div className="highlight-card-icon customer__stats-card-icon">{ chartBar }</div>
+					<div className="highlight-card-heading customer__stats-card-heading">Total Spent</div>
+					<div className="highlight-card-count customer__stats-card-count">
+						<span
+							className="highlight-card-count-value customer__stats-card-value"
+							title={ String( customer.all_time_total ) }
+						>
+							{ formatCurrency( customer.all_time_total, customer.plan.currency ) }
+						</span>
+					</div>
+				</Card>
+			</div>
+		</div>
+	);
+};
+
+export default CustomerStats;

--- a/client/my-sites/earn/customers/customer/customer-stats.tsx
+++ b/client/my-sites/earn/customers/customer/customer-stats.tsx
@@ -15,7 +15,7 @@ const CustomerStats = ( { customer }: CustomerStatsProps ) => {
 			<div className="customer__stats-list highlight-cards-list">
 				<Card className="highlight-card customer__stats-card">
 					<div className="highlight-card-icon customer__stats-card-icon">{ payment }</div>
-					<div className="highlight-card-heading customer__stats-card-heading">Last 30 Days</div>
+					<div className="highlight-card-heading customer__stats-card-heading">Last Payment</div>
 					<div className="highlight-card-count customer__stats-card-count">
 						<span
 							className="highlight-card-count-value customer__stats-card-value"

--- a/client/my-sites/earn/customers/customer/index.tsx
+++ b/client/my-sites/earn/customers/customer/index.tsx
@@ -1,0 +1,138 @@
+import { Card } from '@automattic/components';
+import formatCurrency from '@automattic/format-currency';
+import { payment, chartBar } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { Item } from 'calypso/components/breadcrumb';
+import Gravatar from 'calypso/components/gravatar';
+import NavigationHeader from 'calypso/components/navigation-header';
+import TimeSince from 'calypso/components/time-since';
+import { decodeEntities } from 'calypso/lib/formatting';
+import { useSelector } from 'calypso/state';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import {
+	PLAN_YEARLY_FREQUENCY,
+	PLAN_MONTHLY_FREQUENCY,
+	PLAN_ONE_TIME_FREQUENCY,
+} from '../../memberships/constants';
+import { Subscriber } from '../../types';
+
+import '@automattic/components/src/highlight-cards/style.scss';
+import './style.scss';
+
+type CustomerProps = {
+	customer: Subscriber;
+};
+
+const Customer = ( { customer }: CustomerProps ) => {
+	const translate = useTranslate();
+	const siteSlug = useSelector( getSelectedSiteSlug );
+
+	const breadcrumbs: Item[] = [
+		{
+			label: translate( 'Monetize' ),
+			href: `/earn/${ siteSlug }`,
+		},
+		{
+			label: translate( 'Supporters' ),
+			href: `/earn/supporters/${ siteSlug }`,
+		},
+		{
+			label: translate( 'Details' ),
+			href: '#',
+		},
+	];
+
+	function getPaymentIntervalWording( interval: string ) {
+		switch ( interval ) {
+			case PLAN_ONE_TIME_FREQUENCY:
+				return translate( ' once' );
+				break;
+			case PLAN_MONTHLY_FREQUENCY:
+				return translate( ' monthly' );
+				break;
+			case PLAN_YEARLY_FREQUENCY:
+				return translate( ' yearly' );
+				break;
+			default:
+				break;
+		}
+	}
+
+	return (
+		<div className="customer">
+			<NavigationHeader navigationItems={ breadcrumbs } />
+			<div className="customer__header">
+				<Gravatar user={ customer.user } size={ 40 } className="customer__header-image" />
+				<div className="customer__header-details">
+					<span className="customer__header-name">{ decodeEntities( customer.user.name ) }</span>
+					<span className="customer__header-email">{ customer.user.user_email }</span>
+				</div>
+			</div>
+			<div className="customer__stats">
+				<div className="customer__stats-list highlight-cards-list">
+					<Card className="highlight-card customer__stats-card">
+						<div className="highlight-card-icon customer__stats-card-icon">{ payment }</div>
+						<div className="highlight-card-heading customer__stats-card-heading">Last 30 Days</div>
+						<div className="highlight-card-count customer__stats-card-count">
+							<span
+								className="highlight-card-count-value customer__stats-card-value"
+								title={ String( customer.plan.renewal_price ) }
+							>
+								{ formatCurrency( customer.plan.renewal_price, customer.plan.currency ) }
+							</span>
+						</div>
+					</Card>
+					<Card className="highlight-card customer__stats-card">
+						<div className="highlight-card-icon customer__stats-card-icon">{ chartBar }</div>
+						<div className="highlight-card-heading customer__stats-card-heading">Total Spent</div>
+						<div className="highlight-card-count customer__stats-card-count">
+							<span
+								className="highlight-card-count-value customer__stats-card-value"
+								title={ String( customer.all_time_total ) }
+							>
+								{ formatCurrency( customer.all_time_total, customer.plan.currency ) }
+							</span>
+						</div>
+					</Card>
+				</div>
+			</div>
+			<div className="customer-details__content">
+				<h3 className="customer-details__content-title">{ translate( 'Details' ) }</h3>
+				<div className="customer-details__content-body">
+					<div className="customer-details__content-column">
+						<div className="customer-details__content-label">{ translate( 'Offer Type' ) }</div>
+						<div className="customer-details__content-value">{ customer.plan.title }</div>
+					</div>
+					<div className="customer-details__content-column">
+						<div className="customer-details__content-label">{ translate( 'Amount' ) }</div>
+						<div className="customer-details__content-value">
+							{ formatCurrency( customer.plan.renewal_price, customer.plan.currency ) }
+							{ getPaymentIntervalWording( customer.plan.renew_interval ) }
+						</div>
+					</div>
+					<div className="customer-details__content-column">
+						<div className="customer-details__content-label">{ translate( 'Since' ) }</div>
+						<TimeSince
+							className="customer-details__content-value"
+							date={ customer.start_date }
+							dateFormat="LL"
+						/>
+					</div>
+				</div>
+			</div>
+			<div className="customer-details__content">
+				<h3 className="customer-details__content-title">
+					{ translate( 'Subscriber information' ) }
+				</h3>
+				<div className="customer-details__content-body">
+					<div className="customer-details__content-column">
+						<div className="customer-details__content-label">{ translate( 'Email' ) }</div>
+						<div className="customer-details__content-value">{ customer.user.user_email }</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export default Customer;

--- a/client/my-sites/earn/customers/customer/index.tsx
+++ b/client/my-sites/earn/customers/customer/index.tsx
@@ -1,22 +1,10 @@
-import { Card } from '@automattic/components';
-import formatCurrency from '@automattic/format-currency';
-import { payment, chartBar } from '@wordpress/icons';
+import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { Item } from 'calypso/components/breadcrumb';
-import Gravatar from 'calypso/components/gravatar';
-import NavigationHeader from 'calypso/components/navigation-header';
-import TimeSince from 'calypso/components/time-since';
-import { decodeEntities } from 'calypso/lib/formatting';
-import { useSelector } from 'calypso/state';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-import {
-	PLAN_YEARLY_FREQUENCY,
-	PLAN_MONTHLY_FREQUENCY,
-	PLAN_ONE_TIME_FREQUENCY,
-} from '../../memberships/constants';
 import { Subscriber } from '../../types';
+import CustomerDetails from './customer-details';
+import CustomerHeader from './customer-header';
+import CustomerStats from './customer-stats';
 
-import '@automattic/components/src/highlight-cards/style.scss';
 import './style.scss';
 
 type CustomerProps = {
@@ -25,112 +13,20 @@ type CustomerProps = {
 
 const Customer = ( { customer }: CustomerProps ) => {
 	const translate = useTranslate();
-	const siteSlug = useSelector( getSelectedSiteSlug );
 
-	const breadcrumbs: Item[] = [
-		{
-			label: translate( 'Monetize' ),
-			href: `/earn/${ siteSlug }`,
-		},
-		{
-			label: translate( 'Supporters' ),
-			href: `/earn/supporters/${ siteSlug }`,
-		},
-		{
-			label: translate( 'Details' ),
-			href: '#',
-		},
-	];
-
-	function getPaymentIntervalWording( interval: string ) {
-		switch ( interval ) {
-			case PLAN_ONE_TIME_FREQUENCY:
-				return translate( ' once' );
-				break;
-			case PLAN_MONTHLY_FREQUENCY:
-				return translate( ' monthly' );
-				break;
-			case PLAN_YEARLY_FREQUENCY:
-				return translate( ' yearly' );
-				break;
-			default:
-				break;
-		}
+	function redirectToStripe() {
+		const stripeUrl = `https://dashboard.stripe.com/search?query=metadata%3A${ customer.user.ID }`;
+		window.open( stripeUrl, '_blank' );
 	}
 
 	return (
 		<div className="customer">
-			<NavigationHeader navigationItems={ breadcrumbs } />
-			<div className="customer__header">
-				<Gravatar user={ customer.user } size={ 40 } className="customer__header-image" />
-				<div className="customer__header-details">
-					<span className="customer__header-name">{ decodeEntities( customer.user.name ) }</span>
-					<span className="customer__header-email">{ customer.user.user_email }</span>
-				</div>
-			</div>
-			<div className="customer__stats">
-				<div className="customer__stats-list highlight-cards-list">
-					<Card className="highlight-card customer__stats-card">
-						<div className="highlight-card-icon customer__stats-card-icon">{ payment }</div>
-						<div className="highlight-card-heading customer__stats-card-heading">Last 30 Days</div>
-						<div className="highlight-card-count customer__stats-card-count">
-							<span
-								className="highlight-card-count-value customer__stats-card-value"
-								title={ String( customer.plan.renewal_price ) }
-							>
-								{ formatCurrency( customer.plan.renewal_price, customer.plan.currency ) }
-							</span>
-						</div>
-					</Card>
-					<Card className="highlight-card customer__stats-card">
-						<div className="highlight-card-icon customer__stats-card-icon">{ chartBar }</div>
-						<div className="highlight-card-heading customer__stats-card-heading">Total Spent</div>
-						<div className="highlight-card-count customer__stats-card-count">
-							<span
-								className="highlight-card-count-value customer__stats-card-value"
-								title={ String( customer.all_time_total ) }
-							>
-								{ formatCurrency( customer.all_time_total, customer.plan.currency ) }
-							</span>
-						</div>
-					</Card>
-				</div>
-			</div>
-			<div className="customer-details__content">
-				<h3 className="customer-details__content-title">{ translate( 'Details' ) }</h3>
-				<div className="customer-details__content-body">
-					<div className="customer-details__content-column">
-						<div className="customer-details__content-label">{ translate( 'Offer Type' ) }</div>
-						<div className="customer-details__content-value">{ customer.plan.title }</div>
-					</div>
-					<div className="customer-details__content-column">
-						<div className="customer-details__content-label">{ translate( 'Amount' ) }</div>
-						<div className="customer-details__content-value">
-							{ formatCurrency( customer.plan.renewal_price, customer.plan.currency ) }
-							{ getPaymentIntervalWording( customer.plan.renew_interval ) }
-						</div>
-					</div>
-					<div className="customer-details__content-column">
-						<div className="customer-details__content-label">{ translate( 'Since' ) }</div>
-						<TimeSince
-							className="customer-details__content-value"
-							date={ customer.start_date }
-							dateFormat="LL"
-						/>
-					</div>
-				</div>
-			</div>
-			<div className="customer-details__content">
-				<h3 className="customer-details__content-title">
-					{ translate( 'Subscriber information' ) }
-				</h3>
-				<div className="customer-details__content-body">
-					<div className="customer-details__content-column">
-						<div className="customer-details__content-label">{ translate( 'Email' ) }</div>
-						<div className="customer-details__content-value">{ customer.user.user_email }</div>
-					</div>
-				</div>
-			</div>
+			<CustomerHeader customer={ customer } />
+			<CustomerStats customer={ customer } />
+			<CustomerDetails customer={ customer } />
+			<Button className="customer__stripe-button" primary onClick={ redirectToStripe }>
+				{ translate( 'Visit Stripe Dashboard' ) }
+			</Button>
 		</div>
 	);
 };

--- a/client/my-sites/earn/customers/customer/style.scss
+++ b/client/my-sites/earn/customers/customer/style.scss
@@ -87,4 +87,8 @@
 			letter-spacing: -0.15px;
 		}
 	}
+
+	.customer__stripe-button {
+		margin-top: 30px;
+	}
 }

--- a/client/my-sites/earn/customers/customer/style.scss
+++ b/client/my-sites/earn/customers/customer/style.scss
@@ -1,0 +1,90 @@
+@import "@automattic/color-studio/dist/color-variables";
+@import "@automattic/typography/styles/variables";
+
+.customer {
+	.customer__header {
+		display: flex;
+		margin: 16px 0 48px;
+
+		.customer__header-image {
+			height: 56px;
+			width: 56px;
+			margin-right: 16px;
+		}
+
+		.customer__header-details {
+			display: flex;
+			flex-direction: column;
+			justify-content: center;
+
+			.customer__header-name {
+				font-weight: 500;
+				font-size: $font-title-small;
+				line-height: rem(26px);
+			}
+
+			.customer__header-email {
+				font-weight: 400;
+				font-size: $font-body;
+				line-height: rem(24px);
+				color: $studio-gray-40;
+			}
+		}
+	}
+
+	.customer__stats {
+		.customer__stats-card-heading {
+			display: flex;
+			align-items: center;
+		}
+		.customer__stats-card-icon {
+			max-width: 30px;
+			margin-bottom: 20px;
+		}
+	}
+
+	.customer-details__content {
+		display: flex;
+		flex-direction: column;
+		padding: 24px;
+		margin-top: 30px;
+		border-radius: 4px;
+		border: 1px solid $studio-gray-5;
+		gap: 16px;
+	}
+
+	.customer-details__content-title {
+		color: #000;
+		font-size: $font-body-large;
+		line-height: rem(26px);
+	}
+
+	.customer-details__content-body {
+		display: flex;
+		gap: 32px;
+
+		.customer-details__content-column {
+			flex: 1 1 0;
+			overflow: hidden;
+			word-wrap: break-word;
+		}
+
+		.customer-details__content-label {
+			border-bottom: 1px solid #eee;
+			font-size: $font-body-small;
+			font-weight: 500;
+			line-height: rem(20px);
+			letter-spacing: -0.15px;
+			margin-bottom: 6px;
+			padding-bottom: 5px;
+		}
+
+		.customer-details__content-value {
+			display: block;
+			color: $studio-gray-60;
+			font-size: $font-body-small;
+			line-height: rem(20px);
+			letter-spacing: -0.15px;
+		}
+	}
+}

--- a/client/my-sites/earn/main.tsx
+++ b/client/my-sites/earn/main.tsx
@@ -16,7 +16,7 @@ import { useSelector } from 'calypso/state';
 import { canAccessWordAds, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import AdsWrapper from './ads/wrapper';
-import CustomerSection from './customers';
+import CustomersSection from './customers';
 import Home from './home';
 import MembershipsSection from './memberships/section';
 import ReferAFriendSection from './refer-a-friend';
@@ -40,6 +40,7 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 	const canAccessAds = useSelector( ( state ) => canAccessWordAds( state, site?.ID ) );
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, site?.ID ) );
 	const adsProgramName = isJetpack ? 'Ads' : 'WordAds';
+	const subscriberId = new URLSearchParams( window.location.search ).get( 'subscriber' );
 
 	const layoutTitles = {
 		'ads-earnings': translate( '%(wordads)s Earnings', { args: { wordads: adsProgramName } } ),
@@ -122,6 +123,9 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 	const isAdSection = ( currentSection: string | undefined ) =>
 		currentSection && currentSection.startsWith( 'ads' );
 
+	const isSingleSupporterSection = ( currentSection: string | undefined ) =>
+		currentSection && currentSection.startsWith( 'supporters' ) && subscriberId;
+
 	const getComponent = ( currentSection: string | undefined ) => {
 		switch ( currentSection ) {
 			case 'ads-earnings':
@@ -147,7 +151,7 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 				return <MembershipsSection query={ query } />;
 
 			case 'supporters':
-				return <CustomerSection />;
+				return <CustomersSection />;
 
 			case 'refer-a-friend':
 				return <ReferAFriendSection />;
@@ -237,19 +241,23 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 			<DocumentHead
 				title={ layoutTitles[ section as keyof typeof layoutTitles ] ?? translate( 'Monetize' ) }
 			/>
-			<NavigationHeader
-				navigationItems={ [] }
-				title={ translate( 'Monetize' ) }
-				subtitle={ translate(
-					'Explore tools to earn money with your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
-					{
-						components: {
-							learnMoreLink: <InlineSupportLink supportContext="earn" showIcon={ false } />,
-						},
-					}
-				) }
-			/>
-			{ getEarnSectionNav() }
+			{ ! isSingleSupporterSection( section ) && (
+				<>
+					<NavigationHeader
+						navigationItems={ [] }
+						title={ translate( 'Monetize' ) }
+						subtitle={ translate(
+							'Explore tools to earn money with your site. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+							{
+								components: {
+									learnMoreLink: <InlineSupportLink supportContext="earn" showIcon={ false } />,
+								},
+							}
+						) }
+					/>
+					{ getEarnSectionNav() }
+				</>
+			) }
 			{ isAdSection( section ) && getAdsHeader() }
 			{ getComponent( section ) }
 		</Main>

--- a/client/my-sites/earn/types.ts
+++ b/client/my-sites/earn/types.ts
@@ -17,3 +17,26 @@ export type Product = {
 export type Query = {
 	[ key: string ]: string;
 };
+
+export type Subscriber = {
+	id: string;
+	status: string;
+	start_date: string;
+	end_date: string;
+	// appears as both subscriber.user_email & subscriber.user.user_email in this file
+	user_email: string;
+	user: {
+		ID: string;
+		name: string;
+		user_email: string;
+	};
+	plan: {
+		connected_account_product_id: string;
+		title: string;
+		renewal_price: number;
+		currency: string;
+		renew_interval: string;
+	};
+	renew_interval: string;
+	all_time_total: number;
+};


### PR DESCRIPTION
## Proposed Changes
* Adds new single customer screen to the Monetize area, accessed from the Monetize > Supporters list. 
* See Figma designs here: DqXCQr1dEWpF3P2dIEwiwd-fi-868_25180

**Monetize > Supporters**
<img width="1085" alt="monetize-supporters" src="https://github.com/Automattic/wp-calypso/assets/21228350/a2e43a10-f0ba-4197-875f-d2cb76d4cc71">

**Monetize > Single Supporter**
<img width="1081" alt="monetize-single" src="https://github.com/Automattic/wp-calypso/assets/21228350/e1ca5af4-188f-4b79-87a2-aed1aab8ce91">

## Testing Instructions

1) You will need a test site with paid customers. 
2) Load this branch and go to the Supporters screen at `http://calypso.localhost:3000/earn/supporters/YOURSITESLUG`
3) Test Supporters screen: For a specific supporter in the table, click the ellipsis icon on the far right. Confirm you see a new 'View' option. Click that and confirm you are taken to the single supporters screen. 
4) Test Single Supporter screen: 
   - Confirm the screen loads without error and looks like the screenshot above
   - Confirm you can navigate back to the Supporters or Monetize screens using the breadcrumbs at the top.
   - Confirm that correct information shows: name / email / icon / last billing amount / total amount billed / etc
   - Click on the View Stripe Dashboard button and confirm you are taken to the customer page in Stripe.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?