### PR TITLE
Replace the hardcoded plan name in `plans-faq` by the plan definition data

### DIFF
--- a/client/my-sites/plans-features-main/components/plan-faq.jsx
+++ b/client/my-sites/plans-features-main/components/plan-faq.jsx
@@ -1,3 +1,11 @@
+import {
+	PLAN_PERSONAL,
+	PLAN_PREMIUM,
+	PLAN_BUSINESS,
+	PLAN_ECOMMERCE,
+	getPlan,
+} from '@automattic/calypso-products';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
@@ -21,6 +29,7 @@ const FoldableFAQ = styled( FoldableFAQComponent )`
 const PlanFAQ = ( { titanMonthlyRenewalCost = 0 } ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
+	const isEnglishLocale = useIsEnglishLocale();
 	const onFaqToggle = useCallback(
 		( faqArgs ) => {
 			const { id, isExpanded } = faqArgs;
@@ -168,21 +177,44 @@ const PlanFAQ = ( { titanMonthlyRenewalCost = 0 } ) => {
 				question={ translate( 'Can I install plugins?' ) }
 				onToggle={ onFaqToggle }
 			>
-				{ translate(
-					'Yes! When you subscribe to the WordPress.com Business or eCommerce plans, you’ll be able to ' +
-						'search for and install over 50,000 available plugins in the WordPress repository.'
-				) }
+				{ isEnglishLocale
+					? translate(
+							'Yes! When you subscribe to the WordPress.com %(businessPlanName)s or %(ecommercePlanName)s plans, you’ll be able to ' +
+								'search for and install over 50,000 available plugins in the WordPress repository.',
+							{
+								args: {
+									businessPlanName: getPlan( PLAN_BUSINESS ).getTitle(),
+									ecommercePlanName: getPlan( PLAN_ECOMMERCE ).getTitle(),
+								},
+							}
+					  )
+					: translate(
+							'Yes! When you subscribe to the WordPress.com Business or eCommerce plans, you’ll be able to ' +
+								'search for and install over 50,000 available plugins in the WordPress repository.'
+					  ) }
 			</FoldableFAQ>
 			<FoldableFAQ
 				id="faq-10"
 				question={ translate( 'Can I install my own theme?' ) }
 				onToggle={ onFaqToggle }
 			>
-				{ translate(
-					'Yes! All plans give you access to our directory of free and premium themes that have been ' +
-						'handpicked and reviewed for quality by our team. With the WordPress.com Business or ' +
-						"eCommerce plan, you can upload and install any theme you'd like."
-				) }
+				{ isEnglishLocale
+					? translate(
+							'Yes! All plans give you access to our directory of free and premium themes that have been ' +
+								'handpicked and reviewed for quality by our team. With the WordPress.com %(businessPlanName)s or ' +
+								"%(ecommercePlanName)s plan, you can upload and install any theme you'd like.",
+							{
+								args: {
+									businessPlanName: getPlan( PLAN_BUSINESS ).getTitle(),
+									ecommercePlanName: getPlan( PLAN_ECOMMERCE ).getTitle(),
+								},
+							}
+					  )
+					: translate(
+							'Yes! All plans give you access to our directory of free and premium themes that have been ' +
+								'handpicked and reviewed for quality by our team. With the WordPress.com Business or ' +
+								"eCommerce plan, you can upload and install any theme you'd like."
+					  ) }
 			</FoldableFAQ>
 			<FoldableFAQ
 				id="faq-11"
@@ -212,17 +244,33 @@ const PlanFAQ = ( { titanMonthlyRenewalCost = 0 } ) => {
 				question={ translate( 'Can I talk to a live person?' ) }
 				onToggle={ onFaqToggle }
 			>
-				{ translate(
-					'We’d love to chat with you! All paid plans include access to one-on-one support from our ' +
-						'team of WordPress experts (we call them Happiness Engineers). The Personal plan includes ' +
-						'email support while the Premium plan and above all include live chat support.{{br /}}{{br /}}' +
-						'If you have pre-purchase questions, we offer live chat on the checkout page. Select the plan ' +
-						'that looks like the best fit for you and click the “Questions? Ask a Happiness Engineer” ' +
-						'link on the next page.',
-					{
-						components: { br: <br /> },
-					}
-				) }
+				{ isEnglishLocale
+					? translate(
+							'We’d love to chat with you! All paid plans include access to one-on-one support from our ' +
+								'team of WordPress experts (we call them Happiness Engineers). The %(personalPlanName)s plan includes ' +
+								'email support while the %(premiumPlanName)s plan and above all include live chat support.{{br /}}{{br /}}' +
+								'If you have pre-purchase questions, we offer live chat on the checkout page. Select the plan ' +
+								'that looks like the best fit for you and click the “Questions? Ask a Happiness Engineer” ' +
+								'link on the next page.',
+							{
+								args: {
+									personalPlanName: getPlan( PLAN_PERSONAL ).getTitle(),
+									premiumPlanName: getPlan( PLAN_PREMIUM ).getTitle(),
+								},
+								components: { br: <br /> },
+							}
+					  )
+					: translate(
+							'We’d love to chat with you! All paid plans include access to one-on-one support from our ' +
+								'team of WordPress experts (we call them Happiness Engineers). The Personal plan includes ' +
+								'email support while the Premium plan and above all include live chat support.{{br /}}{{br /}}' +
+								'If you have pre-purchase questions, we offer live chat on the checkout page. Select the plan ' +
+								'that looks like the best fit for you and click the “Questions? Ask a Happiness Engineer” ' +
+								'link on the next page.',
+							{
+								components: { br: <br /> },
+							}
+					  ) }
 			</FoldableFAQ>
 		</div>
 	);

--- a/client/my-sites/plans-features-main/components/plan-faq.jsx
+++ b/client/my-sites/plans-features-main/components/plan-faq.jsx
@@ -7,7 +7,7 @@ import {
 } from '@automattic/calypso-products';
 import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import styled from '@emotion/styled';
-import { useTranslate } from 'i18n-calypso';
+import i18n, { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 import ExternalLinkWithTracking from 'calypso/components/external-link/with-tracking';
@@ -177,7 +177,11 @@ const PlanFAQ = ( { titanMonthlyRenewalCost = 0 } ) => {
 				question={ translate( 'Can I install plugins?' ) }
 				onToggle={ onFaqToggle }
 			>
-				{ isEnglishLocale
+				{ isEnglishLocale ||
+				i18n.hasTranslation(
+					'Yes! When you subscribe to the WordPress.com %(businessPlanName)s or %(ecommercePlanName)s plans, you’ll be able to ' +
+						'search for and install over 50,000 available plugins in the WordPress repository.'
+				)
 					? translate(
 							'Yes! When you subscribe to the WordPress.com %(businessPlanName)s or %(ecommercePlanName)s plans, you’ll be able to ' +
 								'search for and install over 50,000 available plugins in the WordPress repository.',
@@ -198,7 +202,12 @@ const PlanFAQ = ( { titanMonthlyRenewalCost = 0 } ) => {
 				question={ translate( 'Can I install my own theme?' ) }
 				onToggle={ onFaqToggle }
 			>
-				{ isEnglishLocale
+				{ isEnglishLocale ||
+				i18n.hasTranslation(
+					'Yes! All plans give you access to our directory of free and premium themes that have been ' +
+						'handpicked and reviewed for quality by our team. With the WordPress.com %(businessPlanName)s or ' +
+						"%(ecommercePlanName)s plan, you can upload and install any theme you'd like."
+				)
 					? translate(
 							'Yes! All plans give you access to our directory of free and premium themes that have been ' +
 								'handpicked and reviewed for quality by our team. With the WordPress.com %(businessPlanName)s or ' +
@@ -244,7 +253,15 @@ const PlanFAQ = ( { titanMonthlyRenewalCost = 0 } ) => {
 				question={ translate( 'Can I talk to a live person?' ) }
 				onToggle={ onFaqToggle }
 			>
-				{ isEnglishLocale
+				{ isEnglishLocale ||
+				i18n.hasTranslation(
+					'We’d love to chat with you! All paid plans include access to one-on-one support from our ' +
+						'team of WordPress experts (we call them Happiness Engineers). The %(personalPlanName)s plan includes ' +
+						'email support while the %(premiumPlanName)s plan and above all include live chat support.{{br /}}{{br /}}' +
+						'If you have pre-purchase questions, we offer live chat on the checkout page. Select the plan ' +
+						'that looks like the best fit for you and click the “Questions? Ask a Happiness Engineer” ' +
+						'link on the next page.'
+				)
 					? translate(
 							'We’d love to chat with you! All paid plans include access to one-on-one support from our ' +
 								'team of WordPress experts (we call them Happiness Engineers). The %(personalPlanName)s plan includes ' +


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

_This is part of the series of replacing hard-coded plan names by the plan definition data in `calypso-product` package. For more details, please refer to the new plan names experiment outlined in pcNC1U-WN-p2._

## Proposed Changes

This PR replaces the hardcoded plan names in the `plans-faq` component. To make sure we can safely deploy before the translations are completed, the en-locale guard is included.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go thorough the hosting flow, `/start/hosting`, and reach the plans step.
* Open the FAQ section below and make sure every copy referring the plan names work as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
