### PR TITLE
Replace the hardcoded plan name in the plugin detail sidebar

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/usps.tsx
+++ b/client/my-sites/plugins/plugin-details-CTA/usps.tsx
@@ -10,7 +10,7 @@ import {
 import { Gridicon } from '@automattic/components';
 import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import styled from '@emotion/styled';
-import { useTranslate } from 'i18n-calypso';
+import i18n, { useTranslate } from 'i18n-calypso';
 import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
 import PluginDetailsSidebarUSP from 'calypso/my-sites/plugins/plugin-details-sidebar-usp';
 import usePluginsSupportText from 'calypso/my-sites/plugins/use-plugins-support-text/';
@@ -148,20 +148,24 @@ export const PlanUSPS: React.FC< Props > = ( {
 	switch ( requiredPlan ) {
 		case PLAN_PERSONAL:
 		case PLAN_PERSONAL_MONTHLY:
-			planText = isEnglishLocale
-				? translate( 'Included in the %(personalPlanName)s plan (%(cost)s/%(periodicity)s):', {
-						args: {
-							personalPlanName: getPlan( PLAN_PERSONAL )?.getTitle() as string,
-							cost: planDisplayCost as string,
-							periodicity: periodicityLabel,
-						},
-				  } )
-				: translate( 'Included in the Personal plan (%(cost)s/%(periodicity)s):', {
-						args: {
-							cost: planDisplayCost as string,
-							periodicity: periodicityLabel,
-						},
-				  } );
+			planText =
+				isEnglishLocale ||
+				i18n.hasTranslation(
+					'Included in the %(personalPlanName)s plan (%(cost)s/%(periodicity)s):'
+				)
+					? translate( 'Included in the %(personalPlanName)s plan (%(cost)s/%(periodicity)s):', {
+							args: {
+								personalPlanName: getPlan( PLAN_PERSONAL )?.getTitle() as string,
+								cost: planDisplayCost as string,
+								periodicity: periodicityLabel,
+							},
+					  } )
+					: translate( 'Included in the Personal plan (%(cost)s/%(periodicity)s):', {
+							args: {
+								cost: planDisplayCost as string,
+								periodicity: periodicityLabel,
+							},
+					  } );
 			break;
 		case PLAN_BUSINESS:
 		case PLAN_BUSINESS_MONTHLY:

--- a/client/my-sites/plugins/plugin-details-CTA/usps.tsx
+++ b/client/my-sites/plugins/plugin-details-CTA/usps.tsx
@@ -5,8 +5,10 @@ import {
 	PLAN_PERSONAL,
 	PLAN_PERSONAL_MONTHLY,
 	PLAN_ECOMMERCE_TRIAL_MONTHLY,
+	getPlan,
 } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
@@ -122,6 +124,7 @@ export const PlanUSPS: React.FC< Props > = ( {
 	billingPeriod,
 } ) => {
 	const translate = useTranslate();
+	const isEnglishLocale = useIsEnglishLocale();
 
 	const selectedSite = useSelector( getSelectedSite );
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, selectedSite?.ID ) );
@@ -145,21 +148,37 @@ export const PlanUSPS: React.FC< Props > = ( {
 	switch ( requiredPlan ) {
 		case PLAN_PERSONAL:
 		case PLAN_PERSONAL_MONTHLY:
-			planText = translate( 'Included in the Personal plan (%(cost)s/%(periodicity)s):', {
-				args: {
-					cost: planDisplayCost as string,
-					periodicity: periodicityLabel,
-				},
-			} );
+			planText = isEnglishLocale
+				? translate( 'Included in the %(personalPlanName)s plan (%(cost)s/%(periodicity)s):', {
+						args: {
+							personalPlanName: getPlan( PLAN_PERSONAL )?.getTitle() as string,
+							cost: planDisplayCost as string,
+							periodicity: periodicityLabel,
+						},
+				  } )
+				: translate( 'Included in the Personal plan (%(cost)s/%(periodicity)s):', {
+						args: {
+							cost: planDisplayCost as string,
+							periodicity: periodicityLabel,
+						},
+				  } );
 			break;
 		case PLAN_BUSINESS:
 		case PLAN_BUSINESS_MONTHLY:
-			planText = translate( 'Included in the Business plan (%(cost)s/%(periodicity)s):', {
-				args: {
-					cost: planDisplayCost as string,
-					periodicity: periodicityLabel,
-				},
-			} );
+			planText = isEnglishLocale
+				? translate( 'Included in the %(businessPlanName)s plan (%(cost)s/%(periodicity)s):', {
+						args: {
+							businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() as string,
+							cost: planDisplayCost as string,
+							periodicity: periodicityLabel,
+						},
+				  } )
+				: translate( 'Included in the Business plan (%(cost)s/%(periodicity)s):', {
+						args: {
+							cost: planDisplayCost as string,
+							periodicity: periodicityLabel,
+						},
+				  } );
 			break;
 		case PLAN_ECOMMERCE_TRIAL_MONTHLY:
 			planText = translate( 'Included in ecommerce plans:' );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

This is part of the series of replacing hard-coded plan names by the plan definition data in calypso-product package. For more details, please refer to the new plan names experiment outlined in pcNC1U-WN-p2.

## Proposed Changes

This PR replaces the hard-coded plan names in the plugin details sidebar:
<img width="981" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1842898/c24434f4-bd1f-452f-bb0b-97b93a9e951a">



At the moment, the most relevant one is the Business plan, but I've updated the other as well just in case.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Log in to a non-Business plan site.
* Visit /plugins and pick a plugin randomly.
* Confirm that the copy in the sidebar works as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
