### PR TITLE
Replace the hard-coded plan name in the podcast settings.

### DIFF
--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -5,7 +5,7 @@ import {
 } from '@automattic/calypso-products';
 import { Button, Card } from '@automattic/components';
 import classNames from 'classnames';
-import { getLocaleSlug, localize } from 'i18n-calypso';
+import i18n, { getLocaleSlug, localize } from 'i18n-calypso';
 import { pick, flowRight } from 'lodash';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
@@ -209,7 +209,8 @@ class PodcastingDetails extends Component {
 						<UpsellNudge
 							plan={ PLAN_PERSONAL }
 							title={
-								isEnglishLocale
+								isEnglishLocale ||
+								i18n.hasTranslation( 'Upload Audio with WordPress.com %(personalPlanName)s' )
 									? translate( 'Upload Audio with WordPress.com %(personalPlanName)s', {
 											args: { personalPlanName: getPlan( PLAN_PERSONAL ).getTitle() },
 									  } )

--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -1,7 +1,11 @@
-import { PLAN_PERSONAL, WPCOM_FEATURES_UPLOAD_AUDIO_FILES } from '@automattic/calypso-products';
+import {
+	PLAN_PERSONAL,
+	WPCOM_FEATURES_UPLOAD_AUDIO_FILES,
+	getPlan,
+} from '@automattic/calypso-products';
 import { Button, Card } from '@automattic/components';
 import classNames from 'classnames';
-import { localize } from 'i18n-calypso';
+import { getLocaleSlug, localize } from 'i18n-calypso';
 import { pick, flowRight } from 'lodash';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
@@ -181,6 +185,9 @@ class PodcastingDetails extends Component {
 			'is-disabled': ! error && ! isPodcastingEnabled,
 		} );
 
+		const currentLocale = getLocaleSlug();
+		const isEnglishLocale = currentLocale === 'en' || currentLocale === 'en-gb';
+
 		return (
 			<Main>
 				<DocumentHead title={ translate( 'Podcasting' ) } />
@@ -201,7 +208,13 @@ class PodcastingDetails extends Component {
 					{ ! error && plansDataLoaded && (
 						<UpsellNudge
 							plan={ PLAN_PERSONAL }
-							title={ translate( 'Upload Audio with WordPress.com Personal' ) }
+							title={
+								isEnglishLocale
+									? translate( 'Upload Audio with WordPress.com %(personalPlanName)s', {
+											args: { personalPlanName: getPlan( PLAN_PERSONAL ).getTitle() },
+									  } )
+									: translate( 'Upload Audio with WordPress.com Personal' )
+							}
 							description={ translate(
 								'Embed podcast episodes directly from your media library.'
 							) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

_This is part of the series of replacing hard-coded plan names by the plan definition data in calypso-product package. For more details, please refer to the new plan names experiment outlined in pcNC1U-WN-p2._

## Proposed Changes

This PR replaces the hard-coded plan name in the podcasting settings page:
<img width="1137" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1842898/b3a95f18-cd14-4c09-9685-a5a37f40b75c">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visiting `/settings/podcasting`, confirm that the banner copy works as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
