### PR TITLE
Jetpack Manage: Implement a revoke button for the License bundle.

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/license-details/actions.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/actions.tsx
@@ -108,7 +108,7 @@ export default function LicenseDetailsActions( {
 					product={ product }
 					siteUrl={ siteUrl }
 					onClose={ closeRevokeDialog }
-					isChildLicense={ isChildLicense }
+					roleType={ isChildLicense ? 'child' : 'single' }
 				/>
 			) }
 		</div>

--- a/client/jetpack-cloud/sections/partner-portal/license-details/actions.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/actions.tsx
@@ -3,7 +3,11 @@ import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
 import useLicenseDownloadUrlMutation from 'calypso/components/data/query-jetpack-partner-portal-licenses/use-license-download-url-mutation';
 import RevokeLicenseDialog from 'calypso/jetpack-cloud/sections/partner-portal/revoke-license-dialog';
-import { LicenseState, LicenseType } from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import {
+	LicenseRole,
+	LicenseState,
+	LicenseType,
+} from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import { addQueryArgs } from 'calypso/lib/url';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -108,7 +112,7 @@ export default function LicenseDetailsActions( {
 					product={ product }
 					siteUrl={ siteUrl }
 					onClose={ closeRevokeDialog }
-					licenseRole={ isChildLicense ? 'child' : 'single' }
+					licenseRole={ isChildLicense ? LicenseRole.Child : LicenseRole.Single }
 				/>
 			) }
 		</div>

--- a/client/jetpack-cloud/sections/partner-portal/license-details/actions.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/actions.tsx
@@ -108,7 +108,7 @@ export default function LicenseDetailsActions( {
 					product={ product }
 					siteUrl={ siteUrl }
 					onClose={ closeRevokeDialog }
-					roleType={ isChildLicense ? 'child' : 'single' }
+					licenseRole={ isChildLicense ? 'child' : 'single' }
 				/>
 			) }
 		</div>

--- a/client/jetpack-cloud/sections/partner-portal/license-list-item/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-list-item/style.scss
@@ -57,7 +57,7 @@ $grid-wide: 0.5fr 0.5fr 128px 128px 128px 74px;
 		}
 
 		> *:nth-child(#{$column-actions}) {
-			display: flex;
+			display: block;
 		}
 
 		> *:nth-child(#{$column-domain}) {

--- a/client/jetpack-cloud/sections/partner-portal/license-list-item/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-list-item/style.scss
@@ -193,7 +193,7 @@ $grid-wide: 0.5fr 0.5fr 128px 128px 128px 74px;
 	}
 }
 
-.preview__badge-container {
+.license-preview__badge-container {
 	display: flex;
 
 	.license-preview__license-count {

--- a/client/jetpack-cloud/sections/partner-portal/license-list-item/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-list-item/style.scss
@@ -6,8 +6,8 @@ $column-domain: 2;
 $column-actions: 5;
 $column-toggle: 6;
 
-$grid-xlarge: 0.5fr 0.5fr 114px 114px 128px 30px;
-$grid-wide: 0.5fr 0.5fr 128px 128px 128px 36px;
+$grid-xlarge: 0.5fr 0.5fr 114px 114px 160px 30px;
+$grid-wide: 0.5fr 0.5fr 128px 128px 160px 36px;
 
 .license-list-item {
 	display: grid;
@@ -55,7 +55,7 @@ $grid-wide: 0.5fr 0.5fr 128px 128px 128px 36px;
 		}
 
 		> *:nth-child(#{$column-actions}) {
-			display: block;
+			display: flex;
 		}
 
 		> *:nth-child(#{$column-domain}) {
@@ -191,8 +191,10 @@ $grid-wide: 0.5fr 0.5fr 128px 128px 128px 36px;
 	}
 }
 
-.license-preview__badge-container {
+.license-preview__extras {
 	display: flex;
+	justify-content: space-between;
+	align-items: center;
 
 	.license-preview__license-count {
 		text-wrap: nowrap;

--- a/client/jetpack-cloud/sections/partner-portal/license-list-item/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-list-item/style.scss
@@ -6,12 +6,12 @@ $column-domain: 2;
 $column-actions: 5;
 $column-toggle: 6;
 
-$grid-xlarge: 0.5fr 0.5fr 114px 114px 160px 30px;
-$grid-wide: 0.5fr 0.5fr 128px 128px 160px 36px;
+$grid-xlarge: 0.5fr 0.5fr 114px 114px 128px 74px;
+$grid-wide: 0.5fr 0.5fr 128px 128px 128px 74px;
 
 .license-list-item {
 	display: grid;
-	grid-template-columns: 1fr 36px;
+	grid-template-columns: 1fr 74px;
 
 	> * {
 		display: none;
@@ -29,8 +29,10 @@ $grid-wide: 0.5fr 0.5fr 128px 128px 160px 36px;
 	}
 
 	> *:nth-child(#{$column-toggle}) {
-		grid-column-end: -1;
-		display: inherit;
+		display: flex;
+		justify-content: flex-end;
+		align-items: center;
+		gap: 16px;
 		padding: 0;
 	}
 
@@ -191,10 +193,8 @@ $grid-wide: 0.5fr 0.5fr 128px 128px 160px 36px;
 	}
 }
 
-.license-preview__extras {
+.preview__badge-container {
 	display: flex;
-	justify-content: space-between;
-	align-items: center;
 
 	.license-preview__license-count {
 		text-wrap: nowrap;

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
@@ -120,8 +120,7 @@ export default function LicensePreview( {
 	const isSiteAtomic =
 		isEnabled( 'jetpack/pro-dashboard-wpcom-atomic-hosting' ) && site?.is_wpcom_atomic;
 
-	const isParentLicenseBundle =
-		isEnabled( 'jetpack/bundle-licensing' ) && quantity && parentLicenseId;
+	const isParentLicense = isEnabled( 'jetpack/bundle-licensing' ) && quantity && parentLicenseId;
 
 	const bundleCountContent = quantity && (
 		<Badge className="license-preview__license-count" type="info">
@@ -226,8 +225,8 @@ export default function LicensePreview( {
 					</div>
 				) }
 
-				<div className="license-preview__extras">
-					{ isParentLicenseBundle
+				<div className="license-preview__badge-container">
+					{ isParentLicense
 						? bundleCountContent
 						: LicenseType.Standard === licenseType && (
 								<Badge type="success">{ translate( 'Standard license' ) }</Badge>
@@ -235,7 +234,7 @@ export default function LicensePreview( {
 				</div>
 
 				<div>
-					{ isParentLicenseBundle && (
+					{ isParentLicense && (
 						<LicenseBundleDropDown
 							product={ product }
 							licenseKey={ licenseKey }
@@ -261,7 +260,7 @@ export default function LicensePreview( {
 			</LicenseListItem>
 
 			{ isOpen &&
-				( isParentLicenseBundle ? (
+				( isParentLicense ? (
 					<BundleDetails parentLicenseId={ parentLicenseId } />
 				) : (
 					<LicenseDetails

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
@@ -24,6 +24,7 @@ import { doesPartnerRequireAPaymentMethod } from 'calypso/state/partner-portal/p
 import { getSite } from 'calypso/state/sites/selectors';
 import BundleDetails from '../license-details/bundle-details';
 import LicenseActions from './license-actions';
+import LicenseBundleDropDown from './license-bundle-dropdown';
 
 import './style.scss';
 
@@ -119,7 +120,8 @@ export default function LicensePreview( {
 	const isSiteAtomic =
 		isEnabled( 'jetpack/pro-dashboard-wpcom-atomic-hosting' ) && site?.is_wpcom_atomic;
 
-	const showBundleDetails = isEnabled( 'jetpack/bundle-licensing' ) && quantity && parentLicenseId;
+	const isParentLicenseBundle =
+		isEnabled( 'jetpack/bundle-licensing' ) && quantity && parentLicenseId;
 
 	const bundleCountContent = quantity && (
 		<Badge className="license-preview__license-count" type="info">
@@ -224,12 +226,17 @@ export default function LicensePreview( {
 					</div>
 				) }
 
-				<div className="license-preview__badge-container">
-					{ showBundleDetails
-						? bundleCountContent
-						: LicenseType.Standard === licenseType && (
-								<Badge type="success">{ translate( 'Standard license' ) }</Badge>
-						  ) }
+				<div className="license-preview__extras">
+					{ isParentLicenseBundle ? (
+						<>
+							{ bundleCountContent }
+							<LicenseBundleDropDown />
+						</>
+					) : (
+						LicenseType.Standard === licenseType && (
+							<Badge type="success">{ translate( 'Standard license' ) }</Badge>
+						)
+					) }
 				</div>
 
 				<div>
@@ -252,7 +259,7 @@ export default function LicensePreview( {
 			</LicenseListItem>
 
 			{ isOpen &&
-				( showBundleDetails ? (
+				( isParentLicenseBundle ? (
 					<BundleDetails parentLicenseId={ parentLicenseId } />
 				) : (
 					<LicenseDetails

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
@@ -230,7 +230,11 @@ export default function LicensePreview( {
 					{ isParentLicenseBundle ? (
 						<>
 							{ bundleCountContent }
-							<LicenseBundleDropDown />
+							<LicenseBundleDropDown
+								product={ product }
+								licenseKey={ licenseKey }
+								bundleSize={ quantity }
+							/>
 						</>
 					) : (
 						LicenseType.Standard === licenseType && (

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/index.tsx
@@ -227,23 +227,21 @@ export default function LicensePreview( {
 				) }
 
 				<div className="license-preview__extras">
-					{ isParentLicenseBundle ? (
-						<>
-							{ bundleCountContent }
-							<LicenseBundleDropDown
-								product={ product }
-								licenseKey={ licenseKey }
-								bundleSize={ quantity }
-							/>
-						</>
-					) : (
-						LicenseType.Standard === licenseType && (
-							<Badge type="success">{ translate( 'Standard license' ) }</Badge>
-						)
-					) }
+					{ isParentLicenseBundle
+						? bundleCountContent
+						: LicenseType.Standard === licenseType && (
+								<Badge type="success">{ translate( 'Standard license' ) }</Badge>
+						  ) }
 				</div>
 
 				<div>
+					{ isParentLicenseBundle && (
+						<LicenseBundleDropDown
+							product={ product }
+							licenseKey={ licenseKey }
+							bundleSize={ quantity }
+						/>
+					) }
 					{ isSiteAtomic ? (
 						<LicenseActions
 							siteUrl={ siteUrl }

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/license-actions.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/license-actions.tsx
@@ -78,7 +78,7 @@ export default function LicenseActions( {
 					product={ product }
 					siteUrl={ siteUrl }
 					onClose={ () => setShowRevokeDialog( false ) }
-					roleType={ isChildLicense ? 'child' : 'single' }
+					licenseRole={ isChildLicense ? 'child' : 'single' }
 				/>
 			) }
 		</>

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/license-actions.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/license-actions.tsx
@@ -4,8 +4,8 @@ import { useState, useRef } from 'react';
 import PopoverMenu from 'calypso/components/popover-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import RevokeLicenseDialog from '../revoke-license-dialog';
+import { LicenseRole, type LicenseAction, type LicenseType } from '../types';
 import useLicenseActions from './use-license-actions';
-import type { LicenseAction, LicenseType } from '../types';
 
 interface Props {
 	licenseKey: string;
@@ -78,7 +78,7 @@ export default function LicenseActions( {
 					product={ product }
 					siteUrl={ siteUrl }
 					onClose={ () => setShowRevokeDialog( false ) }
-					licenseRole={ isChildLicense ? 'child' : 'single' }
+					licenseRole={ isChildLicense ? LicenseRole.Child : LicenseRole.Single }
 				/>
 			) }
 		</>

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/license-actions.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/license-actions.tsx
@@ -78,7 +78,7 @@ export default function LicenseActions( {
 					product={ product }
 					siteUrl={ siteUrl }
 					onClose={ () => setShowRevokeDialog( false ) }
-					isChildLicense={ isChildLicense }
+					roleType={ isChildLicense ? 'child' : 'single' }
 				/>
 			) }
 		</>

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/license-bundle-dropdown.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/license-bundle-dropdown.tsx
@@ -1,0 +1,53 @@
+import { Gridicon, Button } from '@automattic/components';
+import { translate } from 'i18n-calypso';
+import { useCallback, useRef, useState } from 'react';
+import PopoverMenu from 'calypso/components/popover-menu';
+import PopoverMenuItem from 'calypso/components/popover-menu/item';
+
+export default function LicenseBundleDropDown() {
+	const [ showRevokeDialog, setShowRevokeDialog ] = useState( false );
+	const buttonActionRef = useRef< HTMLButtonElement | null >( null );
+
+	const onShowRevokeDialog = useCallback( () => {
+		setShowRevokeDialog( true );
+	}, [] );
+
+	const onHideRevokeDialog = useCallback( () => {
+		setShowRevokeDialog( false );
+	}, [] );
+
+	const onRevokeLicense = useCallback( () => {}, [] );
+
+	return (
+		<>
+			<Button
+				className="license-bundle-dropdown__button"
+				borderless
+				compact
+				onClick={ onShowRevokeDialog }
+				ref={ buttonActionRef }
+			>
+				<Gridicon icon="ellipsis" size={ 18 } />
+			</Button>
+
+			<PopoverMenu
+				className="license-bundle-dropdown__popover-menu"
+				context={ buttonActionRef.current }
+				isVisible={ showRevokeDialog }
+				onClose={ onHideRevokeDialog }
+				position="bottom left"
+			>
+				<span className="license-bundle-dropdown__popover-menu-title">
+					{ translate( 'Option' ) }
+				</span>
+
+				<PopoverMenuItem
+					onClick={ onRevokeLicense }
+					className="license-bundle-dropdown__popover-menu-item-revoke"
+				>
+					{ translate( 'Revoke bundle' ) } <Gridicon icon="trash" size={ 18 } />
+				</PopoverMenuItem>
+			</PopoverMenu>
+		</>
+	);
+}

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/license-bundle-dropdown.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/license-bundle-dropdown.tsx
@@ -63,7 +63,7 @@ export default function LicenseBundleDropDown( { licenseKey, product, bundleSize
 
 			{ showRevokeDialog && (
 				<RevokeLicenseDialog
-					roleType="parent"
+					licenseRole="parent"
 					licenseKey={ licenseKey }
 					product={ product }
 					siteUrl={ null }

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/license-bundle-dropdown.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/license-bundle-dropdown.tsx
@@ -3,10 +3,26 @@ import { translate } from 'i18n-calypso';
 import { useCallback, useRef, useState } from 'react';
 import PopoverMenu from 'calypso/components/popover-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
+import RevokeLicenseDialog from '../revoke-license-dialog';
 
-export default function LicenseBundleDropDown() {
+type Props = {
+	licenseKey: string;
+	product: string;
+	bundleSize: number;
+};
+
+export default function LicenseBundleDropDown( { licenseKey, product, bundleSize }: Props ) {
 	const [ showRevokeDialog, setShowRevokeDialog ] = useState( false );
+	const [ showContextMenu, setShowContextMenu ] = useState( false );
 	const buttonActionRef = useRef< HTMLButtonElement | null >( null );
+
+	const onShowContextMenu = useCallback( () => {
+		setShowContextMenu( true );
+	}, [] );
+
+	const onHideContextMenu = useCallback( () => {
+		setShowContextMenu( false );
+	}, [] );
 
 	const onShowRevokeDialog = useCallback( () => {
 		setShowRevokeDialog( true );
@@ -16,15 +32,13 @@ export default function LicenseBundleDropDown() {
 		setShowRevokeDialog( false );
 	}, [] );
 
-	const onRevokeLicense = useCallback( () => {}, [] );
-
 	return (
 		<>
 			<Button
 				className="license-bundle-dropdown__button"
 				borderless
 				compact
-				onClick={ onShowRevokeDialog }
+				onClick={ onShowContextMenu }
 				ref={ buttonActionRef }
 			>
 				<Gridicon icon="ellipsis" size={ 18 } />
@@ -33,8 +47,8 @@ export default function LicenseBundleDropDown() {
 			<PopoverMenu
 				className="license-bundle-dropdown__popover-menu"
 				context={ buttonActionRef.current }
-				isVisible={ showRevokeDialog }
-				onClose={ onHideRevokeDialog }
+				isVisible={ showContextMenu }
+				onClose={ onHideContextMenu }
 				position="bottom left"
 			>
 				<span className="license-bundle-dropdown__popover-menu-title">
@@ -42,12 +56,23 @@ export default function LicenseBundleDropDown() {
 				</span>
 
 				<PopoverMenuItem
-					onClick={ onRevokeLicense }
+					onClick={ onShowRevokeDialog }
 					className="license-bundle-dropdown__popover-menu-item-revoke"
 				>
 					{ translate( 'Revoke bundle' ) } <Gridicon icon="trash" size={ 18 } />
 				</PopoverMenuItem>
 			</PopoverMenu>
+
+			{ showRevokeDialog && (
+				<RevokeLicenseDialog
+					roleType="parent"
+					licenseKey={ licenseKey }
+					product={ product }
+					siteUrl={ null }
+					onClose={ onHideRevokeDialog }
+					bundleSize={ bundleSize }
+				/>
+			) }
 		</>
 	);
 }

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/license-bundle-dropdown.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/license-bundle-dropdown.tsx
@@ -5,6 +5,7 @@ import { useCallback, useRef, useState } from 'react';
 import PopoverMenu from 'calypso/components/popover-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import RevokeLicenseDialog from '../revoke-license-dialog';
+import { LicenseRole } from '../types';
 
 type Props = {
 	licenseKey: string;
@@ -63,7 +64,7 @@ export default function LicenseBundleDropDown( { licenseKey, product, bundleSize
 
 			{ showRevokeDialog && (
 				<RevokeLicenseDialog
-					licenseRole="parent"
+					licenseRole={ LicenseRole.Parent }
 					licenseKey={ licenseKey }
 					product={ product }
 					siteUrl={ null }

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/license-bundle-dropdown.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/license-bundle-dropdown.tsx
@@ -1,4 +1,5 @@
 import { Gridicon, Button } from '@automattic/components';
+import { Icon, trash } from '@wordpress/icons';
 import { translate } from 'i18n-calypso';
 import { useCallback, useRef, useState } from 'react';
 import PopoverMenu from 'calypso/components/popover-menu';
@@ -50,16 +51,13 @@ export default function LicenseBundleDropDown( { licenseKey, product, bundleSize
 				isVisible={ showContextMenu }
 				onClose={ onHideContextMenu }
 				position="bottom left"
+				focusOnShow={ false }
 			>
-				<span className="license-bundle-dropdown__popover-menu-title">
-					{ translate( 'Option' ) }
-				</span>
-
 				<PopoverMenuItem
 					onClick={ onShowRevokeDialog }
 					className="license-bundle-dropdown__popover-menu-item-revoke"
 				>
-					{ translate( 'Revoke bundle' ) } <Gridicon icon="trash" size={ 18 } />
+					{ translate( 'Revoke bundle' ) } <Icon className="gridicon" icon={ trash } size={ 24 } />
 				</PopoverMenuItem>
 			</PopoverMenu>
 

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/style.scss
@@ -224,12 +224,13 @@ button {
 	border-radius: 2px;
 
 	.popover__menu {
-		padding: 8px;
+		padding: 8px 4px;
 	}
 
 	.popover__menu-item {
 		display: flex;
 		justify-content: space-between;
+		align-items: center;
 	}
 
 	.popover__menu-item:hover,

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/style.scss
@@ -254,13 +254,6 @@ button {
 	}
 }
 
-.license-bundle-dropdown__popover-menu-title {
-	text-align: left;
-	padding: 8px 16px;
-	font-size: rem(14px);
-	font-weight: 400;
-}
-
 .popover__menu-item.license-bundle-dropdown__popover-menu-item-revoke {
 	&,
 	&:hover,

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/style.scss
@@ -209,6 +209,7 @@ button {
 }
 
 .button.is-borderless.license-bundle-dropdown__button {
+	text-overflow: clip;
 	padding: 4px;
 	max-height: 24px;
 	&:hover,

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/style.scss
@@ -210,6 +210,7 @@ button {
 
 .button.is-borderless.license-bundle-dropdown__button {
 	padding: 4px;
+	max-height: 24px;
 	&:hover,
 	&:focus {
 		background: var(--color-sidebar-menu-hover-background);
@@ -222,6 +223,10 @@ button {
 	font-size: rem(14px);
 	font-weight: 400;
 	border-radius: 2px;
+
+	.popover__arrow {
+		display: none;
+	}
 
 	.popover__menu {
 		padding: 8px 4px;

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/style.scss
@@ -208,6 +208,16 @@ button {
 	background-color: #fafafa;
 }
 
+.button.is-borderless.license-bundle-dropdown__button {
+	padding: 4px;
+	&:hover,
+	&:focus {
+		background: var(--color-sidebar-menu-hover-background);
+		color: var(--color-text);
+		fill: var(--color-text);
+	}
+}
+
 .license-bundle-dropdown__popover-menu {
 	font-size: rem(14px);
 	font-weight: 400;

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/style.scss
@@ -207,3 +207,52 @@ button {
 	padding: 16px 32px;
 	background-color: #fafafa;
 }
+
+.license-bundle-dropdown__popover-menu {
+	font-size: rem(14px);
+	font-weight: 400;
+	border-radius: 2px;
+
+	.popover__menu {
+		padding: 8px;
+	}
+
+	.popover__menu-item {
+		display: flex;
+		justify-content: space-between;
+	}
+
+	.popover__menu-item:hover,
+	.popover__menu-item:focus {
+		background: var(--color-sidebar-menu-hover-background);
+		color: var(--color-text);
+		fill: var(--color-text);
+
+		.gridicon {
+			fill: var(--color-text);
+		}
+	}
+
+	.popover__menu-item .gridicon {
+		margin: 0;
+	}
+}
+
+.license-bundle-dropdown__popover-menu-title {
+	text-align: left;
+	padding: 8px 16px;
+	font-size: rem(14px);
+	font-weight: 400;
+}
+
+.popover__menu-item.license-bundle-dropdown__popover-menu-item-revoke {
+	&,
+	&:hover,
+	&:focus {
+		color: var(--studio-red-50);
+
+		.gridicon {
+			fill: var(--studio-red-50);
+		}
+	}
+}

--- a/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/index.tsx
@@ -8,8 +8,9 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice } from 'calypso/state/notices/actions';
 import useRefreshLicenseList from 'calypso/state/partner-portal/licenses/hooks/use-refresh-license-list';
 import useRevokeLicenseMutation from 'calypso/state/partner-portal/licenses/hooks/use-revoke-license-mutation';
-import './style.scss';
 import { LicenseRole } from '../types';
+
+import './style.scss';
 
 interface Props {
 	licenseKey: string;

--- a/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/index.tsx
@@ -15,7 +15,7 @@ interface Props {
 	product: string;
 	siteUrl: string | null;
 	onClose: ( action?: string ) => void;
-	roleType?: 'parent' | 'child' | 'single';
+	licenseRole?: 'parent' | 'child' | 'single';
 	bundleSize?: number;
 }
 
@@ -24,7 +24,7 @@ export default function RevokeLicenseDialog( {
 	product,
 	siteUrl,
 	onClose,
-	roleType = 'single',
+	licenseRole = 'single',
 	bundleSize = 1,
 	...rest
 }: Props ) {
@@ -53,7 +53,7 @@ export default function RevokeLicenseDialog( {
 		mutation.mutate( { licenseKey } );
 	}, [ dispatch, licenseKey, mutation ] );
 
-	const isAssignedChildLicense = roleType === 'child' && siteUrl;
+	const isAssignedChildLicense = licenseRole === 'child' && siteUrl;
 
 	const buttons = [
 		<Button disabled={ false } onClick={ close }>
@@ -66,7 +66,7 @@ export default function RevokeLicenseDialog( {
 	];
 
 	const renderHeading = () => {
-		if ( roleType === 'parent' ) {
+		if ( licenseRole === 'parent' ) {
 			return translate( 'Revoke bundle of %(count)s %(product)s licenses?', {
 				args: {
 					product,
@@ -90,7 +90,7 @@ export default function RevokeLicenseDialog( {
 	};
 
 	const renderContent = () => {
-		if ( roleType === 'parent' ) {
+		if ( licenseRole === 'parent' ) {
 			return (
 				<p>
 					{ translate(

--- a/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/index.tsx
@@ -15,7 +15,8 @@ interface Props {
 	product: string;
 	siteUrl: string | null;
 	onClose: ( action?: string ) => void;
-	isChildLicense?: boolean;
+	roleType?: 'parent' | 'child' | 'single';
+	bundleSize?: number;
 }
 
 export default function RevokeLicenseDialog( {
@@ -23,7 +24,8 @@ export default function RevokeLicenseDialog( {
 	product,
 	siteUrl,
 	onClose,
-	isChildLicense,
+	roleType = 'single',
+	bundleSize = 1,
 	...rest
 }: Props ) {
 	let close = noop;
@@ -51,7 +53,7 @@ export default function RevokeLicenseDialog( {
 		mutation.mutate( { licenseKey } );
 	}, [ dispatch, licenseKey, mutation ] );
 
-	const isAssignedChildLicense = isChildLicense && siteUrl;
+	const isAssignedChildLicense = roleType === 'child' && siteUrl;
 
 	const buttons = [
 		<Button disabled={ false } onClick={ close }>
@@ -64,6 +66,17 @@ export default function RevokeLicenseDialog( {
 	];
 
 	const renderHeading = () => {
+		if ( roleType === 'parent' ) {
+			return translate( 'Revoke bundle of %(count)s %(product)s licenses?', {
+				args: {
+					product,
+					count: bundleSize,
+				},
+				comment:
+					'The %(product)s is replaced with the product name and %(count)s is replace with the bundle size.',
+			} );
+		}
+
 		if ( isAssignedChildLicense ) {
 			return translate( 'Revoke %(product)s license?', {
 				args: {
@@ -77,6 +90,27 @@ export default function RevokeLicenseDialog( {
 	};
 
 	const renderContent = () => {
+		if ( roleType === 'parent' ) {
+			return (
+				<p>
+					{ translate(
+						'Revoking this bundle will cause {{b}}%(product)s{{/b}} to stop working on your %(count)s assigned sites.',
+						{
+							args: {
+								product,
+								count: bundleSize,
+							},
+							components: {
+								b: <b />,
+							},
+							comment:
+								'The %(product)s is replaced with the product name and %(count)s is replace with the number of assigned sites.',
+						}
+					) }
+				</p>
+			);
+		}
+
 		if ( isAssignedChildLicense ) {
 			return (
 				<p>

--- a/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/index.tsx
@@ -9,13 +9,14 @@ import { errorNotice } from 'calypso/state/notices/actions';
 import useRefreshLicenseList from 'calypso/state/partner-portal/licenses/hooks/use-refresh-license-list';
 import useRevokeLicenseMutation from 'calypso/state/partner-portal/licenses/hooks/use-revoke-license-mutation';
 import './style.scss';
+import { LicenseRole } from '../types';
 
 interface Props {
 	licenseKey: string;
 	product: string;
 	siteUrl: string | null;
 	onClose: ( action?: string ) => void;
-	licenseRole?: 'parent' | 'child' | 'single';
+	licenseRole?: LicenseRole;
 	bundleSize?: number;
 }
 
@@ -24,7 +25,7 @@ export default function RevokeLicenseDialog( {
 	product,
 	siteUrl,
 	onClose,
-	licenseRole = 'single',
+	licenseRole = LicenseRole.Single,
 	bundleSize = 1,
 	...rest
 }: Props ) {
@@ -53,7 +54,8 @@ export default function RevokeLicenseDialog( {
 		mutation.mutate( { licenseKey } );
 	}, [ dispatch, licenseKey, mutation ] );
 
-	const isAssignedChildLicense = licenseRole === 'child' && siteUrl;
+	const isParentLicense = licenseRole === LicenseRole.Parent;
+	const isAssignedChildLicense = licenseRole === LicenseRole.Child && siteUrl;
 
 	const buttons = [
 		<Button disabled={ false } onClick={ close }>
@@ -61,12 +63,12 @@ export default function RevokeLicenseDialog( {
 		</Button>,
 
 		<Button primary scary busy={ mutation.isLoading } onClick={ revoke }>
-			{ translate( 'Revoke License' ) }
+			{ isParentLicense ? translate( 'Revoke bundle' ) : translate( 'Revoke License' ) }
 		</Button>,
 	];
 
 	const renderHeading = () => {
-		if ( licenseRole === 'parent' ) {
+		if ( isParentLicense ) {
 			return translate( 'Revoke bundle of %(count)s %(product)s licenses?', {
 				args: {
 					product,
@@ -90,7 +92,7 @@ export default function RevokeLicenseDialog( {
 	};
 
 	const renderContent = () => {
-		if ( licenseRole === 'parent' ) {
+		if ( isParentLicense ) {
 			return (
 				<p>
 					{ translate(

--- a/client/jetpack-cloud/sections/partner-portal/types.ts
+++ b/client/jetpack-cloud/sections/partner-portal/types.ts
@@ -30,6 +30,12 @@ export enum LicenseType {
 	Partner = 'jetpack_partner_key',
 }
 
+export enum LicenseRole {
+	Parent = 'parent',
+	Child = 'child',
+	Single = 'single',
+}
+
 export interface AssignLicenceProps {
 	selectedSite?: SiteDetails | null;
 	suggestedProduct?: string;


### PR DESCRIPTION
This pull request adds a dropdown menu button for a bundle's license, allowing users to revoke the entire bundle. A separate revoke message is displayed to warn the user.

<img width="226" alt="Screen Shot 2023-12-08 at 2 50 42 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/d5db3d3c-f374-4ba8-95ba-0d2e75bbcd1b">

Closes https://github.com/Automattic/jetpack-genesis/issues/134

## Proposed Changes

* Adjust the licenses table to include a new dropdown button. Please note that this change will slightly affect the production table where additional spacing is added with the toggle container.
* Update the RevokeDialog to accommodate new messages for revoking a Bundle License.

## Testing Instructions
Before testing, please issue a license bundle. Go to `/issue-license?flags=jetpack/bundle-licensing`. If you can't see any bundles in your list, please update your billing scheme using the command 32b1d-pb in your WPCOM sandbox.

* Use the live link below, Go to `/partner-portal/licenses?flags=jetpack/bundle-licensing`
* Confirm that the dropdown menu button is visible for bundled licenses. Clicking this should reveal the revoke button.
* Revoke the license and confirm the correct messaging is displayed.
* Click the Revoke license button and confirm the bundled licenses are revoked.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?