### PR TITLE
Self-service site resets: show progress bar for Atomic resets

### DIFF
--- a/client/my-sites/site-settings/start-over.jsx
+++ b/client/my-sites/site-settings/start-over.jsx
@@ -1,9 +1,12 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { Button, Gridicon } from '@automattic/components';
-import { useSiteResetMutation, useSiteResetContentSummaryQuery } from '@automattic/data-stores';
-import { isSiteAtomic } from '@automattic/data-stores/src/site/selectors';
+import {
+	useSiteResetContentSummaryQuery,
+	useSiteResetMutation,
+	useSiteResetStatusQuery,
+} from '@automattic/data-stores';
 import { useLocalizeUrl } from '@automattic/i18n-utils';
-import { createInterpolateElement, useState } from '@wordpress/element';
+import { createInterpolateElement, useEffect, useState } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
@@ -16,6 +19,7 @@ import FormLabel from 'calypso/components/forms/form-label';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import HeaderCake from 'calypso/components/header-cake';
 import InlineSupportLink from 'calypso/components/inline-support-link';
+import { LoadingBar } from 'calypso/components/loading-bar';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -23,7 +27,7 @@ import { EMPTY_SITE } from 'calypso/lib/url/support';
 import { useDispatch, useSelector } from 'calypso/state';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import isUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
-import { getSite, getSiteDomain } from 'calypso/state/sites/selectors';
+import { getSite, getSiteDomain, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { BuiltByUpsell } from './built-by-upsell-banner';
 
@@ -113,7 +117,33 @@ function SiteResetCard( {
 	const dispatch = useDispatch();
 
 	const { data } = useSiteResetContentSummaryQuery( siteId );
+	const { data: status, refetch: refetchResetStatus } = useSiteResetStatusQuery( siteId );
+	let resetStatus = 'ready';
+	if ( status ) {
+		resetStatus = status.status;
+	}
 	const [ isDomainConfirmed, setDomainConfirmed ] = useState( false );
+	const [ resetProgress, setResetProgress ] = useState( 1 );
+
+	if ( resetStatus !== 'ready' && resetProgress === 1 ) {
+		//it's already in progress on load
+		setResetProgress( 0 );
+	}
+
+	useEffect( () => {
+		let interval = 1;
+		if ( resetProgress !== 1 ) {
+			interval = setInterval( async () => {
+				const {
+					data: { status: latestStatus },
+				} = await refetchResetStatus();
+				if ( latestStatus === 'ready' ) {
+					setResetProgress( 1 );
+				}
+			}, 3000 );
+		}
+		return () => clearInterval( interval );
+	}, [ resetProgress ] );
 
 	const handleError = () => {
 		dispatch(
@@ -125,6 +155,7 @@ function SiteResetCard( {
 	};
 
 	const handleResult = ( result ) => {
+		setResetProgress( 0 );
 		if ( result.success ) {
 			if ( isAtomic ) {
 				dispatch(
@@ -143,6 +174,7 @@ function SiteResetCard( {
 						duration: 4000,
 					} )
 				);
+				setResetProgress( 1 );
 			}
 		} else {
 			handleError();
@@ -203,11 +235,12 @@ function SiteResetCard( {
 		return result;
 	};
 
-	const handleReset = () => {
+	const handleReset = async () => {
 		if ( ! isDomainConfirmed ) {
 			return;
 		}
 		resetSite( siteId );
+		setDomainConfirmed( false );
 	};
 
 	const instructions = createInterpolateElement(
@@ -241,6 +274,8 @@ function SiteResetCard( {
 				}
 		  );
 
+	const isResetInProgress = resetProgress < 1;
+
 	return (
 		<Main className="site-settings__reset-site">
 			<NavigationHeader
@@ -259,59 +294,72 @@ function SiteResetCard( {
 			<HeaderCake backHref={ '/settings/general/' + selectedSiteSlug }>
 				<h1>{ translate( 'Site Reset' ) }</h1>
 			</HeaderCake>
-			<ActionPanel style={ { margin: 0 } }>
-				<ActionPanelBody>
-					<p>{ instructions }</p>
-					<p>{ translate( 'The following content will be removed:' ) }</p>
-					<ul>
-						{ contentInfo().map( ( { message, url } ) => {
-							if ( url ) {
-								return (
-									<li key={ message }>
-										<a href={ url }>{ message }</a>
-									</li>
-								);
-							}
-							return <li key={ message }>{ message }</li>;
-						} ) }
-					</ul>
-				</ActionPanelBody>
-				<ActionPanelFooter>
-					<FormLabel htmlFor="confirmResetInput" className="reset-site__confirm-label">
-						{ createInterpolateElement(
-							sprintf(
-								// translators: %s is the site domain
-								translate( 'Enter <strong>%s</strong> to continue' ),
-								siteDomain
-							),
-							{
-								strong: <strong />,
-							}
+			{ isResetInProgress ? (
+				<ActionPanel style={ { margin: 0 } }>
+					<ActionPanelBody>
+						<LoadingBar progress={ resetProgress / 100 } />
+						<p className="reset-site__in-progress-message">
+							{ translate( "We're resetting your site. We'll email you once it's ready." ) }
+						</p>
+					</ActionPanelBody>
+				</ActionPanel>
+			) : (
+				<ActionPanel style={ { margin: 0 } }>
+					<ActionPanelBody>
+						<p>{ instructions }</p>
+						<p>{ translate( 'The following content will be removed:' ) }</p>
+						<ul>
+							{ contentInfo().map( ( { message, url } ) => {
+								if ( url ) {
+									return (
+										<li key={ message }>
+											<a href={ url }>{ message }</a>
+										</li>
+									);
+								}
+								return <li key={ message }>{ message }</li>;
+							} ) }
+						</ul>
+					</ActionPanelBody>
+					<ActionPanelFooter>
+						<FormLabel htmlFor="confirmResetInput" className="reset-site__confirm-label">
+							{ createInterpolateElement(
+								sprintf(
+									// translators: %s is the site domain
+									translate( 'Enter <strong>%s</strong> to continue' ),
+									siteDomain
+								),
+								{
+									strong: <strong />,
+								}
+							) }
+						</FormLabel>
+						<div className="site-settings__reset-site-controls">
+							<FormTextInput
+								autoCapitalize="off"
+								aria-required="true"
+								id="confirmResetInput"
+								disabled={ isLoading }
+								style={ { flex: 0.5 } }
+								onChange={ ( event ) =>
+									setDomainConfirmed( event.currentTarget.value.trim() === siteDomain )
+								}
+							/>
+							<Button
+								primary // eslint-disable-line wpcalypso/jsx-classname-namespace
+								onClick={ handleReset }
+								disabled={ isLoading || ! isDomainConfirmed }
+								busy={ isLoading }
+							>
+								{ translate( 'Reset Site' ) }
+							</Button>
+						</div>
+						{ backupHint && (
+							<p className="site-settings__reset-site-backup-hint">{ backupHint }</p>
 						) }
-					</FormLabel>
-					<div className="site-settings__reset-site-controls">
-						<FormTextInput
-							autoCapitalize="off"
-							aria-required="true"
-							id="confirmResetInput"
-							disabled={ isLoading }
-							style={ { flex: 0.5 } }
-							onChange={ ( event ) =>
-								setDomainConfirmed( event.currentTarget.value.trim() === siteDomain )
-							}
-						/>
-						<Button
-							primary // eslint-disable-line wpcalypso/jsx-classname-namespace
-							onClick={ handleReset }
-							disabled={ isLoading || ! isDomainConfirmed }
-							busy={ isLoading }
-						>
-							{ translate( 'Reset Site' ) }
-						</Button>
-					</div>
-					{ backupHint && <p className="site-settings__reset-site-backup-hint">{ backupHint }</p> }
-				</ActionPanelFooter>
-			</ActionPanel>
+					</ActionPanelFooter>
+				</ActionPanel>
+			) }
 			<BuiltByUpsell site={ site } isUnlaunchedSite={ isUnlaunchedSiteProp } />
 		</Main>
 	);
@@ -325,7 +373,7 @@ export default connect( ( state ) => {
 		siteDomain,
 		site,
 		selectedSiteSlug: getSelectedSiteSlug( state ),
-		isAtomic: isSiteAtomic( state, siteId ),
+		isAtomic: isJetpackSite( state, siteId ),
 		isUnlaunchedSite: isUnlaunchedSite( state, siteId ),
 	};
 } )( localize( StartOver ) );

--- a/client/my-sites/site-settings/start-over.jsx
+++ b/client/my-sites/site-settings/start-over.jsx
@@ -25,6 +25,7 @@ import NavigationHeader from 'calypso/components/navigation-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { EMPTY_SITE } from 'calypso/lib/url/support';
 import { useDispatch, useSelector } from 'calypso/state';
+import { transferStates } from 'calypso/state/automated-transfer/constants';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import isUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
 import { getSite, getSiteDomain, isJetpackSite } from 'calypso/state/sites/selectors';
@@ -117,33 +118,50 @@ function SiteResetCard( {
 	const dispatch = useDispatch();
 
 	const { data } = useSiteResetContentSummaryQuery( siteId );
-	const { data: status, refetch: refetchResetStatus } = useSiteResetStatusQuery( siteId );
-	let resetStatus = 'ready';
-	if ( status ) {
-		resetStatus = status.status;
-	}
+	const {
+		data: status,
+		refetch: refetchResetStatus,
+		isFetching: isFetchingResetStatus,
+	} = useSiteResetStatusQuery( siteId );
+	const [ resetStatus, setResetStatus ] = useState( status?.status ?? 'completed' );
+	const [ wasResetting, setWasReseting ] = useState( false );
 	const [ isDomainConfirmed, setDomainConfirmed ] = useState( false );
-	const [ resetProgress, setResetProgress ] = useState( 1 );
-
-	if ( resetStatus !== 'ready' && resetProgress === 1 ) {
-		//it's already in progress on load
-		setResetProgress( 0 );
-	}
+	const [ resetProgress, setResetProgress ] = useState( 0.1 );
 
 	useEffect( () => {
 		let interval = 1;
-		if ( resetProgress !== 1 ) {
+		if ( ! siteId || resetStatus === 'completed' ) {
+			return;
+		}
+		if ( ! isFetchingResetStatus ) {
 			interval = setInterval( async () => {
 				const {
 					data: { status: latestStatus },
 				} = await refetchResetStatus();
-				if ( latestStatus === 'ready' ) {
-					setResetProgress( 1 );
-				}
+				setResetStatus( latestStatus );
 			}, 3000 );
 		}
 		return () => clearInterval( interval );
-	}, [ resetProgress ] );
+	}, [ isFetchingResetStatus, refetchResetStatus, resetStatus, siteId ] );
+
+	useEffect( () => {
+		setResetProgress( ( prevProgress ) => {
+			switch ( resetStatus ) {
+				case null:
+					return 0.1;
+				case transferStates.RELOCATING_REVERT:
+				case transferStates.ACTIVE:
+					return 0.5;
+				case transferStates.PROVISIONED:
+					return 0.6;
+				case transferStates.REVERTED:
+				case transferStates.RELOCATING:
+					return 0.85;
+				default:
+					return prevProgress + 0.05;
+			}
+		} );
+	}, [ resetStatus ] );
 
 	const handleError = () => {
 		dispatch(
@@ -154,32 +172,7 @@ function SiteResetCard( {
 		);
 	};
 
-	const handleResult = ( result ) => {
-		setResetProgress( 0 );
-		if ( result.success ) {
-			if ( isAtomic ) {
-				dispatch(
-					successNotice( translate( 'Your site will be reset. ' ), {
-						id: 'site-reset-success-notice',
-						duration: 6000,
-					} )
-				);
-			} else {
-				dispatch(
-					successNotice( translate( 'Your site has been reset.' ), {
-						id: 'site-reset-success-notice',
-						duration: 4000,
-					} )
-				);
-				setResetProgress( 1 );
-			}
-		} else {
-			handleError();
-		}
-	};
-
 	const { resetSite, isLoading } = useSiteResetMutation( {
-		onSuccess: handleResult,
 		onError: handleError,
 	} );
 
@@ -236,6 +229,9 @@ function SiteResetCard( {
 		if ( ! isDomainConfirmed ) {
 			return;
 		}
+		setResetStatus( null );
+		setWasReseting( true );
+		setResetProgress( 0.1 );
 		resetSite( siteId );
 		setDomainConfirmed( false );
 	};
@@ -271,7 +267,29 @@ function SiteResetCard( {
 				}
 		  );
 
-	const isResetInProgress = resetProgress < 1;
+	const isSiteResetComplete = resetStatus === 'completed';
+
+	const isResetInProgress = ! isSiteResetComplete && ( resetStatus !== null || wasResetting );
+
+	useEffect( () => {
+		if ( wasResetting && isSiteResetComplete && ! isLoading ) {
+			dispatch(
+				successNotice( translate( 'Your site has been reset.' ), {
+					id: 'site-reset-success-notice',
+					duration: 4000,
+				} )
+			);
+		}
+	}, [ dispatch, isSiteResetComplete, translate, wasResetting, isLoading ] );
+
+	useEffect( () => {
+		// if user navigates away or reset the page while reset in progress
+		// we continue show progress bar when user comes back
+		// if reset is incomplete and siteId is present;
+		if ( ! wasResetting && ! isSiteResetComplete && siteId ) {
+			setWasReseting( true );
+		}
+	}, [ wasResetting, isSiteResetComplete, siteId ] );
 
 	return (
 		<Main className="site-settings__reset-site">
@@ -291,10 +309,10 @@ function SiteResetCard( {
 			<HeaderCake backHref={ '/settings/general/' + selectedSiteSlug }>
 				<h1>{ translate( 'Site Reset' ) }</h1>
 			</HeaderCake>
-			{ isResetInProgress ? (
+			{ isResetInProgress && isAtomic ? (
 				<ActionPanel style={ { margin: 0 } }>
 					<ActionPanelBody>
-						<LoadingBar progress={ resetProgress / 100 } />
+						<LoadingBar progress={ resetProgress } />
 						<p className="reset-site__in-progress-message">
 							{ translate( "We're resetting your site. We'll email you once it's ready." ) }
 						</p>

--- a/client/my-sites/site-settings/start-over.jsx
+++ b/client/my-sites/site-settings/start-over.jsx
@@ -159,13 +159,10 @@ function SiteResetCard( {
 		if ( result.success ) {
 			if ( isAtomic ) {
 				dispatch(
-					successNotice(
-						translate( 'Your site will be reset. It can take up to one minute to complete. ' ),
-						{
-							id: 'site-reset-success-notice',
-							duration: 6000,
-						}
-					)
+					successNotice( translate( 'Your site will be reset. ' ), {
+						id: 'site-reset-success-notice',
+						duration: 6000,
+					} )
 				);
 			} else {
 				dispatch(
@@ -267,7 +264,7 @@ function SiteResetCard( {
 		  )
 		: createInterpolateElement(
 				translate(
-					'To keep a copy of your current site, head to the <a>Export page</a> before reseting your site.'
+					'To keep a copy of your current site, head to the <a>Export page</a> before resetting.'
 				),
 				{
 					a: <a href={ `/settings/export/${ selectedSiteSlug }` } />,

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -747,6 +747,11 @@ button.site-settings__general-settings-set-guessed-timezone.button.is-borderless
 	.banner {
 		margin-top: 16px;
 	}
+
+	.reset-site__in-progress-message {
+		color: var(--gray-gray-100, #101517);
+		margin-top: 8px;
+	}
 }
 
 .site-settings__reset-site-backup-hint {

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -733,7 +733,7 @@ button.site-settings__general-settings-set-guessed-timezone.button.is-borderless
 }
 
 .site-settings__reset-site {
-	.card {
+	.card.action-panel {
 		margin-bottom: 0;
 		padding: 24px;
 	}

--- a/packages/data-stores/src/site-reset/index.ts
+++ b/packages/data-stores/src/site-reset/index.ts
@@ -1,2 +1,3 @@
 export * from './use-site-reset-content-summary-query';
 export * from './use-site-reset-mutation';
+export * from './use-site-reset-status-query';

--- a/packages/data-stores/src/site-reset/use-site-reset-status-query.ts
+++ b/packages/data-stores/src/site-reset/use-site-reset-status-query.ts
@@ -3,7 +3,7 @@ import wpcomRequest from 'wpcom-proxy-request';
 import { APIError } from './use-site-reset-mutation';
 
 export type SiteResetStatus = {
-	status: 'in-progress' | 'ready';
+	status: string;
 };
 
 export const useSiteResetStatusQuery = (

--- a/packages/data-stores/src/site-reset/use-site-reset-status-query.ts
+++ b/packages/data-stores/src/site-reset/use-site-reset-status-query.ts
@@ -1,0 +1,23 @@
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import wpcomRequest from 'wpcom-proxy-request';
+import { APIError } from './use-site-reset-mutation';
+
+export type SiteResetStatus = {
+	status: 'in-progress' | 'ready';
+};
+
+export const useSiteResetStatusQuery = (
+	siteId: number
+): UseQueryResult< SiteResetStatus, APIError > => {
+	const queryKey = [ 'site-reset-status', siteId ];
+
+	return useQuery< SiteResetStatus, APIError >( {
+		queryKey,
+		queryFn: () => {
+			return wpcomRequest( {
+				path: `/sites/${ siteId }/reset-site/status`,
+				apiNamespace: 'wpcom/v2',
+			} );
+		},
+	} );
+};

--- a/packages/data-stores/src/site-reset/use-site-reset-status-query.ts
+++ b/packages/data-stores/src/site-reset/use-site-reset-status-query.ts
@@ -3,7 +3,7 @@ import wpcomRequest from 'wpcom-proxy-request';
 import { APIError } from './use-site-reset-mutation';
 
 export type SiteResetStatus = {
-	status: string;
+	status: 'in-progress' | 'ready';
 };
 
 export const useSiteResetStatusQuery = (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/4812

<img width="1001" alt="Screenshot 2566-12-08 at 14 17 16" src="https://github.com/Automattic/wp-calypso/assets/6851384/88e7031c-c48c-4708-9890-d1e2aa763660">


## Proposed Changes

* Show a progress bar when an Atomic reset is in progress. This will kick in on load or after a reset request is accepted. It should clear once the reset is complete, and at that point, you should be able to queue another reset request. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use this branch or Calypso Live
* If using Calypso Live, be sure to append `?flags=settings/self-serve-site-reset` to your URLs
* Go to `/settings/start-over/:atomic-site` and do a reset
* Confirm progress UI is shown
* Do a hard refresh and confirm it persists
* Try `/settings/start-over/:simple-site`, and you won't see a progress bar as that blocks until complete.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?