### PR TITLE
Free Flow: Complete the setup_free task after the site created

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/style.scss
@@ -366,7 +366,6 @@
 
 // Free flow
 .free.launchpad {
-	padding: 0;
 	.signup-header {
 		display: none;
 	}
@@ -378,7 +377,6 @@
 
 // Link in Bio flow
 .link-in-bio-tld.launchpad {
-	padding: 0;
 	.signup-header {
 		display: none;
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/link-in-bio-setup/styles.scss
@@ -26,7 +26,3 @@ $font-family: "SF Pro Text", $sans;
 		}
 	}
 }
-
-.link-in-bio.launchpad .launchpad__sidebar-header {
-	display: none;
-}

--- a/packages/onboarding/src/setup-tailored-site-after-creation.ts
+++ b/packages/onboarding/src/setup-tailored-site-after-creation.ts
@@ -1,5 +1,11 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { Onboard, Site, OnboardSelect, SiteActions } from '@automattic/data-stores';
+import {
+	Onboard,
+	Site,
+	OnboardSelect,
+	SiteActions,
+	updateLaunchpadSettings,
+} from '@automattic/data-stores';
 import { select, dispatch } from '@wordpress/data';
 import wpcomRequest from 'wpcom-proxy-request';
 import {
@@ -127,6 +133,16 @@ export function setupSiteAfterCreation( { siteId, flowName }: SetupOnboardingSit
 				// resetOnboardStore();
 			} )
 		);
+
+		if ( isFreeFlow( flowName ) ) {
+			if ( siteTitle || siteDescription || siteLogo ) {
+				promises.push(
+					updateLaunchpadSettings( siteId, {
+						checklist_statuses: { setup_free: true },
+					} )
+				);
+			}
+		}
 
 		return Promise.all( promises );
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack/pull/34511

## Proposed Changes

* We made changes to avoid the setup_free task being marked as completed at the beginning via https://github.com/Automattic/jetpack/pull/34511. However, the free flow finishes that step before the site creation. As a result, the PR completes that task for the free flow right after the site creation.

> [!NOTE]
> Another way is to create a new task that is not marked as completed at the beginning instead of using the same task id. Any thoughts?

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /setup/free to create a new site
* Continue to land on the lanchpad
* On the launchpad, the “Personalize your site” should be marked as completed

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?