### PR TITLE
Jetpack Manage: Improve Issue license page header with actions responsiveness breakpoint.

### DIFF
--- a/client/jetpack-cloud/components/layout/header.tsx
+++ b/client/jetpack-cloud/components/layout/header.tsx
@@ -74,7 +74,11 @@ export default function LayoutHeader( { showStickyContent, children }: Props ) {
 					'jetpack-cloud-layout__sticky-header': showStickyContent && hasCrossed,
 				} ) }
 			>
-				<div className={ classNames( 'jetpack-cloud-layout__header' ) }>
+				<div
+					className={ classNames( 'jetpack-cloud-layout__header', {
+						'has-actions': !! headerActions,
+					} ) }
+				>
 					<div className="jetpack-cloud-layout__header-main">
 						{ headerTitle }
 						{ headerSubtitle }

--- a/client/jetpack-cloud/components/layout/style.scss
+++ b/client/jetpack-cloud/components/layout/style.scss
@@ -71,22 +71,26 @@
 	margin: auto;
 	height: 100%;
 
-
 	> * + * {
 		margin-inline-start: 24px;
 	}
 
-	@include breakpoint-deprecated( "<960px" ) {
+	@include breakpoint-deprecated( "<1280px" ) {
 		flex-wrap: wrap;
 
 		> * {
 			width: 100%;
-			margin-block-end: 16px;
 		}
 
 		> * + * {
 			margin-inline-start: 0;
 		}
+	}
+}
+
+.jetpack-cloud-layout__header.has-actions > .jetpack-cloud-layout__header-main {
+	@include breakpoint-deprecated( "<1280px" ) {
+		margin-block-end: 16px;
 	}
 }
 

--- a/client/jetpack-cloud/components/layout/style.scss
+++ b/client/jetpack-cloud/components/layout/style.scss
@@ -160,6 +160,8 @@
 }
 
 .section-nav.jetpack-cloud-layout__navigation {
+	margin-block-start: 16px;
+
 	.section-nav__mobile-header-text .count {
 		margin-inline-start: 8px;
 	}

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/index.tsx
@@ -93,8 +93,8 @@ export default function IssueLicenseV2( { selectedSite, suggestedProduct }: Assi
 						<Subtitle>
 							{ translate( 'Select single product licenses or save when you issue in bulk' ) }
 						</Subtitle>
-						<Actions>
-							{ selectedLicenses.length > 0 && (
+						{ selectedLicenses.length > 0 && (
+							<Actions>
 								<div className="issue-license-v2__controls">
 									<div className="issue-license-v2__actions">
 										<TotalCost selectedLicenses={ selectedLicenses } />
@@ -118,8 +118,8 @@ export default function IssueLicenseV2( { selectedSite, suggestedProduct }: Assi
 										</Button>
 									</div>
 								</div>
-							) }
-						</Actions>
+							</Actions>
+						) }
 					</LayoutHeader>
 
 					<LayoutNavigation selectedText={ selectedText }>


### PR DESCRIPTION
This pull request aims to improve the header behavior when it collapses at certain breakpoints. Currently, the heading and action container are too close to each other, which causes some issues. This changes fix this particular problem.

**Before**
<img width="767" alt="Screen Shot 2023-12-08 at 4 16 57 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/d6d1d7b0-35d2-4d5f-b2c2-dc1ced639659">

**After**
<img width="709" alt="Screen Shot 2023-12-08 at 4 17 29 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/150866c9-59ed-4b11-8ced-4237d17f6a5c">

Closes https://github.com/Automattic/jetpack-genesis/issues/132

## Proposed Changes

* Update the breakpoint to 1280px from 960px to prevent the heading and actions from getting too close.
* **Extra: Fix an issue where the viewport allocates a few margin spacing for the action container even though there are no actions to display.**

## Testing Instructions
Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

* Use the Jetpack cloud live link below and Go to the Issue License page (`/partner-portal/issue-license?flags=jetpack/bundle-licensing`)
* Select some license so that the **Review license** button appears.
* Resize your browser and confirm that the header collapses correctly.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?