### PR TITLE
Staging Sites: Clarify error message for failed staging sync

### DIFF
--- a/client/my-sites/hosting/staging-site-card/card-content/staging-sync-card.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/staging-sync-card.tsx
@@ -354,11 +354,14 @@ const SyncCardContainer = ( {
 							status="is-error"
 							icon="mention"
 							showDismiss={ false }
-							text={ translate( 'We couldn’t synchronize changes to the %(siteType)s site.', {
-								args: {
-									siteType: siteToSync,
-								},
-							} ) }
+							text={ translate(
+								'We couldn’t synchronize changes to the %(siteType)s site and will need to manually diagnose the issue. Please contact support.',
+								{
+									args: {
+										siteType: siteToSync,
+									},
+								}
+							) }
 						>
 							<NoticeAction href="/help">{ translate( 'Contact support' ) }</NoticeAction>
 						</Notice>

--- a/client/my-sites/hosting/staging-site-card/card-content/staging-sync-card.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/staging-sync-card.tsx
@@ -355,7 +355,7 @@ const SyncCardContainer = ( {
 							icon="mention"
 							showDismiss={ false }
 							text={ translate(
-								'We couldn’t synchronize changes to the %(siteType)s site and will need to manually diagnose the issue. Please contact support.',
+								'We couldn’t synchronize changes to the %(siteType)s site. Please contact support.',
 								{
 									args: {
 										siteType: siteToSync,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4784

## Proposed Changes

In this PR, I propose to add more details to the error message displayed when production-staging site synchronization fails.

![Screenshot 2023-12-12 at 17 16 26](https://github.com/Automattic/wp-calypso/assets/727413/ea94eb4d-a8b9-4c47-8fa5-3cd9a01d2268)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a site with a Business plan
2. Activate hosting features, create a staging site, run synchronization
3. Using snippet from D131105-code, change sync status to `failed` and confirm that updated error message is displayed
4. Change sync status back to `completed`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?