### PR TITLE
Fixed info icon margins in user list

### DIFF
--- a/client/my-sites/people/people-profile/style.scss
+++ b/client/my-sites/people/people-profile/style.scss
@@ -114,4 +114,9 @@
 .people-profile__role-badge-info {
 	float: left;
 	margin-left: 4px;
+	margin-top: 2px;
+
+	button {
+		line-height: 12px;
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/68487

## Proposed Changes

This PR fixes the margin top of the info icon in the user list, From this:

<img width="400" alt="Screenshot 2023-12-08 at 11 05 48" src="https://github.com/Automattic/wp-calypso/assets/3832570/a91065d5-4fed-4479-8be0-c65e985919f4">

to this:
<img width="364" alt="Screenshot 2023-12-08 at 11 06 14" src="https://github.com/Automattic/wp-calypso/assets/3832570/f76705fc-9ed4-470e-878f-29f1112f7b6a">

Some screenshots of the result:

Desktop:

<img width="1079" alt="Screenshot 2023-12-08 at 11 06 04" src="https://github.com/Automattic/wp-calypso/assets/3832570/1b71cb2e-69d8-4641-beae-e1c0b64807b4">

Mobile:

<img width="359" alt="Screenshot 2023-12-08 at 11 06 23" src="https://github.com/Automattic/wp-calypso/assets/3832570/eb060928-e251-48e6-9e3c-818e214b74f7">


## Testing Instructions

- Apply this PR and start the application.
- Go to http://calypso.localhost:3000/people/team/[the domain of your site].
- Add or modify a user so it becomes contractor by checking the corresponding checkbox:
<img width="766" alt="Screenshot 2023-12-08 at 11 11 19" src="https://github.com/Automattic/wp-calypso/assets/3832570/ff8fc095-0f17-481b-93ea-1fc1cb78bae5">
- Go back to the list of users and behold a well placed `i` info icon.
- Click on the icon and check that the info popup is still showing.
- Change to mobile view and check the `i` icon is still there.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?