### PR TITLE
Assembler First: Don't use the new base theme (season 2)

### DIFF
--- a/client/landing/stepper/declarative-flow/assembler-first-flow.ts
+++ b/client/landing/stepper/declarative-flow/assembler-first-flow.ts
@@ -1,5 +1,5 @@
 import { Onboard, updateLaunchpadSettings } from '@automattic/data-stores';
-import { getAssemblerDesign, isAssemblerSupported } from '@automattic/design-picker';
+import { DEFAULT_ASSEMBLER_DESIGN, isAssemblerSupported } from '@automattic/design-picker';
 import { useLocale } from '@automattic/i18n-utils';
 import { ASSEMBLER_FIRST_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -34,7 +34,7 @@ const assemblerFirstFlow: Flow = {
 			[]
 		);
 		const { setSelectedDesign, setIntent } = useDispatch( ONBOARD_STORE );
-		const selectedTheme = getAssemblerDesign().slug;
+		const selectedTheme = DEFAULT_ASSEMBLER_DESIGN.slug;
 		const theme = useSelector( ( state ) => getTheme( state, 'wpcom', selectedTheme ) );
 
 		// We have to query theme for the Jetpack site.

--- a/packages/design-picker/src/utils/designs.ts
+++ b/packages/design-picker/src/utils/designs.ts
@@ -70,7 +70,7 @@ export const getDesignPreviewUrl = (
 };
 
 export const getAssemblerDesign = () => {
-	if ( isEnabled( 'pattern-assembler/v2' ) && ! isEnabled( 'themes/assembler-first' ) ) {
+	if ( isEnabled( 'pattern-assembler/v2' ) ) {
 		return ASSEMBLER_V2_DESIGN;
 	}
 	return DEFAULT_ASSEMBLER_DESIGN;


### PR DESCRIPTION
## Proposed Changes

This is an alternative to https://github.com/Automattic/wp-calypso/pull/85019, so that in Horizon:

- Assembler flow uses the new base theme,
- Assembler-First flow still uses the old base theme (Creatio 2)

We will consolidate the Assembler designs after the new base theme is finalized.

## Testing Instructions

1. Enable the `pattern-assembler/v2` flag (on Calypso Live or locally)
1. Go to Assembler Flow, make sure that you see the new base theme in the flow and in the final site.
1. Go to Assembler-First Flow (`/setup/assembler-first`), make sure that you see the old base theme in the flow and in the final site.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?