### PR TITLE
PlanPrice to packages (Step 3): Update references to use new package component

### DIFF
--- a/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-details.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/upgrade-plan-details.tsx
@@ -1,6 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { getPlan, PLAN_BUSINESS, PLAN_BUSINESS_MONTHLY } from '@automattic/calypso-products';
-import { CloudLogo, Button } from '@automattic/components';
+import { CloudLogo, Button, PlanPrice } from '@automattic/components';
 import { Title } from '@automattic/onboarding';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
@@ -8,7 +8,6 @@ import React, { useState, useEffect } from 'react';
 import ButtonGroup from 'calypso/components/button-group';
 import QueryPlans from 'calypso/components/data/query-plans';
 import { useSelectedPlanUpgradeMutation } from 'calypso/data/import-flow/use-selected-plan-upgrade';
-import PlanPrice from 'calypso/my-sites/plan-price';
 import { Plans2023Tooltip } from 'calypso/my-sites/plans-grid/components/plans-2023-tooltip';
 import { useManageTooltipToggle } from 'calypso/my-sites/plans-grid/hooks/use-manage-tooltip-toggle';
 import { useSelector } from 'calypso/state';

--- a/client/components/backup-storage-space/usage-warning/upsell.tsx
+++ b/client/components/backup-storage-space/usage-warning/upsell.tsx
@@ -1,7 +1,7 @@
+import { PlanPrice } from '@automattic/components';
 import classNames from 'classnames';
 import { useCallback, useEffect } from 'react';
 import TimeFrame from 'calypso/components/jetpack/card/jetpack-product-card/display-price/time-frame';
-import PlanPrice from 'calypso/my-sites/plan-price';
 import { buildCheckoutURL } from 'calypso/my-sites/plans/jetpack-plans/get-purchase-url-callback';
 import { SelectorProduct } from 'calypso/my-sites/plans/jetpack-plans/types';
 import { useDispatch } from 'calypso/state';

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -8,7 +8,7 @@ import {
 	GROUP_JETPACK,
 	GROUP_WPCOM,
 } from '@automattic/calypso-products';
-import { Button, Card, Gridicon } from '@automattic/components';
+import { Button, Card, Gridicon, PlanPrice } from '@automattic/components';
 import { isMobile } from '@automattic/viewport';
 import classNames from 'classnames';
 import DOMPurify from 'dompurify';
@@ -21,7 +21,6 @@ import JetpackLogo from 'calypso/components/jetpack-logo';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { preventWidows } from 'calypso/lib/formatting';
 import { addQueryArgs } from 'calypso/lib/url';
-import PlanPrice from 'calypso/my-sites/plan-price';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';

--- a/client/components/banner/test/index.jsx
+++ b/client/components/banner/test/index.jsx
@@ -9,15 +9,6 @@ import preferencesReducer from 'calypso/state/preferences/reducer';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import { Banner } from '../index';
 
-jest.mock( 'calypso/my-sites/plan-price', () => ( { rawPrice, original } ) => (
-	<div
-		data-testid="banner-price-plan-mock"
-		className={ original ? 'is-original' : 'is-discounted' }
-	>
-		{ rawPrice }
-	</div>
-) );
-
 jest.mock( 'calypso/state/analytics/actions', () => ( {
 	recordTracksEvent: jest.fn( () => ( {
 		type: 'ANALYTICS_EVENT_RECORD',
@@ -77,23 +68,24 @@ describe( 'Banner basic tests', () => {
 	} );
 
 	test( 'should render a <PlanPrice /> when price is specified', () => {
-		render( <Banner { ...props } price={ 100 } /> );
-		expect( screen.queryByTestId( 'banner-price-plan-mock' ) ).toHaveTextContent( '100' );
+		const { container } = render( <Banner { ...props } price={ 100 } /> );
+		expect( container.getElementsByClassName( 'plan-price' ) ).toHaveLength( 1 );
+		const [ price ] = container.getElementsByClassName( 'plan-price__integer' );
+		expect( price ).toHaveTextContent( '100' );
 	} );
 
 	test( 'should render two <PlanPrice /> components when there are two prices', () => {
-		render( <Banner { ...props } price={ [ 100, 80 ] } /> );
-		const planPriceMock = screen.queryAllByTestId( 'banner-price-plan-mock' );
-		expect( planPriceMock ).toHaveLength( 2 );
-		expect( planPriceMock[ 0 ] ).toHaveTextContent( 100 );
-		expect( planPriceMock[ 0 ] ).toHaveAttribute( 'class', 'is-original' );
-		expect( planPriceMock[ 1 ] ).toHaveTextContent( 80 );
-		expect( planPriceMock[ 1 ] ).toHaveAttribute( 'class', 'is-discounted' );
+		const { container } = render( <Banner { ...props } price={ [ 100, 80 ] } /> );
+		expect( container.getElementsByClassName( 'plan-price' ) ).toHaveLength( 2 );
+
+		const [ price1, price2 ] = container.getElementsByClassName( 'plan-price__integer' );
+		expect( price1 ).toHaveTextContent( 100 );
+		expect( price2 ).toHaveTextContent( 80 );
 	} );
 
 	test( 'should render no <PlanPrice /> components when there are no prices', () => {
 		render( <Banner { ...props } /> );
-		expect( screen.queryByTestId( 'banner-price-plan-mock' ) ).not.toBeInTheDocument();
+		expect( screen.queryByTestId( 'plan-price' ) ).not.toBeInTheDocument();
 	} );
 
 	test( 'should render a .banner__description when description is specified', () => {

--- a/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/display-price/paid.tsx
@@ -1,7 +1,7 @@
+import { PlanPrice } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import { TranslateResult } from 'i18n-calypso';
 import InfoPopover from 'calypso/components/info-popover';
-import PlanPrice from 'calypso/my-sites/plan-price';
 import PriceAriaLabel from './price-aria-label';
 import TimeFrame from './time-frame';
 import type { Duration } from 'calypso/my-sites/plans/jetpack-plans/types';

--- a/client/components/premium-global-styles-upgrade-modal/index.tsx
+++ b/client/components/premium-global-styles-upgrade-modal/index.tsx
@@ -1,12 +1,11 @@
 import { PLAN_PREMIUM } from '@automattic/calypso-products';
-import { Button, Gridicon, Dialog, ScreenReaderText } from '@automattic/components';
+import { Button, Gridicon, Dialog, ScreenReaderText, PlanPrice } from '@automattic/components';
 import { formatCurrency } from '@automattic/format-currency';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import QueryPlans from 'calypso/components/data/query-plans';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
-import PlanPrice from 'calypso/my-sites/plan-price';
 import usePricingMetaForGridPlans from 'calypso/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans';
 import useCheckPlanAvailabilityForPurchase from 'calypso/my-sites/plans-features-main/hooks/use-check-plan-availability-for-purchase';
 import { useSelector } from 'calypso/state';

--- a/client/components/product-card/price-group.jsx
+++ b/client/components/product-card/price-group.jsx
@@ -1,6 +1,6 @@
+import { PlanPrice } from '@automattic/components';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import PlanPrice from 'calypso/my-sites/plan-price';
 
 const ProductCardPriceGroup = ( props ) => {
 	const { billingTimeFrame, currencyCode, discountedPrice, fullPrice } = props;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.tsx
@@ -1,12 +1,11 @@
 import { PLAN_PREMIUM } from '@automattic/calypso-products';
-import { Button, Gridicon, LoadingPlaceholder } from '@automattic/components';
+import { Button, Gridicon, LoadingPlaceholder, PlanPrice } from '@automattic/components';
 import { formatCurrency } from '@automattic/format-currency';
 import { NavigatorHeader } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import QueryPlans from 'calypso/components/data/query-plans';
 import useGlobalStylesUpgradeTranslations from 'calypso/components/premium-global-styles-upgrade-modal/use-global-styles-upgrade-translations';
-import PlanPrice from 'calypso/my-sites/plan-price';
 import usePricingMetaForGridPlans from 'calypso/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans';
 import useCheckPlanAvailabilityForPurchase from 'calypso/my-sites/plans-features-main/hooks/use-check-plan-availability-for-purchase';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/index.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
+import { PlanPrice } from '@automattic/components';
 import { useLocale } from '@automattic/i18n-utils';
 import { useSelect } from '@wordpress/data';
 import { useCallback, useState } from '@wordpress/element';
@@ -11,7 +12,6 @@ import PlanItem from 'calypso/../packages/plans-grid/src/plans-table/plan-item';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import PlanPrice from 'calypso/my-sites/plan-price';
 import { SenseiStepContainer } from '../components/sensei-step-container';
 import { SenseiStepError } from '../components/sensei-step-error';
 import { SenseiStepProgress } from '../components/sensei-step-progress';

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -49,6 +49,7 @@ import {
 	CompactCard,
 	ProductIcon,
 	Gridicon,
+	PlanPrice,
 } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import classNames from 'classnames';
@@ -106,7 +107,6 @@ import ProductLink from 'calypso/me/purchases/product-link';
 import titles from 'calypso/me/purchases/titles';
 import TrackPurchasePageView from 'calypso/me/purchases/track-purchase-page-view';
 import WordAdsEligibilityWarningDialog from 'calypso/me/purchases/wordads-eligibility-warning-dialog';
-import PlanPrice from 'calypso/my-sites/plan-price';
 import PlanRenewalMessage from 'calypso/my-sites/plans/jetpack-plans/plan-renewal-message';
 import {
 	getCancelPurchaseUrlFor,

--- a/client/my-sites/migrate/step-upgrade.jsx
+++ b/client/my-sites/migrate/step-upgrade.jsx
@@ -1,5 +1,5 @@
 import { getPlan, PLAN_BUSINESS } from '@automattic/calypso-products';
-import { CompactCard, ProductIcon, Gridicon } from '@automattic/components';
+import { CompactCard, ProductIcon, Gridicon, PlanPrice } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
@@ -8,7 +8,6 @@ import { connect } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
 import QueryPlans from 'calypso/components/data/query-plans';
 import HeaderCake from 'calypso/components/header-cake';
-import PlanPrice from 'calypso/my-sites/plan-price';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import { getPlanRawPrice } from 'calypso/state/plans/selectors';

--- a/client/my-sites/plans-grid/components/header-price.tsx
+++ b/client/my-sites/plans-grid/components/header-price.tsx
@@ -1,7 +1,7 @@
 import { isWpcomEnterpriseGridPlan, type PlanSlug } from '@automattic/calypso-products';
+import { PlanPrice } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
-import PlanPrice from 'calypso/my-sites/plan-price';
 import { usePlansGridContext } from '../grid-context';
 import type { GridPlan } from '../hooks/npm-ready/data-store/use-grid-plans';
 

--- a/client/my-sites/plans/jetpack-plans/product-lightbox/payment-plan.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/payment-plan.tsx
@@ -1,9 +1,9 @@
+import { PlanPrice } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import TimeFrame from 'calypso/components/jetpack/card/jetpack-product-card/display-price/time-frame';
-import PlanPrice from 'calypso/my-sites/plan-price';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import { useItemPriceCompact } from '../product-store/hooks/use-item-price-compact';

--- a/client/my-sites/plans/jetpack-plans/product-store/pricing-breakdown/render-price.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/pricing-breakdown/render-price.tsx
@@ -1,4 +1,4 @@
-import PlanPrice from 'calypso/my-sites/plan-price';
+import { PlanPrice } from '@automattic/components';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 

--- a/client/my-sites/plans/jetpack-plans/upsell/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/upsell/index.tsx
@@ -7,7 +7,7 @@ import {
 	getJetpackProductsDisplayNames,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
-import { Gridicon, Button } from '@automattic/components';
+import { Gridicon, Button, PlanPrice } from '@automattic/components';
 import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
 import { useEffect, useMemo, useCallback } from 'react';
@@ -16,7 +16,6 @@ import QuerySiteProducts from 'calypso/components/data/query-site-products';
 import { useExperiment } from 'calypso/lib/explat';
 import { preventWidows } from 'calypso/lib/formatting';
 import badge14Src from 'calypso/my-sites/checkout/src/components/assets/icons/badge-14.svg';
-import PlanPrice from 'calypso/my-sites/plan-price';
 import { GUARANTEE_DAYS } from 'calypso/my-sites/plans/jetpack-plans/constants';
 import { buildCheckoutURL } from 'calypso/my-sites/plans/jetpack-plans/get-purchase-url-callback';
 import useItemPrice from 'calypso/my-sites/plans/jetpack-plans/use-item-price';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/84912
Branched from https://github.com/Automattic/wp-calypso/pull/85026

We should wait for https://github.com/Automattic/wp-calypso/pull/85026 to sit in production for several days before merging this PR. It will allow us to see if there were any problems with our migration.

## Proposed Changes

- Repoints any references to `PlanPrice` from Calypso components to `@automattic/components`
- This is a change that touches many files. We effectively made this change in the background with https://github.com/Automattic/wp-calypso/pull/85026, so all `PlanPrice` components are running the new/relocated code already. This PR repoints the reference from the wrapper to the "real" code, so I don't expect this to cause any issues.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Make sure tests pass.
- Do a spot-check of `PlanPrice` instances to ensure they still look/work as expected. See https://github.com/Automattic/wp-calypso/pull/85026 for some examples.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?