### PR TITLE
Show only launchpad on Subscriber Stats when no subscribers.

### DIFF
--- a/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
@@ -2,11 +2,8 @@ import config from '@automattic/calypso-config';
 import { CountComparisonCard } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import QueryMembershipProducts from 'calypso/components/data/query-memberships';
-import { SubscriberLaunchpad } from 'calypso/my-sites/subscribers/components/subscriber-launchpad';
 import { useSelector } from 'calypso/state';
 import './style.scss';
-import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
-import { isSimpleSite } from 'calypso/state/sites/selectors';
 import useSubscribersTotalsQueries from '../hooks/use-subscribers-totals-query';
 
 function useSubscriberHighlights(
@@ -105,23 +102,11 @@ function SubscriberHighlightsListing( { siteId }: { siteId: number | null } ) {
 	);
 }
 
-function SubscriberLaunchpadSection( { siteId }: { siteId: number | null } ) {
-	const { data: subscribersTotals, isLoading } = useSubscribersTotalsQueries( siteId );
-
-	const isSimple = useSelector( isSimpleSite );
-	const isAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
-
-	const showLaunchpad = ! isLoading && ( isSimple || isAtomic ) && ! subscribersTotals?.total;
-
-	return showLaunchpad ? <SubscriberLaunchpad launchpadContext="subscriber-stats" /> : <></>;
-}
-
 export default function SubscribersHighlightSection( { siteId }: { siteId: number | null } ) {
 	return (
 		<div className="highlight-cards subscribers-page has-odyssey-stats-bg-color">
 			<SubscriberHighlightsHeader />
 			<SubscriberHighlightsListing siteId={ siteId } />
-			<SubscriberLaunchpadSection siteId={ siteId } />
 		</div>
 	);
 }

--- a/client/my-sites/stats/stats-subscribers/index.tsx
+++ b/client/my-sites/stats/stats-subscribers/index.tsx
@@ -10,13 +10,17 @@ import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
 import version_compare from 'calypso/lib/version-compare';
+import { SubscriberLaunchpad } from 'calypso/my-sites/subscribers/components/subscriber-launchpad';
 import { useSelector } from 'calypso/state';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import {
 	isJetpackSite,
 	getSiteSlug,
 	getJetpackStatsAdminVersion,
+	isSimpleSite,
 } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import useSubscribersTotalsQueries from '../hooks/use-subscribers-totals-query';
 import Followers from '../stats-followers';
 import StatsModuleEmails from '../stats-module-emails';
 import PageViewTracker from '../stats-page-view-tracker';
@@ -63,6 +67,11 @@ const StatsSubscribersPage = ( { period }: StatsSubscribersPageProps ) => {
 		'subscribers-page'
 	);
 
+	const { data: subscribersTotals, isLoading } = useSubscribersTotalsQueries( siteId );
+	const isSimple = useSelector( isSimpleSite );
+	const isAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
+	const showLaunchpad = ! isLoading && ( isSimple || isAtomic ) && ! subscribersTotals?.total;
+
 	// Track the last viewed tab.
 	// Necessary to properly configure the fixed navigation headers.
 	// sessionStorage.setItem( 'jp-stats-last-tab', 'subscribers' );
@@ -89,20 +98,30 @@ const StatsSubscribersPage = ( { period }: StatsSubscribersPageProps ) => {
 					</div>
 				) }
 				<StatsNavigation selectedItem="subscribers" siteId={ siteId } slug={ siteSlug } />
-				<SubscribersHighlightSection siteId={ siteId } />
-				{ isChartVisible && (
+				{ showLaunchpad ? (
+					<SubscriberLaunchpad launchpadContext="subscriber-stats" />
+				) : (
 					<>
-						<SubscribersChartSection siteId={ siteId } slug={ siteSlug } period={ period.period } />
-						<SubscribersOverview siteId={ siteId } />
+						<SubscribersHighlightSection siteId={ siteId } />
+						{ isChartVisible && (
+							<>
+								<SubscribersChartSection
+									siteId={ siteId }
+									slug={ siteSlug }
+									period={ period.period }
+								/>
+								<SubscribersOverview siteId={ siteId } />
+							</>
+						) }
+						<div className={ statsModuleListClass }>
+							<Followers path="followers" />
+							<Reach />
+							{ ! isOdysseyStats && period && (
+								<StatsModuleEmails period={ period } query={ { period, date: today } } />
+							) }
+						</div>
 					</>
 				) }
-				<div className={ statsModuleListClass }>
-					<Followers path="followers" />
-					<Reach />
-					{ ! isOdysseyStats && period && (
-						<StatsModuleEmails period={ period } query={ { period, date: today } } />
-					) }
-				</div>
 				<JetpackColophon />
 			</div>
 		</Main>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Show only subscriber launchpad on subscriber stats page when there are no subscribers.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On a site with no subscribers, go to `/stats/subscribers/site-with-no-subscribers.wordpress.com`.
  * You should see the launchpad only.
* On a site with subscribers, go to `/stats/subscribers/site-with-subscribers.wordpress.com`.
  * You should see subscriber stats.

<img width="1528" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1287077/fb1fa252-7e9f-4769-b6da-91a305fd2828">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?