### PR TITLE
Stats: Apply dynamic progress to the usage bar

### DIFF
--- a/client/my-sites/stats/stats-plan-usage/index.tsx
+++ b/client/my-sites/stats/stats-plan-usage/index.tsx
@@ -38,6 +38,7 @@ const PlanUsage: React.FC< PlanUsageProps > = ( {
 	const progressClassNames = classNames( 'plan-usage-progress', {
 		'is-over-limit': isOverLimit,
 	} );
+	const progressWidthInPercentage = limit ? ( usage / limit ) * 100 : 0;
 
 	// 0, 1, 2, or greater than 2
 	let overLimitMonthsText = '';
@@ -77,6 +78,10 @@ const PlanUsage: React.FC< PlanUsageProps > = ( {
 		<div className="plan-usage">
 			<h3 className="plan-usage-heading">{ translate( 'Your Stats plan usage' ) }</h3>
 			<div className={ progressClassNames }>
+				<div
+					className="plan-usage-progress-bar"
+					style={ { width: `${ progressWidthInPercentage }%` } }
+				></div>
 				<div>
 					{ translate( '%(numberOfUsage)s / %(numberOfLimit)s views this month', {
 						args: {

--- a/client/my-sites/stats/stats-plan-usage/style.scss
+++ b/client/my-sites/stats/stats-plan-usage/style.scss
@@ -24,18 +24,30 @@
 
 .plan-usage-progress {
 	box-sizing: border-box;
+	display: flex;
+	justify-content: space-between;
+	position: relative;
 	margin-top: 16px;
-	background-color: rgba(var(--studio-jetpack-green-40-rgb), 0.15);
 	width: 100%;
 	height: 36px;
 	line-height: 36px;
 	padding: 0 10px;
+	background-color: var(--studio-gray-0);
 	border-radius: 2px;
-	display: flex;
-	justify-content: space-between;
+	overflow: hidden;
 
 	&.is-over-limit {
-		background-color: rgba(var(--studio-red-40-rgb), 0.15);
+		.plan-usage-progress-bar {
+			background-color: rgba(var(--studio-red-40-rgb), 0.15);
+		}
+	}
+
+	.plan-usage-progress-bar {
+		position: absolute;
+		left: 0;
+		height: 100%;
+		background-color: rgba(var(--studio-jetpack-green-40-rgb), 0.15);
+		border-radius: 2px;
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #84485 

## Proposed Changes

* Apply the dynamic background color width to the plan usage bar according to the current usage and limit.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change on the local Calypso.
* Edit the code for different usage and limit if your testing site does not have enough data.
* Ensure the usage bar works with a dynamic background width aligned with the percentage of usage dividing limit.

<img width="1260" alt="截圖 2023-12-08 下午4 46 57" src="https://github.com/Automattic/wp-calypso/assets/6869813/196495e6-14fc-445d-b37c-8560f360a3c9">
<img width="1273" alt="截圖 2023-12-08 下午4 50 59" src="https://github.com/Automattic/wp-calypso/assets/6869813/9975ad5e-4296-40d6-8617-b7363975c1d6">
<img width="1257" alt="截圖 2023-12-08 下午4 51 18" src="https://github.com/Automattic/wp-calypso/assets/6869813/beda3417-fad0-4e37-bc08-ad14b91a8192">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?