### PR TITLE
Marketplace: updates installed plugin checkmark.

### DIFF
--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -275,7 +275,7 @@
 	}
 
 	.gridicon.checkmark {
-		color: var(--studio-gray-30);
+		color: var(--studio-gray-60);
 		border: 1px solid var(--studio-gray-60);
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Relates to p58i-g1B-p2#comment-60617

## Proposed Changes

* makes the checkmark more visible

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Search for jetpack backup
- Inspect the installed icon

|Before | After|
|-------|------|
|![CleanShot 2023-12-08 at 16 24 15@2x](https://github.com/Automattic/wp-calypso/assets/12430020/b33322f0-59db-4e12-8084-f07fe4e8c30d)|![CleanShot 2023-12-08 at 16 23 38@2x](https://github.com/Automattic/wp-calypso/assets/12430020/5c4d76b6-354f-4d49-8efc-9e12be6120d9)|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?