### PR TITLE
Disable comment email follow field

### DIFF
--- a/client/my-sites/site-settings/settings-newsletter/EmailsTextSetting.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/EmailsTextSetting.tsx
@@ -81,16 +81,10 @@ export const EmailsTextSetting = ( { value, disabled, updateFields }: EmailsText
 				<FormLabel htmlFor="comment_follow_email_message">
 					{ translate( 'Comment follow email message' ) }
 				</FormLabel>
-				<FormTextarea
-					name="comment_follow_email_message"
-					id="comment_follow_email_message"
-					value={ value?.comment_follow }
-					onChange={ updateSubscriptionOptions( 'comment_follow' ) }
-					disabled={ disabled }
-					autoCapitalize="none"
-				/>
 				<FormSettingExplanation>
-					{ translate( 'The email sent out when someone follows one of your posts.' ) }
+					{ translate(
+						'The ability to customize the comment follow email message had to be disabled to prevent abuse. It will revert to the default message for all new subscribers.'
+					) }
 				</FormSettingExplanation>
 
 				<FormLabel htmlFor="confirmation_email_message">


### PR DESCRIPTION
## Proposed Changes

Remove the Comment follow email message from the UI


![CleanShot 2023-12-08 at 15 49 06@2x](https://github.com/Automattic/wp-calypso/assets/528287/9c4807c1-a1f3-4b28-9915-889032f07019)


## Testing Instructions

1. Navigate to Settings > Newsletters

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?