### PR TITLE
Hosting Command Palette: Add 'Jetpack Activity Log' keyword

### DIFF
--- a/client/sites-dashboard/components/wpcom-smp-commands.tsx
+++ b/client/sites-dashboard/components/wpcom-smp-commands.tsx
@@ -572,6 +572,11 @@ export const useCommandsArrayWpcom = ( {
 		{
 			name: 'openActivityLog',
 			label: __( 'Open activity log' ),
+			searchLabel: [
+				_x( 'open activity log', 'Keyword for the Open activity log command' ),
+				_x( 'jetpack activity log', 'Keyword for the Open activity log command' ),
+				_x( 'audit log', 'Keyword for the Open activity log command' ),
+			].join( ' ' ),
 			callback: setStateCallback( 'openActivityLog', __( 'Select site to open activity log' ) ),
 			siteFunctions: {
 				onClick: ( { site, close }: { site: SiteExcerptData; close: () => void } ) => {


### PR DESCRIPTION
From pdtkmj-28F-p2#comment-3854

## Proposed Changes

Adds 'jetpack activity log' as a keyword to 'Open activity log':

![CleanShot 2023-12-08 at 07 41 55@2x](https://github.com/Automattic/wp-calypso/assets/36432/f7266572-696f-4d9d-aa3f-f7af5b051df1)

## Testing Instructions

1. Try searching 'jetpack activity log' and verify 'Open activity log' is present as a command.