### PR TITLE
Align design for toggle to calypso style (horizontal dots)

### DIFF
--- a/client/reader/site-subscriptions-manager/subscriptions-manager-wrapper.tsx
+++ b/client/reader/site-subscriptions-manager/subscriptions-manager-wrapper.tsx
@@ -94,7 +94,6 @@ const SubscriptionsManagerWrapper = ( {
 						<SubscriptionsEllipsisMenu
 							toggleTitle={ translate( 'More' ) }
 							popoverClassName="site-subscriptions-manager__import-export-popover"
-							verticalToggle
 						>
 							{ ellipsisMenuItems }
 						</SubscriptionsEllipsisMenu>


### PR DESCRIPTION
Context: p1701942106797179/1701941161.609379-slack-C9EJ7KSGH

## Proposed Changes

* Align design for menu dots to calypso style

Before
![image](https://github.com/Automattic/wp-calypso/assets/6586048/6ce1a804-fb94-4c06-97f1-d949ecb7c25f)


After
![align toggle](https://github.com/Automattic/wp-calypso/assets/6586048/1276d2bd-8a29-41f8-84ca-6f330e1e1303)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /read/subscriptions
* Check the toggle dots

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?