### PR TITLE
Recommended Posts - temporarily remove from reader streams.

### DIFF
--- a/client/reader/stream/post-lifecycle.jsx
+++ b/client/reader/stream/post-lifecycle.jsx
@@ -84,7 +84,7 @@ class PostLifecycle extends Component {
 
 		if ( postKey.isRecommendationBlock ) {
 			// We are temporarily disabling these from our feeds while investigating issues with
-			// irrelevant mature content.
+			// irrelevant mature content. https://github.com/Automattic/wp-calypso/pull/85045
 			return null;
 		} else if ( postKey.isPromptBlock ) {
 			return (

--- a/client/reader/stream/post-lifecycle.jsx
+++ b/client/reader/stream/post-lifecycle.jsx
@@ -6,7 +6,6 @@ import PostBlocked from 'calypso/blocks/reader-post-card/blocked';
 import BloggingPromptCard from 'calypso/components/blogging-prompt-card';
 import QueryReaderPost from 'calypso/components/data/query-reader-post';
 import compareProps from 'calypso/lib/compare-props';
-import { IN_STREAM_RECOMMENDATION } from 'calypso/reader/follow-sources';
 import ListGap from 'calypso/reader/list-gap';
 import XPostHelper, { isXPost } from 'calypso/reader/xpost-helper';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
@@ -15,7 +14,6 @@ import EmptySearchRecommendedPost from './empty-search-recommended-post';
 import Post from './post';
 import PostPlaceholder from './post-placeholder';
 import PostUnavailable from './post-unavailable';
-import RecommendedPosts from './recommended-posts';
 import CrossPost from './x-post';
 
 /**
@@ -82,18 +80,12 @@ class PostLifecycle extends Component {
 	};
 
 	render() {
-		const { post, postKey, isSelected, recsStreamKey, streamKey, siteId, isDiscoverStream } =
-			this.props;
+		const { post, postKey, isSelected, streamKey, siteId, isDiscoverStream } = this.props;
 
 		if ( postKey.isRecommendationBlock ) {
-			return (
-				<RecommendedPosts
-					recommendations={ postKey.recommendations }
-					index={ postKey.index }
-					streamKey={ recsStreamKey }
-					followSource={ IN_STREAM_RECOMMENDATION }
-				/>
-			);
+			// We are temporarily disabling these from our feeds while investigating issues with
+			// irrelevant mature content.
+			return null;
 		} else if ( postKey.isPromptBlock ) {
 			return (
 				<div


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # p1701989843771469-slack-C03NLNTPZ2T

## Proposed Changes

* We are having issues where recommended posts are showing mature content to users where it is not anticipated, related, or desired. This PR removes recommended posts from our streams temporarily while we can investigate the issue further.
* This simply returns `null` instead of the `<RecommendedPosts/>` component. This seemed to make more sense for a temporary removal than messing with the injections system and related tests.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch. 
* Verify recommended posts **no longer show up** in reader feeds.

Recommended posts generally look like this. Definitely within the 'Recent' feed, possibly others as this is done at the stream component level as seen here in the file we are removing the component from.

<img width="496" alt="Screenshot 2023-12-08 at 11 49 48 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/aab9183d-c02d-47cf-b6a7-00a6c61c3a64">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?