### PR TITLE
(E2E) Fix E2Es in praparation of the Gutenberg 17.2.0 release in WPCOM

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -23,8 +23,8 @@ const selectors = {
 	postPasswordInput: '.editor-post-visibility__password-input',
 
 	// Schedule
-	scheduleButton: `button.edit-post-post-schedule__toggle`,
-	scheduleInput: ( name: string ) => `.edit-post-post-schedule__dialog label:has-text("${ name }")`,
+	scheduleButton: `button.editor-post-schedule__dialog-toggle`,
+	scheduleInput: ( name: string ) => `.editor-post-schedule__dialog label:has-text("${ name }")`,
 	scheduleMeridianButton: ( meridian: 'am' | 'pm' ) => `role=button[name="${ meridian }"i]`,
 
 	// Category

--- a/test/e2e/specs/appearance/widgets__legacy-visibility.ts
+++ b/test/e2e/specs/appearance/widgets__legacy-visibility.ts
@@ -55,8 +55,8 @@ skipDescribeIf( envVariables.TEST_ON_ATOMIC || envVariables.VIEWPORT_NAME === 'm
 		// Skipped for mobile due to https://github.com/Automattic/wp-calypso/issues/59960
 		it( 'Insert a Legacy Widget', async function () {
 			await page.getByRole( 'button', { name: 'Add block' } ).click();
-			await page.fill( 'input[placeholder="Search"]', 'Top Posts and Pages' );
-			await page.click( 'button.editor-block-list-item-legacy-widget\\/top-posts' );
+			await page.fill( 'input[placeholder="Search"]', 'Authors' );
+			await page.click( 'button.editor-block-list-item-legacy-widget\\/authors' );
 		} );
 
 		it( 'Visibility options are shown for the Legacy Widget', async function () {

--- a/test/e2e/specs/blocks/blocks__jetpack-forms.ts
+++ b/test/e2e/specs/blocks/blocks__jetpack-forms.ts
@@ -21,13 +21,13 @@ const blockFlows: BlockFlow[] = [
 	new FormPatternsFlow(
 		{
 			labelPrefix: 'Form Patterns',
-			patternName: 'RSVP Form',
+			patternName: 'Lead Capture Form',
 		},
 		{
 			otherExpectedFields: [
-				{ type: 'radio', accessibleName: 'Yes' },
-				{ type: 'radio', accessibleName: 'No' },
-				{ type: 'button', accessibleName: 'Send RSVP' },
+				{ type: 'textbox', accessibleName: 'Name' },
+				{ type: 'textbox', accessibleName: 'Email' },
+				{ type: 'button', accessibleName: 'Subscribe' },
 			],
 		}
 	),


### PR DESCRIPTION
## Proposed Changes

Fix E2Es. Some failures are not related to GB 17.2.0, but to other changes in Calypso/WPCOM/Jetpack.

## Testing Instructions

* All checks should pass;
* Gutenberg builds in TC from this branch should be green when run from this branch

