### PR TITLE
Fix Sensei Learning Mode template and blocks broken in site editor after onboarding

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/create-sensei-site.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/create-sensei-site.ts
@@ -1,5 +1,5 @@
 import { useLocale } from '@automattic/i18n-utils';
-import { SENSEI_FLOW } from '@automattic/onboarding';
+import { SENSEI_FLOW, setThemeOnSite } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useState } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
@@ -7,6 +7,7 @@ import { useNewSiteVisibility } from 'calypso/landing/stepper/hooks/use-selected
 import { ONBOARD_STORE, SITE_STORE, USER_STORE } from 'calypso/landing/stepper/stores';
 import wpcom from 'calypso/lib/wp';
 import { Progress } from '../components/sensei-step-progress';
+import { wait } from '../sensei-launch/launch-completion-tasks';
 import type { OnboardSelect, SiteSelect, UserSelect } from '@automattic/data-stores';
 import type { StyleVariation } from 'calypso/../packages/design-picker';
 
@@ -97,6 +98,8 @@ export const useCreateSenseiSite = () => {
 		} );
 
 		if ( siteId ) {
+			await setThemeOnSite( siteId.toString(), COURSE_THEME );
+			wait( 1200 );
 			const selectedStyleVariationTitle = getSelectedStyleVariation()?.title;
 			const [ styleVariations, theme ]: [ StyleVariation[], Theme ] = await Promise.all( [
 				getStyleVariations( siteId, COURSE_THEME ),
@@ -111,6 +114,7 @@ export const useCreateSenseiSite = () => {
 			if ( styleVariation && userGlobalStylesId ) {
 				await updateGlobalStyles( siteId, userGlobalStylesId, styleVariation );
 			}
+			wait( 1200 );
 		}
 		setProgress( {
 			percentage: 100,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/85038

## Proposed Changes

This issue was tricky to reproduce and fix. After noticing the template being broken, the first response from muscle memory was to deactivate Gutenberg. And it fixed the issue. Neat! So it's a clear conflict with Gutenberg! Easy peasy.

Well, it wasn't. After trying a whole bunch of things, I could not reproduce it locally, either with Gutenberg on or off. So maybe it happens with Gutenberg only on the Atomic sites! Created a bunch of atomic sites with Sensei, Sensei-Pro, and Gutenberg activated. Nope, still couldn't reproduce it. Saw a bunch of jetpack-initiated calls in the stack. So could it be a difference in Jetpack settings being different? Matched everything there is to match. Nope, nothing.

So as Sherlock Holmes once said, _"When you have eliminated all which is impossible, then whatever remains, however improbable, must be the truth"_.

So it's not Sensei, it's not Atomic, the fault is in our ~~stars~~ flow, I thought. But where in it _Horatio_? Okay, let's see if it's only a block theme issue. So I switched to Astra on a site I'm having this problem in, and this issue wasn't there anymore! Wah, so a block theme issue definitely, I thought. Just to be sure, switched to another block theme, aaaand... nope! The issue isn't there! So a Course theme issue? Switched back to the Course theme, and lo and behold, it's not happening on the Course theme either, not anymore!

So all I needed was to switch the theme and get back after the first time the site gets created using the onboarding flow? To test my theory, I created a bunch of sites using the onboarding flow and found the problem of broken templates every time, and after a theme switch and back, it was solved in all of them.

So maybe the way we were activating the Course theme during the onboarding was causing the issue, maybe it wasn't getting properly updated. So after creating the site in the flow, I added a call to switch the theme using the theme-switch API, and it was solved. Also had to add the delays, otherwise, I was seeing some discrepancies here and there.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a Sensei site completing the whole flow after hitting `http://calypso.localhost:3000/setup/sensei`
2. Now you can check the LM template from a few different places. Mainly
    - From SenseiLMS -> Home -> Customize your theme
    - From Appearance -> Editor -> Templates -> <Your current LM template> `(check the image below)`
    - From SenseiLMS -> Settings -> Appearance -> Customize button on the template picture on hover
    - From Appearance -> Customize -> Use Site Editor -> Templates -> <Your current LM template>    
<img width="759" alt="Screenshot 2023-12-09 at 2 17 59 AM" src="https://github.com/Automattic/wp-calypso/assets/6820724/661ea4d7-2f0c-4e80-858b-301a0118add6">
3. The LM template should not be broken, try to get out and in the editor a few times
4. Now switch to the other (pro) LM templates, go to the editor, and check them just like default one

#### Before
<img width="1460" alt="Screenshot 2023-12-09 at 1 36 22 AM" src="https://github.com/Automattic/wp-calypso/assets/6820724/6188ae28-a2c4-4d5a-88d7-50cac85e7b8b">

#### After
<img width="1516" alt="Screenshot 2023-12-09 at 1 37 37 AM" src="https://github.com/Automattic/wp-calypso/assets/6820724/3b7159d8-3478-43c7-83ae-9e56ba4324c9">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?