### PR TITLE
Storage Add-On: Fix storage add-on offset price alignment

### DIFF
--- a/client/my-sites/plans-grid/style.scss
+++ b/client/my-sites/plans-grid/style.scss
@@ -840,6 +840,13 @@ body.is-section-signup.is-white-signup,
 	}
 }
 
+.plans-features-main__comparison-grid-container {
+	.plan-comparison-grid {
+		.plan-comparison-grid__feature-group-row.is-storage-feature {
+			align-items: flex-start;
+		}
+	}
+}
 
 .plan-comparison-grid {
 	.plan-features-2023-gridrison__actions {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/83837

## Proposed Changes

* Ensure vertical alignment between storage labels and the storage dropdown when an inline price is displayed

## Screenshots

### Before
<img width="1274" alt="Screenshot 2023-12-08 at 5 40 10 PM" src="https://github.com/Automattic/wp-calypso/assets/5414230/295d1f33-c583-4752-a4c4-8e9e602e1dd0">

### After
<img width="1254" alt="Screenshot 2023-12-08 at 5 36 10 PM" src="https://github.com/Automattic/wp-calypso/assets/5414230/d2c3bb77-c009-4821-9a08-ac36e339edf7">

![2023-12-08 17 33 11](https://github.com/Automattic/wp-calypso/assets/5414230/b3dd3182-28ef-44e3-a7ad-ec895cd537a2)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch or use Calypso live
* Navigate to `/start/plans`
* Scroll down and toggle the display of the comparison grid
* Scroll down to the storage add-on dropdown in the comparison grid and select an add-on upgrade
* Verify that the storage labels and dropdown are in alignment
* Repeat the above for the Calypso admin `/plans` page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?