### PR TITLE
Checkout: Redirect to standalone failed purchases page when purchase fails after payment

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -220,7 +220,7 @@ class Layout extends Component {
 
 		const isCheckoutFailed =
 			this.props.sectionName === 'checkout' &&
-			this.props.currentRoute.startsWith( '/checkout/thank-you-failed-purchases' );
+			this.props.currentRoute.startsWith( '/checkout/failed-purchases' );
 
 		return (
 			<MasterbarComponent

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -218,11 +218,16 @@ class Layout extends Component {
 			? JetpackCloudMasterbar
 			: MasterbarLoggedIn;
 
+		const isCheckoutFailed =
+			this.props.sectionName === 'checkout' &&
+			this.props.currentRoute.startsWith( '/checkout/thank-you-failed-purchases' );
+
 		return (
 			<MasterbarComponent
 				section={ this.props.sectionGroup }
 				isCheckout={ this.props.sectionName === 'checkout' }
 				isCheckoutPending={ this.props.sectionName === 'checkout-pending' }
+				isCheckoutFailed={ isCheckoutFailed }
 				loadHelpCenterIcon={ loadHelpCenterIcon }
 			/>
 		);

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -82,6 +82,8 @@ const LayoutLoggedOut = ( {
 
 	const isCheckout = sectionName === 'checkout';
 	const isCheckoutPending = sectionName === 'checkout-pending';
+	const isCheckoutFailed =
+		sectionName === 'checkout' && currentRoute.startsWith( '/checkout/thank-you-failed-purchases' );
 	const isJetpackCheckout =
 		sectionName === 'checkout' && currentRoute.startsWith( '/checkout/jetpack' );
 
@@ -204,6 +206,7 @@ const LayoutLoggedOut = ( {
 				sectionName={ sectionName }
 				isCheckout={ isCheckout }
 				isCheckoutPending={ isCheckoutPending }
+				isCheckoutFailed={ isCheckoutFailed }
 				redirectUri={ redirectUri }
 			/>
 		);

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -83,7 +83,7 @@ const LayoutLoggedOut = ( {
 	const isCheckout = sectionName === 'checkout';
 	const isCheckoutPending = sectionName === 'checkout-pending';
 	const isCheckoutFailed =
-		sectionName === 'checkout' && currentRoute.startsWith( '/checkout/thank-you-failed-purchases' );
+		sectionName === 'checkout' && currentRoute.startsWith( '/checkout/failed-purchases' );
 	const isJetpackCheckout =
 		sectionName === 'checkout' && currentRoute.startsWith( '/checkout/jetpack' );
 

--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -21,6 +21,7 @@ interface Props {
 	previousPath?: string;
 	siteSlug?: string;
 	isLeavingAllowed?: boolean;
+	shouldClearCartWhenLeaving?: boolean;
 	loadHelpCenterIcon?: boolean;
 }
 
@@ -30,6 +31,7 @@ const CheckoutMasterbar = ( {
 	previousPath,
 	siteSlug,
 	isLeavingAllowed,
+	shouldClearCartWhenLeaving,
 	loadHelpCenterIcon,
 }: Props ) => {
 	const translate = useTranslate();
@@ -61,7 +63,7 @@ const CheckoutMasterbar = ( {
 		} );
 
 	const clickClose = () => {
-		if ( responseCart.products.length > 0 ) {
+		if ( shouldClearCartWhenLeaving && responseCart.products.length > 0 ) {
 			setIsModalVisible( true );
 			return;
 		}

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -71,6 +71,7 @@ class MasterbarLoggedIn extends Component {
 		hasMoreThanOneSite: PropTypes.bool,
 		isCheckout: PropTypes.bool,
 		isCheckoutPending: PropTypes.bool,
+		isCheckoutFailed: PropTypes.bool,
 		isInEditor: PropTypes.bool,
 		hasDismissedThePopover: PropTypes.bool,
 		isUserNewerThanNewNavigation: PropTypes.bool,
@@ -275,6 +276,7 @@ class MasterbarLoggedIn extends Component {
 	renderCheckout() {
 		const {
 			isCheckoutPending,
+			isCheckoutFailed,
 			previousPath,
 			currentSelectedSiteSlug,
 			isJetpackNotAtomic,
@@ -291,6 +293,7 @@ class MasterbarLoggedIn extends Component {
 				previousPath={ previousPath }
 				siteSlug={ currentSelectedSiteSlug }
 				isLeavingAllowed={ ! isCheckoutPending }
+				shouldClearCartWhenLeaving={ ! isCheckoutFailed }
 				loadHelpCenterIcon={ loadHelpCenterIcon }
 			/>
 		);
@@ -514,10 +517,11 @@ class MasterbarLoggedIn extends Component {
 	}
 
 	render() {
-		const { isInEditor, isCheckout, isCheckoutPending, loadHelpCenterIcon } = this.props;
+		const { isInEditor, isCheckout, isCheckoutPending, isCheckoutFailed, loadHelpCenterIcon } =
+			this.props;
 		const { isMobile } = this.state;
 
-		if ( isCheckout || isCheckoutPending ) {
+		if ( isCheckout || isCheckoutPending || isCheckoutFailed ) {
 			return this.renderCheckout();
 		}
 

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -24,6 +24,7 @@ class MasterbarLoggedOut extends Component {
 		title: PropTypes.string,
 		isCheckout: PropTypes.bool,
 		isCheckoutPending: PropTypes.bool,
+		isCheckoutFailed: PropTypes.bool,
 
 		// Connected props
 		currentQuery: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.object ] ),
@@ -197,15 +198,16 @@ class MasterbarLoggedOut extends Component {
 	}
 
 	render() {
-		const { title, isCheckout, isCheckoutPending } = this.props;
+		const { title, isCheckout, isCheckoutPending, isCheckoutFailed } = this.props;
 
-		if ( isCheckout || isCheckoutPending ) {
+		if ( isCheckout || isCheckoutPending || isCheckoutFailed ) {
 			return (
 				<AsyncLoad
 					require="calypso/layout/masterbar/checkout.tsx"
 					placeholder={ null }
 					title={ title }
 					isLeavingAllowed={ ! isCheckoutPending }
+					shouldClearCartWhenLeaving={ ! isCheckoutFailed }
 				/>
 			);
 		}

--- a/client/my-sites/checkout/checkout-thank-you/failed-purchase-details.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/failed-purchase-details.tsx
@@ -1,9 +1,20 @@
-import { localize } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import PurchaseDetail from 'calypso/components/purchase-detail';
 import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
 
-const FailedPurchaseDetails = ( { failedPurchases, purchases, translate } ) => {
-	const successfulPurchases = purchases.length > 0 && (
+export default function FailedPurchaseDetails( {
+	failedPurchases,
+	purchases,
+}: {
+	failedPurchases?: { productId: string; productName: string; meta?: string }[];
+	purchases?: {
+		productId: string;
+		productName: string;
+		meta?: string;
+	}[];
+} ) {
+	const translate = useTranslate();
+	const successfulPurchasesForDisplay = purchases && purchases.length > 0 && (
 		<div>
 			<p>{ translate( 'These items were added successfully:' ) }</p>
 			<ul className="checkout-thank-you__failed-purchases-details-list">
@@ -19,9 +30,8 @@ const FailedPurchaseDetails = ( { failedPurchases, purchases, translate } ) => {
 			<hr />
 		</div>
 	);
-	const description = (
-		<div>
-			{ successfulPurchases }
+	const failedPurchasesForDisplay = failedPurchases ? (
+		<>
 			<p>{ translate( 'These items could not be added:' ) }</p>
 			<ul className="checkout-thank-you__failed-purchases-details-list">
 				{ failedPurchases.map( ( item, index ) => {
@@ -33,6 +43,14 @@ const FailedPurchaseDetails = ( { failedPurchases, purchases, translate } ) => {
 					);
 				} ) }
 			</ul>
+		</>
+	) : (
+		<p>{ translate( 'Some items failed to be purchased.' ) }</p>
+	);
+	const description = (
+		<div>
+			{ successfulPurchasesForDisplay }
+			{ failedPurchasesForDisplay }
 			<p>
 				{ translate(
 					'We added credits to your account, so you can try adding these items again. ' +
@@ -60,6 +78,4 @@ const FailedPurchaseDetails = ( { failedPurchases, purchases, translate } ) => {
 			</div>
 		</div>
 	);
-};
-
-export default localize( FailedPurchaseDetails );
+}

--- a/client/my-sites/checkout/checkout-thank-you/failed-purchase-details.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/failed-purchase-details.tsx
@@ -1,17 +1,14 @@
 import { useTranslate } from 'i18n-calypso';
 import PurchaseDetail from 'calypso/components/purchase-detail';
 import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
+import type { FailedReceiptPurchase, ReceiptPurchase } from 'calypso/state/receipts/types';
 
 export default function FailedPurchaseDetails( {
 	failedPurchases,
 	purchases,
 }: {
-	failedPurchases?: { productId: string; productName: string; meta?: string }[];
-	purchases?: {
-		productId: string;
-		productName: string;
-		meta?: string;
-	}[];
+	purchases?: ReceiptPurchase[];
+	failedPurchases?: FailedReceiptPurchase[];
 } ) {
 	const translate = useTranslate();
 	const successfulPurchasesForDisplay = purchases && purchases.length > 0 && (

--- a/client/my-sites/checkout/checkout-thank-you/failed-purchase-details.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/failed-purchase-details.tsx
@@ -57,7 +57,7 @@ export default function FailedPurchaseDetails( {
 						"If the problem persists, please don't hesitate to {{a}}contact support{{/a}}.",
 					{
 						components: {
-							a: <a href={ CALYPSO_CONTACT } target="_blank" rel="noopener noreferrer" />,
+							a: <a href={ CALYPSO_CONTACT } />,
 						},
 					}
 				) }

--- a/client/my-sites/checkout/checkout-thank-you/failed-purchase-page.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/failed-purchase-page.tsx
@@ -9,7 +9,7 @@ export function FailedPurchasePage() {
 	const translate = useTranslate();
 	return (
 		<div className="failed-purchases-page">
-			<PageViewTracker path="/checkout/thank-you-failed-purchases" title="Failed purchases" />
+			<PageViewTracker path="/checkout/failed-purchases" title="Failed purchases" />
 			<DocumentHead title={ translate( 'Checkout' ) } />
 			<FailedPurchaseDetails />
 		</div>

--- a/client/my-sites/checkout/checkout-thank-you/failed-purchase-page.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/failed-purchase-page.tsx
@@ -1,0 +1,17 @@
+import { useTranslate } from 'i18n-calypso';
+import DocumentHead from 'calypso/components/data/document-head';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import FailedPurchaseDetails from './failed-purchase-details';
+
+import './style.scss';
+
+export function FailedPurchasePage() {
+	const translate = useTranslate();
+	return (
+		<div className="failed-purchases-page">
+			<PageViewTracker path="/checkout/thank-you-failed-purchases" title="Failed purchases" />
+			<DocumentHead title={ translate( 'Checkout' ) } />
+			<FailedPurchaseDetails />
+		</div>
+	);
+}

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -987,3 +987,9 @@ main.akismet-checkout-thank-you {
 .jetpack-instruction-list__item .gridicon {
 	margin-bottom: -3px;
 }
+
+.failed-purchases-page {
+	padding-top: 72px;
+	background: #fff;
+	height: calc(100vh - 72px);
+}

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -32,6 +32,7 @@ import CheckoutMainWrapper from './checkout-main-wrapper';
 import CheckoutThankYouComponent from './checkout-thank-you';
 import AkismetCheckoutThankYou from './checkout-thank-you/akismet-checkout-thank-you';
 import DomainTransferToAnyUser from './checkout-thank-you/domain-transfer-to-any-user';
+import FailedPurchaseDetails from './checkout-thank-you/failed-purchase-details';
 import GiftThankYou from './checkout-thank-you/gift/gift-thank-you';
 import HundredYearPlanThankYou from './checkout-thank-you/hundred-year-plan-thank-you';
 import JetpackCheckoutThankYou from './checkout-thank-you/jetpack-checkout-thank-you';
@@ -45,6 +46,12 @@ import UpsellNudge, {
 import { getProductSlugFromContext, isContextJetpackSitelessCheckout } from './utils';
 
 const debug = debugFactory( 'calypso:checkout-controller' );
+
+export function checkoutFailedPurchases( context, next ) {
+	context.primary = <FailedPurchaseDetails />;
+
+	next();
+}
 
 export function checkoutJetpackSiteless( context, next ) {
 	const connectAfterCheckout = context.query?.connect_after_checkout === 'true';

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -32,7 +32,7 @@ import CheckoutMainWrapper from './checkout-main-wrapper';
 import CheckoutThankYouComponent from './checkout-thank-you';
 import AkismetCheckoutThankYou from './checkout-thank-you/akismet-checkout-thank-you';
 import DomainTransferToAnyUser from './checkout-thank-you/domain-transfer-to-any-user';
-import FailedPurchaseDetails from './checkout-thank-you/failed-purchase-details';
+import { FailedPurchasePage } from './checkout-thank-you/failed-purchase-page';
 import GiftThankYou from './checkout-thank-you/gift/gift-thank-you';
 import HundredYearPlanThankYou from './checkout-thank-you/hundred-year-plan-thank-you';
 import JetpackCheckoutThankYou from './checkout-thank-you/jetpack-checkout-thank-you';
@@ -48,7 +48,7 @@ import { getProductSlugFromContext, isContextJetpackSitelessCheckout } from './u
 const debug = debugFactory( 'calypso:checkout-controller' );
 
 export function checkoutFailedPurchases( context, next ) {
-	context.primary = <FailedPurchaseDetails />;
+	context.primary = <FailedPurchasePage />;
 
 	next();
 }

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -27,6 +27,7 @@ import {
 	akismetCheckoutThankYou,
 	hundredYearCheckoutThankYou,
 	transferDomainToAnyUser,
+	checkoutFailedPurchases,
 } from './controller';
 
 export default function () {
@@ -204,6 +205,8 @@ export default function () {
 		makeLayout,
 		clientRender
 	);
+
+	page( '/checkout/thank-you-failed-purchases', checkoutFailedPurchases, makeLayout, clientRender );
 
 	page( '/checkout/no-site/:lang?', noSite, checkout, makeLayout, clientRender );
 

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -206,7 +206,7 @@ export default function () {
 		clientRender
 	);
 
-	page( '/checkout/thank-you-failed-purchases', checkoutFailedPurchases, makeLayout, clientRender );
+	page( '/checkout/failed-purchases', checkoutFailedPurchases, makeLayout, clientRender );
 
 	page( '/checkout/no-site/:lang?', noSite, checkout, makeLayout, clientRender );
 

--- a/client/my-sites/checkout/src/lib/pending-page.ts
+++ b/client/my-sites/checkout/src/lib/pending-page.ts
@@ -348,9 +348,9 @@ export function getRedirectFromPendingPage( {
 	saasRedirectUrl,
 	fromSiteSlug,
 }: RedirectForTransactionStatusArgs ): RedirectInstructions | undefined {
-	const checkoutUrl = siteSlug ? `/checkout/${ siteSlug }` : '/';
+	const checkoutUrl = siteSlug ? `/checkout/${ siteSlug }` : '/checkout/no-site';
 	const planRoute = siteSlug ? `/plans/my-plan/${ siteSlug }` : '/pricing';
-	const defaultFailUrl = `/checkout/failed-purchases`;
+	const errorUrl = `/checkout/failed-purchases`;
 
 	// If SaaS Product Redirect URL was passed then just return as redirect instruction so that
 	// we can redirect user immediately to vendor application.
@@ -406,13 +406,20 @@ export function getRedirectFromPendingPage( {
 			};
 		}
 
-		// If the processing status indicates that there was something wrong, it
-		// could be because the user has cancelled the payment, or because the
-		// payment failed after being authorized. Redirect users back to the
-		// checkout page so they can try again.
-		if ( ERROR === processingStatus || FAILURE === processingStatus ) {
+		// If the processing status indicates that there was something wrong,
+		// it could be because the user has cancelled the payment, or because
+		// the payment failed after being authorized. Redirect users back to
+		// the checkout page so they can try again on a failure or to a
+		// dedicated error page on an error.
+		if ( ERROR === processingStatus ) {
 			return {
-				url: defaultFailUrl,
+				url: errorUrl,
+				isError: true,
+			};
+		}
+		if ( FAILURE === processingStatus ) {
+			return {
+				url: checkoutUrl,
 				isError: true,
 			};
 		}

--- a/client/my-sites/checkout/src/lib/pending-page.ts
+++ b/client/my-sites/checkout/src/lib/pending-page.ts
@@ -348,8 +348,9 @@ export function getRedirectFromPendingPage( {
 	saasRedirectUrl,
 	fromSiteSlug,
 }: RedirectForTransactionStatusArgs ): RedirectInstructions | undefined {
-	const defaultFailUrl = siteSlug ? `/checkout/${ siteSlug }` : '/';
+	const checkoutUrl = siteSlug ? `/checkout/${ siteSlug }` : '/';
 	const planRoute = siteSlug ? `/plans/my-plan/${ siteSlug }` : '/pricing';
+	const defaultFailUrl = `/checkout/thank-you-failed-purchases`;
 
 	// If SaaS Product Redirect URL was passed then just return as redirect instruction so that
 	// we can redirect user immediately to vendor application.
@@ -429,7 +430,7 @@ export function getRedirectFromPendingPage( {
 	// A HTTP error occured; we will send the user back to checkout.
 	if ( error ) {
 		return {
-			url: defaultFailUrl,
+			url: checkoutUrl,
 			isError: true,
 		};
 	}

--- a/client/my-sites/checkout/src/lib/pending-page.ts
+++ b/client/my-sites/checkout/src/lib/pending-page.ts
@@ -350,7 +350,7 @@ export function getRedirectFromPendingPage( {
 }: RedirectForTransactionStatusArgs ): RedirectInstructions | undefined {
 	const checkoutUrl = siteSlug ? `/checkout/${ siteSlug }` : '/';
 	const planRoute = siteSlug ? `/plans/my-plan/${ siteSlug }` : '/pricing';
-	const defaultFailUrl = `/checkout/thank-you-failed-purchases`;
+	const defaultFailUrl = `/checkout/failed-purchases`;
 
 	// If SaaS Product Redirect URL was passed then just return as redirect instruction so that
 	// we can redirect user immediately to vendor application.

--- a/client/my-sites/checkout/src/test/pending-page.ts
+++ b/client/my-sites/checkout/src/test/pending-page.ts
@@ -318,7 +318,7 @@ describe( 'getRedirectFromPendingPage', () => {
 		expect( actual ).toEqual( { url: '/checkout/failed-purchases', isError: true } );
 	} );
 
-	it( 'returns a failure url if the transaction fails', () => {
+	it( 'returns a checkout url if the transaction fails', () => {
 		const actual = getRedirectFromPendingPage( {
 			redirectTo: '/home',
 			siteSlug: 'example.com',
@@ -328,10 +328,10 @@ describe( 'getRedirectFromPendingPage', () => {
 				processingStatus: FAILURE,
 			},
 		} );
-		expect( actual ).toEqual( { url: '/checkout/failed-purchases', isError: true } );
+		expect( actual ).toEqual( { url: '/checkout/example.com', isError: true } );
 	} );
 
-	it( 'returns a failure url url if the transaction has an error and there is no site', () => {
+	it( 'returns a failure url if the transaction has an error and there is no site', () => {
 		const actual = getRedirectFromPendingPage( {
 			redirectTo: '/home',
 			transaction: {
@@ -343,7 +343,7 @@ describe( 'getRedirectFromPendingPage', () => {
 		expect( actual ).toEqual( { url: '/checkout/failed-purchases', isError: true } );
 	} );
 
-	it( 'returns a failure url if the transaction fails and there is no site', () => {
+	it( 'returns a checkout url if the transaction fails and there is no site', () => {
 		const actual = getRedirectFromPendingPage( {
 			redirectTo: '/home',
 			transaction: {
@@ -352,10 +352,10 @@ describe( 'getRedirectFromPendingPage', () => {
 				processingStatus: FAILURE,
 			},
 		} );
-		expect( actual ).toEqual( { url: '/checkout/failed-purchases', isError: true } );
+		expect( actual ).toEqual( { url: '/checkout/no-site', isError: true } );
 	} );
 
-	it( 'returns a checkout url if there was an error', () => {
+	it( 'returns a checkout url if there was an HTTP error', () => {
 		const actual = getRedirectFromPendingPage( {
 			redirectTo: '/home',
 			siteSlug: 'example.com',

--- a/client/my-sites/checkout/src/test/pending-page.ts
+++ b/client/my-sites/checkout/src/test/pending-page.ts
@@ -305,7 +305,7 @@ describe( 'getRedirectFromPendingPage', () => {
 		expect( actual ).toEqual( { url: url } );
 	} );
 
-	it( 'returns a checkout url if the transaction has an error', () => {
+	it( 'returns a failure url if the transaction has an error', () => {
 		const actual = getRedirectFromPendingPage( {
 			redirectTo: '/home',
 			siteSlug: 'example.com',
@@ -315,10 +315,10 @@ describe( 'getRedirectFromPendingPage', () => {
 				processingStatus: ERROR,
 			},
 		} );
-		expect( actual ).toEqual( { url: '/checkout/example.com', isError: true } );
+		expect( actual ).toEqual( { url: '/checkout/failed-purchases', isError: true } );
 	} );
 
-	it( 'returns a checkout url if the transaction fails', () => {
+	it( 'returns a failure url if the transaction fails', () => {
 		const actual = getRedirectFromPendingPage( {
 			redirectTo: '/home',
 			siteSlug: 'example.com',
@@ -328,10 +328,10 @@ describe( 'getRedirectFromPendingPage', () => {
 				processingStatus: FAILURE,
 			},
 		} );
-		expect( actual ).toEqual( { url: '/checkout/example.com', isError: true } );
+		expect( actual ).toEqual( { url: '/checkout/failed-purchases', isError: true } );
 	} );
 
-	it( 'returns a root url if the transaction has an error and there is no site', () => {
+	it( 'returns a failure url url if the transaction has an error and there is no site', () => {
 		const actual = getRedirectFromPendingPage( {
 			redirectTo: '/home',
 			transaction: {
@@ -340,10 +340,10 @@ describe( 'getRedirectFromPendingPage', () => {
 				processingStatus: ERROR,
 			},
 		} );
-		expect( actual ).toEqual( { url: '/', isError: true } );
+		expect( actual ).toEqual( { url: '/checkout/failed-purchases', isError: true } );
 	} );
 
-	it( 'returns a root url if the transaction fails and there is no site', () => {
+	it( 'returns a failure url if the transaction fails and there is no site', () => {
 		const actual = getRedirectFromPendingPage( {
 			redirectTo: '/home',
 			transaction: {
@@ -352,7 +352,7 @@ describe( 'getRedirectFromPendingPage', () => {
 				processingStatus: FAILURE,
 			},
 		} );
-		expect( actual ).toEqual( { url: '/', isError: true } );
+		expect( actual ).toEqual( { url: '/checkout/failed-purchases', isError: true } );
 	} );
 
 	it( 'returns a checkout url if there was an error', () => {


### PR DESCRIPTION
Most of the time if a transaction fails after the user has confirmed their payment, they will not be charged and will be returned to checkout with an error message. However, there are several edge cases where the purchase will fail _after_ the user has been charged. In these situations, the user will be given credits for their purchase and shown a successful purchase page and only later will discover the problem.

This is part of https://github.com/Automattic/payments-shilling/issues/2053

## Proposed Changes

In this diff, we detect the cases where a purchase fails in this way and redirect the user to a new page that tells them that the purchase failed. It suggests that they try again or contact support, and it informs them that they received credits for the purchase.

Current screenshot:

<img width="937" alt="Screenshot 2023-12-11 at 4 44 22 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/e2b24310-a0e4-4afd-9acc-16f3bab9785e">


Requires D123620-code

## Testing Instructions

- Apply D123620-code and point public-api.wordpress.com at your sandbox.
- Also edit your sandbox to cause one of these errors on the transactions endpoint by applying the changes suggested in D123620-code.
- Next, add a product to your cart in calypso and complete checkout.
- Verify that you are redirected to a page that says the purchase failed.

To make sure that this does not use the failure page unnecessarily, we can make sure that if the user was not charged (if the purchase failed before the user was charged) then they will be returned to checkout.

- Remove the changes that break the transactions endpoint but leave D123620-code applied.
- Next, add a product to your cart in calypso and select a 3DS card to complete checkout.
- When the 3DS confirmation dialog is displayed, click to fail the transaction.
- Verify that you are returned to checkout.