### PR TITLE
Jetpack Manage: show appropriate pricing info for bundle products

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/license-lightbox/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-lightbox/index.tsx
@@ -23,6 +23,7 @@ export type LicenseLightBoxProps = {
 	product: APIProductFamilyProduct;
 	extraAsideContent?: JSX.Element;
 	className?: string;
+	quantity?: number;
 };
 
 const LicenseLightbox: FunctionComponent< LicenseLightBoxProps > = ( {
@@ -34,6 +35,7 @@ const LicenseLightbox: FunctionComponent< LicenseLightBoxProps > = ( {
 	product,
 	extraAsideContent,
 	className,
+	quantity,
 } ) => {
 	const isLargeScreen = useBreakpoint( '>782px' );
 	const { title, product: productInfo } = useLicenseLightboxData( product );
@@ -59,7 +61,7 @@ const LicenseLightbox: FunctionComponent< LicenseLightBoxProps > = ( {
 			</JetpackLightboxMain>
 
 			<JetpackLightboxAside ref={ sidebarRef }>
-				<LicenseLightboxPaymentPlan product={ product } />
+				<LicenseLightboxPaymentPlan product={ product } quantity={ quantity } />
 
 				<Button
 					className="license-lightbox__cta-button"

--- a/client/jetpack-cloud/sections/partner-portal/license-lightbox/license-lightbox-payment-plan.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-lightbox/license-lightbox-payment-plan.tsx
@@ -5,9 +5,10 @@ import ProductPriceWithDiscount from '../primary/product-price-with-discount-inf
 
 type Props = {
 	product: APIProductFamilyProduct;
+	quantity?: number;
 };
 
-const LicenseLightboxPaymentPlan: FunctionComponent< Props > = ( { product } ) => {
+const LicenseLightboxPaymentPlan: FunctionComponent< Props > = ( { product, quantity } ) => {
 	const translate = useTranslate();
 
 	return (
@@ -15,7 +16,7 @@ const LicenseLightboxPaymentPlan: FunctionComponent< Props > = ( { product } ) =
 			<h3 className="license-lightbox__payment-plan-title">{ translate( 'Payment plan:' ) }</h3>
 
 			<div className="license-lightbox__pricing">
-				<ProductPriceWithDiscount product={ product } />
+				<ProductPriceWithDiscount product={ product } quantity={ quantity } />
 			</div>
 		</div>
 	);

--- a/client/jetpack-cloud/sections/partner-portal/license-multi-product-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-multi-product-card/index.tsx
@@ -190,6 +190,7 @@ export default function LicenseMultiProductCard( props: Props ) {
 			{ showLightbox && (
 				<LicenseLightbox
 					product={ product }
+					quantity={ quantity }
 					ctaLabel={ isSelected ? translate( 'Unselect License' ) : translate( 'Select License' ) }
 					isCTAPrimary={ ! isSelected }
 					isDisabled={ isDisabled }

--- a/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
@@ -170,6 +170,7 @@ export default function LicenseProductCard( props: Props ) {
 			{ showLightbox && (
 				<LicenseLightbox
 					product={ product }
+					quantity={ quantity }
 					ctaLabel={ isSelected ? translate( 'Unselect License' ) : translate( 'Select License' ) }
 					isCTAPrimary={ ! isSelected }
 					isDisabled={ isDisabled }

--- a/client/jetpack-cloud/sections/partner-portal/primary/product-price-with-discount-info/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/product-price-with-discount-info/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import formatCurrency from '@automattic/format-currency';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -25,6 +26,8 @@ export default function ProductPriceWithDiscount( {
 
 	const userProducts = useSelector( ( state ) => getProductsList( state ) );
 	const isDailyPricing = product.price_interval === 'day';
+
+	const isBundle = isEnabled( 'jetpack/bundle-licensing' ) && quantity > 1;
 
 	const { actualCost, discountedCost, discountPercentage } = getProductPricingInfo(
 		userProducts,
@@ -68,8 +71,14 @@ export default function ProductPriceWithDiscount( {
 				}
 			</div>
 			<div className="product-price-with-discount__price-interval">
-				{ isDailyPricing && translate( '/USD per license per day' ) }
-				{ product.price_interval === 'month' && translate( '/USD per license per month' ) }
+				{ isDailyPricing &&
+					( isBundle
+						? translate( '/USD per bundle per day' )
+						: translate( '/USD per license per day' ) ) }
+				{ product.price_interval === 'month' &&
+					( isBundle
+						? translate( '/USD per bundle per month' )
+						: translate( '/USD per license per month' ) ) }
 			</div>
 		</div>
 	);


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/137

## Proposed Changes

This PR shows appropriate pricing info for bundle products.

- `/USD per bundle` if the product is a bundle
- `/USD per license` if the product is not a bundle

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

**Instructions**

1. Visit the Jetpack Cloud link > Replace `dashboard` in the URL with `/partner-portal/issue-license?flags=jetpack/bundle-licensing`.
2. Verify that the single license cards display `/USD per license per month` > Click on the `More about ...` link and verify the same is shown.

<img width="522" alt="Screenshot 2023-12-11 at 10 44 08 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/c0e93d52-94f2-41ad-8434-32cecdd1e720">

<img width="434" alt="Screenshot 2023-12-11 at 11 02 03 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/8112eb73-4d91-41ac-989c-02b6905ab2ba">


3. Click on any bundle size tab > Verify that the bundle license cards display `/USD per bundle per month` > Click on the `More about ...` link and verify the same is shown.

<img width="522" alt="Screenshot 2023-12-11 at 10 44 04 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/8ba039e2-b3fd-44fe-bf55-38a558334600">

<img width="434" alt="Screenshot 2023-12-11 at 11 01 44 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/b4eb7d9c-97f3-442c-8ac7-ec3e78856e28">


4. [OPTIONAL] Manually set `product.price_interval` to `day` in `client/jetpack-cloud/sections/partner-portal/primary/product-price-with-discount-info/index.tsx` and verify the below is displayed based on the quantity. This is mainly uploaded to help the translators. 

<img width="522" alt="Screenshot 2023-12-11 at 10 44 04 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/19383cd5-add9-4731-89e0-2ec81c87cbb2">

<img width="522" alt="Screenshot 2023-12-11 at 10 44 08 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/a1ed6463-f7bc-4a1e-b251-bd08b6d682f0">




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?