### PR TITLE
Jetpack Manage: Fix mobile view styling for license details' actions.

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/license-details/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/style.scss
@@ -108,8 +108,20 @@
 
 .license-details--child-license {
 	&,
-	.license-details__actions a,
+	.license-details__actions a:not(.license-details__assign-button),
 	.license-details__actions button {
 		background-color: #fafafa;
+	}
+}
+
+.license-details__actions .button.is-compact {
+	padding: 8px 14px;
+	font-size: 1rem;
+	line-height: 1.375;
+
+	@include break-large {
+		padding: 7px;
+		font-size: 0.75rem;
+		line-height: 1;
 	}
 }


### PR DESCRIPTION
This PR fixes mobile styling for the license details' actions:

The background color for Child licenses does not appear green when viewed on a mobile device.
<img width="443" alt="Screen Shot 2023-12-11 at 2 10 20 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/a1093652-cdc8-4467-8ce0-3e09ad10e6e3">

The height of the action button is too small for it to be easily clicked on mobile devices.
<img width="443" alt="Screen Shot 2023-12-11 at 2 10 38 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/dfc13a8d-bb2e-4fce-95bd-0a552c1fcc09">

Closes https://github.com/Automattic/jetpack-genesis/issues/138

## Proposed Changes

* Do not set background color to `#fafafa` for buttons with class name `.license-details__assign-button`.
* increase the compact button size to at least 40px on a smaller screen.

## Testing Instructions
Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.
* Use the live link below and go to the licenses page (`/partner-portal/licenses`)
* Shrink down the size of your browser to mobile view
* Expand any child licenses that are not assigned. Confirm that the button has green background.
<img width="426" alt="Screen Shot 2023-12-11 at 2 17 34 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/0e09b659-e300-40db-82ba-7c6008038a29">

* Expand any licenses with actions. Confirm that the button size is at least 40px.
<img width="420" alt="Screen Shot 2023-12-11 at 2 17 28 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/04da598e-9601-45d3-8955-ffab16152f95">


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?s