### PR TITLE
Stats: Validate initial slider state

### DIFF
--- a/client/my-sites/stats/stats-purchase/tier-upgrade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/tier-upgrade-slider/index.tsx
@@ -58,10 +58,19 @@ function TierUpgradeSlider( {
 		return <div { ...props }>{ thumbSVG }</div>;
 	} ) as RenderThumbFunction;
 
+	// Bounds check the initial index value.
+	const maxIndex = steps.length - 1;
+	let initialIndex = Math.floor( initialValue );
+	if ( initialIndex < 0 ) {
+		initialIndex = 0;
+	} else if ( initialIndex > maxIndex ) {
+		initialIndex = maxIndex;
+	}
+
 	// Slider state.
-	const [ currentPlanIndex, setCurrentPlanIndex ] = useState( initialValue );
+	const [ currentPlanIndex, setCurrentPlanIndex ] = useState( initialIndex );
 	const sliderMin = 0;
-	const sliderMax = steps?.length - 1;
+	const sliderMax = maxIndex;
 
 	const handleSliderChange = ( value: number ) => {
 		setCurrentPlanIndex( value );

--- a/client/my-sites/stats/stats-purchase/tier-upgrade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/tier-upgrade-slider/index.tsx
@@ -58,8 +58,14 @@ function TierUpgradeSlider( {
 		return <div { ...props }>{ thumbSVG }</div>;
 	} ) as RenderThumbFunction;
 
-	// Bounds check the initial index value.
+	// We need at least two steps for the slider to work.
+	let errorMessage = null;
 	const maxIndex = steps.length - 1;
+	if ( maxIndex < 1 ) {
+		errorMessage = <p>Slider has not been configured properly.</p>;
+	}
+
+	// Bounds check the initial index value.
 	let initialIndex = Math.floor( initialValue );
 	if ( initialIndex < 0 ) {
 		initialIndex = 0;
@@ -83,6 +89,10 @@ function TierUpgradeSlider( {
 	const showPopup = currentPlanIndex === sliderMax && popupInfoString !== undefined;
 	const lhValue = steps[ currentPlanIndex ]?.lhValue;
 	const rhValue = steps[ currentPlanIndex ]?.rhValue;
+
+	if ( errorMessage !== null ) {
+		return errorMessage;
+	}
 
 	return (
 		<div className={ componentClassNames }>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #84859 

## Proposed Changes

Confirm we have at least two steps for the slider and bounds check the initial starting index is valid. Adds a very simple error message if we don't have valid inputs.

<img width="425" alt="SCR-20231208-qgcj" src="https://github.com/Automattic/wp-calypso/assets/40267301/f123e837-6c05-43dd-b1bc-fa2a7fa73c0f">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Launch the Calypso Live link.
* Navigate to **Stats → Traffic**.
* Click on CTA to purchase Stats plan.
* Add `stats/tier-upgrade-slider` to URL flags.
* Confirm tier slider shows the amount and the emoji correctly.

I set my currency to JPY to trigger this bug. Depends on the steps computation logic generating an odd number of steps.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?