### PR TITLE
 The plan comparison toggle width on mobile should match the plan card.

### DIFF
--- a/client/my-sites/plans-features-main/components/comparison-grid-toggle.tsx
+++ b/client/my-sites/plans-features-main/components/comparison-grid-toggle.tsx
@@ -17,8 +17,6 @@ const ComparisonGridToggle = forwardRef<
 		display: flex;
 		justify-content: center;
 		margin-top: 32px;
-		margin-left: 20px;
-		margin-right: 20px;
 
 		button {
 			background: var( --studio-white );
@@ -33,6 +31,7 @@ const ComparisonGridToggle = forwardRef<
 			line-height: 20px;
 			padding: 0 24px;
 			width: 100%;
+			max-width: 440px;
 			transition: border-color 0.15s ease-out;
 
 			${ plansBreakSmall( css`


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This PR is part of the sequence of fixes addressing the design feedback listed in Uzd0AYiDAV4eFq1V35T9Ef-fi-57-52629. The width of the "Compare Plans" toggle button should match the width of plan cards on mobile.

Before, the case when the button is too wide:

<img width="693" alt="CleanShot 2023-12-11 at 15 56 45@2x" src="https://github.com/Automattic/wp-calypso/assets/1842898/155a9a19-b4ce-44b7-b364-862034e4b58e">

After:
<img width="633" alt="CleanShot 2023-12-11 at 15 57 02@2x" src="https://github.com/Automattic/wp-calypso/assets/1842898/b3f023ee-5317-448d-880f-099100376eb8">


Before, the case when the button is too narrow:
<img width="478" alt="CleanShot 2023-12-11 at 15 57 24@2x" src="https://github.com/Automattic/wp-calypso/assets/1842898/a630f107-9c18-4a7f-8a30-29799e3cf7b0">

After:

<img width="479" alt="CleanShot 2023-12-11 at 15 57 42@2x" src="https://github.com/Automattic/wp-calypso/assets/1842898/3f892e16-feae-4dec-931f-589b482fcbf0">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On the mobile resolutions, confirm that the "Compare Plans" button matches the width of mobile plan cards in various places, e.g. `/start/plans`, `/plans`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
