### PR TITLE
getTask: remove createInterpolateElement call

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -1,4 +1,3 @@
-import { createInterpolateElement } from '@wordpress/element';
 import { translate } from 'i18n-calypso';
 import AnimatedIcon from 'calypso/components/animated-icon';
 import InlineSupportLink from 'calypso/components/inline-support-link';
@@ -200,13 +199,14 @@ export const getTask = (
 				: translate(
 						"Your site is private and only visible to you. When you're ready, launch your site to make it public."
 				  );
-			const descriptionOnCompleted = createInterpolateElement(
-				/* translators: pressing <Link> will redirect user to Settings -> Privacy where they can change the site visibilidty */
-				translate(
-					'Your site is already live. You can change your site visibility in <Link>privacy options</Link> at any time.'
-				),
+			const descriptionOnCompleted = translate(
+				'Your site is already live. You can change your site visibility in <Link>privacy options</Link> at any time.',
 				{
-					Link: <a href={ `/settings/general/${ siteSlug }#site-privacy-settings` } />,
+					components: {
+						Link: <a href={ `/settings/general/${ siteSlug }#site-privacy-settings` } />,
+					},
+					comment:
+						'pressing <Link> will redirect the user to Settings -> Privacy where they can change the site visibility',
 				}
 			);
 


### PR DESCRIPTION
Removes redundant call of `createIntepolateElement` and uses a built-in functionality of `translate` instead. We don't need to mix WordPress and Calypso i18n libraries.

Maybe fixes a crash reported in Sentry, but I'm not really 100% sure about that.