### PR TITLE
Jetpack Manage: Add search query filter support for included products in a Plan.

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/lib/filter.ts
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/lib/filter.ts
@@ -1,6 +1,27 @@
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+import getProductInfo from '../../lib/get-product-info';
 
-/* check if product matches the search query
+// Helper function to get the product name from the product slug. Only applicable for this filter logic.
+function getProductNameBySlug( slug: string ) {
+	if ( slug.startsWith( 'jetpack_anti_spam' ) ) {
+		return 'Akismet Anti-spam';
+	}
+
+	if ( slug.startsWith( 'jetpack_backup_t1' ) ) {
+		return 'VaultPress Backup 10GB';
+	}
+
+	if ( slug.startsWith( 'jetpack_backup_t2' ) ) {
+		return 'VaultPress Backup 1TB';
+	}
+
+	return slug
+		.replace( /t1|t2|monthly|yearly|jetpack/g, '' )
+		.replace( /_/g, ' ' )
+		.trim();
+}
+
+/* Check if product matches the search query.
  *
  * @param product - product to check
  * @param productSearchQuery - search query to match against
@@ -11,29 +32,12 @@ export const isProductMatch = ( product: APIProductFamilyProduct, productSearchQ
 	const nameFilter = ( name: string ) =>
 		name.toLowerCase().includes( productSearchQuery.toLowerCase() );
 
-	if ( product.slug.startsWith( 'jetpack-complete' ) ) {
-		return [
-			product.name,
-			'Jetpack VaultPress Backup',
-			'Jetpack Scan',
-			'Jetpack Akismet Anti-spam',
-			'Jetpack VideoPress',
-			'Jetpack Boost',
-			'Jetpack Social',
-			'Jetpack Search',
-			'Jetpack Stats',
-			'Jetpack CRM',
-			'Jetpack Creator',
-		].some( nameFilter );
-	}
+	const productInfo = getProductInfo( product.slug );
 
-	if ( product.slug.startsWith( 'jetpack-security' ) ) {
-		return [
-			product.name,
-			'Jetpack VaultPress Backup',
-			'Jetpack Scan',
-			'Jetpack Akismet Anti-spam',
-		].some( nameFilter );
+	if ( productInfo?.productsIncluded?.length ) {
+		return [ product.name, ...productInfo.productsIncluded.map( getProductNameBySlug ) ].some(
+			nameFilter
+		);
 	}
 
 	return nameFilter( product.name );

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/lib/filter.ts
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/lib/filter.ts
@@ -13,6 +13,7 @@ export const isProductMatch = ( product: APIProductFamilyProduct, productSearchQ
 
 	if ( product.slug.startsWith( 'jetpack-complete' ) ) {
 		return [
+			product.name,
 			'Jetpack VaultPress Backup',
 			'Jetpack Scan',
 			'Jetpack Akismet Anti-spam',
@@ -27,9 +28,12 @@ export const isProductMatch = ( product: APIProductFamilyProduct, productSearchQ
 	}
 
 	if ( product.slug.startsWith( 'jetpack-security' ) ) {
-		return [ 'Jetpack VaultPress Backup', 'Jetpack Scan', 'Jetpack Akismet Anti-spam' ].some(
-			nameFilter
-		);
+		return [
+			product.name,
+			'Jetpack VaultPress Backup',
+			'Jetpack Scan',
+			'Jetpack Akismet Anti-spam',
+		].some( nameFilter );
 	}
 
 	return nameFilter( product.name );

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/lib/filter.ts
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/lib/filter.ts
@@ -1,0 +1,36 @@
+import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+
+/* check if product matches the search query
+ *
+ * @param product - product to check
+ * @param productSearchQuery - search query to match against
+ *
+ * @returns boolean - true if product matches the search query, false otherwise
+ */
+export const isProductMatch = ( product: APIProductFamilyProduct, productSearchQuery: string ) => {
+	const nameFilter = ( name: string ) =>
+		name.toLowerCase().includes( productSearchQuery.toLowerCase() );
+
+	if ( product.slug.startsWith( 'jetpack-complete' ) ) {
+		return [
+			'Jetpack VaultPress Backup',
+			'Jetpack Scan',
+			'Jetpack Akismet Anti-spam',
+			'Jetpack VideoPress',
+			'Jetpack Boost',
+			'Jetpack Social',
+			'Jetpack Search',
+			'Jetpack Stats',
+			'Jetpack CRM',
+			'Jetpack Creator',
+		].some( nameFilter );
+	}
+
+	if ( product.slug.startsWith( 'jetpack-security' ) ) {
+		return [ 'Jetpack VaultPress Backup', 'Jetpack Scan', 'Jetpack Akismet Anti-spam' ].some(
+			nameFilter
+		);
+	}
+
+	return nameFilter( product.name );
+};

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/lib/filter.ts
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/lib/filter.ts
@@ -4,19 +4,19 @@ import getProductInfo from '../../lib/get-product-info';
 // Helper function to get the product name from the product slug. Only applicable for this filter logic.
 function getProductNameBySlug( slug: string ) {
 	if ( slug.startsWith( 'jetpack_anti_spam' ) ) {
-		return 'Akismet Anti-spam';
+		return 'Jetpack Akismet Anti-spam';
 	}
 
 	if ( slug.startsWith( 'jetpack_backup_t1' ) ) {
-		return 'VaultPress Backup 10GB';
+		return 'Jetpack VaultPress Backup 10GB';
 	}
 
 	if ( slug.startsWith( 'jetpack_backup_t2' ) ) {
-		return 'VaultPress Backup 1TB';
+		return 'Jetpack VaultPress Backup 1TB';
 	}
 
 	return slug
-		.replace( /t1|t2|monthly|yearly|jetpack/g, '' )
+		.replace( /t1|t2|monthly|yearly/g, '' )
 		.replace( /_/g, ' ' )
 		.trim();
 }

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/hooks/use-product-and-plans.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/hooks/use-product-and-plans.tsx
@@ -20,6 +20,7 @@ import {
 	PRODUCT_FILTER_VAULTPRESS_BACKUP_ADDONS,
 	PRODUCT_FILTER_WOOCOMMERCE_EXTENSIONS,
 } from '../../constants';
+import { isProductMatch } from '../../lib/filter';
 import type { SiteDetails } from '@automattic/data-stores';
 
 // Plans and Products that we can merged into 1 card.
@@ -164,8 +165,8 @@ export default function useProductAndPlans( {
 
 		// Filter products based on the search term
 		if ( productSearchQuery ) {
-			filteredProductsAndBundles = filteredProductsAndBundles.filter(
-				( product ) => product.name?.toLowerCase().includes( productSearchQuery.toLowerCase() )
+			filteredProductsAndBundles = filteredProductsAndBundles.filter( ( product ) =>
+				isProductMatch( product, productSearchQuery )
 			);
 		}
 

--- a/client/jetpack-cloud/sections/partner-portal/lib/get-product-info.ts
+++ b/client/jetpack-cloud/sections/partner-portal/lib/get-product-info.ts
@@ -1,0 +1,17 @@
+import slugToSelectorProduct from 'calypso/my-sites/plans/jetpack-plans/slug-to-selector-product';
+
+/**
+ * Get SelectorProduct from productSlug
+ * @param slug Product slug
+ * @returns SelectorProduct | null
+ */
+export default function getProductInfo( slug: string ) {
+	/*
+	 * To reuse existing product info, we need to convert the product slug to the format used in the product store.
+	 * We are also using only the monthly slug to ensure we hit the equivalent product in the product store.
+	 */
+	const baseSlug = slug.replaceAll( /-/g, '_' ).replace( /_(monthly|yearly)$/, '' );
+	return (
+		slugToSelectorProduct( baseSlug + '_monthly' ) || slugToSelectorProduct( baseSlug + '_yearly' )
+	);
+}

--- a/client/jetpack-cloud/sections/partner-portal/license-lightbox/hooks/use-license-lightbox-data.ts
+++ b/client/jetpack-cloud/sections/partner-portal/license-lightbox/hooks/use-license-lightbox-data.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
-import slugToSelectorProduct from 'calypso/my-sites/plans/jetpack-plans/slug-to-selector-product';
 import { SelectorProduct } from 'calypso/my-sites/plans/jetpack-plans/types';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+import getProductInfo from '../../lib/get-product-info';
 import getProductTitle from '../../lib/get-product-title';
 
 type LicenseLightboxData = {
@@ -11,14 +11,7 @@ type LicenseLightboxData = {
 
 export function useLicenseLightboxData( product: APIProductFamilyProduct ): LicenseLightboxData {
 	return useMemo( () => {
-		/*
-		 * To reuse existing product info, we need to convert the product slug to the format used in the product store.
-		 * We are also using only the monthly slug to ensure we hit the equivalent product in the product store.
-		 */
-		const baseSlug = product.slug.replaceAll( /-/g, '_' ).replace( /_(monthly|yearly)$/, '' );
-		const productInfo =
-			slugToSelectorProduct( baseSlug + '_monthly' ) ||
-			slugToSelectorProduct( baseSlug + '_yearly' );
+		const productInfo = getProductInfo( product.slug );
 
 		const title = getProductTitle( product.name );
 


### PR DESCRIPTION
Currently, the Issue License page search query only filters products by name. This PR will now also check for included product names in the filter.

<img width="1384" alt="Screen Shot 2023-12-11 at 4 28 30 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/fa801370-a73b-4cce-bb78-09e34e05b13f">

Closes https://github.com/orgs/Automattic/projects/818/views/1?pane=issue&itemId=47148929

## Proposed Changes

* Update the Search query logic to search for included products for both Complete and Security plans.

## Testing Instructions

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

* Use the live link below and go to the licenses page (`/partner-portal/issue-license`)
* Use the the product search filter and type **Backup**
* Confirm that both **Security** and **Complete** plans appear as a match.
* Search for other products such as Akismet, Scan, Monitor, Social, etc.
* Confirm that the correct Plans that include it also appear as a match.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?