### PR TITLE
Fix invalid email address passing from sign up to login screen

### DIFF
--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -166,11 +166,8 @@ export class UserStep extends Component {
 	}
 
 	getLoginUrl() {
-		const { oauth2Client, wccomFrom, isReskinned, sectionName, from, locale } = this.props;
-		const emailAddress =
-			typeof this.props?.step?.form?.email === 'object'
-				? this.props?.step?.form?.email?.value
-				: this.props?.step?.form?.email;
+		const { oauth2Client, wccomFrom, isReskinned, sectionName, from, locale, step } = this.props;
+		const emailAddress = step?.form?.email?.value ?? step?.form?.email;
 
 		return login( {
 			isJetpack: 'jetpack-connect' === sectionName,

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -167,6 +167,10 @@ export class UserStep extends Component {
 
 	getLoginUrl() {
 		const { oauth2Client, wccomFrom, isReskinned, sectionName, from, locale } = this.props;
+		const emailAddress =
+			typeof this.props?.step?.form?.email === 'object'
+				? this.props?.step?.form?.email?.value
+				: this.props?.step?.form?.email;
 
 		return login( {
 			isJetpack: 'jetpack-connect' === sectionName,
@@ -177,7 +181,7 @@ export class UserStep extends Component {
 			wccomFrom,
 			isWhiteLogin: isReskinned,
 			signupUrl: window.location.pathname + window.location.search,
-			emailAddress: this.props?.step?.form?.email,
+			emailAddress,
 		} );
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Close https://github.com/Automattic/wp-calypso/issues/84843

## Proposed Changes

The `email_address` was added to login URL in https://github.com/Automattic/wp-calypso/pull/83515. However, `this.props.step.form.email` is an object in wpcc flow. This PR fixes the issues by checking the prop type and passing the correct value to the login screen.

https://github.com/Automattic/wp-calypso/assets/4344253/c1a3a5c3-c0ab-4a3b-9aed-dd9d5ec9fb74

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


1. In incognito browser, go to https://woo.com/start and go through all NUX steps
1. When prompted with sign up screen, enter your email address only
2. Click on the `Login` link at the description `Already registered? Log in`
3. Confirm  the correct email from signup to login screen

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?