### PR TITLE
Stats: Update tier extension handling

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
@@ -96,7 +96,6 @@ function StatsCommercialUpgradeSlider( {
 				},
 			}
 		) as string;
-		lastTier.views = `${ formatNumber( EXTENSION_THRESHOLD * 1000000 ) }+`;
 	}
 
 	const steps = getStepsForTiers( tiers );

--- a/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
@@ -40,12 +40,14 @@ function getStepsForTiers( tiers: StatsPlanTierUI[] ) {
 		if ( typeof tier.price === 'string' ) {
 			price = tier.price;
 		}
-		// Views can be a number or a string so address that.
+		// View should be a number but the current mock data
+		// includes a string for the final tier.
+		// Special case that scenario for now.
 		let views = '';
-		if ( typeof tier.views === 'string' ) {
-			views = tier.views;
-		} else if ( typeof tier.views === 'number' ) {
+		if ( typeof tier.views === 'number' ) {
 			views = formatNumber( tier.views );
+		} else if ( typeof tier.views === 'string' ) {
+			views = `${ formatNumber( EXTENSION_THRESHOLD * 1000000 ) }+`;
 		}
 		// Return the new step with string values.
 		return {
@@ -98,6 +100,7 @@ function StatsCommercialUpgradeSlider( {
 		) as string;
 	}
 
+	// Transform the tiers into a format that the slider can use.
 	const steps = getStepsForTiers( tiers );
 
 	const handleSliderChanged = ( index: number ) => {

--- a/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
@@ -40,15 +40,17 @@ function getStepsForTiers( tiers: StatsPlanTierUI[] ) {
 		if ( typeof tier.price === 'string' ) {
 			price = tier.price;
 		}
+
 		// View should be a number but the current mock data
 		// includes a string for the final tier.
 		// Special case that scenario for now.
 		let views = '';
-		if ( typeof tier.views === 'number' ) {
-			views = formatNumber( tier.views );
-		} else if ( typeof tier.views === 'string' ) {
+		if ( tier.views === null ) {
 			views = `${ formatNumber( EXTENSION_THRESHOLD * 1000000 ) }+`;
+		} else {
+			views = formatNumber( tier.views );
 		}
+
 		// Return the new step with string values.
 		return {
 			lhValue: views,

--- a/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
@@ -8,6 +8,10 @@ import { StatsPlanTierUI } from '../types';
 import useAvailableUpgradeTiers from '../use-available-upgrade-tiers';
 import './styles.scss';
 
+// Special case for per-unit fees over the max tier.
+// In millions.
+const EXTENSION_THRESHOLD = 2;
+
 function useTranslatedStrings() {
 	const translate = useTranslate();
 	const limits = translate( 'Monthly site views limit', {
@@ -79,7 +83,6 @@ function StatsCommercialUpgradeSlider( {
 	const lastTier = tiers.at( -1 );
 	const hasPerUnitFee = !! lastTier?.per_unit_fee;
 	if ( hasPerUnitFee ) {
-		const EXTENSION_THRESHOLD = 2; // in millions
 		const perUnitFee = Number( lastTier?.per_unit_fee );
 		perUnitFeeMessaging = translate(
 			'This is the base price for %(views_extension_limit)s million monthly views; beyond that, you will be charged additional +%(extension_value)s per million views.',

--- a/client/my-sites/stats/stats-purchase/types.ts
+++ b/client/my-sites/stats/stats-purchase/types.ts
@@ -13,7 +13,7 @@ export type PriceTierListItemProps = {
 export type StatsPlanTierUI = {
 	price: string | undefined;
 	description?: string;
-	views: string | number | undefined;
+	views: number | null;
 	extension?: boolean;
 	per_unit_fee?: number;
 };

--- a/client/my-sites/stats/stats-purchase/use-available-upgrade-tiers.tsx
+++ b/client/my-sites/stats/stats-purchase/use-available-upgrade-tiers.tsx
@@ -38,7 +38,7 @@ const MOCK_PLAN_DATA = [
 	},
 	{
 		price: '$89.99',
-		views: '1M++',
+		views: null,
 		extension: true,
 		per_unit_fee: 1799,
 		description: '$25/month per million views if views exceed 1M',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #84859.

## Proposed Changes

Updates the logic to treat the data from the API as immutable and to handle the tier extension in the transform code. This logic may need further updates depending on what the final API data looks like.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Launch the Calypso Live link.
* Navigate to **Stats → Traffic**.
* Click on CTA to purchase Stats plan.
* Add `stats/tier-upgrade-slider` to URL flags.
* Click the "choose a commercial plan" link in the highlighted box.
* Confirm the new tier slider shows correctly.
* Confirm the view limit of the last tier is shown as "2M+".

Should work correctly on both DotCom and Jetpack sites.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?