### PR TITLE
Reverts: swc minifier changes

### DIFF
--- a/apps/blaze-dashboard/webpack.config.js
+++ b/apps/blaze-dashboard/webpack.config.js
@@ -59,14 +59,7 @@ module.exports = {
 	optimization: {
 		minimize: ! isDevelopment,
 		concatenateModules: ! shouldEmitStats,
-		minimizer: Minify( {
-			extractComments: false,
-			terserOptions: {
-				ecma: 5,
-				safari10: true,
-				mangle: { reserved: [ '__', '_n', '_nx', '_x' ] },
-			},
-		} ),
+		minimizer: Minify(),
 		splitChunks: false,
 	},
 	module: {

--- a/apps/odyssey-stats/.size-limit.js
+++ b/apps/odyssey-stats/.size-limit.js
@@ -3,7 +3,7 @@ const path = require( 'path' );
 module.exports = [
 	{
 		path: path.join( __dirname, 'dist/build.min.js' ),
-		limit: '300 KiB',
+		limit: '308 KiB',
 	},
 	{
 		path: path.join( __dirname, 'dist/widget-loader.min.js' ),

--- a/apps/odyssey-stats/webpack.config.js
+++ b/apps/odyssey-stats/webpack.config.js
@@ -64,14 +64,7 @@ module.exports = {
 	optimization: {
 		minimize: ! isDevelopment,
 		concatenateModules: ! shouldEmitStats,
-		minimizer: Minify( {
-			extractComments: false,
-			terserOptions: {
-				ecma: 5,
-				safari10: true,
-				mangle: { reserved: [ '__', '_n', '_nx', '_x' ] },
-			},
-		} ),
+		minimizer: Minify(),
 		splitChunks: false,
 	},
 	module: {

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -208,14 +208,7 @@ const webpackConfig = {
 		moduleIds: 'named',
 		chunkIds: isDevelopment || shouldEmitStats ? 'named' : 'deterministic',
 		minimize: shouldMinify,
-		minimizer: Minify( {
-			parallel: workerCount,
-			// Note: terserOptions will override (Object.assign) default terser options in packages/calypso-build/webpack/minify.js
-			terserOptions: {
-				compress: true,
-				mangle: true,
-			},
-		} ),
+		minimizer: Minify(),
 	},
 	module: {
 		strictExportPresence: true,

--- a/packages/calypso-build/webpack.config.js
+++ b/packages/calypso-build/webpack.config.js
@@ -87,15 +87,7 @@ function getWebpackConfig(
 		},
 		optimization: {
 			minimize: ! isDevelopment,
-			minimizer: Minify( {
-				parallel: workerCount,
-				extractComments: false,
-				terserOptions: {
-					ecma: 5,
-					safari10: true,
-					mangle: { reserved: [ '__', '_n', '_nx', '_x' ] },
-				},
-			} ),
+			minimizer: Minify(),
 		},
 		module: {
 			strictExportPresence: true,

--- a/packages/calypso-build/webpack/minify.js
+++ b/packages/calypso-build/webpack/minify.js
@@ -112,8 +112,11 @@ module.exports = ( {
 	extractComments = true,
 } = {} ) => {
 	terserOptions = {
+		compress: true,
+		mangle: {
+			reserved: [ '__', '_n', '_nx', '_x' ],
+		},
 		ecma: chooseTerserEcmaVersion( supportedBrowsers ),
-		ie8: false,
 		safari10: supportedBrowsers.some(
 			( browser ) => browser.includes( 'safari 10' ) || browser.includes( 'ios_saf 10' )
 		),
@@ -125,7 +128,13 @@ module.exports = ( {
 	};
 
 	return [
-		new TerserPlugin( { parallel, extractComments, terserOptions } ),
+		new TerserPlugin( {
+			// SWC handles parallelization internally.
+			parallel,
+			extractComments,
+			terserOptions,
+			minify: TerserPlugin.swcMinify,
+		} ),
 		new CssMinimizerPlugin( { parallel, minimizerOptions: cssMinimizerOptions } ),
 	];
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Reverts https://github.com/Automattic/wp-calypso/pull/84226


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?