### PR TITLE
Assembler Level-Up: Support font pairings from the Assembler theme

### DIFF
--- a/packages/global-styles/src/components/font-pairing-variations/font-families-loader.tsx
+++ b/packages/global-styles/src/components/font-pairing-variations/font-families-loader.tsx
@@ -11,8 +11,14 @@ const FONT_API_BASE = 'https://fonts-api.wp.com/css2';
 
 const FONT_AXIS = 'ital,wght@0,400;0,700;1,400;1,700';
 
-// Fix to avoid error in Google Fonts API
-const removeSingleQuotes = ( fontFamily: string ) => fontFamily.replaceAll( "'", '' );
+/**
+ * Supports the following formats:
+ * - Albert Sans
+ * - 'Albert Sans'
+ * - "Albert Sans", sans-serif
+ */
+const normalizeFontFamily = ( fontFamily: string ) =>
+	fontFamily.split( ',' )[ 0 ].replaceAll( "'", '' ).replaceAll( '"', '' ).trim();
 
 const FontFamiliesLoader = ( { fontFamilies, onLoad }: Props ) => {
 	const params = useMemo(
@@ -20,11 +26,11 @@ const FontFamiliesLoader = ( { fontFamilies, onLoad }: Props ) => {
 			new URLSearchParams( [
 				...fontFamilies.map( ( { fontFamily } ) => [
 					'family',
-					`${ removeSingleQuotes( fontFamily ) }:${ FONT_AXIS }`,
+					`${ normalizeFontFamily( fontFamily ) }:${ FONT_AXIS }`,
 				] ),
 				[ 'display', 'swap' ],
 			] ),
-		fontFamilies
+		[ fontFamilies ]
 	);
 
 	if ( ! params.getAll( 'family' ).length ) {

--- a/packages/global-styles/src/components/font-pairing-variations/preview.tsx
+++ b/packages/global-styles/src/components/font-pairing-variations/preview.tsx
@@ -29,18 +29,38 @@ const FontPairingVariationPreview = () => {
 	const [ textFontStyle = 'normal' ] = useGlobalStyle( 'typography.fontStyle' );
 	const [ textLetterSpacing = '-0.15px' ] = useGlobalStyle( 'typography.letterSpacing' );
 	const [ textFontWeight = 400 ] = useGlobalStyle( 'typography.fontWeight' );
+	const [ textTextTransform = 'none' ] = useGlobalStyle( 'typography.textTransform' );
 
-	const [ headingFontFamily = textFontFamily ] = useGlobalStyle(
+	const [ baseHeadingFontFamily = textFontFamily ] = useGlobalStyle(
 		'elements.heading.typography.fontFamily'
 	);
-	const [ headingFontStyle = textFontStyle ] = useGlobalStyle(
+	const [ baseHeadingFontStyle = textFontStyle ] = useGlobalStyle(
 		'elements.heading.typography.fontStyle'
 	);
-	const [ headingFontWeight = textFontWeight ] = useGlobalStyle(
+	const [ baseHeadingFontWeight = textFontWeight ] = useGlobalStyle(
 		'elements.heading.typography.fontWeight'
 	);
-	const [ headingLetterSpacing = textLetterSpacing ] = useGlobalStyle(
+	const [ baseHeadingLetterSpacing = textLetterSpacing ] = useGlobalStyle(
 		'elements.heading.typography.letterSpacing'
+	);
+	const [ baseHeadingTextTransform = textTextTransform ] = useGlobalStyle(
+		'elements.heading.typography.textTransform'
+	);
+
+	const [ headingFontFamily = baseHeadingFontFamily ] = useGlobalStyle(
+		'elements.h1.typography.fontFamily'
+	);
+	const [ headingFontStyle = baseHeadingFontStyle ] = useGlobalStyle(
+		'elements.h1.typography.fontStyle'
+	);
+	const [ headingFontWeight = baseHeadingFontWeight ] = useGlobalStyle(
+		'elements.h1.typography.fontWeight'
+	);
+	const [ headingLetterSpacing = baseHeadingLetterSpacing ] = useGlobalStyle(
+		'elements.h1.typography.letterSpacing'
+	);
+	const [ headingTextTransform = baseHeadingTextTransform ] = useGlobalStyle(
+		'elements.h1.typography.textTransform'
 	);
 
 	const [ containerResizeListener, { width } ] = useResizeObserver();
@@ -49,8 +69,7 @@ const FontPairingVariationPreview = () => {
 	const defaultHeight = isDesktop ? FONT_PREVIEW_LARGE_HEIGHT : FONT_PREVIEW_HEIGHT;
 	const ratio = width ? width / defaultWidth : 1;
 	const normalizedHeight = Math.ceil( defaultHeight * ratio );
-	const externalFontFamilies = fontFamilies.filter( ( { slug } ) => slug !== SYSTEM_FONT_SLUG );
-	const [ isLoaded, setIsLoaded ] = useState( ! externalFontFamilies.length );
+
 	const getFontFamilyName = ( targetFontFamily: string ) => {
 		const fontFamily = fontFamilies.find( ( { fontFamily } ) => fontFamily === targetFontFamily );
 		return fontFamily?.name || fontFamily?.fontFamily || targetFontFamily;
@@ -65,6 +84,12 @@ const FontPairingVariationPreview = () => {
 		() => getFontFamilyName( headingFontFamily ),
 		[ headingFontFamily, fontFamilies ]
 	);
+
+	const externalFontFamilies = fontFamilies
+		.filter( ( { slug } ) => slug !== SYSTEM_FONT_SLUG )
+		.filter( ( { fontFamily } ) => [ textFontFamily, headingFontFamily ].includes( fontFamily ) );
+
+	const [ isLoaded, setIsLoaded ] = useState( ! externalFontFamilies.length );
 
 	const handleOnLoad = () => setIsLoaded( true );
 
@@ -115,6 +140,7 @@ const FontPairingVariationPreview = () => {
 										fontWeight: headingFontWeight,
 										fontFamily: headingFontFamily,
 										fontStyle: headingFontStyle,
+										textTransform: headingTextTransform,
 									} }
 								>
 									{ headingFontFamilyName }

--- a/packages/global-styles/src/components/font-pairing-variations/preview.tsx
+++ b/packages/global-styles/src/components/font-pairing-variations/preview.tsx
@@ -29,7 +29,6 @@ const FontPairingVariationPreview = () => {
 	const [ textFontStyle = 'normal' ] = useGlobalStyle( 'typography.fontStyle' );
 	const [ textLetterSpacing = '-0.15px' ] = useGlobalStyle( 'typography.letterSpacing' );
 	const [ textFontWeight = 400 ] = useGlobalStyle( 'typography.fontWeight' );
-	const [ textTextTransform = 'none' ] = useGlobalStyle( 'typography.textTransform' );
 
 	const [ baseHeadingFontFamily = textFontFamily ] = useGlobalStyle(
 		'elements.heading.typography.fontFamily'
@@ -43,9 +42,6 @@ const FontPairingVariationPreview = () => {
 	const [ baseHeadingLetterSpacing = textLetterSpacing ] = useGlobalStyle(
 		'elements.heading.typography.letterSpacing'
 	);
-	const [ baseHeadingTextTransform = textTextTransform ] = useGlobalStyle(
-		'elements.heading.typography.textTransform'
-	);
 
 	const [ headingFontFamily = baseHeadingFontFamily ] = useGlobalStyle(
 		'elements.h1.typography.fontFamily'
@@ -58,9 +54,6 @@ const FontPairingVariationPreview = () => {
 	);
 	const [ headingLetterSpacing = baseHeadingLetterSpacing ] = useGlobalStyle(
 		'elements.h1.typography.letterSpacing'
-	);
-	const [ headingTextTransform = baseHeadingTextTransform ] = useGlobalStyle(
-		'elements.h1.typography.textTransform'
 	);
 
 	const [ containerResizeListener, { width } ] = useResizeObserver();
@@ -140,7 +133,6 @@ const FontPairingVariationPreview = () => {
 										fontWeight: headingFontWeight,
 										fontFamily: headingFontFamily,
 										fontStyle: headingFontStyle,
-										textTransform: headingTextTransform,
 									} }
 								>
 									{ headingFontFamilyName }


### PR DESCRIPTION
Related to

- https://github.com/Automattic/dotcom-forge/issues/4783

## Proposed Changes

Support font pairings from the Assembler theme.

Added support for:

- `text-transform` CSS. The Assembler theme has `text-transform: uppercase` for the heading of some variations.
- Font family name in the form of `"Albert Sans", sans-serif`

Also, I refactored the font families loader so that it only loads the heading and text fonts, instead of currently ALL Jetpack Google Fonts!!

## Testing Instructions

Follow the instructions on: D131541-code.

cc: @richtabor 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?