### PR TITLE
Add bloganuary banner to reader

### DIFF
--- a/client/components/bloganuary-header/index.tsx
+++ b/client/components/bloganuary-header/index.tsx
@@ -1,0 +1,39 @@
+import { useTranslate } from 'i18n-calypso';
+import { useDispatch } from 'react-redux';
+import BloganuaryIcon from 'calypso/components/blogging-prompt-card/bloganuary-icon';
+import isBloganuary from 'calypso/data/blogging-prompt/is-bloganuary';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import './style.scss';
+
+const BloganuaryHeader = () => {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+
+	const trackBloganuaryMoreInfoClick = () => {
+		dispatch( recordTracksEvent( 'reader_bloganuary_more_info_click' ) );
+	};
+
+	if ( ! isBloganuary() ) {
+		return;
+	}
+
+	return (
+		<div className="bloganuary-header">
+			<div>
+				<BloganuaryIcon />
+				<span className="bloganuary-header__title">{ translate( 'Bloganuary' ) }</span>
+			</div>
+			<a
+				href="https://wordpress.com/bloganuary"
+				className="bloganuary-header__link button"
+				target="_blank"
+				rel="noopener noreferrer"
+				onClick={ trackBloganuaryMoreInfoClick }
+			>
+				{ translate( 'Learn more' ) }
+			</a>
+		</div>
+	);
+};
+
+export default BloganuaryHeader;

--- a/client/components/bloganuary-header/index.tsx
+++ b/client/components/bloganuary-header/index.tsx
@@ -1,10 +1,9 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { Button } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
-import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import FollowButton from 'calypso/blocks/follow-button/button';
 import BloganuaryIcon from 'calypso/components/blogging-prompt-card/bloganuary-icon';
 import isBloganuary from 'calypso/data/blogging-prompt/is-bloganuary';
 import ReaderFollowFeedIcon from 'calypso/reader/components/icons/follow-feed-icon';
@@ -66,20 +65,17 @@ const BloganuaryHeader = () => {
 				<span className="bloganuary-header__title">{ translate( 'Bloganuary' ) }</span>
 			</div>
 			<div>
-				<Button
-					className={ classNames( 'bloganuary-header__button', {
-						'is-following': isFollowingBloganuary,
-					} ) }
-					onClick={ toggleFollowBloganuary }
+				<FollowButton
+					followLabel={ translate( 'Follow' ) }
+					followingLabel={ translate( 'Following' ) }
+					iconSize={ 24 }
+					following={ isFollowingBloganuary }
+					onFollowToggle={ toggleFollowBloganuary }
+					followIcon={ ReaderFollowFeedIcon( { iconSize: 20 } ) }
+					followingIcon={ ReaderFollowingFeedIcon( { iconSize: 20 } ) }
+					className="bloganuary-header__button"
 					disabled={ isFollowingBloganuary === undefined }
-				>
-					{ isFollowingBloganuary
-						? ReaderFollowingFeedIcon( { iconSize: 20 } )
-						: ReaderFollowFeedIcon( { iconSize: 20 } ) }
-					<span className="bloganuary-header__follow-label">
-						{ isFollowingBloganuary ? translate( 'Following' ) : translate( 'Follow' ) }
-					</span>
-				</Button>
+				/>
 				<a
 					href={ localizeUrl( 'https://wordpress.com/bloganuary' ) }
 					className="bloganuary-header__link"

--- a/client/components/bloganuary-header/index.tsx
+++ b/client/components/bloganuary-header/index.tsx
@@ -1,21 +1,55 @@
+import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { useDispatch } from 'react-redux';
+import { useEffect, useRef } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import BloganuaryIcon from 'calypso/components/blogging-prompt-card/bloganuary-icon';
 import isBloganuary from 'calypso/data/blogging-prompt/is-bloganuary';
+import { Tag } from 'calypso/reader/list-manage/types';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { successNotice } from 'calypso/state/notices/actions';
+import { requestFollowTag } from 'calypso/state/reader/tags/items/actions';
+import { getReaderFollowedTags } from 'calypso/state/reader/tags/selectors';
+import { toggleReaderSidebarTags } from 'calypso/state/reader-ui/sidebar/actions';
+import { isTagsOpen } from 'calypso/state/reader-ui/sidebar/selectors';
 import './style.scss';
+
+const containsBloganuary = ( followedTags: Tag[] | undefined ): boolean | undefined => {
+	return followedTags?.some( ( tag: Tag ) => tag.slug === 'bloganuary' );
+};
 
 const BloganuaryHeader = () => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
+	const followedTags = useSelector( getReaderFollowedTags ) as Tag[];
+	const prevIsFollowingBloganuary = useRef( containsBloganuary( followedTags ) );
+	const isFollowingBloganuary = containsBloganuary( followedTags );
+	const isTagsSidebarOpen = useSelector( isTagsOpen );
+
+	useEffect( () => {
+		dispatch( recordTracksEvent( 'calypso_reader_bloganuary_banner_view' ) );
+	}, [ dispatch ] );
+
+	// Handle successfully subscribing to 'bloganuary' the redux-y way
+	// Errors are handled in client/state/data-layer/wpcom/read/tags/mine/new/index.js:receiveError
+	useEffect( () => {
+		// tripple equals check is needed because 'undefined' means the value has not been loaded yet.
+		if ( prevIsFollowingBloganuary.current === false && isFollowingBloganuary ) {
+			dispatch( successNotice( translate( 'Subscribed to bloganuary tag' ) ) );
+		}
+		prevIsFollowingBloganuary.current = isFollowingBloganuary;
+	}, [ isFollowingBloganuary, prevIsFollowingBloganuary, dispatch, translate ] );
 
 	const trackBloganuaryMoreInfoClick = () => {
-		dispatch( recordTracksEvent( 'reader_bloganuary_more_info_click' ) );
+		dispatch( recordTracksEvent( 'calypso_reader_bloganuary_banner_more_info_click' ) );
 	};
 
-	if ( ! isBloganuary() ) {
-		return;
-	}
+	const subscribeToBloganuaryTag = () => {
+		dispatch( requestFollowTag( 'bloganuary' ) );
+		if ( ! isTagsSidebarOpen ) {
+			dispatch( toggleReaderSidebarTags() );
+		}
+		dispatch( recordTracksEvent( 'calypso_reader_bloganuary_banner_subscribe_to_tag' ) );
+	};
 
 	return (
 		<div className="bloganuary-header">
@@ -23,17 +57,34 @@ const BloganuaryHeader = () => {
 				<BloganuaryIcon />
 				<span className="bloganuary-header__title">{ translate( 'Bloganuary' ) }</span>
 			</div>
-			<a
-				href="https://wordpress.com/bloganuary"
-				className="bloganuary-header__link button"
-				target="_blank"
-				rel="noopener noreferrer"
-				onClick={ trackBloganuaryMoreInfoClick }
-			>
-				{ translate( 'Learn more' ) }
-			</a>
+			<div>
+				<Button
+					className="bloganuary-header__button"
+					onClick={ subscribeToBloganuaryTag }
+					disabled={ isFollowingBloganuary }
+				>
+					{ isFollowingBloganuary ? translate( 'Subscribed' ) : translate( 'Subscribe' ) }
+				</Button>
+				<a
+					href="https://wordpress.com/bloganuary"
+					className="bloganuary-header__link"
+					target="_blank"
+					rel="noopener noreferrer"
+					onClick={ trackBloganuaryMoreInfoClick }
+				>
+					{ translate( 'Learn more' ) }
+				</a>
+			</div>
 		</div>
 	);
 };
 
-export default BloganuaryHeader;
+const BloganuaryHeaderWrapper = () => {
+	if ( ! isBloganuary() ) {
+		return null;
+	}
+
+	return <BloganuaryHeader />;
+};
+
+export default BloganuaryHeaderWrapper;

--- a/client/components/bloganuary-header/index.tsx
+++ b/client/components/bloganuary-header/index.tsx
@@ -9,6 +9,7 @@ import isBloganuary from 'calypso/data/blogging-prompt/is-bloganuary';
 import ReaderFollowFeedIcon from 'calypso/reader/components/icons/follow-feed-icon';
 import ReaderFollowingFeedIcon from 'calypso/reader/components/icons/following-feed-icon';
 import { Tag } from 'calypso/reader/list-manage/types';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { requestFollowTag, requestUnfollowTag } from 'calypso/state/reader/tags/items/actions';
 import { getReaderFollowedTags } from 'calypso/state/reader/tags/selectors';
 import { toggleReaderSidebarTags } from 'calypso/state/reader-ui/sidebar/actions';
@@ -25,7 +26,7 @@ const BloganuaryHeader = () => {
 	const followedTags = useSelector( getReaderFollowedTags ) as Tag[];
 	const isFollowingBloganuary = containsBloganuary( followedTags );
 	const isTagsSidebarOpen = useSelector( isTagsOpen );
-
+	const isLoggedIn = useSelector( isUserLoggedIn );
 	useEffect( () => {
 		recordTracksEvent( 'calypso_bloganuary_banner_view' );
 	}, [] );
@@ -65,17 +66,19 @@ const BloganuaryHeader = () => {
 				<span className="bloganuary-header__title">{ translate( 'Bloganuary' ) }</span>
 			</div>
 			<div>
-				<FollowButton
-					followLabel={ translate( 'Follow' ) }
-					followingLabel={ translate( 'Following' ) }
-					iconSize={ 24 }
-					following={ isFollowingBloganuary }
-					onFollowToggle={ toggleFollowBloganuary }
-					followIcon={ ReaderFollowFeedIcon( { iconSize: 20 } ) }
-					followingIcon={ ReaderFollowingFeedIcon( { iconSize: 20 } ) }
-					className="bloganuary-header__button"
-					disabled={ isFollowingBloganuary === undefined }
-				/>
+				{ isLoggedIn && (
+					<FollowButton
+						followLabel={ translate( 'Follow' ) }
+						followingLabel={ translate( 'Following' ) }
+						iconSize={ 24 }
+						following={ isFollowingBloganuary }
+						onFollowToggle={ toggleFollowBloganuary }
+						followIcon={ ReaderFollowFeedIcon( { iconSize: 20 } ) }
+						followingIcon={ ReaderFollowingFeedIcon( { iconSize: 20 } ) }
+						className="bloganuary-header__button"
+						disabled={ isFollowingBloganuary === undefined }
+					/>
+				) }
 				<a
 					href={ localizeUrl( 'https://wordpress.com/bloganuary' ) }
 					className="bloganuary-header__link"

--- a/client/components/bloganuary-header/style.scss
+++ b/client/components/bloganuary-header/style.scss
@@ -16,6 +16,7 @@
 	.blogging-bloganuary-icon {
 		vertical-align: middle;
 		padding-right: 10px;
+		display: inline-block;
 
 		> svg {
 			width: 44px;

--- a/client/components/bloganuary-header/style.scss
+++ b/client/components/bloganuary-header/style.scss
@@ -13,16 +13,6 @@
 	vertical-align: middle;
 	margin-bottom: 20px;
 
-	.bloganuary-header__title {
-		font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
-		vertical-align: middle;
-		font-size: 22px; /* stylelint-disable-line declaration-property-unit-allowed-list */
-
-		@include break-small {
-			font-size: 40px; /* stylelint-disable-line declaration-property-unit-allowed-list */
-		}
-	}
-
 	.blogging-bloganuary-icon {
 		vertical-align: middle;
 		padding-right: 10px;
@@ -34,5 +24,26 @@
 				fill: var(--studio-white);
 			}
 		}
+	}
+
+	.bloganuary-header__title {
+		font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
+		vertical-align: middle;
+		font-size: 22px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+
+		@include break-small {
+			font-size: 40px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		}
+	}
+
+	.bloganuary-header__button {
+		vertical-align: middle;
+		font-size: 1rem;
+		margin-right: 10px;
+	}
+
+	.bloganuary-header__link {
+		vertical-align: middle;
+		color: var(--studio-white);
 	}
 }

--- a/client/components/bloganuary-header/style.scss
+++ b/client/components/bloganuary-header/style.scss
@@ -1,0 +1,38 @@
+@import "~@wordpress/base-styles/breakpoints";
+@import "~@wordpress/base-styles/mixins";
+
+.bloganuary-header {
+	background-color: var(--studio-gray-100);
+	color: var(--studio-white);
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	flex-wrap: wrap;
+	gap: 10px;
+	padding: 20px 40px;
+	vertical-align: middle;
+	margin-bottom: 20px;
+
+	.bloganuary-header__title {
+		font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
+		vertical-align: middle;
+		font-size: 22px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+
+		@include break-small {
+			font-size: 40px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		}
+	}
+
+	.blogging-bloganuary-icon {
+		vertical-align: middle;
+		padding-right: 10px;
+
+		> svg {
+			width: 44px;
+			height: 44px;
+			> path {
+				fill: var(--studio-white);
+			}
+		}
+	}
+}

--- a/client/components/bloganuary-header/style.scss
+++ b/client/components/bloganuary-header/style.scss
@@ -40,26 +40,10 @@
 		vertical-align: middle;
 		font-size: 1rem;
 		margin-right: 10px;
-
-		&.is-following {
-			color: var(--color-success);
-			.following-icon-background {
-				fill: var(--color-success);
-			}
-			.following-icon-tick {
-				stroke: var(--color-success);
-			}
-		}
-
-		.reader-follow-feed,
-		.reader-following-feed {
-			vertical-align: middle;
-			margin-right: 5px;
-		}
-
-		.bloganuary-header__follow-label {
-			vertical-align: middle;
-		}
+		background-color: var(--color-surface);
+		display: inline-flex;
+		padding: 8px 14px;
+		border: 1px solid var(--color-neutral-10);
 	}
 
 	.bloganuary-header__link {

--- a/client/components/bloganuary-header/style.scss
+++ b/client/components/bloganuary-header/style.scss
@@ -40,6 +40,26 @@
 		vertical-align: middle;
 		font-size: 1rem;
 		margin-right: 10px;
+
+		&.is-following {
+			color: var(--color-success);
+			.following-icon-background {
+				fill: var(--color-success);
+			}
+			.following-icon-tick {
+				stroke: var(--color-success);
+			}
+		}
+
+		.reader-follow-feed,
+		.reader-following-feed {
+			vertical-align: middle;
+			margin-right: 5px;
+		}
+
+		.bloganuary-header__follow-label {
+			vertical-align: middle;
+		}
 	}
 
 	.bloganuary-header__link {

--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
 import AsyncLoad from 'calypso/components/async-load';
+import BloganuaryHeader from 'calypso/components/bloganuary-header';
 import NavigationHeader from 'calypso/components/navigation-header';
 import withDimensions from 'calypso/lib/with-dimensions';
 import SuggestionProvider from 'calypso/reader/search-stream/suggestion-provider';
@@ -18,6 +19,7 @@ function FollowingStream( { ...props } ) {
 				className="following"
 				streamSidebar={ () => <ReaderListFollowedSites path={ window.location.pathname } /> }
 			>
+				<BloganuaryHeader />
 				<NavigationHeader
 					title={ translate( 'Recent' ) }
 					subtitle={ translate( "Stay current with the blogs you've subscribed to." ) }

--- a/client/reader/tag-stream/header.jsx
+++ b/client/reader/tag-stream/header.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import FollowButton from 'calypso/blocks/follow-button/button';
+import BloganuaryHeader from 'calypso/components/bloganuary-header';
 import NavigationHeader from 'calypso/components/navigation-header';
 import SegmentedControl from 'calypso/components/segmented-control';
 import { addQueryArgs } from 'calypso/lib/url';
@@ -82,6 +83,7 @@ class TagStreamHeader extends Component {
 
 		return (
 			<div className={ classes }>
+				<BloganuaryHeader />
 				<NavigationHeader title={ titleText } subtitle={ subtitleText } />
 				{ ( showSort || showFollow ) && (
 					<div className="tag-stream__header-controls">


### PR DESCRIPTION
Adds a banner to the reader p1701190496797509-slack-C03NLNTPZ2T.

I've added it to the /read and /tag/$tag pages, we could add it to more pages if needed.


<img width="715" alt="Screen Shot 2023-12-11 at 11 49 50 pm" src="https://github.com/Automattic/wp-calypso/assets/22446385/23f4e71a-f63c-475e-b989-e165c940ff34">

### Testing instructions 
The banner is only active if $bloganuary is true, test with:
`/read?flags=+bloganuary`
`/tag/art?flags=+bloganuary`


