### PR TITLE
Allow moving a domain from site to another during onboarding

### DIFF
--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -155,6 +155,24 @@ class DomainProductPrice extends Component {
 		);
 	}
 
+	renderDomainMovePrice() {
+		const { showStrikedOutPrice, translate } = this.props;
+
+		const className = classnames( 'domain-product-price', {
+			'domain-product-price__domain-step-signup-flow': showStrikedOutPrice,
+		} );
+
+		return (
+			<div className={ className }>
+				<span>
+					{ translate( 'Move your existing domain registration to your new site.', {
+						context: 'Line item description in cart.',
+					} ) }
+				</span>
+			</div>
+		);
+	}
+
 	renderSalePrice() {
 		const { price, salePrice, translate } = this.props;
 
@@ -223,6 +241,8 @@ class DomainProductPrice extends Component {
 			case 'INCLUDED_IN_HIGHER_PLAN':
 			case 'UPGRADE_TO_HIGHER_PLAN_TO_BUY':
 				return this.renderFreeWithPlan();
+			case 'DOMAIN_MOVE_PRICE':
+				return this.renderDomainMovePrice();
 			case 'PRICE':
 			default:
 				return this.renderPrice();

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -433,7 +433,13 @@ class RegisterDomainStep extends Component {
 	}
 
 	render() {
-		const { isSignupStep, showAlreadyOwnADomain, isDomainAndPlanPackageFlow } = this.props;
+		const {
+			isSignupStep,
+			showAlreadyOwnADomain,
+			isDomainAndPlanPackageFlow,
+			replaceDomainFailedMessage,
+			dismissReplaceDomainFailed,
+		} = this.props;
 
 		const {
 			availabilityError,
@@ -499,6 +505,14 @@ class RegisterDomainStep extends Component {
 							text={ suggestionMessage }
 							status={ `is-${ suggestionSeverity }` }
 							showDismiss={ false }
+						/>
+					) }
+					{ replaceDomainFailedMessage && (
+						<Notice
+							status="is-error"
+							text={ replaceDomainFailedMessage }
+							showDismiss={ true }
+							onDismissClick={ dismissReplaceDomainFailed }
 						/>
 					) }
 					{ this.renderFilterContent() }

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -433,13 +433,7 @@ class RegisterDomainStep extends Component {
 	}
 
 	render() {
-		const {
-			isSignupStep,
-			showAlreadyOwnADomain,
-			isDomainAndPlanPackageFlow,
-			replaceDomainFailedMessage,
-			dismissReplaceDomainFailed,
-		} = this.props;
+		const { isSignupStep, showAlreadyOwnADomain, isDomainAndPlanPackageFlow } = this.props;
 
 		const {
 			availabilityError,
@@ -505,14 +499,6 @@ class RegisterDomainStep extends Component {
 							text={ suggestionMessage }
 							status={ `is-${ suggestionSeverity }` }
 							showDismiss={ false }
-						/>
-					) }
-					{ replaceDomainFailedMessage && (
-						<Notice
-							status="is-error"
-							text={ replaceDomainFailedMessage }
-							showDismiss={ true }
-							onDismissClick={ dismissReplaceDomainFailed }
 						/>
 					) }
 					{ this.renderFilterContent() }
@@ -1076,8 +1062,13 @@ class RegisterDomainStep extends Component {
 						TRANSFERRABLE,
 						TRANSFERRABLE_PREMIUM,
 						UNKNOWN,
+						REGISTERED_OTHER_SITE_SAME_USER,
 					} = domainAvailability;
-					const isDomainAvailable = [ AVAILABLE, UNKNOWN ].includes( status );
+					const isDomainAvailable = [
+						AVAILABLE,
+						UNKNOWN,
+						REGISTERED_OTHER_SITE_SAME_USER,
+					].includes( status );
 					const isDomainTransferrable = TRANSFERRABLE === status;
 					const isDomainMapped = MAPPED === mappable;
 					const isAvailablePremiumDomain = AVAILABLE_PREMIUM === status;
@@ -1158,6 +1149,7 @@ class RegisterDomainStep extends Component {
 				.replace( ' ', ',' )
 				.toLocaleLowerCase(),
 			...this.getActiveFiltersForAPI(),
+			include_internal_move_eligible: 'onboarding' === this.props.flowName,
 		};
 
 		debug( 'Fetching domains suggestions with the following query', query );
@@ -1483,7 +1475,7 @@ class RegisterDomainStep extends Component {
 						status,
 						this.props.analyticsSection
 					);
-					if ( status ) {
+					if ( status && status !== domainAvailability.REGISTERED_OTHER_SITE_SAME_USER ) {
 						this.setState( { unavailableDomains: [ ...this.state.unavailableDomains, domain ] } );
 						this.showAvailabilityErrorMessage( domain, status, {
 							availabilityPreCheck: true,
@@ -1521,8 +1513,9 @@ class RegisterDomainStep extends Component {
 
 		const matchesSearchedDomain = ( suggestion ) => suggestion.domain_name === exactMatchDomain;
 		const availableDomain =
-			lastDomainStatus === domainAvailability.AVAILABLE &&
-			find( this.state.searchResults, matchesSearchedDomain );
+			[ domainAvailability.AVAILABLE, domainAvailability.REGISTERED_OTHER_SITE_SAME_USER ].includes(
+				lastDomainStatus
+			) && find( this.state.searchResults, matchesSearchedDomain );
 		const onAddMapping = ( domain ) => this.props.onAddMapping( domain, this.state );
 
 		const suggestions = this.getSuggestionsFromProps();

--- a/client/lib/cart-values/cart-items.ts
+++ b/client/lib/cart-values/cart-items.ts
@@ -12,6 +12,7 @@ import {
 	isCustomDesign,
 	isDIFMProduct,
 	isDomainMapping,
+	isDomainMoveInternal,
 	isDomainProduct,
 	isDomainRegistration,
 	isDomainTransfer,
@@ -838,6 +839,10 @@ export function getDomainPriceRule(
 
 	if ( suggestion?.is_premium ) {
 		return 'PRICE';
+	}
+
+	if ( hasSomeSlug( suggestion ) && isDomainMoveInternal( suggestion ) ) {
+		return 'DOMAIN_MOVE_PRICE';
 	}
 
 	if ( isMonthlyOrFreeFlow( flowName ) ) {

--- a/client/lib/cart-values/cart-items.ts
+++ b/client/lib/cart-values/cart-items.ts
@@ -535,6 +535,15 @@ export function getDomainRegistrations( cart: ObjectWithProducts ): ResponseCart
 }
 
 /**
+ * Retrieves all the domain registration items in the specified shopping cart.
+ */
+export function getDomainsInCart( cart: ObjectWithProducts ): ResponseCartProduct[] {
+	return getAllCartItems( cart ).filter(
+		( product ) => isDomainRegistration( product ) || isDomainMoveInternal( product )
+	);
+}
+
+/**
  * Retrieves all the domain mapping items in the specified shopping cart.
  */
 export function getDomainMappings( cart: ObjectWithProducts ): ResponseCartProduct[] {

--- a/client/lib/domains/get-domain-price.js
+++ b/client/lib/domains/get-domain-price.js
@@ -4,7 +4,7 @@ import { getUnformattedDomainPrice } from './get-unformatted-domain-price';
 export function getDomainPrice( slug, productsList, currencyCode, stripZeros = false ) {
 	let price = getUnformattedDomainPrice( slug, productsList );
 
-	if ( price ) {
+	if ( typeof price === 'number' ) {
 		price = formatCurrency( price, currencyCode, { stripZeros } );
 	}
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -24,12 +24,12 @@ import {
 	domainRegistration,
 	domainMapping,
 	domainTransfer,
-	getDomainRegistrations,
 	updatePrivacyForDomain,
 	hasDomainInCart,
 	planItem,
 	hasPlan,
 	hasDomainRegistration,
+	getDomainsInCart,
 } from 'calypso/lib/cart-values/cart-items';
 import {
 	getDomainProductSlug,
@@ -126,7 +126,7 @@ export class RenderDomainsStep extends Component {
 			const productSlug = getDomainProductSlug( domain );
 			const domainItem = domainRegistration( { productSlug, domain } );
 			const domainCart = shouldUseMultipleDomainsInCart( props.flowName )
-				? getDomainRegistrations( this.props.cart )
+				? getDomainsInCart( this.props.cart )
 				: {};
 
 			props.submitSignupStep(
@@ -736,7 +736,7 @@ export class RenderDomainsStep extends Component {
 		const { step, cart, multiDomainDefaultPlan, shoppingCartManager, goToNextStep } = this.props;
 		const { lastDomainSearched } = step.domainForm ?? {};
 
-		const domainCart = getDomainRegistrations( this.props.cart );
+		const domainCart = getDomainsInCart( this.props.cart );
 		const { suggestion } = step;
 		const isPurchasingItem =
 			( suggestion && Boolean( suggestion.product_slug ) ) || domainCart?.length > 0;
@@ -814,7 +814,7 @@ export class RenderDomainsStep extends Component {
 
 	getSideContent = () => {
 		const { flowName } = this.props;
-		const domainsInCart = getDomainRegistrations( this.props.cart );
+		const domainsInCart = getDomainsInCart( this.props.cart );
 
 		const additionalDomains = this.state.temporaryCart
 			.map( ( cartDomain ) => {

--- a/packages/calypso-products/src/constants/domain.ts
+++ b/packages/calypso-products/src/constants/domain.ts
@@ -1,4 +1,5 @@
 export const domainProductSlugs = {
 	TRANSFER_IN: 'domain_transfer',
 	DOTCOM_DOMAIN_REGISTRATION: 'domain_reg',
+	DOMAIN_MOVE_INTERNAL: 'domain_move_internal',
 };

--- a/packages/calypso-products/src/is-domain-move-internal.ts
+++ b/packages/calypso-products/src/is-domain-move-internal.ts
@@ -1,0 +1,7 @@
+import { camelOrSnakeSlug } from './camel-or-snake-slug';
+import { domainProductSlugs } from './constants';
+import type { WithSnakeCaseSlug, WithCamelCaseSlug } from './types';
+
+export function isDomainMoveInternal( product: WithSnakeCaseSlug | WithCamelCaseSlug ): boolean {
+	return camelOrSnakeSlug( product ) === domainProductSlugs.DOMAIN_MOVE_INTERNAL;
+}

--- a/packages/calypso-products/src/is-domain-product.ts
+++ b/packages/calypso-products/src/is-domain-product.ts
@@ -1,4 +1,5 @@
 import { isDomainMapping } from './is-domain-mapping';
+import { isDomainMoveInternal } from './is-domain-move-internal';
 import { isDomainRegistration } from './is-domain-registration';
 import type { WithSnakeCaseSlug, WithCamelCaseSlug } from './types';
 
@@ -8,5 +9,7 @@ export function isDomainProduct(
 		isDomainRegistration?: boolean;
 	}
 ): boolean {
-	return isDomainMapping( product ) || isDomainRegistration( product );
+	return (
+		isDomainMapping( product ) || isDomainRegistration( product ) || isDomainMoveInternal( product )
+	);
 }

--- a/packages/calypso-products/src/product-values.ts
+++ b/packages/calypso-products/src/product-values.ts
@@ -55,6 +55,7 @@ export { isCustomDesign } from './is-custom-design';
 export { isDelayedDomainTransfer } from './is-delayed-domain-transfer';
 export { isDIFMProduct } from './is-difm-product';
 export { isDomainMapping } from './is-domain-mapping';
+export { isDomainMoveInternal } from './is-domain-move-internal';
 export { isDomainProduct } from './is-domain-product';
 export { isDomainRedemption } from './is-domain-redemption';
 export { isDomainRegistration } from './is-domain-registration';

--- a/packages/data-stores/src/domain-suggestions/types.ts
+++ b/packages/data-stores/src/domain-suggestions/types.ts
@@ -20,6 +20,11 @@ export interface DomainSuggestionQuery {
 	include_wordpressdotcom: boolean;
 
 	/**
+	 * True to include domains registered with wpcom in the response
+	 */
+	include_internal_move_eligible?: boolean;
+
+	/**
 	 * Localizes domain results, e.g., price format
 	 */
 	locale?: string;


### PR DESCRIPTION
Currently, during the onboarding process, an error message appears if a domain already registered with us and mapped to an existing site is entered in the domain search screen. We want to prevent this by allowing users to select a domain they already own and that is mapped to a different site.

![image-2.png](https://github.com/Automattic/wp-calypso/assets/1080253/0f0c6e3e-b30a-44ed-aae7-8971fc8cc81b)

