### PR TITLE
Stats: Apply usePlanUsageQuery to TierUpgradeNotice

### DIFF
--- a/client/my-sites/stats/stats-notices/all-notice-definitions.ts
+++ b/client/my-sites/stats/stats-notices/all-notice-definitions.ts
@@ -119,7 +119,7 @@ const ALL_STATS_NOTICES: StatsNoticeType[] = [
 			isSiteJetpackNotAtomic,
 			isCommercial,
 		}: StatsNoticeProps ) => {
-			// TODO: Maybe we won't show tier upgrade notice for WPCOM sites for now?
+			// TODO: We don't show the notice for WPCOM sites for now.
 			const showTierUpgradeNoticeForWpcomSites = isWpcom && ! isVip && ! isP2 && ! isOwnedByTeam51;
 
 			// Show the notice if the site is Jetpack or it is Odyssey Stats.
@@ -127,9 +127,8 @@ const ALL_STATS_NOTICES: StatsNoticeType[] = [
 			const showTierUpgradeNoticeForJetpackNotAtomic = isSiteJetpackNotAtomic;
 
 			return !! (
-				( showTierUpgradeNoticeOnOdyssey ||
-					showTierUpgradeNoticeForJetpackNotAtomic ||
-					showTierUpgradeNoticeForWpcomSites ) &&
+				! showTierUpgradeNoticeForWpcomSites &&
+				( showTierUpgradeNoticeOnOdyssey || showTierUpgradeNoticeForJetpackNotAtomic ) &&
 				config.isEnabled( 'stats/tier-upgrade-slider' ) &&
 				isCommercial &&
 				hasPaidStats

--- a/client/my-sites/stats/stats-notices/all-notice-definitions.ts
+++ b/client/my-sites/stats/stats-notices/all-notice-definitions.ts
@@ -112,26 +112,18 @@ const ALL_STATS_NOTICES: StatsNoticeType[] = [
 		isVisibleFunc: ( {
 			isOdysseyStats,
 			isWpcom,
-			isVip,
-			isP2,
-			isOwnedByTeam51,
-			hasPaidStats,
+			isCommercialOwned,
 			isSiteJetpackNotAtomic,
-			isCommercial,
 		}: StatsNoticeProps ) => {
-			// TODO: We don't show the notice for WPCOM sites for now.
-			const showTierUpgradeNoticeForWpcomSites = isWpcom && ! isVip && ! isP2 && ! isOwnedByTeam51;
-
 			// Show the notice if the site is Jetpack or it is Odyssey Stats.
 			const showTierUpgradeNoticeOnOdyssey = isOdysseyStats;
 			const showTierUpgradeNoticeForJetpackNotAtomic = isSiteJetpackNotAtomic;
-
+			// We don't show the notice for WPCOM sites for now.
 			return !! (
-				! showTierUpgradeNoticeForWpcomSites &&
+				! isWpcom &&
 				( showTierUpgradeNoticeOnOdyssey || showTierUpgradeNoticeForJetpackNotAtomic ) &&
 				config.isEnabled( 'stats/tier-upgrade-slider' ) &&
-				isCommercial &&
-				hasPaidStats
+				isCommercialOwned
 			);
 		},
 		disabled: false,

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -20,10 +20,10 @@ import hasSiteProductJetpackStatsFree from 'calypso/state/sites/selectors/has-si
 import hasSiteProductJetpackStatsPaid from 'calypso/state/sites/selectors/has-site-product-jetpack-stats-paid';
 import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import getSelectedSite from 'calypso/state/ui/selectors/get-selected-site';
+import useStatsPurchases from '../hooks/use-stats-purchases';
 import ALL_STATS_NOTICES from './all-notice-definitions';
 import { StatsNoticeProps, StatsNoticesProps } from './types';
 import './style.scss';
-import useStatsPurchases from '../hooks/use-stats-purchases';
 
 const TEAM51_OWNER_ID = 70055110;
 

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -23,6 +23,7 @@ import getSelectedSite from 'calypso/state/ui/selectors/get-selected-site';
 import ALL_STATS_NOTICES from './all-notice-definitions';
 import { StatsNoticeProps, StatsNoticesProps } from './types';
 import './style.scss';
+import useStatsPurchases from '../hooks/use-stats-purchases';
 
 const TEAM51_OWNER_ID = 70055110;
 
@@ -87,6 +88,8 @@ const NewStatsNotices = ( { siteId, isOdysseyStats, statsPurchaseSuccess }: Stat
 		wpcomSiteHasPaidPlan;
 	const hasFreeStats = useSelector( ( state ) => hasSiteProductJetpackStatsFree( state, siteId ) );
 
+	const { isRequestingSitePurchases, isCommercialOwned } = useStatsPurchases( siteId );
+
 	const noticeOptions = {
 		siteId,
 		isOdysseyStats,
@@ -99,6 +102,7 @@ const NewStatsNotices = ( { siteId, isOdysseyStats, statsPurchaseSuccess }: Stat
 		isSiteJetpackNotAtomic,
 		statsPurchaseSuccess,
 		isCommercial,
+		isCommercialOwned,
 	};
 
 	const { isLoading, isError, data: serverNoticesVisibility } = useNoticesVisibilityQuery( siteId );
@@ -109,7 +113,13 @@ const NewStatsNotices = ( { siteId, isOdysseyStats, statsPurchaseSuccess }: Stat
 	const hasLoadedPlans =
 		useSelector( ( state ) => hasLoadedSitePlansFromServer( state, siteId ) ) || isOdysseyStats;
 
-	if ( ! hasLoadedPurchases || ! hasLoadedPlans || isLoading || isError ) {
+	if (
+		! hasLoadedPurchases ||
+		! hasLoadedPlans ||
+		isLoading ||
+		isError ||
+		isRequestingSitePurchases
+	) {
 		return null;
 	}
 

--- a/client/my-sites/stats/stats-notices/tier-upgrade-notice.tsx
+++ b/client/my-sites/stats/stats-notices/tier-upgrade-notice.tsx
@@ -17,7 +17,7 @@ const TierUpgradeNotice = ( { siteId, isOdysseyStats }: StatsNoticeProps ) => {
 	const translate = useTranslate();
 	const [ noticeDismissed, setNoticeDismissed ] = useState( false );
 
-	// TODO: Consolidate this with the usage section in the Traffic page.
+	// TODO: Consolidate the query here with the usage section on the Traffic page.
 	const { data } = usePlanUsageQuery( siteId );
 	const currentUsage = data?.current_usage.views_count || 0;
 	const tierLimit = data?.views_limit || null;

--- a/client/my-sites/stats/stats-notices/tier-upgrade-notice.tsx
+++ b/client/my-sites/stats/stats-notices/tier-upgrade-notice.tsx
@@ -17,6 +17,7 @@ const TierUpgradeNotice = ( { siteId, isOdysseyStats }: StatsNoticeProps ) => {
 	const translate = useTranslate();
 	const [ noticeDismissed, setNoticeDismissed ] = useState( false );
 
+	// TODO: Consolidate this with the usage section in the Traffic page.
 	const { data } = usePlanUsageQuery( siteId );
 	const currentUsage = data?.current_usage.views_count || 0;
 	const tierLimit = data?.views_limit || null;

--- a/client/my-sites/stats/stats-notices/tier-upgrade-notice.tsx
+++ b/client/my-sites/stats/stats-notices/tier-upgrade-notice.tsx
@@ -38,7 +38,7 @@ const TierUpgradeNotice = ( { siteId, isOdysseyStats }: StatsNoticeProps ) => {
 				}
 		  )
 		: translate(
-				'{{p}}You site is receiving more attention and is close to the monthly view limit provided by your current plan. Consider increasing your tier limit to avoid potential service disruptions.{{/p}}',
+				'{{p}}Your site is receiving more attention and is close to the monthly view limit provided by your current plan. Consider increasing your tier limit to avoid potential service disruptions.{{/p}}',
 				{
 					components: {
 						p: <p />,

--- a/client/my-sites/stats/stats-notices/tier-upgrade-notice.tsx
+++ b/client/my-sites/stats/stats-notices/tier-upgrade-notice.tsx
@@ -3,11 +3,11 @@ import page from '@automattic/calypso-router';
 import NoticeBanner from '@automattic/components/src/notice-banner';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
+import usePlanUsageQuery from 'calypso/my-sites/stats/hooks/use-plan-usage-query';
 import { StatsNoticeProps } from './types';
 
 const getStatsPurchaseURL = ( siteId: number | null, isOdysseyStats: boolean ) => {
 	const from = isOdysseyStats ? 'jetpack' : 'calypso';
-	// TODO: Return the tier upgrade path according to the current plan tier.
 	const purchasePath = `/stats/purchase/${ siteId }?flags=stats/tier-upgrade-slider&from=${ from }-stats-tier-upgrade-notice&productType=commercial`;
 
 	return purchasePath;
@@ -17,12 +17,12 @@ const TierUpgradeNotice = ( { siteId, isOdysseyStats }: StatsNoticeProps ) => {
 	const translate = useTranslate();
 	const [ noticeDismissed, setNoticeDismissed ] = useState( false );
 
-	// TODO: Use usePlanUsageQuery hook to get the current plan usage and display the notice accordingly.
-	const currentUsage = 9;
-	const tierLimit = 10;
+	const { data } = usePlanUsageQuery( siteId );
+	const currentUsage = data?.current_usage.views_count || 0;
+	const tierLimit = data?.views_limit || null;
 
-	const showNotice = currentUsage / tierLimit >= 0.9;
-	const isOverLimit = currentUsage / tierLimit >= 1;
+	const showNotice = tierLimit ? currentUsage / tierLimit >= 0.9 : false;
+	const isOverLimit = tierLimit ? currentUsage / tierLimit >= 1 : false;
 
 	const bannerTitle = isOverLimit
 		? translate( 'You have reached your monthly views limit' )

--- a/client/my-sites/stats/stats-notices/types.ts
+++ b/client/my-sites/stats/stats-notices/types.ts
@@ -17,6 +17,7 @@ export interface StatsNoticeProps {
 	isSiteJetpackNotAtomic?: boolean;
 	statsPurchaseSuccess?: string;
 	isCommercial?: boolean;
+	isCommercialOwned?: boolean;
 }
 
 export interface NoticeBodyProps {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #84671 

## Proposed Changes

* Apply the `usePlanUsageQuery` hook to fetch usage data to show the tier upgrade notice.
* Hide the tier upgrade notice for **WPCOM sites** temporarily.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change on local Calypso.
* Navigate to **Stats > Traffic** page for a commercial Jetpack site with the Commercial license.
* Edit the code to enforce showing the notice if your purchased plan is still legacy:
https://github.com/Automattic/wp-calypso/blob/c2d2da7518d5c1824b99448e1ed53cd78f5c9cd4/client/my-sites/stats/stats-notices/tier-upgrade-notice.tsx#L25-L26
* Ensure the notice shows according to the views limit and current views usage.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?