### PR TITLE
Plans 2023: Plans data-store refactors

### DIFF
--- a/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
+++ b/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
@@ -193,7 +193,8 @@ const usePricingMetaForGridPlans: UsePricingMetaForGridPlans = ( {
 	 * - We can optimise Error states in the UI / when everything gets ported into data-stores
 	 * - `pricedAPISitePlans` being a dependent query will only get fetching status when enabled (when `siteId` exists)
 	 */
-	if ( pricedAPISitePlans.isFetching || pricedAPIPlans.isFetching ) {
+
+	if ( ( selectedSiteId && pricedAPISitePlans.isLoading ) || pricedAPIPlans.isLoading ) {
 		return null;
 	}
 

--- a/client/my-sites/plans-features-main/hooks/test/use-pricing-meta-for-grid-plans.ts
+++ b/client/my-sites/plans-features-main/hooks/test/use-pricing-meta-for-grid-plans.ts
@@ -44,12 +44,12 @@ describe( 'usePricingMetaForGridPlans', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 		Plans.useSitePlans.mockImplementation( () => ( {
-			isFetching: false,
+			isLoading: false,
 			data: null,
 		} ) );
 		Purchases.useSitePurchaseById.mockImplementation( () => undefined );
 		Plans.usePlans.mockImplementation( () => ( {
-			isFetching: false,
+			isLoading: false,
 			data: {
 				[ PLAN_PREMIUM ]: {
 					billPeriod: 365,

--- a/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
+++ b/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
@@ -329,7 +329,7 @@ const useGridPlans = ( {
 	} );
 
 	// Null return would indicate that we are still loading the data. No grid without grid plans.
-	if ( ! pricingMeta || pricedAPIPlans.isFetching ) {
+	if ( ! pricingMeta || pricedAPIPlans.isLoading ) {
 		return null;
 	}
 

--- a/packages/data-stores/src/plans/hooks/use-intro-offers.ts
+++ b/packages/data-stores/src/plans/hooks/use-intro-offers.ts
@@ -3,7 +3,7 @@ import usePlans from '../queries/use-plans';
 import useSitePlans from '../queries/use-site-plans';
 import type { PlanIntroductoryOffer } from '../types';
 
-export interface IntroOffersIndex {
+interface IntroOffersIndex {
 	[ planSlug: string ]: PlanIntroductoryOffer | null;
 }
 

--- a/packages/data-stores/src/plans/hooks/use-intro-offers.ts
+++ b/packages/data-stores/src/plans/hooks/use-intro-offers.ts
@@ -3,7 +3,7 @@ import usePlans from '../queries/use-plans';
 import useSitePlans from '../queries/use-site-plans';
 import type { PlanIntroductoryOffer } from '../types';
 
-interface IntroOffersIndex {
+export interface IntroOffersIndex {
 	[ planSlug: string ]: PlanIntroductoryOffer | null;
 }
 

--- a/packages/data-stores/src/plans/queries/use-plans.ts
+++ b/packages/data-stores/src/plans/queries/use-plans.ts
@@ -4,24 +4,20 @@ import unpackIntroOffer from './lib/unpack-intro-offer';
 import useQueryKeysFactory from './lib/use-query-keys-factory';
 import type { PricedAPIPlan, PlanNext } from '../types';
 
-interface PlansIndex {
+export interface PlansIndex {
 	[ planSlug: string ]: PlanNext;
-}
-
-interface Props< T > {
-	select?: ( data: PlansIndex ) => T;
 }
 
 /**
  * Plans from `/plans` endpoint, transformed into a map of planSlug => PlanNext
  * - The generic T allows to define generic select functions that can be used to select a subset of the data
  */
-function usePlans< T >( { select }: Props< T > = {} ) {
+function usePlans() {
 	const queryKeys = useQueryKeysFactory();
 
 	return useQuery( {
 		queryKey: queryKeys.plans(),
-		queryFn: async () => {
+		queryFn: async (): Promise< PlansIndex > => {
 			const data: PricedAPIPlan[] = await wpcomRequest( {
 				path: `/plans`,
 				apiVersion: '1.5',
@@ -42,7 +38,6 @@ function usePlans< T >( { select }: Props< T > = {} ) {
 				] )
 			);
 		},
-		select,
 		staleTime: 1000 * 60 * 5, // 5 minutes
 	} );
 }

--- a/packages/data-stores/src/plans/queries/use-plans.ts
+++ b/packages/data-stores/src/plans/queries/use-plans.ts
@@ -37,7 +37,6 @@ function usePlans(): UseQueryResult< PlansIndex > {
 				] )
 			);
 		},
-		staleTime: 1000 * 60 * 5, // 5 minutes
 	} );
 }
 

--- a/packages/data-stores/src/plans/queries/use-plans.ts
+++ b/packages/data-stores/src/plans/queries/use-plans.ts
@@ -1,23 +1,22 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 import wpcomRequest from 'wpcom-proxy-request';
 import unpackIntroOffer from './lib/unpack-intro-offer';
 import useQueryKeysFactory from './lib/use-query-keys-factory';
 import type { PricedAPIPlan, PlanNext } from '../types';
 
-export interface PlansIndex {
+interface PlansIndex {
 	[ planSlug: string ]: PlanNext;
 }
 
 /**
  * Plans from `/plans` endpoint, transformed into a map of planSlug => PlanNext
- * - The generic T allows to define generic select functions that can be used to select a subset of the data
  */
-function usePlans() {
+function usePlans(): UseQueryResult< PlansIndex > {
 	const queryKeys = useQueryKeysFactory();
 
 	return useQuery( {
 		queryKey: queryKeys.plans(),
-		queryFn: async (): Promise< PlansIndex > => {
+		queryFn: async () => {
 			const data: PricedAPIPlan[] = await wpcomRequest( {
 				path: `/plans`,
 				apiVersion: '1.5',

--- a/packages/data-stores/src/plans/queries/use-site-plans.ts
+++ b/packages/data-stores/src/plans/queries/use-site-plans.ts
@@ -4,16 +4,15 @@ import unpackIntroOffer from './lib/unpack-intro-offer';
 import useQueryKeysFactory from './lib/use-query-keys-factory';
 import type { PricedAPISitePlan, SitePlan } from '../types';
 
-interface SitePlansIndex {
+export interface SitePlansIndex {
 	[ planSlug: string ]: SitePlan;
 }
 interface PricedAPISitePlansIndex {
 	[ productId: number ]: PricedAPISitePlan;
 }
 
-interface Props< T > {
+interface Props {
 	siteId?: string | number | null;
-	select?: ( data: SitePlansIndex ) => T;
 }
 
 /**
@@ -22,12 +21,12 @@ interface Props< T > {
  * - UI works with product/plan slugs everywhere, so returned index is transformed to be keyed by product_slug
  * - The generic T allows to define generic select functions that can be used to select a subset of the data
  */
-function useSitePlans< T >( { siteId, select }: Props< T > ) {
+function useSitePlans( { siteId }: Props ) {
 	const queryKeys = useQueryKeysFactory();
 
 	return useQuery( {
 		queryKey: queryKeys.sitePlans( siteId ),
-		queryFn: async () => {
+		queryFn: async (): Promise< SitePlansIndex > => {
 			const data: PricedAPISitePlansIndex = await wpcomRequest( {
 				path: `/sites/${ encodeURIComponent( siteId as string ) }/plans`,
 				apiVersion: '1.3',
@@ -52,7 +51,6 @@ function useSitePlans< T >( { siteId, select }: Props< T > ) {
 				} )
 			);
 		},
-		select,
 		staleTime: 1000 * 60 * 5, // 5 minutes
 		enabled: !! siteId,
 	} );

--- a/packages/data-stores/src/plans/queries/use-site-plans.ts
+++ b/packages/data-stores/src/plans/queries/use-site-plans.ts
@@ -1,10 +1,10 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 import wpcomRequest from 'wpcom-proxy-request';
 import unpackIntroOffer from './lib/unpack-intro-offer';
 import useQueryKeysFactory from './lib/use-query-keys-factory';
 import type { PricedAPISitePlan, SitePlan } from '../types';
 
-export interface SitePlansIndex {
+interface SitePlansIndex {
 	[ planSlug: string ]: SitePlan;
 }
 interface PricedAPISitePlansIndex {
@@ -19,14 +19,13 @@ interface Props {
  * Plans from `/sites/[siteId]/plans` endpoint, transformed into a map of planSlug => SitePlan
  * - Plans from `/sites/[siteId]/plans`, unlike `/plans`, are returned indexed by product_id, and do not include that in the plan's payload.
  * - UI works with product/plan slugs everywhere, so returned index is transformed to be keyed by product_slug
- * - The generic T allows to define generic select functions that can be used to select a subset of the data
  */
-function useSitePlans( { siteId }: Props ) {
+function useSitePlans( { siteId }: Props ): UseQueryResult< SitePlansIndex > {
 	const queryKeys = useQueryKeysFactory();
 
 	return useQuery( {
 		queryKey: queryKeys.sitePlans( siteId ),
-		queryFn: async (): Promise< SitePlansIndex > => {
+		queryFn: async () => {
 			const data: PricedAPISitePlansIndex = await wpcomRequest( {
 				path: `/sites/${ encodeURIComponent( siteId as string ) }/plans`,
 				apiVersion: '1.3',

--- a/packages/data-stores/src/plans/queries/use-site-plans.ts
+++ b/packages/data-stores/src/plans/queries/use-site-plans.ts
@@ -50,7 +50,6 @@ function useSitePlans( { siteId }: Props ): UseQueryResult< SitePlansIndex > {
 				} )
 			);
 		},
-		staleTime: 1000 * 60 * 5, // 5 minutes
 		enabled: !! siteId,
 	} );
 }

--- a/packages/data-stores/src/plans/queries/use-site-plans.ts
+++ b/packages/data-stores/src/plans/queries/use-site-plans.ts
@@ -1,5 +1,4 @@
 import { useQuery } from '@tanstack/react-query';
-import { useCallback } from '@wordpress/element';
 import wpcomRequest from 'wpcom-proxy-request';
 import unpackIntroOffer from './lib/unpack-intro-offer';
 import useQueryKeysFactory from './lib/use-query-keys-factory';
@@ -12,42 +11,48 @@ interface PricedAPISitePlansIndex {
 	[ productId: number ]: PricedAPISitePlan;
 }
 
-interface Props {
+interface Props< T > {
 	siteId?: string | number | null;
+	select?: ( data: SitePlansIndex ) => T;
 }
 
 /**
+ * Plans from `/sites/[siteId]/plans` endpoint, transformed into a map of planSlug => SitePlan
  * - Plans from `/sites/[siteId]/plans`, unlike `/plans`, are returned indexed by product_id, and do not include that in the plan's payload.
  * - UI works with product/plan slugs everywhere, so returned index is transformed to be keyed by product_slug
+ * - The generic T allows to define generic select functions that can be used to select a subset of the data
  */
-function useSitePlans( { siteId }: Props ) {
+function useSitePlans< T >( { siteId, select }: Props< T > ) {
 	const queryKeys = useQueryKeysFactory();
 
-	return useQuery< PricedAPISitePlansIndex, Error, SitePlansIndex >( {
+	return useQuery( {
 		queryKey: queryKeys.sitePlans( siteId ),
-		queryFn: async () =>
-			await wpcomRequest( {
+		queryFn: async () => {
+			const data: PricedAPISitePlansIndex = await wpcomRequest( {
 				path: `/sites/${ encodeURIComponent( siteId as string ) }/plans`,
 				apiVersion: '1.3',
-			} ),
-		select: useCallback( ( data: PricedAPISitePlansIndex ) => {
-			return Object.keys( data ).reduce< SitePlansIndex >( ( acc, productId ) => {
-				const plan = data[ Number( productId ) ];
-				return {
-					...acc,
-					[ plan.product_slug ]: {
-						planSlug: plan.product_slug,
-						productSlug: plan.product_slug,
-						productId: Number( productId ),
-						introOffer: unpackIntroOffer( plan ),
-						expiry: plan.expiry,
-						currentPlan: plan.current_plan,
-						purchaseId: plan.id ? Number( plan.id ) : undefined,
-					},
-				};
-			}, {} );
-		}, [] ),
-		refetchOnWindowFocus: false,
+			} );
+
+			return Object.fromEntries(
+				Object.keys( data ).map( ( productId ) => {
+					const plan = data[ Number( productId ) ];
+
+					return [
+						plan.product_slug,
+						{
+							planSlug: plan.product_slug,
+							productSlug: plan.product_slug,
+							productId: Number( productId ),
+							introOffer: unpackIntroOffer( plan ),
+							expiry: plan.expiry,
+							currentPlan: plan.current_plan,
+							purchaseId: plan.id ? Number( plan.id ) : undefined,
+						},
+					];
+				} )
+			);
+		},
+		select,
 		staleTime: 1000 * 60 * 5, // 5 minutes
 		enabled: !! siteId,
 	} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

General cleanup to query hooks in plans data-store. Better transformation logic done in `queryFn`, better typing, remove unnecessary `refetchOnWindowFocus` and set `staleTime` to 0. The status for showing the spinner is based on `isLoading` now and not `isFetching`. 

Somehow the small spinner shown before got lost completely in my testing. Not sure if that brings up anything suspicious.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- confirm `/plans` page renders billing descriptions and pricing correctly
- confirm introductory offers (based entirely on these hooks) render correct intro offers and billing descriptions (see for testing details: https://github.com/Automattic/wp-calypso/pull/84763 )
- confirm the pricing works as expected
- focus/unfocus the browser window and ensure nothing breaks
- keep the page open for a few minutes then go back to it, etc.
- that nothing gets injected in unexpectedly (e.g. in the case of a fresh wooexpress site with intro offers, it shouldn't flicker between the regular price and the intro offer)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?