### PR TITLE
POC: Add marketplace siteless checkout

### DIFF
--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -70,6 +70,10 @@ export function checkoutAkismetSiteless( context, next ) {
 	sitelessCheckout( context, next, { sitelessCheckoutType: 'akismet' } );
 }
 
+export function checkoutMarketplaceSiteless( context, next ) {
+	sitelessCheckout( context, next, { sitelessCheckoutType: 'marketplace' } );
+}
+
 function sitelessCheckout( context, next, extraProps ) {
 	const state = context.store.getState();
 	const isLoggedOut = ! isUserLoggedIn( state );

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -27,6 +27,7 @@ import {
 	akismetCheckoutThankYou,
 	hundredYearCheckoutThankYou,
 	transferDomainToAnyUser,
+	checkoutMarketplaceSiteless,
 } from './controller';
 
 export default function () {
@@ -102,6 +103,15 @@ export default function () {
 		'/checkout/100-year/thank-you/:site/:receiptId',
 		loggedInSiteSelection,
 		hundredYearCheckoutThankYou,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		`/checkout/marketplace/:productSlug`,
+		setLocaleMiddleware(),
+		noSite,
+		checkoutMarketplaceSiteless,
 		makeLayout,
 		clientRender
 	);

--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -100,6 +100,7 @@ export interface CheckoutMainProps {
 	disabledThankYouPage?: boolean;
 	sitelessCheckoutType?: SitelessCheckoutType;
 	akismetSiteSlug?: string;
+	marketplaceSiteSlug?: string;
 	jetpackSiteSlug?: string;
 	jetpackPurchaseToken?: string;
 	isUserComingFromLoginForm?: boolean;
@@ -137,6 +138,7 @@ export default function CheckoutMain( {
 	disabledThankYouPage,
 	sitelessCheckoutType,
 	akismetSiteSlug,
+	marketplaceSiteSlug,
 	jetpackSiteSlug,
 	jetpackPurchaseToken,
 	isUserComingFromLoginForm,
@@ -170,8 +172,12 @@ export default function CheckoutMain( {
 			return akismetSiteSlug;
 		}
 
+		if ( sitelessCheckoutType === 'marketplace' ) {
+			return marketplaceSiteSlug;
+		}
+
 		return siteSlug;
-	}, [ akismetSiteSlug, jetpackSiteSlug, sitelessCheckoutType, siteSlug ] );
+	}, [ akismetSiteSlug, jetpackSiteSlug, marketplaceSiteSlug, sitelessCheckoutType, siteSlug ] );
 
 	const showErrorMessageBriefly = useCallback(
 		( error: string ) => {

--- a/client/my-sites/checkout/src/hooks/use-checkout-flow-track-key.ts
+++ b/client/my-sites/checkout/src/hooks/use-checkout-flow-track-key.ts
@@ -34,6 +34,10 @@ export default function useCheckoutFlowTrackKey( {
 			return 'akismet_siteless_checkout';
 		}
 
+		if ( sitelessCheckoutType === 'marketplace' ) {
+			return 'marketplace_siteless_checkout';
+		}
+
 		if ( isLoggedOutCart ) {
 			return 'wpcom_registrationless';
 		}

--- a/client/my-sites/checkout/src/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/src/hooks/use-prepare-products-for-cart.ts
@@ -303,7 +303,7 @@ function useAddProductFromBillingIntent( {
 			debug( 'creating products from billing intent failed' );
 			dispatch( {
 				type: 'PRODUCTS_ADD_ERROR',
-				message: 'I tried and failed to create products from signup',
+				message: 'I tried and failed to create products from a billing intent',
 			} );
 			return;
 		}

--- a/client/my-sites/checkout/use-cart-key.ts
+++ b/client/my-sites/checkout/use-cart-key.ts
@@ -17,9 +17,14 @@ export default function useCartKey(): ReturnType< typeof getCartKey > {
 		( !! jetpackPurchaseToken || !! jetpackPurchaseNonce );
 	const isAkismetSitelessCheckout =
 		currentUrlPath.includes( '/checkout/akismet' ) && isLoggedOutCart;
+
+	const isMarketplaceSitelessCheckout =
+		currentUrlPath.includes( '/checkout/marketplace' ) && isLoggedOutCart;
+
 	const isNoSiteCart =
 		isJetpackCheckout ||
 		isAkismetSitelessCheckout ||
+		isMarketplaceSitelessCheckout ||
 		( ! isLoggedOutCart &&
 			currentUrlPath.includes( '/checkout/no-site' ) &&
 			'no-user' === searchParams.get( 'cart' ) );

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -598,6 +598,7 @@ export interface ResponseCartProductExtra {
 	afterPurchaseUrl?: string;
 	isJetpackCheckout?: boolean;
 	isAkismetSitelessCheckout?: boolean;
+	isMarketplaceSitelessCheckout?: boolean;
 
 	/**
 	 * Marketplace properties
@@ -619,6 +620,7 @@ export interface ResponseCartGiftDetails {
 export interface RequestCartProductExtra extends ResponseCartProductExtra {
 	purchaseId?: string;
 	isAkismetSitelessCheckout?: boolean;
+	isMarketplaceSitelessCheckout?: boolean;
 	isJetpackCheckout?: boolean;
 	isGiftPurchase?: boolean;
 	jetpackSiteSlug?: string;

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -592,4 +592,4 @@ export interface CountryListItemWithVat extends CountryListItemBase {
 }
 export type CountryListItem = CountryListItemWithVat | CountryListItemWithoutVat;
 
-export type SitelessCheckoutType = 'jetpack' | 'akismet' | undefined;
+export type SitelessCheckoutType = 'jetpack' | 'akismet' | 'marketplace' | undefined;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4937

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?