### PR TITLE
Un-hardcode plan names in ETK

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.js
@@ -1,6 +1,7 @@
 /*** THIS MUST BE THE FIRST THING EVALUATED IN THIS SCRIPT *****/
 import './public-path';
 
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import domReady from '@wordpress/dom-ready';
 import { registerPlugin } from '@wordpress/plugins';
 import GlobalStylesModal from './modal';
@@ -10,10 +11,10 @@ import './store';
 const showGlobalStylesComponents = () => {
 	registerPlugin( 'wpcom-global-styles', {
 		render: () => (
-			<>
+			<QueryClientProvider client={ new QueryClient() }>
 				<GlobalStylesModal />
 				<GlobalStylesNotices />
-			</>
+			</QueryClientProvider>
 		),
 	} );
 };

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/modal.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/modal.js
@@ -1,10 +1,13 @@
 /* global wpcomGlobalStyles */
 
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { usePlans } from '@automattic/data-stores/src/plans';
+import { PLAN_PREMIUM } from '@automattic/data-stores/src/plans/constants';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { Button, Modal } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf, hasTranslation } from '@wordpress/i18n';
 import React from 'react';
 import image from './image.svg';
 import { useCanvas } from './use-canvas';
@@ -14,6 +17,8 @@ import './modal.scss';
 const GlobalStylesModal = () => {
 	const isSiteEditor = useSelect( ( select ) => !! select( 'core/edit-site' ), [] );
 	const { viewCanvasPath } = useCanvas();
+	const isEnglishLocale = useIsEnglishLocale();
+	const plans = usePlans();
 
 	const isVisible = useSelect(
 		( select ) => {
@@ -61,10 +66,24 @@ const GlobalStylesModal = () => {
 		return null;
 	}
 
-	const description = __(
-		"Change all of your site's fonts, colors and more. Available on the Premium plan.",
-		'full-site-editing'
-	);
+	const description =
+		isEnglishLocale ||
+		hasTranslation(
+			"Change all of your site's fonts, colors and more. Available on the %s plan.",
+			'full-site-editing'
+		)
+			? sprintf(
+					/* translators: %s is the short-form Premium plan name */
+					__(
+						"Change all of your site's fonts, colors and more. Available on the %s plan.",
+						'full-site-editing'
+					),
+					plans.data?.[ PLAN_PREMIUM ]?.productNameShort || ''
+			  )
+			: __(
+					"Change all of your site's fonts, colors and more. Available on the Premium plan.",
+					'full-site-editing'
+			  );
 
 	return (
 		<Modal

--- a/client/components/theme-upgrade-modal/index.tsx
+++ b/client/components/theme-upgrade-modal/index.tsx
@@ -18,12 +18,9 @@ import {
 	FEATURE_VIDEOPRESS_JP,
 	FEATURE_WAF_V2,
 	FEATURE_WORDADS,
-	PLAN_BUSINESS,
-	PLAN_ECOMMERCE,
-	PLAN_PREMIUM,
 } from '@automattic/calypso-products';
 import { Button, Gridicon, Dialog, ScreenReaderText } from '@automattic/components';
-import { ProductsList, Plans } from '@automattic/data-stores';
+import { ProductsList } from '@automattic/data-stores';
 import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { Tooltip } from '@wordpress/components';
@@ -90,7 +87,7 @@ export const ThemeUpgradeModal = ( {
 		( select ) => select( ProductsList.store ).getProductBySlug( 'business-bundle-monthly' ),
 		[]
 	);
-	const plans = Plans.usePlans();
+
 	//Wait until we have theme and product data to show content
 	const isLoading = ! premiumPlanProduct || ! businessPlanProduct || ! theme.data;
 
@@ -105,31 +102,15 @@ export const ThemeUpgradeModal = ( {
 			),
 			text: (
 				<p>
-					{ isEnglishLocale ||
-					i18n.hasTranslation(
-						'Get access to our Premium themes, and a ton of other features, with a subscription to the %(premiumPlanName)s plan. It’s {{strong}}%(planPrice)s{{/strong}} a year, risk-free with a 14-day money-back guarantee.'
-					)
-						? translate(
-								'Get access to our Premium themes, and a ton of other features, with a subscription to the %(premiumPlanName)s plan. It’s {{strong}}%(planPrice)s{{/strong}} a year, risk-free with a 14-day money-back guarantee.',
-								{
-									components: {
-										strong: <strong />,
-									},
-									args: {
-										planPrice: planPrice || '',
-										premiumPlanName: plans.data?.[ PLAN_PREMIUM ]?.productNameShort || '',
-									},
-								}
-						  )
-						: translate(
-								'Get access to our Premium themes, and a ton of other features, with a subscription to the Premium plan. It’s {{strong}}%s{{/strong}} a year, risk-free with a 14-day money-back guarantee.',
-								{
-									components: {
-										strong: <strong />,
-									},
-									args: planPrice,
-								}
-						  ) }
+					{ translate(
+						'Get access to our Premium themes, and a ton of other features, with a subscription to the Premium plan. It’s {{strong}}%s{{/strong}} a year, risk-free with a 14-day money-back guarantee.',
+						{
+							components: {
+								strong: <strong />,
+							},
+							args: planPrice,
+						}
+					) }
 				</p>
 			),
 			price: null,
@@ -184,27 +165,13 @@ export const ThemeUpgradeModal = ( {
 			text: (
 				<p>
 					{ bundledPluginMessage }{ ' ' }
-					{ isEnglishLocale ||
-					i18n.hasTranslation(
-						'Upgrade to a %(businessPlanName)s plan to select this theme and unlock all its features. It’s %(businessPlanPrice)s per year with a 14-day money-back guarantee.'
-					)
-						? translate(
-								// translators: %s is the business plan price.
-								'Upgrade to a %(businessPlanName)s plan to select this theme and unlock all its features. It’s %(businessPlanPrice)s per year with a 14-day money-back guarantee.',
-								{
-									args: {
-										businessPlanPrice: businessPlanPrice || '',
-										businessPlanName: plans.data?.[ PLAN_BUSINESS ]?.productNameShort || '',
-									},
-								}
-						  )
-						: translate(
-								// translators: %s is the business plan price.
-								'Upgrade to a Business plan to select this theme and unlock all its features. It’s %s per year with a 14-day money-back guarantee.',
-								{
-									args: businessPlanPrice,
-								}
-						  ) }
+					{ translate(
+						// translators: %s is the business plan price.
+						'Upgrade to a Business plan to select this theme and unlock all its features. It’s %s per year with a 14-day money-back guarantee.',
+						{
+							args: businessPlanPrice,
+						}
+					) }
 				</p>
 			),
 			price: null,
@@ -250,22 +217,9 @@ export const ThemeUpgradeModal = ( {
 			text: (
 				<>
 					<p>
-						{ isEnglishLocale ||
-						i18n.hasTranslation(
-							'This partner theme is only available to buy on the %(businessPlanName)s or %(commercePlanName)s plans.'
-						)
-							? translate(
-									'This partner theme is only available to buy on the %(businessPlanName)s or %(commercePlanName)s plans.',
-									{
-										args: {
-											businessPlanName: plans.data?.[ PLAN_BUSINESS ]?.productNameShort || '',
-											commercePlanName: plans.data?.[ PLAN_ECOMMERCE ]?.productNameShort || '',
-										},
-									}
-							  )
-							: translate(
-									'This partner theme is only available to buy on the Business or eCommerce plans.'
-							  ) }
+						{ translate(
+							'This partner theme is only available to buy on the Business or eCommerce plans.'
+						) }
 					</p>
 					<div>
 						<label>
@@ -283,15 +237,7 @@ export const ThemeUpgradeModal = ( {
 							) }
 							{ isMarketplacePlanSubscriptionNeeeded && (
 								<div className="theme-upgrade-modal__price-item">
-									<label>
-										{ isEnglishLocale || i18n.hasTranslation( '%(businessPlanName)s plan' )
-											? translate( '%(businessPlanName)s plan', {
-													args: {
-														businessPlanName: plans.data?.[ PLAN_BUSINESS ]?.productNameShort || '',
-													},
-											  } )
-											: translate( 'Business plan' ) }
-									</label>
+									<label>{ translate( 'Business plan' ) }</label>
 									<label className="theme-upgrade-modal__price-value">
 										<strong>{ businessPlanPriceText }</strong>
 									</label>
@@ -372,29 +318,23 @@ export const ThemeUpgradeModal = ( {
 		modalData = getBundledFirstPartyPurchaseModalData();
 		featureList = getBundledFirstPartyPurchaseFeatureList();
 		featureListHeader =
-			isEnglishLocale || i18n.hasTranslation( 'Included with your %(businessPlanName)s plan' )
-				? translate( 'Included with your %(businessPlanName)s plan', {
-						args: { businessPlanName: plans.data?.[ PLAN_BUSINESS ]?.productNameShort || '' },
-				  } )
-				: translate( 'Included with your Business plan' );
+			isEnglishLocale || i18n.hasTranslation( 'Included with your Business plan' )
+				? translate( 'Included with your Business plan' )
+				: translate( 'Included with your purchase' );
 	} else if ( isExternallyManaged ) {
 		modalData = getExternallyManagedPurchaseModalData();
 		featureList = getExternallyManagedFeatureList();
 		featureListHeader =
-			isEnglishLocale || i18n.hasTranslation( 'Included with your %(businessPlanName)s plan' )
-				? translate( 'Included with your %(businessPlanName)s plan', {
-						args: { businessPlanName: plans.data?.[ PLAN_BUSINESS ]?.productNameShort || '' },
-				  } )
-				: translate( 'Included with your Business plan' );
+			isEnglishLocale || i18n.hasTranslation( 'Included with your Business plan' )
+				? translate( 'Included with your Business plan' )
+				: translate( 'Included with your purchase' );
 	} else {
 		modalData = getStandardPurchaseModalData();
 		featureList = getStandardPurchaseFeatureList();
 		featureListHeader =
-			isEnglishLocale || i18n.hasTranslation( 'Included with your %(premiumPlanName)s plan' )
-				? translate( 'Included with your %(premiumPlanName)s plan', {
-						args: { premiumPlanName: plans.data?.[ PLAN_PREMIUM ]?.productNameShort || '' },
-				  } )
-				: translate( 'Included with your Premium plan' );
+			isEnglishLocale || i18n.hasTranslation( 'Included with your Premium plan' )
+				? translate( 'Included with your Premium plan' )
+				: translate( 'Included with your purchase' );
 	}
 
 	const features =

--- a/client/components/theme-upgrade-modal/index.tsx
+++ b/client/components/theme-upgrade-modal/index.tsx
@@ -18,9 +18,12 @@ import {
 	FEATURE_VIDEOPRESS_JP,
 	FEATURE_WAF_V2,
 	FEATURE_WORDADS,
+	PLAN_BUSINESS,
+	PLAN_ECOMMERCE,
+	PLAN_PREMIUM,
 } from '@automattic/calypso-products';
 import { Button, Gridicon, Dialog, ScreenReaderText } from '@automattic/components';
-import { ProductsList } from '@automattic/data-stores';
+import { ProductsList, Plans } from '@automattic/data-stores';
 import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { Tooltip } from '@wordpress/components';
@@ -87,7 +90,7 @@ export const ThemeUpgradeModal = ( {
 		( select ) => select( ProductsList.store ).getProductBySlug( 'business-bundle-monthly' ),
 		[]
 	);
-
+	const plans = Plans.usePlans();
 	//Wait until we have theme and product data to show content
 	const isLoading = ! premiumPlanProduct || ! businessPlanProduct || ! theme.data;
 
@@ -102,15 +105,31 @@ export const ThemeUpgradeModal = ( {
 			),
 			text: (
 				<p>
-					{ translate(
-						'Get access to our Premium themes, and a ton of other features, with a subscription to the Premium plan. It’s {{strong}}%s{{/strong}} a year, risk-free with a 14-day money-back guarantee.',
-						{
-							components: {
-								strong: <strong />,
-							},
-							args: planPrice,
-						}
-					) }
+					{ isEnglishLocale ||
+					i18n.hasTranslation(
+						'Get access to our Premium themes, and a ton of other features, with a subscription to the %(premiumPlanName)s plan. It’s {{strong}}%(planPrice)s{{/strong}} a year, risk-free with a 14-day money-back guarantee.'
+					)
+						? translate(
+								'Get access to our Premium themes, and a ton of other features, with a subscription to the %(premiumPlanName)s plan. It’s {{strong}}%(planPrice)s{{/strong}} a year, risk-free with a 14-day money-back guarantee.',
+								{
+									components: {
+										strong: <strong />,
+									},
+									args: {
+										planPrice: planPrice || '',
+										premiumPlanName: plans.data?.[ PLAN_PREMIUM ]?.productNameShort || '',
+									},
+								}
+						  )
+						: translate(
+								'Get access to our Premium themes, and a ton of other features, with a subscription to the Premium plan. It’s {{strong}}%s{{/strong}} a year, risk-free with a 14-day money-back guarantee.',
+								{
+									components: {
+										strong: <strong />,
+									},
+									args: planPrice,
+								}
+						  ) }
 				</p>
 			),
 			price: null,
@@ -165,13 +184,27 @@ export const ThemeUpgradeModal = ( {
 			text: (
 				<p>
 					{ bundledPluginMessage }{ ' ' }
-					{ translate(
-						// translators: %s is the business plan price.
-						'Upgrade to a Business plan to select this theme and unlock all its features. It’s %s per year with a 14-day money-back guarantee.',
-						{
-							args: businessPlanPrice,
-						}
-					) }
+					{ isEnglishLocale ||
+					i18n.hasTranslation(
+						'Upgrade to a %(businessPlanName)s plan to select this theme and unlock all its features. It’s %(businessPlanPrice)s per year with a 14-day money-back guarantee.'
+					)
+						? translate(
+								// translators: %s is the business plan price.
+								'Upgrade to a %(businessPlanName)s plan to select this theme and unlock all its features. It’s %(businessPlanPrice)s per year with a 14-day money-back guarantee.',
+								{
+									args: {
+										businessPlanPrice: businessPlanPrice || '',
+										businessPlanName: plans.data?.[ PLAN_BUSINESS ]?.productNameShort || '',
+									},
+								}
+						  )
+						: translate(
+								// translators: %s is the business plan price.
+								'Upgrade to a Business plan to select this theme and unlock all its features. It’s %s per year with a 14-day money-back guarantee.',
+								{
+									args: businessPlanPrice,
+								}
+						  ) }
 				</p>
 			),
 			price: null,
@@ -217,9 +250,22 @@ export const ThemeUpgradeModal = ( {
 			text: (
 				<>
 					<p>
-						{ translate(
-							'This partner theme is only available to buy on the Business or eCommerce plans.'
-						) }
+						{ isEnglishLocale ||
+						i18n.hasTranslation(
+							'This partner theme is only available to buy on the %(businessPlanName)s or %(commercePlanName)s plans.'
+						)
+							? translate(
+									'This partner theme is only available to buy on the %(businessPlanName)s or %(commercePlanName)s plans.',
+									{
+										args: {
+											businessPlanName: plans.data?.[ PLAN_BUSINESS ]?.productNameShort || '',
+											commercePlanName: plans.data?.[ PLAN_ECOMMERCE ]?.productNameShort || '',
+										},
+									}
+							  )
+							: translate(
+									'This partner theme is only available to buy on the Business or eCommerce plans.'
+							  ) }
 					</p>
 					<div>
 						<label>
@@ -237,7 +283,15 @@ export const ThemeUpgradeModal = ( {
 							) }
 							{ isMarketplacePlanSubscriptionNeeeded && (
 								<div className="theme-upgrade-modal__price-item">
-									<label>{ translate( 'Business plan' ) }</label>
+									<label>
+										{ isEnglishLocale || i18n.hasTranslation( '%(businessPlanName)s plan' )
+											? translate( '%(businessPlanName)s plan', {
+													args: {
+														businessPlanName: plans.data?.[ PLAN_BUSINESS ]?.productNameShort || '',
+													},
+											  } )
+											: translate( 'Business plan' ) }
+									</label>
 									<label className="theme-upgrade-modal__price-value">
 										<strong>{ businessPlanPriceText }</strong>
 									</label>
@@ -318,23 +372,29 @@ export const ThemeUpgradeModal = ( {
 		modalData = getBundledFirstPartyPurchaseModalData();
 		featureList = getBundledFirstPartyPurchaseFeatureList();
 		featureListHeader =
-			isEnglishLocale || i18n.hasTranslation( 'Included with your Business plan' )
-				? translate( 'Included with your Business plan' )
-				: translate( 'Included with your purchase' );
+			isEnglishLocale || i18n.hasTranslation( 'Included with your %(businessPlanName)s plan' )
+				? translate( 'Included with your %(businessPlanName)s plan', {
+						args: { businessPlanName: plans.data?.[ PLAN_BUSINESS ]?.productNameShort || '' },
+				  } )
+				: translate( 'Included with your Business plan' );
 	} else if ( isExternallyManaged ) {
 		modalData = getExternallyManagedPurchaseModalData();
 		featureList = getExternallyManagedFeatureList();
 		featureListHeader =
-			isEnglishLocale || i18n.hasTranslation( 'Included with your Business plan' )
-				? translate( 'Included with your Business plan' )
-				: translate( 'Included with your purchase' );
+			isEnglishLocale || i18n.hasTranslation( 'Included with your %(businessPlanName)s plan' )
+				? translate( 'Included with your %(businessPlanName)s plan', {
+						args: { businessPlanName: plans.data?.[ PLAN_BUSINESS ]?.productNameShort || '' },
+				  } )
+				: translate( 'Included with your Business plan' );
 	} else {
 		modalData = getStandardPurchaseModalData();
 		featureList = getStandardPurchaseFeatureList();
 		featureListHeader =
-			isEnglishLocale || i18n.hasTranslation( 'Included with your Premium plan' )
-				? translate( 'Included with your Premium plan' )
-				: translate( 'Included with your purchase' );
+			isEnglishLocale || i18n.hasTranslation( 'Included with your %(premiumPlanName)s plan' )
+				? translate( 'Included with your %(premiumPlanName)s plan', {
+						args: { premiumPlanName: plans.data?.[ PLAN_PREMIUM ]?.productNameShort || '' },
+				  } )
+				: translate( 'Included with your Premium plan' );
 	}
 
 	const features =


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

This replaces the hardcoded plan names in the Editing toolkit so that they point to the real values. This will be needed for any upcoming plan name experiments (ex. pcNC1U-WN-p2)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow instructions from D130166-code to get assigned the experiment
* The plan mentions should show the updated plan names.
<img width="359" alt="Screenshot 2023-12-12 at 10 55 19" src="https://github.com/Automattic/wp-calypso/assets/2749938/a60d8ac5-ee60-41f6-bedc-4790d730e459">
<img width="1251" alt="Screenshot 2023-12-12 at 10 43 56" src="https://github.com/Automattic/wp-calypso/assets/2749938/f2f617bb-4c64-4271-8aab-b54564a6bfd1">

<img width="837" alt="Screenshot 2023-12-12 at 10 24 37" src="https://github.com/Automattic/wp-calypso/assets/2749938/2c7568e5-dd2f-4b57-b72b-b47605361baa">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
