### PR TITLE
Import flow: Update title/subtitle styles, layout adjustments, and optimize imports

### DIFF
--- a/client/blocks/import/capture/index.tsx
+++ b/client/blocks/import/capture/index.tsx
@@ -27,7 +27,7 @@ const Capture: FunctionComponent< Props > = ( props ) => {
 
 	return (
 		<>
-			<div className="import__header">
+			<div className="import__heading import__heading-center">
 				<Title>{ translate( 'Where will you import from?' ) }</Title>
 			</div>
 			<div className="import__capture-container">

--- a/client/blocks/import/list/index.tsx
+++ b/client/blocks/import/list/index.tsx
@@ -73,7 +73,7 @@ export default function ListStep( props: Props ) {
 
 	return (
 		<>
-			<div className="import-layout list__wrapper">
+			<div className="list__wrapper">
 				<div className="import__heading import__heading-center">
 					<Title>{ __( 'Import content from another platform' ) }</Title>
 					<SubTitle>{ __( 'Select the platform where your content lives' ) }</SubTitle>

--- a/client/blocks/import/list/style.scss
+++ b/client/blocks/import/list/style.scss
@@ -37,22 +37,6 @@ html[dir="rtl"] {
 	}
 
 	.list__wrapper {
-		margin-left: auto !important;
-		margin-right: auto !important;
-
-		.import__heading {
-			margin-bottom: 2.5rem;
-
-			.onboarding-title {
-				width: 100%;
-				max-width: 100%;
-			}
-		}
-
-		@include break-wide {
-			max-width: 1032px;
-		}
-
 		h3 {
 			font-size: 1.125em; /* stylelint-disable-line declaration-property-unit-allowed-list */
 			color: var(--studio-gray-90);
@@ -80,6 +64,8 @@ html[dir="rtl"] {
 }
 
 .list__importers {
+	max-width: 430px;
+
 	.select-dropdown > div {
 		width: 100%;
 	}

--- a/client/blocks/import/ready/index.tsx
+++ b/client/blocks/import/ready/index.tsx
@@ -157,7 +157,7 @@ const ReadyNotStep: React.FunctionComponent< ReadyNotProps > = ( {
 	return (
 		<div className="import-layout__center">
 			<div className="import__header">
-				<div className="import__heading  import__heading-center">
+				<div className="import__heading import__heading-center">
 					<Title>{ __( "Your existing content can't be imported" ) }</Title>
 					<SubTitle>
 						{ __(
@@ -215,7 +215,7 @@ const ReadyStep: React.FunctionComponent< ReadyProps > = ( props ) => {
 	return (
 		<div className="import-layout__center">
 			<div className="import__header">
-				<div className="import__heading  import__heading-center">
+				<div className="import__heading import__heading-center">
 					<Title>{ __( 'Your content is ready for its new home' ) }</Title>
 					<SubTitle>
 						{ sprintf(
@@ -314,7 +314,7 @@ const ReadyAlreadyOnWPCOMStep: React.FunctionComponent< ReadyWpComProps > = ( {
 	return (
 		<div className="import-layout__center">
 			<div className="import__header">
-				<div className="import__heading  import__heading-center">
+				<div className="import__heading import__heading-center">
 					<Title>{ __( 'Your site is already on WordPress.com' ) }</Title>
 					<SubTitle>
 						{ createInterpolateElement(

--- a/client/blocks/import/ready/style.scss
+++ b/client/blocks/import/ready/style.scss
@@ -2,6 +2,13 @@
 @import "@wordpress/base-styles/mixins";
 
 .import__onboarding-page {
+	&.ready,
+	&.importReadyNot {
+		.onboarding-title {
+			max-width: 500px;
+		}
+	}
+
 	.import__preview {
 		width: 100%;
 		max-width: 100%;

--- a/client/blocks/import/style/base.scss
+++ b/client/blocks/import/style/base.scss
@@ -34,29 +34,27 @@
 		@include break-small {
 			width: 600px;
 		}
+
+		button {
+			padding: 0;
+			color: inherit;
+			font-size: inherit;
+			text-decoration: underline;
+		}
 	}
 
 	.import__header {
 		@include onboarding-heading-padding;
 		display: flex;
+		flex-direction: column;
 		justify-content: center;
 		align-items: center;
 	}
 
 	.import__heading {
 		flex-grow: 1;
-
-		@include break-medium {
-			h1 {
-				max-width: 500px;
-				margin: auto;
-			}
-
-			h2 {
-				max-width: 560px;
-				margin: auto;
-			}
-		}
+		margin-top: rem(26px);
+		margin-bottom: rem(52px);
 
 		&.center {
 			text-align: center;
@@ -91,6 +89,12 @@
 
 	.import__heading-center {
 		text-align: center;
+
+		.onboarding-title,
+		.onboarding-subtitle {
+			margin-left: auto;
+			margin-right: auto;
+		}
 	}
 
 	.scanning__header {

--- a/client/blocks/import/style/base.scss
+++ b/client/blocks/import/style/base.scss
@@ -32,7 +32,7 @@
 		color: var(--studio-gray-60);
 
 		@include break-small {
-			width: 600px;
+			max-width: 600px;
 		}
 
 		button {

--- a/client/blocks/import/style/base.scss
+++ b/client/blocks/import/style/base.scss
@@ -97,6 +97,10 @@
 		}
 	}
 
+	.onboarding-hooray .import__heading {
+		margin-top: 0;
+	}
+
 	.scanning__header {
 		.import__heading {
 			.onboarding-title {

--- a/client/blocks/import/style/base.scss
+++ b/client/blocks/import/style/base.scss
@@ -54,13 +54,13 @@
 
 		.onboarding-title {
 			@include onboarding-import-heading-text;
-			margin-bottom: 20px;
+			margin-bottom: rem(12px);
 		}
 
 		.onboarding-subtitle {
-			font-size: 1.125rem; /* stylelint-disable-line scales/font-sizes */
-			/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-			line-height: 1.4444em;
+			font-size: 1rem;
+			line-height: 1.5;
+			color: var(--studio-gray-60);
 
 			@include break-small {
 				width: 600px;

--- a/client/blocks/import/style/base.scss
+++ b/client/blocks/import/style/base.scss
@@ -21,6 +21,21 @@
 		}
 	}
 
+	.onboarding-title {
+		@include onboarding-import-heading-text;
+		margin-bottom: rem(12px);
+	}
+
+	.onboarding-subtitle {
+		font-size: 1rem;
+		line-height: 1.5;
+		color: var(--studio-gray-60);
+
+		@include break-small {
+			width: 600px;
+		}
+	}
+
 	.import__header {
 		@include onboarding-heading-padding;
 		display: flex;
@@ -50,21 +65,6 @@
 		strong {
 			font-weight: 500;
 			color: var(--studio-gray-100);
-		}
-
-		.onboarding-title {
-			@include onboarding-import-heading-text;
-			margin-bottom: rem(12px);
-		}
-
-		.onboarding-subtitle {
-			font-size: 1rem;
-			line-height: 1.5;
-			color: var(--studio-gray-60);
-
-			@include break-small {
-				width: 600px;
-			}
 		}
 
 		.formatted-header__subtitle {

--- a/client/blocks/import/style/mixins.scss
+++ b/client/blocks/import/style/mixins.scss
@@ -8,6 +8,6 @@
 	color: var(--studio-gray-100);
 
 	@include break-small {
-		font-size: 3rem; // 48px
+		font-size: 2.75rem; // 44px
 	}
 }

--- a/client/blocks/importer/blogger/index.tsx
+++ b/client/blocks/importer/blogger/index.tsx
@@ -91,7 +91,7 @@ export const BloggerImporter: React.FunctionComponent< ImporterBaseProps > = ( p
 
 	return (
 		<>
-			<div className={ classnames( `importer-${ importer }`, 'import-layout__center' ) }>
+			<div className={ classnames( `importer-${ importer }` ) }>
 				{ ( () => {
 					if ( ! job ) {
 						return;

--- a/client/blocks/importer/components/complete-screen/index.tsx
+++ b/client/blocks/importer/components/complete-screen/index.tsx
@@ -22,14 +22,16 @@ const CompleteScreen: React.FunctionComponent< Props > = ( props ) => {
 
 	return (
 		<Hooray>
-			<Title>{ __( 'Hooray!' ) }</Title>
-			<SubTitle>{ __( 'Congratulations. Your content was successfully imported.' ) }</SubTitle>
-			<DoneButton
-				siteId={ siteId }
-				job={ job as ImportJob }
-				resetImport={ resetImport }
-				onSiteViewClick={ onSiteViewClick }
-			/>
+			<div className="import__heading import__heading-center">
+				<Title>{ __( 'Hooray!' ) }</Title>
+				<SubTitle>{ __( 'Congratulations. Your content was successfully imported.' ) }</SubTitle>
+				<DoneButton
+					siteId={ siteId }
+					job={ job as ImportJob }
+					resetImport={ resetImport }
+					onSiteViewClick={ onSiteViewClick }
+				/>
+			</div>
 		</Hooray>
 	);
 };

--- a/client/blocks/importer/components/error-message/index.tsx
+++ b/client/blocks/importer/components/error-message/index.tsx
@@ -23,7 +23,7 @@ const ErrorMessage: React.FunctionComponent< Props > = ( props ) => {
 	return (
 		<div className="import-layout__center">
 			<div className="import__header">
-				<div className="import__heading-center">
+				<div className="import__heading import__heading-center">
 					<Title>{ translate( 'Oops, something went wrong' ) }</Title>
 					<SubTitle>
 						{ translate( 'Please try again soon or {{a}}contact support{{/a}} for help.', {

--- a/client/blocks/importer/components/error-message/style.scss
+++ b/client/blocks/importer/components/error-message/style.scss
@@ -1,5 +1,3 @@
-@import "~calypso/blocks/import/style/base";
-
 .import__error-message {
 	.onboarding-title,
 	.onboarding-subtitle {

--- a/client/blocks/importer/components/importer-drag/style.scss
+++ b/client/blocks/importer/components/importer-drag/style.scss
@@ -1,19 +1,4 @@
 .importer-drag {
-	.import__heading {
-		margin-bottom: 3.25rem;
-
-		.onboarding-title,
-		.onboarding-subtitle {
-			max-width: none;
-			width: 100%;
-		}
-	}
-
-	.importer-header {
-		margin-bottom: 40px;
-		padding-bottom: 20px;
-	}
-
 	.uploading-pane__upload-content.importer-ready-for-upload {
 		flex-direction: column;
 

--- a/client/blocks/importer/components/not-authorized/index.tsx
+++ b/client/blocks/importer/components/not-authorized/index.tsx
@@ -3,7 +3,7 @@ import { BackButton, NextButton, SubTitle, Title } from '@automattic/onboarding'
 import { useI18n } from '@wordpress/react-i18n';
 import React, { useEffect } from 'react';
 
-/* eslint-disable wpcalypso/jsx-classname-namespace */
+import './style.scss';
 
 interface Props {
 	onBackToStart?: () => void;
@@ -22,7 +22,7 @@ const NotAuthorized: React.FunctionComponent< Props > = ( props ) => {
 	}, [] );
 
 	return (
-		<div className="import-layout__center">
+		<div className="import__not-authorized import-layout__center">
 			<div className="import__header">
 				<div className="import__heading  import__heading-center">
 					<Title>{ __( 'You are not authorized to import content' ) }</Title>

--- a/client/blocks/importer/components/not-authorized/style.scss
+++ b/client/blocks/importer/components/not-authorized/style.scss
@@ -1,0 +1,5 @@
+.import__not-authorized {
+	.import__header .onboarding-title {
+		max-width: 500px;
+	}
+}

--- a/client/blocks/importer/components/not-found/index.tsx
+++ b/client/blocks/importer/components/not-found/index.tsx
@@ -1,11 +1,10 @@
 import { Title, SubTitle } from '@automattic/onboarding';
-import classnames from 'classnames';
 import { translate } from 'i18n-calypso';
 import React from 'react';
 
 const NotFound: React.FunctionComponent = () => {
 	return (
-		<div className={ classnames( 'import-layout__text-center' ) }>
+		<div className="import__heading import__heading-center">
 			<Title>{ translate( 'Uh oh. Page not found.' ) }</Title>
 			<SubTitle>
 				{ translate( "Sorry, the page you were looking for doesn't exist or has been moved." ) }

--- a/client/blocks/importer/medium/index.tsx
+++ b/client/blocks/importer/medium/index.tsx
@@ -91,7 +91,7 @@ export const MediumImporter: React.FunctionComponent< ImporterBaseProps > = ( pr
 
 	return (
 		<>
-			<div className={ classnames( `importer-${ importer }`, 'import-layout__center' ) }>
+			<div className={ classnames( `importer-${ importer }` ) }>
 				{ ( () => {
 					if ( ! job ) {
 						return;

--- a/client/blocks/importer/squarespace/index.tsx
+++ b/client/blocks/importer/squarespace/index.tsx
@@ -91,7 +91,7 @@ export const SquarespaceImporter: React.FunctionComponent< ImporterBaseProps > =
 
 	return (
 		<>
-			<div className={ classnames( `importer-${ importer }`, 'import-layout__center' ) }>
+			<div className={ classnames( `importer-${ importer }` ) }>
 				{ ( () => {
 					if ( ! job ) {
 						return;

--- a/client/blocks/importer/wix/index.tsx
+++ b/client/blocks/importer/wix/index.tsx
@@ -136,7 +136,7 @@ export const WixImporter: React.FunctionComponent< Props > = ( props ) => {
 
 	return (
 		<>
-			<div className={ classnames( `importer-${ importer }`, 'import-layout__center' ) }>
+			<div className={ classnames( `importer-${ importer }` ) }>
 				{ ( () => {
 					if ( checkIsFailed() ) {
 						return (

--- a/client/blocks/importer/wordpress/import-content-only/index.tsx
+++ b/client/blocks/importer/wordpress/import-content-only/index.tsx
@@ -121,7 +121,11 @@ const ImportContentOnly: React.FunctionComponent< Props > = ( props ) => {
 	}
 
 	function renderProgress() {
-		return <ProgressScreen job={ job } />;
+		return (
+			<div className="import-layout__center">
+				<ProgressScreen job={ job } />
+			</div>
+		);
 	}
 
 	function renderImportDrag() {

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/credentials-cta.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/credentials-cta.tsx
@@ -13,7 +13,7 @@ export const CredentialsCta = ( props: Props ) => {
 	return (
 		<div className="pre-migration__content pre-migration__credentials">
 			{ translate(
-				'Want to speed up the migration? {{button}}Provide the server credentials{{/button}} of your site',
+				'Want to speed up the migration? {{button}}Provide the server credentials{{/button}} of your site.',
 				{
 					components: {
 						button: (

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/credentials.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/credentials.tsx
@@ -33,7 +33,7 @@ export function Credentials( props: Props ) {
 
 	return (
 		<div className="import__pre-migration import__import-everything import__import-everything--redesign">
-			<div className="import__heading-title">
+			<div className="import__heading import__heading-center">
 				<Title>{ translate( 'You are ready to migrate' ) }</Title>
 			</div>
 

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/migration-ready.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/migration-ready.tsx
@@ -83,7 +83,7 @@ export function MigrationReady( props: Props ) {
 				/>
 			) }
 			<div className="import__pre-migration import__import-everything import__import-everything--redesign">
-				<div className="import__heading-title">
+				<div className="import__heading import__heading-center">
 					<Title>{ translate( 'You are ready to migrate' ) }</Title>
 				</div>
 				{ ! sourceSiteHasCredentials && (

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/style.scss
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/style.scss
@@ -8,11 +8,6 @@
 	padding: 0 rem(20px);
 	max-width: 100%;
 
-	> div {
-		text-align: center;
-		margin: rem(20px) auto rem(40px) auto !important;
-	}
-
 	.pre-migration__form-container {
 		display: flex;
 		flex-wrap: wrap;
@@ -101,6 +96,9 @@
 	}
 
 	.pre-migration__credentials {
+		text-align: center;
+		margin-bottom: rem(40px);
+
 		button {
 			vertical-align: baseline;
 			font-size: 1rem;

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/style.scss
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/style.scss
@@ -1,4 +1,3 @@
-@import "~calypso/blocks/import/style/base";
 @import "../style.scss";
 
 .import__pre-migration.import__import-everything--redesign {

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/update-plugins.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/update-plugins.tsx
@@ -90,7 +90,7 @@ export const UpdatePluginInfo: React.FunctionComponent< Props > = ( props: Props
 
 	return (
 		<div className="import__import-everything import__import-everything--redesign">
-			<div className="import__heading-title">
+			<div className="import__heading import__heading-center">
 				<Title>{ renderTitle() }</Title>
 				<SubTitle>{ renderSubTitle() }</SubTitle>
 			</div>

--- a/client/blocks/importer/wordpress/import-everything/style.scss
+++ b/client/blocks/importer/wordpress/import-everything/style.scss
@@ -19,22 +19,7 @@
 		flex: 100%;
 	}
 
-	.onboarding-title {
-		font-family: var(--font-base, var(--font-base-default));
-		color: var(--studio-gray-100);
-		font-size: 1.25rem;
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-		line-height: 1.5rem;
-		margin-bottom: 1.5rem;
-	}
-
 	.onboarding-subtitle {
-		color: var(--studio-gray-50);
-		font-size: 1rem;
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-		line-height: 1.5rem;
-		margin-bottom: 3rem;
-
 		button.is-borderless {
 			padding: 0;
 			text-decoration: underline;
@@ -105,21 +90,6 @@
 	.onboarding-progress-simple {
 		min-width: 100% !important;
 
-		.onboarding-title {
-			font-size: rem(48px);
-		}
-
-		h2.onboarding-subtitle {
-			color: var(--studio-gray-60);
-			font-size: rem(18px);
-			line-height: rem(26px);
-			margin-bottom: rem(40px);
-		}
-
-		h3.onboarding-subtitle {
-			margin-bottom: rem(50px);
-		}
-
 		.progress-bar {
 			max-width: 385px;
 			margin-bottom: rem(24px);
@@ -128,23 +98,6 @@
 }
 
 .import__import-everything--redesign {
-	.onboarding-title {
-		@include onboarding-font-recoleta;
-		color: var(--studio-gray-100);
-		font-size: 2.75rem;
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-		line-height: 3rem;
-		margin-bottom: 0.5rem;
-	}
-
-	.import__heading-title {
-		text-align: center;
-	}
-
-	.onboarding-subtitle {
-		margin-bottom: 2.5rem;
-	}
-
 	.action-buttons__borderless {
 		font-weight: 500;
 		text-decoration: underline;

--- a/client/blocks/importer/wordpress/index.tsx
+++ b/client/blocks/importer/wordpress/index.tsx
@@ -23,8 +23,6 @@ import { WPImportOption } from './types';
 import { storeMigrateSource, retrieveMigrateSource } from './utils';
 import type { OnboardSelect } from '@automattic/data-stores';
 
-import './style.scss';
-
 interface Props {
 	job?: ImportJob;
 	run?: boolean;

--- a/client/blocks/importer/wordpress/style.scss
+++ b/client/blocks/importer/wordpress/style.scss
@@ -1,4 +1,0 @@
-.importer-wrapper__wordpress {
-	margin-left: auto !important;
-	margin-right: auto !important;
-}

--- a/client/blocks/importer/wordpress/upgrade-plan/index.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/index.tsx
@@ -68,7 +68,7 @@ export const UpgradePlan: React.FunctionComponent< Props > = ( props: Props ) =>
 
 	return (
 		<div className="import__upgrade-plan">
-			<div className="import__heading-center">
+			<div className="import__heading import__heading-center">
 				<Title>{ translate( 'Upgrade your plan' ) }</Title>
 				<SubTitle>
 					{ subTitleText ||

--- a/client/blocks/importer/wordpress/upgrade-plan/style.scss
+++ b/client/blocks/importer/wordpress/upgrade-plan/style.scss
@@ -6,24 +6,6 @@
 $business-plan-color: #7f54b3;
 
 .import__upgrade-plan {
-	.onboarding-title {
-		@include onboarding-font-recoleta;
-		color: var(--studio-gray-100);
-		font-size: 2.75rem;
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-		line-height: 3rem;
-		margin-bottom: 0.5rem;
-	}
-
-	.onboarding-subtitle {
-		button {
-			padding: 0;
-			color: inherit;
-			font-size: inherit;
-			text-decoration: underline;
-		}
-	}
-
 	p {
 		color: var(--studio-gray-40);
 		margin-bottom: 1em;

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -8,6 +8,11 @@
 @import "@automattic/components/src/styles/typography";
 
 /**
+ * Importers styles
+ */
+@import "~calypso/blocks/import/style/base";
+
+/**
  * General onboarding styling
  */
 body {

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -115,11 +115,6 @@ button {
 		}
 	}
 
-	.import-step,
-	.importer-step {
-		@include onboarding-block-margin;
-	}
-
 	&.step-route {
 		padding: 60px 0 0;
 
@@ -134,6 +129,13 @@ button {
 			&.new-or-existing-site {
 				margin-top: -60px;
 			}
+		}
+
+		// Importer flows
+		&.import-focused,
+		&.import-hosted-site,
+		&.site-setup[class*=" import"] {
+			padding: 3.75rem 0;
 		}
 	}
 
@@ -177,7 +179,6 @@ button {
  	 * Step Container
  	 */
 	.step-container {
-
 		.form-fieldset {
 			label {
 				text-transform: none;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import-light/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import-light/style.scss
@@ -1,4 +1,4 @@
-@import "~calypso/blocks/import/style/base";
+@import "@automattic/onboarding/styles/mixins";
 
 .site-setup.import-light {
 	.import__onboarding-page {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import-list/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import-list/index.tsx
@@ -3,7 +3,6 @@ import ListStep from 'calypso/blocks/import/list';
 import { Step } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { ImportWrapper } from '../import';
 import { generateStepPath } from '../import/helper';
-import './style.scss';
 
 const ImportList: Step = function ImportStep( props ) {
 	const { navigation } = props;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import-list/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import-list/style.scss
@@ -1,1 +1,0 @@
-@import "~calypso/blocks/import/style/base";

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready-not/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready-not/index.tsx
@@ -4,7 +4,6 @@ import { Step } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { ImportWrapper } from '../import';
 import { generateStepPath } from '../import/helper';
-import './style.scss';
 
 const ImportReadyNot: Step = function ImportStep( props ) {
 	const { navigation } = props;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready-not/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready-not/style.scss
@@ -1,1 +1,0 @@
-@import "~calypso/blocks/import/style/base";

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready-preview/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready-preview/index.tsx
@@ -13,8 +13,6 @@ import { BASE_ROUTE } from '../import/config';
 import { getFinalImporterUrl } from '../import/helper';
 import type { OnboardSelect } from '@automattic/data-stores';
 
-import './style.scss';
-
 const ImportReadyPreview: Step = function ImportStep( props ) {
 	const { navigation } = props;
 	const siteSlug = useSiteSlugParam();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready-preview/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready-preview/style.scss
@@ -1,1 +1,0 @@
-@import "~calypso/blocks/import/style/base";

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready-wpcom/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready-wpcom/index.tsx
@@ -7,7 +7,6 @@ import { getUrlData } from 'calypso/state/imports/url-analyzer/selectors';
 import { ImportWrapper } from '../import';
 import { BASE_ROUTE } from '../import/config';
 import { generateStepPath } from '../import/helper';
-import './style.scss';
 
 const ImportReadyNot: Step = function ImportStep( props ) {
 	const { navigation } = props;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready-wpcom/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready-wpcom/style.scss
@@ -1,2 +1,0 @@
-@import "~calypso/blocks/import/style/base";
-

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready/index.tsx
@@ -9,7 +9,6 @@ import { getUrlData } from 'calypso/state/imports/url-analyzer/selectors';
 import { ImportWrapper } from '../import';
 import { BASE_ROUTE } from '../import/config';
 import { getFinalImporterUrl } from '../import/helper';
-import './style.scss';
 
 const ImportReady: Step = function ImportStep( props ) {
 	const { navigation } = props;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready/style.scss
@@ -1,1 +1,0 @@
-@import "~calypso/blocks/import/style/base";

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import/style.scss
@@ -1,4 +1,4 @@
-@import "~calypso/blocks/import/style/base";
+@import "@automattic/onboarding/styles/mixins";
 
 .import__onboarding-page.step-container {
 	@include onboarding-block-margin;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import/style.scss
@@ -1,18 +1,14 @@
 @import "~calypso/blocks/import/style/base";
 
-.import-hosted-site.import,
-.site-setup.import,
-.import-focused.import,
-.import-hosted-site.import-list,
-.site-setup.import-list,
-.import-focused.import-list {
-	.import__onboarding-page {
-		@include onboarding-block-margin;
-	}
+.import__onboarding-page.step-container {
+	@include onboarding-block-margin;
 
 	.step-container__content {
 		max-width: 960px;
 		margin: auto;
 	}
-}
 
+	@include break-large {
+		margin: auto;
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer-blogger/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer-blogger/style.scss
@@ -1,2 +1,1 @@
-@import "~calypso/blocks/import/style/base";
 @import "../importer/style";

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer-medium/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer-medium/style.scss
@@ -1,2 +1,1 @@
-@import "~calypso/blocks/import/style/base";
 @import "../importer/style";

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer-squarespace/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer-squarespace/style.scss
@@ -1,2 +1,1 @@
-@import "~calypso/blocks/import/style/base";
 @import "../importer/style";

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer-wix/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer-wix/style.scss
@@ -1,2 +1,1 @@
-@import "~calypso/blocks/import/style/base";
 @import "../importer/style";

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer-wordpress/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer-wordpress/style.scss
@@ -1,2 +1,1 @@
-@import "~calypso/blocks/import/style/base";
 @import "../importer/style";

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer-wordpress/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer-wordpress/style.scss
@@ -1,7 +1,2 @@
 @import "~calypso/blocks/import/style/base";
 @import "../importer/style";
-
-.importer-wordpress .step-container__content {
-	padding: 20px;
-	box-sizing: border-box;
-}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
@@ -191,7 +191,6 @@ export function withImporterWrapper( Importer: ImporterCompType ) {
 				<StepContainer
 					className={ classnames(
 						'import__onboarding-page',
-						'import-layout__center',
 						'importer-wrapper',
 						'import__onboarding-page--redesign',
 						{

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer/style.scss
@@ -1,3 +1,6 @@
+@import "@automattic/typography/styles/fonts";
+@import "@automattic/onboarding/styles/mixins";
+
 /**
  * Common importer integration styles
  */

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer/style.scss
@@ -4,7 +4,7 @@
 .import-hosted-site,
 .site-setup,
 .import-focused {
-	.importer-wrapper:not(.importer-wrapper__wordpress) {
+	.step-container__content > div[class^="importer-"] {
 		max-width: 700px;
 		margin: auto;
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/85052 (First try, gave up of replacing onboarding Title with FormattedHeader component)
Closes https://github.com/Automattic/wp-calypso/issues/84923

## Proposed Changes

* Cleaned up style overrides and set them to rely on global settings (flows have been updated multiple times in the last two years, and that's why there was a mess)
* Adjusted title and subtitle through import flows steps
* Optimized style imports: Before the changes, there were 13 times imports of the same CSS file, causing a stack of overrides
* Matched Figma design except for progress bar, which will be done in the following PR

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/import-focused?siteSlug={SITE_SLUG}`
* Try any flow; Import "content" or "everything"
* Check Title and SubTItle styles. Should be the same between steps
**TIP:** For easier review, follow commits

Optimized styles import:
<table>
  <tr>
    <td width="50%">
      Before:
      <img width="365" alt="Screenshot 2023-12-11 at 18 46 32" src="https://github.com/Automattic/wp-calypso/assets/1241413/cd4c09ef-f881-400f-8082-a2e01e1201f3">
    <td width="50%">
      After:
      <img width="367" alt="Screenshot 2023-12-11 at 18 46 48" src="https://github.com/Automattic/wp-calypso/assets/1241413/97cb5bfe-0dfb-440a-8064-885d32a63415">
</table>


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?