### PR TITLE
Domains: Remove `domains/glue-records` feature flag

### DIFF
--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
 import { englishLocales } from '@automattic/i18n-utils';
@@ -636,7 +635,6 @@ const Settings = ( {
 	const renderDomainGlueRecordsSection = () => {
 		// We can only create glue records for domains registered with us through KS_RAM
 		if (
-			! config.isEnabled( 'domains/glue-records' ) ||
 			! domain ||
 			domain.type !== domainTypes.REGISTERED ||
 			domain.registrar !== 'KS_RAM' ||

--- a/config/client.json
+++ b/config/client.json
@@ -3,7 +3,6 @@
 	"boom_analytics_key",
 	"client_slug",
 	"daily_post_blog_id",
-	"domains/glue-records",
 	"env",
 	"env_id",
 	"facebook_api_key",

--- a/config/development.json
+++ b/config/development.json
@@ -62,7 +62,6 @@
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
-		"domains/glue-records": true,
 		"email-accounts/enabled": true,
 		"external-media": true,
 		"external-media/free-photo-library": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -33,7 +33,6 @@
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
 		"domains/transfer-to-any-user": true,
-		"domains/glue-records": true,
 		"external-media": true,
 		"external-media/free-photo-library": true,
 		"external-media/google-photos": true,

--- a/config/production.json
+++ b/config/production.json
@@ -42,7 +42,6 @@
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
 		"domains/premium-domain-purchases": true,
-		"domains/glue-records": false,
 		"external-media": true,
 		"external-media/free-photo-library": true,
 		"external-media/google-photos": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -39,7 +39,6 @@
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
-		"domains/glue-records": true,
 		"domains/premium-domain-purchases": true,
 		"external-media": true,
 		"external-media/free-photo-library": true,

--- a/config/test.json
+++ b/config/test.json
@@ -39,7 +39,6 @@
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": true,
 		"difm/allow-extra-pages": false,
-		"domains/glue-records": true,
 		"domains/transfer-to-any-user": true,
 		"cookie-banner": false,
 		"google-my-business": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -41,7 +41,6 @@
 		"devdocs/color-scheme-picker": true,
 		"devdocs/redirect-loggedout-homepage": true,
 		"domains/gdpr-consent-page": true,
-		"domains/glue-records": true,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,


### PR DESCRIPTION
## Proposed Changes

This PR removes the `domains/glue-records` flag, launching the glue records card implemented in #84261 to all users with domains registered via Key-Systems.

## Testing Instructions

- Open the live Calypso link or build this branch locally
- Go to the domain management page for a domain that's registered with us via Key-Systems
- Ensure the card is shown correctly
- Try adding and removing glue records and ensure it works correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?