### PR TITLE
Added Unique Opens card to Email Stats

### DIFF
--- a/client/my-sites/stats/stats-email-top-row/index.jsx
+++ b/client/my-sites/stats/stats-email-top-row/index.jsx
@@ -34,6 +34,14 @@ export default function StatsEmailTopRow( { siteId, postId, statType, className 
 							isLoading={ isRequesting && ! counts?.hasOwnProperty( 'total_sends' ) }
 							icon={ <Gridicon icon="mail" /> }
 						/>
+						{ counts?.unique_opens && (
+							<TopCard
+								heading={ translate( 'Unique opens' ) }
+								value={ counts.unique_opens }
+								isLoading={ isRequesting && ! counts?.hasOwnProperty( 'unique_opens' ) }
+								icon={ <Icon icon={ eye } /> }
+							/>
+						) }
 						<TopCard
 							heading={ translate( 'Total opens' ) }
 							value={ counts?.total_opens ?? 0 }

--- a/client/state/stats/emails/actions.js
+++ b/client/state/stats/emails/actions.js
@@ -72,6 +72,7 @@ function emailStatsAlltimeTransform( stats ) {
 		rate: {
 			opens_rate: stats.opens_rate,
 			total_opens: stats.total_opens,
+			unique_opens: stats.unique_opens,
 			total_sends: stats.total_sends,
 			total_clicks: stats.total_clicks,
 			clicks_rate: stats.clicks_rate,


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/85097

## Proposed Changes

This PR adds a new Unique Opens box at the top of the Email Stats page.

Before:
<img width="1268" alt="Screenshot 2023-12-11 at 18 17 45" src="https://github.com/Automattic/wp-calypso/assets/3832570/4f11415a-c6fe-4828-8616-9d2be87e61a9">

After:
<img width="1268" alt="Screenshot 2023-12-11 at 18 17 53" src="https://github.com/Automattic/wp-calypso/assets/3832570/e5086931-c69a-456c-8145-01b8c3059144">


## Testing Instructions

- Apply this PR and start the application.
- Go to `https://wordpress.com/stats/day/[your-domain-here]`.
- Scroll down to the card of the emails and select an email you know doesn't have a 100% Open Rate.
- Check you get only 3 cards (not the Unique Opens card).
- Now apply the patch D131460-code to your sandbox and sandbox `public-api.wordpress.com`. That patch adds the `unique_opens` field to the email open rate response, which is required for this new box to appear.
- Refresh the page in calypso, and check that the new Unique Opens card is there on the top, for a total of 4 cards.
**Note: if you have cache problems, you may end up commenting on the lines related to cache in the endpoint in your sandbox (lines 11 to 13 in the patch code).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?