### PR TITLE
Themes: Simplify the useThemeTier Hook After API Changes

### DIFF
--- a/client/components/theme-tier/use-theme-tier.js
+++ b/client/components/theme-tier/use-theme-tier.js
@@ -1,21 +1,13 @@
 import { useSelector } from 'calypso/state';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getTheme } from 'calypso/state/themes/selectors/get-theme';
-import { getThemeTier } from 'calypso/state/themes/selectors/get-theme-tier';
 
 export default function useThemeTier( siteId, themeId ) {
 	const theme = useSelector( ( state ) => getTheme( state, 'wpcom', themeId ) );
-	const tier = useSelector( ( state ) => getThemeTier( state, theme?.theme_tier ) );
+	const themeTier = theme?.theme_tier || {};
 	const isThemeAllowedOnSite = useSelector( ( state ) =>
-		tier?.feature ? siteHasFeature( state, siteId, tier.feature ) : true
+		themeTier?.feature ? siteHasFeature( state, siteId, themeTier.feature ) : true
 	);
-
-	const themeTier = Object.keys( tier ).length
-		? {
-				...tier,
-				slug: theme?.theme_tier,
-		  }
-		: {};
 
 	return {
 		themeTier,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Tracking issue: https://github.com/Automattic/dotcom-forge/issues/4597
Related to: https://github.com/Automattic/wp-calypso/pull/85048

## Proposed Changes

* Simplify the `useThemeTier` hook after API changes introduced in D131579-code.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enable the `themes/tiers` feature flag.
* Open the Theme Showcase.
* Check the label of the following themes:
  * Annalee and Hevor: should be limited to the Premium plan.
  * Screenplay: should be limited to the Personal plan.
  * Bookix: should be limited to the Business plan, and require an additional subscription.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?