### PR TITLE
Updates the fields arrangement of the Blaze campaign details page

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -527,19 +527,19 @@ export default function CampaignItemDetails( props: Props ) {
 												<FlexibleSkeleton />
 											) }
 										</span>
-										<span className="campaign-item-details__label">
-											{ translate( 'Languages' ) }
-										</span>
-										<span className="campaign-item-details__details">
-											{ ! isLoading ? languagesListFormatted : <FlexibleSkeleton /> }
-										</span>
 									</div>
-									<div className="campaign-item-details__interests">
+									<div className="campaign-item-details__second-column">
 										<span className="campaign-item-details__label">
 											{ translate( 'Interests' ) }
 										</span>
 										<span className="campaign-item-details__details">
 											{ ! isLoading ? topicsListFormatted : <FlexibleSkeleton /> }
+										</span>
+										<span className="campaign-item-details__label">
+											{ translate( 'Languages' ) }
+										</span>
+										<span className="campaign-item-details__details">
+											{ ! isLoading ? languagesListFormatted : <FlexibleSkeleton /> }
 										</span>
 									</div>
 								</div>

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
@@ -287,7 +287,7 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 				flex-direction: column;
 				padding: 16px 16px 0;
 
-				&.campaign-item-details__interests {
+				&.campaign-item-details__second-column {
 					padding-top: 0;
 
 					@media (min-width: calc($break-medium + 1px)) {


### PR DESCRIPTION
With the improvement of the Geo-targeting options for Blaze campaigns, we want to improve the arrangement of the fields for the campaign details page. Now that the field Location can grow, we will move Languages to the second column for desktop screens.

![CleanShot 2023-11-01 at 14 42 49@2x (1)](https://github.com/Automattic/wp-calypso/assets/1258162/f8627ac8-947b-4e21-9566-38bfb9ad414b)


## Proposed Changes

* Change the arrangement of the fields in the Promote post - Campaign details page

## Testing Instructions

* Open the live preview and navigate to Tools->Advertising
* Click on the Campaigns tab and then open the details for any of your campaigns (you can create a new campaign if you don't have any)
* Check that the Languages field appears in the second column for desktop, and in the first column for mobile.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?