### PR TITLE
Woo Express Trial: Add a check for previous upgrade from trial before forwarding to trial expired screen

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -1,5 +1,9 @@
 import config from '@automattic/calypso-config';
-import { PLAN_FREE, PLAN_JETPACK_FREE } from '@automattic/calypso-products';
+import {
+	PLAN_ECOMMERCE_TRIAL_MONTHLY,
+	PLAN_FREE,
+	PLAN_JETPACK_FREE,
+} from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { removeQueryArgs } from '@wordpress/url';
 import i18n from 'i18n-calypso';
@@ -85,6 +89,7 @@ import { isSupportSession } from 'calypso/state/support/selectors';
 import { setSelectedSiteId, setAllSitesSelected } from 'calypso/state/ui/actions';
 import { setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
+
 /*
  * @FIXME Shorthand, but I might get rid of this.
  */
@@ -293,12 +298,16 @@ function isPathAllowedForDIFMInProgressSite( path, slug, domains, contextParams 
 function onSelectedSiteAvailable( context ) {
 	const state = context.store.getState();
 	const selectedSite = getSelectedSite( state );
+	// Check the possibly expired plan to ensure it's a trial plan.
+	const maybeExpiredPlanSlug = selectedSite?.plan?.product_slug;
 	// Use getSitePlanSlug() as it ignores expired plans.
 	const currentPlanSlug = getSitePlanSlug( state, selectedSite.ID );
 
-	// If we had a trial plan, and the user doesn't have an active paid plan, redirect to fullpage trial expired page.
+	// If we had a trial plan, and the user doesn't have a paid plan (active or expired),
+	// redirect to full-page trial expired page.
 	if (
 		wasTrialSite( state, selectedSite.ID ) &&
+		PLAN_ECOMMERCE_TRIAL_MONTHLY === maybeExpiredPlanSlug &&
 		[ PLAN_FREE, PLAN_JETPACK_FREE ].includes( currentPlanSlug )
 	) {
 		const permittedPathPrefixes = [

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -1,9 +1,5 @@
 import config from '@automattic/calypso-config';
-import {
-	PLAN_ECOMMERCE_TRIAL_MONTHLY,
-	PLAN_FREE,
-	PLAN_JETPACK_FREE,
-} from '@automattic/calypso-products';
+import { PLAN_FREE, PLAN_JETPACK_FREE } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { removeQueryArgs } from '@wordpress/url';
 import i18n from 'i18n-calypso';
@@ -76,6 +72,7 @@ import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import wasTrialSite from 'calypso/state/selectors/was-trial-site';
+import wasUpgradedFromTrialSite from 'calypso/state/selectors/was-upgraded-from-trial-site';
 import { requestSite } from 'calypso/state/sites/actions';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import {
@@ -298,8 +295,6 @@ function isPathAllowedForDIFMInProgressSite( path, slug, domains, contextParams 
 function onSelectedSiteAvailable( context ) {
 	const state = context.store.getState();
 	const selectedSite = getSelectedSite( state );
-	// Check the possibly expired plan to ensure it's a trial plan.
-	const maybeExpiredPlanSlug = selectedSite?.plan?.product_slug;
 	// Use getSitePlanSlug() as it ignores expired plans.
 	const currentPlanSlug = getSitePlanSlug( state, selectedSite.ID );
 
@@ -307,7 +302,7 @@ function onSelectedSiteAvailable( context ) {
 	// redirect to full-page trial expired page.
 	if (
 		wasTrialSite( state, selectedSite.ID ) &&
-		PLAN_ECOMMERCE_TRIAL_MONTHLY === maybeExpiredPlanSlug &&
+		! wasUpgradedFromTrialSite( state, selectedSite.ID ) &&
 		[ PLAN_FREE, PLAN_JETPACK_FREE ].includes( currentPlanSlug )
 	) {
 		const permittedPathPrefixes = [

--- a/client/my-sites/plans/ecommerce-trial/ecommerce-trial-expired/style.scss
+++ b/client/my-sites/plans/ecommerce-trial/ecommerce-trial-expired/style.scss
@@ -2,6 +2,10 @@
 @import "@wordpress/base-styles/breakpoints";
 
 body.is-section-plans.is-expired-ecommerce-trial-plan {
+	.layout__content {
+		padding-left: 0 !important;
+	}
+
 	&.color-scheme {
 		--color-surface-backdrop: var(--color-surface);
 	}

--- a/client/state/selectors/was-upgraded-from-trial-site.ts
+++ b/client/state/selectors/was-upgraded-from-trial-site.ts
@@ -1,0 +1,8 @@
+import getRawSite from 'calypso/state/selectors/get-raw-site';
+import type { AppState } from 'calypso/types';
+
+export default function wasUpgradedFromTrialSite( state: AppState, siteId: number ) {
+	const site = getRawSite( state, siteId );
+
+	return site?.was_upgraded_from_trial === true;
+}

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -24,6 +24,7 @@ export const SITE_REQUEST_FIELDS = [
 	'is_wpcom_staging_site',
 	'was_ecommerce_trial',
 	'was_migration_trial',
+	'was_upgraded_from_trial',
 	'was_hosting_trial',
 	'description',
 	'user_interactions',

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -132,6 +132,7 @@ export interface SiteDetails {
 	title: string;
 	visible?: boolean;
 	was_ecommerce_trial?: boolean;
+	was_upgraded_from_trial?: boolean;
 	was_migration_trial?: boolean;
 	was_hosting_trial?: boolean;
 	wpcom_url?: string;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #83120

## Proposed Changes

* This PR relies on https://github.com/Automattic/jetpack/pull/34597; this should not ship until that has shipped.
* When determining whether to forward to the trial expired page, check to see if the site has the new flag `was_upgraded_from_trial` -- this indicates the user upgraded their plan prior to the plan expiring, and we should *not* show the trial expired screen.
* Adds a selector for the new flag.
* This should fix the issue in #83120 where users who had somehow subscribed to a non Woo Express plan prior to their trial expiring would see this warning when the trial end date was reached.
* Also fix a layout issue similar to the one in #84930

**Before**

<img width="1451" alt="Screenshot 2023-12-11 at 2 41 16 PM" src="https://github.com/Automattic/wp-calypso/assets/2124984/c4a5376c-a0ac-47f8-8491-c3f77efdce27">

**After**

<img width="1451" alt="Screenshot 2023-12-11 at 2 43 33 PM" src="https://github.com/Automattic/wp-calypso/assets/2124984/f2480583-8b72-4be6-a237-c4bc9b10b5ef">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Sandbox `public-api.wordpress.com`
* Apply this patch to your sandbox: https://github.com/Automattic/jetpack/pull/34597
* Switch to this PR
* Navigate to `/setup/wooexpress` to create a new Woo Express Trial site.
* Navigate to `/checkout/${your woo express trial site}/ecommerce` and check out.
* Navigate to the dev console and GET from WP REST API v1.2 `/sites/{your woo express site}`
* Confirm you see the `was_upgraded_from_trial` key with the correct value in the response:
<img width="491" alt="Screenshot 2023-12-12 at 12 24 12 PM" src="https://github.com/Automattic/wp-calypso/assets/2124984/d4f818c4-e34e-4d87-985b-dac688107c25">

* In the Store Admin, update the expiration date of your ecommerce plan to the day before today to make it expire.
* Visit `/plans/${your woo express trial site}` and you should *not* be forwarded to the trial expired screen.
* Create another Woo Express Trial site
* In the Store Admin, update the expiration date of your second site's trial plan to the day before today.
* Visit `/plans/${your second woo express trial site}` and you should still be forwarded to the trial expired screen.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?