### PR TITLE
Theme Showcase: Add Theme Tier Context and Tooltip

### DIFF
--- a/client/components/theme-tier/constants.js
+++ b/client/components/theme-tier/constants.js
@@ -1,0 +1,14 @@
+import {
+	PLAN_BUSINESS,
+	PLAN_FREE,
+	PLAN_PERSONAL,
+	PLAN_PREMIUM,
+} from '@automattic/calypso-products';
+
+export const THEME_TIER_TO_PLAN = {
+	free: PLAN_FREE,
+	personal: PLAN_PERSONAL,
+	premium: PLAN_PREMIUM,
+	partner: PLAN_BUSINESS,
+	woocommerce: PLAN_BUSINESS,
+};

--- a/client/components/theme-tier/theme-tier-badge/index.js
+++ b/client/components/theme-tier/theme-tier-badge/index.js
@@ -1,7 +1,7 @@
 import { BUNDLED_THEME, DOT_ORG_THEME, MARKETPLACE_THEME } from '@automattic/design-picker';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'calypso/state';
-import { getThemeType } from 'calypso/state/themes/selectors';
+import { getThemeType, isThemePurchased } from 'calypso/state/themes/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import useThemeTier from '../use-theme-tier';
 import { ThemeTierBadgeContextProvider } from './theme-tier-badge-context';
@@ -21,6 +21,9 @@ export default function ThemeTierBadge( {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
 	const themeType = useSelector( ( state ) => getThemeType( state, themeId ) );
+	const isLegacyPremiumPurchased = useSelector( ( state ) =>
+		isThemePurchased( state, themeId, siteId )
+	);
 	const { themeTier, isThemeAllowedOnSite } = useThemeTier( siteId, themeId );
 
 	const getBadge = () => {
@@ -37,14 +40,14 @@ export default function ThemeTierBadge( {
 		}
 
 		if ( 'partner' === themeTier.slug || MARKETPLACE_THEME === themeType ) {
-			return <ThemeTierPartnerBadge themeId={ themeId } />;
+			return <ThemeTierPartnerBadge />;
 		}
 
-		if ( isThemeAllowedOnSite ) {
+		if ( isThemeAllowedOnSite || ( 'premium' === themeTier.slug && isLegacyPremiumPurchased ) ) {
 			return <span>{ siteId ? translate( 'Included in my plan' ) : translate( 'Free' ) }</span>;
 		}
 
-		return <ThemeTierUpgradeBadge themeId={ themeId } />;
+		return <ThemeTierUpgradeBadge />;
 	};
 
 	return (

--- a/client/components/theme-tier/theme-tier-badge/index.js
+++ b/client/components/theme-tier/theme-tier-badge/index.js
@@ -4,6 +4,7 @@ import { useSelector } from 'calypso/state';
 import { getThemeType } from 'calypso/state/themes/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import useThemeTier from '../use-theme-tier';
+import { ThemeTierBadgeContextProvider } from './theme-tier-badge-context';
 import ThemeTierBundledBadge from './theme-tier-bundled-badge';
 import ThemeTierCommunityBadge from './theme-tier-community-badge';
 import ThemeTierPartnerBadge from './theme-tier-partner-badge';
@@ -12,57 +13,45 @@ import ThemeTierUpgradeBadge from './theme-tier-upgrade-badge';
 
 import './style.scss';
 
-export default function ThemeTierBadge( { isLockedStyleVariation, themeId } ) {
+export default function ThemeTierBadge( {
+	canGoToCheckout = true,
+	isLockedStyleVariation,
+	themeId,
+} ) {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
 	const themeType = useSelector( ( state ) => getThemeType( state, themeId ) );
 	const { themeTier, isThemeAllowedOnSite } = useThemeTier( siteId, themeId );
 
-	const labelClassName = 'theme-tier-badge';
+	const getBadge = () => {
+		if ( BUNDLED_THEME === themeType ) {
+			return <ThemeTierBundledBadge />;
+		}
 
-	if ( BUNDLED_THEME === themeType ) {
-		return (
-			<div className={ labelClassName }>
-				<ThemeTierBundledBadge themeId={ themeId } />
-			</div>
-		);
-	}
+		if ( isLockedStyleVariation ) {
+			return <ThemeTierStyleVariationBadge themeId={ themeId } />;
+		}
 
-	if ( isLockedStyleVariation ) {
-		return (
-			<div className={ labelClassName }>
-				<ThemeTierStyleVariationBadge themeId={ themeId } />
-			</div>
-		);
-	}
+		if ( DOT_ORG_THEME === themeType ) {
+			return <ThemeTierCommunityBadge themeId={ themeId } />;
+		}
 
-	if ( DOT_ORG_THEME === themeType ) {
-		return (
-			<div className={ labelClassName }>
-				<ThemeTierCommunityBadge themeId={ themeId } />
-			</div>
-		);
-	}
+		if ( 'partner' === themeTier.slug || MARKETPLACE_THEME === themeType ) {
+			return <ThemeTierPartnerBadge themeId={ themeId } />;
+		}
 
-	if ( 'partner' === themeTier.slug || MARKETPLACE_THEME === themeType ) {
-		return (
-			<div className={ labelClassName }>
-				<ThemeTierPartnerBadge themeId={ themeId } />
-			</div>
-		);
-	}
+		if ( isThemeAllowedOnSite ) {
+			return <span>{ siteId ? translate( 'Included in my plan' ) : translate( 'Free' ) }</span>;
+		}
 
-	if ( isThemeAllowedOnSite ) {
-		return (
-			<div className={ labelClassName }>
-				<span>{ siteId ? translate( 'Included in my plan' ) : translate( 'Free' ) }</span>
-			</div>
-		);
-	}
+		return <ThemeTierUpgradeBadge themeId={ themeId } />;
+	};
 
 	return (
-		<div className={ labelClassName }>
-			<ThemeTierUpgradeBadge themeId={ themeId } />
+		<div className="theme-tier-badge">
+			<ThemeTierBadgeContextProvider canGoToCheckout={ canGoToCheckout } themeId={ themeId }>
+				{ getBadge() }
+			</ThemeTierBadgeContextProvider>
 		</div>
 	);
 }

--- a/client/components/theme-tier/theme-tier-badge/index.js
+++ b/client/components/theme-tier/theme-tier-badge/index.js
@@ -29,7 +29,7 @@ export default function ThemeTierBadge( {
 		}
 
 		if ( isLockedStyleVariation ) {
-			return <ThemeTierStyleVariationBadge themeId={ themeId } />;
+			return <ThemeTierStyleVariationBadge />;
 		}
 
 		if ( DOT_ORG_THEME === themeType ) {

--- a/client/components/theme-tier/theme-tier-badge/index.js
+++ b/client/components/theme-tier/theme-tier-badge/index.js
@@ -33,7 +33,7 @@ export default function ThemeTierBadge( {
 		}
 
 		if ( DOT_ORG_THEME === themeType ) {
-			return <ThemeTierCommunityBadge themeId={ themeId } />;
+			return <ThemeTierCommunityBadge />;
 		}
 
 		if ( 'partner' === themeTier.slug || MARKETPLACE_THEME === themeType ) {

--- a/client/components/theme-tier/theme-tier-badge/style.scss
+++ b/client/components/theme-tier/theme-tier-badge/style.scss
@@ -1,9 +1,9 @@
 @import "@automattic/typography/styles/variables";
 
 .theme-tier-badge {
+	color: var(--color-neutral-60);
 	display: flex;
 	flex-basis: 100%;
-	color: var(--color-neutral-60);
 	font-size: $font-body-small;
 	line-height: 20px;
 
@@ -13,3 +13,32 @@
 	}
 }
 
+.theme-tier-badge-tooltip,
+.theme-tier-badge-tooltip.premium-badge__popover.popover,
+.theme-tier-badge-tooltip.bundled-badge__popover {
+	.popover__inner {
+		background: var(--studio-white);
+		border: 0;
+		border-radius: 4px;
+		box-shadow: 0 3px 8px rgba(0, 0, 0, 0.12), 0 3px 1px rgba(0, 0, 0, 0.04);
+		color: var(--color-neutral-50);
+		font-size: $font-body-small;
+		max-width: 245px;
+		padding: 24px;
+		text-align: left;
+	}
+
+	.popover__arrow {
+		display: none;
+	}
+
+	.theme-tier-badge-tooltip__header {
+		color: var(--color-neutral-100);
+		font-weight: 500;
+		line-height: 20px;
+	}
+
+	.components-button {
+		font-size: inherit;
+	}
+}

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-badge-checkout-link.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-badge-checkout-link.js
@@ -1,0 +1,31 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { Button } from '@wordpress/components';
+import { useSelector } from 'calypso/state';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { useThemeTierBadgeContext } from './theme-tier-badge-context';
+
+export default function ThemeTierBadgeCheckoutLink( { children, plan } ) {
+	const siteSlug = useSelector( getSelectedSiteSlug );
+	const { canGoToCheckout } = useThemeTierBadgeContext();
+
+	if ( ! canGoToCheckout || ! siteSlug ) {
+		return <>{ children }</>;
+	}
+
+	const goToCheckout = () => {
+		recordTracksEvent( 'calypso_theme_tooltip_upgrade_nudge_click', { plan } );
+
+		const params = new URLSearchParams();
+		params.append( 'redirect_to', window.location.href.replace( window.location.origin, '' ) );
+
+		window.location.href = `/checkout/${ encodeURIComponent(
+			siteSlug
+		) }/${ plan }?${ params.toString() }`;
+	};
+
+	return (
+		<Button variant="link" onClick={ goToCheckout }>
+			{ children }
+		</Button>
+	);
+}

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-badge-context.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-badge-context.js
@@ -1,0 +1,21 @@
+import { createContext, useContext } from 'react';
+
+const ThemeTierBadgeContext = createContext( {
+	canGoToCheckout: true,
+	themeId: '',
+} );
+
+export const useThemeTierBadgeContext = () => useContext( ThemeTierBadgeContext );
+
+export function ThemeTierBadgeContextProvider( { canGoToCheckout, children, themeId } ) {
+	const value = {
+		canGoToCheckout,
+		themeId,
+	};
+
+	return (
+		<ThemeTierBadgeContext.Provider value={ value }>{ children }</ThemeTierBadgeContext.Provider>
+	);
+}
+
+export default ThemeTierBadgeContext;

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-bundled-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-bundled-badge.js
@@ -1,14 +1,19 @@
 import { BundledBadge, PremiumBadge } from '@automattic/components';
+import { createInterpolateElement } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import useBundleSettings from 'calypso/my-sites/theme/hooks/use-bundle-settings';
 import { useSelector } from 'calypso/state';
 import { canUseTheme } from 'calypso/state/themes/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import ThemeTierBadgeCheckoutLink from './theme-tier-badge-checkout-link';
+import { useThemeTierBadgeContext } from './theme-tier-badge-context';
 import ThemeTierBadgeTracker from './theme-tier-badge-tracker';
+import ThemeTierTooltipTracker from './theme-tier-tooltip-tracker';
 
-export default function ThemeTierBundledBadge( { themeId } ) {
+export default function ThemeTierBundledBadge() {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
+	const { themeId } = useThemeTierBadgeContext();
 	const bundleSettings = useBundleSettings( themeId );
 	const legacyCanUseTheme = useSelector(
 		( state ) => siteId && canUseTheme( state, siteId, themeId )
@@ -19,19 +24,52 @@ export default function ThemeTierBundledBadge( { themeId } ) {
 	}
 
 	const BadgeIcon = bundleSettings.iconComponent;
+	const bundleName = bundleSettings.name;
+
+	const tooltipContent = (
+		<>
+			<ThemeTierTooltipTracker />
+			<div data-testid="upsell-header" className="theme-tier-badge-tooltip__header">
+				{
+					// Translators: %(bundleName)s is the name of the bundle, sometimes represented as a product name. Examples: "WooCommerce" or "Special".
+					translate( '%(bundleName)s theme', { textOnly: true, args: { bundleName } } )
+				}
+			</div>
+			<div data-testid="upsell-message">
+				{ legacyCanUseTheme
+					? // Translators: %(bundleName)s is the name of the bundle, sometimes represented as a product name. Examples: "WooCommerce" or "Special".
+					  translate( 'This %(bundleName)s theme is included in your plan.', {
+							args: { bundleName },
+					  } )
+					: createInterpolateElement(
+							// Translators: %(bundleName)s is the name of the bundle, sometimes represented as a product name. Examples: "WooCommerce" or "Special".
+							translate(
+								'This %(bundleName)s theme is included in the <Link>Business plan</Link>.',
+								{
+									args: { bundleName },
+									textOnly: true,
+								}
+							),
+							{
+								Link: <ThemeTierBadgeCheckoutLink plan="business" />,
+							}
+					  ) }
+			</div>
+		</>
+	);
 
 	return (
-		<>
+		<div className="theme-tier-badge">
 			{ ! legacyCanUseTheme && (
 				<>
-					<ThemeTierBadgeTracker themeId={ themeId } />
+					<ThemeTierBadgeTracker />
 					<PremiumBadge
 						className="theme-tier-badge__content"
 						focusOnShow={ false }
 						isClickable
 						labelText={ translate( 'Upgrade' ) }
 						tooltipClassName="theme-tier-badge-tooltip"
-						tooltipContent={ null }
+						tooltipContent={ tooltipContent }
 						tooltipPosition="top"
 					/>
 				</>
@@ -44,10 +82,10 @@ export default function ThemeTierBundledBadge( { themeId } ) {
 				isClickable={ false }
 				shouldHideTooltip
 			>
-				{ bundleSettings.name }
+				{ bundleName }
 			</BundledBadge>
 
 			{ !! legacyCanUseTheme && <span>{ translate( 'Included in my plan' ) }</span> }
-		</>
+		</div>
 	);
 }

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-bundled-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-bundled-badge.js
@@ -36,24 +36,16 @@ export default function ThemeTierBundledBadge() {
 				}
 			</div>
 			<div data-testid="upsell-message">
-				{ legacyCanUseTheme
-					? // Translators: %(bundleName)s is the name of the bundle, sometimes represented as a product name. Examples: "WooCommerce" or "Special".
-					  translate( 'This %(bundleName)s theme is included in your plan.', {
-							args: { bundleName },
-					  } )
-					: createInterpolateElement(
-							// Translators: %(bundleName)s is the name of the bundle, sometimes represented as a product name. Examples: "WooCommerce" or "Special".
-							translate(
-								'This %(bundleName)s theme is included in the <Link>Business plan</Link>.',
-								{
-									args: { bundleName },
-									textOnly: true,
-								}
-							),
-							{
-								Link: <ThemeTierBadgeCheckoutLink plan="business" />,
-							}
-					  ) }
+				{ createInterpolateElement(
+					// Translators: %(bundleName)s is the name of the bundle, sometimes represented as a product name. Examples: "WooCommerce" or "Special".
+					translate( 'This %(bundleName)s theme is included in the <Link>Business plan</Link>.', {
+						args: { bundleName },
+						textOnly: true,
+					} ),
+					{
+						Link: <ThemeTierBadgeCheckoutLink plan="business" />,
+					}
+				) }
 			</div>
 		</>
 	);
@@ -85,7 +77,7 @@ export default function ThemeTierBundledBadge() {
 				{ bundleName }
 			</BundledBadge>
 
-			{ !! legacyCanUseTheme && <span>{ translate( 'Included in my plan' ) }</span> }
+			{ legacyCanUseTheme && <span>{ translate( 'Included in my plan' ) }</span> }
 		</div>
 	);
 }

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-community-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-community-badge.js
@@ -5,12 +5,14 @@ import { useSelector } from 'calypso/state';
 import { canUseTheme } from 'calypso/state/themes/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import ThemeTierBadgeCheckoutLink from './theme-tier-badge-checkout-link';
+import { useThemeTierBadgeContext } from './theme-tier-badge-context';
 import ThemeTierBadgeTracker from './theme-tier-badge-tracker';
 import ThemeTierTooltipTracker from './theme-tier-tooltip-tracker';
 
-export default function ThemeTierCommunityBadge( { themeId } ) {
+export default function ThemeTierCommunityBadge() {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
+	const { themeId } = useThemeTierBadgeContext();
 	const legacyCanUseTheme = useSelector(
 		( state ) => siteId && canUseTheme( state, siteId, themeId )
 	);
@@ -43,7 +45,7 @@ export default function ThemeTierCommunityBadge( { themeId } ) {
 
 	return (
 		<>
-			<ThemeTierBadgeTracker themeId={ themeId } />
+			<ThemeTierBadgeTracker />
 			<PremiumBadge
 				className="theme-tier-badge__content"
 				focusOnShow={ false }

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-community-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-community-badge.js
@@ -1,9 +1,12 @@
 import { PremiumBadge } from '@automattic/components';
+import { createInterpolateElement } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'calypso/state';
 import { canUseTheme } from 'calypso/state/themes/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import ThemeTierBadgeCheckoutLink from './theme-tier-badge-checkout-link';
 import ThemeTierBadgeTracker from './theme-tier-badge-tracker';
+import ThemeTierTooltipTracker from './theme-tier-tooltip-tracker';
 
 export default function ThemeTierCommunityBadge( { themeId } ) {
 	const translate = useTranslate();
@@ -16,6 +19,28 @@ export default function ThemeTierCommunityBadge( { themeId } ) {
 		return <span>{ translate( 'Included in my plan' ) }</span>;
 	}
 
+	const tooltipContent = (
+		<>
+			<ThemeTierTooltipTracker />
+			<div data-testid="upsell-header" className="theme-tier-badge-tooltip__header">
+				{ translate( 'Community theme', {
+					context: 'This theme is developed and supported by a community',
+					textOnly: true,
+				} ) }
+			</div>
+			<div data-testid="upsell-message">
+				{ createInterpolateElement(
+					translate(
+						'This community theme can only be installed if you have the <Link>Business plan</Link> or higher on your site.'
+					),
+					{
+						Link: <ThemeTierBadgeCheckoutLink plan="business" />,
+					}
+				) }
+			</div>
+		</>
+	);
+
 	return (
 		<>
 			<ThemeTierBadgeTracker themeId={ themeId } />
@@ -25,7 +50,7 @@ export default function ThemeTierCommunityBadge( { themeId } ) {
 				isClickable
 				labelText={ translate( 'Upgrade' ) }
 				tooltipClassName="theme-tier-badge-tooltip"
-				tooltipContent={ null }
+				tooltipContent={ tooltipContent }
 				tooltipPosition="top"
 			/>
 		</>

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-partner-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-partner-badge.js
@@ -1,10 +1,16 @@
 import { PremiumBadge } from '@automattic/components';
+import { createInterpolateElement } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'calypso/state';
-import { isMarketplaceThemeSubscribed } from 'calypso/state/themes/selectors';
+import {
+	isMarketplaceThemeSubscribed,
+	getMarketplaceThemeSubscriptionPrices,
+} from 'calypso/state/themes/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import useThemeTier from '../use-theme-tier';
+import ThemeTierBadgeCheckoutLink from './theme-tier-badge-checkout-link';
 import ThemeTierBadgeTracker from './theme-tier-badge-tracker';
+import ThemeTierTooltipTracker from './theme-tier-tooltip-tracker';
 
 export default function ThemeTierPartnerBadge( { themeId } ) {
 	const translate = useTranslate();
@@ -12,15 +18,73 @@ export default function ThemeTierPartnerBadge( { themeId } ) {
 	const isPartnerThemePurchased = useSelector( ( state ) =>
 		siteId ? isMarketplaceThemeSubscribed( state, themeId, siteId ) : false
 	);
+	const subscriptionPrices = useSelector( ( state ) =>
+		getMarketplaceThemeSubscriptionPrices( state, themeId )
+	);
 	const { isThemeAllowedOnSite } = useThemeTier( siteId, themeId );
 
-	if ( isPartnerThemePurchased ) {
+	if ( isPartnerThemePurchased && isThemeAllowedOnSite ) {
 		return <span>{ translate( 'Included in my plan' ) }</span>;
 	}
 
 	const labelText = isThemeAllowedOnSite
 		? translate( 'Subscribe' )
 		: translate( 'Upgrade and Subscribe' );
+
+	const getTooltipMessage = () => {
+		if ( isPartnerThemePurchased && ! isThemeAllowedOnSite ) {
+			return createInterpolateElement(
+				translate(
+					'You have a subscription for this theme, but it will only be usable if you have the <link>Business plan</link> on your site.'
+				),
+				{
+					Link: <ThemeTierBadgeCheckoutLink plan="business" />,
+				}
+			);
+		}
+		if ( ! isPartnerThemePurchased && isThemeAllowedOnSite ) {
+			/* translators: annualPrice and monthlyPrice are prices for the theme, examples: US$50, US$7; */
+			return translate(
+				'This theme is only available while your current plan is active and costs %(annualPrice)s per year or %(monthlyPrice)s per month.',
+				{
+					args: {
+						annualPrice: subscriptionPrices.year ?? '',
+						monthlyPrice: subscriptionPrices.month ?? '',
+					},
+				}
+			);
+		}
+		if ( ! isPartnerThemePurchased && ! isThemeAllowedOnSite ) {
+			return createInterpolateElement(
+				/* translators: annualPrice and monthlyPrice are prices for the theme, examples: US$50, US$7; */
+				translate(
+					'This theme costs %(annualPrice)s per year or %(monthlyPrice)s per month, and can only be purchased if you have the <Link>Business plan</Link> on your site.',
+					{
+						args: {
+							annualPrice: subscriptionPrices.year ?? '',
+							monthlyPrice: subscriptionPrices.month ?? '',
+						},
+					}
+				),
+				{
+					Link: <ThemeTierBadgeCheckoutLink plan="business" />,
+				}
+			);
+		}
+	};
+
+	const tooltipContent = (
+		<>
+			<ThemeTierTooltipTracker />
+			<div data-testid="upsell-header" className="theme-tier-badge-tooltip__header">
+				{ translate( 'Partner theme', {
+					context: 'This theme is developed and supported by a theme partner',
+					textOnly: true,
+				} ) }
+			</div>
+			<div data-testid="upsell-message">{ getTooltipMessage() }</div>
+		</>
+	);
 
 	return (
 		<>
@@ -31,7 +95,7 @@ export default function ThemeTierPartnerBadge( { themeId } ) {
 				isClickable
 				labelText={ labelText }
 				tooltipClassName="theme-tier-badge-tooltip"
-				tooltipContent={ null }
+				tooltipContent={ tooltipContent }
 				tooltipPosition="top"
 			/>
 		</>

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-partner-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-partner-badge.js
@@ -9,12 +9,14 @@ import {
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import useThemeTier from '../use-theme-tier';
 import ThemeTierBadgeCheckoutLink from './theme-tier-badge-checkout-link';
+import { useThemeTierBadgeContext } from './theme-tier-badge-context';
 import ThemeTierBadgeTracker from './theme-tier-badge-tracker';
 import ThemeTierTooltipTracker from './theme-tier-tooltip-tracker';
 
-export default function ThemeTierPartnerBadge( { themeId } ) {
+export default function ThemeTierPartnerBadge() {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
+	const { themeId } = useThemeTierBadgeContext();
 	const isPartnerThemePurchased = useSelector( ( state ) =>
 		siteId ? isMarketplaceThemeSubscribed( state, themeId, siteId ) : false
 	);
@@ -88,7 +90,7 @@ export default function ThemeTierPartnerBadge( { themeId } ) {
 
 	return (
 		<>
-			<ThemeTierBadgeTracker themeId={ themeId } />
+			<ThemeTierBadgeTracker />
 			<PremiumBadge
 				className="theme-tier-badge__content"
 				focusOnShow={ false }

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-style-variation-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-style-variation-badge.js
@@ -1,20 +1,33 @@
 import { PremiumBadge } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import ThemeTierBadgeTracker from './theme-tier-badge-tracker';
+import ThemeTierTooltipTracker from './theme-tier-tooltip-tracker';
 
-export default function ThemeTierStyleVariationBadge( { themeId } ) {
+export default function ThemeTierStyleVariationBadge() {
 	const translate = useTranslate();
+
+	const tooltipContent = (
+		<>
+			<ThemeTierTooltipTracker />
+			<div data-testid="upsell-header" className="theme-tier-badge-tooltip__header" />
+			<div data-testid="upsell-message">
+				{ translate(
+					'Unlock this style, and tons of other features, by upgrading to a Premium plan.'
+				) }
+			</div>
+		</>
+	);
 
 	return (
 		<>
-			<ThemeTierBadgeTracker themeId={ themeId } />
+			<ThemeTierBadgeTracker />
 			<PremiumBadge
 				className="theme-tier-badge__content"
 				focusOnShow={ false }
 				isClickable
 				labelText={ translate( 'Upgrade' ) }
 				tooltipClassName="theme-tier-badge-tooltip"
-				tooltipContent={ null }
+				tooltipContent={ tooltipContent }
 				tooltipPosition="top"
 			/>
 		</>

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-tooltip-tracker.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-tooltip-tracker.js
@@ -2,12 +2,12 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useEffect } from 'react';
 import { useThemeTierBadgeContext } from './theme-tier-badge-context';
 
-export default function ThemeTierBadgeTracker() {
+export default function ThemeTierTooltipTracker() {
 	const { themeId } = useThemeTierBadgeContext();
 
 	useEffect( () => {
 		recordTracksEvent( 'calypso_upgrade_nudge_impression', {
-			cta_name: 'theme-upsell',
+			cta_name: 'theme-upsell-popup',
 			theme: themeId,
 		} );
 	}, [ themeId ] );

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-upgrade-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-upgrade-badge.js
@@ -1,9 +1,47 @@
+import { getPlan } from '@automattic/calypso-products';
 import { PremiumBadge } from '@automattic/components';
+import { createInterpolateElement } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'calypso/state';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { THEME_TIER_TO_PLAN } from '../constants';
+import useThemeTier from '../use-theme-tier';
+import ThemeTierBadgeCheckoutLink from './theme-tier-badge-checkout-link';
+import { useThemeTierBadgeContext } from './theme-tier-badge-context';
 import ThemeTierBadgeTracker from './theme-tier-badge-tracker';
+import ThemeTierTooltipTracker from './theme-tier-tooltip-tracker';
 
-export default function ThemeTierUpgradeBadge( { themeId } ) {
+export default function ThemeTierUpgradeBadge() {
 	const translate = useTranslate();
+	const siteId = useSelector( getSelectedSiteId );
+	const { themeId } = useThemeTierBadgeContext();
+	const { themeTier } = useThemeTier( siteId, themeId );
+
+	const planName = getPlan( THEME_TIER_TO_PLAN[ themeTier.slug ] )?.getTitle();
+
+	const tooltipContent = (
+		<>
+			<ThemeTierTooltipTracker />
+			<div data-testid="upsell-header" className="theme-tier-badge-tooltip__header">
+				{
+					// Translators: %(planName)s is the name of the plan that includes this theme. Examples: "Personal" or "Premium".
+					translate( '%(planName)s theme', { textOnly: true, args: { planName } } )
+				}
+			</div>
+			<div data-testid="upsell-message">
+				{ createInterpolateElement(
+					// Translators: %(planName)s is the name of the plan that includes this theme. Examples: "Personal" or "Premium".
+					translate( 'This %(planName)s theme is included in the <Link>%(planName)s plan</Link>.', {
+						args: { planName },
+						textOnly: true,
+					} ),
+					{
+						Link: <ThemeTierBadgeCheckoutLink plan="business" />,
+					}
+				) }
+			</div>
+		</>
+	);
 
 	return (
 		<>
@@ -14,7 +52,7 @@ export default function ThemeTierUpgradeBadge( { themeId } ) {
 				isClickable
 				labelText={ translate( 'Upgrade' ) }
 				tooltipClassName="theme-tier-badge-tooltip"
-				tooltipContent={ null }
+				tooltipContent={ tooltipContent }
 				tooltipPosition="top"
 			/>
 		</>

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-upgrade-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-upgrade-badge.js
@@ -17,7 +17,9 @@ export default function ThemeTierUpgradeBadge() {
 	const { themeId } = useThemeTierBadgeContext();
 	const { themeTier } = useThemeTier( siteId, themeId );
 
-	const planName = getPlan( THEME_TIER_TO_PLAN[ themeTier.slug ] )?.getTitle();
+	const mappedPlan = themeTier?.slug;
+	const planName = getPlan( THEME_TIER_TO_PLAN[ mappedPlan ] )?.getTitle();
+	const planPathSlug = getPlan( THEME_TIER_TO_PLAN[ mappedPlan ] )?.getPathSlug();
 
 	const tooltipContent = (
 		<>
@@ -36,7 +38,7 @@ export default function ThemeTierUpgradeBadge() {
 						textOnly: true,
 					} ),
 					{
-						Link: <ThemeTierBadgeCheckoutLink plan="business" />,
+						Link: <ThemeTierBadgeCheckoutLink plan={ planPathSlug } />,
 					}
 				) }
 			</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Tracking issue: https://github.com/Automattic/dotcom-forge/issues/4597
Related to https://github.com/Automattic/wp-calypso/pull/85048

## Proposed Changes

* Add a new `ThemeTierBadgeContext` to simplify data propagation around theme labels and tooltips.
* Add tooltips to all existing `ThemeTierBadge` variations.
* Simplify them by using the new context.

<img width="486" alt="Screenshot 2023-12-11 at 19 33 40" src="https://github.com/Automattic/wp-calypso/assets/2070010/5e5e2dbc-3212-4ef4-96bb-44502a814792">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enable the `themes/tiers` feature flag.
* Open the Theme Showcase.
* Check the tooltip contained in the label of the following themes:
  * Annalee and Hevor: should be limited to the Premium plan.
  * Screenplay: should be limited to the Personal plan.
  * Bookix: should be limited to the Business plan, and require an additional subscription.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?