### PR TITLE
Checkout: Add box shadow to mobile checkout button section

### DIFF
--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -543,6 +543,7 @@ export const SubmitButtonWrapper = styled.div`
 
 	.checkout__step-wrapper--last-step & {
 		position: fixed;
+		box-shadow: 0 -3px 10px 0 #0000001f;
 	}
 
 	.rtl & {
@@ -561,6 +562,7 @@ export const SubmitButtonWrapper = styled.div`
 
 		.checkout__step-wrapper--last-step & {
 			position: relative;
+			box-shadow: none;
 		}
 
 		.checkout__step-wrapper & {


### PR DESCRIPTION
This PR adds a box shadow to the mobile web checkout 'fixed' payment submit section to give it more distinction from the rest of the page - as outlined in the issue below.

Related to https://github.com/Automattic/payments-shilling/issues/2233

| Before | After |
| ----- | ----- |
| <img width="360" alt="image" src="https://github.com/Automattic/wp-calypso/assets/16580129/9babe773-2410-4ec5-b6f0-613c1255a192"> | <img width="360" alt="image" src="https://github.com/Automattic/wp-calypso/assets/16580129/c8376d95-1d4f-47a2-9729-15d6cd890a8b"> |


## Proposed Changes

* Add a box shadow to `SubmitButtonWrapper`
* Box shadow is taken from `.domains__domain-cart-foldable-card` found in the onboarding flow

## Testing Instructions

* Add a product to your cart and go to checkout
* Resize the window to under 700px wide
* View the submit payment section fixed to the bottom of the screen, there should be a slight shadow above the section
