### PR TITLE
Change to readonly cache for trunk builds

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -53,15 +53,16 @@ const extraPath = browserslistEnv === 'defaults' ? 'fallback' : browserslistEnv;
 const cachePath = path.resolve( '.cache', extraPath );
 const shouldUsePersistentCache = process.env.PERSISTENT_CACHE === 'true';
 
+// NOTE: We reverted some of these changes, but in the future, we will need to avoid
+// using the readonly cache again if we generate the cache image inline on trunk.
+//
 // Readonly cache prevents writing to the cache directory, which is good for performance.
 // However, on trunk (and when generating cache images), we want to write to the cache
 // so that we can then update the cache to use in subsequent builds. While this costs
 // a minute in the current build, an updated cache saves 2 minutes in many future builds.
 // Note that in local builds, IS_DEFAULT_BRANCH is not set, in which case we should also write to the cache.
 const shouldUseReadonlyCache = ! (
-	process.env.IS_DEFAULT_BRANCH === 'true' ||
-	process.env.GENERATE_CACHE_IMAGE === 'true' ||
-	process.env.IS_DEFAULT_BRANCH === undefined
+	process.env.GENERATE_CACHE_IMAGE === 'true' || process.env.IS_DEFAULT_BRANCH === undefined
 );
 
 const shouldProfile = process.env.PROFILE === 'true';


### PR DESCRIPTION
The line of code I'm removing allowed webpack to _write_ to the build cache on trunk builds. This is not necessary at the moment because we cannot save the cache on trunk builds. So we should turn it back into readonly until updating the cache can be done more frequently, which will give us some performance improvements on trunk.

The other purpose of this change is to modify webpack.config.js to see if we can get cache to stop invalidating!