### PR TITLE
Self service site reset: Make built by banner ref property dynamic

### DIFF
--- a/client/my-sites/site-settings/built-by-upsell-banner.tsx
+++ b/client/my-sites/site-settings/built-by-upsell-banner.tsx
@@ -2,13 +2,15 @@ import { SiteDetails } from '@automattic/data-stores';
 import { useI18n } from '@wordpress/react-i18n';
 import builtByLogo from 'calypso/assets/images/illustrations/built-by-wp-vert-blue.png';
 import { Banner } from 'calypso/components/banner';
+import { addQueryArgs } from 'calypso/lib/url';
 
 type Props = {
 	site: SiteDetails;
 	isUnlaunchedSite: boolean;
+	urlRef: string;
 };
 
-export function BuiltByUpsell( { site, isUnlaunchedSite }: Props ) {
+export function BuiltByUpsell( { site, isUnlaunchedSite, urlRef }: Props ) {
 	const { __ } = useI18n();
 	// Do not show for launched sites
 	if ( ! isUnlaunchedSite ) {
@@ -26,7 +28,12 @@ export function BuiltByUpsell( { site, isUnlaunchedSite }: Props ) {
 	if ( Date.now() - siteCreatedAt < FOUR_DAYS_IN_MILLISECONDS ) {
 		return null;
 	}
-
+	const url = addQueryArgs(
+		{
+			ref: urlRef,
+		},
+		'https://wordpress.com/website-design-service/'
+	);
 	return (
 		<Banner
 			className="site-settings__built-by-upsell"
@@ -35,7 +42,7 @@ export function BuiltByUpsell( { site, isUnlaunchedSite }: Props ) {
 				'Leave the heavy lifting to us and let our professional builders craft your compelling website.'
 			) }
 			callToAction={ __( 'Get started' ) }
-			href="https://wordpress.com/website-design-service/?ref=unlaunched-settings"
+			href={ url }
 			target="_blank"
 			iconPath={ builtByLogo }
 			disableCircle={ true }

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -927,7 +927,11 @@ export class SiteSettingsFormGeneral extends Component {
 					? this.renderLaunchSite()
 					: this.privacySettings() }
 				{ this.enhancedOwnershipSettings() }
-				<BuiltByUpsell site={ site } isUnlaunchedSite={ propsisUnlaunchedSite } />
+				<BuiltByUpsell
+					site={ site }
+					isUnlaunchedSite={ propsisUnlaunchedSite }
+					urlRef="unlaunched-settings"
+				/>
 				{ ! isWpcomStagingSite && this.giftOptions() }
 				{ ! isWPForTeamsSite && ! ( siteIsJetpack && ! siteIsAtomic ) && (
 					<div className="site-settings__footer-credit-container">

--- a/client/my-sites/site-settings/start-over.jsx
+++ b/client/my-sites/site-settings/start-over.jsx
@@ -366,7 +366,11 @@ function SiteResetCard( {
 					</ActionPanelFooter>
 				</ActionPanel>
 			) }
-			<BuiltByUpsell site={ site } isUnlaunchedSite={ isUnlaunchedSiteProp } />
+			<BuiltByUpsell
+				site={ site }
+				isUnlaunchedSite={ isUnlaunchedSiteProp }
+				urlRef="unlaunched-site-reset"
+			/>{ ' ' }
 		</Main>
 	);
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

See https://github.com/Automattic/wp-calypso/pull/84944#issuecomment-1849354239 for context 
## Proposed Changes

* add a `urlRef` prop to the built by component so we can pass the ref query arg based on location the component is used.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. go to `/settings/general/siteSlug` and verify Getting Started url has `?ref=unlaunched-settings`
2. go to `/settings/start-over/siteSlug` and verify Getting Started url has `?ref=unlaunched-site-reset` 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?