### PR TITLE
Jetpack Manage: Onboarding - Add Plugin Management guided tour

### DIFF
--- a/client/jetpack-cloud/components/guided-tour/index.tsx
+++ b/client/jetpack-cloud/components/guided-tour/index.tsx
@@ -109,25 +109,20 @@ const GuidedTour = ( { className, tours, preferenceName }: Props ) => {
 	}, [ currentStep, tours.length, endTour ] );
 
 	useEffect( () => {
-		// Function to call nextStep when the target is clicked
-		const handleClick = () => {
-			nextStep();
-		};
-
 		let target: Element | null = null;
 		if ( nextStepOnTargetClick ) {
 			// Find the target element using the nextStepOnTargetClick selector
 			target = document.querySelector( nextStepOnTargetClick );
 			if ( target ) {
 				// Attach the event listener to the target
-				target.addEventListener( 'click', handleClick );
+				target.addEventListener( 'click', nextStep );
 			}
 		}
 
 		// Cleanup function to remove the event listener
 		return () => {
 			if ( target ) {
-				target.removeEventListener( 'click', handleClick );
+				target.removeEventListener( 'click', nextStep );
 			}
 		};
 	}, [ nextStepOnTargetClick, nextStep ] );

--- a/client/jetpack-cloud/components/guided-tour/index.tsx
+++ b/client/jetpack-cloud/components/guided-tour/index.tsx
@@ -1,7 +1,7 @@
 import { Popover, Button } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getJetpackDashboardPreference as getPreference } from 'calypso/state/jetpack-agency-dashboard/selectors';
@@ -23,6 +23,7 @@ export interface Tour {
 		| 'bottom left'
 		| 'left'
 		| 'top left';
+	nextStepOnTargetClick?: string;
 }
 
 interface Props {
@@ -74,7 +75,8 @@ const GuidedTour = ( { className, tours, preferenceName }: Props ) => {
 
 	const isDismissed = preference?.dismiss;
 
-	const { title, description, target, popoverPosition } = tours[ currentStep ];
+	const { title, description, target, popoverPosition, nextStepOnTargetClick } =
+		tours[ currentStep ];
 
 	const targetElement = useAsyncElement( target, 3000 );
 
@@ -89,22 +91,46 @@ const GuidedTour = ( { className, tours, preferenceName }: Props ) => {
 		}
 	}, [ dispatch, isDismissed, preferenceName, targetElement, hasFetched ] );
 
-	const endTour = () => {
+	const endTour = useCallback( () => {
 		dispatch( savePreference( preferenceName, { ...preference, dismiss: true } ) );
 		dispatch(
 			recordTracksEvent( 'calypso_jetpack_cloud_end_tour', {
 				tour: preferenceName,
 			} )
 		);
-	};
+	}, [ dispatch, preferenceName, preference ] );
 
-	const nextStep = () => {
+	const nextStep = useCallback( () => {
 		if ( currentStep < tours.length - 1 ) {
 			setCurrentStep( currentStep + 1 );
 		} else {
 			endTour();
 		}
-	};
+	}, [ currentStep, tours.length, endTour ] );
+
+	useEffect( () => {
+		// Function to call nextStep when the target is clicked
+		const handleClick = () => {
+			nextStep();
+		};
+
+		let target: Element | null = null;
+		if ( nextStepOnTargetClick ) {
+			// Find the target element using the nextStepOnTargetClick selector
+			target = document.querySelector( nextStepOnTargetClick );
+			if ( target ) {
+				// Attach the event listener to the target
+				target.addEventListener( 'click', handleClick );
+			}
+		}
+
+		// Cleanup function to remove the event listener
+		return () => {
+			if ( target ) {
+				target.removeEventListener( 'click', handleClick );
+			}
+		};
+	}, [ nextStepOnTargetClick, nextStep ] );
 
 	if ( isDismissed ) {
 		return null;
@@ -135,17 +161,21 @@ const GuidedTour = ( { className, tours, preferenceName }: Props ) => {
 					}
 				</div>
 				<div className="guided-tour__popover-footer-right-content">
-					{
-						// Show the skip button if there are multiple steps and we're not on the last step
-						tours.length > 1 && currentStep < tours.length - 1 && (
-							<Button borderless onClick={ endTour }>
-								{ translate( 'Skip' ) }
+					{ ! nextStepOnTargetClick && (
+						<>
+							{
+								// Show the skip button if there are multiple steps and we're not on the last step
+								tours.length > 1 && currentStep < tours.length - 1 && (
+									<Button borderless onClick={ endTour }>
+										{ translate( 'Skip' ) }
+									</Button>
+								)
+							}
+							<Button onClick={ nextStep }>
+								{ currentStep === tours.length - 1 ? lastTourLabel : translate( 'Next' ) }
 							</Button>
-						)
-					}
-					<Button onClick={ nextStep }>
-						{ currentStep === tours.length - 1 ? lastTourLabel : translate( 'Next' ) }
-					</Button>
+						</>
+					) }
 				</div>
 			</div>
 		</Popover>

--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -154,6 +154,7 @@ export class PluginsListHeader extends PureComponent {
 					compact
 					disabled={ ! this.hasSelectedPlugins() }
 					onClick={ this.props.updatePluginNotice }
+					id="plugin-list-header__buttons-update-button"
 				>
 					{ translate( 'Update Plugins' ) }
 				</Button>
@@ -198,6 +199,7 @@ export class PluginsListHeader extends PureComponent {
 					disabled={ ! this.hasSelectedPlugins() }
 					compact
 					onClick={ this.props.autoupdateEnablePluginNotice }
+					id="plugin-list-header__buttons-autoupdate-button"
 				>
 					{ translate( 'Autoupdate' ) }
 				</Button>

--- a/client/my-sites/plugins/plugin-management-v2/bulk-actions-header.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/bulk-actions-header.tsx
@@ -28,7 +28,7 @@ const BulkActionsHeader: ( props: Props ) => JSX.Element = ( {
 		<div className="plugin-common-table__bulk-actions">
 			{ showUpdatePlugins && <UpdatePlugins plugins={ plugins } /> }
 			<ButtonGroup className="plugin-management-v2__table-button-group">
-				<Button compact onClick={ onClickEditAll }>
+				<Button compact id="plugin-management-v2__edit-all-button" onClick={ onClickEditAll }>
 					{ translate( 'Edit All', { context: 'button label' } ) }
 				</Button>
 			</ButtonGroup>

--- a/client/my-sites/plugins/plugin-management-v2/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/index.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
 import { ReactElement, useEffect, useMemo } from 'react';
+import GuidedTour from 'calypso/jetpack-cloud/components/guided-tour';
 import { useDispatch } from 'calypso/state';
 import { resetPluginStatuses } from 'calypso/state/plugins/installed/status/actions';
 import BulkActionsHeader from './bulk-actions-header';
@@ -76,7 +77,11 @@ export default function PluginManagementV2( {
 	const columns = [
 		{
 			key: 'plugin',
-			header: translate( 'Installed Plugins' ),
+			header: (
+				<span id="plugin-management-v2__installed-plugins-table-header">
+					{ translate( 'Installed Plugins' ) }
+				</span>
+			),
 		},
 		...( selectedSite
 			? [
@@ -132,24 +137,66 @@ export default function PluginManagementV2( {
 
 		return <div className="plugin-management-v2__no-sites">{ emptyMessage }</div>;
 	}
-
+	const urlParams = new URLSearchParams( window.location.search );
+	const shouldRenderPluginManagementTour = urlParams.get( 'tour' ) === 'plugin-management';
 	return (
-		<div
-			className={ classNames( 'plugin-management-v2__main-content-container', {
-				'is-bulk-management-active': isBulkManagementActive,
-			} ) }
-		>
-			<PluginsList
-				items={ plugins }
-				columns={ columns }
-				isLoading={ isLoading }
-				className={ classNames( {
-					'has-bulk-management-active': isBulkManagementActive,
+		<>
+			<div
+				className={ classNames( 'plugin-management-v2__main-content-container', {
+					'is-bulk-management-active': isBulkManagementActive,
 				} ) }
-				selectedSite={ selectedSite }
-				removePluginNotice={ removePluginNotice }
-				updatePlugin={ updatePlugin }
-			/>
-		</div>
+			>
+				<PluginsList
+					items={ plugins }
+					columns={ columns }
+					isLoading={ isLoading }
+					className={ classNames( {
+						'has-bulk-management-active': isBulkManagementActive,
+					} ) }
+					selectedSite={ selectedSite }
+					removePluginNotice={ removePluginNotice }
+					updatePlugin={ updatePlugin }
+				/>
+			</div>
+			{ shouldRenderPluginManagementTour && (
+				<GuidedTour
+					className="jetpack-cloud-plugin-management-v2__guided-tour"
+					preferenceName="jetpack-cloud-plugin-management-v2-plugin-overview-tour"
+					tours={ [
+						{
+							target: '#plugin-management-v2__installed-plugins-table-header',
+							popoverPosition: 'bottom right',
+							title: translate( 'Plugins overview' ),
+							description: translate(
+								'Here you can see all installed plugins across all of your sites.'
+							),
+						},
+						{
+							target: '#plugin-management-v2__edit-all-button',
+							popoverPosition: 'bottom left',
+							title: translate( 'Select to edit all plugins' ),
+							description: translate( 'You can manage all of your plugins at once.' ),
+							nextStepOnTargetClick: '#plugin-management-v2__edit-all-button',
+						},
+						{
+							target: '#plugin-list-header__buttons-autoupdate-button',
+							popoverPosition: 'bottom left',
+							title: translate( 'Bulk management options' ),
+							description: translate(
+								'Here you can activate or deactivate all of your plugins, set them to autoupdate or disable it entirely.'
+							),
+						},
+						{
+							target: '#plugin-list-header__buttons-update-button',
+							popoverPosition: 'bottom left',
+							title: translate( 'All plugins update' ),
+							description: translate(
+								'You can update all your out-of-date plugins with the auto-update feature.'
+							),
+						},
+					] }
+				/>
+			) }
+		</>
 	);
 }

--- a/client/my-sites/plugins/plugin-management-v2/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/index.tsx
@@ -138,7 +138,9 @@ export default function PluginManagementV2( {
 		return <div className="plugin-management-v2__no-sites">{ emptyMessage }</div>;
 	}
 	const urlParams = new URLSearchParams( window.location.search );
-	const shouldRenderPluginManagementTour = urlParams.get( 'tour' ) === 'plugin-management';
+	const shouldRenderPluginManagementTour =
+		urlParams.get( 'tour' ) === 'plugin-management' && ! isLoading && plugins.length > 0;
+
 	return (
 		<>
 			<div

--- a/client/my-sites/plugins/plugin-management-v2/style.scss
+++ b/client/my-sites/plugins/plugin-management-v2/style.scss
@@ -45,3 +45,12 @@
 		border-width: 1px;
 	}
 }
+
+.jetpack-cloud-plugin-management-v2__guided-tour {
+	.button:not(.is-borderless) {
+		padding: 5px 16px;
+		background-color: var(--studio-jetpack-green-50);
+		border-color: var(--studio-jetpack-green-50);
+		color: var(--color-text-inverted);
+	}
+}

--- a/client/my-sites/plugins/plugin-management-v2/test/use-empty-message.js
+++ b/client/my-sites/plugins/plugin-management-v2/test/use-empty-message.js
@@ -2,7 +2,11 @@
  * @jest-environment jsdom
  */
 jest.mock( 'i18n-calypso', () => ( {
-	useTranslate: jest.fn(),
+	...jest.requireActual( 'i18n-calypso' ),
+	useRtl: jest.fn(),
+	localize: ( x ) => x,
+	translate: ( x ) => x,
+	useTranslate: jest.fn( () => ( text ) => text ),
 } ) );
 jest.mock( '../bulk-actions-header', () => jest.fn() );
 jest.mock( '../plugins-list', () => jest.fn() );


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-manage/issues/161 
Resolves https://github.com/Automattic/jetpack-manage/issues/162

## Proposed Changes

* This PR adds the feature for guided tours to advance steps by clicking a specified target
* This PR adds the Plugin Management guided tour, as described in https://github.com/Automattic/jetpack-manage/issues/162

## Testing Instructions

* You must be an agency to be able to this this PR: 2c49b-pb. Make sure to switch it back to our original type after testing. Or not. Your call!
* Switch to this branch. (`git checkout add/jp-manage/161-162-extend-guidedtour-and-implement-plugin-overview-tour` and yarn start-jetpack-cloud).
* Open http://jetpack.cloud.localhost:3000/, and you'll be redirected to the /dashboard.
* Open the Plugin Management page
* Append the URL with ?tour=plugin-management
* You should see the 4 steps of the plugin management tour.
* Once you finish the tour, to run it again you must erase the preference `jetpack-cloud-plugin-management-v2-plugin-overview-tour`. You can do this by hovering in the bottom right button called `Preferences`, then clicking over the `X` next to the preference name.
* 
![image](https://github.com/Automattic/wp-calypso/assets/37049295/e8d96bab-42d8-4254-a682-29c286e3ea78)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?