### PR TITLE
 Paid stats gating

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -541,7 +541,9 @@ class StatsSite extends Component {
 
 		return (
 			<Main fullWidthLayout ariaLabel={ translate( 'Jetpack Stats' ) }>
-				<QuerySiteFeatures siteIds={ [ siteId ] } />
+				{ config.isEnabled( 'stats/paid-wpcom-v2' ) && (
+					<QuerySiteFeatures siteIds={ [ siteId ] } />
+				) }
 				{ /* Odyssey: Google My Business pages are currently unsupported. */ }
 				{ ! isOdysseyStats && (
 					<>

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -541,7 +541,7 @@ class StatsSite extends Component {
 
 		return (
 			<Main fullWidthLayout ariaLabel={ translate( 'Jetpack Stats' ) }>
-				{ config.isEnabled( 'stats/paid-wpcom-v2' ) && (
+				{ config.isEnabled( 'stats/paid-wpcom-v2' ) && ! isOdysseyStats && (
 					<QuerySiteFeatures siteIds={ [ siteId ] } />
 				) }
 				{ /* Odyssey: Google My Business pages are currently unsupported. */ }

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -19,6 +19,7 @@ import AsyncLoad from 'calypso/components/async-load';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
 import QueryKeyringConnections from 'calypso/components/data/query-keyring-connections';
+import QuerySiteFeatures from 'calypso/components/data/query-site-features';
 import QuerySiteKeyrings from 'calypso/components/data/query-site-keyrings';
 import EmptyContent from 'calypso/components/empty-content';
 import InlineSupportLink from 'calypso/components/inline-support-link';
@@ -540,6 +541,7 @@ class StatsSite extends Component {
 
 		return (
 			<Main fullWidthLayout ariaLabel={ translate( 'Jetpack Stats' ) }>
+				<QuerySiteFeatures siteIds={ [ siteId ] } />
 				{ /* Odyssey: Google My Business pages are currently unsupported. */ }
 				{ ! isOdysseyStats && (
 					<>

--- a/client/my-sites/stats/stats-card-upsell/index.tsx
+++ b/client/my-sites/stats/stats-card-upsell/index.tsx
@@ -33,7 +33,7 @@ const StatsCardUpsell: React.FC< Props > = ( { className, statType, siteId } ) =
 				<div className="stats-card-upsell__lock">
 					<Gridicon icon="lock" />
 				</div>
-				<div className="stats-card-upsell__subtitle">
+				<div className="stats-card-upsell__text">
 					{ translate( 'Upgrade your plan to unlock advanced stats.' ) }
 				</div>
 				<Button className="stats-card-upsell__button" onClick={ onClick }>

--- a/client/my-sites/stats/stats-card-upsell/index.tsx
+++ b/client/my-sites/stats/stats-card-upsell/index.tsx
@@ -36,7 +36,7 @@ const StatsCardUpsell: React.FC< Props > = ( { className, statType, siteId } ) =
 				<div className="stats-card-upsell__text">
 					{ translate( 'Upgrade your plan to unlock advanced stats.' ) }
 				</div>
-				<Button className="stats-card-upsell__button" onClick={ onClick }>
+				<Button primary className="stats-card-upsell__button" onClick={ onClick }>
 					Unlock
 				</Button>
 			</div>

--- a/client/my-sites/stats/stats-card-upsell/index.tsx
+++ b/client/my-sites/stats/stats-card-upsell/index.tsx
@@ -1,0 +1,46 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { isEnabled } from '@automattic/calypso-config';
+import page from '@automattic/calypso-router';
+import { Button, Gridicon } from '@automattic/components';
+import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import './style.scss';
+
+interface Props {
+	className: string;
+	statType: string;
+	siteId: number;
+}
+
+const StatsCardUpsell: React.FC< Props > = ( { className, statType, siteId } ) => {
+	const translate = useTranslate();
+
+	const onClick = ( event: React.MouseEvent< HTMLButtonElement, MouseEvent > ) => {
+		event.preventDefault();
+
+		const source = isEnabled( 'is_running_in_jetpack_site' ) ? 'jetpack' : 'calypso';
+		recordTracksEvent( 'jetpack_stats_upsell_clicked', {
+			statType,
+			source,
+		} );
+
+		page( `/stats/purchase/${ siteId }?productType=personal&from=${ source }` );
+	};
+
+	return (
+		<div className={ classNames( 'stats-card-upsell', className ) }>
+			<div className="stats-card-upsell__content">
+				<div className="stats-card-upsell__lock">
+					<Gridicon icon="lock" />
+				</div>
+				<div className="stats-card-upsell__subtitle">
+					{ translate( 'Upgrade your plan to unlock advanced stats.' ) }
+				</div>
+				<Button className="stats-card-upsell__button" onClick={ onClick }>
+					Unlock
+				</Button>
+			</div>
+		</div>
+	);
+};
+export default StatsCardUpsell;

--- a/client/my-sites/stats/stats-card-upsell/style.scss
+++ b/client/my-sites/stats/stats-card-upsell/style.scss
@@ -1,0 +1,14 @@
+.stats-card-upsell {
+	width: 100%;
+	font-size: $font-body-small;
+
+	.stats-card-upsell__content {
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		align-items: center;
+		height: 100%;
+		row-gap: 10px;
+	}
+}
+

--- a/client/my-sites/stats/stats-card-upsell/style.scss
+++ b/client/my-sites/stats/stats-card-upsell/style.scss
@@ -1,14 +1,18 @@
 .stats-card-upsell {
 	width: 100%;
+	height: 100%;
 	font-size: $font-body-small;
-
 	.stats-card-upsell__content {
 		display: flex;
 		flex-direction: column;
 		justify-content: center;
 		align-items: center;
 		height: 100%;
-		row-gap: 10px;
+		padding: 25px;
+	}
+
+	.stats-card-upsell__text {
+		padding-bottom: 10px;
 	}
 }
 

--- a/client/my-sites/stats/stats-countries/style.scss
+++ b/client/my-sites/stats/stats-countries/style.scss
@@ -21,7 +21,7 @@ $break-large-stats-countries: 1280px;
 	@media (min-width: $break-large-stats-countries ) {
 
 		.stats__module-wrapper--countryviews .stats-module,
-		.list-countryviews {
+		.list-countryviews .stats-card__content {
 			display: flex;
 			flex-direction: row;
 			flex-wrap: wrap;

--- a/client/my-sites/stats/stats-list/stats-list-card.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-card.jsx
@@ -36,6 +36,7 @@ const StatsListCard = ( {
 	showLeftIcon,
 	isLinkUnderlined,
 	listItemClassName,
+	overlay,
 } ) => {
 	const moduleNameTitle = titlecase( moduleType );
 	const debug = debugFactory( `calypso:stats:list:${ moduleType }` );
@@ -140,6 +141,7 @@ const StatsListCard = ( {
 			mainItemLabel={ mainItemLabel }
 			additionalHeaderColumns={ additionalColumns?.header }
 			toggleControl={ toggleControl }
+			overlay={ overlay }
 		>
 			{ !! loader && loader }
 			{ !! error && error }

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -1,5 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
-import { FEATURE_STATS_PAID } from '@automattic/calypso-products';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { includes } from 'lodash';
@@ -7,7 +5,6 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
-import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import {
 	isRequestingSiteStatsForQuery,
@@ -43,6 +40,7 @@ class StatsModule extends Component {
 		mainItemLabel: PropTypes.string,
 		additionalColumns: PropTypes.object,
 		listItemClassName: PropTypes.string,
+		gateStats: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -135,7 +133,7 @@ class StatsModule extends Component {
 			additionalColumns,
 			mainItemLabel,
 			listItemClassName,
-			isGatedStats,
+			gateStats,
 		} = this.props;
 
 		// Only show loading indicators when nothing is in state tree, and request in-flight
@@ -187,9 +185,9 @@ class StatsModule extends Component {
 					showLeftIcon={ path === 'authors' }
 					listItemClassName={ listItemClassName }
 					overlay={
-						isGatedStats &&
 						siteId &&
-						statType && (
+						statType &&
+						gateStats && (
 							<StatsCardUpsell
 								className="stats-module__upsell"
 								siteId={ siteId }
@@ -218,17 +216,13 @@ export default connect( ( state, ownProps ) => {
 	const siteId = getSelectedSiteId( state );
 	const siteSlug = getSiteSlug( state, siteId );
 	const { statType, query } = ownProps;
-	const isPaidStatsEnabled = isEnabled( 'stats/paid-wpcom-v2' );
-	const siteHasPaidStats = siteHasFeature( state, siteId, FEATURE_STATS_PAID );
-	const isGatedStats = shouldGateStats( state, siteId, statType );
+	const gateStats = shouldGateStats( state, siteId, statType );
 
 	return {
 		requesting: isRequestingSiteStatsForQuery( state, siteId, statType, query ),
 		data: getSiteStatsNormalizedData( state, siteId, statType, query ),
 		siteId,
 		siteSlug,
-		isPaidStatsEnabled,
-		siteHasPaidStats,
-		isGatedStats,
+		gateStats,
 	};
 } )( localize( StatsModule ) );

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -15,6 +15,7 @@ import {
 } from 'calypso/state/stats/lists/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import Geochart from '../geochart';
+import { shouldGateStats } from '../hooks/use-should-gate-stats';
 import StatsCardUpsell from '../stats-card-upsell';
 import DatePicker from '../stats-date-picker';
 import DownloadCsv from '../stats-download-csv';
@@ -134,7 +135,7 @@ class StatsModule extends Component {
 			additionalColumns,
 			mainItemLabel,
 			listItemClassName,
-			needsUpgrade,
+			isGatedStats,
 		} = this.props;
 
 		// Only show loading indicators when nothing is in state tree, and request in-flight
@@ -186,7 +187,7 @@ class StatsModule extends Component {
 					showLeftIcon={ path === 'authors' }
 					listItemClassName={ listItemClassName }
 					overlay={
-						needsUpgrade &&
+						isGatedStats &&
 						siteId &&
 						statType && (
 							<StatsCardUpsell
@@ -219,11 +220,7 @@ export default connect( ( state, ownProps ) => {
 	const { statType, query } = ownProps;
 	const isPaidStatsEnabled = isEnabled( 'stats/paid-wpcom-v2' );
 	const siteHasPaidStats = siteHasFeature( state, siteId, FEATURE_STATS_PAID );
-	let needsUpgrade = false;
-	const paidStats = [ 'statsSearchTerms', 'statsClicks', 'statsReferrers', 'statsCountryViews' ];
-	if ( isPaidStatsEnabled && ! siteHasPaidStats && paidStats.includes( statType ) ) {
-		needsUpgrade = true;
-	}
+	const isGatedStats = shouldGateStats( state, siteId, statType );
 
 	return {
 		requesting: isRequestingSiteStatsForQuery( state, siteId, statType, query ),
@@ -232,6 +229,6 @@ export default connect( ( state, ownProps ) => {
 		siteSlug,
 		isPaidStatsEnabled,
 		siteHasPaidStats,
-		needsUpgrade,
+		isGatedStats,
 	};
 } )( localize( StatsModule ) );

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -225,10 +225,6 @@ export default connect( ( state, ownProps ) => {
 		needsUpgrade = true;
 	}
 
-	if ( paidStats.includes( statType ) ) {
-		needsUpgrade = true;
-	}
-
 	return {
 		requesting: isRequestingSiteStatsForQuery( state, siteId, statType, query ),
 		data: getSiteStatsNormalizedData( state, siteId, statType, query ),

--- a/packages/components/src/horizontal-bar-list/stats-card.scss
+++ b/packages/components/src/horizontal-bar-list/stats-card.scss
@@ -14,10 +14,6 @@
 	line-height: $row-line-height;
 	color: $font-color;
 	background-color: var(--studio-white);
-	display: flex;
-	flex-direction: column;
-	justify-content: space-between;
-
 
 	@media ( max-width: $break-medium ) {
 		border-radius: 0;
@@ -94,6 +90,34 @@
 		&:focus {
 			text-decoration: underline;
 		}
+	}
+
+	&.stats-card__hasoverlay {
+		display: grid;
+
+		.stats-card__content,
+		.stats-card__overlay {
+			grid-column: 1;
+			grid-row: 1;
+		}
+
+		.stats-card__content .stats-card--header-and-body .stats-card--body,
+		.stats-card__content .stats-card--hero,
+		.stats-card__content .stats-card--footer {
+			filter: blur(5px);
+			z-index: 0;
+		}
+
+		.stats-card__overlay {
+			z-index: 1;
+		}
+	}
+
+	.stats-card__content {
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
+		height: 100%;
 	}
 }
 

--- a/packages/components/src/horizontal-bar-list/stats-card.scss
+++ b/packages/components/src/horizontal-bar-list/stats-card.scss
@@ -110,6 +110,7 @@
 
 		.stats-card__overlay {
 			z-index: 1;
+			background: rgba(255, 255, 255, 0.5);
 		}
 	}
 

--- a/packages/components/src/horizontal-bar-list/stats-card.tsx
+++ b/packages/components/src/horizontal-bar-list/stats-card.tsx
@@ -22,6 +22,7 @@ const StatsCard = ( {
 	additionalHeaderColumns,
 	toggleControl,
 	headerClassName,
+	overlay,
 }: StatsCardProps ) => {
 	const translate = useTranslate();
 
@@ -76,32 +77,39 @@ const StatsCard = ( {
 	);
 
 	return (
-		<div className={ classNames( className, BASE_CLASS_NAME ) }>
-			{ !! heroElement && <div className={ `${ BASE_CLASS_NAME }--hero` }>{ heroElement }</div> }
-			<div className={ `${ BASE_CLASS_NAME }--header-and-body` }>
-				{ splitHeader ? splitHeaderNode : simpleHeaderNode }
-				<div
-					className={ classNames( `${ BASE_CLASS_NAME }--body`, {
-						[ `${ BASE_CLASS_NAME }--body-empty` ]: isEmpty,
-					} ) }
-				>
-					{ isEmpty ? emptyMessage : children }
+		<div
+			className={ classNames( className, BASE_CLASS_NAME, {
+				[ `${ BASE_CLASS_NAME }__hasoverlay` ]: !! overlay,
+			} ) }
+		>
+			<div className={ `${ BASE_CLASS_NAME }__content` }>
+				{ !! heroElement && <div className={ `${ BASE_CLASS_NAME }--hero` }>{ heroElement }</div> }
+				<div className={ `${ BASE_CLASS_NAME }--header-and-body` }>
+					{ splitHeader ? splitHeaderNode : simpleHeaderNode }
+					<div
+						className={ classNames( `${ BASE_CLASS_NAME }--body`, {
+							[ `${ BASE_CLASS_NAME }--body-empty` ]: isEmpty,
+						} ) }
+					>
+						{ isEmpty ? emptyMessage : children }
+					</div>
 				</div>
+				{ footerAction && (
+					<a
+						className={ `${ BASE_CLASS_NAME }--footer` }
+						href={ footerAction?.url }
+						aria-label={
+							translate( 'View all %(title)s', {
+								args: { title: title.toLocaleLowerCase?.() ?? title.toLowerCase() },
+								comment: '"View all posts & pages", "View all referrers", etc.',
+							} ) as string
+						}
+					>
+						{ footerAction.label || translate( 'View all' ) }
+					</a>
+				) }
 			</div>
-			{ footerAction && (
-				<a
-					className={ `${ BASE_CLASS_NAME }--footer` }
-					href={ footerAction?.url }
-					aria-label={
-						translate( 'View all %(title)s', {
-							args: { title: title.toLocaleLowerCase?.() ?? title.toLowerCase() },
-							comment: '"View all posts & pages", "View all referrers", etc.',
-						} ) as string
-					}
-				>
-					{ footerAction.label || translate( 'View all' ) }
-				</a>
-			) }
+			{ overlay && <div className={ `${ BASE_CLASS_NAME }__overlay` }>{ overlay }</div> }
 		</div>
 	);
 };

--- a/packages/components/src/horizontal-bar-list/types.ts
+++ b/packages/components/src/horizontal-bar-list/types.ts
@@ -69,6 +69,7 @@ export type StatsCardProps = {
 	mainItemLabel?: React.ReactNode;
 	additionalHeaderColumns?: React.ReactNode;
 	toggleControl?: React.ReactNode;
+	overlay?: React.ReactNode;
 };
 
 export type StatsCardAvatarProps = {


### PR DESCRIPTION
Replaces  #84798 
Fixes https://github.com/Automattic/dotcom-forge/issues/4592

## Proposed Changes

* Adds feature gating for various stats behind the PWYW paywall

## Testing Instructions

Enabled by default in development, in calypso live enable with the query param: ?flags=stats/paid-wpcom-v2
Disable paid stats in development with the query param: ?flags=-stats/paid-wpcom-v2

- View stats in calypso.live and jetpack, ensure the feature locking in the screenshots below isn't triggered.

![Screenshot 2023-12-12 at 16-22-04 Jetpack Stats ‹ Explorers Team P2 — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/82f1e2e0-531e-4063-be65-270d1be3bf79)
![Screenshot 2023-12-12 at 16-21-34 Jetpack Stats ‹ Site Title — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/ee4ae2c1-2113-4238-a1f2-6c17ea854bb6)

