### PR TITLE
Jetpack Manage: Sort the bundle child licenses by status in asc order

### DIFF
--- a/client/state/partner-portal/licenses/hooks/use-bundle-licenses-query.ts
+++ b/client/state/partner-portal/licenses/hooks/use-bundle-licenses-query.ts
@@ -7,7 +7,12 @@ import { License } from 'calypso/state/partner-portal/types';
 import { errorNotice } from '../../../notices/actions';
 import { formatLicenses } from '../handlers';
 
-export default function useBundleLicensesQuery( parentLicenseId: number, perPage: number = 25 ) {
+export default function useBundleLicensesQuery(
+	parentLicenseId: number,
+	perPage: number = 25,
+	sortField: string = 'status',
+	sortDirection: string = 'asc'
+) {
 	const [ licenses, setLicenses ] = useState< License[] >( [] );
 	const [ total, setTotal ] = useState< number >( 0 );
 	const [ page, setPage ] = useState< number >( 1 );
@@ -16,7 +21,15 @@ export default function useBundleLicensesQuery( parentLicenseId: number, perPage
 	const dispatch = useDispatch();
 
 	const query = useQuery( {
-		queryKey: [ 'partner-portal', 'bundle-licenses', parentLicenseId, perPage, page ],
+		queryKey: [
+			'partner-portal',
+			'bundle-licenses',
+			parentLicenseId,
+			perPage,
+			page,
+			sortField,
+			sortDirection,
+		],
 		queryFn: () =>
 			wpcomJpl.req.get(
 				{
@@ -27,6 +40,8 @@ export default function useBundleLicensesQuery( parentLicenseId: number, perPage
 					parent_id: parentLicenseId,
 					page,
 					per_page: perPage,
+					sort_field: sortField,
+					sort_direction: sortDirection,
 				}
 			),
 		select: ( data ) => ( {


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/139

## Proposed Changes

This PR 

- Adds a sort field and sort direction to the bundle child licenses API.
- Adds default sort field as `status`
- Adds default sort direction as `asc`

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

**Instructions**

1. Visit the Jetpack Cloud link > Replace `dashboard` in the URL with `/partner-portal/issue-license?flags=jetpack/bundle-licensing`.
3. Select a bundle of 5 licenses > Click the `Review 5 licenses` button > Click the `Issue 5 licenses` button.
4. Expand the bundle that was issued > Click the `Assign` button on any child license > Expand the same bundle again > Click the `Assign` button on any child license >  Expand the same bundle again > Now expand the child license that was assigned to a site > Click the `Revoke` button  Expand the same bundle again > Verify that the child licenses are sorted by status in ascending order(Unassigned - Assigned - Revoked)

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="1279" alt="Screenshot 2023-12-12 at 10 17 38 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/fa21a3fa-6387-440b-bf7e-cc671c7a8368">
</td>
<td>
<img width="1258" alt="Screenshot 2023-12-12 at 10 18 43 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/9fc2152c-817f-459f-ab31-af87f015b838">
</td>
</tr>
</table>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?