### PR TITLE
Self-service site resets: update copy

### DIFF
--- a/client/my-sites/site-settings/start-over.jsx
+++ b/client/my-sites/site-settings/start-over.jsx
@@ -277,7 +277,7 @@ function SiteResetCard( {
 	const isResetInProgress = resetProgress < 1;
 
 	const ctaText =
-		! isAtomic && isLoading ? translate( 'Resetting Site' ) : translate( 'Reset Site' );
+		! isAtomic && isLoading ? translate( 'Resetting site' ) : translate( 'Reset site' );
 
 	return (
 		<Main className="site-settings__reset-site">

--- a/client/my-sites/site-settings/start-over.jsx
+++ b/client/my-sites/site-settings/start-over.jsx
@@ -247,7 +247,7 @@ function SiteResetCard( {
 		sprintf(
 			// translators: %s is the site domain
 			translate(
-				'Resetting <strong>%s</strong> will remove all of its content but keep the site and its URL active. You’ll also lose any modifications you made to your current theme.'
+				"Resetting <strong>%s</strong> will remove all of its content but keep the site and its URL up and running. Keep in mind you'll also lose any modifications you've made to your current theme."
 			),
 			siteDomain
 		),
@@ -259,7 +259,7 @@ function SiteResetCard( {
 	const backupHint = isAtomic
 		? createInterpolateElement(
 				translate(
-					'The site will be automatically backed up before the reset. You can restore it from <a>Activity Log</a>.'
+					"Having second thoughts? Don't fret, we'll automatically back up your site content before the reset and you can restore it any time from the <a>Activity Log</a>."
 				),
 				{
 					a: <a href={ `/activity-log/${ selectedSiteSlug }` } />,
@@ -267,7 +267,7 @@ function SiteResetCard( {
 		  )
 		: createInterpolateElement(
 				translate(
-					'To keep a copy of your current site, head to the <a>Export page</a> before resetting.'
+					'To keep a copy of your current site, head to the <a>Export page</a> before starting the reset.'
 				),
 				{
 					a: <a href={ `/settings/export/${ selectedSiteSlug }` } />,
@@ -276,14 +276,17 @@ function SiteResetCard( {
 
 	const isResetInProgress = resetProgress < 1;
 
+	const ctaText =
+		! isAtomic && isLoading ? translate( 'Resetting Site' ) : translate( 'Reset Site' );
+
 	return (
 		<Main className="site-settings__reset-site">
 			<Interval onTick={ checkStatus } period={ EVERY_FIVE_SECONDS } />
 			<NavigationHeader
 				navigationItems={ [] }
-				title={ translate( 'Site Reset' ) }
+				title={ translate( 'Reset your site' ) }
 				subtitle={ translate(
-					"Keep your site's address and theme, but delete all posts, pages, and media to start fresh. {{a}}Learn more.{{/a}}",
+					"Remove all posts, pages, and media to start fresh while keeping your site's address.{{a}}Learn more.{{/a}}",
 					{
 						components: {
 							a: <InlineSupportLink supportContext="site-transfer" showIcon={ false } />,
@@ -327,7 +330,9 @@ function SiteResetCard( {
 							{ createInterpolateElement(
 								sprintf(
 									// translators: %s is the site domain
-									translate( 'Enter <strong>%s</strong> to continue' ),
+									translate(
+										"Type <strong>%s</strong> below to confirm you're ready to reset the site:"
+									),
 									siteDomain
 								),
 								{
@@ -352,7 +357,7 @@ function SiteResetCard( {
 								disabled={ isLoading || ! isDomainConfirmed }
 								busy={ isLoading }
 							>
-								{ translate( 'Reset Site' ) }
+								{ ctaText }
 							</Button>
 						</div>
 						{ backupHint && (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/85080

## Proposed Changes

* Update the copy as per https://github.com/Automattic/wp-calypso/issues/85080

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Use this branch or Calypso Live
- If using Calypso Live, be sure to append `?flags=settings/self-serve-site-reset` to your URLs
- Go to `/settings/start-over/:atomic-site` and ` /settings/start-over/:simple-site` and compare with Figma
- For Simple, confirm the CTA text is updated when the reset is in progress

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?