### PR TITLE
Upsell Nudge: fix product addition to cart

### DIFF
--- a/client/my-sites/checkout/upsell-nudge/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/index.tsx
@@ -300,18 +300,23 @@ export class UpsellNudge extends Component< UpsellNudgeProps, UpsellNudgeState >
 		}
 	};
 
+	getProductToAdd = () => {
+		let productToAdd = this.props.product;
+		if ( PROFESSIONAL_EMAIL_UPSELL === this.props.upsellType && this.state.cartItem ) {
+			productToAdd = this.state.cartItem;
+		}
+		return productToAdd;
+	};
+
 	handleClickAccept = async ( buttonAction: string ) => {
-		const { product, siteSlug, trackUpsellButtonClick, upgradeItem, upsellType } = this.props;
+		const { siteSlug, trackUpsellButtonClick, upgradeItem, upsellType } = this.props;
 		debug( 'accept upsell clicked' );
 
 		trackUpsellButtonClick(
 			`calypso_${ upsellType.replace( /-/g, '_' ) }_${ buttonAction }_button_click`
 		);
 
-		let productToAdd = product;
-		if ( PROFESSIONAL_EMAIL_UPSELL === upsellType && this.state.cartItem ) {
-			productToAdd = this.state.cartItem;
-		}
+		const productToAdd = this.getProductToAdd();
 
 		if ( this.isEligibleForOneClickUpsell( buttonAction ) && productToAdd ) {
 			debug( 'accept upsell allows one-click, has a product, and a stored card' );
@@ -411,14 +416,16 @@ export class UpsellNudge extends Component< UpsellNudgeProps, UpsellNudgeState >
 			this.setState( { showPurchaseModal: false } );
 		};
 
-		if ( ! this.props.siteSlug || ! this.props.product ) {
+		const productToAdd = this.getProductToAdd();
+
+		if ( ! this.props.siteSlug || ! productToAdd ) {
 			return null;
 		}
 
 		return (
 			<StripeHookProvider fetchStripeConfiguration={ getStripeConfiguration }>
 				<PurchaseModal
-					productToAdd={ this.props.product }
+					productToAdd={ productToAdd }
 					onClose={ onCloseModal }
 					siteSlug={ this.props.siteSlug }
 					showFeatureList={


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

https://github.com/Automattic/wp-calypso/pull/84632 introduced a bug where if the upsell type was `PROFESSIONAL_EMAIL_UPSELL`, the correct product object was not added to the cart. This is because the product object is used from the component state instead of the props.

https://github.com/Automattic/wp-calypso/blob/bb0385aa542ee381f862487e20f5c7c07da54ee7/client/my-sites/checkout/upsell-nudge/index.tsx#L311-L314

This PR encapsulates this logic in a function, and uses the result to pass to `<PurchaseModal/>`, which handles adding the product to the cart.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure that you have a saved credit card.
* Go to `/checkout/offer-professional-email/<domain>/12345/<site slug>`.
* Click on the "Add Professional Email" button.
* Confirm that you can see the 1-click checkout purchase modal and that the email product is in the cart.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?