### PR TITLE
Stats: Fixing missing currency code

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-pwyw-uprade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-pwyw-uprade-slider/index.tsx
@@ -27,7 +27,7 @@ function getPWYWPlanTiers( minPrice: number, stepPrice: number ) {
 	return tiers;
 }
 
-function useTranslatedStrings() {
+function useTranslatedStrings( currencyCode: string ) {
 	const translate = useTranslate();
 	const limits = translate( 'Your monthly contribution', {
 		comment: 'Heading for Stats PWYW Upgrade slider. The monthly payment amount.',
@@ -39,7 +39,7 @@ function useTranslatedStrings() {
 	const strategy = translate( 'The average person pays %(value)s per month, billed yearly', {
 		comment: 'Stats PWYW Upgrade slider message. The billing strategy.',
 		args: {
-			value: formatCurrency( defaultAverageAmount, '', { stripZeros: true } ),
+			value: formatCurrency( defaultAverageAmount, currencyCode, { stripZeros: true } ),
 		},
 	} ) as string;
 
@@ -106,7 +106,7 @@ function StatsPWYWUpgradeSlider( {
 	// 3. Rendering the slider.
 	// 4. Nofiying the parent component when the slider changes.
 
-	const uiStrings = useTranslatedStrings();
+	const uiStrings = useTranslatedStrings( currencyCode );
 
 	let steps = getPWYWPlanTiers( 0, 50 );
 	if ( settings !== undefined ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #n/a

## Proposed Changes

* fixing missing currency code

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* apply `stats/tier-upgrade-slider` feature flags
* go to a non-commercial page and try to purchase a plan
* verify that currency in the slider and the text below match

| Before | After |
| --- | --- |
| <img width="408" alt="SCR-20231212-pmrg" src="https://github.com/Automattic/wp-calypso/assets/112354940/4ffedf03-abc2-444e-bbbc-8ee1ec82ce7c"> | <img width="417" alt="SCR-20231212-pndb" src="https://github.com/Automattic/wp-calypso/assets/112354940/71801f4d-6ea4-48ea-be25-6bcd3f1e7afd"> |


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?