### PR TITLE
Purchase Modal: fix feature list styling bug

### DIFF
--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/style.scss
@@ -49,7 +49,6 @@ $left-margin: 36px;
 }
 
 .purchase-modal__steps {
-	flex: 1;
 	display: flex;
 	flex-direction: column;
 	max-width: 100%;
@@ -57,6 +56,7 @@ $left-margin: 36px;
 	@include break-medium {
 		padding: 45px 36px;
 		.has-feature-list & {
+			max-width: 50%;
 			padding: 45px 0 45px 36px;
 		}
 	}
@@ -65,11 +65,9 @@ $left-margin: 36px;
 .purchase-modal__features {
 	background: var(--gray-gray-0, #f6f7f7);
 	padding: 45px 36px;
+	flex: 1;
 	@include break-medium {
-		padding: 45px 64px 45px 36px;
-	}
-	&.is-placeholder {
-		flex: 1;
+		padding: 45px 48px 45px 36px;
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Fixes a styling bug where the feature list of the purchase modal stretched more than it should.

**Before**
![image](https://github.com/Automattic/wp-calypso/assets/5436027/d679f2ed-fc7f-4c78-8290-5ac5ba7a41ab)

**After**
<img width="925" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/c8915320-81e5-495b-b85f-9fcf4ea8db43">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure that you have a saved credit card.
* Go to `/checkout/<site slug>/offer-plan-upgrade/business/12345` where `<site slug>` can be the slug for any site.
* Click on the "Upgrade Now" button.
* Confirm that you can see the 1-click checkout purchase modal and that the feature list is visible.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?