### PR TITLE
Enable the "Preview & Customize" button for Premium and WooCommerce themes (on horizon)

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/live-preview-modal/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/live-preview-modal/style.scss
@@ -49,7 +49,7 @@
 }
 
 .dialog__backdrop.live-preview-modal__overlay {
-	background-color: rgba(0, 0, 0, 0.7);
+	background-color: rgba(var(--color-neutral-70-rgb), 0.8);
 	// Dialog sets `z-index: z-index("root", ".dialog__backdrop")`,
 	// but this modal is used outside of Calypso, so we need to set it manually.
 	// We can refactor to use Modal from `@wordpress/components` instead of Dialog.

--- a/apps/wpcom-block-editor/src/wpcom/editor.scss
+++ b/apps/wpcom-block-editor/src/wpcom/editor.scss
@@ -1,5 +1,5 @@
 @import "./features/use-classic-block-guide";
-@import "./features/live-preview/upgrade-notice";
+@import "./features/live-preview";
 
 .blog-onboarding-hide {
 	.components-external-link, // "Connect an account" link in Jetpack sidebar

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-previewing-theme.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-previewing-theme.ts
@@ -31,15 +31,14 @@ export const usePreviewingTheme = () => {
 	}, [] );
 	const [ previewingTheme, setPreviewingTheme ] = useState< Theme | undefined >( undefined );
 
+	const previewingThemeId =
+		( previewingThemeSlug as string )?.split( '/' )?.[ 1 ] || previewingThemeSlug;
 	const previewingThemeName = previewingTheme?.name || previewingThemeSlug;
 	const previewingThemeType = previewingTheme ? getThemeType( previewingTheme ) : undefined;
 	const previewingThemeTypeDisplay =
 		previewingThemeType === WOOCOMMERCE_THEME ? 'WooCommerce' : 'Premium';
 
 	useEffect( () => {
-		const previewingThemeId =
-			( previewingThemeSlug as string )?.split( '/' )?.[ 1 ] || previewingThemeSlug;
-
 		if ( previewingThemeId ) {
 			wpcom.req
 				.get( `/themes/${ previewingThemeId }`, { apiVersion: '1.2' } )
@@ -53,9 +52,10 @@ export const usePreviewingTheme = () => {
 			setPreviewingTheme( undefined );
 		}
 		return;
-	}, [ previewingThemeSlug ] );
+	}, [ previewingThemeId, previewingThemeSlug ] );
 
 	return {
+		id: previewingThemeId,
 		name: previewingThemeName,
 		type: previewingThemeType,
 		typeDisplay: previewingThemeTypeDisplay,

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/index.scss
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/index.scss
@@ -1,0 +1,2 @@
+@import "./upgrade-modal";
+@import "./upgrade-notice";

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/index.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/index.tsx
@@ -6,6 +6,7 @@ import { FC, useEffect } from 'react';
 import { useCanPreviewButNeedUpgrade } from './hooks/use-can-preview-but-need-upgrade';
 import { useHideTemplatePartHint } from './hooks/use-hide-template-part-hint';
 import { usePreviewingTheme } from './hooks/use-previewing-theme';
+import { LivePreviewUpgradeModal } from './upgrade-modal';
 import { LivePreviewUpgradeNotice } from './upgrade-notice';
 import { getUnlock } from './utils';
 
@@ -77,7 +78,12 @@ const LivePreviewNoticePlugin = () => {
 	}
 
 	if ( canPreviewButNeedUpgrade ) {
-		return <LivePreviewUpgradeNotice { ...{ previewingTheme, upgradePlan, dashboardLink } } />;
+		return (
+			<>
+				<LivePreviewUpgradeModal { ...{ themeId: previewingTheme.id as string, upgradePlan } } />
+				<LivePreviewUpgradeNotice { ...{ previewingTheme, upgradePlan, dashboardLink } } />
+			</>
+		);
 	}
 	return <LivePreviewNotice { ...{ dashboardLink, previewingThemeName: previewingTheme.name } } />;
 };

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/index.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/index.tsx
@@ -81,7 +81,7 @@ const LivePreviewNoticePlugin = () => {
 		return (
 			<>
 				<LivePreviewUpgradeModal { ...{ themeId: previewingTheme.id as string, upgradePlan } } />
-				<LivePreviewUpgradeNotice { ...{ previewingTheme, upgradePlan, dashboardLink } } />
+				<LivePreviewUpgradeNotice { ...{ previewingTheme, dashboardLink } } />
 			</>
 		);
 	}

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-modal.scss
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-modal.scss
@@ -35,7 +35,8 @@
 	}
 }
 
-.wpcom-live-preview-upgrade-modal__overlay {
+.dialog__backdrop.wpcom-live-preview-upgrade-modal__overlay {
+	background-color: rgba(var(--color-neutral-70-rgb), 0.8);
 	// Dialog sets `z-index: z-index("root", ".dialog__backdrop")`,
 	// but this modal is used outside of Calypso, so we need to set it manually.
 	z-index: 100000;

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-modal.scss
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-modal.scss
@@ -1,0 +1,42 @@
+@import "@automattic/typography/styles/variables";
+// stylelint-disable-next-line scss/at-import-no-partial-leading-underscore
+@import "calypso/assets/stylesheets/shared/mixins/_breakpoints";
+// stylelint-disable-next-line scss/at-import-no-partial-leading-underscore
+@import "calypso/assets/stylesheets/shared/_loading";
+
+// Overriding `.wp-core-ui` styles back to Calypso styles.
+.wpcom-live-preview-upgrade-modal {
+	&.card {
+		border: none;
+	}
+	.theme-upgrade-modal p {
+		font-size: $font-body;
+	}
+	.theme-upgrade-modal .theme-upgrade-modal__actions.bundle {
+		.button {
+			color: var(--color-neutral-70);
+			border-color: var(--color-neutral-10);
+			background-color: transparent;
+			font-size: $font-body-small;
+			line-height: 22px;
+			&.is-primary {
+				color: var(--color-text-inverted);
+				border-color: var(--color-primary);
+				background-color: var(--color-primary);
+			}
+		}
+	}
+	.theme-upgrade-modal__included h2 {
+		margin-top: 0;
+		line-height: 1.5;
+	}
+	.theme-upgrade-modal__close {
+		padding: 8px 14px;
+	}
+}
+
+.wpcom-live-preview-upgrade-modal__overlay {
+	// Dialog sets `z-index: z-index("root", ".dialog__backdrop")`,
+	// but this modal is used outside of Calypso, so we need to set it manually.
+	z-index: 100000;
+}

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-modal.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-modal.tsx
@@ -1,0 +1,63 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { FC, useEffect, useState } from 'react';
+import { ThemeUpgradeModal } from 'calypso/components/theme-upgrade-modal';
+import './upgrade-modal.scss';
+
+const GRIDICONS_URL =
+	'https://widgets.wp.com/wpcom-block-editor/images/gridicons-47c7fb356fcb2d963681.svg';
+const GRIDICONS_ID = 'wpcom-live-preview-gridicons';
+
+
+export const LivePreviewUpgradeModal: FC< { themeId: string; upgradePlan: () => void } > = ( {
+	themeId,
+	upgradePlan,
+} ) => {
+	const [ isThemeUpgradeModalOpen, setIsThemeUpgradeModalOpen ] = useState( false );
+
+	/**
+	 * FIXME: This is only testing purpose to show the modal.
+	 * SaveButton customization should be changed to use https://github.com/WordPress/gutenberg/pull/56807.
+	 */
+	useEffect( () => {
+		const button = document.querySelector( '.edit-site-save-hub__button' );
+		button?.addEventListener( 'click', ( e ) => {
+			e.preventDefault();
+			setIsThemeUpgradeModalOpen( true );
+		} );
+	}, [] );
+
+	/**
+	 * Load the SVG sprite for `Gridicon` in `@automattic/components`.
+	 */
+	useEffect( () => {
+		fetch( GRIDICONS_URL )
+			.then( ( response ) => response.text() )
+			.then( ( svgData ) => {
+				if ( document.getElementById( GRIDICONS_ID ) ) {
+					return;
+				}
+				const div = document.createElement( 'div' );
+				div.innerHTML = svgData;
+				div.style.display = 'none';
+				div.id = GRIDICONS_ID;
+				document.body.insertBefore( div, document.body.childNodes[ 0 ] );
+			} )
+			.catch( () => {
+				/** Do nothing */
+			} );
+	}, [] );
+
+	const queryClient = new QueryClient();
+	return (
+		<QueryClientProvider client={ queryClient }>
+			<ThemeUpgradeModal
+				additionalClassNames="wpcom-live-preview-upgrade-modal"
+				additionalOverlayClassNames="wpcom-live-preview-upgrade-modal__overlay"
+				slug={ themeId }
+				isOpen={ isThemeUpgradeModalOpen }
+				closeModal={ () => setIsThemeUpgradeModalOpen( false ) }
+				checkout={ upgradePlan }
+			/>
+		</QueryClientProvider>
+	);
+};

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-modal.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-modal.tsx
@@ -1,30 +1,57 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useSelect } from '@wordpress/data';
 import { FC, useEffect, useState } from 'react';
 import { ThemeUpgradeModal } from 'calypso/components/theme-upgrade-modal';
+import { getUnlock } from './utils';
 import './upgrade-modal.scss';
+
+const SAVE_HUB_SAVE_BUTTON_SELECTOR = '.edit-site-save-hub__button';
+const HEADER_SAVE_BUTTON_SELECTOR = '.edit-site-save-button__button';
 
 const GRIDICONS_URL =
 	'https://widgets.wp.com/wpcom-block-editor/images/gridicons-47c7fb356fcb2d963681.svg';
 const GRIDICONS_ID = 'wpcom-live-preview-gridicons';
 
+const unlock = getUnlock();
 
 export const LivePreviewUpgradeModal: FC< { themeId: string; upgradePlan: () => void } > = ( {
 	themeId,
 	upgradePlan,
 } ) => {
 	const [ isThemeUpgradeModalOpen, setIsThemeUpgradeModalOpen ] = useState( false );
+	const canvasMode = useSelect(
+		( select ) =>
+			unlock && select( 'core/edit-site' ) && unlock( select( 'core/edit-site' ) ).getCanvasMode(),
+		[]
+	);
 
 	/**
-	 * FIXME: This is only testing purpose to show the modal.
-	 * SaveButton customization should be changed to use https://github.com/WordPress/gutenberg/pull/56807.
+	 * This adds a listener to the `SaveButton`.
+	 * Our objective is to open a custom modal ('ThemeUpgradeModal') instead of proceeding with the default behavior.
+	 * For more context, see the discussion on adding an official customization method: https://github.com/WordPress/gutenberg/pull/56807.
 	 */
 	useEffect( () => {
-		const button = document.querySelector( '.edit-site-save-hub__button' );
-		button?.addEventListener( 'click', ( e ) => {
-			e.preventDefault();
+		const handler: EventListener = ( e ) => {
+			e.stopPropagation();
 			setIsThemeUpgradeModalOpen( true );
-		} );
-	}, [] );
+		};
+		if ( canvasMode === 'view' ) {
+			document.querySelector( SAVE_HUB_SAVE_BUTTON_SELECTOR )?.addEventListener( 'click', handler );
+			return;
+		}
+		if ( canvasMode === 'edit' ) {
+			document.querySelector( HEADER_SAVE_BUTTON_SELECTOR )?.addEventListener( 'click', handler );
+			return;
+		}
+		return () => {
+			document
+				.querySelector( SAVE_HUB_SAVE_BUTTON_SELECTOR )
+				?.removeEventListener( 'click', handler );
+			document
+				.querySelector( HEADER_SAVE_BUTTON_SELECTOR )
+				?.removeEventListener( 'click', handler );
+		};
+	}, [ canvasMode ] );
 
 	/**
 	 * Load the SVG sprite for `Gridicon` in `@automattic/components`.

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-modal.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-modal.tsx
@@ -1,5 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
 import { FC, useEffect, useState } from 'react';
 import { ThemeUpgradeModal } from 'calypso/components/theme-upgrade-modal';
 import { getUnlock } from './utils';
@@ -26,7 +27,7 @@ export const LivePreviewUpgradeModal: FC< { themeId: string; upgradePlan: () => 
 	);
 
 	/**
-	 * This adds a listener to the `SaveButton`.
+	 * This overrides the `SaveButton` behavior by adding a listener and changing the copy.
 	 * Our objective is to open a custom modal ('ThemeUpgradeModal') instead of proceeding with the default behavior.
 	 * For more context, see the discussion on adding an official customization method: https://github.com/WordPress/gutenberg/pull/56807.
 	 */
@@ -35,12 +36,19 @@ export const LivePreviewUpgradeModal: FC< { themeId: string; upgradePlan: () => 
 			e.stopPropagation();
 			setIsThemeUpgradeModalOpen( true );
 		};
+		const overrideSaveButton = ( selector: string ) => {
+			const button = document.querySelector( selector );
+			if ( button ) {
+				button.textContent = __( 'Upgrade now', 'wpcom-live-preview' );
+				button.addEventListener( 'click', handler );
+			}
+		};
 		if ( canvasMode === 'view' ) {
-			document.querySelector( SAVE_HUB_SAVE_BUTTON_SELECTOR )?.addEventListener( 'click', handler );
+			overrideSaveButton( SAVE_HUB_SAVE_BUTTON_SELECTOR );
 			return;
 		}
 		if ( canvasMode === 'edit' ) {
-			document.querySelector( HEADER_SAVE_BUTTON_SELECTOR )?.addEventListener( 'click', handler );
+			overrideSaveButton( HEADER_SAVE_BUTTON_SELECTOR );
 			return;
 		}
 		return () => {

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-notice.scss
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-notice.scss
@@ -6,6 +6,13 @@
 .wpcom-live-preview-upgrade-notice-view-container {
 	padding: 24px 24px 0;
 	border-top: 1px solid #2f2f2f;
+
+	// Hide the original border only when the notice is present.
+	+ .edit-site-save-hub {
+		border-top: none;
+		padding-top: 0;
+	}
+
 	.wpcom-live-preview-upgrade-notice-view {
 		margin: 0 0 24px;
 		color: var(--color-text);

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-notice.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-notice.tsx
@@ -21,21 +21,13 @@ const unlock = getUnlock();
 
 const LivePreviewUpgradeNoticeView: FC< {
 	noticeText: string;
-	upgradePlan: () => void;
-} > = ( { noticeText, upgradePlan } ) => {
+} > = ( { noticeText } ) => {
 	return (
 		<Notice
 			status="warning"
 			isDismissible={ false }
 			className="wpcom-live-preview-upgrade-notice-view"
-			actions={ [
-				{
-					// TODO: Add the tracking event.
-					label: __( 'Upgrade now', 'wpcom-live-preview' ),
-					onClick: upgradePlan,
-					variant: 'primary',
-				},
-			] }
+			// TODO: Add the tracking event.
 		>
 			{ noticeText }
 		</Notice>
@@ -45,8 +37,7 @@ const LivePreviewUpgradeNoticeView: FC< {
 export const LivePreviewUpgradeNotice: FC< {
 	dashboardLink?: string;
 	previewingTheme: ReturnType< typeof usePreviewingTheme >;
-	upgradePlan: () => void;
-} > = ( { dashboardLink, previewingTheme, upgradePlan } ) => {
+} > = ( { dashboardLink, previewingTheme } ) => {
 	const [ isRendered, setIsRendered ] = useState( false );
 	const { createWarningNotice } = useDispatch( 'core/notices' );
 	const canvasMode = useSelect(
@@ -75,11 +66,6 @@ export const LivePreviewUpgradeNotice: FC< {
 			isDismissible: false,
 			__unstableHTML: true,
 			actions: [
-				{
-					label: __( 'Upgrade now', 'wpcom-live-preview' ),
-					onClick: upgradePlan,
-					variant: 'primary',
-				},
 				...( dashboardLink
 					? [
 							{
@@ -91,7 +77,7 @@ export const LivePreviewUpgradeNotice: FC< {
 					: [] ),
 			],
 		} );
-	}, [ createWarningNotice, dashboardLink, noticeText, upgradePlan ] );
+	}, [ createWarningNotice, dashboardLink, noticeText ] );
 
 	/**
 	 * Show the notice when the canvas mode is 'view'.
@@ -119,13 +105,10 @@ export const LivePreviewUpgradeNotice: FC< {
 			container.insertBefore( noticeContainer, saveHub );
 		}
 
-		render(
-			<LivePreviewUpgradeNoticeView noticeText={ noticeText } upgradePlan={ upgradePlan } />,
-			noticeContainer
-		);
+		render( <LivePreviewUpgradeNoticeView noticeText={ noticeText } />, noticeContainer );
 
 		setIsRendered( true );
-	}, [ canvasMode, isRendered, noticeText, upgradePlan ] );
+	}, [ canvasMode, isRendered, noticeText ] );
 
 	return null;
 };

--- a/apps/wpcom-block-editor/webpack.config.js
+++ b/apps/wpcom-block-editor/webpack.config.js
@@ -5,6 +5,7 @@
 const path = require( 'path' );
 const getBaseWebpackConfig = require( '@automattic/calypso-build/webpack.config.js' );
 const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
+const webpack = require( 'webpack' );
 
 /**
  * Internal variables
@@ -58,6 +59,13 @@ function getWebpackConfig(
 			...webpackConfig.plugins.filter(
 				( plugin ) => plugin.constructor.name !== 'DependencyExtractionWebpackPlugin'
 			),
+			new webpack.DefinePlugin( {
+				'process.env.NODE_DEBUG': JSON.stringify( process.env.NODE_DEBUG || false ),
+			} ),
+			// Replace the `packages/components/src/gridicon/index.tsx` with a replacement that does not enqueue the SVG sprite.
+			// The sprite is loaded separately in `apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-modal.tsx`.
+			new webpack.NormalModuleReplacementPlugin( /^\.\.\/gridicon$/, '../gridicon/no-asset' ),
+			new webpack.NormalModuleReplacementPlugin( /^\.\/gridicon$/, './gridicon/no-asset' ),
 			new DependencyExtractionWebpackPlugin( {
 				requestToExternal( request ) {
 					if ( request === 'tinymce/tinymce' ) {

--- a/client/components/theme-upgrade-modal/index.tsx
+++ b/client/components/theme-upgrade-modal/index.tsx
@@ -29,14 +29,14 @@ import classNames from 'classnames';
 import i18n, { useTranslate } from 'i18n-calypso';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { getPlanFeaturesObject } from 'calypso/lib/plans/features-list';
-import useBundleSettings from 'calypso/my-sites/theme/hooks/use-bundle-settings';
-import { useSelector } from 'calypso/state';
+import { useBundleSettingsFromThemeSoftwareSet } from 'calypso/my-sites/theme/hooks/use-bundle-settings';
 import { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
 import { useThemeDetails } from 'calypso/state/themes/hooks/use-theme-details';
-import { isExternallyManagedTheme } from 'calypso/state/themes/selectors';
+import { ThemeSoftwareSet } from 'calypso/types';
 import './style.scss';
 
 interface UpgradeModalProps {
+	additionalClassNames?: string;
 	/* Theme slug */
 	slug: string;
 	isOpen: boolean;
@@ -55,6 +55,7 @@ interface UpgradeModalContent {
 }
 
 export const ThemeUpgradeModal = ( {
+	additionalClassNames,
 	slug,
 	isOpen,
 	isMarketplaceThemeSubscriptionNeeded,
@@ -71,9 +72,13 @@ export const ThemeUpgradeModal = ( {
 	// Check current theme: Does it have a plugin bundled?
 	const theme_software_set = theme?.data?.taxonomies?.theme_software_set?.length;
 	const showBundleVersion = theme_software_set;
-	const isExternallyManaged = useSelector( ( state ) => isExternallyManagedTheme( state, slug ) );
+	const isExternallyManaged = theme?.data?.theme_type === 'managed-external';
 
-	const bundleSettings = useBundleSettings( slug );
+	const bundleSettings = useBundleSettingsFromThemeSoftwareSet(
+		( theme?.data?.taxonomies?.theme_software_set as ThemeSoftwareSet[] )?.map(
+			( item ) => item.slug
+		)
+	);
 
 	const premiumPlanProduct = useSelect(
 		( select ) => select( ProductsList.store ).getProductBySlug( 'value_bundle' ),
@@ -358,6 +363,7 @@ export const ThemeUpgradeModal = ( {
 
 	return (
 		<Dialog
+			additionalClassNames={ additionalClassNames }
 			className={ classNames( 'theme-upgrade-modal', { loading: isLoading } ) }
 			isVisible={ isOpen }
 			onClose={ () => closeModal() }

--- a/client/components/theme-upgrade-modal/index.tsx
+++ b/client/components/theme-upgrade-modal/index.tsx
@@ -37,6 +37,7 @@ import './style.scss';
 
 interface UpgradeModalProps {
 	additionalClassNames?: string;
+	additionalOverlayClassNames?: string;
 	/* Theme slug */
 	slug: string;
 	isOpen: boolean;
@@ -56,6 +57,7 @@ interface UpgradeModalContent {
 
 export const ThemeUpgradeModal = ( {
 	additionalClassNames,
+	additionalOverlayClassNames,
 	slug,
 	isOpen,
 	isMarketplaceThemeSubscriptionNeeded,
@@ -364,6 +366,7 @@ export const ThemeUpgradeModal = ( {
 	return (
 		<Dialog
 			additionalClassNames={ additionalClassNames }
+			additionalOverlayClassNames={ additionalOverlayClassNames }
 			className={ classNames( 'theme-upgrade-modal', { loading: isLoading } ) }
 			isVisible={ isOpen }
 			onClose={ () => closeModal() }

--- a/client/components/theme-upgrade-modal/style.scss
+++ b/client/components/theme-upgrade-modal/style.scss
@@ -1,3 +1,5 @@
+@import "@automattic/typography/styles/variables";
+@import "@automattic/typography/styles/fonts";
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 

--- a/client/my-sites/theme/hooks/use-bundle-settings.tsx
+++ b/client/my-sites/theme/hooks/use-bundle-settings.tsx
@@ -24,11 +24,11 @@ const WooOnPlansIcon = () => (
 );
 
 /**
- * Hook to get the bundle settings for a given theme.
- * If the theme doesn't have a sotfware set defined, it returns `null`.
+ * Hook to get the bundle settings for a software set.
  */
-const useBundleSettings = ( themeId: string ): BundleSettings | null => {
-	const themeSoftwareSet = useSelector( ( state ) => getThemeSoftwareSet( state, themeId ) );
+export const useBundleSettingsFromThemeSoftwareSet = (
+	themeSoftwareSet: string[] = []
+): BundleSettings | null => {
 	const translate = useTranslate();
 
 	const bundleSettings = useMemo( () => {
@@ -63,6 +63,15 @@ const useBundleSettings = ( themeId: string ): BundleSettings | null => {
 	}, [ translate, themeSoftwareSet ] );
 
 	return bundleSettings;
+};
+
+/**
+ * Hook to get the bundle settings for a given theme.
+ * If the theme doesn't have a software set defined, it returns `null`.
+ */
+const useBundleSettings = ( themeId: string ): BundleSettings | null => {
+	const themeSoftwareSet = useSelector( ( state ) => getThemeSoftwareSet( state, themeId ) );
+	return useBundleSettingsFromThemeSoftwareSet( themeSoftwareSet );
 };
 
 export default useBundleSettings;

--- a/client/state/themes/hooks/use-theme-details.ts
+++ b/client/state/themes/hooks/use-theme-details.ts
@@ -11,6 +11,7 @@ type Theme = {
 	date_updated: string;
 	price: string;
 	taxonomies: Record< string, [] >;
+	theme_type: string;
 };
 
 export function useThemeDetails( slug = '' ): UseQueryResult< Theme > {

--- a/client/state/themes/selectors/get-is-live-preview-supported.ts
+++ b/client/state/themes/selectors/get-is-live-preview-supported.ts
@@ -82,14 +82,9 @@ const isNotCompatibleThemes = ( themeId: string ) => {
  * - On Simple sites;
  *   - If the theme is externally managed.
  *   - If the theme is a wporg theme.
- *   - If the theme is NOT included in a plan.
- * @see pbxlJb-3Uv-p2
+ *   - If the theme is NOT a Premium and WooCommerce theme, and is NOT included in a plan.
  */
 export const getIsLivePreviewSupported = ( state: AppState, themeId: string, siteId: number ) => {
-	if ( ! config.isEnabled( 'themes/block-theme-previews' ) ) {
-		return false;
-	}
-
 	// The "Live" Preview does NOT make sense for logged out users.
 	if ( ! isUserLoggedIn( state ) ) {
 		return false;

--- a/client/state/themes/selectors/get-is-live-preview-supported.ts
+++ b/client/state/themes/selectors/get-is-live-preview-supported.ts
@@ -10,6 +10,8 @@ import {
 	isExternallyManagedTheme,
 	canUseTheme,
 	isSiteEligibleForManagedExternalThemes,
+	isThemeWooCommerce,
+	isThemePremium,
 } from '.';
 
 /**
@@ -151,11 +153,23 @@ export const getIsLivePreviewSupported = ( state: AppState, themeId: string, sit
 
 		/**
 		 * Disable Live Preview for themes that are NOT included in a plan.
-		 * This should be updated as we implement the flow for them.
-		 * Note that BTP works on Atomic sites if a theme is installed.
-		 * @see https://github.com/Automattic/wp-calypso/issues/79223
 		 */
 		if ( ! canUseTheme( state, siteId, themeId ) ) {
+			/**
+			 * Enable Live Preview for Premium and WooCommerce themes.
+			 * @see https://github.com/Automattic/wp-calypso/issues/79223
+			 */
+			if (
+				config.isEnabled( 'themes/block-theme-previews-premium-and-woo' ) &&
+				( isThemePremium( state, themeId ) || isThemeWooCommerce( state, themeId ) )
+			) {
+				return true;
+			}
+
+			/**
+			 * Handling Bundle themes except for WooCommerce themes here.
+			 * We can enable Live Preview for Bundle themes by supporting them on the Live Preview notices.
+			 */
 			return false;
 		}
 	}

--- a/client/state/themes/selectors/get-live-preview-url.ts
+++ b/client/state/themes/selectors/get-live-preview-url.ts
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { addQueryArgs } from 'calypso/lib/route';
 import getSiteEditorUrl from 'calypso/state/selectors/get-site-editor-url';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
@@ -8,10 +7,6 @@ import { getTheme } from '.';
 const QUERY_NAME = 'wp_theme_preview';
 
 export const getLivePreviewUrl = ( state: AppState, themeId: string, siteId: number ) => {
-	if ( ! config.isEnabled( 'themes/block-theme-previews' ) ) {
-		return undefined;
-	}
-
 	const siteEditorUrl = getSiteEditorUrl( state, siteId );
 
 	if ( isSiteAutomatedTransfer( state, siteId ) ) {

--- a/client/state/themes/selectors/index.js
+++ b/client/state/themes/selectors/index.js
@@ -68,6 +68,7 @@ export { isThemeActive } from 'calypso/state/themes/selectors/is-theme-active';
 export { isThemeGutenbergFirst } from 'calypso/state/themes/selectors/is-theme-gutenberg-first';
 export { isThemePremium } from 'calypso/state/themes/selectors/is-theme-premium';
 export { isThemePurchased } from 'calypso/state/themes/selectors/is-theme-purchased';
+export { isThemeWooCommerce } from 'calypso/state/themes/selectors/is-theme-woo-commerce';
 export { isThemesLastPageForQuery } from 'calypso/state/themes/selectors/is-themes-last-page-for-query';
 export { isUpsellCardDisplayed } from 'calypso/state/themes/selectors/is-upsell-card-displayed';
 export { isValidThemeFilterTerm } from 'calypso/state/themes/selectors/is-valid-theme-filter-term';

--- a/client/state/themes/selectors/is-theme-woo-commerce.ts
+++ b/client/state/themes/selectors/is-theme-woo-commerce.ts
@@ -1,0 +1,14 @@
+import { getTheme } from 'calypso/state/themes/selectors/get-theme';
+import { IAppState } from 'calypso/state/types';
+import { ThemeSoftwareSet } from 'calypso/types';
+import 'calypso/state/themes/init';
+
+/**
+ * Returns whether a theme is a WooCommerce theme.
+ */
+export function isThemeWooCommerce( state: IAppState, themeId: string ) {
+	const theme = getTheme( state, 'wpcom', themeId );
+	const themeSoftwareSetTaxonomy: ThemeSoftwareSet[] | undefined =
+		theme?.taxonomies?.theme_software_set;
+	return themeSoftwareSetTaxonomy?.some( ( { slug } ) => slug === 'woo-on-plan' );
+}

--- a/config/development.json
+++ b/config/development.json
@@ -209,7 +209,6 @@
 		"subscription-management/migrate-subscribers": true,
 		"subscription-management-redirect-following": true,
 		"themes/atomic-homepage-replace": true,
-		"themes/block-theme-previews": true,
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/display-thank-you-page-for-woo": true,

--- a/config/development.json
+++ b/config/development.json
@@ -210,6 +210,7 @@
 		"subscription-management-redirect-following": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/block-theme-previews": true,
+		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/display-thank-you-page-for-woo": true,
 		"themes/premium": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -147,6 +147,7 @@
 		"subscription-management-redirect-following": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/block-theme-previews": true,
+		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/display-thank-you-page-for-woo": true,
 		"themes/premium": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -146,7 +146,6 @@
 		"subscription-management/migrate-subscribers": true,
 		"subscription-management-redirect-following": true,
 		"themes/atomic-homepage-replace": true,
-		"themes/block-theme-previews": true,
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/display-thank-you-page-for-woo": true,

--- a/config/production.json
+++ b/config/production.json
@@ -175,7 +175,6 @@
 		"subscription-management/migrate-subscribers": true,
 		"subscription-management-redirect-following": true,
 		"themes/atomic-homepage-replace": true,
-		"themes/block-theme-previews": true,
 		"themes/block-theme-previews-premium-and-woo": false,
 		"themes/discovery": true,
 		"themes/display-thank-you-page-for-woo": true,

--- a/config/production.json
+++ b/config/production.json
@@ -176,6 +176,7 @@
 		"subscription-management-redirect-following": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/block-theme-previews": true,
+		"themes/block-theme-previews-premium-and-woo": false,
 		"themes/discovery": true,
 		"themes/display-thank-you-page-for-woo": true,
 		"themes/premium": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -170,7 +170,6 @@
 		"subscription-management/migrate-subscribers": true,
 		"subscription-management-redirect-following": true,
 		"themes/atomic-homepage-replace": true,
-		"themes/block-theme-previews": true,
 		"themes/block-theme-previews-premium-and-woo": false,
 		"themes/discovery": true,
 		"themes/display-thank-you-page-for-woo": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -171,6 +171,7 @@
 		"subscription-management-redirect-following": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/block-theme-previews": true,
+		"themes/block-theme-previews-premium-and-woo": false,
 		"themes/discovery": true,
 		"themes/display-thank-you-page-for-woo": true,
 		"themes/premium": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -178,7 +178,6 @@
 		"subscription-management/comments-list-controls": true,
 		"subscription-management-redirect-following": true,
 		"themes/atomic-homepage-replace": true,
-		"themes/block-theme-previews": true,
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/display-thank-you-page-for-woo": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -179,6 +179,7 @@
 		"subscription-management-redirect-following": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/block-theme-previews": true,
+		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/display-thank-you-page-for-woo": true,
 		"themes/premium": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
thelinked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/79223
https://github.com/Automattic/wp-calypso/pull/84483

## Proposed Changes

This PR enables the "Preview & Customize" button for Premium and WooCommerce themes on the Horizon environment. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?