### PR TITLE
Sync/site reset UI layout with mockup

### DIFF
--- a/client/my-sites/site-settings/start-over.jsx
+++ b/client/my-sites/site-settings/start-over.jsx
@@ -286,7 +286,7 @@ function SiteResetCard( {
 				navigationItems={ [] }
 				title={ translate( 'Reset your site' ) }
 				subtitle={ translate(
-					"Remove all posts, pages, and media to start fresh while keeping your site's address.{{a}}Learn more.{{/a}}",
+					"Remove all posts, pages, and media to start fresh while keeping your site's address. {{a}}Learn more.{{/a}}",
 					{
 						components: {
 							a: <InlineSupportLink supportContext="site-transfer" showIcon={ false } />,

--- a/client/my-sites/site-settings/start-over.jsx
+++ b/client/my-sites/site-settings/start-over.jsx
@@ -346,7 +346,7 @@ function SiteResetCard( {
 								aria-required="true"
 								id="confirmResetInput"
 								disabled={ isLoading }
-								style={ { flex: 0.5 } }
+								style={ { flex: 1 } }
 								onChange={ ( event ) =>
 									setDomainConfirmed( event.currentTarget.value.trim() === siteDomain )
 								}

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -748,7 +748,6 @@ button.site-settings__general-settings-set-guessed-timezone.button.is-borderless
 
 	.action-panel__body a,
 	li a {
-		color: var(--gray-gray-100, #101517);
 		text-decoration: underline;
 	}
 

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -746,9 +746,11 @@ button.site-settings__general-settings-set-guessed-timezone.button.is-borderless
 		height: 0 !important;
 	}
 
+	.site-settings__reset-site-backup-hint a,
+	a.inline-support-link,
 	.action-panel__body a,
 	li a {
-		text-decoration: underline;
+		text-decoration: underline !important;
 	}
 
 	.banner {

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -740,6 +740,10 @@ button.site-settings__general-settings-set-guessed-timezone.button.is-borderless
 	.card.action-panel {
 		margin-bottom: 0;
 		padding: 24px;
+		.action-panel__body ul {
+			margin-left: 20px;
+			margin-bottom: 0;
+		}
 	}
 
 	.action-panel__footer::before {

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -742,6 +742,10 @@ button.site-settings__general-settings-set-guessed-timezone.button.is-borderless
 		padding: 24px;
 	}
 
+	.action-panel__footer::before {
+		height: 0 !important;
+	}
+
 	.action-panel__body a,
 	li a {
 		color: var(--gray-gray-100, #101517);

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -733,6 +733,10 @@ button.site-settings__general-settings-set-guessed-timezone.button.is-borderless
 }
 
 .site-settings__reset-site {
+	.card.header-cake {
+		margin-bottom: 0;
+		border-bottom: none;
+	}
 	.card.action-panel {
 		margin-bottom: 0;
 		padding: 24px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/85081

<img width="854" alt="Screenshot 2566-12-12 at 14 36 09" src="https://github.com/Automattic/wp-calypso/assets/6851384/b3f4979f-f294-42d4-81cd-279079773fd0">


## Proposed Changes

* Apply design tweaks from https://github.com/Automattic/wp-calypso/issues/85081

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Use this branch or Calypso Live
- If using Calypso Live, be sure to append `?flags=settings/self-serve-site-reset` to your URLs
- Go to `/settings/start-over/:atomic-site` and  `/settings/start-over/:simple-site` and compare with Figma

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?