### PR TITLE
Jetpack Manage: Implement paging for retrieving child licenses.

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/license-details/bundle-details.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/bundle-details.tsx
@@ -1,3 +1,5 @@
+import { Button, CompactCard } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
 import { LicenseType } from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import useBundleLicensesQuery from 'calypso/state/partner-portal/licenses/hooks/use-bundle-licenses-query';
 import LicensePreview, { LicensePreviewPlaceholder } from '../license-preview';
@@ -7,28 +9,41 @@ interface Props {
 }
 
 export default function BundleDetails( { parentLicenseId }: Props ) {
-	const { data } = useBundleLicensesQuery( parentLicenseId );
+	const translate = useTranslate();
+	const { licenses, total, loadMore, fetching } = useBundleLicensesQuery( parentLicenseId );
 
-	if ( ! data ) {
-		return <LicensePreviewPlaceholder />;
-	}
+	return (
+		<div className="bundle-details">
+			{ licenses.map( ( item ) => (
+				<LicensePreview
+					isChildLicense
+					key={ item.licenseId }
+					licenseKey={ item.licenseKey }
+					product={ item.product }
+					username={ item.username }
+					blogId={ item.blogId }
+					siteUrl={ item.siteUrl }
+					hasDownloads={ item.hasDownloads }
+					issuedAt={ item.issuedAt }
+					attachedAt={ item.attachedAt }
+					revokedAt={ item.revokedAt }
+					licenseType={
+						item.ownerType === LicenseType.Standard ? LicenseType.Standard : LicenseType.Partner
+					}
+				/>
+			) ) }
 
-	return data.map( ( item ) => (
-		<LicensePreview
-			isChildLicense
-			key={ item.licenseId }
-			licenseKey={ item.licenseKey }
-			product={ item.product }
-			username={ item.username }
-			blogId={ item.blogId }
-			siteUrl={ item.siteUrl }
-			hasDownloads={ item.hasDownloads }
-			issuedAt={ item.issuedAt }
-			attachedAt={ item.attachedAt }
-			revokedAt={ item.revokedAt }
-			licenseType={
-				item.ownerType === LicenseType.Standard ? LicenseType.Standard : LicenseType.Partner
-			}
-		/>
-	) );
+			{ fetching && <LicensePreviewPlaceholder /> }
+
+			{ loadMore && (
+				<CompactCard className="bundle-details__footer">
+					<Button compact onClick={ loadMore } disabled={ fetching }>
+						{ translate( 'Load more (%(remainingItems)d)', {
+							args: { remainingItems: total - licenses.length },
+						} ) }
+					</Button>
+				</CompactCard>
+			) }
+		</div>
+	);
 }

--- a/client/jetpack-cloud/sections/partner-portal/license-details/bundle-details.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/bundle-details.tsx
@@ -10,7 +10,7 @@ interface Props {
 
 export default function BundleDetails( { parentLicenseId }: Props ) {
 	const translate = useTranslate();
-	const { licenses, total, loadMore, fetching } = useBundleLicensesQuery( parentLicenseId );
+	const { licenses, total, loadMore, isLoading } = useBundleLicensesQuery( parentLicenseId );
 
 	return (
 		<div className="bundle-details">
@@ -33,11 +33,11 @@ export default function BundleDetails( { parentLicenseId }: Props ) {
 				/>
 			) ) }
 
-			{ fetching && <LicensePreviewPlaceholder /> }
+			{ isLoading && <LicensePreviewPlaceholder /> }
 
 			{ loadMore && (
 				<CompactCard className="bundle-details__footer">
-					<Button compact onClick={ loadMore } disabled={ fetching }>
+					<Button compact onClick={ loadMore } disabled={ isLoading }>
 						{ translate( 'Load more (%(remainingItems)d)', {
 							args: { remainingItems: total - licenses.length },
 						} ) }

--- a/client/jetpack-cloud/sections/partner-portal/license-details/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/style.scss
@@ -125,3 +125,15 @@
 		line-height: 1;
 	}
 }
+
+.bundle-details__footer {
+	padding: 16px 32px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.bundle-details__footer,
+.bundle-details .license-preview.license-preview--placeholder .license-preview__card {
+	background-color: #fafafa;
+}

--- a/client/state/partner-portal/licenses/hooks/use-bundle-licenses-query.ts
+++ b/client/state/partner-portal/licenses/hooks/use-bundle-licenses-query.ts
@@ -11,7 +11,6 @@ export default function useBundleLicensesQuery( parentLicenseId: number, perPage
 	const [ licenses, setLicenses ] = useState< License[] >( [] );
 	const [ total, setTotal ] = useState< number >( 0 );
 	const [ page, setPage ] = useState< number >( 1 );
-	const [ fetching, setFetching ] = useState< boolean >( false );
 
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -36,7 +35,7 @@ export default function useBundleLicensesQuery( parentLicenseId: number, perPage
 		} ),
 	} );
 
-	const { isError, data, isFetched } = query;
+	const { isError, data, isLoading } = query;
 
 	const loadMore = useCallback( () => {
 		setPage( ( page ) => page + 1 );
@@ -52,28 +51,20 @@ export default function useBundleLicensesQuery( parentLicenseId: number, perPage
 					}
 				)
 			);
-			setFetching( false );
 		}
 	}, [ dispatch, translate, isError ] );
 
 	useEffect( () => {
 		if ( data ) {
-			setFetching( false );
 			setTotal( data.total );
 			setLicenses( ( licenses ) => [ ...licenses, ...data.licenses ] );
 		}
 	}, [ data ] );
 
-	useEffect( () => {
-		if ( ! isFetched ) {
-			setFetching( true );
-		}
-	}, [ isFetched ] );
-
 	return {
 		licenses,
 		total,
 		loadMore: licenses.length < total ? loadMore : undefined,
-		fetching,
+		isLoading,
 	};
 }


### PR DESCRIPTION
This pull request includes an update to the bundle licenses, allowing child licenses to be retrieved in a paginated manner. Page is set to a maximum of 25 items. a "Load more" button has been added to enable users to access this functionality.

<img width="1553" alt="Screen Shot 2023-12-12 at 4 39 32 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/e4129949-9158-4119-a95a-95fd784c9fad">


Closes https://github.com/Automattic/jetpack-genesis/issues/135

## Proposed Changes

* Update the `useBundleLicensesQuery` hook to support pagination and load more feature.
* Update bundle details to add a **'Load more'** button.

## Testing Instructions
Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

* Use the Jetpack Cloud live link below and go to the Issue license page (`/partner-portal/issue-license`)
* Issue a bundle of 50 or 100 licenses.
* Go to the Licenses page (`/partner-portal/licenses`)
* Find the bundle you issued and expand.
* Confirm that it only loads 25 items and that a **'Load more'** button is visible in the details footer.
* Click the **'Load more'** button and confirm it loads another 25 items. Once all items are loaded, the button should disappear. 

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?