### PR TITLE
Theme Showcase: Add the Design Your Own button

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -2,6 +2,8 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { FEATURE_INSTALL_THEMES } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
+import { Button } from '@automattic/components';
+import { isAssemblerSupported } from '@automattic/design-picker';
 import classNames from 'classnames';
 import { localize, translate } from 'i18n-calypso';
 import { compact, pickBy } from 'lodash';
@@ -15,6 +17,7 @@ import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import QueryThemeFilters from 'calypso/components/data/query-theme-filters';
 import { SearchThemes, SearchThemesV2 } from 'calypso/components/search-themes';
 import SelectDropdown from 'calypso/components/select-dropdown';
+import getSiteAssemblerUrl from 'calypso/components/themes-list/get-site-assembler-url';
 import { getOptionLabel } from 'calypso/landing/subscriptions/helpers';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { buildRelativeSearchUrl } from 'calypso/lib/build-url';
@@ -26,11 +29,12 @@ import ThemeShowcaseSurvey, { SurveyType } from 'calypso/my-sites/themes/survey'
 import ThanksModal from 'calypso/my-sites/themes/thanks-modal';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import getLastNonEditorRoute from 'calypso/state/selectors/get-last-non-editor-route';
+import getSiteEditorUrl from 'calypso/state/selectors/get-site-editor-url';
 import getSiteFeaturesById from 'calypso/state/selectors/get-site-features';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { isSiteOnWooExpress, isSiteOnECommerceTrial } from 'calypso/state/sites/plans/selectors';
-import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSite, getSiteSlug } from 'calypso/state/sites/selectors';
 import { setBackPath } from 'calypso/state/themes/actions';
 import {
 	arePremiumThemesEnabled,
@@ -367,6 +371,23 @@ class ThemeShowcase extends Component {
 		this.scrollToSearchInput();
 	};
 
+	onDesignYourOwnClick = () => {
+		const { isLoggedIn, site: selectedSite, siteEditorUrl } = this.props;
+		const shouldGoToAssemblerStep = isAssemblerSupported();
+		recordTracksEvent( 'calypso_themeshowcase_pattern_assembler_top_button_click', {
+			is_logged_in: isLoggedIn,
+		} );
+
+		const destinationUrl = getSiteAssemblerUrl( {
+			isLoggedIn,
+			selectedSite,
+			shouldGoToAssemblerStep,
+			siteEditorUrl,
+		} );
+
+		window.location.assign( destinationUrl );
+	};
+
 	shouldShowCollections = () => {
 		const { category, search, filter, isCollectionView, tier } = this.props;
 
@@ -624,17 +645,27 @@ class ThemeShowcase extends Component {
 									></SelectDropdown>
 								) }
 							</div>
-							{ tabFilters && ! isSiteWooExpressOrEcomFreeTrial && (
-								<ThemesToolbarGroup
-									items={ Object.values( tabFilters ) }
-									selectedKey={ this.getSelectedTabFilter().key }
-									onSelect={ ( key ) =>
-										this.onFilterClick(
-											Object.values( tabFilters ).find( ( tabFilter ) => tabFilter.key === key )
-										)
-									}
-								/>
-							) }
+							<div className="themes__filters">
+								{ tabFilters && ! isSiteWooExpressOrEcomFreeTrial && (
+									<ThemesToolbarGroup
+										items={ Object.values( tabFilters ) }
+										selectedKey={ this.getSelectedTabFilter().key }
+										onSelect={ ( key ) =>
+											this.onFilterClick(
+												Object.values( tabFilters ).find( ( tabFilter ) => tabFilter.key === key )
+											)
+										}
+									/>
+								) }
+								{ tabFilters && (
+									<Button
+										className="themes__pattern-assembler-top-button"
+										onClick={ this.onDesignYourOwnClick }
+									>
+										{ translate( 'Design your own' ) }
+									</Button>
+								) }
+							</div>
 						</div>
 					) }
 					{ isCollectionView && (
@@ -673,7 +704,9 @@ const mapStateToProps = ( state, { siteId, filter } ) => {
 		isLoggedIn: isUserLoggedIn( state ),
 		isAtomicSite: isAtomicSite( state, siteId ),
 		areSiteFeaturesLoaded: !! getSiteFeaturesById( state, siteId ),
+		site: getSite( state, siteId ),
 		siteCanInstallThemes: siteHasFeature( state, siteId, FEATURE_INSTALL_THEMES ),
+		siteEditorUrl: getSiteEditorUrl( state, siteId ),
 		siteSlug: getSiteSlug( state, siteId ),
 		subjects: getThemeFilterTerms( state, 'subject' ) || {},
 		premiumThemesEnabled: arePremiumThemesEnabled( state, siteId ),

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -55,10 +55,6 @@
 	.themes__content {
 		position: relative;
 
-		.themes-toolbar-group {
-			padding: 72px 0 24px;
-		}
-
 		.themes__controls,
 		.themes__showcase {
 			padding: 0 16px;
@@ -122,19 +118,6 @@
 		}
 	}
 
-	.theme__filters {
-		margin: 0;
-		padding: 72px 0 24px;
-
-		.segmented-control {
-			background-color: var(--studio-blue-5);
-
-			.segmented-control__text {
-				color: var(--studio-gray-80);
-			}
-		}
-	}
-
 	.theme__search {
 
 		@include break-mobile {
@@ -158,6 +141,8 @@
 		}
 
 		.section-nav-tabs__dropdown {
+			min-width: 140px;
+
 			box-shadow:
 				0 0 0 0 rgba(38, 19, 19, 0.03),
 				0 1px 2px 0 rgba(38, 19, 19, 0.03),
@@ -186,6 +171,24 @@
 				background-color: rgba(var(--studio-blue-rgb), 0.1);
 			}
 		}
+	}
+
+
+	.themes__filters {
+		margin-top: 66px;
+		padding-bottom: 18px;
+	}
+
+	.themes__pattern-assembler-top-button {
+		border-width: 0;
+		box-shadow:
+			0 0 0 0 rgba(38, 19, 19, 0.03),
+			0 1px 2px 0 rgba(38, 19, 19, 0.03),
+			0 4px 4px 0 rgba(38, 19, 19, 0.03),
+			0 9px 5px 0 rgba(38, 19, 19, 0.02),
+			0 16px 6px 0 rgba(38, 19, 19, 0),
+			0 25px 7px 0 rgba(38, 19, 19, 0);
+		color: #575d63;
 	}
 }
 
@@ -257,8 +260,8 @@
 	}
 
 	.themes-toolbar-group {
-		padding-top: 15px;
 		margin: 0;
+		width: 100%;
 	}
 
 	.themes__showcase {
@@ -452,59 +455,23 @@
 	}
 }
 
-.theme__filters {
+.themes__filters {
 	align-items: center;
 	display: flex;
-	flex-direction: column;
-	flex-wrap: wrap;
-	gap: 24px;
-	justify-content: center;
-	margin-top: 24px;
-	padding: 0;
+	gap: 10px;
+	height: 40px;
+	justify-content: space-between;
+	margin: 8px 0;
+}
 
-	@include breakpoint-deprecated( ">660px" ) {
-		flex-direction: row;
-		gap: 0;
-	}
+.themes__pattern-assembler-top-button {
+	display: none;
+	flex-shrink: 0;
+	min-width: 140px;
+	padding: 8px 14px;
 
-	.themes-toolbar-group {
-		height: 28px;
-		max-width: 100%;
-		// See https://stackoverflow.com/a/66689926
-		min-width: 0;
-		flex: 1;
-	}
-
-	.segmented-control {
-		background-color: var(--studio-gray-0);
-		border-radius: 4px;
-		box-sizing: border-box;
-		height: 28px;
-		padding: 4px;
-		z-index: 1;
-
-		.segmented-control__item {
-			&.is-selected {
-				.segmented-control__link {
-					background-color: var(--color-surface);
-					box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
-					color: var(--color-neutral-100);
-				}
-			}
-
-			.segmented-control__link {
-				color: var(--color-neutral-60);
-				border: 0;
-				border-radius: 4px;
-				font-size: 0.875rem;
-				line-height: 20px;
-				padding: 0 16px;
-
-				.accessible-focus &:focus {
-					box-shadow: inset 0 0 0 2px var(--color-primary-light);
-				}
-			}
-		}
+	@include break-large {
+		display: block;
 	}
 }
 

--- a/client/my-sites/themes/themes-toolbar-group/style.scss
+++ b/client/my-sites/themes/themes-toolbar-group/style.scss
@@ -13,6 +13,10 @@
 		justify-content: space-between;
 		padding: 0;
 
+		@include break-large {
+			justify-content: flex-start;
+		}
+
 		> div {
 			&:first-of-type {
 				margin-left: 0;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #84624

## Proposed Changes

This PR adds a Design Your Own button to the Theme Showcase. This button is not visible to viewport width < 960px, since the Assembler is not available in those resolutions. Clicking the button will take users to the Assembler.

LiTS:
![Screenshot 2023-12-12 at 5 28 29 PM](https://github.com/Automattic/wp-calypso/assets/797888/6cc6cf82-bff8-4844-9b38-e16e0e522190)

LoTS:
![Screenshot 2023-12-12 at 5 28 42 PM](https://github.com/Automattic/wp-calypso/assets/797888/8bb53f5f-4a59-4776-ab10-3bfce525014b)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the logged-in Theme Showcase.
* Ensure that the button Design Your Own button is visible in viewport width >= 960px.
* Ensure that clicking the button takes users to the Assembler.
* Then head to the logged-out Theme Showcase.
* Ensure that the criteria is also fulfilled as in the logged-in Theme Showcase. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?