### PR TITLE
Replace hardcoded plan names

### DIFF
--- a/client/blocks/product-purchase-features-list/advertising-removed.jsx
+++ b/client/blocks/product-purchase-features-list/advertising-removed.jsx
@@ -1,8 +1,25 @@
-import { localize } from 'i18n-calypso';
+import { getPlan } from '@automattic/calypso-products';
+import { PLAN_BUSINESS } from '@automattic/data-stores/src/plans/constants';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
+import i18n, { localize } from 'i18n-calypso';
 import adsRemovedImage from 'calypso/assets/images/illustrations/removed-ads.svg';
 import PurchaseDetail from 'calypso/components/purchase-detail';
 
 export default localize( ( { isEligiblePlan, selectedSite, translate } ) => {
+	const isEnglishLocale = useIsEnglishLocale();
+	const uneligiblePlanDescription =
+		isEnglishLocale || i18n.hasTranslation
+			? translate(
+					'All WordPress.com advertising has been removed from your site. Upgrade to %(businessPlanName)s ' +
+						'to remove the WordPress.com footer credit.',
+					{
+						args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() },
+					}
+			  )
+			: translate(
+					'All WordPress.com advertising has been removed from your site. Upgrade to Business ' +
+						'to remove the WordPress.com footer credit.'
+			  );
 	return (
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail
@@ -13,10 +30,7 @@ export default localize( ( { isEligiblePlan, selectedSite, translate } ) => {
 						? translate(
 								'All WordPress.com advertising has been removed from your site so your brand can stand out without distractions.'
 						  )
-						: translate(
-								'All WordPress.com advertising has been removed from your site. Upgrade to Business ' +
-									'to remove the WordPress.com footer credit.'
-						  )
+						: uneligiblePlanDescription
 				}
 				buttonText={ ! isEligiblePlan ? translate( 'Upgrade to Business' ) : null }
 				href={ ! isEligiblePlan ? '/checkout/' + selectedSite.slug + '/business' : null }

--- a/client/blocks/product-purchase-features-list/advertising-removed.jsx
+++ b/client/blocks/product-purchase-features-list/advertising-removed.jsx
@@ -8,7 +8,11 @@ import PurchaseDetail from 'calypso/components/purchase-detail';
 export default localize( ( { isEligiblePlan, selectedSite, translate } ) => {
 	const isEnglishLocale = useIsEnglishLocale();
 	const uneligiblePlanDescription =
-		isEnglishLocale || i18n.hasTranslation
+		isEnglishLocale ||
+		i18n.hasTranslation(
+			'All WordPress.com advertising has been removed from your site. Upgrade to %(businessPlanName)s ' +
+				'to remove the WordPress.com footer credit.'
+		)
 			? translate(
 					'All WordPress.com advertising has been removed from your site. Upgrade to %(businessPlanName)s ' +
 						'to remove the WordPress.com footer credit.',

--- a/client/components/premium-global-styles-upgrade-modal/use-global-styles-upgrade-translations.tsx
+++ b/client/components/premium-global-styles-upgrade-modal/use-global-styles-upgrade-translations.tsx
@@ -1,5 +1,6 @@
 import { PLAN_PREMIUM, getPlan } from '@automattic/calypso-products';
-import { useTranslate } from 'i18n-calypso';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
+import i18n, { useTranslate } from 'i18n-calypso';
 
 interface Props {
 	numOfSelectedGlobalStyles?: number;
@@ -7,6 +8,7 @@ interface Props {
 
 const useGlobalStylesUpgradeTranslations = ( { numOfSelectedGlobalStyles = 1 }: Props ) => {
 	const translate = useTranslate();
+	const isEnglishLocale = useIsEnglishLocale();
 	const plan = getPlan( PLAN_PREMIUM );
 	const planTitle = plan?.getTitle() ?? '';
 	const features = [
@@ -20,7 +22,12 @@ const useGlobalStylesUpgradeTranslations = ( { numOfSelectedGlobalStyles = 1 }: 
 
 	return {
 		planTitle,
-		featuresTitle: translate( 'Included with your Premium plan' ),
+		featuresTitle:
+			isEnglishLocale || i18n.hasTranslation( 'Included with your %(planTitle)s plan' )
+				? translate( 'Included with your %(planTitle)s plan', {
+						args: { planTitle },
+				  } )
+				: translate( 'Included with your Premium plan' ),
 		features: features,
 		description: translate(
 			'You’ve selected a premium style that will only be visible to visitors after upgrading to the %(planTitle)s plan or higher.',

--- a/client/components/theme-upgrade-modal/index.tsx
+++ b/client/components/theme-upgrade-modal/index.tsx
@@ -23,7 +23,8 @@ import {
 	PLAN_PREMIUM,
 } from '@automattic/calypso-products';
 import { Button, Gridicon, Dialog, ScreenReaderText } from '@automattic/components';
-import { ProductsList, Plans } from '@automattic/data-stores';
+import { ProductsList } from '@automattic/data-stores';
+import { usePlans } from '@automattic/data-stores/src/plans';
 import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { Tooltip } from '@wordpress/components';
@@ -90,7 +91,8 @@ export const ThemeUpgradeModal = ( {
 		( select ) => select( ProductsList.store ).getProductBySlug( 'business-bundle-monthly' ),
 		[]
 	);
-	const plans = Plans.usePlans();
+	const plans = usePlans();
+
 	//Wait until we have theme and product data to show content
 	const isLoading = ! premiumPlanProduct || ! businessPlanProduct || ! theme.data;
 

--- a/client/components/theme-upgrade-modal/index.tsx
+++ b/client/components/theme-upgrade-modal/index.tsx
@@ -18,9 +18,12 @@ import {
 	FEATURE_VIDEOPRESS_JP,
 	FEATURE_WAF_V2,
 	FEATURE_WORDADS,
+	PLAN_BUSINESS,
+	PLAN_ECOMMERCE,
+	PLAN_PREMIUM,
 } from '@automattic/calypso-products';
 import { Button, Gridicon, Dialog, ScreenReaderText } from '@automattic/components';
-import { ProductsList } from '@automattic/data-stores';
+import { ProductsList, Plans } from '@automattic/data-stores';
 import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { Tooltip } from '@wordpress/components';
@@ -87,7 +90,7 @@ export const ThemeUpgradeModal = ( {
 		( select ) => select( ProductsList.store ).getProductBySlug( 'business-bundle-monthly' ),
 		[]
 	);
-
+	const plans = Plans.usePlans();
 	//Wait until we have theme and product data to show content
 	const isLoading = ! premiumPlanProduct || ! businessPlanProduct || ! theme.data;
 
@@ -102,15 +105,31 @@ export const ThemeUpgradeModal = ( {
 			),
 			text: (
 				<p>
-					{ translate(
-						'Get access to our Premium themes, and a ton of other features, with a subscription to the Premium plan. It’s {{strong}}%s{{/strong}} a year, risk-free with a 14-day money-back guarantee.',
-						{
-							components: {
-								strong: <strong />,
-							},
-							args: planPrice,
-						}
-					) }
+					{ isEnglishLocale ||
+					i18n.hasTranslation(
+						'Get access to our Premium themes, and a ton of other features, with a subscription to the %(premiumPlanName)s plan. It’s {{strong}}%(planPrice)s{{/strong}} a year, risk-free with a 14-day money-back guarantee.'
+					)
+						? translate(
+								'Get access to our Premium themes, and a ton of other features, with a subscription to the %(premiumPlanName)s plan. It’s {{strong}}%(planPrice)s{{/strong}} a year, risk-free with a 14-day money-back guarantee.',
+								{
+									components: {
+										strong: <strong />,
+									},
+									args: {
+										planPrice: planPrice || '',
+										premiumPlanName: plans.data?.[ PLAN_PREMIUM ]?.productNameShort || '',
+									},
+								}
+						  )
+						: translate(
+								'Get access to our Premium themes, and a ton of other features, with a subscription to the Premium plan. It’s {{strong}}%s{{/strong}} a year, risk-free with a 14-day money-back guarantee.',
+								{
+									components: {
+										strong: <strong />,
+									},
+									args: planPrice,
+								}
+						  ) }
 				</p>
 			),
 			price: null,
@@ -165,13 +184,27 @@ export const ThemeUpgradeModal = ( {
 			text: (
 				<p>
 					{ bundledPluginMessage }{ ' ' }
-					{ translate(
-						// translators: %s is the business plan price.
-						'Upgrade to a Business plan to select this theme and unlock all its features. It’s %s per year with a 14-day money-back guarantee.',
-						{
-							args: businessPlanPrice,
-						}
-					) }
+					{ isEnglishLocale ||
+					i18n.hasTranslation(
+						'Upgrade to a %(businessPlanName)s plan to select this theme and unlock all its features. It’s %(businessPlanPrice)s per year with a 14-day money-back guarantee.'
+					)
+						? translate(
+								// translators: %s is the business plan price.
+								'Upgrade to a %(businessPlanName)s plan to select this theme and unlock all its features. It’s %(businessPlanPrice)s per year with a 14-day money-back guarantee.',
+								{
+									args: {
+										businessPlanPrice: businessPlanPrice || '',
+										businessPlanName: plans.data?.[ PLAN_BUSINESS ]?.productNameShort || '',
+									},
+								}
+						  )
+						: translate(
+								// translators: %s is the business plan price.
+								'Upgrade to a Business plan to select this theme and unlock all its features. It’s %s per year with a 14-day money-back guarantee.',
+								{
+									args: businessPlanPrice,
+								}
+						  ) }
 				</p>
 			),
 			price: null,
@@ -217,9 +250,22 @@ export const ThemeUpgradeModal = ( {
 			text: (
 				<>
 					<p>
-						{ translate(
-							'This partner theme is only available to buy on the Business or eCommerce plans.'
-						) }
+						{ isEnglishLocale ||
+						i18n.hasTranslation(
+							'This partner theme is only available to buy on the %(businessPlanName)s or %(commercePlanName)s plans.'
+						)
+							? translate(
+									'This partner theme is only available to buy on the %(businessPlanName)s or %(commercePlanName)s plans.',
+									{
+										args: {
+											businessPlanName: plans.data?.[ PLAN_BUSINESS ]?.productNameShort || '',
+											commercePlanName: plans.data?.[ PLAN_ECOMMERCE ]?.productNameShort || '',
+										},
+									}
+							  )
+							: translate(
+									'This partner theme is only available to buy on the Business or eCommerce plans.'
+							  ) }
 					</p>
 					<div>
 						<label>
@@ -237,7 +283,15 @@ export const ThemeUpgradeModal = ( {
 							) }
 							{ isMarketplacePlanSubscriptionNeeeded && (
 								<div className="theme-upgrade-modal__price-item">
-									<label>{ translate( 'Business plan' ) }</label>
+									<label>
+										{ isEnglishLocale || i18n.hasTranslation( '%(businessPlanName)s plan' )
+											? translate( '%(businessPlanName)s plan', {
+													args: {
+														businessPlanName: plans.data?.[ PLAN_BUSINESS ]?.productNameShort || '',
+													},
+											  } )
+											: translate( 'Business plan' ) }
+									</label>
 									<label className="theme-upgrade-modal__price-value">
 										<strong>{ businessPlanPriceText }</strong>
 									</label>
@@ -318,23 +372,29 @@ export const ThemeUpgradeModal = ( {
 		modalData = getBundledFirstPartyPurchaseModalData();
 		featureList = getBundledFirstPartyPurchaseFeatureList();
 		featureListHeader =
-			isEnglishLocale || i18n.hasTranslation( 'Included with your Business plan' )
-				? translate( 'Included with your Business plan' )
-				: translate( 'Included with your purchase' );
+			isEnglishLocale || i18n.hasTranslation( 'Included with your %(businessPlanName)s plan' )
+				? translate( 'Included with your %(businessPlanName)s plan', {
+						args: { businessPlanName: plans.data?.[ PLAN_BUSINESS ]?.productNameShort || '' },
+				  } )
+				: translate( 'Included with your Business plan' );
 	} else if ( isExternallyManaged ) {
 		modalData = getExternallyManagedPurchaseModalData();
 		featureList = getExternallyManagedFeatureList();
 		featureListHeader =
-			isEnglishLocale || i18n.hasTranslation( 'Included with your Business plan' )
-				? translate( 'Included with your Business plan' )
-				: translate( 'Included with your purchase' );
+			isEnglishLocale || i18n.hasTranslation( 'Included with your %(businessPlanName)s plan' )
+				? translate( 'Included with your %(businessPlanName)s plan', {
+						args: { businessPlanName: plans.data?.[ PLAN_BUSINESS ]?.productNameShort || '' },
+				  } )
+				: translate( 'Included with your Business plan' );
 	} else {
 		modalData = getStandardPurchaseModalData();
 		featureList = getStandardPurchaseFeatureList();
 		featureListHeader =
-			isEnglishLocale || i18n.hasTranslation( 'Included with your Premium plan' )
-				? translate( 'Included with your Premium plan' )
-				: translate( 'Included with your purchase' );
+			isEnglishLocale || i18n.hasTranslation( 'Included with your %(premiumPlanName)s plan' )
+				? translate( 'Included with your %(premiumPlanName)s plan', {
+						args: { premiumPlanName: plans.data?.[ PLAN_PREMIUM ]?.productNameShort || '' },
+				  } )
+				: translate( 'Included with your Premium plan' );
 	}
 
 	const features =

--- a/client/me/security-ssh-key/security-ssh-key.tsx
+++ b/client/me/security-ssh-key/security-ssh-key.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-nested-ternary */
+import { PLAN_BUSINESS, PLAN_ECOMMERCE, getPlan } from '@automattic/calypso-products';
 import { Button, CompactCard, Dialog, LoadingPlaceholder } from '@automattic/components';
-import { localizeUrl } from '@automattic/i18n-utils';
+import { localizeUrl, useIsEnglishLocale } from '@automattic/i18n-utils';
 import styled from '@emotion/styled';
 import { createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
@@ -78,8 +79,9 @@ export const SecuritySSHKey = ( { queryParams }: SecuritySSHKeyProps ) => {
 	const [ sshKeyNameToUpdate, setSSHKeyNameToUpdate ] = useState( '' );
 	const [ oldSSHFingerprint, setOldSSHFingerprint ] = useState( '' );
 	const [ showDialog, setShowDialog ] = useState( false );
+	const isEnglishLocale = useIsEnglishLocale();
 
-	const { __ } = useI18n();
+	const { __, hasTranslation } = useI18n();
 
 	const { addSSHKey, isLoading: isAdding } = useAddSSHKeyMutation( {
 		onMutate: () => {
@@ -191,9 +193,21 @@ export const SecuritySSHKey = ( { queryParams }: SecuritySSHKeyProps ) => {
 						) }
 					</p>
 					<p>
-						{ __(
-							'Once added, attach the SSH key to a site with a Business or eCommerce plan to enable SSH key authentication for that site.'
-						) }
+						{ isEnglishLocale ||
+						hasTranslation(
+							'Once added, attach the SSH key to a site with a %1$s or %2$s plan to enable SSH key authentication for that site.'
+						)
+							? sprintf(
+									// translators: %1$s is the short-form name of the Business plan, %2$s is the short-form name of the eCommerce plan.
+									__(
+										'Once added, attach the SSH key to a site with a %1$s or %2$s plan to enable SSH key authentication for that site.'
+									),
+									getPlan( PLAN_BUSINESS )?.getTitle() || '',
+									getPlan( PLAN_ECOMMERCE )?.getTitle() || ''
+							  )
+							: __(
+									'Once added, attach the SSH key to a site with a Business or eCommerce plan to enable SSH key authentication for that site.'
+							  ) }
 					</p>
 					<p style={ isLoading || hasKeys ? { marginBlockEnd: 0 } : undefined }>
 						{ createInterpolateElement(

--- a/client/my-sites/earn/ads/wrapper.tsx
+++ b/client/my-sites/earn/ads/wrapper.tsx
@@ -3,9 +3,11 @@ import {
 	PLAN_JETPACK_SECURITY_DAILY,
 	WPCOM_FEATURES_WORDADS,
 	FEATURE_WORDADS_INSTANT,
+	getPlan,
 } from '@automattic/calypso-products';
 import { Card } from '@automattic/components';
-import { useTranslate } from 'i18n-calypso';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
+import i18n, { useTranslate } from 'i18n-calypso';
 import { ReactNode } from 'react';
 import wordAdsImage from 'calypso/assets/images/illustrations/dotcom-wordads.svg';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
@@ -62,6 +64,8 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 	const adsProgramName = useSelector( ( state ) =>
 		isJetpackSite( state, site?.ID ) ? 'Ads' : 'WordAds'
 	);
+
+	const isEnglishLocale = useIsEnglishLocale();
 
 	const canActivateWordadsInstant =
 		! site?.options?.wordads && canActivateWordAds && hasWordAdsFeature;
@@ -213,11 +217,33 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 			<UpsellNudge
 				callToAction={ translate( 'Upgrade' ) }
 				plan={ PLAN_PREMIUM }
-				title={ translate( 'Upgrade to the Premium plan and start earning' ) }
-				description={ translate(
-					"By upgrading to the Premium plan, you'll be able to monetize your site through the <a href='%(url)s'>WordAds program</>.",
-					{ args: { url: 'https://wordads.co/' } }
-				) }
+				title={
+					isEnglishLocale ||
+					i18n.hasTranslation( 'Upgrade to the %(premiumPlanName)s plan and start earning' )
+						? translate( 'Upgrade to the %(premiumPlanName)s plan and start earning', {
+								args: { premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() || '' },
+						  } )
+						: translate( 'Upgrade to the Premium plan and start earning' )
+				}
+				description={
+					isEnglishLocale ||
+					i18n.hasTranslation(
+						"By upgrading to the %(premiumPlanName)s plan, you'll be able to monetize your site through the <a href='%(url)s'>WordAds program</>."
+					)
+						? translate(
+								"By upgrading to the %(premiumPlanName)s plan, you'll be able to monetize your site through the <a href='%(url)s'>WordAds program</>.",
+								{
+									args: {
+										url: 'https://wordads.co/',
+										premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() || '',
+									},
+								}
+						  )
+						: translate(
+								"By upgrading to the Premium plan, you'll be able to monetize your site through the <a href='%(url)s'>WordAds program</>.",
+								{ args: { url: 'https://wordads.co/' } }
+						  )
+				}
 				feature={ WPCOM_FEATURES_WORDADS }
 				href={ bannerURL }
 				showIcon
@@ -280,7 +306,14 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 					forceDisplay={ true }
 					callToAction={ translate( 'Upgrade' ) }
 					plan={ PLAN_PREMIUM }
-					title={ translate( 'Upgrade to the Premium plan to continue earning' ) }
+					title={
+						isEnglishLocale ||
+						i18n.hasTranslation( 'Upgrade to the %(premiumPlanName)s plan to continue earning' )
+							? translate( 'Upgrade to the %(premiumPlanName)s plan to continue earning', {
+									args: { premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() || '' },
+							  } )
+							: translate( 'Upgrade to the Premium plan to continue earning' )
+					}
 					description={ translate(
 						'WordAds is disabled for this site because it does not have an eligible plan. You are no longer earning ad revenue, but you can view your earning and payment history. To restore access to WordAds please upgrade to an eligible plan.'
 					) }

--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -1,13 +1,16 @@
 import {
 	FEATURE_SIMPLE_PAYMENTS,
 	FEATURE_WORDADS_INSTANT,
+	PLAN_BUSINESS,
+	PLAN_ECOMMERCE,
 	PLAN_JETPACK_SECURITY_DAILY,
 	PLAN_PREMIUM,
+	getPlan,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
-import { localizeUrl } from '@automattic/i18n-utils';
+import { localizeUrl, useIsEnglishLocale } from '@automattic/i18n-utils';
 import { addQueryArgs } from '@wordpress/url';
-import { useTranslate } from 'i18n-calypso';
+import i18n, { useTranslate } from 'i18n-calypso';
 import { compact } from 'lodash';
 import { useState, useEffect } from 'react';
 import ClipboardButtonInput from 'calypso/components/clipboard-button-input';
@@ -60,6 +63,8 @@ const Home = () => {
 	const isRequestingWordAds = useSelector( ( state ) =>
 		isRequestingWordAdsApprovalForSite( state, site )
 	);
+
+	const isEnglishLocale = useIsEnglishLocale();
 
 	const hasConnectedAccount = Boolean( connectedAccountId );
 	const isNonAtomicJetpack = Boolean( isJetpack && ! isSiteTransfer );
@@ -127,9 +132,22 @@ const Home = () => {
 	};
 
 	const getPremiumPlanNames = () => {
-		const nonAtomicJetpackText = translate(
-			'Available only with a Premium, Business, or Commerce plan.'
-		);
+		const nonAtomicJetpackText =
+			isEnglishLocale ||
+			i18n.hasTranslation(
+				'Available only with a %(premiumPlanName)s, %(businessPlanName)s, or %(commercePlanName)s plan.'
+			)
+				? translate(
+						'Available only with a %(premiumPlanName)s, %(businessPlanName)s, or %(commercePlanName)s plan.',
+						{
+							args: {
+								premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() || '',
+								businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() || '',
+								commerce: getPlan( PLAN_ECOMMERCE )?.getTitle() || '',
+							},
+						}
+				  )
+				: translate( 'Available only with a Premium, Business, or Commerce plan.' );
 
 		// Space isn't included in the translatable string to prevent it being easily missed.
 		return isNonAtomicJetpack ? getAnyPlanNames() : ' ' + nonAtomicJetpackText;

--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -143,7 +143,7 @@ const Home = () => {
 							args: {
 								premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() || '',
 								businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() || '',
-								commerce: getPlan( PLAN_ECOMMERCE )?.getTitle() || '',
+								commercePlanName: getPlan( PLAN_ECOMMERCE )?.getTitle() || '',
 							},
 						}
 				  )

--- a/client/my-sites/marketing/main.jsx
+++ b/client/my-sites/marketing/main.jsx
@@ -1,5 +1,5 @@
 import config from '@automattic/calypso-config';
-import { WPCOM_FEATURES_NO_ADVERTS } from '@automattic/calypso-products';
+import { PLAN_PREMIUM, WPCOM_FEATURES_NO_ADVERTS, getPlan } from '@automattic/calypso-products';
 import i18n, { localize } from 'i18n-calypso';
 import { find } from 'lodash';
 import PropTypes from 'prop-types';
@@ -34,9 +34,12 @@ export const Sharing = ( {
 	isVip,
 	siteSlug,
 	translate,
+	premiumPlanName,
+	locale,
 } ) => {
 	const pathSuffix = siteSlug ? '/' + siteSlug : '';
 	let filters = [];
+	const isEnglishLocale = [ 'en', 'en-gb' ].includes( locale );
 
 	filters.push( {
 		id: 'marketing-tools',
@@ -158,7 +161,14 @@ export const Sharing = ( {
 					event="sharing_no_ads"
 					feature={ WPCOM_FEATURES_NO_ADVERTS }
 					description={ translate( 'Prevent ads from showing on your site.' ) }
-					title={ translate( 'No ads with WordPress.com Premium' ) }
+					title={
+						isEnglishLocale ||
+						i18n.hasTranslation( 'No ads with WordPress.com %(premiumPlanName)s' )
+							? translate( 'No ads with WordPress.com %(premiumPlanName)s', {
+									args: { premiumPlanName },
+							  } )
+							: translate( 'No ads with WordPress.com Premium' )
+					}
 					tracksImpressionName="calypso_upgrade_nudge_impression"
 					tracksClickName="calypso_upgrade_nudge_cta_click"
 					showIcon={ true }
@@ -187,6 +197,7 @@ export default connect( ( state ) => {
 	const isJetpack = isJetpackSite( state, siteId );
 	const isAtomic = isSiteWpcomAtomic( state, siteId );
 	const canManageOptions = canCurrentUser( state, siteId, 'manage_options' );
+	const premiumPlanName = getPlan( PLAN_PREMIUM )?.getTitle();
 
 	return {
 		isP2Hub: isSiteP2Hub( state, siteId ),
@@ -198,5 +209,6 @@ export default connect( ( state ) => {
 		siteId,
 		siteSlug: getSiteSlug( state, siteId ),
 		isJetpack: isJetpack,
+		premiumPlanName,
 	};
 } )( localize( Sharing ) );

--- a/client/my-sites/plugins/mailpoet-upgrade/index.tsx
+++ b/client/my-sites/plugins/mailpoet-upgrade/index.tsx
@@ -1,5 +1,7 @@
+import { PLAN_ECOMMERCE, getPlan } from '@automattic/calypso-products';
 import { Card, Button } from '@automattic/components';
-import { useTranslate } from 'i18n-calypso';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
+import i18n, { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useDispatch } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -14,6 +16,7 @@ export const MailPoetUpgradePage = ( { siteId }: { siteId: number } ) => {
 	const dispatch = useDispatch();
 	const [ isBusy, setIsBusy ] = useState( false );
 	const [ isCompleted, setIsCompleted ] = useState( false );
+	const isEnglishLocale = useIsEnglishLocale();
 
 	const getItNowClickHandler = async () => {
 		setIsBusy( true );
@@ -49,9 +52,17 @@ export const MailPoetUpgradePage = ( { siteId }: { siteId: number } ) => {
 			/>
 			<Card>
 				<p>
-					{ translate(
-						'Your Commerce plan provides a complimentary MailPoet Business subscription, allowing you to send visually appealing emails that consistently land in inboxes and cultivate a loyal subscriber base.'
-					) }
+					{ isEnglishLocale ||
+					i18n.hasTranslation(
+						'Your %(commercePlanName)s plan provides a complimentary MailPoet Business subscription, allowing you to send visually appealing emails that consistently land in inboxes and cultivate a loyal subscriber base.'
+					)
+						? translate(
+								'Your %(commercePlanName)s plan provides a complimentary MailPoet Business subscription, allowing you to send visually appealing emails that consistently land in inboxes and cultivate a loyal subscriber base.',
+								{ args: { commercePlanName: getPlan( PLAN_ECOMMERCE )?.getTitle() || '' } }
+						  )
+						: translate(
+								'Your Commerce plan provides a complimentary MailPoet Business subscription, allowing you to send visually appealing emails that consistently land in inboxes and cultivate a loyal subscriber base.'
+						  ) }
 				</p>
 				<p>
 					{ translate( 'Know more about {{a/}}', {

--- a/client/my-sites/site-settings/analytics/form-cloudflare-analytics.js
+++ b/client/my-sites/site-settings/analytics/form-cloudflare-analytics.js
@@ -3,9 +3,12 @@ import {
 	TYPE_PREMIUM,
 	FEATURE_CLOUDFLARE_ANALYTICS,
 	FEATURE_GOOGLE_ANALYTICS,
+	getPlan,
+	PLAN_PREMIUM,
 } from '@automattic/calypso-products';
 import { CompactCard, FormInputValidation as FormTextValidation } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
+import i18n from 'i18n-calypso';
 import { pick } from 'lodash';
 import { useState, useEffect } from 'react';
 import { connect } from 'react-redux';
@@ -41,6 +44,8 @@ export function CloudflareAnalyticsSettings( {
 	uniqueEventTracker,
 	showUpgradeNudge,
 	site,
+	locale,
+	premiumPlanName,
 } ) {
 	const [ isCodeValid, setIsCodeValid ] = useState( true );
 	const [ isCloudflareEnabled, setIsCloudflareEnabled ] = useState( false );
@@ -115,8 +120,14 @@ export function CloudflareAnalyticsSettings( {
 
 	const renderForm = () => {
 		const placeholderText = isRequestingSettings ? translate( 'Loading' ) : '';
+		const isEnglishLocale = [ 'en', 'en-gb' ].includes( locale );
 
-		const nudgeTitle = translate( 'Available with Premium plans or higher' );
+		const nudgeTitle =
+			isEnglishLocale || i18n.hasTranslation( 'Available with %(premiumPlanName)s plans or higher' )
+				? translate( 'Available with %(premiumPlanName)s plans or higher', {
+						args: { premiumPlanName },
+				  } )
+				: translate( 'Available with Premium plans or higher' );
 
 		const plan = findFirstSimilarPlanKey( site.plan.product_slug, {
 			type: TYPE_PREMIUM,
@@ -243,6 +254,7 @@ const mapStateToProps = ( state ) => {
 		siteIsJetpack,
 		showUpgradeNudge: ! isAnalyticsEligible,
 		enableForm: isAnalyticsEligible,
+		premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle(),
 	};
 };
 

--- a/client/my-sites/site-settings/analytics/form-google-analytics-simple.jsx
+++ b/client/my-sites/site-settings/analytics/form-google-analytics-simple.jsx
@@ -2,10 +2,13 @@ import {
 	findFirstSimilarPlanKey,
 	FEATURE_GOOGLE_ANALYTICS,
 	TYPE_PREMIUM,
+	getPlan,
+	PLAN_PREMIUM,
 } from '@automattic/calypso-products';
 import { CompactCard, FormInputValidation as FormTextValidation } from '@automattic/components';
-import { localizeUrl } from '@automattic/i18n-utils';
+import { localizeUrl, useIsEnglishLocale } from '@automattic/i18n-utils';
 import { ToggleControl } from '@wordpress/components';
+import i18n from 'i18n-calypso';
 import { useEffect } from 'react';
 import googleIllustration from 'calypso/assets/images/illustrations/google-analytics-logo.svg';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
@@ -38,9 +41,17 @@ const GoogleAnalyticsSimpleForm = ( {
 	translate,
 } ) => {
 	const analyticsSupportUrl = localizeUrl( 'https://wordpress.com/support/google-analytics/' );
-	const nudgeTitle = translate(
-		'Connect your site to Google Analytics in seconds with the Premium plan'
-	);
+	const isEnglishLocale = useIsEnglishLocale();
+	const nudgeTitle =
+		isEnglishLocale ||
+		i18n.hasTranslation(
+			'Connect your site to Google Analytics in seconds with the %(premiumPlanName)s plan'
+		)
+			? translate(
+					'Connect your site to Google Analytics in seconds with the %(premiumPlanName)s plan',
+					{ args: { premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() } }
+			  )
+			: translate( 'Connect your site to Google Analytics in seconds with the Premium plan' );
 
 	useEffect( () => {
 		if ( fields?.wga?.code ) {

--- a/client/my-sites/site-settings/cloudflare.js
+++ b/client/my-sites/site-settings/cloudflare.js
@@ -1,7 +1,14 @@
 import config from '@automattic/calypso-config';
-import { WPCOM_FEATURES_CDN, WPCOM_FEATURES_CLOUDFLARE_CDN } from '@automattic/calypso-products';
+import {
+	PLAN_BUSINESS,
+	PLAN_PREMIUM,
+	WPCOM_FEATURES_CDN,
+	WPCOM_FEATURES_CLOUDFLARE_CDN,
+	getPlan,
+} from '@automattic/calypso-products';
 import { CompactCard } from '@automattic/components';
-import { useTranslate } from 'i18n-calypso';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
+import i18n, { useTranslate } from 'i18n-calypso';
 import { useDispatch, useSelector } from 'react-redux';
 import cloudflareIllustration from 'calypso/assets/images/illustrations/cloudflare-logo-small.svg';
 import jetpackIllustration from 'calypso/assets/images/illustrations/jetpack-logo.svg';
@@ -22,6 +29,7 @@ const Cloudflare = () => {
 	const hasJetpackCDN = useSelector( ( state ) =>
 		siteHasFeature( state, siteId, WPCOM_FEATURES_CDN )
 	);
+	const isEnglishLocale = useIsEnglishLocale();
 
 	const recordClick = () => {
 		dispatch(
@@ -44,7 +52,19 @@ const Cloudflare = () => {
 									{ translate( 'Jetpack Site Accelerator' ) }
 								</p>
 								<p>
-									{ translate( 'The CDN that comes built-in with WordPress.com Business plans.' ) }
+									{ isEnglishLocale ||
+									i18n.hasTranslation(
+										'The CDN that comes built-in with WordPress.com %(businessPlanName)s plans.'
+									)
+										? translate(
+												'The CDN that comes built-in with WordPress.com %(businessPlanName)s plans.',
+												{
+													args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() },
+												}
+										  )
+										: translate(
+												'The CDN that comes built-in with WordPress.com Business plans.'
+										  ) }
 								</p>
 								<p>
 									<a
@@ -61,7 +81,14 @@ const Cloudflare = () => {
 					</CompactCard>
 					{ ! hasJetpackCDN && (
 						<UpsellNudge
-							title={ translate( 'Available on Business plan or higher' ) }
+							title={
+								isEnglishLocale ||
+								i18n.hasTranslation( 'Available on %(businessPlanName)s plan or higher' )
+									? translate( 'Available on %(businessPlanName)s plan or higher', {
+											args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() },
+									  } )
+									: translate( 'Available on Business plan or higher' )
+							}
 							feature={ WPCOM_FEATURES_CDN }
 							event="calypso_settings_cloudflare_cdn_upsell_nudge_click"
 							showIcon={ true }
@@ -97,7 +124,14 @@ const Cloudflare = () => {
 					</CompactCard>
 					{ ! hasCloudflareCDN && (
 						<UpsellNudge
-							title={ translate( 'Available with Premium plans or higher' ) }
+							title={
+								isEnglishLocale ||
+								i18n.hasTranslation( 'Available with %(premiumPlanName)s plans or higher' )
+									? translate( 'Available with %(premiumPlanName)s plans or higher', {
+											args: { premiumPlanName: getPlan( PLAN_PREMIUM ).getTitle() },
+									  } )
+									: translate( 'Available with Premium plans or higher' )
+							}
 							description={ translate(
 								'A CDN (Content Delivery Network) optimizes your content to provide users with the fastest experience.'
 							) }

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -5,6 +5,7 @@ import {
 	WPCOM_FEATURES_NO_WPCOM_BRANDING,
 	WPCOM_FEATURES_SITE_PREVIEW_LINKS,
 	FEATURE_STYLE_CUSTOMIZATION,
+	getPlan,
 } from '@automattic/calypso-products';
 import {
 	WPCOM_FEATURES_SUBSCRIPTION_GIFTING,
@@ -16,6 +17,7 @@ import { guessTimezone, localizeUrl } from '@automattic/i18n-utils';
 import languages from '@automattic/languages';
 import { ToggleControl } from '@wordpress/components';
 import classNames from 'classnames';
+import i18n from 'i18n-calypso';
 import { flowRight, get } from 'lodash';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
@@ -893,8 +895,9 @@ export class SiteSettingsFormGeneral extends Component {
 			isAtomicAndEditingToolkitDeactivated,
 			isWpcomStagingSite,
 			isUnlaunchedSite: propsisUnlaunchedSite,
+			locale,
 		} = this.props;
-
+		const isEnglishLocale = [ 'en', 'en-gb' ].includes( locale );
 		const classes = classNames( 'site-settings__general-settings', {
 			'is-loading': isRequestingSettings,
 		} );
@@ -958,9 +961,15 @@ export class SiteSettingsFormGeneral extends Component {
 							<UpsellNudge
 								feature={ WPCOM_FEATURES_NO_WPCOM_BRANDING }
 								plan={ PLAN_BUSINESS }
-								title={ translate(
-									'Remove the footer credit entirely with WordPress.com Business'
-								) }
+								title={
+									isEnglishLocale || i18n.hasTranslation
+										? translate(
+												'Remove the footer credit entirely with WordPress.com %(businessPlanName)s',
+
+												{ args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() } }
+										  )
+										: translate( 'Remove the footer credit entirely with WordPress.com Business' )
+								}
 								description={ translate(
 									'Upgrade to remove the footer credit, use advanced SEO tools and more'
 								) }

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -962,7 +962,10 @@ export class SiteSettingsFormGeneral extends Component {
 								feature={ WPCOM_FEATURES_NO_WPCOM_BRANDING }
 								plan={ PLAN_BUSINESS }
 								title={
-									isEnglishLocale || i18n.hasTranslation
+									isEnglishLocale ||
+									i18n.hasTranslation(
+										'Remove the footer credit entirely with WordPress.com %(businessPlanName)s'
+									)
 										? translate(
 												'Remove the footer credit entirely with WordPress.com %(businessPlanName)s',
 

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -1,11 +1,13 @@
 import {
 	FEATURE_ADVANCED_SEO,
 	FEATURE_SEO_PREVIEW_TOOLS,
+	PLAN_BUSINESS,
 	TYPE_BUSINESS,
 	findFirstSimilarPlanKey,
+	getPlan,
 } from '@automattic/calypso-products';
 import { Card, Button, FormInputValidation } from '@automattic/components';
-import { localize } from 'i18n-calypso';
+import i18n, { localize } from 'i18n-calypso';
 import { get, isEqual, mapValues, pickBy } from 'lodash';
 import { Component, createRef } from 'react';
 import { connect } from 'react-redux';
@@ -229,8 +231,10 @@ export class SiteSettingsFormSEO extends Component {
 			translate,
 			isFetchingSettings,
 			isSavingSettings,
+			locale,
 		} = this.props;
 		const { slug = '', URL: siteUrl = '' } = selectedSite;
+		const isEnglishLocale = [ 'en', 'en-gb' ].includes( locale );
 
 		const {
 			frontPageMetaDescription,
@@ -255,9 +259,18 @@ export class SiteSettingsFormSEO extends Component {
 						href: `/checkout/${ slug }/${ PRODUCT_UPSELLS_BY_FEATURE[ FEATURE_ADVANCED_SEO ] }`,
 				  }
 				: {
-						title: translate(
-							'Boost your search engine ranking with the powerful SEO tools in the Business plan'
-						),
+						title:
+							isEnglishLocale ||
+							i18n.hasTranslation(
+								'Boost your search engine ranking with the powerful SEO tools in the %(businessPlanName)s plan'
+							)
+								? translate(
+										'Boost your search engine ranking with the powerful SEO tools in the %(businessPlanName)s plan',
+										{ args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() } }
+								  )
+								: translate(
+										'Boost your search engine ranking with the powerful SEO tools in the Business plan'
+								  ),
 						feature: FEATURE_ADVANCED_SEO,
 						plan:
 							selectedSite.plan &&

--- a/client/my-sites/theme/hooks/use-bundle-settings.tsx
+++ b/client/my-sites/theme/hooks/use-bundle-settings.tsx
@@ -1,5 +1,7 @@
+import { PLAN_BUSINESS, getPlan } from '@automattic/calypso-products';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { ExternalLink } from '@wordpress/components';
-import { useTranslate, TranslateResult } from 'i18n-calypso';
+import i18n, { useTranslate, TranslateResult } from 'i18n-calypso';
 import { type FC, useMemo } from 'react';
 import { useSelector } from 'calypso/state';
 import { getThemeSoftwareSet } from 'calypso/state/themes/selectors';
@@ -30,6 +32,8 @@ const WooOnPlansIcon = () => (
 const useBundleSettings = ( themeId: string ): BundleSettings | null => {
 	const themeSoftwareSet = useSelector( ( state ) => getThemeSoftwareSet( state, themeId ) );
 	const translate = useTranslate();
+	const isEnglishLocale = useIsEnglishLocale();
+	const businessPlanName = getPlan( PLAN_BUSINESS )?.getTitle() || '';
 
 	const bundleSettings = useMemo( () => {
 		// Currently, it always get the first software set. In the future, the whole applications can be enhanced to support multiple ones.
@@ -44,9 +48,18 @@ const useBundleSettings = ( themeId: string ): BundleSettings | null => {
 					designPickerBadgeTooltip: translate(
 						'This theme comes bundled with WooCommerce, the best way to sell online.'
 					),
-					bannerUpsellDescription: translate(
-						'This theme comes bundled with the WooCommerce plugin. Upgrade to a Business plan to select this theme and unlock all its features.'
-					),
+					bannerUpsellDescription:
+						isEnglishLocale ||
+						i18n.hasTranslation(
+							'This theme comes bundled with the WooCommerce plugin. Upgrade to a %(businessPlanName)s plan to select this theme and unlock all its features.'
+						)
+							? translate(
+									'This theme comes bundled with the WooCommerce plugin. Upgrade to a %(businessPlanName)s plan to select this theme and unlock all its features.',
+									{ args: { businessPlanName } }
+							  )
+							: translate(
+									'This theme comes bundled with the WooCommerce plugin. Upgrade to a Business plan to select this theme and unlock all its features.'
+							  ),
 					bundledPluginMessage: translate(
 						'This theme comes bundled with {{link}}WooCommerce{{/link}} plugin.',
 						{
@@ -60,7 +73,7 @@ const useBundleSettings = ( themeId: string ): BundleSettings | null => {
 			default:
 				return null;
 		}
-	}, [ translate, themeSoftwareSet ] );
+	}, [ translate, businessPlanName, themeSoftwareSet ] );
 
 	return bundleSettings;
 };

--- a/client/my-sites/theme/hooks/use-bundle-settings.tsx
+++ b/client/my-sites/theme/hooks/use-bundle-settings.tsx
@@ -53,10 +53,10 @@ const useBundleSettings = ( themeId: string ): BundleSettings | null => {
 						i18n.hasTranslation(
 							'This theme comes bundled with the WooCommerce plugin. Upgrade to a %(businessPlanName)s plan to select this theme and unlock all its features.'
 						)
-							? translate(
+							? ( translate(
 									'This theme comes bundled with the WooCommerce plugin. Upgrade to a %(businessPlanName)s plan to select this theme and unlock all its features.',
 									{ args: { businessPlanName } }
-							  )
+							  ) as string )
 							: translate(
 									'This theme comes bundled with the WooCommerce plugin. Upgrade to a Business plan to select this theme and unlock all its features.'
 							  ),

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -1225,8 +1225,16 @@ class ThemeSheet extends Component {
 	};
 
 	getStyleVariationDescription = () => {
-		const { defaultOption, isActive, isWpcomTheme, themeId, shouldLimitGlobalStyles, translate } =
-			this.props;
+		const {
+			defaultOption,
+			isActive,
+			isWpcomTheme,
+			themeId,
+			shouldLimitGlobalStyles,
+			translate,
+			locale,
+		} = this.props;
+		const isEnglishLocale = [ 'en', 'en-gb' ].includes( locale );
 
 		if ( isActive && defaultOption.getUrl ) {
 			return translate( 'Open the {{a}}site editor{{/a}} to change your site’s style.', {
@@ -1242,7 +1250,12 @@ class ThemeSheet extends Component {
 			return;
 		}
 
-		return translate( 'Additional styles require the Business plan or higher.' );
+		return isEnglishLocale ||
+			i18n.hasTranslation( 'Additional styles require the %(businessPlanName)s plan or higher.' )
+			? translate( 'Additional styles require the %(businessPlanName)s plan or higher.', {
+					args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() },
+			  } )
+			: translate( 'Additional styles require the Business plan or higher.' );
 	};
 
 	handleAddReview = () => {
@@ -1272,6 +1285,8 @@ class ThemeSheet extends Component {
 			isThemeActivationSyncStarted,
 			isWpcomTheme,
 		} = this.props;
+
+		const isEnglishLocale = [ 'en', 'en-gb' ].includes( this.props.locale );
 
 		const analyticsPath = `/theme/${ themeId }${ section ? '/' + section : '' }${
 			siteId ? '/:site' : ''
@@ -1393,11 +1408,28 @@ class ThemeSheet extends Component {
 					plan={ PLAN_BUSINESS }
 					className="theme__page-upsell-banner"
 					onClick={ () => this.props.setProductToBeInstalled( themeId, siteSlug ) }
-					title={ translate( 'Access this third-party theme with the Business plan!' ) }
-					description={ preventWidows(
-						translate(
-							'Instantly unlock thousands of different themes and install your own when you upgrade to the Business plan.'
+					title={
+						isEnglishLocale ||
+						i18n.hasTranslation(
+							'Access this third-party theme with the %(businessPlanName)s plan!'
 						)
+							? translate( 'Access this third-party theme with the %(businessPlanName)s plan!', {
+									args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() },
+							  } )
+							: translate( 'Access this third-party theme with the Business plan!' )
+					}
+					description={ preventWidows(
+						isEnglishLocale ||
+							i18n.hasTranslation(
+								'Instantly unlock thousands of different themes and install your own when you upgrade to the %(businessPlanName)s plan.'
+							)
+							? translate(
+									'Instantly unlock thousands of different themes and install your own when you upgrade to the %(businessPlanName)s plan.',
+									{ args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() } }
+							  )
+							: translate(
+									'Instantly unlock thousands of different themes and install your own when you upgrade to the Business plan.'
+							  )
 					) }
 					forceHref
 					feature={ FEATURE_UPLOAD_THEMES }

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -7,6 +7,7 @@ import {
 	PLAN_BUSINESS,
 	PLAN_PREMIUM,
 	WPCOM_FEATURES_PREMIUM_THEMES,
+	getPlan,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button, Card, Gridicon } from '@automattic/components';
@@ -16,10 +17,10 @@ import {
 	getDesignPreviewUrl,
 	isDefaultGlobalStylesVariationSlug,
 } from '@automattic/design-picker';
-import { localizeUrl } from '@automattic/i18n-utils';
+import { localizeUrl, useIsEnglishLocale } from '@automattic/i18n-utils';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import classNames from 'classnames';
-import { localize, getLocaleSlug } from 'i18n-calypso';
+import i18n, { localize, getLocaleSlug } from 'i18n-calypso';
 import photon from 'photon';
 import PropTypes from 'prop-types';
 import { cloneElement, Component } from 'react';
@@ -128,20 +129,37 @@ const BannerUpsellDescription = ( {
 	isMarketplaceThemeSubscribed,
 } ) => {
 	const bundleSettings = useBundleSettings( themeId );
+	const isEnglishLocale = useIsEnglishLocale();
 
 	if ( isBundledSoftwareSet && ! isExternallyManagedTheme ) {
 		if ( ! bundleSettings ) {
-			return translate(
-				'This theme comes bundled with a plugin. Upgrade to a Business plan to select this theme and unlock all its features.'
-			);
+			return isEnglishLocale ||
+				i18n.hasTranslation(
+					'This theme comes bundled with a plugin. Upgrade to a %(businessPlanName)s plan to select this theme and unlock all its features.'
+				)
+				? translate(
+						'This theme comes bundled with a plugin. Upgrade to a %(businessPlanName)s plan to select this theme and unlock all its features.',
+						{ args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() } }
+				  )
+				: translate(
+						'This theme comes bundled with a plugin. Upgrade to a Business plan to select this theme and unlock all its features.'
+				  );
 		}
 
 		return bundleSettings.bannerUpsellDescription;
 	} else if ( isExternallyManagedTheme && ! isMarketplaceThemeSubscribed ) {
 		if ( ! isSiteEligibleForManagedExternalThemes ) {
-			return translate(
-				'Unlock this theme by upgrading to a Business plan and subscribing to this theme.'
-			);
+			return isEnglishLocale ||
+				i18n.hasTranslation(
+					'Unlock this theme by upgrading to a %(businessPlanName)s plan and subscribing to this theme.'
+				)
+				? translate(
+						'Unlock this theme by upgrading to a %(businessPlanName)s plan and subscribing to this theme.',
+						{ args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() } }
+				  )
+				: translate(
+						'Unlock this theme by upgrading to a Business plan and subscribing to this theme.'
+				  );
 		}
 		return translate( 'Subscribe to this theme and unlock all its features.' );
 	}
@@ -172,26 +190,55 @@ const BannerUpsellTitle = ( {
 	isMarketplaceThemeSubscribed,
 } ) => {
 	const bundleSettings = useBundleSettings( themeId );
+	const isEnglishLocale = useIsEnglishLocale();
 
 	if ( isBundledSoftwareSet && ! isExternallyManagedTheme ) {
 		if ( ! bundleSettings ) {
-			return translate( 'Access this theme with a Business plan!' );
+			return isEnglishLocale ||
+				i18n.hasTranslation( 'Access this theme with a %(businessPlanName)s plan!' )
+				? translate( 'Access this theme with a %(businessPlanName)s plan!', {
+						args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() },
+				  } )
+				: translate( 'Access this theme with a Business plan!' );
 		}
 
 		const bundleName = bundleSettings.name;
 
-		// Translators: %(bundleName)s is the name of the bundle, sometimes represented as a product name. Examples: "WooCommerce" or "Special".
-		return translate( 'Access this %(bundleName)s theme with a Business plan!', {
-			args: { bundleName },
-		} );
+		/* Translators: %(bundleName)s is the name of the bundle, sometimes represented as a product name. Examples: "WooCommerce" or "Special", %(businessPlanName) is the short-form of the Business plan name.*/
+		return isEnglishLocale ||
+			i18n.hasTranslation( 'Access this %(bundleName)s theme with a %(businessPlanName)s plan!' )
+			? translate( 'Access this %(bundleName)s theme with a %(businessPlanName)s plan!', {
+					args: { bundleName, businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() },
+			  } )
+			: translate( 'Access this %(bundleName)s theme with a Business plan!', {
+					args: { bundleName },
+			  } );
 	} else if ( isExternallyManagedTheme && ! isMarketplaceThemeSubscribed ) {
 		if ( ! isSiteEligibleForManagedExternalThemes ) {
-			return translate( 'Upgrade to a Business plan and subscribe to this theme!' );
+			return isEnglishLocale ||
+				i18n.hasTranslation( 'Upgrade to a %(businessPlanName)s plan and subscribe to this theme!' )
+				? translate( 'Upgrade to a %(businessPlanName)s plan and subscribe to this theme!', {
+						args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() },
+				  } )
+				: translate( 'Upgrade to a Business plan and subscribe to this theme!' );
 		}
 		return translate( 'Subscribe to this theme!' );
 	}
 
-	return translate( 'Access this theme for FREE with a Premium or Business plan!' );
+	return isEnglishLocale ||
+		i18n.hasTranslation(
+			'Access this theme for FREE with a %(premiumPlanName)s or %(businessPlanName)s plan!'
+		)
+		? translate(
+				'Access this theme for FREE with a %(premiumPlanName)s or %(businessPlanName)s plan!',
+				{
+					args: {
+						premiumPlanName: getPlan( PLAN_PREMIUM ).getTitle(),
+						businessPlanName: getPlan( PLAN_BUSINESS ).getTitle(),
+					},
+				}
+		  )
+		: translate( 'Access this theme for FREE with a Premium or Business plan!' );
 };
 
 class ThemeSheet extends Component {

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -7,7 +7,7 @@ import {
 } from '@automattic/calypso-products';
 import { Card, ProgressBar, Button } from '@automattic/components';
 import debugFactory from 'debug';
-import i18n, { localize } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import { includes, find, isEmpty, flowRight } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -7,7 +7,7 @@ import {
 } from '@automattic/calypso-products';
 import { Card, ProgressBar, Button } from '@automattic/components';
 import debugFactory from 'debug';
-import { localize } from 'i18n-calypso';
+import i18n, { localize } from 'i18n-calypso';
 import { includes, find, isEmpty, flowRight } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

This replaces the hardcoded plan names in multiple places so that they point to the real values. This will be needed for any upcoming plan name experiments (ex. pcNC1U-WN-p2)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow instructions from D130166-code to get assigned the experiment
* The plan mentions should show the updated plan names.

<img width="240" alt="Screenshot 2023-12-12 at 13 31 01" src="https://github.com/Automattic/wp-calypso/assets/2749938/6fad50b8-8c6f-4489-a800-bfc6e07fa2c0">
<img width="240" alt="Screenshot 2023-12-12 at 13 26 23" src="https://github.com/Automattic/wp-calypso/assets/2749938/8e40c84e-2096-4b99-8472-fad4a09f2d82">
<img width="240" alt="Screenshot 2023-12-12 at 13 20 57" src="https://github.com/Automattic/wp-calypso/assets/2749938/b17e1bd0-b53e-497d-b60a-3780a7d60a44">
<img width="240" alt="Screenshot 2023-12-12 at 13 13 46" src="https://github.com/Automattic/wp-calypso/assets/2749938/1c003c57-af7f-4771-8d42-7266a7b99f59">
<img width="240" alt="Screenshot 2023-12-12 at 12 25 19" src="https://github.com/Automattic/wp-calypso/assets/2749938/c96f861e-e884-4ed0-9e69-5ac5c84ceaf8">
<img width="240" alt="Screenshot 2023-12-12 at 12 12 22" src="https://github.com/Automattic/wp-calypso/assets/2749938/acb5cb3b-cde7-457c-bfed-8a2193203846">
<img width="240" alt="Screenshot 2023-12-12 at 11 42 59" src="https://github.com/Automattic/wp-calypso/assets/2749938/17ed07e7-d049-4a45-834c-7e640ff2bef4">
<img width="240" alt="Screenshot 2023-12-12 at 11 33 26" src="https://github.com/Automattic/wp-calypso/assets/2749938/e5143d84-fced-4bd3-84c1-cb16fdb20a4b">
<img width="240" alt="Screenshot 2023-12-12 at 11 33 02" src="https://github.com/Automattic/wp-calypso/assets/2749938/c28b9e28-e32f-4504-be95-ec5927850127">
<img width="240" alt="Screenshot 2023-12-12 at 11 23 44" src="https://github.com/Automattic/wp-calypso/assets/2749938/3fca83ae-5c2a-4856-8701-579e4d71d6d7">
<img width="240" alt="Screenshot 2023-12-12 at 14 42 03" src="https://github.com/Automattic/wp-calypso/assets/2749938/a1275ab9-e170-4f13-b895-c5152abec806">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
