### PR TITLE
We now only show the theme showcase survey on the lits

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -584,10 +584,12 @@ class ThemeShowcase extends Component {
 					isCollectionView={ isCollectionView }
 					noIndex={ isCollectionView }
 				/>
-				<ThemeShowcaseSurvey
-					survey={ SurveyType.DECEMBER_2023 }
-					condition={ () => lastNonEditorRoute.includes( 'theme/' ) }
-				/>
+				{ isLoggedIn && (
+					<ThemeShowcaseSurvey
+						survey={ SurveyType.DECEMBER_2023 }
+						condition={ () => lastNonEditorRoute.includes( 'theme/' ) }
+					/>
+				) }
 				<div className="themes__content" ref={ this.scrollRef }>
 					<QueryThemeFilters />
 					{ isSiteWooExpressOrEcomFreeTrial && (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* We now hide the Theme Showcase survey for logged out users.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso live link.
* Navigate to the LoTS.
* Click on a theme and navigate back.
* You should not see the survey banner.
* Goto the LiTS and perform the same steps.
* The survey banner should be visible.

Before:
![Captura de pantalla 2023-12-12 a las 12 32 07](https://github.com/Automattic/wp-calypso/assets/1989914/4f63a3a7-89e6-4708-91cd-a47b438e64fe)

After:
![Captura de pantalla 2023-12-12 a las 12 32 18](https://github.com/Automattic/wp-calypso/assets/1989914/09027c67-7a48-4407-97df-78bf7c764a53)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?