### PR TITLE
Design Picker: Add the New Tier Badge

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { PLAN_BUSINESS_MONTHLY, WPCOM_FEATURES_PREMIUM_THEMES } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import {
@@ -29,6 +30,7 @@ import { useQueryTheme } from 'calypso/components/data/query-theme';
 import { useQueryThemes } from 'calypso/components/data/query-themes';
 import FormattedHeader from 'calypso/components/formatted-header';
 import PremiumGlobalStylesUpgradeModal from 'calypso/components/premium-global-styles-upgrade-modal';
+import ThemeTierBadge from 'calypso/components/theme-tier/theme-tier-badge';
 import ThemeTypeBadge from 'calypso/components/theme-type-badge';
 import { ThemeUpgradeModal as UpgradeModal } from 'calypso/components/theme-upgrade-modal';
 import { ActiveTheme } from 'calypso/data/themes/use-active-theme-query';
@@ -405,15 +407,22 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		! isJetpack &&
 		( eligibility?.eligibilityHolds?.length || eligibility?.eligibilityWarnings?.length );
 
-	const getBadge = ( themeId: string, isLockedStyleVariation: boolean ) => (
-		<ThemeTypeBadge
-			canGoToCheckout={ false }
-			isLockedStyleVariation={ isLockedStyleVariation }
-			siteId={ site?.ID ?? null }
-			siteSlug={ siteSlug }
-			themeId={ themeId }
-		/>
-	);
+	const getBadge = ( themeId: string, isLockedStyleVariation: boolean ) =>
+		isEnabled( 'themes/tiers' ) ? (
+			<ThemeTierBadge
+				canGoToCheckout={ false }
+				isLockedStyleVariation={ isLockedStyleVariation }
+				themeId={ themeId }
+			/>
+		) : (
+			<ThemeTypeBadge
+				canGoToCheckout={ false }
+				isLockedStyleVariation={ isLockedStyleVariation }
+				siteId={ site?.ID ?? null }
+				siteSlug={ siteSlug }
+				themeId={ themeId }
+			/>
+		);
 
 	function upgradePlan() {
 		if ( selectedDesign ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Tracking issue: https://github.com/Automattic/dotcom-forge/issues/4597
Based on https://github.com/Automattic/wp-calypso/pull/85105

## Proposed Changes

* Add the new `ThemeTierBadge` to the Design Picker.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enable the `themes/tiers` feature flag.
* Open the Design Picker: `/setup/site-setup/designSetup?siteSlug={ SITE }`.
* Check the label and tooltip contained in the label of the following themes:
  * Podcasty: should be limited to the Premium plan.
  * Screenplay: should be limited to the Personal plan.
  * Bricksy Pro: should be limited to the Business plan, and require an additional subscription.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?