### PR TITLE
[WIP] Attempt on locking datepicker for stats

### DIFF
--- a/client/components/stats-date-control/index.tsx
+++ b/client/components/stats-date-control/index.tsx
@@ -11,7 +11,13 @@ import './style.scss';
 
 const COMPONENT_CLASS_NAME = 'stats-date-control';
 
-const StatsDateControl = ( { slug, queryParams, dateRange }: StatsDateControlProps ) => {
+const StatsDateControl = ( {
+	slug,
+	queryParams,
+	dateRange,
+	overlay,
+	disabled,
+}: StatsDateControlProps ) => {
 	// ToDo: Consider removing period from shortcuts.
 	// We could use the bestPeriodForDays() helper and keep the shortcuts
 	// consistent with the custom ranges.
@@ -141,7 +147,11 @@ const StatsDateControl = ( { slug, queryParams, dateRange }: StatsDateControlPro
 	};
 
 	return (
-		<div className={ COMPONENT_CLASS_NAME }>
+		<div
+			className={ COMPONENT_CLASS_NAME }
+			style={ { position: overlay ? 'relative' : 'initial' } }
+		>
+			{ overlay }
 			<DateControlPicker
 				buttonLabel={ getButtonLabel() }
 				dateRange={ dateRange }
@@ -149,6 +159,7 @@ const StatsDateControl = ( { slug, queryParams, dateRange }: StatsDateControlPro
 				selectedShortcut={ getShortcutForRange()?.id }
 				onShortcut={ onShortcutHandler }
 				onApply={ onApplyButtonHandler }
+				disabled={ disabled }
 			/>
 		</div>
 	);

--- a/client/components/stats-date-control/stats-date-control-picker.tsx
+++ b/client/components/stats-date-control/stats-date-control-picker.tsx
@@ -17,6 +17,7 @@ const DateControlPicker = ( {
 	selectedShortcut,
 	onShortcut,
 	onApply,
+	disabled,
 }: DateControlPickerProps ) => {
 	const moment = useLocalizedMoment();
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
@@ -84,7 +85,11 @@ const DateControlPicker = ( {
 
 	return (
 		<div className="stats-date-control-picker">
-			<Button onClick={ togglePopoverVisibility } ref={ infoReferenceElement }>
+			<Button
+				onClick={ togglePopoverVisibility }
+				ref={ infoReferenceElement }
+				disabled={ disabled }
+			>
 				{ buttonLabel }
 				<Icon className="gridicon" icon={ calendar } />
 			</Button>

--- a/client/components/stats-date-control/types.d.ts
+++ b/client/components/stats-date-control/types.d.ts
@@ -3,6 +3,8 @@ interface StatsDateControlProps {
 	queryParams: string;
 	period: 'day' | 'week' | 'month' | 'year';
 	dateRange: any;
+	overlay: JSX.Element;
+	disabled: boolean;
 }
 
 interface DateControlPickerProps {
@@ -10,6 +12,7 @@ interface DateControlPickerProps {
 	dateRange: any;
 	shortcutList: DateControlPickerShortcut[];
 	selectedShortcut: string | undefined;
+	disabled: boolean;
 	onShortcut: ( shortcut: DateControlPickerShortcut ) => void;
 	onApply: ( startDate: string, endDate: string ) => void;
 }

--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -1,4 +1,5 @@
 import page from '@automattic/calypso-router';
+import { Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { localize, withRtl } from 'i18n-calypso';
 import { flowRight } from 'lodash';
@@ -174,7 +175,24 @@ class StatsPeriodNavigation extends PureComponent {
 				<div className="stats-period-navigation__children">{ children }</div>
 				{ isWithNewDateControl ? (
 					<div className="stats-period-navigation__date-control">
-						<StatsDateControl slug={ slug } queryParams={ queryParams } dateRange={ dateRange } />
+						<StatsDateControl
+							slug={ slug }
+							queryParams={ queryParams }
+							dateRange={ dateRange }
+							overlay={
+								<div
+									style={ {
+										position: 'absolute',
+										top: -12,
+										right: -12,
+										zIndex: 1,
+									} }
+								>
+									<Gridicon icon="lock" />
+								</div>
+							}
+							disabled={ true }
+						/>
 						<div className="stats-period-navigation__period-control">
 							{ this.props.activeTab && (
 								<Legend


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

> [!WARNING]  
> This is not intended to be merged, just showing an example

Related to https://github.com/Automattic/dotcom-forge/issues/4592
Fixes https://github.com/Automattic/dotcom-forge/issues/4895

## Proposed Changes

*
![button UI](https://github.com/Automattic/wp-calypso/assets/6586048/ae8be61b-5f92-441a-9a4e-ed7eb6a634e5)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?