### PR TITLE
Import flows: Update logic for generating importer URL (unified importers)

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready-preview/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready-preview/index.tsx
@@ -2,7 +2,6 @@ import { useSelect } from '@wordpress/data';
 import React, { useEffect } from 'react';
 import { ReadyPreviewStep } from 'calypso/blocks/import/ready';
 import { Step } from 'calypso/landing/stepper/declarative-flow/internals/types';
-import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -16,8 +15,6 @@ import type { OnboardSelect } from '@automattic/data-stores';
 const ImportReadyPreview: Step = function ImportStep( props ) {
 	const { navigation } = props;
 	const siteSlug = useSiteSlugParam();
-	const site = useSite();
-	const isAtomicSite = !! site?.options?.is_automated_transfer;
 	const urlData = useSelector( getUrlData );
 	const isMigrateFromWp = useSelect(
 		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getIsMigrateFromWp(),
@@ -51,12 +48,7 @@ const ImportReadyPreview: Step = function ImportStep( props ) {
 			return;
 		}
 
-		const url = getFinalImporterUrl(
-			siteSlug as string,
-			urlData.url,
-			urlData.platform,
-			isAtomicSite
-		);
+		const url = getFinalImporterUrl( siteSlug as string, urlData.url, urlData.platform );
 
 		navigation.submit?.( { url } );
 	}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { ReadyStep } from 'calypso/blocks/import/ready';
 import { Step } from 'calypso/landing/stepper/declarative-flow/internals/types';
-import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector } from 'calypso/state';
@@ -13,8 +12,6 @@ import { getFinalImporterUrl } from '../import/helper';
 const ImportReady: Step = function ImportStep( props ) {
 	const { navigation } = props;
 	const siteSlug = useSiteSlugParam();
-	const site = useSite();
-	const isAtomicSite = !! site?.options?.is_automated_transfer;
 	const urlData = useSelector( getUrlData );
 
 	/**
@@ -29,12 +26,7 @@ const ImportReady: Step = function ImportStep( props ) {
 	 ↓ Methods
 	 */
 	const goToImporterPage = () => {
-		const url = getFinalImporterUrl(
-			siteSlug as string,
-			urlData.url,
-			urlData.platform,
-			isAtomicSite
-		);
+		const url = getFinalImporterUrl( siteSlug as string, urlData.url, urlData.platform );
 
 		navigation.submit?.( { url, platform: urlData.platform } );
 	};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
@@ -13,33 +13,24 @@ import { BASE_ROUTE } from './config';
 export function getFinalImporterUrl(
 	targetSlug: string,
 	fromSite: string,
-	platform: ImporterPlatform,
-	isAtomicSite: boolean | null
+	platform: ImporterPlatform
 ) {
 	let importerUrl;
 	const encodedFromSite = encodeURIComponent( fromSite );
-	// Escape WordPress, has two sub-flows "Import everything" and "Content only"
-	// firstly show import type chooser screen and then decide about importer url
-	if ( isAtomicSite && platform !== 'wordpress' ) {
-		importerUrl = getWpOrgImporterUrl( targetSlug, platform );
-	} else if (
-		[ 'blogger', 'medium', 'squarespace', 'wix', 'wordpress' ].some( ( targetPlatform ) => {
-			return (
-				platform === targetPlatform && isEnabled( `onboarding/import-from-${ targetPlatform }` )
-			);
-		} )
-	) {
-		importerUrl = getWpComOnboardingUrl( targetSlug, platform, encodedFromSite );
+	const productImporters = [ 'blogger', 'medium', 'substack', 'squarespace', 'wix', 'wordpress' ];
 
-		if ( platform === 'wordpress' && ! fromSite && isAtomicSite ) {
-			importerUrl = getWpOrgImporterUrl( targetSlug, platform );
-		} else if ( platform === 'wordpress' && ! fromSite ) {
+	if ( productImporters.includes( platform ) ) {
+		importerUrl = isEnabled( `onboarding/import-from-${ platform }` )
+			? getWpComOnboardingUrl( targetSlug, platform, encodedFromSite )
+			: getImporterUrl( targetSlug, platform, encodedFromSite );
+
+		if ( platform === 'wordpress' && ! fromSite ) {
 			importerUrl = addQueryArgs( importerUrl, {
 				option: WPImportOption.CONTENT_ONLY,
 			} );
 		}
 	} else {
-		importerUrl = getImporterUrl( targetSlug, platform, encodedFromSite );
+		importerUrl = getWpOrgImporterUrl( targetSlug, platform );
 	}
 
 	return importerUrl;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/85145

## Proposed Changes

* Update logic for generating importer URLs (unified importers)

Before this PR, onboarding flows for Atomic sites redirect to the old plugin importers. The unified importer's efforts allow us to have the same UX for Simple and Atomic.

## Testing Instructions

* Go to `/setup/import-focused?siteSlug={ATOMIC or SIMPLE slug}`
* Click on "choose a content platform" link
* Try different scenarios; try selecting any importer from the list
* For importers `[ 'blogger', 'medium', 'squarespace', 'wix', 'wordpress' ]`, check if redirect to the `onboarding` flow
* For importer: `[ 'substack' ]`, check if redirects to the in-product importer
* For the rest: `[ 'blogroll', 'tumblr', ... ]`, check if redirect to the `wp-admin -> plugin`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?