### PR TITLE
Domains: Simplify single site domains page.

### DIFF
--- a/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
@@ -149,7 +149,6 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 									hasDomainCredit={ !! hasDomainCredit }
 									isCompact={ hasNonWpcomDomains }
 									hasNonWpcomDomains={ hasNonWpcomDomains }
-									showIllustration={ false }
 								/>
 							) }
 							{ showManageAllDomainsCTA && (

--- a/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
@@ -82,6 +82,10 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 	const [ changeSiteAddressSourceDomain, setChangeSiteAddressSourceDomain ] =
 		useState< ResponseDomain | null >( null );
 
+	// If a site contains more than one domain that is not a subdomain.
+	const showManageAllDomainsCTA =
+		( data?.domains ?? [] ).filter( ( domain ) => ! domain.is_subdomain ).length > 1;
+
 	return (
 		<>
 			<PageViewTracker path={ props.analyticsPath } title={ props.analyticsTitle } />
@@ -147,7 +151,9 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 									hasNonWpcomDomains={ hasNonWpcomDomains }
 								/>
 							) }
-							<ManageAllDomainsCTA shouldDisplaySeparator={ false } />
+							{ showManageAllDomainsCTA && (
+								<ManageAllDomainsCTA shouldDisplaySeparator={ false } />
+							) }
 						</>
 					}
 					fetchAllDomains={ fetchAllDomains }

--- a/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
@@ -149,6 +149,7 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 									hasDomainCredit={ !! hasDomainCredit }
 									isCompact={ hasNonWpcomDomains }
 									hasNonWpcomDomains={ hasNonWpcomDomains }
+									showIllustration={ false }
 								/>
 							) }
 							{ showManageAllDomainsCTA && (

--- a/client/my-sites/domains/domain-management/list/empty-domains-list-card-skeleton.tsx
+++ b/client/my-sites/domains/domain-management/list/empty-domains-list-card-skeleton.tsx
@@ -1,6 +1,5 @@
 import { Card, Button } from '@automattic/components';
 import classNames from 'classnames';
-import customerHomeIllustrationTaskFindDomain from 'calypso/assets/images/domains/free-domain.svg';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -16,7 +15,6 @@ interface EmptyDomainsListCardSkeletonProps {
 	action: string;
 	secondaryActionURL: string;
 	secondaryAction: string;
-	showIllustration?: boolean;
 }
 
 export const EmptyDomainsListCardSkeleton = ( {
@@ -30,7 +28,6 @@ export const EmptyDomainsListCardSkeleton = ( {
 	action,
 	secondaryActionURL,
 	secondaryAction,
-	showIllustration = true,
 }: EmptyDomainsListCardSkeletonProps ) => {
 	const dispatch = useDispatch();
 
@@ -45,10 +42,6 @@ export const EmptyDomainsListCardSkeleton = ( {
 			);
 		};
 
-	const illustration = customerHomeIllustrationTaskFindDomain && (
-		<img src={ customerHomeIllustrationTaskFindDomain } alt="" width={ 150 } />
-	);
-
 	return (
 		<Card className={ classNames( 'empty-domains-list-card', className ) }>
 			<div
@@ -57,9 +50,6 @@ export const EmptyDomainsListCardSkeleton = ( {
 					'has-title-only': title && ! line,
 				} ) }
 			>
-				{ showIllustration && (
-					<div className="empty-domains-list-card__illustration">{ illustration }</div>
-				) }
 				<div className="empty-domains-list-card__content">
 					<div className="empty-domains-list-card__text">
 						{ title ? <h2>{ title }</h2> : null }

--- a/client/my-sites/domains/domain-management/list/empty-domains-list-card-skeleton.tsx
+++ b/client/my-sites/domains/domain-management/list/empty-domains-list-card-skeleton.tsx
@@ -16,6 +16,7 @@ interface EmptyDomainsListCardSkeletonProps {
 	action: string;
 	secondaryActionURL: string;
 	secondaryAction: string;
+	showIllustration?: boolean;
 }
 
 export const EmptyDomainsListCardSkeleton = ( {
@@ -29,6 +30,7 @@ export const EmptyDomainsListCardSkeleton = ( {
 	action,
 	secondaryActionURL,
 	secondaryAction,
+	showIllustration = true,
 }: EmptyDomainsListCardSkeletonProps ) => {
 	const dispatch = useDispatch();
 
@@ -55,7 +57,9 @@ export const EmptyDomainsListCardSkeleton = ( {
 					'has-title-only': title && ! line,
 				} ) }
 			>
-				<div className="empty-domains-list-card__illustration">{ illustration }</div>
+				{ showIllustration && (
+					<div className="empty-domains-list-card__illustration">{ illustration }</div>
+				) }
 				<div className="empty-domains-list-card__content">
 					<div className="empty-domains-list-card__text">
 						{ title ? <h2>{ title }</h2> : null }

--- a/client/my-sites/domains/domain-management/list/empty-domains-list-card.jsx
+++ b/client/my-sites/domains/domain-management/list/empty-domains-list-card.jsx
@@ -11,13 +11,7 @@ import { EmptyDomainsListCardSkeleton } from './empty-domains-list-card-skeleton
 
 import './empty-domains-list-card-styles.scss';
 
-function EmptyDomainsListCard( {
-	selectedSite,
-	hasDomainCredit,
-	isCompact,
-	hasNonWpcomDomains,
-	showIllustration = true,
-} ) {
+function EmptyDomainsListCard( { selectedSite, hasDomainCredit, isCompact, hasNonWpcomDomains } ) {
 	const translate = useTranslate();
 	const hasEnTranslation = useHasEnTranslation();
 
@@ -101,7 +95,6 @@ function EmptyDomainsListCard( {
 				actionURL={ actionURL }
 				secondaryAction={ secondaryAction }
 				secondaryActionURL={ secondaryActionURL }
-				showIllustration={ showIllustration }
 			/>
 		</>
 	);
@@ -114,7 +107,6 @@ EmptyDomainsListCard.propTypes = {
 	domains: PropTypes.array,
 	dispatchRecordTracksEvent: PropTypes.func,
 	hasNonWpcomDomains: PropTypes.bool,
-	showIllustration: PropTypes.bool,
 };
 
 export default EmptyDomainsListCard;

--- a/client/my-sites/domains/domain-management/list/empty-domains-list-card.jsx
+++ b/client/my-sites/domains/domain-management/list/empty-domains-list-card.jsx
@@ -11,7 +11,13 @@ import { EmptyDomainsListCardSkeleton } from './empty-domains-list-card-skeleton
 
 import './empty-domains-list-card-styles.scss';
 
-function EmptyDomainsListCard( { selectedSite, hasDomainCredit, isCompact, hasNonWpcomDomains } ) {
+function EmptyDomainsListCard( {
+	selectedSite,
+	hasDomainCredit,
+	isCompact,
+	hasNonWpcomDomains,
+	showIllustration = true,
+} ) {
 	const translate = useTranslate();
 	const hasEnTranslation = useHasEnTranslation();
 
@@ -95,6 +101,7 @@ function EmptyDomainsListCard( { selectedSite, hasDomainCredit, isCompact, hasNo
 				actionURL={ actionURL }
 				secondaryAction={ secondaryAction }
 				secondaryActionURL={ secondaryActionURL }
+				showIllustration={ showIllustration }
 			/>
 		</>
 	);
@@ -107,6 +114,7 @@ EmptyDomainsListCard.propTypes = {
 	domains: PropTypes.array,
 	dispatchRecordTracksEvent: PropTypes.func,
 	hasNonWpcomDomains: PropTypes.bool,
+	showIllustration: PropTypes.bool,
 };
 
 export default EmptyDomainsListCard;

--- a/client/my-sites/domains/domain-management/list/empty-domains-list-card.jsx
+++ b/client/my-sites/domains/domain-management/list/empty-domains-list-card.jsx
@@ -1,7 +1,7 @@
 import { PLAN_100_YEARS, domainProductSlugs, isFreePlan } from '@automattic/calypso-products';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
 import classNames from 'classnames';
-import { useTranslate } from 'i18n-calypso';
+import { useTranslate, hasTranslation } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import { domainAddNew, domainUseMyDomain } from 'calypso/my-sites/domains/paths';
@@ -20,7 +20,9 @@ function EmptyDomainsListCard( { selectedSite, hasDomainCredit, isCompact, hasNo
 
 	const siteHasHundredYearPlan = selectedSite?.plan?.product_slug === PLAN_100_YEARS;
 
-	let title = translate( 'Get your free domain' );
+	let title = hasTranslation( 'Get your free domain' )
+		? translate( 'Get your free domain' )
+		: translate( 'Get your domain' );
 	let line = translate(
 		'Get a free one-year domain registration or transfer with any annual paid plan.'
 	);

--- a/client/my-sites/domains/domain-management/list/empty-domains-list-card.jsx
+++ b/client/my-sites/domains/domain-management/list/empty-domains-list-card.jsx
@@ -20,7 +20,7 @@ function EmptyDomainsListCard( { selectedSite, hasDomainCredit, isCompact, hasNo
 
 	const siteHasHundredYearPlan = selectedSite?.plan?.product_slug === PLAN_100_YEARS;
 
-	let title = translate( 'Get your domain' );
+	let title = translate( 'Get your free domain' );
 	let line = translate(
 		'Get a free one-year domain registration or transfer with any annual paid plan.'
 	);

--- a/client/my-sites/domains/domain-management/list/empty-domains-list-card.jsx
+++ b/client/my-sites/domains/domain-management/list/empty-domains-list-card.jsx
@@ -1,7 +1,7 @@
 import { PLAN_100_YEARS, domainProductSlugs, isFreePlan } from '@automattic/calypso-products';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
 import classNames from 'classnames';
-import { useTranslate, hasTranslation } from 'i18n-calypso';
+import i18n, { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import { domainAddNew, domainUseMyDomain } from 'calypso/my-sites/domains/paths';
@@ -20,7 +20,7 @@ function EmptyDomainsListCard( { selectedSite, hasDomainCredit, isCompact, hasNo
 
 	const siteHasHundredYearPlan = selectedSite?.plan?.product_slug === PLAN_100_YEARS;
 
-	let title = hasTranslation( 'Get your free domain' )
+	let title = i18n.hasTranslation( 'Get your free domain' )
 		? translate( 'Get your free domain' )
 		: translate( 'Get your domain' );
 	let line = translate(

--- a/packages/domains-table/src/domains-table/domains-table.tsx
+++ b/packages/domains-table/src/domains-table/domains-table.tsx
@@ -304,9 +304,8 @@ export const useGenerateDomainsTableState = ( props: DomainsTableProps ) => {
 	const selectableDomains = ( domains ?? [] ).filter( canBulkUpdate );
 	const canSelectAnyDomains = isAllSitesView
 		? selectableDomains.length > 0
-		: domains &&
-		  ( domains as unknown as DomainData[] ).filter( ( domain ) => ! domain.is_subdomain ).length >
-				1;
+		: ( ( domains as unknown as DomainData[] ) ?? [] ).filter( ( domain ) => ! domain.is_subdomain )
+				.length > 1;
 	const areAllDomainsSelected = selectableDomains.length === selectedDomains.size;
 
 	const getBulkSelectionStatus = () => {

--- a/packages/domains-table/src/domains-table/domains-table.tsx
+++ b/packages/domains-table/src/domains-table/domains-table.tsx
@@ -47,7 +47,7 @@ type OnDomainAction = (
 ) => DomainActionDescription | void;
 
 interface BaseDomainsTableProps {
-	domains: PartialDomainData[] | undefined;
+	domains: PartialDomainData[] | DomainData[] | undefined;
 	isAllSitesView: boolean;
 	domainStatusPurchaseActions?: DomainStatusPurchaseActions;
 	onDomainAction?: OnDomainAction;
@@ -302,7 +302,11 @@ export const useGenerateDomainsTableState = ( props: DomainsTableProps ) => {
 
 	const hasSelectedDomains = selectedDomains.size > 0;
 	const selectableDomains = ( domains ?? [] ).filter( canBulkUpdate );
-	const canSelectAnyDomains = selectableDomains.length > 0;
+	const canSelectAnyDomains = isAllSitesView
+		? selectableDomains.length > 0
+		: domains &&
+		  ( domains as unknown as DomainData[] ).filter( ( domain ) => ! domain.is_subdomain ).length >
+				1;
 	const areAllDomainsSelected = selectableDomains.length === selectedDomains.size;
 
 	const getBulkSelectionStatus = () => {

--- a/packages/domains-table/src/domains-table/index.tsx
+++ b/packages/domains-table/src/domains-table/index.tsx
@@ -1,3 +1,4 @@
+import { DomainData } from '@automattic/data-stores';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import classnames from 'classnames';
 import { ReactNode } from 'react';
@@ -19,11 +20,20 @@ export function DomainsTable( props: DomainsTableProps & { footer?: ReactNode } 
 
 	const state = useGenerateDomainsTableState( allProps );
 
+	const { isAllSitesView, domains } = props;
+
+	const showDomainsToolbar =
+		isAllSitesView ||
+		( ! isAllSitesView &&
+			( ( domains as unknown as DomainData[] ) ?? [] ).filter(
+				( domain ) => ! domain?.is_subdomain
+			).length > 1 );
+
 	return (
 		<DomainsTableStateContext.Provider value={ state }>
 			<div className="domains-table">
 				<DomainsTableBulkUpdateNotice />
-				<DomainsTableToolbar />
+				{ showDomainsToolbar && <DomainsTableToolbar /> }
 				{ isMobile ? (
 					<DomainsTableMobileCards />
 				) : (


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/84992

## Proposed Changes

On single site domains page:
 - Don't show search field if there's only one domain _(subdomains not part of it)_.
 - Don't show checkbox column if site has only one domain _(subdomains not part of it)_.
 - Don't show Manage All Domains CTA if the user has only one domain _(subdomains not part of it)_.
 - Update the "Get your domain" in Get Your Free Domain CTA to "Get your free domain".
 - Remove illustration on Get Your Free Domain CTA.

## Testing Instructions

**Using the link `/domains/manage/your-test-site.wordpress.com`:**
* On a simple site that has a subdomain, it should match all of the above proposed changes.
* On a simple site that has a subdomain and a domain, it should match all of the above proposed changes.
* On a simple site that has a subdomain and 2 domains and above, it should only match the last 2 proposed changes above.

**Test regression at `/domains/manage`:**
* There should be no regressions on the All Domains page.

## Screenshot

| Before | After |
| --- | --- |
| <img width="1726" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1287077/2192bb52-df5d-40de-9e31-389bb9e24ba2"> | <img width="1726" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1287077/32a384ed-dc96-4c74-9c26-ff61d31b29ef"> |
| <img width="1726" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1287077/08a8a833-8697-4294-8ecc-7a7173de8cbe"> | <img width="1726" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1287077/ee036537-ebbf-4390-8439-ef2bbede93c3"> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?