### PR TITLE
GF Signup: Mobile sticky for dropdown and other cosmetic fixes and refactors

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -243,6 +243,8 @@ const PlansFeaturesMain = ( {
 	isSpotlightOnCurrentPlan,
 	renderSiblingWhenLoaded,
 }: PlansFeaturesMainProps ) => {
+	const isVariant = config.isEnabled( 'onboarding/interval-dropdown' );
+
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const [ lastClickedPlan, setLastClickedPlan ] = useState< string | null >( null );
 	const [ showPlansComparisonGrid, setShowPlansComparisonGrid ] = useState( false );
@@ -824,7 +826,10 @@ const PlansFeaturesMain = ( {
 					<>
 						{ ! hidePlanSelector && (
 							<div className="plans-features-main__plan-type-selector">
-								<PlanTypeSelector { ...planTypeSelectorProps } />
+								<PlanTypeSelector
+									{ ...planTypeSelectorProps }
+									isDropDownExperimentActive={ true }
+								/>
 							</div>
 						) }
 						<div
@@ -897,7 +902,10 @@ const PlansFeaturesMain = ( {
 											</PlanComparisonHeader>
 											{ ! hidePlanSelector && showPlansComparisonGrid && (
 												<div className="plans-features-main__plan-type-selector">
-													<PlanTypeSelector { ...planTypeSelectorProps } />
+													<PlanTypeSelector
+														{ ...planTypeSelectorProps }
+														isDropDownExperimentActive={ isVariant }
+													/>
 												</div>
 											) }
 											<ComparisonGrid
@@ -922,6 +930,7 @@ const PlansFeaturesMain = ( {
 												planTypeSelectorProps={
 													! hidePlanSelector ? planTypeSelectorProps : undefined
 												}
+												isDropDownExperimentActive={ isVariant }
 											/>
 											<ComparisonGridToggle
 												onClick={ toggleShowPlansComparisonGrid }

--- a/client/my-sites/plans-grid/components/comparison-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/comparison-grid/index.tsx
@@ -10,6 +10,7 @@ import {
 	getPlans,
 } from '@automattic/calypso-products';
 import { Gridicon, JetpackLogo } from '@automattic/components';
+import { isMobile } from '@automattic/viewport';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useMemo } from '@wordpress/element';
@@ -971,6 +972,7 @@ const ComparisonGrid = ( {
 	onStorageAddOnClick,
 	showRefundPeriod,
 	planTypeSelectorProps,
+	isDropDownExperimentActive,
 }: ComparisonGridProps ) => {
 	const { gridPlans } = usePlansGridContext();
 	const [ activeTooltipId, setActiveTooltipId ] = useManageTooltipToggle();
@@ -1099,8 +1101,10 @@ const ComparisonGrid = ( {
 			<Grid isInSignup={ isInSignup }>
 				<StickyContainer
 					disabled={ isBottomHeaderInView }
-					stickyClass="is-sticky-header-row"
-					stickyOffset={ stickyRowOffset }
+					stickyClass="is-sticky-header-row plan-comparison-header-sticky-container"
+					stickyOffset={
+						isDropDownExperimentActive && isMobile() ? stickyRowOffset + 48 : stickyRowOffset
+					}
 				>
 					{ ( isStuck: boolean ) => (
 						<ComparisonGridHeader

--- a/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-dropdown.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-dropdown.tsx
@@ -14,9 +14,10 @@ const AddOnOption = styled.a`
 	.discount {
 		color: var( --studio-green-40 );
 		display: inline-block;
-		font-size: 0.7rem;
+		font-size: 14px;
 	}
 	.name {
+		font-size: 14px;
 		margin-right: 4px;
 	}
 `;
@@ -28,10 +29,38 @@ const StyledCustomSelectControl = styled( CustomSelectControl )`
 		color: var( --color-text );
 	}
 	.components-custom-select-control__button {
-		min-width: 225px;
+		min-width: 246px;
 	}
 	.components-custom-select-control__menu {
 		margin: 0;
+		z-index: 3;
+	}
+	div.components-input-control__backdrop.components-input-control__backdrop.components-input-control__backdrop.components-input-control__backdrop {
+		border: 1px solid var( --studio-gray-10 );
+	}
+
+	.components-input-control__container {
+		padding: 8px;
+	}
+`;
+
+const FixedCustomSelectControl = styled( CustomSelectControl )`
+	.components-flex {
+		position: fixed;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 48px;
+		z-index: 2;
+	}
+
+	.components-custom-select-control__menu {
+		position: fixed;
+		left: 0;
+		top: 47px;
+		width: 100%;
+		margin: 0;
+		z-index: 3;
 	}
 `;
 
@@ -39,7 +68,7 @@ export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > 
 	const { intervalType } = props;
 	const dropdownRef = useRef( null );
 	const [ isMobileState, setIsMobileState ] = useState( isMobile() );
-	const [ isDropdownVisible, setIsDropdownVisible ] = useState( true );
+	const [ isDropDownFixed, setIsDropDownFixed ] = useState( false );
 
 	const supportedIntervalType = (
 		[ 'yearly', '2yearly', '3yearly', 'monthly' ].includes( intervalType ) ? intervalType : 'yearly'
@@ -70,11 +99,17 @@ export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > 
 		}
 		const observer = new IntersectionObserver(
 			( [ entry ] ) => {
-				if ( entry.intersectionRatio === 1 ) {
-					setIsDropdownVisible( true );
+				if ( ! isMobileState ) {
+					if ( isDropDownFixed ) {
+						setIsDropDownFixed( false );
+					}
 					return;
 				}
-				setIsDropdownVisible( false );
+				if ( entry.intersectionRatio === 1 ) {
+					setIsDropDownFixed( false );
+					return;
+				}
+				setIsDropDownFixed( true );
 			},
 			{
 				rootMargin: `-${ 0 + 1 }px 0px 0px 0px`,
@@ -89,19 +124,28 @@ export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > 
 		return () => {
 			observer.disconnect();
 		};
-	}, [] );
+	}, [ isDropDownFixed, isMobileState ] );
 
 	return (
-		<div
-			className={ `${ isDropdownVisible }_${ isMobileState }` }
-			style={ { visibility: isDropdownVisible ? 'visible' : 'hidden' } }
-			ref={ dropdownRef }
-		>
-			<StyledCustomSelectControl
-				label=""
-				options={ selectOptionsList }
-				value={ selectOptionsList.find( ( { key } ) => key === supportedIntervalType ) }
-			/>
-		</div>
+		<>
+			<div className={ `${ isDropDownFixed }_${ isMobileState }` } ref={ dropdownRef }>
+				{ ! isDropDownFixed && (
+					<StyledCustomSelectControl
+						isDropDownFixed={ isDropDownFixed }
+						label=""
+						options={ selectOptionsList }
+						value={ selectOptionsList.find( ( { key } ) => key === supportedIntervalType ) }
+					/>
+				) }
+			</div>
+			{ isDropDownFixed && (
+				<FixedCustomSelectControl
+					isDropDownFixed={ isDropDownFixed }
+					label=""
+					options={ selectOptionsList }
+					value={ selectOptionsList.find( ( { key } ) => key === supportedIntervalType ) }
+				/>
+			) }
+		</>
 	);
 };

--- a/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-dropdown.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-dropdown.tsx
@@ -44,7 +44,7 @@ const StyledCustomSelectControl = styled( CustomSelectControl )`
 	}
 `;
 
-const FixedCustomSelectControl = styled( CustomSelectControl )`
+const StickyDropdown = styled( CustomSelectControl )`
 	.components-flex {
 		position: fixed;
 		top: 0;
@@ -61,6 +61,12 @@ const FixedCustomSelectControl = styled( CustomSelectControl )`
 		width: 100%;
 		margin: 0;
 		z-index: 3;
+
+		border: 1px solid #e0e0e0;
+	}
+	.components-input-control__backdrop.components-input-control__backdrop.components-input-control__backdrop.components-input-control__backdrop {
+		border: none;
+		border-bottom: 1px solid #e0e0e0;
 	}
 `;
 
@@ -68,7 +74,7 @@ export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > 
 	const { intervalType } = props;
 	const dropdownRef = useRef( null );
 	const [ isMobileState, setIsMobileState ] = useState( isMobile() );
-	const [ isDropDownFixed, setIsDropDownFixed ] = useState( false );
+	const [ isStickyDropdownVisible, setIsStickyDropdownVisible ] = useState( false );
 
 	const supportedIntervalType = (
 		[ 'yearly', '2yearly', '3yearly', 'monthly' ].includes( intervalType ) ? intervalType : 'yearly'
@@ -83,7 +89,7 @@ export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > 
 			</AddOnOption>
 		),
 	} ) );
-
+	setIsStickyDropdownVisible;
 	useLayoutEffect( () => {
 		const onResize = () => {
 			setIsMobileState( isMobile() );
@@ -100,16 +106,22 @@ export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > 
 		const observer = new IntersectionObserver(
 			( [ entry ] ) => {
 				if ( ! isMobileState ) {
-					if ( isDropDownFixed ) {
-						setIsDropDownFixed( false );
+					// If the viewport is mobile, the sticky dropdown will be disabled
+					if ( isStickyDropdownVisible ) {
+						setIsStickyDropdownVisible( false );
 					}
 					return;
 				}
 				if ( entry.intersectionRatio === 1 ) {
-					setIsDropDownFixed( false );
+					// If the original dropdown is fully visible in the viewport, the sticky dropdown will be hidden
+					setIsStickyDropdownVisible( false );
+					return;
+				} else if ( entry.boundingClientRect.top > 0 ) {
+					// If the original dropdown is below the viewport, the sticky dropdown will be hidden
+					setIsStickyDropdownVisible( false );
 					return;
 				}
-				setIsDropDownFixed( true );
+				setIsStickyDropdownVisible( true );
 			},
 			{
 				rootMargin: `-${ 0 + 1 }px 0px 0px 0px`,
@@ -124,23 +136,23 @@ export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > 
 		return () => {
 			observer.disconnect();
 		};
-	}, [ isDropDownFixed, isMobileState ] );
+	}, [ isStickyDropdownVisible, isMobileState ] );
 
 	return (
 		<>
-			<div className={ `${ isDropDownFixed }_${ isMobileState }` } ref={ dropdownRef }>
-				{ ! isDropDownFixed && (
+			<div className={ `${ isStickyDropdownVisible }_${ isMobileState }` } ref={ dropdownRef }>
+				{ ! isStickyDropdownVisible && (
 					<StyledCustomSelectControl
-						isDropDownFixed={ isDropDownFixed }
+						isStickyDropdownVisible={ isStickyDropdownVisible }
 						label=""
 						options={ selectOptionsList }
 						value={ selectOptionsList.find( ( { key } ) => key === supportedIntervalType ) }
 					/>
 				) }
 			</div>
-			{ isDropDownFixed && (
-				<FixedCustomSelectControl
-					isDropDownFixed={ isDropDownFixed }
+			{ isStickyDropdownVisible && (
+				<StickyDropdown
+					isStickyDropdownVisible={ isStickyDropdownVisible }
 					label=""
 					options={ selectOptionsList }
 					value={ selectOptionsList.find( ( { key } ) => key === supportedIntervalType ) }

--- a/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-selector.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-selector.tsx
@@ -1,10 +1,11 @@
-import config from '@automattic/calypso-config';
 import { IntervalTypeProps } from '../types';
 import { IntervalTypeDropdown } from './interval-type-dropdown';
 import { IntervalTypeToggle } from './interval-type-toggle';
 
 export const IntervalTypeSelector: React.FunctionComponent< IntervalTypeProps > = ( props ) => {
-	const isVariant = config.isEnabled( 'onboarding/interval-dropdown' );
-
-	return isVariant ? <IntervalTypeDropdown { ...props } /> : <IntervalTypeToggle { ...props } />;
+	return props.isDropDownExperimentActive ? (
+		<IntervalTypeDropdown { ...props } />
+	) : (
+		<IntervalTypeToggle { ...props } />
+	);
 };

--- a/client/my-sites/plans-grid/components/plan-type-selector/types.ts
+++ b/client/my-sites/plans-grid/components/plan-type-selector/types.ts
@@ -26,6 +26,7 @@ export type PlanTypeSelectorProps = {
 	 * Whether to render the selector along with a title if passed.
 	 */
 	title?: TranslateResult;
+	isDropDownExperimentActive?: boolean;
 };
 export type IntervalTypeProps = Pick<
 	PlanTypeSelectorProps,
@@ -42,6 +43,7 @@ export type IntervalTypeProps = Pick<
 	| 'currentSitePlanSlug'
 	| 'usePricingMetaForGridPlans'
 	| 'title'
+	| 'isDropDownExperimentActive'
 >;
 
 export type SupportedUrlFriendlyTermType = Extract<

--- a/client/my-sites/plans-grid/types.ts
+++ b/client/my-sites/plans-grid/types.ts
@@ -75,6 +75,7 @@ export interface FeaturesGridProps extends CommonGridProps {
 export interface ComparisonGridProps extends CommonGridProps {
 	// Value of the `?plan=` query param, so we can highlight a given plan.
 	selectedPlan?: string;
+	isDropDownExperimentActive?: boolean;
 }
 
 export type GridContextProps = {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
- Related https://github.com/Automattic/growth-foundations/issues/296

## Proposed Changes

- Introduces the a sticky dropdown for mobile based screens
- Externalises the config flag as an external prop to the grid
- Fix styling issues 


https://github.com/Automattic/wp-calypso/assets/3422709/5eebca67-8bca-4d2b-a197-60da6ef475b7



*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?