### PR TITLE
Improving "Change your address" popup in domain management screen

### DIFF
--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -4,6 +4,7 @@ import { debounce, get, isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import Banner from 'calypso/components/banner';
 import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormSectionHeading from 'calypso/components/forms/form-section-heading';
@@ -258,13 +259,13 @@ export class SiteAddressChanger extends Component {
 			: validationMessage || serverValidationMessage;
 	}
 
-	resendConfirmationLink() {
+	resendConfirmationLink = () => {
 		const { sendVerifyEmail } = this.props;
 		sendVerifyEmail();
 		this.setState( {
 			confirmEmailSent: 1,
 		} );
-	}
+	};
 
 	getConfirmEmailMessage() {
 		return this.state.confirmEmailSent
@@ -414,43 +415,31 @@ export class SiteAddressChanger extends Component {
 					eventName="calypso_siteaddresschange_form_view"
 					eventProperties={ { blog_id: siteId } }
 				/>
+				{ ! isEmailVerified && (
+					<Banner
+						title=""
+						className="site-address-changer__email-confirmation-banner"
+						callToAction={ ! confirmEmailSent ? translate( 'Resend email' ) : null }
+						description={ confirmEmailMessage }
+						icon="info-outline"
+						onClick={ ! confirmEmailSent ? this.resendConfirmationLink : null }
+						disableHref
+					/>
+				) }
 				<FormSectionHeading>
 					<strong>{ translate( 'Change your site address' ) }</strong>
 				</FormSectionHeading>
 				<div className="site-address-changer__info">
 					<p>
-						{ hasNonWpcomDomains
-							? translate(
-									'Once you change your site address, %(currentDomainName)s will no longer be available.',
-									{
-										args: { currentDomainName },
-									}
-							  )
-							: translate(
-									'Once you change your site address, %(currentDomainName)s will no longer be available. {{a}}Did you want to add a custom domain instead?{{/a}}',
-									{
-										args: { currentDomainName },
-										components: {
-											a: <a href={ addDomainPath } onClick={ this.handleAddDomainClick } />,
-										},
-									}
-							  ) }
+						{ translate(
+							'Once you change your site address, %(currentDomainName)s will no longer be available.',
+							{
+								args: { currentDomainName },
+							}
+						) }
 					</p>
 				</div>
 				<div className="site-address-changer__details">
-					<FormInputValidation
-						isHidden={ isEmailVerified }
-						isError={ true }
-						text={ confirmEmailMessage || '\u00A0' }
-						className={ `email-not-verified ${ confirmEmailSent ? 'already-sent' : '' }` }
-					/>
-					{ ! isEmailVerified && ! confirmEmailSent && (
-						<div className="site-address-changer__resend-email-link">
-							<button onClick={ () => this.resendConfirmationLink() }>
-								{ translate( 'Click here to receive another confirmation email' ) }
-							</button>
-						</div>
-					) }
 					<FormLabel htmlFor="site-address-changer__text-input">
 						{ translate( 'Enter your new site address' ) }
 					</FormLabel>
@@ -465,11 +454,16 @@ export class SiteAddressChanger extends Component {
 						disabled={ ! isEmailVerified }
 						noWrap
 					/>
-					<FormInputValidation
-						isHidden={ ! shouldShowValidationMessage }
-						isError={ ! isAvailable }
-						text={ validationMessage || '\u00A0' }
-					/>
+					{ shouldShowValidationMessage && (
+						<FormInputValidation isError={ ! isAvailable } text={ validationMessage || '\u00A0' } />
+					) }
+					{ ! hasNonWpcomDomains && (
+						<div className="site-address-changer__info-custom-domain">
+							<a href={ addDomainPath } onClick={ this.handleAddDomainClick }>
+								{ translate( 'Did you want to add a custom domain instead?' ) }
+							</a>
+						</div>
+					) }
 				</div>
 			</div>
 		);

--- a/client/blocks/site-address-changer/style.scss
+++ b/client/blocks/site-address-changer/style.scss
@@ -1,7 +1,19 @@
 @import "@automattic/typography/styles/variables";
+@import "@wordpress/base-styles/colors.native";
 
 .dialog__content.site-address-changer {
-	padding: 24px 24px 0;
+	padding: 48px 48px 0;
+	max-width: 800px;
+
+}
+
+.dialog__action-buttons {
+	border: 0;
+	padding: 35px 48px 48px;
+
+	&::before {
+		display: none;
+	}
 }
 
 .site-address-changer__dialog {
@@ -66,7 +78,7 @@
 }
 
 .site-address-changer__details {
-	margin-top: 20px;
+	margin-top: 32px;
 
 	.form-input-validation.email-not-verified {
 		padding-bottom: 0;
@@ -85,6 +97,12 @@
 			cursor: pointer;
 			font-size: $font-body-small;
 		}
+	}
+
+	.site-address-changer__info-custom-domain a {
+		margin-top: 10px;
+		font-size: 0.875rem;
+		color: $gray-60;
 	}
 }
 
@@ -107,7 +125,22 @@
 }
 
 .site-address-changer__content {
-	max-width: 800px;
+	.form-section-heading {
+		font-size: 1.25rem;
+		margin: 0;
+		padding: 10px 0 5px;
+	}
+
+	.site-address-changer__email-confirmation-banner {
+
+		.gridicon {
+			fill: var(--color-accent);
+		}
+
+		.banner__icon-circle {
+			background-color: transparent !important;
+		}
+	}
 
 	@include breakpoint-deprecated( "<480px" ) {
 		.form-text-input-with-affixes__suffix {

--- a/client/blocks/site-address-changer/style.scss
+++ b/client/blocks/site-address-changer/style.scss
@@ -1,3 +1,8 @@
+@import "@automattic/typography/styles/variables";
+
+.dialog__content.site-address-changer {
+	padding: 24px 24px 0;
+}
 
 .site-address-changer__dialog {
 	text-align: left;
@@ -62,6 +67,25 @@
 
 .site-address-changer__details {
 	margin-top: 20px;
+
+	.form-input-validation.email-not-verified {
+		padding-bottom: 0;
+
+		&.already-sent {
+			padding-bottom: 16px;
+		}
+	}
+
+	.site-address-changer__resend-email-link {
+		margin-left: 33px;
+		margin-bottom: 16px;
+
+		button {
+			color: var(--color-link);
+			cursor: pointer;
+			font-size: $font-body-small;
+		}
+	}
 }
 
 .site-address-changer__only-owner-info {
@@ -83,6 +107,8 @@
 }
 
 .site-address-changer__content {
+	max-width: 800px;
+
 	@include breakpoint-deprecated( "<480px" ) {
 		.form-text-input-with-affixes__suffix {
 			padding-left: 8px;


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/84995

## Proposed Changes

The changes in this PR improve the "Change your address" popup in the Domain Management screen. These changes are:

- Added a `Cancel` button to the first step in the popup.
- Limited the width of the popup to 800px.
- Changed "Change site address" to "Next" in the first step of the popup.
- Added a check for the user's email to be verified. If it's not verified, the `Next` button and the input text are disabled, and a message requiring the user to confirm their emails is shown, alongside a link to re-send the confirmation email.

There are several states to the popup that have been modified with this PR:

- The user's email is verified:
<img width="811" alt="Screenshot 2023-12-15 at 00 49 06" src="https://github.com/Automattic/wp-calypso/assets/3832570/0c03a7fd-c8f6-4f55-879c-553b88ca4314">

- The user's email is not verified:
<img width="808" alt="Screenshot 2023-12-15 at 00 51 06" src="https://github.com/Automattic/wp-calypso/assets/3832570/50acb46c-8dcb-439c-9789-6a549d5e24cd">

- The user's email is not verified, and the "re-send confirmation email" has been clicked:
<img width="810" alt="Screenshot 2023-12-15 at 00 51 56" src="https://github.com/Automattic/wp-calypso/assets/3832570/d3b0f91e-a60e-4ec8-a082-9a22ef345058">

## Testing Instructions

**For verified users**
- Apply this PR and start the application.
- Go to `http://calypso.localhost:3000/domains/manage/[your-domain-here]`.
- Click the 3-dots button on the right of your domain and select "Change site address".
- The popup will appear. Check that the new `Cancel` button is there and working, and the `Next` button is there.
- Make a search for a new domain and click `Next` so you can check it's still working.

**For non-verified users**
- Apply this PR and start the application.
- Open an incognito window on your browser.
- Go to `calypso.localhost:3000`.
- Select `Register` and create a new account.
- You will end up in the Reader. Click on `My sites` and create one.
- Go to `Upgrades -> Domains`.
- Click the 3-dots button on the right of your domain and select "Change site address".
- The popup will appear. You should check the "confirmation required" message and the link to re-send the confirmation email. You should also see the textbox and the `Next` button disabled.
- Click the link to re-send the confirmation email. You should see the red message telling you to check your inbox.
- Check that you received the confirmation email in your inbox.

Do you feel there is any other use case worth testing?

Thanks for the review 🙇 

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?