### PR TITLE
Themes: Update (New) Tiers Labels Design

### DIFF
--- a/client/components/theme-tier/theme-tier-badge/index.js
+++ b/client/components/theme-tier/theme-tier-badge/index.js
@@ -1,5 +1,4 @@
 import { BUNDLED_THEME, DOT_ORG_THEME, MARKETPLACE_THEME } from '@automattic/design-picker';
-import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'calypso/state';
 import { getThemeType, isThemePurchased } from 'calypso/state/themes/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -18,7 +17,6 @@ export default function ThemeTierBadge( {
 	isLockedStyleVariation,
 	themeId,
 } ) {
-	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
 	const themeType = useSelector( ( state ) => getThemeType( state, themeId ) );
 	const isLegacyPremiumPurchased = useSelector( ( state ) =>
@@ -44,7 +42,7 @@ export default function ThemeTierBadge( {
 		}
 
 		if ( isThemeAllowedOnSite || ( 'premium' === themeTier.slug && isLegacyPremiumPurchased ) ) {
-			return <span>{ siteId ? translate( 'Included in my plan' ) : translate( 'Free' ) }</span>;
+			return null;
 		}
 
 		return <ThemeTierUpgradeBadge />;

--- a/client/components/theme-tier/theme-tier-badge/style.scss
+++ b/client/components/theme-tier/theme-tier-badge/style.scss
@@ -10,6 +10,11 @@
 	.theme-tier-badge__content {
 		margin: 0 8px 0 0;
 		vertical-align: middle;
+
+		&.is-third-party {
+			background-color: var(--color-neutral-5);
+			color: var(--color-neutral-70);
+		}
 	}
 }
 

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-bundled-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-bundled-badge.js
@@ -15,7 +15,7 @@ export default function ThemeTierBundledBadge() {
 	const siteId = useSelector( getSelectedSiteId );
 	const { themeId } = useThemeTierBadgeContext();
 	const bundleSettings = useBundleSettings( themeId );
-	const legacyCanUseTheme = useSelector(
+	const isThemeIncluded = useSelector(
 		( state ) => siteId && canUseTheme( state, siteId, themeId )
 	);
 
@@ -52,7 +52,7 @@ export default function ThemeTierBundledBadge() {
 
 	return (
 		<div className="theme-tier-badge">
-			{ ! legacyCanUseTheme && (
+			{ ! isThemeIncluded && (
 				<>
 					<ThemeTierBadgeTracker />
 					<PremiumBadge

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-bundled-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-bundled-badge.js
@@ -76,8 +76,6 @@ export default function ThemeTierBundledBadge() {
 			>
 				{ bundleName }
 			</BundledBadge>
-
-			{ legacyCanUseTheme && <span>{ translate( 'Included in my plan' ) }</span> }
 		</div>
 	);
 }

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-community-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-community-badge.js
@@ -17,10 +17,6 @@ export default function ThemeTierCommunityBadge() {
 		( state ) => siteId && canUseTheme( state, siteId, themeId )
 	);
 
-	if ( legacyCanUseTheme ) {
-		return null;
-	}
-
 	const tooltipContent = (
 		<>
 			<ThemeTierTooltipTracker />
@@ -46,14 +42,25 @@ export default function ThemeTierCommunityBadge() {
 	return (
 		<>
 			<ThemeTierBadgeTracker />
+			{ ! legacyCanUseTheme && (
+				<PremiumBadge
+					className="theme-tier-badge__content"
+					focusOnShow={ false }
+					isClickable
+					labelText={ translate( 'Upgrade' ) }
+					tooltipClassName="theme-tier-badge-tooltip"
+					tooltipContent={ tooltipContent }
+					tooltipPosition="top"
+				/>
+			) }
+
 			<PremiumBadge
-				className="theme-tier-badge__content"
+				className="theme-tier-badge__content is-third-party"
 				focusOnShow={ false }
-				isClickable
-				labelText={ translate( 'Upgrade' ) }
-				tooltipClassName="theme-tier-badge-tooltip"
-				tooltipContent={ tooltipContent }
-				tooltipPosition="top"
+				isClickable={ false }
+				labelText={ translate( 'Community' ) }
+				shouldHideIcon
+				shouldHideTooltip
 			/>
 		</>
 	);

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-community-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-community-badge.js
@@ -41,17 +41,19 @@ export default function ThemeTierCommunityBadge() {
 
 	return (
 		<>
-			<ThemeTierBadgeTracker />
 			{ ! legacyCanUseTheme && (
-				<PremiumBadge
-					className="theme-tier-badge__content"
-					focusOnShow={ false }
-					isClickable
-					labelText={ translate( 'Upgrade' ) }
-					tooltipClassName="theme-tier-badge-tooltip"
-					tooltipContent={ tooltipContent }
-					tooltipPosition="top"
-				/>
+				<>
+					<ThemeTierBadgeTracker />
+					<PremiumBadge
+						className="theme-tier-badge__content"
+						focusOnShow={ false }
+						isClickable
+						labelText={ translate( 'Upgrade' ) }
+						tooltipClassName="theme-tier-badge-tooltip"
+						tooltipContent={ tooltipContent }
+						tooltipPosition="top"
+					/>
+				</>
 			) }
 
 			<PremiumBadge

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-community-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-community-badge.js
@@ -18,7 +18,7 @@ export default function ThemeTierCommunityBadge() {
 	);
 
 	if ( legacyCanUseTheme ) {
-		return <span>{ translate( 'Included in my plan' ) }</span>;
+		return null;
 	}
 
 	const tooltipContent = (

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-community-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-community-badge.js
@@ -13,7 +13,7 @@ export default function ThemeTierCommunityBadge() {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
 	const { themeId } = useThemeTierBadgeContext();
-	const legacyCanUseTheme = useSelector(
+	const isThemeIncluded = useSelector(
 		( state ) => siteId && canUseTheme( state, siteId, themeId )
 	);
 
@@ -41,7 +41,7 @@ export default function ThemeTierCommunityBadge() {
 
 	return (
 		<>
-			{ ! legacyCanUseTheme && (
+			{ ! isThemeIncluded && (
 				<>
 					<ThemeTierBadgeTracker />
 					<PremiumBadge

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-partner-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-partner-badge.js
@@ -25,10 +25,6 @@ export default function ThemeTierPartnerBadge() {
 	);
 	const { isThemeAllowedOnSite } = useThemeTier( siteId, themeId );
 
-	if ( isPartnerThemePurchased && isThemeAllowedOnSite ) {
-		return <span>{ translate( 'Included in my plan' ) }</span>;
-	}
-
 	const labelText = isThemeAllowedOnSite
 		? translate( 'Subscribe' )
 		: translate( 'Upgrade and Subscribe' );
@@ -90,15 +86,28 @@ export default function ThemeTierPartnerBadge() {
 
 	return (
 		<>
-			<ThemeTierBadgeTracker />
+			{ ( ! isPartnerThemePurchased || ! isThemeAllowedOnSite ) && (
+				<>
+					<ThemeTierBadgeTracker />
+					<PremiumBadge
+						className="theme-tier-badge__content"
+						focusOnShow={ false }
+						isClickable
+						labelText={ labelText }
+						tooltipClassName="theme-tier-badge-tooltip"
+						tooltipContent={ tooltipContent }
+						tooltipPosition="top"
+					/>
+				</>
+			) }
+
 			<PremiumBadge
-				className="theme-tier-badge__content"
+				className="theme-tier-badge__content is-third-party"
 				focusOnShow={ false }
-				isClickable
-				labelText={ labelText }
-				tooltipClassName="theme-tier-badge-tooltip"
-				tooltipContent={ tooltipContent }
-				tooltipPosition="top"
+				isClickable={ false }
+				labelText={ translate( 'Partner' ) }
+				shouldHideIcon
+				shouldHideTooltip
 			/>
 		</>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Tracking issue: https://github.com/Automattic/dotcom-forge/issues/4597

## Proposed Changes

* We now have two types of labels with different rules:
  * Availability label
    * Not displayed on themes that are readily available to use on the site without further purchases.
    * Displayed on themes that require a plan upgrade ("Upgrade"), a subscription ("Subscribe"), or both ("Upgrade and Subscribe").
  * Special type label
    * Displayed on external themes ("Partner", "Community").
    * Displayed on internal themes that we want to highlight ("WooCommerce", "Sensei").

| Free | Premium | Community | Partner | WooCommerce |
|--------|--------|--------|--------|--------|
| <img width="492" alt="Screenshot 2023-12-12 at 16 59 16" src="https://github.com/Automattic/wp-calypso/assets/2070010/361ae415-b622-48b7-9579-c07f1ed1b969"> | <img width="494" alt="Screenshot 2023-12-12 at 17 00 11" src="https://github.com/Automattic/wp-calypso/assets/2070010/80d918c7-6812-4a69-8208-1eb0208cf0c2"> | <img width="488" alt="Screenshot 2023-12-12 at 17 00 01" src="https://github.com/Automattic/wp-calypso/assets/2070010/2358ef09-d422-4605-9283-1c6140d3480f"> | <img width="493" alt="Screenshot 2023-12-12 at 16 58 40" src="https://github.com/Automattic/wp-calypso/assets/2070010/4ceee301-ea32-4d48-81e8-afae264e1bcd"> | <img width="492" alt="Screenshot 2023-12-12 at 16 58 31" src="https://github.com/Automattic/wp-calypso/assets/2070010/dafd686b-2790-4bb4-842e-981549666147"> |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enable the `themes/tiers` feature flag.
* Open the Theme Showcase on a Free site.
* Check that:
  * Free themes have no labels.
  * Premium themes have 1 label.
  * Community, Partner, WooCommerce themes have 2 labels.
* Try with a Business site subscribed to a Partner theme.
  * Free themes have no labels.
  * Premium themes have no labels.
  * Community and WooCommerce themes have 1 label.
  * The subscribed Partner theme has 1 label.
  * Partner themes have 2 labels

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?