### PR TITLE
Domains: Vertically center glue record domain name in glue records form

### DIFF
--- a/client/my-sites/domains/domain-management/settings/cards/style.scss
+++ b/client/my-sites/domains/domain-management/settings/cards/style.scss
@@ -442,6 +442,16 @@
 }
 
 .domain-glue-records-card__accordion {
+	.form-text-input-with-affixes__suffix {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+
+		.form-label {
+			margin-bottom: 0;
+		}
+	}
+
 	.domain-glue-records-card__error-field {
 		height: 20px;
 	}


### PR DESCRIPTION
## Proposed Changes

This PR vertically centers the root domain name in the glue records form.

### Screenshots

- Before

![Markup on 2023-12-12 at 14:38:07](https://github.com/Automattic/wp-calypso/assets/5324818/354e4cce-9964-4bb7-a845-30957d4f474c)

- After

![Markup on 2023-12-12 at 14:43:47](https://github.com/Automattic/wp-calypso/assets/5324818/2acf7858-db11-4522-b2ee-45c17708b6a8)

## Testing Instructions

- Open the live Calypso link or build this branch locally
- Go to the domain management page of a domain that's registered via Key-Systems
- Open the glue records card and ensure the root domain name is vertically centered in the form, as shown in the screenshots

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?