### PR TITLE
Hide Add Review button if user cannot review the product

### DIFF
--- a/client/my-sites/marketplace/components/reviews-summary/index.tsx
+++ b/client/my-sites/marketplace/components/reviews-summary/index.tsx
@@ -2,13 +2,16 @@ import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
+import { useSelector } from 'react-redux';
 import Rating from 'calypso/components/rating';
 import {
 	useMarketplaceReviewsQuery,
 	type ProductProps,
 } from 'calypso/data/marketplace/use-marketplace-reviews';
 import { ReviewsModal } from 'calypso/my-sites/marketplace/components/reviews-modal';
+import { canPublishProductReviews } from 'calypso/state/marketplace/selectors';
 import './styles.scss';
+import { type IAppState } from 'calypso/state/types';
 
 type Props = ProductProps & {
 	productName: string;
@@ -22,6 +25,11 @@ export const ReviewsSummary = ( { slug, productName, productType }: Props ) => {
 		productType,
 		slug,
 	} );
+
+	const userCanPublishReviews = useSelector( ( state: IAppState ) =>
+		canPublishProductReviews( state, productType, slug )
+	);
+
 	// TODO: The averageRating will come from the server. Calculating it here temporarily.
 	let averageRating = null;
 	let numberOfReviews = null;
@@ -65,7 +73,9 @@ export const ReviewsSummary = ( { slug, productName, productType }: Props ) => {
 						</Button>
 					</div>
 				) }
-				<Button onClick={ () => setIsVisible( true ) }>{ translate( 'Add Review' ) }</Button>
+				{ userCanPublishReviews && (
+					<Button onClick={ () => setIsVisible( true ) }>{ translate( 'Add Review' ) }</Button>
+				) }
 			</div>
 		</>
 	);

--- a/client/state/marketplace/selectors.ts
+++ b/client/state/marketplace/selectors.ts
@@ -79,7 +79,7 @@ export function canPublishProductReviews(
 		return canPublishThemeReview( state, productSlug );
 	}
 	if ( productType === 'plugin' ) {
-		throw new Error( `Selector nnt implemented for plugins` );
+		throw new Error( `Selector not implemented for plugins` );
 	}
 	throw new Error( `Unknown product type: ${ productType }` );
 }

--- a/client/state/marketplace/selectors.ts
+++ b/client/state/marketplace/selectors.ts
@@ -8,6 +8,7 @@ import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-t
 import { default as isVipSite } from 'calypso/state/selectors/is-vip-site';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { canPublishThemeReview } from 'calypso/state/themes/selectors/can-publish-theme-review';
 import { IAppState } from 'calypso/state/types';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
@@ -31,6 +32,8 @@ const shouldUpgradeCheck = ( state: IAppState, siteId: number | null ): boolean 
 	const isVip = isVipSite( state, siteId );
 	return ! canInstallPurchasedPlugins && ! isStandaloneJetpack && ! isVip;
 };
+
+export default shouldUpgradeCheck;
 
 /*
  * hasOrIntendsToBuyLiveSupport:
@@ -67,4 +70,16 @@ export const hasOrIntendsToBuyLiveSupport = ( state: IAppState ): boolean => {
 	return hasLiveSupport;
 };
 
-export default shouldUpgradeCheck;
+export function canPublishProductReviews(
+	state: IAppState,
+	productType: string,
+	productSlug: string
+) {
+	if ( productType === 'theme' ) {
+		return canPublishThemeReview( state, productSlug );
+	}
+	if ( productType === 'plugin' ) {
+		throw new Error( `Selector nnt implemented for plugins` );
+	}
+	throw new Error( `Unknown product type: ${ productType }` );
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #https://github.com/Automattic/dotcom-forge/issues/4737

## Proposed Changes

* Add a selector to check if a product can be reviewed based on type and slug
* Use that selector to decide if the `Add Review` button should be displayed

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On an environment with the `marketplace-reviews-show` flag enabled, for example `wpcalypso.wordpress.com` or activating the flag in production
* Navigate to a Partner theme that does not have a subscription with your user, e.g. `/themes/solarone/:siteId` 
* Make sure the `Add Review` button is not displayed
* Purchase a subscription with the previous theme or select a theme with a Marketplace subscription
* Navigate to the theme details page, e.g. `/themes/solarone/:siteId` 
* Make sure the `Add Review` button is displayed


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?