### PR TITLE
Plans 2023: Add TODO to usePlanUpgradeabilityCheck

### DIFF
--- a/client/my-sites/plans-features-main/hooks/use-plan-upgradeability-check.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plan-upgradeability-check.ts
@@ -16,6 +16,12 @@ type PlanUpgradeability = {
  * Note that if there is no selectedSiteId, then we assume that we are in onboarding or
  * signup, which will, by default, make the plan purchaseable.
  */
+
+// TODO: The term "upgrade" is only relevant in the context of a selected site. Because
+// this hook handles situations where both a site is selected and is not selected,
+// "upgrade" doesn't make sense. Let's rename this hook to something like
+// usePlanAvailabilityCheck, or update the hook to only handle the case where a site is
+// selected.
 const usePlanUpgradeabilityCheck = ( { planSlugs }: Props ): PlanUpgradeability => {
 	const selectedSiteId = useSelector( getSelectedSiteId );
 	const planUpgradeability = useSelector( ( state ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/83940#discussion_r1423767026

## Proposed Changes

* Add inline comment to usePlanUpgradeabilityCheck hook

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* N/A

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?