### PR TITLE
Marketplace Reviews: Update list layout

### DIFF
--- a/client/my-sites/marketplace/components/reviews-list/index.tsx
+++ b/client/my-sites/marketplace/components/reviews-list/index.tsx
@@ -18,6 +18,9 @@ export const MarketplaceReviewsList = forwardRef<
 	const translate = useTranslate();
 	const { data: reviews } = useMarketplaceReviewsQuery( props );
 
+	// TODO: Get the proper value as a URL to the profile picture
+	const authorProfilePic = null;
+
 	if ( ! isEnabled( 'marketplace-reviews-show' ) ) {
 		return null;
 	}
@@ -29,10 +32,23 @@ export const MarketplaceReviewsList = forwardRef<
 		return null;
 	}
 
+	if ( Array.isArray( reviews ) && reviews?.length === 0 ) {
+		return (
+			<div className="marketplace-reviews-list__no-reviews">
+				<h2 className="marketplace-reviews-list__no-reviews-title">
+					{ translate( 'No reviews yet' ) }
+				</h2>
+				<h3 className="marketplace-reviews-list__no-reviews-subtitle">
+					{ translate(
+						'There are no reviews for this plugin at the moment. Your feedback could be the first to guide others.'
+					) }
+				</h3>
+			</div>
+		);
+	}
+
 	return (
 		<div className="marketplace-reviews-list__container" ref={ ref }>
-			<h2 className="marketplace-reviews-list__title">{ translate( 'Customer reviews' ) }</h2>
-
 			<div className="marketplace-reviews-list__customer-reviews">
 				{ Array.isArray( reviews ) &&
 					reviews.map( ( review: MarketplaceReviewResponse ) => (
@@ -40,22 +56,40 @@ export const MarketplaceReviewsList = forwardRef<
 							className="marketplace-reviews-list__review-container"
 							key={ `review-${ review.id }` }
 						>
-							<div className="marketplace-reviews-list__author">{ review.author_name }</div>
-							<div className="marketplace-reviews-list__rating-data">
-								<Rating rating={ review.meta.wpcom_marketplace_rating * 20 } />
+							<div className="marketplace-reviews-list__review-container-header">
+								<div className="marketplace-reviews-list__profile-picture">
+									{ authorProfilePic ? (
+										<img
+											className="marketplace-reviews-list__profile-picture-img"
+											src={ authorProfilePic }
+											alt={ translate( "%(reviewer)s's profile picture", {
+												comment: 'Alt description for the profile picture of a reviewer',
+												args: { reviewer: review.author_name },
+											} ).toString() }
+										/>
+									) : (
+										<div className="marketplace-reviews-list__profile-picture-placeholder" />
+									) }
+								</div>
 
-								<div
-									// sanitized with sanitizeSectionContent
-									// eslint-disable-next-line react/no-danger
-									dangerouslySetInnerHTML={ {
-										__html: sanitizeSectionContent( review.content.rendered ),
-									} }
-									className="marketplace-reviews-list__content"
-								></div>
+								<div className="marketplace-reviews-list__rating-data">
+									<div className="marketplace-reviews-list__author">{ review.author_name }</div>
+
+									<Rating rating={ review.meta.wpcom_marketplace_rating * 20 } />
+								</div>
+								<div className="marketplace-reviews-list__date">
+									{ moment( review.date ).format( 'll' ) }
+								</div>
 							</div>
-							<div className="marketplace-reviews-list__date">
-								{ moment( review.date ).format( 'll' ) }
-							</div>
+
+							<div
+								// sanitized with sanitizeSectionContent
+								// eslint-disable-next-line react/no-danger
+								dangerouslySetInnerHTML={ {
+									__html: sanitizeSectionContent( review.content.rendered ),
+								} }
+								className="marketplace-reviews-list__content"
+							></div>
 						</div>
 					) ) }
 			</div>

--- a/client/my-sites/marketplace/components/reviews-list/style.scss
+++ b/client/my-sites/marketplace/components/reviews-list/style.scss
@@ -1,3 +1,6 @@
+$profile-picture-size: 36px;
+$border-color: #eee;
+
 .marketplace-reviews-list__container {
 	padding: 0 16px;
 
@@ -13,61 +16,108 @@
 	}
 
 	.marketplace-reviews-list__customer-reviews {
-		margin-top: 10px;
-
 		.marketplace-reviews-list__review-container {
-			display: grid;
-			grid-template-columns: 200px 1fr 150px;
-			border-top: 1px solid var(--studio-gray-5);
-			padding: 20px 0;
+			border-top: 1px solid $border-color;
+			padding: 32px 0;
 
 			&:first-of-type {
 				border-top: none;
+				padding-top: 0;
 			}
 
-			.marketplace-reviews-list__author {
-				font-weight: bold;
-				padding-right: 20px;
-				font-size: $font-body-small;
+			&:last-of-type {
+				padding-bottom: 0;
+			}
+
+			.marketplace-reviews-list__review-container-header {
+				display: grid;
+				grid-template-columns: calc($profile-picture-size + 8px) 1fr 100px;
+
+				.marketplace-reviews-list__rating-data {
+					display: flex;
+					flex-direction: column;
+
+					.rating {
+						margin-left: -1px;
+					}
+				}
+
+				.marketplace-reviews-list__profile-picture {
+					display: flex;
+					flex-direction: column;
+					justify-content: center;
+
+					.marketplace-reviews-list__profile-picture-img,
+					.marketplace-reviews-list__profile-picture-placeholder {
+						height: $profile-picture-size;
+						width: $profile-picture-size;
+						border-radius: 50%;
+					}
+
+					.marketplace-reviews-list__profile-picture-placeholder {
+						background-color: var(--studio-gray-20);
+					}
+				}
+
+				.marketplace-reviews-list__date {
+					color: var(--studio-gray-60);
+					font-size: $font-body-small;
+					text-align: right;
+					align-self: center;
+				}
+
+				.marketplace-reviews-list__author {
+					color: var(--studio-gray-100);
+					font-size: $font-body-small;
+				}
 			}
 
 			.marketplace-reviews-list__content {
-				margin-top: 10px;
-				margin-left: 3px;
+				color: var(--studio-gray-100);
+				font-size: $font-body-small;
+				margin-top: 16px;
 
 				p {
 					margin-bottom: 0;
 				}
 			}
-
-			.marketplace-reviews-list__date {
-				font-weight: bold;
-				font-size: $font-body-extra-small;
-				text-align: right;
-			}
-
-			@include breakpoint-deprecated( "<960px" ) {
-				position: relative;
-				grid-template-areas:
-					"content"
-					"author";
-				grid-template-columns: 100%;
-
-				.marketplace-reviews-list__author {
-					margin-top: 20px;
-					grid-area: author;
-				}
-
-				.marketplace-reviews-list__content {
-					grid-area: content;
-				}
-
-				.marketplace-reviews-list__date {
-					position: absolute;
-					right: 0;
-					top: 20px;
-				}
-			}
 		}
+	}
+	.rating .rating__overlay .is-empty,
+	.rating .rating__star-outline .is-empty {
+		fill: var(--studio-yellow-20);
+	}
+
+	.rating .rating__overlay .gridicon,
+	.rating .rating__star-outline .gridicon {
+		fill: var(--studio-yellow-20);
+	}
+}
+
+.marketplace-reviews-list__no-reviews,
+.marketplace-reviews-list__customer-reviews {
+	margin-top: 10px;
+	padding: 40px;
+	border: 1px solid $border-color;
+	border-radius: 9px; /* stylelint-disable-line scales/radii */
+}
+
+.marketplace-reviews-list__no-reviews {
+	display: flex;
+	flex-direction: column;
+	text-align: center;
+	align-items: center;
+
+	.marketplace-reviews-list__no-reviews-title {
+		font-family: Recoleta, $sans;
+		color: var(--studio-gray-100);
+		font-size: $font-title-medium;
+	}
+
+	.marketplace-reviews-list__no-reviews-subtitle {
+		font-family: "SF Pro Text", $sans;
+		color: var(--studio-gray-60);
+		font-size: $font-body-small;
+		max-width: 400px;
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/4840
Design f84fqtCG4pCnCh2Hq0But5-fi-6829_26644

## Proposed Changes

* Update the list according the layouts
* Remove the title as this won't be necessary according new layouts
* Add empty state layout

| List layout  | Empty list |
| ------------- | ------------- |
|![CleanShot 2023-12-12 at 15 30 30@2x](https://github.com/Automattic/wp-calypso/assets/5039531/a2b8d49a-33d8-4dad-87d7-5e82be05a29e)|![CleanShot 2023-12-12 at 15 30 03@2x](https://github.com/Automattic/wp-calypso/assets/5039531/c03796a8-babf-467d-a7a5-0e703721cfde)|



PS: for the profile picture a placeholder is being used while the data is not being retrieved yet.


## Testing Instructions

* Using this live link or local dev env
* Go to a plugin page of a plugin with reviews. Ex: `/plugins/woocommerce-bookings/`
* Check the layout matches the above and matches the proposed layout
* Go to a plugin page of a plugin without reviews. Ex: `/plugins/sensei-pro`
* Check the layout matches the above and matches the proposed layout


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
