### PR TITLE
Import content flow: Add granular progress screen

### DIFF
--- a/client/blocks/importer/components/progress-screen/index.tsx
+++ b/client/blocks/importer/components/progress-screen/index.tsx
@@ -18,7 +18,7 @@ const ProgressScreen: React.FunctionComponent< Props > = ( props ) => {
 			case 'unpack_file':
 			case 'preprocess':
 			case 'process_files':
-				return __( 'Moving your data' );
+				return __( 'Moving your files' );
 
 			case 'recreate_database':
 			case 'postprocess_database':

--- a/client/blocks/importer/components/progress-screen/index.tsx
+++ b/client/blocks/importer/components/progress-screen/index.tsx
@@ -1,6 +1,6 @@
 import { Progress, SubTitle, Title } from '@automattic/onboarding';
 import { useI18n } from '@wordpress/react-i18n';
-import React from 'react';
+import React, { useCallback } from 'react';
 import { ProgressBar } from 'calypso/devdocs/design/playground-scope';
 import { calculateProgress } from 'calypso/my-sites/importer/importing-pane';
 import type { ImportJob } from '../../types';
@@ -11,11 +11,34 @@ interface Props {
 const ProgressScreen: React.FunctionComponent< Props > = ( props ) => {
 	const { __ } = useI18n();
 	const { job } = props;
+	const { customData } = job || {};
 
+	const getPlaygroundImportTitle = useCallback( () => {
+		switch ( customData?.current_step ) {
+			case 'unpack_file':
+			case 'preprocess':
+			case 'process_files':
+				return __( 'Moving your data' );
+
+			case 'recreate_database':
+			case 'postprocess_database':
+			case 'clean_up':
+				return __( 'Migrating your data' );
+
+			case 'convert_to_atomic':
+			case 'download_archive':
+			default:
+				return __( 'Backing up your data' );
+		}
+	}, [ customData?.current_step ] );
+
+	const title =
+		job?.importerFileType !== 'playground' ? __( 'Importing' ) : getPlaygroundImportTitle();
 	const progress = job ? calculateProgress( job.progress ) : NaN;
+
 	return (
 		<Progress>
-			<Title>{ __( 'Importing' ) }...</Title>
+			<Title>{ title }...</Title>
 			<ProgressBar compact={ true } value={ Number.isNaN( progress ) ? 0 : progress } />
 			<SubTitle>
 				{ __( 'Feel free to close this window. We’ll email you when your new site is ready.' ) }

--- a/client/blocks/importer/types.ts
+++ b/client/blocks/importer/types.ts
@@ -36,7 +36,18 @@ export interface ImportJob {
 	statusMessage?: string;
 	type: string;
 	site: { ID: number };
-	customData: { [ key: string ]: any };
+	customData: {
+		[ key: string ]: any;
+		current_step?:
+			| 'convert_to_atomic'
+			| 'download_archive'
+			| 'unpack_file'
+			| 'preprocess'
+			| 'process_files'
+			| 'recreate_database'
+			| 'postprocess_database'
+			| 'clean_up';
+	};
 	errorData: {
 		type: string;
 		description: string;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer/style.scss
@@ -14,11 +14,11 @@
 
 	.import__onboarding-page {
 		.onboarding-progress {
-			max-width: 500px;
+			min-width: auto;
 			margin: auto;
 
 			@include break-small {
-				min-width: 465px;
+				min-width: 530px;
 			}
 		}
 

--- a/packages/onboarding/src/progress/style.scss
+++ b/packages/onboarding/src/progress/style.scss
@@ -13,18 +13,14 @@
 	}
 
 	.onboarding-title {
-		color: var(--studio-gray-100);
-		font-size: 2rem;
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-		line-height: 1em;
-		margin-bottom: 1.5rem;
+		/* stylelint-disable-next-line scales/font-sizes */
+		font-size: 1.625rem; // 26px
+		margin-bottom: 2rem;
 	}
 
 	.onboarding-subtitle {
-		color: var(--studio-gray-40);
 		font-size: 0.875rem;
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-		line-height: 1.5rem;
+		line-height: 1.5;
 
 		span {
 			color: var(--studio-gray-100);
@@ -32,12 +28,7 @@
 	}
 
 	.progress-bar {
-		margin-bottom: 1.5em;
-		background: var(--studio-gray-5);
-		border-radius: 0;
-
-		.progress-bar__progress {
-			border-radius: 0;
-		}
+		margin-bottom: 1.5rem;
+		background: var(--studio-gray-10);
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/85146

## Proposed Changes

* Updated progress screen styles, matching Figma design
* Updated progress title based on the current step (only for playground type of files)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/import-focused/importerWordpress?siteSlug={PLAGROUND_TESTING_SLUG}&option=content`
* Drag & drop playground file
* Check the granular progress (see the screenshots)

<img width="645" alt="Screenshot 2023-12-12 at 21 06 06" src="https://github.com/Automattic/wp-calypso/assets/1241413/fb029eb6-f834-4609-afbe-d56958461f02">
<img width="669" alt="Screenshot 2023-12-12 at 21 06 25" src="https://github.com/Automattic/wp-calypso/assets/1241413/3327ba7a-1bd3-44cc-877c-ff2dbf5620cb">
<img width="656" alt="Screenshot 2023-12-12 at 21 07 23" src="https://github.com/Automattic/wp-calypso/assets/1241413/551547b2-2234-4f3a-9ac4-f6aa18b8d67f">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?