### PR TITLE
Jetpack Manage: 169 - Move intro video to its own component

### DIFF
--- a/client/components/jetpack/videopress-iframe/index.tsx
+++ b/client/components/jetpack/videopress-iframe/index.tsx
@@ -1,0 +1,44 @@
+import classnames from 'classnames';
+import './style.scss';
+
+interface Props {
+	videoURL: string;
+	title?: string;
+	className?: string;
+	maintainAspectRatio: boolean;
+	fullWidth: boolean;
+	allowFullScreen: boolean;
+}
+
+const VideoPressIframe = ( {
+	videoURL,
+	title,
+	className,
+	maintainAspectRatio,
+	fullWidth,
+	allowFullScreen,
+}: Props ) => {
+	return (
+		<iframe
+			className={ classnames(
+				{
+					'maintain-aspect-ratio': maintainAspectRatio,
+					'full-width': fullWidth,
+				},
+				className
+			) }
+			title={ title }
+			aria-label={ title }
+			src={ videoURL }
+			allowFullScreen={ allowFullScreen }
+		></iframe>
+	);
+};
+
+VideoPressIframe.defaultProps = {
+	maintainAspectRatio: true,
+	fullWidth: true,
+	allowFullScreen: true,
+};
+
+export default VideoPressIframe;

--- a/client/components/jetpack/videopress-iframe/index.tsx
+++ b/client/components/jetpack/videopress-iframe/index.tsx
@@ -1,4 +1,5 @@
 import classnames from 'classnames';
+
 import './style.scss';
 
 interface Props {

--- a/client/components/jetpack/videopress-iframe/style.scss
+++ b/client/components/jetpack/videopress-iframe/style.scss
@@ -1,0 +1,7 @@
+.maintain-aspect-ratio {
+	aspect-ratio: 16/9;
+}
+
+.full-width {
+	width: 100%;
+}

--- a/client/jetpack-cloud/sections/overview/primary/intro-video/index.tsx
+++ b/client/jetpack-cloud/sections/overview/primary/intro-video/index.tsx
@@ -1,0 +1,18 @@
+import { useTranslate } from 'i18n-calypso';
+import styles from './style.module.css';
+
+export default function IntroVideo() {
+	const translate = useTranslate();
+
+	return (
+		<iframe
+			className={ styles[ 'intro-video' ] }
+			title={ translate( 'Jetpack Manage Overview' ) }
+			aria-label={ translate( 'Jetpack Manage Overview' ) }
+			src={
+				'https://video.wordpress.com/embed/Z9piKY9s?hd=1&amp;autoPlay=0&amp;permalink=1&amp;loop=0&amp;preloadContent=metadata&amp;muted=0&amp;playsinline=0&amp;controls=1&amp;cover=1%27'
+			}
+			allowFullScreen
+		></iframe>
+	);
+}

--- a/client/jetpack-cloud/sections/overview/primary/intro-video/index.tsx
+++ b/client/jetpack-cloud/sections/overview/primary/intro-video/index.tsx
@@ -1,18 +1,12 @@
 import { useTranslate } from 'i18n-calypso';
-import styles from './style.module.css';
+import VideoPressIframe from 'calypso/components/jetpack/videopress-iframe';
 
 export default function IntroVideo() {
 	const translate = useTranslate();
 
-	return (
-		<iframe
-			className={ styles[ 'intro-video' ] }
-			title={ translate( 'Jetpack Manage Overview' ) }
-			aria-label={ translate( 'Jetpack Manage Overview' ) }
-			src={
-				'https://video.wordpress.com/embed/Z9piKY9s?hd=1&amp;autoPlay=0&amp;permalink=1&amp;loop=0&amp;preloadContent=metadata&amp;muted=0&amp;playsinline=0&amp;controls=1&amp;cover=1%27'
-			}
-			allowFullScreen
-		></iframe>
-	);
+	const videoURL =
+		'https://video.wordpress.com/embed/Z9piKY9s?hd=1&amp;autoPlay=0&amp;permalink=1&amp;loop=0&amp;preloadContent=metadata&amp;muted=0&amp;playsinline=0&amp;controls=1&amp;cover=1%27';
+	const title = translate( 'Jetpack Manage Overview' );
+
+	return <VideoPressIframe videoURL={ videoURL } title={ title } />;
 }

--- a/client/jetpack-cloud/sections/overview/primary/intro-video/style.module.css
+++ b/client/jetpack-cloud/sections/overview/primary/intro-video/style.module.css
@@ -1,0 +1,4 @@
+.intro-video {
+	width: 100%;
+	aspect-ratio: 16/9;
+}

--- a/client/jetpack-cloud/sections/overview/primary/intro-video/style.module.css
+++ b/client/jetpack-cloud/sections/overview/primary/intro-video/style.module.css
@@ -1,4 +1,0 @@
-.intro-video {
-	width: 100%;
-	aspect-ratio: 16/9;
-}

--- a/client/jetpack-cloud/sections/overview/primary/sidebar/index.tsx
+++ b/client/jetpack-cloud/sections/overview/primary/sidebar/index.tsx
@@ -4,6 +4,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import GetHelpNav from '../get-help-nav';
+import IntroVideo from '../intro-video';
 import QuickLinksNav from '../quick-links-nav';
 import './style.scss';
 
@@ -13,15 +14,7 @@ export default function OverviewSidebar() {
 	return (
 		<>
 			<section>
-				<iframe
-					className="intro-video"
-					title={ translate( 'Jetpack Manage Overview' ) }
-					aria-label={ translate( 'Jetpack Manage Overview' ) }
-					src={
-						'https://video.wordpress.com/embed/Z9piKY9s?hd=1&amp;autoPlay=0&amp;permalink=1&amp;loop=0&amp;preloadContent=metadata&amp;muted=0&amp;playsinline=0&amp;controls=1&amp;cover=1%27'
-					}
-					allowFullScreen
-				></iframe>
+				<IntroVideo />
 			</section>
 
 			<section>

--- a/client/jetpack-cloud/sections/overview/primary/sidebar/style.scss
+++ b/client/jetpack-cloud/sections/overview/primary/sidebar/style.scss
@@ -3,11 +3,6 @@
 
 .jetpack-cloud-content-sidebar {
 	.right-sidebar {
-
-		.intro-video {
-			width: 100%;
-		}
-
 		.foldable-card__expand {
 			width: 24px;
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves Automattic/jetpack-manage#169 - Move intro video to its own component

## Proposed Changes

This is a simple PR that moves the Jetpack Manage intro video into its own component. It also forces a 16/9 aspect ratio.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Ensure the video loads and maintains its ratio and 100% sidebar width on a local dev setup:

http://jetpack.cloud.localhost:3000/overview

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
