### PR TITLE
GF Signup: Fix bug in plan interval dropdown drop down

### DIFF
--- a/client/my-sites/plans-grid/components/plan-type-selector/hooks/use-interval-options.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/hooks/use-interval-options.tsx
@@ -1,4 +1,3 @@
-import { UrlFriendlyTermType } from '@automattic/calypso-products';
 import { LocalizeProps, TranslateResult, useTranslate } from 'i18n-calypso';
 import { IntervalTypeProps, SupportedUrlFriendlyTermType } from '../types';
 import generatePath from '../utils';
@@ -13,7 +12,8 @@ const getDiscountText = ( discountPercentage: number, translate: LocalizeProps[ 
 		comment: 'Discount percentage',
 	} );
 };
-export default function useIntervalOptions( props: IntervalTypeProps ): Record<
+
+type IntervalSelectOptionsMap = Record<
 	SupportedUrlFriendlyTermType,
 	{
 		key: string;
@@ -21,11 +21,11 @@ export default function useIntervalOptions( props: IntervalTypeProps ): Record<
 		discountText: TranslateResult;
 		url: string;
 		termInMonths: number;
-		ui?: any;
 	}
-> {
+>;
+export default function useIntervalOptions( props: IntervalTypeProps ): IntervalSelectOptionsMap {
 	const translate = useTranslate();
-	const optionList: Record<
+	let optionList: Record<
 		SupportedUrlFriendlyTermType,
 		{
 			key: string;
@@ -85,7 +85,7 @@ export default function useIntervalOptions( props: IntervalTypeProps ): Record<
 		isJetpackAppFlow = new URLSearchParams( window.location.search ).get( 'jetpackAppPlans' );
 	}
 
-	Object.fromEntries(
+	optionList = Object.fromEntries(
 		Object.keys( optionList ).map( ( key ) => [
 			key,
 			{
@@ -98,12 +98,12 @@ export default function useIntervalOptions( props: IntervalTypeProps ): Record<
 					...additionalPathProps,
 				} ),
 				discountText: getDiscountText(
-					termWiseMaxDiscount[ key as UrlFriendlyTermType ],
+					termWiseMaxDiscount[ key as SupportedUrlFriendlyTermType ],
 					translate
 				),
 			},
 		] )
-	);
+	) as IntervalSelectOptionsMap;
 
 	return optionList;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Related to https://github.com/Automattic/wp-calypso/pull/84895

## Proposed Changes

* Fixes a minor bug

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure the dropdown works as shown in #84895

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?