### PR TITLE
Fix view post iframe URL

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -522,6 +522,7 @@ async function openLinksInParentFrame( calypsoPort ) {
 	const viewPostLinks = [
 		'.components-notice-list .is-success .components-notice__action.is-link', // View Post link in success notice, Gutenberg <5.9
 		'.components-snackbar-list .components-snackbar__content a', // View Post link in success snackbar, Gutenberg >=5.9
+		'.components-snackbar-list a.components-snackbar__action', // View Post link in success snackbar. Added for Gutenberg 17.2, and possibly earlier.
 		'.post-publish-panel__postpublish .components-panel__body.is-opened a', // Post title link in publish panel
 		'.components-panel__body.is-opened .post-publish-panel__postpublish-buttons a.components-button', // View Post button in publish panel
 		'.wpcom-block-editor-post-published-sharing-modal__view-post-link', // View Post button in sharing modal

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -568,7 +568,7 @@ async function openLinksInParentFrame( calypsoPort ) {
 				'Could not find the snackbar list element. As a result, the "View Post" link may open inside the iframe.'
 			);
 		}
-		// Note: the 3s timeout is necessary because the snackbar list element isn't
+		// Note: the timeout is necessary because the snackbar list element isn't
 		// rendered immediately. Even 1s is too slow to find it. Thankfully, this
 		// snackbar (triggered after publishing/updating a post) isn't rendered
 		// until

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -562,16 +562,14 @@ async function openLinksInParentFrame( calypsoPort ) {
 	// Essentially, when the snackbar list changes, attempt to update the link.
 	// Only called once when a snackbar item is added and when removed, so
 	// it doesn't cost much.
-	const snackbarObserver = new window.MutationObserver( updateViewPostLinkNotice );
 	const snackbarList = document.querySelector( '.components-snackbar-list' );
 	if ( snackbarList ) {
-		snackbarObserver.observe( document.querySelector( '.components-snackbar-list' ), {
-			childList: true,
-		} );
+		const snackbarObserver = new window.MutationObserver( updateViewPostLinkNotice );
+		snackbarObserver.observe( snackbarList, { childList: true } );
 	} else {
 		// eslint-disable-next-line no-console
 		console.warn(
-			'Could not find the snackbar list element. As a result, the "View Post" link may open inside the iframe.'
+			'Could not find the snackbar list element so, the "View post" link may open inside the iframe.'
 		);
 	}
 

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -564,7 +564,7 @@ async function openLinksInParentFrame( calypsoPort ) {
 			} );
 		} else {
 			// eslint-disable-next-line no-console
-			console.warning(
+			console.warn(
 				'Could not find the snackbar list element. As a result, the "View Post" link may open inside the iframe.'
 			);
 		}
@@ -572,7 +572,7 @@ async function openLinksInParentFrame( calypsoPort ) {
 		// rendered immediately. Even 1s is too slow to find it. Thankfully, this
 		// snackbar (triggered after publishing/updating a post) isn't rendered
 		// until
-	}, 3000 );
+	}, 5000 );
 
 	const { createNewPostUrl, manageReusableBlocksUrl } = calypsoifyGutenberg;
 	if ( ! createNewPostUrl && ! manageReusableBlocksUrl ) {

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -537,6 +537,13 @@ async function openLinksInParentFrame( calypsoPort ) {
 		} );
 	} );
 
+	const { createNewPostUrl, manageReusableBlocksUrl } = calypsoifyGutenberg;
+	if ( ! createNewPostUrl && ! manageReusableBlocksUrl ) {
+		return;
+	}
+
+	await isEditorReadyWithBlocks();
+
 	// Handle the view post link in the snackbar, which unfortunately has a click
 	// handler which stops propagation, so we can't override it with the global handler.
 	const updateViewPostLinkNotice = () => {
@@ -556,30 +563,17 @@ async function openLinksInParentFrame( calypsoPort ) {
 	// Only called once when a snackbar item is added and when removed, so
 	// it doesn't cost much.
 	const snackbarObserver = new window.MutationObserver( updateViewPostLinkNotice );
-	setTimeout( () => {
-		const snackbarList = document.querySelector( '.components-snackbar-list' );
-		if ( snackbarList ) {
-			snackbarObserver.observe( document.querySelector( '.components-snackbar-list' ), {
-				childList: true,
-			} );
-		} else {
-			// eslint-disable-next-line no-console
-			console.warn(
-				'Could not find the snackbar list element. As a result, the "View Post" link may open inside the iframe.'
-			);
-		}
-		// Note: the timeout is necessary because the snackbar list element isn't
-		// rendered immediately. Even 1s is too slow to find it. Thankfully, this
-		// snackbar (triggered after publishing/updating a post) isn't rendered
-		// until
-	}, 5000 );
-
-	const { createNewPostUrl, manageReusableBlocksUrl } = calypsoifyGutenberg;
-	if ( ! createNewPostUrl && ! manageReusableBlocksUrl ) {
-		return;
+	const snackbarList = document.querySelector( '.components-snackbar-list' );
+	if ( snackbarList ) {
+		snackbarObserver.observe( document.querySelector( '.components-snackbar-list' ), {
+			childList: true,
+		} );
+	} else {
+		// eslint-disable-next-line no-console
+		console.warn(
+			'Could not find the snackbar list element. As a result, the "View Post" link may open inside the iframe.'
+		);
 	}
-
-	await isEditorReadyWithBlocks();
 
 	// Create a new post link in block settings sidebar for Query block
 	const tryToReplaceCreateNewPostLink = () => {


### PR DESCRIPTION
Fixes the "view post" link in the post-publish message which appears after updating or publishing content:

<img width="467" alt="image" src="https://github.com/Automattic/wp-calypso/assets/6265975/b81a7980-120b-45e3-adb3-19150d0250f0">

On trunk, it opens the page inside the editor iframe, and the top-level URL does not change. This PR changes to use mutation observers, since the click event is stopped before propagating to our global click override handler.

Resolves #78059

### Testing instructions:
1. sandbox a test site and widgets.wp.com
2. Run `install-plugin.sh wbe fix-post-url` on your sandbox to download the build of wpcom block editor
3. Visit the editor. (Force-refresh to ensure the browser cache is updated.)
4. Publish or update a post.
5. Click the link shown in the above screenshot.
6. The link should open in a new tab with the correct URL.