### PR TITLE
Update: marketing sharing buttons view for Sharing Buttons block

### DIFF
--- a/client/my-sites/marketing/buttons/buttons-block-message.jsx
+++ b/client/my-sites/marketing/buttons/buttons-block-message.jsx
@@ -1,0 +1,37 @@
+import { localize } from 'i18n-calypso';
+import SharingButtonsPreviewButtons from './preview-buttons';
+
+const buttons = [
+	{ ID: 'facebook', name: 'Facebook', shortname: 'facebook' },
+	{ ID: 'reddit', name: 'Reddit', shortname: 'reddit' },
+	{ ID: 'tumblr', name: 'Tumblr', shortname: 'tumblr' },
+	{ ID: 'pinterest', name: 'Pinterest', shortname: 'pinterest' },
+];
+
+const ButtonsBlockMessage = ( { translate } ) => {
+	return (
+		<>
+			<div className="sharing-buttons__panel sharing-buttons-appearance">
+				<p className="sharing-buttons-appearance__description">
+					{ translate(
+						'Allow readers to easily share your posts with others by adding sharing buttons throughout your site.'
+					) }
+				</p>
+				<div>
+					<button className="button sharing-buttons__submit">
+						{ translate( 'Go to the Site Editor' ) }
+					</button>
+
+					<button className="button sharing-buttons__submit">
+						{ translate( 'Learn how to add Sharing Buttons' ) }
+					</button>
+				</div>
+				<p>{ translate( 'Sharing Buttons example:' ) }</p>
+
+				<SharingButtonsPreviewButtons buttons={ buttons } style="icon-text" />
+			</div>
+		</>
+	);
+};
+
+export default localize( ButtonsBlockMessage );

--- a/client/my-sites/marketing/buttons/buttons.jsx
+++ b/client/my-sites/marketing/buttons/buttons.jsx
@@ -126,16 +126,11 @@ class SharingButtons extends Component {
 	}
 
 	showSharingButtonsBlockAppearance() {
-		const { isJetpack, isBlockTheme, queryArgs } = this.props;
+		const { isBlockTheme, queryArgs } = this.props;
 
-		const skipShow = !! queryArgs.hasOwnProperty( 'no-block-apperance' );
+		const skipShow = !! queryArgs.hasOwnProperty( 'no-block-appearance' );
 
-		return (
-			isJetpack &&
-			! skipShow &&
-			isBlockTheme &&
-			isEnabled( 'jetpack/sharing-buttons-block-enabled' )
-		);
+		return ! skipShow && isBlockTheme && isEnabled( 'jetpack/sharing-buttons-block-enabled' );
 	}
 
 	render() {

--- a/client/my-sites/marketing/buttons/buttons.jsx
+++ b/client/my-sites/marketing/buttons/buttons.jsx
@@ -128,7 +128,7 @@ class SharingButtons extends Component {
 	showSharingButtonsBlockAppearance() {
 		const { isBlockTheme, queryArgs } = this.props;
 
-		const skipShow = !! queryArgs.hasOwnProperty( 'no-block-appearance' );
+		const skipShow = !! queryArgs[ 'no-block-appearance' ];
 
 		return ! skipShow && isBlockTheme && isEnabled( 'jetpack/sharing-buttons-block-enabled' );
 	}

--- a/client/my-sites/marketing/buttons/buttons.jsx
+++ b/client/my-sites/marketing/buttons/buttons.jsx
@@ -26,7 +26,7 @@ import {
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import ButtonsAppearance from './appearance';
-import ButtonsBlockMessage from './buttons-block-message';
+import ButtonsBlockMessage from './components/buttons-block-appearance';
 import ButtonsOptions from './options';
 import { useSharingButtonsQuery, useSaveSharingButtonsMutation } from './use-sharing-buttons-query';
 

--- a/client/my-sites/marketing/buttons/components/buttons-block-appearance.jsx
+++ b/client/my-sites/marketing/buttons/components/buttons-block-appearance.jsx
@@ -1,5 +1,6 @@
 import { localize } from 'i18n-calypso';
-import SharingButtonsPreviewButtons from './preview-buttons';
+import SharingButtonsPreviewButtons from '../preview-buttons';
+import './style.scss';
 
 const buttons = [
 	{ ID: 'facebook', name: 'Facebook', shortname: 'facebook' },
@@ -8,7 +9,7 @@ const buttons = [
 	{ ID: 'pinterest', name: 'Pinterest', shortname: 'pinterest' },
 ];
 
-const ButtonsBlockMessage = ( { translate } ) => {
+const ButtonsBlockAppearance = ( { translate } ) => {
 	return (
 		<>
 			<div className="sharing-buttons__panel sharing-buttons-appearance">
@@ -17,21 +18,20 @@ const ButtonsBlockMessage = ( { translate } ) => {
 						'Allow readers to easily share your posts with others by adding sharing buttons throughout your site.'
 					) }
 				</p>
-				<div>
-					<button className="button sharing-buttons__submit">
+				<div className="sharing-buttons__buttons-wrapper">
+					<button className="button is-primary sharing-buttons__button-site-editor">
 						{ translate( 'Go to the Site Editor' ) }
 					</button>
 
-					<button className="button sharing-buttons__submit">
+					<button className="button sharing-buttons__button-learn-more">
 						{ translate( 'Learn how to add Sharing Buttons' ) }
 					</button>
 				</div>
-				<p>{ translate( 'Sharing Buttons example:' ) }</p>
-
+				<p className="sharing-buttons__example-text">{ translate( 'Sharing Buttons example:' ) }</p>
 				<SharingButtonsPreviewButtons buttons={ buttons } style="icon-text" />
 			</div>
 		</>
 	);
 };
 
-export default localize( ButtonsBlockMessage );
+export default localize( ButtonsBlockAppearance );

--- a/client/my-sites/marketing/buttons/components/buttons-block-appearance.jsx
+++ b/client/my-sites/marketing/buttons/components/buttons-block-appearance.jsx
@@ -1,4 +1,6 @@
 import { localize } from 'i18n-calypso';
+import { useSelector } from 'calypso/state';
+import { getSiteAdminUrl } from 'calypso/state/sites/selectors';
 import SharingButtonsPreviewButtons from '../preview-buttons';
 import './style.scss';
 
@@ -9,28 +11,27 @@ const buttons = [
 	{ ID: 'pinterest', name: 'Pinterest', shortname: 'pinterest' },
 ];
 
-const ButtonsBlockAppearance = ( { translate } ) => {
-	return (
-		<>
-			<div className="sharing-buttons__panel sharing-buttons-appearance">
-				<p className="sharing-buttons-appearance__description">
-					{ translate(
-						'Allow readers to easily share your posts with others by adding sharing buttons throughout your site.'
-					) }
-				</p>
-				<div className="sharing-buttons__buttons-wrapper">
-					<button className="button is-primary sharing-buttons__button-site-editor">
-						{ translate( 'Go to the Site Editor' ) }
-					</button>
+const ButtonsBlockAppearance = ( { translate, siteId } ) => {
+	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
+	const siteEditorUrl = siteAdminUrl + 'site-editor.php?path=%2Fwp_template';
 
-					<button className="button sharing-buttons__button-learn-more">
-						{ translate( 'Learn how to add Sharing Buttons' ) }
-					</button>
-				</div>
-				<p className="sharing-buttons__example-text">{ translate( 'Sharing Buttons example:' ) }</p>
-				<SharingButtonsPreviewButtons buttons={ buttons } style="icon-text" />
+	return (
+		<div className="sharing-buttons__panel sharing-buttons-appearance">
+			<p className="sharing-buttons-appearance__description">
+				{ translate(
+					'Allow readers to easily share your posts with others by adding sharing buttons throughout your site.'
+				) }
+			</p>
+			<div className="sharing-buttons__buttons-wrapper">
+				<a className="button is-primary" href={ siteEditorUrl }>
+					{ translate( 'Go to the Site Editor' ) }
+				</a>
+
+				<button className="button">{ translate( 'Learn how to add Sharing Buttons' ) }</button>
 			</div>
-		</>
+			<p className="sharing-buttons__example-text">{ translate( 'Sharing Buttons example:' ) }</p>
+			<SharingButtonsPreviewButtons buttons={ buttons } style="icon-text" />
+		</div>
 	);
 };
 

--- a/client/my-sites/marketing/buttons/components/style.scss
+++ b/client/my-sites/marketing/buttons/components/style.scss
@@ -1,0 +1,9 @@
+.sharing-buttons__buttons-wrapper {
+	margin-bottom: 2rem;
+	display: inline-flex;
+	gap: 10px;
+}
+
+.sharing-buttons__example-text {
+	margin-bottom: 1rem;
+}

--- a/config/development.json
+++ b/config/development.json
@@ -101,6 +101,7 @@
 		"jetpack/plugin-management": true,
 		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page-annual-only": true,
+		"jetpack/sharing-buttons-block-enabled": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack/offer-complete-after-activation": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -61,6 +61,7 @@
 		"jetpack/magic-link-signup": true,
 		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page-annual-only": true,
+		"jetpack/sharing-buttons-block-enabled": false,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack/offer-complete-after-activation": false,

--- a/config/production.json
+++ b/config/production.json
@@ -72,6 +72,7 @@
 		"jetpack/plugin-management": false,
 		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page-annual-only": true,
+		"jetpack/sharing-buttons-block-enabled": false,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack-social/advanced-plan": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -68,6 +68,7 @@
 		"jetpack/plugin-management": true,
 		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page-annual-only": true,
+		"jetpack/sharing-buttons-block-enabled": false,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack-social/advanced-plan": true,

--- a/config/test.json
+++ b/config/test.json
@@ -54,6 +54,7 @@
 		"jetpack/features-section/simple": true,
 		"jetpack/plugin-management": false,
 		"jetpack/pricing-page-annual-only": true,
+		"jetpack/sharing-buttons-block-enabled": false,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack-social/advanced-plan": false,
 		"jetpack/offer-complete-after-activation": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -77,6 +77,7 @@
 		"jetpack/plugin-management": false,
 		"jetpack/pricing-add-boost-social": true,
 		"jetpack/pricing-page-annual-only": true,
+		"jetpack/sharing-buttons-block-enabled": false,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack-social/advanced-plan": false,
 		"jetpack/offer-complete-after-activation": false,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack/issues/34327

## Proposed Changes
This changes the behavior of `/marketing/sharing-buttons/:site` page by adding new view, that will refclect new usage of the Sharing Buttons Block.
Some important notices:
- New feature flag added `jetpack/sharing-buttons-block-enabled`. This is now available only for Dev environment.
- New view is visible only if site has a block-based theme
- Additionally added a check for `no-block-appearance` query arg if we would want to use it.
- `Learn how to add Sharing Buttons` button is not functional are the Docs aren't ready yet.

<img width="866" alt="Screenshot 2023-12-13 at 10 23 29" src="https://github.com/Automattic/wp-calypso/assets/60262784/6ccc77b6-f896-45ac-a98a-f3b4d2a6bdfc">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
- Spin up a new JN site
- Run the branch locally or use Live links
- Navigate to `/marketing/sharing-buttons/:site` (add `?flags=jetpack/sharing-buttons-block-enabled` if using Live Link)
- You should see the new screen. Check it's behavior.
- Check with param  `&no-block-appearance=true` in the url, old screen should show up.
- Test on classic theme (eg Twenty Ten). You should see old screen.
- Test on Simple/Atomic


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?