### PR TITLE
Enable the "Preview & Customize" button for Premium and WooCommerce themes (on horizon)

### DIFF
--- a/client/state/themes/selectors/get-is-live-preview-supported.ts
+++ b/client/state/themes/selectors/get-is-live-preview-supported.ts
@@ -82,14 +82,9 @@ const isNotCompatibleThemes = ( themeId: string ) => {
  * - On Simple sites;
  *   - If the theme is externally managed.
  *   - If the theme is a wporg theme.
- *   - If the theme is NOT included in a plan.
- * @see pbxlJb-3Uv-p2
+ *   - If the theme is NOT a Premium and WooCommerce theme, and is NOT included in a plan.
  */
 export const getIsLivePreviewSupported = ( state: AppState, themeId: string, siteId: number ) => {
-	if ( ! config.isEnabled( 'themes/block-theme-previews' ) ) {
-		return false;
-	}
-
 	// The "Live" Preview does NOT make sense for logged out users.
 	if ( ! isUserLoggedIn( state ) ) {
 		return false;

--- a/client/state/themes/selectors/get-is-live-preview-supported.ts
+++ b/client/state/themes/selectors/get-is-live-preview-supported.ts
@@ -10,6 +10,8 @@ import {
 	isExternallyManagedTheme,
 	canUseTheme,
 	isSiteEligibleForManagedExternalThemes,
+	isThemeWooCommerce,
+	isThemePremium,
 } from '.';
 
 /**
@@ -151,11 +153,23 @@ export const getIsLivePreviewSupported = ( state: AppState, themeId: string, sit
 
 		/**
 		 * Disable Live Preview for themes that are NOT included in a plan.
-		 * This should be updated as we implement the flow for them.
-		 * Note that BTP works on Atomic sites if a theme is installed.
-		 * @see https://github.com/Automattic/wp-calypso/issues/79223
 		 */
 		if ( ! canUseTheme( state, siteId, themeId ) ) {
+			/**
+			 * Enable Live Preview for Premium and WooCommerce themes.
+			 * @see https://github.com/Automattic/wp-calypso/issues/79223
+			 */
+			if (
+				config.isEnabled( 'themes/block-theme-previews-premium-and-woo' ) &&
+				( isThemePremium( state, themeId ) || isThemeWooCommerce( state, themeId ) )
+			) {
+				return true;
+			}
+
+			/**
+			 * Handling Bundle themes except for WooCommerce themes here.
+			 * We can enable Live Preview for Bundle themes by supporting them on the Live Preview notices.
+			 */
 			return false;
 		}
 	}

--- a/client/state/themes/selectors/get-live-preview-url.ts
+++ b/client/state/themes/selectors/get-live-preview-url.ts
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { addQueryArgs } from 'calypso/lib/route';
 import getSiteEditorUrl from 'calypso/state/selectors/get-site-editor-url';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
@@ -8,10 +7,6 @@ import { getTheme } from '.';
 const QUERY_NAME = 'wp_theme_preview';
 
 export const getLivePreviewUrl = ( state: AppState, themeId: string, siteId: number ) => {
-	if ( ! config.isEnabled( 'themes/block-theme-previews' ) ) {
-		return undefined;
-	}
-
 	const siteEditorUrl = getSiteEditorUrl( state, siteId );
 
 	if ( isSiteAutomatedTransfer( state, siteId ) ) {

--- a/client/state/themes/selectors/index.js
+++ b/client/state/themes/selectors/index.js
@@ -68,6 +68,7 @@ export { isThemeActive } from 'calypso/state/themes/selectors/is-theme-active';
 export { isThemeGutenbergFirst } from 'calypso/state/themes/selectors/is-theme-gutenberg-first';
 export { isThemePremium } from 'calypso/state/themes/selectors/is-theme-premium';
 export { isThemePurchased } from 'calypso/state/themes/selectors/is-theme-purchased';
+export { isThemeWooCommerce } from 'calypso/state/themes/selectors/is-theme-woo-commerce';
 export { isThemesLastPageForQuery } from 'calypso/state/themes/selectors/is-themes-last-page-for-query';
 export { isUpsellCardDisplayed } from 'calypso/state/themes/selectors/is-upsell-card-displayed';
 export { isValidThemeFilterTerm } from 'calypso/state/themes/selectors/is-valid-theme-filter-term';

--- a/client/state/themes/selectors/is-theme-woo-commerce.ts
+++ b/client/state/themes/selectors/is-theme-woo-commerce.ts
@@ -1,0 +1,14 @@
+import { getTheme } from 'calypso/state/themes/selectors/get-theme';
+import { IAppState } from 'calypso/state/types';
+import { ThemeSoftwareSet } from 'calypso/types';
+import 'calypso/state/themes/init';
+
+/**
+ * Returns whether a theme is a WooCommerce theme.
+ */
+export function isThemeWooCommerce( state: IAppState, themeId: string ) {
+	const theme = getTheme( state, 'wpcom', themeId );
+	const themeSoftwareSetTaxonomy: ThemeSoftwareSet[] | undefined =
+		theme?.taxonomies?.theme_software_set;
+	return themeSoftwareSetTaxonomy?.some( ( { slug } ) => slug === 'woo-on-plan' );
+}

--- a/config/development.json
+++ b/config/development.json
@@ -209,7 +209,6 @@
 		"subscription-management/migrate-subscribers": true,
 		"subscription-management-redirect-following": true,
 		"themes/atomic-homepage-replace": true,
-		"themes/block-theme-previews": true,
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/display-thank-you-page-for-woo": true,

--- a/config/development.json
+++ b/config/development.json
@@ -210,6 +210,7 @@
 		"subscription-management-redirect-following": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/block-theme-previews": true,
+		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/display-thank-you-page-for-woo": true,
 		"themes/premium": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -147,6 +147,7 @@
 		"subscription-management-redirect-following": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/block-theme-previews": true,
+		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/display-thank-you-page-for-woo": true,
 		"themes/premium": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -146,7 +146,6 @@
 		"subscription-management/migrate-subscribers": true,
 		"subscription-management-redirect-following": true,
 		"themes/atomic-homepage-replace": true,
-		"themes/block-theme-previews": true,
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/display-thank-you-page-for-woo": true,

--- a/config/production.json
+++ b/config/production.json
@@ -175,7 +175,6 @@
 		"subscription-management/migrate-subscribers": true,
 		"subscription-management-redirect-following": true,
 		"themes/atomic-homepage-replace": true,
-		"themes/block-theme-previews": true,
 		"themes/block-theme-previews-premium-and-woo": false,
 		"themes/discovery": true,
 		"themes/display-thank-you-page-for-woo": true,

--- a/config/production.json
+++ b/config/production.json
@@ -176,6 +176,7 @@
 		"subscription-management-redirect-following": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/block-theme-previews": true,
+		"themes/block-theme-previews-premium-and-woo": false,
 		"themes/discovery": true,
 		"themes/display-thank-you-page-for-woo": true,
 		"themes/premium": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -170,7 +170,6 @@
 		"subscription-management/migrate-subscribers": true,
 		"subscription-management-redirect-following": true,
 		"themes/atomic-homepage-replace": true,
-		"themes/block-theme-previews": true,
 		"themes/block-theme-previews-premium-and-woo": false,
 		"themes/discovery": true,
 		"themes/display-thank-you-page-for-woo": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -171,6 +171,7 @@
 		"subscription-management-redirect-following": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/block-theme-previews": true,
+		"themes/block-theme-previews-premium-and-woo": false,
 		"themes/discovery": true,
 		"themes/display-thank-you-page-for-woo": true,
 		"themes/premium": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -178,7 +178,6 @@
 		"subscription-management/comments-list-controls": true,
 		"subscription-management-redirect-following": true,
 		"themes/atomic-homepage-replace": true,
-		"themes/block-theme-previews": true,
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/display-thank-you-page-for-woo": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -179,6 +179,7 @@
 		"subscription-management-redirect-following": true,
 		"themes/atomic-homepage-replace": true,
 		"themes/block-theme-previews": true,
+		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/display-thank-you-page-for-woo": true,
 		"themes/premium": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
thelinked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/79223
https://github.com/Automattic/wp-calypso/pull/84483

## Proposed Changes

This PR enables the "Preview & Customize" button for Premium and WooCommerce themes on the Horizon environment. 

Note that the whole "Live Preview in Premium and Woo themes" feature is under development. See https://github.com/Automattic/wp-calypso/issues/79223.

| before | after |
|--------|--------|
| <img width="375" alt="Screenshot 2023-12-13 at 10 59 59" src="https://github.com/Automattic/wp-calypso/assets/5287479/932f6211-6535-4fa9-9c18-b944317a0962"> |<img width="378" alt="Screenshot 2023-12-13 at 10 55 45" src="https://github.com/Automattic/wp-calypso/assets/5287479/348525bb-2413-4bed-a9be-a96ef49bdaeb"> |
| <img width="1432" alt="Screenshot 2023-12-13 at 10 59 52" src="https://github.com/Automattic/wp-calypso/assets/5287479/14b5efa1-3c46-4f54-b19d-af184cfe08bf"> | <img width="1436" alt="Screenshot 2023-12-13 at 10 56 47" src="https://github.com/Automattic/wp-calypso/assets/5287479/3079f408-3046-47b5-b676-2361a2d14a48"> | 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the Theme Showcase page.
* Click the three-dot menu on a Premium (e.g., Hevor) or WooCommerce (e.g., Amulet) theme.
	* Click the `Preview & Customize` button.
		<img width="378" alt="Screenshot 2023-12-13 at 10 55 45" src="https://github.com/Automattic/wp-calypso/assets/5287479/348525bb-2413-4bed-a9be-a96ef49bdaeb">
	* Verify it redirects to the Site Editor and you're live-previewing the theme. 

Regression testing for Simple sites;

* Click the three-dots menu on a Free (e.g., Epi) theme.
	* Click the `Preview & Customize` button.
	* Verify it redirects to the Site Editor and you're live-previewing the theme. 
* Click the three-dots menu on a Partner (e.g., Eben) / wporg (e.g., Classified Listings) theme.
	* Verify you don't see the `Preview & Customize` button.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?