### PR TITLE
Assembler Level-Up: Enable in wpcalypso env instead of Horizon

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -87,7 +87,7 @@
 		"my-sites/add-ons": true,
 		"network-connection": true,
 		"p2/p2-plus": true,
-		"pattern-assembler/v2": true,
+		"pattern-assembler/v2": false,
 		"pattern-assembler/add-pages": true,
 		"plans/hosting-trial": false,
 		"plans/migration-trial": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -116,7 +116,7 @@
 		"onboarding/import-redirect-to-themes": true,
 		"onboarding/interval-dropdown": false,
 		"p2/p2-plus": true,
-		"pattern-assembler/v2": false,
+		"pattern-assembler/v2": true,
 		"pattern-assembler/add-pages": true,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,

--- a/test/e2e/specs/onboarding/onboarding__site-assembler.ts
+++ b/test/e2e/specs/onboarding/onboarding__site-assembler.ts
@@ -103,7 +103,8 @@ describe( 'Onboarding: Site Assembler', () => {
 			expect( await siteAssemblerFlow.getAssembledComponentsCount() ).toBe( 1 );
 		} );
 
-		it( 'Select a Quote pattern', async function () {
+		// Skip section patterns while the Assembler v2 is being developed.
+		it.skip( 'Select a Quote pattern', async function () {
 			await siteAssemblerFlow.clickLayoutComponentType( 'Quotes' );
 			await siteAssemblerFlow.selectLayoutComponent( { index: 0 } );
 
@@ -114,7 +115,7 @@ describe( 'Onboarding: Site Assembler', () => {
 			await siteAssemblerFlow.clickLayoutComponentType( 'Footer' );
 			await siteAssemblerFlow.selectLayoutComponent( { index: 0 } );
 
-			expect( await siteAssemblerFlow.getAssembledComponentsCount() ).toBe( 3 );
+			expect( await siteAssemblerFlow.getAssembledComponentsCount() ).toBe( 2 );
 		} );
 
 		it( 'Pick default style', async function () {


### PR DESCRIPTION
See discussion at: https://github.com/Automattic/wp-calypso/pull/84977#issuecomment-1853038378

## Proposed Changes

Enable the new Assembler theme in wpcalypso env by default, and disable in horizon by default.

## Testing Instructions

Go to the Assembler flow using the Calypso live URL, and verify that you see the new theme, new patterns, new colors, and new fonts.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?