### PR TITLE
Enable stats/paid-wpcom-v2 config in development

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -194,6 +194,7 @@
 		"stats/date-control": true,
 		"stats/new-video-summary": true,
 		"stats/paid-wpcom-stats": true,
+		"stats/paid-wpcom-v2": true,
 		"stats/plan-usage": true,
 		"stats/tier-upgrade-slider": true,
 		"stats/type-detection": true,


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/4592

## Proposed Changes

* Enables the `stats/paid-wpcom-v2` feature flag in development

## Testing Instructions

* http://calypso.localhost:3000/stats/ should work like normal.