### PR TITLE
Assembler: Remove Assembler Survey #2

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -77,7 +77,6 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 	const [ sectionPosition, setSectionPosition ] = useState< number | null >( null );
 	const wrapperRef = useRef< HTMLDivElement | null >( null );
 	const [ activePosition, setActivePosition ] = useState( -1 );
-	const [ surveyDismissed, setSurveyDismissed ] = useState( false );
 	const { goBack, goNext, submit } = navigation;
 	const { assembleSite } = useDispatch( SITE_STORE );
 	const reduxDispatch = useReduxDispatch();
@@ -622,11 +621,7 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 				</NavigatorScreen>
 
 				<NavigatorScreen path={ NAVIGATOR_PATHS.CONFIRMATION } className="screen-confirmation">
-					<ScreenConfirmation
-						onConfirm={ onConfirm }
-						surveyDismissed={ surveyDismissed }
-						setSurveyDismissed={ setSurveyDismissed }
-					/>
+					<ScreenConfirmation onConfirm={ onConfirm } />
 				</NavigatorScreen>
 
 				<NavigatorScreen path={ NAVIGATOR_PATHS.UPSELL } className="screen-upsell">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-confirmation.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-confirmation.tsx
@@ -8,16 +8,13 @@ import { Icon, image, verse, layout } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useScreen } from './hooks';
 import NavigatorTitle from './navigator-title';
-import Survey from './survey';
 import './screen-confirmation.scss';
 
 interface Props {
 	onConfirm: () => void;
-	surveyDismissed: boolean;
-	setSurveyDismissed: ( dismissed: boolean ) => void;
 }
 
-const ScreenConfirmation = ( { onConfirm, surveyDismissed, setSurveyDismissed }: Props ) => {
+const ScreenConfirmation = ( { onConfirm }: Props ) => {
 	const translate = useTranslate();
 	const { title, description, continueLabel } = useScreen( 'confirmation' );
 
@@ -60,13 +57,6 @@ const ScreenConfirmation = ( { onConfirm, surveyDismissed, setSurveyDismissed }:
 						</HStack>
 					) ) }
 				</VStack>
-				{ ! surveyDismissed && (
-					<Survey
-						eventName="assembler-november-2023"
-						eventUrl="https://automattic.survey.fm/assembler-survey-2"
-						setSurveyDismissed={ setSurveyDismissed }
-					/>
-				) }
 			</div>
 			<div className="screen-container__footer">
 				<Button className="pattern-assembler__button" primary onClick={ onConfirm }>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #https://github.com/Automattic/wp-calypso/issues/85125

## Proposed Changes

See p1702406623277089-slack-CRWCHQGUB. This PR removes the Assembler survey #2 banner.

| Before | After |
| --- | --- |
 | ![Screenshot 2023-12-13 at 10 47 29 AM](https://github.com/Automattic/wp-calypso/assets/797888/583b22f9-b380-4e77-8a67-88e3111ff4ec) | ![Screenshot 2023-12-13 at 10 47 03 AM](https://github.com/Automattic/wp-calypso/assets/797888/b3ca36a1-5f6f-4665-bc8e-54cd525bd6d7) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Assembler from the onboarding.
* Select any pattern.
* Select any styles.
* Select any pages.
* Ensure that once landing in the Confirmation screen, the survey banner is no longer present.
* Ensure that there are no JS errors and that the flow can be completed successfully.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?