### PR TITLE
Jetpack Manage: Show the selected bundle count in bundle size tabs

### DIFF
--- a/client/jetpack-cloud/components/layout/nav.tsx
+++ b/client/jetpack-cloud/components/layout/nav.tsx
@@ -66,6 +66,7 @@ export default function LayoutNavigation( {
 					{ Number.isInteger( selectedCount ) && <Count count={ selectedCount } compact /> }
 				</span>
 			}
+			selectedCount={ selectedCount }
 		>
 			{ children }
 		</SectionNav>

--- a/client/jetpack-cloud/components/layout/style.scss
+++ b/client/jetpack-cloud/components/layout/style.scss
@@ -89,7 +89,7 @@
 }
 
 .jetpack-cloud-layout__header.has-actions > .jetpack-cloud-layout__header-main {
-	@include breakpoint-deprecated( "<1280px" ) {
+	@include breakpoint-deprecated( "660px-1280px" ) {
 		margin-block-end: 16px;
 	}
 }

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/index.tsx
@@ -77,6 +77,29 @@ export default function IssueLicenseV2( { selectedSite, suggestedProduct }: Assi
 			? translate( 'Single license' )
 			: ( translate( '%(size)d licenses', { args: { size: selectedSize } } ) as string );
 
+	const selectedCount = selectedLicenses.filter( ( license ) => license.quantity === selectedSize )
+		?.length;
+
+	const navItems = availableSizes.map( ( size ) => {
+		const count = selectedLicenses.filter( ( license ) => license.quantity === size ).length;
+		return {
+			label:
+				size === 1
+					? translate( 'Single license' )
+					: ( translate( '%(size)d licenses', {
+							args: { size },
+					  } ) as string ),
+			selected: selectedSize === size,
+			onClick: () => setSelectedSize( size ),
+			...( count && { count } ),
+		};
+	} );
+
+	const selectedItemProps = {
+		selectedText,
+		...( selectedCount && { selectedCount } ),
+	};
+
 	return (
 		<>
 			<Layout
@@ -122,20 +145,8 @@ export default function IssueLicenseV2( { selectedSite, suggestedProduct }: Assi
 						) }
 					</LayoutHeader>
 
-					<LayoutNavigation selectedText={ selectedText }>
-						<NavigationTabs
-							selectedText={ selectedText }
-							items={ availableSizes.map( ( size ) => ( {
-								label:
-									size === 1
-										? translate( 'Single license' )
-										: ( translate( '%(size)d licenses', {
-												args: { size },
-										  } ) as string ),
-								selected: selectedSize === size,
-								onClick: () => setSelectedSize( size ),
-							} ) ) }
-						/>
+					<LayoutNavigation { ...selectedItemProps }>
+						<NavigationTabs { ...selectedItemProps } items={ navItems } />
 					</LayoutNavigation>
 				</LayoutTop>
 


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/141

## Proposed Changes

This PR shows the selected bundle count in the bundle size tabs.

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

**Instructions**

1. Visit the Jetpack Cloud link > Replace `dashboard` in the URL with `/partner-portal/issue-license?flags=jetpack/bundle-licensing`.
2. Select any license and verify that the count updates based on the selection. Verify it looks good on various devices too.

Large screen: 

<img width="1112" alt="Screenshot 2023-12-13 at 9 46 26 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/f26b1155-d557-4710-9922-abd4139bca3e">

Tablet: 

<img width="541" alt="Screenshot 2023-12-13 at 9 47 02 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/625d822e-6cc3-4d56-ad83-18442e33dd94">

Mobile: 

<img width="321" alt="Screenshot 2023-12-13 at 9 46 45 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/a9074ce3-867c-4d2b-a812-0d60121a60c1">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?