### PR TITLE
Jetpack Manage: Fix bundle discount information in the product card

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/lib/pricing.ts
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/lib/pricing.ts
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import type { SelectedLicenseProp } from '../types';
 import type { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
@@ -14,6 +15,8 @@ export const getProductPricingInfo = (
 		: parseFloat( product?.amount ) || 0;
 
 	const isDailyPricing = product.price_interval === 'day';
+
+	const isBundleUIEnabled = isEnabled( 'jetpack/bundle-licensing' );
 
 	const discountInfo: {
 		actualCost: number;
@@ -40,7 +43,8 @@ export const getProductPricingInfo = (
 			);
 		// If a monthly product is found, calculate the actual cost and discount percentage
 		if ( monthlyProduct ) {
-			const monthlyProductBundleCost = monthlyProduct.cost * quantity;
+			const monthlyProductBundleCost =
+				( isBundleUIEnabled ? parseFloat( product.amount ) : monthlyProduct.cost ) * quantity;
 			const actualCost = isDailyPricing ? monthlyProductBundleCost / 365 : monthlyProductBundleCost;
 			const discountedCost = actualCost - productBundleCost;
 			discountInfo.discountPercentage = productBundleCost


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/136

## Proposed Changes

This PR fixes bundle discount information in the product card by using the product cost directly instead of calculating based on user products.

Single: 

<img width="758" alt="Screenshot 2023-12-13 at 10 34 20 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/ac9e7b36-355a-4d58-9c36-563700395a5c">

Bundle of 10:

<img width="769" alt="Screenshot 2023-12-13 at 10 34 29 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/d90ae0ea-f346-434b-b2dc-a188ea34ed9d">

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

**Instructions**

1. Visit the Jetpack Cloud link > Replace `dashboard` in the URL with `/partner-portal/issue-license?flags=jetpack/bundle-licensing`.
2. Verify that the price is now properly displayed(single license * quantity), add a few products, and verify that the total is calculated and displayed correctly.
3. Click the `Review X licenses` button > Verify the total cost and breakfast is displayed correctly.
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?