### PR TITLE
Assembler AI: Fix Launchpad issues

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/free-post-setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/free-post-setup/index.tsx
@@ -1,4 +1,9 @@
-import { StepContainer, base64ImageToBlob, uploadAndSetSiteLogo } from '@automattic/onboarding';
+import {
+	StepContainer,
+	base64ImageToBlob,
+	isSiteAssemblerFlow,
+	uploadAndSetSiteLogo,
+} from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
@@ -12,8 +17,8 @@ import useSetupFormInitialValues from '../components/setup-form/hooks/use-setup-
 import type { Step } from '../../types';
 import '../free-setup/styles.scss';
 
-const FreePostSetup: Step = ( { navigation } ) => {
-	const { submit } = navigation;
+const FreePostSetup: Step = ( { navigation, flow } ) => {
+	const { goBack, submit } = navigation;
 	const translate = useTranslate();
 	const site = useSite();
 
@@ -71,7 +76,8 @@ const FreePostSetup: Step = ( { navigation } ) => {
 		<StepContainer
 			stepName="free-setup"
 			isWideLayout={ true }
-			hideBack={ true }
+			hideBack={ ! isSiteAssemblerFlow( flow ) }
+			goBack={ goBack }
 			flowName="free"
 			formattedHeader={
 				<FormattedHeader

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/launchpad-site-preview.tsx
@@ -10,6 +10,7 @@ import {
 	VIDEOPRESS_FLOW,
 	VIDEOPRESS_ACCOUNT,
 	ASSEMBLER_FIRST_FLOW,
+	AI_ASSEMBLER_FLOW,
 	isVideoPressFlow,
 } from '@automattic/onboarding';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
@@ -33,6 +34,7 @@ const LaunchpadSitePreview = ( { siteSlug, flow }: Props ) => {
 			case START_WRITING_FLOW:
 			case DESIGN_FIRST_FLOW:
 			case ASSEMBLER_FIRST_FLOW:
+			case AI_ASSEMBLER_FLOW:
 				return DEVICE_TYPES.COMPUTER;
 			case VIDEOPRESS_FLOW:
 			case VIDEOPRESS_ACCOUNT:

--- a/config/stage.json
+++ b/config/stage.json
@@ -21,7 +21,7 @@
 		"akismet/siteless-checkout": true,
 		"akismet/checkout-quantity-dropdown": true,
 		"calypso/ai-blogging-prompts": false,
-		"calypso/ai-assembler": true,
+		"calypso/ai-assembler": false,
 		"calypso/help-center": true,
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #84839

## Proposed Changes

This PR fixes several issues with the Launchpad:

- The Launchpad now shows the site preview using desktop resolution instead of mobile.
- The Launchpad's "Skip for now" button works correctly.  
- The "Personalize your site" task now correctly takes user to the corresponding step. 
- The "Personalize your site" step shows a Back button which takes to the Launchpad.

In addition, this PR adds a redirect to the `assembler-first` flow for the staging and production environments.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/setup/ai-assembler`.
* Create a new site to ensure a fresh Launchpad experience.
* Click on Skip for now in the AI prompt screen.
* Complete the Assembler flow.
* Once in the Site Editor, head to the Launchpad by either exiting the Site Editor or going directly to `/setup/ai-assembler/launchpad?siteSlug=${site_slug}.
* Ensure that:
  * The site preview is shown in desktop resolution.
  * The "Personalize your site" task is clickable and takes you to the corresponding step.
  * The "Personalize your site" has a Back button that takes you back to the Launchpad.
  * The Launchpad's Skip for now works as intended.
 
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?