### PR TITLE
Paid stats: paywall the download csv button

### DIFF
--- a/client/my-sites/stats/hooks/use-should-gate-stats.ts
+++ b/client/my-sites/stats/hooks/use-should-gate-stats.ts
@@ -14,7 +14,7 @@ const trafficPaidStats = [
 	'statsCountryViews',
 ];
 
-const featureFlags = [ 'stats/date-control' ];
+const featureFlags = [ 'stats/date-control', 'download-csv' ];
 
 /*
  * Check if a site has access to a paid stats feature in wpcom.

--- a/client/my-sites/stats/stats-download-csv-upsell/index.tsx
+++ b/client/my-sites/stats/stats-download-csv-upsell/index.tsx
@@ -1,0 +1,47 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { isEnabled } from '@automattic/calypso-config';
+import page from '@automattic/calypso-router';
+import { Button, Gridicon } from '@automattic/components';
+import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+
+interface Props {
+	className: string;
+	statType: string;
+	siteId: number;
+	borderless: boolean;
+}
+
+const StatsDownloadCsvUpsell: React.FC< Props > = ( {
+	className,
+	statType,
+	siteId,
+	borderless,
+} ) => {
+	const translate = useTranslate();
+
+	const onClick = ( event: React.MouseEvent< HTMLButtonElement, MouseEvent > ) => {
+		event.preventDefault();
+
+		const source = isEnabled( 'is_running_in_jetpack_site' ) ? 'jetpack' : 'calypso';
+		recordTracksEvent( 'jetpack_stats_csv_upsell_clicked', {
+			statType,
+			source,
+		} );
+
+		page( `/stats/purchase/${ siteId }?productType=personal&from=${ source }` );
+	};
+
+	return (
+		<Button
+			className={ classNames( className, 'stats-download-csv-upsell', 'stats-download-csv' ) }
+			compact
+			borderless={ borderless }
+			onClick={ onClick }
+		>
+			<Gridicon icon="cloud-download" /> { translate( 'Upgrade & Download to CSV' ) }
+		</Button>
+	);
+};
+
+export default StatsDownloadCsvUpsell;

--- a/client/my-sites/stats/stats-list/stats-list-card.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-card.jsx
@@ -8,6 +8,7 @@ import {
 import { Icon, tag, file } from '@wordpress/icons';
 import classNames from 'classnames';
 import debugFactory from 'debug';
+import { localize } from 'i18n-calypso';
 import { useState, useCallback } from 'react';
 import titlecase from 'to-title-case';
 import { gaRecordEvent } from 'calypso/lib/analytics/ga';
@@ -180,4 +181,4 @@ const StatsListCard = ( {
 	);
 };
 
-export default StatsListCard;
+export default localize( StatsListCard );

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -16,6 +16,7 @@ import { shouldGateStats } from '../hooks/use-should-gate-stats';
 import StatsCardUpsell from '../stats-card-upsell';
 import DatePicker from '../stats-date-picker';
 import DownloadCsv from '../stats-download-csv';
+import DownloadCsvUpsell from '../stats-download-csv-upsell';
 import ErrorPanel from '../stats-error';
 import StatsListCard from '../stats-list/stats-list-card';
 import StatsModulePlaceholder from './placeholder';
@@ -41,6 +42,7 @@ class StatsModule extends Component {
 		additionalColumns: PropTypes.object,
 		listItemClassName: PropTypes.string,
 		gateStats: PropTypes.bool,
+		gateDownloads: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -134,6 +136,7 @@ class StatsModule extends Component {
 			mainItemLabel,
 			listItemClassName,
 			gateStats,
+			gateDownloads,
 		} = this.props;
 
 		// Only show loading indicators when nothing is in state tree, and request in-flight
@@ -198,13 +201,17 @@ class StatsModule extends Component {
 				/>
 				{ isAllTime && (
 					<div className={ footerClass }>
-						<DownloadCsv
-							statType={ statType }
-							query={ query }
-							path={ path }
-							borderless
-							period={ period }
-						/>
+						{ gateDownloads ? (
+							<DownloadCsvUpsell statType={ statType } siteId={ siteId } borderless />
+						) : (
+							<DownloadCsv
+								statType={ statType }
+								query={ query }
+								path={ path }
+								borderless
+								period={ period }
+							/>
+						) }
 					</div>
 				) }
 			</>
@@ -217,6 +224,7 @@ export default connect( ( state, ownProps ) => {
 	const siteSlug = getSiteSlug( state, siteId );
 	const { statType, query } = ownProps;
 	const gateStats = shouldGateStats( state, siteId, statType );
+	const gateDownloads = shouldGateStats( state, siteId, 'download-csv' );
 
 	return {
 		requesting: isRequestingSiteStatsForQuery( state, siteId, statType, query ),
@@ -224,5 +232,6 @@ export default connect( ( state, ownProps ) => {
 		siteId,
 		siteSlug,
 		gateStats,
+		gateDownloads,
 	};
 } )( localize( StatsModule ) );


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/4900

Currently rebased against https://github.com/Automattic/wp-calypso/pull/85041/ for development, that should rebase out later once merged. (There are changes coming)

## Proposed Changes

* Puts the download csv feature behind the paid stats feature gating

## Testing Instructions

Enabled by default in development, in calypso live enable with the query param: ?flags=stats/paid-wpcom-v2
Disable paid stats in development with the query param: ?flags=-stats/paid-wpcom-v2

* Click view details on a paid stat and a non paid stat:
* Without paid stats: both download csv buttons should be replaced with an upgrade button
* With paid stats: both buttons should not be replaced with an upgrade button

Checking Jetpack:
- The upgrade button should never be shown.

![Screenshot(80)](https://github.com/Automattic/wp-calypso/assets/811776/f14e6fcd-9dd5-41b4-9ea7-405861c5627f)

