### PR TITLE
Jetpack Manage: Remove redundancy on the product titles.

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/lib/get-product-short-title.ts
+++ b/client/jetpack-cloud/sections/partner-portal/lib/get-product-short-title.ts
@@ -13,7 +13,7 @@ export default function getProductShortTitle(
 ): string {
 	const title = getProductTitle( product, removeVariant );
 
-	if ( title.startsWith( 'VaultPress Backup' ) ) {
+	if ( title.startsWith( 'VaultPress Backup Add-on' ) ) {
 		return getProductVariantShortTitle( title );
 	}
 

--- a/client/jetpack-cloud/sections/partner-portal/lib/get-product-short-title.ts
+++ b/client/jetpack-cloud/sections/partner-portal/lib/get-product-short-title.ts
@@ -1,0 +1,21 @@
+import getProductTitle from './get-product-title';
+import getProductVariantShortTitle from './get-product-variant-short-title';
+
+/**
+ * Get the short version of the product title
+ * @param product Product
+ * @param removeVariant if we need to remove variant information
+ * @returns Product title
+ */
+export default function getProductShortTitle(
+	product: string,
+	removeVariant: boolean = false
+): string {
+	const title = getProductTitle( product, removeVariant );
+
+	if ( title.startsWith( 'VaultPress Backup' ) ) {
+		return getProductVariantShortTitle( title );
+	}
+
+	return title.replaceAll( /(?:Woocommerce\s|[)(])/gi, '' );
+}

--- a/client/jetpack-cloud/sections/partner-portal/lib/get-product-short-title.ts
+++ b/client/jetpack-cloud/sections/partner-portal/lib/get-product-short-title.ts
@@ -1,3 +1,4 @@
+import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import getProductTitle from './get-product-title';
 import getProductVariantShortTitle from './get-product-variant-short-title';
 
@@ -8,12 +9,12 @@ import getProductVariantShortTitle from './get-product-variant-short-title';
  * @returns Product title
  */
 export default function getProductShortTitle(
-	product: string,
+	product: APIProductFamilyProduct,
 	removeVariant: boolean = false
 ): string {
-	const title = getProductTitle( product, removeVariant );
+	const title = getProductTitle( product.name, removeVariant );
 
-	if ( title.startsWith( 'VaultPress Backup Add-on' ) ) {
+	if ( product.family_slug === 'jetpack-backup-storage' ) {
 		return getProductVariantShortTitle( title );
 	}
 

--- a/client/jetpack-cloud/sections/partner-portal/license-multi-product-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-multi-product-card/index.tsx
@@ -151,7 +151,7 @@ export default function LicenseMultiProductCard( props: Props ) {
 						<div className="license-product-card__main">
 							<div className="license-product-card__heading">
 								<h3 className="license-product-card__title">
-									{ getProductShortTitle( product.name, true ) }
+									{ getProductShortTitle( product, true ) }
 								</h3>
 
 								<MultipleChoiceQuestion
@@ -175,7 +175,7 @@ export default function LicenseMultiProductCard( props: Props ) {
 
 								{ ! /^jetpack-backup-addon-storage-/.test( product.slug ) && (
 									<LicenseLightboxLink
-										productName={ getProductShortTitle( product.name ) }
+										productName={ getProductShortTitle( product ) }
 										onClick={ onShowLightbox }
 									/>
 								) }

--- a/client/jetpack-cloud/sections/partner-portal/license-multi-product-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-multi-product-card/index.tsx
@@ -7,7 +7,8 @@ import MultipleChoiceQuestion from 'calypso/components/multiple-choice-question'
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { APIProductFamilyProduct } from '../../../../state/partner-portal/types';
 import { useProductDescription, useURLQueryParams } from '../hooks';
-import { getProductTitle, LICENSE_INFO_MODAL_ID } from '../lib';
+import { LICENSE_INFO_MODAL_ID } from '../lib';
+import getProductShortTitle from '../lib/get-product-short-title';
 import getProductVariantShortTitle from '../lib/get-product-variant-short-title';
 import LicenseLightbox from '../license-lightbox';
 import LicenseLightboxLink from '../license-lightbox-link';
@@ -150,7 +151,7 @@ export default function LicenseMultiProductCard( props: Props ) {
 						<div className="license-product-card__main">
 							<div className="license-product-card__heading">
 								<h3 className="license-product-card__title">
-									{ getProductTitle( product.name, true ) }
+									{ getProductShortTitle( product.name, true ) }
 								</h3>
 
 								<MultipleChoiceQuestion
@@ -174,7 +175,7 @@ export default function LicenseMultiProductCard( props: Props ) {
 
 								{ ! /^jetpack-backup-addon-storage-/.test( product.slug ) && (
 									<LicenseLightboxLink
-										productName={ getProductTitle( product.name ) }
+										productName={ getProductShortTitle( product.name ) }
 										onClick={ onShowLightbox }
 									/>
 								) }

--- a/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
@@ -8,6 +8,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { APIProductFamilyProduct } from '../../../../state/partner-portal/types';
 import { useProductDescription, useURLQueryParams } from '../hooks';
 import { getProductTitle, LICENSE_INFO_MODAL_ID } from '../lib';
+import getProductShortTitle from '../lib/get-product-short-title';
 import LicenseLightbox from '../license-lightbox';
 import LicenseLightboxLink from '../license-lightbox-link';
 import ProductPriceWithDiscount from '../primary/product-price-with-discount-info';
@@ -40,9 +41,13 @@ export default function LicenseProductCard( props: Props ) {
 		withBackground,
 		quantity,
 	} = props;
+	const isNewCardFormat = isEnabled( 'jetpack/bundle-licensing' );
+
 	const { setParams, resetParams, getParamValue } = useURLQueryParams();
 	const modalParamValue = getParamValue( LICENSE_INFO_MODAL_ID );
-	const productTitle = getProductTitle( product.name );
+	const productTitle = isNewCardFormat
+		? getProductShortTitle( product.name )
+		: getProductTitle( product.name );
 	const [ showLightbox, setShowLightbox ] = useState( modalParamValue === product.slug );
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -103,8 +108,6 @@ export default function LicenseProductCard( props: Props ) {
 		resetParams( [ LICENSE_INFO_MODAL_ID ] );
 		setShowLightbox( false );
 	}, [ resetParams ] );
-
-	const isNewCardFormat = isEnabled( 'jetpack/bundle-licensing' );
 
 	return (
 		<>

--- a/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
@@ -46,7 +46,7 @@ export default function LicenseProductCard( props: Props ) {
 	const { setParams, resetParams, getParamValue } = useURLQueryParams();
 	const modalParamValue = getParamValue( LICENSE_INFO_MODAL_ID );
 	const productTitle = isNewCardFormat
-		? getProductShortTitle( product.name )
+		? getProductShortTitle( product )
 		: getProductTitle( product.name );
 	const [ showLightbox, setShowLightbox ] = useState( modalParamValue === product.slug );
 	const translate = useTranslate();


### PR DESCRIPTION
This pull request aims to eliminate the issue of title redundancy on two sections, namely the **VaultPress Backup Addons** and **WooCommerce**.

**Before**
<img width="1400" alt="Screen Shot 2023-12-13 at 2 39 34 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/9d203e5c-0008-4c8d-92a9-e72e52def194">
<img width="1399" alt="Screen Shot 2023-12-13 at 2 39 51 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/909a722f-3c04-4e5a-915b-6098dde7b67e">

**After**
<img width="1370" alt="Screen Shot 2023-12-13 at 2 40 39 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/5e151e2b-5fbb-4394-a9e5-971a9af81d3f">
<img width="1366" alt="Screen Shot 2023-12-13 at 2 40 49 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/ca64b2d0-f0a9-4e33-877f-bfd08ddd650b">

Closes https://github.com/Automattic/jetpack-manage/issues/168

## Proposed Changes

* Implement a `getProductShortTitle` function to get the displayable title.
* Update existing product cards to usee the new function.

## Testing Instructions
Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

* Use the Jetpack cloud live link below and go to the Issue License page. (`/partner-portal/issue-license`)
* Scroll down to Woocommerce extensions and VaultPress Backup Add-ons section.
* Confirm that the title is correct.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?