### PR TITLE
Fix "Log in with WordPress.com" page when first time logging in NUX

### DIFF
--- a/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
+++ b/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
@@ -175,7 +175,14 @@ const wooexpress: Flow = {
 
 					if ( providedDependencies?.pluginsInstalled ) {
 						recordGTMDatalayerEvent( 'free trial processing' );
-						return exitFlow( `${ adminUrl }admin.php?page=wc-admin` );
+						// Redirect users to the login page with the 'action=jetpack-sso' parameter to initiate Jetpack SSO login and redirect them to the wc admin page after.
+						const redirectTo = encodeURIComponent(
+							`${ adminUrl as string }admin.php?page=wc-admin`
+						);
+
+						return exitFlow(
+							`//${ siteSlug }/wp-login.php?action=jetpack-sso&redirect_to=${ redirectTo }`
+						);
 					}
 
 					return navigate( 'assignTrialPlan', { siteSlug } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/woocommerce/team-ghidorah/issues/274

"Log in with WordPress.com page" is shown when first time logging into site after NUX

This is because we set ‘Classic style’ as the default admin style in D129564-code, and meanwhile, Jetpack team added a logic in https://github.com/Automattic/jetpack/pull/33940 to skip the redirection if the user chooses to use the classic interface. 

This PR fixes the issue so that users are redirected to WC homescreen after NUX loading screen.

https://github.com/Automattic/wp-calypso/assets/4344253/0f77fe3e-b24f-4358-bbc7-fac1e93e1cc9


## Proposed Changes

* Update the flow exit path 
  
## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set up woocommerce-start-dev-env https://github.com/woocommerce/woocommerce-start-dev-env
* Go to `https://woo.com/start`
* Complete the Woo Express flow
* Confirm you're redirected to WC homescreen after NUX loading screen

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?