### PR TITLE
Jetpack Manage: Implement sidebar navigation for the Issue License page

### DIFF
--- a/client/jetpack-cloud/components/layout/index.tsx
+++ b/client/jetpack-cloud/components/layout/index.tsx
@@ -7,6 +7,7 @@ import './style.scss';
 
 type Props = {
 	children: ReactNode;
+	sidebarNavigation?: ReactNode;
 	className?: string;
 	title: ReactNode;
 	wide?: boolean;
@@ -19,6 +20,7 @@ export default function Layout( {
 	title,
 	wide = false,
 	withBorder = false,
+	sidebarNavigation,
 }: Props ) {
 	return (
 		<Main
@@ -29,6 +31,7 @@ export default function Layout( {
 			wideLayout={ ! wide } // When we set to full width, we want to set this to false.
 		>
 			<DocumentHead title={ title } />
+			{ sidebarNavigation }
 
 			<div className="jetpack-cloud-layout__container">{ children }</div>
 		</Main>

--- a/client/jetpack-cloud/components/layout/style.scss
+++ b/client/jetpack-cloud/components/layout/style.scss
@@ -11,8 +11,6 @@
 	padding-inline: 0;
 
 	header.current-section {
-		padding: 0 16px;
-
 		button {
 			padding: 20px 8px;
 		}

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/index.tsx
@@ -14,6 +14,7 @@ import LayoutNavigation, {
 	LayoutNavigationTabs as NavigationTabs,
 } from 'calypso/jetpack-cloud/components/layout/nav';
 import LayoutTop from 'calypso/jetpack-cloud/components/layout/top';
+import PartnerPortalSidebarNavigation from 'calypso/jetpack-cloud/sections/partner-portal/sidebar-navigation';
 import AssignLicenseStepProgress from '../assign-license-step-progress';
 import IssueLicenseContext from './context';
 import { useProductBundleSize } from './hooks/use-product-bundle-size';
@@ -107,6 +108,7 @@ export default function IssueLicenseV2( { selectedSite, suggestedProduct }: Assi
 				title={ translate( 'Issue a new License' ) }
 				wide
 				withBorder
+				sidebarNavigation={ <PartnerPortalSidebarNavigation /> }
 			>
 				<LayoutTop>
 					<AssignLicenseStepProgress currentStep={ currentStep } isBundleLicensing />

--- a/client/jetpack-cloud/sections/partner-portal/sidebar-navigation/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/sidebar-navigation/index.tsx
@@ -1,6 +1,7 @@
 import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import { useSelector } from 'calypso/state';
 import { getDocumentHeadTitle } from 'calypso/state/document-head/selectors/get-document-head-title';
+
 import './style.scss';
 
 export default function PartnerPortalSidebarNavigation() {


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/142
Resolves https://github.com/Automattic/jetpack-genesis/issues/143

## Proposed Changes

This PR

- Fixes the product cards overflowing issue on small screen devices.
- Adds a sidebar navigation for the Issue License page.



## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

**Instructions**

1. Visit the Jetpack Cloud link > Replace `dashboard` in the URL with `/partner-portal/issue-license?flags=jetpack/bundle-licensing`.
2. Switch to a small screen view(<660px) > Verify that you can now see navigation on top to go to other pages and the product cards are not overflowing.

![mobile (56)](https://github.com/Automattic/wp-calypso/assets/10586875/da021440-2bd4-4350-ba1f-a4b2ca87d1be)

![mobile (57)](https://github.com/Automattic/wp-calypso/assets/10586875/5ab7d286-c84d-4e09-8378-a4e55f33fd41)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?