### PR TITLE
Self-service site resets: prepare for CfT

### DIFF
--- a/client/my-sites/site-settings/site-tools/index.jsx
+++ b/client/my-sites/site-settings/site-tools/index.jsx
@@ -216,7 +216,7 @@ export default compose( [
 				cloneUrl,
 				showChangeAddress: ! isJetpack && ! isVip && ! isP2,
 				showClone: 'active' === rewindState.state && ! isAtomic,
-				showDeleteContent: ! isJetpack && ! isVip && ! isP2Hub,
+				showDeleteContent: isAtomic || ( ! isJetpack && ! isVip && ! isP2Hub ),
 				showDeleteSite: ( ! isJetpack || isAtomic ) && ! isVip && sitePurchasesLoaded,
 				showManageConnection: isJetpack && ! isAtomic,
 				showStartSiteTransfer,

--- a/client/my-sites/site-settings/site-tools/index.jsx
+++ b/client/my-sites/site-settings/site-tools/index.jsx
@@ -68,10 +68,9 @@ class SiteTools extends Component {
 		const manageConnectionLink = `/settings/manage-connection/${ siteSlug }`;
 
 		const changeSiteAddress = translate( 'Change your site address' );
-		const startOver = translate( 'Delete your content' );
+		const startOver = translate( 'Reset your site' );
 		const startOverText = translate(
-			"Keep your site's address and current theme, but remove all posts, " +
-				'pages, and media so you can start fresh.'
+			"Remove all posts, pages, and media to start fresh while keeping your site's address."
 		);
 		const deleteSite = translate( 'Delete your site permanently' );
 		const deleteSiteText = translate(

--- a/config/stage.json
+++ b/config/stage.json
@@ -140,7 +140,7 @@
 		"server-side-rendering": true,
 		"settings/newsletter-settings-page": true,
 		"settings/security/monitor": true,
-		"settings/self-serve-site-reset": false,
+		"settings/self-serve-site-reset": true,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
 		"signup/design-picker-preview-colors": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
![image](https://github.com/Automattic/wp-calypso/assets/47489215/2d625d97-0f91-47b1-ad1a-4319d237053c)

## Proposed Changes
1.  Enable code in Staging
2. Show the "Delete your content" option for Atomic sites in the **Site tools** at the bottom of the `Settings` > `General` page. 



## Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* It's not possible to test change 1 above with merging AFAIK
* For the second change:
     * If using Calypso Live, be sure to append ?flags=settings/self-serve-site-reset to your URLs
     * Go to `/settings/general/:atomic-site` and `/settings/general/:simple-site` and make sure you see "Delete your content" for both. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?