### PR TITLE
Jetpack Manage: Fix the broken filter UI in the dashboard

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-search-filter-container/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-search-filter-container/style.scss
@@ -5,6 +5,7 @@
 	margin: 0 0 8px;
 	background: #fff;
 	position: relative;
+
 	@include break-large() {
 		position: static;
 		display: flex;
@@ -18,13 +19,16 @@
 .site-search-filter-container__search {
 	height: 52px;
 	box-shadow: 0 0 0 1px var(--color-neutral-5);
+
 	@include break-large() {
 		width: 40%;
 		height: auto;
 		box-shadow: none;
 	}
+
 	.search.is-open {
 		box-shadow: none;
+
 		.search__open-icon {
 			width: 40px;
 		}
@@ -33,6 +37,7 @@
 
 .site-search-filter-container__filter-bar {
 	box-shadow: 0 0 0 1px var(--color-neutral-5);
+
 	@include break-large() {
 		z-index: 99;
 		width: 60%;
@@ -40,19 +45,28 @@
 		display: flex;
 		box-shadow: none;
 	}
+
 	.filterbar {
 		max-width: 100%;
 	}
+
 	.filterbar__wrap.card {
 		overflow-x: auto;
 		box-shadow: none;
-		.filterbar__label {
-			margin-left: 12px;
-		}
+
 		.filterbar__control-list {
 			li {
 				display: inline-flex;
 			}
+		}
+	}
+
+	@include breakpoint-deprecated( "<660px" ) {
+		margin-block-start: 1px;
+
+		.filterbar__wrap.card {
+			display: flex;
+			height: 50px;
 		}
 	}
 }


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-manage/issues/170

## Proposed Changes

This PR fixes the broken filter UI in the Jetpack Manage Dashboard.

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

**Instructions**

1. Visit the Jetpack Cloud link > You'll be redirected to /dashboard
2. Switch to mobile view and verify that the filter UI looks fine, not broken. Verify it looks fine on large-screen devices as well.

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="321" alt="Screenshot 2023-12-13 at 3 10 04 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/d8704852-5ded-4679-becf-0cc210306889">
</td>
<td>
<img width="321" alt="Screenshot 2023-12-13 at 3 19 56 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/8e1eddcf-2842-4063-b002-7e07e9a049af"></td>
</tr>
</table>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?