### PR TITLE
Pressable promo banner: further polishing.

### DIFF
--- a/client/my-sites/plans-features-main/components/pressable-promo-banner.tsx
+++ b/client/my-sites/plans-features-main/components/pressable-promo-banner.tsx
@@ -17,10 +17,31 @@ const Banner = styled.div`
 	padding: 24px;
 	align-items: center;
 	gap: 32px;
+	max-width: 392px;
 
 	${ plansBreakSmall( css`
 		flex-direction: row;
 	` ) }
+
+	@media ( min-width: 440px ) {
+		margin-left: auto;
+		margin-right: auto;
+	}
+
+	@media ( min-width: 780px ) {
+		width: 620px;
+		max-width: none;
+	}
+
+	@media ( min-width: 1024px ) {
+		width: 812px;
+	}
+
+	@media ( min-width: 1200px ) {
+		width: auto;
+		margin-left: 20px;
+		margin-right: 20px;
+	}
 `;
 
 const LogoContainer = styled.div`

--- a/client/my-sites/plans-features-main/components/pressable-promo-banner.tsx
+++ b/client/my-sites/plans-features-main/components/pressable-promo-banner.tsx
@@ -74,6 +74,10 @@ const Title = styled.h2`
 	color: var( --studio-black );
 	margin-top: 6px;
 	margin-bottom: 6px;
+
+	${ plansBreakSmall( css`
+		font-size: 16px;
+	` ) }
 `;
 
 const Description = styled.p`

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -19,7 +19,6 @@ import {
 import page from '@automattic/calypso-router';
 import { Button, Spinner, LoadingPlaceholder } from '@automattic/components';
 import { WpcomPlansUI } from '@automattic/data-stores';
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { isAnyHostingFlow } from '@automattic/onboarding';
 import styled from '@emotion/styled';
 import { useDispatch } from '@wordpress/data';
@@ -247,7 +246,6 @@ const PlansFeaturesMain = ( {
 	const [ lastClickedPlan, setLastClickedPlan ] = useState< string | null >( null );
 	const [ showPlansComparisonGrid, setShowPlansComparisonGrid ] = useState( false );
 	const translate = useTranslate();
-	const isEnglishLocale = useIsEnglishLocale();
 	const storageAddOns = useStorageAddOns( { siteId, isInSignup } );
 	const currentPlan = useSelector( ( state: IAppState ) => getCurrentPlan( state, siteId ) );
 	const eligibleForWpcomMonthlyPlans = useSelector( ( state: IAppState ) =>
@@ -939,7 +937,7 @@ const PlansFeaturesMain = ( {
 								) }
 							</div>
 						</div>
-						{ isEnglishLocale && showPressablePromoBanner && (
+						{ showPressablePromoBanner && (
 							<AsyncLoad
 								require="./components/pressable-promo-banner"
 								onShow={ onShowPressablePromoBanner }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This is a direct follow-up to https://github.com/Automattic/wp-calypso/pull/85077, addressing:

1. Match the width of the plans grid at all resolutions.
2. Remove the en-locale check now that all the translations has been completed.
3. Update the title font size to be 16px on desktop resolutions.

Before:

https://github.com/Automattic/wp-calypso/assets/1842898/dea77a44-4603-43f9-9c3b-f56ccf7e1fa8

After:

https://github.com/Automattic/wp-calypso/assets/1842898/15914cce-b6b8-4045-9062-44490bb029b5

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Confirm the translations by using a non-en locale.
* Resize to check the responsiveness works as described.
* Confirm the title font size is 16px on desktop, and 20px on mobile.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
