### PR TITLE
Domains: Fix badge alignment in domain search results

### DIFF
--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -118,7 +118,7 @@
 	}
 
 	.domain-registration-suggestion__badges {
-		align-self: flex-start;
+		align-self: center;
 		align-items: center;
 		display: flex;
 		font-size: $font-body-extra-small;


### PR DESCRIPTION
## Proposed Changes

This PR vertically centers the badge in domain search result item.

### Screenshots
- Before
![alignment - before](https://github.com/Automattic/wp-calypso/assets/2797601/3e067d56-6d62-4856-a46e-bb0badb60275)

- After
![alignment - after](https://github.com/Automattic/wp-calypso/assets/2797601/f18b1988-b19f-400b-920e-99389c6e7c56)

## Testing Instructions

- Open the live Calypso link or build this branch locally
- Visit the onboarding flow (/start/domains) and search for a domain
- Verify that the badge alignment is correct
- 
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?