### PR TITLE
Theme tiers: Added the Personal tier as a theme showcase tier

### DIFF
--- a/client/components/data/query-themes/index.jsx
+++ b/client/components/data/query-themes/index.jsx
@@ -31,7 +31,7 @@ QueryThemes.propTypes = {
 		// The search string
 		search: PropTypes.string,
 		// The tier to look for -- 'free', 'premium', 'marketplace', or '' (for all themes)
-		tier: PropTypes.oneOf( [ '', 'free', 'premium', 'marketplace' ] ),
+		tier: PropTypes.oneOf( [ '', 'free', 'personal', 'premium', 'marketplace' ] ),
 		// Comma-separated list of filters; see my-sites/themes/theme-filters
 		filter: PropTypes.string,
 		// Which page of the results list to display

--- a/client/my-sites/themes/index.node.js
+++ b/client/my-sites/themes/index.node.js
@@ -20,12 +20,12 @@ export default function ( router ) {
 	const langParam = getLanguageRouteParam();
 
 	const showcaseRoutes = [
-		`/${ langParam }/themes/:tier(free|premium|marketplace)?/:view(collection)?`,
-		`/${ langParam }/themes/:tier(free|premium|marketplace)?/filter/:filter?/:view(collection)?`,
-		`/${ langParam }/themes/:category(all)?/:tier(free|premium|marketplace)?/:view(collection)?`,
-		`/${ langParam }/themes/:category(all)?/:tier(free|premium|marketplace)?/filter/:filter/:view(collection)?`,
-		`/${ langParam }/themes/:vertical?/:tier(free|premium|marketplace)?/:view(collection)?`,
-		`/${ langParam }/themes/:vertical?/:tier(free|premium|marketplace)?/filter/:filter/:view(collection)?`,
+		`/${ langParam }/themes/:tier(free|personal|premium|marketplace)?/:view(collection)?`,
+		`/${ langParam }/themes/:tier(free|personal|premium|marketplace)?/filter/:filter?/:view(collection)?`,
+		`/${ langParam }/themes/:category(all)?/:tier(free|personal|premium|marketplace)?/:view(collection)?`,
+		`/${ langParam }/themes/:category(all)?/:tier(free|personal|premium|marketplace)?/filter/:filter/:view(collection)?`,
+		`/${ langParam }/themes/:vertical?/:tier(free|personal|premium|marketplace)?/:view(collection)?`,
+		`/${ langParam }/themes/:vertical?/:tier(free|personal|premium|marketplace)?/filter/:filter/:view(collection)?`,
 	];
 
 	router(
@@ -45,15 +45,15 @@ export default function ( router ) {
 	router(
 		[
 			'/themes/:site?/search/:search',
-			'/themes/:site?/type/:tier(free|premium|marketplace)',
-			'/themes/:site?/search/:search/type/:tier(free|premium|marketplace)',
+			'/themes/:site?/type/:tier(free|personal|premium|marketplace)',
+			'/themes/:site?/search/:search/type/:tier(free|personal|premium|marketplace)',
 		],
 		redirectSearchAndType
 	);
 	router(
 		[
 			'/themes/:site?/filter/:filter',
-			'/themes/:site?/filter/:filter/type/:tier(free|premium|marketplace)',
+			'/themes/:site?/filter/:filter/type/:tier(free|personal|premium|marketplace)',
 		],
 		redirectFilterAndType
 	);

--- a/client/my-sites/themes/index.web.js
+++ b/client/my-sites/themes/index.web.js
@@ -26,20 +26,20 @@ export default function ( router ) {
 
 	const langParam = getLanguageRouteParam();
 	const routesWithoutSites = [
-		`/${ langParam }/themes/:tier(free|premium|marketplace)?/:view(collection)?`,
-		`/${ langParam }/themes/:tier(free|premium|marketplace)?/filter/:filter/:view(collection)?`,
-		`/${ langParam }/themes/:category(all|my-themes)?/:tier(free|premium|marketplace)?/:view(collection)?`,
-		`/${ langParam }/themes/:category(all|my-themes)?/:tier(free|premium|marketplace)?/filter/:filter/:view(collection)?`,
-		`/${ langParam }/themes/:vertical?/:tier(free|premium|marketplace)?/:view(collection)?`,
-		`/${ langParam }/themes/:vertical?/:tier(free|premium|marketplace)?/filter/:filter/:view(collection)?`,
+		`/${ langParam }/themes/:tier(free|personal|premium|marketplace)?/:view(collection)?`,
+		`/${ langParam }/themes/:tier(free|personal|premium|marketplace)?/filter/:filter/:view(collection)?`,
+		`/${ langParam }/themes/:category(all|my-themes)?/:tier(free|personal|premium|marketplace)?/:view(collection)?`,
+		`/${ langParam }/themes/:category(all|my-themes)?/:tier(free|personal|premium|marketplace)?/filter/:filter/:view(collection)?`,
+		`/${ langParam }/themes/:vertical?/:tier(free|personal|premium|marketplace)?/:view(collection)?`,
+		`/${ langParam }/themes/:vertical?/:tier(free|personal|premium|marketplace)?/filter/:filter/:view(collection)?`,
 	];
 	const routesWithSites = [
-		`/${ langParam }/themes/:tier(free|premium|marketplace)?/:view(collection)?/:site_id(${ siteId })`,
-		`/${ langParam }/themes/:tier(free|premium|marketplace)?/filter/:filter/:view(collection)?/:site_id(${ siteId })`,
-		`/${ langParam }/themes/:category(all|my-themes)?/:tier(free|premium|marketplace)?/:view(collection)?/:site_id(${ siteId })`,
-		`/${ langParam }/themes/:category(all|my-themes)?/:tier(free|premium|marketplace)?/filter/:filter/:view(collection)?/:site_id(${ siteId })`,
-		`/${ langParam }/themes/:vertical?/:tier(free|premium|marketplace)?/:view(collection)?/:site_id(${ siteId })`,
-		`/${ langParam }/themes/:vertical?/:tier(free|premium|marketplace)?/filter/:filter/:view(collection)?/:site_id(${ siteId })`,
+		`/${ langParam }/themes/:tier(free|personal|premium|marketplace)?/:view(collection)?/:site_id(${ siteId })`,
+		`/${ langParam }/themes/:tier(free|personal|premium|marketplace)?/filter/:filter/:view(collection)?/:site_id(${ siteId })`,
+		`/${ langParam }/themes/:category(all|my-themes)?/:tier(free|personal|premium|marketplace)?/:view(collection)?/:site_id(${ siteId })`,
+		`/${ langParam }/themes/:category(all|my-themes)?/:tier(free|personal|premium|marketplace)?/filter/:filter/:view(collection)?/:site_id(${ siteId })`,
+		`/${ langParam }/themes/:vertical?/:tier(free|personal|premium|marketplace)?/:view(collection)?/:site_id(${ siteId })`,
+		`/${ langParam }/themes/:vertical?/:tier(free|personal|premium|marketplace)?/filter/:filter/:view(collection)?/:site_id(${ siteId })`,
 	];
 
 	// Upload routes are valid only when logged in. In logged-out sessions they redirect to login page.

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -85,7 +85,7 @@ class ThemeShowcase extends Component {
 	}
 
 	static propTypes = {
-		tier: PropTypes.oneOf( [ '', 'free', 'premium', 'marketplace' ] ),
+		tier: PropTypes.oneOf( [ '', 'free', 'personal', 'premium', 'marketplace' ] ),
 		search: PropTypes.string,
 		isCollectionView: PropTypes.bool,
 		pathName: PropTypes.string,
@@ -184,6 +184,10 @@ class ThemeShowcase extends Component {
 			{ value: 'all', label: this.props.translate( 'All' ) },
 			{ value: 'free', label: this.props.translate( 'Free' ) },
 		];
+
+		if ( config.isEnabled( 'themes/tiers' ) ) {
+			tiers.push( { value: 'personal', label: this.props.translate( 'Personal' ) } );
+		}
 
 		if ( ! isSiteWooExpressOrEcomFreeTrial ) {
 			tiers.push( { value: 'premium', label: this.props.translate( 'Premium' ) } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
- https://github.com/Automattic/wp-calypso/pull/85166

## Proposed Changes

* Added the Personal tier to the Theme Showcase Tier system

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso live link
* Apply D131846-code on your sandbox
* Sandbox your API
* Go to the LiTS and/or LoTS
* Apply this flag `?flags=themes/tiers`
* The tier dropdown should show the personal tier.
* When selecting the personal tier theme results are filtered.

Test Evidence:
https://github.com/Automattic/wp-calypso/assets/1989914/c6264754-11b3-4646-a3ad-fb692fe37f88



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?