### PR TITLE
Add custom color support to confetti component

### DIFF
--- a/packages/components/src/confetti/index.ts
+++ b/packages/components/src/confetti/index.ts
@@ -10,12 +10,12 @@ type FireOptions = {
 	scalar?: number;
 };
 
-function fireConfetti() {
+function fireConfetti( colors?: string[] ) {
 	const count = 60;
 	const scale = 2;
 	const defaults = {
 		origin: { y: 0.4 },
-		colors: COLORS,
+		colors: colors ?? COLORS,
 		scalar: scale,
 		spread: 180,
 		gravity: 6,
@@ -58,12 +58,12 @@ function fireConfetti() {
 	} );
 }
 
-const ConfettiAnimation = ( { trigger = true, delay = 0 } ) => {
+const ConfettiAnimation = ( { trigger = true, delay = 0, colors = [] } ) => {
 	useEffect( () => {
 		if ( trigger ) {
-			setTimeout( () => fireConfetti(), delay );
+			setTimeout( () => fireConfetti( colors ), delay );
 		}
-	}, [ trigger, delay ] );
+	}, [ trigger, delay, colors ] );
 
 	return null;
 };


### PR DESCRIPTION
## Proposed Changes

* This PR adds a color prop that will allow the confetti component to be reused with different colors

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch
* yarn start
* Create a launchpad site through any flow that requires the site to be launched ( [write](https://github.com/Automattic/wp-calypso/pull/wordpress.com/start), [build](https://github.com/Automattic/wp-calypso/pull/wordpress.com/start), link-in-bio, etc. )
* Launch the site from the Launchpad
* Confirm that the confetti loaded (see video)

### Alternative

- Add this code after line 106 in `client/my-sites/customer-home/components/celebrate-launch-modal.jsx`
```
<ConfettiAnimation colors={ [ '#DFD1FB', '#CFB9F6', '#AD86E9', '#966CCF', '#966CCF', '#674399', '#533582' ] } />
```
- Open home _http://calypso.localhost:3000/home/SITE_
- Confirm that confetti is loaded and it's purple

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?


https://github.com/Automattic/wp-calypso/assets/1199991/2c82f9cf-9449-425c-a54e-3fc43050b756


