### PR TITLE
Ensure the Login Screen's "Create a new account" URL is localized

### DIFF
--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { addLocaleToPath } from '@automattic/i18n-utils';
 import cookie from 'cookie';
 import { get, includes, startsWith } from 'lodash';
 import {
@@ -158,7 +159,7 @@ export function getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, 
 		return `${ signupUrl }/account?${ params.toString() }`;
 	}
 
-	return signupUrl;
+	return addLocaleToPath( signupUrl, locale );
 }
 
 export const isReactLostPasswordScreenEnabled = () => {

--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -1,5 +1,5 @@
 import config from '@automattic/calypso-config';
-import { addLocaleToPath } from '@automattic/i18n-utils';
+import { addLocaleToPath, isDefaultLocale } from '@automattic/i18n-utils';
 import cookie from 'cookie';
 import { get, includes, startsWith } from 'lodash';
 import {
@@ -159,7 +159,7 @@ export function getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, 
 		return `${ signupUrl }/account?${ params.toString() }`;
 	}
 
-	if ( locale && locale !== 'en' ) {
+	if ( ! isDefaultLocale( locale ) ) {
 		return addLocaleToPath( signupUrl, locale );
 	}
 

--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -159,7 +159,11 @@ export function getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, 
 		return `${ signupUrl }/account?${ params.toString() }`;
 	}
 
-	return addLocaleToPath( signupUrl, locale );
+	if ( locale && locale !== 'en' ) {
+		return addLocaleToPath( signupUrl, locale );
+	}
+
+	return signupUrl;
 }
 
 export const isReactLostPasswordScreenEnabled = () => {

--- a/client/lib/login/test/index.js
+++ b/client/lib/login/test/index.js
@@ -27,6 +27,8 @@ jest.mock( '@automattic/calypso-config', () => ( {
 		switch ( key ) {
 			case 'signup_url':
 				return '/start';
+			case 'i18n_default_locale_slug':
+				return 'en';
 			default:
 				return null;
 		}

--- a/client/lib/login/test/index.js
+++ b/client/lib/login/test/index.js
@@ -39,6 +39,11 @@ describe( 'getSignupUrl', () => {
 		expect( getSignupUrl( undefined, currentRoute, null, 'en', '' ) ).toEqual( '/start' );
 	} );
 
+	test( 'should localize the /log-in route', () => {
+		const currentRoute = '/log-in';
+		expect( getSignupUrl( undefined, currentRoute, null, 'de', '' ) ).toEqual( '/start/de' );
+	} );
+
 	test( 'should work for /log-in route with redirect_to', () => {
 		const currentQuery = {
 			redirect_to: '/me/',

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -1,7 +1,7 @@
 import config from '@automattic/calypso-config';
 import { getUrlParts } from '@automattic/calypso-url';
 import { Gridicon } from '@automattic/components';
-import { addLocaleToPath, localizeUrl } from '@automattic/i18n-utils';
+import { localizeUrl } from '@automattic/i18n-utils';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { get, startsWith } from 'lodash';
@@ -355,10 +355,9 @@ export class Login extends Component {
 		}
 
 		// use '?signup_url' if explicitly passed as URL query param
-		const signup_url_en = this.props.signupUrl
+		const signupUrl = this.props.signupUrl
 			? window.location.origin + pathWithLeadingSlash( this.props.signupUrl )
 			: getSignupUrl( query, currentRoute, oauth2Client, locale, pathname );
-		const signupUrl = addLocaleToPath( signup_url_en, locale );
 
 		return (
 			<a

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -1,7 +1,7 @@
 import config from '@automattic/calypso-config';
 import { getUrlParts } from '@automattic/calypso-url';
 import { Gridicon } from '@automattic/components';
-import { localizeUrl } from '@automattic/i18n-utils';
+import { addLocaleToPath, localizeUrl } from '@automattic/i18n-utils';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { get, startsWith } from 'lodash';
@@ -355,9 +355,10 @@ export class Login extends Component {
 		}
 
 		// use '?signup_url' if explicitly passed as URL query param
-		const signupUrl = this.props.signupUrl
+		const signup_url_en = this.props.signupUrl
 			? window.location.origin + pathWithLeadingSlash( this.props.signupUrl )
 			: getSignupUrl( query, currentRoute, oauth2Client, locale, pathname );
+		const signupUrl = addLocaleToPath( signup_url_en, locale );
 
 		return (
 			<a


### PR DESCRIPTION
Related to 4233-gh-Automattic/dotcom-forge

## Proposed Changes

Localize the "Create a new account" URL

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the following paths after starting Calypso

1. /log-in/
2. /log-in/es

Verify that the 'Create a new account' link is localized

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?