### PR TITLE
Import flows: Remove the "Ready" screen which comes from the importers' list

### DIFF
--- a/client/blocks/import/capture/style.scss
+++ b/client/blocks/import/capture/style.scss
@@ -57,7 +57,9 @@
 
 	.action-buttons__importer-list {
 		font-size: 0.875rem;
+		font-weight: 400;
 		text-align: center;
+		text-decoration: none;
 		color: var(--studio-gray-90);
 		margin-top: 1rem;
 

--- a/client/blocks/import/list/index.tsx
+++ b/client/blocks/import/list/index.tsx
@@ -5,9 +5,7 @@ import { chevronRight, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import React, { useEffect } from 'react';
 import ImporterLogo from 'calypso/my-sites/importer/importer-logo';
-import { useDispatch } from 'calypso/state';
-import { urlDataUpdate } from 'calypso/state/imports/url-analyzer/actions';
-import type { GoToStep, ImporterPlatform } from '../types';
+import type { ImporterPlatform } from '../types';
 import './style.scss';
 
 const trackEventName = 'calypso_signup_step_start';
@@ -23,13 +21,14 @@ interface ImporterOption {
 }
 
 interface Props {
-	goToStep: GoToStep;
+	siteSlug: string | null;
+	submit?: ( dependencies: Record< string, unknown > ) => void;
+	getFinalImporterUrl: ( siteSlug: string, fromSite: string, platform: ImporterPlatform ) => string;
 }
 
 export default function ListStep( props: Props ) {
-	const dispatch = useDispatch();
 	const { __ } = useI18n();
-	const { goToStep } = props;
+	const { siteSlug, submit, getFinalImporterUrl } = props;
 
 	const primaryListOptions: ImporterOption[] = [
 		{ value: 'wordpress', label: 'WordPress', icon: 'wordpress' },
@@ -49,26 +48,14 @@ export default function ListStep( props: Props ) {
 	];
 
 	const onImporterSelect = ( platform: ImporterPlatform ): void => {
-		dispatch(
-			urlDataUpdate( {
-				url: '',
-				platform,
-				meta: {
-					favicon: null,
-					title: null,
-				},
-			} )
-		);
-		goToStep( `ready` );
+		const importerUrl = getFinalImporterUrl( siteSlug ?? '', '', platform );
+		submit?.( { platform, url: importerUrl } );
 	};
 
 	const recordImportList = () => {
 		recordTracksEvent( trackEventName, trackEventParams );
 	};
 
-	/**
-	 ↓ Effects
-	 */
 	useEffect( recordImportList, [] );
 
 	return (
@@ -98,7 +85,7 @@ export default function ListStep( props: Props ) {
 						selectedText={ __( 'Select other platform' ) }
 						options={ secondaryListOptions }
 						onSelect={ ( x: ImporterOption ) => onImporterSelect( x.value ) }
-					></SelectDropdown>
+					/>
 				</div>
 			</div>
 		</>

--- a/client/blocks/import/list/style.scss
+++ b/client/blocks/import/list/style.scss
@@ -37,6 +37,8 @@ html[dir="rtl"] {
 	}
 
 	.list__wrapper {
+		padding-bottom: 2rem;
+
 		h3 {
 			font-size: 1.125em; /* stylelint-disable-line declaration-property-unit-allowed-list */
 			color: var(--studio-gray-90);

--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -117,6 +117,7 @@ const importFlow: Flow = {
 
 		const submit = ( providedDependencies: ProvidedDependencies = {}, ...params: string[] ) => {
 			switch ( _currentStep ) {
+				case 'importList':
 				case 'importReady': {
 					const depUrl = ( providedDependencies?.url as string ) || '';
 

--- a/client/landing/stepper/declarative-flow/import-hosted-site.ts
+++ b/client/landing/stepper/declarative-flow/import-hosted-site.ts
@@ -80,6 +80,7 @@ const importHostedSiteFlow: Flow = {
 
 		const submit = ( providedDependencies: ProvidedDependencies = {}, ...params: string[] ) => {
 			switch ( _currentStep ) {
+				case 'importList':
 				case 'importReady': {
 					const depUrl = ( providedDependencies?.url as string ) || '';
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import-list/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import-list/index.tsx
@@ -1,16 +1,21 @@
 import React from 'react';
 import ListStep from 'calypso/blocks/import/list';
 import { Step } from 'calypso/landing/stepper/declarative-flow/internals/types';
+import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
 import { ImportWrapper } from '../import';
-import { generateStepPath } from '../import/helper';
+import { getFinalImporterUrl } from '../import/helper';
 
 const ImportList: Step = function ImportStep( props ) {
+	const siteSlug = useSiteSlug();
 	const { navigation } = props;
 
 	return (
 		<ImportWrapper { ...props }>
 			<ListStep
-				goToStep={ ( step, section ) => navigation.goToStep?.( generateStepPath( step, section ) ) }
+				siteSlug={ siteSlug }
+				submit={ navigation?.submit }
+				getFinalImporterUrl={ getFinalImporterUrl }
+				{ ...props }
 			/>
 		</ImportWrapper>
 	);

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -419,6 +419,7 @@ const siteSetupFlow: Flow = {
 					return exitFlow( `/post/${ siteSlug }` );
 				}
 
+				case 'importList':
 				case 'importReady': {
 					const depUrl = ( providedDependencies?.url as string ) || '';
 

--- a/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
@@ -274,7 +274,7 @@ export class StartImportFlow {
 	async selectImporterFromList( index: number ): Promise< void > {
 		await this.page.click( selectors.importerListButton( index ) );
 		await this.page
-			.locator( selectors.startBuildingHeader( 'Your content is ready for its new home' ) )
+			.locator( selectors.startBuildingHeader( 'Import content from WordPress' ) )
 			.waitFor();
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/84820

## Proposed Changes

* Removed the unnecessary extra step "Ready screen" coming from the importers' list 
* Fixed minor CSS issue

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/import-focused?siteSlug={SITE_SLUG}`
* Click on `choose a content platform`
* Select WordPress
* Check if the WP content importer is rendered
* Click the navigation's "Back" link
* From the dropdown, select "Substack"
* Check if redirects to Tools -> Import -> Substack page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?