### PR TITLE
Don't show 3rd party account checkbox during checkout for Sensei

### DIFF
--- a/client/my-sites/checkout/src/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout.tsx
@@ -333,9 +333,14 @@ export default function WPCheckout( {
 	const paymentMethod = usePaymentMethod();
 	const showToSFoldableCard = useToSFoldableCard() === 'treatment';
 	const shouldCollapseLastStep = useShouldCollapseLastStep() === 'collapse';
+	const excluded3PDAccountProductSlugs = [ 'sensei_pro_monthly', 'sensei_pro_yearly' ];
 
 	const hasMarketplaceProduct = useSelector( ( state ) => {
-		return responseCart?.products?.some( ( p ) => isMarketplaceProduct( state, p.product_slug ) );
+		return responseCart?.products
+			?.filter(
+				( p ) => ! ( p.product_slug && excluded3PDAccountProductSlugs.includes( p.product_slug ) )
+			)
+			.some( ( p ) => isMarketplaceProduct( state, p.product_slug ) );
 	} );
 
 	const has100YearPlan = cartHas100YearPlan( responseCart );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/85053

## Proposed Changes

* If the only marketplace products in cart are Sensei monthly or yearly, we won't show the checkbox during checkout related to Third party account creation

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to `http://calypso.localhost:3000/setup/sensei`
2. When you are selecting plans, select the yearly plan
3. In the checkout page, make sure you Don't see the checkbox like the following in the bottom
![image](https://github.com/Automattic/wp-calypso/assets/6820724/35945e7c-2cf9-4154-b538-d6870748e419)
4. Now check the same for the monthly plan too
5. Now in code, go to `client/my-sites/checkout/src/components/wp-checkout.tsx` and in the array `excluded3PDAccountProductSlugs`, change the product slugs slightly to replicate the behavior of having different products in cart and save your changes so that yarn rebuilds your local changes
6. Go to the checkout page and check that the checkbox is appearing as it did previously

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?