### PR TITLE
Unhardcode VideoAudioPosts from plan names

### DIFF
--- a/client/blocks/product-purchase-features-list/test/video-audio-posts.jsx
+++ b/client/blocks/product-purchase-features-list/test/video-audio-posts.jsx
@@ -50,15 +50,15 @@ describe( 'VideoAudioPosts should use proper description', () => {
 		},
 	};
 
-	test.each( [ PLAN_BUSINESS, PLAN_BUSINESS_2_YEARS ] )( `for business plan %s`, ( plan ) => {
-		render( <VideoAudioPosts { ...props } plan={ plan } /> );
-		expect( screen.queryByTestId( 'purchase-detail' ) ).toHaveTextContent( /Business Plan/ );
-	} );
-
-	test.each( [ PLAN_ECOMMERCE, PLAN_ECOMMERCE_2_YEARS ] )( `for ecommerce plan %s`, ( plan ) => {
-		render( <VideoAudioPosts { ...props } plan={ plan } /> );
-		expect( screen.queryByTestId( 'purchase-detail' ) ).toHaveTextContent( /Ecommerce Plan/ );
-	} );
+	test.each( [ PLAN_BUSINESS, PLAN_BUSINESS_2_YEARS, PLAN_ECOMMERCE, PLAN_ECOMMERCE_2_YEARS ] )(
+		`for business plan %s`,
+		( plan ) => {
+			render( <VideoAudioPosts { ...props } plan={ plan } /> );
+			expect( screen.queryByTestId( 'purchase-detail' ) ).toHaveTextContent(
+				/the %\(planName\)s Plan has %\(storageLimit\)d GB storage/
+			);
+		}
+	);
 
 	test.each( [ PLAN_PREMIUM, PLAN_PREMIUM_2_YEARS ] )( `for premium plan %s`, ( plan ) => {
 		render( <VideoAudioPosts { ...props } plan={ plan } /> );

--- a/client/blocks/product-purchase-features-list/video-audio-posts.jsx
+++ b/client/blocks/product-purchase-features-list/video-audio-posts.jsx
@@ -9,7 +9,9 @@ import {
 	isWpComPremiumPlan,
 	isWpComProPlan,
 } from '@automattic/calypso-products';
-import { localize } from 'i18n-calypso';
+import { englishLocales } from '@automattic/i18n-utils';
+import { hasTranslation } from '@wordpress/i18n';
+import { localize, getLocaleSlug } from 'i18n-calypso';
 import videoImage from 'calypso/assets/images/illustrations/video-hosting.svg';
 import PurchaseDetail from 'calypso/components/purchase-detail';
 import { newPost } from 'calypso/lib/paths';
@@ -24,17 +26,30 @@ function getDescription( plan, translate ) {
 
 	if ( isWpComBusinessPlan( plan ) ) {
 		const businessPlan = getPlan( plan );
+		if (
+			englishLocales.includes( String( getLocaleSlug() ) ) ||
+			hasTranslation(
+				'Enrich your posts and pages with video or audio. Upload plenty of media, ' +
+					'directly to your site — the %(planName)s Plan has %(storageLimit)d GB storage.'
+			)
+		) {
+			return translate(
+				'Enrich your posts and pages with video or audio. Upload plenty of media, ' +
+					'directly to your site — the %(planName)s Plan has %(storageLimit)d GB storage.',
+				{
+					args: {
+						planName: businessPlan.getTitle(),
+						storageLimit: 50,
+					},
+				}
+			);
+		}
 		return translate(
 			'Enrich your posts and pages with video or audio. Upload plenty of media, ' +
-				'directly to your site — the %(planName)s Plan has %(storageLimit)d GB storage.',
-			{
-				args: {
-					planName: businessPlan.getTitle(),
-					storageLimit: 50,
-				},
-			}
+				'directly to your site — the Business Plan has 200 GB storage.'
 		);
 	}
+
 	if ( isProPlan( plan ) ) {
 		return translate(
 			'Enrich your posts and pages with video or audio. Upload plenty of media, ' +
@@ -63,15 +78,27 @@ function getDescription( plan, translate ) {
 	}
 	if ( isWpComEcommercePlan( plan ) ) {
 		const eCommercePlan = getPlan( plan );
+		if (
+			englishLocales.includes( String( getLocaleSlug() ) ) ||
+			hasTranslation(
+				'Enrich your posts and pages with video or audio. Upload plenty of media, ' +
+					'directly to your site — the %(planName)s Plan has %(storageLimit)d GB storage.'
+			)
+		) {
+			return translate(
+				'Enrich your posts and pages with video or audio. Upload plenty of media, ' +
+					'directly to your site — the %(planName)s Plan has %(storageLimit)d GB storage.',
+				{
+					args: {
+						planName: eCommercePlan.getTitle(),
+						storageLimit: 50,
+					},
+				}
+			);
+		}
 		return translate(
 			'Enrich your posts and pages with video or audio. Upload plenty of media, ' +
-				'directly to your site — the %(planName)s Plan has %(storageLimit)d GB storage.',
-			{
-				args: {
-					planName: eCommercePlan.getTitle(),
-					storageLimit: 50,
-				},
-			}
+				'directly to your site — the eCommerce Plan has 200 GB storage.'
 		);
 	}
 

--- a/client/blocks/product-purchase-features-list/video-audio-posts.jsx
+++ b/client/blocks/product-purchase-features-list/video-audio-posts.jsx
@@ -23,9 +23,16 @@ function getDescription( plan, translate ) {
 	}
 
 	if ( isWpComBusinessPlan( plan ) ) {
+		const businessPlan = getPlan( plan );
 		return translate(
 			'Enrich your posts and pages with video or audio. Upload plenty of media, ' +
-				'directly to your site — the Business Plan has 200 GB storage.'
+				'directly to your site — the %(planName)s Plan has %(storageLimit)d GB storage.',
+			{
+				args: {
+					planName: businessPlan.getTitle(),
+					storageLimit: 50,
+				},
+			}
 		);
 	}
 	if ( isProPlan( plan ) ) {
@@ -55,9 +62,16 @@ function getDescription( plan, translate ) {
 		);
 	}
 	if ( isWpComEcommercePlan( plan ) ) {
+		const eCommercePlan = getPlan( plan );
 		return translate(
 			'Enrich your posts and pages with video or audio. Upload plenty of media, ' +
-				'directly to your site — the Ecommerce Plan has 200 GB storage.'
+				'directly to your site — the %(planName)s Plan has %(storageLimit)d GB storage.',
+			{
+				args: {
+					planName: eCommercePlan.getTitle(),
+					storageLimit: 50,
+				},
+			}
 		);
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Remove two hardcoded instances of plan names in VideoAudioPosts

Note that I'm also replacing 200 with 50 to match the real space new users will get with their plans

## Testing Instructions

* Add Business to your test site
* Go to /plans, click my plan
* Confirm that the videoaudiopost works and now shows 50GB of space
* Repeat with eCommerce

<img width="505" alt="Screenshot 2023-12-13 at 17 31 10" src="https://github.com/Automattic/wp-calypso/assets/82778/279f1ff3-29c3-4e78-ba89-0a0044f71759">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
