### PR TITLE
Self service site reset: Update a few copy and general progress bar styling

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -242,6 +242,10 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/transferring-a-site-to-another-wordpress-com-account/',
 		post_id: 102743,
 	},
+	'site-reset': {
+		link: 'https://wordpress.com/support/reset-your-site/',
+		post_id: 296649,
+	},
 	'site-verification': {
 		link: 'https://wordpress.com/support/site-verification-services/',
 		post_id: 5022,

--- a/client/my-sites/site-settings/site-tools/index.jsx
+++ b/client/my-sites/site-settings/site-tools/index.jsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { compose } from '@wordpress/compose';
 import { addQueryArgs } from '@wordpress/url';
 import { localize } from 'i18n-calypso';
@@ -93,10 +92,6 @@ class SiteTools extends Component {
 		const startSiteTransferText = translate(
 			'Transfer your site and plan to another WordPress.com user.'
 		);
-		const resetSiteTitle = translate( 'Reset your site' );
-		const resetSiteText = translate(
-			"Remove all posts, pages, and media to start fresh while keeping your site's address."
-		);
 
 		return (
 			<div className="site-tools">
@@ -129,13 +124,6 @@ class SiteTools extends Component {
 						href={ startSiteTransferLink }
 						title={ startSiteTransferTitle }
 						description={ startSiteTransferText }
-					/>
-				) }
-				{ isEnabled( 'settings/self-serve-site-reset' ) && (
-					<SiteToolsLink
-						title={ resetSiteTitle }
-						description={ resetSiteText }
-						href={ startOverLink }
 					/>
 				) }
 				{ showDeleteContent && (

--- a/client/my-sites/site-settings/site-tools/index.jsx
+++ b/client/my-sites/site-settings/site-tools/index.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { compose } from '@wordpress/compose';
 import { addQueryArgs } from '@wordpress/url';
 import { localize } from 'i18n-calypso';
@@ -92,6 +93,10 @@ class SiteTools extends Component {
 		const startSiteTransferText = translate(
 			'Transfer your site and plan to another WordPress.com user.'
 		);
+		const resetSiteTitle = translate( 'Reset your site' );
+		const resetSiteText = translate(
+			"Remove all posts, pages, and media to start fresh while keeping your site's address."
+		);
 
 		return (
 			<div className="site-tools">
@@ -124,6 +129,13 @@ class SiteTools extends Component {
 						href={ startSiteTransferLink }
 						title={ startSiteTransferTitle }
 						description={ startSiteTransferText }
+					/>
+				) }
+				{ isEnabled( 'settings/self-serve-site-reset' ) && (
+					<SiteToolsLink
+						title={ resetSiteTitle }
+						description={ resetSiteText }
+						href={ startOverLink }
 					/>
 				) }
 				{ showDeleteContent && (

--- a/client/my-sites/site-settings/start-over.jsx
+++ b/client/my-sites/site-settings/start-over.jsx
@@ -284,12 +284,12 @@ function SiteResetCard( {
 			<Interval onTick={ checkStatus } period={ EVERY_FIVE_SECONDS } />
 			<NavigationHeader
 				navigationItems={ [] }
-				title={ translate( 'Reset your site' ) }
+				title={ translate( 'Site Reset' ) }
 				subtitle={ translate(
 					"Remove all posts, pages, and media to start fresh while keeping your site's address. {{a}}Learn more.{{/a}}",
 					{
 						components: {
-							a: <InlineSupportLink supportContext="site-transfer" showIcon={ false } />,
+							a: <InlineSupportLink supportContext="site-reset" showIcon={ false } />,
 						},
 					}
 				) }
@@ -370,7 +370,7 @@ function SiteResetCard( {
 				site={ site }
 				isUnlaunchedSite={ isUnlaunchedSiteProp }
 				urlRef="unlaunched-site-reset"
-			/>{ ' ' }
+			/>
 		</Main>
 	);
 }

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -765,6 +765,12 @@ button.site-settings__general-settings-set-guessed-timezone.button.is-borderless
 		color: var(--gray-gray-100, #101517);
 		margin-top: 8px;
 	}
+
+	.loading-bar {
+		&::before {
+			background: var(--color-accent);
+		}
+	}
 }
 
 .site-settings__reset-site-backup-hint {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

closes https://github.com/Automattic/wp-calypso/issues/85210

## Proposed Changes

* Add correct support doc context link
* Update title and description copy to be consistent

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to `/settings/start-over/siteSlug`
* Verify the copy is consistent with the copy in https://github.com/Automattic/wp-calypso/issues/85210
* go to `/settings/general/siteSlug` and verify the `Reset your site` tool is present and redirect to reset site card

![image](https://github.com/Automattic/wp-calypso/assets/47489215/23a4c4a4-c1a4-4f8b-8dbb-1862b211246b)

![image](https://github.com/Automattic/wp-calypso/assets/47489215/9d3d84b3-9611-45aa-8e8e-cf7273375c2c)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?