### PR TITLE
Import flow: Fix minor issues on ReadyPreview screen

### DIFF
--- a/client/blocks/import/ready/index.tsx
+++ b/client/blocks/import/ready/index.tsx
@@ -61,39 +61,38 @@ const ReadyPreviewStep: React.FunctionComponent< ReadyPreviewProps > = ( {
 
 	return (
 		<>
-			<div className="import__header">
-				<div className="import__heading import__heading-center">
-					<Title>{ __( 'Your content is ready for its brand new home' ) }</Title>
-					<SubTitle>
-						{ createInterpolateElement(
-							sprintf(
-								/* translators: the website could be any domain (eg: "yourname.com") that is built with a platform (eg: Wix, Squarespace, Blogger, etc.) */
-								__(
-									'It looks like <strong>%(website)s</strong> is built with %(platform)s. To move your existing content to your newly created WordPress.com site, try our %(platform)s importer.'
-								),
-								{
-									website: convertToFriendlyWebsiteName( urlData.url ),
-									platform: convertPlatformName( urlData.platform ),
-								}
+			<div className="import__heading import__heading-center">
+				<Title>{ __( 'Your content is ready for its brand new home' ) }</Title>
+				<SubTitle>
+					{ createInterpolateElement(
+						sprintf(
+							/* translators: the website could be any domain (eg: "yourname.com") that is built with a platform (eg: Wix, Squarespace, Blogger, etc.) */
+							__(
+								'It looks like <strong>%(website)s</strong> is built with %(platform)s. To move your existing content to your newly created WordPress.com site, try our %(platform)s importer.'
 							),
-							{ strong: createElement( 'strong' ) }
-						) }
-					</SubTitle>
+							{
+								website: convertToFriendlyWebsiteName( urlData.url ),
+								platform: convertPlatformName( urlData.platform ),
+							}
+						),
+						{ strong: createElement( 'strong' ) }
+					) }
+				</SubTitle>
 
-					<div className="import__buttons-group">
-						<NextButton onClick={ () => goToImporterPage( urlData.platform ) }>
-							{ __( 'Import your content' ) }
-						</NextButton>
-						{ coveredPlatforms.includes( urlData.platform ) && (
-							<div>
-								<BackButton onClick={ setIsModalDetailsOpen.bind( this, true ) }>
-									{ __( 'What can be imported?' ) }
-								</BackButton>
-							</div>
-						) }
-					</div>
+				<div className="import__buttons-group">
+					<NextButton onClick={ () => goToImporterPage( urlData.platform ) }>
+						{ __( 'Import your content' ) }
+					</NextButton>
+					{ coveredPlatforms.includes( urlData.platform ) && (
+						<div>
+							<BackButton onClick={ setIsModalDetailsOpen.bind( this, true ) }>
+								{ __( 'What can be imported?' ) }
+							</BackButton>
+						</div>
+					) }
 				</div>
 			</div>
+
 			<div className="import__content">
 				<ImportPreview website={ urlData.url } />
 			</div>

--- a/client/blocks/import/ready/style.scss
+++ b/client/blocks/import/ready/style.scss
@@ -16,7 +16,6 @@
 		padding-left: 0;
 
 		@include break-wide {
-			width: calc(100% - 163px);
 			margin: 100px auto 0;
 		}
 

--- a/client/blocks/importer/wix/index.tsx
+++ b/client/blocks/importer/wix/index.tsx
@@ -45,19 +45,12 @@ export const WixImporter: React.FunctionComponent< Props > = ( props ) => {
 	/**
 	 ↓ Effects
 	 */
-	useEffect( handleImporterReadiness, [] );
 	useEffect( handleRunFlagChange, [ run ] );
 	useEffect( handleJobStateTransition, [ job ] );
 
 	/**
 	 ↓ Methods
 	 */
-	function handleImporterReadiness() {
-		if ( ! checkIsImporterReady() ) {
-			stepNavigator?.goToImportCapturePage?.();
-		}
-	}
-
 	function handleJobStateTransition() {
 		// If there is no existing import job, create a new job
 		if ( job === undefined ) {
@@ -95,10 +88,6 @@ export const WixImporter: React.FunctionComponent< Props > = ( props ) => {
 			supportedContent: [],
 			unsupportedContent: [],
 		};
-	}
-
-	function checkIsImporterReady() {
-		return job || run;
 	}
 
 	function checkProgress() {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
@@ -28,6 +28,10 @@ export function getFinalImporterUrl(
 			importerUrl = addQueryArgs( importerUrl, {
 				option: WPImportOption.CONTENT_ONLY,
 			} );
+		} else if ( platform === 'wix' && fromSite ) {
+			importerUrl = addQueryArgs( importerUrl, {
+				run: true,
+			} );
 		}
 	} else {
 		importerUrl = getWpOrgImporterUrl( targetSlug, platform );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer/style.scss
@@ -29,41 +29,6 @@
 	}
 }
 
-/**
- * Formatted Header
- */
-.formatted-header {
-	margin: 0 !important;
-	flex-grow: 1;
-
-	.formatted-header__title {
-		@include onboarding-font-recoleta;
-		color: var(--studio-gray-100);
-		letter-spacing: 0.2px;
-		font-size: 2.15rem; /* stylelint-disable-line scales/font-sizes */
-		font-weight: 400;
-		padding: 0;
-		margin: 0;
-
-		@include break-xlarge {
-			font-size: 2.75rem;
-		}
-	}
-
-	.formatted-header__subtitle {
-		padding: 0;
-		text-align: left;
-		color: var(--studio-gray-60);
-		font-size: 1rem;
-		margin-top: 16px;
-		line-height: 24px;
-
-		@include break-small {
-			margin-top: 8px;
-		}
-	}
-}
-
 .step-wrapper__header-image {
 	margin-top: 64px;
 	display: none;

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -541,14 +541,12 @@ const siteSetupFlow: Flow = {
 				case 'importReadyNot':
 				case 'importReadyWpcom':
 				case 'importReadyPreview':
-					return navigate( 'import' );
-
 				case 'importerWix':
 				case 'importerBlogger':
 				case 'importerMedium':
 				case 'importerSquarespace':
 				case 'importerWordpress':
-					return navigate( 'import' );
+					return navigate( `import?siteSlug=${ siteSlugParam }` );
 
 				case 'options':
 					return navigate( 'goals' );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Removed unused CSS
* Adjusted layout of the ReadyPreview step
* site-setup flow: Fixed navigation's back issue from the ReadyPreview step
* Removed obsolete logic from the Wix importer
* Added `run` query param to the Wix importer URL, which clears the finished job and starts a new one (it was there before, but after some refactoring, we forgot to cover this use-case)

## Testing Instructions

* Go to `/setup/site-setup/import?siteSlug={SITE_SLUG}`
* Enter a WIX website URL
* Press "Continue"
* Check the ReadyPreview screen layout (see screenshots)
* Press the navigation's "Back"
* Check if redirects to import step
* Re-enter the URL and press "Continue"
* Press "Import your content"
* Check if import goes well

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Screenshots

**Before:**
<img width="1726" alt="Screenshot 2023-12-13 at 16 39 20" src="https://github.com/Automattic/wp-calypso/assets/1241413/16848aa3-1a47-4db3-bc1b-d6c4efc52313">

**After:**
<img width="1728" alt="Screenshot 2023-12-13 at 16 42 08" src="https://github.com/Automattic/wp-calypso/assets/1241413/88d667ac-3ec0-4af9-87d9-26d8074fba78">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?