### PR TITLE
Jetpack AI: add jetpack/ai-logo-generator feature flag

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -86,6 +86,7 @@
 		"individual-subscriber-stats": true,
 		"jetpack/agency-dashboard": true,
 		"jetpack/ai-assistant-request-limit": true,
+		"jetpack/ai-logo-generator": true,
 		"jetpack/api-cache": true,
 		"jetpack/backup-contents-page": true,
 		"jetpack/backup-messaging-i3": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -50,6 +50,7 @@
 		"importers/substack": true,
 		"individual-subscriber-stats": true,
 		"jetpack/ai-assistant-request-limit": true,
+		"jetpack/ai-logo-generator": false,
 		"jetpack/api-cache": true,
 		"jetpack/backup-messaging-i3": true,
 		"jetpack/backup-retention-settings": true,

--- a/config/production.json
+++ b/config/production.json
@@ -59,6 +59,7 @@
 		"is_running_in_jetpack_site": false,
 		"jetpack/agency-dashboard": true,
 		"jetpack/ai-assistant-request-limit": true,
+		"jetpack/ai-logo-generator": false,
 		"jetpack/api-cache": false,
 		"jetpack/backup-messaging-i3": true,
 		"jetpack/backup-retention-settings": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -55,6 +55,7 @@
 		"individual-subscriber-stats": true,
 		"jetpack/agency-dashboard": true,
 		"jetpack/ai-assistant-request-limit": true,
+		"jetpack/ai-logo-generator": false,
 		"jetpack/api-cache": true,
 		"jetpack/backup-messaging-i3": true,
 		"jetpack/backup-retention-settings": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -66,6 +66,7 @@
 		"individual-subscriber-stats": true,
 		"jetpack/agency-dashboard": true,
 		"jetpack/ai-assistant-request-limit": true,
+		"jetpack/ai-logo-generator": false,
 		"jetpack/api-cache": true,
 		"jetpack/backup-retention-settings": true,
 		"jetpack/cancel-through-main-flow": true,


### PR DESCRIPTION
In order to work on the new Jetpack AI logo generator, we need a feature flag

Related to #85171 
Related to https://github.com/Automattic/jetpack/issues/34375
Related to p1702412853241739-slack-C054LN8RNVA

## Proposed Changes
This PR adds jetpack/ai-logo-generator feature flag to the configs development, horizon, production and stage. Only enabled on development.

## Testing Instructions

No test needed, but you can spin up local development and add: 

```js
import config from '@automattic/calypso-config';
...
console.log( config.isEnabled( 'jetpack/ai-logo-generator' ) );
```
on `client/my-site/customer-home` and watch the developer console. It should read `true`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?