### PR TITLE
Hosting Command Palette: Restore the search text when going back from a nested command to root commands

### DIFF
--- a/client/components/command-palette/index.tsx
+++ b/client/components/command-palette/index.tsx
@@ -151,6 +151,7 @@ const CommandPalette = () => {
 	const [ placeHolderOverride, setPlaceholderOverride ] = useState( '' );
 	const [ search, setSearch ] = useState( '' );
 	const [ selectedCommandName, setSelectedCommandName ] = useState( '' );
+	const [ lastEnteredSearch, setLastEnteredSearch ] = useState( '' );
 	const [ isOpen, setIsOpen ] = useState( false );
 	const { close, toggle } = {
 		close: () => setIsOpen( false ),
@@ -172,7 +173,7 @@ const CommandPalette = () => {
 
 	const reset = () => {
 		setPlaceholderOverride( '' );
-		setSearch( '' );
+		setSearch( selectedCommandName ? lastEnteredSearch : '' );
 		setSelectedCommandName( '' );
 	};
 	const closeAndReset = () => {
@@ -229,7 +230,12 @@ const CommandPalette = () => {
 						) }
 						<CommandInput
 							search={ search }
-							setSearch={ setSearch }
+							setSearch={ ( value ) => {
+								setSearch( value );
+								if ( ! selectedCommandName ) {
+									setLastEnteredSearch( value );
+								}
+							} }
 							isOpen={ isOpen }
 							placeholder={ placeHolderOverride }
 						/>

--- a/client/components/command-palette/index.tsx
+++ b/client/components/command-palette/index.tsx
@@ -175,6 +175,7 @@ const CommandPalette = () => {
 		setPlaceholderOverride( '' );
 		setSearch( selectedCommandName ? lastEnteredSearch : '' );
 		setSelectedCommandName( '' );
+		setLastEnteredSearch( '' );
 	};
 	const closeAndReset = () => {
 		reset();


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/4754

## Proposed Changes

This PR adds a behavior of preserving the text entered in the search field when you go back from the nested command to the root command:

https://github.com/Automattic/wp-calypso/assets/25575134/2fa3548e-7dd0-4f5b-8e03-4cc3a9b4ea27


## Testing Instructions

* Navigate to Calypso Live Link
* Press `cmd + k` on macOS or `ctrl + k` on Windows to trigger the command palette
* Enter a search text in the input field e.g. `he`
* Navigate to one of the nested commands that appear as a result
* Navigate back to the root commands e.g. with the back button
* Confirm that the search text `he` is preserved in the search input field
* Close the command palette
* Press `cmd + k` on macOS or `ctrl + k` on Windows to trigger the command palette
* Confirm that the search text is not preserved
* Navigate to one of the nested commands e.g. `Open site dashboard`
* Type something in the searched field
* Navigate back to the root commands e.g. with the back button
* Confirm that no input text is appearing on the root commands and it is reset

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?