### PR TITLE
Hosting Command Palette: Move register domain next to other domain related commands

### DIFF
--- a/client/sites-dashboard/components/wpcom-smp-commands.tsx
+++ b/client/sites-dashboard/components/wpcom-smp-commands.tsx
@@ -470,6 +470,16 @@ export const useCommandsArrayWpcom = ( {
 			icon: creditCardIcon,
 		},
 		{
+			name: 'registerDomain',
+			label: __( 'Register domain' ),
+			context: [ '/sites' ],
+			callback: ( { close }: { close: () => void } ) => {
+				close();
+				navigate( `/start/domain/domain-only?ref=command-palette` );
+			},
+			icon: domainsIcon,
+		},
+		{
 			name: 'manageDomains',
 			label: __( 'Manage domains' ),
 			searchLabel: [
@@ -570,16 +580,6 @@ export const useCommandsArrayWpcom = ( {
 				},
 			},
 			icon: statsIcon,
-		},
-		{
-			name: 'registerDomain',
-			label: __( 'Register domain' ),
-			context: [ '/sites' ],
-			callback: ( { close }: { close: () => void } ) => {
-				close();
-				navigate( `/start/domain/domain-only?ref=command-palette` );
-			},
-			icon: domainsIcon,
 		},
 		{
 			name: 'openActivityLog',


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/4835

## Proposed Changes

This PR moves the `Register domain` command to be close to `Manage domains` and `Manage DNS records` commands:

<img width="744" alt="Screenshot 2023-12-13 at 9 44 19 PM" src="https://github.com/Automattic/wp-calypso/assets/25575134/09d2c2c2-965f-41b2-9aee-dc909325975a">

## Testing Instructions

* Navigate to Calypso Live Link
* Press `cmd + k` on macOS or `ctrl + k` on Windows to open the command palette
* Scroll down to the `Register domain` command and confirm that it appears together with `Manage domains` and `Manage DNS records` commands

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?