### PR TITLE
Checkout: Display reason for discount under line items instead of generic text

### DIFF
--- a/client/my-sites/checkout/src/test/checkout-main.tsx
+++ b/client/my-sites/checkout/src/test/checkout-main.tsx
@@ -671,10 +671,10 @@ describe( 'CheckoutMain', () => {
 		expect( screen.getByText( 'Loading checkout' ) ).toBeInTheDocument();
 	} );
 
-	it( 'renders the promo code field', async () => {
+	it( 'renders the promotional code in a human readable way', async () => {
 		render( <MockCheckout initialCart={ getPromoCart() } setCart={ mockSetCartEndpoint } /> );
 		await waitFor( () => {
-			expect( screen.getByText( /First-year promotional discount/ ) ).toBeInTheDocument();
+			expect( screen.getByText( /First-year promotional discount/ ) ).toBeVisible();
 		} );
 	} );
 } );

--- a/client/my-sites/checkout/src/test/checkout-main.tsx
+++ b/client/my-sites/checkout/src/test/checkout-main.tsx
@@ -23,6 +23,7 @@ import {
 	getActivePersonalPlanDataForType,
 	countryList,
 	getBasicCart,
+	getPromoCart,
 	mockMatchMediaOnWindow,
 	mockGetPaymentMethodsEndpoint,
 	mockGetVatInfoEndpoint,
@@ -668,5 +669,12 @@ describe( 'CheckoutMain', () => {
 			render( <MockCheckout initialCart={ initialCart } setCart={ mockSetCartEndpoint } /> );
 		} );
 		expect( screen.getByText( 'Loading checkout' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders the promo code field', async () => {
+		render( <MockCheckout initialCart={ getPromoCart() } setCart={ mockSetCartEndpoint } /> );
+		await waitFor( () => {
+			expect( screen.getByText( /First-year promotional discount/ ) ).toBeInTheDocument();
+		} );
 	} );
 } );

--- a/client/my-sites/checkout/src/test/util/index.ts
+++ b/client/my-sites/checkout/src/test/util/index.ts
@@ -263,6 +263,33 @@ export const planWithoutDomain: ResponseCartProduct = {
 	months_per_bill_period: 12,
 };
 
+export const planWithoutDomainYearly: ResponseCartProduct = {
+	...getEmptyResponseCartProduct(),
+	product_name: 'WordPress.com Personal',
+	product_slug: 'personal-bundle',
+	currency: 'INR',
+	extra: {
+		context: 'signup',
+	},
+	meta: '',
+	product_id: 1009,
+	volume: 1,
+	item_original_cost_integer: 2400,
+	item_subtotal_integer: 1920,
+	bill_period: '365',
+	months_per_bill_period: 12,
+	item_original_subtotal_integer: 2400,
+	cost_overrides: [
+		{
+			old_subtotal_integer: 240000,
+			new_subtotal_integer: 192000,
+			override_code: 'first-year-promotional-discounts',
+			does_override_original_cost: false,
+			human_readable_reason: 'First-year promotional discount',
+		},
+	],
+};
+
 export const planWithoutDomainMonthly: ResponseCartProduct = {
 	...getEmptyResponseCartProduct(),
 	product_name: 'WordPress.com Personal Monthly',
@@ -1330,6 +1357,28 @@ export function getBasicCart(): ResponseCart {
 		total_tax_integer: 700,
 		total_cost_integer: 15600,
 		sub_total_integer: 15600,
+		coupon_discounts_integer: [],
+	};
+}
+
+export function getPromoCart(): ResponseCart {
+	const cart = getEmptyResponseCart();
+	return {
+		...cart,
+		coupon: '',
+		coupon_savings_total_integer: 0,
+		currency: 'INR',
+		locale: 'en-IN',
+		is_coupon_applied: false,
+		products: [ planWithoutDomainYearly ],
+		tax: {
+			display_taxes: true,
+			location: {},
+		},
+		allowed_payment_methods: normalAllowedPaymentMethods,
+		total_tax_integer: 170.4,
+		total_cost_integer: 2090.4,
+		sub_total_integer: 1920,
 		coupon_discounts_integer: [],
 	};
 }

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -889,8 +889,7 @@ function UpgradeCreditInformation( { product }: { product: ResponseCartProduct }
 			<>
 				{ translate( '%(humanReadableCode)s : %(upgradeCredit)s applied in first month only.', {
 					comment:
-						'The upgrade credit is a pro rated balance of the previous plan which is to be applied' +
-						'as a deduction to the first year of next purchased plan. It will be applied once only in the first term',
+						'The reason for the discounted price, It will be applied only once in the first month',
 					args: {
 						humanReadableCode: humanReadableCode,
 						upgradeCredit: formatCurrency( upgradeCredit, product.currency, {
@@ -909,8 +908,7 @@ function UpgradeCreditInformation( { product }: { product: ResponseCartProduct }
 			<>
 				{ translate( '%(humanReadableCode)s : %(upgradeCredit)s applied in first year only.', {
 					comment:
-						'The upgrade credit is a pro rated balance of the previous plan which is to be applied' +
-						'as a deduction to the first year of next purchased plan. It will be applied once only in the first term',
+						'The reason for the discounted price, It will be applied only once in the first year',
 					args: {
 						humanReadableCode: humanReadableCode,
 						upgradeCredit: formatCurrency( upgradeCredit, product.currency, {
@@ -924,13 +922,31 @@ function UpgradeCreditInformation( { product }: { product: ResponseCartProduct }
 		);
 	}
 
-	if ( isBiennially( product ) || isTriennially( product ) ) {
+	if ( isBiennially( product ) ) {
 		return (
 			<>
-				{ translate( '%(humanReadableCode)s : %(discount)s applied in first term only', {
+				{ translate( '%(humanReadableCode)s : %(discount)s applied in first two years only', {
 					comment:
-						'The upgrade credit is a pro rated balance of the previous plan which is to be applied' +
-						'as a deduction to the first year of next purchased plan. It will be applied once only in the first term',
+						'The reason for the discounted price, It will be applied only once in the first two years',
+					args: {
+						humanReadableCode: humanReadableCode,
+						discount: formatCurrency( upgradeCredit, product.currency, {
+							isSmallestUnit: true,
+							stripZeros: true,
+						} ),
+					},
+				} ) }
+				<UpgradeCreditHelpIconLink />
+			</>
+		);
+	}
+
+	if ( isTriennially( product ) ) {
+		return (
+			<>
+				{ translate( '%(humanReadableCode)s : %(discount)s applied in first three years only', {
+					comment:
+						'The reason for the discounted price, It will be applied only once in the first three years',
 					args: {
 						humanReadableCode: humanReadableCode,
 						discount: formatCurrency( upgradeCredit, product.currency, {

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -847,13 +847,18 @@ const UpgradeCreditHelpIconLink = () => {
 };
 
 function FetchOverrideCode( { product }: { product: ResponseCartProduct } ) {
-	//inspect the contents of the product object to see if "cost_overrides" array is not empty
-	if ( product.cost_overrides && product.cost_overrides.length > 0 ) {
-		const overrideCode = product.cost_overrides[ 0 ];
-		//return the override code
-		return overrideCode.human_readable_reason;
+	//Ensure product has cost overrides
+	if ( ! product || ! Array.isArray( product.cost_overrides ) ) {
+		return '';
 	}
-	return '';
+
+	// Find the first cost override with a non-empty 'human_readable_reason'
+	const firstValidOverride = product.cost_overrides.find(
+		( override ) => override && override.human_readable_reason
+	);
+
+	// Return the human readable reason of the first valid override, if found
+	return firstValidOverride ? firstValidOverride.human_readable_reason : '';
 }
 
 function UpgradeCreditInformation( { product }: { product: ResponseCartProduct } ) {
@@ -878,16 +883,16 @@ function UpgradeCreditInformation( { product }: { product: ResponseCartProduct }
 	) {
 		return null;
 	}
-	const readableCode = FetchOverrideCode( { product } );
-	if ( isMonthlyProduct( product ) && readableCode ) {
+	const humanReadableCode = FetchOverrideCode( { product } );
+	if ( isMonthlyProduct( product ) && humanReadableCode ) {
 		return (
 			<>
-				{ translate( '%(readableCode)s : %(upgradeCredit)s applied in first month only.', {
+				{ translate( '%(humanReadableCode)s : %(upgradeCredit)s applied in first month only.', {
 					comment:
 						'The upgrade credit is a pro rated balance of the previous plan which is to be applied' +
 						'as a deduction to the first year of next purchased plan. It will be applied once only in the first term',
 					args: {
-						readableCode: readableCode,
+						humanReadableCode: humanReadableCode,
 						upgradeCredit: formatCurrency( upgradeCredit, product.currency, {
 							isSmallestUnit: true,
 							stripZeros: true,
@@ -899,15 +904,15 @@ function UpgradeCreditInformation( { product }: { product: ResponseCartProduct }
 		);
 	}
 
-	if ( isYearly( product ) && readableCode ) {
+	if ( isYearly( product ) && humanReadableCode ) {
 		return (
 			<>
-				{ translate( '%(readableCode)s : %(upgradeCredit)s applied in first month only.', {
+				{ translate( '%(humanReadableCode)s : %(upgradeCredit)s applied in first month only.', {
 					comment:
 						'The upgrade credit is a pro rated balance of the previous plan which is to be applied' +
 						'as a deduction to the first year of next purchased plan. It will be applied once only in the first term',
 					args: {
-						readableCode: readableCode,
+						humanReadableCode: humanReadableCode,
 						upgradeCredit: formatCurrency( upgradeCredit, product.currency, {
 							isSmallestUnit: true,
 							stripZeros: true,
@@ -922,12 +927,12 @@ function UpgradeCreditInformation( { product }: { product: ResponseCartProduct }
 	if ( isBiennially( product ) || isTriennially( product ) ) {
 		return (
 			<>
-				{ translate( '%(readableCode)s : %(discount)s applied in first term only', {
+				{ translate( '%(humanReadableCode)s : %(discount)s applied in first term only', {
 					comment:
 						'The upgrade credit is a pro rated balance of the previous plan which is to be applied' +
 						'as a deduction to the first year of next purchased plan. It will be applied once only in the first term',
 					args: {
-						readableCode: readableCode,
+						humanReadableCode: humanReadableCode,
 						discount: formatCurrency( upgradeCredit, product.currency, {
 							isSmallestUnit: true,
 							stripZeros: true,

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -846,6 +846,16 @@ const UpgradeCreditHelpIconLink = () => {
 	);
 };
 
+function FetchOverrideCode( { product }: { product: ResponseCartProduct } ) {
+	//inspect the contents of the product object to see if "cost_overrides" array is not empty
+	if ( product.cost_overrides && product.cost_overrides.length > 0 ) {
+		const overrideCode = product.cost_overrides[ 0 ];
+		//return the override code
+		return overrideCode.human_readable_reason;
+	}
+	return null;
+}
+
 function UpgradeCreditInformation( { product }: { product: ResponseCartProduct } ) {
 	const translate = useTranslate();
 	const origCost = product.item_original_subtotal_integer;
@@ -868,14 +878,16 @@ function UpgradeCreditInformation( { product }: { product: ResponseCartProduct }
 	) {
 		return null;
 	}
+	const readableCode = FetchOverrideCode( { product } );
 	if ( isMonthlyProduct( product ) ) {
 		return (
 			<>
-				{ translate( 'Upgrade Credit: %(upgradeCredit)s applied in first month only', {
+				{ translate( '%(readableCode)s : %(upgradeCredit)s applied in first month only.', {
 					comment:
 						'The upgrade credit is a pro rated balance of the previous plan which is to be applied' +
 						'as a deduction to the first year of next purchased plan. It will be applied once only in the first term',
 					args: {
+						readableCode: readableCode,
 						upgradeCredit: formatCurrency( upgradeCredit, product.currency, {
 							isSmallestUnit: true,
 							stripZeros: true,
@@ -890,11 +902,12 @@ function UpgradeCreditInformation( { product }: { product: ResponseCartProduct }
 	if ( isYearly( product ) ) {
 		return (
 			<>
-				{ translate( 'Upgrade Credit: %(upgradeCredit)s applied in first year only', {
+				{ translate( '%(readableCode)s : %(upgradeCredit)s applied in first month only.', {
 					comment:
 						'The upgrade credit is a pro rated balance of the previous plan which is to be applied' +
 						'as a deduction to the first year of next purchased plan. It will be applied once only in the first term',
 					args: {
+						readableCode: readableCode,
 						upgradeCredit: formatCurrency( upgradeCredit, product.currency, {
 							isSmallestUnit: true,
 							stripZeros: true,
@@ -909,11 +922,12 @@ function UpgradeCreditInformation( { product }: { product: ResponseCartProduct }
 	if ( isBiennially( product ) || isTriennially( product ) ) {
 		return (
 			<>
-				{ translate( 'Upgrade Credit: %(discount)s applied in first term only', {
+				{ translate( '%(readableCode)s : %(discount)s applied in first term only', {
 					comment:
 						'The upgrade credit is a pro rated balance of the previous plan which is to be applied' +
 						'as a deduction to the first year of next purchased plan. It will be applied once only in the first term',
 					args: {
+						readableCode: readableCode,
 						discount: formatCurrency( upgradeCredit, product.currency, {
 							isSmallestUnit: true,
 							stripZeros: true,

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -853,7 +853,7 @@ function FetchOverrideCode( { product }: { product: ResponseCartProduct } ) {
 		//return the override code
 		return overrideCode.human_readable_reason;
 	}
-	return null;
+	return '';
 }
 
 function UpgradeCreditInformation( { product }: { product: ResponseCartProduct } ) {
@@ -879,7 +879,7 @@ function UpgradeCreditInformation( { product }: { product: ResponseCartProduct }
 		return null;
 	}
 	const readableCode = FetchOverrideCode( { product } );
-	if ( isMonthlyProduct( product ) ) {
+	if ( isMonthlyProduct( product ) && readableCode ) {
 		return (
 			<>
 				{ translate( '%(readableCode)s : %(upgradeCredit)s applied in first month only.', {
@@ -899,7 +899,7 @@ function UpgradeCreditInformation( { product }: { product: ResponseCartProduct }
 		);
 	}
 
-	if ( isYearly( product ) ) {
+	if ( isYearly( product ) && readableCode ) {
 		return (
 			<>
 				{ translate( '%(readableCode)s : %(upgradeCredit)s applied in first month only.', {

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -907,7 +907,7 @@ function UpgradeCreditInformation( { product }: { product: ResponseCartProduct }
 	if ( isYearly( product ) && humanReadableCode ) {
 		return (
 			<>
-				{ translate( '%(humanReadableCode)s : %(upgradeCredit)s applied in first month only.', {
+				{ translate( '%(humanReadableCode)s : %(upgradeCredit)s applied in first year only.', {
 					comment:
 						'The upgrade credit is a pro rated balance of the previous plan which is to be applied' +
 						'as a deduction to the first year of next purchased plan. It will be applied once only in the first term',


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/83956

### Summary:


For countries like India, Mexico and Philippines we offer a introductory first year promotional discount. When the customer from these countries add the yearly product to cart however, the discount reason is incorrectly labelled as  "Upgrade Credit":


![EDpRpf.png](https://github.com/Automattic/wp-calypso/assets/552016/6dde4f14-56d8-4cce-8197-f2f07937234f)


## Proposed Changes:

The purchase object does include the override codes array which includes a human readable one. Here we replace the incorrect text with the correct reason for discount which should look like this:

![YhbQVd.png](https://github.com/Automattic/wp-calypso/assets/552016/d4d6f661-d341-4b3d-8b70-d8911155aefe)

## Testing Instructions

* With out patch, set your currency to INR from Store Admin and add a WordPress.com personal yearly plan to cart. You should now see the discount reason which should look like this   `Upgrade Credit: ₹480 applied in first year only`  just like in the first screenshot

* Now Apply the patch and refresh that same page to see an update discount reason updated like this  `First-year promotional discount : ₹480 applied in first month only.` just like in the second screenshot
* Newly added automated test should pass.
* Switch the currency to USD and the discount reason should go away as no discount is given and should look like this: ![blQNPc.png](https://github.com/Automattic/wp-calypso/assets/552016/e4f23f56-4b73-4870-b77e-9f4feb7da921)