### PR TITLE
handleAppBannerShowing: Be defensive against the automattic/wpcom-welcome-guide store not existing

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -1032,7 +1032,12 @@ function handleSiteEditorBackButton( calypsoPort ) {
  * @param {MessagePort} calypsoPort Port used for communication with parent frame.
  */
 function handleAppBannerShowing( calypsoPort ) {
-	const isWelcomeGuideShown = select( 'automattic/wpcom-welcome-guide' ).isWelcomeGuideShown();
+	const welcomeGuideStore = select( 'automattic/wpcom-welcome-guide' );
+	if ( ! welcomeGuideStore || ! welcomeGuideStore.isWelcomeGuideShown ) {
+		return;
+	}
+
+	const isWelcomeGuideShown = welcomeGuideStore.isWelcomeGuideShown();
 	if ( ! isWelcomeGuideShown ) {
 		return;
 	}


### PR DESCRIPTION
Related to 7421959-zen

## Proposed Changes

On a user's AT site, I'm seeing this bit of code crash:
```
function (e) {
            if (
              !(0, c.select) ('automattic/wpcom-welcome-guide').isWelcomeGuideShown()
            ) return;
            const {
              port1: t,
              port2: n
            }
            = new MessageChannel;
            e.postMessage({
              action: 'getIsAppBannerVisible',
              payload: {
              }
            }, [
              n
            ]),
```
With error: `Uncaught TypeError: can't access property "isWelcomeGuideShown", c.select(...) is undefined`. It's coming from `https://widgets.wp.com/wpcom-block-editor/calypso.editor.min.js?ver=20231213`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?