### PR TITLE
Fetch reviews stats from wpcom stats endpoint and display them on the summary

### DIFF
--- a/client/my-sites/marketplace/components/reviews-summary/index.tsx
+++ b/client/my-sites/marketplace/components/reviews-summary/index.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 import { useSelector } from 'react-redux';
 import Rating from 'calypso/components/rating';
 import {
-	useMarketplaceReviewsQuery,
+	useMarketplaceReviewsStatsQuery,
 	type ProductProps,
 } from 'calypso/data/marketplace/use-marketplace-reviews';
 import { ReviewsModal } from 'calypso/my-sites/marketplace/components/reviews-modal';
@@ -21,7 +21,7 @@ export const ReviewsSummary = ( { slug, productName, productType }: Props ) => {
 	const translate = useTranslate();
 	const [ isVisible, setIsVisible ] = useState( false );
 
-	const { data: marketplaceReviews } = useMarketplaceReviewsQuery( {
+	const { data: marketplaceReviewsStats } = useMarketplaceReviewsStatsQuery( {
 		productType,
 		slug,
 	} );
@@ -30,24 +30,18 @@ export const ReviewsSummary = ( { slug, productName, productType }: Props ) => {
 		canPublishProductReviews( state, productType, slug )
 	);
 
-	// TODO: The averageRating will come from the server. Calculating it here temporarily.
 	let averageRating = null;
 	let numberOfReviews = null;
+
 	if (
 		isEnabled( 'marketplace-reviews-show' ) &&
-		marketplaceReviews &&
-		! ( 'message' in marketplaceReviews ) &&
-		marketplaceReviews.length > 0
+		marketplaceReviewsStats?.ratings_count !== undefined &&
+		marketplaceReviewsStats?.ratings_average !== undefined
 	) {
-		const totalReviews = marketplaceReviews.reduce(
-			( acc, review ) => acc + review.meta.wpcom_marketplace_rating,
-			0
-		);
-
-		numberOfReviews = marketplaceReviews.length;
-
-		averageRating = totalReviews / numberOfReviews;
-		averageRating = ( averageRating * 100 ) / 5; // Normalize to 100
+		numberOfReviews = marketplaceReviewsStats.ratings_count;
+		averageRating = marketplaceReviewsStats.ratings_average;
+		// Normalize to 100
+		averageRating = ( averageRating * 100 ) / 5;
 	}
 
 	return (
@@ -60,9 +54,9 @@ export const ReviewsSummary = ( { slug, productName, productType }: Props ) => {
 				productType={ productType }
 			/>
 			<div className="reviews-summary__container">
-				{ numberOfReviews && (
+				{ numberOfReviews !== null && (
 					<div>
-						{ averageRating && <Rating rating={ averageRating } /> }
+						{ averageRating !== null && <Rating rating={ averageRating } /> }
 						<Button borderless className="reviews-summary__number-reviews-link is-link">
 							{ translate( '%(numberOfReviews)d review', '%(numberOfReviews)d reviews', {
 								count: numberOfReviews,


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/4761

## Proposed Changes

- Add functions to fetch review stats from the WPCOM reviews stats endpoint.
- Display reviews count and average in the reviews summary.

## Testing Instructions

- On an environment with the marketplace-reviews-show flag enabled, for example wpcalypso.wordpress.com or activating the flag in production
- Navigate to a Partner theme that has reviews, e.g. /themes/annalee/:siteId
- Check that a request to the stats endpoint is made `https://public-api.wordpress.com/wpcom/v2/sites/marketplace.wordpress.com/marketplace/reviews/theme/annalee/stats`
- Check that the data in the response is the same data displayed on the reviews component and the review count.

<img width="754" alt="Screenshot 2023-12-13 at 8 41 49 PM" src="https://github.com/Automattic/wp-calypso/assets/351784/e54f9d7f-c33d-485e-a1cd-8b8b0e95cd91">

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?