### PR TITLE
Components: Add compact variation to PromoCard

### DIFF
--- a/client/components/promo-section/index.tsx
+++ b/client/components/promo-section/index.tsx
@@ -25,6 +25,7 @@ const PromoSectionCard: FunctionComponent< PromoSectionCardProps > = ( {
 	body,
 	badge,
 	actions,
+	variation,
 } ) => {
 	const cta = actions?.cta;
 	const learnMoreLink = actions?.learnMoreLink;
@@ -45,6 +46,7 @@ const PromoSectionCard: FunctionComponent< PromoSectionCardProps > = ( {
 			image={ image }
 			badge={ badge }
 			icon={ icon }
+			variation={ variation }
 		>
 			<p>{ body }</p>
 			{ ctaComponent }

--- a/client/components/promo-section/promo-card/index.tsx
+++ b/client/components/promo-section/promo-card/index.tsx
@@ -23,6 +23,11 @@ export enum TitleLocation {
 	FIGURE,
 }
 
+export enum PromoCardVariation {
+	Compact = 'compact',
+	Default = 'default',
+}
+
 export interface Props {
 	icon?: string;
 	image?: Image | ReactElement;
@@ -33,6 +38,7 @@ export interface Props {
 	badge?: string | ReactElement;
 	className?: string;
 	children?: React.ReactNode;
+	variation?: PromoCardVariation;
 }
 
 const isImage = ( image: Image | ReactElement ): image is Image => image.hasOwnProperty( 'path' );
@@ -47,11 +53,15 @@ const PromoCard: FunctionComponent< Props > = ( {
 	children,
 	badge,
 	className,
+	variation = PromoCardVariation.Default,
 } ) => {
+	const isCompact = variation === PromoCardVariation.Compact;
+
 	const classes = classNames(
 		{
 			'promo-card': true,
 			'is-primary': isPrimary,
+			compact: isCompact,
 		},
 		className
 	);
@@ -72,7 +82,7 @@ const PromoCard: FunctionComponent< Props > = ( {
 
 	return (
 		<ActionPanel className={ classes }>
-			{ image && (
+			{ image && ! isCompact && (
 				<ActionPanelFigure inlineBodyText={ false } align={ imageActionPanelAlignment }>
 					{ isImage( image ) ? (
 						<img src={ image.path } alt={ image.alt || '' } className={ image.className } />
@@ -82,7 +92,7 @@ const PromoCard: FunctionComponent< Props > = ( {
 					{ titleComponentLocation === TitleLocation.FIGURE && titleComponentHeader }
 				</ActionPanelFigure>
 			) }
-			{ icon && (
+			{ icon && ! isCompact && (
 				<ActionPanelFigure inlineBodyText={ false } align="left">
 					<Gridicon icon={ icon } size={ 32 } />
 					{ titleComponentLocation === TitleLocation.FIGURE && titleComponentHeader }
@@ -91,6 +101,7 @@ const PromoCard: FunctionComponent< Props > = ( {
 			<ActionPanelBody>
 				{ title && (
 					<ActionPanelTitle className={ classNames( { 'is-primary': isPrimary } ) }>
+						{ icon && isCompact && <Gridicon icon={ icon } size={ 32 } /> }
 						{ title }
 						{ badgeComponent }
 					</ActionPanelTitle>

--- a/client/components/promo-section/promo-card/style.scss
+++ b/client/components/promo-section/promo-card/style.scss
@@ -92,6 +92,27 @@
 		}
 	}
 
+	&.compact {
+		.action-panel__title {
+			justify-content: flex-start;
+			gap: 12px;
+			align-items: center;
+			font-size: $font-body;
+			font-weight: 500;
+		}
+		.action-panel__cta {
+			padding-top: 0;
+		}
+		.gridicon {
+			fill: var(--studio-gray-30);
+			width: 20px;
+			height: 20px;
+			background: var(--studio-gray-0);
+			padding: 8px;
+			border-radius: 3px;
+		}
+	}
+
 	.action-panel__cta {
 		.button {
 			margin: 0 1em 4px 0;

--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -22,6 +22,7 @@ import PromoSection, {
 	Props as PromoSectionProps,
 	PromoSectionCardProps,
 } from 'calypso/components/promo-section';
+import { PromoCardVariation } from 'calypso/components/promo-section/promo-card';
 import { CtaButton } from 'calypso/components/promo-section/promo-card/cta';
 import wp from 'calypso/lib/wp';
 import { useDispatch, useSelector } from 'calypso/state';
@@ -182,19 +183,15 @@ const Home = () => {
 					},
 			  };
 		const title = translate( 'Collect PayPal payments' );
-		const body = (
-			<>
-				{ translate(
-					'Accept credit card payments via PayPal for physical products, services, donations, or support of your creative work.'
-				) }
-				{ ! hasSimplePayments && <em>{ getPremiumPlanNames() }</em> }
-			</>
+		const body = translate(
+			'Accept credit and debit card payments via PayPal for physical products, services, donations, tips, or memberships.'
 		);
 
 		return {
 			title,
 			body,
 			icon: 'credit-card',
+			variation: PromoCardVariation.Compact,
 			actions: {
 				cta,
 			},
@@ -235,6 +232,7 @@ const Home = () => {
 			title,
 			body,
 			icon: 'money',
+			variation: PromoCardVariation.Compact,
 			actions: {
 				cta,
 			},
@@ -258,25 +256,17 @@ const Home = () => {
 			},
 		};
 
-		const title = translate( 'Accept donations and tips' );
+		const title = translate( 'Receive donations and tips' );
 
-		const body = (
-			<>
-				{ hasConnectedAccount
-					? translate(
-							'Accept one-time and recurring donations by inserting the Donations Form block.'
-					  )
-					: translate(
-							'Accept one-time and recurring donations by enabling the Donations Form block.'
-					  ) }
-				<></>
-			</>
+		const body = translate(
+			'The Donations Form block lets you accept credit and debit card payments for one-time donations, contributions, and tips.'
 		);
 
 		return {
 			title,
 			body,
 			icon: 'heart-outline',
+			variation: PromoCardVariation.Compact,
 			actions: {
 				cta,
 			},
@@ -302,19 +292,16 @@ const Home = () => {
 				}
 			},
 		};
-		const title = translate( 'Profit from subscriber-only content' );
-		const hasConnectionBodyText = translate(
-			'Create paid subscriptions so only subscribers can see selected content on your site — everyone else will see a paywall.'
+		const title = translate( 'Create subscriber-only content' );
+		const body = translate(
+			'Create paid subscription options and gate access to text, video, image, or any other kind of content.'
 		);
-		const noConnectionBodyText = translate(
-			'Create paid subscription options to share premium content like text, images, video, and any other content on your website.'
-		);
-		const body = <>{ hasConnectedAccount ? hasConnectionBodyText : noConnectionBodyText }</>;
 
 		return {
 			title,
 			body,
 			icon: 'bookmark-outline',
+			variation: PromoCardVariation.Compact,
 			actions: {
 				cta,
 			},
@@ -338,15 +325,16 @@ const Home = () => {
 				}
 			},
 		};
-		const title = translate( 'Send paid email newsletters' );
+		const title = translate( 'Set up a paid newsletter' );
 		const body = translate(
-			'Share premium content with paying subscribers automatically through email.'
+			'Reach and grow your audience with a newsletter and earn with paid subscriptions, gated content options, and one-time offerings.'
 		);
 
 		return {
 			title,
 			body,
 			icon: 'mail',
+			variation: PromoCardVariation.Compact,
 			actions: {
 				cta,
 			},
@@ -374,10 +362,10 @@ const Home = () => {
 		}
 
 		return {
-			title: translate( 'Refer a friend, you’ll both earn credits' ),
+			title: translate( 'Refer a friend' ),
 			body: peerReferralLink
 				? translate(
-						'To earn free credits, share the link below with your friends, family, and website visitors.'
+						'Share the link below and, for every paying customer you send our way, you’ll both earn US$25 in credits.'
 				  )
 				: translate(
 						'Share WordPress.com with friends, family, and website visitors. For every paying customer you send our way, you’ll both earn US$25 in free credits. By clicking “Earn free credits”, you agree to {{a}}these terms{{/a}}.',
@@ -394,6 +382,7 @@ const Home = () => {
 						}
 				  ),
 			icon: 'user-add',
+			variation: PromoCardVariation.Compact,
 			actions: {
 				cta,
 			},
@@ -433,7 +422,7 @@ const Home = () => {
 		) : (
 			<>
 				{ translate(
-					'Make money each time someone visits your site by displaying advertisements on all your posts and pages.'
+					'Make money each time someone visits your site by displaying ads on your posts and pages.'
 				) }
 				{ ! hasWordAdsFeature && <em>{ getPremiumPlanNames() }</em> }
 			</>
@@ -447,6 +436,7 @@ const Home = () => {
 			title,
 			body,
 			icon: 'speaker',
+			variation: PromoCardVariation.Compact,
 			actions: {
 				cta,
 				learnMoreLink,

--- a/client/my-sites/earn/style.scss
+++ b/client/my-sites/earn/style.scss
@@ -71,10 +71,10 @@
 	}
 }
 
-.earn .promo-section__promos .gridicon {
-	fill: var(--color-primary-10);
-	position: relative;
-	top: -8px;
+.earn .promo-card {
+	@include breakpoint-deprecated( ">1280px" ) {
+		width: calc(33% - 1em);
+	}
 }
 
 @include break-wide {


### PR DESCRIPTION
**This PR updates a calypso component. We'll want to ensure the change is backward compatible with existing uses of the component, and also update documentation if we adopt the change**

## Proposed Changes

* Adds a 'variation' prop to the PromoCard component. This can be undefined, or an enum of 'compact' or 'default'. When compact, it make small adjustments to PromoCard markup and styling. 
* The new compact variation is then applied to the Monetize feature cards. I also update text for some cards.
* The reason for this change is an effort update the Monetize screen based on Figma designs. But I'm assuming that if we're adopting this new style here, we may want to adopt the same style elsewhere. See designs: DqXCQr1dEWpF3P2dIEwiwd-fi-873_137897

**Before**
<img width="1055" alt="promos-before" src="https://github.com/Automattic/wp-calypso/assets/21228350/b14d63fc-47c1-4149-b74b-0dd53379a696">

**After**
<img width="1046" alt="promos-after" src="https://github.com/Automattic/wp-calypso/assets/21228350/69ebea3c-f16e-40d4-ab61-125bcf75e2b9">

## Testing Instructions

1) Go to http://calypso.localhost:3000/earn/YOURSITESLUG and confirm the new Monetize feature cards look like the new screenshot above.
2) Consider resizing your browsers, testing an alternative browser, or testing on mobile to confirm the design looks good and consistent across a range of situations. 
3) Check other screens that use the Promo card and confirm they are unaffected (as they will not be passing the new variation prop). 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?