### PR TITLE
Merge trunk before running e2e tests in branches

### DIFF
--- a/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
+++ b/.teamcity/_self/lib/customBuildType/E2EBuildType.kt
@@ -2,6 +2,7 @@ package _self.lib.customBuildType
 
 import Settings
 import _self.bashNodeScript
+import _self.lib.utils.mergeTrunk
 import jetbrains.buildServer.configs.kotlin.v2019_2.AbsoluteId
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildSteps
@@ -100,6 +101,12 @@ open class E2EBuildType(
 		}
 
 		steps {
+			// IMPORTANT! This step MUST match what the docker image does. If trunk
+			// is merged when building the docker image, it must also be merged
+			// to run the tests, or they may not be compatible. See the "mergeTrunk"
+			// step in BuildDockerImage in WebApp.kt.
+			mergeTrunk( skipIfConflict = true )
+
 			bashNodeScript {
 				name = "Prepare environment"
 				scriptContent = """


### PR DESCRIPTION
Since we merge trunk to generate the docker image build, we must also merge it for the e2e tests.