### PR TITLE
Fix desktop app e2e

### DIFF
--- a/.teamcity/_self/projects/DesktopApp.kt
+++ b/.teamcity/_self/projects/DesktopApp.kt
@@ -17,7 +17,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.retryBuild
 
 object DesktopApp : Project({
 	id("WpDesktop")
-	name = "Desktop app"
+	name = "Linux Desktop App"
 	buildType(E2ETests)
 
 	params {
@@ -32,7 +32,7 @@ object DesktopApp : Project({
 
 object E2ETests : BuildType({
 	id("WpDesktop_DesktopE2ETests")
-	name = "Run e2e tests"
+	name = "Electron E2E Smoke Test"
 	description = "Run wp-desktop e2e tests in Linux"
 
 	dependencies {

--- a/.teamcity/_self/projects/DesktopApp.kt
+++ b/.teamcity/_self/projects/DesktopApp.kt
@@ -2,6 +2,7 @@ package _self.projects
 
 import Settings
 import _self.bashNodeScript
+import _self.lib.utils.mergeTrunk
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
 import jetbrains.buildServer.configs.kotlin.v2019_2.FailureAction
@@ -52,6 +53,10 @@ object E2ETests : BuildType({
 	}
 
 	steps {
+		// Since the calypso.live image includes trunk, make sure any
+		// tests in this build also run with trunk changes.
+		mergeTrunk( skipIfConflict = true )
+
 		bashNodeScript {
 			name = "Prepare environment"
 			scriptContent = """

--- a/.teamcity/_self/projects/DesktopApp.kt
+++ b/.teamcity/_self/projects/DesktopApp.kt
@@ -103,7 +103,7 @@ object E2ETests : BuildType({
 				export WP_DESKTOP_BASE_URL="${'$'}URL"
 
 				# Start framebuffer
-				Xvfb ${'$'}{DISPLAY} -screen 0 1280x1024x24 &
+				Xvfb ${'$'}{DISPLAY} -screen 0 1280x1024x24 -ac -nolisten tcp -nolisten unix &
 
 				echo "Base URL is '${'$'}WP_DESKTOP_BASE_URL'"
 

--- a/.teamcity/_self/projects/DesktopApp.kt
+++ b/.teamcity/_self/projects/DesktopApp.kt
@@ -103,14 +103,14 @@ object E2ETests : BuildType({
 				export WP_DESKTOP_BASE_URL="${'$'}URL"
 
 				# Start framebuffer
-				# Xvfb ${'$'}{DISPLAY} -screen 0 1280x1024x24 -ac -nolisten tcp -nolisten unix &
+				Xvfb ${'$'}{DISPLAY} -screen 0 1280x1024x24 -ac -nolisten tcp -nolisten unix &
 
 				echo "Base URL is '${'$'}WP_DESKTOP_BASE_URL'"
 
 				cd desktop
 
 				# Run tests
-				xvfb-run yarn run test:e2e --reporters=jest-teamcity --reporters=default --detectOpenHandles
+				yarn run test:e2e --reporters=jest-teamcity --reporters=default --detectOpenHandles
 			"""
 			dockerImage = "%docker_image_desktop%"
 			// See https://stackoverflow.com/a/53975412 and https://blog.jessfraz.com/post/how-to-use-new-docker-seccomp-profiles/

--- a/.teamcity/_self/projects/DesktopApp.kt
+++ b/.teamcity/_self/projects/DesktopApp.kt
@@ -111,6 +111,7 @@ object E2ETests : BuildType({
 
 				# Run tests
 				yarn run test:e2e --reporters=jest-teamcity --reporters=default --detectOpenHandles
+				pkill Xvfb
 			"""
 			dockerImage = "%docker_image_desktop%"
 			// See https://stackoverflow.com/a/53975412 and https://blog.jessfraz.com/post/how-to-use-new-docker-seccomp-profiles/

--- a/.teamcity/_self/projects/DesktopApp.kt
+++ b/.teamcity/_self/projects/DesktopApp.kt
@@ -110,7 +110,7 @@ object E2ETests : BuildType({
 				cd desktop
 
 				# Run tests
-				yarn run test:e2e --reporters=jest-teamcity --reporters=default
+				yarn run test:e2e --reporters=jest-teamcity --reporters=default --detectOpenHandles
 			"""
 			dockerImage = "%docker_image_desktop%"
 			// See https://stackoverflow.com/a/53975412 and https://blog.jessfraz.com/post/how-to-use-new-docker-seccomp-profiles/

--- a/.teamcity/_self/projects/DesktopApp.kt
+++ b/.teamcity/_self/projects/DesktopApp.kt
@@ -103,14 +103,14 @@ object E2ETests : BuildType({
 				export WP_DESKTOP_BASE_URL="${'$'}URL"
 
 				# Start framebuffer
-				Xvfb ${'$'}{DISPLAY} -screen 0 1280x1024x24 -ac -nolisten tcp -nolisten unix &
+				# Xvfb ${'$'}{DISPLAY} -screen 0 1280x1024x24 -ac -nolisten tcp -nolisten unix &
 
 				echo "Base URL is '${'$'}WP_DESKTOP_BASE_URL'"
 
 				cd desktop
 
 				# Run tests
-				yarn run test:e2e --reporters=jest-teamcity --reporters=default --detectOpenHandles
+				xvfb-run yarn run test:e2e --reporters=jest-teamcity --reporters=default --detectOpenHandles
 			"""
 			dockerImage = "%docker_image_desktop%"
 			// See https://stackoverflow.com/a/53975412 and https://blog.jessfraz.com/post/how-to-use-new-docker-seccomp-profiles/

--- a/desktop/app/env.js
+++ b/desktop/app/env.js
@@ -43,6 +43,11 @@ if ( process.platform === 'linux' ) {
 	app.disableHardwareAcceleration();
 }
 
+// May help with resource issues in TeamCity. See https://github.com/electron/electron/issues/4280
+if ( process.platform === 'darwin' || process.platform === 'linux' ) {
+	process.setFdLimit( 8192 );
+}
+
 // Force sandbox: true for all BrowserWindow instances
 app.enableSandbox();
 

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -43,7 +43,7 @@
 		"electron-rebuild": "^2.3.5",
 		"jest": "^29.7.0",
 		"lodash": "^4.17.21",
-		"playwright": "^1.37",
+		"playwright": "^1.40.1",
 		"postcss": "^8.4.5",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",

--- a/desktop/test/e2e/specs/login.js
+++ b/desktop/test/e2e/specs/login.js
@@ -33,6 +33,7 @@ const RESULTS_PATH = path.join( __dirname, '../results' );
 const CONSOLE_PATH = path.join( RESULTS_PATH, '/console.log' );
 const SCREENSHOT_PATH = path.join( RESULTS_PATH, '/screenshot.png' );
 const RECORD_VIDEO_DIR = path.join( RESULTS_PATH, '/record_video' );
+const TRACE_DIR = path.join( RESULTS_PATH, '/trace' );
 const HAR_PATH = path.join( RESULTS_PATH, '/network.har' );
 const WP_DEBUG_LOG = path.resolve( RESULTS_PATH, '/app.log' );
 
@@ -59,6 +60,7 @@ describe( 'User Can log in', () => {
 			recordVideo: {
 				dir: RECORD_VIDEO_DIR,
 			},
+			tracesDir: TRACE_DIR,
 			env: {
 				...process.env,
 				WP_DESKTOP_BASE_URL: BASE_URL,

--- a/desktop/test/e2e/specs/login.js
+++ b/desktop/test/e2e/specs/login.js
@@ -55,7 +55,7 @@ describe( 'User Can log in', () => {
 				path: HAR_PATH,
 			},
 			recordVideo: {
-				dir: SCREENSHOT_PATH,
+				dir: SCREENSHOT_PATH + '/screen_record',
 			},
 			env: {
 				...process.env,

--- a/desktop/test/e2e/specs/login.js
+++ b/desktop/test/e2e/specs/login.js
@@ -70,9 +70,6 @@ describe( 'User Can log in', () => {
 				CI: true,
 			},
 		} );
-		// Increase the file descriptor limit to avoid ERR_INSUFFICIENT_RESOURCES errors.
-		// See https://github.com/electron/electron/issues/4280#issue-129919093
-		electronApp.process().setFdLimit( 8192 );
 
 		// Find main window. Playwright has problems identifying the main window
 		// when using `firstWindow`, so we find it by URL.

--- a/desktop/test/e2e/specs/login.js
+++ b/desktop/test/e2e/specs/login.js
@@ -108,11 +108,7 @@ describe( 'User Can log in', () => {
 		// 	- closed account
 		//	- wrong password
 		if ( response.status() === 400 ) {
-			throw new Error(
-				await mainWindow
-					.waitForSelector( 'div.is-error' )
-					.then( ( element ) => element.innerText() )
-			);
+			throw new Error( await mainWindow.locator( 'div.is-error' ).innerText() );
 		}
 
 		expect( response.status() ).toBe( 200 );

--- a/desktop/test/e2e/specs/login.js
+++ b/desktop/test/e2e/specs/login.js
@@ -89,6 +89,8 @@ describe( 'User Can log in', () => {
 
 	// eslint-disable-next-line jest/expect-expect
 	it( 'Log in', async () => {
+		console.log( window.url() );
+
 		await window.screenshot( { path: path.join( RESULTS_PATH, '01.png' ) } );
 
 		await window.getByLabel( 'Email Address or Username' ).fill( process.env.E2EGUTENBERGUSER );

--- a/desktop/test/e2e/specs/login.js
+++ b/desktop/test/e2e/specs/login.js
@@ -97,7 +97,7 @@ describe( 'User Can log in', () => {
 
 		// Wait for response from the Login endpoint.
 		const [ response ] = await Promise.all( [
-			mainWindow.waitForResponse( '**/wp-login.php?action=login-endpoint' ),
+			mainWindow.waitForResponse( '**/wp-login.php?action=login-endpoint' ), // wait for response.
 			mainWindow.click( 'button:has-text("Log In")' ),
 		] );
 

--- a/desktop/test/e2e/specs/login.js
+++ b/desktop/test/e2e/specs/login.js
@@ -48,6 +48,8 @@ describe( 'User Can log in', () => {
 
 	beforeAll( async () => {
 		await mkdir( path.dirname( CONSOLE_PATH ), { recursive: true } );
+		await mkdir( path.dirname( TRACE_DIR ), { recursive: true } );
+
 		consoleStream = createWriteStream( CONSOLE_PATH );
 
 		electronApp = await electron.launch( {

--- a/desktop/test/e2e/specs/login.js
+++ b/desktop/test/e2e/specs/login.js
@@ -33,7 +33,6 @@ const RESULTS_PATH = path.join( __dirname, '../results' );
 const CONSOLE_PATH = path.join( RESULTS_PATH, '/console.log' );
 const SCREENSHOT_PATH = path.join( RESULTS_PATH, '/screenshot.png' );
 const RECORD_VIDEO_DIR = path.join( RESULTS_PATH, '/record_video' );
-const TRACE_DIR = path.join( RESULTS_PATH, '/trace' );
 const HAR_PATH = path.join( RESULTS_PATH, '/network.har' );
 const WP_DEBUG_LOG = path.resolve( RESULTS_PATH, '/app.log' );
 
@@ -48,7 +47,6 @@ describe( 'User Can log in', () => {
 
 	beforeAll( async () => {
 		await mkdir( path.dirname( CONSOLE_PATH ), { recursive: true } );
-		await mkdir( path.dirname( TRACE_DIR ), { recursive: true } );
 
 		consoleStream = createWriteStream( CONSOLE_PATH );
 
@@ -62,7 +60,7 @@ describe( 'User Can log in', () => {
 			recordVideo: {
 				dir: RECORD_VIDEO_DIR,
 			},
-			tracesDir: TRACE_DIR,
+			tracesDir: RESULTS_PATH,
 			env: {
 				...process.env,
 				WP_DESKTOP_BASE_URL: BASE_URL,
@@ -85,6 +83,9 @@ describe( 'User Can log in', () => {
 		window.on( 'console', ( data ) =>
 			consoleStream.write( `${ new Date().toUTCString() } [${ data.type() }] ${ data.text() }\n` )
 		);
+
+		// Start tracing
+		window.context().tracing.start( { screenshots: true, snapshots: true } );
 	} );
 
 	// eslint-disable-next-line jest/expect-expect
@@ -125,6 +126,7 @@ describe( 'User Can log in', () => {
 		}
 
 		if ( window ) {
+			await window.context().tracing.stop( { path: path.join( RESULTS_PATH, 'trace.zip' ) } );
 			await window.screenshot( { path: SCREENSHOT_PATH } );
 		}
 

--- a/desktop/test/e2e/specs/login.js
+++ b/desktop/test/e2e/specs/login.js
@@ -91,9 +91,13 @@ describe( 'User Can log in', () => {
 
 	// eslint-disable-next-line jest/expect-expect
 	it( 'Log in', async () => {
+		await mainWindow.screenshot( { path: SCREENSHOT_PATH } );
 		await mainWindow.fill( '#usernameOrEmail', process.env.E2EGUTENBERGUSER );
+		await mainWindow.screenshot( { path: SCREENSHOT_PATH } );
 		await mainWindow.keyboard.press( 'Enter' );
+		await mainWindow.screenshot( { path: SCREENSHOT_PATH } );
 		await mainWindow.fill( '#password', process.env.E2EPASSWORD );
+		await mainWindow.screenshot( { path: SCREENSHOT_PATH } );
 
 		// Wait for response from the Login endpoint.
 		const [ response ] = await Promise.all( [

--- a/desktop/test/e2e/specs/login.js
+++ b/desktop/test/e2e/specs/login.js
@@ -90,7 +90,7 @@ describe( 'User Can log in', () => {
 		await window.getByLabel( 'Email Address or Username' ).fill( process.env.E2EGUTENBERGUSER );
 		await window.screenshot( { path: path.join( RESULTS_PATH, '02.png' ) } );
 
-		await window.getByRole( 'button', { name: 'Continue' } ).click();
+		await window.getByRole( 'button', { name: 'Continue', exact: true } ).click();
 		await window.screenshot( { path: path.join( RESULTS_PATH, '03.png' ) } );
 
 		await window.getByLabel( 'Password' ).fill( process.env.E2EPASSWORD );

--- a/desktop/test/e2e/specs/login.js
+++ b/desktop/test/e2e/specs/login.js
@@ -84,12 +84,6 @@ describe( 'User Can log in', () => {
 		mainWindow.on( 'console', ( data ) =>
 			consoleStream.write( `${ new Date().toUTCString() } [${ data.type() }] ${ data.text() }\n` )
 		);
-
-		// Wait for everythingm to be loaded before starting
-		await mainWindow.waitForLoadState();
-		for ( const [ , frame ] of mainWindow.frames().entries() ) {
-			await frame.waitForLoadState();
-		}
 	} );
 
 	// eslint-disable-next-line jest/expect-expect

--- a/desktop/test/e2e/specs/login.js
+++ b/desktop/test/e2e/specs/login.js
@@ -54,6 +54,9 @@ describe( 'User Can log in', () => {
 			recordHar: {
 				path: HAR_PATH,
 			},
+			recordVideo: {
+				dir: SCREENSHOT_PATH,
+			},
 			env: {
 				...process.env,
 				WP_DESKTOP_BASE_URL: BASE_URL,

--- a/desktop/test/e2e/specs/login.js
+++ b/desktop/test/e2e/specs/login.js
@@ -4,35 +4,37 @@ const { mkdir } = require( 'fs/promises' );
 const path = require( 'path' );
 const { _electron: electron } = require( 'playwright' );
 
+const RELEASE_PATH = path.join( __dirname, '../../../release' );
+
 let APP_PATH;
 
 switch ( process.platform ) {
 	case 'linux':
-		APP_PATH = path.join( __dirname, '../../../release/linux-unpacked/wpcom' );
+		APP_PATH = path.join( RELEASE_PATH, '/linux-unpacked/wpcom' );
 		break;
 	case 'darwin':
 		// On Apple Silicon, the output file is under a separate directory.
 		if ( process.arch.includes( 'arm' ) ) {
 			APP_PATH = path.join(
-				__dirname,
-				'../../../release/mac-arm64/WordPress.com.app/Contents/MacOS/WordPress.com'
+				RELEASE_PATH,
+				'/mac-arm64/WordPress.com.app/Contents/MacOS/WordPress.com'
 			);
 			break;
 		}
 		// Codepath for Intel architecture.
-		APP_PATH = path.join(
-			__dirname,
-			'../../../release/mac/WordPress.com.app/Contents/MacOS/WordPress.com'
-		);
+		APP_PATH = path.join( RELEASE_PATH, '/mac/WordPress.com.app/Contents/MacOS/WordPress.com' );
 		break;
 	default:
 		throw new Error( 'unsupported platform' );
 }
 
-const CONSOLE_PATH = path.join( __dirname, '../results/console.log' );
-const SCREENSHOT_PATH = path.join( __dirname, '../results/screenshot.png' );
-const HAR_PATH = path.join( __dirname, '../results/network.har' );
-const WP_DEBUG_LOG = path.resolve( __dirname, '../results/app.log' );
+const RESULTS_PATH = path.join( __dirname, '../results' );
+
+const CONSOLE_PATH = path.join( RESULTS_PATH, '/console.log' );
+const SCREENSHOT_PATH = path.join( RESULTS_PATH, '/screenshot.png' );
+const RECORD_VIDEO_DIR = path.join( RESULTS_PATH, '/record_video' );
+const HAR_PATH = path.join( RESULTS_PATH, '/network.har' );
+const WP_DEBUG_LOG = path.resolve( RESULTS_PATH, '/app.log' );
 
 const BASE_URL = process.env.WP_DESKTOP_BASE_URL?.replace( /\/$/, '' ) ?? 'https://wordpress.com';
 
@@ -55,7 +57,7 @@ describe( 'User Can log in', () => {
 				path: HAR_PATH,
 			},
 			recordVideo: {
-				dir: SCREENSHOT_PATH + '/screen_record',
+				dir: RECORD_VIDEO_DIR,
 			},
 			env: {
 				...process.env,

--- a/desktop/test/e2e/specs/login.js
+++ b/desktop/test/e2e/specs/login.js
@@ -86,6 +86,14 @@ describe( 'User Can log in', () => {
 
 		// Start tracing
 		window.context().tracing.start( { screenshots: true, snapshots: true } );
+
+		// Ensure that the CSP report endpoint is mocked to avoid
+		// ERR_INSUFFICIENT_RESOURCES errors.
+		await window.route( '**/cspreport', ( route ) => {
+			route.fulfill( {
+				status: 200,
+			} );
+		} );
 	} );
 
 	// eslint-disable-next-line jest/expect-expect

--- a/desktop/test/e2e/specs/login.js
+++ b/desktop/test/e2e/specs/login.js
@@ -45,7 +45,7 @@ describe( 'User Can log in', () => {
 
 	beforeAll( async () => {
 		await mkdir( path.dirname( CONSOLE_PATH ), { recursive: true } );
-		consoleStream = await createWriteStream( CONSOLE_PATH );
+		consoleStream = createWriteStream( CONSOLE_PATH );
 
 		electronApp = await electron.launch( {
 			executablePath: APP_PATH,
@@ -69,8 +69,8 @@ describe( 'User Can log in', () => {
 
 		// Find main window. Playwright has problems identifying the main window when using `firstWindow`, so we
 		// iterate over all windows and find it by URL.
-		for ( const window of await electronApp.windows() ) {
-			const windowUrl = await window.url();
+		for ( const window of electronApp.windows() ) {
+			const windowUrl = window.url();
 			if ( windowUrl.startsWith( BASE_URL ) ) {
 				mainWindow = window;
 				break;

--- a/desktop/test/e2e/specs/login.js
+++ b/desktop/test/e2e/specs/login.js
@@ -85,19 +85,20 @@ describe( 'User Can log in', () => {
 
 	// eslint-disable-next-line jest/expect-expect
 	it( 'Log in', async () => {
-		await window.screenshot( { path: SCREENSHOT_PATH } );
+		await window.screenshot( { path: path.join( RESULTS_PATH, '01.png' ) } );
 
 		await window.getByLabel( 'Email Address or Username' ).fill( process.env.E2EGUTENBERGUSER );
-		await window.screenshot( { path: SCREENSHOT_PATH } );
+		await window.screenshot( { path: path.join( RESULTS_PATH, '02.png' ) } );
 
 		await window.getByRole( 'button', { name: 'Continue' } ).click();
-		await window.screenshot( { path: SCREENSHOT_PATH } );
+		await window.screenshot( { path: path.join( RESULTS_PATH, '03.png' ) } );
 
 		await window.getByLabel( 'Password' ).fill( process.env.E2EPASSWORD );
-		await window.screenshot( { path: SCREENSHOT_PATH } );
+		await window.screenshot( { path: path.join( RESULTS_PATH, '04.png' ) } );
 
 		const responsePromise = window.waitForResponse( '**/wp-login.php?action=login-endpoint' );
 		await window.getByRole( 'button', { name: 'Log In' } ).click();
+		await window.screenshot( { path: path.join( RESULTS_PATH, '05.png' ) } );
 
 		// If the account credentials are rejected, throw an error containing the text of
 		// the validation error.

--- a/desktop/test/e2e/specs/login.js
+++ b/desktop/test/e2e/specs/login.js
@@ -90,7 +90,7 @@ describe( 'User Can log in', () => {
 	} );
 
 	// eslint-disable-next-line jest/expect-expect
-	it( 'Log in', async function () {
+	it( 'Log in', async () => {
 		await mainWindow.fill( '#usernameOrEmail', process.env.E2EGUTENBERGUSER );
 		await mainWindow.keyboard.press( 'Enter' );
 		await mainWindow.fill( '#password', process.env.E2EPASSWORD );

--- a/desktop/test/e2e/specs/login.js
+++ b/desktop/test/e2e/specs/login.js
@@ -70,6 +70,9 @@ describe( 'User Can log in', () => {
 				CI: true,
 			},
 		} );
+		// Increase the file descriptor limit to avoid ERR_INSUFFICIENT_RESOURCES errors.
+		// See https://github.com/electron/electron/issues/4280#issue-129919093
+		electronApp.process().setFdLimit( 8192 );
 
 		// Find main window. Playwright has problems identifying the main window
 		// when using `firstWindow`, so we find it by URL.

--- a/desktop/test/e2e/specs/login.js
+++ b/desktop/test/e2e/specs/login.js
@@ -62,7 +62,7 @@ describe( 'User Can log in', () => {
 				WP_DESKTOP_BASE_URL: BASE_URL,
 				WP_DEBUG_LOG, // This will override logging path from the Electron main process.
 				// Ensure other CI-specific overrides (such as disabling the auto-updater)
-				DEBUG: true,
+				DEBUG: 'pw:api',
 				CI: true,
 			},
 		} );

--- a/desktop/test/e2e/specs/login.js
+++ b/desktop/test/e2e/specs/login.js
@@ -25,7 +25,7 @@ switch ( process.platform ) {
 		APP_PATH = path.join( RELEASE_PATH, '/mac/WordPress.com.app/Contents/MacOS/WordPress.com' );
 		break;
 	default:
-		throw new Error( 'unsupported platform' );
+		throw new Error( `Unsupported platform: ${ process.platform }` );
 }
 
 const RESULTS_PATH = path.join( __dirname, '../results' );

--- a/yarn.lock
+++ b/yarn.lock
@@ -10145,7 +10145,7 @@ __metadata:
     js-yaml: "npm:^4.0.0"
     lodash: "npm:^4.17.21"
     make-dir: "npm:^3.1.0"
-    playwright: "npm:^1.37"
+    playwright: "npm:^1.40.1"
     postcss: "npm:^8.4.5"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
@@ -17463,7 +17463,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@npm:^2.3.2, fsevents@npm:~2.3.1, fsevents@npm:~2.3.2":
+"fsevents@npm:2.3.2, fsevents@npm:^2.3.2, fsevents@npm:~2.3.1, fsevents@npm:~2.3.2":
   version: 2.3.2
   resolution: "fsevents@npm:2.3.2"
   dependencies:
@@ -17473,7 +17473,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@patch:fsevents@npm%3A^2.3.2#optional!builtin<compat/fsevents>, fsevents@patch:fsevents@npm%3A~2.3.1#optional!builtin<compat/fsevents>, fsevents@patch:fsevents@npm%3A~2.3.2#optional!builtin<compat/fsevents>":
+"fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>, fsevents@patch:fsevents@npm%3A^2.3.2#optional!builtin<compat/fsevents>, fsevents@patch:fsevents@npm%3A~2.3.1#optional!builtin<compat/fsevents>, fsevents@patch:fsevents@npm%3A~2.3.2#optional!builtin<compat/fsevents>":
   version: 2.3.2
   resolution: "fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"
   dependencies:
@@ -24593,6 +24593,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"playwright-core@npm:1.40.1":
+  version: 1.40.1
+  resolution: "playwright-core@npm:1.40.1"
+  bin:
+    playwright-core: cli.js
+  checksum: 56c283012974982313a6ae583b975ee4af76d52059fb9a25d9cc616a11224685ec64682b391910c795d2b12d2ab5c7eec31124722c75c0b1703a76ac9b6fd1c2
+  languageName: node
+  linkType: hard
+
 "playwright@npm:^1.37":
   version: 1.37.0
   resolution: "playwright@npm:1.37.0"
@@ -24601,6 +24610,21 @@ __metadata:
   bin:
     playwright: cli.js
   checksum: 78a711fe8e7faff8012bd277a8d8dd73faeb795e266d6ce07d07a9c5f9a2333f823dc70813ec34dbf3d3177c84d9c152287c02c3545b4ee33f47a3e716ef14f8
+  languageName: node
+  linkType: hard
+
+"playwright@npm:^1.40.1":
+  version: 1.40.1
+  resolution: "playwright@npm:1.40.1"
+  dependencies:
+    fsevents: "npm:2.3.2"
+    playwright-core: "npm:1.40.1"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    playwright: cli.js
+  checksum: 5dae164d1f69162da8d7eee52da651296fb885c76a8b36049f216975c751a0a826ff05795a1c0902dc0bd193fe606ae17d5def655f4cbcccb8d8b71afb74b950
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR aims to fix the broken electron desktop e2e tests. (See here: https://teamcity.a8c.com/buildConfiguration/calypso_WpDesktop_DesktopE2ETests?branch=&buildTypeTab=overview&mode=builds)

So far this includes the following changes:
- Update the name of the builds in TC so that it's easier to differentiate from the web app desktop e2es. (I think people sometimes don't realize this specific suite is for the electron app.) I also changed it to "smoke test" to reflect that it's really just one or two tests, not a big suite.
- Merge trunk. This matches #85253. I don't think this will fix anything currently, but it is the correct behavior since the calypso.live image it will test on includes a merged trunk.

TBD: test changes to fix the failure.