### PR TITLE
update support link for search terms/click/video

### DIFF
--- a/client/my-sites/stats/const.js
+++ b/client/my-sites/stats/const.js
@@ -1,3 +1,6 @@
 // No need to localize this URL, since it's used as the prefix for other localized URLs.
 // eslint-disable-next-line wpcalypso/i18n-unlocalized-url
 export const SUPPORT_URL = 'https://wordpress.com/support/stats/';
+export const UNDERSTAND_YOUR_TRAFFIC_SUPPORT_URL =
+	// eslint-disable-next-line wpcalypso/i18n-unlocalized-url
+	'https://wordpress.com/support/stats/understand-your-sites-traffic/';

--- a/client/my-sites/stats/stats-strings.js
+++ b/client/my-sites/stats/stats-strings.js
@@ -1,6 +1,6 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { translate } from 'i18n-calypso';
-import { SUPPORT_URL } from './const';
+import { SUPPORT_URL, UNDERSTAND_YOUR_TRAFFIC_SUPPORT_URL } from './const';
 
 export default function () {
 	const statsStrings = {};
@@ -48,7 +48,7 @@ export default function () {
 		empty: translate( 'Your most {{link}}clicked external links{{/link}} will display here.', {
 			comment: '{{link}} links to support documentation.',
 			components: {
-				link: <a href={ localizeUrl( `${ SUPPORT_URL }#clicks` ) } />,
+				link: <a href={ localizeUrl( `${ UNDERSTAND_YOUR_TRAFFIC_SUPPORT_URL }#clicks` ) } />,
 			},
 			context: 'Stats: Info box label when the Clicks module is empty',
 		} ),
@@ -83,7 +83,7 @@ export default function () {
 		empty: translate( 'See {{link}}terms that visitors search{{/link}} to find your site, here. ', {
 			comment: '{{link}} links to support documentation.',
 			components: {
-				link: <a href={ localizeUrl( `${ SUPPORT_URL }#search-terms` ) } />,
+				link: <a href={ localizeUrl( `${ UNDERSTAND_YOUR_TRAFFIC_SUPPORT_URL }#search-terms` ) } />,
 			},
 			context: 'Stats: Info box label when the Search Terms module is empty',
 		} ),
@@ -113,7 +113,7 @@ export default function () {
 		empty: translate( 'Your most viewed {{link}}video stats{{/link}} will show up here.', {
 			comment: '{{link}} links to support documentation.',
 			components: {
-				link: <a href={ localizeUrl( `${ SUPPORT_URL }#videos` ) } />,
+				link: <a href={ localizeUrl( `${ UNDERSTAND_YOUR_TRAFFIC_SUPPORT_URL }#videos` ) } />,
 			},
 			context: 'Stats: Info box label when the Videos module is empty',
 		} ),


### PR DESCRIPTION
Related to #81632

## Proposed Changes

Updated support doc links per request.

## Testing Instructions

* Ensure support URL for Search Terms, Clicks and Video work okay

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?