### PR TITLE
Jetpack Manage: Fix bundle size tabs not working with Browser's back button.

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/hooks/use-product-bundle-size.ts
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/hooks/use-product-bundle-size.ts
@@ -1,3 +1,4 @@
+import { addQueryArgs, getQueryArgs } from '@wordpress/url';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
@@ -29,7 +30,7 @@ export function useProductBundleSize() {
 
 	const supportedBundleSizes = getSupportedBundleSizes( products );
 
-	const { setParams, resetParams, getParamValue } = useURLQueryParams();
+	const { resetParams, getParamValue } = useURLQueryParams();
 
 	const [ selectedSize, setSelectedSize ] = useState< number | undefined >( undefined );
 
@@ -45,16 +46,23 @@ export function useProductBundleSize() {
 			if ( size === 1 ) {
 				resetParams( [ BUNDLE_SIZE_PARAM_KEY ] );
 			} else {
-				setParams( [
-					{
-						key: BUNDLE_SIZE_PARAM_KEY,
-						value: `${ size }`,
-					},
-				] );
+				/* Ideally we would like to use setParams from useURLQueryParams hook but
+				 * for a reason it causes the Page context to throw exception when
+				 * popping the history stack (browser back button). This implementation is
+				 * a workaround for that issue.
+				 */
+				window.history.pushState(
+					null,
+					'',
+					addQueryArgs( '', {
+						...getQueryArgs( window.location.href ),
+						[ BUNDLE_SIZE_PARAM_KEY ]: `${ size }`,
+					} )
+				);
 			}
 			setSelectedSize( size );
 		},
-		[ resetParams, setParams ]
+		[ resetParams ]
 	);
 
 	return useMemo( () => {

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/hooks/use-product-bundle-size.ts
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/hooks/use-product-bundle-size.ts
@@ -1,8 +1,7 @@
-import { addQueryArgs, getQueryArgs } from '@wordpress/url';
+import { addQueryArgs, getQueryArgs, removeQueryArgs } from '@wordpress/url';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
-import { useURLQueryParams } from '../../hooks';
 
 const BUNDLE_SIZE_PARAM_KEY = 'bundle_size';
 
@@ -30,39 +29,33 @@ export function useProductBundleSize() {
 
 	const supportedBundleSizes = getSupportedBundleSizes( products );
 
-	const { resetParams, getParamValue } = useURLQueryParams();
-
 	const [ selectedSize, setSelectedSize ] = useState< number | undefined >( undefined );
 
 	// When products are changed, we need to reevaluate if selected bundle size is still valid
 	useEffect( () => {
-		setSelectedSize(
-			parseLocationHash( supportedBundleSizes, getParamValue( BUNDLE_SIZE_PARAM_KEY ) )
-		);
-	}, [ getParamValue, supportedBundleSizes ] );
+		const { [ BUNDLE_SIZE_PARAM_KEY ]: bundleSize } = getQueryArgs( window.location.href );
+		setSelectedSize( parseLocationHash( supportedBundleSizes, bundleSize?.toString() ) );
+	}, [ supportedBundleSizes ] );
 
 	const setSelectedSizeAndLocationHash = useCallback(
 		( size: number ) => {
-			if ( size === 1 ) {
-				resetParams( [ BUNDLE_SIZE_PARAM_KEY ] );
-			} else {
-				/* Ideally we would like to use setParams from useURLQueryParams hook but
-				 * for a reason it causes the Page context to throw exception when
-				 * popping the history stack (browser back button). This implementation is
-				 * a workaround for that issue.
-				 */
-				window.history.pushState(
-					null,
-					'',
-					addQueryArgs( '', {
-						...getQueryArgs( window.location.href ),
-						[ BUNDLE_SIZE_PARAM_KEY ]: `${ size }`,
-					} )
-				);
+			if ( size === selectedSize ) {
+				return;
 			}
+
+			const queryArgs =
+				size === 1
+					? removeQueryArgs( window.location.href, BUNDLE_SIZE_PARAM_KEY )
+					: addQueryArgs( window.location.href, {
+							...getQueryArgs( window.location.href ),
+							[ BUNDLE_SIZE_PARAM_KEY ]: `${ size }`,
+					  } );
+
+			window.history.pushState( null, '', queryArgs );
+
 			setSelectedSize( size );
 		},
-		[ resetParams ]
+		[ selectedSize ]
 	);
 
 	return useMemo( () => {


### PR DESCRIPTION
This PR fixes an issue with the bundle size tabs not working with the Browser's back button. An exception is thrown when the page switches back to the page with the bundle size query param.

<img width="575" alt="Screen Shot 2023-12-14 at 12 46 42 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/b052bf85-59ad-4fcd-b7d7-dbee5c1bcd32">

Closes https://github.com/Automattic/jetpack-genesis/issues/144

## Proposed Changes

* This pull request updates the implementation of pushing the bundle size query param to the history stack. This is because setParams from the useURLQueryParams hook caused exceptions with Page context.

## Testing Instructions
Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

* Use the Jetpack cloud live link below and go to the Issue License page. (/partner-portal/issue-license)
* Navigate from various bundle tiers by clicking the bundle size tabs.
* Press the browser's back button.
* Confirm that the back button now works and the tab is updated.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?