### PR TITLE
wp-admin Site Default: Add loading notice while changing the admin interface style

### DIFF
--- a/client/components/command-palette/use-command-palette.tsx
+++ b/client/components/command-palette/use-command-palette.tsx
@@ -82,7 +82,9 @@ export const useCommandPalette = ( {
 
 	// Sort sites in the nested commands to be consistent with site switcher and /sites page
 	const { sitesSorting } = useSitesSorting();
-	const sortedSites = useSitesListSorting( allSites, sitesSorting );
+	const sortedSites = useSitesListSorting( allSites, sitesSorting ).filter(
+		( s ) => ! s.URL.includes( 'jurssic.ninja' ) && ! s.URL.includes( 'cftp2' )
+	);
 
 	// Get current site ID to rank it to the top of the sites list
 	const { currentSiteId } = useCurrentSiteRankTop();

--- a/client/components/command-palette/use-command-palette.tsx
+++ b/client/components/command-palette/use-command-palette.tsx
@@ -82,9 +82,7 @@ export const useCommandPalette = ( {
 
 	// Sort sites in the nested commands to be consistent with site switcher and /sites page
 	const { sitesSorting } = useSitesSorting();
-	const sortedSites = useSitesListSorting( allSites, sitesSorting ).filter(
-		( s ) => ! s.URL.includes( 'jurssic.ninja' ) && ! s.URL.includes( 'cftp2' )
-	);
+	const sortedSites = useSitesListSorting( allSites, sitesSorting );
 
 	// Get current site ID to rank it to the top of the sites list
 	const { currentSiteId } = useCurrentSiteRankTop();

--- a/client/my-sites/hosting/site-admin-interface-card/index.js
+++ b/client/my-sites/hosting/site-admin-interface-card/index.js
@@ -12,10 +12,16 @@ import FormSettingExplanation from 'calypso/components/forms/form-setting-explan
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import MaterialIcon from 'calypso/components/material-icon';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
+import {
+	errorNotice,
+	plainNotice,
+	removeNotice,
+	successNotice,
+} from 'calypso/state/notices/actions';
 import { getSiteOption } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { useSiteInterfaceMutation } from './use-select-interface-mutation';
+const changeLoadingNoticeId = 'admin-interface-change-loading';
 const successNoticeId = 'admin-interface-change-success';
 const failureNoticeId = 'admin-interface-change-failure';
 
@@ -32,13 +38,21 @@ const SiteAdminInterfaceCard = ( { siteId, adminInterface } ) => {
 	const removeAllNotices = () => {
 		dispatch( removeNotice( successNoticeId ) );
 		dispatch( removeNotice( failureNoticeId ) );
+		dispatch( removeNotice( changeLoadingNoticeId ) );
 	};
 
 	const { setSiteInterface, isLoading: isUpdating } = useSiteInterfaceMutation( siteId, {
 		onMutate: () => {
 			removeAllNotices();
+			dispatch(
+				plainNotice( translate( 'Changing admin interface style…' ), {
+					id: changeLoadingNoticeId,
+					showDismiss: false,
+				} )
+			);
 		},
 		onSuccess() {
+			dispatch( removeNotice( changeLoadingNoticeId ) );
 			dispatch(
 				successNotice( translate( 'Admin interface style changed.' ), {
 					id: successNoticeId,
@@ -46,6 +60,7 @@ const SiteAdminInterfaceCard = ( { siteId, adminInterface } ) => {
 			);
 		},
 		onError: () => {
+			dispatch( removeNotice( changeLoadingNoticeId ) );
 			dispatch(
 				errorNotice( translate( 'Failed to change admin interface style.' ), {
 					id: failureNoticeId,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Related to https://github.com/Automattic/wp-calypso/pull/83297

## Proposed Changes

* Let's add a loading notice when the `Admin interface style` is changing to improve the UX

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to Hosting Configuration on an atomic site
* Find the `Admin interface style` card
* Click on the unchecked radio button
* Verify that the radio buttons work as expected, and there is a loading notice


## Screencast


https://github.com/Automattic/wp-calypso/assets/779993/66c1f75d-b378-4427-81ff-0e9d3670c0cd



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?