### PR TITLE
Hosting Command Palette: Fix spelling on clear cache success notice

### DIFF
--- a/client/sites-dashboard/components/wpcom-smp-commands.tsx
+++ b/client/sites-dashboard/components/wpcom-smp-commands.tsx
@@ -157,7 +157,7 @@ export const useCommandsArrayWpcom = ( {
 					path: `/sites/${ siteId }/hosting/edge-cache/purge`,
 					apiNamespace: 'wpcom/v2',
 				} );
-				displayNotice( __( 'Succesfully cleared cache.' ) );
+				displayNotice( __( 'Successfully cleared cache.' ) );
 			} else {
 				// If global edge cache is not active, clear WordPress cache
 				dispatch( clearWordPressCache( siteId, 'Cache not active' ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Related to https://github.com/Automattic/wp-calypso/pull/84819

## Proposed Changes

* Fix the spelling on `Clear cache` success notice.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure you have a public atomic site with the edge cache enabled
* Open the command
* Search for `Clear cache` command 
* Select your site
* Observe the correct spelling on the success message. `Successfully cleared cache.`


## Screencast

https://github.com/Automattic/wp-calypso/assets/779993/c93524cc-7ded-4c6a-9e90-1a90dcdf55d5



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?