### PR TITLE
Assembler: Add flag pattern-assembler/skip-rendered-pattern-cache in Calypso

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -119,6 +119,7 @@
 		"p2/p2-plus": true,
 		"pattern-assembler/v2": true,
 		"pattern-assembler/add-pages": true,
+		"pattern-assembler/skip-rendered-pattern-cache": true,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,

--- a/packages/block-renderer/src/hooks/use-rendered-patterns.ts
+++ b/packages/block-renderer/src/hooks/use-rendered-patterns.ts
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { useQueries } from '@tanstack/react-query';
 import wpcomRequest from 'wpcom-proxy-request';
 import type { RenderedPattern, RenderedPatterns, SiteInfo } from '../types';
@@ -41,7 +42,7 @@ const useRenderedPatterns = (
 	const queries = Object.entries( patternIdsByCategory ).map( ( [ category, patternIds ] ) => ( {
 		queryKey: [ 'rendered-patterns', siteId, stylesheet, category, patternIds, siteInfo ],
 		queryFn: () => fetchRenderedPatterns( siteId, stylesheet, category, patternIds, siteInfo ),
-		staleTime: 1000 * 60 * 5, // 5 minutes
+		staleTime: isEnabled( 'pattern-assembler/skip-rendered-pattern-cache' ) ? 0 : 1000 * 60 * 5, // 5 minutes
 		refetchOnWindowFocus: false,
 	} ) );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to D131807-code

## Proposed Changes

* Add flag pattern-assembler/skip-rendered-pattern-cache in Calypso
* Set `staleTime: 0` when the flag is enabled.

> [!NOTE]  
> Initially, I thought that we could use the flag `pattern-assembler/v2` to skip the cache. It sounds better to use a new flag so we can enable this feature any time passing the flag in the URL.

> [!WARNING]  
> This PR alone is not enough to skip the cache because the request to fetch patterns from the PTK API `/rest/v1.1/ptk/patterns/en` is also cached. See D131807-code


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Using the Calypso Live link below
* Access `/setup/with-theme-assembler/patternAssembler?siteSlug={ SITE }`
* Open "Chrome dev tools > Network" and verify that the renderer requests `/wpcom/v2/sites/215354566/block-renderer/patterns/render` are done whenever you refresh the browser. 


https://github.com/Automattic/wp-calypso/assets/1881481/44bafdd4-29dc-46f5-b9c2-4a1bd096464d



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?