### PR TITLE
Self-service site resets: hide new copy behind flag

### DIFF
--- a/client/my-sites/site-settings/site-tools/index.jsx
+++ b/client/my-sites/site-settings/site-tools/index.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { compose } from '@wordpress/compose';
 import { addQueryArgs } from '@wordpress/url';
 import { localize } from 'i18n-calypso';
@@ -68,10 +69,20 @@ class SiteTools extends Component {
 		const manageConnectionLink = `/settings/manage-connection/${ siteSlug }`;
 
 		const changeSiteAddress = translate( 'Change your site address' );
-		const startOver = translate( 'Reset your site' );
-		const startOverText = translate(
-			"Remove all posts, pages, and media to start fresh while keeping your site's address."
-		);
+
+		const hasSiteReset = isEnabled( 'settings/self-serve-site-reset' );
+		const startOver = hasSiteReset
+			? translate( 'Reset your site' )
+			: translate( 'Delete your content' );
+		const startOverText = hasSiteReset
+			? translate(
+					"Remove all posts, pages, and media to start fresh while keeping your site's address."
+			  )
+			: translate(
+					"Keep your site's address and current theme, but remove all posts, " +
+						'pages, and media so you can start fresh.'
+			  );
+
 		const deleteSite = translate( 'Delete your site permanently' );
 		const deleteSiteText = translate(
 			"Delete all your posts, pages, media, and data, and give up your site's address."


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
thelinked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/85203#discussion_r1425963184
## Proposed Changes

* Title, plus see this review comment https://github.com/Automattic/wp-calypso/pull/85203#discussion_r1425963184

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Try visiting `/settings/general/:site?flags=-settings/self-serve-site-reset`, it should show the old copy
* Try visiting `/settings/general/:site?flags=settings/self-serve-site-reset`, it should show the new copy


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?