### PR TITLE
Jetpack Manage: Add tracking for the new Bundle licenses UI.

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/hooks/use-product-bundle-size.ts
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/hooks/use-product-bundle-size.ts
@@ -63,6 +63,7 @@ export function useProductBundleSize() {
 			selectedSize: selectedSize ?? 1,
 			setSelectedSize: setSelectedSizeAndLocationHash,
 			availableSizes: supportedBundleSizes,
+			fetchingAvailableSizes: ! selectedSize, // We know we are still fetching if our selected size is undefined.
 		};
 	}, [ selectedSize, setSelectedSizeAndLocationHash, supportedBundleSizes ] );
 }

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/index.tsx
@@ -51,13 +51,22 @@ export default function IssueLicenseV2( { selectedSite, suggestedProduct }: Assi
 		.map( ( license ) => license.quantity )
 		.reduce( ( a, b ) => a + b, 0 );
 
-	const handleShowLicenseOverview = useCallback( () => {
+	const onShowReviewLicensesModal = useCallback( () => {
 		setShowReviewLicenses( true );
-	}, [] );
+		dispatch(
+			recordTracksEvent( 'calypso_jetpack_agency_issue_license_review_licenses_show', {
+				total_licenses: selectedLicenseCount,
+				items: selectedLicenses
+					?.map( ( license ) => `${ license.slug } x ${ license.quantity }` )
+					.join( ',' ),
+			} )
+		);
+	}, [ dispatch, selectedLicenseCount, selectedLicenses ] );
 
-	const onClickIssueLicenses = useCallback( () => {
-		handleShowLicenseOverview();
-	}, [ handleShowLicenseOverview ] );
+	const onDismissReviewLicensesModal = useCallback( () => {
+		setShowReviewLicenses( false );
+		dispatch( recordTracksEvent( 'calypso_jetpack_agency_issue_license_review_licenses_dimiss' ) );
+	}, [ dispatch ] );
 
 	const showStickyContent = useBreakpoint( '>660px' ) && selectedLicenses.length > 0;
 
@@ -156,7 +165,7 @@ export default function IssueLicenseV2( { selectedSite, suggestedProduct }: Assi
 											primary
 											className="issue-license-v2__select-license"
 											busy={ ! isReady }
-											onClick={ onClickIssueLicenses }
+											onClick={ onShowReviewLicensesModal }
 										>
 											{ translate(
 												'Review %(numLicenses)d license',
@@ -195,7 +204,7 @@ export default function IssueLicenseV2( { selectedSite, suggestedProduct }: Assi
 			</Layout>
 			{ showReviewLicenses && (
 				<ReviewLicenses
-					onClose={ () => setShowReviewLicenses( false ) }
+					onClose={ onDismissReviewLicensesModal }
 					selectedLicenses={ getGroupedLicenses() }
 					selectedSite={ selectedSite }
 				/>

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/index.tsx
@@ -95,7 +95,14 @@ export default function IssueLicenseV2( { selectedSite, suggestedProduct }: Assi
 							args: { size },
 					  } ) as string ),
 			selected: selectedSize === size,
-			onClick: () => setSelectedSize( size ),
+			onClick: () => {
+				setSelectedSize( size );
+				dispatch(
+					recordTracksEvent( 'calypso_jetpack_agency_issue_license_bundle_tab_click', {
+						bundle_size: size,
+					} )
+				);
+			},
 			...( count && { count } ),
 		};
 	} );

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/index.tsx
@@ -34,7 +34,8 @@ export default function IssueLicenseV2( { selectedSite, suggestedProduct }: Assi
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const { selectedSize, setSelectedSize, availableSizes } = useProductBundleSize();
+	const { selectedSize, setSelectedSize, availableSizes, fetchingAvailableSizes } =
+		useProductBundleSize();
 
 	// We need the suggested products (i.e., the products chosen from the dashboard) to properly
 	// track if the user purchases a different set of products.
@@ -124,12 +125,14 @@ export default function IssueLicenseV2( { selectedSite, suggestedProduct }: Assi
 	const showBundle = ! selectedSite;
 
 	useEffect( () => {
-		dispatch(
-			recordTracksEvent( 'calypso_jetpack_agency_issue_license_visit', {
-				bundle_size: selectedSize,
-			} )
-		);
-	}, [ dispatch, selectedSize ] );
+		if ( ! fetchingAvailableSizes ) {
+			dispatch(
+				recordTracksEvent( 'calypso_jetpack_agency_issue_license_visit', {
+					bundle_size: selectedSize,
+				} )
+			);
+		}
+	}, [ dispatch, fetchingAvailableSizes, selectedSize ] );
 
 	return (
 		<>

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/index.tsx
@@ -3,7 +3,7 @@ import { useBreakpoint } from '@automattic/viewport-react';
 import { getQueryArg } from '@wordpress/url';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import Layout from 'calypso/jetpack-cloud/components/layout';
 import LayoutBody from 'calypso/jetpack-cloud/components/layout/body';
 import LayoutHeader, {
@@ -16,6 +16,8 @@ import LayoutNavigation, {
 } from 'calypso/jetpack-cloud/components/layout/nav';
 import LayoutTop from 'calypso/jetpack-cloud/components/layout/top';
 import PartnerPortalSidebarNavigation from 'calypso/jetpack-cloud/sections/partner-portal/sidebar-navigation';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import AssignLicenseStepProgress from '../assign-license-step-progress';
 import IssueLicenseContext from './context';
 import { useProductBundleSize } from './hooks/use-product-bundle-size';
@@ -30,6 +32,7 @@ import './style.scss';
 
 export default function IssueLicenseV2( { selectedSite, suggestedProduct }: AssignLicenceProps ) {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 
 	const { selectedSize, setSelectedSize, availableSizes } = useProductBundleSize();
 
@@ -103,6 +106,14 @@ export default function IssueLicenseV2( { selectedSite, suggestedProduct }: Assi
 	};
 
 	const showBundle = ! selectedSite;
+
+	useEffect( () => {
+		dispatch(
+			recordTracksEvent( 'calypso_jetpack_agency_issue_license_visit', {
+				bundle_size: selectedSize,
+			} )
+		);
+	}, [ dispatch, selectedSize ] );
 
 	return (
 		<>

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
@@ -118,12 +118,24 @@ export default function LicensesForm( {
 			if ( index === -1 ) {
 				// Item doesn't exist, add it
 				setSelectedLicenses( [ ...selectedLicenses, productBundle ] );
+				dispatch(
+					recordTracksEvent( 'calypso_partner_portal_issue_license_select_product', {
+						product: product.slug,
+						quantity,
+					} )
+				);
 			} else {
 				// Item exists, remove it
 				setSelectedLicenses( selectedLicenses.filter( ( _, i ) => i !== index ) );
+				dispatch(
+					recordTracksEvent( 'calypso_partner_portal_issue_license_unselect_product', {
+						product: product.slug,
+						quantity,
+					} )
+				);
 			}
 		},
-		[ quantity, selectedLicenses, setSelectedLicenses ]
+		[ dispatch, quantity, selectedLicenses, setSelectedLicenses ]
 	);
 
 	const onSelectProduct = useCallback(
@@ -145,11 +157,26 @@ export default function LicensesForm( {
 						return item;
 					} )
 				);
+
+				// Unselecting the current selected variant
+				dispatch(
+					recordTracksEvent( 'calypso_partner_portal_issue_license_unselect_product', {
+						product: replace.slug,
+						quantity,
+					} )
+				);
+
+				dispatch(
+					recordTracksEvent( 'calypso_partner_portal_issue_license_select_product', {
+						product: product.slug,
+						quantity,
+					} )
+				);
 			} else {
 				handleSelectBundleLicense( product );
 			}
 		},
-		[ handleSelectBundleLicense, quantity, selectedLicenses, setSelectedLicenses ]
+		[ dispatch, handleSelectBundleLicense, quantity, selectedLicenses, setSelectedLicenses ]
 	);
 
 	const { isReady } = useSubmitForm( selectedSite, suggestedProductSlugs );
@@ -184,6 +211,17 @@ export default function LicensesForm( {
 		[ dispatch ]
 	);
 
+	const onClickVariantOption = useCallback(
+		( product: APIProductFamilyProduct ) => {
+			dispatch(
+				recordTracksEvent( 'calypso_partner_portal_issue_license_variant_option_click', {
+					product: product.slug,
+				} )
+			);
+		},
+		[ dispatch ]
+	);
+
 	const trackClickCallback = useCallback(
 		( component: string ) => () =>
 			dispatch( recordTracksEvent( `calypso_partner_portal_issue_license_${ component }_click` ) ),
@@ -199,6 +237,7 @@ export default function LicensesForm( {
 					key={ productOption.map( ( { slug } ) => slug ).join( ',' ) }
 					products={ productOption }
 					onSelectProduct={ onSelectOrReplaceProduct }
+					onVariantChange={ onClickVariantOption }
 					isSelected={ isSelected( productOption.map( ( { slug } ) => slug ) ) }
 					selectedOption={ productOption.find( ( option ) =>
 						selectedLicenses.find(

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/product-filter-search.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/product-filter-search.tsx
@@ -3,14 +3,16 @@ import Search from 'calypso/components/search';
 
 type Props = {
 	onProductSearch: ( value: string ) => void;
+	onClick?: () => void;
 };
 
-export default function ProductFilterSearch( { onProductSearch }: Props ) {
+export default function ProductFilterSearch( { onProductSearch, onClick }: Props ) {
 	const translate = useTranslate();
 
 	return (
 		<div className="licenses-form__product-filter-search">
 			<Search
+				onClick={ onClick }
 				onSearch={ onProductSearch }
 				placeholder={ translate( 'Search plans, products, add-ons, and extensions' ) }
 				compact

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/product-filter-select.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/product-filter-select.tsx
@@ -1,6 +1,6 @@
 import { SelectDropdown } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import {
 	PRODUCT_FILTER_ALL,
 	PRODUCT_FILTER_PLANS,
@@ -11,6 +11,7 @@ import {
 
 type Props = {
 	selectedProductFilter: string | null;
+	onClick?: () => void;
 	onProductFilterSelect: ( value: string | null ) => void;
 	isSingleLicense?: boolean;
 };
@@ -26,6 +27,7 @@ const getOptionByValue = ( options: Option[], value: string | null ): Option => 
 
 export default function ProductFilterSelect( {
 	selectedProductFilter,
+	onClick,
 	onProductFilterSelect,
 	isSingleLicense,
 }: Props ) {
@@ -75,6 +77,15 @@ export default function ProductFilterSelect( {
 		comment: 'productFilter is the selected filter type.',
 	} );
 
+	const onToggle = useCallback(
+		( { open }: { open: boolean } ) => {
+			if ( open ) {
+				onClick?.();
+			}
+		},
+		[ onClick ]
+	);
+
 	useEffect( () => {
 		if (
 			! isSingleLicense &&
@@ -90,6 +101,7 @@ export default function ProductFilterSelect( {
 			className="licenses-form__product-filter-select"
 			selectedText={ selectedText }
 			options={ productFilterOptions }
+			onToggle={ onToggle }
 			onSelect={ ( option: { value: string | null } ) => onProductFilterSelect( option.value ) }
 			compact
 		/>

--- a/client/jetpack-cloud/sections/partner-portal/license-details/bundle-details.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-details/bundle-details.tsx
@@ -1,6 +1,9 @@
 import { Button, CompactCard } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
 import { LicenseType } from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import useBundleLicensesQuery from 'calypso/state/partner-portal/licenses/hooks/use-bundle-licenses-query';
 import LicensePreview, { LicensePreviewPlaceholder } from '../license-preview';
 
@@ -10,7 +13,13 @@ interface Props {
 
 export default function BundleDetails( { parentLicenseId }: Props ) {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 	const { licenses, total, loadMore, isLoading } = useBundleLicensesQuery( parentLicenseId );
+
+	const onLoadMore = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_partner_portal_license_details_bundle_load_more' ) );
+		loadMore?.();
+	}, [ dispatch, loadMore ] );
 
 	return (
 		<div className="bundle-details">
@@ -37,7 +46,7 @@ export default function BundleDetails( { parentLicenseId }: Props ) {
 
 			{ loadMore && (
 				<CompactCard className="bundle-details__footer">
-					<Button compact onClick={ loadMore } disabled={ isLoading }>
+					<Button compact onClick={ onLoadMore } disabled={ isLoading }>
 						{ translate( 'Load more (%(remainingItems)d)', {
 							args: { remainingItems: total - licenses.length },
 						} ) }

--- a/client/jetpack-cloud/sections/partner-portal/license-multi-product-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-multi-product-card/index.tsx
@@ -25,6 +25,7 @@ interface Props {
 		value: APIProductFamilyProduct,
 		replace?: APIProductFamilyProduct
 	) => void | null;
+	onVariantChange?: ( value: APIProductFamilyProduct ) => void;
 	suggestedProduct?: string | null;
 	hideDiscount?: boolean;
 	quantity?: number;
@@ -38,6 +39,7 @@ export default function LicenseMultiProductCard( props: Props ) {
 		isSelected,
 		isDisabled,
 		onSelectProduct,
+		onVariantChange,
 		suggestedProduct,
 		hideDiscount,
 		quantity,
@@ -132,8 +134,9 @@ export default function LicenseMultiProductCard( props: Props ) {
 			}
 
 			setProduct( selectedProduct );
+			onVariantChange?.( selectedProduct );
 		},
-		[ isDisabled, isSelected, onSelectProduct, product, products ]
+		[ isDisabled, isSelected, onSelectProduct, onVariantChange, product, products ]
 	);
 
 	useEffect( () => {

--- a/client/jetpack-cloud/sections/partner-portal/license-preview/license-bundle-dropdown.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-preview/license-bundle-dropdown.tsx
@@ -1,9 +1,11 @@
 import { Gridicon, Button } from '@automattic/components';
 import { Icon, trash } from '@wordpress/icons';
-import { translate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { useCallback, useRef, useState } from 'react';
 import PopoverMenu from 'calypso/components/popover-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import RevokeLicenseDialog from '../revoke-license-dialog';
 import { LicenseRole } from '../types';
 
@@ -14,6 +16,9 @@ type Props = {
 };
 
 export default function LicenseBundleDropDown( { licenseKey, product, bundleSize }: Props ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
 	const [ showRevokeDialog, setShowRevokeDialog ] = useState( false );
 	const [ showContextMenu, setShowContextMenu ] = useState( false );
 	const buttonActionRef = useRef< HTMLButtonElement | null >( null );
@@ -27,12 +32,18 @@ export default function LicenseBundleDropDown( { licenseKey, product, bundleSize
 	}, [] );
 
 	const onShowRevokeDialog = useCallback( () => {
+		dispatch(
+			recordTracksEvent( 'calypso_partner_portal_license_list_revoke_bundle_dialog_open' )
+		);
 		setShowRevokeDialog( true );
-	}, [] );
+	}, [ dispatch ] );
 
 	const onHideRevokeDialog = useCallback( () => {
+		dispatch(
+			recordTracksEvent( 'calypso_partner_portal_license_list_revoke_bundle_dialog_close' )
+		);
 		setShowRevokeDialog( false );
-	}, [] );
+	}, [ dispatch ] );
 
 	return (
 		<>

--- a/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/index.tsx
@@ -51,9 +51,13 @@ export default function RevokeLicenseDialog( {
 	}, [ onClose, mutation.isLoading ] );
 
 	const revoke = useCallback( () => {
-		dispatch( recordTracksEvent( 'calypso_partner_portal_license_list_revoke_dialog_revoke' ) );
+		dispatch(
+			recordTracksEvent( 'calypso_partner_portal_license_list_revoke_dialog_revoke', {
+				license_role: licenseRole,
+			} )
+		);
 		mutation.mutate( { licenseKey } );
-	}, [ dispatch, licenseKey, mutation ] );
+	}, [ dispatch, licenseKey, licenseRole, mutation ] );
 
 	const isParentLicense = licenseRole === LicenseRole.Parent;
 	const isAssignedChildLicense = licenseRole === LicenseRole.Child && siteUrl;


### PR DESCRIPTION
The purpose of this PR is to implement tracking events for the new Bundle licenses UI.

Closes https://github.com/Automattic/jetpack-genesis/issues/117

## Proposed Changes

* Add tracking when visiting the issue license page (with the current bundle size).
* Add tracking when clicking the Bundle tabs.
* Add tracking when clicking and submitting filtering (search & filter).
* Add tracking when selecting products and plans.
* Add tracking when reviewing and issuing licenses.
* Add tracking when revoking a bundle.
* Add tracking when loading more child licenses.

## Testing Instructions

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

**How to check if tracking is triggered?**

In your browser's developer tool, go to the network tab and filter all requests with `.gif`. **_Note that the image below uses a Chrome browser. Please look for the equivalent function with your browser._**

<img width="658" alt="Screen Shot 2023-12-14 at 3 29 27 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/99f399f8-c5a3-42ef-adf5-921aee28d100">

### Test areas

**Issue License Page**

* Visiting the Issue licenses page (`/partner-portal/issue-license`), confirm that **calypso_jetpack_agency_issue_license_visit** event is triggered with parameter **bundle_size**. When changing the bundle size, this event is also triggered.
* Click any bundle tab and confirm **calypso_jetpack_agency_issue_license_bundle_tab_click** event is triggered with parameter **bundle_size**.
  <img width="694" alt="Screen Shot 2023-12-14 at 3 36 56 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/9bbeab4e-9122-4c7d-9d9c-4791b2dedc3b">
* Click the search bar and confirm **calypso_partner_portal_issue_license_search_click** is triggered. Input any values and confirm **calypso_partner_portal_issue_license_search_submit** is triggered with parameter **value**.
  <img width="433" alt="Screen Shot 2023-12-14 at 3 41 46 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/f1f58377-e62f-4c0b-a18f-73ce6084fd18">
* Click the product filter and confirm **calypso_partner_portal_issue_license_filter_click** is triggered. Select any value and confirm **calypso_partner_portal_issue_license_filter_submit** is triggered with parameter **value**.
  <img width="185" alt="Screen Shot 2023-12-14 at 3 54 01 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/8e5da5fd-876a-40b8-befa-9a84f9eae856">
* Select and Unselect any product card, and confirm that **calypso_partner_portal_issue_license_select_product** and **calypso_partner_portal_issue_license_unselect_product** is triggered with parameter **product** and **quantity**.
   <img width="512" alt="Screen Shot 2023-12-14 at 3 55 12 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/d34c0769-3063-465b-9ef7-c28b7f42e4a7">
* When selecting a variant option, confirm that **calypso_partner_portal_issue_license_variant_option_click** is triggered with parameter **product**. **_Note that to access this card, you need to reset your billing scheme to load the 1TB variant_**.
    <img width="773" alt="Screen Shot 2023-12-14 at 3 59 41 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/abc749b9-5aa4-426e-989c-b812f504ea9e">
* Select some products then click **Issue X licenses** button, confirm that **calypso_jetpack_agency_issue_license_review_licenses_show** is triggered with parameter **total_licenses** and **items**.
    <img width="404" alt="Screen Shot 2023-12-14 at 4 02 48 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/10611d1b-78d2-43be-9784-21bd81bb1064">

**Review licenses modal**

* Click the dismiss button in the Review licenses modal and confirm that **calypso_jetpack_agency_issue_license_review_licenses_dimiss** is triggered.
    <img width="124" alt="Screen Shot 2023-12-14 at 4 02 57 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/9dfe7282-335e-43e4-bc78-6692a58e910a">
* Click the **Learn more** link and confirm that **calypso_jetpack_agency_issue_license_review_licenses_learn_more_click** is triggered.
    <img width="171" alt="Screen Shot 2023-12-14 at 4 03 05 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/a5f3a33d-24a2-4958-832c-ad885e8bdb64">
* Click the Issue license button and confirm **calypso_jetpack_agency_issue_license_review_licenses_submit** is triggered with parameter **total_licenses** and **items**.
    <img width="439" alt="Screen Shot 2023-12-14 at 4 03 01 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/6f1f476f-efa2-4660-ad7a-5097ea38c45d">

**Licenses page**
* Visiting the licenses page (`/partner-portal/licenses`)
* Look for a bundle then press the revoke bundle button. Confirm that  **calypso_partner_portal_license_list_revoke_bundle_dialog_open** is triggered.
   <img width="260" alt="Screen Shot 2023-12-14 at 4 11 52 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/21b0175f-6561-47fc-bdff-a419f73fe349">
* Dismiss the modal, confirm that **calypso_partner_portal_license_list_revoke_bundle_dialog_close** is triggered.
    <img width="717" alt="Screen Shot 2023-12-14 at 4 13 12 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/f8ce1f29-a258-4bfa-86b6-b833bd4b8505">
* Click the revoke button, confirm **calypso_partner_portal_license_list_revoke_dialog_revoke** is triggered with parameter **license_role**.
* Look for a bundle of 50 or 100 licenses. Expand the item, and click the **'Load more'** button. Confirm that **calypso_partner_portal_license_details_bundle_load_more** is loaded.
<img width="544" alt="Screen Shot 2023-12-14 at 4 15 45 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/8f8c5963-708c-47e3-b900-a7d40624a61f">



## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?