### PR TITLE
Jetpack Manage: Implement pre-select previously chosen licenses when the Go Back button is clicked

### DIFF
--- a/client/components/multiple-choice-question/index.jsx
+++ b/client/components/multiple-choice-question/index.jsx
@@ -1,6 +1,6 @@
 import { memoize, pick, shuffle, values } from 'lodash';
 import PropTypes from 'prop-types';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLegend from 'calypso/components/forms/form-legend';
 import MultipleChoiceAnswer from './answer';
@@ -29,6 +29,11 @@ const MultipleChoiceQuestion = ( {
 } ) => {
 	const [ selectedAnswer, setSelectedAnswer ] = useState( selectedAnswerId );
 	const shuffledAnswers = shouldShuffleAnswers ? shuffleAnswers( answers ) : answers;
+
+	useEffect( () => {
+		setSelectedAnswer( selectedAnswerId );
+	}, [ selectedAnswerId ] );
+
 	return (
 		<FormFieldset className="multiple-choice-question" onClick={ ( e ) => e.stopPropagation() }>
 			<FormLegend>{ question }</FormLegend>

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/hooks/use-product-bundle-size.ts
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/hooks/use-product-bundle-size.ts
@@ -11,7 +11,7 @@ const parseLocationHash = ( supportedBundleSizes: number[], value: string ) => {
 	return supportedBundleSizes.find( ( size ) => value === `${ size }` ) || 1;
 };
 
-const getSupportedBundleSizes = ( products?: APIProductFamilyProduct[] ) => {
+export const getSupportedBundleSizes = ( products?: APIProductFamilyProduct[] ) => {
 	if ( ! products ) {
 		return [ 1 ];
 	}

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/hooks/use-product-and-plans.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/hooks/use-product-and-plans.tsx
@@ -85,7 +85,7 @@ const getDisplayablePlans = ( filteredProductsAndBundles: APIProductFamilyProduc
 		return ! MERGABLE_PLANS.some( ( filter ) => slug.startsWith( filter ) );
 	} );
 
-	return [ ...filteredPlans, ...restOfPlans ];
+	return [ ...filteredPlans, ...restOfPlans ] as APIProductFamilyProduct[];
 };
 
 // This function gets the displayable Products based on how it should be arranged in the listing.
@@ -110,7 +110,7 @@ const getDisplayableProducts = ( filteredProductsAndBundles: APIProductFamilyPro
 		const product_a = Array.isArray( a ) ? a[ 0 ].name : a.name;
 		const product_b = Array.isArray( b ) ? b[ 0 ].name : b.name;
 		return product_a.localeCompare( product_b );
-	} );
+	} ) as APIProductFamilyProduct[];
 };
 
 export default function useProductAndPlans( {
@@ -183,20 +183,27 @@ export default function useProductAndPlans( {
 			?.toString()
 			.split( ',' );
 
+		const plans = getDisplayablePlans( filteredProductsAndBundles );
+		const products = getDisplayableProducts( filteredProductsAndBundles );
+		const backupAddons = getProductsAndPlansByFilter(
+			PRODUCT_FILTER_VAULTPRESS_BACKUP_ADDONS,
+			filteredProductsAndBundles
+		);
+		const wooExtensions = getProductsAndPlansByFilter(
+			PRODUCT_FILTER_WOOCOMMERCE_EXTENSIONS,
+			filteredProductsAndBundles
+		);
+
 		return {
 			isLoadingProducts,
 			filteredProductsAndBundles,
-			plans: getDisplayablePlans( filteredProductsAndBundles ),
-			products: getDisplayableProducts( filteredProductsAndBundles ),
-			backupAddons: getProductsAndPlansByFilter(
-				PRODUCT_FILTER_VAULTPRESS_BACKUP_ADDONS,
-				filteredProductsAndBundles
-			),
-			wooExtensions: getProductsAndPlansByFilter(
-				PRODUCT_FILTER_WOOCOMMERCE_EXTENSIONS,
-				filteredProductsAndBundles
-			),
+			plans,
+			products,
+			backupAddons,
+			wooExtensions,
 			suggestedProductSlugs,
+			// We need to merge all the products and plans that we are displaying in the UI
+			allSelectableProducts: [ ...plans, ...products, ...backupAddons, ...wooExtensions ],
 		};
 	}, [
 		addedPlanAndProducts,

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/hooks/use-product-and-plans.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/hooks/use-product-and-plans.tsx
@@ -183,27 +183,20 @@ export default function useProductAndPlans( {
 			?.toString()
 			.split( ',' );
 
-		const plans = getDisplayablePlans( filteredProductsAndBundles );
-		const products = getDisplayableProducts( filteredProductsAndBundles );
-		const backupAddons = getProductsAndPlansByFilter(
-			PRODUCT_FILTER_VAULTPRESS_BACKUP_ADDONS,
-			filteredProductsAndBundles
-		);
-		const wooExtensions = getProductsAndPlansByFilter(
-			PRODUCT_FILTER_WOOCOMMERCE_EXTENSIONS,
-			filteredProductsAndBundles
-		);
-
 		return {
 			isLoadingProducts,
 			filteredProductsAndBundles,
-			plans,
-			products,
-			backupAddons,
-			wooExtensions,
+			plans: getDisplayablePlans( filteredProductsAndBundles ),
+			products: getDisplayableProducts( filteredProductsAndBundles ),
+			backupAddons: getProductsAndPlansByFilter(
+				PRODUCT_FILTER_VAULTPRESS_BACKUP_ADDONS,
+				filteredProductsAndBundles
+			),
+			wooExtensions: getProductsAndPlansByFilter(
+				PRODUCT_FILTER_WOOCOMMERCE_EXTENSIONS,
+				filteredProductsAndBundles
+			),
 			suggestedProductSlugs,
-			// We need to merge all the products and plans that we are displaying in the UI
-			allSelectableProducts: [ ...plans, ...products, ...backupAddons, ...wooExtensions ],
 		};
 	}, [
 		addedPlanAndProducts,

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
@@ -1,6 +1,6 @@
 import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useContext, useEffect, useState } from 'react';
+import { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import LicenseProductCard from 'calypso/jetpack-cloud/sections/partner-portal/license-product-card';
 import { JETPACK_CONTACT_SUPPORT_NO_ASSISTANT } from 'calypso/lib/url/support';
@@ -58,6 +58,14 @@ export default function LicensesForm( {
 		productSearchQuery,
 	} );
 
+	// Create a ref for `filteredProductsAndBundles` to prevent unnecessary re-renders caused by the `useEffect` hook.
+	const filteredProductsAndBundlesRef = useRef( filteredProductsAndBundles );
+
+	// Update the ref whenever `filteredProductsAndBundles` changes.
+	useEffect( () => {
+		filteredProductsAndBundlesRef.current = filteredProductsAndBundles;
+	}, [ filteredProductsAndBundles ] );
+
 	const preSelectProducts = useCallback( () => {
 		const productsQueryArg = getQueryArg( window.location.href, 'products' )?.toString?.();
 		const parsedItems = parseQueryStringProducts( productsQueryArg );
@@ -67,7 +75,7 @@ export default function LicensesForm( {
 			? ( parsedItems
 					.map( ( item ) => {
 						// Add licenses & bundles that are supported
-						const product = filteredProductsAndBundles.find(
+						const product = filteredProductsAndBundlesRef.current.find(
 							( product ) => product.slug === item.slug
 						);
 						const quantity = availableSizes.find( ( size ) => size === item.quantity );
@@ -85,7 +93,7 @@ export default function LicensesForm( {
 		if ( allProductsAndBundles ) {
 			setSelectedLicenses( allProductsAndBundles );
 		}
-	}, [ filteredProductsAndBundles, setSelectedLicenses, data ] );
+	}, [ setSelectedLicenses, data ] );
 
 	useEffect( () => {
 		if ( isLoadingProducts ) {

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
@@ -180,6 +180,9 @@ export default function LicensesForm( {
 					products={ productOption }
 					onSelectProduct={ onSelectOrReplaceProduct }
 					isSelected={ isSelected( productOption.map( ( { slug } ) => slug ) ) }
+					selectedOption={ productOption.find( ( option ) =>
+						selectedLicenses.find( ( license ) => license.slug === option.slug )
+					) }
 					isDisabled={ ! isReady }
 					tabIndex={ 100 + i }
 					hideDiscount={ isSingleLicenseView }

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
@@ -51,7 +51,6 @@ export default function LicensesForm( {
 		products,
 		wooExtensions,
 		suggestedProductSlugs,
-		allSelectableProducts,
 	} = useProductAndPlans( {
 		selectedSite,
 		selectedProductFilter,
@@ -68,7 +67,9 @@ export default function LicensesForm( {
 			? ( parsedItems
 					.map( ( item ) => {
 						// Add licenses & bundles that are supported
-						const product = allSelectableProducts.find( ( product ) => product.slug === item.slug );
+						const product = filteredProductsAndBundles.find(
+							( product ) => product.slug === item.slug
+						);
 						const quantity = availableSizes.find( ( size ) => size === item.quantity );
 						if ( product && quantity ) {
 							return {
@@ -84,7 +85,7 @@ export default function LicensesForm( {
 		if ( allProductsAndBundles ) {
 			setSelectedLicenses( allProductsAndBundles );
 		}
-	}, [ allSelectableProducts, setSelectedLicenses, data ] );
+	}, [ filteredProductsAndBundles, setSelectedLicenses, data ] );
 
 	useEffect( () => {
 		if ( isLoadingProducts ) {

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
@@ -1,19 +1,24 @@
+import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useContext, useState } from 'react';
+import { useCallback, useContext, useEffect, useState } from 'react';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import LicenseProductCard from 'calypso/jetpack-cloud/sections/partner-portal/license-product-card';
 import { JETPACK_CONTACT_SUPPORT_NO_ASSISTANT } from 'calypso/lib/url/support';
 import { useSelector } from 'calypso/state';
+import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
 import { getDisabledProductSlugs } from 'calypso/state/partner-portal/products/selectors';
+import { parseQueryStringProducts } from '../../lib/querystring-products';
 import LicenseMultiProductCard from '../../license-multi-product-card';
 import { PRODUCT_FILTER_ALL } from '../constants';
 import IssueLicenseContext from '../context';
+import { getSupportedBundleSizes } from '../hooks/use-product-bundle-size';
 import useSubmitForm from '../hooks/use-submit-form';
 import useProductAndPlans from './hooks/use-product-and-plans';
 import ProductFilterSearch from './product-filter-search';
 import ProductFilterSelect from './product-filter-select';
 import LicensesFormSection from './sections';
 import type { AssignLicenceProps } from '../../types';
+import type { SelectedLicenseProp } from '../types';
 import type {
 	APIProductFamilyProduct,
 	PartnerPortalStore,
@@ -36,6 +41,8 @@ export default function LicensesForm( {
 		PRODUCT_FILTER_ALL
 	);
 
+	const { data } = useProductsQuery();
+
 	const {
 		filteredProductsAndBundles,
 		isLoadingProducts,
@@ -44,6 +51,7 @@ export default function LicensesForm( {
 		products,
 		wooExtensions,
 		suggestedProductSlugs,
+		allSelectableProducts,
 	} = useProductAndPlans( {
 		selectedSite,
 		selectedProductFilter,
@@ -51,20 +59,39 @@ export default function LicensesForm( {
 		productSearchQuery,
 	} );
 
-	// useEffect( () => {
-	// 	const productsQueryArg = getQueryArg( window.location.href, 'products' )?.toString?.();
-	// 	if ( ! productsQueryArg ) {
-	// 		return;
-	// 	}
+	const preSelectProducts = useCallback( () => {
+		const productsQueryArg = getQueryArg( window.location.href, 'products' )?.toString?.();
+		const parsedItems = parseQueryStringProducts( productsQueryArg );
+		const availableSizes = getSupportedBundleSizes( data );
 
-	// 	if ( isLoadingProducts ) {
-	// 		return;
-	// 	}
+		const allProductsAndBundles = parsedItems?.length
+			? ( parsedItems
+					.map( ( item ) => {
+						// Add licenses & bundles that are supported
+						const product = allSelectableProducts.find( ( product ) => product.slug === item.slug );
+						const quantity = availableSizes.find( ( size ) => size === item.quantity );
+						if ( product && quantity ) {
+							return {
+								...product,
+								quantity,
+							};
+						}
+						return null;
+					} )
+					.filter( Boolean ) as SelectedLicenseProp[] )
+			: null;
 
-	// 	const parsedItems = parseQueryStringProducts( productsQueryArg );
-	// 	// TODO: Validate parsed items from the query string exist and are selectable;
-	// 	// then, set them as selected items on the page
-	// }, [ isLoadingProducts ] );
+		if ( allProductsAndBundles ) {
+			setSelectedLicenses( allProductsAndBundles );
+		}
+	}, [ allSelectableProducts, setSelectedLicenses, data ] );
+
+	useEffect( () => {
+		if ( isLoadingProducts ) {
+			return;
+		}
+		preSelectProducts();
+	}, [ isLoadingProducts, preSelectProducts ] );
 
 	const disabledProductSlugs = useSelector< PartnerPortalStore, string[] >( ( state ) =>
 		getDisabledProductSlugs( state, filteredProductsAndBundles ?? [] )
@@ -144,9 +171,7 @@ export default function LicensesForm( {
 
 	const isSingleLicenseView = quantity === 1;
 
-	const getProductCards = (
-		products: ( APIProductFamilyProduct | APIProductFamilyProduct[] )[]
-	) => {
+	const getProductCards = ( products: APIProductFamilyProduct[] ) => {
 		return products.map( ( productOption, i ) =>
 			Array.isArray( productOption ) ? (
 				<LicenseMultiProductCard

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/index.tsx
@@ -35,7 +35,10 @@ export default function ReviewLicenses( { onClose, selectedLicenses }: Props ) {
 					</div>
 					<div className="review-licenses__selected-licenses">
 						{ selectedLicenses.map( ( license ) => (
-							<LicenseInfo key={ `license-info-${ license.product_id }` } product={ license } />
+							<LicenseInfo
+								key={ `license-info-${ license.product_id }-${ license.quantity }` }
+								product={ license }
+							/>
 						) ) }
 					</div>
 				</div>

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/pricing-breakdown.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/pricing-breakdown.tsx
@@ -53,7 +53,7 @@ export default function PricingBreakdown( {
 			<div className="review-licenses__pricing-breakdown">
 				{ selectedLicenses.map( ( license ) => (
 					<LicenseItem
-						key={ `license-item-${ license.product_id }` }
+						key={ `license-item-${ license.product_id }-${ license.quantity }` }
 						license={ license }
 						userProducts={ userProducts }
 					/>

--- a/client/jetpack-cloud/sections/partner-portal/license-multi-product-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-multi-product-card/index.tsx
@@ -28,6 +28,7 @@ interface Props {
 	suggestedProduct?: string | null;
 	hideDiscount?: boolean;
 	quantity?: number;
+	selectedOption: APIProductFamilyProduct;
 }
 
 export default function LicenseMultiProductCard( props: Props ) {
@@ -40,6 +41,7 @@ export default function LicenseMultiProductCard( props: Props ) {
 		suggestedProduct,
 		hideDiscount,
 		quantity,
+		selectedOption,
 	} = props;
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -131,6 +133,12 @@ export default function LicenseMultiProductCard( props: Props ) {
 		},
 		[ isDisabled, isSelected, onSelectProduct, product, products ]
 	);
+
+	useEffect( () => {
+		if ( selectedOption ) {
+			setProduct( selectedOption );
+		}
+	}, [ selectedOption ] );
 
 	return (
 		<>

--- a/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add/index.tsx
@@ -281,8 +281,9 @@ function PaymentMethodAdd( { selectedSite }: { selectedSite?: SiteDetails | null
 								>
 									{ translate( 'Go back' ) }
 								</Button>
-
-								<CheckoutFormSubmit />
+								<span className="payment-method-add__submit-button">
+									<CheckoutFormSubmit />
+								</span>
 							</div>
 						</div>
 						<div className="payment-method-add__image">

--- a/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add/style.scss
@@ -43,6 +43,8 @@
 		display: flex;
 		flex-wrap: wrap;
 		flex-direction: column-reverse;
+		margin-top: 1.5rem;
+		gap: 16px;
 
 		@include break-large {
 			flex-direction: row;
@@ -57,22 +59,15 @@
 	&__back-button {
 		width: 100%;
 		font-size: 1rem;
-		margin-top: 1.5rem;
 
 		@include break-large {
 			width: auto;
-			margin-right: 1rem;
 		}
 	}
 
 	&__submit-button {
-		width: 100%;
-		font-size: 1rem;
-		margin-top: 1.5rem;
-
-		@include break-large {
-			width: auto;
-			display: inline;
+		.checkout-steps__submit-button-wrapper {
+			padding: 0;
 		}
 
 		button {


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/145

## Proposed Changes

This PR

- Fixes the duplicate key warning in the review licenses modal.
- Aligns the CTA button on the Payment Method page.
- Enables the Issue Licenses page to pre-select previously chosen licenses when the Go Back button is clicked on the Payment Method page.

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

**Instructions**

1. Visit the Jetpack Cloud link > Visit /partner-portal/payment-methods > Remove all the payment methods 
2. Click on Billing > Click the `Issue New License` button > Select a few licenses from different bundles including one from the Single License 
3. Click the `Review N licenses` button > Click the `Issue N licenses` button > When redirected to the Payment Methods page, wait for the `Go back` button to be enabled > Verify that the `Go Back`  & `Save payment method` buttons are aligned properly.

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="1052" alt="Screenshot 2023-12-14 at 12 30 28 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/80a81ff8-4495-42a6-9401-485495b0266f">
</td>
<td>
<img width="1052" alt="Screenshot 2023-12-14 at 12 30 14 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/941a6b44-c038-488f-bae3-6d1d0eb94614">
</tr>
</table>

4. Click the `Go back` button > Verify that previously selected licenses are pre-selected > Select/Deselect a few licenses > Click the `Review N licenses` button > Verify that the selection is accurate.

<img width="1453" alt="Screenshot 2023-12-14 at 12 17 20 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/d3b34521-9387-4303-8490-21279c02a820">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?