### PR TITLE
Add passwordless login for Jetpack WooDNA flow

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -2,6 +2,7 @@ import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { localizeUrl } from '@automattic/i18n-utils';
 import classNames from 'classnames';
+import emailValidator from 'email-validator';
 import { localize } from 'i18n-calypso';
 import { capitalize, get, isEmpty, startsWith } from 'lodash';
 import PropTypes from 'prop-types';
@@ -146,7 +147,7 @@ class Login extends Component {
 		if (
 			this.props.isJetpackWooDnaFlow &&
 			this.props.requestError?.code === 'unknown_user' &&
-			this.props.usernameOrEmail.includes( '@' )
+			emailValidator.validate( this.props.usernameOrEmail )
 		) {
 			this.sendMagicLoginLink( {
 				createAccount: true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Add passwordless login for Jetpack WooDNA flow

Related to https://github.com/Automattic/woocommerce-payments-server/issues/3996

https://github.com/Automattic/wp-calypso/assets/4344253/ef4024d9-2b5b-4bc0-968c-b997f5e8e032

![Screenshot 2023-12-14 at 16 52 20](https://github.com/Automattic/wp-calypso/assets/4344253/d0901c39-7522-434d-aeb7-2cc53993c4b2)



https://github.com/Automattic/wp-calypso/assets/4344253/8ef3c45b-730c-4377-acca-425fb79295ca



## Proposed Changes

* Send a magic link to the user if the account doesn't exist when entering WooDNA flow

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set up [woocommerce-start-dev-env](https://github.com/woocommerce/woocommerce-start-dev-env) or local wpcalypso env
* Create a new WooCommerce site
* Go to onboarding wizard
* Choose a store country that supports WCPay.
* Select WCPay in the plugin step 
* Complete the onboarding wizard without connecting to Jetpack
* Go to WooCommerce > Home
* Click on the setup payment task
* Click on the Finish setup button
* Observe that you should be redirected to the Jetpack connection page
* If you're not using woocommerce-start-dev-env,  replace the URL host with local wpcalypso, such as `https://wpcalypso.wordpress.com/jetpack/connect/authorize?......`
* Use an email that is not connected to the WPCOM account.
* Confirm it sends a magic link email when you click on the "Continue" button
* Confirm that the magic link brings you back into the flow


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?