### PR TITLE
Assembler First Flow: Allow people to choose the wordpress.com subdomain

### DIFF
--- a/client/landing/stepper/declarative-flow/assembler-first-flow.ts
+++ b/client/landing/stepper/declarative-flow/assembler-first-flow.ts
@@ -74,6 +74,7 @@ const assemblerFirstFlow: Flow = {
 			STEPS.ERROR,
 			STEPS.LAUNCHPAD,
 			STEPS.PLANS,
+			STEPS.DOMAINS,
 			STEPS.SITE_LAUNCH,
 			STEPS.CELEBRATION,
 		];
@@ -87,7 +88,7 @@ const assemblerFirstFlow: Flow = {
 		);
 		const { setPendingAction, setSelectedSite } = useDispatch( ONBOARD_STORE );
 		const { saveSiteSettings, setIntentOnSite } = useDispatch( SITE_STORE );
-		const { siteSlug, siteId } = useSiteData();
+		const { site, siteSlug, siteId } = useSiteData();
 
 		const exitFlow = ( to: string ) => {
 			setPendingAction( () => {
@@ -215,6 +216,19 @@ const assemblerFirstFlow: Flow = {
 					return navigate( 'launchpad' );
 				}
 
+				case 'domains': {
+					await updateLaunchpadSettings( siteSlug, {
+						checklist_statuses: { domain_upsell_deferred: true },
+					} );
+
+					if ( providedDependencies?.freeDomain && providedDependencies?.domainName ) {
+						// We have to use the site id since the domain is changed.
+						return navigate( `launchpad?siteId=${ site?.ID }` );
+					}
+
+					return navigate( 'launchpad' );
+				}
+
 				case 'site-launch':
 					return navigate( 'processing' );
 
@@ -229,7 +243,8 @@ const assemblerFirstFlow: Flow = {
 					return navigate( 'new-or-existing-site' );
 				}
 
-				case 'freePostSetup': {
+				case 'freePostSetup':
+				case 'domains': {
 					return navigate( 'launchpad' );
 				}
 

--- a/client/landing/stepper/declarative-flow/assembler-first-flow.ts
+++ b/client/landing/stepper/declarative-flow/assembler-first-flow.ts
@@ -209,7 +209,7 @@ const assemblerFirstFlow: Flow = {
 				}
 
 				case 'plans': {
-					await updateLaunchpadSettings( siteSlug, {
+					await updateLaunchpadSettings( siteId, {
 						checklist_statuses: { plan_completed: true },
 					} );
 
@@ -217,7 +217,7 @@ const assemblerFirstFlow: Flow = {
 				}
 
 				case 'domains': {
-					await updateLaunchpadSettings( siteSlug, {
+					await updateLaunchpadSettings( siteId, {
 						checklist_statuses: { domain_upsell_deferred: true },
 					} );
 

--- a/client/landing/stepper/declarative-flow/design-first.ts
+++ b/client/landing/stepper/declarative-flow/design-first.ts
@@ -1,7 +1,7 @@
-import { OnboardSelect, updateLaunchpadSettings } from '@automattic/data-stores';
+import { updateLaunchpadSettings } from '@automattic/data-stores';
 import { useLocale } from '@automattic/i18n-utils';
 import { DESIGN_FIRST_FLOW } from '@automattic/onboarding';
-import { useSelect, useDispatch, dispatch } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { addQueryArgs, getQueryArg } from '@wordpress/url';
 import { useSelector } from 'react-redux';
@@ -18,9 +18,7 @@ import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
 import { SITE_STORE, ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { skipLaunchpad } from 'calypso/landing/stepper/utils/skip-launchpad';
-import { freeSiteAddressType } from 'calypso/lib/domains/constants';
 import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import { requestSiteAddressChange } from 'calypso/state/site-address-change/actions';
 import { useSiteIdParam } from '../hooks/use-site-id-param';
 import { useLoginUrl } from '../utils/path';
 
@@ -84,10 +82,6 @@ const designFirst: Flow = {
 
 		const { saveSiteSettings, setIntentOnSite } = useDispatch( SITE_STORE );
 		const { setSelectedSite } = useDispatch( ONBOARD_STORE );
-		const state = useSelect(
-			( select ) => select( ONBOARD_STORE ) as OnboardSelect,
-			[]
-		).getState();
 		const site = useSite();
 
 		// This flow clear the site_intent when flow is completed.
@@ -196,24 +190,6 @@ const designFirst: Flow = {
 					}
 
 					if ( providedDependencies?.freeDomain ) {
-						const freeDomainSuffix = '.wordpress.com';
-						const newDomainName = String( providedDependencies?.domainName ).replace(
-							freeDomainSuffix,
-							''
-						);
-
-						if ( providedDependencies?.domainName ) {
-							await requestSiteAddressChange(
-								site?.ID,
-								newDomainName,
-								'wordpress.com',
-								siteSlug,
-								freeSiteAddressType.BLOG,
-								true,
-								false
-							)( dispatch, state );
-						}
-
 						return window.location.assign( `/setup/design-first/launchpad?siteId=${ site?.ID }` );
 					}
 

--- a/client/landing/stepper/declarative-flow/design-first.ts
+++ b/client/landing/stepper/declarative-flow/design-first.ts
@@ -14,12 +14,10 @@ import {
 	Flow,
 	ProvidedDependencies,
 } from 'calypso/landing/stepper/declarative-flow/internals/types';
-import { useSite } from 'calypso/landing/stepper/hooks/use-site';
-import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
 import { SITE_STORE, ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { skipLaunchpad } from 'calypso/landing/stepper/utils/skip-launchpad';
 import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import { useSiteIdParam } from '../hooks/use-site-id-param';
+import { useSiteData } from '../hooks/use-site-data';
 import { useLoginUrl } from '../utils/path';
 
 const designFirst: Flow = {
@@ -77,12 +75,9 @@ const designFirst: Flow = {
 
 	useStepNavigation( currentStep, navigate ) {
 		const flowName = this.name;
-		const siteSlug = useSiteSlug();
-		const siteId = useSiteIdParam();
-
 		const { saveSiteSettings, setIntentOnSite } = useDispatch( SITE_STORE );
 		const { setSelectedSite } = useDispatch( ONBOARD_STORE );
-		const site = useSite();
+		const { site, siteSlug, siteId } = useSiteData();
 
 		// This flow clear the site_intent when flow is completed.
 		// We need to check if the site is launched and if so, clear the site_intent to avoid errors.
@@ -183,8 +178,8 @@ const designFirst: Flow = {
 					return navigate( 'launchpad' );
 				}
 				case 'domains':
-					if ( siteSlug ) {
-						await updateLaunchpadSettings( siteSlug, {
+					if ( siteId ) {
+						await updateLaunchpadSettings( siteId, {
 							checklist_statuses: { domain_upsell_deferred: true },
 						} );
 					}
@@ -195,22 +190,22 @@ const designFirst: Flow = {
 
 					return navigate( 'plans' );
 				case 'use-my-domain':
-					if ( siteSlug ) {
-						await updateLaunchpadSettings( siteSlug, {
+					if ( siteId ) {
+						await updateLaunchpadSettings( siteId, {
 							checklist_statuses: { domain_upsell_deferred: true },
 						} );
 					}
 					return navigate( 'plans' );
 				case 'plans':
-					if ( siteSlug ) {
-						await updateLaunchpadSettings( siteSlug, {
+					if ( siteId ) {
+						await updateLaunchpadSettings( siteId, {
 							checklist_statuses: { plan_completed: true },
 						} );
 					}
 					return navigate( 'launchpad' );
 				case 'setup-blog':
-					if ( siteSlug ) {
-						await updateLaunchpadSettings( siteSlug, {
+					if ( siteId ) {
+						await updateLaunchpadSettings( siteId, {
 							checklist_statuses: { setup_blog: true },
 						} );
 					}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/choose-a-domain/index.tsx
@@ -20,6 +20,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
+import useChangeSiteDomain from '../../../../hooks/use-change-site-domain';
 import type { Step } from '../../types';
 import type { OnboardSelect, DomainSuggestion } from '@automattic/data-stores';
 import './style.scss';
@@ -41,6 +42,8 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 	const [ isCartPendingUpdateDomain, setIsCartPendingUpdateDomain ] =
 		useState< DomainSuggestion >();
 	const site = useSite();
+
+	const changeSiteDomain = useChangeSiteDomain();
 
 	const getDefaultStepContent = () => <h1>Choose a domain step</h1>;
 
@@ -91,6 +94,10 @@ const ChooseADomain: Step = function ChooseADomain( { navigation, flow } ) {
 
 			setHideFreePlan( true );
 			setDomainCartItem( domainCartItem );
+		}
+
+		if ( suggestion?.is_free && suggestion?.domain_name ) {
+			changeSiteDomain( suggestion?.domain_name );
 		}
 
 		submit?.( { freeDomain: suggestion?.is_free, domainName: suggestion?.domain_name } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/domain-form-control.tsx
@@ -3,6 +3,7 @@ import {
 	HUNDRED_YEAR_PLAN_FLOW,
 	isDomainUpsellFlow,
 	LINK_IN_BIO_TLD_FLOW,
+	isSiteAssemblerFlow,
 } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { isEmpty } from 'lodash';
@@ -209,7 +210,7 @@ export function DomainFormControl( {
 			return false;
 		}
 
-		return isDomainUpsellFlow( flow );
+		return isDomainUpsellFlow( flow ) || isSiteAssemblerFlow( flow );
 	};
 
 	const renderDomainForm = () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/index.tsx
@@ -10,6 +10,7 @@ import {
 	DOMAIN_UPSELL_FLOW,
 	HUNDRED_YEAR_PLAN_FLOW,
 	isDomainUpsellFlow,
+	isSiteAssemblerFlow,
 } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
@@ -32,6 +33,7 @@ import {
 	recordAddDomainButtonClickInMapDomain,
 	recordAddDomainButtonClickInTransferDomain,
 } from 'calypso/state/domains/actions';
+import useChangeSiteDomain from '../../../../hooks/use-change-site-domain';
 import { ONBOARD_STORE } from '../../../../stores';
 import HundredYearPlanStepWrapper from '../hundred-year-plan-step-wrapper';
 import { DomainFormControl } from './domain-form-control';
@@ -50,6 +52,8 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 	const [ showUseYourDomain, setShowUseYourDomain ] = useState( false );
 
 	const dispatch = useReduxDispatch();
+
+	const changeSiteDomain = useChangeSiteDomain();
 
 	const { submit, exitFlow, goBack } = navigation;
 
@@ -119,6 +123,10 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 
 			setHideFreePlan( Boolean( suggestion.product_slug ) || shouldHideFreePlan );
 			setDomainCartItem( domainCartItem );
+		}
+
+		if ( suggestion?.is_free && suggestion?.domain_name ) {
+			changeSiteDomain( suggestion?.domain_name );
 		}
 
 		submit?.( { freeDomain: suggestion?.is_free, domainName: suggestion?.domain_name } );
@@ -270,21 +278,21 @@ const DomainsStep: Step = function DomainsStep( { navigation, flow } ) {
 			return setShowUseYourDomain( false );
 		}
 
-		if ( [ DOMAIN_UPSELL_FLOW ].includes( flow ) ) {
+		if ( isDomainUpsellFlow( flow ) || isSiteAssemblerFlow( flow ) ) {
 			return goBack?.();
 		}
 		return exitFlow?.( '/sites' );
 	};
 
 	const getBackLabelText = () => {
-		if ( [ DOMAIN_UPSELL_FLOW ].includes( flow ) ) {
+		if ( isDomainUpsellFlow( flow ) || isSiteAssemblerFlow( flow ) ) {
 			return __( 'Back' );
 		}
 		return __( 'Back to sites' );
 	};
 
 	const shouldHideBackButton = () => {
-		if ( isDomainUpsellFlow( flow ) ) {
+		if ( isDomainUpsellFlow( flow ) || isSiteAssemblerFlow( flow ) ) {
 			return false;
 		}
 		return ! isCopySiteFlow( flow );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
@@ -263,8 +263,12 @@
 	}
 }
 
-// Domain upsell flow
-
+/**
+ * Layout for the following flows
+ * - assembler-first
+ * - domain-upsell
+ */
+.assembler-first.domains,
 .domain-upsell.domains {
 
 	$domain-stepper-component-width: 1040px;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -37,13 +37,13 @@ const Launchpad: Step = ( { navigation, flow }: LaunchpadProps ) => {
 	const siteIdParam = useSiteIdParam();
 	const siteSlugParam = useSiteSlugParam();
 	const siteSlug = urlToSlug( site?.URL ?? '' ) || siteSlugParam || '';
-	const launchpadKey = siteIdParam || site?.ID || siteSlugParam || '';
+	const launchpadKey = String( siteIdParam || site?.ID || siteSlugParam || '' );
 	const siteIntentOption = site?.options?.site_intent;
 	const isSiteLaunched = site?.launch_status === 'launched' || false;
 	const {
 		isError: launchpadFetchError,
 		data: { launchpad_screen: launchpadScreenOption, checklist: launchpadChecklist } = {},
-	} = useLaunchpad( launchpadKey.toString(), siteIntentOption );
+	} = useLaunchpad( launchpadKey, siteIntentOption );
 
 	const dispatch = useDispatch();
 	const { saveSiteSettings } = useWPDispatch( SITE_STORE );
@@ -107,6 +107,7 @@ const Launchpad: Step = ( { navigation, flow }: LaunchpadProps ) => {
 				hideBack={ true }
 				stepContent={
 					<StepContent
+						launchpadKey={ launchpadKey }
 						siteSlug={ siteSlug }
 						submit={ navigation.submit }
 						goNext={ navigation.goNext }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -31,6 +31,7 @@ import { type Task } from './types';
 
 type SidebarProps = {
 	sidebarDomain: ResponseDomain;
+	launchpadKey: string;
 	siteSlug: string | null;
 	submit: NavigationControls[ 'submit' ];
 	goNext: NavigationControls[ 'goNext' ];
@@ -49,7 +50,14 @@ function getUrlInfo( url: string ) {
 	return [ siteName, topLevelDomain ];
 }
 
-const Sidebar = ( { sidebarDomain, siteSlug, submit, goToStep, flow }: SidebarProps ) => {
+const Sidebar = ( {
+	sidebarDomain,
+	launchpadKey,
+	siteSlug,
+	submit,
+	goToStep,
+	flow,
+}: SidebarProps ) => {
 	let siteName = '';
 	let topLevelDomain = '';
 	let showClipboardButton = false;
@@ -66,7 +74,7 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goToStep, flow }: SidebarPr
 
 	const {
 		data: { checklist_statuses: checklistStatuses, checklist: launchpadChecklist },
-	} = useLaunchpad( siteSlug, siteIntentOption, {
+	} = useLaunchpad( launchpadKey, siteIntentOption, {
 		onSuccess: sortLaunchpadTasksByCompletionStatus,
 	} );
 
@@ -266,7 +274,7 @@ const Sidebar = ( { sidebarDomain, siteSlug, submit, goToStep, flow }: SidebarPr
 						</div>
 					) }
 					<LaunchpadInternal
-						siteSlug={ siteSlug }
+						siteSlug={ launchpadKey }
 						taskFilter={ () => enhancedTasks || [] }
 						makeLastTaskPrimaryAction={ true }
 					/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/step-content.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/step-content.tsx
@@ -12,6 +12,7 @@ import { getLaunchpadTranslations } from './translations';
 import type { SiteSelect } from '@automattic/data-stores';
 
 type StepContentProps = {
+	launchpadKey: string;
 	siteSlug: string | null;
 	submit: NavigationControls[ 'submit' ];
 	goNext: NavigationControls[ 'goNext' ];
@@ -23,7 +24,14 @@ function sortByRegistrationDate( domainObjectA: ResponseDomain, domainObjectB: R
 	return domainObjectA.registrationDate > domainObjectB.registrationDate ? -1 : 1;
 }
 
-const StepContent = ( { siteSlug, submit, goNext, goToStep, flow }: StepContentProps ) => {
+const StepContent = ( {
+	launchpadKey,
+	siteSlug,
+	submit,
+	goNext,
+	goToStep,
+	flow,
+}: StepContentProps ) => {
 	const { flowName } = getLaunchpadTranslations( flow );
 	const site = useSite();
 	const adminUrl = useSelect(
@@ -59,6 +67,7 @@ const StepContent = ( { siteSlug, submit, goNext, goToStep, flow }: StepContentP
 			<div className="launchpad__content">
 				<Sidebar
 					sidebarDomain={ sidebarDomain }
+					launchpadKey={ launchpadKey }
 					siteSlug={ siteSlug }
 					submit={ submit }
 					goNext={ goNext }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -134,6 +134,14 @@ export function getEnhancedTasks( {
 
 	const shouldDisplayWarning = displayGlobalStylesWarning || isVideoPressFlowWithUnsupportedPlan;
 
+	// We have to use the site id if the flow allows the user to change the site address
+	// as the domain name of the site may be changed.
+	// See https://github.com/Automattic/wp-calypso/pull/84532.
+	const siteInfoQueryArgs =
+		isBlogOnboardingFlow( flow ) || isSiteAssemblerFlow( flow )
+			? { siteId: site?.ID }
+			: { siteSlug };
+
 	const completeMigrateContentTask = async () => {
 		if ( siteSlug ) {
 			await updateLaunchpadSettings( siteSlug, {
@@ -271,9 +279,7 @@ export function getEnhancedTasks( {
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							window.location.assign(
-								addQueryArgs( `/setup/${ flow }/freePostSetup`, {
-									siteSlug,
-								} )
+								addQueryArgs( `/setup/${ flow }/freePostSetup`, siteInfoQueryArgs )
 							);
 						},
 					};
@@ -283,10 +289,7 @@ export function getEnhancedTasks( {
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							window.location.assign(
-								addQueryArgs(
-									`/setup/${ flow }/setup-blog`,
-									isBlogOnboardingFlow( flow ) ? { siteId: site?.ID } : { siteSlug: siteSlug }
-								)
+								addQueryArgs( `/setup/${ flow }/setup-blog`, siteInfoQueryArgs )
 							);
 						},
 						disabled: task.completed && ! isBlogOnboardingFlow( flow ),
@@ -297,9 +300,10 @@ export function getEnhancedTasks( {
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							window.location.assign(
-								addQueryArgs( `/setup/newsletter-post-setup/newsletterPostSetup`, {
-									siteSlug,
-								} )
+								addQueryArgs(
+									`/setup/newsletter-post-setup/newsletterPostSetup`,
+									siteInfoQueryArgs
+								)
 							);
 						},
 					};
@@ -350,10 +354,7 @@ export function getEnhancedTasks( {
 					taskData = {
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
-							const plansUrl = addQueryArgs(
-								`/setup/${ flow }/plans`,
-								isBlogOnboardingFlow( flow ) ? { siteId: site?.ID } : { siteSlug: siteSlug }
-							);
+							const plansUrl = addQueryArgs( `/setup/${ flow }/plans`, siteInfoQueryArgs );
 
 							window.location.assign( plansUrl );
 						},
@@ -420,7 +421,7 @@ export function getEnhancedTasks( {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							window.location.assign(
 								addQueryArgs( `/setup/update-design/designSetup`, {
-									siteSlug,
+									...siteInfoQueryArgs,
 									flowToReturnTo: flow,
 								} )
 							);
@@ -434,7 +435,7 @@ export function getEnhancedTasks( {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							window.location.assign(
 								addQueryArgs( `/setup/update-options/options`, {
-									siteSlug,
+									...siteInfoQueryArgs,
 									flowToReturnTo: flow,
 								} )
 							);
@@ -446,9 +447,10 @@ export function getEnhancedTasks( {
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							window.location.assign(
-								addQueryArgs( `/setup/link-in-bio-post-setup/linkInBioPostSetup`, {
-									siteSlug,
-								} )
+								addQueryArgs(
+									`/setup/link-in-bio-post-setup/linkInBioPostSetup`,
+									siteInfoQueryArgs
+								)
 							);
 						},
 					};
@@ -558,8 +560,7 @@ export function getEnhancedTasks( {
 							if ( isBlogOnboardingFlow( flow ) || isSiteAssemblerFlow( flow ) ) {
 								window.location.assign(
 									addQueryArgs( `/setup/${ flow }/domains`, {
-										siteId: site?.ID,
-										siteSlug,
+										...siteInfoQueryArgs,
 										flowToReturnTo: flow,
 										new: site?.name,
 										domainAndPlanPackage: true,
@@ -572,7 +573,7 @@ export function getEnhancedTasks( {
 							const destinationUrl = domainUpsellCompleted
 								? `/domains/manage/${ siteSlug }`
 								: addQueryArgs( `/setup/domain-upsell/domains`, {
-										siteSlug,
+										...siteInfoQueryArgs,
 										flowToReturnTo: flow,
 										new: site?.name,
 								  } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -555,10 +555,11 @@ export function getEnhancedTasks( {
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, domainUpsellCompleted, task.id );
 
-							if ( isBlogOnboardingFlow( flow ) ) {
+							if ( isBlogOnboardingFlow( flow ) || isSiteAssemblerFlow( flow ) ) {
 								window.location.assign(
 									addQueryArgs( `/setup/${ flow }/domains`, {
 										siteId: site?.ID,
+										siteSlug,
 										flowToReturnTo: flow,
 										new: site?.name,
 										domainAndPlanPackage: true,
@@ -578,7 +579,7 @@ export function getEnhancedTasks( {
 							window.location.assign( destinationUrl );
 						},
 						badge_text:
-							domainUpsellCompleted || isBlogOnboardingFlow( flow )
+							domainUpsellCompleted || isBlogOnboardingFlow( flow ) || isSiteAssemblerFlow( flow )
 								? ''
 								: translate( 'Upgrade plan' ),
 					};

--- a/client/landing/stepper/declarative-flow/internals/steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps.tsx
@@ -31,6 +31,11 @@ export const STEPS = {
 		asyncComponent: () => import( './steps-repository/difm-starting-point' ),
 	},
 
+	DOMAINS: {
+		slug: 'domains',
+		asyncComponent: () => import( './steps-repository/domains' ),
+	},
+
 	EDIT_EMAIL: {
 		slug: 'editEmail',
 		asyncComponent: () => import( './steps-repository/edit-email' ),

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -1,7 +1,7 @@
-import { OnboardSelect, updateLaunchpadSettings } from '@automattic/data-stores';
+import { updateLaunchpadSettings } from '@automattic/data-stores';
 import { useLocale } from '@automattic/i18n-utils';
 import { START_WRITING_FLOW } from '@automattic/onboarding';
-import { useSelect, useDispatch, dispatch } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { getLocaleFromQueryParam, getLocaleFromPathname } from 'calypso/boot/locale';
 import { recordSubmitStep } from 'calypso/landing/stepper/declarative-flow/internals/analytics/record-submit-step';
@@ -16,10 +16,8 @@ import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
 import { SITE_STORE, ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { skipLaunchpad } from 'calypso/landing/stepper/utils/skip-launchpad';
-import { freeSiteAddressType } from 'calypso/lib/domains/constants';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import { requestSiteAddressChange } from 'calypso/state/site-address-change/actions';
 import { useSiteIdParam } from '../hooks/use-site-id-param';
 import { useLoginUrl } from '../utils/path';
 
@@ -82,10 +80,6 @@ const startWriting: Flow = {
 		const siteId = useSiteIdParam();
 		const { saveSiteSettings, setIntentOnSite } = useDispatch( SITE_STORE );
 		const { setSelectedSite } = useDispatch( ONBOARD_STORE );
-		const state = useSelect(
-			( select ) => select( ONBOARD_STORE ) as OnboardSelect,
-			[]
-		).getState();
 		const site = useSite();
 
 		// This flow clear the site_intent when flow is completed.
@@ -173,23 +167,6 @@ const startWriting: Flow = {
 					}
 
 					if ( providedDependencies?.freeDomain ) {
-						const freeDomainSuffix = '.wordpress.com';
-						const newDomainName = String( providedDependencies?.domainName ).replace(
-							freeDomainSuffix,
-							''
-						);
-
-						if ( providedDependencies?.domainName ) {
-							await requestSiteAddressChange(
-								site?.ID,
-								newDomainName,
-								'wordpress.com',
-								siteSlug,
-								freeSiteAddressType.BLOG,
-								true,
-								false
-							)( dispatch, state );
-						}
 						return window.location.assign( `/setup/start-writing/launchpad?siteId=${ site?.ID }` );
 					}
 

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -12,13 +12,11 @@ import {
 	type Flow,
 	type ProvidedDependencies,
 } from 'calypso/landing/stepper/declarative-flow/internals/types';
-import { useSite } from 'calypso/landing/stepper/hooks/use-site';
-import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
 import { SITE_STORE, ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { skipLaunchpad } from 'calypso/landing/stepper/utils/skip-launchpad';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import { useSiteIdParam } from '../hooks/use-site-id-param';
+import { useSiteData } from '../hooks/use-site-data';
 import { useLoginUrl } from '../utils/path';
 
 const startWriting: Flow = {
@@ -76,11 +74,9 @@ const startWriting: Flow = {
 
 	useStepNavigation( currentStep, navigate ) {
 		const flowName = this.name;
-		const siteSlug = useSiteSlug();
-		const siteId = useSiteIdParam();
 		const { saveSiteSettings, setIntentOnSite } = useDispatch( SITE_STORE );
 		const { setSelectedSite } = useDispatch( ONBOARD_STORE );
-		const site = useSite();
+		const { site, siteSlug, siteId } = useSiteData();
 
 		// This flow clear the site_intent when flow is completed.
 		// We need to check if the site is launched and if so, clear the site_intent to avoid errors.
@@ -160,8 +156,8 @@ const startWriting: Flow = {
 					return navigate( 'launchpad' );
 				}
 				case 'domains':
-					if ( siteSlug ) {
-						await updateLaunchpadSettings( siteSlug, {
+					if ( siteId ) {
+						await updateLaunchpadSettings( siteId, {
 							checklist_statuses: { domain_upsell_deferred: true },
 						} );
 					}
@@ -172,22 +168,22 @@ const startWriting: Flow = {
 
 					return navigate( 'plans' );
 				case 'use-my-domain':
-					if ( siteSlug ) {
-						await updateLaunchpadSettings( siteSlug, {
+					if ( siteId ) {
+						await updateLaunchpadSettings( siteId, {
 							checklist_statuses: { domain_upsell_deferred: true },
 						} );
 					}
 					return navigate( 'plans' );
 				case 'plans':
-					if ( siteSlug ) {
-						await updateLaunchpadSettings( siteSlug, {
+					if ( siteId ) {
+						await updateLaunchpadSettings( siteId, {
 							checklist_statuses: { plan_completed: true },
 						} );
 					}
 					return navigate( 'launchpad' );
 				case 'setup-blog':
-					if ( siteSlug ) {
-						await updateLaunchpadSettings( siteSlug, {
+					if ( siteId ) {
+						await updateLaunchpadSettings( siteId, {
 							checklist_statuses: { setup_blog: true },
 						} );
 					}

--- a/client/landing/stepper/hooks/use-change-site-domain.ts
+++ b/client/landing/stepper/hooks/use-change-site-domain.ts
@@ -1,0 +1,34 @@
+import { freeSiteAddressType } from 'calypso/lib/domains/constants';
+import { useDispatch } from 'calypso/state';
+import { requestSiteAddressChange } from 'calypso/state/site-address-change/actions';
+import { useSiteData } from './use-site-data';
+
+const FREE_DOMAIN_SUFFIX = '.wordpress.com';
+
+const useChangeSiteDomain = () => {
+	const dispatch = useDispatch();
+	const { siteId, siteSlug } = useSiteData();
+
+	const changeSiteDomain = async ( domain: string ) => {
+		if ( domain === siteSlug || ! domain.endsWith( FREE_DOMAIN_SUFFIX ) ) {
+			return;
+		}
+
+		await dispatch(
+			requestSiteAddressChange(
+				siteId,
+				domain.replace( FREE_DOMAIN_SUFFIX, '' ),
+				'wordpress.com',
+				siteSlug,
+				freeSiteAddressType.BLOG,
+				true,
+				false,
+				true
+			)
+		);
+	};
+
+	return changeSiteDomain;
+};
+
+export default useChangeSiteDomain;

--- a/client/landing/stepper/hooks/use-site-data.ts
+++ b/client/landing/stepper/hooks/use-site-data.ts
@@ -1,11 +1,14 @@
+import { urlToSlug } from 'calypso/lib/url';
 import { useSite } from './use-site';
 import { useSiteIdParam } from './use-site-id-param';
 import { useSiteSlugParam } from './use-site-slug-param';
 
 export const useSiteData = () => {
 	const site = useSite();
-	const siteSlug = useSiteSlugParam() ?? '';
-	const siteId = Number( useSiteIdParam() ) ?? 0;
+	const siteSlugParam = useSiteSlugParam() ?? '';
+	const siteIdParam = Number( useSiteIdParam() ) ?? 0;
+	const siteSlug = site?.URL ? urlToSlug( site?.URL ?? '' ) : siteSlugParam;
+	const siteId = site?.ID ?? siteIdParam;
 	const siteSlugOrId = siteSlug ? siteSlug : siteId;
 
 	return {

--- a/client/landing/stepper/utils/skip-launchpad.ts
+++ b/client/landing/stepper/utils/skip-launchpad.ts
@@ -9,18 +9,22 @@ type SkipLaunchpadProps = {
 };
 
 export const skipLaunchpad = async ( { checklistSlug, siteId, siteSlug }: SkipLaunchpadProps ) => {
-	if ( siteSlug ) {
+	const siteIdOrSlug = siteId || siteSlug;
+	if ( siteIdOrSlug ) {
 		// Only set the active checklist if we have the checklist slug AND the feature is enabled.
 		if ( checklistSlug && isEnabled( 'launchpad/navigator' ) ) {
 			// If we're making both API calls, allow them to happen concurrently.
 			await Promise.allSettled( [
-				updateLaunchpadSettings( siteSlug, { launchpad_screen: 'skipped' } ),
-				dispatch( LaunchpadNavigator.store ).setActiveChecklist( siteSlug, checklistSlug ),
+				updateLaunchpadSettings( siteIdOrSlug, { launchpad_screen: 'skipped' } ),
+				dispatch( LaunchpadNavigator.store ).setActiveChecklist(
+					String( siteIdOrSlug ),
+					checklistSlug
+				),
 			] );
 		} else {
-			await updateLaunchpadSettings( siteSlug, { launchpad_screen: 'skipped' } );
+			await updateLaunchpadSettings( siteIdOrSlug, { launchpad_screen: 'skipped' } );
 		}
 	}
 
-	return window.location.assign( `/home/${ siteId ? siteId : siteSlug }` );
+	return window.location.assign( `/home/${ siteIdOrSlug }` );
 };

--- a/client/state/site-address-change/actions.js
+++ b/client/state/site-address-change/actions.js
@@ -107,7 +107,8 @@ export const requestSiteAddressChange =
 		oldDomain,
 		siteType,
 		discard = true,
-		requireVerifiedEmail = true
+		requireVerifiedEmail = true,
+		skipRedirection = false
 	) =>
 	async ( dispatch, getState ) => {
 		dispatch( {
@@ -174,7 +175,10 @@ export const requestSiteAddressChange =
 				const siteSlug = getSiteSlug( getState(), siteId );
 				// new name of the `*.wordpress.com` domain that we just changed
 				const newDomain = newSlug + '.' + domain;
-				page( domainManagementEdit( siteSlug, newDomain ) );
+
+				if ( ! skipRedirection ) {
+					page( domainManagementEdit( siteSlug, newDomain ) );
+				}
 			}
 		} catch ( error ) {
 			dispatch(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pekYwv-3vI-p2#comment-2714

## Proposed Changes

* On the Domain screen, allow users to choose another `*.wordpress.com` subdomain
* On the Launchpad screen, don't show the `Upgrade plan` badge on the “Choose a domain” task

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /setup/assembler-first
* Create a new site
* Finish the Assembler screen
* Exit the Site Editor
* On the Launchpad screen, make sure you won't see the `Upgrade plan` badge on the “Choose a domain” task
* Pick the “Choose a domain” task, and make sure you can see the `*.wordpress.com` domain
* Select the domain, and make sure the domain of your site changed successfully

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?