### PR TITLE
Unhardcode plan name instances

### DIFF
--- a/client/blocks/product-purchase-features-list/advertising-removed.jsx
+++ b/client/blocks/product-purchase-features-list/advertising-removed.jsx
@@ -24,6 +24,12 @@ export default localize( ( { isEligiblePlan, selectedSite, translate } ) => {
 					'All WordPress.com advertising has been removed from your site. Upgrade to Business ' +
 						'to remove the WordPress.com footer credit.'
 			  );
+	const buttonText =
+		isEnglishLocale || i18n.hasTranslation( 'Upgrade to %(planName)s' )
+			? translate( 'Upgrade to %(planName)s', {
+					args: { planName: getPlan( PLAN_BUSINESS ).getTitle() },
+			  } )
+			: translate( 'Upgrade to Business' );
 	return (
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail
@@ -36,7 +42,7 @@ export default localize( ( { isEligiblePlan, selectedSite, translate } ) => {
 						  )
 						: uneligiblePlanDescription
 				}
-				buttonText={ ! isEligiblePlan ? translate( 'Upgrade to Business' ) : null }
+				buttonText={ ! isEligiblePlan ? buttonText : null }
 				href={ ! isEligiblePlan ? '/checkout/' + selectedSite.slug + '/business' : null }
 			/>
 		</div>

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -1,12 +1,13 @@
-import { FEATURE_INSTALL_THEMES } from '@automattic/calypso-products';
+import { FEATURE_INSTALL_THEMES, PLAN_BUSINESS, getPlan } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import {
 	PatternAssemblerCta,
 	usePatternAssemblerCtaData,
 	isAssemblerSupported,
 } from '@automattic/design-picker';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { Icon, addTemplate, brush, cloudUpload } from '@wordpress/icons';
-import { localize } from 'i18n-calypso';
+import i18n, { localize } from 'i18n-calypso';
 import { isEmpty, times } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
@@ -244,6 +245,7 @@ function Options( { isFSEActive, recordTracksEvent, searchTerm, translate, upsel
 		getSiteThemeInstallUrl( state, selectedSite?.ID )
 	);
 	const assemblerCtaData = usePatternAssemblerCtaData();
+	const isEnglishLocale = useIsEnglishLocale();
 
 	const options = [];
 
@@ -306,9 +308,18 @@ function Options( { isFSEActive, recordTracksEvent, searchTerm, translate, upsel
 		options.push( {
 			title: translate( 'Upload a theme' ),
 			icon: cloudUpload,
-			description: translate(
-				'With a Business plan, you can upload and install third-party themes, including your own themes.'
-			),
+			description:
+				isEnglishLocale ||
+				i18n.hasTranslation(
+					'With a %(businessPlanName)s plan, you can upload and install third-party themes, including your own themes.'
+				)
+					? translate(
+							'With a %(businessPlanName)s plan, you can upload and install third-party themes, including your own themes.',
+							{ args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() } }
+					  )
+					: translate(
+							'With a Business plan, you can upload and install third-party themes, including your own themes.'
+					  ),
 			onClick: () =>
 				recordTracksEvent( 'calypso_themeshowcase_more_options_upload_theme_click', {
 					site_plan: sitePlan,
@@ -338,9 +349,18 @@ function Options( { isFSEActive, recordTracksEvent, searchTerm, translate, upsel
 		options.push( {
 			title: translate( 'Upload a theme' ),
 			icon: cloudUpload,
-			description: translate(
-				'With a Business plan, you can upload and install third-party themes, including your own themes.'
-			),
+			description:
+				isEnglishLocale ||
+				i18n.hasTranslation(
+					'With a %(businessPlanName)s plan, you can upload and install third-party themes, including your own themes.'
+				)
+					? translate(
+							'With a %(businessPlanName)s plan, you can upload and install third-party themes, including your own themes.',
+							{ args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() } }
+					  )
+					: translate(
+							'With a Business plan, you can upload and install third-party themes, including your own themes.'
+					  ),
 			onClick: () =>
 				recordTracksEvent( 'calypso_themeshowcase_more_options_upload_theme_click', {
 					site_plan: sitePlan,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/migration-trial-acknowledge.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/migration-trial-acknowledge.tsx
@@ -1,6 +1,6 @@
 import { getPlan, PLAN_BUSINESS, PLAN_MIGRATION_TRIAL_MONTHLY } from '@automattic/calypso-products';
 import { SiteDetails } from '@automattic/data-stores';
-import { useHasEnTranslation } from '@automattic/i18n-utils';
+import { useHasEnTranslation, useIsEnglishLocale } from '@automattic/i18n-utils';
 import { Title, SubTitle, NextButton } from '@automattic/onboarding';
 import { createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
@@ -38,6 +38,7 @@ const MigrationTrialAcknowledgeInternal = function ( props: Props ) {
 	const hasEnTranslation = useHasEnTranslation();
 	const urlQueryParams = useQuery();
 	const { user, site, siteSlug, flowName, stepName, submit } = props;
+	const isEnglishLocale = useIsEnglishLocale();
 
 	const { data: migrationTrialEligibility, isLoading: isCheckingEligibility } =
 		useCheckEligibilityMigrationTrialPlan( site?.ID );
@@ -94,9 +95,20 @@ const MigrationTrialAcknowledgeInternal = function ( props: Props ) {
 				<Title>{ __( 'You already have an active free trial' ) }</Title>
 				<SubTitle>
 					{ createInterpolateElement(
-						__(
-							"You're currently enrolled in a free trial. Please wait until it expires to start a new one.<br />To migrate your site now, upgrade to the Business plan."
-						),
+						isEnglishLocale ||
+							hasEnTranslation(
+								"You're currently enrolled in a free trial. Please wait until it expires to start a new one.<br />To migrate your site now, upgrade to the %(planName)s plan."
+							)
+							? sprintf(
+									/* translators: the planName is the short-from of the Business plan */
+									__(
+										"You're currently enrolled in a free trial. Please wait until it expires to start a new one.<br />To migrate your site now, upgrade to the %(planName)s plan."
+									),
+									{ planName: plan?.getTitle() }
+							  )
+							: __(
+									"You're currently enrolled in a free trial. Please wait until it expires to start a new one.<br />To migrate your site now, upgrade to the Business plan."
+							  ),
 						{ br: <br /> }
 					) }
 				</SubTitle>

--- a/client/my-sites/backup/wpcom-backup-upsell.tsx
+++ b/client/my-sites/backup/wpcom-backup-upsell.tsx
@@ -1,7 +1,12 @@
-import { WPCOM_FEATURES_FULL_ACTIVITY_LOG } from '@automattic/calypso-products';
+import {
+	PLAN_BUSINESS,
+	WPCOM_FEATURES_FULL_ACTIVITY_LOG,
+	getPlan,
+} from '@automattic/calypso-products';
 import { Button, Gridicon } from '@automattic/components';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { addQueryArgs } from '@wordpress/url';
-import { useTranslate } from 'i18n-calypso';
+import i18n, { useTranslate } from 'i18n-calypso';
 import JetpackBackupSVG from 'calypso/assets/images/illustrations/jetpack-backup.svg';
 import VaultPressLogo from 'calypso/assets/images/jetpack/vaultpress-logo.svg';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -22,7 +27,6 @@ import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-
 import './style.scss';
 
 const JetpackBackupErrorSVG = '/calypso/images/illustrations/jetpack-cloud-backup-error.svg';
@@ -80,6 +84,7 @@ const BackupUpsellBody = () => {
 	const postCheckoutUrl = window.location.pathname + window.location.search;
 	const isJetpack = useSelector( ( state ) => siteId && isJetpackSite( state, siteId ) );
 	const isAtomic = useSelector( ( state ) => siteId && isSiteWpcomAtomic( state, siteId ) );
+	const isEnglishLocale = useIsEnglishLocale();
 	const isWPcomSite = ! isJetpack || isAtomic;
 	const onUpgradeClick = useTrackCallback(
 		undefined,
@@ -129,7 +134,12 @@ const BackupUpsellBody = () => {
 				{ isAdmin && isWPcomSite && (
 					<PromoCardCTA
 						cta={ {
-							text: translate( 'Upgrade to Business Plan' ),
+							text:
+								isEnglishLocale || i18n.hasTranslation( 'Upgrade to %(planName)s Plan' )
+									? translate( 'Upgrade to %(planName)s Plan', {
+											args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
+									  } )
+									: translate( 'Upgrade to Business Plan' ),
 							action: {
 								url: `/checkout/${ siteSlug }/business`,
 								onClick: onUpgradeClick,
@@ -157,7 +167,11 @@ const BackupUpsellBody = () => {
 			{ isWPcomSite && ! hasFullActivityLogFeature && (
 				<>
 					<h2 className="backup__subheader">
-						{ translate( 'Also included in the Business Plan' ) }
+						{ isEnglishLocale || i18n.hasTranslation( 'Also included in the %(planName)s Plan' )
+							? translate( 'Also included in the %(planName)s Plan', {
+									args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
+							  } )
+							: translate( 'Also included in the Business Plan' ) }
 					</h2>
 
 					<PromoSection { ...promos } />

--- a/client/my-sites/backup/wpcom-upsell.tsx
+++ b/client/my-sites/backup/wpcom-upsell.tsx
@@ -1,6 +1,11 @@
-import { WPCOM_FEATURES_FULL_ACTIVITY_LOG } from '@automattic/calypso-products';
+import {
+	PLAN_BUSINESS,
+	WPCOM_FEATURES_FULL_ACTIVITY_LOG,
+	getPlan,
+} from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
-import { useTranslate } from 'i18n-calypso';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
+import i18n, { useTranslate } from 'i18n-calypso';
 import JetpackBackupSVG from 'calypso/assets/images/illustrations/jetpack-backup.svg';
 import DocumentHead from 'calypso/components/data/document-head';
 import WhatIsJetpack from 'calypso/components/jetpack/what-is-jetpack';
@@ -17,7 +22,6 @@ import { useSelector } from 'calypso/state';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-
 import './style.scss';
 
 const trackEventName = 'calypso_jetpack_backup_business_upsell';
@@ -29,6 +33,7 @@ export default function WPCOMUpsellPage() {
 	const isAdmin = useSelector( ( state ) =>
 		canCurrentUser( state, siteId ?? 0, 'manage_options' )
 	);
+	const isEnglishLocale = useIsEnglishLocale();
 	const hasFullActivityLogFeature = useSelector( ( state ) =>
 		siteHasFeature( state, siteId, WPCOM_FEATURES_FULL_ACTIVITY_LOG )
 	);
@@ -69,14 +74,29 @@ export default function WPCOMUpsellPage() {
 				{ ! isAdmin && (
 					<Notice
 						status="is-warning"
-						text={ translate( 'Only site administrators can upgrade to the Business plan.' ) }
+						text={
+							isEnglishLocale ||
+							i18n.hasTranslation(
+								'Only site administrators can upgrade to the %(businessPlanName)s plan.'
+							)
+								? translate(
+										'Only site administrators can upgrade to the %(businessPlanName)s plan.',
+										{ args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' } }
+								  )
+								: translate( 'Only site administrators can upgrade to the Business plan.' )
+						}
 						showDismiss={ false }
 					/>
 				) }
 				{ isAdmin && (
 					<PromoCardCTA
 						cta={ {
-							text: translate( 'Upgrade to Business Plan' ),
+							text:
+								isEnglishLocale || i18n.hasTranslation( 'Upgrade to %(planName)s Plan' )
+									? translate( 'Upgrade to %(planName)s Plan', {
+											args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
+									  } )
+									: translate( 'Upgrade to Business Plan' ),
 							action: {
 								url: `/checkout/${ siteSlug }/business`,
 								onClick: onUpgradeClick,
@@ -90,7 +110,11 @@ export default function WPCOMUpsellPage() {
 			{ ! hasFullActivityLogFeature && (
 				<>
 					<h2 className="backup__subheader">
-						{ translate( 'Also included in the Business Plan' ) }
+						{ isEnglishLocale || i18n.hasTranslation( 'Also included in the %(planName)s Plan' )
+							? translate( 'Also included in the %(planName)s Plan', {
+									args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
+							  } )
+							: translate( 'Also included in the Business Plan' ) }
 					</h2>
 
 					<PromoSection { ...promos } />

--- a/client/my-sites/checkout/checkout-thank-you/personal-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/personal-plan-details.jsx
@@ -1,5 +1,10 @@
-import { isPersonal, isGSuiteOrExtraLicenseOrGoogleWorkspace } from '@automattic/calypso-products';
-import { localize } from 'i18n-calypso';
+import {
+	isPersonal,
+	isGSuiteOrExtraLicenseOrGoogleWorkspace,
+	getPlan,
+	PLAN_BUSINESS,
+} from '@automattic/calypso-products';
+import i18n, { localize } from 'i18n-calypso';
 import { find } from 'lodash';
 import PropTypes from 'prop-types';
 import earnImage from 'calypso/assets/images/customer-home/illustration--task-earn.svg';
@@ -8,8 +13,9 @@ import PurchaseDetail from 'calypso/components/purchase-detail';
 import CustomDomainPurchaseDetail from './custom-domain-purchase-detail';
 import GoogleAppsDetails from './google-apps-details';
 
-const PersonalPlanDetails = ( { translate, selectedSite, sitePlans, purchases } ) => {
+const PersonalPlanDetails = ( { translate, selectedSite, sitePlans, purchases, locale } ) => {
 	const plan = find( sitePlans.data, isPersonal );
+	const isEnglishLocale = [ 'en', 'en-gb' ].includes( locale );
 	const googleAppsWasPurchased = purchases.some( isGSuiteOrExtraLicenseOrGoogleWorkspace );
 
 	return (
@@ -35,10 +41,22 @@ const PersonalPlanDetails = ( { translate, selectedSite, sitePlans, purchases } 
 			<PurchaseDetail
 				icon={ <img alt="" src={ adsRemovedImage } /> }
 				title={ translate( 'Advertising Removed' ) }
-				description={ translate(
-					'With your plan, all WordPress.com advertising has been removed from your site. ' +
-						'You can upgrade to a Business plan to also remove the WordPress.com footer credit.'
-				) }
+				description={
+					isEnglishLocale ||
+					i18n.hasTranslation(
+						'With your plan, all WordPress.com advertising has been removed from your site. ' +
+							'You can upgrade to a %(businessPlanName)s plan to also remove the WordPress.com footer credit.'
+					)
+						? translate(
+								'With your plan, all WordPress.com advertising has been removed from your site. ' +
+									'You can upgrade to a %(businessPlanName)s plan to also remove the WordPress.com footer credit.',
+								{ args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() } }
+						  )
+						: translate(
+								'With your plan, all WordPress.com advertising has been removed from your site. ' +
+									'You can upgrade to a Business plan to also remove the WordPress.com footer credit.'
+						  )
+				}
 			/>
 		</div>
 	);

--- a/client/my-sites/hosting/hosting-upsell-nudge/index.tsx
+++ b/client/my-sites/hosting/hosting-upsell-nudge/index.tsx
@@ -1,5 +1,6 @@
-import { FEATURE_SFTP, PLAN_BUSINESS, WPCOM_PLANS } from '@automattic/calypso-products';
-import { useTranslate } from 'i18n-calypso';
+import { FEATURE_SFTP, PLAN_BUSINESS, WPCOM_PLANS, getPlan } from '@automattic/calypso-products';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
+import i18n, { useTranslate } from 'i18n-calypso';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import { preventWidows } from 'calypso/lib/formatting';
 import iconCloud from './icons/icon-cloud.svg';
@@ -9,7 +10,6 @@ import iconServerRacks from './icons/icon-server-racks.svg';
 import iconSSH from './icons/icon-ssh.svg';
 import iconTerminal from './icons/icon-terminal.svg';
 import type { TranslateResult } from 'i18n-calypso';
-
 import './style.scss';
 
 interface FeatureListItem {
@@ -35,16 +35,28 @@ export function HostingUpsellNudge( { siteId, targetPlan }: HostingUpsellNudgePr
 	const translate = useTranslate();
 
 	const features = useFeatureList();
+	const isEnglishLocale = useIsEnglishLocale();
+	const callToActionText =
+		isEnglishLocale || i18n.hasTranslation( 'Upgrade to %(businessPlanName)s Plan' )
+			? translate( 'Upgrade to %(businessPlanName)s Plan', {
+					args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
+			  } )
+			: translate( 'Upgrade to Business Plan' );
+	const titleText =
+		isEnglishLocale ||
+		i18n.hasTranslation(
+			'Upgrade to the %(businessPlanName)s plan to access all hosting features:'
+		)
+			? translate( 'Upgrade to the %(businessPlanName)s plan to access all hosting features:', {
+					args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
+			  } )
+			: translate( 'Upgrade to the Business plan to access all hosting features:' );
 
-	const callToAction = targetPlan
-		? targetPlan.callToAction
-		: translate( 'Upgrade to Business Plan' );
+	const callToAction = targetPlan ? targetPlan.callToAction : callToActionText;
 	const feature = targetPlan ? targetPlan.feature : FEATURE_SFTP;
 	const href = targetPlan ? targetPlan.href : `/checkout/${ siteId }/business`;
 	const plan = targetPlan ? targetPlan.plan : PLAN_BUSINESS;
-	const title = targetPlan
-		? targetPlan.title
-		: translate( 'Upgrade to the Business plan to access all hosting features:' );
+	const title = targetPlan ? targetPlan.title : titleText;
 
 	return (
 		<UpsellNudge

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -1,8 +1,9 @@
 import config from '@automattic/calypso-config';
+import { PLAN_BUSINESS, PLAN_ECOMMERCE, getPlan } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
-import { localizeUrl } from '@automattic/i18n-utils';
-import { useTranslate, getLocaleSlug } from 'i18n-calypso';
+import { localizeUrl, useIsEnglishLocale } from '@automattic/i18n-utils';
+import i18n, { useTranslate, getLocaleSlug } from 'i18n-calypso';
 import { Fragment, FunctionComponent } from 'react';
 import fiverrLogo from 'calypso/assets/images/customer-home/fiverr-logo.svg';
 import rocket from 'calypso/assets/images/customer-home/illustration--rocket.svg';
@@ -28,6 +29,7 @@ export const MarketingTools: FunctionComponent = () => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const recordTracksEvent = ( event: string ) => dispatch( recordTracksEventAction( event ) );
+	const isEnglishLocale = useIsEnglishLocale();
 
 	const selectedSiteSlug: T.SiteSlug | null = useSelector( getSelectedSiteSlug );
 	const siteId = useSelector( getSelectedSiteId ) || 0;
@@ -124,14 +126,32 @@ export const MarketingTools: FunctionComponent = () => {
 				{ ! facebookPluginInstalled && (
 					<MarketingToolsFeature
 						title={ translate( 'Want to connect with your audience on Facebook and Instagram?' ) }
-						description={ translate(
-							'Discover an easy way to advertise your brand across Facebook and Instagram. Capture website actions to help you target audiences and measure results. {{em}}Available on Business and Commerce plans{{/em}}.',
-							{
-								components: {
-									em: <em />,
-								},
-							}
-						) }
+						description={
+							isEnglishLocale ||
+							i18n.hasTranslation(
+								'Discover an easy way to advertise your brand across Facebook and Instagram. Capture website actions to help you target audiences and measure results. {{em}}Available on %(businessPlanName)s and %(commercePlanName)s plans{{/em}}.'
+							)
+								? translate(
+										'Discover an easy way to advertise your brand across Facebook and Instagram. Capture website actions to help you target audiences and measure results. {{em}}Available on %(businessPlanName)s and %(commercePlanName)s plans{{/em}}.',
+										{
+											components: {
+												em: <em />,
+											},
+											args: {
+												businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+												commercePlanName: getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '',
+											},
+										}
+								  )
+								: translate(
+										'Discover an easy way to advertise your brand across Facebook and Instagram. Capture website actions to help you target audiences and measure results. {{em}}Available on Business and Commerce plans{{/em}}.',
+										{
+											components: {
+												em: <em />,
+											},
+										}
+								  )
+						}
 						imagePath={ facebookLogo }
 						imageAlt={ translate( 'Facebook logo' ) }
 					>

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -1,8 +1,9 @@
-import { WPCOM_FEATURES_ATOMIC } from '@automattic/calypso-products';
+import { PLAN_BUSINESS, WPCOM_FEATURES_ATOMIC, getPlan } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { WordPressWordmark, Button } from '@automattic/components';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { ThemeProvider } from '@emotion/react';
-import { useTranslate } from 'i18n-calypso';
+import i18n, { useTranslate } from 'i18n-calypso';
 import { useEffect, useState, useMemo, useRef } from 'react';
 import QueryActiveTheme from 'calypso/components/data/query-active-theme';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
@@ -137,6 +138,8 @@ const MarketplaceProductInstall = ( {
 		isSiteAutomatedTransfer( state, selectedSite?.ID ?? null )
 	);
 	const isJetpackSelfHosted = selectedSite && isJetpack && ! isAtomic;
+
+	const isEnglishLocale = useIsEnglishLocale();
 
 	const hasAtomicFeature = useSelector( ( state ) =>
 		siteHasFeature( state, selectedSite?.ID ?? null, WPCOM_FEATURES_ATOMIC )
@@ -355,10 +358,28 @@ const MarketplaceProductInstall = ( {
 				<EmptyContent
 					illustration="/calypso/images/illustrations/error.svg"
 					title={ null }
-					line={ translate(
-						"Your current plan doesn't allow plugin installation. Please upgrade to Business plan first."
-					) }
-					action={ translate( 'Upgrade to Business Plan' ) }
+					line={
+						isEnglishLocale ||
+						i18n.hasTranslation(
+							"Your current plan doesn't allow plugin installation. Please upgrade to %(businessPlanName)s plan first."
+						)
+							? translate(
+									"Your current plan doesn't allow plugin installation. Please upgrade to %(businessPlanName)s plan first.",
+									{
+										args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
+									}
+							  )
+							: translate(
+									"Your current plan doesn't allow plugin installation. Please upgrade to Business plan first."
+							  )
+					}
+					action={
+						isEnglishLocale || i18n.hasTranslation( 'Upgrade to %(planName)s Plan' )
+							? translate( 'Upgrade to %(planName)s Plan', {
+									args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
+							  } )
+							: translate( 'Upgrade to Business Plan' )
+					}
 					actionURL={ `/checkout/${ selectedSite?.slug }/business?redirect_to=/marketplace/plugin/${ pluginSlug }/install/${ selectedSite?.slug }#step2` }
 				/>
 			);

--- a/client/my-sites/migrate/step-confirm-migration.jsx
+++ b/client/my-sites/migrate/step-confirm-migration.jsx
@@ -1,7 +1,12 @@
-import { planHasFeature, FEATURE_UPLOAD_THEMES_PLUGINS } from '@automattic/calypso-products';
+import {
+	planHasFeature,
+	FEATURE_UPLOAD_THEMES_PLUGINS,
+	getPlan,
+	PLAN_BUSINESS,
+} from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button, CompactCard, Gridicon } from '@automattic/components';
-import { localize } from 'i18n-calypso';
+import i18n, { localize } from 'i18n-calypso';
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -64,7 +69,8 @@ class StepConfirmMigration extends Component {
 	}
 
 	renderCardBusinessFooter() {
-		const { translate } = this.props;
+		const { translate, locale } = this.props;
+		const isEnglishLocale = [ 'en', 'en-gb' ].includes( locale );
 
 		// If the site is has an appropriate plan, no upgrade footer is required
 		if ( this.isTargetSitePlanCompatible() ) {
@@ -75,7 +81,14 @@ class StepConfirmMigration extends Component {
 			<CompactCard className="migrate__card-footer">
 				<Gridicon className="migrate__card-footer-gridicon" icon="info-outline" size={ 12 } />
 				<span className="migrate__card-footer-text">
-					{ translate( 'A Business Plan is required to import everything.' ) }
+					{ isEnglishLocale ||
+					i18n.hasTranslation( 'A %(businessPlanName)s Plan is required to import everything.' )
+						? translate( 'A %(businessPlanName)s Plan is required to import everything.', {
+								args: {
+									businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle(),
+								},
+						  } )
+						: translate( 'A Business Plan is required to import everything.' ) }
 				</span>
 			</CompactCard>
 		);

--- a/client/my-sites/plugins/plugins-discovery-page/upgrade-nudge.jsx
+++ b/client/my-sites/plugins/plugins-discovery-page/upgrade-nudge.jsx
@@ -8,9 +8,8 @@ import {
 	TYPE_BUSINESS,
 	WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS,
 } from '@automattic/calypso-products';
-import { useLocale } from '@automattic/i18n-utils';
-import { useI18n } from '@wordpress/react-i18n';
-import { useTranslate } from 'i18n-calypso';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
+import i18n, { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import getPlansForFeature from 'calypso/state/selectors/get-plans-for-feature';
@@ -51,13 +50,11 @@ const UpgradeNudge = ( { siteSlug, paidPlugins } ) => {
 	);
 
 	const pluginsPlansPageFlag = isEnabled( 'plugins-plans-page' );
+	const isEnglishLocale = useIsEnglishLocale();
 
 	const pluginsPlansPage = `/plugins/plans/yearly/${ selectedSite?.slug }`;
 
 	const translate = useTranslate();
-	const { hasTranslation } = useI18n();
-	const locale = useLocale();
-
 	if (
 		jetpackNonAtomic ||
 		! selectedSite?.ID ||
@@ -128,24 +125,31 @@ const UpgradeNudge = ( { siteSlug, paidPlugins } ) => {
 		);
 	}
 
-	let title = translate( 'You need to upgrade your plan to install plugins.' );
-	if (
-		'en' === locale ||
-		hasTranslation(
-			'You need to upgrade to a Business Plan to install plugins. Get a free domain with an annual plan.'
+	const title =
+		isEnglishLocale ||
+		i18n.hasTranslation(
+			'You need to upgrade to a %(businessPlanName)s Plan to install plugins. Get a free domain with an annual plan.'
 		)
-	) {
-		title = translate(
-			'You need to upgrade to a Business Plan to install plugins. Get a free domain with an annual plan.'
-		);
-	}
+			? translate(
+					'You need to upgrade to a %(businessPlanName)s Plan to install plugins. Get a free domain with an annual plan.',
+					{ args: { businessPlanName: getPlan( plan )?.getTitle() } }
+			  )
+			: translate(
+					'You need to upgrade to a Business Plan to install plugins. Get a free domain with an annual plan.'
+			  );
 
 	// This banner upsells the ability to install free and paid plugins on a Business plan.
 	return (
 		<UpsellNudge
 			event="calypso_plugins_browser_upgrade_nudge"
 			className="plugins-discovery-page__upsell"
-			callToAction={ translate( 'Upgrade to Business' ) }
+			callToAction={
+				isEnglishLocale || i18n.hasTranslation( 'Upgrade to %(planName)s' )
+					? translate( 'Upgrade to %(planName)s', {
+							args: { planName: getPlan( plan )?.getTitle() },
+					  } )
+					: translate( 'Upgrade to Business' )
+			}
 			icon="notice-outline"
 			showIcon={ true }
 			href={ pluginsPlansPageFlag ? pluginsPlansPage : `/checkout/${ siteSlug }/business` }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #85139

## Proposed Changes

This replaces the hardcoded plan names in multiple places so that they point to the real values. This will be needed for any upcoming plan name experiments (ex. pcNC1U-WN-p2)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow instructions from D130166-code to get assigned the experiment
* The plan mentions should show the updated plan names.

<img width="240" alt="Screenshot 2023-12-14 at 13 11 31" src="https://github.com/Automattic/wp-calypso/assets/2749938/2d22ba39-d723-48b9-bdbf-99f69e4bb080">
<img width="240" alt="Screenshot 2023-12-14 at 13 01 31" src="https://github.com/Automattic/wp-calypso/assets/2749938/6d4c6dc5-f1a1-4ac2-9469-4a48ca1bb0f1">
<img width="240" alt="Screenshot 2023-12-14 at 12 31 49" src="https://github.com/Automattic/wp-calypso/assets/2749938/db120ab2-e701-45f5-8f50-4d759cdc53f0">
<img width="240" alt="Screenshot 2023-12-14 at 12 28 39" src="https://github.com/Automattic/wp-calypso/assets/2749938/124f096f-5635-4379-97e0-6718ffb83845">
<img width="240" alt="Screenshot 2023-12-14 at 12 24 20" src="https://github.com/Automattic/wp-calypso/assets/2749938/aa806aee-3f8b-4373-834b-524f658de7f1">
<img width="240" alt="Screenshot 2023-12-14 at 12 18 30" src="https://github.com/Automattic/wp-calypso/assets/2749938/ade0a0e5-2e28-42ad-9f1b-d0a20758d967">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
