### PR TITLE
Jetpack Manage: Redirect user to the correct support page when clicking the Learn more button.

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/pricing-summary.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/pricing-summary.tsx
@@ -35,6 +35,9 @@ export default function PricingSummary( {
 		submitForm( selectedLicenses );
 	}, [ isFormReady, selectedLicenses, submitForm ] );
 
+	const learnMoreLink =
+		'https://jetpack.com/support/jetpack-manage-instructions/jetpack-manage-billing-payment-faqs';
+
 	const currency = selectedLicenses[ 0 ].currency; // FIXME: Fix if multiple currencies are supported
 
 	return (
@@ -59,7 +62,12 @@ export default function PricingSummary( {
 			</Button>
 			<div className="review-licenses__notice">
 				{ translate(
-					'You will be billed at the end of every month. Your first month may be less than the above amount.'
+					'You will be billed at the end of every month. Your first month may be less than the above amount. {{a}}Learn more{{/a}}',
+					{
+						components: {
+							a: <a href={ learnMoreLink } target="_blank" rel="noopener noreferrer" />,
+						},
+					}
 				) }
 			</div>
 			<PricingBreakdown userProducts={ userProducts } selectedLicenses={ selectedLicenses } />

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/pricing-summary.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/pricing-summary.tsx
@@ -35,8 +35,6 @@ export default function PricingSummary( {
 		submitForm( selectedLicenses );
 	}, [ isFormReady, selectedLicenses, submitForm ] );
 
-	const link = '#link'; // TODO: Add link
-
 	const currency = selectedLicenses[ 0 ].currency; // FIXME: Fix if multiple currencies are supported
 
 	return (
@@ -61,12 +59,7 @@ export default function PricingSummary( {
 			</Button>
 			<div className="review-licenses__notice">
 				{ translate(
-					'You will be billed at the end of every month. Your first month may be less than the above amount. {{a}}Learn more{{/a}}',
-					{
-						components: {
-							a: <a href={ link } target="_blank" rel="noopener noreferrer" />,
-						},
-					}
+					'You will be billed at the end of every month. Your first month may be less than the above amount.'
 				) }
 			</div>
 			<PricingBreakdown userProducts={ userProducts } selectedLicenses={ selectedLicenses } />


### PR DESCRIPTION
This pull request aims to update the 'Learn more' button by redirecting it to https://jetpack.com/support/jetpack-manage-instructions/jetpack-manage-billing-payment-faqs.

<img width="430" alt="Screen Shot 2023-12-14 at 6 36 15 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/f60c023d-11e0-4035-869e-733e182b9834">

Closes https://github.com/Automattic/jetpack-genesis/issues/147

## Proposed Changes

* Remove the **'learn more'** link from the review licenses modal since we don't have a good place to redirect users yet.

## Testing Instructions
Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

* Use the Jetpack Cloud live link and go to the Issue License page (`/partner-portal/issue-license`)
* Select some products and Click the Review Licenses button.
* In the review licenses modal, click the **Issue licenses** button.
* Confirm that you are redirect to https://jetpack.com/support/jetpack-manage-instructions/jetpack-manage-billing-payment-faqs


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?