### PR TITLE
Assembler First Flow: Do not use the theme headstart

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -156,7 +156,10 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, da
 	const urlQueryParams = useQuery();
 	const sourceSiteSlug = urlQueryParams.get( 'from' ) || '';
 	const { data: sourceMigrationStatus } = useSourceMigrationStatusQuery( sourceSiteSlug );
-	const useThemeHeadstart = ! isStartWritingFlow( flow ) && ! isNewHostedSiteCreationFlow( flow );
+	const useThemeHeadstart =
+		! isStartWritingFlow( flow ) &&
+		! isNewHostedSiteCreationFlow( flow ) &&
+		! isSiteAssemblerFlow( flow );
 
 	async function createSite() {
 		if ( isManageSiteFlow ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sites-checker/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sites-checker/index.tsx
@@ -1,5 +1,6 @@
 import { SiteDetails } from '@automattic/data-stores';
 import { StepContainer, isBlogOnboardingFlow, isSiteAssemblerFlow } from '@automattic/onboarding';
+import { useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -9,6 +10,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector } from 'calypso/state';
 import getSites from 'calypso/state/selectors/get-sites';
 import { hasAllSitesList } from 'calypso/state/sites/selectors';
+import { ONBOARD_STORE } from '../../../../stores';
 import type { Step } from '../../types';
 
 import './styles.scss';
@@ -18,6 +20,11 @@ const SitesChecker: Step = function SitePicker( { navigation, flow } ) {
 	const { submit } = navigation;
 	const hasAllSitesFetched = useSelector( ( state ) => hasAllSitesList( state ) );
 	const allSites = useSelector( ( state ) => getSites( state ) );
+	const { resetOnboardStore } = useDispatch( ONBOARD_STORE );
+
+	useEffect( () => {
+		resetOnboardStore();
+	}, [] );
 
 	useEffect( () => {
 		if ( hasAllSitesFetched ) {
@@ -30,7 +37,7 @@ const SitesChecker: Step = function SitePicker( { navigation, flow } ) {
 			submit?.( { filteredSitesCount: filteredSites.length } );
 			return;
 		}
-	} );
+	}, [ hasAllSitesFetched, allSites ] );
 
 	return (
 		<>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pekYwv-3vI-p2#comment-2714

## Proposed Changes

* Fix the duplicate “About” pages when you go through the assembler-first flow to create a new site because we use the headstart annotation.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /setup/assembler-first
* Create a new site
* Finish the Assembler screen
* On the Site Editor, make sure there is only 1 “About” page on the navigation

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?