### PR TITLE
Assembler: support for `wp_block` patterns on Assembler v2 (Calypso only)

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-dotcom-patterns.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-dotcom-patterns.ts
@@ -19,6 +19,7 @@ const useDotcomPatterns = (
 					isEnabled( 'pattern-assembler/v2' )
 						? {
 								site: getPatternSourceSiteID(),
+								post_type: 'wp_block',
 						  }
 						: {
 								tags:
@@ -26,6 +27,7 @@ const useDotcomPatterns = (
 									// There are more pages tagged with assembler_page that still aren't offered in Assembler.
 									'assembler,assembler_priority',
 								categories: PATTERN_CATEGORIES.join( ',' ),
+								post_type: 'post',
 						  }
 				).toString(),
 			} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/84977

## Proposed Changes

* Assembler v2 with support for `wp_block` patterns

> [!NOTE]
> It's still pending to fetch pages as `wp_block` patterns. That can be done using the category `pages` and hiding that category from the list of section patterns. cc: @fushar 

https://github.com/Automattic/wp-calypso/assets/1881481/ea925fd1-9881-4c26-a719-87dfe6c47b1f

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox the site and public api
* Apply the patch in D132003-code
* Access the assembler `/setup/with-theme-assembler/patternAssembler?siteSlug={ SITE }`
* Verify you see `wp_block` patterns from assemblerv2patterns.wordpress.com and you can choose them as expected
* Verify that the request to `/rest/v1.1/ptk/patterns/en` includes the param `post_type: block` and returns patterns with `post_type: wp_block`

<img width="1185" alt="Screenshot 2566-12-14 at 17 57 52" src="https://github.com/Automattic/wp-calypso/assets/1881481/73c573ef-e313-4eea-a816-b2aa725f27f7">

To test that production still works as expected, we have to test locally on http://calypso.localhost:3000 without passing the flag `pattern-assembler/v2`.


https://github.com/Automattic/wp-calypso/assets/1881481/1236995e-76f1-4ef0-a97d-2ced773f4db0



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?