### PR TITLE
Multi-Domain: No busy state with api call debounce

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -105,7 +105,7 @@ class DomainRegistrationSuggestion extends Component {
 		}
 	}
 
-	onButtonClick = () => {
+	onButtonClick = ( previousState ) => {
 		const { suggestion, railcarId, uiPosition } = this.props;
 
 		if ( this.isUnavailableDomain( suggestion.domain_name ) ) {
@@ -119,7 +119,7 @@ class DomainRegistrationSuggestion extends Component {
 			} );
 		}
 
-		this.props.onButtonClick( suggestion, uiPosition );
+		this.props.onButtonClick( suggestion, uiPosition, previousState );
 	};
 
 	isUnavailableDomain = ( domain ) => {
@@ -152,7 +152,8 @@ class DomainRegistrationSuggestion extends Component {
 		// If we're removing this domain, let's instantly show that for the user
 		if (
 			domainRemovalQueue?.length > 0 &&
-			domainRemovalQueue.some( ( item ) => item.meta === domain )
+			domainRemovalQueue.some( ( item ) => item.meta === domain ) &&
+			! ( temporaryCart && temporaryCart.some( ( item ) => item.meta === domain ) )
 		) {
 			isAdded = false;
 		}
@@ -211,19 +212,13 @@ class DomainRegistrationSuggestion extends Component {
 		}
 
 		if ( shouldUseMultipleDomainsInCart( flowName ) ) {
-			const isDomainAtRemovalQueue = domainRemovalQueue?.some( ( item ) => item.meta === domain );
-			const isDomainAtAddingQueue = temporaryCart?.some( ( item ) => item.meta === domain );
-
-			if ( isDomainAtRemovalQueue || isDomainAtAddingQueue ) {
-				buttonStyles = { ...buttonStyles, primary: false, busy: true, disabled: true };
-			} else {
-				buttonStyles = { ...buttonStyles, primary: false, busy: false, disabled: false };
-			}
+			buttonStyles = { ...buttonStyles, primary: false, busy: false, disabled: false };
 		}
 
 		return {
 			buttonContent,
 			buttonStyles,
+			isAdded,
 		};
 	}
 

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -174,7 +174,7 @@ class DomainRegistrationSuggestion extends Component {
 
 				buttonContent = translate( '{{checkmark/}} Selected', {
 					context: 'Domain is already added to shopping cart',
-					components: { checkmark: <Gridicon icon="checkmark" /> },
+					components: { checkmark: <Gridicon style={ { height: 21 } } icon="checkmark" /> },
 				} );
 			}
 		} else {

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -19,6 +19,7 @@ class DomainSuggestion extends Component {
 		domain: PropTypes.string,
 		hidePrice: PropTypes.bool,
 		showChevron: PropTypes.bool,
+		isAdded: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -82,7 +83,9 @@ class DomainSuggestion extends Component {
 		return (
 			<div
 				className={ classes }
-				onClick={ this.props.onButtonClick }
+				onClick={ () => {
+					this.props.onButtonClick( isAdded );
+				} }
 				data-tracks-button-click-source={ this.props.tracksButtonClickSource }
 				role="button"
 				data-e2e-domain={ this.props.domain }

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -226,6 +226,7 @@
 .domain-suggestion__action-container {
 	flex: 0 0 auto;
 	width: 100%;
+	height: 40px;
 
 	@include break-mobile {
 		width: auto;
@@ -243,11 +244,16 @@
 .button.domain-suggestion__action {
 	width: 100%;
 	height: 40px;
-	min-width: 66px;
+	min-width: 120px;
 	text-align: center;
-	margin-top: 16px;
 	padding: 0.25em 3em;
-	transition: all 0.1s linear;
+	transition: all 0.1s ease-in-out;
+	margin-top: 10px;
+
+	&:focus {
+		box-shadow: none !important;
+		border-color: #c3c4c7 !important;
+	}
 
 	@include break-mobile {
 		width: auto;
@@ -268,9 +274,14 @@
 
 	&.is-borderless {
 		color: var(--color-primary);
-		margin-top: 0;
 		padding: 0;
+
+		&:focus {
+			box-shadow: none !important;
+			border-color: transparent !important;
+		}
 	}
+
 }
 
 .domain-suggestion__chevron {

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -260,6 +260,7 @@ class RegisterDomainStep extends Component {
 			trademarkClaimsNoticeInfo: null,
 			selectedSuggestion: null,
 			isInitialQueryActive: !! props.suggestion,
+			checkAvailabilityTimeout: null,
 		};
 	}
 
@@ -1477,35 +1478,39 @@ class RegisterDomainStep extends Component {
 		if ( ! hasDomainInCart( this.props.cart, domain ) && ! isSubDomainSuggestion ) {
 			// For Multi-domain flows, add the domain first, than check availability
 			if ( shouldUseMultipleDomainsInCart( this.props.flowName ) ) {
-				await this.props.onAddDomain( suggestion, position, previousState );
+				this.props.onAddDomain( suggestion, position, previousState );
 			}
 
-			this.preCheckDomainAvailability( domain )
-				.catch( () => [] )
-				.then( ( { status, trademarkClaimsNoticeInfo } ) => {
-					this.setState( { pendingCheckSuggestion: null } );
-					this.props.recordDomainAddAvailabilityPreCheck(
-						domain,
-						status,
-						this.props.analyticsSection
-					);
-					if ( status && status !== domainAvailability.REGISTERED_OTHER_SITE_SAME_USER ) {
-						this.setState( { unavailableDomains: [ ...this.state.unavailableDomains, domain ] } );
-						this.showAvailabilityErrorMessage( domain, status, {
-							availabilityPreCheck: true,
-						} );
-						this.props.onMappingError( domain, status );
-					} else if ( trademarkClaimsNoticeInfo ) {
-						this.setState( {
-							trademarkClaimsNoticeInfo: trademarkClaimsNoticeInfo,
-							selectedSuggestion: suggestion,
-							selectedSuggestionPosition: position,
-						} );
-						this.props.onMappingError( domain, status );
-					} else if ( ! shouldUseMultipleDomainsInCart( this.props.flowName ) ) {
-						this.props.onAddDomain( suggestion, position, previousState );
-					}
-				} );
+			// Avoid too much API calls for Multi-domains flow
+			clearTimeout( this.state.checkAvailabilityTimeout );
+			this.state.checkAvailabilityTimeout = setTimeout( () => {
+				this.preCheckDomainAvailability( domain )
+					.catch( () => [] )
+					.then( ( { status, trademarkClaimsNoticeInfo } ) => {
+						this.setState( { pendingCheckSuggestion: null } );
+						this.props.recordDomainAddAvailabilityPreCheck(
+							domain,
+							status,
+							this.props.analyticsSection
+						);
+						if ( status && status !== domainAvailability.REGISTERED_OTHER_SITE_SAME_USER ) {
+							this.setState( { unavailableDomains: [ ...this.state.unavailableDomains, domain ] } );
+							this.showAvailabilityErrorMessage( domain, status, {
+								availabilityPreCheck: true,
+							} );
+							this.props.onMappingError( domain, status );
+						} else if ( trademarkClaimsNoticeInfo ) {
+							this.setState( {
+								trademarkClaimsNoticeInfo: trademarkClaimsNoticeInfo,
+								selectedSuggestion: suggestion,
+								selectedSuggestionPosition: position,
+							} );
+							this.props.onMappingError( domain, status );
+						} else if ( ! shouldUseMultipleDomainsInCart( this.props.flowName ) ) {
+							this.props.onAddDomain( suggestion, position, previousState );
+						}
+					} );
+			}, 500 );
 		} else {
 			this.props.onAddDomain( suggestion, position, previousState );
 		}

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1457,7 +1457,7 @@ class RegisterDomainStep extends Component {
 		return <FreeDomainExplainer onSkip={ this.props.hideFreePlan } />;
 	}
 
-	onAddDomain = async ( suggestion, position ) => {
+	onAddDomain = async ( suggestion, position, previousState ) => {
 		const domain = get( suggestion, 'domain_name' );
 		const { premiumDomains } = this.state;
 
@@ -1477,7 +1477,7 @@ class RegisterDomainStep extends Component {
 		if ( ! hasDomainInCart( this.props.cart, domain ) && ! isSubDomainSuggestion ) {
 			// For Multi-domain flows, add the domain first, than check availability
 			if ( shouldUseMultipleDomainsInCart( this.props.flowName ) ) {
-				await this.props.onAddDomain( suggestion, position );
+				await this.props.onAddDomain( suggestion, position, previousState );
 			}
 
 			this.preCheckDomainAvailability( domain )
@@ -1503,11 +1503,11 @@ class RegisterDomainStep extends Component {
 						} );
 						this.props.onMappingError( domain, status );
 					} else if ( ! shouldUseMultipleDomainsInCart( this.props.flowName ) ) {
-						this.props.onAddDomain( suggestion, position );
+						this.props.onAddDomain( suggestion, position, previousState );
 					}
 				} );
 		} else {
-			this.props.onAddDomain( suggestion, position );
+			this.props.onAddDomain( suggestion, position, previousState );
 		}
 	};
 

--- a/client/signup/steps/domains/domains-mini-cart.jsx
+++ b/client/signup/steps/domains/domains-mini-cart.jsx
@@ -100,7 +100,7 @@ class DomainsMiniCart extends Component {
 
 		// Only deduct a removal domain if it's on removal queue and is at the temporarycart
 		// This avoids the case where a domain is removed from the temporarycart but is still on the removal queue
-		if ( this.props.temporaryCart.length > 0 && this.props.domainRemovalQueue.length > 0 ) {
+		if ( this.props.temporaryCart?.length > 0 && this.props.domainRemovalQueue?.length > 0 ) {
 			this.props.domainRemovalQueue.forEach( ( item ) => {
 				if ( this.props.temporaryCart.some( ( domain ) => domain.meta === item.meta ) ) {
 					result--;

--- a/client/signup/steps/domains/domains-mini-cart.jsx
+++ b/client/signup/steps/domains/domains-mini-cart.jsx
@@ -96,11 +96,19 @@ class DomainsMiniCart extends Component {
 	};
 
 	domainCount = () => {
-		return (
-			this.props.domainsInCart.length +
-			( this.props.wpcomSubdomainSelected ? 1 : 0 ) -
-			this.props.domainRemovalQueue.length
-		);
+		let result = this.props.domainsInCart.length + ( this.props.wpcomSubdomainSelected ? 1 : 0 );
+
+		// Only deduct a removal domain if it's on removal queue and is at the temporarycart
+		// This avoids the case where a domain is removed from the temporarycart but is still on the removal queue
+		if ( this.props.temporaryCart.length > 0 && this.props.domainRemovalQueue.length > 0 ) {
+			this.props.domainRemovalQueue.forEach( ( item ) => {
+				if ( this.props.temporaryCart.some( ( domain ) => domain.meta === item.meta ) ) {
+					result--;
+				}
+			} );
+		}
+
+		return result;
 	};
 
 	freeDomain = () => {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -642,6 +642,7 @@ export class RenderDomainsStep extends Component {
 			// Replace the products in the cart with the freshly sorted products.
 			clearTimeout( this.state.addDomainTimeout );
 
+			// Avoid too much API calls for Multi-domains flow
 			this.state.addDomainTimeout = setTimeout( async () => {
 				await this.props.shoppingCartManager.reloadFromServer();
 
@@ -740,6 +741,8 @@ export class RenderDomainsStep extends Component {
 
 		this.setState( { isCartPendingUpdateDomain: { domain_name: domain_name } } );
 		clearTimeout( this.state.removeDomainTimeout );
+
+		// Avoid too much API calls for Multi-domains flow
 		this.state.removeDomainTimeout = setTimeout( async () => {
 			await this.props.shoppingCartManager.reloadFromServer();
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -366,23 +366,13 @@ export class RenderDomainsStep extends Component {
 	};
 
 	handleDomainToDomainCart = async ( previousState ) => {
-		const { step } = this.props;
-
-		const { suggestion } = step;
-		const isPurchasingItem = suggestion && Boolean( suggestion.product_slug );
-		const siteUrl =
-			suggestion &&
-			( isPurchasingItem
-				? suggestion.domain_name
-				: suggestion.domain_name.replace( '.wordpress.com', '' ) );
+		const { suggestion } = this.props.step;
 
 		if ( previousState ) {
 			this.removeDomain( suggestion );
 		} else {
 			await this.addDomain( suggestion );
 			this.props.setDesignType( this.getDesignType() );
-			// Start the username suggestion process.
-			siteUrl && this.props.fetchUsernameSuggestion( siteUrl.split( '.' )[ 0 ] );
 		}
 	};
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -731,13 +731,16 @@ export class RenderDomainsStep extends Component {
 			} ) );
 		}
 
-		this.setState( ( prevState ) => ( {
-			isMiniCartContinueButtonBusy: true,
-			domainRemovalQueue: [
-				...prevState.domainRemovalQueue,
-				{ meta: domain_name, productSlug: product_slug },
-			],
-		} ) );
+		// check if the domain is alreay in the domainRemovalQueue queue
+		if ( ! this.state.domainRemovalQueue.find( ( domain ) => domain.meta === domain_name ) ) {
+			this.setState( ( prevState ) => ( {
+				isMiniCartContinueButtonBusy: true,
+				domainRemovalQueue: [
+					...prevState.domainRemovalQueue,
+					{ meta: domain_name, productSlug: product_slug },
+				],
+			} ) );
+		}
 
 		this.setState( { isCartPendingUpdateDomain: { domain_name: domain_name } } );
 		clearTimeout( this.state.removeDomainTimeout );
@@ -916,6 +919,7 @@ export class RenderDomainsStep extends Component {
 				{ domainsInCart.length > 0 || this.state.wpcomSubdomainSelected ? (
 					<DomainsMiniCart
 						domainsInCart={ domainsInCart }
+						temporaryCart={ this.state.temporaryCart }
 						domainRemovalQueue={ this.state.domainRemovalQueue }
 						cartIsLoading={ cartIsLoading }
 						flowName={ this.props.flowName }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Follow-up of https://github.com/Automattic/wp-calypso/pull/85152
Related to 4847-gh-Automattic/dotcom-forge
Slack context: p1702324186992199-slack-CKZHG0QCR

## Proposed Changes

* No busy state on domain buttons
* Busy state on Continue button
* Reduced API calls
* No issue with race conditions
* “Selected” is aligned properly
* Mini-cart domains count is working as expected even with multiple Add domain clicks

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


https://github.com/Automattic/wp-calypso/assets/1044309/4a9aa4b4-b01a-45f9-8900-4ed16190d57b



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?