### PR TITLE
Domain suggestions: don't break TLD in the middle

### DIFF
--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -223,7 +223,7 @@
 }
 
 .domain-registration-suggestion__domain-title-tld {
-	word-break: break-word;
+	word-break: normal;
 }
 
 .domain-suggestion__price-container,

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -222,6 +222,10 @@
 	}
 }
 
+.domain-registration-suggestion__domain-title-tld {
+	word-break: break-word;
+}
+
 .domain-suggestion__price-container,
 .domain-suggestion__action-container {
 	flex: 0 0 auto;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Avoids breaking the TLD in the middle, allowing it to flow to next line.

Before:

<img width="517" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/c8ab4a49-0a7a-4e0c-accb-760e7dc5d44d">

After:

<img width="522" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/19c39fb3-fd9e-4f02-a0b5-0a3fae178b61">

Also applies to `.wordpress.com` TLD:

Before:

<img width="345" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/93dd5122-d4b5-44c8-ab20-75b980b9e653">

After:

<img width="310" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/edb340bb-c7fc-4671-b05e-1fc9580e6451">


## Proposed Changes

* Applies `word-break: break-word;` to the TLD, letting rest of the domain be `word-break: break-all;`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
