### PR TITLE
WP Import content flow: Fix the author mapping issue

### DIFF
--- a/client/my-sites/importer/author-mapping-item.jsx
+++ b/client/my-sites/importer/author-mapping-item.jsx
@@ -40,7 +40,10 @@ class ImporterAuthorMapping extends PureComponent {
 	}
 
 	componentDidUpdate( prevProps ) {
-		if ( ! prevProps.users.length && this.props.users.length ) {
+		if (
+			prevProps.hasSingleAuthor !== this.props.hasSingleAuthor ||
+			( ! prevProps.users.length && this.props.users.length )
+		) {
 			this.setAuthor();
 		}
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/85238

## Proposed Changes

* Fixed issue with redirecting to the author mapping screen twice before the content import starts.

## Testing Instructions

It used to happen to the sites that have yet to fetch the users. To reproduce, clear the browser's IndexDB right before uploading a file.

* Go to `/setup/import-focused?siteSlug={SITE_SLUG}`
* Click on "choose a content platform"
* Select WordPress platform
* Upload file
* Check if you see the Author mapping screen once
* Start the import
* Check if there is Hooray screen

<img width="865" alt="Screenshot 2023-12-14 at 16 38 03" src="https://github.com/Automattic/wp-calypso/assets/1241413/510eb4d4-0592-47b9-aa6c-9268e3254b6b">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?