### PR TITLE
Marketplace: adds review delete action

### DIFF
--- a/client/data/marketplace/use-marketplace-reviews.ts
+++ b/client/data/marketplace/use-marketplace-reviews.ts
@@ -37,7 +37,7 @@ type UpdateMarketplaceReviewProps = {
 
 type DeleteMarketplaceReviewProps = {
 	reviewId: number;
-} & ProductProps;
+};
 
 export type MarketplaceReviewResponse = {
 	id: number;

--- a/client/my-sites/marketplace/components/reviews-list/index.tsx
+++ b/client/my-sites/marketplace/components/reviews-list/index.tsx
@@ -2,22 +2,38 @@ import { isEnabled } from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import moment from 'moment';
 import { LegacyRef, forwardRef } from 'react';
+import { useSelector } from 'react-redux';
 import Rating from 'calypso/components/rating';
 import {
 	useMarketplaceReviewsQuery,
 	MarketplaceReviewResponse,
 	MarketplaceReviewsQueryProps,
+	useDeleteMarketplaceReviewMutation,
 } from 'calypso/data/marketplace/use-marketplace-reviews';
 import './style.scss';
 import { sanitizeSectionContent } from 'calypso/lib/plugins/sanitize-section-content';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { IAppState } from 'calypso/state/types';
 
 export const MarketplaceReviewsList = forwardRef<
 	HTMLDivElement,
 	MarketplaceReviewsQueryProps & { innerRef: LegacyRef< HTMLDivElement > }
 >( ( props, ref ) => {
 	const translate = useTranslate();
-	const { data: reviews } = useMarketplaceReviewsQuery( props );
+	const { data: reviews, refetch: reviewsRefetch } = useMarketplaceReviewsQuery( props );
 
+	// ...
+	const currentUserId = useSelector( ( state: IAppState ) => getCurrentUserId( state ) );
+	const deleteReviewMutation = useDeleteMarketplaceReviewMutation();
+	const deleteReview = ( reviewId: number ) => {
+		if ( confirm( translate( 'Are you sure you want to delete your review?' ) ) ) {
+			deleteReviewMutation.mutate( {
+				reviewId: reviewId,
+			} );
+			deleteReviewMutation?.isSuccess && reviewsRefetch();
+			deleteReviewMutation?.isError && alert( ( deleteReviewMutation.error as Error ).message );
+		}
+	};
 	// TODO: Get the proper value as a URL to the profile picture
 	const authorProfilePic = null;
 
@@ -90,6 +106,24 @@ export const MarketplaceReviewsList = forwardRef<
 								} }
 								className="marketplace-reviews-list__content"
 							></div>
+							<div className="marketplace-reviews-list__review-actions">
+								{ review.author === currentUserId && (
+									<div className="marketplace-reviews-list__review-actions-editable">
+										<button
+											className="marketplace-reviews-list__review-actions-editable-button"
+											onClick={ () => alert( 'Not implemented yet' ) }
+										>
+											{ translate( 'Update my review' ) }
+										</button>
+										<button
+											className="marketplace-reviews-list__review-actions-editable-button"
+											onClick={ () => deleteReview( review.id ) }
+										>
+											{ translate( 'Delete my review' ) }
+										</button>
+									</div>
+								) }
+							</div>
 						</div>
 					) ) }
 			</div>

--- a/client/my-sites/marketplace/components/reviews-list/style.scss
+++ b/client/my-sites/marketplace/components/reviews-list/style.scss
@@ -94,6 +94,24 @@ $border-color: #eee;
 	}
 }
 
+.marketplace-reviews-list__review-actions {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: space-between;
+	margin-top: 15px;
+	font-size: $font-body-small;
+
+	.marketplace-reviews-list__review-actions-editable {
+		display: flex;
+
+		.marketplace-reviews-list__review-actions-editable-button {
+			color: var(--studio-blue-50);
+			margin-right: 15px;
+			cursor: pointer;
+		}
+	}
+}
+
 .marketplace-reviews-list__no-reviews,
 .marketplace-reviews-list__customer-reviews {
 	margin-top: 10px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/3922

## Proposed Changes

* Adds the delete functionality in reviews
* Needs some styling related to the icon and the popup messages

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


* Leave a comment for woocommerce-bookings through `/marketplace/test/[siteId]`
* Go to `/plugins/woocommerce-bookings/[siteId]`
* Scroll down to your comment, make sure that both Update and Delete buttons are visible ONLY for your comment
* Click delete - your comment should get removed 
* Update is not implemented yet

![CleanShot 2023-12-14 at 17 52 29@2x](https://github.com/Automattic/wp-calypso/assets/12430020/ac35e0f3-98a6-49a5-9a54-555d285e7a7d)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?