### PR TITLE
Checkout: Fix billing Information errors for logged out users of $0 carts

### DIFF
--- a/client/my-sites/checkout/src/lib/get-contact-details-type.ts
+++ b/client/my-sites/checkout/src/lib/get-contact-details-type.ts
@@ -1,10 +1,8 @@
 import {
-	isAkismetProduct,
 	isGoogleWorkspaceExtraLicence,
 	isGoogleWorkspaceProductSlug,
 	isGSuiteProductSlug,
 } from '@automattic/calypso-products';
-import { doesPurchaseHaveFullCredits } from '@automattic/wpcom-checkout';
 import {
 	hasDomainRegistration,
 	hasTransferProduct,
@@ -36,17 +34,6 @@ export default function getContactDetailsType( responseCart: ResponseCart ): Con
 
 	if ( hasNewGSuite && ! hasOnlyRenewals ) {
 		return 'gsuite';
-	}
-
-	const isPurchaseFree = responseCart.total_cost_integer === 0;
-	const isFullCredits = doesPurchaseHaveFullCredits( responseCart );
-	const isAkismetPurchase = responseCart.products.some( ( product ) => {
-		return isAkismetProduct( product );
-	} );
-
-	// Akismet free purchases still need contact information if logged out
-	if ( isPurchaseFree && ! isAkismetPurchase && ! isFullCredits ) {
-		return 'none';
 	}
 
 	return 'tax';

--- a/client/my-sites/checkout/src/lib/get-contact-details-type.ts
+++ b/client/my-sites/checkout/src/lib/get-contact-details-type.ts
@@ -3,13 +3,13 @@ import {
 	isGoogleWorkspaceProductSlug,
 	isGSuiteProductSlug,
 } from '@automattic/calypso-products';
+import { doesPurchaseHaveFullCredits, type ContactDetailsType } from '@automattic/wpcom-checkout';
 import {
 	hasDomainRegistration,
 	hasTransferProduct,
 	hasOnlyRenewalItems,
 } from 'calypso/lib/cart-values/cart-items';
 import type { ResponseCart } from '@automattic/shopping-cart';
-import type { ContactDetailsType } from '@automattic/wpcom-checkout';
 
 export default function getContactDetailsType( responseCart: ResponseCart ): ContactDetailsType {
 	const hasDomainProduct =
@@ -34,6 +34,27 @@ export default function getContactDetailsType( responseCart: ResponseCart ): Con
 
 	if ( hasNewGSuite && ! hasOnlyRenewals ) {
 		return 'gsuite';
+	}
+
+	const isPurchaseFree = responseCart.total_cost_integer === 0;
+	const isFullCredits = doesPurchaseHaveFullCredits( responseCart );
+	const doesCartContainOnlyOneTimePurchases = responseCart.products.every(
+		( product ) => product.is_one_time_purchase
+	);
+	const isCartForSite = responseCart.cart_key !== 'no-user' && responseCart.cart_key !== 'no-site';
+
+	// Hide contact step entirely for free purchases (that are not free because
+	// of credits) for carts that contain only one-time purchases. In that
+	// situation, there's no need to collect tax information since we will not
+	// be charging the user now or ever. However, we must still show the
+	// contact step for logged-out carts because in those cases we need to
+	// collect an email address that is part of the tax form.
+	//
+	// The backend has similar conditions which hide the credit card payment
+	// method (for which we need tax info from the contact step) if the cart
+	// has only one-time purchases.
+	if ( isPurchaseFree && doesCartContainOnlyOneTimePurchases && ! isFullCredits && isCartForSite ) {
+		return 'none';
 	}
 
 	return 'tax';

--- a/client/my-sites/checkout/src/test/checkout-contact-step.tsx
+++ b/client/my-sites/checkout/src/test/checkout-contact-step.tsx
@@ -24,9 +24,10 @@ import {
 	mockGetPaymentMethodsEndpoint,
 	mockLogStashEndpoint,
 	mockGetSupportedCountriesEndpoint,
+	oneTimePurchase,
 } from './util';
 import { MockCheckout } from './util/mock-checkout';
-import type { CartKey } from '@automattic/shopping-cart';
+import type { CartKey, ResponseCart } from '@automattic/shopping-cart';
 
 jest.mock( 'calypso/state/sites/selectors' );
 jest.mock( 'calypso/state/sites/domains/selectors' );
@@ -39,7 +40,8 @@ jest.mock( 'calypso/lib/navigate' );
 
 describe( 'Checkout contact step', () => {
 	const mainCartKey = 'foo.com' as CartKey;
-	const initialCart = getBasicCart();
+	const siteId = 123456;
+	const initialCart: ResponseCart = { ...getBasicCart(), cart_key: siteId };
 	const defaultPropsForMockCheckout = {
 		initialCart,
 	};
@@ -63,16 +65,30 @@ describe( 'Checkout contact step', () => {
 		mockGetSupportedCountriesEndpoint( countryList );
 	} );
 
-	it( 'does not render the contact step when the purchase is free', async () => {
+	it( 'does render the contact step when the purchase is free and some items are recurring', async () => {
 		const cartChanges = { total_cost_integer: 0, total_cost_display: '0' };
+		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
+		expect( await screen.findByText( /Enter your (billing|contact) information/ ) ).toBeVisible();
+	} );
+
+	it( 'does not render the contact step when the purchase is free and all items are one-time purchases', async () => {
+		const cartChanges = {
+			total_cost_integer: 0,
+			total_cost_display: '0',
+			products: [ oneTimePurchase ],
+		};
 		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
 		await expect( screen.findByText( /Enter your (billing|contact) information/ ) ).toNeverAppear();
 	} );
 
-	it( 'renders the step after the contact step as active if the purchase is free', async () => {
-		const cartChanges = { total_cost_integer: 0, total_cost_display: '0' };
+	it( 'renders the step after the contact step as active if the purchase is free and all items are one-time purchases', async () => {
+		const cartChanges = {
+			total_cost_integer: 0,
+			total_cost_display: '0',
+			products: [ oneTimePurchase ],
+		};
 		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
-		expect( await screen.findByText( 'Assign a payment method later' ) ).toBeVisible();
+		expect( await screen.findByText( 'Free Purchase' ) ).toBeVisible();
 	} );
 
 	it( 'renders the contact step when the purchase is not free', async () => {

--- a/client/my-sites/checkout/src/test/util/index.ts
+++ b/client/my-sites/checkout/src/test/util/index.ts
@@ -246,6 +246,24 @@ export const planWithBundledDomain: ResponseCartProduct = {
 	months_per_bill_period: 12,
 };
 
+export const oneTimePurchase: ResponseCartProduct = {
+	...getEmptyResponseCartProduct(),
+	product_name: 'Premium Theme',
+	product_slug: 'premium_theme',
+	currency: 'BRL',
+	extra: {
+		context: 'signup',
+	},
+	meta: '',
+	is_one_time_purchase: true,
+	product_id: 1009,
+	volume: 1,
+	item_original_cost_integer: 14400,
+	item_subtotal_integer: 14400,
+	bill_period: '365',
+	months_per_bill_period: 12,
+};
+
 export const planWithoutDomain: ResponseCartProduct = {
 	...getEmptyResponseCartProduct(),
 	product_name: 'WordPress.com Personal',
@@ -1468,6 +1486,7 @@ export function getPlansItemsState(): PricedAPIPlan[] {
 			product_type: 'bundle',
 			raw_price: 48,
 			raw_price_integer: 4800,
+			orig_cost_integer: 4800,
 		},
 		{
 			product_id: planWithoutDomainMonthly.product_id,
@@ -1479,6 +1498,7 @@ export function getPlansItemsState(): PricedAPIPlan[] {
 			product_type: 'bundle',
 			raw_price: 7,
 			raw_price_integer: 700,
+			orig_cost_integer: 700,
 		},
 		{
 			product_id: planWithoutDomainBiannual.product_id,
@@ -1490,6 +1510,7 @@ export function getPlansItemsState(): PricedAPIPlan[] {
 			product_type: 'bundle',
 			raw_price: 84,
 			raw_price_integer: 8400,
+			orig_cost_integer: 8400,
 		},
 		{
 			product_id: planLevel2.product_id,
@@ -1501,6 +1522,7 @@ export function getPlansItemsState(): PricedAPIPlan[] {
 			product_type: 'bundle',
 			raw_price: 300,
 			raw_price_integer: 30000,
+			orig_cost_integer: 30000,
 		},
 		{
 			product_id: planLevel2Monthly.product_id,
@@ -1512,6 +1534,7 @@ export function getPlansItemsState(): PricedAPIPlan[] {
 			product_type: 'bundle',
 			raw_price: 33,
 			raw_price_integer: 3300,
+			orig_cost_integer: 3300,
 		},
 		{
 			product_id: planLevel2Biannual.product_id,
@@ -1523,6 +1546,7 @@ export function getPlansItemsState(): PricedAPIPlan[] {
 			product_type: 'bundle',
 			raw_price: 499,
 			raw_price_integer: 49900,
+			orig_cost_integer: 49900,
 		},
 		{
 			product_id: jetpackMonthly.product_id,
@@ -1534,6 +1558,7 @@ export function getPlansItemsState(): PricedAPIPlan[] {
 			product_type: 'product',
 			raw_price: 14.95,
 			raw_price_integer: 1495,
+			orig_cost_integer: 1495,
 		},
 		{
 			product_id: jetpackYearly.product_id,
@@ -1545,6 +1570,7 @@ export function getPlansItemsState(): PricedAPIPlan[] {
 			product_type: 'product',
 			raw_price: 119.4,
 			raw_price_integer: 11940,
+			orig_cost_integer: 11940,
 		},
 		{
 			product_id: jetpackBiannual.product_id,
@@ -1556,6 +1582,7 @@ export function getPlansItemsState(): PricedAPIPlan[] {
 			product_type: 'product',
 			raw_price: 238.8,
 			raw_price_integer: 23880,
+			orig_cost_integer: 23880,
 		},
 	];
 }


### PR DESCRIPTION
## Proposed Changes

Context: @madebynoam reported an issue with WordPress.com Checkout for logged-out Jetpack users. 

If the cart was set to a $0 amount, the `checkout-contact-form-step` is hidden. If a user had not already entered an email address, this creates an error when they submit the cart.

Video available in p1702561723370259-slack-payments-shilling

After investigating with @michaeldcain, we found a block of code responsible for rendering the contact form step returns `none` if the cart meets these three requirements: `isPurchaseFree && ! isAkismetPurchase && ! isFullCredits`

Since we now allow users to save a payment method even for free purchases, it doesn't seem to make sense to hide the Billing Information form under these conditions. 
 
This PR removes the code block holding the conditional `none` return if the user's cart key is `no-site` or `no-user` and the cart contains only one-time purchases which should have the effect that logged-out Jetpack users always see the tax form which contains the email field.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

** Reproduce the Checkout issue by following the original report:
* Visit [jetpack.com/pricing](http://jetpack.com/pricing) in Incognito (logged out of [WordPress.com](http://wordpress.com/))
* Click a Get on a product
* Insert a coupon code (it must be for 100%)
* Click Complete Checkout
* You get a blocking “Invalid email error” and are stuck
* Remove the coupon and see that the `Billing Information` section is added back into checkout

** Test this patch
* Visit [jetpack.com/pricing](http://jetpack.com/pricing) in Incognito (logged out of [WordPress.com](http://wordpress.com/))
* Click a Get on a product
* Insert a coupon code (it must be for 100%)
* See that the `Billing Information` section is still available and you can complete checkout

![Screenshot 2023-12-14 at 09 23 49](https://github.com/Automattic/wp-calypso/assets/12505355/c4862f89-a3d7-4806-b89f-e7a940514831)


** Other things to check
* That Checkout for Akismet and WordPress products are not affected. They should remain the same

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?