### PR TITLE
Marketplace Reviews: Add cursor pointer to reviews star component

### DIFF
--- a/client/components/reviews-rating-stars/reviews-ratings-stars.tsx
+++ b/client/components/reviews-rating-stars/reviews-ratings-stars.tsx
@@ -121,6 +121,7 @@ const ReviewsRatingsStars = ( props: ReviewsRatingsStarsProps ) => {
 									onMouseEnter: onStarMouseEnter,
 									onMouseLeave: onStarMouseLeave,
 									onClick: onSaveRating,
+									className: 'reviews-ratings-stars__star',
 									isInteractive: true,
 									tabIndex: 0,
 									ariaLabel: ratingStarsScreenReaderText as string,

--- a/client/components/reviews-rating-stars/star.tsx
+++ b/client/components/reviews-rating-stars/star.tsx
@@ -15,6 +15,7 @@ export type StarProps = {
 	size?: number;
 	title?: string;
 	onClick?: ( ( e: React.MouseEvent | React.KeyboardEvent, index: number ) => void ) | null;
+	className?: string;
 	onMouseEnter?: ( index: number ) => void;
 	onMouseLeave?: () => void;
 	tracksEvent?: string;
@@ -34,6 +35,7 @@ const Star = forwardRef< SVGSVGElement, StarProps >( ( props, ref ) => {
 		size = 24,
 		title,
 		onClick,
+		className,
 		onMouseEnter,
 		onMouseLeave,
 		tracksEvent,
@@ -44,6 +46,9 @@ const Star = forwardRef< SVGSVGElement, StarProps >( ( props, ref ) => {
 		tabIndex,
 		ariaHidden,
 	} = props;
+
+	const classes = [ 'wccom-star', className ];
+	classes.push( 'wccom-star__' + index );
 
 	function handleOnClick( e: React.MouseEvent | React.KeyboardEvent, i: number ) {
 		if ( ! isInteractive ) {
@@ -62,6 +67,7 @@ const Star = forwardRef< SVGSVGElement, StarProps >( ( props, ref ) => {
 	}
 
 	const svgProps: React.SVGProps< SVGSVGElement > = {
+		className: classes.join( ' ' ),
 		width: size,
 		height: size,
 		viewBox: '0 0 24 24',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Add cursor pointer to the review ratings star component
* This will be achieved using the existing CSS class in parent component and passing them as props as suggested by @WBerredo  in the following comment https://github.com/Automattic/wp-calypso/pull/84832#discussion_r1424505060

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In an environment with the `marketplace-add-review` flag enabled, e.g. wpcalypso
* Navigate to a theme and click on `Add Review`
* Make sure the reviews star component is looking as expected and the cursor changes to the CSS pointer cursor when selecting a star using the mouse

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?