### PR TITLE
[Odie] Add redirect flow in case of Wapuu in troubles

### DIFF
--- a/client/odie/index.tsx
+++ b/client/odie/index.tsx
@@ -1,3 +1,4 @@
+import i18n from 'i18n-calypso';
 import { forwardRef, WheelEvent, useCallback, useEffect, useRef, useState } from 'react';
 import { useInView } from 'react-intersection-observer';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
@@ -7,8 +8,10 @@ import { OdieSendMessageButton } from './send-message-input';
 
 import './style.scss';
 
-export const WAPUU_ERROR_MESSAGE =
-	"Wapuu oopsie! 😺 My bad, but even cool pets goof. Let's laugh it off! 🎉, ask me again as I forgot what you said!";
+export const WAPUU_ERROR_MESSAGE = i18n.translate(
+	"Wapuu oopsie! 😺 I'm in snooze mode and can't chat just now. Don't fret, just browse through the buttons below to connect with WordPress.com support. They're on the ball and ready to assist!",
+	{ comment: 'Error message when Wapuu fails to send a message' }
+);
 
 const ForwardedChatMessage = forwardRef( ChatMessage );
 

--- a/client/odie/index.tsx
+++ b/client/odie/index.tsx
@@ -9,7 +9,7 @@ import { OdieSendMessageButton } from './send-message-input';
 import './style.scss';
 
 export const WAPUU_ERROR_MESSAGE = i18n.translate(
-	"Wapuu oopsie! 😺 I'm in snooze mode and can't chat just now. Don't fret, just browse through the buttons below to connect with WordPress.com support. They're on the ball and ready to assist!",
+	"Wapuu oopsie! 😺 I'm in snooze mode and can't chat just now. Don't fret, just browse through the buttons below to connect with WordPress.com support.",
 	{ comment: 'Error message when Wapuu fails to send a message', textOnly: true }
 );
 

--- a/client/odie/index.tsx
+++ b/client/odie/index.tsx
@@ -10,7 +10,7 @@ import './style.scss';
 
 export const WAPUU_ERROR_MESSAGE = i18n.translate(
 	"Wapuu oopsie! 😺 I'm in snooze mode and can't chat just now. Don't fret, just browse through the buttons below to connect with WordPress.com support. They're on the ball and ready to assist!",
-	{ comment: 'Error message when Wapuu fails to send a message' }
+	{ comment: 'Error message when Wapuu fails to send a message', textOnly: true }
 );
 
 const ForwardedChatMessage = forwardRef( ChatMessage );

--- a/client/odie/message/index.tsx
+++ b/client/odie/message/index.tsx
@@ -231,6 +231,21 @@ const ChatMessage = (
 		<div className={ odieChatBoxMessageSourcesContainerClass } ref={ fullscreenRef }>
 			<div className={ messageClasses }>
 				{ messageHeader }
+				{ message.type === 'error' && (
+					<>
+						<AsyncLoad
+							require="react-markdown"
+							placeholder={ <ComponentLoadedReporter callback={ scrollToBottom } /> }
+							transformLinkUri={ uriTransformer }
+							components={ {
+								a: CustomALink,
+							} }
+						>
+							{ message.content }
+						</AsyncLoad>
+						{ extraContactOptions }
+					</>
+				) }
 				{ ( message.type === 'message' || ! message.type ) && (
 					<>
 						<AsyncLoad


### PR DESCRIPTION
## Proposed Changes

If a user has been assigned to an experiment, there might be a chance for the user to not be assigned anymore. This would cause caching problems and show Wapuu when it shouldnt.

## Testing Instructions

Sandbox your wpcom and return early when checking permissions.

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?