### PR TITLE
Components: Add minimal variation to SectionNav

### DIFF
--- a/client/components/section-nav/index.jsx
+++ b/client/components/section-nav/index.jsx
@@ -18,6 +18,7 @@ class SectionNav extends Component {
 		onMobileNavPanelOpen: PropTypes.func,
 		className: PropTypes.string,
 		allowDropdown: PropTypes.bool,
+		variation: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -78,6 +79,7 @@ class SectionNav extends Component {
 			'is-open': this.state.mobileOpen,
 			'section-nav-updated': this.props.applyUpdatedStyles,
 			'has-pinned-items': this.hasPinnedSearch || this.props.hasPinnedItems,
+			minimal: 'minimal' === this.props.variation,
 		} );
 
 		return (

--- a/client/components/section-nav/item.scss
+++ b/client/components/section-nav/item.scss
@@ -86,6 +86,12 @@
 		}
 	}
 
+	.notouch .minimal & {
+		&:hover {
+			background-color: transparent;
+		}
+	}
+
 	.notouch .is-selected & {
 		&:hover {
 			color: var(--color-text-inverted);
@@ -116,6 +122,10 @@
 			&:hover {
 				color: var(--color-neutral-70);
 			}
+		}
+
+		.minimal & {
+			color: var(--color-neutral-70);
 		}
 	}
 }

--- a/client/components/section-nav/style.scss
+++ b/client/components/section-nav/style.scss
@@ -30,6 +30,10 @@
 			padding-right: 50px;
 		}
 	}
+	&.minimal {
+		background: transparent;
+		box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.05);
+	}
 }
 
 .section-nav__mobile-header {
@@ -43,6 +47,10 @@
 	color: var(--color-neutral-70);
 	font-weight: 600;
 	cursor: pointer;
+
+	.minimal & {
+		background: var(--color-surface);
+	}
 
 	.gridicons-chevron-down {
 		fill: var(--color-neutral-50);

--- a/client/my-sites/earn/main.tsx
+++ b/client/my-sites/earn/main.tsx
@@ -187,7 +187,7 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 	const getEarnSectionNav = () => {
 		return (
 			<div id="earn-navigation">
-				<SectionNav selectedText={ getEarnSelectedText() }>
+				<SectionNav selectedText={ getEarnSelectedText() } variation="minimal">
 					<NavTabs>
 						{ getEarnTabs().map( ( tabItem ) => {
 							return (


### PR DESCRIPTION
*This PR updates a calypso component. We'll want to ensure the change is backward compatible with existing uses of the component, and also update documentation if we adopt the change.*

## Proposed Changes

* Adds a 'variation' prop to the SectionNav component. If this is undefined, component will render as before. If it is set to 'minimal' we apply a class with very slight style adjustmetns. 
* The new minimal variation is applied to the Monetize screen.
* The initial reason for this change is an effort update the Monetize screen based on Figma designs: DqXCQr1dEWpF3P2dIEwiwd-fi-873_137897
* But there are several other screen using a similar new style for section nav. Each of those are doing it separate using custom css on a per-screen basis. 

**Before**
<img width="1074" alt="nav-before" src="https://github.com/Automattic/wp-calypso/assets/21228350/06d43d75-e428-406b-9e4c-bd38a49944ef">

**After**
<img width="1073" alt="nav-after" src="https://github.com/Automattic/wp-calypso/assets/21228350/32c0bc0e-880a-4e6c-aa2f-ab5dd412e54d">

**Hover State Before**
<img width="1067" alt="nav-before-hover" src="https://github.com/Automattic/wp-calypso/assets/21228350/6b710273-64ab-449a-9425-8bcd7b3d958e">

**Hover State After**
<img width="1081" alt="nav-before-after" src="https://github.com/Automattic/wp-calypso/assets/21228350/e6ab20a5-e15e-4bb8-ad03-a7fbcbc8f4f5">

**Mobile Before**
<img width="301" alt="nav-mobile-before" src="https://github.com/Automattic/wp-calypso/assets/21228350/56d1453e-6fe7-452b-8a6a-e19edf610816">

**Mobile After** *(the changes to box shadow effectively remove links before/after the nav - I like it this way but we could keep 1-to-1 on mobile by adding the old box-shadow rule back in for mobile screens)*
<img width="289" alt="nav-mobile-after" src="https://github.com/Automattic/wp-calypso/assets/21228350/b084a3df-b532-4d2b-865e-f5c0f6744d7b">


## Testing Instructions

1) Go to http://calypso.localhost:3000/earn/YOURSITESLUG and confirm SectionNav on the Monetize screen looks like the new screenshot above.
2) Consider resizing your browsers, testing an alternative browser, or testing on mobile to confirm the design looks good and consistent across a range of situations. 
3) Check other screens that use the SectionNav component confirm they are unaffected (as they will not be passing the new variation prop). 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?