### PR TITLE
GF Signup: Fix "up to" discount translation

### DIFF
--- a/client/my-sites/plans-grid/components/plan-type-selector/hooks/use-interval-options.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/hooks/use-interval-options.tsx
@@ -7,7 +7,7 @@ const getDiscountText = ( discountPercentage: number, translate: LocalizeProps[ 
 	if ( ! discountPercentage ) {
 		return '';
 	}
-	return translate( 'upto %(discount)d% off', {
+	return translate( 'up to %(discount)d% off', {
 		args: { discount: discountPercentage },
 		comment: 'Discount percentage',
 	} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/84895#issuecomment-1848365913

## Proposed Changes

* Update misspelled translation from "upto" to "up to"

## Screenshots
### Before
<img width="849" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3422709/2d47bb18-a172-4618-b8f3-85553d424380">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start?flags=onboarding%2Finterval-dropdown`
* Make sure the dropdown with term interval appears
* Click on a different interval than yearly and make sure the selected plan stays selected
* Select a monthly plan, checkout and make sure the multi year plan selecter discounts matches the discount shown on the plans page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?