### PR TITLE
Domain move product tweaks

### DIFF
--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -165,7 +165,7 @@ class DomainProductPrice extends Component {
 		return (
 			<div className={ className }>
 				<span>
-					{ translate( 'Move your existing domain registration to your new site.', {
+					{ translate( 'Move your existing domain.', {
 						context: 'Line item description in cart.',
 					} ) }
 				</span>

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1507,7 +1507,7 @@ class RegisterDomainStep extends Component {
 						! status ||
 						( status === REGISTERED_OTHER_SITE_SAME_USER && includeOwnedDomainInSuggestions );
 
-					if ( skipAvailabilityErrors ) {
+					if ( ! skipAvailabilityErrors ) {
 						this.setState( { unavailableDomains: [ ...this.state.unavailableDomains, domain ] } );
 						this.showAvailabilityErrorMessage( domain, status, {
 							availabilityPreCheck: true,

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1043,6 +1043,7 @@ export class RenderDomainsStep extends Component {
 						includeWordPressDotCom={
 							experimentAssignment?.variationName === 'treatment' ? false : includeWordPressDotCom
 						}
+						includeOwnedDomainInSuggestions={ true && ! this.props.isDomainOnly }
 						includeDotBlogSubdomain={ this.shouldIncludeDotBlogSubdomain() }
 						isSignupStep
 						isPlanSelectionAvailableInFlow={ this.props.isPlanSelectionAvailableLaterInFlow }

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1043,7 +1043,7 @@ export class RenderDomainsStep extends Component {
 						includeWordPressDotCom={
 							experimentAssignment?.variationName === 'treatment' ? false : includeWordPressDotCom
 						}
-						includeOwnedDomainInSuggestions={ true && ! this.props.isDomainOnly }
+						includeOwnedDomainInSuggestions={ ! this.props.isDomainOnly }
 						includeDotBlogSubdomain={ this.shouldIncludeDotBlogSubdomain() }
 						isSignupStep
 						isPlanSelectionAvailableInFlow={ this.props.isPlanSelectionAvailableLaterInFlow }


### PR DESCRIPTION
## Proposed Changes

* Go for a more concise product description to avoid breaking the layout
* Show the domain move product only during onboarding
* Show the error message when a user searches for a full domain they already own in a view where the domain move product is not supported.

## Related to

https://github.com/Automattic/wp-calypso/pull/85085

## Testing Instructions

#### Testing the onboarding flow

* Go to `Switch site > Add New site`
* Search for a full domain name that you already own and is mapped to one of your sites
* The top suggestion should be that domain and you can select it and add it for free.

#### Testing adding a domain to a site the user already owns
* Select one of your sites
* Go to `Upgrades > Domains > Add a domain > Search for a domain`
* Search for a full domain name that you already own and is mapped to one of your sites
* You should see a notice telling you that you own that domain with a link to map it to this site if you choose to
* The domain you searched for should not be one of the offered suggestions