### PR TITLE
Theme Showcase: Remove More Menu

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -268,7 +268,19 @@ export class Theme extends Component {
 
 	renderMoreButton = () => {
 		const { active, buttonContents, index, theme } = this.props;
-		if ( isEmpty( buttonContents ) ) {
+
+		let moreOptions = buttonContents;
+		if ( isEnabled( 'themes/tiers' ) ) {
+			if ( active && buttonContents.info ) {
+				moreOptions = { info: buttonContents.info };
+			} else if ( buttonContents.deleteTheme ) {
+				moreOptions = { deleteTheme: buttonContents.deleteTheme };
+			} else {
+				moreOptions = {};
+			}
+		}
+
+		if ( isEmpty( moreOptions ) ) {
 			return null;
 		}
 
@@ -280,7 +292,7 @@ export class Theme extends Component {
 				active={ active }
 				onMoreButtonClick={ this.props.onMoreButtonClick }
 				onMoreButtonItemClick={ this.props.onMoreButtonItemClick }
-				options={ buttonContents }
+				options={ moreOptions }
 			/>
 		);
 	};

--- a/client/my-sites/themes/theme-preview.jsx
+++ b/client/my-sites/themes/theme-preview.jsx
@@ -96,10 +96,6 @@ class ThemePreview extends Component {
 	};
 
 	shouldShowUnlockStyleButton = () => {
-		if ( isEnabled( 'themes/tiers' ) ) {
-			return false;
-		}
-
 		const { options, shouldLimitGlobalStyles, themeOptions } = this.props;
 		if ( ! themeOptions ) {
 			return false;
@@ -182,10 +178,6 @@ class ThemePreview extends Component {
 	};
 
 	renderPrimaryButton = () => {
-		if ( isEnabled( 'themes/tiers' ) ) {
-			return null;
-		}
-
 		const primaryOption = this.getPrimaryOption();
 		if ( ! primaryOption ) {
 			return;
@@ -204,10 +196,6 @@ class ThemePreview extends Component {
 	};
 
 	renderSecondaryButton = () => {
-		if ( isEnabled( 'themes/tiers' ) ) {
-			return null;
-		}
-
 		const secondaryButton = this.getSecondaryOption();
 		if ( ! secondaryButton ) {
 			return;
@@ -263,12 +251,16 @@ class ThemePreview extends Component {
 						externalUrl={ demoUrl }
 						belowToolbar={ this.props.belowToolbar }
 					>
-						{ showActionIndicator && <PulsingDot active={ true } /> }
-						{ ! showActionIndicator && this.renderSecondaryButton() }
-						{ ! showActionIndicator &&
-							( this.shouldShowUnlockStyleButton()
-								? this.renderUnlockStyleButton()
-								: this.renderPrimaryButton() ) }
+						{ ! isEnabled( 'themes/tiers' ) && (
+							<>
+								{ showActionIndicator && <PulsingDot active={ true } /> }
+								{ ! showActionIndicator && this.renderSecondaryButton() }
+								{ ! showActionIndicator &&
+									( this.shouldShowUnlockStyleButton()
+										? this.renderUnlockStyleButton()
+										: this.renderPrimaryButton() ) }
+							</>
+						) }
 					</WebPreview>
 				) }
 				{ showUnlockStyleUpgradeModal && (

--- a/client/my-sites/themes/theme-preview.jsx
+++ b/client/my-sites/themes/theme-preview.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
 import { createHigherOrderComponent } from '@wordpress/compose';
@@ -95,6 +96,10 @@ class ThemePreview extends Component {
 	};
 
 	shouldShowUnlockStyleButton = () => {
+		if ( isEnabled( 'themes/tiers' ) ) {
+			return false;
+		}
+
 		const { options, shouldLimitGlobalStyles, themeOptions } = this.props;
 		if ( ! themeOptions ) {
 			return false;
@@ -177,6 +182,10 @@ class ThemePreview extends Component {
 	};
 
 	renderPrimaryButton = () => {
+		if ( isEnabled( 'themes/tiers' ) ) {
+			return null;
+		}
+
 		const primaryOption = this.getPrimaryOption();
 		if ( ! primaryOption ) {
 			return;
@@ -195,6 +204,10 @@ class ThemePreview extends Component {
 	};
 
 	renderSecondaryButton = () => {
+		if ( isEnabled( 'themes/tiers' ) ) {
+			return null;
+		}
+
 		const secondaryButton = this.getSecondaryOption();
 		if ( ! secondaryButton ) {
 			return;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Tracking issue: https://github.com/Automattic/dotcom-forge/issues/4597
Based on #85166

## Proposed Changes

Remove the "More menu (three dots)" from the theme showcase in most places. It now only appears in these cases:

 1. On the currently active theme - gives access to theme details as the default action is to customize
 2. On "My Themes" (atomic) - gives access to delete the theme.  

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Site type | Before | After
----|---|------
 Simple| <img width="1156" alt="Screenshot 2023-12-20 at 14 25 53" src="https://github.com/Automattic/wp-calypso/assets/93301/d8c9a57c-49e2-4d51-9a19-0db2108508a7"> | <img width="1156" alt="Screenshot 2023-12-20 at 14 14 44" src="https://github.com/Automattic/wp-calypso/assets/93301/c107aa6d-5c81-40b2-8f05-b4848700178f">
Atomic | <img width="1156" alt="Screenshot 2023-12-20 at 14 27 38" src="https://github.com/Automattic/wp-calypso/assets/93301/b2f0cd5b-b5f2-406b-b61d-d148f0641dcc"> | <img width="1156" alt="Screenshot 2023-12-20 at 14 27 25" src="https://github.com/Automattic/wp-calypso/assets/93301/72c33a9f-b3e7-4563-bad4-3ce010daad87">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?