### PR TITLE
E2E: Fix form tests for Gutenberg 17.2 changes

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/form-patterns.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/form-patterns.ts
@@ -97,9 +97,7 @@ export class FormPatternsFlow implements BlockFlow {
 		const editorParent = await context.editorPage.getEditorParent();
 		await editorParent
 			.getByRole( 'dialog', { name: 'Choose a pattern' } )
-			// The a11y is a little bit messed up here -- the right label isn't directly assocaited with the option element.
-			.locator( `[aria-label="${ this.configurationData.patternName }"]` )
-			.getByRole( 'option' )
+			.getByRole( 'option', { name: this.configurationData.patternName } )
 			// These patterns can load in quite slowly, messing with animation wait checks, so let's give extra time.
 			.click( { timeout: 30 * 1000 } );
 	}

--- a/packages/calypso-e2e/src/lib/components/editor-block-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-block-toolbar-component.ts
@@ -112,7 +112,7 @@ export class EditorBlockToolbarComponent {
 			const editorParent = await this.editor.parent();
 			const locator = editorParent
 				.locator( parentSelector )
-				.getByRole( 'button', { name: `Select ${ expectedParentBlockName }` } );
+				.getByRole( 'button', { name: `Select parent block: ${ expectedParentBlockName }` } );
 			await locator.click();
 			await locator.waitFor( { state: 'detached' } );
 		} else {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Fixes two tests for changes in Gutenberg 17.2:

* In 17.2.0, the "Select X" button in the block toolbar had its text changed to "Select parent block: X". The test looking for the former label needs updating for the new one.
* In the dialog used for selecting a form pattern, there used to be a bug in that the a11y label for each option was not on the role=option element itself. In either 17.2.0 or 17.2.1, that was fixed, so the test needs updating to no longer try to work around the incorrect structure.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run the test, it should work now with Simple trunk.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?