### PR TITLE
Add Xmas chat and Quick Start session closure dates and message

### DIFF
--- a/client/me/concierge/shared/closure-notice.js
+++ b/client/me/concierge/shared/closure-notice.js
@@ -21,8 +21,8 @@ const ClosureNotice = ( { closesAt, displayAt, reopensAt } ) => {
 	if ( currentDate.isBefore( closesAt ) ) {
 		message = translate(
 			'{{strong}}Notice:{{/strong}} Quick Start sessions will be closed from %(closesAt)s until %(reopensAt)s. ' +
-				'If you need to get in touch with us, you’ll be able to {{link}}submit a support request{{/link}} and we’ll ' +
-				'get to it as fast as we can. Thank you!',
+				'If you need to get in touch with us, you’ll be able to {{link}}submit a support request{{/link}} ' +
+				'and we’ll get to it as fast as we can. Thank you!',
 			{
 				args: {
 					closesAt: moment.tz( closesAt, guessedTimezone ).format( DATE_FORMAT ),

--- a/client/me/concierge/shared/closure-notice.js
+++ b/client/me/concierge/shared/closure-notice.js
@@ -36,9 +36,8 @@ const ClosureNotice = ( { closesAt, displayAt, reopensAt } ) => {
 		);
 	} else {
 		message = translate(
-			'{{strong}}Quick Start Sessions will be closed from %(closesAt)s – %(reopensAt)s.{{/strong}}{{br/}}' +
-				'Once a year, Happiness Engineers get together to work on improving our services, building new features, and learning how to better serve you. ' +
-				'During this time, we will continue to provide support over email. If you need to get in touch with us, please submit a {{link}}support request from this page{{/link}} and we will get to it as fast as we can. ' +
+			'{{strong}}Quick Start Sessions will be closed from %(closesAt)s – %(reopensAt)s for the Christmas holiday.{{/strong}}{{br/}}' +
+				'If you need to get in touch with us, please submit a {{link}}support request from this page{{/link}} and we will get to it as fast as we can. ' +
 				'Quick Start Sessions will re-open at %(reopensAt)s. Thank you for your understanding!',
 			{
 				args: {

--- a/client/me/concierge/shared/primary-header.js
+++ b/client/me/concierge/shared/primary-header.js
@@ -13,7 +13,7 @@ class PrimaryHeader extends Component {
 		return (
 			<Fragment>
 				<ClosureNotice
-					displayAt="2023-12-13 00:00Z"
+					displayAt="2023-12-18 00:00Z"
 					closesAt="2023-12-24 00:00Z"
 					reopensAt="2023-12-26 07:00Z"
 				/>

--- a/client/me/concierge/shared/primary-header.js
+++ b/client/me/concierge/shared/primary-header.js
@@ -13,9 +13,9 @@ class PrimaryHeader extends Component {
 		return (
 			<Fragment>
 				<ClosureNotice
-					displayAt="2023-11-06 00:00Z"
-					closesAt="2023-11-11 00:00Z"
-					reopensAt="2023-11-21 07:00Z"
+					displayAt="2023-12-13 00:00Z"
+					closesAt="2023-12-24 00:00Z"
+					reopensAt="2023-12-26 07:00Z"
 				/>
 				<Card>
 					<img

--- a/packages/components/src/gm-closure-notice/gm-closure-notice.tsx
+++ b/packages/components/src/gm-closure-notice/gm-closure-notice.tsx
@@ -34,7 +34,7 @@ export function GMClosureNotice( { displayAt, closesAt, reopensAt, enabled }: Pr
 		before: sprintf(
 			/* translators: closes_at and reopens_at are dates */
 			__(
-				'Live chat support will be closed from %(closes_at)s until %(reopens_at)s. Customer support via email will remain open.',
+				'During this time, we will continue to provide support over email. If you need to get in touch with us submit a support request from this page, and we will get to it as fast as we can. Chat will re-open at %(reopens_at)s. Thank you for your understanding!',
 				__i18n_text_domain__
 			),
 			{
@@ -45,7 +45,7 @@ export function GMClosureNotice( { displayAt, closesAt, reopensAt, enabled }: Pr
 		during: sprintf(
 			/* translators:  reopens_at is a date */
 			__(
-				'Once a year, Happiness Engineers get together to work on improving our services, building new features, and learning how to better serve you. During this time, we will continue to provide support over email. If you need to get in touch with us, please submit a support request from this page, and we will get to it as fast as we can. Chat will re-open at %(reopens_at)s. Thank you for your understanding!',
+				'Chat will re-open at %(reopens_at)s. If you need to get in touch with us now, please submit a support request from this page. We will get to it as fast as we can. Thank you for your understanding!',
 				__i18n_text_domain__
 			),
 			{
@@ -64,7 +64,10 @@ export function GMClosureNotice( { displayAt, closesAt, reopensAt, enabled }: Pr
 
 	const heading = sprintf(
 		/* translators: closes and reopens are dates */
-		__( 'Live chat will be closed from %(closes)s – %(reopens)s', __i18n_text_domain__ ),
+		__(
+			'Live chat will be closed from %(closes)s – %(reopens)s for the Christmas holiday',
+			__i18n_text_domain__
+		),
 		{
 			closes: format( DATE_FORMAT_SHORT, closesAtDate ),
 			reopens: format( isSameMonth ? 'd' : DATE_FORMAT_SHORT, reopensAtDate ),

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -158,7 +158,7 @@ export const HelpCenterContactPage: FC< HelpCenterContactPageProps > = ( {
 				) }
 				{ supportActivity && <HelpCenterActiveTicketNotice tickets={ supportActivity } /> }
 				<GMClosureNotice
-					displayAt="2023-12-13 00:00Z"
+					displayAt="2023-12-18 00:00Z"
 					closesAt="2023-12-24 00:00Z"
 					reopensAt="2023-12-26 07:00Z"
 					enabled={ renderChat.render }

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -158,9 +158,9 @@ export const HelpCenterContactPage: FC< HelpCenterContactPageProps > = ( {
 				) }
 				{ supportActivity && <HelpCenterActiveTicketNotice tickets={ supportActivity } /> }
 				<GMClosureNotice
-					displayAt="2023-11-06 00:00Z"
-					closesAt="2023-11-11 00:00Z"
-					reopensAt="2023-11-21 07:00Z"
+					displayAt="2023-12-13 00:00Z"
+					closesAt="2023-12-24 00:00Z"
+					reopensAt="2023-12-26 07:00Z"
 					enabled={ renderChat.render }
 				/>
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Requested on peCdcN-oA-p2

## Proposed Changes

* Adds a notice for Live Chat closure from Dec 24 to 26.
* Sets the notice to appear since Dec 18.
* Updates the message for the notice to the one proposed on the P2 post.
## Testing Instructions

1. Change the dates in the code to simulate different cases - before, during and after the closure dates.
2. Test http://calypso.localhost:3000/help/contact, the Help Center (? in the main menu bar on top) and http://calypso.localhost:3000/me/quickstart/
3. Check the message at the top when checking the dates for now, during and after the holiday.

Before:

![CleanShot 2023-12-14 at 14 50 07](https://github.com/Automattic/wp-calypso/assets/3696121/dc7498a3-4caf-49d7-812c-0c749a8c2e54)

![CleanShot 2023-12-14 at 14 53 25](https://github.com/Automattic/wp-calypso/assets/3696121/64edc0f9-16b9-486e-9844-0d8456af0284)

During:
The start date in these screenshots was edited in browser to serve as an example:

![CleanShot 2023-12-14 at 14 56 12](https://github.com/Automattic/wp-calypso/assets/3696121/88652ce4-16c3-4e75-9908-5b67746dc304)

![CleanShot 2023-12-14 at 14 57 14](https://github.com/Automattic/wp-calypso/assets/3696121/9933e250-b42b-47b6-ab52-752d838fc0d8)
