### PR TITLE
Domains: Fix "Update your name servers" link in domain management page

### DIFF
--- a/client/my-sites/domains/domain-management/dns/dns-records.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records.jsx
@@ -6,8 +6,11 @@ import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryDomainDns from 'calypso/components/data/query-domain-dns';
+import { modeType, stepSlug } from 'calypso/components/domains/connect-domain-step/constants';
 import Main from 'calypso/components/main';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
+import { isSubdomain } from 'calypso/lib/domains';
+import { type as domainTypes } from 'calypso/lib/domains/constants';
 import InfoNotice from 'calypso/my-sites/domains/domain-management/components/domain/info-notice';
 import DomainMainPlaceholder from 'calypso/my-sites/domains/domain-management/components/domain/main-placeholder';
 import DomainHeader from 'calypso/my-sites/domains/domain-management/components/domain-header';
@@ -18,6 +21,7 @@ import withDomainNameservers from 'calypso/my-sites/domains/domain-management/na
 import {
 	domainManagementEdit,
 	domainManagementList,
+	domainMappingSetup,
 	isUnderDomainManagementAll,
 } from 'calypso/my-sites/domains/paths';
 import { fetchDns } from 'calypso/state/domains/dns/actions';
@@ -30,6 +34,7 @@ import DnsAddNewRecordButton from './dns-add-new-record-button';
 import DnsDetails from './dns-details';
 import DnsImportBindFileButton from './dns-import-bind-file-button';
 import DnsMenuOptionsButton from './dns-menu-options-button';
+
 import './style.scss';
 
 class DnsRecords extends Component {
@@ -149,7 +154,8 @@ class DnsRecords extends Component {
 	};
 
 	renderNotice = () => {
-		const { translate, selectedSite, currentRoute, selectedDomainName, nameservers } = this.props;
+		const { translate, selectedSite, currentRoute, selectedDomainName, nameservers, domains } =
+			this.props;
 
 		if (
 			( ! englishLocales.includes( getLocaleSlug() ) &&
@@ -161,6 +167,19 @@ class DnsRecords extends Component {
 			! nameservers.length
 		) {
 			return null;
+		}
+
+		const selectedDomain = domains?.find( ( domain ) => domain?.name === selectedDomainName );
+
+		let mappingSetupStep =
+			selectedDomain.connectionMode === modeType.ADVANCED
+				? stepSlug.ADVANCED_UPDATE
+				: stepSlug.SUGGESTED_UPDATE;
+		if ( isSubdomain( selectedDomainName ) ) {
+			mappingSetupStep =
+				selectedDomain.connectionMode === modeType.ADVANCED
+					? stepSlug.SUBDOMAIN_ADVANCED_UPDATE
+					: stepSlug.SUBDOMAIN_SUGGESTED_UPDATE;
 		}
 
 		return (
@@ -178,12 +197,20 @@ class DnsRecords extends Component {
 							components: {
 								a: (
 									<a
-										href={ domainManagementEdit(
-											selectedSite.slug,
-											selectedDomainName,
-											currentRoute,
-											{ nameservers: true }
-										) }
+										href={
+											selectedDomain.type === domainTypes.MAPPED
+												? domainMappingSetup(
+														selectedSite.slug,
+														selectedDomainName,
+														mappingSetupStep
+												  )
+												: domainManagementEdit(
+														selectedSite.slug,
+														selectedDomainName,
+														currentRoute,
+														{ nameservers: true }
+												  )
+										}
 									></a>
 								),
 							},

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -8,13 +8,22 @@ import i18n, { getLocaleSlug, useTranslate } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import Accordion from 'calypso/components/domains/accordion';
-import { useMyDomainInputMode } from 'calypso/components/domains/connect-domain-step/constants';
+import {
+	modeType,
+	stepSlug,
+	useMyDomainInputMode,
+} from 'calypso/components/domains/connect-domain-step/constants';
 import TwoColumnsLayout from 'calypso/components/domains/layout/two-columns-layout';
 import Main from 'calypso/components/main';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
-import { getSelectedDomain, isDomainInGracePeriod, isDomainUpdateable } from 'calypso/lib/domains';
+import {
+	getSelectedDomain,
+	isDomainInGracePeriod,
+	isDomainUpdateable,
+	isSubdomain,
+} from 'calypso/lib/domains';
 import { transferStatus, type as domainTypes } from 'calypso/lib/domains/constants';
 import { findRegistrantWhois } from 'calypso/lib/domains/whois/utils';
 import DomainDeleteInfoCard from 'calypso/my-sites/domains/domain-management/components/domain/domain-info-card/delete';
@@ -31,6 +40,7 @@ import {
 	domainManagementEdit,
 	domainManagementEditContactInfo,
 	domainManagementList,
+	domainMappingSetup,
 	domainUseMyDomain,
 	isUnderDomainManagementAll,
 } from 'calypso/my-sites/domains/paths';
@@ -323,8 +333,19 @@ const Settings = ( {
 	};
 
 	const renderExternalNameserversNotice = ( noticeType: string ) => {
-		if ( areAllWpcomNameServers() || ! nameservers || ! nameservers.length ) {
+		if ( ! domain || areAllWpcomNameServers() || ! nameservers || ! nameservers.length ) {
 			return null;
+		}
+
+		let mappingSetupStep: string =
+			domain.connectionMode === modeType.ADVANCED
+				? stepSlug.ADVANCED_UPDATE
+				: stepSlug.SUGGESTED_UPDATE;
+		if ( isSubdomain( selectedDomainName ) ) {
+			mappingSetupStep =
+				domain.connectionMode === modeType.ADVANCED
+					? stepSlug.SUBDOMAIN_ADVANCED_UPDATE
+					: stepSlug.SUBDOMAIN_SUGGESTED_UPDATE;
 		}
 
 		const dnsRecordsNotice = translate(
@@ -333,9 +354,13 @@ const Settings = ( {
 				components: {
 					a: (
 						<a
-							href={ domainManagementEdit( selectedSite.slug, selectedDomainName, currentRoute, {
-								nameservers: true,
-							} ) }
+							href={
+								domain.type === domainTypes.MAPPED
+									? domainMappingSetup( selectedSite.slug, selectedDomainName, mappingSetupStep )
+									: domainManagementEdit( selectedSite.slug, selectedDomainName, currentRoute, {
+											nameservers: true,
+									  } )
+							}
 						/>
 					),
 				},
@@ -348,9 +373,13 @@ const Settings = ( {
 				components: {
 					a: (
 						<a
-							href={ domainManagementEdit( selectedSite.slug, selectedDomainName, currentRoute, {
-								nameservers: true,
-							} ) }
+							href={
+								domain.type === domainTypes.MAPPED
+									? domainMappingSetup( selectedSite.slug, selectedDomainName, mappingSetupStep )
+									: domainManagementEdit( selectedSite.slug, selectedDomainName, currentRoute, {
+											nameservers: true,
+									  } )
+							}
 						/>
 					),
 				},


### PR DESCRIPTION
In the "DNS records" section of the domain management page, we display a notice for domains that don't use our name servers, so they can click on it and update their NS to ours if they want.
Once they click the link, the "Name servers" card expands, and they can edit the NS.
However, the link wasn't working for domain connections since the "Name servers" card isn't rendered - they need to edit the NS on their provider in this case. 

This PR fixes it by changing the link's `href` to the domain connection setup.

## Testing Instructions
- Go to `/manage/domain` and click on any domain connection;
- On the "DNS records" section, click the "Update your name servers now" link;
- Ensure you will be redirected to the domain connection setup page;
- Ensure your preferred setup option is used - `advanced` or `suggested`, according to which was selected when adding the connection;
- Ensure this change is only reflected in domain mappings, registrations should keep the current behavior of expanding the "Name servers" card.

## Preview

### Before
https://github.com/Automattic/wp-calypso/assets/18705930/c1f4210c-059c-4aa7-9f4b-6609db5417ef

### After - mapping

https://github.com/Automattic/wp-calypso/assets/18705930/26332ed9-1df8-41b7-bc56-e7d631b8772a


### After - registration (same behavior)

https://github.com/Automattic/wp-calypso/assets/18705930/791d0a83-4770-4c99-a335-fa62d353796f


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?