### PR TITLE
Marketplace Reviews: Create the MarketplaceReviewCards component and add to Plugin Details page

### DIFF
--- a/client/my-sites/marketplace/components/reviews-cards/index.tsx
+++ b/client/my-sites/marketplace/components/reviews-cards/index.tsx
@@ -29,6 +29,8 @@ export const MarketplaceReviewsCards = ( props: ProductProps ) => {
 		Array.isArray( reviews ) && reviews?.some( ( review ) => review.author === currentUserId );
 	const addLeaveAReviewCard = ! hasReview && reviews.length < 2;
 
+	const addEmptyCard = reviews.length === 0;
+
 	return (
 		<div className="marketplace-reviews-cards__container">
 			<div className="marketplace-reviews-cards__reviews">
@@ -55,6 +57,7 @@ export const MarketplaceReviewsCards = ( props: ProductProps ) => {
 			<div className="marketplace-reviews-cards__content">
 				{ Array.isArray( reviews ) &&
 					reviews.map( ( review ) => <MarketplaceReviewCard review={ review } /> ) }
+				{ addEmptyCard && <MarketplaceReviewCard empty={ true } /> }
 				{ addLeaveAReviewCard && <MarketplaceReviewCard leaveAReview={ true } /> }
 			</div>
 		</div>

--- a/client/my-sites/marketplace/components/reviews-cards/index.tsx
+++ b/client/my-sites/marketplace/components/reviews-cards/index.tsx
@@ -1,0 +1,42 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { useTranslate } from 'i18n-calypso';
+import {
+	useMarketplaceReviewsQuery,
+	ProductProps,
+} from 'calypso/data/marketplace/use-marketplace-reviews';
+import './style.scss';
+import { MarketplaceReviewCard } from './review-card';
+
+export const MarketplaceReviewsCards = ( props: ProductProps ) => {
+	const translate = useTranslate();
+	const { data: reviews } = useMarketplaceReviewsQuery( { ...props, perPage: 2, page: 1 } );
+
+	if ( ! isEnabled( 'marketplace-reviews-show' ) ) {
+		return null;
+	}
+
+	// TODO: In the future there should a form of catching and displaying an error
+	// But as currently we returns errors for products without reviews,
+	// its better to just avoid rendering the component at all
+	if ( ! Array.isArray( reviews ) && ( ! reviews || reviews.message ) ) {
+		return null;
+	}
+
+	return (
+		<div className="marketplace-reviews-cards__container">
+			<div className="marketplace-reviews-cards__no-reviews">
+				<h2 className="marketplace-reviews-cards__no-reviews-title">
+					{ translate( 'Customer reviews' ) }
+				</h2>
+				<h3 className="marketplace-reviews-cards__no-reviews-subtitle">
+					{ translate( 'What other users are saying' ) }
+				</h3>
+			</div>
+
+			<div className="marketplace-reviews-cards__content">
+				{ Array.isArray( reviews ) &&
+					reviews.map( ( review ) => <MarketplaceReviewCard review={ review } /> ) }
+			</div>
+		</div>
+	);
+};

--- a/client/my-sites/marketplace/components/reviews-cards/index.tsx
+++ b/client/my-sites/marketplace/components/reviews-cards/index.tsx
@@ -20,9 +20,6 @@ export const MarketplaceReviewsCards = ( props: ProductProps ) => {
 		return null;
 	}
 
-	// TODO: In the future there should a form of catching and displaying an error
-	// But as currently we returns errors for products without reviews,
-	// its better to just avoid rendering the component at all
 	if ( ! Array.isArray( reviews ) || ! reviews || 'message' in reviews ) {
 		return null;
 	}

--- a/client/my-sites/marketplace/components/reviews-cards/index.tsx
+++ b/client/my-sites/marketplace/components/reviews-cards/index.tsx
@@ -25,8 +25,7 @@ export const MarketplaceReviewsCards = ( props: ProductProps ) => {
 	}
 
 	// Add a review card if the user has not left a review yet
-	const hasReview =
-		Array.isArray( reviews ) && reviews?.some( ( review ) => review.author === currentUserId );
+	const hasReview = reviews?.some( ( review ) => review.author === currentUserId );
 	const addLeaveAReviewCard = ! hasReview && reviews.length < 2;
 
 	const addEmptyCard = reviews.length === 0;
@@ -55,10 +54,13 @@ export const MarketplaceReviewsCards = ( props: ProductProps ) => {
 			</div>
 
 			<div className="marketplace-reviews-cards__content">
-				{ Array.isArray( reviews ) &&
-					reviews.map( ( review ) => <MarketplaceReviewCard review={ review } /> ) }
-				{ addEmptyCard && <MarketplaceReviewCard empty={ true } /> }
-				{ addLeaveAReviewCard && <MarketplaceReviewCard leaveAReview={ true } /> }
+				{ reviews.map( ( review ) => (
+					<MarketplaceReviewCard review={ review } key={ review.id } />
+				) ) }
+				{ addEmptyCard && <MarketplaceReviewCard empty={ true } key="empty-card" /> }
+				{ addLeaveAReviewCard && (
+					<MarketplaceReviewCard leaveAReview={ true } key="leave-a-review-card" />
+				) }
 			</div>
 		</div>
 	);

--- a/client/my-sites/marketplace/components/reviews-cards/index.tsx
+++ b/client/my-sites/marketplace/components/reviews-cards/index.tsx
@@ -1,4 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import {
 	useMarketplaceReviewsQuery,
@@ -24,13 +25,25 @@ export const MarketplaceReviewsCards = ( props: ProductProps ) => {
 
 	return (
 		<div className="marketplace-reviews-cards__container">
-			<div className="marketplace-reviews-cards__no-reviews">
-				<h2 className="marketplace-reviews-cards__no-reviews-title">
+			<div className="marketplace-reviews-cards__reviews">
+				<h2 className="marketplace-reviews-cards__reviews-title">
 					{ translate( 'Customer reviews' ) }
 				</h2>
-				<h3 className="marketplace-reviews-cards__no-reviews-subtitle">
+				<h3 className="marketplace-reviews-cards__reviews-subtitle">
 					{ translate( 'What other users are saying' ) }
 				</h3>
+
+				<div className="marketplace-reviews-cards__read-all">
+					<Button
+						className="is-link"
+						borderless
+						primary
+						onClick={ () => alert( 'Not implemented yet!' ) }
+						href=""
+					>
+						{ translate( 'Read all reviews' ) }
+					</Button>
+				</div>
 			</div>
 
 			<div className="marketplace-reviews-cards__content">

--- a/client/my-sites/marketplace/components/reviews-cards/index.tsx
+++ b/client/my-sites/marketplace/components/reviews-cards/index.tsx
@@ -24,6 +24,7 @@ export const MarketplaceReviewsCards = ( props: ProductProps ) => {
 		return null;
 	}
 
+	// TODO: Double check this verification according what's being sent from the server
 	// Add a review card if the user has not left a review yet
 	const hasReview = reviews?.some( ( review ) => review.author === currentUserId );
 	const addLeaveAReviewCard = ! hasReview && reviews.length < 2;

--- a/client/my-sites/marketplace/components/reviews-cards/review-card.tsx
+++ b/client/my-sites/marketplace/components/reviews-cards/review-card.tsx
@@ -6,11 +6,25 @@ import { sanitizeSectionContent } from 'calypso/lib/plugins/sanitize-section-con
 type MarketplaceReviewCardProps = {
 	review?: MarketplaceReviewResponse;
 	leaveAReview?: boolean;
+	empty?: boolean;
 };
 
 export const MarketplaceReviewCard = ( props: MarketplaceReviewCardProps ) => {
 	const translate = useTranslate();
-	const { review, leaveAReview } = props;
+	const { review, leaveAReview, empty } = props;
+
+	if ( empty ) {
+		return (
+			<div className="marketplace-reviews-card__empty-container">
+				<h2 className="marketplace-reviews-card__empty-title">{ translate( 'No reviews yet' ) }</h2>
+				<h3 className="marketplace-reviews-card__empty-subtitle">
+					{ translate(
+						'There are no reviews for this plugin at the moment. Your feedback could be the first to guide others.'
+					) }
+				</h3>
+			</div>
+		);
+	}
 
 	if ( leaveAReview || ! review ) {
 		return (

--- a/client/my-sites/marketplace/components/reviews-cards/review-card.tsx
+++ b/client/my-sites/marketplace/components/reviews-cards/review-card.tsx
@@ -3,9 +3,27 @@ import Rating from 'calypso/components/rating';
 import { MarketplaceReviewResponse } from 'calypso/data/marketplace/use-marketplace-reviews';
 import { sanitizeSectionContent } from 'calypso/lib/plugins/sanitize-section-content';
 
-export const MarketplaceReviewCard = ( props: { review: MarketplaceReviewResponse } ) => {
+type MarketplaceReviewCardProps = {
+	review?: MarketplaceReviewResponse;
+	leaveAReview?: boolean;
+};
+
+export const MarketplaceReviewCard = ( props: MarketplaceReviewCardProps ) => {
 	const translate = useTranslate();
-	const { review } = props;
+	const { review, leaveAReview } = props;
+
+	if ( leaveAReview || ! review ) {
+		return (
+			<div className="marketplace-reviews-card__leave-a-review">
+				<div className="marketplace-reviews-card__leave-a-review-message">
+					{ translate( 'How would you rate your overall experience?' ) }
+				</div>
+				<div className="marketplace-reviews-card__leave-a-review-rating">
+					<Rating rating={ 0 } size={ 32 } />
+				</div>
+			</div>
+		);
+	}
 
 	return (
 		<div className="marketplace-reviews-card__container">

--- a/client/my-sites/marketplace/components/reviews-cards/review-card.tsx
+++ b/client/my-sites/marketplace/components/reviews-cards/review-card.tsx
@@ -1,0 +1,38 @@
+import { useTranslate } from 'i18n-calypso';
+import Rating from 'calypso/components/rating';
+import { MarketplaceReviewResponse } from 'calypso/data/marketplace/use-marketplace-reviews';
+import { sanitizeSectionContent } from 'calypso/lib/plugins/sanitize-section-content';
+
+export const MarketplaceReviewCard = ( props: { review: MarketplaceReviewResponse } ) => {
+	const translate = useTranslate();
+	const { review } = props;
+
+	return (
+		<div className="marketplace-reviews-card__container">
+			<div className="marketplace-reviews-card__rating">
+				<Rating rating={ review.meta.wpcom_marketplace_rating * 20 } />
+			</div>
+
+			<div className="marketplace-reviews-card__review-data">
+				<div
+					// sanitized with sanitizeSectionContent
+					// eslint-disable-next-line react/no-danger
+					dangerouslySetInnerHTML={ {
+						__html: sanitizeSectionContent( review.content.rendered ),
+					} }
+					className="marketplace-reviews-list__review-data-content"
+				></div>
+			</div>
+
+			<div className="marketplace-reviews-card__author">
+				{ translate( 'By {{span}}%(author)s{{/span}}', {
+					comment: 'Show "By *Author Name*" in the review card',
+					args: { author: review.author_name },
+					components: {
+						span: <span className="marketplace-reviews-card__author-name" />,
+					},
+				} ) }
+			</div>
+		</div>
+	);
+};

--- a/client/my-sites/marketplace/components/reviews-cards/style.scss
+++ b/client/my-sites/marketplace/components/reviews-cards/style.scss
@@ -31,41 +31,6 @@ $border-color: #eee;
 		gap: 20px;
 	}
 
-	.marketplace-reviews-card__container {
-		padding: 24px 30px;
-		border: 1px solid $border-color;
-		border-radius: 4px;
-		width: 50%;
-
-		display: flex;
-		flex-direction: column;
-		gap: 16px;
-	}
-
-	.marketplace-reviews-card__review-data {
-		font-family: "SF Pro Text", $sans;
-		color: var(--studio-gray-80);
-		font-size: $font-body-small;
-		line-height: 20px;
-
-		display: -webkit-box;
-		-webkit-line-clamp: 2;
-		-webkit-box-orient: vertical;
-		overflow: hidden;
-	}
-
-	.marketplace-reviews-card__author {
-		font-family: "SF Pro Text", $sans;
-		color: var(--studio-gray-60);
-		font-size: $font-body-extra-small;
-		line-height: 20px;
-
-		.marketplace-reviews-card__author-name {
-			color: var(--studio-black);
-			font-family: Inter, $sans;
-		}
-	}
-
 	.rating .rating__overlay .is-empty,
 	.rating .rating__star-outline .is-empty {
 		fill: var(--studio-yellow-20);
@@ -74,5 +39,62 @@ $border-color: #eee;
 	.rating .rating__overlay .gridicon,
 	.rating .rating__star-outline .gridicon {
 		fill: var(--studio-yellow-20);
+	}
+}
+
+
+.marketplace-reviews-card__container {
+	padding: 24px 30px;
+
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+}
+
+.marketplace-reviews-card__container,
+.marketplace-reviews-card__leave-a-review {
+	border: 1px solid $border-color;
+	border-radius: 4px;
+	width: 50%;
+}
+
+.marketplace-reviews-card__review-data {
+	font-family: "SF Pro Text", $sans;
+	color: var(--studio-gray-80);
+	font-size: $font-body-small;
+	line-height: 20px;
+
+	display: -webkit-box;
+	-webkit-line-clamp: 2;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
+}
+
+.marketplace-reviews-card__author {
+	font-family: "SF Pro Text", $sans;
+	color: var(--studio-gray-60);
+	font-size: $font-body-extra-small;
+	line-height: 20px;
+
+	.marketplace-reviews-card__author-name {
+		color: var(--studio-black);
+		font-family: Inter, $sans;
+	}
+}
+
+.marketplace-reviews-card__leave-a-review {
+	display: flex;
+	gap: 8px;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+	padding: 40px;
+	cursor: pointer;
+
+	.marketplace-reviews-card__leave-a-review-message {
+		font-family: "SF Pro Text", $sans;
+		color: var(--studio-gray-100);
+		font-size: $font-body;
+		line-height: 24px;
 	}
 }

--- a/client/my-sites/marketplace/components/reviews-cards/style.scss
+++ b/client/my-sites/marketplace/components/reviews-cards/style.scss
@@ -1,0 +1,69 @@
+$border-color: #eee;
+
+.marketplace-reviews-cards__container {
+	display: flex;
+	flex-direction: column;
+	gap: 24px;
+
+	.marketplace-reviews-cards__no-reviews-title {
+		font-family: Recoleta, $sans;
+		color: var(--studio-gray-80);
+		font-size: $font-title-medium;
+	}
+
+	.marketplace-reviews-cards__no-reviews-subtitle {
+		font-family: "SF Pro Text", $sans;
+		color: var(--studio-gray-60);
+		font-size: $font-body-small;
+	}
+
+	.marketplace-reviews-cards__content {
+		display: flex;
+		gap: 20px;
+	}
+
+	.marketplace-reviews-card__container {
+		padding: 24px 30px;
+		border: 1px solid $border-color;
+		border-radius: 4px;
+		width: 50%;
+
+		display: flex;
+		flex-direction: column;
+		gap: 16px;
+	}
+
+	.marketplace-reviews-card__review-data {
+		font-family: "SF Pro Text", $sans;
+		color: var(--studio-gray-80);
+		font-size: $font-body-small;
+		line-height: 20px;
+
+		display: -webkit-box;
+		-webkit-line-clamp: 2;
+		-webkit-box-orient: vertical;
+		overflow: hidden;
+	}
+
+	.marketplace-reviews-card__author {
+		font-family: "SF Pro Text", $sans;
+		color: var(--studio-gray-60);
+		font-size: $font-body-extra-small;
+		line-height: 20px;
+
+		.marketplace-reviews-card__author-name {
+			color: var(--studio-black);
+			font-family: Inter, $sans;
+		}
+	}
+
+	.rating .rating__overlay .is-empty,
+	.rating .rating__star-outline .is-empty {
+		fill: var(--studio-yellow-20);
+	}
+
+	.rating .rating__overlay .gridicon,
+	.rating .rating__star-outline .gridicon {
+		fill: var(--studio-yellow-20);
+	}
+}

--- a/client/my-sites/marketplace/components/reviews-cards/style.scss
+++ b/client/my-sites/marketplace/components/reviews-cards/style.scss
@@ -1,20 +1,29 @@
 $border-color: #eee;
 
 .marketplace-reviews-cards__container {
+	position: relative;
 	display: flex;
 	flex-direction: column;
 	gap: 24px;
 
-	.marketplace-reviews-cards__no-reviews-title {
+	.marketplace-reviews-cards__reviews-title {
 		font-family: Recoleta, $sans;
 		color: var(--studio-gray-80);
 		font-size: $font-title-medium;
 	}
 
-	.marketplace-reviews-cards__no-reviews-subtitle {
+	.marketplace-reviews-cards__reviews-subtitle {
 		font-family: "SF Pro Text", $sans;
 		color: var(--studio-gray-60);
 		font-size: $font-body-small;
+	}
+
+	.marketplace-reviews-cards__read-all {
+		font-family: "SF Pro Text", $sans;
+		font-size: $font-body-small;
+		position: absolute;
+		right: 0;
+		top: 25px;
 	}
 
 	.marketplace-reviews-cards__content {

--- a/client/my-sites/marketplace/components/reviews-cards/style.scss
+++ b/client/my-sites/marketplace/components/reviews-cards/style.scss
@@ -78,6 +78,7 @@ $cards-gap: 20px;
 	color: var(--studio-gray-60);
 	font-size: $font-body-extra-small;
 	line-height: 20px;
+	font-weight: 500;
 
 	.marketplace-reviews-card__author-name {
 		color: var(--studio-black);
@@ -98,6 +99,7 @@ $cards-gap: 20px;
 		font-family: "SF Pro Text", $sans;
 		color: var(--studio-gray-100);
 		font-size: $font-body;
+		font-weight: 500;
 		line-height: 24px;
 	}
 }

--- a/client/my-sites/marketplace/components/reviews-cards/style.scss
+++ b/client/my-sites/marketplace/components/reviews-cards/style.scss
@@ -53,7 +53,8 @@ $cards-gap: 20px;
 }
 
 .marketplace-reviews-card__container,
-.marketplace-reviews-card__leave-a-review {
+.marketplace-reviews-card__leave-a-review,
+.marketplace-reviews-card__empty-container {
 	border: 1px solid $border-color;
 	border-radius: 4px;
 	width: calc((100% - $cards-gap)/2); // Half of the available space
@@ -98,5 +99,26 @@ $cards-gap: 20px;
 		color: var(--studio-gray-100);
 		font-size: $font-body;
 		line-height: 24px;
+	}
+}
+
+.marketplace-reviews-card__empty-container {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+	padding: 30px;
+
+	.marketplace-reviews-card__empty-title {
+		font-family: Recoleta, $sans;
+		color: var(--studio-gray-100);
+		font-size: $font-title-medium;
+	}
+
+	.marketplace-reviews-card__empty-subtitle {
+		font-family: "SF Pro Text", $sans;
+		color: var(--studio-gray-60);
+		font-size: $font-body-small;
+		text-align: center;
 	}
 }

--- a/client/my-sites/marketplace/components/reviews-cards/style.scss
+++ b/client/my-sites/marketplace/components/reviews-cards/style.scss
@@ -1,4 +1,5 @@
 $border-color: #eee;
+$cards-gap: 20px;
 
 .marketplace-reviews-cards__container {
 	position: relative;
@@ -28,7 +29,7 @@ $border-color: #eee;
 
 	.marketplace-reviews-cards__content {
 		display: flex;
-		gap: 20px;
+		gap: $cards-gap;
 	}
 
 	.rating .rating__overlay .is-empty,
@@ -55,7 +56,8 @@ $border-color: #eee;
 .marketplace-reviews-card__leave-a-review {
 	border: 1px solid $border-color;
 	border-radius: 4px;
-	width: 50%;
+	width: calc((100% - $cards-gap)/2); // Half of the available space
+	box-sizing: border-box;
 }
 
 .marketplace-reviews-card__review-data {

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -20,7 +20,7 @@ import NoticeAction from 'calypso/components/notice/notice-action';
 import { useESPlugin } from 'calypso/data/marketplace/use-es-query';
 import { useWPCOMPlugin } from 'calypso/data/marketplace/use-wpcom-plugins-query';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { MarketplaceReviewsList } from 'calypso/my-sites/marketplace/components/reviews-list';
+import { MarketplaceReviewsCards } from 'calypso/my-sites/marketplace/components/reviews-cards';
 import PluginNotices from 'calypso/my-sites/plugins/notices';
 import { isCompatiblePlugin } from 'calypso/my-sites/plugins/plugin-compatibility';
 import PluginDetailsCTA from 'calypso/my-sites/plugins/plugin-details-CTA';
@@ -459,11 +459,7 @@ function PluginDetails( props ) {
 			</div>
 			{ isEnabled( 'marketplace-reviews-show' ) && ! showPlaceholder && (
 				<div className="plugin-details__reviews">
-					<MarketplaceReviewsList
-						slug={ fullPlugin.slug }
-						productType="plugin"
-						ref={ reviewsListRef }
-					/>
+					<MarketplaceReviewsCards slug={ fullPlugin.slug } productType="plugin" />
 				</div>
 			) }
 			{ isMarketplaceProduct && ! showPlaceholder && <MarketplaceFooter /> }

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -529,8 +529,11 @@ body.is-section-plugins #primary {
 }
 
 .plugin-details__reviews {
-	margin-top: 20px;
 	margin-bottom: 40px;
+
+	@media screen and ( max-width: 1040px ) {
+		padding: 16px;
+	}
 }
 
 .plugin__header {


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/4842

## Proposed Changes

Create and add the Marketplace Reviews Cards sections to the Plugin Details page.
The component will:
* Display up to 2 review cards
* If there aren't reviews for the product, display a card with the empty state
* If fewer than 2 reviews are available AND the user has not left a review yet
  * Display a card asking the user to leave a review

The changes are behind the flag `marketplace-reviews-show` which is disabled in prod but available in dev.

## Testing Instructions
* Go to a plugin with multiple reviews. Ex: 
* Check if the layout is similar to below. Ex: `/plugins/woocommerce-bookings`
* Go to a plugin with a single review. Ex: `/plugins/woocommerce-subscriptions`
* Check if the layout is similar to below

| Multiple reviews  | Single review | No reviews|
| ------------- | ------------- |------------- |
|![CleanShot 2023-12-14 at 19 06 24@2x](https://github.com/Automattic/wp-calypso/assets/5039531/1632c1d3-89c2-4ec8-8fc2-04aec22f772e)|![CleanShot 2023-12-14 at 19 06 50@2x](https://github.com/Automattic/wp-calypso/assets/5039531/150978bc-0999-485f-9aa6-407a3eebc5be)|![CleanShot 2023-12-14 at 19 07 07@2x](https://github.com/Automattic/wp-calypso/assets/5039531/205b8c44-cdab-4549-b2cf-af0e00436c24)|


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
