### PR TITLE
Oauth login -> signup: add support for existing currentQuery prop when query is not set

### DIFF
--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -339,6 +339,7 @@ export class Login extends Component {
 			oauth2Client,
 			pathname,
 			query,
+			currentQuery,
 			translate,
 			usernameOrEmail,
 		} = this.props;
@@ -357,7 +358,7 @@ export class Login extends Component {
 		// use '?signup_url' if explicitly passed as URL query param
 		const signupUrl = this.props.signupUrl
 			? window.location.origin + pathWithLeadingSlash( this.props.signupUrl )
-			: getSignupUrl( query, currentRoute, oauth2Client, locale, pathname );
+			: getSignupUrl( query || currentQuery, currentRoute, oauth2Client, locale, pathname );
 
 		return (
 			<a

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -333,13 +333,13 @@ export class Login extends Component {
 	renderSignUpLink( signupLinkText ) {
 		// Taken from client/layout/masterbar/logged-out.jsx
 		const {
+			currentQuery,
 			currentRoute,
 			isP2Login,
 			locale,
 			oauth2Client,
 			pathname,
 			query,
-			currentQuery,
 			translate,
 			usernameOrEmail,
 		} = this.props;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

I was testing the Crowdsignal signup today and the "create account" link on the Login screen appears to be broken. The following minimal change is what was necessary to correct it.

cc @escapemanuele  as this might be related to changes made in https://github.com/Automattic/wp-calypso/pull/84692 , although it looks like you just moved that code and it was already like that. Its entirely possible this has been broken for a long time and nobody noticed?

## Proposed Changes

* add support for `currentQuery` when `query` is not set for oauth signups on the Login screen

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In Prod, with a Private browser: visit a Crowdsignal or Akismet 'Login' button
* hover over the `Create a new account` button below the login form
* Notice that the links are very generic
* pull the branch
* `yarn && yarn start` (or use the Calypso live link below)
* replace `https://wordpress.com` with `calypso.localhost:3000` (or with the Calypso live url) in the URL bar
* hover over the `Create a new account` button again
* Notice that the links now have product specific parameters
   * if testing crowdsignal, it should match the url params you see when visiting `https://app.crowdsignal.com/signup` after being redirected to the signup page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?