### PR TITLE
Gate stats for atomic sites without feature

### DIFF
--- a/client/my-sites/stats/hooks/test/use-should-gate-stats.ts
+++ b/client/my-sites/stats/hooks/test/use-should-gate-stats.ts
@@ -28,12 +28,36 @@ describe( 'shouldGateStats in Calypso', () => {
 		jest.clearAllMocks();
 	} );
 
-	it( 'should not gate stats when site is atomic', () => {
+	it( 'should gate stats when site is atomic without site feature', () => {
 		const mockState = {
 			sites: {
 				items: {
 					[ siteId ]: {
 						jetpack: true, // true for atomic sites
+						options: {
+							is_wpcom_atomic: true,
+						},
+					},
+				},
+			},
+		};
+		const isGatedStats = shouldGateStats( mockState, siteId, gatedStatType );
+		expect( isGatedStats ).toBe( true );
+	} );
+
+	it( 'should not gate stats when site is atomic and has paid stat feature', () => {
+		const mockState = {
+			sites: {
+				features: {
+					[ siteId ]: {
+						data: {
+							active: [ FEATURE_STATS_PAID ],
+						},
+					},
+				},
+				items: {
+					[ siteId ]: {
+						jetpack: true,
 						options: {
 							is_wpcom_atomic: true,
 						},
@@ -158,13 +182,37 @@ describe( 'shouldGateStats in Odyssey stats', () => {
 		jest.clearAllMocks();
 	} );
 
-	it( 'should not gate stats for jetpack sites', () => {
+	it( 'should not gate stats for jetpack sites with feature', () => {
 		const mockState = {
 			sites: {
 				features: {
 					[ siteId ]: {
 						data: {
 							active: [ FEATURE_STATS_PAID ],
+						},
+					},
+				},
+				items: {
+					[ siteId ]: {
+						jetpack: true,
+						options: {
+							is_wpcom_atomic: false,
+						},
+					},
+				},
+			},
+		};
+		const isGatedStats = shouldGateStats( mockState, siteId, gatedStatType );
+		expect( isGatedStats ).toBe( false );
+	} );
+
+	it( 'should not gate stats for jetpack sites without feature', () => {
+		const mockState = {
+			sites: {
+				features: {
+					[ siteId ]: {
+						data: {
+							active: [],
 						},
 					},
 				},

--- a/client/my-sites/stats/hooks/use-should-gate-stats.ts
+++ b/client/my-sites/stats/hooks/use-should-gate-stats.ts
@@ -34,7 +34,7 @@ export const shouldGateStats = ( state: object, siteId: number | null, statType:
 	const siteHasPaidStats = siteHasFeature( state, siteId, FEATURE_STATS_PAID );
 
 	// check site type
-	if ( jetpackSite || atomicSite ) {
+	if ( jetpackSite && ! atomicSite ) {
 		return false;
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/4922

Atomic sites should be treated  the same way as simple sites re Jetpack stats. Defer to the site plan / feature set to determine if stats should be gated.

## Proposed Changes

- Paywall atomic sites from paid stats the same way simple sites are

## Testing Instructions

```
yarn run test-client client/my-sites/stats/hooks/test/use-should-gate-stats.ts
```

* Check Atomic sites have gated stats when they're missing the PWYW upgrade
* Check Jetpack sites are still not being gated

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?