### PR TITLE
Promote subscription: Show toggle for Atomic + Simple sites

### DIFF
--- a/client/my-sites/site-settings/settings-newsletter/main.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/main.tsx
@@ -108,14 +108,6 @@ const NewsletterSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 		);
 	} );
 
-	const shouldShowSubscriptionOnCommentModule = useSelector( ( state ) => {
-		const isJetpackSite = isJetpackSiteSelector( state, siteId, {
-			treatAtomicAsJetpackSite: true,
-		} );
-
-		return ! isJetpackSite;
-	} );
-
 	const disabled = isSubscriptionModuleInactive || isRequestingSettings || isSavingSettings;
 	const savedSubscriptionOptions = settings?.subscription_options;
 
@@ -147,15 +139,13 @@ const NewsletterSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 					value={ sm_enabled }
 				/>
 			</Card>
-			{ shouldShowSubscriptionOnCommentModule && (
-				<Card className="site-settings__card">
-					<SubscribeModalOnCommentSetting
-						disabled={ disabled }
-						handleToggle={ handleToggle }
-						value={ jetpack_verbum_subscription_modal }
-					/>
-				</Card>
-			) }
+			<Card className="site-settings__card">
+				<SubscribeModalOnCommentSetting
+					disabled={ disabled }
+					handleToggle={ handleToggle }
+					value={ jetpack_verbum_subscription_modal }
+				/>
+			</Card>
 
 			{ /* @ts-expect-error SettingsSectionHeader is not typed and is causing errors */ }
 			<SettingsSectionHeader

--- a/client/my-sites/site-settings/settings-newsletter/main.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/main.tsx
@@ -108,6 +108,14 @@ const NewsletterSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 		);
 	} );
 
+	const shouldShowSubscriptionOnCommentModule = useSelector( ( state ) => {
+		const isJetpackSite = isJetpackSiteSelector( state, siteId, {
+			treatAtomicAsJetpackSite: false,
+		} );
+
+		return ! isJetpackSite;
+	} );
+
 	const disabled = isSubscriptionModuleInactive || isRequestingSettings || isSavingSettings;
 	const savedSubscriptionOptions = settings?.subscription_options;
 
@@ -139,14 +147,15 @@ const NewsletterSettingsForm = wrapSettingsForm( getFormSettings )( ( {
 					value={ sm_enabled }
 				/>
 			</Card>
-			<Card className="site-settings__card">
-				<SubscribeModalOnCommentSetting
-					disabled={ disabled }
-					handleToggle={ handleToggle }
-					value={ jetpack_verbum_subscription_modal }
-				/>
-			</Card>
-
+			{ shouldShowSubscriptionOnCommentModule && (
+				<Card className="site-settings__card">
+					<SubscribeModalOnCommentSetting
+						disabled={ disabled }
+						handleToggle={ handleToggle }
+						value={ jetpack_verbum_subscription_modal }
+					/>
+				</Card>
+			) }
 			{ /* @ts-expect-error SettingsSectionHeader is not typed and is causing errors */ }
 			<SettingsSectionHeader
 				disabled={ disabled }


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/4584

## Proposed Changes

Show subscription modal on comment toggle for all Atomic & Simple sites, but hide for Jetpack self hosted.

> **Warning**
> Do not merge until the next Jetpack release is happening
> *The next release is scheduled for January 9, 2024 (scheduled code freeze on January 8, 2024).*

## Testing Instructions

* Using an Atomic site go to `/settings/newsletter/SITE_ID`
* Check for Subscription modal toggle

<img width="1538" alt="image" src="https://github.com/Automattic/wp-calypso/assets/402286/f82b89fe-c055-4123-8d8c-ba43640a0e3e">

For context on the modal this setting enables: pdtkmj-2ey-p2