### PR TITLE
Jetpack Manage: Fix issue licenses flow from the dashboard

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/index.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@automattic/components';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { getQueryArg } from '@wordpress/url';
+import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
 import Layout from 'calypso/jetpack-cloud/components/layout';
@@ -101,10 +102,12 @@ export default function IssueLicenseV2( { selectedSite, suggestedProduct }: Assi
 		...( selectedCount && { selectedCount } ),
 	};
 
+	const showBundle = ! selectedSite;
+
 	return (
 		<>
 			<Layout
-				className="issue-license-v2"
+				className={ classNames( 'issue-license-v2', { 'without-bundle': ! showBundle } ) }
 				title={ translate( 'Issue a new License' ) }
 				wide
 				withBorder
@@ -155,7 +158,7 @@ export default function IssueLicenseV2( { selectedSite, suggestedProduct }: Assi
 						) }
 					</LayoutHeader>
 
-					{ ! selectedSite && (
+					{ showBundle && (
 						<LayoutNavigation { ...selectedItemProps }>
 							<NavigationTabs { ...selectedItemProps } items={ navItems } />
 						</LayoutNavigation>

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/index.tsx
@@ -155,9 +155,11 @@ export default function IssueLicenseV2( { selectedSite, suggestedProduct }: Assi
 						) }
 					</LayoutHeader>
 
-					<LayoutNavigation { ...selectedItemProps }>
-						<NavigationTabs { ...selectedItemProps } items={ navItems } />
-					</LayoutNavigation>
+					{ ! selectedSite && (
+						<LayoutNavigation { ...selectedItemProps }>
+							<NavigationTabs { ...selectedItemProps } items={ navItems } />
+						</LayoutNavigation>
+					) }
 				</LayoutTop>
 
 				<LayoutBody>
@@ -174,6 +176,7 @@ export default function IssueLicenseV2( { selectedSite, suggestedProduct }: Assi
 				<ReviewLicenses
 					onClose={ () => setShowReviewLicenses( false ) }
 					selectedLicenses={ getGroupedLicenses() }
+					selectedSite={ selectedSite }
 				/>
 			) }
 		</>

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/hooks/use-product-and-plans.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/hooks/use-product-and-plans.tsx
@@ -183,20 +183,27 @@ export default function useProductAndPlans( {
 			?.toString()
 			.split( ',' );
 
+		const plans = getDisplayablePlans( filteredProductsAndBundles );
+		const products = getDisplayableProducts( filteredProductsAndBundles );
+		const backupAddons = getProductsAndPlansByFilter(
+			PRODUCT_FILTER_VAULTPRESS_BACKUP_ADDONS,
+			filteredProductsAndBundles
+		);
+		const wooExtensions = getProductsAndPlansByFilter(
+			PRODUCT_FILTER_WOOCOMMERCE_EXTENSIONS,
+			filteredProductsAndBundles
+		);
+
 		return {
 			isLoadingProducts,
 			filteredProductsAndBundles,
-			plans: getDisplayablePlans( filteredProductsAndBundles ),
-			products: getDisplayableProducts( filteredProductsAndBundles ),
-			backupAddons: getProductsAndPlansByFilter(
-				PRODUCT_FILTER_VAULTPRESS_BACKUP_ADDONS,
-				filteredProductsAndBundles
-			),
-			wooExtensions: getProductsAndPlansByFilter(
-				PRODUCT_FILTER_WOOCOMMERCE_EXTENSIONS,
-				filteredProductsAndBundles
-			),
+			plans,
+			products,
+			backupAddons,
+			wooExtensions,
 			suggestedProductSlugs,
+			// We need to merge all the products and plans that we are displaying in the UI
+			allSelectableProducts: [ ...plans, ...products, ...backupAddons, ...wooExtensions ],
 		};
 	}, [
 		addedPlanAndProducts,

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/hooks/use-product-and-plans.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/hooks/use-product-and-plans.tsx
@@ -1,17 +1,12 @@
 import { getQueryArg } from '@wordpress/url';
-import { useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 import {
-	isJetpackBundle,
 	isWooCommerceProduct,
 	isWpcomHostingProduct,
 } from 'calypso/jetpack-cloud/sections/partner-portal/lib';
-import { useDispatch, useSelector } from 'calypso/state';
+import { useSelector } from 'calypso/state';
 import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
 import { getAssignedPlanAndProductIDsForSite } from 'calypso/state/partner-portal/licenses/selectors';
-import {
-	addSelectedProductSlugs,
-	clearSelectedProductSlugs,
-} from 'calypso/state/partner-portal/products/actions';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import {
 	PRODUCT_FILTER_ALL,
@@ -120,28 +115,6 @@ export default function useProductAndPlans( {
 	productSearchQuery,
 }: Props ) {
 	const { data, isLoading: isLoadingProducts } = useProductsQuery();
-	const dispatch = useDispatch();
-
-	useEffect( () => {
-		// If the user comes from the flow for adding a new payment method during an attempt to issue a license
-		// after the payment method is added, we will make an attempt to issue the chosen license automatically.
-		const defaultProductSlugs = getQueryArg( window.location.href, 'products' )
-			?.toString()
-			.split( ',' );
-		// Select the slugs included in the URL
-		defaultProductSlugs &&
-			dispatch(
-				addSelectedProductSlugs(
-					// Filter the bundles and select only individual products
-					defaultProductSlugs.filter( ( slug ) => ! isJetpackBundle( slug ) )
-				)
-			);
-
-		// Clear all selected slugs when navigating away from the page to avoid persisting the data.
-		return () => {
-			dispatch( clearSelectedProductSlugs() );
-		};
-	}, [ dispatch ] );
 
 	const addedPlanAndProducts = useSelector( ( state ) =>
 		selectedSite ? getAssignedPlanAndProductIDsForSite( state, selectedSite.ID ) : null
@@ -185,6 +158,7 @@ export default function useProductAndPlans( {
 
 		return {
 			isLoadingProducts,
+			data,
 			filteredProductsAndBundles,
 			plans: getDisplayablePlans( filteredProductsAndBundles ),
 			products: getDisplayableProducts( filteredProductsAndBundles ),

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/hooks/use-product-and-plans.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/hooks/use-product-and-plans.tsx
@@ -183,27 +183,20 @@ export default function useProductAndPlans( {
 			?.toString()
 			.split( ',' );
 
-		const plans = getDisplayablePlans( filteredProductsAndBundles );
-		const products = getDisplayableProducts( filteredProductsAndBundles );
-		const backupAddons = getProductsAndPlansByFilter(
-			PRODUCT_FILTER_VAULTPRESS_BACKUP_ADDONS,
-			filteredProductsAndBundles
-		);
-		const wooExtensions = getProductsAndPlansByFilter(
-			PRODUCT_FILTER_WOOCOMMERCE_EXTENSIONS,
-			filteredProductsAndBundles
-		);
-
 		return {
 			isLoadingProducts,
 			filteredProductsAndBundles,
-			plans,
-			products,
-			backupAddons,
-			wooExtensions,
+			plans: getDisplayablePlans( filteredProductsAndBundles ),
+			products: getDisplayableProducts( filteredProductsAndBundles ),
+			backupAddons: getProductsAndPlansByFilter(
+				PRODUCT_FILTER_VAULTPRESS_BACKUP_ADDONS,
+				filteredProductsAndBundles
+			),
+			wooExtensions: getProductsAndPlansByFilter(
+				PRODUCT_FILTER_WOOCOMMERCE_EXTENSIONS,
+				filteredProductsAndBundles
+			),
 			suggestedProductSlugs,
-			// We need to merge all the products and plans that we are displaying in the UI
-			allSelectableProducts: [ ...plans, ...products, ...backupAddons, ...wooExtensions ],
 		};
 	}, [
 		addedPlanAndProducts,

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
@@ -51,7 +51,6 @@ export default function LicensesForm( {
 		products,
 		wooExtensions,
 		suggestedProductSlugs,
-		allSelectableProducts,
 	} = useProductAndPlans( {
 		selectedSite,
 		selectedProductFilter,

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
@@ -187,7 +187,9 @@ export default function LicensesForm( {
 					onSelectProduct={ onSelectOrReplaceProduct }
 					isSelected={ isSelected( productOption.map( ( { slug } ) => slug ) ) }
 					selectedOption={ productOption.find( ( option ) =>
-						selectedLicenses.find( ( license ) => license.slug === option.slug )
+						selectedLicenses.find(
+							( license ) => license.slug === option.slug && license.quantity === quantity
+						)
 					) }
 					isDisabled={ ! isReady }
 					tabIndex={ 100 + i }

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
@@ -51,6 +51,7 @@ export default function LicensesForm( {
 		products,
 		wooExtensions,
 		suggestedProductSlugs,
+		allSelectableProducts,
 	} = useProductAndPlans( {
 		selectedSite,
 		selectedProductFilter,

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
@@ -5,7 +5,6 @@ import QueryProductsList from 'calypso/components/data/query-products-list';
 import LicenseProductCard from 'calypso/jetpack-cloud/sections/partner-portal/license-product-card';
 import { JETPACK_CONTACT_SUPPORT_NO_ASSISTANT } from 'calypso/lib/url/support';
 import { useSelector } from 'calypso/state';
-import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
 import { getDisabledProductSlugs } from 'calypso/state/partner-portal/products/selectors';
 import { parseQueryStringProducts } from '../../lib/querystring-products';
 import LicenseMultiProductCard from '../../license-multi-product-card';
@@ -41,8 +40,6 @@ export default function LicensesForm( {
 		PRODUCT_FILTER_ALL
 	);
 
-	const { data } = useProductsQuery();
-
 	const {
 		filteredProductsAndBundles,
 		isLoadingProducts,
@@ -51,6 +48,7 @@ export default function LicensesForm( {
 		products,
 		wooExtensions,
 		suggestedProductSlugs,
+		data,
 	} = useProductAndPlans( {
 		selectedSite,
 		selectedProductFilter,

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/index.tsx
@@ -7,15 +7,17 @@ import useMobileSidebar from 'calypso/components/jetpack/jetpack-lightbox/hooks/
 import LicenseInfo from './license-info';
 import PricingSummary from './pricing-summary';
 import type { SelectedLicenseProp } from '../types';
+import type { SiteDetails } from '@automattic/data-stores';
 
 import './style.scss';
 
 interface Props {
 	onClose: () => void;
 	selectedLicenses: SelectedLicenseProp[];
+	selectedSite?: SiteDetails | null;
 }
 
-export default function ReviewLicenses( { onClose, selectedLicenses }: Props ) {
+export default function ReviewLicenses( { onClose, selectedLicenses, selectedSite }: Props ) {
 	const translate = useTranslate();
 
 	const { sidebarRef, mainRef, initMobileSidebar } = useMobileSidebar();
@@ -38,6 +40,7 @@ export default function ReviewLicenses( { onClose, selectedLicenses }: Props ) {
 							<LicenseInfo
 								key={ `license-info-${ license.product_id }-${ license.quantity }` }
 								product={ license }
+								selectedSite={ selectedSite }
 							/>
 						) ) }
 					</div>
@@ -45,7 +48,7 @@ export default function ReviewLicenses( { onClose, selectedLicenses }: Props ) {
 			</JetpackLightboxMain>
 
 			<JetpackLightboxAside ref={ sidebarRef }>
-				<PricingSummary selectedLicenses={ selectedLicenses } />
+				<PricingSummary selectedLicenses={ selectedLicenses } selectedSite={ selectedSite } />
 			</JetpackLightboxAside>
 		</JetpackLightbox>
 	);

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/license-info.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/license-info.tsx
@@ -2,8 +2,15 @@ import { useTranslate } from 'i18n-calypso';
 import getProductIcon from 'calypso/my-sites/plans/jetpack-plans/product-store/utils/get-product-icon';
 import { useLicenseLightboxData } from '../../license-lightbox/hooks/use-license-lightbox-data';
 import type { SelectedLicenseProp } from '../types';
+import type { SiteDetails } from '@automattic/data-stores';
 
-export default function LicenseInfo( { product }: { product: SelectedLicenseProp } ) {
+export default function LicenseInfo( {
+	product,
+	selectedSite,
+}: {
+	product: SelectedLicenseProp;
+	selectedSite?: SiteDetails | null;
+} ) {
 	const translate = useTranslate();
 
 	const { title, product: productInfo } = useLicenseLightboxData( product );
@@ -23,15 +30,17 @@ export default function LicenseInfo( { product }: { product: SelectedLicenseProp
 						<label htmlFor={ title } className="review-licenses__license-label">
 							{ title }
 						</label>
-						<span className="review-licenses__license-count">
-							{ translate( '%(numLicenses)d license', '%(numLicenses)d licenses', {
-								context: 'button label',
-								count: product.quantity,
-								args: {
-									numLicenses: product.quantity,
-								},
-							} ) }
-						</span>
+						{ ! selectedSite && (
+							<span className="review-licenses__license-count">
+								{ translate( '%(numLicenses)d license', '%(numLicenses)d licenses', {
+									context: 'button label',
+									count: product.quantity,
+									args: {
+										numLicenses: product.quantity,
+									},
+								} ) }
+							</span>
+						) }
 					</div>
 					<p className="review-licenses__license-description">
 						{ productInfo.lightboxDescription }

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/pricing-breakdown.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/pricing-breakdown.tsx
@@ -4,14 +4,17 @@ import { useTranslate } from 'i18n-calypso';
 import { useLicenseLightboxData } from '../../license-lightbox/hooks/use-license-lightbox-data';
 import { getProductPricingInfo, getTotalInvoiceValue } from '../lib/pricing';
 import type { SelectedLicenseProp } from '../types';
+import type { SiteDetails } from '@automattic/data-stores';
 import type { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
 
 const LicenseItem = ( {
 	license,
 	userProducts,
+	selectedSite,
 }: {
 	license: SelectedLicenseProp;
 	userProducts: Record< string, ProductListItem >;
+	selectedSite?: SiteDetails | null;
 } ) => {
 	const { actualCost, discountedCost } = getProductPricingInfo(
 		userProducts,
@@ -25,7 +28,7 @@ const LicenseItem = ( {
 		<div className="review-licenses__license-item">
 			<span className="review-licenses__license-item-column">
 				<Icon size={ 24 } icon={ check } />
-				{ title } x{ license.quantity }
+				{ title } { ! selectedSite && `x ${ license.quantity }` }
 			</span>
 			<span className="review-licenses__license-item-column">
 				{ formatCurrency( discountedCost, license.currency ) }
@@ -40,9 +43,11 @@ const LicenseItem = ( {
 export default function PricingBreakdown( {
 	selectedLicenses,
 	userProducts,
+	selectedSite,
 }: {
 	selectedLicenses: SelectedLicenseProp[];
 	userProducts: Record< string, ProductListItem >;
+	selectedSite?: SiteDetails | null;
 } ) {
 	const translate = useTranslate();
 
@@ -56,6 +61,7 @@ export default function PricingBreakdown( {
 						key={ `license-item-${ license.product_id }-${ license.quantity }` }
 						license={ license }
 						userProducts={ userProducts }
+						selectedSite={ selectedSite }
 					/>
 				) ) }
 			</div>

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/pricing-summary.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/review-licenses/pricing-summary.tsx
@@ -8,11 +8,14 @@ import useSubmitForm from '../hooks/use-submit-form';
 import { getTotalInvoiceValue } from '../lib/pricing';
 import PricingBreakdown from './pricing-breakdown';
 import type { SelectedLicenseProp } from '../types';
+import type { SiteDetails } from '@automattic/data-stores';
 
 export default function PricingSummary( {
 	selectedLicenses,
+	selectedSite,
 }: {
 	selectedLicenses: SelectedLicenseProp[];
+	selectedSite?: SiteDetails | null;
 } ) {
 	const translate = useTranslate();
 
@@ -23,9 +26,7 @@ export default function PricingSummary( {
 		.map( ( license ) => license.quantity )
 		.reduce( ( a, b ) => a + b, 0 );
 
-	// NOTE: Because we're now able to issue multiple licenses, we may need to
-	// re-spec the behavior for when a specific site is selected
-	const { isReady: isFormReady, submitForm } = useSubmitForm( null );
+	const { isReady: isFormReady, submitForm } = useSubmitForm( selectedSite );
 	const handleCTAClick = useCallback( () => {
 		if ( ! isFormReady ) {
 			return;
@@ -75,7 +76,11 @@ export default function PricingSummary( {
 					}
 				) }
 			</div>
-			<PricingBreakdown userProducts={ userProducts } selectedLicenses={ selectedLicenses } />
+			<PricingBreakdown
+				userProducts={ userProducts }
+				selectedLicenses={ selectedLicenses }
+				selectedSite={ selectedSite }
+			/>
 		</>
 	);
 }

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/style.scss
@@ -35,3 +35,9 @@
 	@include licensing-portal-bottom-action-bar;
 	padding: 14px;
 }
+
+.issue-license-v2.without-bundle {
+	.jetpack-cloud-layout__header-subtitle {
+		padding-block-end: 16px;
+	}
+}


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/148

## Proposed Changes

This PR

- Fixes the issue that doesn't pre-select all the licenses when redirected from the Dashboard
- Hides the bundle tabs when a user is trying to purchase a license for a selected site.
- Removes from unnecessary code.
- Updates the redirect link from the dashboard to pass `products` instead of `product_slug`

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

**Instructions**

1. Visit the Jetpack Cloud link > Visit /partner-portal/payment-methods > Remove all the payment methods 
2. Visit the dashboard > Select both Backup & Scan for any site > Click the `Issue 2 license` button on top > Verify that both the licenses are selected on the Issue license page & you can now see the site ID. We should ideally show the site name, which we will do in another PR. Also, verify that no bundles are shown.

<img width="1178" alt="Screenshot 2023-12-15 at 9 00 16 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/d79efda0-064b-4550-b8b4-5724adffdb43">

3. Select any other license if you would like > Click the `Review N licenses` button > Click the `Issue N licenses` button > When redirected to the Payment Methods page, wait for the `Go back` button to be enabled > Verify that site ID is available in the URL
4. Click the `Go back` button > Verify that previously selected licenses are pre-selected & site ID is available in the URL > Select/Deselect a few licenses > Click the Review N licenses button > Verify that the selection is accurate.
5. Click the `Issue N licenses` button > Add payment details > Verify that all the selected licenses are issued & assigned to the site selected.
6. Repeat step 2 >  Click the `Review N licenses` button > Click the `Issue N licenses` button > Verify that the selected licenses are issued and assigned to the site.
7. Repeat the same steps with the feature flag disabled: `?flags=-jetpack/bundle-licensing` and verify everything works as expected. Mainly verify that you are able to issue and assign licenses to a selected site with & without payment method.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?