### PR TITLE
Assembler: Add event calypso_signup_pattern_assembler_pattern_final_select

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/events.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/events.ts
@@ -13,6 +13,7 @@ export const PATTERN_ASSEMBLER_EVENTS = {
 	 */
 	MAIN_ITEM_SELECT: 'calypso_signup_pattern_assembler_main_item_select',
 	BACK_CLICK: 'calypso_signup_pattern_assembler_back_click',
+	PAGE_FINAL_SELECT: 'calypso_signup_pattern_assembler_page_final_select',
 	PATTERN_FINAL_SELECT: 'calypso_signup_pattern_assembler_pattern_final_select',
 	CATEGORY_LIST_CATEGORY_CLICK: 'calypso_signup_pattern_assembler_category_click',
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -232,9 +232,9 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 		pages.forEach( ( { ID, name, categories = {} } ) => {
 			const category_slug = Object.keys( categories )[ 0 ];
 			recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.PAGE_FINAL_SELECT, {
-				page_id: ID,
-				page_name: name,
-				...( category_slug && { page_category: category_slug } ),
+				pattern_id: ID,
+				pattern_name: name,
+				...( category_slug && { pattern_category: category_slug } ),
 			} );
 		} );
 	};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -143,7 +143,6 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 				font_variation_type: getVariationType( fontVariation ),
 				assembler_source: getAssemblerSource( selectedDesign ),
 				has_global_styles_selected: numOfSelectedGlobalStyles > 0,
-				page_slugs: ( pageSlugs || [] ).join( ',' ),
 			} ),
 		[
 			flow,
@@ -219,6 +218,7 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 			pattern_categories: categories.join( ',' ),
 			category_count: categories.length,
 			pattern_count: patterns.length,
+			page_slugs: ( pageSlugs || [] ).join( ',' ),
 		} );
 
 		patterns.forEach( ( { ID, name, category } ) => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -220,11 +220,21 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 			category_count: categories.length,
 			pattern_count: patterns.length,
 		} );
+
 		patterns.forEach( ( { ID, name, category } ) => {
 			recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.PATTERN_FINAL_SELECT, {
 				pattern_id: ID,
 				pattern_name: name,
 				pattern_category: category?.name,
+			} );
+		} );
+
+		pages.forEach( ( { ID, name, categories = {} } ) => {
+			const category_slug = Object.keys( categories )[ 0 ];
+			recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.PAGE_FINAL_SELECT, {
+				page_id: ID,
+				page_name: name,
+				...( category_slug && { page_category: category_slug } ),
 			} );
 		} );
 	};


### PR DESCRIPTION
## Proposed Changes

See https://github.com/Automattic/dotcom-forge/issues/4899. This PR adds the event `calypso_signup_pattern_assembler_page_final_select` which is fired for every selected page, upon Assembler completion.

The event has three properties of note:
| Name | Description |
| --- | --- |
| `pattern_id` | The pattern ID |
| `pattern_name` | The pattern name (slug) |
| `pattern_category` | The category of the pattern. Show the first one if there are multiple categories | 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Assembler.
* Select any patterns.
* Select any styles.
* Select at least one page.
* Complete the Assembler flow, and ensure that the `calypso_signup_pattern_assembler_page_final_select` is fired n time for n pages selected.
* Ensure that the event has the properties as described above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?