### PR TITLE
Jetpack Manage: Show the site name when a site is selected while issuing licenses

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/index.tsx
@@ -116,7 +116,15 @@ export default function IssueLicenseV2( { selectedSite, suggestedProduct }: Assi
 					<LayoutHeader showStickyContent={ showStickyContent }>
 						<Title>{ translate( 'Issue product licenses' ) } </Title>
 						<Subtitle>
-							{ translate( 'Select single product licenses or save when you issue in bulk' ) }
+							{ selectedSite?.domain
+								? translate(
+										'Select the Jetpack products you would like to add to {{strong}}%(selectedSiteDomain)s{{/strong}}:',
+										{
+											args: { selectedSiteDomain: selectedSite.domain },
+											components: { strong: <strong /> },
+										}
+								  )
+								: translate( 'Select single product licenses or save when you issue in bulk' ) }
 						</Subtitle>
 						{ selectedLicenses.length > 0 && (
 							<Actions>


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/151

## Proposed Changes

This PR shows the site name when a site is selected while issuing licenses

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

**Instructions**

1. Visit the Jetpack Cloud link > Click the `...` button on any site > Select the `Issue new license` option  > Verify that the site name is displayed on the issue license page

<img width="688" alt="Screenshot 2023-12-15 at 9 17 14 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/f257f66f-670c-4ae8-98f2-8ce7509873dc">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?