### PR TITLE
Fix blogger intent button on hover color

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/blogger-intent/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/blogger-intent/style.scss
@@ -114,7 +114,7 @@
 				background: var(--studio-blue-60);
 			}
 			&:hover {
-				background-color: var(--wp-admin-theme-color-darker-10);
+				background-color: var(--studio-blue-60);
 			}
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/4902

## Proposed Changes

* Changes button hover color to blue-60

## Testing Instructions

While logged out, go to https://wordpress.com/setup/blog, creating a new user will land you on the blogger intent step: /setup/blog/blogger-intent

Before

![Screenshot_2023-12-15_16-09-19](https://github.com/Automattic/wp-calypso/assets/811776/f08ebf3c-d6d8-4086-b915-5c44fb585030)

After

![Screenshot_2023-12-15_16-13-22](https://github.com/Automattic/wp-calypso/assets/811776/e2a27a37-af05-4aa0-acc4-1df969b02bcb)
