### PR TITLE
Fix domain package plan plan selection padding

### DIFF
--- a/client/my-sites/plans/style.scss
+++ b/client/my-sites/plans/style.scss
@@ -63,6 +63,7 @@ body.is-section-plans.is-domain-plan-package-flow {
 	background: var(--color-body-background);
 
 	.layout__content {
+		padding-top: 0 !important;
 		padding-left: 0 !important;
 	}
 


### PR DESCRIPTION
Context: p1702614766205829-slack-C9EJ7KSGH

## Proposed Changes

* Not super happy with the fix as it incorporates `!important`, creating an issue to track on improving it: https://github.com/Automattic/wp-calypso/issues/85340
* This also fixes when the launchpad is using the same flow to upgrade their domain e.g., newsletter flow

Before

https://github.com/Automattic/wp-calypso/assets/6586048/0307ee4e-0538-4bca-8131-5e26d2f1313a

After

![after](https://github.com/Automattic/wp-calypso/assets/6586048/2e912853-772f-4faf-b1f5-fc28cfb3f41f)


## Testing Instructions

Entrypoint 1: On a free site /home:
![image](https://github.com/Automattic/wp-calypso/assets/6586048/9a916fb2-d0b7-48ff-9719-c632d9b1af52)

Entrypoint 2: Go through the /setup/newsletter
![newsletter](https://github.com/Automattic/wp-calypso/assets/6586048/825c37c5-af4c-42f4-80fb-a89fcb7364a7)

Check layout

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?