### PR TITLE
Jetpack Manage: Fix the flickering review licenses button on the Issue license page.

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/license-multi-product-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-multi-product-card/index.tsx
@@ -85,7 +85,8 @@ export default function LicenseMultiProductCard( props: Props ) {
 				onSelect();
 			}
 		}
-	}, [ onSelect, product.slug, suggestedProduct ] );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ product.slug, suggestedProduct ] );
 
 	const onShowLightbox = useCallback(
 		( e: React.MouseEvent< HTMLElement > ) => {

--- a/client/jetpack-cloud/sections/partner-portal/license-multi-product-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-multi-product-card/index.tsx
@@ -85,6 +85,7 @@ export default function LicenseMultiProductCard( props: Props ) {
 				onSelect();
 			}
 		}
+		// Do not add onSelect to the dependency array as it will cause an infinite loop
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ product.slug, suggestedProduct ] );
 


### PR DESCRIPTION
When initiating an Issue Backup license flow from the dashboard, the Issue Licenses page keeps flickering.

https://github.com/Automattic/wp-calypso/assets/56598660/f3907dc8-f264-4cfa-ad95-7c77a2904dff


Closes https://github.com/orgs/Automattic/projects/818/views/1?pane=issue&itemId=47640143

## Proposed Changes

* Remove the `onSelect` from the `useEffect` dependency list to prevent the multi-variant card from re-rendering.

## Testing Instructions
Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

Use the Jetpack Cloud live link and go to the Dashboard page (/dashboard)

* Click the Backup tooltip in the header to open the Product modal and Issue a license.
   <img width="303" alt="Screen Shot 2023-12-15 at 2 22 38 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/05162778-8b6d-4682-ad36-23a1278473f2">
* Confirm that the flickering issue has been resolved.


## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?