### PR TITLE
Stats: Fix for average payment amount in PWYW flow

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -140,6 +140,7 @@ const PersonalPurchase = ( {
 				<StatsPWYWUpgradeSlider
 					settings={ sliderSettings }
 					currencyCode={ currencyCode }
+					defaultStartingValue={ defaultStartingValue }
 					onSliderChange={ handleSliderChanged }
 				/>
 			) }

--- a/client/my-sites/stats/stats-purchase/stats-pwyw-uprade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-pwyw-uprade-slider/index.tsx
@@ -27,7 +27,7 @@ function getPWYWPlanTiers( minPrice: number, stepPrice: number ) {
 	return tiers;
 }
 
-function useTranslatedStrings( defaultAveragePayment: number ) {
+function useTranslatedStrings( defaultAveragePayment: number, currencyCode: string ) {
 	const translate = useTranslate();
 	const limits = translate( 'Your monthly contribution', {
 		comment: 'Heading for Stats PWYW Upgrade slider. The monthly payment amount.',
@@ -38,7 +38,7 @@ function useTranslatedStrings( defaultAveragePayment: number ) {
 	const strategy = translate( 'The average person pays %(value)s per month, billed yearly', {
 		comment: 'Stats PWYW Upgrade slider message. The billing strategy.',
 		args: {
-			value: formatCurrency( defaultAveragePayment, '', { stripZeros: true } ),
+			value: formatCurrency( defaultAveragePayment, currencyCode, { stripZeros: true } ),
 		},
 	} ) as string;
 
@@ -108,7 +108,7 @@ function StatsPWYWUpgradeSlider( {
 	// 4. Nofiying the parent component when the slider changes.
 
 	const defaultAveragePayment = defaultStartingValue * settings.sliderStepPrice;
-	const uiStrings = useTranslatedStrings( defaultAveragePayment );
+	const uiStrings = useTranslatedStrings( defaultAveragePayment, currencyCode );
 
 	let steps = getPWYWPlanTiers( 0, 50 );
 	if ( settings !== undefined ) {

--- a/client/my-sites/stats/stats-purchase/stats-pwyw-uprade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-pwyw-uprade-slider/index.tsx
@@ -107,6 +107,7 @@ function StatsPWYWUpgradeSlider( {
 	// 3. Rendering the slider.
 	// 4. Nofiying the parent component when the slider changes.
 
+	// TODO: Figure out how to get the actual average payment from the API in the future.
 	const defaultAveragePayment = defaultStartingValue * settings.sliderStepPrice;
 	const uiStrings = useTranslatedStrings( defaultAveragePayment, currencyCode );
 

--- a/client/my-sites/stats/stats-purchase/stats-pwyw-uprade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-pwyw-uprade-slider/index.tsx
@@ -27,7 +27,7 @@ function getPWYWPlanTiers( minPrice: number, stepPrice: number ) {
 	return tiers;
 }
 
-function useTranslatedStrings() {
+function useTranslatedStrings( defaultAveragePayment: number ) {
 	const translate = useTranslate();
 	const limits = translate( 'Your monthly contribution', {
 		comment: 'Heading for Stats PWYW Upgrade slider. The monthly payment amount.',
@@ -35,11 +35,10 @@ function useTranslatedStrings() {
 	const price = translate( 'Thank you!', {
 		comment: 'Heading for Stats PWYW Upgrade slider. The thank you message.',
 	} ) as string;
-	const defaultAverageAmount = 7; // Matches the default set in the slider.
 	const strategy = translate( 'The average person pays %(value)s per month, billed yearly', {
 		comment: 'Stats PWYW Upgrade slider message. The billing strategy.',
 		args: {
-			value: formatCurrency( defaultAverageAmount, '', { stripZeros: true } ),
+			value: formatCurrency( defaultAveragePayment, '', { stripZeros: true } ),
 		},
 	} ) as string;
 
@@ -90,14 +89,16 @@ function stepsFromSettings( settings: StatsPWYWSliderSettings, currencyCode: str
 }
 
 type StatsPWYWUpgradeSliderProps = {
-	settings?: StatsPWYWSliderSettings;
-	currencyCode?: string;
+	settings: StatsPWYWSliderSettings;
+	currencyCode: string;
+	defaultStartingValue: number;
 	onSliderChange: ( index: number ) => void;
 };
 
 function StatsPWYWUpgradeSlider( {
 	settings,
 	currencyCode,
+	defaultStartingValue,
 	onSliderChange,
 }: StatsPWYWUpgradeSliderProps ) {
 	// Responsible for:
@@ -106,7 +107,8 @@ function StatsPWYWUpgradeSlider( {
 	// 3. Rendering the slider.
 	// 4. Nofiying the parent component when the slider changes.
 
-	const uiStrings = useTranslatedStrings();
+	const defaultAveragePayment = defaultStartingValue * settings.sliderStepPrice;
+	const uiStrings = useTranslatedStrings( defaultAveragePayment );
 
 	let steps = getPWYWPlanTiers( 0, 50 );
 	if ( settings !== undefined ) {
@@ -123,7 +125,7 @@ function StatsPWYWUpgradeSlider( {
 			className="stats-pwyw-upgrade-slider"
 			uiStrings={ uiStrings }
 			steps={ steps }
-			initialValue={ ( steps.length - 1 ) / 2 }
+			initialValue={ defaultStartingValue }
 			onSliderChange={ handleSliderChanged }
 			marks={ marks }
 		/>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #85343.

## Proposed Changes

Uses the initial value (the default plan index) as provided by the caller to determine the "average" amount. We don't actually have the info we are reporting here and instead we are just picking the middle of the computed range of plans. Should properly reflect this strategy and print with the user's currency now.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Launch the Calypso Live link.
* Navigate to **Stats → Traffic**.
* Click on CTA to purchase Stats plan.
* Add `stats/tier-upgrade-slider` to URL flags.
* Confirm the slider defaults to the middle tier.
* Confirm the "average" amount matches the tier and shows the correct currency info.

**Note:** The emoji aren't computed correctly at the moment. I'll address that in a separate PR.

### Example using CAD
<img width="584" alt="SCR-20231215-omys" src="https://github.com/Automattic/wp-calypso/assets/40267301/10e59961-0f40-4151-9b25-c5934befff80">

### Example using JPY
<img width="582" alt="SCR-20231215-onfs" src="https://github.com/Automattic/wp-calypso/assets/40267301/4a566956-1c19-4d53-bd45-eba48c2221f3">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?