### PR TITLE
Hide the dotcom assembler when the user filters by 'free' for WooExpress

### DIFF
--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -18,6 +18,7 @@ import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import getSiteEditorUrl from 'calypso/state/selectors/get-site-editor-url';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
+import { isSiteOnECommerceTrial, isSiteOnWooExpress } from 'calypso/state/sites/plans/selectors';
 import { getSiteThemeInstallUrl } from 'calypso/state/sites/selectors';
 import { upsellCardDisplayed as upsellCardDisplayedAction } from 'calypso/state/themes/actions';
 import { DEFAULT_THEME_QUERY } from 'calypso/state/themes/constants';
@@ -130,9 +131,9 @@ export const ThemesList = ( { tabFilter, ...props } ) => {
 				 Second plan upsell at 7th row is implemented through CSS. */ }
 			{ showSecondUpsellNudge && SecondUpsellNudge }
 			{ /* The Pattern Assembler CTA will display on the 9th row and the behavior is controlled by CSS */ }
-			{ tabFilter !== 'my-themes' && props.themes.length > 0 && (
-				<PatternAssemblerCta onButtonClick={ goToSiteAssemblerFlow } />
-			) }
+			{ ! ( props.isSiteWooExpressOrEcomFreeTrial && props.tier === 'free' ) &&
+				tabFilter !== 'my-themes' &&
+				props.themes.length > 0 && <PatternAssemblerCta onButtonClick={ goToSiteAssemblerFlow } /> }
 			{ props.children }
 			{ props.loading && <LoadingPlaceholders placeholderCount={ props.placeholderCount } /> }
 			<InfiniteScroll nextPageMethod={ fetchNextPage } />
@@ -165,6 +166,7 @@ ThemesList.propTypes = {
 	] ),
 	siteId: PropTypes.number,
 	searchTerm: PropTypes.string,
+	tier: PropTypes.oneOf( [ '', 'free', 'premium', 'marketplace' ] ),
 	upsellCardDisplayed: PropTypes.func,
 	children: PropTypes.node,
 };
@@ -412,9 +414,13 @@ function LoadingPlaceholders( { placeholderCount } ) {
 	} );
 }
 
-const mapStateToProps = ( state ) => ( {
-	themesBookmark: getThemesBookmark( state ),
-} );
+const mapStateToProps = ( state, { siteId } ) => {
+	return {
+		themesBookmark: getThemesBookmark( state ),
+		isSiteWooExpressOrEcomFreeTrial:
+			isSiteOnECommerceTrial( state, siteId ) || isSiteOnWooExpress( state, siteId ),
+	};
+};
 
 const mapDispatchToProps = {
 	upsellCardDisplayed: upsellCardDisplayedAction,

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -212,6 +212,7 @@ class ThemesSelection extends Component {
 			shouldFetchWpOrgThemes,
 			wpOrgQuery,
 			wpOrgThemes,
+			tier,
 		} = this.props;
 
 		const interlacedThemes = interlaceThemes( themes, wpOrgThemes, query.search, isLastPage );
@@ -243,6 +244,7 @@ class ThemesSelection extends Component {
 					siteId={ siteId }
 					searchTerm={ query.search }
 					tabFilter={ tabFilter }
+					tier={ tier }
 				>
 					{ this.props.children }
 				</ThemesList>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1702413214216389/1702332881.674889-slack-C03Q87XT1QF

## Proposed Changes

* Hide the dotcom assembler when the user filters by 'free' for WooExpress 

Before:

![Screenshot 2023-12-15 at 15 19 51](https://github.com/Automattic/wp-calypso/assets/4344253/8f0f0f45-d322-42fc-8c38-f12d850cd988)

After:
![Screenshot 2023-12-15 at 15 19 03](https://github.com/Automattic/wp-calypso/assets/4344253/f63bb033-30e5-40b9-8082-ac380baa8533)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a woo express site
* Go to `http://calypso.localhost:3000/themes/all/free/<site-url>`
* Confirm dotcom assembler is hidden
* Go to `http://calypso.localhost:3000/themes/all/<site-url>`
* Confirm dotcom assembler is shown

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?