### PR TITLE
Fix incorrect padding on the `ThemeUpgradeModal`

### DIFF
--- a/client/components/theme-upgrade-modal/style.scss
+++ b/client/components/theme-upgrade-modal/style.scss
@@ -171,6 +171,7 @@ $design-button-primary-hover-color: var(--color-primary-60);
 		position: absolute;
 		top: 12px;
 		right: 12px;
+		padding: 0;
 
 		.wpicon {
 			fill: var(--color-text-subtle);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/85013

## Proposed Changes

This PR addresses a regression in the `ThemeUpgradeModal`, which was introduced in https://github.com/Automattic/wp-calypso/pull/85013. It fixes padding on the close icon by resetting the style from components. 

| before | after |
|--------|--------|
| <img width="1437" alt="Screenshot 2023-12-15 at 16 25 24" src="https://github.com/Automattic/wp-calypso/assets/5287479/b38d82ef-0794-4773-844c-48aed4f64ef5"> | <img width="1433" alt="Screenshot 2023-12-15 at 16 21 49" src="https://github.com/Automattic/wp-calypso/assets/5287479/dec593a8-f4d3-4745-94cc-a264df955c19"> |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Prepare a Free site
* Go to `/setup/site-setup/designSetup?siteSlug=<your-site>`
* Pick a Premium theme
* Click `Unlock theme`
* Verify padding is correct

I also confirmed there is no regression on the Live Preview Upgrade modal. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?