### PR TITLE
Jetpack Manage: Fix the child license revoke message

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-list/index.tsx
@@ -99,6 +99,7 @@ export default function LicenseList() {
 										: LicenseType.Partner
 								}
 								quantity={ license.quantity }
+								isChildLicense={ !! license.parentLicenseId }
 							/>
 						</LicenseTransition>
 					) ) }

--- a/client/state/partner-portal/licenses/handlers.ts
+++ b/client/state/partner-portal/licenses/handlers.ts
@@ -38,6 +38,7 @@ interface APILicense {
 	revoked_at: string | null;
 	owner_type: string | null;
 	quantity: number | null;
+	parent_license_id: number | null;
 }
 
 interface APIPaginatedItems< T > {
@@ -113,6 +114,7 @@ export function formatLicenses( items: APILicense[] ): License[] {
 		revokedAt: item.revoked_at,
 		ownerType: item.owner_type,
 		quantity: item.quantity,
+		parentLicenseId: item.parent_license_id,
 	} ) );
 }
 

--- a/client/state/partner-portal/types.ts
+++ b/client/state/partner-portal/types.ts
@@ -243,6 +243,7 @@ export interface License {
 	revokedAt: string | null;
 	ownerType: string | null;
 	quantity: number | null;
+	parentLicenseId: number | null;
 }
 
 export interface LicenseCounts {


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/150

## Proposed Changes

This PR fixes the child license revoke message.

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

**Instructions**

1. Apply the patch: D132158-code
2. Visit the Jetpack Cloud link > Go to the Licenses page > Search for a Child license by using its license key.
3. Click the Revoke button > Verify that the dialog shows a specific message for revoking a child license.

<img width="694" alt="Screenshot 2023-12-15 at 2 14 45 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/dde1e0e9-e23f-46cb-a796-809023963c42">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?