### PR TITLE
Unhardcode plan name instances - part 2

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -1,6 +1,7 @@
+import { PLAN_PREMIUM, getPlan } from '@automattic/calypso-products';
 import { CompactCard, ScreenReaderText } from '@automattic/components';
 import classNames from 'classnames';
-import { localize } from 'i18n-calypso';
+import i18n, { localize } from 'i18n-calypso';
 import { get, times } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -69,12 +70,14 @@ class DomainSearchResults extends Component {
 			selectedSite,
 			translate,
 			isDomainOnly,
+			locale,
 		} = this.props;
 		const availabilityElementClasses = classNames( {
 			'domain-search-results__domain-is-available': availableDomain,
 			'domain-search-results__domain-not-available': ! availableDomain,
 		} );
 		const suggestions = this.props.suggestions || [];
+		const isEnglishLocale = [ 'en', 'en-gb' ].includes( locale );
 		const {
 			MAPPABLE,
 			MAPPED,
@@ -123,10 +126,22 @@ class DomainSearchResults extends Component {
 						{ args: { domain }, components }
 					);
 				} else {
-					offer = translate(
-						'If you purchased %(domain)s elsewhere, you can {{a}}connect it{{/a}} with WordPress.com Premium.',
-						{ args: { domain }, components }
-					);
+					offer =
+						isEnglishLocale ||
+						i18n.hasTranslation(
+							'If you purchased %(domain)s elsewhere, you can {{a}}connect it{{/a}} with WordPress.com %(premiumPlanName)s.'
+						)
+							? translate(
+									'If you purchased %(domain)s elsewhere, you can {{a}}connect it{{/a}} with WordPress.com %(premiumPlanName)s.',
+									{
+										args: { domain, premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() ?? '' },
+										components,
+									}
+							  )
+							: translate(
+									'If you purchased %(domain)s elsewhere, you can {{a}}connect it{{/a}} with WordPress.com Premium.',
+									{ args: { domain }, components }
+							  );
 				}
 			}
 

--- a/client/components/premium-global-styles-upgrade-modal/use-global-styles-upgrade-translations.tsx
+++ b/client/components/premium-global-styles-upgrade-modal/use-global-styles-upgrade-translations.tsx
@@ -1,4 +1,5 @@
-import { PLAN_PREMIUM, getPlan } from '@automattic/calypso-products';
+import { PLAN_PREMIUM } from '@automattic/calypso-products';
+import { usePlans } from '@automattic/data-stores/src/plans';
 import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import i18n, { useTranslate } from 'i18n-calypso';
 
@@ -9,8 +10,9 @@ interface Props {
 const useGlobalStylesUpgradeTranslations = ( { numOfSelectedGlobalStyles = 1 }: Props ) => {
 	const translate = useTranslate();
 	const isEnglishLocale = useIsEnglishLocale();
-	const plan = getPlan( PLAN_PREMIUM );
-	const planTitle = plan?.getTitle() ?? '';
+	const plans = usePlans();
+	const planTitle = plans?.data?.[ PLAN_PREMIUM ]?.productNameShort ?? '';
+
 	const features = [
 		<strong>{ translate( 'Free domain for one year' ) }</strong>,
 		<strong>{ translate( 'Premium themes' ) }</strong>,

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-bundled-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-bundled-badge.js
@@ -1,6 +1,8 @@
+import { PLAN_BUSINESS, getPlan } from '@automattic/calypso-products';
 import { BundledBadge, PremiumBadge } from '@automattic/components';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { createInterpolateElement } from '@wordpress/element';
-import { useTranslate } from 'i18n-calypso';
+import i18n, { useTranslate } from 'i18n-calypso';
 import { useBundleSettingsByTheme } from 'calypso/my-sites/theme/hooks/use-bundle-settings';
 import { useSelector } from 'calypso/state';
 import { canUseTheme } from 'calypso/state/themes/selectors';
@@ -18,6 +20,8 @@ export default function ThemeTierBundledBadge() {
 	const isThemeIncluded = useSelector(
 		( state ) => siteId && canUseTheme( state, siteId, themeId )
 	);
+
+	const isEnglishLocale = useIsEnglishLocale();
 
 	if ( ! bundleSettings ) {
 		return;
@@ -37,11 +41,26 @@ export default function ThemeTierBundledBadge() {
 			</div>
 			<div data-testid="upsell-message">
 				{ createInterpolateElement(
-					// Translators: %(bundleName)s is the name of the bundle, sometimes represented as a product name. Examples: "WooCommerce" or "Special".
-					translate( 'This %(bundleName)s theme is included in the <Link>Business plan</Link>.', {
-						args: { bundleName },
-						textOnly: true,
-					} ),
+					isEnglishLocale ||
+						i18n.hasTranslation(
+							'This %(bundleName)s theme is included in the <Link>%(businessPlanName)s plan</Link>.'
+						)
+						? // Translators: %(bundleName)s is the name of the bundle, sometimes represented as a product name. Examples: "WooCommerce" or "Special".
+						  translate(
+								'This %(bundleName)s theme is included in the <Link>%(businessPlanName)s plan</Link>.',
+								{
+									args: { bundleName },
+									textOnly: true,
+									businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+								}
+						  )
+						: translate(
+								'This %(bundleName)s theme is included in the <Link>Business plan</Link>.',
+								{
+									args: { bundleName },
+									textOnly: true,
+								}
+						  ),
 					{
 						Link: <ThemeTierBadgeCheckoutLink plan="business" />,
 					}

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-community-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-community-badge.js
@@ -1,6 +1,8 @@
+import { PLAN_BUSINESS, getPlan } from '@automattic/calypso-products';
 import { PremiumBadge } from '@automattic/components';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { createInterpolateElement } from '@wordpress/element';
-import { useTranslate } from 'i18n-calypso';
+import i18n, { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'calypso/state';
 import { canUseTheme } from 'calypso/state/themes/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -13,6 +15,7 @@ export default function ThemeTierCommunityBadge() {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
 	const { themeId } = useThemeTierBadgeContext();
+	const isEnglishLocale = useIsEnglishLocale();
 	const isThemeIncluded = useSelector(
 		( state ) => siteId && canUseTheme( state, siteId, themeId )
 	);
@@ -28,9 +31,17 @@ export default function ThemeTierCommunityBadge() {
 			</div>
 			<div data-testid="upsell-message">
 				{ createInterpolateElement(
-					translate(
-						'This community theme can only be installed if you have the <Link>Business plan</Link> or higher on your site.'
-					),
+					isEnglishLocale ||
+						i18n.hasTranslation(
+							'This community theme can only be installed if you have the <Link>%(businessNamePlan)s plan</Link> or higher on your site.'
+						)
+						? translate(
+								'This community theme can only be installed if you have the <Link>%(businessNamePlan)s plan</Link> or higher on your site.',
+								{ args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' } }
+						  )
+						: translate(
+								'This community theme can only be installed if you have the <Link>Business plan</Link> or higher on your site.'
+						  ),
 					{
 						Link: <ThemeTierBadgeCheckoutLink plan="business" />,
 					}

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-partner-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-partner-badge.js
@@ -1,6 +1,8 @@
+import { PLAN_BUSINESS, getPlan } from '@automattic/calypso-products';
 import { PremiumBadge } from '@automattic/components';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { createInterpolateElement } from '@wordpress/element';
-import { useTranslate } from 'i18n-calypso';
+import i18n, { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'calypso/state';
 import {
 	isMarketplaceThemeSubscribed,
@@ -17,6 +19,7 @@ export default function ThemeTierPartnerBadge() {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
 	const { themeId } = useThemeTierBadgeContext();
+	const isEnglishLocale = useIsEnglishLocale();
 	const isPartnerThemePurchased = useSelector( ( state ) =>
 		siteId ? isMarketplaceThemeSubscribed( state, themeId, siteId ) : false
 	);
@@ -32,9 +35,17 @@ export default function ThemeTierPartnerBadge() {
 	const getTooltipMessage = () => {
 		if ( isPartnerThemePurchased && ! isThemeAllowedOnSite ) {
 			return createInterpolateElement(
-				translate(
-					'You have a subscription for this theme, but it will only be usable if you have the <link>Business plan</link> on your site.'
-				),
+				isEnglishLocale ||
+					i18n.hasTranslation(
+						'You have a subscription for this theme, but it will only be usable if you have the <link>%(businessPlanName)s plan</link> on your site.'
+					)
+					? translate(
+							'You have a subscription for this theme, but it will only be usable if you have the <link>%(businessPlanName)s plan</link> on your site.',
+							{ args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' } }
+					  )
+					: translate(
+							'You have a subscription for this theme, but it will only be usable if you have the <link>Business plan</link> on your site.'
+					  ),
 				{
 					Link: <ThemeTierBadgeCheckoutLink plan="business" />,
 				}
@@ -54,16 +65,30 @@ export default function ThemeTierPartnerBadge() {
 		}
 		if ( ! isPartnerThemePurchased && ! isThemeAllowedOnSite ) {
 			return createInterpolateElement(
-				/* translators: annualPrice and monthlyPrice are prices for the theme, examples: US$50, US$7; */
-				translate(
-					'This theme costs %(annualPrice)s per year or %(monthlyPrice)s per month, and can only be purchased if you have the <Link>Business plan</Link> on your site.',
-					{
-						args: {
-							annualPrice: subscriptionPrices.year ?? '',
-							monthlyPrice: subscriptionPrices.month ?? '',
-						},
-					}
-				),
+				isEnglishLocale ||
+					/* translators: annualPrice and monthlyPrice are prices for the theme, examples: US$50, US$7; */
+					i18n.hasTranslation(
+						'This theme costs %(annualPrice)s per year or %(monthlyPrice)s per month, and can only be purchased if you have the <Link>%(businessPlanName)s plan</Link> on your site.'
+					)
+					? translate(
+							'This theme costs %(annualPrice)s per year or %(monthlyPrice)s per month, and can only be purchased if you have the <Link>%(businessPlanName)s plan</Link> on your site.',
+							{
+								args: {
+									annualPrice: subscriptionPrices.year ?? '',
+									monthlyPrice: subscriptionPrices.month ?? '',
+									businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+								},
+							}
+					  )
+					: translate(
+							'This theme costs %(annualPrice)s per year or %(monthlyPrice)s per month, and can only be purchased if you have the <Link>%(businessPlanName)s plan</Link> on your site.',
+							{
+								args: {
+									annualPrice: subscriptionPrices.year ?? '',
+									monthlyPrice: subscriptionPrices.month ?? '',
+								},
+							}
+					  ),
 				{
 					Link: <ThemeTierBadgeCheckoutLink plan="business" />,
 				}

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-style-variation-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-style-variation-badge.js
@@ -1,19 +1,32 @@
+import { PLAN_PREMIUM, getPlan } from '@automattic/calypso-products';
 import { PremiumBadge } from '@automattic/components';
-import { useTranslate } from 'i18n-calypso';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
+import i18n, { useTranslate } from 'i18n-calypso';
 import ThemeTierBadgeTracker from './theme-tier-badge-tracker';
 import ThemeTierTooltipTracker from './theme-tier-tooltip-tracker';
 
 export default function ThemeTierStyleVariationBadge() {
 	const translate = useTranslate();
+	const isEnglishLocale = useIsEnglishLocale();
 
 	const tooltipContent = (
 		<>
 			<ThemeTierTooltipTracker />
 			<div data-testid="upsell-header" className="theme-tier-badge-tooltip__header" />
 			<div data-testid="upsell-message">
-				{ translate(
-					'Unlock this style, and tons of other features, by upgrading to a Premium plan.'
-				) }
+				{ isEnglishLocale ||
+				i18n.hasTranslation(
+					'Unlock this style, and tons of other features, by upgrading to a %(premiumPlanName)s plan.'
+				)
+					? translate(
+							'Unlock this style, and tons of other features, by upgrading to a %(premiumPlanName)s plan.',
+							{
+								args: { premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() },
+							}
+					  )
+					: translate(
+							'Unlock this style, and tons of other features, by upgrading to a Premium plan.'
+					  ) }
 			</div>
 		</>
 	);

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-upgrade-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-upgrade-badge.js
@@ -1,5 +1,6 @@
 import { getPlan } from '@automattic/calypso-products';
 import { PremiumBadge } from '@automattic/components';
+import { usePlans } from '@automattic/data-stores/src/plans';
 import { createInterpolateElement } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'calypso/state';
@@ -19,8 +20,11 @@ export default function ThemeTierUpgradeBadge() {
 
 	const tierMinimumUpsellPlan = THEME_TIERS[ themeTier?.slug ]?.minimumUpsellPlan;
 	const mappedPlan = getPlan( tierMinimumUpsellPlan );
-	const planName = mappedPlan?.getTitle();
 	const planPathSlug = mappedPlan?.getPathSlug();
+
+	// Using API plans because the updated getTitle() method doesn't take the experiment assignment into account.
+	const plans = usePlans();
+	const planName = plans?.data?.[ THEME_TIERS[ mappedPlan ] ]?.productNameShort;
 
 	const tooltipContent = (
 		<>

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-upgrade-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-upgrade-badge.js
@@ -24,7 +24,7 @@ export default function ThemeTierUpgradeBadge() {
 
 	// Using API plans because the updated getTitle() method doesn't take the experiment assignment into account.
 	const plans = usePlans();
-	const planName = plans?.data?.[ THEME_TIERS[ mappedPlan ] ]?.productNameShort;
+	const planName = plans?.data?.[ mappedPlan.getStoreSlug() ]?.productNameShort;
 
 	const tooltipContent = (
 		<>

--- a/client/components/theme-type-badge/tooltip.tsx
+++ b/client/components/theme-type-badge/tooltip.tsx
@@ -1,13 +1,15 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { PLAN_BUSINESS, PLAN_PREMIUM, getPlan } from '@automattic/calypso-products';
 import {
 	BUNDLED_THEME,
 	DOT_ORG_THEME,
 	MARKETPLACE_THEME,
 	PREMIUM_THEME,
 } from '@automattic/design-picker';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { Button as LinkButton } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
-import { useTranslate } from 'i18n-calypso';
+import i18n, { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { useBundleSettingsByTheme } from 'calypso/my-sites/theme/hooks/use-bundle-settings';
 import { useSelector } from 'calypso/state';
@@ -93,6 +95,8 @@ const ThemeTypeBadgeTooltip = ( {
 		type === MARKETPLACE_THEME ? getMarketplaceThemeSubscriptionPrices( state, themeId ) : {}
 	);
 
+	const isEnglishLocale = useIsEnglishLocale();
+
 	useEffect( () => {
 		recordTracksEvent( 'calypso_upgrade_nudge_impression', {
 			cta_name: 'theme-upsell-popup',
@@ -137,9 +141,18 @@ const ThemeTypeBadgeTooltip = ( {
 
 	let message;
 	if ( isLockedStyleVariation ) {
-		message = translate(
-			'Unlock this style, and tons of other features, by upgrading to a Premium plan.'
-		);
+		message =
+			isEnglishLocale ||
+			i18n.hasTranslation(
+				'Unlock this style, and tons of other features, by upgrading to a %(premiumPlanName)s plan.'
+			)
+				? translate(
+						'Unlock this style, and tons of other features, by upgrading to a %(premiumPlanName)s plan.',
+						{ args: { premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() ?? '' } }
+				  )
+				: translate(
+						'Unlock this style, and tons of other features, by upgrading to a Premium plan.'
+				  );
 	} else if ( type === PREMIUM_THEME ) {
 		if ( isPurchased ) {
 			message = translate( 'You have purchased this theme.' );
@@ -147,7 +160,15 @@ const ThemeTypeBadgeTooltip = ( {
 			message = translate( 'This premium theme is included in your plan.' );
 		} else {
 			message = createInterpolateElement(
-				translate( 'This premium theme is included in the <Link>Premium plan</Link>.' ),
+				isEnglishLocale ||
+					i18n.hasTranslation(
+						'This premium theme is included in the <Link>%(premiumPlanName)s plan</Link>.'
+					)
+					? ( translate(
+							'This premium theme is included in the <Link>%(premiumPlanName)s plan</Link>.',
+							{ args: { premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() ?? '' } }
+					  ) as string )
+					: translate( 'This premium theme is included in the <Link>Premium plan</Link>.' ),
 				{
 					Link: (
 						<ThemeTypeBadgeTooltipUpgradeLink
@@ -163,9 +184,17 @@ const ThemeTypeBadgeTooltip = ( {
 		message = isIncludedCurrentPlan
 			? translate( 'This community theme is included in your plan.' )
 			: createInterpolateElement(
-					translate(
-						'This community theme can only be installed if you have the <Link>Business plan</Link> or higher on your site.'
-					),
+					isEnglishLocale ||
+						i18n.hasTranslation(
+							'This community theme can only be installed if you have the <Link>%(businessPlanName)s plan</Link> or higher on your site.'
+						)
+						? ( translate(
+								'This community theme can only be installed if you have the <Link>%(businessPlanName)s plan</Link> or higher on your site.',
+								{ args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' } }
+						  ) as string )
+						: translate(
+								'This community theme can only be installed if you have the <Link>Business plan</Link> or higher on your site.'
+						  ),
 					{
 						Link: (
 							<ThemeTypeBadgeTooltipUpgradeLink
@@ -187,11 +216,28 @@ const ThemeTypeBadgeTooltip = ( {
 				} );
 			} else {
 				message = createInterpolateElement(
-					// Translators: %(bundleName)s is the name of the bundle, sometimes represented as a product name. Examples: "WooCommerce" or "Special".
-					translate( 'This %(bundleName)s theme is included in the <Link>Business plan</Link>.', {
-						args: { bundleName },
-						textOnly: true,
-					} ),
+					isEnglishLocale ||
+						i18n.hasTranslation(
+							'This %(bundleName)s theme is included in the <Link>%(businessPlanName)s plan</Link>.'
+						)
+						? // Translators: %(bundleName)s is the name of the bundle, sometimes represented as a product name. Examples: "WooCommerce" or "Special".
+						  translate(
+								'This %(bundleName)s theme is included in the <Link>%(businessPlanName)s plan</Link>.',
+								{
+									args: {
+										bundleName,
+										businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+									},
+									textOnly: true,
+								}
+						  )
+						: translate(
+								'This %(bundleName)s theme is included in the <Link>Business plan</Link>.',
+								{
+									args: { bundleName },
+									textOnly: true,
+								}
+						  ),
 					{
 						Link: (
 							<ThemeTypeBadgeTooltipUpgradeLink
@@ -206,14 +252,31 @@ const ThemeTypeBadgeTooltip = ( {
 		}
 	} else if ( type === MARKETPLACE_THEME ) {
 		if ( isPurchased && isIncludedCurrentPlan ) {
-			message = translate(
-				'You have a subscription for this theme, and it will be usable as long as you keep a Business plan or higher on your site.'
-			);
+			message =
+				isEnglishLocale ||
+				i18n.hasTranslation(
+					'You have a subscription for this theme, and it will be usable as long as you keep a %(businessPlanName)s plan or higher on your site.'
+				)
+					? translate(
+							'You have a subscription for this theme, and it will be usable as long as you keep a %(businessPlanName)s plan or higher on your site.',
+							{ args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' } }
+					  )
+					: translate(
+							'You have a subscription for this theme, and it will be usable as long as you keep a Business plan or higher on your site.'
+					  );
 		} else if ( isPurchased && ! isIncludedCurrentPlan ) {
 			message = createInterpolateElement(
-				translate(
-					'You have a subscription for this theme, but it will only be usable if you have the <link>Business plan</link> on your site.'
-				),
+				isEnglishLocale ||
+					i18n.hasTranslation(
+						'You have a subscription for this theme, but it will only be usable if you have the <link>%(businessPlanName)s plan</link> on your site.'
+					)
+					? ( translate(
+							'You have a subscription for this theme, but it will only be usable if you have the <link>%(businessPlanName)s plan</link> on your site.',
+							{ args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' } }
+					  ) as string )
+					: translate(
+							'You have a subscription for this theme, but it will only be usable if you have the <link>Business plan</link> on your site.'
+					  ),
 				{
 					link: (
 						<ThemeTypeBadgeTooltipUpgradeLink
@@ -237,16 +300,30 @@ const ThemeTypeBadgeTooltip = ( {
 			);
 		} else if ( ! isPurchased && ! isIncludedCurrentPlan ) {
 			message = createInterpolateElement(
-				/* translators: annualPrice and monthlyPrice are prices for the theme, examples: US$50, US$7; */
-				translate(
-					'This theme costs %(annualPrice)s per year or %(monthlyPrice)s per month, and can only be purchased if you have the <Link>Business plan</Link> on your site.',
-					{
-						args: {
-							annualPrice: subscriptionPrices.year ?? '',
-							monthlyPrice: subscriptionPrices.month ?? '',
-						},
-					}
-				) as string,
+				isEnglishLocale ||
+					i18n.hasTranslation(
+						'This theme costs %(annualPrice)s per year or %(monthlyPrice)s per month, and can only be purchased if you have the <Link>%(businessNamePlan)s plan</Link> on your site.'
+					)
+					? /* translators: annualPrice and monthlyPrice are prices for the theme, examples: US$50, US$7; */
+					  ( translate(
+							'This theme costs %(annualPrice)s per year or %(monthlyPrice)s per month, and can only be purchased if you have the <Link>%(businessNamePlan)s plan</Link> on your site.',
+							{
+								args: {
+									annualPrice: subscriptionPrices.year ?? '',
+									monthlyPrice: subscriptionPrices.month ?? '',
+									businessNamePlan: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+								},
+							}
+					  ) as string )
+					: ( translate(
+							'This theme costs %(annualPrice)s per year or %(monthlyPrice)s per month, and can only be purchased if you have the <Link>Business plan</Link> on your site.',
+							{
+								args: {
+									annualPrice: subscriptionPrices.year ?? '',
+									monthlyPrice: subscriptionPrices.month ?? '',
+								},
+							}
+					  ) as string ),
 				{
 					Link: (
 						<ThemeTypeBadgeTooltipUpgradeLink

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-screen.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-screen.tsx
@@ -1,3 +1,5 @@
+import { PLAN_PREMIUM } from '@automattic/calypso-products';
+import { usePlans } from '@automattic/data-stores/src/plans';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { useTranslate, TranslateResult } from 'i18n-calypso';
 import { NAVIGATOR_PATHS } from '../constants';
@@ -23,6 +25,7 @@ export type Screen = {
 const useScreen = ( screenName: ScreenName, options: UseScreenOptions = {} ): Screen => {
 	const translate = useTranslate();
 	const hasEnTranslation = useHasEnTranslation();
+	const plans = usePlans();
 	const screens: Record< ScreenName, Screen > = {
 		main: {
 			name: 'main',
@@ -76,9 +79,16 @@ const useScreen = ( screenName: ScreenName, options: UseScreenOptions = {} ): Sc
 		upsell: {
 			name: 'upsell',
 			title: translate( 'Premium styles' ),
-			description: translate(
-				"You've chosen premium styles which are exclusive to the Premium plan or higher."
-			),
+			description: hasEnTranslation(
+				"You've chosen premium styles which are exclusive to the %(premiumPlanName)s plan or higher."
+			)
+				? translate(
+						"You've chosen premium styles which are exclusive to the %(premiumPlanName)s plan or higher.",
+						{ args: { premiumPlanName: plans?.data?.[ PLAN_PREMIUM ]?.productNameShort } }
+				  )
+				: translate(
+						"You've chosen premium styles which are exclusive to the Premium plan or higher."
+				  ),
 			continueLabel: translate( 'Continue' ),
 			backLabel: hasEnTranslation( 'premium styles' ) ? translate( 'premium styles' ) : undefined,
 			initialPath: NAVIGATOR_PATHS.UPSELL,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-screen.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-screen.tsx
@@ -84,7 +84,7 @@ const useScreen = ( screenName: ScreenName, options: UseScreenOptions = {} ): Sc
 			)
 				? translate(
 						"You've chosen premium styles which are exclusive to the %(premiumPlanName)s plan or higher.",
-						{ args: { premiumPlanName: plans?.data?.[ PLAN_PREMIUM ]?.productNameShort } }
+						{ args: { premiumPlanName: plans?.data?.[ PLAN_PREMIUM ]?.productNameShort || '' } }
 				  )
 				: translate(
 						"You've chosen premium styles which are exclusive to the Premium plan or higher."

--- a/client/my-sites/checkout/checkout-thank-you/premium-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/premium-plan-details.jsx
@@ -1,6 +1,12 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { isPremium, isGSuiteOrExtraLicenseOrGoogleWorkspace } from '@automattic/calypso-products';
-import { useTranslate } from 'i18n-calypso';
+import {
+	isPremium,
+	isGSuiteOrExtraLicenseOrGoogleWorkspace,
+	getPlan,
+	PLAN_PREMIUM,
+} from '@automattic/calypso-products';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
+import i18n, { useTranslate } from 'i18n-calypso';
 import { find } from 'lodash';
 import PropTypes from 'prop-types';
 import earnImage from 'calypso/assets/images/customer-home/illustration--task-earn.svg';
@@ -25,6 +31,8 @@ const PremiumPlanDetails = ( {
 	const plan = find( sitePlans.data, isPremium );
 	const isPremiumPlan = isPremium( selectedSite.plan );
 	const googleAppsWasPurchased = purchases.some( isGSuiteOrExtraLicenseOrGoogleWorkspace );
+
+	const isEnglishLocale = useIsEnglishLocale();
 
 	return (
 		<div>
@@ -108,10 +116,22 @@ const PremiumPlanDetails = ( {
 					<img alt={ translate( 'Add Media to Your Posts Illustration' ) } src={ mediaPostImage } />
 				}
 				title={ translate( 'Video and audio posts' ) }
-				description={ translate(
-					'Enrich your posts with video and audio, uploaded directly on your site. ' +
-						'No ads. The Premium plan offers 13GB of file storage.'
-				) }
+				description={
+					isEnglishLocale ||
+					i18n.hasTranslation(
+						'Enrich your posts with video and audio, uploaded directly on your site. ' +
+							'No ads. The %(premiumPlanName)s plan offers 13GB of file storage.'
+					)
+						? translate(
+								'Enrich your posts with video and audio, uploaded directly on your site. ' +
+									'No ads. The %(premiumPlanName)s plan offers 13GB of file storage.',
+								{ args: { premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() } }
+						  )
+						: translate(
+								'Enrich your posts with video and audio, uploaded directly on your site. ' +
+									'No ads. The Premium plan offers 13GB of file storage.'
+						  )
+				}
 				buttonText={ translate( 'Start a new post' ) }
 				href={ newPost( selectedSite ) }
 			/>

--- a/client/my-sites/media-library/list-plan-promo.js
+++ b/client/my-sites/media-library/list-plan-promo.js
@@ -1,6 +1,7 @@
+import { PLAN_BUSINESS, PLAN_ECOMMERCE, PLAN_PREMIUM, getPlan } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
-import { localize } from 'i18n-calypso';
+import i18n, { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -41,6 +42,25 @@ class MediaLibraryListPlanPromo extends Component {
 	};
 
 	getSummary = () => {
+		const isEnglishLocale = [ 'en', 'en-gb' ].includes( this.props.locale );
+		const contactAdminText =
+			isEnglishLocale ||
+			i18n.hasTranslation(
+				'Contact your site administrator and ask them to upgrade this site to WordPress.com %(premiumPlanName)s, %(businessPlanName)s, or %(commercePlanName)s.'
+			)
+				? this.props.translate(
+						'Contact your site administrator and ask them to upgrade this site to WordPress.com %(premiumPlanName)s, %(businessPlanName)s, or %(commercePlanName)s.',
+						{
+							args: {
+								premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle(),
+								businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle(),
+								commercePlanName: getPlan( PLAN_ECOMMERCE )?.getTitle(),
+							},
+						}
+				  )
+				: this.props.translate(
+						'Contact your site administrator and ask them to upgrade this site to WordPress.com Premium, Business, or eCommerce.'
+				  );
 		switch ( this.props.filter ) {
 			case 'videos':
 				return preventWidows(
@@ -51,9 +71,7 @@ class MediaLibraryListPlanPromo extends Component {
 						  } )
 						: this.props.translate( 'Uploading video requires a paid plan.' ) +
 								' ' +
-								this.props.translate(
-									'Contact your site administrator and ask them to upgrade this site to WordPress.com Premium, Business, or eCommerce.'
-								),
+								contactAdminText,
 					2
 				);
 
@@ -66,9 +84,7 @@ class MediaLibraryListPlanPromo extends Component {
 						  } )
 						: this.props.translate( 'Uploading audio requires a paid plan.' ) +
 								' ' +
-								this.props.translate(
-									'Contact your site administrator and ask them to upgrade this site to WordPress.com Premium, Business, or eCommerce.'
-								),
+								contactAdminText,
 					2
 				);
 

--- a/client/my-sites/migrate/step-upgrade.jsx
+++ b/client/my-sites/migrate/step-upgrade.jsx
@@ -1,6 +1,6 @@
 import { getPlan, PLAN_BUSINESS } from '@automattic/calypso-products';
 import { CompactCard, ProductIcon, Gridicon } from '@automattic/components';
-import { localize } from 'i18n-calypso';
+import i18n, { localize } from 'i18n-calypso';
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -40,10 +40,12 @@ class StepUpgrade extends Component {
 			targetSiteSlug,
 			themes,
 			translate,
+			locale,
 		} = this.props;
 		const sourceSiteDomain = get( sourceSite, 'domain' );
 		const targetSiteDomain = get( targetSite, 'domain' );
 		const backHref = `/migrate/from/${ sourceSiteSlug }/to/${ targetSiteSlug }`;
+		const isEnglishLocale = [ 'en', 'en-bg' ].includes( locale );
 
 		return (
 			<>
@@ -52,7 +54,12 @@ class StepUpgrade extends Component {
 
 				<CompactCard>
 					<CardHeading>
-						{ translate( 'A Business Plan is required to import everything.' ) }
+						{ isEnglishLocale ||
+						i18n.hasTranslation( 'A %(businessPlanName)s Plan is required to import everything.' )
+							? translate( 'A %(businessPlanName)s Plan is required to import everything.', {
+									args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() },
+							  } )
+							: translate( 'A Business Plan is required to import everything.' ) }
 					</CardHeading>
 					<div>
 						{ translate(

--- a/client/my-sites/plans/ecommerce-trial/business-upgrade-confirmation/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/business-upgrade-confirmation/index.tsx
@@ -1,6 +1,8 @@
+import { PLAN_BUSINESS, getPlan } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { StepContainer } from '@automattic/onboarding';
-import { useTranslate } from 'i18n-calypso';
+import i18n, { useTranslate } from 'i18n-calypso';
 import { useLayoutEffect } from 'react';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 import Main from 'calypso/components/main';
@@ -10,7 +12,6 @@ import BusinessTrialIncluded from 'calypso/my-sites/plans/current-plan/trials/bu
 import { useDispatch, useSelector } from 'calypso/state';
 import { hideMasterbar, showMasterbar } from 'calypso/state/ui/actions';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-
 import './style.scss';
 
 const noop = () => {};
@@ -19,6 +20,7 @@ const BusinessUpgradeConfirmation = () => {
 	const selectedSite = useSelector( getSelectedSite );
 	const dispatch = useDispatch();
 	const translate = useTranslate();
+	const isEnglishLocale = useIsEnglishLocale();
 
 	useLayoutEffect( () => {
 		dispatch( hideMasterbar() );
@@ -47,18 +49,38 @@ const BusinessUpgradeConfirmation = () => {
 						<>
 							<div className="trial-upgrade-confirmation__header">
 								<h1 className="trial-upgrade-confirmation__title">
-									{ translate( 'Welcome to the Business plan' ) }
+									{ isEnglishLocale ||
+									i18n.hasTranslation( 'Welcome to the %(businessPlanName) plan' )
+										? translate( 'Welcome to the %(businessPlanName) plan', {
+												args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() || '' },
+										  } )
+										: translate( 'Welcome to the Business plan' ) }
 								</h1>
 								<div className="trial-upgrade-confirmation__subtitle">
 									<span className="trial-upgrade-confirmation__subtitle-line">
-										{ translate(
-											"Your purchase is complete, and you're now on the {{strong}}Business plan{{/strong}}. It's time to take your website to the next level—here are some options.",
-											{
-												components: {
-													strong: <strong />,
-												},
-											}
-										) }
+										{ isEnglishLocale ||
+										i18n.hasTranslation(
+											"Your purchase is complete, and you're now on the {{strong}}%(businessPlanName)s plan{{/strong}}. It's time to take your website to the next level—here are some options."
+										)
+											? translate(
+													"Your purchase is complete, and you're now on the {{strong}}%(businessPlanName)s plan{{/strong}}. It's time to take your website to the next level—here are some options.",
+													{
+														components: {
+															strong: <strong />,
+														},
+														args: {
+															businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() || '',
+														},
+													}
+											  )
+											: translate(
+													"Your purchase is complete, and you're now on the {{strong}}Business plan{{/strong}}. It's time to take your website to the next level—here are some options.",
+													{
+														components: {
+															strong: <strong />,
+														},
+													}
+											  ) }
 									</span>
 								</div>
 							</div>

--- a/client/my-sites/post-type-list/index.jsx
+++ b/client/my-sites/post-type-list/index.jsx
@@ -1,7 +1,7 @@
-import { WPCOM_FEATURES_NO_ADVERTS } from '@automattic/calypso-products';
+import { PLAN_PREMIUM, WPCOM_FEATURES_NO_ADVERTS, getPlan } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import classnames from 'classnames';
-import { localize, getLocaleSlug } from 'i18n-calypso';
+import i18n, { localize, getLocaleSlug } from 'i18n-calypso';
 import { isEqual, range, throttle, difference, isEmpty, get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -243,7 +243,7 @@ class PostTypeList extends Component {
 	}
 
 	render() {
-		const { query, siteId, isRequestingPosts, translate, isVip, isJetpack } = this.props;
+		const { query, siteId, isRequestingPosts, translate, isVip, isJetpack, locale } = this.props;
 		const { maxRequestedPage, recentViewIds } = this.state;
 		const posts = this.props.posts || [];
 		const postStatuses = query.status.split( ',' );
@@ -251,6 +251,8 @@ class PostTypeList extends Component {
 		const classes = classnames( 'post-type-list', {
 			'is-empty': isLoadedAndEmpty,
 		} );
+
+		const isEnglishLocale = [ 'en', 'en-gb' ].includes( locale );
 
 		const isSingleSite = !! siteId;
 
@@ -278,7 +280,14 @@ class PostTypeList extends Component {
 				{ posts.slice( 0, 10 ).map( this.renderPost ) }
 				{ showUpgradeNudge && (
 					<UpsellNudge
-						title={ translate( 'No Ads with WordPress.com Premium' ) }
+						title={
+							isEnglishLocale ||
+							i18n.hasTranslation( 'No Ads with WordPress.com %(premiumPlanName)s' )
+								? translate( 'No Ads with WordPress.com %(premiumPlanName)s', {
+										args: { premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() },
+								  } )
+								: translate( 'No Ads with WordPress.com Premium' )
+						}
 						description={ translate( 'Prevent ads from showing on your site.' ) }
 						feature={ WPCOM_FEATURES_NO_ADVERTS }
 						event="published_posts_no_ads"

--- a/client/my-sites/stats/mini-carousel/index.jsx
+++ b/client/my-sites/stats/mini-carousel/index.jsx
@@ -1,6 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { isFreePlan, isPersonalPlan } from '@automattic/calypso-products';
-import { translate } from 'i18n-calypso';
+import { PLAN_PREMIUM, getPlan, isFreePlan, isPersonalPlan } from '@automattic/calypso-products';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
+import i18n, { translate } from 'i18n-calypso';
 import { useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import rocketImage from 'calypso/assets/images/customer-home/illustration--rocket.svg';
@@ -17,7 +18,6 @@ import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import MiniCarouselBlock from './mini-carousel-block';
 import { isBlockDismissed } from './selectors';
-
 import './style.scss';
 
 const EVENT_TRAFFIC_BLAZE_PROMO_VIEW = 'calypso_stats_traffic_blaze_banner_view';
@@ -57,6 +57,8 @@ const MiniCarousel = ( { slug, isSitePrivate } ) => {
 	const [ dotPagerIndex, setDotPagerIndex ] = useState( 0 );
 
 	const shouldShowAdvertisingOption = usePromoteWidget() === PromoteWidgetStatus.ENABLED;
+
+	const isEnglishLocale = useIsEnglishLocale();
 
 	// Private site banner.
 	const showPrivateSiteBanner =
@@ -189,9 +191,21 @@ const MiniCarousel = ( { slug, isSitePrivate } ) => {
 				dismissEvent={ EVENT_GOOGLE_ANALYTICS_BANNER_DISMISS }
 				image={ <img src={ GoogleAnalyticsLogo } alt="" width={ 45 } height={ 45 } /> }
 				headerText={ translate( 'Connect your site to Google Analytics' ) }
-				contentText={ translate(
-					'Linking Google Analytics to your account is effortless with our Premium plan – no coding required. Gain valuable insights in seconds.'
-				) }
+				contentText={
+					isEnglishLocale ||
+					i18n.hasTranslation(
+						'Linking Google Analytics to your account is effortless with our %(premiumPlanName)s plan – no coding required. Gain valuable insights in seconds.'
+					)
+						? translate(
+								'Linking Google Analytics to your account is effortless with our %(premiumPlanName)s plan – no coding required. Gain valuable insights in seconds.',
+								{
+									args: { premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() },
+								}
+						  )
+						: translate(
+								'Linking Google Analytics to your account is effortless with our Premium plan – no coding required. Gain valuable insights in seconds.'
+						  )
+				}
 				ctaText={ translate( 'Get Premium' ) }
 				href={ `/checkout/premium/${ slug || '' }` }
 				key="google-analytics"

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -1,5 +1,5 @@
-import { FEATURE_GOOGLE_ANALYTICS, PLAN_PREMIUM } from '@automattic/calypso-products';
-import { localize } from 'i18n-calypso';
+import { FEATURE_GOOGLE_ANALYTICS, PLAN_PREMIUM, getPlan } from '@automattic/calypso-products';
+import i18n, { localize } from 'i18n-calypso';
 import { merge } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -52,7 +52,8 @@ class StatsSummary extends Component {
 	}
 
 	render() {
-		const { translate, statsQueryOptions, siteId } = this.props;
+		const { translate, statsQueryOptions, siteId, locale } = this.props;
+		const isEnglishLocale = [ 'en', 'en-gb' ].includes( locale );
 		const summaryViews = [];
 		let title;
 		let summaryView;
@@ -145,9 +146,17 @@ class StatsSummary extends Component {
 						<div className="stats-module__footer-actions--summary-tall">
 							<UpsellNudge
 								title={ translate( 'Add Google Analytics' ) }
-								description={ translate(
-									'Upgrade to a Premium Plan for Google Analytics integration.'
-								) }
+								description={
+									isEnglishLocale ||
+									i18n.hasTranslation(
+										'Upgrade to a %(premiumPlanName)s Plan for Google Analytics integration.'
+									)
+										? translate(
+												'Upgrade to a %(premiumPlanName)s Plan for Google Analytics integration.',
+												{ args: { premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() } }
+										  )
+										: translate( 'Upgrade to a Premium Plan for Google Analytics integration.' )
+								}
 								event="googleAnalytics-stats-countries"
 								feature={ FEATURE_GOOGLE_ANALYTICS }
 								plan={ PLAN_PREMIUM }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #85284

## Proposed Changes

This replaces the hardcoded plan names in multiple places so that they point to the real values. This will be needed for any upcoming plan name experiments (ex. pcNC1U-WN-p2)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow instructions from D130166-code to get assigned the experiment
* The plan mentions should show the updated plan names.

<img width="240" alt="Screenshot 2023-12-15 at 11 35 16" src="https://github.com/Automattic/wp-calypso/assets/2749938/825a61e9-e9af-447a-8936-eb30fd773d3b">
<img width="240" alt="Screenshot 2023-12-15 at 11 22 18" src="https://github.com/Automattic/wp-calypso/assets/2749938/f339176a-4e37-4bb1-9c30-986be4208999">
<img width="240" alt="Screenshot 2023-12-15 at 11 08 09" src="https://github.com/Automattic/wp-calypso/assets/2749938/161412d8-3166-46c6-894a-f943dad1d94d">
<img width="240" alt="Screenshot 2023-12-15 at 11 00 12" src="https://github.com/Automattic/wp-calypso/assets/2749938/b9617780-0c68-4eb0-90cb-7e417782a79b">
<img width="240" alt="Screenshot 2023-12-14 at 17 08 30" src="https://github.com/Automattic/wp-calypso/assets/2749938/446824cf-2f28-496b-a166-8c7382f25418">
<img width="240" alt="Screenshot 2023-12-14 at 16 59 45" src="https://github.com/Automattic/wp-calypso/assets/2749938/ac1eef32-f043-4ce0-b053-51048203d5c5">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
