### PR TITLE
Assembler: Save site title/description from the prompt endpoint

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -78,7 +78,7 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 	const wrapperRef = useRef< HTMLDivElement | null >( null );
 	const [ activePosition, setActivePosition ] = useState( -1 );
 	const { goBack, goNext, submit } = navigation;
-	const { assembleSite } = useDispatch( SITE_STORE );
+	const { assembleSite, saveSiteSettings } = useDispatch( SITE_STORE );
 	const reduxDispatch = useReduxDispatch();
 	const { setPendingAction } = useDispatch( ONBOARD_STORE );
 	const selectedDesign = useSelect(
@@ -397,6 +397,17 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 					} )
 				)
 		);
+
+		const siteTitleFromUrl = ( searchParams.get( 'site_title' ) || '' ).trim();
+		const siteTaglineFromUrl = searchParams.get( 'site_tagline' ) || '';
+
+		// Save site title/description passed to the Assembler.
+		if ( siteTitleFromUrl || siteTaglineFromUrl ) {
+			saveSiteSettings( siteSlugOrId, {
+				...( siteTitleFromUrl && { blogname: siteTitleFromUrl } ),
+				...( siteTaglineFromUrl && { blogdescription: siteTaglineFromUrl } ),
+			} );
+		}
 
 		recordSelectedDesign( { flow, intent, design } );
 		trackSubmit();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #84839

## Proposed Changes

This PR implements saving site title/description when provided in the URL parameters.
Note that the site title/description could have been saved in the AI prompt screen, but I ultimately decided against it since that screen is site-agnostic (it doesn't assume that the user has a site at that point).

Discussion: Should the "Personalized your site" be checked or unchecked? I think it should be checked since their site title/description have been personalized by their prompt.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/setup/ai-assembler`.
* Create a new site.
* Enter a prompt in the AI prompt screen, for instance "podcast about movies"
![Screenshot 2023-12-15 at 4 54 00 PM](https://github.com/Automattic/wp-calypso/assets/797888/87830b1f-afe3-4dae-835a-1a431d16aec6)
* Ensure that the prompt endpoint returns a payload that populates the Assembler site title and description.
![Screenshot 2023-12-15 at 4 54 18 PM](https://github.com/Automattic/wp-calypso/assets/797888/69b10d92-b898-42bd-8343-7935d8bfa441)
* Complete the Assembler.
* Once in the Site Editor, ensure that the site title is correctly applied.
![Screenshot 2023-12-15 at 4 55 01 PM](https://github.com/Automattic/wp-calypso/assets/797888/e07f9a5b-1c32-473b-86f0-2eb92e62119c)
* Leave the Site Editor, and once in the Launchpad ensure that the task "Personalize your site" is checked.
![Screenshot 2023-12-15 at 4 55 18 PM](https://github.com/Automattic/wp-calypso/assets/797888/e89472c4-6430-4b9b-a55f-5da49a817589)
* Click the "Personalize your site" and ensure that the site title and description is as provided by the endpoint.
![Screenshot 2023-12-15 at 4 55 31 PM](https://github.com/Automattic/wp-calypso/assets/797888/cf895609-bc97-42c3-9066-20cdcbeecb51)

* Ensure that non-ai-assembler flows works as before and not impacted by this PR.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?