### PR TITLE
WP Import content: Show 'View site' instead of 'Pick design' CTA

### DIFF
--- a/client/blocks/importer/components/complete-screen/index.tsx
+++ b/client/blocks/importer/components/complete-screen/index.tsx
@@ -10,11 +10,12 @@ interface Props {
 	siteId: number;
 	siteSlug: string;
 	resetImport: ( siteId: number, importerId: string ) => void;
+	buttonLabel?: string;
 	onSiteViewClick?: () => void;
 }
 const CompleteScreen: React.FunctionComponent< Props > = ( props ) => {
 	const { __ } = useI18n();
-	const { job, siteId, resetImport, onSiteViewClick } = props;
+	const { job, siteId, buttonLabel, resetImport, onSiteViewClick } = props;
 
 	useEffect( () => {
 		recordTracksEvent( 'calypso_site_importer_start_import_success' );
@@ -29,6 +30,7 @@ const CompleteScreen: React.FunctionComponent< Props > = ( props ) => {
 					siteId={ siteId }
 					job={ job as ImportJob }
 					resetImport={ resetImport }
+					label={ buttonLabel }
 					onSiteViewClick={ onSiteViewClick }
 				/>
 			</div>

--- a/client/blocks/importer/wordpress/import-content-only/index.tsx
+++ b/client/blocks/importer/wordpress/import-content-only/index.tsx
@@ -101,7 +101,10 @@ const ImportContentOnly: React.FunctionComponent< Props > = ( props ) => {
 	 */
 	function renderHooray() {
 		function onSiteViewClick() {
-			if ( isEnabled( 'onboarding/import-redirect-to-themes' ) ) {
+			if (
+				job?.importerFileType !== 'playground' &&
+				isEnabled( 'onboarding/import-redirect-to-themes' )
+			) {
 				stepNavigator?.navigate?.( 'designSetup' );
 			} else {
 				stepNavigator?.goToSiteViewPage?.();
@@ -112,6 +115,9 @@ const ImportContentOnly: React.FunctionComponent< Props > = ( props ) => {
 				siteId={ siteItem?.ID as number }
 				siteSlug={ siteSlug }
 				job={ job as ImportJob }
+				buttonLabel={
+					job?.importerFileType === 'playground' ? translate( 'View site' ) : undefined
+				}
 				resetImport={ () => {
 					dispatch( resetImport( siteItem?.ID, job?.importerId ) );
 				} }


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/4908

## Proposed Changes

* Replaced "Pick design" with "View site" CTA from the Hooray screen

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/import-focused/importerWordpress?siteSlug={ATOMIC_SITE_SLUG}&option=content`
* Upload a playground backup file
* Check if there is a Hooray screen with "View site" CTA

<img width="817" alt="Screenshot 2023-12-15 at 10 41 06" src="https://github.com/Automattic/wp-calypso/assets/1241413/12cc4473-73b2-4d4d-8a10-f47f03127ed7">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?