### PR TITLE
Jetpack Manage: Add products compatible check in the new Issue License page.

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/lib/incompatible-products.ts
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/lib/incompatible-products.ts
@@ -1,26 +1,29 @@
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import getProductInfo from '../../lib/get-product-info';
 
-/* Helper function to get the product slug. Some of lower tier products is replaced with higher tier products.
- * For example, jetpack-social-basic is replaced with jetpack-social-advanced.
+/* Helper function to transform a Partner product slug to match User product slug for backward compatibility checking.
+ * Tiered products information such as t1 and t2 are removed while some are replaced with higher tier.
+ * For examples:
+ *  - jetpack-backup-t1 is replaced with jetpack-backup.
+ *  - jetpack-social-basic is replaced with jetpack_social_advanced.
  *
  * @param product
  * @returns product slug
  * */
 function getProductSlug( product: APIProductFamilyProduct ) {
 	if ( product.slug === 'jetpack-social-basic' ) {
-		return 'jetpack-social-advanced';
+		return 'jetpack_social_advanced';
 	}
 
-	if ( product.slug.startsWith( 'jetpack-backup' ) ) {
-		return 'jetpack-backup-t2';
+	if ( product.slug.startsWith( 'jetpack-backup-t' ) ) {
+		return 'jetpack_backup';
 	}
 
 	if ( product.slug.startsWith( 'jetpack-security' ) ) {
-		return 'jetpack-security-t2';
+		return 'jetpack_security';
 	}
 
-	return product.slug;
+	return product.slug.replaceAll( /-/g, '_' );
 }
 
 /* Helper function to check if the selected product is included in the product.
@@ -37,8 +40,8 @@ function isProductIncluded(
 	const productInfo = getProductInfo( product.slug );
 
 	return productInfo?.productsIncluded
-		?.map( ( slug ) => slug.replace( /_(monthly|yearly)$/, '' ) )
-		.includes( getProductSlug( selectedProduct ).replaceAll( /-/g, '_' ) );
+		?.map( ( slug ) => slug.replace( /_(monthly|yearly|t[0-9])/g, '' ) )
+		.includes( getProductSlug( selectedProduct ) );
 }
 
 /* Return list of incompatible products based on the selected products.

--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/lib/incompatible-products.ts
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/lib/incompatible-products.ts
@@ -1,0 +1,88 @@
+import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+import getProductInfo from '../../lib/get-product-info';
+
+/* Helper function to get the product slug. Some of lower tier products is replaced with higher tier products.
+ * For example, jetpack-social-basic is replaced with jetpack-social-advanced.
+ *
+ * @param product
+ * @returns product slug
+ * */
+function getProductSlug( product: APIProductFamilyProduct ) {
+	if ( product.slug === 'jetpack-social-basic' ) {
+		return 'jetpack-social-advanced';
+	}
+
+	if ( product.slug.startsWith( 'jetpack-backup' ) ) {
+		return 'jetpack-backup-t2';
+	}
+
+	if ( product.slug.startsWith( 'jetpack-security' ) ) {
+		return 'jetpack-security-t2';
+	}
+
+	return product.slug;
+}
+
+/* Helper function to check if the selected product is included in the product.
+ *
+ * @param product
+ * @param selectedProduct
+ *
+ * @returns boolean
+ */
+function isProductIncluded(
+	product: APIProductFamilyProduct,
+	selectedProduct: APIProductFamilyProduct
+) {
+	const productInfo = getProductInfo( product.slug );
+
+	return productInfo?.productsIncluded
+		?.map( ( slug ) => slug.replace( /_(monthly|yearly)$/, '' ) )
+		.includes( getProductSlug( selectedProduct ).replaceAll( /-/g, '_' ) );
+}
+
+/* Return list of incompatible products based on the selected products.
+ *
+ * @param selectedProducts - list of selected products
+ * @param products - list of all products
+ *
+ * @returns list of incompatible products slug
+ */
+export function getIncompatibleProducts(
+	selectedProducts: APIProductFamilyProduct[],
+	products: APIProductFamilyProduct[]
+) {
+	return products
+		.filter( ( product ) => {
+			return selectedProducts.some( ( selectedProduct ) => {
+				const isSelectedProductIncluded = isProductIncluded( product, selectedProduct );
+				const isIncludedInSelectedProduct = isProductIncluded( selectedProduct, product );
+				const isSelectedProductOnSameFamily = product.family_slug === selectedProduct.family_slug;
+				return (
+					( isSelectedProductIncluded ||
+						isIncludedInSelectedProduct ||
+						isSelectedProductOnSameFamily ) &&
+					product.slug !== selectedProduct.slug
+				);
+			} );
+		} )
+		.map( ( product ) => product.slug );
+}
+
+/* Check if the product is incompatible with the selected products.
+ *
+ * @param products
+ * @param incompatibleProducts
+ *
+ * @returns boolean
+ */
+export function isIncompatibleProduct(
+	products: APIProductFamilyProduct | APIProductFamilyProduct[],
+	incompatibleProducts: string[]
+) {
+	if ( Array.isArray( products ) ) {
+		return products.some( ( product ) => incompatibleProducts.includes( product.slug ) );
+	}
+
+	return incompatibleProducts.includes( products.slug );
+}


### PR DESCRIPTION
Currently, we do not restrict incompatible products when we initiate, issue, and assign license flow. This PR adds a compatibility check and ensures that we are not assigning incompatible products.
<img width="1613" alt="Screen Shot 2023-12-15 at 5 44 53 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/256d1d46-4556-4e0c-813a-43b0d17dee89">


Closes  https://github.com/Automattic/jetpack-genesis/issues/153

## Proposed Changes

* Disable product cards that are not compatible with the current selected products.

## Testing Instructions

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

* Spin up a JN site and connect it to the Jetpack cloud.
* Use the Jetpack Cloud live link and go to the Dashboard page (`/dashboard`)
* add some licenses to the newly connected site in the Dashboard and initiate an issue license flow.
* Confirm if incompatible products are restricted on product cards. Test different combinations.
* Note that the restriction only applies when issuing and assigning licenses. Make sure to test the page if it does not restrict during a regular Issue license flow.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?