### PR TITLE
Email stats: Fix for displaying value "0"

### DIFF
--- a/client/my-sites/stats/stats-email-top-row/index.jsx
+++ b/client/my-sites/stats/stats-email-top-row/index.jsx
@@ -34,14 +34,14 @@ export default function StatsEmailTopRow( { siteId, postId, statType, className 
 							isLoading={ isRequesting && ! counts?.hasOwnProperty( 'total_sends' ) }
 							icon={ <Gridicon icon="mail" /> }
 						/>
-						{ counts?.unique_opens && (
+						{ counts?.unique_opens ? (
 							<TopCard
 								heading={ translate( 'Unique opens' ) }
 								value={ counts.unique_opens }
 								isLoading={ isRequesting && ! counts?.hasOwnProperty( 'unique_opens' ) }
 								icon={ <Icon icon={ eye } /> }
 							/>
-						) }
+						) : null }
 						<TopCard
 							heading={ translate( 'Total opens' ) }
 							value={ counts?.total_opens ?? 0 }


### PR DESCRIPTION
## Proposed Changes

Fixes this

<img width="1327" alt="image" src="https://github.com/Automattic/wp-calypso/assets/528287/efdeea4b-bb41-45c6-9192-6ffd922e241d">


## Testing Instructions



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?