### PR TITLE
Import content: Reset import job on the 'Back to start' CTA click

### DIFF
--- a/client/blocks/importer/blogger/index.tsx
+++ b/client/blocks/importer/blogger/index.tsx
@@ -63,6 +63,11 @@ export const BloggerImporter: React.FunctionComponent< ImporterBaseProps > = ( p
 		};
 	}
 
+	function onBackToStartClick() {
+		job?.importerId && resetImport( siteId, job.importerId );
+		stepNavigator?.goToImportCapturePage?.();
+	}
+
 	function checkProgress() {
 		return job?.importerState === appStates.IMPORTING;
 	}
@@ -109,7 +114,7 @@ export const BloggerImporter: React.FunctionComponent< ImporterBaseProps > = ( p
 						return (
 							<ErrorMessage
 								onStartBuilding={ stepNavigator?.goToIntentPage }
-								onBackToStart={ stepNavigator?.goToImportCapturePage }
+								onBackToStart={ onBackToStartClick }
 							/>
 						);
 					} else if ( checkProgress() ) {

--- a/client/blocks/importer/medium/index.tsx
+++ b/client/blocks/importer/medium/index.tsx
@@ -63,6 +63,11 @@ export const MediumImporter: React.FunctionComponent< ImporterBaseProps > = ( pr
 		};
 	}
 
+	function onBackToStartClick() {
+		job?.importerId && resetImport( siteId, job.importerId );
+		stepNavigator?.goToImportCapturePage?.();
+	}
+
 	function checkProgress() {
 		return job?.importerState === appStates.IMPORTING;
 	}
@@ -109,7 +114,7 @@ export const MediumImporter: React.FunctionComponent< ImporterBaseProps > = ( pr
 						return (
 							<ErrorMessage
 								onStartBuilding={ stepNavigator?.goToIntentPage }
-								onBackToStart={ stepNavigator?.goToImportCapturePage }
+								onBackToStart={ onBackToStartClick }
 							/>
 						);
 					} else if ( checkProgress() ) {

--- a/client/blocks/importer/squarespace/index.tsx
+++ b/client/blocks/importer/squarespace/index.tsx
@@ -63,6 +63,11 @@ export const SquarespaceImporter: React.FunctionComponent< ImporterBaseProps > =
 		};
 	}
 
+	function onBackToStartClick() {
+		job?.importerId && resetImport( siteId, job.importerId );
+		stepNavigator?.goToImportCapturePage?.();
+	}
+
 	function checkProgress() {
 		return job?.importerState === appStates.IMPORTING;
 	}
@@ -109,7 +114,7 @@ export const SquarespaceImporter: React.FunctionComponent< ImporterBaseProps > =
 						return (
 							<ErrorMessage
 								onStartBuilding={ stepNavigator?.goToIntentPage }
-								onBackToStart={ stepNavigator?.goToImportCapturePage }
+								onBackToStart={ onBackToStartClick }
 							/>
 						);
 					} else if ( checkProgress() ) {

--- a/client/blocks/importer/wix/index.tsx
+++ b/client/blocks/importer/wix/index.tsx
@@ -90,6 +90,11 @@ export const WixImporter: React.FunctionComponent< Props > = ( props ) => {
 		};
 	}
 
+	function onBackToStartClick() {
+		job?.importerId && resetImport( siteId, job.importerId );
+		stepNavigator?.goToImportCapturePage?.();
+	}
+
 	function checkProgress() {
 		return (
 			job?.importerState === appStates.IMPORTING ||
@@ -131,7 +136,7 @@ export const WixImporter: React.FunctionComponent< Props > = ( props ) => {
 						return (
 							<ErrorMessage
 								onStartBuilding={ stepNavigator?.goToIntentPage }
-								onBackToStart={ stepNavigator?.goToImportCapturePage }
+								onBackToStart={ onBackToStartClick }
 							/>
 						);
 					} else if ( checkProgress() ) {

--- a/client/blocks/importer/wordpress/import-content-only/index.tsx
+++ b/client/blocks/importer/wordpress/import-content-only/index.tsx
@@ -77,6 +77,11 @@ const ImportContentOnly: React.FunctionComponent< Props > = ( props ) => {
 		};
 	}
 
+	function onBackToStartClick() {
+		dispatch( resetImport( siteItem?.ID, job?.importerId ) );
+		stepNavigator?.goToImportCapturePage?.();
+	}
+
 	function checkProgress() {
 		return job?.importerState === appStates.IMPORTING;
 	}
@@ -173,7 +178,7 @@ const ImportContentOnly: React.FunctionComponent< Props > = ( props ) => {
 					return (
 						<ErrorMessage
 							onStartBuilding={ stepNavigator?.goToIntentPage }
-							onBackToStart={ stepNavigator?.goToImportCapturePage }
+							onBackToStart={ onBackToStartClick }
 						/>
 					);
 				} else if ( checkProgress() ) {


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/85280

## Proposed Changes

* Invoked `resetImport` action on "Back to start" CTA click

## Testing Instructions

When user clicks "Back to start" button on the import failed screen, we should set the import status to cancel, so once user is back to the beginning of the flow, they can start with the import flow again.

- Go to `/setup/import-focused?siteSlug={SITE_SLUG}`
- Select any platform for the content only import
- Try importer
- On the error screen, check if the "Back to start" button resets job state

<img width="814" alt="Screenshot 2023-12-15 at 12 42 19" src="https://github.com/Automattic/wp-calypso/assets/1241413/5649f40c-f966-46af-9971-6723b9cfce82">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?