### PR TITLE
WP import content: Hide upload success screen for the playground import flow

### DIFF
--- a/client/blocks/importer/components/importer-drag/config.tsx
+++ b/client/blocks/importer/components/importer-drag/config.tsx
@@ -67,7 +67,7 @@ export function getImportDragConfig( importer: Importer, supportLinkModal?: bool
 			),
 			uploadDescription: isEnabled( 'importer/site-backups' )
 				? translate(
-						'We support: XML, ZIP, and TAR.GZ files from Playground exports ' +
+						'We support: WordPress export files in XML & ZIP and Playground ZIP files. ' +
 							'{{supportLinkAlt/}}',
 						options
 				  )


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/4904
Closes https://github.com/Automattic/dotcom-forge/issues/4909

## Proposed Changes

* Hid Uploaded success screen (it was there by intention, but I agree the UX is wrong to have unnecessary jumping between screens)
* Updated uploader description
* Refactored content only component; Optimized and simplified for the future maintenance

## Testing Instructions

* Go to `/start`
* Create a new free plan website
* Set "import" as a goal
* Select WordPress content only flow
* Upload playground backup file
* Purchase a plan or choose 7 days free plan
* Check if there is a progress screen right after the plan upgrade

**TIP:** For a more straightforward review, follow the commits.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?