### PR TITLE
AppBanner: Update titles to remove the  periods

### DIFF
--- a/client/blocks/app-banner/utils.js
+++ b/client/blocks/app-banner/utils.js
@@ -24,7 +24,7 @@ export function getAppBannerData( translate, sectionName, isRTL ) {
 	switch ( sectionName ) {
 		case GUTENBERG:
 			return {
-				title: translate( 'Rich mobile publishing.' ),
+				title: translate( 'Rich mobile publishing' ),
 				copy: translate(
 					'A streamlined editor with faster, simpler image uploading? Check and mate.'
 				),
@@ -32,7 +32,7 @@ export function getAppBannerData( translate, sectionName, isRTL ) {
 			};
 		case NOTES:
 			return {
-				title: translate( 'Watch engagement happening.' ),
+				title: translate( 'Watch engagement happening' ),
 				copy: translate(
 					'Is your new post a hit? With push notifications, see reactions as they roll in.'
 				),
@@ -40,19 +40,19 @@ export function getAppBannerData( translate, sectionName, isRTL ) {
 			};
 		case READER:
 			return {
-				title: translate( 'Read posts, even offline.' ),
+				title: translate( 'Read posts, even offline' ),
 				copy: translate( 'Catch up with new posts on the go or save them to read offline.' ),
 				icon: `/calypso/animations/app-promo/jp-reader${ isRTL ? '-rtl' : '' }.json`,
 			};
 		case STATS:
 			return {
-				title: translate( 'Stats at your fingertips.' ),
+				title: translate( 'Stats at your fingertips' ),
 				copy: translate( 'See your real-time stats anytime, anywhere.' ),
 				icon: `/calypso/animations/app-promo/jp-stats${ isRTL ? '-rtl' : '' }.json`,
 			};
 		case HOME:
 			return {
-				title: translate( 'The Jetpack app makes WordPress better.' ),
+				title: translate( 'The Jetpack app makes WordPress better' ),
 				copy: translate( 'Everything you need to write, publish, and manage a world-class site.' ),
 				icon: `/calypso/animations/app-promo/wp-to-jp${ isRTL ? '-rtl' : '' }.json`,
 			};


### PR DESCRIPTION
As per p58i-g5m-p2

## Proposed Changes

* Remove the periods in the title. 

## Testing Instructions

* Load this PR in dev tools as a mobile browser.
* Remove any banner cookies/local storage. 
* Notice that there are no more periods at the end of titles. 
* Do this for /stats, /reader, /home, /notifications 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?