### PR TITLE
Marketplace Reviews: Remove ErrorResponse as one of the possible outcomes of a resolved promise

### DIFF
--- a/client/data/marketplace/use-marketplace-reviews.ts
+++ b/client/data/marketplace/use-marketplace-reviews.ts
@@ -68,7 +68,7 @@ export type ErrorResponse = {
 };
 
 type MarketplaceReviewsQueryOptions = Pick<
-	UseQueryOptions< MarketplaceReviewResponse[] | ErrorResponse >,
+	UseQueryOptions< MarketplaceReviewResponse[] >,
 	'enabled' | 'staleTime' | 'refetchOnMount'
 >;
 
@@ -77,7 +77,7 @@ const fetchMarketplaceReviews = (
 	productSlug: string,
 	page: number = 1,
 	perPage: number = 10
-): Promise< MarketplaceReviewResponse[] | ErrorResponse > => {
+): Promise< MarketplaceReviewResponse[] > => {
 	return wpcom.req.get(
 		{
 			path: reviewsApiBase,
@@ -97,7 +97,7 @@ const createReview = ( {
 	slug,
 	content,
 	rating,
-}: MarketplaceReviewBody ): Promise< MarketplaceReviewResponse | ErrorResponse > => {
+}: MarketplaceReviewBody ): Promise< MarketplaceReviewResponse > => {
 	return wpcom.req.post(
 		reviewsApiBase,
 		{
@@ -118,7 +118,7 @@ const updateReview = ( {
 	slug,
 	content,
 	rating,
-}: UpdateMarketplaceReviewProps ): Promise< MarketplaceReviewResponse | ErrorResponse > => {
+}: UpdateMarketplaceReviewProps ): Promise< MarketplaceReviewResponse > => {
 	return wpcom.req.post(
 		`${ reviewsApiBase }/${ reviewId }`,
 		{
@@ -135,7 +135,7 @@ const updateReview = ( {
 
 const deleteReview = ( {
 	reviewId,
-}: DeleteMarketplaceReviewProps ): Promise< MarketplaceReviewResponse | ErrorResponse > => {
+}: DeleteMarketplaceReviewProps ): Promise< MarketplaceReviewResponse > => {
 	return wpcom.req.post( {
 		method: 'DELETE',
 		path: `${ reviewsApiBase }/${ reviewId }`,
@@ -153,13 +153,7 @@ export const useMarketplaceReviewsQuery = (
 ) => {
 	const queryKey: QueryKey = [ queryKeyBase, productType, slug, page, perPage ];
 	const queryFn = () => fetchMarketplaceReviews( productType, slug, page, perPage );
-	return useQuery( {
-		queryKey,
-		queryFn,
-		enabled,
-		staleTime,
-		refetchOnMount,
-	} );
+	return useQuery( { queryKey, queryFn, enabled, staleTime, refetchOnMount } );
 };
 
 export const useCreateMarketplaceReviewMutation = () => {

--- a/client/my-sites/marketplace/components/reviews-cards/index.tsx
+++ b/client/my-sites/marketplace/components/reviews-cards/index.tsx
@@ -14,13 +14,13 @@ import './style.scss';
 export const MarketplaceReviewsCards = ( props: ProductProps ) => {
 	const translate = useTranslate();
 	const currentUserId = useSelector( ( state: IAppState ) => getCurrentUserId( state ) );
-	const { data: reviews } = useMarketplaceReviewsQuery( { ...props, perPage: 2, page: 1 } );
+	const { data: reviews, error } = useMarketplaceReviewsQuery( { ...props, perPage: 2, page: 1 } );
 
 	if ( ! isEnabled( 'marketplace-reviews-show' ) ) {
 		return null;
 	}
 
-	if ( ! Array.isArray( reviews ) || ! reviews || 'message' in reviews ) {
+	if ( ! Array.isArray( reviews ) || error ) {
 		return null;
 	}
 

--- a/client/my-sites/marketplace/components/reviews-list/index.tsx
+++ b/client/my-sites/marketplace/components/reviews-list/index.tsx
@@ -20,7 +20,7 @@ export const MarketplaceReviewsList = forwardRef<
 	MarketplaceReviewsQueryProps & { innerRef: LegacyRef< HTMLDivElement > }
 >( ( props, ref ) => {
 	const translate = useTranslate();
-	const { data: reviews, refetch: reviewsRefetch } = useMarketplaceReviewsQuery( props );
+	const { data: reviews, refetch: reviewsRefetch, error } = useMarketplaceReviewsQuery( props );
 
 	// ...
 	const currentUserId = useSelector( ( state: IAppState ) => getCurrentUserId( state ) );
@@ -44,7 +44,7 @@ export const MarketplaceReviewsList = forwardRef<
 	// TODO: In the future there should a form of catching and displaying an error
 	// But as currently we returns errors for products without reviews,
 	// its better to just avoid rendering the component at all
-	if ( ! Array.isArray( reviews ) && ( ! reviews || reviews.message ) ) {
+	if ( ! Array.isArray( reviews ) || error ) {
 		return null;
 	}
 


### PR DESCRIPTION
## Proposed Changes

Remove ErrorResponse as one of the possible outcomes of a resolved promise; when an error is returned, this promise should fail, and the error should be handled from there.

Some checks for this possibility were also removed. 

## Testing Instructions

* Check if all automated tests pass.
* Check if adding a new review for theme still working as expected, even displaying the error on the screen, showing the error handling still working properly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
