### PR TITLE
Stats: Fix cases of non-string title

### DIFF
--- a/client/my-sites/stats/stats-strings.js
+++ b/client/my-sites/stats/stats-strings.js
@@ -6,7 +6,7 @@ export default function () {
 	const statsStrings = {};
 
 	statsStrings.posts = {
-		title: translate( 'Posts & pages', { context: 'Stats: title of module' } ),
+		title: translate( 'Posts & pages', { context: 'Stats: title of module', textOnly: true } ),
 		item: translate( 'Title', { context: 'Stats: module row header for post title.' } ),
 		value: translate( 'Views', { context: 'Stats: module row header for number of post views.' } ),
 		empty: translate(
@@ -22,7 +22,7 @@ export default function () {
 	};
 
 	statsStrings.referrers = {
-		title: translate( 'Referrers', { context: 'Stats: title of module' } ),
+		title: translate( 'Referrers', { context: 'Stats: title of module', textOnly: true } ),
 		item: translate( 'Referrer', { context: 'Stats: module row header for post referrer.' } ),
 		value: translate( 'Views', {
 			context: 'Stats: module row header for number of post views by referrer.',
@@ -40,7 +40,7 @@ export default function () {
 	};
 
 	statsStrings.clicks = {
-		title: translate( 'Clicks', { context: 'Stats: title of module' } ),
+		title: translate( 'Clicks', { context: 'Stats: title of module', textOnly: true } ),
 		item: translate( 'Link', { context: 'Stats: module row header for links in posts.' } ),
 		value: translate( 'Clicks', {
 			context: 'Stats: module row header for number of clicks on a given link in a post.',
@@ -55,7 +55,7 @@ export default function () {
 	};
 
 	statsStrings.countries = {
-		title: translate( 'Countries', { context: 'Stats: title of module' } ),
+		title: translate( 'Countries', { context: 'Stats: title of module', textOnly: true } ),
 		item: translate( 'Country', { context: 'Stats: module row header for views by country.' } ),
 		value: translate( 'Views', {
 			context: 'Stats: module row header for number of views from a country.',
@@ -73,7 +73,7 @@ export default function () {
 	};
 
 	statsStrings.search = {
-		title: translate( 'Search terms', { context: 'Stats: title of module' } ),
+		title: translate( 'Search terms', { context: 'Stats: title of module', textOnly: true } ),
 		item: translate( 'Search term', {
 			context: 'Stats: module row header for search in search terms.',
 		} ),
@@ -90,7 +90,7 @@ export default function () {
 	};
 
 	statsStrings.authors = {
-		title: translate( 'Authors', { context: 'Stats: title of module' } ),
+		title: translate( 'Authors', { context: 'Stats: title of module', textOnly: true } ),
 		item: translate( 'Author', { context: 'Stats: module row header for authors.' } ),
 		value: translate( 'Views', {
 			context: 'Stats: module row header for number of views per author.',
@@ -105,7 +105,7 @@ export default function () {
 	};
 
 	statsStrings.videoplays = {
-		title: translate( 'Videos', { context: 'Stats: title of module' } ),
+		title: translate( 'Videos', { context: 'Stats: title of module', textOnly: true } ),
 		item: translate( 'Video', { context: 'Stats: module row header for videos.' } ),
 		value: translate( 'Views', {
 			context: 'Stats: module row header for number of views per video.',
@@ -120,7 +120,7 @@ export default function () {
 	};
 
 	statsStrings.filedownloads = {
-		title: translate( 'File downloads', { context: 'Stats: title of module' } ),
+		title: translate( 'File downloads', { context: 'Stats: title of module', textOnly: true } ),
 		item: translate( 'Files', { context: 'Stats: module row header for file downloads.' } ),
 		value: translate( 'downloads', {
 			context: 'Stats: module row header for number of downloads per file.',
@@ -135,7 +135,7 @@ export default function () {
 	};
 
 	statsStrings.tags = {
-		title: translate( 'Tags & categories', { context: 'Stats: title of module' } ),
+		title: translate( 'Tags & categories', { context: 'Stats: title of module', textOnly: true } ),
 		item: translate( 'Topic', { context: 'Stats: module row header for tags and categories.' } ),
 		value: translate( 'Views', {
 			context: 'Stats: module row header for number of views per tag or category.',
@@ -150,7 +150,7 @@ export default function () {
 	};
 
 	statsStrings.publicize = {
-		title: translate( 'Publicize', { context: 'Stats: title of module' } ),
+		title: translate( 'Publicize', { context: 'Stats: title of module', textOnly: true } ),
 		item: translate( 'Service', { context: 'Stats: module row header for publicize service.' } ),
 		value: translate( 'Subscribers', {
 			context: 'Stats: module row header for number of subscribers on the service.',
@@ -161,7 +161,7 @@ export default function () {
 	};
 
 	statsStrings.emails = {
-		title: translate( 'Emails', { context: 'Stats: title of module' } ),
+		title: translate( 'Emails', { context: 'Stats: title of module', textOnly: true } ),
 		item: translate( 'Title', { context: 'Stats: module row header for post title.' } ),
 		value: translate( 'Opens', { context: 'Stats: module row header for number of email opens.' } ),
 		empty: translate( 'Stats from {{link}}your emails{{/link}} will display here.', {
@@ -174,7 +174,7 @@ export default function () {
 	};
 
 	statsStrings.emailsClickStats = {
-		title: translate( 'Email clicks', { context: 'Stats: title of module' } ),
+		title: translate( 'Email clicks', { context: 'Stats: title of module', textOnly: true } ),
 		item: translate( 'Title', { context: 'Stats: module row header for post title.' } ),
 		value: translate( 'Clicks', {
 			context: 'Stats: module row header for number of email clicks.',
@@ -185,7 +185,7 @@ export default function () {
 	};
 
 	statsStrings.devices = {
-		title: translate( 'Devices', { context: 'Stats: title of module' } ),
+		title: translate( 'Devices', { context: 'Stats: title of module', textOnly: true } ),
 		item: translate( 'Device', { context: 'Stats: module row header for views by country.' } ),
 		value: translate( 'Views', {
 			context: 'Stats: module row header for number of views from a country.',
@@ -196,7 +196,7 @@ export default function () {
 	};
 
 	statsStrings.clients = {
-		title: translate( 'Clients', { context: 'Stats: title of module' } ),
+		title: translate( 'Clients', { context: 'Stats: title of module', textOnly: true } ),
 		item: translate( 'Client', { context: 'Stats: module row header for views by country.' } ),
 		value: translate( 'Views', {
 			context: 'Stats: module row header for number of views from a country.',
@@ -207,7 +207,7 @@ export default function () {
 	};
 
 	statsStrings.links = {
-		title: translate( 'Links', { context: 'Stats: title of module' } ),
+		title: translate( 'Links', { context: 'Stats: title of module', textOnly: true } ),
 		item: translate( 'Link', { context: 'Stats: module row header for links in posts.' } ),
 		value: translate( 'Clicks', {
 			context: 'Stats: module row header for number of clicks on a given link in a post.',


### PR DESCRIPTION
Currently, if you open the Stats page on one of your sites, and enable the community translator, you'll see this error:

![Screenshot 2023-12-15 at 17 27 39](https://github.com/Automattic/wp-calypso/assets/8436925/2410c9b8-bfac-40ed-8437-13547f6a43f1)

This has also been [reported in Senty](https://a8c.sentry.io/issues/4715595806/?project=6313676).

This happens because since #75732 we've been trying to programmatically lowercase localized strings before using in `aria-label`, and when using the community translator, the localized string is a React element, and not a string, resulting in it lacking regular String prototype functions like `toLowerCase()`. cc @jsnmoon for awareness.

## Proposed Changes

To fix this, we're intentionally using the `textOnly` setting for those strings, which ensures we're going to deal with strings indeed when lowercasing.

Ideally, the solution would be to have a separate string for each "View all %s", since in some languages "%s" can have different genders and that can result in having different "View all" for the different genders, ultimately needing to have a separate string for all. However, the fix here is a compromise that resolves the problem while keeping the original accessibility improvement that was done in #75732.

## Testing Instructions

* Go to `/stats/:site` where `:site` is one of your sites with high traffic.
* Enable the community translator
* Verify the page doesn't crash and the community translator works well. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?