### PR TITLE
Hosting Command Palette: Focus on search input when clicking

### DIFF
--- a/client/components/command-palette/index.tsx
+++ b/client/components/command-palette/index.tsx
@@ -121,20 +121,28 @@ interface CommandInputProps {
 	isOpen: boolean;
 	search: string;
 	setSearch: ( search: string ) => void;
+	selectedCommandName: string;
 	placeholder?: string;
 }
 
-function CommandInput( { isOpen, search, setSearch, placeholder }: CommandInputProps ) {
+function CommandInput( {
+	isOpen,
+	search,
+	setSearch,
+	placeholder,
+	selectedCommandName,
+}: CommandInputProps ) {
 	const commandMenuInput = useRef< HTMLInputElement >( null );
 	const itemValue = useCommandState( ( state ) => state.value );
 	const itemId = useMemo( () => cleanForSlug( itemValue ), [ itemValue ] );
 
 	useEffect( () => {
-		// Focus the command palette input when mounting the modal.
-		if ( isOpen ) {
+		// Focus the command palette input when mounting the modal,
+		// or when a command is selected.
+		if ( isOpen || selectedCommandName ) {
 			commandMenuInput.current?.focus();
 		}
-	}, [ isOpen ] );
+	}, [ isOpen, selectedCommandName ] );
 
 	return (
 		<Command.Input
@@ -236,6 +244,7 @@ const CommandPalette = () => {
 							<Icon icon={ inputIcon } />
 						) }
 						<CommandInput
+							selectedCommandName={ selectedCommandName }
 							search={ search }
 							setSearch={ setSearch }
 							isOpen={ isOpen }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Related to https://github.com/Automattic/wp-calypso/pull/85299




## Proposed Changes

* In addition to fix the scroll we can focus on the search input
  * when a command is clicked
  * when the back button is clicked

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the command palette with `cmd+k` on Mac and `ctrl+k` on Windows.
* Scroll a bit
* Click on a command with ellipsis to open the nested commands
* Observe the search input has de focus to type.
* Click on the Back button
* Observe the search input has de focus to type.


## Screencast

**Before**

https://github.com/Automattic/wp-calypso/assets/779993/74f77da9-0e4f-4c3f-9037-658bbfe03e8c



**After**

https://github.com/Automattic/wp-calypso/assets/779993/726c6183-aba9-4845-a378-b28a85cb55dd

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?