### PR TITLE
Multi-Domains: fixed anonymous user cart behavior

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -649,7 +649,9 @@ export class RenderDomainsStep extends Component {
 			this.state.addDomainTimeout = setTimeout( async () => {
 				// Only saves after all domain are checked.
 				Promise.all( this.state.checkDomainAvailabilityPromises ).then( async () => {
-					await this.props.shoppingCartManager.reloadFromServer();
+					if ( this.props.currentUser ) {
+						await this.props.shoppingCartManager.reloadFromServer();
+					}
 
 					// Add productsToAdd to productsInCart.
 					let productsInCart = [
@@ -754,7 +756,9 @@ export class RenderDomainsStep extends Component {
 
 		// Avoid too much API calls for Multi-domains flow
 		this.state.removeDomainTimeout = setTimeout( async () => {
-			await this.props.shoppingCartManager.reloadFromServer();
+			if ( this.props.currentUser ) {
+				await this.props.shoppingCartManager.reloadFromServer();
+			}
 
 			const productsToKeep = this.props.cart.products.filter( ( product ) => {
 				// check current item


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1702654988516649-slack-CKZHG0QCR

## Proposed Changes

* Anonymous users can now add multiple domains to the cart again.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open http://calypso.localhost:3000/start/domain/domain-only/ with an anonymous user and make sure you can add multiple domains to the cart.
* Make sure the experience looks good.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?