### PR TITLE
Jetpack Manage: Remove mock content and update content sidebar styles

### DIFF
--- a/client/jetpack-cloud/components/content-sidebar/index.tsx
+++ b/client/jetpack-cloud/components/content-sidebar/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Main from 'calypso/components/main';
 
 import './style.scss';
 
@@ -9,10 +10,11 @@ type Props = {
 
 const ContentSidebar = ( { mainContent, rightSidebar }: Props ) => {
 	return (
-		<div className="content-sidebar">
+		// todo: We have to add here the header for the mobile menu
+		<Main wideLayout className="content-sidebar">
 			<div className="content-sidebar__main-content">{ mainContent }</div>
 			<aside className="content-sidebar__right-sidebar">{ rightSidebar }</aside>
-		</div>
+		</Main>
 	);
 };
 

--- a/client/jetpack-cloud/components/content-sidebar/index.tsx
+++ b/client/jetpack-cloud/components/content-sidebar/index.tsx
@@ -1,5 +1,6 @@
-import './style.scss';
 import React from 'react';
+
+import './style.scss';
 
 type Props = {
 	mainContent: React.ReactNode;
@@ -8,9 +9,9 @@ type Props = {
 
 const ContentSidebar = ( { mainContent, rightSidebar }: Props ) => {
 	return (
-		<div className="jetpack-cloud-content-sidebar">
-			<div className="main-content">{ mainContent }</div>
-			<aside className="right-sidebar">{ rightSidebar }</aside>
+		<div className="content-sidebar">
+			<div className="content-sidebar__main-content">{ mainContent }</div>
+			<aside className="content-sidebar__right-sidebar">{ rightSidebar }</aside>
 		</div>
 	);
 };

--- a/client/jetpack-cloud/components/content-sidebar/style.scss
+++ b/client/jetpack-cloud/components/content-sidebar/style.scss
@@ -18,13 +18,13 @@
 		grid-gap: 32px;
 		grid-column-gap: 24px;
 	}
-	.content-sidebar__main-content {
+	&__main-content {
 		@include break-xlarge {
 			grid-column: 1 / span 8;
 		}
 	}
 
-	.content-sidebar__right-sidebar {
+	&__right-sidebar {
 		@include break-xlarge {
 			grid-column: 9 / span 4;
 		}

--- a/client/jetpack-cloud/components/content-sidebar/style.scss
+++ b/client/jetpack-cloud/components/content-sidebar/style.scss
@@ -1,7 +1,7 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-.jetpack-cloud-content-sidebar {
+.content-sidebar {
 
 	margin: 40px auto auto;
 
@@ -14,12 +14,5 @@
 		column-gap: 32px;
 		min-height: calc(100vh - 123px);
 		max-width: 1500px;
-	}
-
-	.right-sidebar {
-
-		> *:not(:first-child) {
-			margin-top: 40px;
-		}
 	}
 }

--- a/client/jetpack-cloud/components/content-sidebar/style.scss
+++ b/client/jetpack-cloud/components/content-sidebar/style.scss
@@ -2,17 +2,31 @@
 @import "@wordpress/base-styles/mixins";
 
 .content-sidebar {
+	&.main {
+		margin-top: 32px;
+	}
 
-	margin: 40px auto auto;
-
-	display: flex;
-	flex-direction: column;
+	grid-row: 4 / span 1;
 
 	@include break-xlarge {
+		&.main {
+			margin-top: 40px;
+		}
+		grid-column: 1 / span 12;
 		display: grid;
-		grid-template-columns: 3fr 1fr;
-		column-gap: 32px;
-		min-height: calc(100vh - 123px);
-		max-width: 1500px;
+		grid-template-columns: repeat(12, [col-start] minmax(0, 1fr));
+		grid-gap: 32px;
+		grid-column-gap: 24px;
+	}
+	.content-sidebar__main-content {
+		@include break-xlarge {
+			grid-column: 1 / span 8;
+		}
+	}
+
+	.content-sidebar__right-sidebar {
+		@include break-xlarge {
+			grid-column: 9 / span 4;
+		}
 	}
 }

--- a/client/jetpack-cloud/sections/overview/primary/overview/index.tsx
+++ b/client/jetpack-cloud/sections/overview/primary/overview/index.tsx
@@ -1,43 +1,14 @@
 import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
-import Main from 'calypso/components/main';
+
 import './style.scss';
 
 export default function Overview() {
 	const translate = useTranslate();
 
 	return (
-		<Main className="manage-overview">
+		<div className="overview">
 			<DocumentHead title={ translate( 'Overview' ) } />
-			<div className="welcome-section">
-				<h1>Welcome to Jetpack Manage 👋</h1>
-				<p>
-					Jetpack Manage helps you to monitor security and performance across all of your sites in a
-					single place.
-				</p>
-				<ul className="benefits-list">
-					<li>Insights: traffic and real-time uptime stats.</li>
-					<li>Plugin Updates: bulk update plugins in one click.</li>
-					<li>Backups & Scans: safeguard your sites and data.</li>
-					<li>Boost: manage performance across all of your sites.</li>
-				</ul>
-				<button className="next-button">Next</button>
-			</div>
-
-			<section className="next-steps">
-				<h2>Next steps</h2>
-				<ol className="steps-list">
-					<li>Get familiar with the sites management dashboard</li>
-					<li>Learn how to add new sites</li>
-					<li>Learn bulk editing and enabling downtime monitoring</li>
-					<li>Explore plugin management</li>
-				</ol>
-			</section>
-
-			<section className="jetpack-products">
-				<h2>Jetpack products</h2>
-				<p>Purchase single products or save big when you buy in bulk.</p>
-			</section>
-		</Main>
+		</div>
 	);
 }

--- a/client/jetpack-cloud/sections/overview/primary/overview/index.tsx
+++ b/client/jetpack-cloud/sections/overview/primary/overview/index.tsx
@@ -1,3 +1,4 @@
+import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 
@@ -9,6 +10,13 @@ export default function Overview() {
 	return (
 		<div className="overview">
 			<DocumentHead title={ translate( 'Overview' ) } />
+			<Card className="overview__welcome">{ /*<OverviewWelcome />*/ }</Card>
+			{ /*<Card className="overview__steps">*/ }
+			{ /*	/!*<OverviewSteps />*!/*/ }
+			{ /*</Card>*/ }
+			{ /*<Card className="overview__tools">*/ }
+			{ /*	/!*<OverviewTools />*!/*/ }
+			{ /*</Card>*/ }
 		</div>
 	);
 }

--- a/client/jetpack-cloud/sections/overview/primary/overview/style.scss
+++ b/client/jetpack-cloud/sections/overview/primary/overview/style.scss
@@ -1,13 +1,9 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-.content-sidebar {
-	.overview {
-		width: 100%;
-	}
-	.overview__content-block {
-		margin: 0 0 16px 0;
-		max-width: 100%;
-		background-color: var(--studio-white);
+.overview > .card {
+	margin-bottom: 32px;
+	@include break-xlarge {
+		margin-bottom: 16px;
 	}
 }

--- a/client/jetpack-cloud/sections/overview/primary/overview/style.scss
+++ b/client/jetpack-cloud/sections/overview/primary/overview/style.scss
@@ -1,67 +1,13 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-.jetpack-cloud-content-sidebar {
-	.main-content {
-		.manage-overview {
-			padding-left: 0;
-			padding-right: 0;
-			max-width: 100%;
-			h1 {
-				font-size: rem(36px);
-				font-weight: 700;
-				line-height: 48px;
-			}
-			h2 {
-				font-size: rem(16px);
-				font-weight: 500;
-				line-height: 24px;
-				color: var(--studio-gray-100);
-			}
-			.welcome-section {
-				padding: 32px;
-				background-color: var(--studio-white);
-
-				p {
-					color: #333;
-					margin-bottom: 16px;
-				}
-				.benefits-list {
-					list-style: none;
-					padding: 0;
-					margin-bottom: 24px;
-					li {
-						margin-bottom: 8px;
-					}
-				}
-				.next-button {
-					padding: 8px 16px;
-					background-color: var(--studio-jetpack-green-50);
-					color: var(--studio-white);
-					border: none;
-					cursor: pointer;
-				}
-			}
-
-			.next-steps {
-				margin-top: 16px;
-				padding: 16px 32px 16px 32px;
-				background-color: var(--studio-white);
-
-				.steps-list {
-					list-style: none;
-					padding: 0;
-					li {
-						margin-bottom: 16px;
-					}
-				}
-			}
-
-			.jetpack-products {
-				background-color: var(--studio-white);
-				margin-top: 32px;
-				padding: 24px;
-			}
-		}
+.content-sidebar {
+	.overview {
+		width: 100%;
+	}
+	.overview__content-block {
+		margin: 0 0 16px 0;
+		max-width: 100%;
+		background-color: var(--studio-white);
 	}
 }

--- a/client/jetpack-cloud/sections/overview/primary/sidebar/style.scss
+++ b/client/jetpack-cloud/sections/overview/primary/sidebar/style.scss
@@ -2,7 +2,7 @@
 @import "@wordpress/base-styles/mixins";
 
 .content-sidebar {
-	.content-sidebar__right-sidebar {
+	&__right-sidebar {
 
 		> *:not(:first-child) {
 			margin-top: 40px;

--- a/client/jetpack-cloud/sections/overview/primary/sidebar/style.scss
+++ b/client/jetpack-cloud/sections/overview/primary/sidebar/style.scss
@@ -1,8 +1,13 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-.jetpack-cloud-content-sidebar {
-	.right-sidebar {
+.content-sidebar {
+	.content-sidebar__right-sidebar {
+
+		> *:not(:first-child) {
+			margin-top: 40px;
+		}
+
 		.foldable-card__expand {
 			width: 24px;
 		}


### PR DESCRIPTION
Resolve https://github.com/Automattic/jetpack-manage/issues/177

## Proposed Changes

This PR removes mock content and updates the content-sidebar styles to fit with the design, applying the wideLayout style.

<img width="1515" alt="image" src="https://github.com/Automattic/wp-calypso/assets/9832440/f5a87e09-1ac5-404b-bc9a-96636e2ab572">

## Testing Instructions

- Check the code and styles applied.
- Check that the content appears with a card placeholder (WIP) and the right sidebar.
- On large horizontal screens, the content and the sidebar should be in the center at a fixed width (wide layout).
- Check that it is responsive and below 1080px the sidebar goes at the bottom and the content at the top.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
